### PR TITLE
RAG-port P0: profile-honoring retrieval + Console send-path injection (TASK-3170, task-406)

### DIFF
--- a/Docs/User_Guide/console/context-and-rag.md
+++ b/Docs/User_Guide/console/context-and-rag.md
@@ -347,4 +347,15 @@ profile by an unrelated Library workspace-eligibility gate, so that part
 is verified at the code level, not live). Verified against e2c706303 —
 2026-08-06 (PR-T2, docs pass against shipped code/tests, live check
 pending Task 9): staged evidence now counts toward the context estimate
-and the cost chip (as an estimated `~` row) instead of reporting zero.*
+and the cost chip (as an estimated `~` row) instead of reporting zero.
+Verified against d6b6a738f — 2026-08-07 (RAG-port P0 live walkthrough, real
+Anthropic provider): flipping **Auto-retrieve on send** in the RAG chip
+modal writes `[chat_defaults] rag_auto_retrieve_on_send = true` at
+toggle time — before Esc, and Esc leaves it set. A plain-text send then
+showed "Auto-retrieving Library evidence for this message." with the chip
+reading `RAG: on · Sources: 1 staged` about a second in, then "Evidence
+sent with this message · 15 sources", and the model's own reply named the
+injected block back ("the evidence sections [S1] through [S15] …") — the
+end-to-end proof that retrieved evidence reaches the provider. A send
+beginning with a slash command fired no retrieval at all: no placeholder,
+no chip flip, no evidence line.*

--- a/Docs/User_Guide/console/context-and-rag.md
+++ b/Docs/User_Guide/console/context-and-rag.md
@@ -161,11 +161,44 @@ line — by default "Sources: Notes, Media, Conversations (Prompts off)" —
 and is editable: the **Library search** chip (or **Search Library** with
 nothing typed) opens the **Library search** settings modal, which carries
 the query box plus a toggle per source kind (**✓ Notes**, **○ Media**,
-**✓ Conversations**, **○ Prompts**). Running keeps the edited selection
-(it also survives leaving and returning to Console); **Cancel** discards
-it. Run stays disabled until there is both a query and at least one
-source kind. Note this is a different setting from **RAG scope** above:
-"Sources" picks the source *kinds*, "Scope" picks the *items*.
+**✓ Conversations**, **○ Prompts**) and the **Auto-retrieve on send**
+switch described below. Running keeps the edited query/source-kind
+selection (it also survives leaving and returning to Console); **Cancel**
+discards it. Run stays disabled until there is both a query and at least
+one source kind. Note this is a different setting from **RAG scope**
+above: "Sources" picks the source *kinds*, "Scope" picks the *items*.
+
+Both a manual **Search Library** run and auto-retrieve (below) search to
+the depth your **active RAG profile** specifies (`Settings ▸ RAG`'s
+**Default results** field) rather than a fixed count, so manual and
+automatic retrieval can't disagree about how many results come back.
+
+### Auto-retrieve on send
+
+The **Library search** settings modal also carries an **Auto-retrieve on
+send** switch, default **OFF**. Turn it on and every plain text send —
+never a slash command, a `$skill` invocation, a tool approval, or a
+regenerate — first runs a Library search using your draft as the
+query and stages whatever it finds into the staged-evidence strip before
+the send goes out: the same visible, consume-on-send pipeline a manual
+**Search Library** run produces, never invisible prompt injection. It's
+skipped automatically when evidence is already staged (a manual run or a
+Library "Use in Console" handoff), so a send can't double-retrieve.
+
+The switch persists the instant you flip it, unlike the query and
+source-kind edits in the same modal — closing with **Escape** or a
+backdrop click still keeps the change. If your resolved RAG scope comes
+back **empty**, auto-retrieve short-circuits with the same shared notice
+the manual path shows, rather than searching everything.
+
+While a send is retrieving, the staged-evidence strip briefly shows a
+"Retrieving…" state; the search is capped at a **5-second timeout**, and
+a send is never blocked on it. If retrieval times out, fails, or the RAG
+service is still starting up (a first-use embedding-model load can take a
+while), the send goes out without evidence and a quiet notice names which
+of the two happened — "still initializing" vs. "failed" — rather than
+staying silent. A zero-result outcome currently clears the in-flight
+placeholder with no further notice.
 
 The Inspector tray is not the only place staged evidence shows up: a
 **staged-evidence strip** sits on the main surface itself, between the
@@ -246,6 +279,10 @@ Inspector shows what's in play:
    click the two items, press **Save**. The strip shows **Scope: 2**.
 5. **Open a citation's source in Library** — click **Sources (N)** under
    the reply, select an `[S1]` row, press **Open in Library**.
+6. **Have every send ground itself automatically** — click the **RAG**
+   chip (or **Run Library RAG**) to open **Library RAG** settings, turn on
+   **Auto-retrieve on send**, close the modal. It stays on across sends
+   until you flip it off; it's off by default.
 
 ## Keyboard & commands
 
@@ -265,7 +302,13 @@ Enter again to send as text."
 
 - `config.toml` `[rag]` (and legacy `[rag_search]`) — retrieval and
   processing settings; covered in
-  [Library ▸ Search & RAG](../library/search-and-rag.md).
+  [Library ▸ Search & RAG](../library/search-and-rag.md), including how
+  the active RAG profile now drives retrieval mode.
+- `config.toml` `[chat_defaults] rag_auto_retrieve_on_send` — the
+  persisted **Auto-retrieve on send** value (default `false`); the modal
+  is the supported way to change it.
+- [Settings ▸ RAG](../settings/rag.md) — the profile that both auto- and
+  manual Library RAG retrieval read for search mode and result depth.
 - [Library ▸ Prompts](../library/prompts.md) — where saved prompts are
   created and managed.
 - [Console orientation](../console.md) — layout tour, rails, and chips.
@@ -284,6 +327,15 @@ Enter again to send as text."
   state warns before you send into it — **Clear** or **Edit** the scope.
 - **The viewer's token count is a draft-derived estimate** — a guide, not
   a billing meter.
+- **Auto-retrieve fires on every plain-text send while it's on**,
+  including repeated sends in the same conversation — there's no
+  once-per-conversation memory yet, so an empty resolved scope re-shows
+  its notice on each send until you clear or edit the scope.
+- **Reranking-enabled profiles cost more per search.** If your active RAG
+  profile has reranking on, both auto- and manual Library RAG retrieval
+  spend one LLM provider call per candidate result (up to the profile's
+  **Rerank results** count) — see
+  [Settings ▸ RAG](../settings/rag.md#the-editing-card).
 
 —
 *Verified against c2cbb8081 — 2026-08-04 (PR-T1 live check S1-S6: staged

--- a/Docs/User_Guide/library/search-and-rag.md
+++ b/Docs/User_Guide/library/search-and-rag.md
@@ -418,4 +418,18 @@ check uses — not just an endpoint name. Verified against 42b28089f —
 2026-08-06 (task-2852: live check on a fresh profile — "Use in Console"
 on a locked Console now warns before navigating and stages a visible
 receipt on the "Get started" card; a configured Console still lands on
-the unchanged staged-evidence strip).*
+the unchanged staged-evidence strip). Verified against d6b6a738f —
+2026-08-07 (RAG-port P0 live walkthrough on a scratch profile holding a
+copy of the real Library DBs, real provider): under the default Hybrid
+Basic profile a RAG Answer run returned rows banded on real similarity —
+"match: moderate" for the two best and "match: weak (0.18)" / "weak
+(0.17)" below them — not the old wall of "weak (0.02)" that banding a
+rank-fused score produced. Under BM25 Only the same panel disclosed
+"Profile 'BM25 Only': keyword search (no vectors)." and returned both a
+note and a **media** row, the keyword leg that previously could not
+return a row at all. Under Hybrid Full with no matching index the run
+disclosed "Semantic search found nothing from: Notes, Conversations.
+Semantic leg empty — keyword-only results." and rendered its FTS-leg row
+as "keyword match" rather than inventing a similarity. Turning Media off
+routed the run to semantic and said so: "Media excluded — semantic
+only." Every one of those route notes rendered on zero-row outcomes too.*

--- a/Docs/User_Guide/library/search-and-rag.md
+++ b/Docs/User_Guide/library/search-and-rag.md
@@ -181,10 +181,30 @@ Console](#sending-evidence-to-console) below.
 Each hit is one block:
 
 - **Title** — numbered, e.g. "1. g2_demo_article", with a match band
-  appended when the row carries a score: `| match: strong` (≥ 0.5),
-  `| match: moderate` (≥ 0.2), or `| match: weak (0.09)` — the weak band
-  keeps the raw number so you can see how weak. Keyword ("Search") mode
-  rows carry no score, so nothing is appended.
+  appended when the row carries a similarity score: `| match: strong`
+  (≥ 0.5), `| match: moderate` (≥ 0.2), or `| match: weak (0.09)` — the
+  weak band keeps the raw number so you can see how weak. Keyword
+  ("Search") mode rows carry no score, so nothing is appended.
+
+  The band is a statement about *semantic similarity*, so rows scored
+  another way say what they are instead of borrowing a band they don't
+  fit:
+
+  - Hybrid profiles (Hybrid Basic / Hybrid Full) blend the keyword and
+    vector rankings into a fused score that maxes out near 0.016 — far
+    below the weak boundary. Those rows are banded on the vector leg's own
+    similarity, so a strong hybrid hit reads `| match: strong`, exactly as
+    the same hit would in a semantic profile.
+  - A hybrid row that only the keyword leg found has no similarity at all
+    and reads `| keyword match`.
+  - A reranked row reads `| reranked`: reranker scores are on the
+    reranking model's own scale, not a 0-1 similarity, so the band is
+    withheld rather than guessed.
+
+  The "No strong semantic matches — results below are weak." line above
+  the list follows the same rule: only rows carrying a real similarity can
+  trigger it, so keyword-match and reranked rows neither cause it nor
+  suppress it.
 - **Badge line** — the source type first (e.g. "Media"), then a workspace
   name when it isn't "all workspaces", a citation count ("2 citations")
   when the hit carries citations, and "excluded from context" when the row

--- a/Docs/User_Guide/library/search-and-rag.md
+++ b/Docs/User_Guide/library/search-and-rag.md
@@ -71,7 +71,9 @@ statement, not a confirmation gate; nothing blocks Run because of it.
 
 - **Search** — keyword matching over your sources; works with nothing extra
   installed.
-- **RAG Answer** — semantic retrieval. If embeddings support isn't
+- **RAG Answer** — retrieval driven by your active RAG profile (see
+  [Retrieval mode follows your RAG profile](#retrieval-mode-follows-your-rag-profile)
+  below), then a generated answer. If embeddings support isn't
   installed, the run blocks as "RAG unavailable" with the next step
   `Install RAG support: pip install "tldw_chatbook[embeddings_rag]", then
   restart, or switch mode to Search.` and the recovery pointer
@@ -79,6 +81,39 @@ statement, not a confirmation gate; nothing blocks Run because of it.
   "Index empty" — "The semantic index has no content yet" — with the
   recovery "Ingest content to index it automatically, run a semantic index
   backfill, or switch mode to Search".
+
+### Retrieval mode follows your RAG profile
+
+RAG Answer's retrieval step is no longer fixed to "always semantic" — it
+follows whichever **search mode** your active RAG profile
+([Settings ▸ RAG](../settings/rag.md)) is set to:
+
+- **Plain keyword** profiles (e.g. the built-in "BM25 Only") route the
+  query through the same keyword search Search mode uses, honestly
+  labeled — no vector index required, and no `match: strong`-style
+  similarity band on the resulting rows (they read `| keyword match`
+  instead — see [Evidence rows](#evidence-rows) below).
+- **Semantic** profiles run vector retrieval, same as before.
+- **Hybrid** profiles blend keyword and vector retrieval when the query
+  is unscoped and Media is a selected source. A query narrowed by a RAG
+  scope, or one with Media toggled off, falls back to semantic-only
+  retrieval for now — scope-aware and multi-source hybrid retrieval are
+  later work — and that fallback is disclosed rather than silent.
+
+A quiet one-line disclosure can appear above the evidence rows,
+alongside the "No strong semantic matches" / "Semantic search found
+nothing from…" lines described below, when the route taken is worth
+naming: `Profile 'BM25 Only': keyword search (no vectors).`,
+`Scope active — semantic only until scope-aware hybrid lands.`,
+`Media excluded — semantic only.`, or `Semantic leg empty — keyword-only
+results.` (shown when a hybrid profile's vector leg came back empty but
+its keyword leg still found rows — the "Index empty" recovery state is
+withheld in that case, since the index genuinely isn't empty).
+
+RAG Answer mode still needs embeddings support installed regardless of
+which mode the active profile resolves to, and generating the answer
+itself still calls your configured LLM provider either way — only the
+*retrieval* step's behavior depends on the profile.
 
 ### Sources scope
 
@@ -329,8 +364,14 @@ indexes — if RAG Answer mode reports an empty index, go there to backfill.
 
 - **"top 5" is fixed here.** The tunable top-k in Settings ▸ RAG does not
   change this canvas. "Per source" only appears in Search mode — RAG
-  Answer mode runs one merged semantic query across sources, not one per
-  source, so the heading doesn't claim it.
+  Answer mode runs one merged query across sources (semantic, keyword, or
+  hybrid depending on the active profile — see [Retrieval mode follows
+  your RAG profile](#retrieval-mode-follows-your-rag-profile)), not one
+  per source, so the heading doesn't claim it.
+- **Which retrieval mode RAG Answer actually uses depends on your active
+  profile**, not a fixed "always semantic" assumption — see [Retrieval
+  mode follows your RAG profile](#retrieval-mode-follows-your-rag-profile)
+  above.
 - **The scope summary line tracks the toggles.** Deselecting a source (e.g.
   turning Media off) updates "Scope: …" to name what's still in scope and
   what's off — it's a live summary of the ✓/○ toggles below it, not a fixed

--- a/Docs/User_Guide/settings/rag.md
+++ b/Docs/User_Guide/settings/rag.md
@@ -10,6 +10,14 @@ search comes back empty (you need **Backfill**), or when you want to change how
 sources are chunked, embedded, ranked, or cited. The profiles that ship with
 the app are read-only, so tuning always starts by cloning one.
 
+The active profile's **Search mode** now genuinely drives retrieval, not
+just a stored preference: Library's Search/RAG canvas and Console's
+Library RAG evidence handoff (manual or auto-retrieve) both resolve it
+and route accordingly — a `Plain keyword` profile searches keyword-only,
+`Hybrid` blends keyword and vector search, and `Semantic` runs vector
+search — see [Library Search/RAG](../library/search-and-rag.md#retrieval-mode-follows-your-rag-profile)
+and [Console: Context & RAG](../console/context-and-rag.md#auto-retrieve-on-send).
+
 ## Getting there
 
 Open **Settings** — press **F9**, click "F9 Settings" in the nav bar, or
@@ -118,7 +126,14 @@ not:
   removes that config entirely." With it off the two fields dim and gain
   " (enable reranking to edit)". **Rerank results** above **Default results**
   warns without blocking the save: "Rerank results (`n`) exceeds default
-  results (`m`); reranking will not see all requested results."
+  results (`m`); reranking will not see all requested results." **Cost:**
+  the default reranking strategy scores every candidate individually, so
+  enabling it means one extra LLM provider call per result (up to
+  **Rerank results** many) on every search this profile runs — a profile
+  with **Rerank results** at 15 can issue up to 15 provider calls per
+  query. If the reranker can't run (missing model or dependency), search
+  results still come back — reranking is skipped, disclosed, and never
+  fails the search outright.
 
 ### The four dialogs
 
@@ -169,7 +184,8 @@ testing a connection ("RAG check started." → "RAG check: `<state>` index ·
 5. **Turn on reranking.** With your own profile active, expand **Reranking**,
    tick **Enable reranking**, optionally name a **Reranker model** (blank uses
    the reranker's default), keep **Rerank results** at or below **Default
-   results**, and **Save (s)** — no backfill needed.
+   results**, and **Save (s)** — no backfill needed. Every search this profile
+   runs will now spend one extra provider call per candidate result.
 6. **Delete a profile you no longer want.** With a profile *of your own* active
    (see Quirks), pick the one to remove, press **Delete**, confirm — delete the
    active one and the pointer falls back to a built-in.
@@ -223,6 +239,11 @@ field has focus the footer relabels the hints as `Esc, s` / `Esc, r` /
   the next Library query does, not anything already rendered. Library Search's
   "top 5 per source" ignores **Default results** entirely — see
   [Library Search/RAG](../library/search-and-rag.md).
+- **Reranking is not free.** The default (pointwise) strategy scores every
+  candidate result with a separate provider call, so a profile with
+  **Rerank results** at 15 can spend up to 15 calls on a single search —
+  every surface that reads this profile (Library, Console manual/auto
+  retrieval) pays that cost, not just this pane.
 - **Backfill needs embeddings support.** Without it you get "Semantic indexing
   is unavailable (missing embeddings extras, or disabled in config)." and the
   index never builds; keyword search keeps working regardless. "RAG backfill

--- a/Docs/User_Guide/settings/rag.md
+++ b/Docs/User_Guide/settings/rag.md
@@ -252,4 +252,15 @@ field has focus the footer relabels the hints as `Esc, s` / `Esc, r` /
   shortly." is different — that one is transient, so press **Backfill** again.
 
 —
-*Verified against dev @ e7b9ebabd — 2026-08-06*
+*Verified against dev @ e7b9ebabd — 2026-08-06. Verified against d6b6a738f
+— 2026-08-07 (RAG-port P0 live walkthrough on a scratch profile holding a
+copy of the real Library DBs): **Set active** on the Profile select writes
+`[rag.service] profile` immediately and the "Active:" line follows it —
+switched Hybrid Basic → BM25 Only → Hybrid Full → Hybrid Basic, and every
+switch changed what the next Library Search/RAG run actually did. The index
+line is honest about the switch: Hybrid Basic reads "Index: built · 453
+vectors · built with all-MiniLM-L6-v2 / chunk 384·64", and selecting a
+profile with a different embedding model immediately reads "Index: absent —
+will be created on next backfill" plus "Semantic index not built — Hybrid
+search is keyword-only until you Backfill" — which is exactly what the
+subsequent search then disclosed.*

--- a/Docs/User_Guide/settings/rag.md
+++ b/Docs/User_Guide/settings/rag.md
@@ -107,10 +107,11 @@ balance** and **Citation and snippets**: **Search mode** (`Plain keyword` /
 `Semantic` / `Hybrid`); **Default results**, **Keyword results**, **Vector
 results** (1–100 each); **Hybrid balance**, **Min score** (0.0–1.0 each);
 **Include citations**; **Citation style** (`Inline` / `Footnote` / `None`);
-**Snippet chars** (50–10000); **Context budget** (1000–1000000). Its caption is
-honest about reach — "Used by future Library-native Search/RAG and Console
-evidence handoff defaults." — so these are persisted now and consumed when
-Library runs a query, not applied to what is already on screen.
+**Snippet chars** (50–10000); **Context budget** (1000–1000000). Its caption
+confirms the reach — "Drives Library Search/RAG retrieval and Console
+evidence handoff defaults." — these are persisted here and consumed the next
+time Library or Console runs a query, not applied to what is already on
+screen.
 
 The four collapsed folds; the first three rebuild the index, **Reranking** does
 not:

--- a/Docs/superpowers/plans/2026-08-07-rag-port-p0-foundations.md
+++ b/Docs/superpowers/plans/2026-08-07-rag-port-p0-foundations.md
@@ -1,0 +1,556 @@
+# RAG Server-Port P0 Foundations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the retrieval tldw_chatbook already owns reachable and honest: the live Library `rag` mode honors the active RAG profile (hybrid/semantic/plain + reranking), and the native Console send path gets opt-in RAG injection through the staged-evidence pipeline (TASK-406).
+
+**Architecture:** Engine fixes first (fusion metadata, keyword leg, reranker factory), then the Library service's mode resolution, then score-kind-aware presentation, then the Console send path. No server code is lifted; the spec is authority: `Docs/superpowers/specs/2026-08-07-rag-port-p0-foundations-design.md`.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, pytest (venv-only), SQLite FTS5, chromadb (optional `embeddings_rag` extra).
+
+## Global Constraints
+
+- Spec: `Docs/superpowers/specs/2026-08-07-rag-port-p0-foundations-design.md` — read it before any task.
+- Worktree: `.worktrees/rag-port-p0`, branch `feat/rag-port-p0-foundations`. **Background-Bash cwd silently resets to the main checkout — start every command block with `cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/rag-port-p0`.**
+- Python: the worktree has NO venv. Run pytest as `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <paths>` with cwd in the worktree (cwd-first import resolution picks up the worktree's package).
+- pytest is the ONLY python entry point — never `python -c "import tldw_chatbook..."` (a bare probe once wrote to the live config).
+- "no tests ran" is a FAILED gate: read the numeric passed count every time.
+- Targeted suites only (user ruling): run the test files this branch touches plus a `--collect-only -q` sweep; never full `Tests/UI`.
+- Never `git stash` (repo-wide across 100+ worktrees). Never `git checkout HEAD -- <file>` to undo a mutation probe — use Edit-based restores with unique marker strings.
+- Push after every task (`git push`) — durability begins at origin.
+- Config honesty: retrieval changes must never present a fused/reranker score as a similarity; every degradation is disclosed, never silent.
+- Commit messages end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+
+## Verified code anchors (read before relying on them; line numbers drift)
+
+- `tldw_chatbook/RAG_Search/simplified/rag_service.py` — `RAGService.search` dispatch (~L627), `_keyword_search` (~L775: path-guess list, create-on-miss `MediaDatabase` side effect, `_perform_fts5_search` media-schema SQL), `_process_keyword_results_basic` / `_with_citations` (metadata keys: `doc_id, doc_title, media_type, url, author, ingestion_date, text_preview` — **no `source_type`**), `_hybrid_search` (~L914), `_fuse_hybrid_results` (fused score replaces leg scores; `metadata["hybrid_fusion"]` = alpha/rrf_k/ranks/RRF contributions only).
+- `tldw_chatbook/RAG_Search/fusion.py::reciprocal_rank_fusion` (~L98) — `FusedResult` has `fts_item/vector_item/fts_rank/vector_rank/fts_rrf/vector_rrf/score`; original leg items retain their own `.score`.
+- `tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py` — `__init__` (~L97-103) calls `create_reranker(strategy=..., **self.reranking_config.__dict__)` → **TypeError: multiple values for 'strategy'** (reranking has NEVER constructed); second site ~L343; experiment site ~L238. `search()` applies `self.reranker.rerank` UNGUARDED (~L232-244).
+- `tldw_chatbook/RAG_Search/reranker.py::create_reranker` (~L624) — only `pointwise|pairwise|listwise` (all LLM-based); raises ValueError otherwise.
+- `tldw_chatbook/RAG_Search/config_profiles.py` — `hybrid_full_rerank = RerankingConfig(strategy="cross_encoder", ...)` (~L352) — **unsupported strategy**; profile field `search.default_search_mode` values `"plain"|"semantic"|"hybrid"` (~L239/261/283).
+- `tldw_chatbook/RAG_Search/simplified/rag_factory.py` (~L55-83) — `enable_reranking = profile.reranking_config is not None`.
+- `tldw_chatbook/Library/library_local_rag_search_service.py` — mode dispatch (~L178-182: `mode == "rag"` → `_search_semantic`, else `_search_keyword`); `_search_keyword` (~L184: four-seam, scope-aware via per-seam allowlists); `_SEMANTIC_SOURCE_TYPE_MAP` (~L54: note/notes→notes, media/media_chunk→media, conversation(s)/chat→conversations); `_search_semantic` (~L417: post-filters rows by canonicalized provenance `source_type`).
+- `tldw_chatbook/Library/library_rag_state.py` — `LIBRARY_RAG_MATCH_STRONG_THRESHOLD = 0.5`, `MODERATE = 0.2` (~L95); `library_rag_score_suffix(score: float | None)` (~L601, pure); `library_rag_all_matches_weak(rows)` (~L1505).
+- `tldw_chatbook/UI/Views/RAGSearch/search_handoff.py::_library_rag_score` (~L163) — clamps to [0,1]; feeds `EvidenceBundle` scores (~L397/469).
+- `tldw_chatbook/UI/Screens/chat_screen.py` — chip manual run builds `LibraryRagSearchRequest(mode="rag", top_k=5, ...)` (~L12674); staging seam `_stage_console_library_rag_launch` (~L3207); send-path capture `await capture_console_staged_evidence_for_chat(...)` (~L4654).
+- `tldw_chatbook/Chat/console_chat_controller.py::submit_draft` (~L1803).
+- `tldw_chatbook/Widgets/Console/console_rag_settings_modal.py` — `ConsoleRagSettingsResult` (~L102), `ConsoleRagSettingsModal` (~L119).
+- `tldw_chatbook/config.py::get_media_db_path()` (~L5712) — the real media DB is `~/.local/share/tldw_cli/tldw_cli_media_v2.db`; the keyword leg's guesses (`media_db.db`, `chacha_notes.db`) can NEVER match it.
+- Cache: `simple_cache.py::_make_key(query, search_type, top_k, filters, metadata_allowlist)` — search_type in key; no stale-cache hazard on mode change (spec verification item 5: RESOLVED, no work needed).
+
+---
+
+### Task 1: Backlog filing + task-406 AC edit
+
+**Files:**
+- Create: `backlog/tasks/task-<ID> - RAG-port-P0-profile-honoring-retrieval-and-Console-send-path-injection.md` (via CLI)
+- Modify: `backlog/tasks/task-406 - Wire-RAG-context-injection-into-the-native-Console-send-path.md` (via CLI)
+
+**Interfaces:**
+- Produces: the P0 backlog task ID, referenced by every later commit message and the final Done notes.
+
+- [ ] **Step 1: Assign a safe ID.** Scan across ALL worktrees and origin/dev for the current max task ID, then leapfrog with headroom (house rule after ten+ collisions):
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/rag-port-p0
+for d in /Users/macbook-dev/Documents/GitHub/tldw_chatbook /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/*; do ls "$d/backlog/tasks" 2>/dev/null; done | grep -oE '^task-[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -3
+git fetch origin dev --quiet && git ls-tree -r --name-only origin/dev -- backlog/tasks | grep -oE 'task-[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -3
+```
+
+Pick max + 100 headroom (e.g. max 3022 → use 3122).
+
+- [ ] **Step 2: Create the P0 task** with `backlog task create` (repeat `--ac` per criterion — comma form writes one run-on criterion): ACs = the spec's Workstream A bullets (profile mode honored; keyword leg replaced with config-injected path + no-write-on-search; score-kind-aware bands; reranker factory fixed + never fails a search; zero-results honesty) and Workstream B bullets (toggle default OFF; plain-text-sends only; staged-evidence routing; EMPTY-scope shared copy; 5s timeout with initializing-vs-failed notice; legacy path unchanged). Set `-s "In Progress"` and add the plan reference via `--plan`.
+
+- [ ] **Step 3: Edit task-406's AC** per backlog rules (AC updated BEFORE implementation): note that enablement re-homes from the legacy sidebar checkbox to the Console RAG chip modal toggle, default OFF, and that injection routes through the staged-evidence strip (visible, consume-on-send), not invisible prompt injection.
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+git add backlog/ && git commit -m "chore(backlog): file RAG-port P0 task; re-home task-406 enablement AC
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>" && git push
+```
+
+---
+
+### Task 2: Fusion preserves original leg scores
+
+**Files:**
+- Modify: `tldw_chatbook/RAG_Search/simplified/rag_service.py` (`_fuse_hybrid_results`)
+- Test: `Tests/RAG_Search/test_hybrid_fusion_metadata.py` (create)
+
+**Interfaces:**
+- Produces: every fused result's `metadata["hybrid_fusion"]` gains `"fts_score": float | None` and `"vector_score": float | None` (the ORIGINAL leg scores, `None` for the absent leg). Task 5's banding and Task 6's bundle rely on `vector_score`.
+
+- [ ] **Step 1: Read** `_fuse_hybrid_results` in full. The `FusedResult` entries carry `fts_item`/`vector_item` (the original `SearchResult`s, each with its own `.score`) — the fused block currently records ranks + RRF contributions but discards those scores.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# Tests/RAG_Search/test_hybrid_fusion_metadata.py
+"""Fusion must preserve original per-leg scores for score-kind-aware display.
+
+RRF-fused scores max out at ~1/(rrf_k+1) ~= 0.016 — far below the UI's
+similarity band thresholds — so the vector leg's original similarity is the
+only honest banding input for hybrid rows (spec Workstream A item 3).
+"""
+import pytest
+from tldw_chatbook.RAG_Search.simplified.rag_service import RAGService
+from tldw_chatbook.RAG_Search.simplified.citations import SearchResult
+
+
+def _result(rid: str, score: float) -> SearchResult:
+    return SearchResult(id=rid, score=score, document=f"doc {rid}", metadata={})
+
+
+def test_fused_rows_preserve_original_leg_scores():
+    keyword = [_result("m1", 0.001), _result("m2", 0.001)]
+    semantic = [_result("m2", 0.83), _result("m3", 0.41)]
+    fused = RAGService._fuse_hybrid_results(
+        keyword_results=keyword, semantic_results=semantic,
+        top_k=10, alpha=0.7, include_citations=False,
+    )
+    by_id = {r.id: r for r in fused}
+    both = by_id["m2"].metadata["hybrid_fusion"]
+    assert both["vector_score"] == pytest.approx(0.83)
+    assert both["fts_score"] == pytest.approx(0.001)
+    fts_only = by_id["m1"].metadata["hybrid_fusion"]
+    assert fts_only["vector_score"] is None
+    vec_only = by_id["m3"].metadata["hybrid_fusion"]
+    assert vec_only["vector_score"] == pytest.approx(0.41)
+    assert vec_only["fts_score"] is None
+```
+
+(If `SearchResult` lives elsewhere or has a different constructor, adjust the import/helper to the real dataclass — read `simplified/citations.py` first.)
+
+- [ ] **Step 3: Run to verify it fails** (KeyError on `vector_score`). Command per Global Constraints; expect FAIL, read the output.
+
+- [ ] **Step 4: Implement** — in `_fuse_hybrid_results`, where `metadata["hybrid_fusion"]` is assembled from each `FusedResult` entry, add:
+
+```python
+"fts_score": entry.fts_item.score if entry.fts_item is not None else None,
+"vector_score": entry.vector_item.score if entry.vector_item is not None else None,
+```
+
+- [ ] **Step 5: Run the new test (PASS) plus the existing fusion tests** (`grep -rl "_fuse_hybrid_results\|reciprocal_rank_fusion" Tests/ | sort -u` and run those files). Read passed counts.
+
+- [ ] **Step 6: Commit and push** (`feat(rag): preserve original leg scores in hybrid_fusion metadata`).
+
+---
+
+### Task 3: Replace the keyword leg's DB resolution (no guessing, no writes)
+
+**Files:**
+- Modify: `tldw_chatbook/RAG_Search/simplified/rag_service.py` (`_keyword_search`, `_process_keyword_results_basic`, `_process_keyword_results_with_citations`)
+- Modify: `tldw_chatbook/RAG_Search/simplified/config.py` (add `media_db_path` to the search/service config — read the config dataclass first and follow its style)
+- Test: `Tests/RAG_Search/test_keyword_leg_db_resolution.py` (create)
+
+**Interfaces:**
+- Consumes: `tldw_chatbook.config.get_media_db_path()` (returns `Path`; honors `TLDW_CONFIG_PATH` scratch profiles).
+- Produces: `_keyword_search` resolves its DB as: explicit `config.search.media_db_path` if set → else `get_media_db_path()`; missing/unopenable DB returns `[]` after logging — **never creates a database**. Keyword rows gain `"source_type": "media"` and `"source": "media"` in metadata.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/RAG_Search/test_keyword_leg_db_resolution.py
+"""The keyword leg must use the configured media DB and never write.
+
+Today it guesses paths (media_db.db / chacha_notes.db) that can never match
+the real tldw_cli_media_v2.db, opens the ChaChaNotes DB with media-schema
+SQL, and on a total miss CREATES a MediaDatabase as a search side effect.
+"""
+import asyncio
+from pathlib import Path
+import pytest
+
+
+def _make_service(tmp_path, media_db_path=None):
+    # Build a RAGService with the in-memory vector store and mock embeddings;
+    # read tests in Tests/RAG_Search/ for the existing construction helper
+    # (several tests build a service with provider="mock") and reuse it,
+    # overriding config.search.media_db_path when given.
+    ...
+
+
+def test_missing_media_db_returns_empty_and_creates_nothing(tmp_path):
+    service = _make_service(tmp_path, media_db_path=tmp_path / "absent.db")
+    results = asyncio.run(service._keyword_search("anything", top_k=5))
+    assert results == []
+    assert not (tmp_path / "absent.db").exists()          # no create-on-miss
+    assert list(tmp_path.glob("*.db")) == []              # no rogue DB anywhere
+
+
+def test_keyword_rows_carry_media_source_type(tmp_path):
+    db_path = tmp_path / "tldw_cli_media_v2.db"
+    # Create a real MediaDatabase and insert one item via its public API
+    # (add_media_with_keywords) so media_fts is populated by triggers.
+    from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+    db = MediaDatabase(db_path=str(db_path), client_id="test_keyword_leg")
+    # read add_media_with_keywords' signature and insert a doc containing
+    # the token "wombat"
+    ...
+    service = _make_service(tmp_path, media_db_path=db_path)
+    results = asyncio.run(service._keyword_search("wombat", top_k=5))
+    assert results, "FTS row expected"
+    assert results[0].metadata["source_type"] == "media"
+
+
+def test_default_resolution_uses_get_media_db_path(monkeypatch, tmp_path):
+    sentinel = tmp_path / "sentinel_media.db"
+    import tldw_chatbook.config as cfg
+    monkeypatch.setattr(cfg, "get_media_db_path", lambda **kw: sentinel)
+    service = _make_service(tmp_path)  # no explicit path configured
+    results = asyncio.run(service._keyword_search("anything", top_k=5))
+    assert results == []                                   # sentinel absent
+    assert not sentinel.exists()                           # still no writes
+```
+
+Fill the `...` bodies against the real APIs (read the neighboring tests and `Client_Media_DB_v2.add_media_with_keywords` first) — the assertions above are the contract and must remain as written.
+
+- [ ] **Step 2: Run to verify failures** — expect the no-writes test to FAIL today (the create-on-miss branch fires) and the source_type test to FAIL (key absent).
+
+- [ ] **Step 3: Implement**
+  - Delete the entire guess-list block and the `MediaDatabase(...)` create-on-miss branch in `_keyword_search`.
+  - Resolve: `db_path = self.config.search.media_db_path or tldw_chatbook.config.get_media_db_path()`; if the file doesn't exist → `logger.warning(...)`, `return []`.
+  - Add `"source_type": "media", "source": "media"` to the metadata dict in BOTH `_process_keyword_results_basic` and `_process_keyword_results_with_citations`.
+  - Add `media_db_path: Optional[Path] = None` to the search config dataclass (import-cycle note: import `get_media_db_path` lazily inside the function, matching the existing lazy-import style there).
+
+- [ ] **Step 4: Run new tests (PASS) + `Tests/RAG_Search/` targeted files touching rag_service.** Read counts.
+
+- [ ] **Step 5: Commit and push** (`fix(rag): keyword leg uses configured media DB; never writes; stamps source_type`).
+
+---
+
+### Task 4: Fix the reranker factory seam (has never constructed)
+
+**Files:**
+- Modify: `tldw_chatbook/RAG_Search/reranker.py` (add `create_reranker_from_config`)
+- Modify: `tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py` (all three `create_reranker` call sites; guard `.rerank`)
+- Modify: `tldw_chatbook/RAG_Search/config_profiles.py` (Hybrid Full's `strategy="cross_encoder"` → `"pointwise"`)
+- Test: `Tests/RAG_Search/test_reranker_construction.py` (create)
+
+**Interfaces:**
+- Produces: `create_reranker_from_config(config: RerankingConfig) -> BaseReranker`; V2's `self.reranker` constructs for every built-in profile; a raising reranker degrades to unreranked results with `metadata["reranking_skipped"] = "<reason>"` on the first result and a warning log — the search NEVER fails because of reranking (spec error-handling rule).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/RAG_Search/test_reranker_construction.py
+"""Reranking profiles must construct and must never fail a search.
+
+V2 called create_reranker(strategy=X, **config.__dict__) — the dict also
+contains 'strategy', so EVERY reranking profile raised TypeError at
+construction; Hybrid Full additionally requests the unimplemented
+'cross_encoder' strategy. Reranking has never executed on any profile.
+"""
+import pytest
+from tldw_chatbook.RAG_Search.reranker import RerankingConfig, create_reranker_from_config
+from tldw_chatbook.RAG_Search.config_profiles import get_builtin_profiles  # read the real accessor name first
+
+
+def test_create_reranker_from_config_does_not_double_pass_strategy():
+    cfg = RerankingConfig(strategy="pointwise", top_k_to_rerank=5)
+    reranker = create_reranker_from_config(cfg)
+    assert reranker.config.strategy == "pointwise"
+
+
+def test_every_builtin_profile_reranking_config_constructs():
+    for profile in get_builtin_profiles():
+        rc = getattr(profile, "reranking_config", None)
+        if rc is not None:
+            create_reranker_from_config(rc)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_raising_reranker_degrades_to_unreranked_results():
+    # Build a V2 service (mock embeddings, in-memory store) whose profile has
+    # reranking; monkeypatch self.reranker.rerank to raise RuntimeError; index
+    # two docs; search must return results with reranking_skipped set, not raise.
+    ...
+```
+
+- [ ] **Step 2: Run to verify failures** (ImportError on `create_reranker_from_config`; profile sweep raises for cross_encoder).
+
+- [ ] **Step 3: Implement**
+  - `reranker.py`: `def create_reranker_from_config(config: RerankingConfig) -> BaseReranker:` dispatching on `config.strategy` to the three classes (reuse `create_reranker`'s mapping; keep `create_reranker` for compatibility).
+  - `enhanced_rag_service_v2.py`: replace all three call sites with `create_reranker_from_config(...)`; wrap the `__init__` construction in try/except (log + `self.reranker = None` — a broken reranker config must not kill service construction); wrap `await self.reranker.rerank(...)` in try/except → on exception log warning, tag `results[0].metadata["reranking_skipped"]`, keep unreranked results.
+  - `config_profiles.py`: Hybrid Full `strategy="cross_encoder"` → `"pointwise"` with a comment stating cross_encoder is not implemented in chatbook (LLM rerankers only).
+  - Note in the code where it's true, not in comments elsewhere: LLM reranking spends provider calls per search — the `_final_score_kind=reranker` provenance is the disclosure channel (Task 5).
+
+- [ ] **Step 4: Run new tests (PASS) + files touching V2/reranker.** Read counts.
+
+- [ ] **Step 5: Commit and push** (`fix(rag): reranker factory double-strategy TypeError; Hybrid Full unsupported strategy; rerank never fails a search`).
+
+---
+
+### Task 5: Library service honors the profile's search mode
+
+**Files:**
+- Modify: `tldw_chatbook/Library/library_local_rag_search_service.py`
+- Test: `Tests/Library/test_library_rag_mode_resolution.py` (create; read `Tests/Library/` for the existing service-test fixtures and mimic them)
+
+**Interfaces:**
+- Consumes: `rag_service.config.search.default_search_mode` (`"plain"|"semantic"|"hybrid"`) from the shared service; `_search_keyword(query, source_types, top_k, scope=...)` (existing four-seam path).
+- Produces: `_resolve_profile_search_mode(rag_service) -> str` (pure mapping, mutation-tested); `rag` mode dispatch:
+  - `"plain"` → route to `_search_keyword` (four-seam, scope-aware); result carries `backend="local-fts"` plus a disclosed note that the active profile forced keyword ("Profile '<name>': keyword search (no vectors)").
+  - `"semantic"` → current behavior, `backend="rag-semantic"`.
+  - `"hybrid"` unscoped AND `"media" in source_types` → engine `search(search_type="hybrid")`, `backend="rag-hybrid"`.
+  - `"hybrid"` scoped OR media deselected → semantic path + coverage note naming the reason ("scope active — semantic only until scope-aware hybrid lands" / "media excluded — semantic only").
+- Zero-results honesty: the "Index empty" recovery state must NOT be claimed when hybrid returned keyword-leg rows; when the vector index is empty but FTS hit, the coverage note reads "semantic leg empty — keyword-only results".
+
+- [ ] **Step 1: Read** the full `search`/`_search_semantic` flow (~L126-500) including how recovery states and `semantic_scope_coverage` diagnostics are assembled, and how the shared service is resolved (`_resolve_rag_runtime`). Read `Tests/Library/` for the fake-service fixtures used by existing mode tests.
+
+- [ ] **Step 2: Write the failing tests** — one per dispatch arm so mutations isolate:
+
+```python
+# Tests/Library/test_library_rag_mode_resolution.py
+"""rag mode must honor the active profile's default_search_mode.
+
+The live path hardcoded search_type="semantic"; the engine's hybrid
+(RRF k=60 + alpha, ADR-005 server parity) was unreachable. Routing rules
+and disclosures per the P0 spec, Workstream A.
+"""
+# Tests (use the existing Library service fixtures with a fake rag_service
+# whose config.search.default_search_mode is parameterized and whose
+# search() records the search_type it was called with):
+
+def test_hybrid_profile_unscoped_calls_engine_hybrid(): ...
+    # fake service mode="hybrid"; source_types include "media"; no scope
+    # -> fake.search called with search_type="hybrid"; backend == "rag-hybrid"
+
+def test_hybrid_profile_with_active_scope_stays_semantic_and_discloses(): ...
+    # scoped request -> search_type="semantic"; coverage note mentions scope
+
+def test_hybrid_profile_with_media_deselected_stays_semantic_and_discloses(): ...
+
+def test_plain_profile_routes_to_four_seam_keyword_path(): ...
+    # fake mode="plain" -> _search_keyword called (spy); engine search NOT called;
+    # disclosed note names the profile and "keyword search (no vectors)"
+
+def test_semantic_profile_unchanged(): ...
+
+def test_index_empty_not_claimed_when_keyword_rows_present(): ...
+    # fake hybrid returns rows whose hybrid_fusion has fts_rank set but
+    # vector_score None for all; vector count == 0
+    # -> recovery state is NOT "index empty"; note says "semantic leg empty — keyword-only results"
+```
+
+Write each body concretely against the real fixtures; the behavioral assertions above are the contract.
+
+- [ ] **Step 3: Run — all new tests FAIL** (dispatch doesn't exist).
+
+- [ ] **Step 4: Implement.** Keep `_resolve_profile_search_mode` a small pure function:
+
+```python
+def _resolve_profile_search_mode(rag_service: Any) -> str:
+    """Map the active profile's default_search_mode to an execution route.
+
+    "plain" deliberately routes to the four-seam scope-aware keyword path,
+    NOT the engine's media-only keyword leg (spec: plain-profile routing).
+    Unknown values fall back to "semantic".
+    """
+    mode = getattr(getattr(getattr(rag_service, "config", None), "search", None),
+                   "default_search_mode", "semantic")
+    return mode if mode in ("plain", "semantic", "hybrid") else "semantic"
+```
+
+Then branch in the `mode == "rag"` dispatch, passing `search_type="hybrid"` only when unscoped and media-selected; thread the disclosure strings through the existing coverage-note mechanism (find where `semantic_scope_coverage` text is built and extend it — do not invent a second note channel).
+
+- [ ] **Step 5: Run new tests (PASS) + existing Library RAG service tests.** Read counts.
+
+- [ ] **Step 6: Mutation checks** (Edit-based restores with unique markers, never `git checkout`):
+  - Mutate the `"plain"` arm to call semantic → ONLY the plain-routing test reds.
+  - Mutate the scoped guard to allow hybrid → ONLY the scoped-disclosure test reds.
+  - Restore both; rerun; read counts.
+
+- [ ] **Step 7: Commit and push** (`feat(library): rag mode honors active profile search mode with disclosed routing`).
+
+---
+
+### Task 6: Score-kind-aware bands (UI state + Answer bundle)
+
+**Files:**
+- Modify: `tldw_chatbook/Library/library_rag_state.py` (`library_rag_score_suffix`, `library_rag_all_matches_weak`)
+- Modify: the row-construction site that feeds them (find with `grep -rn "library_rag_score_suffix(" tldw_chatbook/` — the panel/state builds rows from service results; thread `score_kind` + `vector_score` from `metadata["hybrid_fusion"]` / reranker markers into the row)
+- Modify: `tldw_chatbook/UI/Views/RAGSearch/search_handoff.py` (`_library_rag_score` consumers)
+- Test: extend the existing state tests (find with `grep -rln "score_suffix\|all_matches_weak" Tests/`)
+
+**Interfaces:**
+- Consumes: Task 2's `hybrid_fusion.vector_score` / `.fts_score`; Task 4's reranker provenance.
+- Produces: `library_rag_score_suffix(score, score_kind="vector_similarity", vector_score=None)`:
+  - `vector_similarity` → band as today on `score`.
+  - `hybrid_fusion` with `vector_score is not None` → band on `vector_score` (label unchanged).
+  - `hybrid_fusion` with `vector_score is None` (FTS-only row) → `" | keyword match"` — never a fabricated similarity, never the fused 0.0x number.
+  - `reranker` → `" | reranked"` (kind disclosed; no cosine banding of logits).
+  - `library_rag_all_matches_weak` counts ONLY rows whose effective banding input is a vector similarity; keyword-only and reranked rows neither trigger nor suppress it.
+- The Answer path: `EvidenceBundle` rows carry `score_kind`; whatever copy `_library_rag_score` feeds (locate its consumers) computes weakness only over vector-similarity kinds — a fused 0.016 must not read as "weak similarity" in answer coverage copy.
+
+- [ ] **Step 1: Write the failing tests** (pure functions — exact):
+
+```python
+def test_fused_score_never_bands_on_cosine_thresholds():
+    # A fused RRF score (~0.016) with a strong vector leg must band strong.
+    assert library_rag_score_suffix(0.016, score_kind="hybrid_fusion",
+                                    vector_score=0.83) == " | match: strong"
+
+def test_fts_only_hybrid_row_reads_keyword_match():
+    assert library_rag_score_suffix(0.0161, score_kind="hybrid_fusion",
+                                    vector_score=None) == " | keyword match"
+
+def test_reranker_scores_disclose_kind_not_band():
+    assert library_rag_score_suffix(-3.2, score_kind="reranker") == " | reranked"
+
+def test_all_matches_weak_ignores_non_similarity_kinds():
+    # rows: one keyword-only hybrid row + one weak vector row -> True;
+    # keyword-only rows alone -> False (no scored similarity rows).
+    ...
+```
+
+Plus a row-threading test at the panel/state level: a service result with `hybrid_fusion.vector_score=0.83` renders the strong band in the composed row title (mimic the existing composited-text pins in `Tests/Library/`).
+
+- [ ] **Step 2: Run — FAIL** (signature lacks kwargs).
+
+- [ ] **Step 3: Implement** — extend the two pure functions (default kwargs keep every existing call site green); thread `score_kind`/`vector_score` where rows are built; update `search_handoff.py` so bundle rows carry `score_kind` and its weakness consumers filter on it.
+
+- [ ] **Step 4: Run new + existing state/panel/handoff tests.** Existing suffix tests must pass UNMODIFIED (they call with similarity kinds by default) — if one must change, stop and re-check the design (protected-oracle rule).
+
+- [ ] **Step 5: Commit and push** (`feat(library): score-kind-aware match bands; fused/reranker scores never presented as similarity`).
+
+---
+
+### Task 7: Console auto-retrieve toggle (config + modal)
+
+**Files:**
+- Modify: `tldw_chatbook/config.py` (default for `[chat_defaults] rag_auto_retrieve_on_send = false` — find the chat_defaults defaults block and follow its pattern)
+- Modify: `tldw_chatbook/Widgets/Console/console_rag_settings_modal.py` (Switch + result field)
+- Test: extend the modal's existing test file (find with `grep -rln "ConsoleRagSettingsModal" Tests/`)
+
+**Interfaces:**
+- Produces: `get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False)` readable everywhere; `ConsoleRagSettingsResult` gains `auto_retrieve_on_send: bool`; toggling the Switch persists via the same config-write seam the modal (or Settings) already uses — read the modal's save path first and reuse it.
+
+- [ ] **Step 1: Write the failing tests** — modal composes the Switch defaulted from config; dismiss result carries the flag; flag round-trips to config.
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement** (Switch labeled "Auto-retrieve on send", default OFF; tooltip: "When on, each plain text send first retrieves library evidence into the staged-evidence strip").
+- [ ] **Step 4: Run modal tests. Read counts.**
+- [ ] **Step 5: Commit and push** (`feat(console): auto-retrieve-on-send toggle in RAG chip modal, default off`).
+
+---
+
+### Task 8: Console send-path injection (TASK-406)
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (send flow, before the `capture_console_staged_evidence_for_chat` call ~L4654) and/or `tldw_chatbook/Chat/console_chat_controller.py::submit_draft` — read both first; put the retrieval hook at the same layer that already owns staging (`_stage_console_library_rag_launch`) so the staged-evidence strip renders it exactly like a manual chip run.
+- Test: `Tests/UI/test_console_auto_rag_on_send.py` (create; mimic the existing console staged-evidence tests — find with `grep -rln "capture_console_staged_evidence" Tests/`)
+
+**Interfaces:**
+- Consumes: Task 7's config flag; `_resolve_console_library_rag_scope` (existing); `run_library_rag_search`; `_stage_console_library_rag_launch`; the consume-on-send predicate from PR-4 (unchanged).
+- Produces: `_maybe_auto_retrieve_for_send(draft_text) -> None` on the screen/controller seam with this exact gate, in this order (each clause mutation-tested):
+
+```python
+async def _maybe_auto_retrieve_for_send(self, draft_text: str) -> None:
+    """Auto-retrieve library evidence for a plain text send (TASK-406).
+
+    Fires only when ALL hold: the config toggle is on; the send is plain
+    user text (not a slash command, tool approval, or regeneration); and
+    nothing is already staged (manual staging always wins — no double
+    spend). Retrieval failure or timeout NEVER blocks the send.
+    """
+    if not get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False):
+        return
+    if not _is_plain_text_send(draft_text):     # reuse/extract the send-kind
+        return                                  # classification the send path
+    if self._has_staged_console_evidence():     # already has (read it first)
+        return
+    scope = ...  # resolve_effective_scope_for_chat via the existing seam
+    if scope_is_empty(scope):
+        self._notify_shared_empty_scope_copy()  # the EXISTING shared notice
+        return
+    query = draft_text[:AUTO_RAG_QUERY_MAX_CHARS]   # cap = 2000, a constant
+    try:
+        async with asyncio.timeout(AUTO_RAG_TIMEOUT_SECONDS):   # 5.0, constant
+            outcome = await run_library_rag_search(...)  # profile top_k, mode="rag"
+    except TimeoutError:
+        self._notify_auto_rag_degraded(initializing=self._rag_service_still_initializing())
+        return
+    except Exception:
+        self._notify_auto_rag_degraded(initializing=False)
+        return
+    self._stage_console_library_rag_launch(...)  # same launch shape as chip run
+```
+
+  The strip shows "Retrieving…" while in flight; the notice copy distinguishes "RAG service still initializing" from "retrieval failed" (reuse the recovery-state vocabulary from `library_rag_service`). The retrieval awaits INSIDE the existing send worker (exclusive) — a double-send cannot double-retrieve.
+
+- [ ] **Step 1: Read** the send flow end-to-end (screen handler → `submit_draft` → capture at ~L4654) and the staged-evidence strip states before writing anything.
+
+- [ ] **Step 2: Write the failing tests** — one per gate clause + the happy path:
+
+```python
+def test_toggle_off_means_no_retrieval_call(): ...
+def test_slash_command_send_never_retrieves(): ...
+def test_already_staged_evidence_skips_auto_retrieve(): ...
+def test_empty_scope_short_circuits_with_shared_copy(): ...
+def test_happy_path_stages_then_send_consumes(): ...
+    # fake service returns 2 rows -> launch staged -> capture consumes ->
+    # prompt contains the evidence block; strip shows count
+def test_timeout_sends_without_evidence_and_notifies(): ...
+def test_retrieval_exception_sends_without_evidence(): ...
+```
+
+- [ ] **Step 3: Run — FAIL.**
+- [ ] **Step 4: Implement** per the produced interface above.
+- [ ] **Step 5: Run new + the console staged-evidence suites.** Read counts.
+- [ ] **Step 6: Mutation checks:** drop the already-staged guard → only its test reds; drop the plain-text gate → only its test reds; invert the toggle default → toggle-off test reds. Edit-based restores.
+- [ ] **Step 7: Commit and push** (`feat(console): opt-in RAG auto-retrieve on send via staged evidence (task-406)`).
+
+---
+
+### Task 9: Chip manual run inherits profile top_k
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (~L12674: `top_k=5`)
+- Test: extend the chip-run test (find with `grep -rln "LibraryRagSearchRequest" Tests/UI/`)
+
+**Interfaces:**
+- Consumes: the shared service's `config.search.default_top_k` (read the profile config dataclass for the exact field name — Settings' Search fold edits it).
+- Produces: manual chip runs and Task 8's auto-retrieve use the same depth; fallback to the current literal 5 only when the service/config is unavailable, via one small helper both call sites share.
+
+- [ ] **Step 1: Failing test** — with a fake service whose `default_top_k=12`, the chip run builds `LibraryRagSearchRequest(top_k=12)`; with no service, `top_k=5`.
+- [ ] **Step 2: Run — FAIL. Step 3: Implement** (`_console_rag_top_k()` helper; both the chip run and Task 8 use it). **Step 4: Run tests, read counts. Step 5: Commit and push** (`fix(console): chip manual run inherits profile default_top_k`).
+
+---
+
+### Task 10: Docs, follow-up filing, backlog closure
+
+**Files:**
+- Modify: `Docs/User_Guide/library/search-and-rag.md`, `Docs/User_Guide/console/context-and-rag.md`, `Docs/User_Guide/settings/rag.md` (content + "Verified against" stamps — house rule: UI-changing PRs update the matching guide page)
+- Create: follow-up backlog task (MCP/agent divergence)
+- Modify: the P0 backlog task + task-406 (Done, ticked ACs, Implementation Notes)
+
+- [ ] **Step 1: Update the three guide pages**: rag mode is profile-driven (hybrid default; what each profile mode means; the plain-profile routing); match-band meanings incl. "keyword match" and "reranked"; the Console auto-retrieve toggle (default OFF, staged-evidence visibility, timeout behavior); reranking profiles spend provider calls per search (cost disclosure).
+- [ ] **Step 2: File the follow-up task** (fresh cross-worktree ID scan): "Align MCP perform_rag_search + agent RAGSearchTool with profile-driven retrieval" — description states the P0 non-goal: Library and MCP currently disagree about what a rag search is; reference TASK-694/TASK-1077.
+- [ ] **Step 3: Close the backlog tasks**: tick every AC that the merged work satisfies, add Implementation Notes (approach, decisions — notably the never-worked reranker finding and plain-profile routing — and modified files), `backlog task edit <id> -s Done`.
+- [ ] **Step 4: Commit and push** (`docs(guide): profile-driven rag mode, score bands, console auto-retrieve; backlog closure`).
+
+---
+
+### Task 11: Gates + live TUI walkthrough
+
+**Files:** none created — verification only. Evidence goes to the scratchpad directory, not the repo.
+
+- [ ] **Step 1: Targeted suite battery** — every test file this branch created or modified, in one run; READ the numeric passed count. Then `--collect-only -q` over `Tests/` and compare against a fresh `origin/dev` baseline count with exact arithmetic (new total = old total + exactly the number of tests this branch added).
+- [ ] **Step 2: Live TUI walkthrough** (PR-2 recipe): scratch config via `TLDW_CONFIG_PATH` with `[first_run] setup_started/setup_completed = true`, copy the real ChaChaNotes + media DBs AND the chromadb dir into the scratch profile BEFORE first launch; `tmux -L ragp0 new-session -d -x 235 -y 52`; verify live:
+  1. Library rag mode with the default (Hybrid Basic) profile: results appear, bands render (no "weak (0.02)" wall), backend label reads `rag-hybrid`.
+  2. Switch to BM25 Only in Settings → rag mode routes to keyword with the disclosed note.
+  3. Switch to Hybrid Full → service constructs (the pre-fix TypeError would kill it); a search completes even with no reranking provider ready (skip-disclosed).
+  4. Console: toggle auto-retrieve ON in the chip modal → plain text send shows "Retrieving…" → "Evidence sent · N" → reply arrives; a `/command` send does NOT retrieve.
+  5. Scope a conversation → rag search discloses semantic-only.
+  Delete the scratch profile after; verify the live config untouched.
+- [ ] **Step 3: Fix-forward anything found** (each fix RED-first), rerun the battery, push.
+
+---
+
+## Self-review (done at plan time)
+
+- **Spec coverage:** Workstream A items 1-5 → Tasks 2-6; Workstream B → Tasks 7-9; error handling → Tasks 4/5/8; non-goals → Task 10 step 2; testing section → per-task steps + Task 11. Verification items: 1 (Task 3, resolved: real DB is `tldw_cli_media_v2.db`), 2 (resolved: rerankers are LLM-based, no model download; the crash was the double-strategy TypeError — Task 4), 3 (resolved: stamp `source_type: "media"` — Task 3), 4 (Task 6 handoff changes), 5 (resolved: no work), 6 (Task 6 tests + Task 5's threshold audit during implementation).
+- **Type consistency:** `library_rag_score_suffix(score, score_kind=..., vector_score=...)` used identically in Tasks 6; `hybrid_fusion.vector_score/fts_score` named identically in Tasks 2/5/6; `_console_rag_top_k()` shared by Tasks 8/9; `create_reranker_from_config` in Task 4 only.
+- **Known unknowns pushed into read-first steps:** exact fixture helpers in `Tests/Library`/`Tests/UI`, the config-write seam for the modal, `add_media_with_keywords` signature, the coverage-note assembly point. Each task names the grep to find them.

--- a/Docs/superpowers/specs/2026-08-07-rag-port-p0-foundations-design.md
+++ b/Docs/superpowers/specs/2026-08-07-rag-port-p0-foundations-design.md
@@ -61,8 +61,16 @@ Two workstreams. TASK-657 (dep-gate never runs) was found already fixed
 `search_type="semantic"`. Change it to resolve the **active RAG profile**:
 
 - `default_search_mode` (profile vocabulary: `"plain"` / `"semantic"` /
-  `"hybrid"`) maps plain→`"keyword"`, semantic→`"semantic"`,
-  hybrid→`"hybrid"` and is passed to `rag_service.search`.
+  `"hybrid"`) maps semantic→`"semantic"` and hybrid→`"hybrid"` on
+  `rag_service.search`. **Plain-profile routing**: `"plain"` does NOT use the
+  engine's media-only keyword leg — a BM25 Only user in `rag` mode would get a
+  strictly worse version of the Library's own `search` mode (one guessed-path
+  seam vs four authorized, scope-aware seams). Instead, plain-profile `rag`
+  queries route through the existing four-seam `_search_keyword` path,
+  honestly labeled. The engine's keyword leg therefore runs **only as
+  hybrid's FTS leg** in P0, never as a standalone mode. This also resolves
+  the scoped+plain conflict for free (the seam path is already scope-aware,
+  so a BM25 Only profile is never silently forced onto vectors).
 - Reranking needs **no new plumbing** (`rag_factory.py:65` already sets
   `enable_reranking = profile.reranking_config is not None`; V2 applies it
   post-search). P0 verifies it and fixes the load-time hazard (below).
@@ -89,6 +97,9 @@ Constraints, each handled by disclosure rather than silence:
      RED-first test.
    - The leg covers **media only** in P0; provenance and the coverage note say
      so. Four-seam keyword coverage (notes/conversations/prompts) is P2.
+   - When "media" is not among the selected source types, hybrid **skips the
+     keyword leg** (it could only contribute rows the post-filter drops) and
+     the coverage note discloses that the search ran semantic-only.
 3. **Score-kind-aware presentation** (ship-breaking defect found in review):
    the Library match bands are calibrated for cosine similarity
    (strong ≥ 0.5, moderate ≥ 0.2 — `library_rag_state.py`), but RRF-fused
@@ -126,7 +137,10 @@ injection. Design:
   This consciously re-homes TASK-406's assumed enablement from the legacy
   sidebar checkbox; the task's AC is edited accordingly before implementation
   (per backlog rules: update the AC first, then implement).
-- When ON at send: the retrieval query is the **outgoing draft text**; scope is
+- Auto-retrieve fires only for **plain user text sends** — never for slash
+  commands, tool approvals, or regenerations.
+- When ON at send: the retrieval query is the **outgoing draft text,
+  length-capped** (cap value decided in the plan); scope is
   resolved via `resolve_effective_scope_for_chat`; retrieval runs through the
   same profile-driven Library service as Workstream A; results route through
   the **existing staged-evidence pipeline** — strip shows "Evidence sent · N",
@@ -139,9 +153,15 @@ injection. Design:
   hybrid, until P2 extends allowlists to the FTS leg.
 - EMPTY scope short-circuits with the shared notice copy (task-406 AC #2).
 - Explicit **5s timeout** with a visible "Retrieving…" strip state; on failure
-  or timeout the send proceeds without evidence plus a quiet notice. A send is
-  never blocked on retrieval. Retrieval runs in an **exclusive worker** so a
-  double-send cannot double-retrieve.
+  or timeout the send proceeds without evidence plus a quiet notice. The
+  notice distinguishes "RAG service still initializing" (first-use model
+  load can take minutes) from "retrieval failed", reusing the existing
+  recovery-state vocabulary. A send is never blocked on retrieval. Retrieval
+  runs in an **exclusive worker** so a double-send cannot double-retrieve.
+- The Console chip's existing **manual run inherits the same profile-driven
+  service**: its hardcoded `top_k=5` (chat_screen.py) is replaced by the
+  active profile's `default_top_k`, so manual and auto retrieval cannot
+  disagree about depth.
 - Legacy path untouched (task-406 AC #3).
 
 ## Non-goals (declared, with follow-ups filed)
@@ -195,3 +215,6 @@ empty, scope empty). New rules:
    as "similarity".
 5. `SimpleRAGCache` keys include search type — confirm no stale-cache hazard
    when the default mode changes.
+6. Confirm no layer (engine, Library service, UI state, Answer bundle)
+   applies similarity-scale thresholds (`score_threshold`, min-score
+   filters) to fused or reranker score kinds.

--- a/Docs/superpowers/specs/2026-08-07-rag-port-p0-foundations-design.md
+++ b/Docs/superpowers/specs/2026-08-07-rag-port-p0-foundations-design.md
@@ -1,0 +1,197 @@
+# RAG Server-Port Programme — P0 Foundations (design)
+
+Date: 2026-08-07
+Status: approved-pending-user-review
+Programme: port retrieval improvements from tldw_server2's RAG pipeline into tldw_chatbook
+Phase: P0 of 5
+
+## Background
+
+A full mapping of both RAG stacks (tldw_server2 `app/core/{RAG,Chunking,Embeddings}`,
+~85k LOC, vs tldw_chatbook `RAG_Search/` + Library/Console surfaces) established:
+
+- Chatbook's **plumbing and honesty layers are stronger** than the server's
+  (incremental ingestion indexing, profiles UI, named degradation states,
+  abstention + citation validation).
+- Chatbook's **live retrieval is weaker than what it already owns**: the Library
+  `rag` mode issues a single unranked vector query, while the engine underneath
+  (`RAG_Search/simplified/rag_service.py`) already implements hybrid RRF
+  (k=60 + alpha, built for tldw_server parity under ADR-005) and keyword search,
+  and `rag_factory` already wires profile-driven reranking through
+  `EnhancedRAGServiceV2`. None of it is reachable from the live path.
+- The native Console send path performs **no RAG injection at all** (TASK-406);
+  the only wired injection path is the legacy, unreachable chat-events path.
+- The server's own orchestrator (`unified_pipeline.py`, one 5,800-line function)
+  must be treated as a **spec, never lifted** — its stage list informs later
+  phases; no server code is copied wholesale in any phase.
+
+## Programme skeleton (context — each later phase gets its own spec)
+
+- **P0 Foundations** (this spec): make the retrieval chatbook already owns
+  reachable, honestly.
+- **P1 Eval harness**: golden query set over a fixture corpus; port the server's
+  `retrieval_metrics.py` (P/R/MRR/NDCG), `regression.py` (JSON metric
+  baselines), `quality_gating.py` (thresholds). Pure python. After P1, every
+  retrieval change must move measured numbers.
+- **P2 Retrieval intelligence**: query expansion + synonyms registry + rewrite
+  cache, HyDE, PRF, clarification gate, granularity router, sibling/parent
+  inclusion, semantic (similarity-keyed) cache; extend scope allowlists and the
+  keyword leg to all four source seams. Each feature admitted only if it
+  improves P1's baselines.
+- **P3 Answer trust**: document grader → rewrite-retry loop, groundedness /
+  utility graders (heuristic fallbacks), hard per-sentence citations, numeric
+  fidelity, faithfulness scoring.
+- **P4 Chunking**: auto-planner, `structure_aware` / `code_ast` / `propositions`
+  strategies, template auto-classifier. Forces re-indexing, hence last.
+
+Sequencing honesty: P0 flips default retrieval behavior (hybrid) **before** the
+P1 harness exists. This is deliberate: ADR-005 committed to server parity, the
+default profile (Hybrid Basic) already *promises* hybrid to the user in
+Settings, and P0 is reachability-not-tuning. The spec states this rather than
+hiding it.
+
+## P0 scope
+
+Two workstreams. TASK-657 (dep-gate never runs) was found already fixed
+(2026-07-25) and is out of scope.
+
+### Workstream A — profile-honoring retrieval on the live Library path
+
+`Library/library_local_rag_search_service.py::_search_semantic` hardcodes
+`search_type="semantic"`. Change it to resolve the **active RAG profile**:
+
+- `default_search_mode` (profile vocabulary: `"plain"` / `"semantic"` /
+  `"hybrid"`) maps plain→`"keyword"`, semantic→`"semantic"`,
+  hybrid→`"hybrid"` and is passed to `rag_service.search`.
+- Reranking needs **no new plumbing** (`rag_factory.py:65` already sets
+  `enable_reranking = profile.reranking_config is not None`; V2 applies it
+  post-search). P0 verifies it and fixes the load-time hazard (below).
+
+Constraints, each handled by disclosure rather than silence:
+
+1. **Scope allowlists are semantic-only** — `RAGService.search` raises
+   `ValueError` for hybrid/keyword with a non-empty `metadata_allowlist`.
+   Scoped queries (conversation/workspace scope active) therefore stay on the
+   semantic path in P0, disclosed via the existing coverage-note vocabulary.
+   Extending allowlists to the FTS leg is P2.
+2. **The keyword leg is replaced, not patched** (data-safety findings, verified
+   in code):
+   - Today it *guesses* DB paths, including opening `chacha_notes.db` (the
+     ChaChaNotes DB) with media-schema SQL (`FROM Media m JOIN media_fts`),
+     and on a total miss it **creates a new MediaDatabase as a side effect of
+     a search**. Both behaviors are removed: the media DB path is injected
+     explicitly from config; the create-on-miss branch is deleted; a failed
+     leg is a disclosed degradation, never a write.
+   - Keyword rows carry no `source_type` provenance, so the Library layer's
+     canonicalizing post-filter would drop them silently (hybrid degenerating
+     to semantic with zero error). P0 stamps `source_type` on keyword rows and
+     pins "hybrid returns keyword-leg rows through the Library seam" with a
+     RED-first test.
+   - The leg covers **media only** in P0; provenance and the coverage note say
+     so. Four-seam keyword coverage (notes/conversations/prompts) is P2.
+3. **Score-kind-aware presentation** (ship-breaking defect found in review):
+   the Library match bands are calibrated for cosine similarity
+   (strong ≥ 0.5, moderate ≥ 0.2 — `library_rag_state.py`), but RRF-fused
+   scores max out at ~`1/(rrf_k+1) ≈ 0.016`, and cross-encoder reranker scores
+   are unbounded logits. Without this item, every hybrid result bands
+   "weak (0.02)" and `library_rag_all_matches_weak` fires on every search.
+   Therefore:
+   - `_fuse_hybrid_results` preserves the original per-leg scores in the
+     `hybrid_fusion` metadata block (ranks + RRF contributions are already
+     there).
+   - Banding becomes score-kind-aware: band on the vector-leg similarity when
+     present; FTS-only rows render as "keyword match" (never a fabricated
+     similarity); reranked rows disclose their score kind instead of being
+     banded on cosine thresholds.
+   - `library_rag_all_matches_weak` only speaks over vector-similarity score
+     kinds.
+   - The backend label becomes mode-truthful (`rag-hybrid` / `rag-keyword` /
+     `rag-semantic`).
+4. **Reranker model load must not block the event loop**: if the reranker
+   model loads lazily at first `.rerank()`, the first search under a reranking
+   profile freezes the UI (task-641's scar class: a model download froze the
+   app for 6+ minutes). The plan verifies load timing and moves model load to
+   off-thread service construction if needed.
+5. **Zero-results honesty under hybrid**: the "Index empty" recovery state
+   (vector count == 0) must not fire when the keyword leg returned rows; the
+   converse case discloses "semantic leg empty — keyword-only results".
+
+### Workstream B — Console native send-path injection (TASK-406)
+
+The native send path (`ConsoleChatController.submit_draft`) performs no RAG
+injection. Design:
+
+- An **"Auto-retrieve on send" toggle** in the existing Console RAG chip modal,
+  default **OFF**, persisted as a global config key (the modal toggles it).
+  This consciously re-homes TASK-406's assumed enablement from the legacy
+  sidebar checkbox; the task's AC is edited accordingly before implementation
+  (per backlog rules: update the AC first, then implement).
+- When ON at send: the retrieval query is the **outgoing draft text**; scope is
+  resolved via `resolve_effective_scope_for_chat`; retrieval runs through the
+  same profile-driven Library service as Workstream A; results route through
+  the **existing staged-evidence pipeline** — strip shows "Evidence sent · N",
+  consumption reuses PR-4's consume-on-send predicate. Never invisible
+  injection.
+- If evidence is already manually staged, auto-retrieve **skips** (no double
+  retrieval/spend).
+- Because Console retrieval is conversation-scoped, it inherits Workstream A's
+  constraint 1: with an active scope allowlist it runs the semantic path, not
+  hybrid, until P2 extends allowlists to the FTS leg.
+- EMPTY scope short-circuits with the shared notice copy (task-406 AC #2).
+- Explicit **5s timeout** with a visible "Retrieving…" strip state; on failure
+  or timeout the send proceeds without evidence plus a quiet notice. A send is
+  never blocked on retrieval. Retrieval runs in an **exclusive worker** so a
+  double-send cannot double-retrieve.
+- Legacy path untouched (task-406 AC #3).
+
+## Non-goals (declared, with follow-ups filed)
+
+- MCP `perform_rag_search` and the agent-side `RAGSearchTool` do **not** honor
+  profiles in P0 — Library and MCP will briefly disagree about what a "rag
+  search" means. A follow-up task is filed at ship time (adjacent to open
+  TASK-694 / TASK-1077) rather than diverging silently.
+- No retrieval-quality tuning (alpha, rrf_k, thresholds, rerank models) — that
+  is P1+P2 work, done against measured baselines.
+- No new server-ported features in P0 (expansion, HyDE, PRF, etc. are P2).
+- Four-seam keyword leg and hybrid-compatible scope allowlists are P2.
+
+## Error handling / degradation
+
+All existing named-degradation states are unchanged (deps missing, index
+empty, scope empty). New rules:
+
+- Keyword leg failing (DB missing/locked/query error) → fall back to the
+  semantic leg **with a disclosed coverage note**, never silently narrower.
+- Reranker unavailable (model/dep missing) → skip reranking; provenance says
+  so; the search itself never fails because of reranking.
+- Console auto-retrieve failure/timeout → quiet notice, send proceeds.
+
+## Testing
+
+- RED-first tests per behavior; mutation checks on the mode-mapping and the
+  consume-on-send predicate (each mutation reddens exactly its own test).
+- Pinned regression tests for: keyword rows surviving the Library post-filter;
+  score-kind-aware banding (a fused 0.016 score must not band "weak"; an
+  FTS-only row must not display a similarity); no-write-on-search (the deleted
+  create-on-miss branch stays deleted); "Index empty" suppressed when keyword
+  rows exist.
+- Targeted suites with collection-count arithmetic (house rule: read the
+  passed count; "no tests ran" is a failed gate).
+- Live TUI walkthrough on a scratch profile with copied real DBs (the proven
+  PR-2 recipe: scratch `TLDW_CONFIG_PATH`, `[first_run]` pre-set, real
+  ChaChaNotes + media DBs copied in, config verified untouched after).
+- P0 makes no retrieval-quality claims; behavioral verification only.
+
+## Plan-phase verification items (carried into writing-plans)
+
+1. Real media DB filename/path on a standard install vs the keyword leg's
+   guess list — determine whether the leg has ever returned rows in the wild.
+2. Reranker model load timing (construction vs first `.rerank()`), and whether
+   `create_reranker` downloads models on the event loop.
+3. Exact metadata shape needed for keyword rows to pass
+   `_SEMANTIC_SOURCE_TYPE_MAP` canonicalization.
+4. Where the Answer path (`build_library_rag_evidence_bundle` + coverage note)
+   consumes scores, so fused/reranked score kinds don't leak into answer copy
+   as "similarity".
+5. `SimpleRAGCache` keys include search type — confirm no stale-cache hazard
+   when the default mode changes.

--- a/Tests/Library/test_library_rag_mode_resolution.py
+++ b/Tests/Library/test_library_rag_mode_resolution.py
@@ -1,0 +1,354 @@
+"""rag mode must honor the active profile's default_search_mode.
+
+The live path hardcoded search_type="semantic"; the engine's hybrid
+(RRF k=60 + alpha, ADR-005 server parity) was unreachable, so a user who
+picked "Hybrid Basic" or "BM25 Only" in Settings > RAG got vector-only
+retrieval anyway, silently. Routing rules and disclosures per the P0 spec,
+Workstream A.
+
+Fixtures mirror `test_library_local_rag_search_service.py` (its
+`FakeNotesScopeService`/`FakeRagService` are imported directly rather than
+re-declared); the mode-aware double below adds the profile surface the
+Library service now reads (`config.search.default_search_mode`,
+`profile.name`) and reproduces `RAGService.search`'s real
+`metadata_allowlist`-only-with-semantic ValueError, so the scoped-hybrid
+test proves the guard is respected rather than assuming it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Chat.rag_scope import (
+    EffectiveScope,
+    SOURCE_TYPE_MEDIA,
+)
+from tldw_chatbook.Library.library_local_rag_search_service import (
+    LibraryLocalRagSearchService,
+)
+from tldw_chatbook.Library.library_rag_service import LibraryRagSearchOutcome
+
+from Tests.Library.test_library_local_rag_search_service import (
+    FakeNotesScopeService,
+    FakeRagService,
+)
+
+# The diagnostics slot the routing disclosures travel in, and the exact
+# disclosure copy. Spelled literally here (not imported) so this file pins
+# the contract rather than restating whatever the implementation happens to
+# define.
+_ROUTE_NOTES_KEY = "retrieval_route_notes"
+_NOTE_HYBRID_SCOPED = "scope active — semantic only until scope-aware hybrid lands"
+_NOTE_HYBRID_MEDIA_EXCLUDED = "media excluded — semantic only"
+_NOTE_SEMANTIC_LEG_EMPTY = "semantic leg empty — keyword-only results"
+
+
+class _FakeVectorStore:
+    """Mirrors the VectorStore stats seam used for empty-index detection."""
+
+    def __init__(self, count: int):
+        self.count = count
+        self.calls = 0
+
+    def get_collection_stats(self):
+        self.calls += 1
+        return {"count": self.count}
+
+
+class _ProfileRagService:
+    """`RAGService.search`'s signature plus the profile surface (rag_service.py:542).
+
+    `default_search_mode` is the profile knob the Library service resolves;
+    `profile.name` is what the plain-profile disclosure names.
+    """
+
+    def __init__(
+        self,
+        *,
+        mode: str = "semantic",
+        profile_name: str | None = None,
+        results=None,
+        vector_count: int = 12,
+    ):
+        self.config = SimpleNamespace(
+            search=SimpleNamespace(default_search_mode=mode)
+        )
+        self.profile = (
+            SimpleNamespace(name=profile_name) if profile_name is not None else None
+        )
+        self.results = results if results is not None else []
+        self.calls: list[dict] = []
+        self.vector_store = _FakeVectorStore(vector_count)
+
+    async def search(
+        self,
+        query,
+        top_k=None,
+        search_type="semantic",
+        filter_metadata=None,
+        include_citations=None,
+        score_threshold=None,
+        metadata_allowlist=None,
+    ):
+        # The real engine raises here (rag_service.py:580) -- allowlists are
+        # a semantic-only pushdown. Reproduced so a routing bug that sends a
+        # scoped query to hybrid fails loudly in this suite too.
+        if metadata_allowlist and search_type != "semantic":
+            raise ValueError(
+                "metadata_allowlist is only supported for search_type='semantic'"
+            )
+        self.calls.append(
+            {
+                "query": query,
+                "top_k": top_k,
+                "search_type": search_type,
+                "include_citations": include_citations,
+                "metadata_allowlist": metadata_allowlist,
+            }
+        )
+        return self.results
+
+
+def _media_result(source_id: str = "media-1", score: float = 0.8, **metadata):
+    return {
+        "id": f"{source_id}-chunk",
+        "score": score,
+        "document": "Media evidence.",
+        "metadata": {
+            "title": "Media doc",
+            "source_id": source_id,
+            "source_type": "media",
+            **metadata,
+        },
+    }
+
+
+def _note_result(source_id: str = "note-1", score: float = 0.9):
+    return {
+        "id": f"{source_id}-chunk",
+        "score": score,
+        "document": "Note evidence.",
+        "metadata": {
+            "title": "Note doc",
+            "source_id": source_id,
+            "source_type": "note",
+        },
+    }
+
+
+def _scoped(**allowlist: set) -> EffectiveScope:
+    return EffectiveScope(
+        state="scoped",
+        allowlist={key: frozenset(value) for key, value in allowlist.items()},
+        cause=None,
+    )
+
+
+def _route_notes(result) -> tuple[str, ...]:
+    diagnostics = (
+        result.diagnostics
+        if isinstance(result, LibraryRagSearchOutcome)
+        else (result.get("diagnostics") or {})
+    )
+    return tuple(diagnostics.get(_ROUTE_NOTES_KEY, ()))
+
+
+# --- The pure mapping -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "configured, expected",
+    [
+        ("plain", "plain"),
+        ("semantic", "semantic"),
+        ("hybrid", "hybrid"),
+        ("nonsense", "semantic"),
+        ("", "semantic"),
+        (None, "semantic"),
+    ],
+)
+def test_resolve_profile_search_mode_maps_known_modes_and_falls_back(
+    configured, expected
+):
+    from tldw_chatbook.Library.library_local_rag_search_service import (
+        _resolve_profile_search_mode,
+    )
+
+    service = _ProfileRagService(mode=configured)
+
+    assert _resolve_profile_search_mode(service) == expected
+
+
+def test_resolve_profile_search_mode_defaults_when_the_runtime_has_no_config():
+    """Every pre-existing test fake (and any non-profile runtime) has no
+    `config` at all -- it must keep today's semantic behavior, not crash."""
+    from tldw_chatbook.Library.library_local_rag_search_service import (
+        _resolve_profile_search_mode,
+    )
+
+    assert _resolve_profile_search_mode(SimpleNamespace()) == "semantic"
+    assert _resolve_profile_search_mode(FakeRagService()) == "semantic"
+
+
+# --- Dispatch arms ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hybrid_profile_unscoped_calls_engine_hybrid():
+    """The whole point of the port: a hybrid profile actually reaches the
+    engine's hybrid path (FTS leg + vector leg, RRF-fused)."""
+    rag = _ProfileRagService(mode="hybrid", results=[_media_result()])
+    service = LibraryLocalRagSearchService(SimpleNamespace(_rag_service=rag))
+
+    result = await service.search(
+        "credential", ("notes", "media"), "rag", top_k=5, include_citations=True
+    )
+
+    assert [call["search_type"] for call in rag.calls] == ["hybrid"]
+    assert rag.calls[0]["top_k"] == 5
+    assert rag.calls[0]["include_citations"] is True
+    assert result["runtime_backend"] == "rag-hybrid"
+    assert [row["source_id"] for row in result["results"]] == ["media-1"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_profile_with_active_scope_stays_semantic_and_discloses():
+    """Scope allowlists are a semantic-only pushdown (the engine raises for
+    hybrid + allowlist), so a scoped query under a hybrid profile runs
+    semantic -- and says so rather than pretending it ran hybrid."""
+    rag = _ProfileRagService(mode="hybrid", results=[_media_result()])
+    service = LibraryLocalRagSearchService(SimpleNamespace(_rag_service=rag))
+    scope = _scoped(**{SOURCE_TYPE_MEDIA: {"media-1"}})
+
+    result = await service.search(
+        "credential", ("media",), "rag", top_k=5, scope=scope
+    )
+
+    assert rag.calls, "the scoped query never reached the runtime"
+    assert {call["search_type"] for call in rag.calls} == {"semantic"}
+    assert result["runtime_backend"] == "rag-semantic"
+    assert _NOTE_HYBRID_SCOPED in _route_notes(result)
+
+
+@pytest.mark.asyncio
+async def test_hybrid_profile_with_media_deselected_stays_semantic_and_discloses():
+    """The engine's FTS leg is media-only in P0: with media deselected it
+    could only contribute rows the Library post-filter drops, so hybrid is
+    skipped -- disclosed, not silent."""
+    rag = _ProfileRagService(mode="hybrid", results=[_note_result()])
+    service = LibraryLocalRagSearchService(SimpleNamespace(_rag_service=rag))
+
+    result = await service.search("credential", ("notes",), "rag", top_k=5)
+
+    assert [call["search_type"] for call in rag.calls] == ["semantic"]
+    assert result["runtime_backend"] == "rag-semantic"
+    assert _NOTE_HYBRID_MEDIA_EXCLUDED in _route_notes(result)
+
+
+@pytest.mark.asyncio
+async def test_plain_profile_routes_to_four_seam_keyword_path():
+    """A BM25 Only profile in rag mode must NOT get the engine's media-only
+    keyword leg (a strictly worse version of the Library's own Search mode);
+    it routes through the four-seam, scope-aware keyword path, labeled."""
+    rag = _ProfileRagService(mode="plain", profile_name="BM25 Only")
+    notes = FakeNotesScopeService(
+        rows=[{"id": "note-1", "title": "Runbook", "content": "Rotate the credential."}]
+    )
+    service = LibraryLocalRagSearchService(
+        SimpleNamespace(_rag_service=rag, notes_scope_service=notes)
+    )
+
+    result = await service.search("credential", ("notes",), "rag", top_k=5)
+
+    assert rag.calls == [], "plain profile must not query the vector engine"
+    assert notes.calls, "plain profile must run the four-seam keyword path"
+    assert result["runtime_backend"] == "local-fts"
+    assert [row["source_id"] for row in result["results"]] == ["note-1"]
+    assert "Profile 'BM25 Only': keyword search (no vectors)" in _route_notes(result)
+
+
+@pytest.mark.asyncio
+async def test_semantic_profile_unchanged():
+    """The default profile keeps today's exact payload -- same search_type,
+    same backend label, no routing note to explain (nothing was diverted)."""
+    rag = _ProfileRagService(mode="semantic", results=[_note_result()])
+    service = LibraryLocalRagSearchService(SimpleNamespace(_rag_service=rag))
+
+    result = await service.search("credential", ("notes",), "rag", top_k=5)
+
+    assert [call["search_type"] for call in rag.calls] == ["semantic"]
+    assert result["runtime_backend"] == "rag-semantic"
+    assert _route_notes(result) == ()
+    assert result["diagnostics"] == {
+        "semantic_scope_coverage": {"covered": ["notes"], "uncovered": []}
+    }
+
+
+@pytest.mark.asyncio
+async def test_index_empty_not_claimed_when_keyword_rows_present():
+    """Zero-results honesty under hybrid: an empty vector store plus a
+    hitting FTS leg is "semantic leg empty", never "nothing is indexed" --
+    the user has evidence on screen while being told the index is empty."""
+    rag = _ProfileRagService(
+        mode="hybrid",
+        vector_count=0,
+        results=[
+            _media_result(
+                "media-1",
+                hybrid_fusion={
+                    "fts_rank": 1,
+                    "vector_rank": None,
+                    "fts_score": 0.001,
+                    "vector_score": None,
+                },
+            ),
+            _media_result(
+                "media-2",
+                hybrid_fusion={
+                    "fts_rank": 2,
+                    "vector_rank": None,
+                    "fts_score": 0.0005,
+                    "vector_score": None,
+                },
+            ),
+        ],
+    )
+    service = LibraryLocalRagSearchService(SimpleNamespace(_rag_service=rag))
+
+    result = await service.search("credential", ("media",), "rag", top_k=5)
+
+    assert not isinstance(result, LibraryRagSearchOutcome), (
+        "hybrid returned keyword-leg rows -- 'Index empty' must not be claimed"
+    )
+    assert [row["source_id"] for row in result["results"]] == ["media-1", "media-2"]
+    assert result["runtime_backend"] == "rag-hybrid"
+    assert _NOTE_SEMANTIC_LEG_EMPTY in _route_notes(result)
+
+
+@pytest.mark.asyncio
+async def test_semantic_leg_empty_note_never_fires_when_the_vector_leg_scored():
+    """The converse pin: a row carrying a real vector score proves the
+    semantic leg contributed, so the keyword-only disclosure must stay
+    silent (it would otherwise be a false claim on every hybrid search)."""
+    rag = _ProfileRagService(
+        mode="hybrid",
+        vector_count=0,  # deliberately lying: a scored vector leg outranks it
+        results=[
+            _media_result(
+                "media-1",
+                hybrid_fusion={
+                    "fts_rank": 1,
+                    "vector_rank": 1,
+                    "fts_score": 0.001,
+                    "vector_score": 0.83,
+                },
+            )
+        ],
+    )
+    service = LibraryLocalRagSearchService(SimpleNamespace(_rag_service=rag))
+
+    result = await service.search("credential", ("media",), "rag", top_k=5)
+
+    assert _NOTE_SEMANTIC_LEG_EMPTY not in _route_notes(result)

--- a/Tests/Library/test_library_rag_mode_resolution.py
+++ b/Tests/Library/test_library_rag_mode_resolution.py
@@ -25,6 +25,7 @@ from tldw_chatbook.Chat.rag_scope import (
     EffectiveScope,
     SOURCE_TYPE_MEDIA,
 )
+from tldw_chatbook.Library import library_local_rag_search_service as rag_service_module
 from tldw_chatbook.Library.library_local_rag_search_service import (
     LibraryLocalRagSearchService,
 )
@@ -352,3 +353,88 @@ async def test_semantic_leg_empty_note_never_fires_when_the_vector_leg_scored():
     result = await service.search("credential", ("media",), "rag", top_k=5)
 
     assert _NOTE_SEMANTIC_LEG_EMPTY not in _route_notes(result)
+
+
+# --- Profile switching mid-session ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_switch_mid_session_reroutes_and_renames_the_disclosure(
+    monkeypatch,
+):
+    """Review finding I1: routing is only honest if it follows the profile
+    that is active NOW.
+
+    `app._rag_service` is a per-app cache that a profile switch never
+    cleared -- `set_active_profile()` / the Settings save path call
+    `reset_shared_rag_service()`, which drops only the module singleton.
+    Without invalidation the second query below still routes through profile
+    A and the disclosure names a profile the user already switched away
+    from: false attribution, the exact defect class this task exists to kill.
+    """
+    from tldw_chatbook.RAG_Search import ingestion_indexing
+    from tldw_chatbook.RAG_Search import simplified as simplified_module
+
+    monkeypatch.setattr(
+        rag_service_module, "embeddings_rag_deps_installed", lambda: True
+    )
+    profile_a = _ProfileRagService(mode="plain", profile_name="BM25 Only")
+    profile_b = _ProfileRagService(
+        mode="hybrid", profile_name="Hybrid Basic", results=[_media_result()]
+    )
+    notes = FakeNotesScopeService(
+        rows=[{"id": "note-1", "title": "Runbook", "content": "Rotate the credential."}]
+    )
+    ingestion_indexing.reset_shared_rag_service()
+    try:
+        # Profile A is the process-wide runtime; the app has no cache yet.
+        ingestion_indexing.set_shared_rag_service(profile_a)
+        app = SimpleNamespace(_rag_service=None, notes_scope_service=notes)
+        service = LibraryLocalRagSearchService(app)
+
+        first = await service.search("credential", ("notes", "media"), "rag", top_k=5)
+
+        assert first["runtime_backend"] == "local-fts"
+        assert "Profile 'BM25 Only': keyword search (no vectors)" in _route_notes(first)
+
+        # The user switches profile in Settings: the pointer write resets the
+        # shared service, and the next resolution rebuilds it (profile B).
+        monkeypatch.setattr(
+            simplified_module, "create_rag_service", lambda **kwargs: profile_b
+        )
+        ingestion_indexing.reset_shared_rag_service()
+
+        second = await service.search("credential", ("notes", "media"), "rag", top_k=5)
+
+        assert [call["search_type"] for call in profile_b.calls] == ["hybrid"]
+        assert second["runtime_backend"] == "rag-hybrid"
+        assert app._rag_service is profile_b
+        assert not any("BM25 Only" in note for note in _route_notes(second))
+    finally:
+        ingestion_indexing.reset_shared_rag_service()
+
+
+@pytest.mark.asyncio
+async def test_injected_runtime_without_a_generation_stamp_still_wins(monkeypatch):
+    """Guard on the staleness fix: a runtime injected straight onto the app
+    (every pre-existing test fake, and any surface that predates the stamp)
+    was never resolved through the shared seam, so it has no generation to
+    compare -- it must keep winning outright, never be treated as stale and
+    rebuilt."""
+    from tldw_chatbook.RAG_Search import ingestion_indexing
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError("an injected runtime must not be re-resolved")
+
+    monkeypatch.setattr(rag_service_module, "embeddings_rag_deps_installed", _forbidden)
+    monkeypatch.setattr(rag_service_module, "get_shared_rag_service", _forbidden)
+    injected = _ProfileRagService(mode="hybrid", results=[_media_result()])
+    service = LibraryLocalRagSearchService(SimpleNamespace(_rag_service=injected))
+    # Bump the generation so a naive "generation moved -> stale" rule would
+    # wrongly discard the injected runtime.
+    ingestion_indexing.set_shared_rag_service(None)
+
+    result = await service.search("credential", ("media",), "rag", top_k=5)
+
+    assert result["runtime_backend"] == "rag-hybrid"
+    assert injected.calls

--- a/Tests/Library/test_library_rag_state.py
+++ b/Tests/Library/test_library_rag_state.py
@@ -1582,6 +1582,61 @@ class TestLibraryRagResultRowScoreKind:
         )
         assert row.score_kind == "reranker"
 
+    def test_the_rerank_score_stamp_is_the_production_marker(self):
+        """`_final_score_kind` is READ by `local_citation_capture` but written
+        by nothing in the app; what a real reranked row actually carries is
+        `metadata["rerank_score"]`, stamped by
+        `PointwiseReranker._apply_scores` as it replaces the score. Keying
+        on that is what makes the reranked band reachable in production."""
+        row = LibraryRagResultRow.from_result(
+            {"title": "A", "score": 7.5, "provenance": {"rerank_score": 7.5}}
+        )
+        assert row.score_kind == "reranker"
+        assert (
+            library_rag_score_suffix(
+                row.score, score_kind=row.score_kind, vector_score=row.vector_score
+            )
+            == " | reranked"
+        )
+
+    def test_a_reranked_score_inside_the_band_range_never_reads_as_strong(self):
+        """The load-bearing case. `RerankingConfig.score_scale` defaults to
+        (0.0, 1.0), so a default-configured pointwise reranker emits scores
+        INSIDE the similarity band range -- 0.83 would have rendered
+        "match: strong", a cosine claim about an LLM relevance score."""
+        row = LibraryRagResultRow.from_result(
+            {"title": "A", "score": 0.83, "provenance": {"rerank_score": 0.95}}
+        )
+        suffix = library_rag_score_suffix(
+            row.score, score_kind=row.score_kind, vector_score=row.vector_score
+        )
+        assert suffix == " | reranked"
+        assert "match:" not in suffix
+
+    def test_reranking_wins_over_a_prior_fusion_block(self):
+        """Reranking runs AFTER fusion, so a hybrid row that was then
+        reranked carries both blocks -- the later stage owns what the final
+        score means, and the row must not band on the stale vector leg."""
+        row = LibraryRagResultRow.from_result(
+            {
+                "title": "A",
+                "score": 0.95,
+                "provenance": {
+                    "rerank_score": 0.95,
+                    "hybrid_fusion": {"fts_rank": 1, "vector_rank": 1,
+                                      "fts_score": 0.001, "vector_score": 0.83},
+                },
+            }
+        )
+        assert row.score_kind == "reranker"
+        assert row.vector_score is None
+        assert (
+            library_rag_score_suffix(
+                row.score, score_kind=row.score_kind, vector_score=row.vector_score
+            )
+            == " | reranked"
+        )
+
     def test_reranking_skipped_tag_is_not_a_score_kind_signal(self):
         """Task 4's `reranking_skipped`/`reranking_degraded` tags disclose
         that reranking FAILED -- the scores on those rows are the base

--- a/Tests/Library/test_library_rag_state.py
+++ b/Tests/Library/test_library_rag_state.py
@@ -1553,6 +1553,36 @@ class TestLibraryRagCoverageNote:
             "Scope active — semantic only until scope-aware hybrid lands."
         )
 
+    def test_route_notes_survive_the_zero_row_outcome(self):
+        """(RAG-port P0 review, I2) The empty-rows guard exists so a
+        no-match search does not enumerate every requested source as
+        "uncovered" -- a claim about coverage. A ROUTING disclosure is a
+        different fact ("vectors were never consulted"), and zero rows is
+        exactly when it is most diagnostic: a plain-profile query that
+        matched nothing must still say the profile ran keyword-only, or the
+        user reads the empty result as "the vector index has nothing"."""
+        assert library_rag_coverage_note(
+            {
+                LIBRARY_RAG_ROUTE_NOTES_KEY: [
+                    "Profile 'BM25 Only': keyword search (no vectors)"
+                ]
+            },
+            (),
+        ) == "Profile 'BM25 Only': keyword search (no vectors)."
+
+    def test_zero_row_coverage_claims_stay_suppressed_alongside_a_route_note(self):
+        """Only the routing fact survives zero rows -- the "found nothing
+        from: …" coverage sentence stays suppressed exactly as before."""
+        diagnostics = {
+            "semantic_scope_coverage": {"covered": [], "uncovered": ["notes", "media"]},
+            LIBRARY_RAG_ROUTE_NOTES_KEY: [
+                "scope active — semantic only until scope-aware hybrid lands"
+            ],
+        }
+        assert library_rag_coverage_note(diagnostics, ()) == (
+            "Scope active — semantic only until scope-aware hybrid lands."
+        )
+
     def test_blank_route_notes_render_nothing(self):
         rows = (self._row(0.6),)
         diagnostics = {"semantic_scope_coverage": {"covered": ["notes"], "uncovered": []}}

--- a/Tests/Library/test_library_rag_state.py
+++ b/Tests/Library/test_library_rag_state.py
@@ -9,6 +9,7 @@ from tldw_chatbook.Library import library_rag_state as _rag_state_module
 from tldw_chatbook.Library.library_rag_state import (
     LIBRARY_RAG_EMPTY_STATE_SELECTOR,
     LIBRARY_RAG_NO_SOURCES_GATE_COPY,
+    LIBRARY_RAG_ROUTE_NOTES_KEY,
     LIBRARY_RAG_SCOPE_ALL_LOCAL_COPY,
     LIBRARY_RAG_SERVICE_ERROR_SELECTOR,
     LIBRARY_RAG_SNIPPET_DISPLAY_MAX_CHARS,
@@ -1504,6 +1505,64 @@ class TestLibraryRagCoverageNote:
             "semantic_scope_coverage": {"covered": [], "uncovered": ["notes", "media"]}
         }
         assert library_rag_coverage_note(diagnostics, ()) == ""
+
+    # (RAG-port P0, Workstream A) The service now also reports how the
+    # retrieval was ROUTED when it could not run the active profile's
+    # configured mode -- a hybrid profile forced onto the semantic path by
+    # an active scope, a plain profile routed to the keyword seams. Those
+    # disclosures share this one quiet line rather than opening a second
+    # note channel on the same screen.
+
+    def test_route_note_renders_as_a_sentence_when_nothing_else_to_say(self):
+        rows = (self._row(0.6),)
+        diagnostics = {
+            LIBRARY_RAG_ROUTE_NOTES_KEY: ["media excluded — semantic only"]
+        }
+        assert (
+            library_rag_coverage_note(diagnostics, rows)
+            == "Media excluded — semantic only."
+        )
+
+    def test_route_note_renders_without_any_coverage_diagnostic(self):
+        """The plain-profile route returns the KEYWORD payload, which carries
+        no `semantic_scope_coverage` at all -- the disclosure must still
+        reach the line (this is the only thing telling the user their rag
+        query ran as keyword search)."""
+        rows = (self._row(score=None),)
+        diagnostics = {
+            LIBRARY_RAG_ROUTE_NOTES_KEY: [
+                "Profile 'BM25 Only': keyword search (no vectors)"
+            ]
+        }
+        assert (
+            library_rag_coverage_note(diagnostics, rows)
+            == "Profile 'BM25 Only': keyword search (no vectors)."
+        )
+
+    def test_route_notes_follow_the_weak_prefix_and_coverage_sentence(self):
+        rows = (self._row(0.09),)
+        diagnostics = {
+            "semantic_scope_coverage": {"covered": [], "uncovered": ["notes"]},
+            LIBRARY_RAG_ROUTE_NOTES_KEY: [
+                "scope active — semantic only until scope-aware hybrid lands"
+            ],
+        }
+        assert library_rag_coverage_note(diagnostics, rows) == (
+            "No strong semantic matches — results below are weak. "
+            "Semantic search found nothing from: Notes. "
+            "Scope active — semantic only until scope-aware hybrid lands."
+        )
+
+    def test_blank_route_notes_render_nothing(self):
+        rows = (self._row(0.6),)
+        diagnostics = {"semantic_scope_coverage": {"covered": ["notes"], "uncovered": []}}
+        assert library_rag_coverage_note(diagnostics, rows) == ""
+        assert (
+            library_rag_coverage_note(
+                {**diagnostics, LIBRARY_RAG_ROUTE_NOTES_KEY: ["", "   "]}, rows
+            )
+            == ""
+        )
 
 
 class TestLibraryRagEmptyStateQuietCopy:

--- a/Tests/Library/test_library_rag_state.py
+++ b/Tests/Library/test_library_rag_state.py
@@ -1398,6 +1398,222 @@ class TestLibraryRagAllMatchesWeak:
         assert library_rag_all_matches_weak(rows) is False
 
 
+class TestLibraryRagScoreKindAwareBands:
+    """(RAG-port P0/Task 6) The match band is a claim about *cosine
+    similarity*. Hybrid retrieval replaces every row's score with an
+    RRF-fused number whose theoretical maximum is `1/(rrf_k + 1)` ~= 0.016
+    at the shipped `rrf_k=60` -- an order of magnitude below the 0.2 weak
+    boundary -- so banding a fused score on cosine thresholds renders a
+    wall of "match: weak (0.02)" on results that are in fact excellent.
+    Reranker scores are worse still: an LLM 0-10 scale or a raw
+    cross-encoder logit is not on the unit interval at all.
+
+    The band must therefore be computed from the score kind's own honest
+    similarity input -- the preserved vector leg for hybrid rows (Task 2's
+    `hybrid_fusion.vector_score`) -- and must disclose the kind instead of
+    inventing a similarity when there is none.
+    """
+
+    def test_fused_score_never_bands_on_cosine_thresholds(self):
+        """A fused RRF score (~0.016) with a strong vector leg bands strong."""
+        assert (
+            library_rag_score_suffix(
+                0.016, score_kind="hybrid_fusion", vector_score=0.83
+            )
+            == " | match: strong"
+        )
+
+    def test_fts_only_hybrid_row_reads_keyword_match(self):
+        """No vector leg means no similarity exists -- say "keyword match",
+        never a fabricated band and never the fused 0.0x number."""
+        assert (
+            library_rag_score_suffix(
+                0.0161, score_kind="hybrid_fusion", vector_score=None
+            )
+            == " | keyword match"
+        )
+
+    def test_reranker_scores_disclose_kind_not_band(self):
+        """Reranker scores are unbounded (logits, 0-10 LLM scales): the kind
+        is disclosed, the number is never banded as a cosine."""
+        assert library_rag_score_suffix(-3.2, score_kind="reranker") == " | reranked"
+
+    def test_hybrid_row_with_weak_vector_leg_still_bands_weak_on_the_leg(self):
+        """The converse pin: hybrid banding reads the VECTOR leg, not the
+        fused score -- a genuinely weak vector leg must still render weak,
+        with the leg's own number, not the fused one."""
+        assert (
+            library_rag_score_suffix(
+                0.0159, score_kind="hybrid_fusion", vector_score=0.09
+            )
+            == " | match: weak (0.09)"
+        )
+
+    def test_default_kind_preserves_the_legacy_similarity_contract(self):
+        """Every pre-existing call site passes a cosine similarity and no
+        kind -- the default must keep banding exactly as before."""
+        assert library_rag_score_suffix(0.93) == " | match: strong"
+        assert library_rag_score_suffix(None) == ""
+        assert (
+            library_rag_score_suffix(0.93, score_kind="vector_similarity")
+            == " | match: strong"
+        )
+
+    def test_reranked_row_discloses_kind_even_without_a_score(self):
+        """`None` means "unscored" for a similarity row, but a reranked row
+        was scored by definition -- the kind stays disclosed."""
+        assert library_rag_score_suffix(None, score_kind="reranker") == " | reranked"
+
+
+class TestLibraryRagAllMatchesWeakScoreKinds:
+    """(RAG-port P0/Task 6) The all-weak coverage note is a claim about
+    semantic similarity ("No strong semantic matches"), so only rows whose
+    effective banding input IS a similarity may participate. Keyword-only
+    hybrid rows and reranked rows neither trigger it nor suppress it."""
+
+    def test_all_matches_weak_ignores_non_similarity_kinds(self):
+        keyword_only = LibraryRagResultRow.from_result(
+            {
+                "title": "Keyword only",
+                "score": 0.0161,
+                "provenance": {
+                    "hybrid_fusion": {"fts_rank": 1, "vector_rank": None,
+                                      "fts_score": 0.001, "vector_score": None},
+                },
+            }
+        )
+        weak_vector = LibraryRagResultRow.from_result({"title": "Weak", "score": 0.09})
+        assert library_rag_all_matches_weak((keyword_only, weak_vector)) is True
+        assert library_rag_all_matches_weak((keyword_only,)) is False
+
+    def test_hybrid_rows_are_judged_on_their_vector_leg(self):
+        """A fused 0.016 must not read as a weak similarity -- the row's
+        strong vector leg makes the whole set non-weak."""
+        strong_hybrid = LibraryRagResultRow.from_result(
+            {
+                "title": "Strong hybrid",
+                "score": 0.0161,
+                "provenance": {
+                    "hybrid_fusion": {"fts_rank": 1, "vector_rank": 1,
+                                      "fts_score": 0.001, "vector_score": 0.83},
+                },
+            }
+        )
+        assert library_rag_all_matches_weak((strong_hybrid,)) is False
+
+    def test_reranked_rows_never_participate(self):
+        reranked = LibraryRagResultRow.from_result(
+            {
+                "title": "Reranked",
+                "score": 0.0,
+                "provenance": {"_final_score_kind": "reranker"},
+            }
+        )
+        # Alone: no similarity row exists at all, so no all-weak claim.
+        assert library_rag_all_matches_weak((reranked,)) is False
+        # Alongside a weak similarity row: does not suppress the claim.
+        weak_vector = LibraryRagResultRow.from_result({"title": "Weak", "score": 0.09})
+        assert library_rag_all_matches_weak((reranked, weak_vector)) is True
+        # Alongside a strong similarity row: does not create one either.
+        strong_vector = LibraryRagResultRow.from_result(
+            {"title": "Strong", "score": 0.83}
+        )
+        assert library_rag_all_matches_weak((reranked, strong_vector)) is False
+
+    def test_duck_typed_rows_without_the_new_fields_still_work(self):
+        """`mcp_inspector._ScoredRow` is a `__slots__ = ("score",)` shim that
+        feeds this same canonical check -- reading the new fields must be
+        `getattr`-tolerant or the MCP Test Tool interpretation line breaks."""
+
+        class _ScoreOnly:
+            __slots__ = ("score",)
+
+            def __init__(self, score):
+                self.score = score
+
+        assert library_rag_all_matches_weak((_ScoreOnly(0.09),)) is True
+        assert library_rag_all_matches_weak((_ScoreOnly(0.83),)) is False
+
+
+class TestLibraryRagResultRowScoreKind:
+    """(RAG-port P0/Task 6) The row is where the service's score provenance
+    becomes display state: `provenance["hybrid_fusion"]` (Task 2 preserves
+    the per-leg scores there) and the `_final_score_kind` reranker channel
+    are normalized once, on the row, so the band and the Console evidence
+    bundle cannot disagree."""
+
+    def test_plain_semantic_row_defaults_to_vector_similarity(self):
+        row = LibraryRagResultRow.from_result({"title": "A", "score": 0.83})
+        assert row.score_kind == "vector_similarity"
+        assert row.vector_score is None
+
+    def test_hybrid_row_carries_the_preserved_vector_leg(self):
+        row = LibraryRagResultRow.from_result(
+            {
+                "title": "A",
+                "score": 0.0161,
+                "provenance": {
+                    "hybrid_fusion": {"fts_rank": 1, "vector_rank": 1,
+                                      "fts_score": 0.001, "vector_score": 0.83},
+                },
+            }
+        )
+        assert row.score_kind == "hybrid_fusion"
+        assert row.vector_score == pytest.approx(0.83)
+        assert row.score == pytest.approx(0.0161)
+
+    def test_fts_only_hybrid_row_has_no_vector_leg(self):
+        row = LibraryRagResultRow.from_result(
+            {
+                "title": "A",
+                "score": 0.0161,
+                "provenance": {
+                    "hybrid_fusion": {"fts_rank": 1, "vector_rank": None,
+                                      "fts_score": 0.001, "vector_score": None},
+                },
+            }
+        )
+        assert row.score_kind == "hybrid_fusion"
+        assert row.vector_score is None
+
+    def test_reranker_channel_is_read_from_provenance(self):
+        row = LibraryRagResultRow.from_result(
+            {"title": "A", "score": 7.5, "provenance": {"_final_score_kind": "reranker"}}
+        )
+        assert row.score_kind == "reranker"
+
+    def test_reranking_skipped_tag_is_not_a_score_kind_signal(self):
+        """Task 4's `reranking_skipped`/`reranking_degraded` tags disclose
+        that reranking FAILED -- the scores on those rows are the base
+        retrieval scores, so treating the tag as a reranker score kind would
+        hide a real similarity behind " | reranked"."""
+        row = LibraryRagResultRow.from_result(
+            {
+                "title": "A",
+                "score": 0.83,
+                "provenance": {"reranking_skipped": "no credentials"},
+            }
+        )
+        assert row.score_kind == "vector_similarity"
+
+    def test_kind_also_resolves_from_engine_metadata(self):
+        """Not every producer folds engine metadata into `provenance` --
+        a top-level `metadata` block carrying the fusion provenance must
+        resolve identically."""
+        row = LibraryRagResultRow.from_result(
+            {
+                "title": "A",
+                "score": 0.0161,
+                "metadata": {
+                    "hybrid_fusion": {"fts_rank": 1, "vector_rank": 1,
+                                      "fts_score": 0.001, "vector_score": 0.51},
+                },
+            }
+        )
+        assert row.score_kind == "hybrid_fusion"
+        assert row.vector_score == pytest.approx(0.51)
+
+
 class TestLibraryRagCoverageNote:
     """(Task 8) `library_rag_coverage_note` builds the Evidence region's
     one-line semantic-coverage note from `_search_semantic`'s

--- a/Tests/RAG/test_semantic_honest_states.py
+++ b/Tests/RAG/test_semantic_honest_states.py
@@ -239,6 +239,42 @@ class TestResolveSemanticRagService:
         assert resolved is service
         assert reason is None
 
+    def test_cache_publishes_one_atomic_service_generation_tuple(self):
+        """(Qodo PR #1428 finding 2) `cache_app_rag_service` used to publish
+        `app._rag_service` and the generation attr as two separate writes,
+        leaving a window where a concurrent reader saw the service with no
+        generation stamp yet and hit the unstamped-injection carve-out,
+        skipping staleness validation for a service that WAS resolved
+        through the shared seam. The fix publishes `(service, generation)`
+        as one attribute; pin that it exists and holds the exact pair."""
+        service = StrictRagService()
+        app = SimpleNamespace()
+
+        sa.cache_app_rag_service(app, service, generation=7)
+
+        stamp = getattr(app, sa.APP_RAG_SERVICE_STAMP_ATTR)
+        assert stamp == (service, 7)
+
+    def test_atomic_stamp_is_the_single_source_when_present(self):
+        """Prove the atomic stamp -- not the legacy raw `_rag_service`
+        attribute -- governs `current_app_rag_service` once it is present,
+        by making the two disagree (simulating exactly the torn-write
+        window the finding describes) and confirming the stamp wins."""
+        from tldw_chatbook.RAG_Search import ingestion_indexing
+
+        stamped_service = StrictRagService()
+        other_service = StrictRagService()
+        app = SimpleNamespace()
+        generation = ingestion_indexing.shared_rag_service_generation()
+
+        sa.cache_app_rag_service(app, stamped_service, generation)
+        # Simulate a stale/disagreeing raw attribute -- the atomic stamp
+        # must still be what `current_app_rag_service` trusts.
+        app._rag_service = other_service
+
+        resolved = sa.current_app_rag_service(app)
+        assert resolved is stamped_service
+
 
 class TestSemanticIndexIsEmpty:
     """Trustworthy-count probe: only an error-free integer 0 counts as empty."""

--- a/Tests/RAG/test_semantic_honest_states.py
+++ b/Tests/RAG/test_semantic_honest_states.py
@@ -186,6 +186,59 @@ class TestResolveSemanticRagService:
         assert resolved is None
         assert reason == SEMANTIC_REASON_INIT_FAILED
 
+    def test_cached_service_is_re_resolved_after_a_profile_switch(self, monkeypatch):
+        """(RAG-port P0 review, I1) This resolver WRITES `app._rag_service`,
+        and a profile switch (`set_active_profile` -> `reset_shared_rag_
+        service`) only clears the module singleton. Whatever it cached must
+        therefore be re-resolved once the shared-service generation moves,
+        or every surface reading this cache keeps serving the old profile
+        for the rest of the session."""
+        from tldw_chatbook.RAG_Search import ingestion_indexing
+
+        old_service = StrictRagService()
+        new_service = StrictRagService()
+        app = SimpleNamespace()
+        _deps(monkeypatch, True)
+        ingestion_indexing.reset_shared_rag_service()
+        try:
+            _factory(monkeypatch, lambda profile_name=None: old_service)
+            resolved, _ = asyncio.run(resolve_semantic_rag_service(app))
+            assert resolved is old_service
+            assert app._rag_service is old_service
+
+            # Profile switch: singleton dropped, generation bumped.
+            ingestion_indexing.reset_shared_rag_service()
+            _factory(monkeypatch, lambda profile_name=None: new_service)
+
+            resolved, reason = asyncio.run(resolve_semantic_rag_service(app))
+            assert reason is None
+            assert resolved is new_service
+            assert app._rag_service is new_service
+        finally:
+            ingestion_indexing.reset_shared_rag_service()
+
+    def test_injected_service_without_a_stamp_wins_even_after_a_reset(
+        self, monkeypatch
+    ):
+        """The injection contract is unchanged: a service placed directly on
+        the app was never resolved through the shared seam, so a generation
+        bump says nothing about it and must not evict it."""
+        from tldw_chatbook.RAG_Search import ingestion_indexing
+
+        service = StrictRagService()
+        app = SimpleNamespace(_rag_service=service)
+        monkeypatch.setattr(
+            sa,
+            "embeddings_rag_deps_installed",
+            lambda: (_ for _ in ()).throw(AssertionError("deps probe must not run")),
+        )
+        _forbidden_factory(monkeypatch)
+        ingestion_indexing.set_shared_rag_service(None)
+
+        resolved, reason = asyncio.run(resolve_semantic_rag_service(app))
+        assert resolved is service
+        assert reason is None
+
 
 class TestSemanticIndexIsEmpty:
     """Trustworthy-count probe: only an error-free integer 0 counts as empty."""

--- a/Tests/RAG_Search/test_db_connection_pool_thread_safety.py
+++ b/Tests/RAG_Search/test_db_connection_pool_thread_safety.py
@@ -1,0 +1,96 @@
+"""Concurrent first keyword searches must not construct duplicate pools.
+
+(Qodo PR #1428 finding 3) `get_connection_pool`'s global `_connection_pools`
+dict was guarded only by an unlocked check-then-set: `if db_path not in
+_connection_pools: ... _connection_pools[db_path] = MediaDatabase(...)`.
+`MediaDatabase.__init__` runs schema init immediately (real I/O), so two
+threads racing the first keyword search for the same db path could both
+pass the `not in` check before either stored its instance -- each
+constructs its own `MediaDatabase`, and the loser's instance (and its open
+sqlite connection) is simply overwritten in the dict and leaked.
+"""
+import threading
+import time
+
+import pytest
+
+from tldw_chatbook.RAG_Search.simplified import db_connection_pool as pool_mod
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeMediaDatabase:
+    """Stand-in for `MediaDatabase` that counts constructions and, like the
+    real class, does non-trivial work in `__init__` (schema init) -- the
+    `sleep` widens the race window so concurrent callers actually overlap
+    inside the critical section under test instead of serializing by
+    accident."""
+
+    construction_count = 0
+    _count_lock = threading.Lock()
+
+    def __init__(self, db_path, client_id):
+        with _FakeMediaDatabase._count_lock:
+            _FakeMediaDatabase.construction_count += 1
+        self.db_path = db_path
+        self.client_id = client_id
+        time.sleep(0.02)
+
+    def close_connection(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _isolated_pool_state(monkeypatch):
+    """Give every test a clean pool dict and the fake constructor, and
+    close whatever it opened afterward."""
+    monkeypatch.setattr(pool_mod, "_connection_pools", {})
+    monkeypatch.setattr(pool_mod, "MediaDatabase", _FakeMediaDatabase)
+    _FakeMediaDatabase.construction_count = 0
+    yield
+    pool_mod.close_all_pools()
+
+
+def test_concurrent_first_callers_construct_exactly_one_media_database():
+    db_path = "/fake/shared/media.db"
+    thread_count = 16
+    results = []
+    results_lock = threading.Lock()
+    barrier = threading.Barrier(thread_count)
+
+    def _worker():
+        barrier.wait(timeout=5)  # maximize overlap: all threads race together
+        pool = pool_mod.get_connection_pool(db_path)
+        with results_lock:
+            results.append(pool)
+
+    threads = [threading.Thread(target=_worker) for _ in range(thread_count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+        assert not t.is_alive(), "worker thread did not complete in time"
+
+    assert _FakeMediaDatabase.construction_count == 1, (
+        "exactly one MediaDatabase must be constructed for concurrent "
+        f"first callers of one db path, got {_FakeMediaDatabase.construction_count}"
+    )
+    assert len(results) == thread_count
+    assert all(pool is results[0] for pool in results), (
+        "every concurrent caller must receive the SAME pooled instance"
+    )
+
+
+def test_pool_size_parameter_still_accepted_and_unused():
+    """`pool_size` stays API-compatible through the locking change."""
+    db_path = "/fake/other/media.db"
+    pool = pool_mod.get_connection_pool(db_path, pool_size=9)
+    assert pool is pool_mod.get_connection_pool(db_path, pool_size=1)
+    assert _FakeMediaDatabase.construction_count == 1
+
+
+def test_close_all_pools_clears_state_under_the_same_lock():
+    pool_mod.get_connection_pool("/fake/closeme/media.db")
+    assert pool_mod._connection_pools
+    pool_mod.close_all_pools()
+    assert pool_mod._connection_pools == {}

--- a/Tests/RAG_Search/test_hybrid_fusion_metadata.py
+++ b/Tests/RAG_Search/test_hybrid_fusion_metadata.py
@@ -1,0 +1,31 @@
+"""Fusion must preserve original per-leg scores for score-kind-aware display.
+
+RRF-fused scores max out at ~1/(rrf_k+1) ~= 0.016 — far below the UI's
+similarity band thresholds — so the vector leg's original similarity is the
+only honest banding input for hybrid rows (spec Workstream A item 3).
+"""
+import pytest
+from tldw_chatbook.RAG_Search.simplified.rag_service import RAGService
+from tldw_chatbook.RAG_Search.simplified.vector_store import SearchResult
+
+
+def _result(rid: str, score: float) -> SearchResult:
+    return SearchResult(id=rid, score=score, document=f"doc {rid}", metadata={})
+
+
+def test_fused_rows_preserve_original_leg_scores():
+    keyword = [_result("m1", 0.001), _result("m2", 0.001)]
+    semantic = [_result("m2", 0.83), _result("m3", 0.41)]
+    fused = RAGService._fuse_hybrid_results(
+        keyword_results=keyword, semantic_results=semantic,
+        top_k=10, alpha=0.7, include_citations=False,
+    )
+    by_id = {r.id: r for r in fused}
+    both = by_id["m2"].metadata["hybrid_fusion"]
+    assert both["vector_score"] == pytest.approx(0.83)
+    assert both["fts_score"] == pytest.approx(0.001)
+    fts_only = by_id["m1"].metadata["hybrid_fusion"]
+    assert fts_only["vector_score"] is None
+    vec_only = by_id["m3"].metadata["hybrid_fusion"]
+    assert vec_only["vector_score"] == pytest.approx(0.41)
+    assert vec_only["fts_score"] is None

--- a/Tests/RAG_Search/test_hybrid_fusion_metadata.py
+++ b/Tests/RAG_Search/test_hybrid_fusion_metadata.py
@@ -29,3 +29,50 @@ def test_fused_rows_preserve_original_leg_scores():
     vec_only = by_id["m3"].metadata["hybrid_fusion"]
     assert vec_only["vector_score"] == pytest.approx(0.41)
     assert vec_only["fts_score"] is None
+
+
+def test_real_fused_metadata_still_classifies_as_rrf_downstream():
+    """The producer's block and its one strict consumer must not drift apart.
+
+    `local_citation_capture._reliable_rrf` certifies a fused score as
+    `RetrievalScoreKind.RRF` / `NON_NEGATIVE` only after re-deriving it from
+    the fusion block. It gated on an EXACT six-key set, so adding
+    `fts_score`/`vector_score` above silently downgraded every real hybrid
+    row to `LEGACY` / `UNBOUNDED` in the Console citation trace -- invisible
+    to that module's own tests, which hand-build their fusion metadata
+    instead of piping the producer's output through it.
+
+    This pins the two ends together: the metadata block and the score here
+    come verbatim from `_fuse_hybrid_results`, never from a literal.
+    """
+    from tldw_chatbook.Chat.citation_trace_models import (
+        RetrievalScoreKind,
+        RetrievalScoreScale,
+    )
+    from tldw_chatbook.RAG_Search.local_citation_capture import normalize_local_result
+    from tldw_chatbook.RAG_Search.pipeline_types import (
+        SearchResult as CaptureSearchResult,
+    )
+
+    fused = RAGService._fuse_hybrid_results(
+        keyword_results=[_result("m1", 0.001), _result("m2", 0.001)],
+        semantic_results=[_result("m2", 0.83), _result("m3", 0.41)],
+        top_k=10,
+        alpha=0.7,
+        include_citations=False,
+    )
+    row = {r.id: r for r in fused}["m2"]
+
+    normalized = normalize_local_result(
+        CaptureSearchResult(
+            source="media",
+            id=row.id,
+            title="Title",
+            content=row.document,
+            score=row.score,
+            metadata=row.metadata,
+        )
+    )
+
+    assert normalized.score_kind is RetrievalScoreKind.RRF
+    assert normalized.score_scale is RetrievalScoreScale.NON_NEGATIVE

--- a/Tests/RAG_Search/test_keyword_leg_db_resolution.py
+++ b/Tests/RAG_Search/test_keyword_leg_db_resolution.py
@@ -156,3 +156,51 @@ def test_keyword_search_orders_strongest_match_first(tmp_path):
         f"weak match ({weak_id}) preferentially kept over a stronger match "
         f"under top_k=2: {top2_ids}"
     )
+
+
+def test_keyword_rows_render_their_real_title_in_library_evidence(tmp_path):
+    """A keyword-leg row must reach the Library evidence list titled.
+
+    Found live (Task 11 walkthrough, Hybrid Full profile): a hybrid search
+    whose semantic leg was empty rendered its one FTS-leg row as
+    "1. Untitled source | keyword match" while its own citation line read
+    "Citations: meeting_notes" -- the title was there, under a key the
+    display layer does not read.
+
+    The vector leg's chunk metadata carries `title` (spread in from the
+    indexing call's document metadata); this leg builds its metadata from
+    scratch and stamped only `doc_title`, which
+    `library_local_rag_search_service._semantic_row` -- the mapper every
+    engine-backed Library row goes through -- does not consult. The symptom
+    was unreachable before this branch because the keyword leg could never
+    return a row at all.
+    """
+    from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+    from tldw_chatbook.Library.library_local_rag_search_service import _semantic_row
+    from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
+
+    db_path = tmp_path / "tldw_cli_media_v2.db"
+    db = MediaDatabase(db_path=str(db_path), client_id="test_keyword_title")
+    media_id, _, message = db.add_media_with_keywords(
+        title="Quokka Census Notes",
+        content="Census notes recording quokka sightings across the island.",
+        media_type="article",
+        author="R. Surveyor",
+        url="https://example.com/quokka-census",
+    )
+    assert media_id is not None, f"seed failed: {message}"
+    db.close_connection()
+
+    service = _make_service(tmp_path, media_db_path=db_path)
+    results = asyncio.run(service._keyword_search("quokka", top_k=5))
+    assert results, "FTS row expected"
+
+    row = _semantic_row(results[0])
+    assert row["title"] == "Quokka Census Notes", (
+        "keyword-leg row lost its title on the way to the Library evidence "
+        f"list: {row['title']!r} (metadata keys: {sorted(results[0].metadata)})"
+    )
+    # And through the display-state normalizer the panel actually renders.
+    assert (
+        LibraryRagResultRow.from_result(row).title == "Quokka Census Notes"
+    ), "row renders as 'Untitled source' in the evidence list"

--- a/Tests/RAG_Search/test_keyword_leg_db_resolution.py
+++ b/Tests/RAG_Search/test_keyword_leg_db_resolution.py
@@ -38,6 +38,86 @@ def test_missing_media_db_returns_empty_and_creates_nothing(tmp_path):
     assert list(tmp_path.glob("*.db")) == []              # no rogue DB anywhere
 
 
+def test_traversal_shaped_media_db_path_is_rejected_before_any_db_open(
+    tmp_path, monkeypatch
+):
+    """(Qodo PR #1428 finding 1) `config.search.media_db_path` reached a
+    filesystem check + DB open without running through path_validation.py.
+    Proof this matters (not just a naive existence check): the traversal
+    string below resolves, at the OS level, to a REAL db file -- so
+    pre-fix code's `.exists()`/`.is_file()` gate would happily pass it
+    through to `get_connection_pool`. The fix must reject it earlier, by
+    running it through the shared path_validation helpers (mirroring
+    config.py's `_get_custom_database_path` treatment), before
+    `get_connection_pool` -- and therefore `MediaDatabase` -- is ever
+    reached, degrading to [] the same way a missing DB does (never raise,
+    never write)."""
+    import tldw_chatbook.RAG_Search.simplified.rag_service as rag_service_mod
+
+    real_subdir = tmp_path / "a" / "b"
+    real_subdir.mkdir(parents=True)
+    real_db_path = tmp_path / "media.db"
+    from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+
+    db = MediaDatabase(db_path=str(real_db_path), client_id="test_traversal_guard")
+    db.close_connection()
+
+    calls = []
+    original_get_connection_pool = rag_service_mod.get_connection_pool
+
+    def _spy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_get_connection_pool(*args, **kwargs)
+
+    monkeypatch.setattr(rag_service_mod, "get_connection_pool", _spy)
+
+    # OS-resolvable traversal: a/b/../../media.db -> tmp_path/media.db,
+    # a real, valid MediaDatabase -- unlike an unresolvable nonsense path,
+    # this would actually be opened by pre-fix code.
+    malicious_path = str(real_subdir / ".." / ".." / "media.db")
+    assert "../.." in malicious_path, "test setup must produce a traversal string"
+
+    service = _make_service(tmp_path, media_db_path=malicious_path)
+    results = asyncio.run(service._keyword_search("anything", top_k=5))
+
+    assert results == []
+    assert calls == [], "get_connection_pool must never be reached for a rejected path"
+
+
+def test_symlinked_media_db_path_yields_empty_and_no_db_open(tmp_path):
+    """A `media_db_path` pointing at a symlink must never actually open a
+    database through it. `validate_path_simple` defers symlink authority to
+    the private SQLite owner (mirrors config.py's `_get_custom_database_
+    path`), so this is enforced by `MediaDatabase` -> `connect_private_
+    sqlite`'s no-follow open. Proven end to end: the symlink target is a
+    REAL, searchable MediaDatabase with a matching row, so if the no-follow
+    guard ever regressed this test would see that row come back instead
+    of []."""
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    real_target = outside_dir / "real_media.db"
+
+    from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+
+    db = MediaDatabase(db_path=str(real_target), client_id="test_symlink_guard")
+    media_id, _, message = db.add_media_with_keywords(
+        title="Symlink Bait",
+        content="This row must never be reachable through a symlinked media_db_path.",
+        media_type="article",
+        author="Tester",
+        url="https://example.com/symlink-bait",
+    )
+    assert media_id is not None, f"seed failed: {message}"
+    db.close_connection()
+
+    symlink_path = tmp_path / "media_via_symlink.db"
+    symlink_path.symlink_to(real_target)
+
+    service = _make_service(tmp_path, media_db_path=symlink_path)
+    results = asyncio.run(service._keyword_search("Bait", top_k=5))
+    assert results == []
+
+
 def test_keyword_rows_carry_media_source_type(tmp_path):
     db_path = tmp_path / "tldw_cli_media_v2.db"
     # Create a real MediaDatabase and insert one item via its public API

--- a/Tests/RAG_Search/test_keyword_leg_db_resolution.py
+++ b/Tests/RAG_Search/test_keyword_leg_db_resolution.py
@@ -68,3 +68,91 @@ def test_default_resolution_uses_get_media_db_path(monkeypatch, tmp_path):
     results = asyncio.run(service._keyword_search("anything", top_k=5))
     assert results == []                                   # sentinel absent
     assert not sentinel.exists()                           # still no writes
+
+
+def test_keyword_search_orders_strongest_match_first(tmp_path):
+    """FTS5's hidden `rank` column is smaller-is-better (more negative =
+    stronger match). Review finding on this task's PR: `_perform_fts5_search`
+    selected `-rank as rank` and then `ORDER BY rank` -- ordering ASCENDING
+    on the NEGATED alias, which is worst-match-first. That bug was invisible
+    while the leg always returned [] (pre-fix), but is now live and actively
+    selects the worst matches, including when a small `top_k` truncates the
+    (already over-fetched, wrongly-ordered) row list -- silently dropping the
+    single best match in favor of noise.
+
+    Seeds three real media rows with deliberately lopsided relevance for the
+    same query term: a short document saturated with the term (strong), a
+    medium document mentioning it once amid modest filler (medium), and a
+    long document mentioning it exactly once buried in heavy filler (weak,
+    penalized hard by bm25's document-length normalization).
+    """
+    from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+
+    db_path = tmp_path / "tldw_cli_media_v2.db"
+    db = MediaDatabase(db_path=str(db_path), client_id="test_keyword_leg_rank")
+
+    strong_id, _, msg = db.add_media_with_keywords(
+        title="platypus platypus platypus field study",
+        content=(
+            ("platypus " * 40)
+            + "Extensive notes on platypus behavior, platypus colonies, "
+            "and platypus diet in the wild."
+        ),
+        media_type="article",
+        author="A. Strong",
+        url="https://example.com/strong-platypus",
+    )
+    assert strong_id is not None, f"seed failed: {msg}"
+
+    medium_id, _, msg = db.add_media_with_keywords(
+        title="Field Notes",
+        content=(
+            ("Several unrelated observations were logged today. " * 5)
+            + "A single platypus was spotted near the creek bank. "
+            + ("Weather conditions remained mild throughout. " * 5)
+        ),
+        media_type="article",
+        author="B. Medium",
+        url="https://example.com/medium-platypus",
+    )
+    assert medium_id is not None, f"seed failed: {msg}"
+
+    weak_id, _, msg = db.add_media_with_keywords(
+        title="Annual Wildlife Survey Report",
+        content=(
+            (
+                "This section of the report covers general survey "
+                "methodology and background unrelated to any single "
+                "species observation. "
+                * 60
+            )
+            + "A platypus was mentioned once in passing near the end of "
+            "this very long report."
+        ),
+        media_type="article",
+        author="C. Weak",
+        url="https://example.com/weak-platypus",
+    )
+    assert weak_id is not None, f"seed failed: {msg}"
+    db.close_connection()
+
+    service = _make_service(tmp_path, media_db_path=db_path)
+
+    # Full result set: strongest match must be FIRST, not last.
+    results = asyncio.run(service._keyword_search("platypus", top_k=5))
+    ids = [r.metadata["doc_id"] for r in results]
+    assert ids and ids[0] == str(strong_id), (
+        f"expected strongest match ({strong_id}) first, got order {ids}"
+    )
+
+    # Small top_k: the single best match must survive truncation, not be
+    # silently dropped in favor of the weak match.
+    top2 = asyncio.run(service._keyword_search("platypus", top_k=2))
+    top2_ids = {r.metadata["doc_id"] for r in top2}
+    assert str(strong_id) in top2_ids, (
+        f"strongest match ({strong_id}) dropped from top_k=2 results: {top2_ids}"
+    )
+    assert str(weak_id) not in top2_ids, (
+        f"weak match ({weak_id}) preferentially kept over a stronger match "
+        f"under top_k=2: {top2_ids}"
+    )

--- a/Tests/RAG_Search/test_keyword_leg_db_resolution.py
+++ b/Tests/RAG_Search/test_keyword_leg_db_resolution.py
@@ -1,0 +1,70 @@
+"""The keyword leg must use the configured media DB and never write.
+
+Today it guesses paths (media_db.db / chacha_notes.db) that can never match
+the real tldw_cli_media_v2.db, opens the ChaChaNotes DB with media-schema
+SQL, and on a total miss CREATES a MediaDatabase as a search side effect.
+"""
+import asyncio
+from pathlib import Path
+import pytest
+
+from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+from tldw_chatbook.RAG_Search.simplified.rag_service import RAGService
+
+
+def _make_service(tmp_path, media_db_path=None):
+    """Build a RAGService with the in-memory vector store and mock (offline,
+    deterministic) embeddings backend -- same pattern as
+    Tests/RAG/test_ingestion_indexing.py's `_make_real_service`.
+    """
+    cfg = RAGConfig()
+    cfg.embedding.model = "mock"
+    cfg.embedding.device = "cpu"
+    cfg.vector_store.type = "memory"
+    cfg.vector_store.persist_directory = None
+    cfg.chunking.chunk_size = 60
+    cfg.chunking.chunk_overlap = 10
+    cfg.search.enable_cache = False
+    if media_db_path is not None:
+        cfg.search.media_db_path = Path(media_db_path)
+    return RAGService(cfg)
+
+
+def test_missing_media_db_returns_empty_and_creates_nothing(tmp_path):
+    service = _make_service(tmp_path, media_db_path=tmp_path / "absent.db")
+    results = asyncio.run(service._keyword_search("anything", top_k=5))
+    assert results == []
+    assert not (tmp_path / "absent.db").exists()          # no create-on-miss
+    assert list(tmp_path.glob("*.db")) == []              # no rogue DB anywhere
+
+
+def test_keyword_rows_carry_media_source_type(tmp_path):
+    db_path = tmp_path / "tldw_cli_media_v2.db"
+    # Create a real MediaDatabase and insert one item via its public API
+    # (add_media_with_keywords) so media_fts is populated by triggers.
+    from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+    db = MediaDatabase(db_path=str(db_path), client_id="test_keyword_leg")
+    media_id, media_uuid, message = db.add_media_with_keywords(
+        title="Wombat Field Notes",
+        content="Field notes mentioning wombat behavior in the wild.",
+        media_type="article",
+        author="J. Naturalist",
+        url="https://example.com/wombat-field-notes",
+    )
+    assert media_id is not None, f"seed failed: {message}"
+    db.close_connection()
+
+    service = _make_service(tmp_path, media_db_path=db_path)
+    results = asyncio.run(service._keyword_search("wombat", top_k=5))
+    assert results, "FTS row expected"
+    assert results[0].metadata["source_type"] == "media"
+
+
+def test_default_resolution_uses_get_media_db_path(monkeypatch, tmp_path):
+    sentinel = tmp_path / "sentinel_media.db"
+    import tldw_chatbook.config as cfg
+    monkeypatch.setattr(cfg, "get_media_db_path", lambda **kw: sentinel)
+    service = _make_service(tmp_path)  # no explicit path configured
+    results = asyncio.run(service._keyword_search("anything", top_k=5))
+    assert results == []                                   # sentinel absent
+    assert not sentinel.exists()                           # still no writes

--- a/Tests/RAG_Search/test_reranker_construction.py
+++ b/Tests/RAG_Search/test_reranker_construction.py
@@ -1,0 +1,129 @@
+"""Reranking profiles must construct and must never fail a search.
+
+V2 called create_reranker(strategy=X, **config.__dict__) -- the dict also
+contains 'strategy', so EVERY reranking profile raised TypeError at
+construction; Hybrid Full additionally requested the unimplemented
+'cross_encoder' strategy. Reranking has never executed on any profile.
+"""
+
+import asyncio
+
+import pytest
+
+from tldw_chatbook.RAG_Search.reranker import RerankingConfig, create_reranker_from_config
+from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig, get_profile_manager
+from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+from tldw_chatbook.RAG_Search.simplified.enhanced_rag_service_v2 import EnhancedRAGServiceV2
+
+
+def test_create_reranker_from_config_does_not_double_pass_strategy():
+    cfg = RerankingConfig(strategy="pointwise", top_k_to_rerank=5)
+    reranker = create_reranker_from_config(cfg)
+    assert reranker.config.strategy == "pointwise"
+
+
+def test_every_builtin_profile_reranking_config_constructs(tmp_path):
+    # get_profile_manager(profiles_dir=...) always returns a FRESH manager
+    # over that directory (never the cached singleton) -- the documented
+    # isolation seam. tmp_path is empty, so list_profiles() is exactly the
+    # built-in set; ``read_only`` marks a profile as a built-in seed (every
+    # profile registered in _load_builtin_profiles sets it True; no custom
+    # profile is ever loaded from an empty directory).
+    manager = get_profile_manager(profiles_dir=tmp_path)
+    builtin_profiles = [
+        manager.get_profile(name)
+        for name in manager.list_profiles()
+        if manager.get_profile(name) and manager.get_profile(name).read_only
+    ]
+    assert builtin_profiles, "expected at least one built-in profile"
+
+    for profile in builtin_profiles:
+        rc = getattr(profile, "reranking_config", None)
+        if rc is not None:
+            create_reranker_from_config(rc)  # must not raise
+
+
+def _make_v2_service_with_reranking(tmp_path):
+    """EnhancedRAGServiceV2 with mock embeddings, in-memory store, and a
+    real (pointwise) reranking config -- mirrors the mock-embeddings pattern
+    used by Tests/RAG/test_ingestion_indexing.py's `_make_real_service`, but
+    routed through a saved profile + the *profile name* (str) construction
+    path so `self.reranking_config` (and thus `self.reranker`) actually gets
+    populated.
+
+    Deliberately NOT `config=<ProfileConfig instance>` (the `elif isinstance
+    (config, ProfileConfig)` branch in `EnhancedRAGServiceV2.__init__`):
+    that branch reassigns the local `config` variable to `config.rag_config`
+    and then reads `config.reranking_config` off of THAT (a plain
+    `RAGConfig`, which has no such attribute) instead of off the original
+    profile -- an unconditional `AttributeError` on every call, unrelated to
+    the double-`strategy` TypeError this task fixes and out of this task's
+    scoped files. Filed as a follow-up rather than silently expanded into
+    this change. The `isinstance(config, str)` branch this test uses instead
+    reads `profile.reranking_config` correctly.
+    """
+    manager = get_profile_manager(profiles_dir=tmp_path)
+
+    rag_cfg = RAGConfig()
+    rag_cfg.embedding.model = "mock"  # deterministic bag-of-words backend, offline
+    rag_cfg.embedding.device = "cpu"
+    rag_cfg.vector_store.type = "memory"
+    rag_cfg.vector_store.persist_directory = None
+    rag_cfg.chunking.chunk_size = 60
+    rag_cfg.chunking.chunk_overlap = 10
+    rag_cfg.search.enable_cache = False
+
+    profile = ProfileConfig(
+        name="test_rerank_profile",
+        description="test profile with reranking enabled",
+        profile_type="balanced",
+        rag_config=rag_cfg,
+        reranking_config=RerankingConfig(strategy="pointwise", top_k_to_rerank=5),
+    )
+    manager.save_profile(profile)
+
+    return EnhancedRAGServiceV2(
+        config=profile.id,
+        profile_manager=manager,
+        enable_parent_retrieval=False,
+        enable_reranking=True,
+        enable_parallel_processing=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_raising_reranker_degrades_to_unreranked_results(tmp_path):
+    service = _make_v2_service_with_reranking(tmp_path)
+    assert service.reranker is not None, "reranker must construct for this profile"
+
+    await service.index_batch_optimized(
+        [
+            {
+                "id": "doc-1",
+                "content": "The quokka is a small marsupial found on Rottnest Island.",
+                "title": "Quokka Facts",
+            },
+            {
+                "id": "doc-2",
+                "content": "Platypuses are egg-laying mammals native to eastern Australia.",
+                "title": "Platypus Facts",
+            },
+        ]
+    )
+
+    async def _raise(*args, **kwargs):
+        raise RuntimeError("boom: reranker backend unavailable")
+
+    service.reranker.rerank = _raise
+
+    results = await service.search(
+        "quokka marsupial",
+        top_k=5,
+        search_type="semantic",
+        include_citations=False,
+    )
+
+    assert results, "base (unreranked) results must still come back"
+    assert results[0].metadata.get("reranking_skipped"), (
+        "first result must be tagged to disclose that reranking was skipped"
+    )

--- a/Tests/RAG_Search/test_reranker_construction.py
+++ b/Tests/RAG_Search/test_reranker_construction.py
@@ -4,6 +4,17 @@ V2 called create_reranker(strategy=X, **config.__dict__) -- the dict also
 contains 'strategy', so EVERY reranking profile raised TypeError at
 construction; Hybrid Full additionally requested the unimplemented
 'cross_encoder' strategy. Reranking has never executed on any profile.
+
+Two further construction-seam bugs found while writing the above (both
+fixed here too, task-3170 P0):
+  - EnhancedRAGServiceV2.__init__'s `elif isinstance(config, ProfileConfig)`
+    branch read `config.reranking_config` AFTER reassigning `config =
+    config.rag_config`, raising AttributeError unconditionally on every
+    from_profile()/create_rag_from_profile() call.
+  - rag_factory.create_rag_service() -- the app's real RAG-service entry
+    point -- computed `enable_reranking` from the profile but passed a bare
+    RAGConfig into the constructor, which forces `reranking_config = None`
+    regardless of that flag, so no reranker ever built in production.
 """
 
 import asyncio
@@ -49,18 +60,10 @@ def _make_v2_service_with_reranking(tmp_path):
     used by Tests/RAG/test_ingestion_indexing.py's `_make_real_service`, but
     routed through a saved profile + the *profile name* (str) construction
     path so `self.reranking_config` (and thus `self.reranker`) actually gets
-    populated.
-
-    Deliberately NOT `config=<ProfileConfig instance>` (the `elif isinstance
-    (config, ProfileConfig)` branch in `EnhancedRAGServiceV2.__init__`):
-    that branch reassigns the local `config` variable to `config.rag_config`
-    and then reads `config.reranking_config` off of THAT (a plain
-    `RAGConfig`, which has no such attribute) instead of off the original
-    profile -- an unconditional `AttributeError` on every call, unrelated to
-    the double-`strategy` TypeError this task fixes and out of this task's
-    scoped files. Filed as a follow-up rather than silently expanded into
-    this change. The `isinstance(config, str)` branch this test uses instead
-    reads `profile.reranking_config` correctly.
+    populated. (The `elif isinstance(config, ProfileConfig)` branch used to
+    be unconditionally broken here -- see
+    `test_from_profile_construction_path_populates_reranker` below, which now
+    covers that path directly since it was fixed.)
     """
     manager = get_profile_manager(profiles_dir=tmp_path)
 
@@ -127,3 +130,95 @@ async def test_raising_reranker_degrades_to_unreranked_results(tmp_path):
     assert results[0].metadata.get("reranking_skipped"), (
         "first result must be tagged to disclose that reranking was skipped"
     )
+
+
+def test_from_profile_construction_path_populates_reranker(tmp_path):
+    """The `elif isinstance(config, ProfileConfig)` branch in
+    `EnhancedRAGServiceV2.__init__` -- the path `from_profile()` /
+    `create_rag_from_profile()` use -- used to reassign the local `config`
+    variable to `config.rag_config` and then read `config.reranking_config`
+    off of THAT (a plain `RAGConfig`, which has no such attribute), instead
+    of off the original profile. That raised `AttributeError` unconditionally
+    on every call through this path, for every profile, reranking or not.
+    Constructing directly with `config=<ProfileConfig instance>` (rather than
+    a profile name string) must now both succeed and actually populate
+    `self.reranker` when the profile has a reranking_config.
+    """
+    manager = get_profile_manager(profiles_dir=tmp_path)
+
+    rag_cfg = RAGConfig()
+    rag_cfg.embedding.model = "mock"
+    rag_cfg.embedding.device = "cpu"
+    rag_cfg.vector_store.type = "memory"
+    rag_cfg.vector_store.persist_directory = None
+    rag_cfg.chunking.chunk_size = 60
+    rag_cfg.chunking.chunk_overlap = 10
+    rag_cfg.search.enable_cache = False
+
+    profile = ProfileConfig(
+        name="from_profile_rerank_test",
+        description="test profile with reranking enabled",
+        profile_type="balanced",
+        rag_config=rag_cfg,
+        reranking_config=RerankingConfig(strategy="pointwise", top_k_to_rerank=5),
+    )
+
+    service = EnhancedRAGServiceV2(
+        config=profile,  # a ProfileConfig instance, not a name string
+        profile_manager=manager,
+        enable_parent_retrieval=False,
+        enable_reranking=True,
+        enable_parallel_processing=False,
+    )
+
+    assert service.reranker is not None
+    assert service.reranking_config is profile.reranking_config
+
+
+def test_create_rag_service_threads_reranking_config_for_hybrid_full():
+    """The app's real RAG-service entry point (`search_service.py` ->
+    `rag_factory.create_rag_service()`) computed `enable_reranking =
+    profile.reranking_config is not None` but passed a bare `RAGConfig` into
+    `EnhancedRAGServiceV2` -- which forces `self.reranking_config = None`
+    unconditionally in the constructor's `else` branch, regardless of the
+    `enable_reranking` flag. So no reranker EVER constructed via this
+    factory in production, for any profile, even after the reranker.py
+    factory-seam fix. `create_rag_service` must thread the profile's actual
+    `reranking_config` through so a reranker actually gets built.
+    """
+    from tldw_chatbook.RAG_Search.simplified.rag_factory import create_rag_service
+
+    mock_cfg = RAGConfig()
+    mock_cfg.embedding.model = "mock"
+    mock_cfg.embedding.device = "cpu"
+    mock_cfg.vector_store.type = "memory"
+    mock_cfg.vector_store.persist_directory = None
+    mock_cfg.chunking.chunk_size = 5
+    mock_cfg.chunking.chunk_overlap = 1
+    mock_cfg.search.enable_cache = False
+
+    service = create_rag_service(profile_name="hybrid_full", config=mock_cfg)
+
+    assert service.enable_reranking is True
+    assert service.reranker is not None
+
+
+def test_create_rag_service_no_reranker_for_profile_without_reranking_config():
+    """Counterpart to the hybrid_full test: a profile with no
+    reranking_config (hybrid_basic) must NOT get a reranker -- confirms the
+    fix threads the profile's actual config through rather than switching
+    reranking on unconditionally."""
+    from tldw_chatbook.RAG_Search.simplified.rag_factory import create_rag_service
+
+    mock_cfg = RAGConfig()
+    mock_cfg.embedding.model = "mock"
+    mock_cfg.embedding.device = "cpu"
+    mock_cfg.vector_store.type = "memory"
+    mock_cfg.vector_store.persist_directory = None
+    mock_cfg.chunking.chunk_size = 60
+    mock_cfg.chunking.chunk_overlap = 10
+    mock_cfg.search.enable_cache = False
+
+    service = create_rag_service(profile_name="hybrid_basic", config=mock_cfg)
+
+    assert service.reranker is None

--- a/Tests/RAG_Search/test_reranker_construction.py
+++ b/Tests/RAG_Search/test_reranker_construction.py
@@ -429,3 +429,101 @@ async def test_listwise_reranker_counts_total_failure():
     assert [r.id for r in reranked] == ["a", "b"]
     assert reranker.last_rerank_failures == 2
     assert reranker.last_rerank_total == 2
+
+
+def test_reranked_rows_carry_a_detectable_marker_and_never_band_as_similarity():
+    """(Task 6, coordinator follow-up) What does a REAL reranked row carry?
+
+    `PointwiseReranker._apply_scores` is the only reranking path that
+    replaces a row's score: it writes `final_score` (by default a weighted
+    blend of the original similarity and the LLM's relevance score) and
+    stamps `metadata["rerank_score"]`. That stamp is the production marker
+    -- `_final_score_kind` is READ by `local_citation_capture` but written
+    by nothing in the app.
+
+    The load-bearing consequence: `RerankingConfig.score_scale` defaults to
+    (0.0, 1.0), so a default-configured pointwise reranker emits scores
+    that sit INSIDE the similarity band range and would silently render as
+    "match: strong" -- a cosine claim about a number that is not a cosine.
+    This pins the whole path: real reranker output -> Library row -> title
+    suffix.
+    """
+    from tldw_chatbook.Library.library_rag_state import (
+        LibraryRagResultRow,
+        library_rag_score_suffix,
+    )
+    from tldw_chatbook.RAG_Search.reranker import PointwiseReranker, RerankingResult
+    from tldw_chatbook.RAG_Search.simplified.vector_store import SearchResult
+
+    reranker = PointwiseReranker(RerankingConfig())
+    original = SearchResult(
+        id="media-42", score=0.83, document="body", metadata={"source_type": "media"}
+    )
+    reranked = reranker._apply_scores(
+        [original],
+        [
+            RerankingResult(
+                original_rank=0, new_rank=0, original_score=0.83, rerank_score=0.95
+            )
+        ],
+    )[0]
+
+    # The marker the real producer writes, and a score that would otherwise
+    # band "strong" on cosine thresholds.
+    assert "rerank_score" in reranked.metadata
+    assert reranked.score >= 0.5
+
+    row = LibraryRagResultRow.from_result(
+        {
+            "title": "Incident Review",
+            "source_id": reranked.id,
+            "score": reranked.score,
+            "provenance": dict(reranked.metadata),
+        }
+    )
+    assert row.score_kind == "reranker"
+    suffix = library_rag_score_suffix(
+        row.score, score_kind=row.score_kind, vector_score=row.vector_score
+    )
+    assert suffix == " | reranked"
+    assert "match:" not in suffix
+
+
+def test_reorder_only_reranking_leaves_a_real_similarity_bandable():
+    """The converse, and why the pairwise/listwise strategies need no marker:
+    both REORDER results and never touch `score` or `metadata`, so those
+    rows still carry the retrieval similarity they came in with. Suppressing
+    their band would throw away a true number, so the marker must be
+    "the score was replaced" (`rerank_score`), not "reranking ran".
+    """
+    import inspect
+
+    from tldw_chatbook.Library.library_rag_state import (
+        LibraryRagResultRow,
+        library_rag_score_suffix,
+    )
+
+    for reranker_cls in (PairwiseReranker, ListwiseReranker):
+        source = inspect.getsource(reranker_cls)
+        assert "rerank_score" not in source, (
+            f"{reranker_cls.__name__} now writes scores -- its rows must be "
+            "detected as reranker-kind too"
+        )
+
+    untouched = LibraryRagResultRow.from_result(
+        {
+            "title": "Incident Review",
+            "source_id": "media-42",
+            "score": 0.83,
+            "provenance": {"source_type": "media"},
+        }
+    )
+    assert untouched.score_kind == "vector_similarity"
+    assert (
+        library_rag_score_suffix(
+            untouched.score,
+            score_kind=untouched.score_kind,
+            vector_score=untouched.vector_score,
+        )
+        == " | match: strong"
+    )

--- a/Tests/RAG_Search/test_reranker_construction.py
+++ b/Tests/RAG_Search/test_reranker_construction.py
@@ -15,16 +15,38 @@ fixed here too, task-3170 P0):
     point -- computed `enable_reranking` from the profile but passed a bare
     RAGConfig into the constructor, which forces `reranking_config = None`
     regardless of that flag, so no reranker ever built in production.
+
+Two more review findings on this same task, both fixed here (task-3170 P0):
+  - The `reranking_skipped` tag was written via `results[0].metadata[...] =
+    ...`, an IN-PLACE mutation. RAGService.search()'s cache stores/returns
+    SearchResult objects by reference, so this permanently poisoned the
+    cached entry for up to cache_ttl seconds regardless of what a later
+    search for the same query did. Fixed by tagging a COPY of the first
+    result (`_tag_first_result` in enhanced_rag_service_v2.py) instead.
+  - The dominant real LLM-reranking failure mode is silent, not an
+    exception: PointwiseReranker swallows each per-result scoring failure
+    and keeps the original score, so a total-failure rerank() call (e.g.
+    every provider call failing under a missing credential) returns
+    NORMALLY with an unchanged ordering and the reranking_skipped tag never
+    fires. Fixed by having every reranker count per-result/per-comparison
+    scoring failures (BaseReranker.last_rerank_failures/last_rerank_total)
+    and tagging `reranking_degraded` when nonzero.
 """
 
 import asyncio
 
 import pytest
 
-from tldw_chatbook.RAG_Search.reranker import RerankingConfig, create_reranker_from_config
+from tldw_chatbook.RAG_Search.reranker import (
+    ListwiseReranker,
+    PairwiseReranker,
+    RerankingConfig,
+    create_reranker_from_config,
+)
 from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig, get_profile_manager
 from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
 from tldw_chatbook.RAG_Search.simplified.enhanced_rag_service_v2 import EnhancedRAGServiceV2
+from tldw_chatbook.RAG_Search.simplified.vector_store import SearchResult
 
 
 def test_create_reranker_from_config_does_not_double_pass_strategy():
@@ -54,7 +76,7 @@ def test_every_builtin_profile_reranking_config_constructs(tmp_path):
             create_reranker_from_config(rc)  # must not raise
 
 
-def _make_v2_service_with_reranking(tmp_path):
+def _make_v2_service_with_reranking(tmp_path, enable_cache=False):
     """EnhancedRAGServiceV2 with mock embeddings, in-memory store, and a
     real (pointwise) reranking config -- mirrors the mock-embeddings pattern
     used by Tests/RAG/test_ingestion_indexing.py's `_make_real_service`, but
@@ -64,6 +86,10 @@ def _make_v2_service_with_reranking(tmp_path):
     be unconditionally broken here -- see
     `test_from_profile_construction_path_populates_reranker` below, which now
     covers that path directly since it was fixed.)
+
+    `enable_cache` defaults to False for the tests that don't care about
+    caching; the cache-poisoning regression tests below pass True since the
+    base search cache is exactly what let a mutated tag leak across queries.
     """
     manager = get_profile_manager(profiles_dir=tmp_path)
 
@@ -74,10 +100,10 @@ def _make_v2_service_with_reranking(tmp_path):
     rag_cfg.vector_store.persist_directory = None
     rag_cfg.chunking.chunk_size = 60
     rag_cfg.chunking.chunk_overlap = 10
-    rag_cfg.search.enable_cache = False
+    rag_cfg.search.enable_cache = enable_cache
 
     profile = ProfileConfig(
-        name="test_rerank_profile",
+        name=f"test_rerank_profile_cache_{enable_cache}",
         description="test profile with reranking enabled",
         profile_type="balanced",
         rag_config=rag_cfg,
@@ -222,3 +248,184 @@ def test_create_rag_service_no_reranker_for_profile_without_reranking_config():
     service = create_rag_service(profile_name="hybrid_basic", config=mock_cfg)
 
     assert service.reranker is None
+
+
+def _quokka_platypus_docs():
+    return [
+        {
+            "id": "doc-1",
+            "content": "The quokka is a small marsupial found on Rottnest Island.",
+            "title": "Quokka Facts",
+        },
+        {
+            "id": "doc-2",
+            "content": "Platypuses are egg-laying mammals native to eastern Australia.",
+            "title": "Platypus Facts",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reranking_skipped_tag_does_not_poison_the_cache(tmp_path):
+    """Review finding on this task (task-3170 P0): RAGService.search()'s
+    base-layer cache stores and returns SearchResult objects BY REFERENCE
+    (rag_service.py's cache.get_async/put_async), not by copy. The old
+    `results[0].metadata["reranking_skipped"] = str(exc)` in-place mutation
+    therefore mutated the exact object sitting in the cache -- poisoning it
+    for up to cache_ttl seconds (3600s default), regardless of what a LATER
+    search for the same query does. Reproduces the reviewer's probe with
+    cache ON: search once with a raising reranker (tags "boom"), then search
+    the identical query again with reranking explicitly off -- the second
+    call must NOT see the first call's tag."""
+    service = _make_v2_service_with_reranking(tmp_path, enable_cache=True)
+    assert service.reranker is not None
+
+    await service.index_batch_optimized(_quokka_platypus_docs())
+
+    query = "quokka marsupial"
+
+    async def _raise(*args, **kwargs):
+        raise RuntimeError("boom: reranker backend unavailable")
+
+    service.reranker.rerank = _raise
+
+    results1 = await service.search(
+        query, top_k=5, search_type="semantic", include_citations=False
+    )
+    assert results1[0].metadata.get("reranking_skipped"), (
+        "sanity check: the first search must still be tagged"
+    )
+
+    # Same query -- base search cache (enable_cache=True) now serves from
+    # cache. Reranking explicitly OFF this time: if the first result object
+    # had been mutated in place rather than copied, the stale tag would
+    # still be sitting on it even though no reranking was attempted here.
+    results2 = await service.search(
+        query,
+        top_k=5,
+        search_type="semantic",
+        include_citations=False,
+        rerank=False,
+    )
+    assert not results2[0].metadata.get("reranking_skipped"), (
+        "stale reranking_skipped tag leaked forward via a cached SearchResult "
+        "object mutated in place by a previous failed rerank attempt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reranking_degraded_tag_when_scoring_silently_fails_for_every_result(
+    tmp_path,
+):
+    """Review finding on this task (task-3170 P0): the dominant real
+    LLM-reranking failure mode is SILENT, not an exception.
+    PointwiseReranker.rerank() catches per-result scoring failures
+    internally and keeps the original score, so a total-failure run (e.g.
+    every provider call failing under a missing credential) returns
+    NORMALLY with an unchanged ordering -- indistinguishable from "nothing
+    needed reranking" without an explicit disclosure. Asserts (a) ordering
+    unchanged, (b) `reranking_degraded` tag present, (c) tag absent on a
+    later clean (reranking-off) search with cache on -- same
+    copy-not-mutate rule as the reranking_skipped test above."""
+    service = _make_v2_service_with_reranking(tmp_path, enable_cache=True)
+    assert service.reranker is not None
+
+    await service.index_batch_optimized(_quokka_platypus_docs())
+
+    query = "quokka marsupial"
+
+    # Baseline: reranking off, primes the base-layer cache with the
+    # PRE-rerank ordering.
+    baseline = await service.search(
+        query,
+        top_k=5,
+        search_type="semantic",
+        include_citations=False,
+        rerank=False,
+    )
+    baseline_order = [r.id for r in baseline]
+    assert len(baseline_order) == 2
+
+    async def _always_fail_scoring(query, result, original_rank):
+        raise ValueError("No API key found for provider: openai")
+
+    service.reranker._score_result = _always_fail_scoring
+
+    # Same query -- base layer serves from cache; reranking is attempted
+    # (enabled by default on this service) and returns NORMALLY (no
+    # exception raised out of rerank()) but every per-result scoring call
+    # failed.
+    results1 = await service.search(
+        query, top_k=5, search_type="semantic", include_citations=False
+    )
+
+    assert [r.id for r in results1] == baseline_order, (
+        "ordering must be unchanged when every per-result scoring attempt fails"
+    )
+    assert results1[0].metadata.get("reranking_degraded") == "2/2 scorings failed"
+
+    # Same query again, reranking explicitly OFF: the cached SearchResult
+    # objects must be untouched by the degraded tag from the previous call.
+    results2 = await service.search(
+        query,
+        top_k=5,
+        search_type="semantic",
+        include_citations=False,
+        rerank=False,
+    )
+    assert not results2[0].metadata.get("reranking_degraded"), (
+        "stale reranking_degraded tag leaked forward via a cached SearchResult "
+        "object mutated in place by a previous degraded rerank attempt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pairwise_reranker_counts_failed_comparisons():
+    """The shared BaseReranker seam (last_rerank_failures/last_rerank_total)
+    must actually work for PairwiseReranker too, not just Pointwise -- it's
+    comparison-based rather than per-result, so a "failure" is a comparison
+    whose LLM call raised and fell back to comparing original scores."""
+    cfg = RerankingConfig(strategy="pairwise", top_k_to_rerank=5)
+    reranker = PairwiseReranker(cfg)
+
+    async def _always_raise(prompt, system_prompt=None):
+        raise ValueError("No API key found for provider: openai")
+
+    reranker._call_llm = _always_raise
+
+    results = [
+        SearchResult(id="a", score=0.9, document="doc a", metadata={}),
+        SearchResult(id="b", score=0.5, document="doc b", metadata={}),
+        SearchResult(id="c", score=0.2, document="doc c", metadata={}),
+    ]
+
+    reranked = await reranker.rerank("query", results)
+
+    assert len(reranked) == 3
+    assert reranker.last_rerank_total > 0
+    assert reranker.last_rerank_failures == reranker.last_rerank_total
+
+
+@pytest.mark.asyncio
+async def test_listwise_reranker_counts_total_failure():
+    """Same shared-seam check as the pairwise test, for ListwiseReranker --
+    a single LLM call covers the whole batch, so a failure there means
+    ALL of results_to_rerank failed, not a per-item count."""
+    cfg = RerankingConfig(strategy="listwise", top_k_to_rerank=5)
+    reranker = ListwiseReranker(cfg)
+
+    async def _always_raise(prompt, system_prompt=None):
+        raise ValueError("No API key found for provider: openai")
+
+    reranker._call_llm = _always_raise
+
+    results = [
+        SearchResult(id="a", score=0.9, document="doc a", metadata={}),
+        SearchResult(id="b", score=0.5, document="doc b", metadata={}),
+    ]
+
+    reranked = await reranker.rerank("query", results)
+
+    assert [r.id for r in reranked] == ["a", "b"]
+    assert reranker.last_rerank_failures == 2
+    assert reranker.last_rerank_total == 2

--- a/Tests/UI/test_console_auto_rag_on_send.py
+++ b/Tests/UI/test_console_auto_rag_on_send.py
@@ -357,6 +357,49 @@ def test_profile_top_k_reads_the_active_rag_config(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_in_flight_placeholder_is_staged_while_retrieval_runs(monkeypatch):
+    """The strip must show "Retrieving..." for the WHOLE retrieval window.
+
+    Review finding: every other assertion about the placeholder is a
+    *clear* assertion (`... is None` afterwards), which stays true when the
+    placeholder is never staged at all -- so deleting the only in-flight
+    signal the user gets during the <=5s window left the whole suite green.
+    This observes the staged launch from INSIDE the retrieval call, which is
+    the only moment the claim is about.
+    """
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    screen = _auto_rag_screen()
+    observed: list = []
+
+    class _StagingObservingRagService:
+        async def search(self, query, source_types, mode, **kwargs):
+            observed.append(
+                (
+                    screen._pending_console_launch_context,
+                    screen._has_staged_console_evidence(),
+                )
+            )
+            return {"runtime_backend": "local-test", "results": list(_rows(2))}
+
+    screen.app_instance.library_rag_search_service = _StagingObservingRagService()
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert len(observed) == 1
+    in_flight, was_staged = observed[0]
+    assert in_flight is not None, "no in-flight staging while retrieval ran"
+    assert was_staged is True
+    assert in_flight.status == "searching"
+    assert in_flight.payload["query"] == "what changed in the notes"
+    assert in_flight.recovery == chat_screen_module.CONSOLE_AUTO_RAG_SEARCHING_COPY
+    # ...and the results replaced it rather than piling up a second card.
+    settled = screen._pending_console_launch_context
+    assert settled is not in_flight
+    assert settled.status == "staged"
+
+
+@pytest.mark.asyncio
 async def test_zero_results_never_leaves_a_blocking_launch_staged(monkeypatch):
     """An auto-retrieve that matched nothing must stage nothing.
 

--- a/Tests/UI/test_console_auto_rag_on_send.py
+++ b/Tests/UI/test_console_auto_rag_on_send.py
@@ -28,7 +28,7 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
 from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
-from tldw_chatbook.Chat.rag_scope import EffectiveScope, SCOPE_EMPTY_NOTICE_TEMPLATE
+from tldw_chatbook.Chat.rag_scope import EffectiveScope, scope_empty_notice
 from tldw_chatbook.config import save_setting_to_cli_config
 from tldw_chatbook.Event_Handlers.Chat_Events.chat_rag_events import (
     LocalRagContextResult,
@@ -303,7 +303,7 @@ async def test_empty_scope_short_circuits_with_shared_copy(monkeypatch):
     assert screen._pending_console_launch_context is None
     assert screen.notices == [
         (
-            SCOPE_EMPTY_NOTICE_TEMPLATE.format(cause="deleted-items"),
+            scope_empty_notice("deleted-items"),
             "warning",
         )
     ]

--- a/Tests/UI/test_console_auto_rag_on_send.py
+++ b/Tests/UI/test_console_auto_rag_on_send.py
@@ -1,0 +1,626 @@
+"""Console opt-in RAG auto-retrieve on send (TASK-406 / TASK-3170 task 8).
+
+The send path grows ONE new hook, ``ChatScreen._maybe_auto_retrieve_for_send``,
+called from the consume-on-send seam (``_capture_console_staged_rag``) so an
+auto-retrieved bundle is staged and consumed by the SAME send and renders in
+the staged-evidence strip exactly like a manual chip run.
+
+Every clause of the hook's gate is pinned by its own test here, in gate order:
+toggle -> plain-text send -> already-staged -> empty scope -> retrieval. The
+tests are deliberately split so a dropped clause reds exactly one of them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import MethodType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from textual.widgets import Static
+
+from Tests.UI.test_console_dictionary_send_integration import (
+    _CapturingGateway,
+    _final_user_content,
+)
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
+from tldw_chatbook.Chat.rag_scope import EffectiveScope, SCOPE_EMPTY_NOTICE_TEMPLATE
+from tldw_chatbook.config import save_setting_to_cli_config
+from tldw_chatbook.Event_Handlers.Chat_Events.chat_rag_events import (
+    LocalRagContextResult,
+)
+from tldw_chatbook.Library.library_rag_service import (
+    LibraryRagSearchOutcome,
+    RETRIEVAL_FAILED_WHY,
+)
+from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
+from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+STRIP_ID = "#console-staged-evidence-strip"
+
+#: Real ChatScreen methods bound onto the lightweight stand-in below. Every
+#: one is production code -- the stand-in supplies only state and the two
+#: surface-refresh seams a mounted screen would provide.
+_REAL_METHODS = (
+    "_maybe_auto_retrieve_for_send",
+    "_has_staged_console_evidence",
+    "_rag_service_still_initializing",
+    "_notify_console_auto_rag_scope_empty",
+    "_notify_auto_rag_degraded",
+    "_notify_console_auto_rag",
+    "_clear_console_auto_rag_placeholder",
+    "_stage_console_library_rag_launch",
+    "_apply_console_library_rag_search_outcome",
+    "_resolve_console_library_rag_scope",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_auto_retrieve_toggle():
+    """Leave the isolated config exactly as this suite found it.
+
+    The toggle is a persisted `[chat_defaults]` key; sibling suites
+    (`test_console_rag_settings_modal.py`) assert it reads False at rest, so
+    a test here that flips it on must not leak that across the session.
+    """
+    yield
+    save_setting_to_cli_config("chat_defaults", "rag_auto_retrieve_on_send", False)
+
+
+def _enable_auto_retrieve() -> None:
+    save_setting_to_cli_config("chat_defaults", "rag_auto_retrieve_on_send", True)
+
+
+class _RecordingRagService:
+    """Records each `search()` and returns preconfigured rows."""
+
+    def __init__(self, rows=(), *, delay: float = 0.0) -> None:
+        self.rows = tuple(rows)
+        self.delay = delay
+        self.calls: list[dict] = []
+
+    async def search(self, query, source_types, mode, **kwargs):
+        self.calls.append(
+            {
+                "query": query,
+                "source_types": tuple(source_types),
+                "mode": mode,
+                **kwargs,
+            }
+        )
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        return {"runtime_backend": "local-test", "results": list(self.rows)}
+
+
+def _rows(count: int) -> tuple[LibraryRagResultRow, ...]:
+    return tuple(
+        LibraryRagResultRow.from_result(
+            {
+                "source_id": f"media-{index}",
+                "chunk_id": f"chunk-{index}",
+                "title": f"Source {index}",
+                "content": f"Body {index}",
+                "score": 1.0 - index / 10,
+                "runtime_backend": "local",
+                "source_type": "media",
+            }
+        )
+        for index in range(1, count + 1)
+    )
+
+
+def _staged_launch() -> ConsoleLiveWorkLaunch:
+    return ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="Manually staged",
+        payload={"query": "manual", "evidence_bundle": {"bundle_id": "manual"}},
+        status="staged",
+    )
+
+
+def _auto_rag_screen(*, service=None, staged=None, has_pending: bool = False):
+    """A ChatScreen stand-in carrying the REAL auto-retrieve methods."""
+    notices: list[tuple[str, str]] = []
+
+    def _notify(message, severity="information", **_kwargs):
+        notices.append((str(message), severity))
+
+    app = SimpleNamespace(
+        library_rag_search_service=service,
+        pending_handoffs=SimpleNamespace(has_pending=lambda _channel: has_pending),
+        notify=_notify,
+        _rag_service=None,
+    )
+    screen = SimpleNamespace(
+        app_instance=app,
+        is_mounted=True,
+        notices=notices,
+        _pending_console_launch_context=staged,
+        _pending_console_launch_auto_open_inspector=False,
+        _console_evidence_sent_notice=None,
+        _console_library_rag_source_types=("media",),
+        _sync_console_pending_launch_surfaces=lambda: True,
+    )
+    for name in _REAL_METHODS:
+        setattr(screen, name, MethodType(getattr(ChatScreen, name), screen))
+    return screen
+
+
+def _patch_scope(monkeypatch, state: str = "unscoped", cause=None) -> None:
+    monkeypatch.setattr(
+        chat_screen_module,
+        "resolve_effective_scope_for_chat",
+        AsyncMock(
+            return_value=EffectiveScope(state=state, allowlist={}, cause=cause)
+        ),
+    )
+
+
+# --------------------------------------------------------------------------
+# Gate clause 1: the config toggle
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_toggle_off_means_no_retrieval_call(monkeypatch):
+    """Default OFF: not one retrieval call, not one staged launch."""
+    _patch_scope(monkeypatch)
+    service = _RecordingRagService(_rows(2))
+    screen = _auto_rag_screen(service=service)
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert service.calls == []
+    assert screen._pending_console_launch_context is None
+    assert screen.notices == []
+
+
+@pytest.mark.asyncio
+async def test_toggle_default_is_off_at_the_read_site(monkeypatch):
+    """Pin the code-level fallback, not just the shipped config value.
+
+    `[chat_defaults] rag_auto_retrieve_on_send = false` ships in the default
+    config, so the test above passes even if this read site's own default
+    were flipped to True -- the key is always present. A user config written
+    before this key existed has no such row, and for them the literal here
+    is the only thing standing between "off by default" and silent spend.
+    """
+    seen: dict[tuple[str, str], object] = {}
+
+    def _recording_get_cli_setting(section, key, default=None, **_kwargs):
+        seen[(section, key)] = default
+        return default
+
+    monkeypatch.setattr(
+        chat_screen_module, "get_cli_setting", _recording_get_cli_setting
+    )
+    _patch_scope(monkeypatch)
+    service = _RecordingRagService(_rows(2))
+    screen = _auto_rag_screen(service=service)
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert seen[("chat_defaults", "rag_auto_retrieve_on_send")] is False
+    assert service.calls == []
+
+
+# --------------------------------------------------------------------------
+# Gate clause 2: plain-text sends only
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("draft", ["/prompt summarize", "$research notes", "  /rewind"])
+async def test_slash_command_send_never_retrieves(monkeypatch, draft):
+    """Slash commands and `$skill` invocations are not questions to retrieve for."""
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    service = _RecordingRagService(_rows(2))
+    screen = _auto_rag_screen(service=service)
+
+    await screen._maybe_auto_retrieve_for_send(draft)
+
+    assert service.calls == []
+    assert screen._pending_console_launch_context is None
+
+
+@pytest.mark.asyncio
+async def test_plain_text_send_does_retrieve(monkeypatch):
+    """Control for the clause above: ordinary prose still retrieves."""
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    service = _RecordingRagService(_rows(2))
+    screen = _auto_rag_screen(service=service)
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert len(service.calls) == 1
+    assert service.calls[0]["query"] == "what changed in the notes"
+    assert service.calls[0]["mode"] == "rag"
+
+
+# --------------------------------------------------------------------------
+# Gate clause 3: manual staging always wins
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_already_staged_evidence_skips_auto_retrieve(monkeypatch):
+    """No double spend: an existing staged bundle is left exactly as it was."""
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    service = _RecordingRagService(_rows(2))
+    staged = _staged_launch()
+    screen = _auto_rag_screen(service=service, staged=staged)
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert service.calls == []
+    assert screen._pending_console_launch_context is staged
+
+
+@pytest.mark.asyncio
+async def test_unclaimed_handoff_also_counts_as_already_staged(monkeypatch):
+    """A handoff the very next consume will claim is staging too.
+
+    `_consume_pending_console_launch` claims an unclaimed CONSOLE_LIVE_WORK
+    entry on the same send, so retrieving here would spend a search whose
+    result the claim immediately supersedes.
+    """
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    service = _RecordingRagService(_rows(2))
+    screen = _auto_rag_screen(service=service, has_pending=True)
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert service.calls == []
+    assert screen._pending_console_launch_context is None
+
+
+# --------------------------------------------------------------------------
+# Gate clause 4: EMPTY scope short-circuit
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_scope_short_circuits_with_shared_copy(monkeypatch):
+    """An EMPTY effective scope never reaches the backend, and says so once."""
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch, state="empty", cause="deleted-items")
+    service = _RecordingRagService(_rows(2))
+    screen = _auto_rag_screen(service=service)
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert service.calls == []
+    assert screen._pending_console_launch_context is None
+    assert screen.notices == [
+        (
+            SCOPE_EMPTY_NOTICE_TEMPLATE.format(cause="deleted-items"),
+            "warning",
+        )
+    ]
+
+
+# --------------------------------------------------------------------------
+# The retrieval itself
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_is_length_capped_before_it_reaches_retrieval(monkeypatch):
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    service = _RecordingRagService(_rows(1))
+    screen = _auto_rag_screen(service=service)
+
+    await screen._maybe_auto_retrieve_for_send("a" * 9_000)
+
+    assert len(service.calls) == 1
+    assert len(service.calls[0]["query"]) == chat_screen_module.AUTO_RAG_QUERY_MAX_CHARS
+
+
+@pytest.mark.asyncio
+async def test_retrieval_requests_the_active_profile_top_k(monkeypatch):
+    """Not a hardcoded 5: the request carries the active profile's top_k."""
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    monkeypatch.setattr(
+        chat_screen_module, "_console_library_rag_profile_top_k", lambda: 7
+    )
+    service = _RecordingRagService(_rows(1))
+    screen = _auto_rag_screen(service=service)
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert service.calls[0]["top_k"] == 7
+
+
+def test_profile_top_k_reads_the_active_rag_config(monkeypatch):
+    """The helper's source of truth is the resolved active profile."""
+    from tldw_chatbook.RAG_Search.simplified import active_config
+
+    monkeypatch.setattr(
+        active_config,
+        "resolve_active_rag_config",
+        lambda: SimpleNamespace(search=SimpleNamespace(default_top_k=11)),
+    )
+
+    assert chat_screen_module._console_library_rag_profile_top_k() == 11
+
+
+@pytest.mark.asyncio
+async def test_zero_results_never_leaves_a_blocking_launch_staged(monkeypatch):
+    """An auto-retrieve that matched nothing must stage nothing.
+
+    `_console_send_blocked_reason` BLOCKS any send while a RAG-sourced
+    launch with zero available evidence is staged -- so staging the manual
+    run's "no results" card here would have made one empty auto-retrieve
+    lock the composer for every later send.
+    """
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    service = _RecordingRagService(())
+    screen = _auto_rag_screen(service=service)
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert len(service.calls) == 1
+    assert screen._pending_console_launch_context is None
+
+
+@pytest.mark.asyncio
+async def test_timeout_sends_without_evidence_and_notifies(monkeypatch):
+    """A slow backend never holds the send: quiet notice, nothing staged."""
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    monkeypatch.setattr(chat_screen_module, "AUTO_RAG_TIMEOUT_SECONDS", 0.01)
+    service = _RecordingRagService(_rows(2), delay=5.0)
+    screen = _auto_rag_screen(service=service)
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert screen._pending_console_launch_context is None
+    assert len(screen.notices) == 1
+    message, severity = screen.notices[0]
+    assert severity == "warning"
+    # No cached runtime on the app -> the timeout is first-run model load,
+    # and the copy must say so rather than blaming retrieval.
+    assert message == chat_screen_module.CONSOLE_AUTO_RAG_INITIALIZING_NOTICE
+
+
+@pytest.mark.asyncio
+async def test_timeout_with_a_live_runtime_reports_failure_not_initializing(
+    monkeypatch,
+):
+    """With a warm runtime the same timeout is an honest retrieval failure."""
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    monkeypatch.setattr(chat_screen_module, "AUTO_RAG_TIMEOUT_SECONDS", 0.01)
+    service = _RecordingRagService(_rows(2), delay=5.0)
+    screen = _auto_rag_screen(service=service)
+    screen.app_instance._rag_service = SimpleNamespace(search=lambda *a, **k: None)
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert screen.notices == [
+        (chat_screen_module.CONSOLE_AUTO_RAG_FAILED_NOTICE, "warning")
+    ]
+    assert RETRIEVAL_FAILED_WHY in chat_screen_module.CONSOLE_AUTO_RAG_FAILED_NOTICE
+
+
+@pytest.mark.asyncio
+async def test_retrieval_exception_sends_without_evidence(monkeypatch):
+    """A raising retrieval seam never escapes into the send."""
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    monkeypatch.setattr(
+        chat_screen_module,
+        "run_library_rag_search",
+        AsyncMock(side_effect=RuntimeError("backend exploded")),
+    )
+    screen = _auto_rag_screen(service=_RecordingRagService(_rows(2)))
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert screen._pending_console_launch_context is None
+    assert screen.notices == [
+        (chat_screen_module.CONSOLE_AUTO_RAG_FAILED_NOTICE, "warning")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_outcome_is_reported_not_silently_swallowed(monkeypatch):
+    """`run_library_rag_search` converts backend errors into a failed OUTCOME."""
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    monkeypatch.setattr(
+        chat_screen_module,
+        "run_library_rag_search",
+        AsyncMock(return_value=LibraryRagSearchOutcome(status="failed")),
+    )
+    screen = _auto_rag_screen(service=_RecordingRagService(()))
+
+    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+
+    assert screen._pending_console_launch_context is None
+    assert screen.notices == [
+        (chat_screen_module.CONSOLE_AUTO_RAG_FAILED_NOTICE, "warning")
+    ]
+
+
+# --------------------------------------------------------------------------
+# Happy path, end to end through the real send
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_stages_then_send_consumes(monkeypatch):
+    """Auto-retrieval stages a bundle the SAME send consumes and prompts."""
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    app = _build_test_app()
+    service = _RecordingRagService(_rows(2))
+    app.library_rag_search_service = service
+    context = "[S1] MEDIA — Source 1\nBody 1"
+    capture = AsyncMock(
+        return_value=LocalRagContextResult(context=context, citation_builder=None)
+    )
+    monkeypatch.setattr(
+        chat_screen_module, "capture_console_staged_evidence_for_chat", capture
+    )
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        assert screen._pending_console_launch_context is None
+
+        controller = screen._ensure_console_chat_controller()
+        gateway = _CapturingGateway()
+        controller.provider_gateway = gateway
+        controller._agent_runtime_enabled = False
+
+        result = await controller.submit_draft("what changed in the notes")
+        await pilot.pause()
+
+        assert result.accepted is True
+        # Retrieval ran once, for this draft, in profile-driven RAG mode.
+        assert len(service.calls) == 1
+        assert service.calls[0]["query"] == "what changed in the notes"
+        assert service.calls[0]["mode"] == "rag"
+        # The auto-staged launch is what the capture received...
+        auto_launch = capture.await_args_list[0].args[1]
+        assert auto_launch is not None
+        assert auto_launch.source == "Library Search/RAG"
+        assert auto_launch.payload["evidence_bundle"]["references"]
+        # ...and this send consumed it.
+        assert screen._pending_console_launch_context is None
+        assert _final_user_content(gateway.captured) == (
+            f"Evidence: {context}\n\n---\n\nwhat changed in the notes"
+        )
+        strip_text = " ".join(
+            str(node.renderable) for node in screen.query(f"{STRIP_ID} Static")
+        )
+        assert "Evidence sent with this message" in strip_text
+
+
+@pytest.mark.asyncio
+async def test_send_proceeds_when_auto_retrieve_fails(monkeypatch):
+    """Retrieval failure is never a send blocker."""
+    _enable_auto_retrieve()
+    _patch_scope(monkeypatch)
+    app = _build_test_app()
+    monkeypatch.setattr(
+        chat_screen_module,
+        "run_library_rag_search",
+        AsyncMock(side_effect=RuntimeError("backend exploded")),
+    )
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        controller = screen._ensure_console_chat_controller()
+        gateway = _CapturingGateway()
+        controller.provider_gateway = gateway
+        controller._agent_runtime_enabled = False
+
+        result = await controller.submit_draft("what changed in the notes")
+        await pilot.pause()
+
+        assert result.accepted is True
+        assert screen._pending_console_launch_context is None
+        assert _final_user_content(gateway.captured) == "what changed in the notes"
+
+
+def test_send_kind_classification_is_shared_not_duplicated():
+    """`_is_plain_text_send` reads the grammar's own prefixes."""
+    from tldw_chatbook.Chat.console_command_grammar import COMMAND_PREFIX
+    from tldw_chatbook.Chat.console_skill_resolver import MENTION_SIGIL
+
+    assert chat_screen_module._is_plain_text_send("a plain question") is True
+    assert chat_screen_module._is_plain_text_send(f"{COMMAND_PREFIX}prompt x") is False
+    assert chat_screen_module._is_plain_text_send(f"{MENTION_SIGIL}skill x") is False
+    assert chat_screen_module._is_plain_text_send("   ") is False
+    assert chat_screen_module._is_plain_text_send(None) is False
+
+
+@pytest.mark.asyncio
+async def test_capture_seam_calls_the_hook_before_consuming(monkeypatch):
+    """The hook must run at the consume-on-send seam, ahead of the consume.
+
+    Placing it anywhere later would stage a bundle the CURRENT send can no
+    longer pick up.
+    """
+    order: list[str] = []
+
+    async def _hook(_draft):
+        order.append("auto-retrieve")
+
+    def _consume():
+        order.append("consume")
+        return None
+
+    screen = SimpleNamespace(
+        app_instance=SimpleNamespace(),
+        _clear_console_evidence_sent_notice=lambda: order.append("clear-notice"),
+        _maybe_auto_retrieve_for_send=_hook,
+        _consume_pending_console_launch=_consume,
+        _release_consumed_console_launch=lambda *a: None,
+    )
+    monkeypatch.setattr(
+        chat_screen_module,
+        "capture_console_staged_evidence_for_chat",
+        AsyncMock(
+            return_value=LocalRagContextResult(context=None, citation_builder=None)
+        ),
+    )
+
+    await ChatScreen._capture_console_staged_rag(screen, "question")
+
+    assert order == ["clear-notice", "auto-retrieve", "consume"]
+
+
+@pytest.mark.asyncio
+async def test_capture_seam_contains_an_exploding_auto_retrieve(monkeypatch):
+    """A raising hook must not cost the send its manually staged evidence.
+
+    `_capture_rag_context` converts any provider exception into
+    `context=None`, so an escape here would drop the bundle the consume was
+    about to hand the model -- an optional convenience taking out the
+    deliberate one.
+    """
+    launch = _staged_launch()
+    released: list[tuple] = []
+    context = "[S1] MEDIA — Source 1\nBody 1"
+
+    async def _explode(_draft):
+        raise RuntimeError("auto-retrieve exploded")
+
+    screen = SimpleNamespace(
+        app_instance=SimpleNamespace(),
+        _clear_console_evidence_sent_notice=lambda: None,
+        _maybe_auto_retrieve_for_send=_explode,
+        _consume_pending_console_launch=lambda: launch,
+        _release_consumed_console_launch=lambda *args: released.append(args),
+    )
+    monkeypatch.setattr(
+        chat_screen_module,
+        "capture_console_staged_evidence_for_chat",
+        AsyncMock(
+            return_value=LocalRagContextResult(
+                context=context, citation_builder=None
+            )
+        ),
+    )
+
+    result = await ChatScreen._capture_console_staged_rag(screen, "question")
+
+    assert result.context == context
+    assert len(released) == 1

--- a/Tests/UI/test_console_internals_decomposition.py
+++ b/Tests/UI/test_console_internals_decomposition.py
@@ -4001,6 +4001,76 @@ async def test_console_rag_action_inherits_active_profile_top_k(monkeypatch):
         ]
 
 
+@pytest.mark.asyncio
+async def test_console_rag_action_falls_back_to_default_top_k_when_profile_unavailable(
+    monkeypatch,
+):
+    """TASK-3170 task 9: the chip run's OTHER branch -- profile unresolvable.
+
+    ``_console_library_rag_profile_top_k`` degrades to
+    ``CONSOLE_LIBRARY_RAG_FALLBACK_TOP_K`` when the active RAG profile can't
+    be read (broken/absent profile), so a manual chip run must never raise
+    inside a send just because profile resolution failed. Patches
+    ``resolve_active_rag_config`` itself (what the helper actually reads,
+    imported lazily inside it) rather than the helper, so this exercises the
+    real try/except fallback path end to end -- not a mock standing in for
+    it.
+    """
+    from tldw_chatbook.RAG_Search.simplified import active_config
+
+    def _raise_profile_unavailable():
+        raise RuntimeError("simulated: active RAG profile unresolvable")
+
+    monkeypatch.setattr(
+        active_config, "resolve_active_rag_config", _raise_profile_unavailable
+    )
+
+    app = _build_test_app()
+    service = StaticConsoleLibraryRagSearchService(
+        {
+            "results": [
+                {
+                    "document_title": "Incident Review",
+                    "snippet": "Expired credential caused the incident.",
+                    "score": 0.93,
+                    "source_id": "note-42",
+                    "chunk_id": "chunk-7",
+                    "runtime_backend": "local-fts",
+                    "citations": [{"label": "Incident Review p.2"}],
+                }
+            ],
+            "runtime_backend": "local-fts",
+        }
+    )
+    app.library_rag_search_service = service
+    host = ConsoleHarness(app)
+    query = "Why did the incident happen?"
+
+    async with host.run_test(size=(196, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _open_console_inspector(console, pilot)
+        await _wait_for_selector(console, pilot, "#console-run-library-rag")
+
+        query_input = console.query_one("#console-library-rag-query-input", Input)
+        query_input.value = query
+        await pilot.pause(0.1)
+
+        run_button = console.query_one("#console-run-library-rag", Button)
+        assert run_button.disabled is False
+        run_button.press()
+        await _wait_for_selector(console, pilot, "#console-live-work-payload-source-id")
+
+        assert service.calls == [
+            {
+                "query": query,
+                "scope": ("notes", "media", "conversations"),
+                "mode": "rag",
+                "top_k": chat_screen_module.CONSOLE_LIBRARY_RAG_FALLBACK_TOP_K,
+                "include_citations": True,
+            }
+        ]
+
+
 def test_console_evidence_display_state_sanitizes_markup_fields():
     launch = ConsoleLiveWorkLaunch.from_values(
         source="Library Search/RAG",

--- a/Tests/UI/test_console_internals_decomposition.py
+++ b/Tests/UI/test_console_internals_decomposition.py
@@ -43,6 +43,7 @@ from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.Library import library_local_rag_search_service
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 from tldw_chatbook.UI.Navigation.pending_handoff_store import HandoffChannel
+from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
 from tldw_chatbook.UI.Screens.chat_screen import (
     CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL,
     CONSOLE_WORKBENCH_SHORTCUT_GROUPS,
@@ -3866,7 +3867,9 @@ async def test_console_run_inspector_mcp_row_shows_blocked_when_stale_server_has
 
 
 @pytest.mark.asyncio
-async def test_console_rag_action_requests_library_retrieval_and_stages_result():
+async def test_console_rag_action_requests_library_retrieval_and_stages_result(
+    monkeypatch,
+):
     app = _build_test_app()
     service = StaticConsoleLibraryRagSearchService(
         {
@@ -3887,6 +3890,13 @@ async def test_console_rag_action_requests_library_retrieval_and_stages_result()
     app.library_rag_search_service = service
     host = ConsoleHarness(app)
     query = "Why did the incident happen?"
+
+    # This test is about scope/evidence staging, not top_k resolution --
+    # pin the shared helper (TASK-3170 task 9) so it stays decoupled from
+    # whatever the real default profile's default_top_k happens to be.
+    monkeypatch.setattr(
+        chat_screen_module, "_console_library_rag_profile_top_k", lambda: 5
+    )
 
     async with host.run_test(size=(196, 48)) as pilot:
         console = host.screen_stack[-1]
@@ -3926,6 +3936,69 @@ async def test_console_rag_action_requests_library_retrieval_and_stages_result()
         assert "source_id: note-42" in text
         assert "chunk_id: chunk-7" in text
         assert "Review citations before sending." in text
+
+
+@pytest.mark.asyncio
+async def test_console_rag_action_inherits_active_profile_top_k(monkeypatch):
+    """TASK-3170 task 9: the chip's manual run must not hardcode top_k=5.
+
+    Task 8 gave auto-retrieve a shared helper,
+    ``_console_library_rag_profile_top_k``, that reads the active RAG
+    profile's ``search.default_top_k`` (fallback 5 when unavailable). The
+    manual chip run built its own request with a literal ``top_k=5`` and
+    ignored the profile entirely -- a profile tuned for more (or fewer)
+    results silently lost that setting the moment a user pressed Run
+    instead of relying on auto-retrieve. This pins the chip run onto the
+    SAME helper so both call sites can never drift again.
+    """
+    app = _build_test_app()
+    service = StaticConsoleLibraryRagSearchService(
+        {
+            "results": [
+                {
+                    "document_title": "Incident Review",
+                    "snippet": "Expired credential caused the incident.",
+                    "score": 0.93,
+                    "source_id": "note-42",
+                    "chunk_id": "chunk-7",
+                    "runtime_backend": "local-fts",
+                    "citations": [{"label": "Incident Review p.2"}],
+                }
+            ],
+            "runtime_backend": "local-fts",
+        }
+    )
+    app.library_rag_search_service = service
+    host = ConsoleHarness(app)
+    query = "Why did the incident happen?"
+
+    monkeypatch.setattr(
+        chat_screen_module, "_console_library_rag_profile_top_k", lambda: 12
+    )
+
+    async with host.run_test(size=(196, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _open_console_inspector(console, pilot)
+        await _wait_for_selector(console, pilot, "#console-run-library-rag")
+
+        query_input = console.query_one("#console-library-rag-query-input", Input)
+        query_input.value = query
+        await pilot.pause(0.1)
+
+        run_button = console.query_one("#console-run-library-rag", Button)
+        assert run_button.disabled is False
+        run_button.press()
+        await _wait_for_selector(console, pilot, "#console-live-work-payload-source-id")
+
+        assert service.calls == [
+            {
+                "query": query,
+                "scope": ("notes", "media", "conversations"),
+                "mode": "rag",
+                "top_k": 12,
+                "include_citations": True,
+            }
+        ]
 
 
 def test_console_evidence_display_state_sanitizes_markup_fields():
@@ -4286,7 +4359,9 @@ async def test_console_control_bar_run_library_rag_guards_a_path_shaped_draft():
 
 
 @pytest.mark.asyncio
-async def test_console_rag_modal_source_toggle_narrows_the_retrieval_request():
+async def test_console_rag_modal_source_toggle_narrows_the_retrieval_request(
+    monkeypatch,
+):
     """RAG-44 end to end: the settings modal's source toggles decide what
     retrieval actually reads. Switching Media off and running must send a
     request WITHOUT media to the search service (and leave the Inspector's
@@ -4296,6 +4371,13 @@ async def test_console_rag_modal_source_toggle_narrows_the_retrieval_request():
     service = StaticConsoleLibraryRagSearchService({"results": []})
     app.library_rag_search_service = service
     host = ConsoleHarness(app)
+
+    # This test is about source-scope narrowing, not top_k resolution --
+    # pin the shared helper (TASK-3170 task 9) so it stays decoupled from
+    # whatever the real default profile's default_top_k happens to be.
+    monkeypatch.setattr(
+        chat_screen_module, "_console_library_rag_profile_top_k", lambda: 5
+    )
 
     async with host.run_test(size=(196, 48)) as pilot:
         console = host.screen_stack[-1]

--- a/Tests/UI/test_console_rag_settings_modal.py
+++ b/Tests/UI/test_console_rag_settings_modal.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 
 import pytest
 from textual.app import App
-from textual.widgets import Button, Input, Static
+from textual.widgets import Button, Input, Static, Switch
 
 from tldw_chatbook.Library.library_rag_state import (
     LIBRARY_RAG_SCOPE_TOGGLE_SOURCE_TYPES,
@@ -127,6 +127,107 @@ async def test_cancel_escape_and_backdrop_all_dismiss_without_changes():
         assert app.screen is not modal
 
     assert received == [None]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_auto_retrieve_switch_defaults_off_when_not_given_a_value():
+    """TASK-3170 (task 7): the Switch defaults to the constructor value --
+    the modal never reads config itself, the caller does (see the
+    ``chat_screen`` tests below) -- and the modal's own default is OFF."""
+
+    class RagHost(App):
+        pass
+
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(ConsoleRagSettingsModal())
+        await pilot.pause()
+        modal = app.screen
+        switch = modal.query_one("#console-rag-settings-auto-retrieve", Switch)
+        assert switch.value is False
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_auto_retrieve_switch_reflects_a_true_constructor_value():
+    """When the caller passes the persisted "on" value, the Switch opens on."""
+
+    class RagHost(App):
+        pass
+
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(ConsoleRagSettingsModal(auto_retrieve_on_send=True))
+        await pilot.pause()
+        modal = app.screen
+        switch = modal.query_one("#console-rag-settings-auto-retrieve", Switch)
+        assert switch.value is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_toggling_auto_retrieve_on_and_running_returns_the_flag_set():
+    """Flipping the switch on, then running, carries ``auto_retrieve_on_send``
+    through in the dismiss result -- the caller (chat_screen) is the one
+    that persists it to config."""
+
+    class RagHost(App):
+        pass
+
+    received: list[ConsoleRagSettingsResult | None] = []
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleRagSettingsModal(query="what changed in auth"),
+            callback=received.append,
+        )
+        await pilot.pause()
+
+        await pilot.click("#console-rag-settings-auto-retrieve")
+        await pilot.pause()
+
+        await pilot.click("#console-rag-settings-run")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert received == [
+        ConsoleRagSettingsResult(
+            query="what changed in auth",
+            run=True,
+            auto_retrieve_on_send=True,
+        )
+    ]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_leaving_auto_retrieve_untouched_returns_the_flag_unset():
+    """Sanity companion: not touching the switch keeps the flag False in
+    the result, matching the constructor default."""
+
+    class RagHost(App):
+        pass
+
+    received: list[ConsoleRagSettingsResult | None] = []
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleRagSettingsModal(query="what changed in auth"),
+            callback=received.append,
+        )
+        await pilot.pause()
+        await pilot.click("#console-rag-settings-run")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert received == [
+        ConsoleRagSettingsResult(
+            query="what changed in auth",
+            run=True,
+            auto_retrieve_on_send=False,
+        )
+    ]
 
 
 def _static_plain_text(widget: Static) -> str:
@@ -451,6 +552,69 @@ def test_modal_choice_stores_the_source_scope_before_running():
         ("notes", "prompts")
     )
     screen._run_console_library_rag_from_visible_action.assert_called_once()
+
+
+@pytest.mark.unit
+def test_choice_persists_the_auto_retrieve_toggle_and_it_round_trips_through_config():
+    """TASK-3170 (task 7): the caller is the persistence seam -- the modal
+    itself never touches config. Uses the real ``save_setting_to_cli_config``
+    / ``get_cli_setting`` pair (isolated per-test by the autouse
+    ``isolate_test_environment`` fixture in ``Tests/conftest.py``), not a
+    mock, so this is a genuine round trip through the config file."""
+    from tldw_chatbook.config import get_cli_setting
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    # Nothing saved yet: the documented default is OFF.
+    assert (
+        get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is False
+    )
+
+    screen = Mock()
+    ChatScreen._apply_console_rag_settings_choice(
+        screen,
+        ConsoleRagSettingsResult(
+            query="what changed", run=False, auto_retrieve_on_send=True
+        ),
+    )
+
+    assert (
+        get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is True
+    )
+
+    # Turning it back off persists too -- not a one-way ratchet.
+    ChatScreen._apply_console_rag_settings_choice(
+        screen,
+        ConsoleRagSettingsResult(
+            query="what changed", run=False, auto_retrieve_on_send=False
+        ),
+    )
+
+    assert (
+        get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is False
+    )
+
+
+@pytest.mark.unit
+def test_modal_open_prefills_auto_retrieve_switch_from_the_persisted_config():
+    """The chip-open site reads the persisted default and hands it to the
+    modal -- the modal's own default (OFF, tested at the modal layer above)
+    only applies when nothing has been saved yet."""
+    from tldw_chatbook.config import save_setting_to_cli_config
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    save_setting_to_cli_config("chat_defaults", "rag_auto_retrieve_on_send", True)
+
+    screen = Mock()
+    screen._console_library_rag_query = ""
+    screen._pending_console_launch_context = None
+    composer = Mock()
+    composer.draft_text.return_value = ""
+    screen._console_composer_or_none.return_value = composer
+
+    ChatScreen._open_console_rag_settings(screen)
+
+    modal = screen.app.push_screen.call_args.args[0]
+    assert modal._auto_retrieve_on_send is True
 
 
 @pytest.mark.unit

--- a/Tests/UI/test_console_rag_settings_modal.py
+++ b/Tests/UI/test_console_rag_settings_modal.py
@@ -17,6 +17,7 @@ from tldw_chatbook.Library.library_rag_state import (
     LIBRARY_RAG_SOURCE_TYPES,
 )
 from tldw_chatbook.Widgets.Console.console_rag_settings_modal import (
+    CONSOLE_RAG_AUTO_RETRIEVE_TOGGLE_ID,
     CONSOLE_RAG_DEFAULT_SOURCE_TYPES,
     CONSOLE_RAG_SOURCE_TOGGLE_ID_PREFIX,
     ConsoleRagSettingsModal,
@@ -228,6 +229,174 @@ async def test_leaving_auto_retrieve_untouched_returns_the_flag_unset():
             auto_retrieve_on_send=False,
         )
     ]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_flipping_auto_retrieve_calls_back_immediately_once_per_toggle():
+    """TASK-3170 re-critique fix: "Auto-retrieve on send" is a standing
+    preference, not part of the query/source-type draft this modal
+    otherwise discards on Cancel/Escape/a backdrop click. Flipping the
+    switch invokes ``on_auto_retrieve_changed`` the instant it flips --
+    before any dismiss -- so the caller can persist it right away. Opening
+    the modal alone must not fire it."""
+
+    class RagHost(App):
+        pass
+
+    changes: list[bool] = []
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleRagSettingsModal(on_auto_retrieve_changed=changes.append)
+        )
+        await pilot.pause()
+        assert changes == []
+
+        await pilot.click(f"#{CONSOLE_RAG_AUTO_RETRIEVE_TOGGLE_ID}")
+        await pilot.pause()
+        assert changes == [True]
+
+        await pilot.click(f"#{CONSOLE_RAG_AUTO_RETRIEVE_TOGGLE_ID}")
+        await pilot.pause()
+        assert changes == [True, False]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_invariant_a_flip_then_escape_keeps_the_toggle_persisted():
+    """Invariant (a): flip + Escape -- the switch's callback already fired
+    (config updated in the real caller) before Escape ran, and Escape does
+    not re-fire it or claw it back, even though it discards the query
+    draft (dismiss result is None) exactly as before."""
+
+    class RagHost(App):
+        pass
+
+    changes: list[bool] = []
+    received: list[ConsoleRagSettingsResult | None] = []
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleRagSettingsModal(
+                query="draft text", on_auto_retrieve_changed=changes.append
+            ),
+            callback=received.append,
+        )
+        await pilot.pause()
+
+        await pilot.click(f"#{CONSOLE_RAG_AUTO_RETRIEVE_TOGGLE_ID}")
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert received == [None]
+    assert changes == [True]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_invariant_b_flip_then_run_persists_exactly_once():
+    """Invariant (b): flip + Run -- the toggle callback fires exactly once
+    (from the flip); Run/dismiss must not duplicate it."""
+
+    class RagHost(App):
+        pass
+
+    changes: list[bool] = []
+    received: list[ConsoleRagSettingsResult | None] = []
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleRagSettingsModal(
+                query="what changed in auth",
+                on_auto_retrieve_changed=changes.append,
+            ),
+            callback=received.append,
+        )
+        await pilot.pause()
+
+        await pilot.click(f"#{CONSOLE_RAG_AUTO_RETRIEVE_TOGGLE_ID}")
+        await pilot.pause()
+        await pilot.click("#console-rag-settings-run")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert changes == [True]
+    assert received == [
+        ConsoleRagSettingsResult(
+            query="what changed in auth",
+            run=True,
+            auto_retrieve_on_send=True,
+        )
+    ]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_invariant_c_run_without_touching_the_switch_never_calls_back():
+    """Invariant (c): open + Run without touching the switch -- the
+    callback (and therefore the config write in the real caller) never
+    fires at all. Kills the old unconditional-write-on-every-dismiss
+    behavior."""
+
+    class RagHost(App):
+        pass
+
+    changes: list[bool] = []
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleRagSettingsModal(
+                query="what changed in auth",
+                on_auto_retrieve_changed=changes.append,
+            )
+        )
+        await pilot.pause()
+        await pilot.click("#console-rag-settings-run")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert changes == []
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_invariant_d_cancel_after_flip_still_discards_the_source_type_draft():
+    """Invariant (d): the query/source-type draft-discard behavior is
+    unchanged by this fix -- a source-type edit is still lost on Cancel
+    (dismiss result None, same as ``test_cancel_discards_toggle_changes``)
+    even though the auto-retrieve toggle, flipped in the same session,
+    already persisted independently and survives the Cancel."""
+
+    class RagHost(App):
+        pass
+
+    changes: list[bool] = []
+    received: list[ConsoleRagSettingsResult | None] = []
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleRagSettingsModal(
+                query="what changed in auth",
+                source_types=CONSOLE_RAG_DEFAULT_SOURCE_TYPES,
+                on_auto_retrieve_changed=changes.append,
+            ),
+            callback=received.append,
+        )
+        await pilot.pause()
+
+        await pilot.click(f"#{CONSOLE_RAG_SOURCE_TOGGLE_ID_PREFIX}prompts")
+        await pilot.click(f"#{CONSOLE_RAG_AUTO_RETRIEVE_TOGGLE_ID}")
+        await pilot.pause()
+
+        await pilot.click("#console-rag-settings-cancel")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert received == [None]
+    assert changes == [True]
 
 
 def _static_plain_text(widget: Static) -> str:
@@ -555,16 +724,16 @@ def test_modal_choice_stores_the_source_scope_before_running():
 
 
 @pytest.mark.unit
-def test_choice_persists_the_auto_retrieve_toggle_and_it_round_trips_through_config():
-    """TASK-3170 (task 7): the caller is the persistence seam -- the modal
-    itself never touches config. Uses the real ``save_setting_to_cli_config``
-    / ``get_cli_setting`` pair (isolated per-test by the autouse
-    ``isolate_test_environment`` fixture in ``Tests/conftest.py``), not a
-    mock, so this is a genuine round trip through the config file."""
+def test_apply_choice_never_writes_config_the_toggle_persists_separately():
+    """TASK-3170 re-critique fix: ``_apply_console_rag_settings_choice`` no
+    longer touches config at all -- persistence moved to the modal's
+    ``on_auto_retrieve_changed`` callback, fired the instant the switch
+    flips (see the modal-level invariant tests above), not gated on this
+    dismiss handler. Guards against the fix regressing back to an
+    unconditional write on every Run."""
     from tldw_chatbook.config import get_cli_setting
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
-    # Nothing saved yet: the documented default is OFF.
     assert (
         get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is False
     )
@@ -577,17 +746,64 @@ def test_choice_persists_the_auto_retrieve_toggle_and_it_round_trips_through_con
         ),
     )
 
+    # Still False: applying the dismissed choice must not write config --
+    # only flipping the switch (through the callback) does that.
+    assert (
+        get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is False
+    )
+
+
+@pytest.mark.unit
+def test_modal_open_wires_the_auto_retrieve_callback_to_the_real_persist_worker():
+    """The modal's ``on_auto_retrieve_changed`` must be the screen's real
+    worker-backed persist method -- not left unwired, and not a
+    synchronous write in the dismiss callback (see the previous test)."""
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    screen = Mock()
+    screen._console_library_rag_query = ""
+    screen._pending_console_launch_context = None
+    composer = Mock()
+    composer.draft_text.return_value = ""
+    screen._console_composer_or_none.return_value = composer
+
+    ChatScreen._open_console_rag_settings(screen)
+
+    modal = screen.app.push_screen.call_args.args[0]
+    assert modal._on_auto_retrieve_changed is (
+        screen._persist_console_rag_auto_retrieve_on_send
+    )
+
+
+@pytest.mark.unit
+def test_persist_worker_body_writes_through_to_config():
+    """TASK-3170 re-critique fix (IMPORTANT 2): the write moved into a
+    ``@work(thread=True)`` method, matching the sibling Console preference
+    writers (``_save_console_rail_preferences``, ``_save_console_
+    onboarding_flag``, ``_save_console_fleet_coachmark_flag``). ``@work``'s
+    dispatch (``self.run_worker(...)``) asserts ``self`` is a live, mounted
+    ``DOMNode``, which a bare test double is not -- so this reaches the
+    original function body directly through ``__wrapped__``
+    (``functools.wraps`` sets it), the same pattern already used elsewhere
+    in this suite, e.g. ``LibraryScreen._run_parakeet_v2_install.__wrapped__``
+    in ``Tests/UI/test_parakeet_v2_install_ui.py``. This is a genuine round
+    trip through the real production code, not a duplicate helper."""
+    from tldw_chatbook.config import get_cli_setting
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    assert (
+        get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is False
+    )
+
+    screen = Mock()
+    ChatScreen._persist_console_rag_auto_retrieve_on_send.__wrapped__(screen, True)
+
     assert (
         get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is True
     )
 
-    # Turning it back off persists too -- not a one-way ratchet.
-    ChatScreen._apply_console_rag_settings_choice(
-        screen,
-        ConsoleRagSettingsResult(
-            query="what changed", run=False, auto_retrieve_on_send=False
-        ),
-    )
+    # Not a one-way ratchet: flipping back off persists too.
+    ChatScreen._persist_console_rag_auto_retrieve_on_send.__wrapped__(screen, False)
 
     assert (
         get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is False

--- a/Tests/UI/test_library_rag_handoffs.py
+++ b/Tests/UI/test_library_rag_handoffs.py
@@ -352,3 +352,135 @@ def test_library_use_in_console_bundle_matches_console_run_builder_shape():
     ).to_payload()
 
     assert launch.payload["evidence_bundle"] == console_run_bundle_payload
+
+
+def test_evidence_bundle_hybrid_reference_scores_the_vector_leg_not_the_fusion():
+    """(RAG-port P0/Task 6) `EvidenceReference.score` is declared as a
+    retrieval score on the unit interval and is adapted downstream as a
+    `ZERO_TO_ONE` similarity -- so a fused RRF number (~0.016, whose
+    theoretical max at the shipped `rrf_k=60` is 1/61) must never occupy
+    that slot. The honest similarity for a hybrid row is Task 2's preserved
+    vector leg; the fused number stays available, unaltered, in the
+    reference's `hybrid_fusion` metadata block."""
+    bundle = build_library_rag_evidence_bundle(
+        {
+            "title": "Incident Review",
+            "snippet": "Expired credential caused the incident.",
+            "source_id": "media-42",
+            "chunk_id": "chunk-7",
+            "score": 0.016393442622950824,
+            "provenance": {
+                "source_type": "media",
+                "hybrid_fusion": {
+                    "fts_rank": 1,
+                    "vector_rank": 1,
+                    "fts_score": 0.001,
+                    "vector_score": 0.83,
+                    "alpha": 0.7,
+                    "rrf_k": 60,
+                },
+            },
+        },
+        query="Why did the incident happen?",
+    )
+
+    reference = bundle.to_payload()["references"][0]
+    assert reference["metadata"]["score_kind"] == "hybrid_fusion"
+    assert reference["score"] == pytest.approx(0.83)
+    assert reference["metadata"]["hybrid_fusion"]["vector_score"] == pytest.approx(0.83)
+
+
+def test_evidence_bundle_fts_only_hybrid_reference_carries_no_similarity():
+    """(RAG-port P0/Task 6) No vector leg means no similarity exists --
+    the reference discloses the kind and leaves `score` absent rather than
+    presenting the fused 0.0x number as a weak similarity."""
+    bundle = build_library_rag_evidence_bundle(
+        {
+            "title": "Incident Review",
+            "snippet": "Expired credential caused the incident.",
+            "source_id": "media-42",
+            "score": 0.004918032786885246,
+            "provenance": {
+                "source_type": "media",
+                "hybrid_fusion": {
+                    "fts_rank": 1,
+                    "vector_rank": None,
+                    "fts_score": 0.001,
+                    "vector_score": None,
+                },
+            },
+        },
+        query="Why did the incident happen?",
+    )
+
+    reference = bundle.to_payload()["references"][0]
+    assert reference["metadata"]["score_kind"] == "hybrid_fusion"
+    assert "score" not in reference
+
+
+def test_evidence_bundle_reranked_reference_never_presents_a_similarity():
+    """(RAG-port P0/Task 6) Reranker scores are unbounded (cross-encoder
+    logits, 0-10 LLM scales). A reranker score that happens to land inside
+    [0, 1] would otherwise silently pass the unit-interval field validator
+    and be read downstream as a cosine similarity."""
+    bundle = build_library_rag_evidence_bundle(
+        {
+            "title": "Incident Review",
+            "snippet": "Expired credential caused the incident.",
+            "source_id": "media-42",
+            "score": 0.4,
+            "provenance": {
+                "source_type": "media",
+                "_final_score_kind": "reranker",
+            },
+        },
+        query="Why did the incident happen?",
+    )
+
+    reference = bundle.to_payload()["references"][0]
+    assert reference["metadata"]["score_kind"] == "reranker"
+    assert "score" not in reference
+
+
+def test_evidence_bundle_plain_similarity_reference_is_unchanged():
+    """Protected oracle: a plain semantic row (no fusion block, no reranker
+    channel) keeps its score verbatim and is labelled for what it is."""
+    bundle = build_library_rag_evidence_bundle(
+        {
+            "title": "Incident Review",
+            "snippet": "Expired credential caused the incident.",
+            "source_id": "note-42",
+            "score": 0.93,
+        },
+        query="Why did the incident happen?",
+    )
+
+    reference = bundle.to_payload()["references"][0]
+    assert reference["score"] == pytest.approx(0.93)
+    assert reference["metadata"]["score_kind"] == "vector_similarity"
+
+
+def test_console_live_work_payload_discloses_score_kind():
+    """(RAG-port P0/Task 6) The Console live-work payload carries the same
+    kind disclosure as the bundle it embeds, so a downstream consumer of
+    `payload["score"]` can tell a similarity from a fused rank score."""
+    payload = build_library_rag_console_live_work_payload(
+        {
+            "title": "Incident Review",
+            "snippet": "Expired credential caused the incident.",
+            "source_id": "media-42",
+            "score": 0.016393442622950824,
+            "provenance": {
+                "hybrid_fusion": {
+                    "fts_rank": 1,
+                    "vector_rank": 1,
+                    "fts_score": 0.001,
+                    "vector_score": 0.83,
+                },
+            },
+        },
+        query="Why did the incident happen?",
+    )
+
+    assert payload["score_kind"] == "hybrid_fusion"
+    assert payload["score"] == pytest.approx(0.83)

--- a/Tests/UI/test_product_maturity_gate16_library_search_rag.py
+++ b/Tests/UI/test_product_maturity_gate16_library_search_rag.py
@@ -334,6 +334,48 @@ def test_empty_status_renders_quiet_two_line_state_not_full_dump() -> None:
     assert "Unavailable: Library Search/RAG retrieval." in dump_text
 
 
+def test_empty_status_still_renders_the_routing_disclosure() -> None:
+    """(RAG-port P0 review, I2) A zero-result search under a plain (BM25)
+    profile is precisely when "vectors were never consulted" is the most
+    diagnostic fact on screen -- without it the quiet "No evidence matched"
+    line reads as a verdict on the semantic index that was never queried.
+    The disclosure rides the SAME coverage-note line (quiet register, same
+    id), above the unchanged no-match copy."""
+    from tldw_chatbook.Library.library_rag_state import (
+        LIBRARY_RAG_ROUTE_NOTES_KEY,
+        LibraryRagPanelState,
+    )
+    from tldw_chatbook.Widgets.Library import library_rag_results_body_children
+
+    state = LibraryRagPanelState.from_values(
+        source_counts={"notes": 1, "media": 1},
+        query="unicorn migration guide",
+        retrieval_status="empty",
+        provider_name="openai",
+        diagnostics={
+            LIBRARY_RAG_ROUTE_NOTES_KEY: [
+                "Profile 'BM25 Only': keyword search (no vectors)"
+            ]
+        },
+    )
+
+    children = library_rag_results_body_children(state)
+
+    note = children[0]
+    assert note.id == "library-rag-coverage-note"
+    assert note.has_class("library-rag-quiet-line")
+    assert (
+        str(note.renderable) == "Profile 'BM25 Only': keyword search (no vectors)."
+    )
+    # The no-match copy itself is untouched, and still follows the note.
+    quiet_static = children[1]
+    assert quiet_static.id == "library-rag-empty-state"
+    assert str(quiet_static.renderable) == (
+        "No evidence matched 'unicorn migration guide'.\nTry broader terms."
+    )
+    assert len(children) == 2
+
+
 # --- Task 13: honest re-run hint on history rows (RAG-38) ------------------
 
 

--- a/Tests/UI/test_product_maturity_gate16_library_search_rag.py
+++ b/Tests/UI/test_product_maturity_gate16_library_search_rag.py
@@ -1813,6 +1813,90 @@ async def test_library_search_rag_query_updates_action_and_survives_recompose() 
         assert screen.query_one("#library-rag-run-query", Button).disabled is False
 
 
+def test_hybrid_result_row_renders_the_vector_leg_band_not_the_fused_score() -> None:
+    """(RAG-port P0/Task 6) End of the thread: a *service-shaped* hybrid
+    result -- fused RRF score ~0.016, strong vector leg preserved in
+    `provenance["hybrid_fusion"]["vector_score"]` (Task 2) -- must compose
+    the STRONG band into the row's title line.
+
+    Before this, every hybrid search rendered a wall of
+    "match: weak (0.02)": RRF fused scores top out at `1/(rrf_k + 1)`
+    ~= 0.016 at the shipped `rrf_k=60`, an order of magnitude below the
+    0.2 weak boundary, so the panel banded excellent results as barely
+    matching. This pins the whole path -- service row shape -> row
+    normalization -> composed title -- not just the pure band function.
+    """
+    from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
+    from tldw_chatbook.Widgets.Library.library_search_rag_panel import (
+        library_rag_result_row_children,
+    )
+
+    row = LibraryRagResultRow.from_result(
+        {
+            "document_title": "Incident Review",
+            "snippet": "Expired credential caused the incident.",
+            "score": 0.016393442622950824,
+            "source_id": "media-42",
+            "chunk_id": "chunk-7",
+            "provenance": {
+                "source_type": "media",
+                "hybrid_fusion": {
+                    "fts_rank": 1,
+                    "vector_rank": 1,
+                    "fts_score": 0.001,
+                    "vector_score": 0.83,
+                    "alpha": 0.7,
+                    "rrf_k": 60,
+                },
+            },
+        }
+    )
+    card = library_rag_result_row_children(row, 0, "")[0]
+    title = next(
+        child
+        for child in _answer_region_children(card)
+        if child.id == "library-rag-result-0"
+    )
+    assert str(title.renderable) == "1. Incident Review | match: strong"
+
+
+def test_fts_only_hybrid_result_row_renders_keyword_match_not_a_band() -> None:
+    """(RAG-port P0/Task 6) The other hybrid shape: an FTS-leg-only row has
+    no similarity at all, so the title discloses "keyword match" rather
+    than inventing a band or exposing the fused 0.0x number."""
+    from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
+    from tldw_chatbook.Widgets.Library.library_search_rag_panel import (
+        library_rag_result_row_children,
+    )
+
+    row = LibraryRagResultRow.from_result(
+        {
+            "document_title": "Incident Review",
+            "snippet": "Expired credential caused the incident.",
+            "score": 0.004918032786885246,
+            "source_id": "media-42",
+            "provenance": {
+                "source_type": "media",
+                "hybrid_fusion": {
+                    "fts_rank": 1,
+                    "vector_rank": None,
+                    "fts_score": 0.001,
+                    "vector_score": None,
+                    "alpha": 0.7,
+                    "rrf_k": 60,
+                },
+            },
+        }
+    )
+    card = library_rag_result_row_children(row, 0, "")[0]
+    title = next(
+        child
+        for child in _answer_region_children(card)
+        if child.id == "library-rag-result-0"
+    )
+    assert str(title.renderable) == "1. Incident Review | keyword match"
+
+
 @pytest.mark.asyncio
 async def test_library_search_rag_run_query_renders_service_results_and_calls_scope() -> (
     None

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1112,3 +1112,72 @@ evidence. Re-run the feature's complete focused suite after rebasing, and verify
 claimed conflict adaptations in the committed files themselves. Newly created
 tests are especially likely to preserve assumptions that the new base has
 intentionally invalidated without producing a textual conflict.
+
+---
+
+## A clear/cleanup assertion cannot pin the thing it cleans up — observe transient state DURING the window
+
+**TASK-3170 Task 8, 2026-08-07 (Console auto-retrieve send-path injection).** The
+in-flight "Retrieving…" placeholder staging call
+(`self._stage_console_library_rag_launch(placeholder)` inside
+`_maybe_auto_retrieve_for_send`, `chat_screen.py`) was pinned by **no test**.
+Replacing the stage call with a bare `pass` left all 22 existing tests in
+`Tests/UI/test_console_auto_rag_on_send.py` green. The reason: every existing
+assertion about the placeholder was a **clear** assertion —
+`assert screen._pending_console_launch_context is None` after a timeout, a
+failure, or a zero-result outcome — and all three stay true whether the
+placeholder was staged and then cleared, or never staged at all. The
+assertions were only *transitively* meaningful; delete the stage call and they
+go vacuous while continuing to pass. A future refactor could therefore remove
+the only in-flight signal the user gets during the retrieval window and the
+suite would say nothing.
+
+**Fix:** a new test whose fake retrieval service observes
+`screen._pending_console_launch_context` and `screen._has_staged_console_evidence()`
+**from inside** the `search()` call — the only moment the claim ("a placeholder
+is staged while retrieval runs") is actually true — then asserts the settled
+launch afterwards is a *different* object with `status == "staged"`. Written
+RED-first: the stage call was stubbed to `pass` before the test existed,
+confirmed exactly 1 failure (the new test) against 22 unaffected; reverted via
+Edit, production source byte-identical to the pre-fix commit.
+
+**What to do.** Transient state — an in-flight marker, a spinner, a lock held
+across an `await`, a placeholder later replaced or cleared — must be observed
+**during** the window it exists, from inside the awaited call or an equivalent
+hook, or it is not tested at all. `assert x is None` taken after the fact
+passes identically whether `x` was set-then-cleared or never set: it is a
+clear/cleanup assertion, not a presence assertion, and clear assertions cannot
+pin the thing they clean up.
+
+---
+
+## A config default that also ships in the config template cannot be mutation-tested through config
+
+**TASK-3170 Task 8, 2026-08-07, same task as above.** Mutating the read
+site's fallback for `rag_auto_retrieve_on_send` — `get_cli_setting("chat_defaults",
+"rag_auto_retrieve_on_send", False)` → `..., True)` — failed **zero** of the
+20 tests then covering the feature. The cause: Task 7 had already added
+`[chat_defaults] rag_auto_retrieve_on_send = false` to `config.py`'s DEFAULT
+CONFIG TEMPLATE, so every freshly-bootstrapped test config carries the key
+explicitly. The lookup therefore always resolves the template's stored value
+and never falls through to the Python-level default argument — the literal
+`False` in the `get_cli_setting(...)` call is dead code for every test, and
+for every real user with a current config. The mutation is only reachable for
+a user whose `config.toml` **predates** the key, a state no test that boots a
+fresh config can ever produce.
+
+**Fix:** `test_toggle_default_is_off_at_the_read_site` monkeypatches
+`get_cli_setting` with a recording stub and asserts the literal default
+argument handed to it is `False`, independent of whatever the template
+supplies.
+
+**What to do.** Before trusting a "defaults to off" (or any) test for a
+config-backed value, check whether that same default also ships in the app's
+default config template or any fixture/bootstrap path the test uses. If it
+does, every test config already carries the key, and the code-level fallback
+can drift to the wrong value with **zero** test failures — a mutation of the
+fallback argument is invisible through the normal read-and-assert path
+because that path is testing the template, not the code. The read site's own
+literal default needs a separate, direct assertion (stub the accessor, assert
+the literal argument passed to it), not an inference from observed runtime
+behavior.

--- a/backlog/tasks/task-3170 - RAG-port-P0-profile-honoring-retrieval-and-Console-send-path-injection.md
+++ b/backlog/tasks/task-3170 - RAG-port-P0-profile-honoring-retrieval-and-Console-send-path-injection.md
@@ -4,6 +4,7 @@ title: RAG-port P0 profile-honoring retrieval and Console send-path injection
 status: In Progress
 assignee: []
 created_date: '2026-08-07 14:19'
+updated_date: '2026-08-07 20:44'
 labels:
   - rag
   - console
@@ -20,17 +21,17 @@ P0 of the RAG server-port programme. Chatbook's live retrieval is weaker than th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Library rag-mode search resolves the active RAG profile's default_search_mode (plain/semantic/hybrid) instead of hardcoding semantic search; plain-profile queries route through the existing four-seam _search_keyword path (honestly labeled), never through the engine's standalone keyword leg.
-- [ ] #2 The engine's keyword leg no longer guesses DB paths or opens chacha_notes.db with media-schema SQL: the media DB path is injected explicitly from config, the create-a-new-MediaDatabase-on-miss side effect is deleted, keyword rows carry source_type provenance so they survive the Library's canonicalizing post-filter, and a failed leg degrades to a disclosed coverage note rather than performing a write.
-- [ ] #3 Match-strength presentation is score-kind-aware: _fuse_hybrid_results preserves per-leg scores in hybrid_fusion metadata, RRF-fused and reranker scores are never banded on the cosine strong/moderate/weak thresholds, FTS-only rows render as 'keyword match' rather than a fabricated similarity, library_rag_all_matches_weak fires only over vector-similarity score kinds, and the backend label is mode-truthful (rag-hybrid/rag-keyword/rag-semantic).
-- [ ] #4 The reranker factory is fixed so a reranking-enabled profile actually constructs a reranker; model loading is verified off the event loop (moved to service construction if it loads lazily at first .rerank()); an unavailable reranker (missing model/dep) skips reranking with disclosed provenance instead of failing the search.
-- [ ] #5 Zero-results honesty under hybrid: the 'Index empty' recovery state does not fire when the keyword leg returned rows, and when the semantic leg is empty but the keyword leg is not, the search discloses 'semantic leg empty -- keyword-only results' instead of the generic empty state.
-- [ ] #6 An 'Auto-retrieve on send' toggle in the Console RAG chip modal controls native send-path injection, defaults to OFF, and persists as a global config key, re-homing enablement away from the legacy sidebar checkbox.
-- [ ] #7 Auto-retrieve fires only for plain user text sends -- never for slash commands, tool approvals, or regenerations -- and skips automatically when evidence is already manually staged (no double retrieval/spend).
-- [ ] #8 When auto-retrieve fires, retrieved results route through the existing staged-evidence pipeline (strip shows 'Evidence sent · N', consumption reuses the consume-on-send predicate) rather than invisible prompt injection; the Console chip's manual run is switched from its hardcoded top_k=5 to the active profile's default_top_k so manual and auto retrieval never disagree about depth.
-- [ ] #9 An EMPTY resolved scope short-circuits auto-retrieve with the same shared notice copy as the manual path (task-406 AC #2).
-- [ ] #10 Auto-retrieve runs in an exclusive worker with a visible 'Retrieving...' strip state and an explicit 5s timeout; on failure or timeout the send proceeds without evidence and shows a quiet notice that distinguishes 'RAG service still initializing' from 'retrieval failed', and a send is never blocked on retrieval.
-- [ ] #11 The legacy chat_events RAG injection path is untouched by this work (task-406 AC #3).
+- [x] #1 Library rag-mode search resolves the active RAG profile's default_search_mode (plain/semantic/hybrid) instead of hardcoding semantic search; plain-profile queries route through the existing four-seam _search_keyword path (honestly labeled), never through the engine's standalone keyword leg.
+- [x] #2 The engine's keyword leg no longer guesses DB paths or opens chacha_notes.db with media-schema SQL: the media DB path is injected explicitly from config, the create-a-new-MediaDatabase-on-miss side effect is deleted, keyword rows carry source_type provenance so they survive the Library's canonicalizing post-filter, and a failed leg degrades to a disclosed coverage note rather than performing a write.
+- [x] #3 Match-strength presentation is score-kind-aware: _fuse_hybrid_results preserves per-leg scores in hybrid_fusion metadata, RRF-fused and reranker scores are never banded on the cosine strong/moderate/weak thresholds, FTS-only rows render as 'keyword match' rather than a fabricated similarity, library_rag_all_matches_weak fires only over vector-similarity score kinds, and the backend label is mode-truthful (rag-hybrid/rag-keyword/rag-semantic).
+- [x] #4 The reranker factory is fixed so a reranking-enabled profile actually constructs a reranker; model loading is verified off the event loop (moved to service construction if it loads lazily at first .rerank()); an unavailable reranker (missing model/dep) skips reranking with disclosed provenance instead of failing the search.
+- [x] #5 Zero-results honesty under hybrid: the 'Index empty' recovery state does not fire when the keyword leg returned rows, and when the semantic leg is empty but the keyword leg is not, the search discloses 'semantic leg empty -- keyword-only results' instead of the generic empty state.
+- [x] #6 An 'Auto-retrieve on send' toggle in the Console RAG chip modal controls native send-path injection, defaults to OFF, and persists as a global config key, re-homing enablement away from the legacy sidebar checkbox.
+- [x] #7 Auto-retrieve fires only for plain user text sends -- never for slash commands, tool approvals, or regenerations -- and skips automatically when evidence is already manually staged (no double retrieval/spend).
+- [x] #8 When auto-retrieve fires, retrieved results route through the existing staged-evidence pipeline (strip shows 'Evidence sent · N', consumption reuses the consume-on-send predicate) rather than invisible prompt injection; the Console chip's manual run is switched from its hardcoded top_k=5 to the active profile's default_top_k so manual and auto retrieval never disagree about depth.
+- [x] #9 An EMPTY resolved scope short-circuits auto-retrieve with the same shared notice copy as the manual path (task-406 AC #2).
+- [x] #10 Auto-retrieve runs in an exclusive worker with a visible 'Retrieving...' strip state and an explicit 5s timeout; on failure or timeout the send proceeds without evidence and shows a quiet notice that distinguishes 'RAG service still initializing' from 'retrieval failed', and a send is never blocked on retrieval.
+- [x] #11 The legacy chat_events RAG injection path is untouched by this work (task-406 AC #3).
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -49,3 +50,90 @@ Docs/superpowers/plans/2026-08-07-rag-port-p0-foundations.md (spec: Docs/superpo
 10. Docs, follow-up filing, backlog closure.
 11. Gates + live TUI walkthrough.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Status note: all 11 ACs above are ticked as CODE-COMPLETE (unit/integration
+tests, RED-first, mutation-checked per task -- see the SDD ledger at
+.superpowers/sdd/2026-08-07-rag-port-p0-foundations/progress.md and each
+task's own report). This task is deliberately left In Progress, not Done --
+Task 11 (gates + a live TUI walkthrough) still owes the Definition of Done's
+live-verification evidence before this closes.
+
+Approach: nine sequential tasks, each RED-first with mutation checks, each
+independently reviewed (most needed one fix round; task-406/AC#1's Console
+injection took two). Two merge-order gates were tracked explicitly in the
+ledger and both cleared before the branch could merge: Task 5's I3 (hybrid
+match-strength honesty depended on Task 6 landing) and the general
+task-406-untouched-until-toggle-exists ordering (task 6/7 before task 8).
+
+Headline findings (the "why this task existed" evidence):
+- Reranking had NEVER activated in production. A double-`strategy` keyword
+  TypeError meant every reranking-enabled profile silently failed to
+  construct a reranker (task 4); even after that fix, the real production
+  factory (`rag_factory.create_rag_service`) separately dropped
+  `reranking_config` before passing it to the constructor, so reranking
+  still could not have run via the app's actual RAG-service entry point
+  until both bugs were fixed together.
+- Library's rag-mode search hardcoded semantic-only retrieval regardless of
+  the active profile's `default_search_mode` -- a user on the "BM25 Only"
+  profile got vector-only search with nothing on screen saying so (task 5).
+- The engine's keyword leg had THREE independent never-worked bugs (guessed
+  DB paths, opened chacha_notes.db with media-schema SQL, a nonexistent
+  Media.tags column) plus an inverted FTS5 ordering (`ORDER BY rank` on a
+  `-rank` alias returns worst-first) -- it could never have returned a
+  correct row (task 3).
+- Hybrid search's fused RRF scores (max ~0.016) were banded against the
+  cosine similarity thresholds meant for vector-only scores, so every
+  hybrid hit rendered "match: weak" regardless of actual relevance --
+  score-kind-aware banding fixed this and also gave FTS-only rows an
+  honest "keyword match" label instead of a fabricated similarity (task 6).
+- The native Console send path (`ConsoleChatController.submit_draft`) had
+  ZERO RAG context injection; the only wired path (`get_rag_context_for_chat`)
+  was the legacy `chat_events` route, unreachable in the live app. Auto-
+  retrieve (opt-in, default OFF, staged-evidence pipeline, 5s timeout, never
+  blocks a send) closes that gap (tasks 7-8), and the manual chip run's
+  hardcoded `top_k=5` now matches the active profile's `default_top_k`
+  (task 9) -- disclosed to users in the docs updated by this task.
+
+Plain-profile routing (task 5): `rag`-mode search now dispatches on the
+active profile's search mode -- `plain` routes through the Library's own
+four-seam, scope-aware keyword path (never the engine's media-only keyword
+leg, which would be a strictly worse search than `search` mode already
+gives); `hybrid` runs the engine's fused hybrid only when unscoped AND
+Media is selected (scoped or Media-deselected hybrid falls back to
+semantic, disclosed, because the engine's allowlist pushdown and FTS leg
+are semantic-only/media-only in P0); `semantic` is unchanged. Every
+divergence from "what you'd expect from a hybrid profile" is disclosed via
+a quiet route-note line, not applied silently.
+
+Files touched (by task; full list in each task-N-report.md):
+RAG_Search/simplified/rag_service.py (fusion leg-score preservation, task 2);
+RAG_Search/{reranker.py,simplified/enhanced_rag_service_v2.py,simplified/
+rag_factory.py,config_profiles.py} (reranker factory + degradation tags,
+task 4); Library/library_local_rag_search_service.py (keyword leg DB
+resolution task 3; profile-mode routing task 5); RAG_Search/
+local_citation_capture.py, Library/library_rag_score_kinds.py (new),
+Library/library_rag_state.py, Widgets/Library/library_search_rag_panel.py,
+UI/Views/RAGSearch/search_handoff.py (score-kind bands, task 6);
+tldw_chatbook/config.py, Widgets/Console/console_rag_settings_modal.py,
+UI/Screens/chat_screen.py (auto-retrieve toggle task 7, send-path injection
+task 8, chip top_k parity task 9); Docs/User_Guide/{library/search-and-rag.md,
+console/context-and-rag.md,settings/rag.md} (this task).
+
+Deviations from the plan: none load-bearing. Two Important review findings
+were fixed per task (task 4 reranker cache-mutation + silent-failure
+disclosure; task 5 stale-profile-cache + zero-row-disclosure-dropped; task 7
+draft-discard coupling + UI-thread write; task 8 unpinned placeholder
+staging) -- all documented in their own task reports, not repeated here.
+
+Follow-ups filed by this task (all reference TASK-3170): TASK-3500 (MCP
+perform_rag_search + agent RAGSearchTool profile-driven-retrieval parity,
+the declared P0 non-goal), TASK-3501 (pipeline_builder_simple.py's hybrid
+merge has the same leg-score aliasing bug task 2 fixed in rag_service.py),
+TASK-3502 (reranker provider/model selection + cost surface, plus two
+re-review residuals), TASK-3503 (config.load_settings cache-miss race can
+return None to worker threads), TASK-3504 (Console auto-retrieve zero-result
+outcome is fully silent).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3170 - RAG-port-P0-profile-honoring-retrieval-and-Console-send-path-injection.md
+++ b/backlog/tasks/task-3170 - RAG-port-P0-profile-honoring-retrieval-and-Console-send-path-injection.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-3170
 title: RAG-port P0 profile-honoring retrieval and Console send-path injection
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-07 14:19'
-updated_date: '2026-08-07 20:44'
+updated_date: '2026-08-07 21:37'
 labels:
   - rag
   - console
@@ -54,12 +54,11 @@ Docs/superpowers/plans/2026-08-07-rag-port-p0-foundations.md (spec: Docs/superpo
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Status note: all 11 ACs above are ticked as CODE-COMPLETE (unit/integration
-tests, RED-first, mutation-checked per task -- see the SDD ledger at
+All 11 ACs are complete: unit/integration tests (RED-first, mutation-checked
+per task -- see the SDD ledger at
 .superpowers/sdd/2026-08-07-rag-port-p0-foundations/progress.md and each
-task's own report). This task is deliberately left In Progress, not Done --
-Task 11 (gates + a live TUI walkthrough) still owes the Definition of Done's
-live-verification evidence before this closes.
+task's own report) PLUS the live TUI walkthrough Task 11 owed, recorded at
+the end of these notes.
 
 Approach: nine sequential tasks, each RED-first with mutation checks, each
 independently reviewed (most needed one fix round; task-406/AC#1's Console
@@ -137,3 +136,61 @@ re-review residuals), TASK-3503 (config.load_settings cache-miss race can
 return None to worker threads), TASK-3504 (Console auto-retrieve zero-result
 outcome is fully silent).
 <!-- SECTION:NOTES:END -->
+
+### Task 11 gates + live TUI walkthrough (2026-08-07)
+
+**Targeted battery.** All 11 test files this branch created or modified, one
+run: **496 passed, 0 failed** (4:58). That equals the sum of their individual
+collected counts, so nothing was skipped or deselected.
+
+**Collection arithmetic** (`--collect-only -q` over `Tests/`, HEAD vs. a
+detached worktree at the merge-base `65c743d1e`): baseline **31,931**, HEAD
+**32,038**, delta **+107**. Accounted for exactly: five new files contribute
+16 + 2 + 4 + 12 + 23 = 57, and six modified files contribute 25 + 2 + 2 + 13
++ 5 + 3 = 50. 31,931 + 57 + 50 = 32,038. No pre-existing test was lost.
+
+**Live walkthrough.** Real TUI in tmux at 235x52, scratch profile via
+`TLDW_CONFIG_PATH` with `users_name = verify_ragp0`, holding a COPY of the
+real ChaChaNotes + media DBs and the real `chromadb/` directory (453 vectors)
+placed before first launch; real OpenAI (Library RAG Answer) and real
+Anthropic (Console) credentials. The live `~/.config/tldw_cli/config.toml`
+was byte-identical afterwards (SHA-256 unchanged, mtime unchanged).
+
+1. **Hybrid Basic (default), Library rag mode** -- rows banded on real cosine
+   similarity: "match: moderate" x2, then "weak (0.18)" / "weak (0.17)".
+   The pre-fix wall of "weak (0.02)" (banding an RRF score whose ceiling is
+   ~0.016) is gone. Zero-row sources disclosed: "Semantic search found
+   nothing from: Notes, Conversations."
+2. **BM25 Only** -- "Set active" repointed `[rag.service] profile` and the
+   next run disclosed "Profile 'BM25 Only': keyword search (no vectors)."
+   and returned a note row AND a **media** row -- the four-seam keyword path
+   including the media seam that AC#2 repaired. The route note also rendered
+   on a zero-row query, which is the AC#5 disclosure-survives-empty rule.
+3. **Hybrid Full** -- the service constructed and the search completed (the
+   pre-AC#4 double-strategy `TypeError` would have killed it). With no index
+   for that profile's embedding model it degraded honestly: "Semantic leg
+   empty -- keyword-only results", and its FTS-leg row rendered "keyword
+   match" rather than a fabricated similarity (AC#3).
+4. **Console** -- see TASK-406's notes: toggle persists at flip time,
+   "Auto-retrieving..." -> `RAG: on / Sources: 1 staged` -> "Evidence sent
+   with this message - 15 sources", and the model quoted the injected
+   `[S1]..[S15]` block back. A slash-command send retrieved nothing.
+5. **Scoped run** -- deselecting Media routed to semantic and said so:
+   "Media excluded -- semantic only."
+
+**Defect found live and fixed forward (RED-first, own commit).** Under
+Hybrid Full the one FTS-leg row rendered as "1. Untitled source | keyword
+match" while its own citation line read "Citations: meeting_notes". The
+vector leg gets `title` for free (indexing spreads document metadata into
+every chunk); the keyword leg builds metadata from scratch and stamped only
+`doc_title`, which `library_local_rag_search_service._semantic_row` -- the
+mapper every engine-backed Library row passes through -- does not read. The
+symptom was unreachable before this branch, because that leg could not
+return a row at all. Both keyword-leg metadata blocks now stamp `title`; the
+new test asserts through `_semantic_row` AND `LibraryRagResultRow.from_result`
+so it pins the rendered title, not a key name. Re-verified live after
+relaunch: the row now reads "1. meeting_notes | keyword match".
+
+Evidence captures (one file per checklist item) live in the session
+scratchpad under `ragp0-evidence/`, and the full gate report is at
+`.superpowers/sdd/2026-08-07-rag-port-p0-foundations/task-11-report.md`.

--- a/backlog/tasks/task-3170 - RAG-port-P0-profile-honoring-retrieval-and-Console-send-path-injection.md
+++ b/backlog/tasks/task-3170 - RAG-port-P0-profile-honoring-retrieval-and-Console-send-path-injection.md
@@ -1,0 +1,51 @@
+---
+id: TASK-3170
+title: RAG-port P0 profile-honoring retrieval and Console send-path injection
+status: In Progress
+assignee: []
+created_date: '2026-08-07 14:19'
+labels:
+  - rag
+  - console
+  - library
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+P0 of the RAG server-port programme. Chatbook's live retrieval is weaker than the profile-driven hybrid/reranking engine it already owns (RAG_Search/simplified/rag_service.py, rag_factory.py): Library/library_local_rag_search_service.py's rag mode hardcodes semantic-only search, and the native Console send path (ConsoleChatController.submit_draft) performs no RAG context injection at all -- the only wired injection path (get_rag_context_for_chat) is the legacy chat_events route, which is unreachable in the live app (see task-406). This task makes the retrieval tldw_chatbook already owns reachable, honestly: the Library path resolves the active RAG profile's search mode with data-safety and score-kind-honesty fixes to the underlying engine, and Console's native send path gains opt-in, visibly-staged retrieval injection. Full design: Docs/superpowers/specs/2026-08-07-rag-port-p0-foundations-design.md.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Library rag-mode search resolves the active RAG profile's default_search_mode (plain/semantic/hybrid) instead of hardcoding semantic search; plain-profile queries route through the existing four-seam _search_keyword path (honestly labeled), never through the engine's standalone keyword leg.
+- [ ] #2 The engine's keyword leg no longer guesses DB paths or opens chacha_notes.db with media-schema SQL: the media DB path is injected explicitly from config, the create-a-new-MediaDatabase-on-miss side effect is deleted, keyword rows carry source_type provenance so they survive the Library's canonicalizing post-filter, and a failed leg degrades to a disclosed coverage note rather than performing a write.
+- [ ] #3 Match-strength presentation is score-kind-aware: _fuse_hybrid_results preserves per-leg scores in hybrid_fusion metadata, RRF-fused and reranker scores are never banded on the cosine strong/moderate/weak thresholds, FTS-only rows render as 'keyword match' rather than a fabricated similarity, library_rag_all_matches_weak fires only over vector-similarity score kinds, and the backend label is mode-truthful (rag-hybrid/rag-keyword/rag-semantic).
+- [ ] #4 The reranker factory is fixed so a reranking-enabled profile actually constructs a reranker; model loading is verified off the event loop (moved to service construction if it loads lazily at first .rerank()); an unavailable reranker (missing model/dep) skips reranking with disclosed provenance instead of failing the search.
+- [ ] #5 Zero-results honesty under hybrid: the 'Index empty' recovery state does not fire when the keyword leg returned rows, and when the semantic leg is empty but the keyword leg is not, the search discloses 'semantic leg empty -- keyword-only results' instead of the generic empty state.
+- [ ] #6 An 'Auto-retrieve on send' toggle in the Console RAG chip modal controls native send-path injection, defaults to OFF, and persists as a global config key, re-homing enablement away from the legacy sidebar checkbox.
+- [ ] #7 Auto-retrieve fires only for plain user text sends -- never for slash commands, tool approvals, or regenerations -- and skips automatically when evidence is already manually staged (no double retrieval/spend).
+- [ ] #8 When auto-retrieve fires, retrieved results route through the existing staged-evidence pipeline (strip shows 'Evidence sent · N', consumption reuses the consume-on-send predicate) rather than invisible prompt injection; the Console chip's manual run is switched from its hardcoded top_k=5 to the active profile's default_top_k so manual and auto retrieval never disagree about depth.
+- [ ] #9 An EMPTY resolved scope short-circuits auto-retrieve with the same shared notice copy as the manual path (task-406 AC #2).
+- [ ] #10 Auto-retrieve runs in an exclusive worker with a visible 'Retrieving...' strip state and an explicit 5s timeout; on failure or timeout the send proceeds without evidence and shows a quiet notice that distinguishes 'RAG service still initializing' from 'retrieval failed', and a send is never blocked on retrieval.
+- [ ] #11 The legacy chat_events RAG injection path is untouched by this work (task-406 AC #3).
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-08-07-rag-port-p0-foundations.md (spec: Docs/superpowers/specs/2026-08-07-rag-port-p0-foundations-design.md).
+1. Backlog filing + task-406 AC edit (this task).
+2. Fusion preserves original leg scores.
+3. Replace the keyword leg's DB resolution (no guessing, no writes).
+4. Fix the reranker factory seam.
+5. Library service honors the profile's search mode.
+6. Score-kind-aware bands (UI state + Answer bundle).
+7. Console auto-retrieve toggle (config + modal).
+8. Console send-path injection (TASK-406).
+9. Chip manual run inherits profile top_k.
+10. Docs, follow-up filing, backlog closure.
+11. Gates + live TUI walkthrough.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-3500 - Align-MCP-perform_rag_search-and-agent-RAGSearchTool-with-profile-driven-retrieval.md
+++ b/backlog/tasks/task-3500 - Align-MCP-perform_rag_search-and-agent-RAGSearchTool-with-profile-driven-retrieval.md
@@ -1,0 +1,30 @@
+---
+id: TASK-3500
+title: >-
+  Align MCP perform_rag_search and agent RAGSearchTool with profile-driven
+  retrieval
+status: To Do
+assignee: []
+created_date: '2026-08-07 20:34'
+labels:
+  - rag
+  - mcp
+  - agents
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The RAG-port P0 programme (TASK-3170) made Library's rag-mode search honor the active RAG profile's search mode (plain/semantic/hybrid), score-kind-aware match bands, a fixed reranker factory, and a rebuilt keyword leg -- but declared this a non-goal for the MCP surface: MCP's perform_rag_search tool and the agent runtime's RAGSearchTool still search however they always have, independent of the active profile. Library and MCP therefore currently disagree about what a 'rag search' means and can return different results, different match semantics, and different reranking behavior for the same query depending on which surface issued it. This task aligns the MCP and agent-tool retrieval paths with the profile-driven engine Library now uses, closing that gap. Related: TASK-694, TASK-1077 (both track other MCP/agent retrieval-parity gaps).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 MCP perform_rag_search resolves and honors the active RAG profile's default_search_mode the same way Library's rag-mode search does, instead of a hardcoded search behavior
+- [ ] #2 The agent runtime's RAGSearchTool resolves and honors the active RAG profile the same way
+- [ ] #3 A query issued through MCP/RAGSearchTool and the same query issued through Library's Search/RAG canvas return results with the same match-strength semantics (score-kind-aware bands, not a fabricated similarity) for the same active profile
+- [ ] #4 Reranking-enabled profiles apply reranking on the MCP/agent path exactly as they do on the Library path, with the same skip-on-unavailable disclosure rather than a hard failure
+- [ ] #5 Existing MCP/agent RAG search callers continue to work without a breaking API change
+<!-- AC:END -->

--- a/backlog/tasks/task-3500 - Align-MCP-perform_rag_search-and-agent-RAGSearchTool-with-profile-driven-retrieval.md
+++ b/backlog/tasks/task-3500 - Align-MCP-perform_rag_search-and-agent-RAGSearchTool-with-profile-driven-retrieval.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-08-07 20:34'
+updated_date: '2026-08-07 22:05'
 labels:
   - rag
   - mcp
@@ -27,4 +28,5 @@ The RAG-port P0 programme (TASK-3170) made Library's rag-mode search honor the a
 - [ ] #3 A query issued through MCP/RAGSearchTool and the same query issued through Library's Search/RAG canvas return results with the same match-strength semantics (score-kind-aware bands, not a fabricated similarity) for the same active profile
 - [ ] #4 Reranking-enabled profiles apply reranking on the MCP/agent path exactly as they do on the Library path, with the same skip-on-unavailable disclosure rather than a hard failure
 - [ ] #5 Existing MCP/agent RAG search callers continue to work without a breaking API change
+- [ ] #6 mcp_inspector._ScoredRow no longer defaults score_kind to vector_similarity blindly -- fused/reranker kinds are handled before MCP routes through profiles (mcp_inspector.py:502)
 <!-- AC:END -->

--- a/backlog/tasks/task-3501 - pipeline_builder_simple.py-hybrid-merge-has-the-same-leg-score-aliasing-bug-Task-2-fixed-in-rag_service.md
+++ b/backlog/tasks/task-3501 - pipeline_builder_simple.py-hybrid-merge-has-the-same-leg-score-aliasing-bug-Task-2-fixed-in-rag_service.md
@@ -1,0 +1,27 @@
+---
+id: TASK-3501
+title: >-
+  pipeline_builder_simple.py hybrid merge has the same leg-score aliasing bug
+  Task 2 fixed in rag_service
+status: To Do
+assignee: []
+created_date: '2026-08-07 20:35'
+labels:
+  - rag
+dependencies:
+  - TASK-3170
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-3170's Task 2 fixed a bug in RAG_Search/simplified/rag_service.py's hybrid fusion where per-leg (keyword/vector) scores were captured AFTER result.score had already been mutated, so entry.item aliased fts_item and the preserved 'original' leg scores were actually already-fused values. RAG_Search/simplified/pipeline_builder_simple.py (~L360-386) is the legacy pipeline-builder path and has its own, separate hybrid merge with the identical aliasing pattern -- it was out of scope for Task 2 (which only touched rag_service.py) and was never fixed. Any caller still routed through the legacy pipeline builder gets the same corrupted per-leg scores in hybrid_fusion metadata that rag_service.py used to produce before Task 2.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 pipeline_builder_simple.py's hybrid merge preserves each leg's original score, captured before any mutation of the shared result/item object
+- [ ] #2 A regression test exercises the real hybrid merge and asserts the leg scores in hybrid_fusion metadata do not silently equal the post-fusion score
+- [ ] #3 No behavior change for non-hybrid search modes on the legacy pipeline path
+<!-- AC:END -->

--- a/backlog/tasks/task-3502 - Reranker-follow-ups-provider-model-selection-cost-surface-and-two-re-review-residuals.md
+++ b/backlog/tasks/task-3502 - Reranker-follow-ups-provider-model-selection-cost-surface-and-two-re-review-residuals.md
@@ -1,0 +1,29 @@
+---
+id: TASK-3502
+title: >-
+  Reranker follow-ups: provider/model selection, cost surface, and two re-review
+  residuals
+status: To Do
+assignee: []
+created_date: '2026-08-07 20:36'
+labels:
+  - rag
+  - settings
+dependencies:
+  - TASK-3170
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-3170's Task 4 fixed the reranker factory so a reranking-enabled profile actually constructs and runs a reranker (it had never worked before -- a double-strategy TypeError meant reranking silently never activated in production). That fix surfaced follow-on gaps that were explicitly left out of Task 4's scope: Settings ▸ RAG's 'Enable reranking' toggle creates a bare RerankingConfig that defaults to provider=openai, model=gpt-3.5-turbo with no way to pick a different provider/model and no cost disclosure before enabling it, even though a single search can now issue up to 15 provider calls for LLM-driven reranking (pointwise scores each candidate individually). Two smaller, already-diagnosed residuals from Task 4's re-review rounds are folded in here rather than filed separately: (a) the reranking_degraded disclosure tag's cache-safety fix (copy-not-mutate) has no dedicated test coverage for the Pairwise/Listwise strategies, where the copy semantics actually matter differently than Pointwise; (b) BaseReranker's last_rerank_failures/last_rerank_total counters are instance state on a shared singleton reranker and are racy under concurrent search() calls -- diagnostic-only corruption (the disclosed count could be wrong), not a correctness bug in the reranked results themselves.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Settings ▸ RAG's Reranking fold lets the user choose the reranking provider and model, not just a bare on/off toggle defaulting to openai/gpt-3.5-turbo
+- [ ] #2 Enabling reranking discloses, before the user commits, that reranking issues one provider call per candidate result (up to Rerank results many) and therefore has a real per-search cost
+- [ ] #3 A regression test drives the real PairwiseReranker and ListwiseReranker strategies through the reranking_degraded copy-not-mutate path and confirms neither poisons a cached SearchResult
+- [ ] #4 BaseReranker's per-call failure counters are safe under concurrent search() calls on the shared reranker singleton, or the diagnostic disclosure is scoped so a race cannot misattribute one search's failures to another's disclosed tag
+<!-- AC:END -->

--- a/backlog/tasks/task-3502 - Reranker-follow-ups-provider-model-selection-cost-surface-and-two-re-review-residuals.md
+++ b/backlog/tasks/task-3502 - Reranker-follow-ups-provider-model-selection-cost-surface-and-two-re-review-residuals.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-08-07 20:36'
+updated_date: '2026-08-07 22:05'
 labels:
   - rag
   - settings
@@ -27,3 +28,9 @@ TASK-3170's Task 4 fixed the reranker factory so a reranking-enabled profile act
 - [ ] #3 A regression test drives the real PairwiseReranker and ListwiseReranker strategies through the reranking_degraded copy-not-mutate path and confirms neither poisons a cached SearchResult
 - [ ] #4 BaseReranker's per-call failure counters are safe under concurrent search() calls on the shared reranker singleton, or the diagnostic disclosure is scoped so a race cannot misattribute one search's failures to another's disclosed tag
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Final whole-branch review (2026-08-07) surfaced two additional scope items to fold in here: (a) the reranking_skipped/reranking_degraded disclosure tags currently have ZERO UI consumers -- disclosure is metadata/log-only, so a Hybrid Full user with a dead reranker credential sees normal-looking results with no indication reranking silently skipped or degraded; (b) partial pointwise failure stamps rerank_score = original_score on failed rows, so a 14/15-failed rerank still renders " | reranked" on rows that were never actually rescored -- conservative in direction (no fabricated score), but an over-claim about what happened to those rows.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3503 - config.load_settings-cache-miss-race-can-return-None-to-worker-threads.md
+++ b/backlog/tasks/task-3503 - config.load_settings-cache-miss-race-can-return-None-to-worker-threads.md
@@ -1,0 +1,25 @@
+---
+id: TASK-3503
+title: config.load_settings cache-miss race can return None to worker threads
+status: To Do
+assignee: []
+created_date: '2026-08-07 20:36'
+labels:
+  - config
+dependencies:
+  - TASK-3170
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Diagnosed during TASK-3170's Task 6 while chasing an intermittent test failure (1/12 runs at commit ceba0f02b, cited in that task's report): config.load_settings() sets the module-level _SETTINGS_CACHE to None under its lock on a cache miss, then rebuilds the real settings object OUTSIDE that lock. A second thread (observed concretely as a Textual worker thread calling config.load_settings() while a cache rebuild is in flight) can read the cache in the None window and receive None instead of a settings mapping or the previous cached value. This is not scoped to RAG -- any code path that calls load_settings() from a worker thread while another thread is mid-rebuild can hit it, and the failure mode (a None where a settings dict is expected) tends to surface as a confusing downstream TypeError/AttributeError far from the real cause.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 config.load_settings() never returns None to a concurrent caller during a cache rebuild -- either the lock is held for the full miss-then-rebuild sequence, or a concurrent reader gets the previous cached value instead of None
+- [ ] #2 A concurrency regression test reproduces the race (multiple threads calling load_settings() while a cache invalidation/rebuild is forced) and fails against the current code before the fix, passes after
+- [ ] #3 No behavior change to the normal single-threaded / cache-hit path
+<!-- AC:END -->

--- a/backlog/tasks/task-3504 - Console-auto-retrieve-zero-result-outcome-is-fully-silent.md
+++ b/backlog/tasks/task-3504 - Console-auto-retrieve-zero-result-outcome-is-fully-silent.md
@@ -4,6 +4,7 @@ title: Console auto-retrieve zero-result outcome is fully silent
 status: To Do
 assignee: []
 created_date: '2026-08-07 20:37'
+updated_date: '2026-08-07 22:05'
 labels:
   - console
   - rag
@@ -24,3 +25,9 @@ TASK-3170's Task 8 (Console send-path auto-retrieve injection) deliberately made
 - [ ] #2 The notice does not block the send and does not stage the manual run's recovery card
 - [ ] #3 A regression test confirms the notice fires exactly on the zero-result auto-retrieve path and not on the already-covered failed/timeout/success paths
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Final whole-branch review (2026-08-07): the blocked outcome (RAG deps missing) currently toasts the generic "Library Search/RAG retrieval failed" copy -- a user with the auto-retrieve toggle ON but embeddings_rag extras missing gets that generic failure copy on every send instead of being routed to setup/install guidance. Fold notice-copy routing for the deps-missing/blocked case into this task's scope alongside the zero-result notice.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3504 - Console-auto-retrieve-zero-result-outcome-is-fully-silent.md
+++ b/backlog/tasks/task-3504 - Console-auto-retrieve-zero-result-outcome-is-fully-silent.md
@@ -1,0 +1,26 @@
+---
+id: TASK-3504
+title: Console auto-retrieve zero-result outcome is fully silent
+status: To Do
+assignee: []
+created_date: '2026-08-07 20:37'
+labels:
+  - console
+  - rag
+dependencies:
+  - TASK-3170
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-3170's Task 8 (Console send-path auto-retrieve injection) deliberately made a zero-result auto-retrieve outcome clear its in-flight 'Retrieving...' placeholder without staging the manual run's blocking recovery card -- correct, since staging that card would lock the composer until the user found the un-stage button. But the accepted trade-off means a zero-result auto-retrieve is now completely silent: the send proceeds with no evidence and nothing tells the user retrieval ran and found nothing, unlike the manual chip run (which shows the recovery card) or a failed/timed-out auto-retrieve (which shows a quiet notice). A user relying on auto-retrieve for grounding has no way to know a given send went out ungrounded because the query matched nothing, versus because retrieval succeeded. The existing degraded-notice seam (used for failed/timeout outcomes) is the natural place to add one more quiet notify call for the empty case.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A zero-result auto-retrieve outcome shows a quiet, non-blocking notice (reusing the existing degraded-notice seam) distinguishing 'retrieval ran and found nothing' from a silent send
+- [ ] #2 The notice does not block the send and does not stage the manual run's recovery card
+- [ ] #3 A regression test confirms the notice fires exactly on the zero-result auto-retrieve path and not on the already-covered failed/timeout/success paths
+<!-- AC:END -->

--- a/backlog/tasks/task-3600 - Console-model-dropdown-offers-retired-Anthropic-models-while-the-catalog-cache-holds-the-current-set.md
+++ b/backlog/tasks/task-3600 - Console-model-dropdown-offers-retired-Anthropic-models-while-the-catalog-cache-holds-the-current-set.md
@@ -1,0 +1,25 @@
+---
+id: TASK-3600
+title: >-
+  Console model dropdown offers retired Anthropic models while the catalog cache
+  holds the current set
+status: To Do
+assignee: []
+created_date: '2026-08-07 22:06'
+labels:
+  - console
+  - models
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found during RAG-port P0's live walkthrough (task-11 report): the Console model dropdown lists models the Anthropic API now 404s (claude-3-haiku-20240307, claude-3-5-haiku-20241022) while the app's own model_catalog_cache.json for that endpoint holds the current set; sending on a listed retired model yields a bare "provider returned HTTP 400".
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Dropdown reflects the current catalog for the configured endpoint
+- [ ] #2 Sending on a retired model yields an actionable error naming the model, not a bare HTTP 400
+<!-- AC:END -->

--- a/backlog/tasks/task-3601 - Library-plain-profile-rag-mode-should-not-require-the-embeddings-runtime.md
+++ b/backlog/tasks/task-3601 - Library-plain-profile-rag-mode-should-not-require-the-embeddings-runtime.md
@@ -1,0 +1,23 @@
+---
+id: TASK-3601
+title: Library plain-profile rag mode should not require the embeddings runtime
+status: To Do
+assignee: []
+created_date: '2026-08-07 22:06'
+labels:
+  - rag
+  - library
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Final-review finding on the P0 branch: _search_rag resolves the heavy RAG runtime before reading the profile mode, so BM25 Only + missing embeddings_rag extras renders "RAG unavailable -- install embeddings" although the plain route needs no vectors, and with deps present the first plain query pays embedding-model construction to read a flag; resolve_active_rag_config() can supply the mode without a runtime.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 With BM25 Only active and embeddings_rag absent, Library rag mode runs the four-seam keyword search instead of the unavailable state
+- [ ] #2 No embedding construction on the plain route
+<!-- AC:END -->

--- a/backlog/tasks/task-406 - Wire-RAG-context-injection-into-the-native-Console-send-path.md
+++ b/backlog/tasks/task-406 - Wire-RAG-context-injection-into-the-native-Console-send-path.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-406
 title: Wire RAG context injection into the native Console send path
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-21 09:48'
-updated_date: '2026-08-07 14:20'
+updated_date: '2026-08-07 20:44'
 labels:
   - rag
   - console
@@ -20,7 +20,59 @@ Verified during the RAG scope program (plan verification V4, re-confirmed by two
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Native Console sends inject RAG context only when the 'Auto-retrieve on send' toggle in the Console RAG chip modal is ON (default OFF; enablement is re-homed from the legacy sidebar checkbox to this modal toggle, persisted as a global config key); when ON, injection routes through the existing staged-evidence pipeline -- a visible 'Evidence sent · N' strip, consumed only on send -- honoring conversation scope end-to-end, never as invisible prompt injection.
-- [ ] #2 EMPTY scope short-circuits with the shared notice copy on the native path
-- [ ] #3 Legacy path behavior unchanged
+- [x] #1 Native Console sends inject RAG context only when the 'Auto-retrieve on send' toggle in the Console RAG chip modal is ON (default OFF; enablement is re-homed from the legacy sidebar checkbox to this modal toggle, persisted as a global config key); when ON, injection routes through the existing staged-evidence pipeline -- a visible 'Evidence sent · N' strip, consumed only on send -- honoring conversation scope end-to-end, never as invisible prompt injection.
+- [x] #2 EMPTY scope short-circuits with the shared notice copy on the native path
+- [x] #3 Legacy path behavior unchanged
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Status note: all 3 ACs above are ticked as CODE-COMPLETE. Left In Progress,
+not Done -- TASK-3170's Task 11 (gates + a live TUI walkthrough) still owes
+the Definition of Done's live-verification evidence for this specific send
+path before either task closes.
+
+Approach: implemented as TASK-3170's tasks 7 (config key + RAG chip modal
+toggle, `chat_screen.py` + `console_rag_settings_modal.py`) and 8 (the actual
+send-path seam, `chat_screen.py`). AC #1's toggle persists the instant it is
+flipped (a modal callback wired to a `@work(thread=True)` writer), not tied
+to the modal's Run/Cancel draft-discard semantics -- an earlier draft
+persisted only on dismiss and lost the change on Escape; fixed in a review
+round before this task counted as code-complete.
+
+`ChatScreen._maybe_auto_retrieve_for_send` is called from
+`_capture_console_staged_rag`, immediately before `_consume_pending_console_
+launch()`, inside the same exclusive `run_worker(..., group=f"console-run-
+{session_id}")` the send already dispatches under -- no second worker, so a
+double-send cannot double-retrieve. Reached only after every send-blocking
+gate (provider readiness, workspace policy, skill-substitution refusal), so
+a blocked/refused send never auto-retrieves. Gate order (each mutation-
+tested to red exactly its own test): toggle off -> return; non-plain-text
+send (slash command, `$skill` invocation, second-Enter literal `/word`) ->
+return; evidence already staged (resident launch OR an unclaimed
+`HandoffChannel.CONSOLE_LIVE_WORK` entry) -> return; EMPTY resolved scope ->
+notify with the shared `SCOPE_EMPTY_NOTICE_TEMPLATE` copy (AC #2), return;
+otherwise stage a "Retrieving..." placeholder and await the search under a
+5s `asyncio.timeout`, with `top_k` from the active profile's `default_top_k`
+(task 9 gave the chip's manual run the same source, so the two paths cannot
+disagree about depth).
+
+Two departures from the original sketch, both because reusing the manual
+chip run's own recovery path wholesale would have let a single empty auto-
+retrieve lock the composer (the existing block-while-`available_count==0`
+guard is screen-level, not query-specific): a zero-result outcome clears the
+placeholder silently rather than staging the manual run's blocking recovery
+card (tracked as a UX follow-up, TASK-3504, not a defect); a failed/timeout
+outcome shows a quiet notice distinguishing "RAG service still initializing"
+(no cached runtime -- the timeout is paying the first-run embedding-model
+load) from "retrieval failed" (a real error), and the auto-retrieve await
+itself is wrapped in try/except so an exploding retrieval cannot also
+discard a manually staged evidence bundle the same send was about to
+consume. AC #3 (legacy path untouched): confirmed by diff -- no
+`chat_events`/`get_rag_context_for_chat` file was touched by tasks 7-8.
+
+Files: tldw_chatbook/config.py, Widgets/Console/console_rag_settings_modal.py,
+UI/Screens/chat_screen.py. Full test/mutation evidence in
+.superpowers/sdd/2026-08-07-rag-port-p0-foundations/task-{7,8,9}-report.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-406 - Wire-RAG-context-injection-into-the-native-Console-send-path.md
+++ b/backlog/tasks/task-406 - Wire-RAG-context-injection-into-the-native-Console-send-path.md
@@ -4,6 +4,7 @@ title: Wire RAG context injection into the native Console send path
 status: To Do
 assignee: []
 created_date: '2026-07-21 09:48'
+updated_date: '2026-08-07 14:20'
 labels:
   - rag
   - console
@@ -19,7 +20,7 @@ Verified during the RAG scope program (plan verification V4, re-confirmed by two
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Native Console sends inject RAG context when RAG is enabled, honoring conversation scope end-to-end
+- [ ] #1 Native Console sends inject RAG context only when the 'Auto-retrieve on send' toggle in the Console RAG chip modal is ON (default OFF; enablement is re-homed from the legacy sidebar checkbox to this modal toggle, persisted as a global config key); when ON, injection routes through the existing staged-evidence pipeline -- a visible 'Evidence sent · N' strip, consumed only on send -- honoring conversation scope end-to-end, never as invisible prompt injection.
 - [ ] #2 EMPTY scope short-circuits with the shared notice copy on the native path
 - [ ] #3 Legacy path behavior unchanged
 <!-- AC:END -->

--- a/backlog/tasks/task-406 - Wire-RAG-context-injection-into-the-native-Console-send-path.md
+++ b/backlog/tasks/task-406 - Wire-RAG-context-injection-into-the-native-Console-send-path.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-406
 title: Wire RAG context injection into the native Console send path
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-21 09:48'
-updated_date: '2026-08-07 20:44'
+updated_date: '2026-08-07 21:36'
 labels:
   - rag
   - console
@@ -41,38 +41,35 @@ to the modal's Run/Cancel draft-discard semantics -- an earlier draft
 persisted only on dismiss and lost the change on Escape; fixed in a review
 round before this task counted as code-complete.
 
-`ChatScreen._maybe_auto_retrieve_for_send` is called from
-`_capture_console_staged_rag`, immediately before `_consume_pending_console_
-launch()`, inside the same exclusive `run_worker(..., group=f"console-run-
-{session_id}")` the send already dispatches under -- no second worker, so a
-double-send cannot double-retrieve. Reached only after every send-blocking
-gate (provider readiness, workspace policy, skill-substitution refusal), so
-a blocked/refused send never auto-retrieves. Gate order (each mutation-
-tested to red exactly its own test): toggle off -> return; non-plain-text
-send (slash command, `$skill` invocation, second-Enter literal `/word`) ->
-return; evidence already staged (resident launch OR an unclaimed
-`HandoffChannel.CONSOLE_LIVE_WORK` entry) -> return; EMPTY resolved scope ->
-notify with the shared `SCOPE_EMPTY_NOTICE_TEMPLATE` copy (AC #2), return;
-otherwise stage a "Retrieving..." placeholder and await the search under a
-5s `asyncio.timeout`, with `top_k` from the active profile's `default_top_k`
-(task 9 gave the chip's manual run the same source, so the two paths cannot
-disagree about depth).
+LIVE VERIFICATION (2026-08-07, TASK-3170 Task 11) -- the status note above is
+now discharged; this task is Done. Driven in the real TUI (tmux 235x52) on a
+scratch profile (`TLDW_CONFIG_PATH`, `users_name = verify_ragp0`) holding a
+copy of the real ChaChaNotes + media DBs and the real `chromadb/` directory,
+against a real Anthropic account (claude-haiku-4-5-20251001) and the default
+Hybrid Basic profile:
 
-Two departures from the original sketch, both because reusing the manual
-chip run's own recovery path wholesale would have let a single empty auto-
-retrieve lock the composer (the existing block-while-`available_count==0`
-guard is screen-level, not query-specific): a zero-result outcome clears the
-placeholder silently rather than staging the manual run's blocking recovery
-card (tracked as a UX follow-up, TASK-3504, not a defect); a failed/timeout
-outcome shows a quiet notice distinguishing "RAG service still initializing"
-(no cached runtime -- the timeout is paying the first-run embedding-model
-load) from "retrieval failed" (a real error), and the auto-retrieve await
-itself is wrapped in try/except so an exploding retrieval cannot also
-discard a manually staged evidence bundle the same send was about to
-consume. AC #3 (legacy path untouched): confirmed by diff -- no
-`chat_events`/`get_rag_context_for_chat` file was touched by tasks 7-8.
+- AC #1 toggle + persistence: flipping "Auto-retrieve on send" in the RAG chip
+  modal wrote `[chat_defaults] rag_auto_retrieve_on_send = true` to the config
+  file at toggle time -- confirmed by reading the file WHILE the modal was
+  still open -- and Escape left it set (the dismiss path is write-free).
+- AC #1 injection through the staged pipeline, end to end: a plain-text send
+  showed "Auto-retrieving Library evidence for this message." at t=1.0s with
+  the footer chip reading `RAG: on · Sources: 1 staged`, then "Evidence sent
+  with this message · 15 sources" at t=2.1s. The reply that came back named
+  the injected block back to us -- "the evidence sections [S1] through [S15]
+  contain only repeated Latin placeholder words..." (the corpus fixture that
+  dominates this profile's index) -- which is the proof that the staged
+  evidence actually reached the provider rather than being staged and dropped.
+  Depth 15 is the profile's `default_top_k`, i.e. the TASK-3170 AC#8 parity.
+- AC #1 gating: a send beginning with a slash command fired NO retrieval --
+  no placeholder, no chip flip, no evidence line (polled at 0.15s for 18s).
+- AC #2/#3 are covered headlessly (Tests/UI/test_console_auto_rag_on_send.py);
+  the empty-scope short-circuit was not driven live because the scratch
+  profile could not cheaply produce an empty resolved scope.
 
-Files: tldw_chatbook/config.py, Widgets/Console/console_rag_settings_modal.py,
-UI/Screens/chat_screen.py. Full test/mutation evidence in
-.superpowers/sdd/2026-08-07-rag-port-p0-foundations/task-{7,8,9}-report.md.
+One live observation worth carrying forward, already filed: an auto-retrieve
+that returns zero rows is completely silent (placeholder cleared, no notice),
+so the model answers unaided and the user cannot tell retrieval was attempted.
+Observed on a first send whose phrasing matched nothing; that is TASK-3504.
+Evidence captures: scratchpad ragp0-evidence/04a..04d.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/library_local_rag_search_service.py
+++ b/tldw_chatbook/Library/library_local_rag_search_service.py
@@ -40,7 +40,18 @@ from tldw_chatbook.RAG_Search.pipeline_functions_simple import SCOPE_DIAGNOSTICS
 # (task-247): resolving through it guarantees Library RAG Answer queries read
 # the exact vector store / collection / embedding model that ingestion-time
 # indexing writes to.
-from tldw_chatbook.RAG_Search.ingestion_indexing import get_shared_rag_service
+from tldw_chatbook.RAG_Search.ingestion_indexing import (
+    get_shared_rag_service,
+    shared_rag_service_generation,
+)
+
+# One staleness rule for the `app._rag_service` cache, shared with the chat/
+# Search resolver (`resolve_semantic_rag_service`): a profile switch resets
+# the shared singleton, and both app-level caches must notice.
+from tldw_chatbook.RAG_Search.semantic_availability import (
+    cache_app_rag_service,
+    current_app_rag_service,
+)
 from tldw_chatbook.UI.destination_recovery import DestinationRecoveryState
 from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
 from tldw_chatbook.Utils.optional_deps import embeddings_rag_deps_installed
@@ -705,8 +716,15 @@ class LibraryLocalRagSearchService:
 
         Resolution order:
 
-        1. An existing ``app._rag_service`` with a callable ``search`` always
-           wins (already initialized by any surface, or injected by tests).
+        1. An existing ``app._rag_service`` with a callable ``search`` wins
+           (already initialized by any surface, or injected by tests) --
+           UNLESS a profile switch superseded it since it was cached
+           (``current_app_rag_service``, the one staleness rule shared with
+           ``semantic_availability``'s resolver). Without that check, a
+           Settings profile change would leave this path retrieving under
+           the OLD profile for the rest of the session, and `_search_rag`
+           would attribute its disclosure to a profile that is no longer
+           active -- a false claim about the very thing being disclosed.
         2. The ``embeddings_rag`` deps gate (cheap ``find_spec`` probe, no
            imports) short-circuits BEFORE any heavy work, so missing-deps
            installs keep the existing recovery routing at zero cost (AC #3).
@@ -726,11 +744,13 @@ class LibraryLocalRagSearchService:
             The RAG runtime, or None when it is unavailable (missing deps or
             failed construction) -- the caller renders the recovery state.
         """
-        rag_service = getattr(self._app, "_rag_service", None)
-        if rag_service is not None and callable(getattr(rag_service, "search", None)):
-            return rag_service
+        cached = current_app_rag_service(self._app)
+        if cached is not None:
+            return cached
         if not embeddings_rag_deps_installed():
             return None
+        # Captured BEFORE the build -- see `cache_app_rag_service`.
+        generation = shared_rag_service_generation()
         try:
             service = await asyncio.to_thread(get_shared_rag_service)
         except Exception:
@@ -741,14 +761,10 @@ class LibraryLocalRagSearchService:
             return None
         if service is None or not callable(getattr(service, "search", None)):
             return None
-        try:
-            # Cache on the app so every RAG surface (chat sidebar readiness,
-            # repeat Library queries) sees the initialized runtime.
-            self._app._rag_service = service
-        except Exception:
-            logger.opt(exception=True).debug(
-                "Could not cache the shared RAG service on the app instance."
-            )
+        # Cache on the app so every RAG surface (chat sidebar readiness,
+        # repeat Library queries) sees the initialized runtime, stamped so a
+        # later profile switch invalidates it.
+        cache_app_rag_service(self._app, service, generation)
         return service
 
     async def _semantic_index_is_empty(self, rag_service: Any) -> bool:

--- a/tldw_chatbook/Library/library_local_rag_search_service.py
+++ b/tldw_chatbook/Library/library_local_rag_search_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping, Sequence
+from dataclasses import replace
 from typing import Any, Optional
 
 from loguru import logger
@@ -25,6 +26,7 @@ from tldw_chatbook.Library.library_rag_service import LibraryRagSearchOutcome
 from tldw_chatbook.Library.library_rag_state import (
     LIBRARY_RAG_EMPTY_STATE_SELECTOR,
     LIBRARY_RAG_QUERY_MAX_LENGTH,
+    LIBRARY_RAG_ROUTE_NOTES_KEY,
     LIBRARY_RAG_SERVICE_ERROR_SELECTOR,
 )
 
@@ -47,7 +49,26 @@ logger = logger.bind(module="LibraryLocalRagSearchService")
 
 _SEARCH_RUNTIME_BACKEND = "local-fts"
 _RAG_RUNTIME_BACKEND = "rag-semantic"
+# Mode-truthful backend label for the engine's RRF-fused hybrid path (spec
+# Workstream A item 3): a hybrid search must never report itself as
+# "rag-semantic", since the two produce different score kinds.
+_RAG_HYBRID_RUNTIME_BACKEND = "rag-hybrid"
 _KNOWN_KEYWORD_SOURCE_TYPES = ("notes", "media", "conversations", "prompts")
+# The active RAG profile's `default_search_mode` vocabulary
+# (`RAG_Search/simplified/config.py::SearchConfig`). Anything else -- a
+# hand-edited TOML, a future mode this build does not know -- resolves to
+# "semantic", the historical behavior.
+_PROFILE_SEARCH_MODES = ("plain", "semantic", "hybrid")
+# Routing disclosures (spec Workstream A: "each handled by disclosure
+# rather than silence"). Lowercase fragments; `library_rag_state`'s
+# `_route_note_sentence` renders them as sentences on the Evidence
+# region's one quiet coverage line.
+ROUTE_NOTE_PLAIN_PROFILE_TEMPLATE = "{profile}: keyword search (no vectors)"
+ROUTE_NOTE_HYBRID_SCOPED = (
+    "scope active — semantic only until scope-aware hybrid lands"
+)
+ROUTE_NOTE_HYBRID_MEDIA_EXCLUDED = "media excluded — semantic only"
+ROUTE_NOTE_SEMANTIC_LEG_EMPTY = "semantic leg empty — keyword-only results"
 # Mirrors `library_rag_state`'s `_OPEN_SOURCE_TYPE_MAP` canonicalization:
 # raw provenance `source_type` values -> the scope-toggle identifiers used
 # by `LibraryRagScopeState`/the Search canvas's per-source toggles.
@@ -114,7 +135,8 @@ class LibraryLocalRagSearchService:
     app's `_rag_service`, lazily initializing it from the process-wide
     shared RAG service on first use when the embeddings deps are installed
     (task-249), and degrades to a blocked outcome with setup routing when
-    the runtime is unavailable.
+    the runtime is unavailable. Which retrieval `rag` mode actually runs is
+    the ACTIVE profile's decision, not a constant -- see `_search_rag`.
     """
 
     def __init__(self, app_instance: Any) -> None:
@@ -137,7 +159,9 @@ class LibraryLocalRagSearchService:
                 `notes`, `media`, `conversations`). Unknown types are
                 ignored quietly.
             mode: Retrieval mode: `search` (keyword, local FTS seams) or
-                `rag` (delegates to the app's optional `_rag_service`).
+                `rag` (routed by the active RAG profile's
+                `default_search_mode` -- keyword seams, semantic, or the
+                engine's fused hybrid; see `_search_rag`).
             scope: Optional resolved RAG retrieval scope (rag-scope
                 narrowing, task-6). Caller-passed only -- this service never
                 resolves scope itself, so a Library-screen call site that
@@ -176,10 +200,106 @@ class LibraryLocalRagSearchService:
                 "calling (there is nothing left to retrieve from)."
             )
         if mode == "rag":
-            return await self._search_semantic(
+            return await self._search_rag(
                 query, source_types, top_k, kwargs, scope=scope
             )
         return await self._search_keyword(query, source_types, top_k, scope=scope)
+
+    async def _search_rag(
+        self,
+        query: str,
+        source_types: tuple[str, ...],
+        top_k: int,
+        kwargs: Mapping[str, Any],
+        *,
+        scope: Optional[EffectiveScope] = None,
+    ) -> Any:
+        """Route a `rag`-mode request per the ACTIVE profile's search mode.
+
+        Before this existed the live path hardcoded `search_type="semantic"`:
+        a user who selected "BM25 Only" or "Hybrid Basic" in Settings > RAG
+        got vector-only retrieval anyway, with nothing on screen saying so
+        (spec Workstream A). Routing, with every divergence disclosed
+        through the coverage-note channel rather than silently applied:
+
+        - `plain` -> the Library's own four-seam, scope-aware keyword path
+          (`_search_keyword`), NOT the engine's media-only keyword leg: a
+          BM25 profile must not get a strictly worse search in `rag` mode
+          than `search` mode already gives it.
+        - `hybrid`, unscoped, media selected -> the engine's fused hybrid.
+        - `hybrid`, scoped -> semantic. `RAGService.search` RAISES for a
+          non-empty `metadata_allowlist` with any non-semantic search type
+          (allowlist pushdown is semantic-only), so this is a hard engine
+          constraint, not a preference. Extending allowlists to the FTS leg
+          is P2.
+        - `hybrid`, media deselected -> semantic. The engine's FTS leg
+          covers media only in P0, so its rows could only be dropped by the
+          source-type post-filter -- running it would spend a query to
+          produce nothing.
+        - `semantic` (and any unknown mode) -> today's exact behavior.
+
+        Args:
+            query: Already-validated user query.
+            source_types: Selected Library source type identifiers.
+            top_k: Result cap.
+            kwargs: Backend options (`include_citations`).
+            scope: Optional resolved retrieval scope; `state == "scoped"`
+                is what forces the semantic path under a hybrid profile.
+
+        Returns:
+            The chosen path's own return shape (mapping or
+            `LibraryRagSearchOutcome`), with any routing disclosure attached
+            under `diagnostics[LIBRARY_RAG_ROUTE_NOTES_KEY]`.
+        """
+        rag_service = await self._resolve_rag_runtime()
+        if rag_service is None:
+            return LibraryRagSearchOutcome(
+                status="blocked",
+                recovery_state=_rag_mode_unavailable_recovery_state(),
+            )
+        profile_mode = _resolve_profile_search_mode(rag_service)
+
+        if profile_mode == "plain":
+            result = await self._search_keyword(
+                query, source_types, top_k, scope=scope
+            )
+            return _with_route_notes(
+                result,
+                (
+                    ROUTE_NOTE_PLAIN_PROFILE_TEMPLATE.format(
+                        profile=_profile_disclosure_label(rag_service)
+                    ),
+                ),
+            )
+
+        if profile_mode == "hybrid":
+            if scope is not None and scope.state == "scoped":
+                return await self._search_semantic(
+                    query,
+                    source_types,
+                    top_k,
+                    kwargs,
+                    scope=scope,
+                    rag_service=rag_service,
+                    route_notes=(ROUTE_NOTE_HYBRID_SCOPED,),
+                )
+            if "media" not in source_types:
+                return await self._search_semantic(
+                    query,
+                    source_types,
+                    top_k,
+                    kwargs,
+                    scope=scope,
+                    rag_service=rag_service,
+                    route_notes=(ROUTE_NOTE_HYBRID_MEDIA_EXCLUDED,),
+                )
+            return await self._search_hybrid(
+                query, source_types, top_k, kwargs, rag_service=rag_service
+            )
+
+        return await self._search_semantic(
+            query, source_types, top_k, kwargs, scope=scope, rag_service=rag_service
+        )
 
     async def _search_keyword(
         self,
@@ -419,6 +539,8 @@ class LibraryLocalRagSearchService:
         kwargs: Mapping[str, Any],
         *,
         scope: Optional[EffectiveScope] = None,
+        rag_service: Any = None,
+        route_notes: Sequence[str] = (),
     ) -> Any:
         """Query the RAG runtime, initializing it lazily on first use (task-249).
 
@@ -452,8 +574,16 @@ class LibraryLocalRagSearchService:
                 and merges the per-type results by score, descending,
                 before trimming to `top_k` (mirrors
                 `pipeline_functions_simple.search_semantic`'s merge).
+            rag_service: Already-resolved runtime, passed by `_search_rag`
+                so profile resolution and the search share one instance.
+                `None` resolves it here, keeping this method self-contained.
+            route_notes: Routing disclosures to attach to whatever this
+                returns (e.g. "a hybrid profile ran semantic because a
+                scope is active"). Empty for a search that ran exactly as
+                the profile configured it.
         """
-        rag_service = await self._resolve_rag_runtime()
+        if rag_service is None:
+            rag_service = await self._resolve_rag_runtime()
         if rag_service is None:
             return LibraryRagSearchOutcome(
                 status="blocked",
@@ -484,43 +614,91 @@ class LibraryLocalRagSearchService:
             per_type_results.sort(key=_raw_semantic_score, reverse=True)
             raw_results = per_type_results[:top_k]
 
-        rows = [_semantic_row(item) for item in raw_results or ()]
-        if source_types:
-            rows = [
-                row for row in rows if _semantic_row_matches_scope(row, source_types)
-            ]
+        rows = _filtered_semantic_rows(raw_results, source_types)
+        if not raw_results and await self._semantic_index_is_empty(rag_service):
+            return _with_route_notes(
+                LibraryRagSearchOutcome(
+                    status="empty",
+                    recovery_state=_rag_index_empty_recovery_state(),
+                    runtime_backend=_RAG_RUNTIME_BACKEND,
+                ),
+                route_notes,
+            )
+        if scope is not None and scope.state == "scoped" and not rows:
+            item_count = _scope_item_count(scope, source_types)
+            return _with_route_notes(
+                LibraryRagSearchOutcome(
+                    status="empty",
+                    recovery_state=_scope_zero_results_recovery_state(item_count),
+                    runtime_backend=_RAG_RUNTIME_BACKEND,
+                ),
+                route_notes,
+            )
+        return _with_route_notes(
+            _retrieval_payload(rows, source_types, _RAG_RUNTIME_BACKEND), route_notes
+        )
+
+    async def _search_hybrid(
+        self,
+        query: str,
+        source_types: tuple[str, ...],
+        top_k: int,
+        kwargs: Mapping[str, Any],
+        *,
+        rag_service: Any,
+    ) -> Any:
+        """Run the engine's RRF-fused hybrid search (unscoped, media selected).
+
+        Only `_search_rag` calls this, and only once it has established the
+        two conditions the engine imposes: no scope allowlist (the pushdown
+        is semantic-only) and `media` among the selected source types (the
+        FTS leg is media-only in P0, so its rows would otherwise all be
+        dropped by the source-type post-filter).
+
+        Zero-results honesty (spec Workstream A item 5): "Index empty" is a
+        claim about the whole runtime, so it may only be made when the
+        engine returned nothing at all. When the FTS leg DID return rows
+        over an empty vector store, the user has evidence on screen and the
+        honest statement is the narrower one -- the semantic leg is empty,
+        these are keyword-only results.
+
+        Args:
+            query: Already-validated user query.
+            source_types: Selected Library source type identifiers.
+            top_k: Result cap (the fused cap; each leg is over-fetched by
+                the engine).
+            kwargs: Backend options (`include_citations`).
+            rag_service: The resolved runtime.
+
+        Returns:
+            A mapping with `results`/`runtime_backend` (`rag-hybrid`) plus
+            diagnostics, or the "Index empty" recovery outcome.
+        """
+        raw_results = await rag_service.search(
+            query=query,
+            top_k=top_k,
+            search_type="hybrid",
+            include_citations=bool(kwargs.get("include_citations", True)),
+        )
+        rows = _filtered_semantic_rows(raw_results, source_types)
         if not raw_results and await self._semantic_index_is_empty(rag_service):
             return LibraryRagSearchOutcome(
                 status="empty",
                 recovery_state=_rag_index_empty_recovery_state(),
-                runtime_backend=_RAG_RUNTIME_BACKEND,
+                runtime_backend=_RAG_HYBRID_RUNTIME_BACKEND,
             )
-        if scope is not None and scope.state == "scoped" and not rows:
-            item_count = _scope_item_count(scope, source_types)
-            return LibraryRagSearchOutcome(
-                status="empty",
-                recovery_state=_scope_zero_results_recovery_state(item_count),
-                runtime_backend=_RAG_RUNTIME_BACKEND,
-            )
-        result: dict[str, Any] = {
-            "results": rows,
-            "runtime_backend": _RAG_RUNTIME_BACKEND,
-        }
-        if rows and source_types:
-            # Task 8: report which requested source types the semantic leg
-            # actually touched. Deliberately omitted (not an empty dict)
-            # when `rows` is empty -- the zero-rows path is the empty/
-            # no-match state (Task 11's territory), not a coverage claim,
-            # and omitting the key keeps the pre-existing bare
-            # `{"results": [], "runtime_backend": ...}` contract for that
-            # path byte-identical (see the two callers above and
-            # `test_rag_mode_zero_results_with_populated_index_stays_generic`).
-            result["diagnostics"] = {
-                "semantic_scope_coverage": _semantic_scope_coverage(
-                    source_types, rows
-                )
-            }
-        return result
+        route_notes: list[str] = []
+        if _rows_are_keyword_only(rows) and await self._semantic_index_is_empty(
+            rag_service
+        ):
+            # Both halves matter: rows with no vector leg alone would also
+            # describe a populated index whose vectors simply lost the
+            # ranking, and "semantic leg empty" would then be a false claim.
+            route_notes.append(ROUTE_NOTE_SEMANTIC_LEG_EMPTY)
+        return _with_route_notes(
+            _retrieval_payload(rows, source_types, _RAG_HYBRID_RUNTIME_BACKEND),
+            route_notes,
+        )
 
     async def _resolve_rag_runtime(self) -> Any:
         """Return a usable RAG runtime, lazily creating the shared one.
@@ -600,6 +778,154 @@ class LibraryLocalRagSearchService:
             return int(stats.get("count")) == 0
         except (TypeError, ValueError):
             return False
+
+
+def _resolve_profile_search_mode(rag_service: Any) -> str:
+    """Map the active profile's default_search_mode to an execution route.
+
+    "plain" deliberately routes to the four-seam scope-aware keyword path,
+    NOT the engine's media-only keyword leg (spec: plain-profile routing).
+    Unknown values -- and any runtime without a profile config at all, which
+    includes every pre-profile test fake -- fall back to "semantic", the
+    behavior this path had before profiles were honored.
+
+    Args:
+        rag_service: The resolved RAG runtime.
+
+    Returns:
+        One of `_PROFILE_SEARCH_MODES`.
+    """
+    mode = getattr(
+        getattr(getattr(rag_service, "config", None), "search", None),
+        "default_search_mode",
+        "semantic",
+    )
+    return mode if mode in _PROFILE_SEARCH_MODES else "semantic"
+
+
+def _profile_disclosure_label(rag_service: Any) -> str:
+    """Name the active profile for a routing disclosure.
+
+    `EnhancedRAGServiceV2` carries the selected `ProfileConfig` on
+    `.profile`; a bare `RAGService` (or a custom config) has none, in which
+    case the disclosure still has to be makeable -- it just cannot name a
+    profile.
+
+    Args:
+        rag_service: The resolved RAG runtime.
+
+    Returns:
+        `"Profile '<name>'"`, or `"Active RAG profile"` when the runtime
+        exposes no usable profile name.
+    """
+    name = getattr(getattr(rag_service, "profile", None), "name", None)
+    if isinstance(name, str) and name.strip():
+        return f"Profile '{name.strip()}'"
+    return "Active RAG profile"
+
+
+def _with_route_notes(result: Any, notes: Sequence[str]) -> Any:
+    """Attach routing disclosures to a retrieval result, without clobbering.
+
+    Works on both shapes this service returns (a raw mapping and a
+    `LibraryRagSearchOutcome`) so a disclosure survives whichever path the
+    query took, including the empty/blocked outcomes. Appends to any notes
+    already present rather than replacing them.
+
+    Args:
+        result: A retrieval payload mapping or `LibraryRagSearchOutcome`.
+        notes: Disclosure fragments to attach. Empty leaves `result`
+            untouched and identical -- callers on the no-divergence path
+            keep their pre-existing byte-for-byte payload (no empty
+            `diagnostics` key materializes).
+
+    Returns:
+        `result` when `notes` is empty, else a copy carrying the notes under
+        `diagnostics[LIBRARY_RAG_ROUTE_NOTES_KEY]`.
+    """
+    if not notes:
+        return result
+    if isinstance(result, LibraryRagSearchOutcome):
+        diagnostics = dict(result.diagnostics or {})
+        diagnostics[LIBRARY_RAG_ROUTE_NOTES_KEY] = [
+            *(diagnostics.get(LIBRARY_RAG_ROUTE_NOTES_KEY) or ()),
+            *notes,
+        ]
+        return replace(result, diagnostics=diagnostics)
+    if isinstance(result, Mapping):
+        existing = result.get("diagnostics")
+        diagnostics = dict(existing) if isinstance(existing, Mapping) else {}
+        diagnostics[LIBRARY_RAG_ROUTE_NOTES_KEY] = [
+            *(diagnostics.get(LIBRARY_RAG_ROUTE_NOTES_KEY) or ()),
+            *notes,
+        ]
+        return {**result, "diagnostics": diagnostics}
+    return result
+
+
+def _filtered_semantic_rows(
+    raw_results: Any, source_types: tuple[str, ...]
+) -> list[dict[str, Any]]:
+    """Normalize engine results and apply the source-type post-filter.
+
+    Shared by the semantic and hybrid arms: hybrid's FTS-leg rows are
+    stamped with a `media` provenance `source_type` upstream precisely so
+    they survive this same canonicalizing filter instead of vanishing.
+    """
+    rows = [_semantic_row(item) for item in raw_results or ()]
+    if not source_types:
+        return rows
+    return [row for row in rows if _semantic_row_matches_scope(row, source_types)]
+
+
+def _rows_are_keyword_only(rows: Sequence[Mapping[str, Any]]) -> bool:
+    """True when every row came from hybrid's FTS leg with no vector leg.
+
+    Reads the fusion block's `vector_score` (preserved by
+    `_fuse_hybrid_results`): `None` means the chunk was never returned by
+    the vector leg. A row with no fusion block at all cannot be judged, so
+    it makes the whole set non-keyword-only rather than being assumed.
+    """
+    if not rows:
+        return False
+    for row in rows:
+        provenance = row.get("provenance")
+        fusion = (
+            provenance.get("hybrid_fusion") if isinstance(provenance, Mapping) else None
+        )
+        if not isinstance(fusion, Mapping) or fusion.get("vector_score") is not None:
+            return False
+    return True
+
+
+def _retrieval_payload(
+    rows: list[dict[str, Any]],
+    source_types: tuple[str, ...],
+    runtime_backend: str,
+) -> dict[str, Any]:
+    """Build the `rag`-mode result mapping plus its coverage diagnostics.
+
+    Task 8: report which requested source types the semantic leg actually
+    touched. Deliberately omitted (not an empty dict) when `rows` is empty
+    -- the zero-rows path is the empty/no-match state (Task 11's
+    territory), not a coverage claim, and omitting the key keeps the
+    pre-existing bare `{"results": [], "runtime_backend": ...}` contract for
+    that path byte-identical (see
+    `test_rag_mode_zero_results_with_populated_index_stays_generic`).
+
+    The hybrid arm shares this: only `uncovered` is ever rendered, and in
+    P0 the FTS leg is media-only, so any non-media type reported uncovered
+    is still a true statement about the semantic leg. Revisit when the
+    keyword leg goes four-seam (P2) -- at that point a type could be
+    "covered" by FTS alone and the note's "Semantic search found nothing
+    from" wording would need a hybrid-aware variant.
+    """
+    result: dict[str, Any] = {"results": rows, "runtime_backend": runtime_backend}
+    if rows and source_types:
+        result["diagnostics"] = {
+            "semantic_scope_coverage": _semantic_scope_coverage(source_types, rows)
+        }
+    return result
 
 
 def _note_row(item: Mapping[str, Any]) -> dict[str, Any]:

--- a/tldw_chatbook/Library/library_rag_score_kinds.py
+++ b/tldw_chatbook/Library/library_rag_score_kinds.py
@@ -44,9 +44,31 @@ LIBRARY_RAG_SCORE_KINDS = frozenset(
 
 #: ``RAGService._fuse_hybrid_results``' per-leg provenance block.
 HYBRID_FUSION_METADATA_KEY = "hybrid_fusion"
+#: What a REAL reranked row carries. ``PointwiseReranker._apply_scores``
+#: (``RAG_Search/reranker.py``) is the only reranking path that REPLACES a
+#: row's score -- with the LLM's relevance score, or by default a weighted
+#: blend of it and the original similarity -- and it stamps this key while
+#: doing so. It is therefore the production signal that "this score is no
+#: longer a similarity".
+#:
+#: It matters that this is keyed on score REPLACEMENT rather than on "a
+#: reranker ran": ``PairwiseReranker`` and ``ListwiseReranker`` only
+#: REORDER results, leaving ``score`` and ``metadata`` untouched, so their
+#: rows still carry the retrieval similarity they came in with and must
+#: keep being banded. Suppressing their band would throw away a true
+#: number.
+#:
+#: The danger this closes is quiet: ``RerankingConfig.score_scale``
+#: defaults to ``(0.0, 1.0)``, so a default-configured pointwise reranker
+#: emits scores INSIDE the similarity band range -- a 0.95 relevance score
+#: would have rendered "match: strong", a cosine claim about a number that
+#: is not a cosine.
+RERANK_SCORE_METADATA_KEY = "rerank_score"
 #: ``RAG_Search/local_citation_capture.py``'s ``FINAL_SCORE_KIND_KEY`` --
-#: the canonical "what scale is the final score on" channel, and the one
-#: signal that means "this score came from the reranker".
+#: the canonical "what scale is the final score on" channel. Accepted as an
+#: additional reranker signal (it costs nothing and is the vocabulary the
+#: citation trace already speaks), but nothing in the app writes it today,
+#: which is why the ``rerank_score`` stamp above is the primary marker.
 #:
 #: Deliberately NOT read as a kind signal: the ``reranking_skipped`` /
 #: ``reranking_degraded`` tags (``enhanced_rag_service_v2.py``), which
@@ -137,9 +159,14 @@ def library_rag_result_score_kind(*candidates: Any) -> tuple[str, float | None]:
     means.
 
     Resolution order, first match wins, across `candidates` in the order
-    given: an explicit `score_kind`; the `_final_score_kind` reranker
-    channel; the presence of a `hybrid_fusion` provenance block. Anything
-    else is a plain vector similarity.
+    given: an explicit `score_kind`; the reranker markers (`rerank_score`,
+    which the pointwise reranker stamps when it replaces the score, or the
+    `_final_score_kind` channel); the presence of a `hybrid_fusion`
+    provenance block. Anything else is a plain vector similarity.
+
+    Reranking is checked BEFORE fusion because it runs after it: a hybrid
+    search whose results were then reranked carries both blocks, and the
+    later stage owns what the final score means.
 
     Args:
         *candidates: Mappings to consult in priority order (typically a
@@ -162,10 +189,14 @@ def library_rag_result_score_kind(*candidates: Any) -> tuple[str, float | None]:
 
     explicit_kind = _first(SCORE_KIND_METADATA_KEY)
     final_kind = _first(FINAL_SCORE_KIND_METADATA_KEY)
+    reranked = any(RERANK_SCORE_METADATA_KEY in mapping for mapping in mappings)
 
     if explicit_kind not in (None, ""):
         kind = normalize_library_rag_score_kind(explicit_kind)
-    elif str(final_kind or "").strip().lower() == LIBRARY_RAG_SCORE_KIND_RERANKER:
+    elif (
+        reranked
+        or str(final_kind or "").strip().lower() == LIBRARY_RAG_SCORE_KIND_RERANKER
+    ):
         kind = LIBRARY_RAG_SCORE_KIND_RERANKER
     elif any(HYBRID_FUSION_METADATA_KEY in mapping for mapping in mappings):
         # Key present with ANY value, including a malformed one: the score
@@ -191,6 +222,7 @@ def library_rag_result_score_kind(*candidates: Any) -> tuple[str, float | None]:
 __all__ = [
     "FINAL_SCORE_KIND_METADATA_KEY",
     "HYBRID_FUSION_METADATA_KEY",
+    "RERANK_SCORE_METADATA_KEY",
     "LIBRARY_RAG_SCORE_KINDS",
     "LIBRARY_RAG_SCORE_KIND_HYBRID_FUSION",
     "LIBRARY_RAG_SCORE_KIND_RERANKER",

--- a/tldw_chatbook/Library/library_rag_score_kinds.py
+++ b/tldw_chatbook/Library/library_rag_score_kinds.py
@@ -1,0 +1,204 @@
+"""What a Library Search/RAG retrieval score MEANS, and what may be banded.
+
+The Library evidence list renders a match band ("match: strong") instead of
+a raw number, and the band is a claim about COSINE SIMILARITY. Nothing else
+the retrieval stack produces lives on that scale:
+
+* hybrid retrieval fuses by RANK (RRF). A fused score's theoretical maximum
+  is ``1 / (rrf_k + 1)`` -- about 0.016 at the shipped ``rrf_k = 60``, an
+  order of magnitude below the 0.2 weak boundary. Banding it on similarity
+  thresholds rendered a wall of "match: weak (0.02)" on every hybrid
+  search, perfect matches included (RAG-port P0/Task 6).
+* reranker scores are unbounded (cross-encoder logits, 0-10 LLM scales); a
+  value that happens to land inside [0, 1] is not a similarity either.
+
+This module owns that vocabulary and the one rule for resolving it from a
+result's provenance. It lives apart from ``library_rag_state`` so the
+Console handoff builder (``UI/Views/RAGSearch/search_handoff.py``) can share
+the rule: ``library_rag_state`` imports ``library_rag_answer_service``,
+which imports that builder, so a direct import would close an import cycle.
+It deliberately depends on nothing but the standard library.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+#: A plain vector-store cosine similarity -- the only kind that existed
+#: before hybrid retrieval and reranking became reachable, and therefore the
+#: default every pre-existing call site keeps.
+LIBRARY_RAG_SCORE_KIND_VECTOR_SIMILARITY = "vector_similarity"
+#: An RRF-fused rank score. Its similarity, when one exists, is the vector
+#: leg preserved in ``metadata["hybrid_fusion"]["vector_score"]``.
+LIBRARY_RAG_SCORE_KIND_HYBRID_FUSION = "hybrid_fusion"
+#: A reranker model's output. Unbounded; never banded.
+LIBRARY_RAG_SCORE_KIND_RERANKER = "reranker"
+LIBRARY_RAG_SCORE_KINDS = frozenset(
+    {
+        LIBRARY_RAG_SCORE_KIND_VECTOR_SIMILARITY,
+        LIBRARY_RAG_SCORE_KIND_HYBRID_FUSION,
+        LIBRARY_RAG_SCORE_KIND_RERANKER,
+    }
+)
+
+#: ``RAGService._fuse_hybrid_results``' per-leg provenance block.
+HYBRID_FUSION_METADATA_KEY = "hybrid_fusion"
+#: ``RAG_Search/local_citation_capture.py``'s ``FINAL_SCORE_KIND_KEY`` --
+#: the canonical "what scale is the final score on" channel, and the one
+#: signal that means "this score came from the reranker".
+#:
+#: Deliberately NOT read as a kind signal: the ``reranking_skipped`` /
+#: ``reranking_degraded`` tags (``enhanced_rag_service_v2.py``), which
+#: disclose that reranking FAILED or partly failed. The scores on those
+#: rows are the base retrieval scores, so treating either tag as a reranker
+#: kind would hide a real similarity behind " | reranked".
+FINAL_SCORE_KIND_METADATA_KEY = "_final_score_kind"
+#: An explicit, already-resolved kind stated by a producer.
+SCORE_KIND_METADATA_KEY = "score_kind"
+VECTOR_SCORE_METADATA_KEY = "vector_score"
+
+
+def coerce_optional_float(value: Any) -> float | None:
+    """Return `value` as a float, or `None` when it isn't numeric.
+
+    Args:
+        value: Any candidate score value.
+
+    Returns:
+        The float, or `None` for `None`, `""`, and anything non-numeric.
+    """
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_library_rag_score_kind(value: Any) -> str:
+    """Canonicalize a score-kind label, defaulting to vector similarity.
+
+    Args:
+        value: A raw kind label from provenance, config, or a caller.
+
+    Returns:
+        A member of `LIBRARY_RAG_SCORE_KINDS`. An unrecognized value falls
+        back to `LIBRARY_RAG_SCORE_KIND_VECTOR_SIMILARITY` -- the historical
+        contract of every call site that predates score kinds, all of which
+        pass a cosine similarity and no kind at all.
+    """
+    kind = str(value or "").strip().lower()
+    if kind in LIBRARY_RAG_SCORE_KINDS:
+        return kind
+    return LIBRARY_RAG_SCORE_KIND_VECTOR_SIMILARITY
+
+
+def library_rag_similarity_input(
+    score: float | None,
+    *,
+    score_kind: str = LIBRARY_RAG_SCORE_KIND_VECTOR_SIMILARITY,
+    vector_score: float | None = None,
+) -> float | None:
+    """Return the cosine similarity to band on, or `None` when none exists.
+
+    The one seam that answers "is this number a similarity?" -- shared by
+    `library_rag_score_suffix` (the per-row band) and
+    `library_rag_all_matches_weak` (the all-weak coverage claim), so the
+    band on screen and the sentence above it can never disagree.
+
+    Args:
+        score: The row's own retrieval score, whatever scale it is on.
+        score_kind: One of `LIBRARY_RAG_SCORE_KINDS`; anything else is
+            treated as `vector_similarity`.
+        vector_score: The vector leg's preserved cosine similarity, for
+            `hybrid_fusion` rows.
+
+    Returns:
+        The similarity to band, or `None` for a row that carries no
+        similarity at all (reranked rows; FTS-leg-only hybrid rows;
+        unscored keyword rows).
+    """
+    kind = normalize_library_rag_score_kind(score_kind)
+    if kind == LIBRARY_RAG_SCORE_KIND_RERANKER:
+        return None
+    if kind == LIBRARY_RAG_SCORE_KIND_HYBRID_FUSION:
+        return vector_score
+    return score
+
+
+def library_rag_result_score_kind(*candidates: Any) -> tuple[str, float | None]:
+    """Resolve `(score_kind, vector_score)` from a result's metadata blocks.
+
+    One derivation rule, shared by the panel row
+    (`LibraryRagResultRow.from_result`) and the Console evidence bundle
+    (`UI/Views/RAGSearch/search_handoff.py`), so the band on screen and the
+    score staged into an answer can never disagree about what a number
+    means.
+
+    Resolution order, first match wins, across `candidates` in the order
+    given: an explicit `score_kind`; the `_final_score_kind` reranker
+    channel; the presence of a `hybrid_fusion` provenance block. Anything
+    else is a plain vector similarity.
+
+    Args:
+        *candidates: Mappings to consult in priority order (typically a
+            row's `provenance`, then its engine `metadata`, then the raw
+            result mapping). Non-mappings are skipped, so callers may pass
+            whatever they have.
+
+    Returns:
+        The canonical score kind, plus the vector leg's similarity for
+        `hybrid_fusion` rows (`None` for every other kind, and for an
+        FTS-leg-only hybrid row).
+    """
+    mappings = [item for item in candidates if isinstance(item, Mapping)]
+
+    def _first(key: str) -> Any:
+        for mapping in mappings:
+            if key in mapping:
+                return mapping[key]
+        return None
+
+    explicit_kind = _first(SCORE_KIND_METADATA_KEY)
+    final_kind = _first(FINAL_SCORE_KIND_METADATA_KEY)
+
+    if explicit_kind not in (None, ""):
+        kind = normalize_library_rag_score_kind(explicit_kind)
+    elif str(final_kind or "").strip().lower() == LIBRARY_RAG_SCORE_KIND_RERANKER:
+        kind = LIBRARY_RAG_SCORE_KIND_RERANKER
+    elif any(HYBRID_FUSION_METADATA_KEY in mapping for mapping in mappings):
+        # Key present with ANY value, including a malformed one: the score
+        # went through fusion, so it is not a similarity. Falling back to
+        # "vector_similarity" on a malformed block would reopen the exact
+        # defect this resolves -- banding a fused ~0.016 on cosine
+        # thresholds.
+        kind = LIBRARY_RAG_SCORE_KIND_HYBRID_FUSION
+    else:
+        kind = LIBRARY_RAG_SCORE_KIND_VECTOR_SIMILARITY
+
+    if kind != LIBRARY_RAG_SCORE_KIND_HYBRID_FUSION:
+        return kind, None
+    fusion = _first(HYBRID_FUSION_METADATA_KEY)
+    if isinstance(fusion, Mapping) and VECTOR_SCORE_METADATA_KEY in fusion:
+        # Authoritative even when it is `None`: the fusion block states
+        # per-leg presence, and `None` means the vector leg never returned
+        # this chunk (an FTS-leg-only row -- no similarity exists).
+        return kind, coerce_optional_float(fusion[VECTOR_SCORE_METADATA_KEY])
+    return kind, coerce_optional_float(_first(VECTOR_SCORE_METADATA_KEY))
+
+
+__all__ = [
+    "FINAL_SCORE_KIND_METADATA_KEY",
+    "HYBRID_FUSION_METADATA_KEY",
+    "LIBRARY_RAG_SCORE_KINDS",
+    "LIBRARY_RAG_SCORE_KIND_HYBRID_FUSION",
+    "LIBRARY_RAG_SCORE_KIND_RERANKER",
+    "LIBRARY_RAG_SCORE_KIND_VECTOR_SIMILARITY",
+    "SCORE_KIND_METADATA_KEY",
+    "VECTOR_SCORE_METADATA_KEY",
+    "coerce_optional_float",
+    "library_rag_result_score_kind",
+    "library_rag_similarity_input",
+    "normalize_library_rag_score_kind",
+]

--- a/tldw_chatbook/Library/library_rag_service.py
+++ b/tldw_chatbook/Library/library_rag_service.py
@@ -320,11 +320,22 @@ def scope_empty_recovery_state(cause: str | None) -> DestinationRecoveryState:
     )
 
 
+#: TASK-406: the one phrase this module uses for "the retrieval attempt
+#: itself did not work". Promoted to a public constant because the Console's
+#: auto-retrieve-on-send notice (``chat_screen.CONSOLE_AUTO_RAG_FAILED_
+#: NOTICE``) must say the same thing the recovery state says -- two
+#: hand-written copies of the same sentence drift, and the Console notice is
+#: often the ONLY place a user sees this outcome (the auto path never renders
+#: a recovery card, by design: a zero-evidence RAG launch would block the
+#: next send).
+RETRIEVAL_FAILED_WHY = "Library Search/RAG retrieval failed"
+
+
 def _retrieval_failed_recovery_state() -> DestinationRecoveryState:
     return DestinationRecoveryState(
         status_label="Retrieval failed",
         unavailable_what="Library Search/RAG retrieval",
-        why="Library Search/RAG retrieval failed",
+        why=RETRIEVAL_FAILED_WHY,
         next_action="Retry the query or check Library indexing",
         recovery_action="Retry",
         authority_owner="Library retrieval",

--- a/tldw_chatbook/Library/library_rag_state.py
+++ b/tldw_chatbook/Library/library_rag_state.py
@@ -1600,9 +1600,13 @@ def library_rag_coverage_note(
             what is about to be shown).
 
     Returns:
-        `""` when `rows` is empty (edge case: zero results overall is the
-        no-match/empty state's territory, not a coverage note enumerating
-        every requested source as "uncovered"), when every requested source
+        `""` when `rows` is empty AND no routing disclosure is present
+        (edge case: zero results overall is the no-match/empty state's
+        territory, not a coverage note enumerating every requested source as
+        "uncovered" -- but a routing disclosure under
+        `LIBRARY_RAG_ROUTE_NOTES_KEY` is a statement about HOW the search
+        ran, still true and still needed at zero rows, so it renders alone
+        there), when every requested source
         type is covered and no row bands weak, or when `diagnostics` carries
         no `semantic_scope_coverage` entry at all (e.g. keyword mode).
         Otherwise `"Semantic search found nothing from: <types>."` (types
@@ -1616,8 +1620,26 @@ def library_rag_coverage_note(
         `library_rag_all_matches_weak(rows)` is True -- or just the
         weak-prefix alone when nothing is uncovered.
     """
+    route_notes = (
+        tuple(
+            str(item)
+            for item in (diagnostics.get(LIBRARY_RAG_ROUTE_NOTES_KEY) or ())
+        )
+        if isinstance(diagnostics, Mapping)
+        else ()
+    )
     if not rows:
-        return ""
+        # Coverage claims stay suppressed with no rows (see the Returns
+        # section) -- but a ROUTING disclosure is a different fact, and zero
+        # rows is exactly when it matters most: a plain-profile query that
+        # matched nothing must still say vectors were never consulted, or
+        # the quiet no-match line reads as a verdict on an index this search
+        # never touched (review finding I2).
+        return " ".join(
+            sentence
+            for sentence in (_route_note_sentence(note) for note in route_notes)
+            if sentence
+        )
     coverage = (
         diagnostics.get("semantic_scope_coverage")
         if isinstance(diagnostics, Mapping)
@@ -1643,14 +1665,6 @@ def library_rag_coverage_note(
         f"Semantic search found nothing from: {', '.join(uncovered_labels)}."
         if uncovered_labels
         else ""
-    )
-    route_notes = (
-        tuple(
-            str(item)
-            for item in (diagnostics.get(LIBRARY_RAG_ROUTE_NOTES_KEY) or ())
-        )
-        if isinstance(diagnostics, Mapping)
-        else ()
     )
     parts = [
         part

--- a/tldw_chatbook/Library/library_rag_state.py
+++ b/tldw_chatbook/Library/library_rag_state.py
@@ -11,6 +11,15 @@ from typing import Any, Mapping, Sequence
 from rich.markup import escape as escape_markup
 
 from tldw_chatbook.Library.library_rag_answer_service import LibraryRagAnswer
+from tldw_chatbook.Library.library_rag_score_kinds import (
+    LIBRARY_RAG_SCORE_KIND_HYBRID_FUSION,
+    LIBRARY_RAG_SCORE_KIND_RERANKER,
+    LIBRARY_RAG_SCORE_KIND_VECTOR_SIMILARITY,
+    coerce_optional_float as _coerce_score,
+    library_rag_result_score_kind,
+    library_rag_similarity_input,
+    normalize_library_rag_score_kind as _normalize_score_kind,
+)
 from tldw_chatbook.Utils.input_validation import (
     sanitize_string,
     validate_number_range,
@@ -104,6 +113,27 @@ LIBRARY_RAG_TOP_K_MAX = 50
 # below are the single seam a future refactor must touch to shift them.
 LIBRARY_RAG_MATCH_STRONG_THRESHOLD = 0.5
 LIBRARY_RAG_MATCH_MODERATE_THRESHOLD = 0.2
+# (RAG-port P0/Task 6) The band thresholds above are a claim about COSINE
+# SIMILARITY, and nothing else the retrieval stack produces lives on that
+# scale:
+#   * hybrid (RRF) fuses by RANK -- a fused score's theoretical maximum is
+#     `1/(rrf_k + 1)`, i.e. ~0.016 at the shipped `rrf_k = 60`, an order of
+#     magnitude below the 0.2 weak boundary. Banding it on the thresholds
+#     above rendered a wall of "match: weak (0.02)" on every hybrid search,
+#     including perfect matches.
+#   * reranker scores are unbounded (cross-encoder logits, 0-10 LLM
+#     scales); a value that happens to land inside [0, 1] is not a
+#     similarity either.
+# So the band's INPUT is chosen by score kind (`library_rag_score_suffix`):
+# hybrid rows band on the vector leg Task 2 preserves in
+# `hybrid_fusion["vector_score"]`, and rows with no similarity at all
+# disclose their kind instead of inventing one. The kind vocabulary and its
+# resolution rule live in `library_rag_score_kinds` (imported above) so the
+# Console evidence-bundle builder can share them without closing an import
+# cycle; only the DISPLAY copy for the two no-similarity kinds is here.
+#: Title-line suffixes for the two kinds that carry no similarity to band.
+LIBRARY_RAG_KEYWORD_MATCH_SUFFIX = " | keyword match"
+LIBRARY_RAG_RERANKED_SUFFIX = " | reranked"
 LIBRARY_RAG_PROVENANCE_KEYS = frozenset(
     {
         "active_context_eligible",
@@ -599,16 +629,12 @@ def _coerce_positive_int(value: Any, fallback: int) -> int:
     return coerced if coerced > 0 else fallback
 
 
-def _coerce_score(value: Any) -> float | None:
-    if value is None or value == "":
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def library_rag_score_suffix(score: float | None) -> str:
+def library_rag_score_suffix(
+    score: float | None,
+    *,
+    score_kind: str = LIBRARY_RAG_SCORE_KIND_VECTOR_SIMILARITY,
+    vector_score: float | None = None,
+) -> str:
     """Return an evidence row's title-line score suffix as an honest band.
 
     Raw three-decimal cosine scores (e.g. "| score 0.091") are meaningless
@@ -624,20 +650,52 @@ def library_rag_score_suffix(score: float | None) -> str:
     `LIBRARY_RAG_MATCH_STRONG_THRESHOLD` is "strong", and a score exactly at
     `LIBRARY_RAG_MATCH_MODERATE_THRESHOLD` is "moderate".
 
+    The band is a claim about cosine similarity, so `score_kind` selects
+    what is banded (RAG-port P0/Task 6 -- see the thresholds' own comment
+    above):
+
+    * `vector_similarity` (the default, and every pre-existing call site):
+      band `score`, exactly as before.
+    * `hybrid_fusion` with a `vector_score`: band the VECTOR LEG. The fused
+      RRF number is a rank blend maxing out near 0.016 and is never banded.
+      The label is unchanged -- "match: strong" means the same thing it
+      always did, because it is computed from the same kind of number.
+    * `hybrid_fusion` with no `vector_score` (an FTS-leg-only row): no
+      similarity exists, so this discloses `" | keyword match"` -- never a
+      fabricated band, and never the fused 0.0x number.
+    * `reranker`: `" | reranked"`. Reranker outputs are unbounded (logits,
+      0-10 LLM scales); the kind is disclosed instead of banding them.
+
     Args:
         score: Retrieval score, or `None` for keyword-mode rows.
+        score_kind: The score's kind
+            (`library_rag_score_kinds.LIBRARY_RAG_SCORE_KINDS`).
+        vector_score: Preserved vector-leg similarity for hybrid rows.
 
     Returns:
-        `""` for `None`; otherwise `" | match: strong"`,
-        `" | match: moderate"`, or `" | match: weak (0.xx)"`.
+        `""` for an unscored similarity row;
+        `LIBRARY_RAG_RERANKED_SUFFIX` for reranked rows;
+        `LIBRARY_RAG_KEYWORD_MATCH_SUFFIX` for FTS-only hybrid rows;
+        otherwise `" | match: strong"`, `" | match: moderate"`, or
+        `" | match: weak (0.xx)"`.
     """
-    if score is None:
-        return ""
-    if score >= LIBRARY_RAG_MATCH_STRONG_THRESHOLD:
+    kind = _normalize_score_kind(score_kind)
+    if kind == LIBRARY_RAG_SCORE_KIND_RERANKER:
+        return LIBRARY_RAG_RERANKED_SUFFIX
+    similarity = library_rag_similarity_input(
+        score, score_kind=kind, vector_score=vector_score
+    )
+    if similarity is None:
+        return (
+            LIBRARY_RAG_KEYWORD_MATCH_SUFFIX
+            if kind == LIBRARY_RAG_SCORE_KIND_HYBRID_FUSION
+            else ""
+        )
+    if similarity >= LIBRARY_RAG_MATCH_STRONG_THRESHOLD:
         return " | match: strong"
-    if score >= LIBRARY_RAG_MATCH_MODERATE_THRESHOLD:
+    if similarity >= LIBRARY_RAG_MATCH_MODERATE_THRESHOLD:
         return " | match: moderate"
-    return f" | match: weak ({score:.2f})"
+    return f" | match: weak ({similarity:.2f})"
 
 
 def _normalize_mode(value: Any) -> str:
@@ -1223,6 +1281,19 @@ class LibraryRagResultRow:
     citations: tuple[LibraryRagCitation, ...]
     provenance: Mapping[str, Any]
     runtime_backend: str = ""
+    #: What scale `score` is on (RAG-port P0/Task 6). Defaults to
+    #: `vector_similarity` -- the only kind that existed before hybrid and
+    #: reranking became reachable -- so every pre-existing construction and
+    #: every `library_rag_score_suffix(row.score)` call site keeps its exact
+    #: prior behavior. Resolved once here, in `from_result`, rather than at
+    #: each display site, so the band, the all-weak coverage sentence and
+    #: the Console evidence bundle cannot disagree about one row.
+    score_kind: str = LIBRARY_RAG_SCORE_KIND_VECTOR_SIMILARITY
+    #: The vector leg's preserved cosine similarity for `hybrid_fusion`
+    #: rows (Task 2's `metadata["hybrid_fusion"]["vector_score"]`), or
+    #: `None` -- including for an FTS-leg-only hybrid row, which has no
+    #: similarity at all. Always `None` for the other kinds.
+    vector_score: float | None = None
     #: Sanitized/collapsed/HTML-entity-decoded snippet text, still UNESCAPED
     #: (RAG-30/31 C1 fix) -- `display_snippet` strips Markdown structure from
     #: this, never from `snippet` (which is already `escape_markup`-escaped
@@ -1281,11 +1352,23 @@ class LibraryRagResultRow:
             if key in values and key not in provenance:
                 provenance[key] = values[key]
         result_id = _result_id(source_id, chunk_id, title)
+        # Score-kind resolution reads the ORIGINAL `provenance_value` and
+        # engine `metadata` blocks, not the sanitized `provenance` copy
+        # above: `LIBRARY_RAG_PROVENANCE_KEYS` is a display allowlist, and
+        # the fusion/reranker channels are retrieval provenance, not
+        # display provenance.
+        score_kind, vector_score = library_rag_result_score_kind(
+            provenance_value,
+            values.get("metadata"),
+            values,
+        )
         return cls(
             result_id=result_id,
             title=title,
             snippet=snippet,
             score=_coerce_score(values.get("score")),
+            score_kind=score_kind,
+            vector_score=vector_score,
             source_id=source_id,
             chunk_id=chunk_id,
             citations=citations,
@@ -1514,23 +1597,54 @@ class LibraryRagResultRow:
 
 
 def library_rag_all_matches_weak(rows: Sequence[LibraryRagResultRow]) -> bool:
-    """True when every scored row among `rows` bands weak (RAG-34/Task 8).
+    """True when every row carrying a similarity bands weak (RAG-34/Task 8).
 
-    Feeds Task 8's evidence-list coverage note. Unscored rows (keyword-mode,
-    `score is None`) are ignored entirely -- neither counted toward "all"
-    nor treated as weak. True only when there is at least one scored row and
-    all of them fall below `LIBRARY_RAG_MATCH_MODERATE_THRESHOLD`; a result
-    set with no scored rows at all (e.g. pure keyword mode) returns `False`,
-    not `True` -- "everything is weak" is a claim about actual scores, not
-    about their absence.
+    Feeds Task 8's evidence-list coverage note, whose wording
+    (`LIBRARY_RAG_ALL_WEAK_COVERAGE_PREFIX`: "No strong semantic
+    matches...") is a claim about SEMANTIC SIMILARITY. Only rows whose
+    effective banding input is a similarity therefore participate --
+    `library_rag_similarity_input`, the same seam
+    `library_rag_score_suffix` bands with:
+
+    * unscored rows (keyword-mode, `score is None`),
+    * FTS-leg-only hybrid rows (no vector leg), and
+    * reranked rows (unbounded scores)
+
+    are ignored entirely -- neither counted toward "all" nor treated as
+    weak. A hybrid row IS counted, on its preserved vector leg: the fused
+    RRF number (~0.016) would otherwise make every hybrid result set read
+    as uniformly weak (RAG-port P0/Task 6).
+
+    True only when there is at least one such row and all of them fall
+    below `LIBRARY_RAG_MATCH_MODERATE_THRESHOLD`; a result set with no
+    similarity-bearing rows at all (e.g. pure keyword mode) returns
+    `False`, not `True` -- "everything is weak" is a claim about actual
+    scores, not about their absence.
 
     Args:
-        rows: Evidence rows to inspect.
+        rows: Evidence rows to inspect. Read by duck typing (`.score`, and
+            optionally `.score_kind`/`.vector_score`) rather than by type:
+            `mcp_inspector._ScoredRow` is a `__slots__ = ("score",)` shim
+            that feeds this same canonical check, so the two newer
+            attributes are read with `getattr` defaults.
 
     Returns:
-        Whether every scored row among `rows` bands weak.
+        Whether every similarity-bearing row among `rows` bands weak.
     """
-    scored = [row.score for row in rows if row.score is not None]
+    scored = [
+        similarity
+        for similarity in (
+            library_rag_similarity_input(
+                getattr(row, "score", None),
+                score_kind=getattr(
+                    row, "score_kind", LIBRARY_RAG_SCORE_KIND_VECTOR_SIMILARITY
+                ),
+                vector_score=getattr(row, "vector_score", None),
+            )
+            for row in rows
+        )
+        if similarity is not None
+    ]
     if not scored:
         return False
     return all(score < LIBRARY_RAG_MATCH_MODERATE_THRESHOLD for score in scored)

--- a/tldw_chatbook/Library/library_rag_state.py
+++ b/tldw_chatbook/Library/library_rag_state.py
@@ -1544,6 +1544,35 @@ LIBRARY_RAG_ALL_WEAK_COVERAGE_PREFIX = (
     "No strong semantic matches — results below are weak."
 )
 
+# (RAG-port P0, Workstream A) Diagnostics slot carrying retrieval-ROUTING
+# disclosures: one short phrase per way the retrieval that actually ran
+# differs from the active RAG profile's configured search mode -- e.g. a
+# hybrid profile forced onto the semantic path because a scope allowlist is
+# active (the engine's allowlist pushdown is semantic-only), or a plain
+# (BM25) profile routed to the Library's own four-seam keyword path.
+# Distinct in MEANING from `semantic_scope_coverage` (which reports which
+# requested source types a search that ran as configured actually touched),
+# but deliberately rendered into the SAME single quiet line under the
+# Evidence heading by `library_rag_coverage_note` -- one note channel on
+# screen, never two competing ones.
+LIBRARY_RAG_ROUTE_NOTES_KEY = "retrieval_route_notes"
+
+
+def _route_note_sentence(note: str) -> str:
+    """Render one service-supplied routing disclosure as a sentence.
+
+    The service states these as lowercase fragments ("media excluded —
+    semantic only") so they read correctly in logs and tests; here they
+    become sentences that can sit after the coverage/weak sentences on one
+    line. Escaped for the same reason the uncovered labels are (task-15
+    finding M8): the text is service-supplied and reaches a `Static`.
+    """
+    text = escape_markup(str(note).strip())
+    if not text:
+        return ""
+    text = text[0].upper() + text[1:]
+    return text if text[-1] in ".!?" else f"{text}."
+
 
 def library_rag_coverage_note(
     diagnostics: Mapping[str, Any] | None,
@@ -1615,13 +1644,26 @@ def library_rag_coverage_note(
         if uncovered_labels
         else ""
     )
-    if library_rag_all_matches_weak(rows):
-        return (
-            f"{LIBRARY_RAG_ALL_WEAK_COVERAGE_PREFIX} {message}"
-            if message
-            else LIBRARY_RAG_ALL_WEAK_COVERAGE_PREFIX
+    route_notes = (
+        tuple(
+            str(item)
+            for item in (diagnostics.get(LIBRARY_RAG_ROUTE_NOTES_KEY) or ())
         )
-    return message
+        if isinstance(diagnostics, Mapping)
+        else ()
+    )
+    parts = [
+        part
+        for part in (
+            LIBRARY_RAG_ALL_WEAK_COVERAGE_PREFIX
+            if library_rag_all_matches_weak(rows)
+            else "",
+            message,
+            *(_route_note_sentence(note) for note in route_notes),
+        )
+        if part
+    ]
+    return " ".join(parts)
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -349,8 +349,15 @@ class ConfigProfileManager:
         hybrid_full_rag.search.parent_inclusion_strategy = "size_based"
         hybrid_full_rag.search.max_context_size = 32000
 
+        # "cross_encoder" is not an implemented reranking strategy in
+        # chatbook -- reranker.py only implements the three LLM-driven
+        # strategies (pointwise/pairwise/listwise); there is no local
+        # cross-encoder model path. This profile previously requested
+        # "cross_encoder" and raised ValueError the moment its reranker
+        # tried to construct (task-3170 P0). "pointwise" is the closest
+        # available strategy to a cross-encoder's per-result scoring.
         hybrid_full_rerank = RerankingConfig(
-            strategy="cross_encoder", top_k_to_rerank=15, include_reasoning=False
+            strategy="pointwise", top_k_to_rerank=15, include_reasoning=False
         )
 
         self._profiles["hybrid_full"] = ProfileConfig(

--- a/tldw_chatbook/RAG_Search/ingestion_indexing.py
+++ b/tldw_chatbook/RAG_Search/ingestion_indexing.py
@@ -415,6 +415,30 @@ def peek_shared_rag_service() -> Optional[Any]:
     return _shared_service
 
 
+def shared_rag_service_generation() -> int:
+    """Return the current shared-service generation counter.
+
+    Bumped by every ``set_shared_rag_service()`` (including
+    ``reset_shared_rag_service()``'s ``set_shared_rag_service(None)``), so a
+    caller that caches the shared service elsewhere -- notably
+    ``app._rag_service``, which a profile switch would otherwise leave
+    pointing at the previous profile's runtime for the rest of the session
+    -- can capture this alongside the service and detect that it has been
+    superseded. See ``semantic_availability.cache_app_rag_service`` /
+    ``current_app_rag_service``, the one pair of helpers both app-level
+    resolvers use.
+
+    Returns:
+        The generation at the moment of the call. Capture it BEFORE
+        resolving/building a service, never after: a reset landing during
+        construction must leave the captured value BEHIND the current one,
+        so the cache is treated as stale rather than trusted (the same
+        ordering rule ``get_shared_rag_service`` follows internally).
+    """
+    with _shared_service_lock:
+        return _shared_service_generation
+
+
 def set_shared_rag_service(service: Optional[Any]) -> None:
     """Directly install (or clear) the shared RAG service instance.
 

--- a/tldw_chatbook/RAG_Search/local_citation_capture.py
+++ b/tldw_chatbook/RAG_Search/local_citation_capture.py
@@ -184,6 +184,39 @@ def _resolve_lineage(metadata: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _reliable_rrf(metadata: Mapping[str, Any], score: float) -> bool:
+    """Whether `score` is verifiably the RRF blend `fusion` describes.
+
+    The claim this gates (`RetrievalScoreKind.RRF` on a `NON_NEGATIVE`
+    scale) is never taken on the producer's word: every required field is
+    type-checked and the score is RE-DERIVED from the recorded ranks and
+    then compared exactly. That arithmetic is the whole defense -- a block
+    that cannot reproduce its own score degrades to `LEGACY`.
+
+    Required fields must all be present; ADDITIONAL fields are tolerated.
+    This was an exact-set equality (`set(fusion) != required`) until
+    task-3170 P0, when `_fuse_hybrid_results` began also preserving the
+    per-leg `fts_score`/`vector_score` for the UI's score-kind-aware match
+    bands -- eight keys instead of six, so every real hybrid row silently
+    degraded to `LEGACY`/`UNBOUNDED` here. The regression was invisible to
+    this module's own tests, which hand-build fusion metadata; it is now
+    pinned end-to-end by piping real `_fuse_hybrid_results` output through
+    `normalize_local_result` (see
+    `Tests/RAG_Search/test_hybrid_fusion_metadata.py`).
+
+    A subset check rather than a widened exact set, so the next additive
+    provenance field does not re-break it. Nothing is given away: an
+    unrecognized extra key cannot make the re-derivation below hold
+    spuriously, and a key that signalled a post-fusion transformation of
+    the score would break that equality and be rejected anyway.
+
+    Args:
+        metadata: The result's engine metadata.
+        score: The result's final score.
+
+    Returns:
+        Whether the fusion block is complete, well-typed, and arithmetically
+        consistent with `score`.
+    """
     fusion = metadata.get("hybrid_fusion")
     if not isinstance(fusion, Mapping):
         return False
@@ -195,7 +228,7 @@ def _reliable_rrf(metadata: Mapping[str, Any], score: float) -> bool:
         "alpha",
         "rrf_k",
     }
-    if set(fusion) != required:
+    if not required.issubset(set(fusion)):
         return False
     alpha = fusion["alpha"]
     rrf_k = fusion["rrf_k"]

--- a/tldw_chatbook/RAG_Search/reranker.py
+++ b/tldw_chatbook/RAG_Search/reranker.py
@@ -83,6 +83,28 @@ class BaseReranker(ABC):
         self.config = config
         self._cache = {} if config.cache_results else None
         self._settings = load_settings()
+        # Per-rerank() call outcome: how many of the `total` per-result (or
+        # per-comparison) scoring attempts failed during the MOST RECENT
+        # `rerank()` invocation. A raising `rerank()` is handled by the
+        # caller's try/except (EnhancedRAGServiceV2.search); this is the
+        # separate, silent failure mode where `rerank()` returns normally
+        # but the underlying per-result LLM calls mostly/entirely failed
+        # (e.g. every call exhausting retries under a missing provider
+        # credential) and the result is an unchanged ordering that looks
+        # identical to "nothing needed reranking" (task-3170 P0 review
+        # finding). Every `rerank()` return path must call
+        # `_record_rerank_outcome` so a caller reading these right after
+        # `await reranker.rerank(...)` never sees a stale value from a
+        # previous call.
+        self.last_rerank_failures: int = 0
+        self.last_rerank_total: int = 0
+
+    def _record_rerank_outcome(self, failed: int, total: int) -> None:
+        """Record how many of `total` scoring attempts failed in the rerank()
+        call that just completed. See `last_rerank_failures` for why this
+        exists."""
+        self.last_rerank_failures = failed
+        self.last_rerank_total = total
 
     @abstractmethod
     async def rerank(
@@ -234,6 +256,7 @@ class PointwiseReranker(BaseReranker):
     ) -> List[Union[SearchResult, SearchResultWithCitations]]:
         """Rerank results using pointwise scoring."""
         if not results:
+            self._record_rerank_outcome(0, 0)
             return results
 
         # Limit to top K results
@@ -247,6 +270,7 @@ class PointwiseReranker(BaseReranker):
             if cache_key in self._cache:
                 log_counter("reranker_cache_hit", labels={"strategy": "pointwise"})
                 cached_scores = self._cache[cache_key]
+                self._record_rerank_outcome(0, len(results_to_rerank))
                 return (
                     self._apply_scores(results_to_rerank, cached_scores)
                     + remaining_results
@@ -269,8 +293,10 @@ class PointwiseReranker(BaseReranker):
 
         # Handle errors and compile results
         reranking_results = []
+        failed_count = 0
         for i, score_result in enumerate(all_scores):
             if isinstance(score_result, Exception):
+                failed_count += 1
                 logger.error(f"Failed to score result {i}: {score_result}")
                 # Keep original score on failure
                 reranking_results.append(
@@ -283,6 +309,12 @@ class PointwiseReranker(BaseReranker):
                 )
             else:
                 reranking_results.append(score_result)
+
+        # This is the ONLY place a caller can tell "rerank() returned
+        # normally but silently scored nothing" apart from "rerank()
+        # returned normally because everything genuinely scored" -- both
+        # look identical (an unchanged/near-unchanged ordering) without it.
+        self._record_rerank_outcome(failed_count, len(results_to_rerank))
 
         # Cache results if enabled
         if self._cache is not None and cache_key:
@@ -438,6 +470,15 @@ class PairwiseReranker(BaseReranker):
             self.config.scoring_prompt_template = get_internal_prompt(
                 "rag_reranker.pairwise_template"
             )
+        # Per-comparison counters for the CURRENT rerank() call, read by
+        # _compare_pair() during the merge-sort recursion and rolled up into
+        # last_rerank_failures/last_rerank_total (see BaseReranker) once
+        # rerank() returns. There's no single "per-result" score here
+        # (pairwise reranking is comparison-based), so a "failure" is a
+        # comparison whose LLM call raised and fell back to the original
+        # scores instead.
+        self._pairwise_comparisons_failed = 0
+        self._pairwise_comparisons_total = 0
 
     @timeit("reranker_pairwise")
     async def rerank(
@@ -448,14 +489,22 @@ class PairwiseReranker(BaseReranker):
     ) -> List[Union[SearchResult, SearchResultWithCitations]]:
         """Rerank using pairwise comparisons with tournament-style ranking."""
         if len(results) <= 1:
+            self._record_rerank_outcome(0, 0)
             return results
 
         # Limit to top K
         results_to_rerank = results[: self.config.top_k_to_rerank]
         remaining_results = results[self.config.top_k_to_rerank :]
 
+        self._pairwise_comparisons_failed = 0
+        self._pairwise_comparisons_total = 0
+
         # Perform tournament-style comparisons
         reranked = await self._tournament_rank(query, results_to_rerank)
+
+        self._record_rerank_outcome(
+            self._pairwise_comparisons_failed, self._pairwise_comparisons_total
+        )
 
         log_counter(
             "reranker_pairwise_complete", labels={"results": len(results_to_rerank)}
@@ -527,6 +576,7 @@ class PairwiseReranker(BaseReranker):
             reasoning=reasoning_part,
         )
 
+        self._pairwise_comparisons_total += 1
         try:
             response = await self._call_llm(prompt)
             result_json = json.loads(response)
@@ -538,6 +588,7 @@ class PairwiseReranker(BaseReranker):
 
         except Exception as e:
             logger.error(f"Pairwise comparison failed: {e}")
+            self._pairwise_comparisons_failed += 1
             # Fall back to original scores
             return result1.score > result2.score
 
@@ -567,6 +618,7 @@ class ListwiseReranker(BaseReranker):
     ) -> List[Union[SearchResult, SearchResultWithCitations]]:
         """Rerank all results together."""
         if len(results) <= 1:
+            self._record_rerank_outcome(0, 0)
             return results
 
         # Limit to top K
@@ -601,6 +653,13 @@ class ListwiseReranker(BaseReranker):
             # Validate ranking
             if not self._validate_ranking(ranking, len(results_to_rerank)):
                 logger.warning("Invalid ranking returned, using original order")
+                # No individual result was scored (the whole ranking is
+                # discarded), so this counts as a total failure -- same
+                # "returned normally but scored nothing" shape as the except
+                # branch below.
+                self._record_rerank_outcome(
+                    len(results_to_rerank), len(results_to_rerank)
+                )
                 return results
 
             # Reorder results
@@ -608,10 +667,13 @@ class ListwiseReranker(BaseReranker):
 
             log_counter("reranker_listwise_complete")
 
+            self._record_rerank_outcome(0, len(results_to_rerank))
+
             return reranked + remaining_results
 
         except Exception as e:
             logger.error(f"Listwise reranking failed: {e}")
+            self._record_rerank_outcome(len(results_to_rerank), len(results_to_rerank))
             return results
 
     def _validate_ranking(self, ranking: List[int], expected_length: int) -> bool:

--- a/tldw_chatbook/RAG_Search/reranker.py
+++ b/tldw_chatbook/RAG_Search/reranker.py
@@ -624,6 +624,24 @@ class ListwiseReranker(BaseReranker):
 def create_reranker(strategy: str = "pointwise", **kwargs) -> BaseReranker:
     """Factory function to create a reranker with the specified strategy."""
     config = RerankingConfig(strategy=strategy, **kwargs)
+    return create_reranker_from_config(config)
+
+
+def create_reranker_from_config(config: RerankingConfig) -> BaseReranker:
+    """Build a reranker directly from an already-constructed ``RerankingConfig``.
+
+    This is the seam every caller that already HAS a ``RerankingConfig``
+    (profiles, experiment configs) must use. ``create_reranker(strategy=X,
+    **config.__dict__)`` -- the previous call pattern everywhere in
+    ``enhanced_rag_service_v2.py`` -- passes ``strategy`` twice (once
+    positionally/by-keyword, once again inside ``**config.__dict__``, since
+    ``strategy`` is itself a field of ``RerankingConfig``), which raised
+    ``TypeError: RerankingConfig() got multiple values for keyword argument
+    'strategy'`` on every reranking-enabled profile. This function takes the
+    config object as-is and dispatches on ``config.strategy`` without
+    reconstructing it.
+    """
+    strategy = config.strategy
 
     if strategy == "pointwise":
         return PointwiseReranker(config)

--- a/tldw_chatbook/RAG_Search/semantic_availability.py
+++ b/tldw_chatbook/RAG_Search/semantic_availability.py
@@ -134,8 +134,22 @@ def record_semantic_ok(
 
 #: Attribute the shared-service generation is stamped under when a resolver
 #: caches a runtime on the app. Deliberately paired with ``_rag_service``:
-#: the two are written together and read together.
+#: the two are written together and read together. Kept (write-only from
+#: `cache_app_rag_service`'s perspective, see below) for back-compat with
+#: anything introspecting this exact name; the atomic stamp below is now
+#: the source of truth for a real resolver write.
 APP_RAG_SERVICE_GENERATION_ATTR = "_rag_service_generation"
+
+#: Single attribute publishing ``(service, generation)`` as one immutable
+#: tuple. Qodo PR #1428 finding: `cache_app_rag_service` used to publish
+#: `app._rag_service` and `APP_RAG_SERVICE_GENERATION_ATTR` as two separate
+#: writes; a concurrent reader landing in the window between them saw a
+#: service with no generation stamp yet and hit the direct-injection
+#: carve-out below, skipping staleness validation for a service that WAS
+#: resolved through the shared seam. A single attribute assignment is
+#: atomic under the GIL, so a reader either sees the fully-formed pair or
+#: nothing -- never a torn service-without-generation.
+APP_RAG_SERVICE_STAMP_ATTR = "_rag_service_stamp"
 
 
 def current_app_rag_service(app: Any) -> Optional[Any]:
@@ -155,6 +169,14 @@ def current_app_rag_service(app: Any) -> Optional[Any]:
     through the shared seam), so the shared generation says nothing about
     it and evicting it would break injection.
 
+    The atomic ``APP_RAG_SERVICE_STAMP_ATTR`` tuple (task-3170 remediation)
+    is checked FIRST and, when present, is the single source of truth --
+    it is only ever written by `cache_app_rag_service`, in one assignment,
+    so it can never be observed with a service that has no matching
+    generation. Only when that attribute is entirely absent does this fall
+    back to the legacy raw-attribute pair, which is what a direct
+    `SimpleNamespace(_rag_service=service)` test injection looks like.
+
     Args:
         app: App-like object carrying ``_rag_service``.
 
@@ -162,6 +184,23 @@ def current_app_rag_service(app: Any) -> Optional[Any]:
         The cached runtime when it has a callable ``search`` and has not
         been superseded, else None (the caller re-resolves).
     """
+    stamp = getattr(app, APP_RAG_SERVICE_STAMP_ATTR, None)
+    if stamp is not None:
+        service, stamped_generation = stamp
+        if service is None or not callable(getattr(service, "search", None)):
+            return None
+        if stamped_generation == shared_rag_service_generation():
+            return service
+        logger.info(
+            "Cached RAG runtime superseded by a profile change; re-resolving "
+            "the shared service."
+        )
+        return None
+
+    # No atomic stamp: either a direct-injection carve-out (tests, or any
+    # surface that never went through the shared seam) or a legacy caller
+    # that wrote the raw pair itself. Preserve the original two-attribute
+    # behavior for that case.
     service = getattr(app, "_rag_service", None)
     if service is None or not callable(getattr(service, "search", None)):
         return None
@@ -178,6 +217,17 @@ def current_app_rag_service(app: Any) -> Optional[Any]:
 def cache_app_rag_service(app: Any, service: Any, generation: int) -> None:
     """Cache a resolved runtime on the app together with its generation.
 
+    Publishes ``(service, generation)`` as ONE atomic attribute
+    (``APP_RAG_SERVICE_STAMP_ATTR``) FIRST, before touching the legacy
+    ``_rag_service`` / ``APP_RAG_SERVICE_GENERATION_ATTR`` pair that ~20
+    existing tests (and any other direct reader of the raw attribute) still
+    rely on. Writing the atomic stamp first means a concurrent
+    `current_app_rag_service` reader either observes nothing yet (falls
+    back to the not-yet-set raw attribute -> None -> re-resolve, safe) or
+    observes the fully-formed pair -- never the raw service with a missing
+    generation, which is the torn read this ordering exists to prevent
+    (Qodo PR #1428 finding).
+
     Args:
         app: App-like object receiving ``_rag_service``.
         service: The resolved shared runtime.
@@ -188,6 +238,7 @@ def cache_app_rag_service(app: Any, service: Any, generation: int) -> None:
             reset was meant to discard.
     """
     try:
+        app._rag_service_stamp = (service, generation)
         app._rag_service = service
         setattr(app, APP_RAG_SERVICE_GENERATION_ATTR, generation)
     except Exception:

--- a/tldw_chatbook/RAG_Search/semantic_availability.py
+++ b/tldw_chatbook/RAG_Search/semantic_availability.py
@@ -15,10 +15,15 @@ returning nothing. This module is the single home for:
   (existing ``app._rag_service`` wins -> cheap ``embeddings_rag`` deps gate ->
   ``get_shared_rag_service`` in ``asyncio.to_thread``, cached on the app);
 - ``semantic_index_is_empty``: the trustworthy-count vector-store probe that
-  distinguishes "no matches" from "nothing indexed yet".
+  distinguishes "no matches" from "nothing indexed yet";
+- ``current_app_rag_service`` / ``cache_app_rag_service``: the ONE staleness
+  rule for the ``app._rag_service`` cache, shared with the Library resolver
+  (see below).
 
-The Library surface (``Library/library_local_rag_search_service.py``) has its
-own equivalent seams from task-249; they are deliberately left untouched.
+The Library surface (``Library/library_local_rag_search_service.py``) keeps
+its own equivalent resolver from task-249, but both now cache and validate
+through the two helpers here -- a profile switch must invalidate the app-level
+cache identically no matter which surface wrote it.
 """
 
 from __future__ import annotations
@@ -30,7 +35,7 @@ from typing import Any, Dict, Optional, Tuple
 from loguru import logger
 
 from ..Utils.optional_deps import embeddings_rag_deps_installed
-from .ingestion_indexing import get_shared_rag_service
+from .ingestion_indexing import get_shared_rag_service, shared_rag_service_generation
 
 logger = logger.bind(module="semantic_availability")
 
@@ -127,6 +132,70 @@ def record_semantic_ok(
     }
 
 
+#: Attribute the shared-service generation is stamped under when a resolver
+#: caches a runtime on the app. Deliberately paired with ``_rag_service``:
+#: the two are written together and read together.
+APP_RAG_SERVICE_GENERATION_ATTR = "_rag_service_generation"
+
+
+def current_app_rag_service(app: Any) -> Optional[Any]:
+    """Return ``app._rag_service`` only when it is usable AND still current.
+
+    The app-level cache exists so every RAG surface shares one runtime, but
+    it survives a profile switch: ``active_config.set_active_profile()`` and
+    the Settings save path call ``reset_shared_rag_service()``, which drops
+    only the module singleton. Without this check the next query keeps using
+    the previous profile's runtime for the rest of the session -- silently
+    retrieving under a profile the user already switched away from, and (on
+    the Library path) attributing the disclosure to a profile that is no
+    longer active.
+
+    A cache with NO generation stamp is honored unconditionally: it was
+    injected directly onto the app (tests, or any surface that never went
+    through the shared seam), so the shared generation says nothing about
+    it and evicting it would break injection.
+
+    Args:
+        app: App-like object carrying ``_rag_service``.
+
+    Returns:
+        The cached runtime when it has a callable ``search`` and has not
+        been superseded, else None (the caller re-resolves).
+    """
+    service = getattr(app, "_rag_service", None)
+    if service is None or not callable(getattr(service, "search", None)):
+        return None
+    stamped = getattr(app, APP_RAG_SERVICE_GENERATION_ATTR, None)
+    if stamped is None or stamped == shared_rag_service_generation():
+        return service
+    logger.info(
+        "Cached RAG runtime superseded by a profile change; re-resolving "
+        "the shared service."
+    )
+    return None
+
+
+def cache_app_rag_service(app: Any, service: Any, generation: int) -> None:
+    """Cache a resolved runtime on the app together with its generation.
+
+    Args:
+        app: App-like object receiving ``_rag_service``.
+        service: The resolved shared runtime.
+        generation: ``shared_rag_service_generation()`` captured BEFORE the
+            resolution that produced `service` -- a reset landing mid-build
+            then leaves this behind the current generation, so the cache
+            reads stale on the next query instead of pinning a runtime the
+            reset was meant to discard.
+    """
+    try:
+        app._rag_service = service
+        setattr(app, APP_RAG_SERVICE_GENERATION_ATTR, generation)
+    except Exception:
+        logger.opt(exception=True).debug(
+            "Could not cache the shared RAG service on the app instance."
+        )
+
+
 async def resolve_semantic_rag_service(
     app: Any, profile_name: Optional[str] = None
 ) -> Tuple[Optional[Any], Optional[str]]:
@@ -135,8 +204,9 @@ async def resolve_semantic_rag_service(
     Resolution order (mirrors the Library canvas's `_resolve_rag_runtime`,
     task-249):
 
-    1. An existing ``app._rag_service`` with a callable ``search`` always wins
-       (already initialized by any surface, or injected by tests).
+    1. An existing ``app._rag_service`` with a callable ``search`` wins --
+       unless a profile switch has superseded it since it was cached
+       (``current_app_rag_service``), in which case it is re-resolved.
     2. The ``embeddings_rag`` deps gate (cheap ``find_spec`` probe, no
        imports) short-circuits BEFORE any heavy work.
     3. ``get_shared_rag_service()`` constructs the process-wide runtime.
@@ -155,11 +225,13 @@ async def resolve_semantic_rag_service(
         ``(service, None)`` when a usable runtime is available, else
         ``(None, reason)`` with a SEMANTIC_REASON_* code saying why.
     """
-    rag_service = getattr(app, "_rag_service", None)
-    if rag_service is not None and callable(getattr(rag_service, "search", None)):
-        return rag_service, None
+    cached = current_app_rag_service(app)
+    if cached is not None:
+        return cached, None
     if not embeddings_rag_deps_installed():
         return None, SEMANTIC_REASON_DEPS_MISSING
+    # Captured BEFORE the build -- see cache_app_rag_service's `generation`.
+    generation = shared_rag_service_generation()
     try:
         service = await asyncio.to_thread(get_shared_rag_service, profile_name)
     except Exception:
@@ -170,14 +242,10 @@ async def resolve_semantic_rag_service(
         return None, SEMANTIC_REASON_INIT_FAILED
     if service is None or not callable(getattr(service, "search", None)):
         return None, SEMANTIC_REASON_INIT_FAILED
-    try:
-        # Cache on the app so every RAG surface (chat sidebar, standalone
-        # Search, Library) sees the initialized runtime.
-        app._rag_service = service
-    except Exception:
-        logger.opt(exception=True).debug(
-            "Could not cache the shared RAG service on the app instance."
-        )
+    # Cache on the app so every RAG surface (chat sidebar, standalone
+    # Search, Library) sees the initialized runtime -- stamped with the
+    # generation so a later profile switch invalidates it.
+    cache_app_rag_service(app, service, generation)
     return service, None
 
 

--- a/tldw_chatbook/RAG_Search/simplified/config.py
+++ b/tldw_chatbook/RAG_Search/simplified/config.py
@@ -327,6 +327,13 @@ class SearchConfig:
     hybrid_cache_ttl: Optional[float] = None  # TTL for hybrid search results
     # Database connection settings
     fts5_connection_pool_size: int = 3  # Connection pool size for FTS5 searches
+    # Explicit override for the keyword (FTS5) leg's media database path.
+    # None (the default) means "resolve via tldw_chatbook.config.get_media_db_path()"
+    # -- the single authoritative resolver for the real on-disk media DB
+    # (honors TLDW_CONFIG_PATH scratch profiles and any user-configured
+    # custom path). Only set this to point the keyword leg at a specific
+    # file (e.g. tests); never guessed/derived from other paths.
+    media_db_path: Optional[Path] = None
 
     # Parent document inclusion settings (RAG pipeline feature)
     include_parent_docs: bool = False

--- a/tldw_chatbook/RAG_Search/simplified/db_connection_pool.py
+++ b/tldw_chatbook/RAG_Search/simplified/db_connection_pool.py
@@ -2,6 +2,7 @@
 Simple database connection pool for FTS5 searches.
 """
 
+import threading
 from typing import Dict
 from loguru import logger
 
@@ -16,6 +17,16 @@ from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 # instance, not a bare path/size record.
 _connection_pools: Dict[str, MediaDatabase] = {}
 
+# Qodo PR #1428 finding 3: the dict above was guarded only by an unlocked
+# check-then-set (`if db_path not in _connection_pools: ... [construct] ...`).
+# `MediaDatabase.__init__` runs schema init immediately, so two threads
+# racing the first keyword search for the same path could both pass the
+# `not in` check before either stored its instance, each construct their own
+# `MediaDatabase`, and the loser's instance (and its open sqlite connection)
+# is simply overwritten and leaked. This lock makes first-construction
+# single-flight: one thread builds, the rest reuse it.
+_connection_pools_lock = threading.Lock()
+
 
 def get_connection_pool(db_path: str, pool_size: int = 3) -> MediaDatabase:
     """
@@ -25,21 +36,30 @@ def get_connection_pool(db_path: str, pool_size: int = 3) -> MediaDatabase:
     `MediaDatabase` hands out one connection per calling thread rather than
     capping a fixed pool.
     """
-    if db_path not in _connection_pools:
-        logger.debug(f"Opening pooled media database connection: {db_path}")
-        _connection_pools[db_path] = MediaDatabase(
-            db_path=db_path, client_id="rag_service_fts5"
-        )
+    # Fast path: no lock needed once the pool for this path already exists.
+    pool = _connection_pools.get(db_path)
+    if pool is not None:
+        return pool
 
-    return _connection_pools[db_path]
+    # Slow path: double-checked locking so only one thread ever constructs
+    # the `MediaDatabase` for a given path, even under concurrent first
+    # callers.
+    with _connection_pools_lock:
+        pool = _connection_pools.get(db_path)
+        if pool is None:
+            logger.debug(f"Opening pooled media database connection: {db_path}")
+            pool = MediaDatabase(db_path=db_path, client_id="rag_service_fts5")
+            _connection_pools[db_path] = pool
+        return pool
 
 
 def close_all_pools():
     """Close all pooled database connections."""
-    for db_path, db in _connection_pools.items():
-        try:
-            db.close_connection()
-        except Exception as e:
-            logger.debug(f"Error closing pooled connection for {db_path}: {e}")
-    _connection_pools.clear()
-    logger.debug("Closed and cleared all connection pool references")
+    with _connection_pools_lock:
+        for db_path, db in _connection_pools.items():
+            try:
+                db.close_connection()
+            except Exception as e:
+                logger.debug(f"Error closing pooled connection for {db_path}: {e}")
+        _connection_pools.clear()
+        logger.debug("Closed and cleared all connection pool references")

--- a/tldw_chatbook/RAG_Search/simplified/db_connection_pool.py
+++ b/tldw_chatbook/RAG_Search/simplified/db_connection_pool.py
@@ -2,30 +2,44 @@
 Simple database connection pool for FTS5 searches.
 """
 
-from typing import Dict, Any
+from typing import Dict
 from loguru import logger
 
-
-# Global connection pools
-_connection_pools: Dict[str, Any] = {}
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 
 
-def get_connection_pool(db_path: str, pool_size: int = 3) -> Any:
+# Global connection pools: one pooled `MediaDatabase` per db_path, reused
+# across searches. `MediaDatabase` already manages a thread-local SQLite
+# connection internally (see `_get_thread_connection`/`transaction()`), which
+# is the pooling behavior callers (`RAGService._perform_fts5_search`, via its
+# `pool.transaction()` call) need -- so the pool IS the `MediaDatabase`
+# instance, not a bare path/size record.
+_connection_pools: Dict[str, MediaDatabase] = {}
+
+
+def get_connection_pool(db_path: str, pool_size: int = 3) -> MediaDatabase:
     """
-    Get or create a connection pool for the given database.
+    Get or create the pooled `MediaDatabase` connection for the given database.
 
-    For now, this just returns a simple connection since the old pool
-    implementation was removed. This maintains backward compatibility.
+    `pool_size` is accepted for backward API compatibility but unused --
+    `MediaDatabase` hands out one connection per calling thread rather than
+    capping a fixed pool.
     """
     if db_path not in _connection_pools:
-        logger.debug(f"Creating connection for database: {db_path}")
-        # For backward compatibility, just store the path and pool size
-        _connection_pools[db_path] = {"path": db_path, "pool_size": pool_size}
+        logger.debug(f"Opening pooled media database connection: {db_path}")
+        _connection_pools[db_path] = MediaDatabase(
+            db_path=db_path, client_id="rag_service_fts5"
+        )
 
     return _connection_pools[db_path]
 
 
 def close_all_pools():
-    """Close all connection pools."""
+    """Close all pooled database connections."""
+    for db_path, db in _connection_pools.items():
+        try:
+            db.close_connection()
+        except Exception as e:
+            logger.debug(f"Error closing pooled connection for {db_path}: {e}")
     _connection_pools.clear()
-    logger.debug("Cleared all connection pool references")
+    logger.debug("Closed and cleared all connection pool references")

--- a/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
+++ b/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
@@ -17,7 +17,7 @@ from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram, tim
 from .enhanced_rag_service import EnhancedRAGService
 from .config import RAGConfig
 from .vector_store import SearchResult, SearchResultWithCitations
-from ..reranker import create_reranker
+from ..reranker import create_reranker_from_config
 from ..parallel_processor import (
     create_embedding_processor,
     create_chunking_processor,
@@ -93,14 +93,21 @@ class EnhancedRAGServiceV2(EnhancedRAGService):
         self.enable_reranking = enable_reranking
         self.enable_parallel_processing = enable_parallel_processing
 
-        # Initialize reranker if enabled
+        # Initialize reranker if enabled. A broken reranking config (bad
+        # strategy, bad provider settings, etc.) must not take the whole
+        # service construction down with it -- fall back to no reranker and
+        # let `search()` return unreranked results instead.
         self.reranker = None
         if self.enable_reranking and self.reranking_config:
-            self.reranker = create_reranker(
-                strategy=self.reranking_config.strategy,
-                **self.reranking_config.__dict__,
-            )
-            logger.info(f"Initialized {self.reranking_config.strategy} reranker")
+            try:
+                self.reranker = create_reranker_from_config(self.reranking_config)
+                logger.info(f"Initialized {self.reranking_config.strategy} reranker")
+            except Exception as exc:
+                logger.warning(
+                    f"Failed to construct {self.reranking_config.strategy} reranker "
+                    f"({exc}); continuing without reranking"
+                )
+                self.reranker = None
 
         # Initialize parallel processors if enabled
         self.embedding_processor = None
@@ -227,25 +234,39 @@ class EnhancedRAGServiceV2(EnhancedRAGService):
             metadata_allowlist=metadata_allowlist,
         )
 
-        # Apply reranking if enabled
+        # Apply reranking if enabled. Reranking must NEVER fail a search:
+        # LLM-based strategies (pointwise/pairwise/listwise -- reranker.py
+        # has no local/offline strategy) spend a provider call per search,
+        # so a raising reranker (bad credentials, provider outage, a
+        # misconfigured profile) degrades to the unreranked base results
+        # instead of raising. `_final_score_kind=reranker` (see
+        # local_citation_capture.py) is the provenance channel that
+        # discloses when a result WAS actually reranked; this
+        # `reranking_skipped` tag is the counterpart that discloses when it
+        # was attempted and skipped.
         should_rerank = rerank if rerank is not None else self.enable_reranking
         if should_rerank and self.reranker and len(results) > 1:
             rerank_start = time.time()
+            try:
+                # Use experiment profile's reranking config if available
+                if experiment_profile and experiment_profile.reranking_config:
+                    # Create temporary reranker with experiment config
+                    temp_reranker = create_reranker_from_config(
+                        experiment_profile.reranking_config
+                    )
+                    results = await temp_reranker.rerank(query, results)
+                else:
+                    results = await self.reranker.rerank(query, results)
 
-            # Use experiment profile's reranking config if available
-            if experiment_profile and experiment_profile.reranking_config:
-                # Create temporary reranker with experiment config
-                temp_reranker = create_reranker(
-                    strategy=experiment_profile.reranking_config.strategy,
-                    **experiment_profile.reranking_config.__dict__,
+                rerank_time = time.time() - rerank_start
+                log_histogram("rag_reranking_time", rerank_time)
+                logger.debug(f"Reranking completed in {rerank_time:.3f}s")
+            except Exception as exc:
+                logger.warning(
+                    f"Reranking failed ({exc}); returning unreranked results"
                 )
-                results = await temp_reranker.rerank(query, results)
-            else:
-                results = await self.reranker.rerank(query, results)
-
-            rerank_time = time.time() - rerank_start
-            log_histogram("rag_reranking_time", rerank_time)
-            logger.debug(f"Reranking completed in {rerank_time:.3f}s")
+                if results:
+                    results[0].metadata["reranking_skipped"] = str(exc)
 
         # Record experiment metrics if active
         if self._current_experiment and user_id:
@@ -338,12 +359,18 @@ class EnhancedRAGServiceV2(EnhancedRAGService):
         self.reranking_config = profile.reranking_config
         self.processing_config = profile.processing_config
 
-        # Reinitialize components if needed
+        # Reinitialize components if needed. Same guard as __init__: a
+        # broken reranking config on the new profile must not raise out of
+        # switch_profile -- fall back to no reranker.
         if self.enable_reranking and self.reranking_config:
-            self.reranker = create_reranker(
-                strategy=self.reranking_config.strategy,
-                **self.reranking_config.__dict__,
-            )
+            try:
+                self.reranker = create_reranker_from_config(self.reranking_config)
+            except Exception as exc:
+                logger.warning(
+                    f"Failed to construct {self.reranking_config.strategy} reranker "
+                    f"for profile '{profile_name}' ({exc}); continuing without reranking"
+                )
+                self.reranker = None
 
         logger.info(f"Switched to profile: {profile_name}")
         log_counter("rag_profile_switch", labels={"profile": profile_name})

--- a/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
+++ b/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
@@ -9,6 +9,7 @@ This extends the Phase 1 enhanced RAG service with:
 
 import asyncio
 import time
+from dataclasses import replace
 from typing import Any, Collection, Dict, List, Literal, Mapping, Optional, Tuple, Union
 
 from loguru import logger
@@ -31,6 +32,34 @@ from ..config_profiles import (
     ConfigProfileManager,
 )
 from .data_models import IndexingResult
+
+
+def _tag_first_result(
+    results: List[Union[SearchResult, SearchResultWithCitations]],
+    key: str,
+    value: str,
+) -> List[Union[SearchResult, SearchResultWithCitations]]:
+    """Return a NEW results list whose first element carries `metadata[key]
+    = value`, without mutating the original first result object or the
+    original list.
+
+    `results` here may be the EXACT objects `RAGService.search()`'s cache
+    is holding by reference (see the `cache.put_async`/`cache.get_async`
+    call sites in rag_service.py) -- caching stores the list and its
+    `SearchResult`/`SearchResultWithCitations` elements by reference, not by
+    copy. An in-place `results[0].metadata[key] = value` mutation there
+    would poison the cached entry for up to `cache_ttl` seconds (3600s by
+    default), regardless of whether a LATER search for the same query
+    reranks successfully or has reranking disabled entirely -- the stale
+    tag would still be sitting on the shared object (task-3170 P0 review
+    finding). Building a new list with a new first-element copy sidesteps
+    this: the original object's metadata dict is only ever read
+    (`**results[0].metadata`), never written.
+    """
+    if not results:
+        return results
+    tagged_first = replace(results[0], metadata={**results[0].metadata, key: value})
+    return [tagged_first] + list(results[1:])
 
 
 class EnhancedRAGServiceV2(EnhancedRAGService):
@@ -258,22 +287,39 @@ class EnhancedRAGServiceV2(EnhancedRAGService):
                 # Use experiment profile's reranking config if available
                 if experiment_profile and experiment_profile.reranking_config:
                     # Create temporary reranker with experiment config
-                    temp_reranker = create_reranker_from_config(
+                    active_reranker = create_reranker_from_config(
                         experiment_profile.reranking_config
                     )
-                    results = await temp_reranker.rerank(query, results)
                 else:
-                    results = await self.reranker.rerank(query, results)
+                    active_reranker = self.reranker
+                results = await active_reranker.rerank(query, results)
 
                 rerank_time = time.time() - rerank_start
                 log_histogram("rag_reranking_time", rerank_time)
                 logger.debug(f"Reranking completed in {rerank_time:.3f}s")
+
+                # rerank() can return NORMALLY while having silently scored
+                # nothing (or almost nothing) -- e.g. every per-result LLM
+                # call exhausting retries under a missing provider
+                # credential -- which looks identical to "nothing needed
+                # reranking" (an unchanged ordering, no exception) unless
+                # disclosed here. See BaseReranker.last_rerank_failures.
+                failed = getattr(active_reranker, "last_rerank_failures", 0)
+                total = getattr(active_reranker, "last_rerank_total", 0)
+                if failed:
+                    logger.warning(
+                        f"Reranking degraded: {failed}/{total} scorings failed"
+                    )
+                    results = _tag_first_result(
+                        results,
+                        "reranking_degraded",
+                        f"{failed}/{total} scorings failed",
+                    )
             except Exception as exc:
                 logger.warning(
                     f"Reranking failed ({exc}); returning unreranked results"
                 )
-                if results:
-                    results[0].metadata["reranking_skipped"] = str(exc)
+                results = _tag_first_result(results, "reranking_skipped", str(exc))
 
         # Record experiment metrics if active
         if self._current_experiment and user_id:

--- a/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
+++ b/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
@@ -73,11 +73,18 @@ class EnhancedRAGServiceV2(EnhancedRAGService):
             self.reranking_config = profile.reranking_config
             self.processing_config = profile.processing_config
         elif isinstance(config, ProfileConfig):
-            # Use provided profile
+            # Use provided profile. Capture reranking_config/processing_config
+            # off the ProfileConfig BEFORE reassigning the local `config` name
+            # to its `.rag_config` below -- reading them off the reassigned
+            # variable instead (a plain RAGConfig, which has neither
+            # attribute) raised AttributeError unconditionally on every call
+            # through this branch, i.e. every from_profile()/
+            # create_rag_from_profile() call, for every profile, reranking or
+            # not (task-3170 P0).
             self.profile = config
-            config = config.rag_config
             self.reranking_config = config.reranking_config
             self.processing_config = config.processing_config
+            config = config.rag_config
             self.profile_manager = profile_manager or get_profile_manager()
         else:
             # Direct RAG config

--- a/tldw_chatbook/RAG_Search/simplified/rag_factory.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_factory.py
@@ -5,6 +5,7 @@ This module provides a unified interface for creating RAG services
 using the V2 implementation with different configuration profiles.
 """
 
+from dataclasses import replace
 from typing import Optional
 from loguru import logger
 
@@ -76,9 +77,22 @@ def create_rag_service(
     except Exception as e:  # never block service creation on migration
         logger.debug(f"Legacy collection adoption skipped: {e}")
 
+    # Pass the profile itself, not just its `rag_config`, so
+    # EnhancedRAGServiceV2.__init__ actually picks up reranking_config /
+    # processing_config: passing a bare RAGConfig hits its `else` branch,
+    # which forces `self.reranking_config = None` unconditionally -- so no
+    # reranker EVER constructed via this factory (the app's real RAG-service
+    # entry point, see search_service.py) regardless of the enable_reranking
+    # flag computed above (task-3170 P0). When an explicit `config` override
+    # was given, swap it in for the profile's own rag_config (via
+    # `dataclasses.replace`, a shallow copy) so a caller overriding e.g. the
+    # embedding backend still gets that override, while the profile's
+    # reranking_config/processing_config still make it through.
+    effective_profile = replace(profile, rag_config=rag_config) if config else profile
+
     # Create service with profile configuration
     return EnhancedRAGServiceV2(
-        config=rag_config,
+        config=effective_profile,
         enable_parent_retrieval=enable_parent_retrieval,
         enable_reranking=enable_reranking,
         enable_parallel_processing=enable_parallel_processing,

--- a/tldw_chatbook/RAG_Search/simplified/rag_service.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_service.py
@@ -998,6 +998,12 @@ class RAGService:
         results = []
         for entry in fused:
             result = entry.item
+            # entry.item aliases entry.fts_item (FTS leg wins -- see
+            # FusedResult.item), so the original leg scores must be read
+            # *before* result.score is overwritten below, or the in-place
+            # mutation clobbers the very value we're trying to preserve.
+            fts_score = entry.fts_item.score if entry.fts_item is not None else None
+            vector_score = entry.vector_item.score if entry.vector_item is not None else None
             # Combine citations when the same chunk surfaced in both legs
             if (
                 include_citations
@@ -1013,6 +1019,8 @@ class RAGService:
                 **(result.metadata or {}),
                 "hybrid_fusion": {
                     **entry.provenance(),
+                    "fts_score": fts_score,
+                    "vector_score": vector_score,
                     "alpha": alpha,
                     "rrf_k": DEFAULT_RRF_K,
                 },

--- a/tldw_chatbook/RAG_Search/simplified/rag_service.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_service.py
@@ -1288,6 +1288,15 @@ class RAGService:
         # a nonexistent `m.tags`, which raised `OperationalError: no such
         # column: m.tags` on every real DB (silently swallowed by the outer
         # exception handler, so keyword search always returned []).
+        # Review finding (Task 3 PR): this used to SELECT `-rank as rank` and
+        # `ORDER BY rank` -- ascending on the NEGATED alias, i.e.
+        # worst-match-first (fts5's raw `rank` column is smaller/more
+        # negative = better; negating it and sorting ascending flips that).
+        # Order on the raw `media_fts.rank` column instead -- ascending is
+        # already best-match-first, the canonical fts5 usage. `rank` is not
+        # read from the result rows anywhere downstream (keyword results use
+        # a fixed KEYWORD_SEARCH_SCORE, not a rank-derived score), so it does
+        # not need to be selected at all, only ordered on.
         sql = """
         SELECT
             m.id,
@@ -1296,13 +1305,12 @@ class RAGService:
             m.url,
             m.type,
             m.author,
-            m.ingestion_date,
-            -rank as rank
+            m.ingestion_date
         FROM Media m
         JOIN media_fts ON m.id = media_fts.rowid
         WHERE media_fts MATCH ?
         AND m.is_trash = 0
-        ORDER BY rank
+        ORDER BY media_fts.rank
         LIMIT ?
         """
 

--- a/tldw_chatbook/RAG_Search/simplified/rag_service.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_service.py
@@ -31,7 +31,6 @@ from tldw_chatbook.Metrics.metrics_logger import (
     log_gauge,
     timeit,
 )
-from tldw_chatbook.Utils.path_validation import validate_path
 from .embeddings_wrapper import EmbeddingsServiceWrapper
 from .vector_store import create_vector_store, SearchResult, SearchResultWithCitations
 from .citations import Citation, CitationType, merge_citations
@@ -786,68 +785,21 @@ class RAGService:
         for efficient keyword-based search with proper connection pooling.
         """
         try:
-            # Get database path from vector store persist directory
-            db_path = None
-            from tldw_chatbook.config import get_user_data_dir
+            # Resolve the media DB path -- explicit override wins, otherwise
+            # defer to the single authoritative resolver. No guessing across
+            # a list of candidate filenames, and no create-on-miss: a search
+            # must never have the side effect of creating a database.
+            from tldw_chatbook.config import get_media_db_path
 
-            base_dir = get_user_data_dir()
-            possible_paths = [base_dir / "chacha_notes.db"]
+            db_path = self.config.search.media_db_path or get_media_db_path()
+            db_path = Path(db_path)
 
-            if self.config.persist_directory:
-                # Try common locations for the media database
-                possible_paths = [
-                    self.config.persist_directory.parent / "media_db.db",
-                    self.config.persist_directory.parent / "chacha_notes.db",
-                    base_dir / "chacha_notes.db",
-                ]
-
-                for path in possible_paths:
-                    # Validate path to prevent traversal attacks
-                    try:
-                        validated_path = validate_path(str(path), str(base_dir))
-                        validated_path_obj = Path(validated_path)
-
-                        # Check if path exists and is not a symlink (security check)
-                        if (
-                            validated_path_obj.exists()
-                            and not validated_path_obj.is_symlink()
-                        ):
-                            # Additional check: ensure it's a regular file
-                            if validated_path_obj.is_file():
-                                db_path = validated_path
-                                logger.debug(f"Found media database at: {db_path}")
-                                break
-                            else:
-                                logger.warning(
-                                    f"Path {validated_path} is not a regular file"
-                                )
-                        elif validated_path_obj.is_symlink():
-                            logger.warning(
-                                f"Skipping symlink at {validated_path} for security reasons"
-                            )
-                    except ValueError as e:
-                        logger.warning(f"Invalid path {path}: {e}")
-                        continue
-
-            if not db_path:
-                logger.error(
-                    f"Could not find media database for keyword search. Searched in: {[str(p) for p in possible_paths]}"
+            if not db_path.exists() or not db_path.is_file():
+                logger.warning(
+                    f"Media database not found at {db_path}; keyword search "
+                    "returning no results (a search never creates a database)."
                 )
-                # Try to create or ensure FTS5 tables exist
-                try:
-                    # Use the first valid path that we can create
-                    default_path = base_dir / "chacha_notes.db"
-                    if not default_path.exists():
-                        logger.info(f"Creating new media database at: {default_path}")
-                        from tldw_chatbook.DB.Client_Media_DB_v2 import (
-                            Database as MediaDatabase,
-                        )
-
-                        MediaDatabase(str(default_path), "rag_service")
-                    db_path = str(default_path)
-                except Exception as e:
-                    logger.error(f"Failed to create media database: {e}")
-                    return []
+                return []
 
             # Get connection pool for this database
             pool_size = getattr(
@@ -855,7 +807,7 @@ class RAGService:
                 "fts5_connection_pool_size",
                 FTS5_CONNECTION_POOL_SIZE,
             )
-            pool = get_connection_pool(db_path, pool_size=pool_size)
+            pool = get_connection_pool(str(db_path), pool_size=pool_size)
 
             # Perform FTS5 search directly using connection pool with retry
             loop = asyncio.get_event_loop()
@@ -1136,6 +1088,8 @@ class RAGService:
                     "author": item.get("author"),
                     "ingestion_date": item.get("ingestion_date"),
                     "text_preview": content[:200],
+                    "source_type": "media",
+                    "source": "media",
                 },
             )
             results.append(base_result)
@@ -1212,6 +1166,8 @@ class RAGService:
             "author": item.get("author"),
             "ingestion_date": item.get("ingestion_date"),
             "text_preview": content[:200],
+            "source_type": "media",
+            "source": "media",
         }
 
         # Find citations
@@ -1326,8 +1282,14 @@ class RAGService:
             limit = DEFAULT_FTS5_LIMIT  # Safe default
         limit = min(limit, MAX_FTS5_LIMIT)  # Cap maximum results
 
+        # Note: `Media` has no `tags` column and `media_fts` only indexes
+        # (title, content) -- see Client_Media_DB_v2's `_FTS_TABLES_SQL` and
+        # its `Media` CREATE TABLE. An earlier version of this query selected
+        # a nonexistent `m.tags`, which raised `OperationalError: no such
+        # column: m.tags` on every real DB (silently swallowed by the outer
+        # exception handler, so keyword search always returned []).
         sql = """
-        SELECT 
+        SELECT
             m.id,
             m.title,
             m.content,
@@ -1335,7 +1297,6 @@ class RAGService:
             m.type,
             m.author,
             m.ingestion_date,
-            m.tags,
             -rank as rank
         FROM Media m
         JOIN media_fts ON m.id = media_fts.rowid
@@ -1363,7 +1324,6 @@ class RAGService:
                             "type": row["type"],
                             "author": row["author"],
                             "ingestion_date": row["ingestion_date"],
-                            "tags": row["tags"],
                         }
                     )
         except Exception as e:

--- a/tldw_chatbook/RAG_Search/simplified/rag_service.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_service.py
@@ -1083,6 +1083,15 @@ class RAGService:
                 metadata={
                     "doc_id": str(item["id"]),
                     "doc_title": item.get("title", "Untitled"),
+                    # The display key. The vector leg gets `title` for free
+                    # (the indexing call spreads the document's own metadata
+                    # into every chunk); this leg builds its metadata from
+                    # scratch, so without this a keyword-leg row reaches the
+                    # Library evidence list as "Untitled source" -- observed
+                    # live under Hybrid Full with an empty semantic leg.
+                    # `_semantic_row` (library_local_rag_search_service) reads
+                    # `title`/`document_title` and never `doc_title`.
+                    "title": item.get("title") or "",
                     "media_type": item.get("type"),
                     "url": item.get("url"),
                     "author": item.get("author"),
@@ -1161,6 +1170,9 @@ class RAGService:
         base_metadata = {
             "doc_id": str(item["id"]),
             "doc_title": item.get("title", "Untitled"),
+            # See the sibling metadata block in `_keyword_search`: `title` is
+            # the key the Library evidence row mapper reads, `doc_title` is not.
+            "title": item.get("title") or "",
             "media_type": item.get("type"),
             "url": item.get("url"),
             "author": item.get("author"),

--- a/tldw_chatbook/RAG_Search/simplified/rag_service.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_service.py
@@ -790,9 +790,37 @@ class RAGService:
             # a list of candidate filenames, and no create-on-miss: a search
             # must never have the side effect of creating a database.
             from tldw_chatbook.config import get_media_db_path
+            from tldw_chatbook.Utils.path_validation import validate_path_simple
+            from tldw_chatbook.Utils.private_paths import lexical_path
 
-            db_path = self.config.search.media_db_path or get_media_db_path()
-            db_path = Path(db_path)
+            db_path_raw = self.config.search.media_db_path or get_media_db_path()
+
+            # Qodo PR #1428 finding 1: `config.search.media_db_path` is a
+            # config-sourced override reaching a filesystem check + DB open
+            # without running through path_validation.py. Mirror config.py's
+            # `_get_custom_database_path` treatment for custom DB paths --
+            # lexical normalization plus `validate_path_simple`'s
+            # traversal/injection screen -- rather than a base-dir jail that
+            # would reject a legitimate custom media DB living outside the
+            # default data dir. `probe_existing=False` matches that same
+            # helper: filesystem/symlink authority is deferred to the
+            # private SQLite owner (MediaDatabase -> connect_private_sqlite)
+            # that actually opens the file below.
+            try:
+                db_path = lexical_path(
+                    validate_path_simple(
+                        Path(str(db_path_raw)).expanduser(),
+                        require_exists=False,
+                        probe_existing=False,
+                    )
+                )
+            except ValueError as e:
+                logger.warning(
+                    f"Rejected media_db_path from config ({db_path_raw!r}): "
+                    f"{e}; keyword search returning no results (a search "
+                    "never creates a database)."
+                )
+                return []
 
             if not db_path.exists() or not db_path.is_file():
                 logger.warning(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -115,6 +115,7 @@ from ...Event_Handlers.Chat_Events.chat_rag_events import (
 )
 from ...Chat.rag_scope import (
     RagScope,
+    SCOPE_EMPTY_NOTICE_TEMPLATE,
     read_conversation_scope,
     write_conversation_scope,
 )
@@ -124,6 +125,7 @@ from ...Chat.scope_picker_listers import (
     build_notes_source_lister,
 )
 from ...Chat.console_command_grammar import (
+    COMMAND_PREFIX,
     GENERATE_IMAGE_COMMAND_HANDLER_ID,
     GENERATE_IMAGE_COMMAND_NAME,
     KIND_COMMAND,
@@ -167,6 +169,7 @@ from ...Chat.console_generate_image import (
 from ...Image_Generation.config import get_image_generation_config
 from ...Image_Generation.listing import list_image_models_for_catalog
 from ...Chat.console_skill_resolver import (
+    MENTION_SIGIL,
     SKILL_UNTRUSTED_REFUSE,
     SkillCommandCandidate,
     cap_skill_args,
@@ -366,6 +369,7 @@ from ...config import (
 from ...Library.library_rag_service import (
     LibraryRagSearchOutcome,
     LibraryRagSearchRequest,
+    RETRIEVAL_FAILED_WHY,
     run_library_rag_search,
     scope_empty_recovery_state,
 )
@@ -1284,11 +1288,98 @@ def _console_library_rag_source_scope(screen: Any) -> tuple[str, ...]:
     )
 
 
+#: TASK-406: hard cap on how much of a composer draft is turned into an
+#: auto-retrieve query. Aliased to the explicitly-typed-query ceiling rather
+#: than re-declared as a second `2000`, so the implicit and explicit paths
+#: can never drift to different limits.
+AUTO_RAG_QUERY_MAX_CHARS = CONSOLE_LIBRARY_RAG_QUERY_MAX_LENGTH
+#: TASK-406: how long an accepted send will wait for auto-retrieval before
+#: giving up and going out WITHOUT evidence. Deliberately short: this await
+#: sits inside the send worker, between "Send pressed" and the first provider
+#: byte, so every second here is dead time the user is staring at.
+AUTO_RAG_TIMEOUT_SECONDS = 5.0
+#: TASK-406: result count used when the active RAG profile's own `default_
+#: top_k` cannot be resolved. Matches the Console chip's historical literal.
+CONSOLE_LIBRARY_RAG_FALLBACK_TOP_K = 5
+#: TASK-406: the two auto-retrieve degradation notices. Both are toasts on an
+#: otherwise-successful send, so they say what the user LOSES (evidence), not
+#: what to click -- the send is already gone by the time either fires.
+CONSOLE_AUTO_RAG_INITIALIZING_NOTICE = (
+    "Auto-retrieve skipped: the RAG service is still initializing. "
+    "Message sent without Library evidence."
+)
+CONSOLE_AUTO_RAG_FAILED_NOTICE = (
+    f"Auto-retrieve skipped: {RETRIEVAL_FAILED_WHY}. "
+    "Message sent without Library evidence."
+)
+#: TASK-406: recovery copy on the in-flight ("Retrieving...") auto-retrieve
+#: card, distinct from the manual run's so a user can tell which one is
+#: spending time on their behalf.
+CONSOLE_AUTO_RAG_SEARCHING_COPY = "Auto-retrieving Library evidence for this message."
+
 #: RAG-43: above this length a composer draft reads as a paste/attachment,
 #: not a retrieval question -- well under ``CONSOLE_LIBRARY_RAG_QUERY_MAX_
 #: LENGTH`` (2000, a safety ceiling for an explicitly-typed query, not a
 #: "does this look like a question" heuristic for an implicit prefill).
 CONSOLE_LIBRARY_RAG_DRAFT_PREFILL_MAX_LENGTH = 200
+
+
+def _is_plain_text_send(draft_text: Any) -> bool:
+    """Return whether ``draft_text`` is an ordinary user question (TASK-406).
+
+    The Console has exactly two sigils that make a draft something other
+    than prose, and both are owned elsewhere: ``COMMAND_PREFIX`` (``/``, the
+    slash-command grammar) and ``MENTION_SIGIL`` (``$``, the skill
+    resolver). They are imported rather than re-spelled here so registering
+    a new command or changing a sigil cannot leave this gate behind.
+
+    Two send kinds reach the controller carrying one of those sigils
+    verbatim: a resolved ``$name`` skill invocation
+    (``_run_resolved_console_skill``) and the deliberate second-Enter
+    literal send of an unrecognized ``/word``. Neither is a retrieval
+    question, so neither auto-retrieves. Tool approvals and regenerations
+    never reach this classification at all -- they do not go through
+    ``submit_draft``/``_capture_rag_context``, which is the only caller.
+
+    Args:
+        draft_text: The validated draft about to be submitted.
+
+    Returns:
+        True when the draft is plain prose worth retrieving evidence for.
+    """
+    draft = str(draft_text or "").lstrip()
+    if not draft:
+        return False
+    return not draft.startswith((COMMAND_PREFIX, MENTION_SIGIL))
+
+
+def _console_library_rag_profile_top_k() -> int:
+    """Return the ACTIVE RAG profile's result count (TASK-406).
+
+    Auto-retrieval must honor the profile the user configured, the same way
+    task-5 made the Library service honor its search mode -- a hardcoded
+    count would silently ignore a profile tuned for more (or fewer)
+    results. Imported lazily: ``active_config`` pulls in the profile
+    manager, which this module has no other reason to load at import time.
+
+    Returns:
+        The profile's ``search.default_top_k`` when it resolves to a
+        positive integer, else ``CONSOLE_LIBRARY_RAG_FALLBACK_TOP_K`` -- a
+        broken/absent profile must degrade to retrieving, not to raising
+        inside a send.
+    """
+    try:
+        from ...RAG_Search.simplified.active_config import resolve_active_rag_config
+
+        value = int(resolve_active_rag_config().search.default_top_k)
+    except Exception as exc:
+        logger.debug(
+            "Console auto-retrieve could not read the active RAG profile's "
+            "top_k (exception_category={}); using the fallback.",
+            type(exc).__name__,
+        )
+        return CONSOLE_LIBRARY_RAG_FALLBACK_TOP_K
+    return value if value > 0 else CONSOLE_LIBRARY_RAG_FALLBACK_TOP_K
 
 
 def _console_draft_looks_like_rag_query(draft: Any) -> bool:
@@ -3956,6 +4047,24 @@ class ChatScreen(BaseAppScreen):
 
         # Whatever the previous send consumed is no longer "this message".
         self._clear_console_evidence_sent_notice()
+        # TASK-406: opt-in auto-retrieve runs HERE, immediately before the
+        # consume, so anything it stages is picked up by this same send. It
+        # is a no-op unless the toggle is on and nothing is already staged.
+        # Contained: this method sits on the provider's capture path, where
+        # `ConsoleChatController._capture_rag_context` turns ANY exception
+        # into `context=None` -- so an auto-retrieve failure escaping here
+        # would also discard whatever the consume below was about to hand
+        # the model. An optional convenience must never be able to do that.
+        try:
+            await self._maybe_auto_retrieve_for_send(draft)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "Console auto-retrieve raised; the send proceeds "
+                "(exception_category={})",
+                type(exc).__name__,
+            )
         launch = self._consume_pending_console_launch()
         result = await capture_console_staged_evidence_for_chat(
             self.app_instance,
@@ -12333,6 +12442,226 @@ class ChatScreen(BaseAppScreen):
                 action_label="Resolve Library search setup",
             )
         )
+
+    def _has_staged_console_evidence(self) -> bool:
+        """Whether this send already has evidence the user staged themselves.
+
+        Two places count as "staged", because
+        ``_consume_pending_console_launch`` reads both on the very next line
+        of the send: the resident launch context, and an UNCLAIMED
+        ``CONSOLE_LIVE_WORK`` handoff (a Library "Use in Console" the user
+        just clicked). Ignoring the second would spend a retrieval whose
+        result the claim immediately supersedes -- the exact "no double
+        spend" the auto-retrieve gate exists to prevent.
+
+        Returns:
+            True when manual staging is present and must win.
+        """
+        if self._pending_console_launch_context is not None:
+            return True
+        try:
+            store = self.app_instance.pending_handoffs
+            return bool(store.has_pending(HandoffChannel.CONSOLE_LIVE_WORK))
+        except Exception:
+            # An unreadable store is not evidence; retrieving is the safe
+            # failure here (worst case a claim supersedes the result).
+            return False
+
+    def _rag_service_still_initializing(self) -> bool:
+        """Whether a timed-out retrieval was most likely first-run warm-up.
+
+        The distinction is real, not cosmetic: the shared RAG runtime's
+        FIRST construction loads an embedding model and can take seconds
+        (``library_local_rag_search_service._resolve_rag_runtime``), which
+        is precisely what blows :data:`AUTO_RAG_TIMEOUT_SECONDS`. A cached
+        runtime on the app means that cost was already paid, so the same
+        timeout is an honest retrieval failure instead.
+
+        Returns:
+            True when no usable, current runtime is cached on the app.
+        """
+        try:
+            from ...RAG_Search.semantic_availability import current_app_rag_service
+
+            return current_app_rag_service(self.app_instance) is None
+        except Exception:
+            return False
+
+    def _notify_console_auto_rag_scope_empty(self, outcome: Any) -> None:
+        """Surface the SHARED empty-scope copy for a skipped auto-retrieve.
+
+        Reuses ``scope_empty_recovery_state``'s ``why`` -- i.e.
+        ``SCOPE_EMPTY_NOTICE_TEMPLATE`` -- rather than writing a third
+        version of this sentence, so the Console's implicit path says
+        exactly what its explicit path and the chat entry point already say.
+
+        Args:
+            outcome: The short-circuit outcome from
+                ``_resolve_console_library_rag_scope``.
+        """
+        recovery = getattr(outcome, "recovery_state", None)
+        message = str(getattr(recovery, "why", "") or "").strip()
+        if not message:
+            message = SCOPE_EMPTY_NOTICE_TEMPLATE.format(cause="unknown")
+        self._notify_console_auto_rag(message)
+
+    def _notify_auto_rag_degraded(self, *, initializing: bool) -> None:
+        """Tell the user this send went out without the evidence it wanted.
+
+        Args:
+            initializing: True when the RAG runtime had not finished
+                building (see ``_rag_service_still_initializing``) -- a
+                "try again in a moment" situation, which reads very
+                differently from a retrieval that genuinely failed.
+        """
+        self._notify_console_auto_rag(
+            CONSOLE_AUTO_RAG_INITIALIZING_NOTICE
+            if initializing
+            else CONSOLE_AUTO_RAG_FAILED_NOTICE
+        )
+
+    def _notify_console_auto_rag(self, message: str) -> None:
+        """Toast one auto-retrieve notice, never at the cost of the send.
+
+        This runs from inside the send worker's capture seam, where an
+        escaping exception costs the message its evidence (see
+        ``_release_consumed_console_launch``) -- so a failing notify is
+        logged and swallowed, exactly as the sibling RAG notice sites do.
+        """
+        try:
+            self.app_instance.notify(message, severity="warning")
+        except Exception:
+            logger.debug(
+                "Console auto-retrieve notification unavailable; "
+                "reason=auto_rag_notification_failure"
+            )
+
+    def _clear_console_auto_rag_placeholder(
+        self, placeholder: ConsoleLiveWorkLaunch
+    ) -> None:
+        """Drop the in-flight "Retrieving..." card when nothing came back.
+
+        Identity-guarded like ``_release_consumed_console_launch``: if
+        anything staged over the placeholder while retrieval was awaited,
+        that newer context is left alone rather than silently dropped.
+
+        Leaving the placeholder behind would be worse than cosmetic --
+        ``_console_send_blocked_reason`` BLOCKS every send while a
+        RAG-sourced launch with zero available evidence is staged, so a
+        single failed auto-retrieve would lock the composer until the user
+        found the un-stage button.
+
+        Args:
+            placeholder: The launch this retrieval staged before awaiting.
+        """
+        if self._pending_console_launch_context is not placeholder:
+            return
+        self._pending_console_launch_context = None
+        self._pending_console_launch_auto_open_inspector = False
+        try:
+            self._sync_console_pending_launch_surfaces()
+        except Exception as exc:
+            logger.warning(
+                "Console surfaces did not refresh after clearing an "
+                "auto-retrieve placeholder (exception_category={})",
+                type(exc).__name__,
+            )
+
+    async def _maybe_auto_retrieve_for_send(self, draft_text: str) -> None:
+        """Auto-retrieve library evidence for a plain text send (TASK-406).
+
+        Fires only when ALL hold: the config toggle is on; the send is plain
+        user text (not a slash command, tool approval, or regeneration); and
+        nothing is already staged (manual staging always wins -- no double
+        spend). Retrieval failure or timeout NEVER blocks the send.
+
+        Called from ``_capture_console_staged_rag``, the one consume-on-send
+        seam, so anything staged here is picked up by the SAME send and
+        renders in the staged-evidence strip exactly like a manual chip run.
+        That seam runs inside the per-session exclusive send worker, past
+        every block gate, which is why this needs no worker of its own: a
+        double-send cannot double-retrieve, and a refused send never
+        retrieves at all.
+
+        Args:
+            draft_text: The validated draft this send is about to transmit.
+        """
+        if not get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False):
+            return
+        if not _is_plain_text_send(draft_text):
+            return
+        if self._has_staged_console_evidence():
+            return
+        query = _sanitize_console_library_rag_query(
+            str(draft_text or "")[:AUTO_RAG_QUERY_MAX_CHARS]
+        )
+        if not query:
+            # Nothing survived centralized validation -- there is no query to
+            # run, and no user action to recommend. Stay silent.
+            return
+        request = LibraryRagSearchRequest(
+            query=query,
+            source_types=_console_library_rag_source_scope(self),
+            mode="rag",
+            top_k=_console_library_rag_profile_top_k(),
+            include_citations=True,
+        )
+        scoped_request, scope_empty_outcome = (
+            await self._resolve_console_library_rag_scope(request)
+        )
+        if scope_empty_outcome is not None:
+            self._notify_console_auto_rag_scope_empty(scope_empty_outcome)
+            return
+        placeholder = ConsoleLiveWorkLaunch.from_values(
+            source="Library Search/RAG",
+            title="Library Search/RAG retrieval",
+            payload={
+                "query": scoped_request.query,
+                "source_scope": ", ".join(scoped_request.source_types),
+            },
+            status="searching",
+            recovery=CONSOLE_AUTO_RAG_SEARCHING_COPY,
+            action_label="Review evidence in Console",
+        )
+        self._stage_console_library_rag_launch(placeholder)
+        try:
+            async with asyncio.timeout(AUTO_RAG_TIMEOUT_SECONDS):
+                outcome = await run_library_rag_search(
+                    self.app_instance, scoped_request
+                )
+        except asyncio.CancelledError:
+            # An interrupted send must not leave its placeholder behind.
+            self._clear_console_auto_rag_placeholder(placeholder)
+            raise
+        except TimeoutError:
+            self._clear_console_auto_rag_placeholder(placeholder)
+            self._notify_auto_rag_degraded(
+                initializing=self._rag_service_still_initializing()
+            )
+            return
+        except Exception as exc:
+            logger.warning(
+                "Console auto-retrieve failed; the send proceeds without "
+                "evidence (exception_category={})",
+                type(exc).__name__,
+            )
+            self._clear_console_auto_rag_placeholder(placeholder)
+            self._notify_auto_rag_degraded(initializing=False)
+            return
+        if not getattr(outcome, "results", ()):
+            # Deliberately NOT `_apply_console_library_rag_search_outcome`'s
+            # zero-result branch: that stages a recovery card, and a staged
+            # RAG launch with no available evidence blocks the NEXT send
+            # (`_console_send_blocked_reason`). One empty implicit retrieval
+            # must never lock the composer.
+            self._clear_console_auto_rag_placeholder(placeholder)
+            if str(getattr(outcome, "status", "") or "") in ("failed", "blocked"):
+                # An empty result set is an ordinary "nothing matched" and
+                # stays silent; a failed/blocked retrieval is a capability
+                # the user turned on not working, and must say so.
+                self._notify_auto_rag_degraded(initializing=False)
+            return
+        await self._apply_console_library_rag_search_outcome(scoped_request, outcome)
 
     def compose_content(self) -> ComposeResult:
         """Compose the chat content."""

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1354,13 +1354,16 @@ def _is_plain_text_send(draft_text: Any) -> bool:
 
 
 def _console_library_rag_profile_top_k() -> int:
-    """Return the ACTIVE RAG profile's result count (TASK-406).
+    """Return the ACTIVE RAG profile's result count (TASK-406/TASK-3170).
 
-    Auto-retrieval must honor the profile the user configured, the same way
-    task-5 made the Library service honor its search mode -- a hardcoded
-    count would silently ignore a profile tuned for more (or fewer)
-    results. Imported lazily: ``active_config`` pulls in the profile
-    manager, which this module has no other reason to load at import time.
+    Both Library RAG entry points on the Console -- the RAG chip's manual
+    Run and the opt-in send-path auto-retrieve -- must honor the profile
+    the user configured, the same way task-5 made the Library service
+    honor its search mode -- a hardcoded count would silently ignore a
+    profile tuned for more (or fewer) results. This is the one place both
+    call sites read that count from, so they can never drift apart again.
+    Imported lazily: ``active_config`` pulls in the profile manager, which
+    this module has no other reason to load at import time.
 
     Returns:
         The profile's ``search.default_top_k`` when it resolves to a
@@ -1374,7 +1377,7 @@ def _console_library_rag_profile_top_k() -> int:
         value = int(resolve_active_rag_config().search.default_top_k)
     except Exception as exc:
         logger.debug(
-            "Console auto-retrieve could not read the active RAG profile's "
+            "Console Library RAG could not read the active RAG profile's "
             "top_k (exception_category={}); using the fallback.",
             type(exc).__name__,
         )
@@ -12123,7 +12126,7 @@ class ChatScreen(BaseAppScreen):
             query=query,
             source_types=_console_library_rag_source_scope(self),
             mode="rag",
-            top_k=5,
+            top_k=_console_library_rag_profile_top_k(),
             include_citations=True,
         )
         self._stage_console_library_rag_launch(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -7991,6 +7991,7 @@ class ChatScreen(BaseAppScreen):
                 auto_retrieve_on_send=get_cli_setting(
                     "chat_defaults", "rag_auto_retrieve_on_send", False
                 ),
+                on_auto_retrieve_changed=self._persist_console_rag_auto_retrieve_on_send,
             ),
             callback=self._apply_console_rag_settings_choice,
         )
@@ -8046,13 +8047,15 @@ class ChatScreen(BaseAppScreen):
         """Store the modal's query and sources, then optionally run now.
 
         The "Auto-retrieve on send" toggle (TASK-3170 / RAG-port P0 task 7)
-        is written straight through to config here -- this is the one
-        write seam, reusing ``save_setting_to_cli_config`` the same way the
-        Console onboarding/rail-preference writers already do. It is a
-        module-level call (not routed through ``self``) so this stays the
-        single source of truth regardless of how the screen is constructed;
-        best-effort, since a write failure here must not block applying the
-        query/source-scope choice the user just made.
+        is NOT handled here -- it is a standing preference, not part of
+        this draft, so it already persisted the instant it flipped inside
+        the modal (see ``_open_console_rag_settings``'s
+        ``on_auto_retrieve_changed=self._persist_console_rag_auto_retrieve_
+        on_send`` and that method below). Gating it on this dismiss
+        callback the way the query/source-type edits are gated would have
+        silently lost the toggle on Escape/Cancel/a backdrop click, and
+        given a blank-query user no way to save it without running a
+        throwaway retrieval.
         """
         if result is None:
             return
@@ -8060,18 +8063,30 @@ class ChatScreen(BaseAppScreen):
         self._set_console_library_rag_query(
             _sanitize_console_library_rag_query(result.query)
         )
+        if result.run:
+            self._run_console_library_rag_from_visible_action()
+
+    @work(thread=True)
+    def _persist_console_rag_auto_retrieve_on_send(self, value: bool) -> None:
+        """Persist the "Auto-retrieve on send" toggle without blocking the UI thread.
+
+        TASK-3170 (RAG-port P0 task 7, re-critique fix): fired the instant
+        the RAG settings modal's switch flips (via its
+        ``on_auto_retrieve_changed`` callback), independent of how -- or
+        whether -- the modal is later dismissed. Mirrors the sibling
+        Console preference writers (``_save_console_rail_preferences``,
+        ``_save_console_onboarding_flag``, ``_save_console_fleet_coachmark_
+        flag``): a small best-effort ``save_setting_to_cli_config`` write
+        on a thread worker, not the UI thread.
+        """
         try:
             save_setting_to_cli_config(
-                "chat_defaults",
-                "rag_auto_retrieve_on_send",
-                bool(result.auto_retrieve_on_send),
+                "chat_defaults", "rag_auto_retrieve_on_send", bool(value)
             )
         except Exception as exc:
             logger.warning(
                 "Failed to persist Console auto-retrieve-on-send setting: {}", exc
             )
-        if result.run:
-            self._run_console_library_rag_from_visible_action()
 
     async def _open_console_character_picker(self) -> None:
         """Load characters off-thread and open the picker modal (task-1672)."""

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -7988,6 +7988,9 @@ class ChatScreen(BaseAppScreen):
                     pending.source if pending else None
                 ),
                 staged_title=(pending.title if pending else ""),
+                auto_retrieve_on_send=get_cli_setting(
+                    "chat_defaults", "rag_auto_retrieve_on_send", False
+                ),
             ),
             callback=self._apply_console_rag_settings_choice,
         )
@@ -8040,13 +8043,33 @@ class ChatScreen(BaseAppScreen):
     def _apply_console_rag_settings_choice(
         self, result: ConsoleRagSettingsResult | None
     ) -> None:
-        """Store the modal's query and sources, then optionally run now."""
+        """Store the modal's query and sources, then optionally run now.
+
+        The "Auto-retrieve on send" toggle (TASK-3170 / RAG-port P0 task 7)
+        is written straight through to config here -- this is the one
+        write seam, reusing ``save_setting_to_cli_config`` the same way the
+        Console onboarding/rail-preference writers already do. It is a
+        module-level call (not routed through ``self``) so this stays the
+        single source of truth regardless of how the screen is constructed;
+        best-effort, since a write failure here must not block applying the
+        query/source-scope choice the user just made.
+        """
         if result is None:
             return
         self._set_console_library_rag_source_scope(result.source_types)
         self._set_console_library_rag_query(
             _sanitize_console_library_rag_query(result.query)
         )
+        try:
+            save_setting_to_cli_config(
+                "chat_defaults",
+                "rag_auto_retrieve_on_send",
+                bool(result.auto_retrieve_on_send),
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to persist Console auto-retrieve-on-send setting: {}", exc
+            )
         if result.run:
             self._run_console_library_rag_from_visible_action()
 

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -11174,7 +11174,7 @@ class SettingsScreen(BaseAppScreen):
             id="settings-library-rag-search-group",
         ):
             yield Static(
-                "Used by future Library-native Search/RAG and Console evidence handoff defaults.",
+                "Drives Library Search/RAG retrieval and Console evidence handoff defaults.",
                 classes="settings-detail-row",
             )
             with Horizontal(classes="settings-input-row settings-select-row"):

--- a/tldw_chatbook/UI/Views/RAGSearch/search_handoff.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_handoff.py
@@ -13,6 +13,16 @@ from ....Chat.citation_evidence_models import (
     EvidenceReference,
 )
 from ....Chat.chat_handoff_models import ChatHandoffPayload
+# The score-kind vocabulary is imported from `library_rag_score_kinds`, NOT
+# from `library_rag_state`: that module imports `library_rag_answer_service`,
+# which imports this one, so a direct import would close an import cycle.
+from ....Library.library_rag_score_kinds import (
+    HYBRID_FUSION_METADATA_KEY,
+    SCORE_KIND_METADATA_KEY,
+    coerce_optional_float,
+    library_rag_result_score_kind,
+    library_rag_similarity_input,
+)
 from ....Utils.input_validation import sanitize_string, validate_text_input
 
 
@@ -160,14 +170,73 @@ def _library_rag_title(result: Any) -> str:
     )
 
 
+def _library_rag_score_kind(result: Any) -> tuple[str, float | None]:
+    """Resolve one result's `(score_kind, vector_score)` (RAG-port P0/Task 6).
+
+    Delegates to the single shared rule in `library_rag_score_kinds` -- the
+    same one `LibraryRagResultRow.from_result` uses -- so a row's on-screen
+    band and the score staged into a grounded answer can never disagree
+    about what its number means.
+
+    Args:
+        result: A Library Search/RAG result mapping or object.
+
+    Returns:
+        The canonical score kind, plus the preserved vector-leg similarity
+        for `hybrid_fusion` rows.
+    """
+    candidates: list[Any] = [_result_provenance(result)]
+    metadata = _result_value(result, "metadata")
+    if isinstance(metadata, Mapping):
+        candidates.append(metadata)
+    if isinstance(result, Mapping):
+        candidates.append(result)
+    else:
+        # Attribute-shaped results: mirror the mapping case for just the two
+        # keys this rule reads off the top level.
+        candidates.append(
+            {
+                key: getattr(result, key)
+                for key in (SCORE_KIND_METADATA_KEY, HYBRID_FUSION_METADATA_KEY)
+                if getattr(result, key, None) is not None
+            }
+        )
+    return library_rag_result_score_kind(*candidates)
+
+
 def _library_rag_score(result: Any) -> float | None:
-    value = _result_or_provenance_value(result, "score")
-    if value in (None, ""):
+    """Return the result's honest cosine similarity, or `None`.
+
+    `EvidenceReference.score` is declared as a retrieval score on the unit
+    interval and is adapted downstream as a `ZERO_TO_ONE` similarity
+    (`Chat/citation_trace_adapters.py`), so only a real similarity may
+    occupy it (RAG-port P0/Task 6):
+
+    * a `hybrid_fusion` row contributes its preserved VECTOR LEG, never the
+      fused RRF number -- which maxes out near 0.016 at the shipped
+      `rrf_k=60` and would read as a near-zero similarity;
+    * an FTS-leg-only hybrid row and a reranked row contribute nothing --
+      no similarity exists, and a reranker score that happens to land
+      inside [0, 1] would otherwise pass the unit-interval check silently.
+
+    The original number is never lost: it stays on the row itself and, for
+    hybrid rows, in the reference's `hybrid_fusion` metadata block.
+
+    Args:
+        result: A Library Search/RAG result mapping or object.
+
+    Returns:
+        A finite similarity in [0, 1], or `None`.
+    """
+    score_kind, vector_score = _library_rag_score_kind(result)
+    similarity = library_rag_similarity_input(
+        coerce_optional_float(_result_or_provenance_value(result, "score")),
+        score_kind=score_kind,
+        vector_score=vector_score,
+    )
+    if similarity is None:
         return None
-    try:
-        score = float(value)
-    except (TypeError, ValueError):
-        return None
+    score = float(similarity)
     if not math.isfinite(score) or score < 0 or score > 1:
         return None
     return score
@@ -359,11 +428,17 @@ def build_library_rag_evidence_bundle(
             source_authority=source_authority,
             result_id=result_id,
         )
+        score_kind = _library_rag_score_kind(result)[0]
         metadata = {
             **_result_provenance(result),
             "result_id": result_id,
             "chunk_id": chunk_id,
             "citations": _library_rag_citation_labels(result),
+            # (RAG-port P0/Task 6) What `score` below is -- and, when it is
+            # absent, why. A consumer computing weakness/coverage copy over
+            # these references must filter on this: a fused 0.016 or a
+            # reranker logit is not a weak similarity.
+            SCORE_KIND_METADATA_KEY: score_kind,
             "runtime_backend": runtime_backend,
             "source_authority": source_authority,
             "source_selector_state": source_authority,
@@ -467,6 +542,10 @@ def build_library_rag_console_live_work_payload(
         ),
         "citations": _library_rag_citation_labels(result),
         "score": _library_rag_score(result),
+        # (RAG-port P0/Task 6) `score` is a cosine similarity or nothing --
+        # this says which retrieval produced it, so a consumer can tell a
+        # similarity from a fused rank score or a reranker logit.
+        SCORE_KIND_METADATA_KEY: _library_rag_score_kind(result)[0],
         "runtime_backend": runtime_backend,
         "source_authority": source_authority,
         "source_selector_state": source_authority,

--- a/tldw_chatbook/Widgets/Console/console_rag_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_rag_settings_modal.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 from textual import on
 from textual.app import ComposeResult
@@ -121,10 +121,13 @@ class ConsoleRagSettingsResult:
             (RAG-44). Deliberately not the retrieval item scope
             (conversation ∩ workspace), which the Console resolves
             separately and this modal never touches.
-        auto_retrieve_on_send: The "Auto-retrieve on send" switch's value
-            (TASK-3170 / RAG-port P0 task 7). The screen persists this to
-            `[chat_defaults] rag_auto_retrieve_on_send`; the modal itself
-            never writes config.
+        auto_retrieve_on_send: The "Auto-retrieve on send" switch's value at
+            dismiss time (TASK-3170 / RAG-port P0 task 7), reported here for
+            completeness/tests. The switch is NOT gated on this dismiss --
+            it already persisted the instant it flipped, through the
+            modal's ``on_auto_retrieve_changed`` callback (see
+            ``ConsoleRagSettingsModal.__init__``), because it is a standing
+            preference rather than part of the query/source-type draft.
     """
 
     query: str
@@ -221,6 +224,7 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
         rag_active: bool = False,
         staged_title: str = "",
         auto_retrieve_on_send: bool = False,
+        on_auto_retrieve_changed: Callable[[bool], None] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the modal.
@@ -238,6 +242,16 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
                 send" switch (TASK-3170). The caller reads this from
                 `[chat_defaults] rag_auto_retrieve_on_send`; the modal's own
                 default here is OFF.
+            on_auto_retrieve_changed: Called with the new value the INSTANT
+                the switch flips (TASK-3170 fix). "Auto-retrieve on send" is
+                a standing preference, not part of the query/source-type
+                draft this modal otherwise discards on Cancel/Escape/a
+                backdrop click -- gating its persistence on those same
+                dismiss paths silently lost the setting on Escape, and gave
+                a blank-query user no way to save it without a throwaway
+                retrieval. The caller wires this to a real (worker-backed)
+                persist call; leaving it unset (e.g. in modal-only tests)
+                just means nothing is persisted.
             **kwargs: Forwarded to ``ModalScreen``.
         """
         super().__init__(**kwargs)
@@ -246,6 +260,7 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
         self._rag_active = rag_active
         self._staged_title = staged_title
         self._auto_retrieve_on_send = bool(auto_retrieve_on_send)
+        self._on_auto_retrieve_changed = on_auto_retrieve_changed
 
     def _status_copy(self) -> str:
         """Return honest Library-search-state copy for the top of the modal."""
@@ -390,13 +405,18 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
 
     @on(Switch.Changed, f"#{CONSOLE_RAG_AUTO_RETRIEVE_TOGGLE_ID}")
     def _auto_retrieve_toggled(self, event: Switch.Changed) -> None:
-        """Track the draft "Auto-retrieve on send" value (TASK-3170).
+        """Persist "Auto-retrieve on send" the instant it flips (TASK-3170).
 
-        Committed to config by the screen's dismiss callback, same as the
-        query and source-type edits this modal already treats as a draft.
+        Deliberately NOT treated as part of the query/source-type draft:
+        this is a standing preference, so it must survive Cancel/Escape/a
+        backdrop click, not be silently discarded with them. Also kept in
+        ``self._auto_retrieve_on_send`` so the dismiss result still reports
+        the current value (see ``_run_result``).
         """
         event.stop()
         self._auto_retrieve_on_send = event.value
+        if self._on_auto_retrieve_changed is not None:
+            self._on_auto_retrieve_changed(event.value)
 
     @on(Input.Changed, "#console-rag-settings-query")
     def _sync_run_availability(self, event: Input.Changed) -> None:

--- a/tldw_chatbook/Widgets/Console/console_rag_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_rag_settings_modal.py
@@ -18,7 +18,7 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.events import Click
 from textual.screen import ModalScreen
-from textual.widgets import Button, Input, Static
+from textual.widgets import Button, Input, Static, Switch
 
 from tldw_chatbook.Library.library_rag_state import (
     LIBRARY_RAG_SCOPE_TOGGLE_SOURCE_TYPES,
@@ -45,6 +45,18 @@ CONSOLE_RAG_SOURCE_SUMMARY_PREFIX = "Sources"
 CONSOLE_RAG_SOURCE_TOGGLE_ID_PREFIX = "console-rag-settings-source-"
 CONSOLE_RAG_SOURCE_TOGGLE_CLASS = "console-rag-settings-source-toggle"
 _SOURCE_TYPE_LABELS = dict(LIBRARY_RAG_SOURCE_TYPES)
+
+#: TASK-3170 (RAG-port P0 task 7): the modal's own default when no
+#: constructor value is given. The CALLER (chat_screen.py's
+#: `_open_console_rag_settings`) is the one that reads the persisted
+#: `[chat_defaults] rag_auto_retrieve_on_send` config value and passes it
+#: in -- the modal never touches config directly.
+CONSOLE_RAG_AUTO_RETRIEVE_TOGGLE_ID = "console-rag-settings-auto-retrieve"
+CONSOLE_RAG_AUTO_RETRIEVE_LABEL = "Auto-retrieve on send"
+CONSOLE_RAG_AUTO_RETRIEVE_TOOLTIP = (
+    "When on, each plain text send first retrieves library evidence into "
+    "the staged-evidence strip"
+)
 
 
 def normalize_console_rag_source_types(value: Any) -> tuple[str, ...]:
@@ -109,11 +121,16 @@ class ConsoleRagSettingsResult:
             (RAG-44). Deliberately not the retrieval item scope
             (conversation ∩ workspace), which the Console resolves
             separately and this modal never touches.
+        auto_retrieve_on_send: The "Auto-retrieve on send" switch's value
+            (TASK-3170 / RAG-port P0 task 7). The screen persists this to
+            `[chat_defaults] rag_auto_retrieve_on_send`; the modal itself
+            never writes config.
     """
 
     query: str
     run: bool
     source_types: tuple[str, ...] = CONSOLE_RAG_DEFAULT_SOURCE_TYPES
+    auto_retrieve_on_send: bool = False
 
 
 class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
@@ -171,6 +188,15 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
         background: $panel;
     }
 
+    .console-rag-settings-auto-retrieve {
+        height: auto;
+        margin: 0 0 1 0;
+    }
+
+    .console-rag-settings-auto-retrieve Switch {
+        margin: 0 1 0 0;
+    }
+
     .console-rag-settings-actions {
         height: 3;
     }
@@ -194,6 +220,7 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
         source_types: Sequence[str] = CONSOLE_RAG_DEFAULT_SOURCE_TYPES,
         rag_active: bool = False,
         staged_title: str = "",
+        auto_retrieve_on_send: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize the modal.
@@ -207,6 +234,10 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
             rag_active: Whether RAG currently reads "on" (staged evidence).
             staged_title: Title of the staged evidence when ``rag_active``,
                 for honest status copy.
+            auto_retrieve_on_send: Initial value for the "Auto-retrieve on
+                send" switch (TASK-3170). The caller reads this from
+                `[chat_defaults] rag_auto_retrieve_on_send`; the modal's own
+                default here is OFF.
             **kwargs: Forwarded to ``ModalScreen``.
         """
         super().__init__(**kwargs)
@@ -214,6 +245,7 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
         self._source_types = normalize_console_rag_source_types(source_types)
         self._rag_active = rag_active
         self._staged_title = staged_title
+        self._auto_retrieve_on_send = bool(auto_retrieve_on_send)
 
     def _status_copy(self) -> str:
         """Return honest Library-search-state copy for the top of the modal."""
@@ -280,6 +312,16 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
                         classes=CONSOLE_RAG_SOURCE_TOGGLE_CLASS,
                         tooltip=f"Include {label} in Library retrieval.",
                     )
+            with Horizontal(classes="console-rag-settings-auto-retrieve"):
+                yield Switch(
+                    value=self._auto_retrieve_on_send,
+                    id=CONSOLE_RAG_AUTO_RETRIEVE_TOGGLE_ID,
+                    tooltip=CONSOLE_RAG_AUTO_RETRIEVE_TOOLTIP,
+                )
+                yield Static(
+                    CONSOLE_RAG_AUTO_RETRIEVE_LABEL,
+                    markup=False,
+                )
             with Horizontal(classes="console-rag-settings-actions"):
                 yield Button(
                     "Search Library",
@@ -307,6 +349,7 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
             query=self._current_query(),
             run=True,
             source_types=self._source_types,
+            auto_retrieve_on_send=self._auto_retrieve_on_send,
         )
 
     def _refresh_run_availability(self, query: str | None = None) -> None:
@@ -344,6 +387,16 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
             self._scope_summary()
         )
         self._refresh_run_availability()
+
+    @on(Switch.Changed, f"#{CONSOLE_RAG_AUTO_RETRIEVE_TOGGLE_ID}")
+    def _auto_retrieve_toggled(self, event: Switch.Changed) -> None:
+        """Track the draft "Auto-retrieve on send" value (TASK-3170).
+
+        Committed to config by the screen's dismiss callback, same as the
+        query and source-type edits this modal already treats as a draft.
+        """
+        event.stop()
+        self._auto_retrieve_on_send = event.value
 
     @on(Input.Changed, "#console-rag-settings-query")
     def _sync_run_availability(self, event: Input.Changed) -> None:

--- a/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
@@ -725,7 +725,11 @@ def library_rag_result_row_children(
         evidence.
     """
     selected = row.result_id == selected_result_id
-    score = library_rag_score_suffix(row.score)
+    score = library_rag_score_suffix(
+        row.score,
+        score_kind=row.score_kind,
+        vector_score=row.vector_score,
+    )
     card_children: list[Widget] = [
         Static(
             f"{index + 1}. {row.title}{score}",

--- a/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
@@ -815,13 +815,17 @@ def library_rag_results_body_children(state: LibraryRagPanelState) -> list[Widge
         The widgets to mount directly below the Evidence heading.
     """
     # Task 8: the coverage note, when there is one, is the very first thing
-    # under the heading -- ahead of the row list. `state.coverage_note` is
-    # only ever non-empty alongside `state.results` (see
-    # `library_rag_coverage_note`'s empty-rows guard), so prepending it
-    # unconditionally here is a no-op in every other branch below rather
-    # than needing its own conditional per branch.
+    # under the heading -- ahead of the row list. It is prepended to EVERY
+    # branch: `state.coverage_note` used to be non-empty only alongside
+    # `state.results`, but a routing disclosure (RAG-port P0: "this profile
+    # ran keyword-only", "scope forced semantic") survives the zero-row
+    # outcome, and zero rows is exactly when it is most diagnostic -- the
+    # quiet no-match line otherwise reads as a verdict on an index the
+    # search never queried. Branches whose state has nothing to disclose
+    # prepend an empty list, i.e. are unchanged.
+    note_children: list[Widget] = list(library_rag_coverage_note_children(state))
     if state.results:
-        children: list[Widget] = list(library_rag_coverage_note_children(state))
+        children: list[Widget] = list(note_children)
         for index, result in enumerate(state.results):
             children.extend(
                 library_rag_result_row_children(result, index, state.selected_result_id)
@@ -841,7 +845,7 @@ def library_rag_results_body_children(state: LibraryRagPanelState) -> list[Widge
                 )
         return children
     if state.retrieval_status == "searching":
-        return [
+        return note_children + [
             Static(
                 searching_status_line(state.scope.selected_source_types),
                 id="library-rag-searching-line",
@@ -849,7 +853,7 @@ def library_rag_results_body_children(state: LibraryRagPanelState) -> list[Widge
         ]
     if state.recovery_copy and state.recovery_selector:
         if state.retrieval_status == "empty":
-            return [
+            return note_children + [
                 Static(
                     # `state.searched_query`, NOT `state.query_state.query`
                     # (task-15 finding I3): the latter is live, not-yet-
@@ -865,15 +869,17 @@ def library_rag_results_body_children(state: LibraryRagPanelState) -> list[Widge
                     classes="library-rag-quiet-line",
                 )
             ]
-        return [Static(state.recovery_copy, id=state.recovery_selector)]
+        return note_children + [
+            Static(state.recovery_copy, id=state.recovery_selector)
+        ]
     if not state.scope.has_available_sources:
         # No Library sources at all: the scope region's single quiet gate
         # line + "Open Import media" action are the entire guidance for
         # this state -- repeating "No evidence yet"/"Add or import
         # sources…" here would re-stack the layered dump the quiet-gate
         # principle retired (2026-07 UAT).
-        return []
-    return [
+        return note_children
+    return note_children + [
         Static(
             "No evidence yet. Run Search/RAG to populate results.",
             id="library-rag-results-empty",

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3248,6 +3248,12 @@ prune_low_watermark = 12000
 # span renderer, which keeps roleplay speech/action flavor colors.
 assistant_markdown = true
 
+# Console's RAG chip settings modal: when true, each plain text send first
+# retrieves Library evidence into the staged-evidence strip before the
+# message goes out. Off by default -- retrieval only runs when a user
+# explicitly asks for it (the RAG chip / "Run Library RAG").
+rag_auto_retrieve_on_send = false
+
 # Image attachment settings for chat
 [chat.images]
 enabled = true


### PR DESCRIPTION
First phase of the RAG server-port programme (spec: `Docs/superpowers/specs/2026-08-07-rag-port-p0-foundations-design.md`, plan: `Docs/superpowers/plans/2026-08-07-rag-port-p0-foundations.md`). P0 makes the retrieval chatbook already owns reachable and honest — no server code lifted.

## Workstream A — the live Library `rag` mode honors the active profile
- `default_search_mode` drives routing: **hybrid** → engine RRF (k=60 + alpha, ADR-005 parity) with `rag-hybrid` backend label; **plain** → the four-seam scope-aware keyword path with a disclosed route note (never the engine's media-only leg); **scoped or media-deselected hybrid** → semantic with the exact reason disclosed. Profile switches invalidate the cached runtime via a generation stamp (routing can never follow a stale profile).
- **Keyword leg rebuilt** — it had *four* independent never-worked defects: guessed DB paths that can't match the real `tldw_chatbook_media_v2.db`, a dict "pool" with no `.transaction()`, SQL selecting a nonexistent `Media.tags` column, and inverted FTS5 ordering (kept the *worst* N). Now: config-injected path, no writes ever from a search (create-on-miss branch deleted), `source_type`/`title` stamped, best-first ordering.
- **Reranking had never constructed** — `create_reranker(strategy=X, **cfg.__dict__)` raised TypeError on every reranking profile, Hybrid Full requested the unimplemented `cross_encoder`, and the real factory dropped `reranking_config` entirely. All fixed through the real construction paths; a rerank failure degrades with `reranking_skipped`/`reranking_degraded` tags (copy-not-mutate — the cache is never poisoned) and never fails a search.
- **Score-kind-aware match bands** — fused RRF scores (≤ ~0.016) and reranker scores are never banded on cosine thresholds: hybrid rows band on the preserved vector-leg similarity, FTS-only rows read `| keyword match`, pointwise-reranked rows read `| reranked`. `all_matches_weak` and the Answer coverage copy count only vector-similarity kinds. Fusion preserves original leg scores in `hybrid_fusion` metadata (with an aliasing fix — `entry.item` IS `fts_item`).
- Zero-results honesty: "Index empty" never claimed when the keyword leg returned rows; "semantic leg empty — keyword-only results" disclosed; route disclosures render on zero-row outcomes too.

## Workstream B — Console native send-path RAG (task-406)
- **Auto-retrieve on send** toggle in the RAG chip modal: default OFF, persists at flip time (Escape keeps it; threaded config write off the UI thread).
- At send: plain-text sends only (never commands/approvals), manual staging wins, EMPTY scope short-circuits with the shared copy, 5s timeout with "Retrieving…" in-flight state and initializing-vs-failed notices, and a send is **never** blocked on retrieval. Success stages through the existing staged-evidence strip and is consumed by the same send — never invisible injection.
- The chip's manual run inherits the profile's `default_top_k` (5→15 on the default profile — disclosed in the guides).

## Verification
- Battery at head: **497 passed / 0 failed** across all branch-touched test files; collection arithmetic exact (31,931 + 107 = 32,038 vs merge-base).
- RED-first throughout; ~20 mutation checks each redding exactly their own test; per-task reviews + scoped re-reviews all closed; final whole-branch review **MERGEABLE, 0 Critical / 0 Important**.
- **Live TUI walkthrough 5/5** on a scratch profile with copied real DBs and real provider credentials — including task-406 end-to-end (auto-retrieve staged 15 sources; the model's reply cited `[S1]..[S15]`). One live find fixed forward: keyword rows rendered "Untitled source" (missing `title` key).
- Guides updated + stamped: `library/search-and-rag.md`, `console/context-and-rag.md`, `settings/rag.md` (incl. reranking cost disclosure).

## Backlog
- TASK-3170 + task-406 Done. Follow-ups filed: TASK-3500 (MCP profile parity), 3501 (pipeline_builder aliasing twin), 3502 (reranker cost/provider surface + degradation-tag UI), 3503 (config.load_settings race), 3504 (silent zero-result auto-retrieve), 3600 (retired Anthropic models in dropdown), 3601 (plain-mode deps gating). Two lessons added to `lessons-testing-evidence.md`.

Note: CI cancellation on this repo is intentional — the local gates above are the merge signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Library retrieval honor the active RAG profile and adds opt‑in Console auto‑retrieve on send, with honest score display and non‑blocking, staged‑evidence injection. Delivers TASK‑3170 P0 and wires task‑406 through the staged‑evidence path.

- **New Features**
  - Library rag mode routes by profile: Plain → scope‑aware keyword; Hybrid → fused RRF (discloses fallbacks); Semantic unchanged. Route notes render even on zero results; app cache invalidates on profile switch.
  - Score‑kind aware display: cosine banding only for true similarities; Hybrid rows band on preserved vector leg; keyword rows show “| keyword match”; reranked rows show “| reranked”. Evidence references include kind and `hybrid_fusion` metadata.
  - Console: RAG chip adds “Auto‑retrieve on send” (default OFF, persisted on toggle). Sends stage evidence via the existing strip using profile `default_top_k`, 5s timeout, clear initializing/failed notices, and never block. Manual Run now also uses profile `default_top_k`.
  - Docs/specs added and updated: profile‑driven retrieval, Console auto‑retrieve, reranking cost note, and the P0 design/plan.

- **Bug Fixes**
  - Reranker: fix factory (no double‑strategy error; Hybrid Full uses a supported strategy), construct via profile, never fail a search; tag `reranking_skipped`/`reranking_degraded` without mutating cached results.
  - Keyword leg: resolve the real media DB path with strict validation, never create/write; correct FTS5 SQL and best‑first ordering; return a real `MediaDatabase` from the pool with single‑flight init; stamp `title`/`source_type`.
  - Hybrid fusion: preserve original per‑leg scores (no aliasing); RRF provenance tolerant to extra fields.
  - Cache and honesty: app‑level RAG runtime invalidated on profile switch with atomic service+generation publication; zero‑result searches still show routing disclosures.

<sup>Written for commit 0c55576506e66384307d5e8553261e0e863c743d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

