### PR TITLE
feat(watchlists): reader-first phase 2 — list and reader quality (TASK-3072)

### DIFF
--- a/Docs/superpowers/plans/2026-08-07-watchlists-reader-first-phase-2-list-reader-quality.md
+++ b/Docs/superpowers/plans/2026-08-07-watchlists-reader-first-phase-2-list-reader-quality.md
@@ -1,0 +1,272 @@
+# Watchlists Reader-First Re-IA — Phase 2: List and Reader Quality — Implementation Plan
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking. Implement task-by-task, TDD throughout: failing test first, then implementation, one conventional commit per task.
+
+**Goal:** Make the Read tab's article list and reader look and behave like the reference feed-reader layout (NetNewsWire): multi-line reader rows with date-group headers, a star that persists, a Starred smart feed in the rail, an action row on the reader that shares its verbs with the Inspector, `o` to open in the browser, and a position footer.
+
+**Architecture:** All work happens in the worktree `.worktrees/watchlists-reader-first`, branch `feat/watchlists-reader-first-p2` (off `origin/dev @ cc0001ff3`, which includes phase 1 and TASK-3071). New filters are threaded through the phase-1 pass-through chain (`Subscriptions_DB.get_new_items` → `LocalWatchlistsService.list_items` → `WatchlistScopeService.list_items` → backend controller `**kwargs`). No schema changes: `is_flagged` and its index are already resident (`Subscriptions_DB.py:640-641`, `:768`).
+
+**Spec:** `Docs/superpowers/specs/2026-08-05-watchlists-reader-first-design.md` — "Article list", "Reading pane", "Dates", "Keybindings" sections; phasing line "Phase 2 — list and reader quality".
+
+**ADR required:** no (already exists)
+**ADR path:** `backlog/decisions/042-watchlists-reader-first-ia.md`
+**Reason:** ADR-042 covers the whole re-IA including the phase-2 surface (reader rows, starred state, shared action verbs, new keys). Phase 2 is a direct implementation of it.
+
+**Backlog task:** TASK-3072 (filed 2026-08-07).
+
+**Tech Stack:** Python 3.11+, Textual (ListView), SQLite (stdlib `sqlite3`), pytest + `textual.pilot`.
+
+**Conventions:**
+- Run everything from the worktree root: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/watchlists-reader-first`
+- Tests: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python3 -m pytest Tests/Watchlists/ -x -q` (the main-checkout venv provides deps; the `timeout` command is NOT available).
+- DB tests use real SQLite in-memory (repo convention).
+- Screen under change: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` (10,135 lines — navigate by the line refs below; exact as of `cc0001ff3`).
+- Commits: `type(scope): summary` conventional style; reference `task-3072`.
+
+**Survey results the plan is built on (all verified 2026-08-07 against `origin/dev @ cc0001ff3`):**
+
+- `items_pane.py` (547 lines) is the DataTable list phase 2 replaces **in Read only**. Its sole construction site is the screen's region factory at `:1985`. Carryovers the new widget must preserve: `displayed_items()` / `select_and_reveal()` (`:482-539`), the `_rendered_items` snapshot authority (`:152-163`, `:499-501`), open-item pinning in `_filtered_items()` (`:257-293`), the in-place single-cell repaint pattern (`update_item_status_cell` :369, `update_item_queued_cell` :404), the `ItemsFilterChanged` mirror message (`:46-63`), `ItemSelected` / `RefreshItemsRequested` / `NextUnreadRequested` messages, the search box's `select_on_focus=False` + recompose focus restore (`:183-198`, `:311-356`), and the pane-bound `space` binding (`:69`, `:545-547`).
+- `content_pane.py` already has the `#content-actions` strip (`:350-389`) and posts `UnreadToggleRequested`; the Inspector posts `IngestRequested` (`inspector_pane.py:108`) and `ToggleBriefingQueueRequested` (`:132`). The action row shares verbs by posting these same screen-handled messages — the no-drift mechanism the spec asks a "shared module" for, achieved at the message layer (screen handlers `:9219`, `:9260`).
+- The spec's `Subscriptions/content_render.py` is **already satisfied** by `Subscriptions/html_text.py` (TASK-2307): dependency-free stdlib `HTMLParser`, `readable_body_text` (`:354`) used by `render_article` today, `html2text` noted as an optional extra that is not required (`:18-23`). Phase 2 records this reconciliation and adds only a snippet helper if the row code needs one. No new renderer module.
+- `humane_time.py` is the house timestamp style (TASK-2308). The spec's `item_dates.py` adds what it lacks: **effective date** (`published_date` falling back to `created_at`), **relative rendering** for rows, and **local-day buckets** for group headers. It reuses `humane_time`'s parse (naive = UTC) rather than growing a second parser.
+- Scope plumbing: `TreeScope` (`watchlist_tree.py:29-34`) is a `Literal["all","unassigned","watchlist","source"]` — phase 2 adds `"starred"`. The screen maps scope → `list_items` kwargs in `_items_scope_query` (`:8412-8428`); status in `_items_status_query` (`:8386-8410`); fetch in `_load_items` (`:8484-8509`, page 100).
+- `get_new_items` (`Subscriptions_DB.py:1793`) builds predicate fragments with bound params (`:1859-1867`); `set_item_briefing_queued` (`:2099`) is the exact precedent for `set_item_flagged`. `normalize_watchlist_item` (`watchlist_normalizers.py:549`) needs the `is_flagged` bool key (precedent `queued_for_briefing` at `:588-592`).
+- Screen `BINDINGS` (`:392-424`): `s`, `o`, `/`, `r` are all free. Phase 2 adds `s` and `o` only (`/` and `r` are phase 3).
+
+---
+
+### Task 1: Task bookkeeping + docs commit
+
+**Files:**
+- Create: this plan
+- Modify: `backlog/tasks/task-3072 - Watchlists-reader-first-re-IA-phase-2-list-and-reader-quality.md` (status → In Progress, plan reference)
+
+- [ ] **Step 1: Move TASK-3072 to In Progress with the plan reference**
+
+```bash
+npx --yes backlog.md task edit 3072 -s "In Progress" --plan "Execute Docs/superpowers/plans/2026-08-07-watchlists-reader-first-phase-2-list-reader-quality.md
+
+ADR required: no (already exists)
+ADR path: backlog/decisions/042-watchlists-reader-first-ia.md
+Reason: ADR-042 covers the re-IA; phase 2 is a direct implementation of it."
+```
+
+- [ ] **Step 2: Commit the docs**
+
+```bash
+git add Docs/superpowers/plans/2026-08-07-watchlists-reader-first-phase-2-list-reader-quality.md backlog/tasks/
+git commit -m "docs(watchlists): phase 2 plan — list and reader quality (task-3072)"
+```
+
+---
+
+### Task 2: `Subscriptions/item_dates.py` — effective date, relative time, day buckets
+
+**Files:**
+- Create: `tldw_chatbook/Subscriptions/item_dates.py`
+- Test: `Tests/Subscriptions/test_item_dates.py`
+
+The date foundation every other task renders with. The stored `published_date` is mixed naive/aware ISO-8601 (the spec's "Dates" section); naive is attached to UTC, matching `humane_time`'s documented house rule.
+
+- [ ] **Step 1: Write the failing tests**
+
+Cover: aware and naive ISO strings parse to the same instant (naive = UTC); `effective_date(item)` prefers `published_date`, falls back to `created_at`, returns `None` when both are missing; `relative_day(dt, now)` returns the bucket the row header wants (`"Today"`, `"Yesterday"`, else a locale date string); future-dated items (bad feed clocks) bucket into Today; unparseable input degrades (bucket falls back to ingest time or `"Unknown date"`, never raises); `relative_time(dt, now)` renders same-day times as clock time ("9:41 AM") and older days as the day label.
+
+- [ ] **Step 2: Implement `item_dates.py`**
+
+API: `parse_stored_datetime(value) -> datetime | None` (delegate the known formats to `humane_time`'s parser if it exposes one — read it first; otherwise `fromisoformat` + the feed formats, naive → `timezone.utc`), `effective_date(item) -> datetime | None`, `relative_time(dt, *, now) -> str`, `day_bucket(dt, *, now) -> str`. Module docstring records: one parser rule (naive = UTC), why effective date exists (TASK-2308 showed ingest time under a "Published" heading once already), and that bucketing is done in Python over displayed rows, not in SQL (mixed stored tz strings cannot be trusted to SQL date functions — the spec's Dates section).
+
+- [ ] **Step 3: Run the tests, commit**
+
+`feat(watchlists): item_dates helper — effective date, relative time, day buckets (task-3072)`
+
+---
+
+### Task 3: `is_flagged` plumbing — DB setter, query predicate, normalization
+
+**Files:**
+- Modify: `tldw_chatbook/DB/Subscriptions_DB.py` (`set_item_flagged` after `set_item_briefing_queued` :2099; `is_flagged` predicate in `get_new_items` :1859-1867; `get_flagged_items_count` near `get_source_item_counts` :1105)
+- Modify: `tldw_chatbook/Subscriptions/watchlist_normalizers.py` (`:549`)
+- Modify: `tldw_chatbook/Subscriptions/local_watchlists_service.py` (`list_items` :355), `tldw_chatbook/Subscriptions/watchlist_scope_service.py` (`list_items` :215)
+- Test: co-locate DB tests with the existing `get_new_items` tests (`grep -rl "get_new_items" Tests/`)
+
+- [ ] **Step 1: Write the failing tests**
+
+`set_item_flagged` flips the column and is readable via `get_new_items(is_flagged=True)`; the flag is global (same item in several watchlists — ADR-018's note on `queued_for_briefing` applies verbatim); **flags persist across re-fetch** (upsert an existing item via `persist_subscription_item` — it must not write `is_flagged`; the spec verified this reads-only claim, now it is pinned by test); `get_flagged_items_count()` counts flagged rows across all sources; the normalized item dict carries `is_flagged` as a real `bool` (the `queued_for_briefing` coercion precedent, `watchlist_normalizers.py:588-592`).
+
+- [ ] **Step 2: Implement**
+
+- `Subscriptions_DB.set_item_flagged(item_id, flagged)` — same transaction shape as `set_item_flagged`'s sibling :2099.
+- `get_new_items(..., is_flagged: bool | None = None)` — one more predicate fragment (`i.is_flagged = ?`), bound param, documented in the docstring's Args.
+- `get_flagged_items_count() -> int` — single `SELECT COUNT(*) ... WHERE is_flagged = 1` (status-agnostic: a starred item stays starred when read).
+- Thread `is_flagged` through `LocalWatchlistsService.list_items` and `WatchlistScopeService.list_items` as another falsey-means-no-filter kwarg (the `watchlist_id` precedent, TASK-2513).
+- `normalize_watchlist_item` gains `"is_flagged": bool(row.get("is_flagged"))`.
+
+- [ ] **Step 3: Run the tests, commit**
+
+`feat(watchlists): is_flagged plumbing — setter, query predicate, normalization (task-3072)`
+
+---
+
+### Task 4: `Subscriptions/item_dates`-ordered listing + snippet helper
+
+**Files:**
+- Modify: `tldw_chatbook/DB/Subscriptions_DB.py` (`get_new_items` ordering, :1844-1846 note says `created_at` desc today)
+- Modify: `tldw_chatbook/Subscriptions/html_text.py` (snippet helper)
+- Test: same DB test file; `Tests/Subscriptions/test_html_text.py` (find with `grep -rl "readable_body_text" Tests/`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Ordering: items with a `published_date` sort by it desc; items without fall back to `created_at`; a stale-published item fetched recently sorts below a fresh-published one. Implement as `ORDER BY COALESCE(i.published_date, i.created_at) DESC` — **no new index**: the sort runs over the scope-filtered, page-bounded set (limit+offset ≤ a few hundred rows); record the EXPLAIN measurement in the commit message (the spec leaves the index conditional on measurement). Snippet: `body_snippet(content, *, max_chars=160)` collapses whitespace, strips tags via the existing extractor, truncates on a word boundary with an ellipsis; hostile input (script tags, control bytes, markup-shaped text) comes out as inert plain text.
+
+- [ ] **Step 2: Implement**
+
+- [ ] **Step 3: Run the tests, commit**
+
+`feat(watchlists): effective-date ordering + body snippet helper (task-3072)`
+
+---
+
+### Task 5: `article_list.py` — the reader rows widget
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/article_list.py`
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` (construction site :1985; nothing else yet)
+- Test: `Tests/Watchlists/test_watchlists_article_list.py`
+
+The phase-2 centrepiece: a ListView-based replacement for ItemsPane's DataTable **in the Read section only**. Rows: line 1 = source name + relative effective time; line 2 = title (**bold** when `status == "new"`); line 3 = 1–2 line snippet; leading unread dot; trailing star glyph when `is_flagged`; queued marker (the existing `●`, `items_pane.py:74`); ingested items render read-styled with a small marker. Date-group headers (Today / Yesterday / locale date) computed in Python over the displayed rows via `item_dates.day_bucket`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Row rendering: unread row is bold with the dot, read row is not; starred row shows the star; queued row shows `●`; ingested row shows its marker and read styling; a hostile title (`[bold red]x[/]`, control bytes) renders literally (the `escape_markup` boundary rule `items_pane.py:226-233` states — ListView row content must follow it wherever a markup-parsing widget renders item text); group headers appear in effective-date-descending order and future-dated items land under Today; **headers are not selectable** and `j`/`k`-style cursor movement skips them; selection posts the same `ItemSelected`-shaped message the screen already handles (`:8511`).
+
+- [ ] **Step 2: Implement the widget**
+
+Carry over, deliberately, from `items_pane.py` (read each one's docstring before re-deriving it): the `_rendered_items` rendered-sequence authority; `displayed_items()` / `select_and_reveal()`; open-item pinning in the filter; `ItemsFilterChanged` mirroring; the search box's `select_on_focus=False` + `recompose()` focus restore; the pane-bound `space` binding; in-place row repaint methods (`update_item_status_row` / `update_item_queued_row` / `update_item_flagged_row` — ListView equivalent of the single-cell repaints; a row repaint replaces the one row widget, never recomposes the list). Keep the row→item mapping in a parallel entries list so group headers never enter `displayed_items()`.
+
+Filter becomes the spec's **Unread / All toggle**: Unread = `status="new"`; All = `statuses=["new","reviewed","ingested"]`. Ignored stays hidden (the user hid it); error stays in Runs. Wire the two values through `ItemsFilterChanged` so the screen's `_items_status_query`/`_load_items` keep their push-the-filter-into-the-query guarantee (`:8386-8410`).
+
+The toolbar keeps Refresh + search; the scope name / unread count live in the region header (existing phase-1 suffix) — do not duplicate them.
+
+- [ ] **Step 3: Swap the construction site**
+
+`:1985` builds `ArticleListPane(id="watchlists-items-pane")` (same DOM id: screen queries and CSS keep working). `ItemsPane` stays in the tree untouched — it is not deleted in this phase; the swap is one line plus imports, revertible.
+
+- [ ] **Step 4: Run the pane + screen suites, commit**
+
+`feat(watchlists): article_list reader rows with date-group headers (task-3072)`
+
+---
+
+### Task 6: Starred smart feed in the rail
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/watchlist_tree.py` (`TreeScope` :29, root nodes :377, badges)
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` (`_items_scope_query` :8412)
+- Test: `Tests/Watchlists/test_watchlists_tree.py` (find with `grep -rl "_root_node\|TreeScope" Tests/Watchlists/ | head -3`)
+
+- [ ] **Step 1: Write the failing tests**
+
+`TreeScope` accepts `kind="starred"`; the tree renders a "Starred" root node with the `get_flagged_items_count` badge; selecting it posts `TreeScopeChanged(starred)`; the screen's `_items_scope_query` maps it to `{"is_flagged": True}`; the badge refreshes through the existing debounced counts path.
+
+- [ ] **Step 2: Implement**
+
+Add `"starred"` to the `TreeScope` Literal, a `_root_node("starred", "Starred", count)` above the watchlist nodes (star glyph label, app-controlled constant — the `_QUEUED_GLYPH` markup rule), and the scope mapping. The node has no children and no expand affordance.
+
+- [ ] **Step 3: Run the tests, commit**
+
+`feat(watchlists): Starred smart feed in the rail (task-3072)`
+
+---
+
+### Task 7: `s` — star toggle on highlighted or open item
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` (BINDINGS :392-424, new action + handler near `toggle_read_selected`)
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/content_pane.py` (Star button on `#content-actions` :350)
+- Test: screen-level, in `Tests/Watchlists/test_watchlists_collections_screen.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`s` with a highlighted/open item flips `is_flagged` through the service, repaints the row's star in place (Task 5's method), refreshes the Starred badge, and never recomposes the list; the reader's Star button reflects the open item's state and posts the same path; `s` with no item selected is a no-op.
+
+- [ ] **Step 2: Implement**
+
+`("s", "toggle_star_selected", "Star")` binding; the handler resolves the highlighted-or-open item exactly like `toggle_read_selected` does, calls the service, then the row repaint + badge refresh. The content-pane button posts a new `StarToggleRequested(item)` message; one screen handler serves both (the same message-layer sharing the Inspector's verbs use).
+
+- [ ] **Step 3: Run the tests, commit**
+
+`feat(watchlists): s toggles star; reader Star button (task-3072)`
+
+---
+
+### Task 8: `o` — open in browser + reader action-row completion
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` (BINDINGS, handler)
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/content_pane.py` (Open in browser, Ingest, Queue/Unqueue buttons on `#content-actions`)
+- Test: screen-level
+
+- [ ] **Step 1: Write the failing tests**
+
+`o` opens the highlighted/open item's `url` via `webbrowser.open` — **http/https only**: a `javascript:`/`file:`/empty URL is refused with a notification, never passed to the OS (this is a remote-derived string reaching an OS primitive; validate at this boundary per `input_validation` conventions). The reader's Open button takes the same path. The Ingest and Queue/Unqueue buttons post the Inspector's own `IngestRequested` / `ToggleBriefingQueueRequested` and reflect state (`Queue` ↔ `Unqueue` label from `queued_for_briefing`, the `_queue_briefing_button` precedent `inspector_pane.py:449-463`). Buttons only — no new keys for those two (spec).
+
+- [ ] **Step 2: Implement**
+
+- [ ] **Step 3: Run the tests, commit**
+
+`feat(watchlists): o opens in browser; reader action row shares inspector verbs (task-3072)`
+
+---
+
+### Task 9: Position footer in the reader
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/content_pane.py`
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` (`handle_item_selected` :8511 and the navigation methods)
+- Test: screen-level
+
+- [ ] **Step 1: Write the failing tests**
+
+With an item open, the footer reads "N of M" where M is `len(displayed_items())` and N is the open item's 1-based index in it; `j` advances both the reader and the footer; a Next Unread control in the footer posts the pane's existing `NextUnreadRequested`; with nothing open the footer is empty (not "0 of 0").
+
+- [ ] **Step 2: Implement**
+
+The pane holds no list state: the screen computes position on selection/navigation and pushes it into a `position` reactive (the `_selected_content_item` re-seed pattern, `:8521-8525`), so a rebuilt pane re-renders the same footer.
+
+- [ ] **Step 3: Run the tests, commit**
+
+`feat(watchlists): reader position footer with Next Unread (task-3072)`
+
+---
+
+### Task 10: Hostile-HTML pins, help text, docs
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` (help overlay text — find the existing `?` content; add `s`/`o`)
+- Test: extend the hostile-input cases if any gap remains
+- Modify: backlog task-3072 (Implementation Notes)
+
+- [ ] **Step 1: The hostile-HTML suite covers the AC end-to-end**
+
+One test that stars, queues, and re-renders an item whose title/content carry `<script>`, `[bold red]`, and control bytes — row, snippet, and reader body all render inert text (the AC's "hostile HTML renders safely as text"), and the flags survive a re-persist (Task 3's pin).
+
+- [ ] **Step 2: Help + footer hints advertise only implemented actions** (decision 031).
+
+- [ ] **Step 3: Full suite + lint**
+
+`/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python3 -m pytest Tests/Watchlists/ Tests/Subscriptions/ -q` and `ruff check` on every touched file.
+
+- [ ] **Step 4: Task Implementation Notes + commit**
+
+`docs(watchlists): help text for s/o; task-3072 implementation notes`
+
+---
+
+## Definition of done (phase 2)
+
+- All task-3072 ACs checked; every plan task committed TDD-style.
+- `Tests/Watchlists/` + `Tests/Subscriptions/` green; ruff clean.
+- A feed reads like the reference layout: date-grouped multi-line rows, bold-unread, working star with a rail feed, reader action row, position footer.
+- Flags persist across re-fetch (pinned by test).
+- Hostile HTML renders as inert text in rows, snippets, and body (pinned by test).

--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -924,3 +924,56 @@ def test_get_flagged_items_count_is_status_agnostic(db_with_memberships):
     db.set_item_flagged(_item_id(db, "https://in.example/2"), True)  # reviewed
 
     assert db.get_flagged_items_count() == 2
+
+
+# --- TASK-3072: effective-date ordering ---------------------------------------
+
+
+def test_get_new_items_orders_by_published_date_desc(db):
+    source_id = db.add_subscription(name="Feed", type="rss", source="https://f.example/f")
+    # Fetched together (created_at ~identical), published in a different
+    # order: the list must follow PUBLISHED order, not fetch order.
+    for url, published in (
+        ("https://f.example/old", "2026-08-01T09:00:00+00:00"),
+        ("https://f.example/newest", "2026-08-07T09:00:00+00:00"),
+        ("https://f.example/middle", "2026-08-05T09:00:00+00:00"),
+    ):
+        _insert_item(db, source_id, url, url, "body")
+        with db.transaction() as conn:
+            conn.execute(
+                "UPDATE subscription_items SET published_date = ? WHERE url = ?",
+                (published, url),
+            )
+
+    rows = db.get_new_items(status=None)
+
+    assert [r["url"] for r in rows] == [
+        "https://f.example/newest",
+        "https://f.example/middle",
+        "https://f.example/old",
+    ]
+
+
+def test_get_new_items_falls_back_to_created_at_when_unpublished(db):
+    source_id = db.add_subscription(name="Feed", type="rss", source="https://f.example/f")
+    _insert_item(db, source_id, "https://f.example/dated", "dated", "body")
+    _insert_item(db, source_id, "https://f.example/undated", "undated", "body")
+    with db.transaction() as conn:
+        # The dated item was fetched BEFORE the undated one (older
+        # created_at), but published long ago: effective-date order puts the
+        # freshly fetched undated item first, not last.
+        conn.execute(
+            "UPDATE subscription_items SET published_date = ?, created_at = ? WHERE url = ?",
+            ("2026-08-01T09:00:00+00:00", "2026-08-06T09:00:00+00:00", "https://f.example/dated"),
+        )
+        conn.execute(
+            "UPDATE subscription_items SET created_at = ? WHERE url = ?",
+            ("2026-08-07T09:00:00+00:00", "https://f.example/undated"),
+        )
+
+    rows = db.get_new_items(status=None)
+
+    assert [r["url"] for r in rows] == [
+        "https://f.example/undated",
+        "https://f.example/dated",
+    ]

--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
 
 
 @pytest.fixture
@@ -823,3 +824,103 @@ def test_restore_items_new_chunks_batches_bigger_than_the_host_parameter_limit(d
 
     assert restored == len(ids)
     assert all(db.get_item_status(item_id) == "new" for item_id in ids)
+
+
+# --- TASK-3072: is_flagged (star) plumbing ------------------------------------
+
+
+def test_set_item_flagged_roundtrip(db_with_memberships):
+    db, _watchlist_id, _in_watchlist, _unassigned = db_with_memberships
+    item_id = _item_id(db, "https://in.example/0")
+
+    db.set_item_flagged(item_id, True)
+
+    rows = db.get_new_items(status=None, is_flagged=True)
+    assert [r["id"] for r in rows] == [item_id]
+
+    db.set_item_flagged(item_id, False)
+    assert db.get_new_items(status=None, is_flagged=True) == []
+
+
+def test_get_new_items_is_flagged_filter_combines_with_scope(db_with_memberships):
+    # The flag is one more independent predicate fragment: it must compose
+    # with the watchlist membership scope, not replace it.
+    db, watchlist_id, in_watchlist, _unassigned = db_with_memberships
+    in_item = _item_id(db, "https://in.example/0")
+    loose_item = _item_id(db, "https://loose.example/0")
+    db.set_item_flagged(in_item, True)
+    db.set_item_flagged(loose_item, True)
+
+    rows = db.get_new_items(status=None, is_flagged=True, watchlist_id=watchlist_id)
+
+    assert [r["id"] for r in rows] == [in_item]
+    assert all(r["subscription_id"] == in_watchlist for r in rows)
+
+
+def test_flag_is_global_not_per_watchlist(db_with_memberships):
+    # ADR-018's note on `queued_for_briefing` applies verbatim: one row, one
+    # flag -- an item starred through any scope reads starred in all of them.
+    db, watchlist_id, _in_watchlist, _unassigned = db_with_memberships
+    item_id = _item_id(db, "https://in.example/0")
+    db.set_item_flagged(item_id, True)
+
+    scoped = db.get_new_items(status=None, watchlist_id=watchlist_id)
+    flagged_row = next(r for r in scoped if r["id"] == item_id)
+    assert flagged_row["is_flagged"] == 1
+
+
+def test_flags_persist_across_re_fetch(db_with_memberships):
+    """The spec's load-bearing claim, pinned end to end.
+
+    `persist_subscription_item`'s upsert never writes `is_flagged` -- the
+    column is absent from both the INSERT list and the ON CONFLICT update --
+    so a re-fetch of the same item (same subscription+url+content_hash, the
+    conflict key) updates the content and leaves the user's star alone.
+    """
+    db, _watchlist_id, in_watchlist, _unassigned = db_with_memberships
+    with db.transaction() as conn:
+        item_id = persist_subscription_item(
+            conn,
+            in_watchlist,
+            {
+                "url": "https://in.example/refetch",
+                "title": "v1",
+                "content": "body v1",
+                "content_kind": "article",
+                "content_format": "text",
+                "content_hash": "hash-1",
+            },
+            run_id=None,
+            now="2026-08-07T10:00:00+00:00",
+        )
+    db.set_item_flagged(item_id, True)
+
+    with db.transaction() as conn:
+        persist_subscription_item(
+            conn,
+            in_watchlist,
+            {
+                "url": "https://in.example/refetch",
+                "title": "v2",
+                "content": "body v2",
+                "content_kind": "article",
+                "content_format": "text",
+                "content_hash": "hash-1",
+            },
+            run_id=None,
+            now="2026-08-07T12:00:00+00:00",
+        )
+
+    rows = db.get_new_items(status=None, is_flagged=True)
+    assert [r["id"] for r in rows] == [item_id]
+    assert rows[0]["title"] == "v2", "precondition: the upsert's UPDATE path fired"
+
+
+def test_get_flagged_items_count_is_status_agnostic(db_with_memberships):
+    # A starred item stays starred when read: the Starred feed's badge
+    # counts across statuses.
+    db, _watchlist_id, _in_watchlist, _unassigned = db_with_memberships
+    db.set_item_flagged(_item_id(db, "https://in.example/0"), True)  # new
+    db.set_item_flagged(_item_id(db, "https://in.example/2"), True)  # reviewed
+
+    assert db.get_flagged_items_count() == 2

--- a/Tests/Subscriptions/test_briefing_selection.py
+++ b/Tests/Subscriptions/test_briefing_selection.py
@@ -473,8 +473,13 @@ def test_overflow_and_watermark_stay_exact_over_a_backlog_larger_than_the_cap():
     source = _new_source(db, watchlist, "torrent")
 
     cap = 5
+    # Now-relative on purpose: the first-briefing window is the last
+    # FIRST_WINDOW_DAYS days by wall clock, so a hard-coded date silently
+    # ages out of it and the selection comes back empty (this exact test
+    # started failing on 2026-07-31 + 7d with an all-empty selection).
+    recent = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
     backlog = [
-        _add_item(db, source, f"Item {n}", "2026-07-29T09:00:00+00:00")
+        _add_item(db, source, f"Item {n}", recent)
         for n in range(cap + 30)
     ]
 

--- a/Tests/Subscriptions/test_html_text.py
+++ b/Tests/Subscriptions/test_html_text.py
@@ -8,14 +8,14 @@ into prose a person can read, not a mangled mess).
 
 import pytest
 
-pytestmark = pytest.mark.unit
-
 from tldw_chatbook.Subscriptions.html_text import (
     html_to_display_text,
     looks_like_html,
     readable_body_text,
     strip_control_characters,
 )
+
+pytestmark = pytest.mark.unit
 
 
 # --- looks_like_html ---------------------------------------------------
@@ -412,3 +412,56 @@ def test_a_self_closed_void_tag_is_bracket_shaped_text_that_still_survives_inert
     markup must reach the caller as literal characters."""
     out = html_to_display_text('<img alt="[bold red]not a style[/]"/>')
     assert "[bold red]not a style[/]" in out
+
+
+def test_body_snippet_collapses_whitespace():
+    from tldw_chatbook.Subscriptions.html_text import body_snippet
+
+    assert body_snippet("line one\n\nline two\t with   gaps") == "line one line two with gaps"
+
+
+def test_body_snippet_strips_tags():
+    from tldw_chatbook.Subscriptions.html_text import body_snippet
+
+    assert body_snippet("<p>Hello <b>world</b></p>") == "Hello world"
+
+
+def test_body_snippet_truncates_on_a_word_boundary_with_ellipsis():
+    from tldw_chatbook.Subscriptions.html_text import body_snippet
+
+    text = " ".join(f"word{i}" for i in range(60))  # 350+ chars
+    snippet = body_snippet(text, max_chars=50)
+
+    assert snippet.endswith("…")
+    assert len(snippet) <= 51  # ellipsis included, boundary-trimmed
+    assert not snippet[:-1].endswith("wor"), "must not cut mid-word"
+
+
+def test_body_snippet_short_text_is_untouched():
+    from tldw_chatbook.Subscriptions.html_text import body_snippet
+
+    assert body_snippet("short and sweet") == "short and sweet"
+
+
+def test_body_snippet_empty_input():
+    from tldw_chatbook.Subscriptions.html_text import body_snippet
+
+    assert body_snippet(None) == ""
+    assert body_snippet("") == ""
+    assert body_snippet("   \n  ") == ""
+
+
+def test_body_snippet_hostile_input_is_inert():
+    """Row snippets are remote text in a terminal: script bodies vanish,
+    control bytes are stripped, markup-shaped brackets survive as literal
+    characters (escaping is the ROW's render-boundary job, not the
+    snippet's)."""
+    from tldw_chatbook.Subscriptions.html_text import body_snippet
+
+    snippet = body_snippet(
+        '<script>alert("x")</script><p>[bold red]real text[/]\x1b[31m</p>'
+    )
+
+    assert "alert" not in snippet
+    assert "\x1b" not in snippet
+    assert "[bold red]real text[/]" in snippet

--- a/Tests/Subscriptions/test_item_dates.py
+++ b/Tests/Subscriptions/test_item_dates.py
@@ -1,0 +1,129 @@
+"""Tests for `Subscriptions/item_dates.py` (task-3072, plan Task 2).
+
+The reader-row date foundation: one parser rule (naive = UTC), the
+effective date, relative rendering, and local-day buckets for group
+headers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from tldw_chatbook.Subscriptions.item_dates import (
+    day_bucket,
+    effective_date,
+    parse_stored_datetime,
+    relative_time,
+)
+
+NOW = datetime(2026, 8, 7, 10, 30, tzinfo=timezone.utc)
+
+
+class TestParseStoredDatetime:
+    def test_naive_iso_is_attached_to_utc(self):
+        parsed = parse_stored_datetime("2026-08-07T09:41:00")
+        assert parsed == datetime(2026, 8, 7, 9, 41, tzinfo=timezone.utc)
+
+    def test_aware_iso_keeps_its_offset(self):
+        parsed = parse_stored_datetime("2026-08-07T05:41:00-04:00")
+        assert parsed == datetime(2026, 8, 7, 9, 41, tzinfo=timezone.utc)
+
+    def test_z_suffix(self):
+        parsed = parse_stored_datetime("2026-08-07T09:41:00Z")
+        assert parsed == datetime(2026, 8, 7, 9, 41, tzinfo=timezone.utc)
+
+    def test_naive_and_aware_of_the_same_instant_agree(self):
+        naive = parse_stored_datetime("2026-08-07T09:41:00")
+        aware = parse_stored_datetime("2026-08-07T09:41:00+00:00")
+        assert naive == aware
+
+    def test_unparseable_returns_none(self):
+        assert parse_stored_datetime("not a date") is None
+        assert parse_stored_datetime("") is None
+        assert parse_stored_datetime(None) is None
+
+    def test_datetime_passthrough(self):
+        naive = datetime(2026, 8, 7, 9, 41)
+        assert parse_stored_datetime(naive) == naive.replace(tzinfo=timezone.utc)
+
+
+class TestEffectiveDate:
+    def test_published_date_wins(self):
+        item = {
+            "published_date": "2026-08-06T15:00:00+00:00",
+            "created_at": "2026-08-07T09:00:00+00:00",
+        }
+        assert effective_date(item) == datetime(2026, 8, 6, 15, 0, tzinfo=timezone.utc)
+
+    def test_falls_back_to_created_at(self):
+        item = {"published_date": None, "created_at": "2026-08-07T09:00:00+00:00"}
+        assert effective_date(item) == datetime(2026, 8, 7, 9, 0, tzinfo=timezone.utc)
+
+    def test_missing_published_key_falls_back(self):
+        item = {"created_at": "2026-08-07T09:00:00+00:00"}
+        assert effective_date(item) == datetime(2026, 8, 7, 9, 0, tzinfo=timezone.utc)
+
+    def test_unparseable_published_falls_back_to_created(self):
+        item = {"published_date": "garbage", "created_at": "2026-08-07T09:00:00+00:00"}
+        assert effective_date(item) == datetime(2026, 8, 7, 9, 0, tzinfo=timezone.utc)
+
+    def test_neither_present_returns_none(self):
+        assert effective_date({}) is None
+        assert effective_date({"published_date": None, "created_at": None}) is None
+
+
+class TestRelativeTime:
+    def test_same_day_renders_clock_time(self):
+        # Built from NOW.astimezone() so the case is "later the same LOCAL
+        # day" in whatever zone the suite runs in.
+        dt = NOW.astimezone().replace(hour=9, minute=41, second=0, microsecond=0)
+        assert relative_time(dt, now=NOW) == "9:41 AM"
+
+    def test_yesterday(self):
+        dt = NOW.astimezone() - timedelta(days=1)
+        assert relative_time(dt, now=NOW) == "Yesterday"
+
+    def test_same_year_older_day(self):
+        dt = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+        assert relative_time(dt, now=NOW) == dt.astimezone().strftime("%b %d")
+
+    def test_other_year(self):
+        dt = datetime(2025, 12, 31, 12, 0, tzinfo=timezone.utc)
+        assert relative_time(dt, now=NOW) == dt.astimezone().strftime("%Y-%m-%d")
+
+    def test_none_renders_dash(self):
+        assert relative_time(None, now=NOW) == "-"
+
+
+class TestDayBucket:
+    def test_today(self):
+        dt = NOW.astimezone().replace(hour=1, minute=0, second=0, microsecond=0)
+        assert day_bucket(dt, now=NOW) == "Today"
+
+    def test_yesterday(self):
+        dt = NOW.astimezone() - timedelta(days=1)
+        assert day_bucket(dt, now=NOW) == "Yesterday"
+
+    def test_older_day_is_a_date_label(self):
+        dt = NOW.astimezone() - timedelta(days=6)
+        assert day_bucket(dt, now=NOW) == dt.strftime("%B %d, %Y")
+
+    def test_future_dated_buckets_into_today(self):
+        # Bad feed clocks: an item "published" tomorrow must not float above
+        # the list under a header of its own (the spec's Dates section).
+        dt = NOW + timedelta(days=3)
+        assert day_bucket(dt, now=NOW) == "Today"
+
+    def test_none_is_unknown_date(self):
+        assert day_bucket(None, now=NOW) == "Unknown date"
+
+    def test_buckets_are_local_day_not_utc_day(self):
+        # 01:30 UTC is still yesterday anywhere west of UTC+1:30; the bucket
+        # must be computed in the viewer's zone, matching humane_time.
+        dt = datetime(2026, 8, 7, 1, 30, tzinfo=timezone.utc)
+        local_date = dt.astimezone().date()
+        today = NOW.astimezone().date()
+        expected = "Today" if local_date == today else (
+            "Yesterday" if local_date == today - timedelta(days=1) else "other"
+        )
+        assert day_bucket(dt, now=NOW) == expected

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -11,8 +11,6 @@ from tldw_chatbook.Notifications import (
     NotificationDispatchService,
 )
 from tldw_chatbook.Subscriptions import LocalWatchlistsService
-from tldw_chatbook.Subscriptions.watchlist_content_alert_service import WatchlistContentAlertService
-from tldw_chatbook.Subscriptions.watchlist_filter_service import WatchlistFilterService
 from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
 
 
@@ -1535,3 +1533,36 @@ async def test_a_queued_run_has_no_duration_yet(tmp_path):
     assert launched["status"] == "queued"
     assert launched["duration"] is None
     assert launched["source_title"] == "Feed"
+
+
+@pytest.mark.asyncio
+async def test_list_items_filters_by_is_flagged(tmp_path):
+    """task-3072: the Starred feed's item page.
+
+    Falsey (`None`, the default) means NO flag filter -- the same convention
+    the TASK-2513 scope kwargs established; `True` narrows to starred rows,
+    and the normalized dicts carry the flag as a real bool.
+    """
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+    source = await service.create_source(
+        {"name": "Feed", "url": "https://example.com/feed.xml", "source_type": "rss"}
+    )
+    with db.transaction() as conn:
+        for index in range(3):
+            conn.execute(
+                "INSERT INTO subscription_items (subscription_id, url, title) "
+                "VALUES (?, ?, ?)",
+                (source["source_id"], f"https://example.com/{index}", f"Item {index}"),
+            )
+    starred_id = db.conn.execute(
+        "SELECT id FROM subscription_items WHERE url = ?", ("https://example.com/1",)
+    ).fetchone()[0]
+    db.set_item_flagged(starred_id, True)
+
+    starred = await service.list_items(status=None, is_flagged=True)
+    everything = await service.list_items(status=None)
+
+    assert [item["item_id"] for item in starred] == [starred_id]
+    assert starred[0]["is_flagged"] is True
+    assert len(everything) == 3, "falsey is_flagged must not filter at all"

--- a/Tests/Subscriptions/test_watchlist_normalizers.py
+++ b/Tests/Subscriptions/test_watchlist_normalizers.py
@@ -439,3 +439,29 @@ def test_a_run_with_a_hostile_stats_blob_still_normalizes():
     assert run["filtered_count"] == 0
     assert run["error_count"] == 0
     assert run["duration"] is None
+
+
+def test_normalize_coerces_is_flagged_to_a_real_bool():
+    """task-3072: the `queued_for_briefing` precedent, repeated.
+
+    `get_new_items` is `SELECT i.*`, so the column is already on the row --
+    but SQLite hands back 0/1 ints, and every downstream consumer (row
+    glyph, Star button state, toggle arithmetic) wants an actual flag.
+    """
+    from tldw_chatbook.Subscriptions.watchlist_normalizers import (
+        normalize_watchlist_item,
+    )
+
+    flagged = normalize_watchlist_item(
+        "local", {"id": 11, "subscription_id": 3, "title": "Starred", "is_flagged": 1}
+    )
+    unflagged = normalize_watchlist_item(
+        "local", {"id": 12, "subscription_id": 3, "title": "Plain", "is_flagged": 0}
+    )
+    legacy_row = normalize_watchlist_item(
+        "local", {"id": 13, "subscription_id": 3, "title": "No column read"}
+    )
+
+    assert flagged["is_flagged"] is True
+    assert unflagged["is_flagged"] is False
+    assert legacy_row["is_flagged"] is False

--- a/Tests/Subscriptions/test_watchlist_scope_service.py
+++ b/Tests/Subscriptions/test_watchlist_scope_service.py
@@ -14,6 +14,10 @@ class FakeLocalWatchlists:
         self.calls.append(("list_sources", kwargs))
         return [{"id": "local:subscription:1", "backend": "local"}]
 
+    async def list_items(self, **kwargs):
+        self.calls.append(("list_items", kwargs))
+        return []
+
     async def get_source(self, source_id):
         self.calls.append(("get_source", source_id))
         return {"id": f"local:subscription:{source_id}", "backend": "local"}
@@ -622,3 +626,25 @@ async def test_a_cancelled_check_produces_exactly_one_notification_not_two(tmp_p
         "the run itself must still reach a terminal state (this is C1's "
         "own guarantee, re-checked here as the test's precondition)"
     )
+
+
+async def test_scope_service_forwards_is_flagged_to_local_list_items():
+    """task-3072: the Starred feed's scope reaches the local backend.
+
+    The scope service names its `list_items` filters explicitly (the
+    TASK-2513 threading), so a new one is only real once it is forwarded --
+    this pins the passthrough the screen's `{"is_flagged": True}` scope
+    mapping relies on.
+    """
+    local = FakeLocalWatchlists()
+    scope = WatchlistScopeService(
+        local_service=local,
+        server_service=FakeServerWatchlists(),
+        policy_enforcer=Mock(),
+    )
+
+    await scope.list_items(runtime_backend="local", is_flagged=True)
+
+    list_calls = [call for call in local.calls if call[0] == "list_items"]
+    assert len(list_calls) == 1
+    assert list_calls[0][1]["is_flagged"] is True

--- a/Tests/UI/test_destination_visual_parity_correction.py
+++ b/Tests/UI/test_destination_visual_parity_correction.py
@@ -3378,7 +3378,8 @@ async def test_watchlists_other_filter_strip_controls_are_visible(size):
         strips = screen._compositor.render_strips()
         items_row = screen.query_one("#items-search-input").region.y
         painted = "".join(seg.text for seg in strips[items_row])
-        for label in ("Search items...", "All statuses"):
+        # TASK-3072: the Select's resting label is now the reader's "All".
+        for label in ("Search items...", "All"):
             assert label in painted, (
                 f"{label!r} never reaches the screen; the Items toolbar is "
                 f"clipped at {size}. Row {items_row} paints: {painted.strip()!r}"

--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -2831,3 +2831,85 @@ async def test_the_reader_action_row_buttons_post_their_messages():
             "Queue on an unqueued item must request the flip TO queued, "
             "carrying the raw item id exactly as the Inspector does"
         )
+
+
+# --- TASK-3072 plan task 9: the reader's position footer -----------------------
+
+
+@pytest.mark.asyncio
+async def test_the_position_footer_renders_and_updates_in_place():
+    """The footer shows the screen-pushed `position` string; updating the
+    reactive re-renders the one Static in place -- never a reader recompose."""
+    from textual.app import App
+    from textual.widgets import Static
+
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+
+    class _PaneHost(App):
+        def compose(self):
+            pane = ContentPane()
+            pane.item = {"title": "x", "content": "y", "content_kind": "article"}
+            pane.position = "2 of 9"
+            yield pane
+
+    app = _PaneHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        position = app.query_one("#content-position", Static)
+        assert str(position.renderable) == "2 of 9"
+
+        app.query_one(ContentPane).position = "3 of 9"
+        await pilot.pause()
+        assert str(position.renderable) == "3 of 9", (
+            "the same Static must update in place (a recompose would replace it)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_next_unread_footer_button_posts_the_panes_message():
+    """The footer's Next Unread control posts the pane's existing
+    `NextUnreadRequested` -- the same message `space` already raises, so one
+    screen handler serves both."""
+    from textual.app import App
+    from textual.widgets import Button
+
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+    from tldw_chatbook.UI.Watchlists_Modules.items_pane import NextUnreadRequested
+
+    class _PaneHost(App):
+        def __init__(self) -> None:
+            super().__init__()
+            self.captured: list[NextUnreadRequested] = []
+
+        def compose(self):
+            pane = ContentPane()
+            pane.item = {"title": "x", "content": "y", "content_kind": "article"}
+            yield pane
+
+        def on_next_unread_requested(self, message: NextUnreadRequested) -> None:
+            self.captured.append(message)
+
+    app = _PaneHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#content-next-unread-button", Button).press()
+        await pilot.pause()
+        assert len(app.captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_empty_reader_has_no_position_footer():
+    """With nothing open the footer is absent entirely -- not "0 of 0"."""
+    from textual.app import App
+
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+
+    class _PaneHost(App):
+        def compose(self):
+            yield ContentPane()
+
+    app = _PaneHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert not app.query("#content-position")
+        assert not app.query("#content-next-unread-button")

--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -2652,3 +2652,80 @@ async def test_selecting_an_html_item_shows_readable_prose_in_the_mounted_reader
         assert "<p>" not in rendered and "<a href=" not in rendered
         assert "here" in rendered
         assert "https://example.test/post" in rendered
+
+
+# --- TASK-3072 plan task 7: the reader's Star button ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_star_button_reflects_the_open_items_state():
+    """The button is seeded from the open item's `is_flagged`: starred items
+    read "★ Starred", unstarred read "☆ Star" -- the same vocabulary the
+    rail's Starred root and the list row's glyph speak."""
+    from textual.app import App
+    from textual.widgets import Button
+
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+
+    class _PaneHost(App):
+        def compose(self):
+            pane = ContentPane()
+            pane.item = {
+                "title": "x",
+                "content": "y",
+                "content_kind": "article",
+                "is_flagged": True,
+            }
+            yield pane
+
+    app = _PaneHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert str(app.query_one("#content-star-button", Button).label) == "★ Starred"
+
+
+@pytest.mark.asyncio
+async def test_the_star_button_posts_the_toggle_and_flips_its_label():
+    """Pressing Star posts `StarToggleRequested` with the full item (the same
+    message the screen's `s` handler serves) and flips its own label
+    optimistically -- the authoritative dict patch lands screen-side, and
+    the next open re-seeds from it."""
+    from textual.app import App
+    from textual.widgets import Button
+
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import (
+        ContentPane,
+        StarToggleRequested,
+    )
+
+    class _PaneHost(App):
+        def __init__(self) -> None:
+            super().__init__()
+            self.captured: list[dict] = []
+
+        def compose(self):
+            pane = ContentPane()
+            pane.item = {"title": "x", "content": "y", "content_kind": "article"}
+            yield pane
+
+        def on_star_toggle_requested(self, message: StarToggleRequested) -> None:
+            self.captured.append(message.item)
+
+    app = _PaneHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        button = app.query_one("#content-star-button", Button)
+        assert str(button.label) == "☆ Star", (
+            "an unstarred item must offer the star, not hide the state"
+        )
+
+        button.press()
+        await pilot.pause()
+
+        assert [item.get("title") for item in app.captured] == ["x"], (
+            "pressing the button must post StarToggleRequested exactly once, "
+            "carrying the open item"
+        )
+        assert str(button.label) == "★ Starred", (
+            "the flip is optimistic; the dict patch lands screen-side"
+        )

--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -325,7 +325,7 @@ async def test_selecting_an_item_renders_it_in_the_content_region():
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
-    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+    from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 
     item = {
         "id": 7,
@@ -344,7 +344,7 @@ async def test_selecting_an_item_renders_it_in_the_content_region():
         screen.active_section = "items"
         await pilot.pause(0.2)
 
-        items_pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        items_pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         items_pane.items = [item]
         await pilot.pause(0.2)
 
@@ -553,14 +553,14 @@ def _seed_three_items(db):
 
 async def _mount_items_screen(pilot, host, expected_count: int = 3):
     """Shared setup: switch to Items, wait for the seeded items to load."""
-    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+    from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 
     await pilot.pause(0.2)
     screen = host.screen_stack[-1]
     screen.active_section = "items"
     await pilot.pause(0.3)
 
-    pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+    pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
     for _ in range(40):
         await pilot.pause()
         if len(pane.items) >= expected_count:
@@ -871,7 +871,7 @@ async def test_j_keeps_the_reader_the_pane_selection_and_the_cursor_in_sync():
     ran) and never re-posted `ItemSelected`. Asserts all three agree after
     `j`, and that a subsequent click on the row the reader left IS honoured.
     """
-    from textual.widgets import DataTable, Static
+    from textual.widgets import ListView, Static
 
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
@@ -886,11 +886,14 @@ async def test_j_keeps_the_reader_the_pane_selection_and_the_cursor_in_sync():
         screen, pane = await _mount_items_screen(pilot, host)
         items = screen._loaded_items
         content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
-        table = pane.query_one("#items-table", DataTable)
+        # TASK-3072 note: the three items share one day bucket, so the
+        # ListView's child 0 is the date-group header and the rows sit at
+        # indices 1-3 -- every old `cursor_row` assertion shifts by one.
+        list_view = pane.query_one("#items-table", ListView)
 
         pane.select_and_reveal(items[0])
         await pilot.pause(0.3)
-        assert table.cursor_row == 0
+        assert list_view.index == 1
 
         await pilot.press("j")
         await pilot.pause(0.3)
@@ -900,11 +903,11 @@ async def test_j_keeps_the_reader_the_pane_selection_and_the_cursor_in_sync():
         )
         assert pane.selected_item is not None
         assert pane.selected_item["id"] == items[1]["id"], (
-            "ItemsPane.selected_item must follow the reader, not stay stuck "
-            "on the previous item"
+            "ArticleListPane.selected_item must follow the reader, not stay "
+            "stuck on the previous item"
         )
-        assert table.cursor_row == 1, (
-            "the table's cursor must follow the reader too, so the "
+        assert list_view.index == 2, (
+            "the list's cursor must follow the reader too, so the "
             "highlighted row and the open item are never out of sync"
         )
         body = content_pane.query_one("#content-body", Static)
@@ -1005,7 +1008,7 @@ async def test_j_and_k_move_forward_and_back_under_a_status_filter():
         screen, pane = await _mount_items_screen(pilot, host)
         content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
 
-        pane.status_filter = "new"
+        pane.status_filter = "unread"
         await pilot.pause(0.3)
         displayed = pane.displayed_items()
         assert len(displayed) == 3, "all three seeded items are still new"
@@ -1057,7 +1060,7 @@ async def test_the_open_item_survives_a_rebuild_of_the_filtered_table():
     async with host.run_test(size=(180, 50)) as pilot:
         screen, pane = await _mount_items_screen(pilot, host)
 
-        pane.status_filter = "new"
+        pane.status_filter = "unread"
         await pilot.pause(0.3)
         open_item = pane.displayed_items()[0]
 
@@ -1111,46 +1114,58 @@ async def test_k_with_nothing_open_goes_to_the_last_item_not_nowhere():
 
 
 @pytest.mark.asyncio
-async def test_opening_an_item_repaints_its_status_cell_in_the_table():
-    """The Items table never showed what you had read.
+async def test_opening_an_item_repaints_its_row_in_the_list():
+    """The Items list never showed what you had read.
 
-    Rows are built once, in `ItemsPane.compose()`, and the mark-read-on-open
-    path deliberately never recomposes (Task 5: a recompose destroys the live
-    table). So `patch_item`'s in-place mutation was invisible: the Status
-    column read "new" for every item the user had opened until they left the
-    tab. Visible with no filter at all.
+    Rows are built once, in `ArticleListPane.compose()`, and the
+    mark-read-on-open path deliberately never recomposes (Task 5: a recompose
+    destroys the live list). So `patch_item`'s in-place mutation was
+    invisible: the row stayed bold with its unread dot for every item the
+    user had opened until they left the tab. Visible with no filter at all.
+
+    TASK-3072 note: what ItemsPane's Status column said in words, the reader
+    row says in shape -- unread is a leading dot and bold title, read is
+    neither. `_repaint_row` rebuilds the row's `Text` in place from the
+    patched dict, which is what the assertions below read back.
     """
-    from textual.widgets import DataTable
+    from textual.widgets import ListView
 
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
-    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+    from tldw_chatbook.UI.Watchlists_Modules.article_list import (
+        ArticleListPane,
+        _ArticleRow,
+    )
 
     app = _build_test_app()
     db = app.local_watchlists_service._db()
     _seed_three_items(db)
 
+    def _row_text(pane, item_id) -> str:
+        list_view = pane.query_one("#items-table", ListView)
+        for node in list_view.children:
+            if isinstance(node, _ArticleRow) and node.item_id_key == str(item_id):
+                return node.children[0].render().plain
+        raise AssertionError(f"no rendered row for {item_id!r}")
+
     host = DestinationHarness(app, "watchlists_collections")
     async with host.run_test(size=(180, 50)) as pilot:
         screen, pane = await _mount_items_screen(pilot, host)
         items = screen._loaded_items
-        table = pane.query_one("#items-table", DataTable)
-        row_key = str(items[0]["id"])
+        item_id = str(items[0]["id"])
 
-        # The column shows the FILTER's vocabulary, not the stored value
-        # (review wave, Minor 1): the filter above this table has always
-        # offered "Read" for the `reviewed` status, and TASK-2301 is what
-        # first put the two words in the same frame.
-        assert table.get_row(row_key)[2] == "New"
+        assert _row_text(pane, item_id).startswith("● "), (
+            "precondition: an unread row leads with the unread dot"
+        )
 
-        pane.select_item_by_id(row_key)
+        pane.select_item_by_id(item_id)
         await pilot.pause(0.6)
 
-        assert table.get_row(row_key)[2] == "Read", (
-            "the Status cell must show what the user has actually read"
+        assert not _row_text(pane, item_id).startswith("● "), (
+            "the row must stop showing unread the moment the user has read it"
         )
         # And it must have got there WITHOUT a recompose (Task 5's CRITICAL).
-        assert screen.query_one("#watchlists-items-pane", ItemsPane) is pane
+        assert screen.query_one("#watchlists-items-pane", ArticleListPane) is pane
 
 
 @pytest.mark.asyncio
@@ -1270,7 +1285,7 @@ async def test_a_workbench_rebuild_keeps_the_items_filter_search_and_selection()
     """
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
-    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+    from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 
     app = _build_test_app()
     db = app.local_watchlists_service._db()
@@ -1280,7 +1295,7 @@ async def test_a_workbench_rebuild_keeps_the_items_filter_search_and_selection()
     async with host.run_test(size=(180, 50)) as pilot:
         screen, pane = await _mount_items_screen(pilot, host)
 
-        pane.status_filter = "new"
+        pane.status_filter = "unread"
         pane.search_query = "Nav item"
         await pilot.pause(0.4)
         open_item = pane.displayed_items()[0]
@@ -1291,11 +1306,11 @@ async def test_a_workbench_rebuild_keeps_the_items_filter_search_and_selection()
         screen.action_toggle_left_rail()
         await pilot.pause(0.5)
 
-        rebuilt = screen.query_one("#watchlists-items-pane", ItemsPane)
+        rebuilt = screen.query_one("#watchlists-items-pane", ArticleListPane)
         assert rebuilt is not pane, (
             "the precondition: the rail toggle really did rebuild the pane"
         )
-        assert rebuilt.status_filter == "new", "the status filter must survive"
+        assert rebuilt.status_filter == "unread", "the status filter must survive"
         assert rebuilt.search_query == "Nav item", "the search box must survive"
         assert rebuilt.selected_item is not None, "the selection must survive"
         assert rebuilt.selected_item["id"] == open_item["id"]
@@ -1654,7 +1669,7 @@ async def test_pressing_expand_actually_solos_content_and_restores_on_a_second_p
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
-    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+    from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
     from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
 
     item = {
@@ -1674,7 +1689,7 @@ async def test_pressing_expand_actually_solos_content_and_restores_on_a_second_p
         screen.active_section = "items"
         await pilot.pause(0.2)
 
-        items_pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        items_pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         items_pane.items = [item]
         await pilot.pause(0.2)
         items_pane.select_item_by_id("11")
@@ -2605,7 +2620,7 @@ async def test_selecting_an_html_item_shows_readable_prose_in_the_mounted_reader
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
-    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+    from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 
     item = {
         "id": 9,
@@ -2624,7 +2639,7 @@ async def test_selecting_an_html_item_shows_readable_prose_in_the_mounted_reader
         screen.active_section = "items"
         await pilot.pause(0.2)
 
-        items_pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        items_pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         items_pane.items = [item]
         await pilot.pause(0.2)
         items_pane.select_item_by_id("9")

--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -2685,11 +2685,11 @@ async def test_the_star_button_reflects_the_open_items_state():
 
 
 @pytest.mark.asyncio
-async def test_the_star_button_posts_the_toggle_and_flips_its_label():
+async def test_the_star_button_posts_the_toggle_without_an_optimistic_flip():
     """Pressing Star posts `StarToggleRequested` with the full item (the same
-    message the screen's `s` handler serves) and flips its own label
-    optimistically -- the authoritative dict patch lands screen-side, and
-    the next open re-seeds from it."""
+    message the screen's `s` handler serves) and does NOT flip its own
+    label: the write is async and can fail, so the flip lands on the
+    screen's success path -- the label can never lie about a failed write."""
     from textual.app import App
     from textual.widgets import Button
 
@@ -2726,8 +2726,8 @@ async def test_the_star_button_posts_the_toggle_and_flips_its_label():
             "pressing the button must post StarToggleRequested exactly once, "
             "carrying the open item"
         )
-        assert str(button.label) == "★ Starred", (
-            "the flip is optimistic; the dict patch lands screen-side"
+        assert str(button.label) == "☆ Star", (
+            "no optimistic flip: the screen flips the label on write success"
         )
 
 

--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -2729,3 +2729,105 @@ async def test_the_star_button_posts_the_toggle_and_flips_its_label():
         assert str(button.label) == "★ Starred", (
             "the flip is optimistic; the dict patch lands screen-side"
         )
+
+
+# --- TASK-3072 plan task 8: the reader's remaining action-row verbs ------------
+
+
+def _action_row_app(item: dict):
+    """A ContentPane host carrying `item`, capturing the three verb messages."""
+    from textual.app import App
+
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import (
+        ContentPane,
+        OpenInBrowserRequested,
+    )
+    from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
+        IngestRequested,
+        ToggleBriefingQueueRequested,
+    )
+
+    class _PaneHost(App):
+        def __init__(self) -> None:
+            super().__init__()
+            self.opened: list[dict] = []
+            self.ingested: list[dict] = []
+            self.queue_toggles: list[tuple] = []
+
+        def compose(self):
+            pane = ContentPane()
+            pane.item = item
+            yield pane
+
+        def on_open_in_browser_requested(self, message: OpenInBrowserRequested) -> None:
+            self.opened.append(message.item)
+
+        def on_ingest_requested(self, message: IngestRequested) -> None:
+            self.ingested.append(message.entity)
+
+        def on_toggle_briefing_queue_requested(
+            self, message: ToggleBriefingQueueRequested
+        ) -> None:
+            self.queue_toggles.append((message.item_id, message.queued))
+
+    return _PaneHost()
+
+
+@pytest.mark.asyncio
+async def test_the_reader_action_row_offers_open_ingest_and_queue():
+    """The reader strip shares the Inspector's verbs (TASK-3072 plan task 8):
+    Open in browser, Ingest, and Queue -- the queue button's label states
+    the CURRENT value, the Inspector's own rule."""
+    from textual.widgets import Button
+
+    app = _action_row_app(
+        {"title": "x", "content": "y", "content_kind": "article", "item_id": 7}
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert str(app.query_one("#content-open-button", Button).label) == "Open"
+        assert str(app.query_one("#content-ingest-button", Button).label) == "Ingest"
+        assert str(app.query_one("#content-queue-button", Button).label) == "Queue"
+
+
+@pytest.mark.asyncio
+async def test_the_queue_button_label_reflects_queued_state():
+    from textual.widgets import Button
+
+    app = _action_row_app(
+        {
+            "title": "x",
+            "content": "y",
+            "content_kind": "article",
+            "item_id": 7,
+            "queued_for_briefing": True,
+        }
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert str(app.query_one("#content-queue-button", Button).label) == "Unqueue"
+
+
+@pytest.mark.asyncio
+async def test_the_reader_action_row_buttons_post_their_messages():
+    """Open posts the reader's own request; Ingest and Queue post the
+    Inspector's OWN message classes, so one screen handler serves both
+    surfaces (the message-layer sharing the plan specifies)."""
+    from textual.widgets import Button
+
+    app = _action_row_app(
+        {"title": "x", "content": "y", "content_kind": "article", "item_id": 7}
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#content-open-button", Button).press()
+        app.query_one("#content-ingest-button", Button).press()
+        app.query_one("#content-queue-button", Button).press()
+        await pilot.pause()
+
+        assert [item.get("title") for item in app.opened] == ["x"]
+        assert [entity.get("title") for entity in app.ingested] == ["x"]
+        assert app.queue_toggles == [(7, True)], (
+            "Queue on an unqueued item must request the flip TO queued, "
+            "carrying the raw item id exactly as the Inspector does"
+        )

--- a/Tests/UI/test_watchlists_destination_shell.py
+++ b/Tests/UI/test_watchlists_destination_shell.py
@@ -1235,7 +1235,12 @@ async def test_bracket_toggle_preserves_loaded_sources_items_and_rules_tables():
             return_value=[{"id": "s1", "name": "Feed One", "source_type": "rss"}]
         )
         screen._controller.list_items = AsyncMock(
-            return_value=[{"id": "i1", "title": "Item One", "source_name": "Feed One"}]
+            return_value=[
+                {"id": "i1", "title": "Item One", "source_name": "Feed One",
+                 # The real backend always carries a status; without one the
+                 # reader-set filter (TASK-3072) legitimately hides the row.
+                 "status": "new"}
+            ]
         )
         screen._controller.list_alert_rules = AsyncMock(
             return_value=[{"id": "r1", "name": "Rule One", "condition_type": "no_items"}]
@@ -1243,7 +1248,6 @@ async def test_bracket_toggle_preserves_loaded_sources_items_and_rules_tables():
 
         for section, table_id in (
             ("sources", "#sources-table"),
-            ("items", "#items-table"),
             ("rules", "#rules-table"),
         ):
             screen.query_one(f"#wl-tab-{section}", Button).press()
@@ -1264,6 +1268,30 @@ async def test_bracket_toggle_preserves_loaded_sources_items_and_rules_tables():
             # is reachable again.
             await pilot.press("[")
             await pilot.pause()
+
+        # The items list is a ListView (TASK-3072), so its row count lives in
+        # the pane's rendered items, not a DataTable: same "an unrelated rail
+        # toggle must not empty it" assertion, one level up.
+        from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
+
+        screen.query_one("#wl-tab-items", Button).press()
+        await pilot.pause()
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+        for _ in range(40):
+            await pilot.pause()
+            if pane.displayed_items():
+                break
+        assert len(pane.displayed_items()) == 1, (
+            "items list never loaded its one row"
+        )
+
+        await pilot.press("[")
+        await pilot.pause()
+
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+        assert len(pane.displayed_items()) == 1, (
+            "items list was emptied by an unrelated left-rail toggle"
+        )
 
 
 @pytest.mark.asyncio
@@ -3212,7 +3240,7 @@ async def test_section_loader_results_landing_in_the_mount_window_still_paint():
     rot.
     """
     from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import ArtifactsPane
-    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane  # noqa: F401
     from tldw_chatbook.UI.Watchlists_Modules.overview_pane import OverviewPane  # noqa: F401
     from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import (
         TreeScope,

--- a/Tests/UI/test_watchlists_inspector.py
+++ b/Tests/UI/test_watchlists_inspector.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from textual.geometry import Region
-from textual.widgets import Button, DataTable, Static, TextArea
+from textual.widgets import Button, DataTable, ListView, Static, TextArea
 
 # The end-to-end check harness (TASK-1362 tests below): the real service, the
 # real DB and the real `URLMonitor.check_url` persistence path. See its own
@@ -41,7 +41,11 @@ from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
     ResumeSourceRequested,
     SaveNoiseSelectorsRequested,
 )
-from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemSelected, ItemsPane
+from tldw_chatbook.UI.Watchlists_Modules.article_list import (
+    ArticleListPane,
+    _ArticleRow,
+)
+from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemSelected
 from tldw_chatbook.UI.Watchlists_Modules.notifications_pane import (
     NotificationSelected,
     RefreshNotificationsRequested,
@@ -1427,15 +1431,28 @@ async def _open_items_with_seeded_item(pilot, screen, app, db):
     """
     screen.active_section = "items"
     await pilot.pause(0.3)
-    pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+    pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
     for _ in range(40):
         await pilot.pause()
         if pane.items:
             break
     assert pane.items, "the seeded item must reach the Items pane"
-    table = pane.query_one("#items-table", DataTable)
     app.watchlist_bundle_service._db = db
-    return pane, table
+    return pane
+
+
+def _queued_indicator_shown(pane: ArticleListPane, row_key: str) -> bool:
+    """Whether the queued glyph shows on `row_key`'s rendered row.
+
+    TASK-3072 shape: ItemsPane's queued CELL became the reader row's inline
+    glyph, so the assertion reads the row's `Text` back off the mounted
+    ListView -- what the user sees, same as the old `get_row(...)[4]`.
+    """
+    list_view = pane.query_one("#items-table", ListView)
+    for node in list_view.children:
+        if isinstance(node, _ArticleRow) and node.item_id_key == row_key:
+            return ArticleListPane._QUEUED_GLYPH in node.children[0].render().plain
+    return False
 
 
 @pytest.mark.asyncio
@@ -1454,10 +1471,11 @@ async def test_pressing_queue_for_briefing_writes_the_flag_and_repaints_the_row(
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane, table = await _open_items_with_seeded_item(pilot, screen, app, db)
+        pane = await _open_items_with_seeded_item(pilot, screen, app, db)
+        list_view = pane.query_one("#items-table", ListView)
 
         row_key = str(pane.items[0]["id"])
-        assert table.get_row(row_key)[4] == "", (
+        assert not _queued_indicator_shown(pane, row_key), (
             "precondition: a freshly seeded item is not queued"
         )
 
@@ -1474,19 +1492,19 @@ async def test_pressing_queue_for_briefing_writes_the_flag_and_repaints_the_row(
         button.press()
         # Fix round 1: the write now happens in a worker (`asyncio.to_thread`
         # then the in-place patch + repaint), so settle on the LAST
-        # observable effect of that sequence -- the repainted cell -- rather
+        # observable effect of that sequence -- the repainted row -- rather
         # than the DB flag alone. The repaint only ever runs after the write
         # has already been awaited, so waiting on it also guarantees the DB
         # assertion below is no longer racing the worker.
         for _ in range(40):
             await pilot.pause()
-            if table.get_row(row_key)[4] == ItemsPane._QUEUED_GLYPH:
+            if _queued_indicator_shown(pane, row_key):
                 break
 
         assert _queued_flag(db, item_id) is True, (
             "the press must reach SubscriptionsDB.set_item_briefing_queued"
         )
-        assert table.get_row(row_key)[4] == ItemsPane._QUEUED_GLYPH, (
+        assert _queued_indicator_shown(pane, row_key), (
             "the row indicator must repaint in place once the write succeeds"
         )
         assert str(button.label) == "Unqueue from briefing", (
@@ -1496,8 +1514,8 @@ async def test_pressing_queue_for_briefing_writes_the_flag_and_repaints_the_row(
 
         # Phase D pattern: no full-screen recompose. The very instances the
         # user was looking at must still be the ones mounted.
-        assert screen.query_one("#watchlists-items-pane", ItemsPane) is pane
-        assert pane.query_one("#items-table", DataTable) is table
+        assert screen.query_one("#watchlists-items-pane", ArticleListPane) is pane
+        assert pane.query_one("#items-table", ListView) is list_view
         assert (
             screen.query_one("#watchlists-entity-inspector", InspectorPane) is inspector
         )
@@ -1531,7 +1549,7 @@ async def test_the_queue_write_runs_off_the_event_loop_thread():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane, table = await _open_items_with_seeded_item(pilot, screen, app, db)
+        pane = await _open_items_with_seeded_item(pilot, screen, app, db)
         row_key = str(pane.items[0]["id"])
 
         pane.select_item_by_id(row_key)
@@ -1592,7 +1610,7 @@ async def test_the_item_status_write_runs_off_the_event_loop_thread():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane, table = await _open_items_with_seeded_item(pilot, screen, app, db)
+        pane = await _open_items_with_seeded_item(pilot, screen, app, db)
         row_key = str(pane.items[0]["id"])
 
         # `LocalWatchlistsService._db()` builds a brand-new `SubscriptionsDB`
@@ -1635,7 +1653,7 @@ async def test_pressing_queue_for_briefing_again_unqueues_and_relabels():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane, table = await _open_items_with_seeded_item(pilot, screen, app, db)
+        pane = await _open_items_with_seeded_item(pilot, screen, app, db)
         row_key = str(pane.items[0]["id"])
 
         pane.select_item_by_id(row_key)
@@ -1644,27 +1662,27 @@ async def test_pressing_queue_for_briefing_again_unqueues_and_relabels():
         inspector = screen.query_one("#watchlists-entity-inspector", InspectorPane)
         button = inspector.query_one("#inspector-queue-briefing-button", Button)
 
-        # Fix round 1: settle on the repainted cell, the LAST effect of the
+        # Fix round 1: settle on the repainted row, the LAST effect of the
         # worker's write-then-patch sequence -- see the comment in
         # `test_pressing_queue_for_briefing_writes_the_flag_and_repaints_the_row`.
         button.press()
         for _ in range(40):
             await pilot.pause()
-            if table.get_row(row_key)[4] == ItemsPane._QUEUED_GLYPH:
+            if _queued_indicator_shown(pane, row_key):
                 break
         assert _queued_flag(db, item_id) is True, "precondition: first press queued it"
-        assert table.get_row(row_key)[4] == ItemsPane._QUEUED_GLYPH
+        assert _queued_indicator_shown(pane, row_key)
 
         button.press()
         for _ in range(40):
             await pilot.pause()
-            if table.get_row(row_key)[4] == "":
+            if not _queued_indicator_shown(pane, row_key):
                 break
 
         assert _queued_flag(db, item_id) is False, (
             "the second press must clear the flag, not queue it again"
         )
-        assert table.get_row(row_key)[4] == "", (
+        assert not _queued_indicator_shown(pane, row_key), (
             "the indicator must clear along with the flag"
         )
         assert str(button.label) == "Queue for briefing", (
@@ -1728,7 +1746,7 @@ async def test_a_failed_queue_write_leaves_the_flag_and_indicator_unchanged():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane, table = await _open_items_with_seeded_item(pilot, screen, app, db)
+        pane = await _open_items_with_seeded_item(pilot, screen, app, db)
         row_key = str(pane.items[0]["id"])
 
         pane.select_item_by_id(row_key)
@@ -1750,7 +1768,7 @@ async def test_a_failed_queue_write_leaves_the_flag_and_indicator_unchanged():
         assert _queued_flag(db, item_id) is False, (
             "a failed write must leave the stored flag exactly as it was"
         )
-        assert table.get_row(row_key)[4] == "", (
+        assert not _queued_indicator_shown(pane, row_key), (
             "a failed write must not repaint the indicator"
         )
         assert str(button.label) == "Queue for briefing", (
@@ -1782,14 +1800,14 @@ async def test_the_queued_indicator_renders_from_the_normalized_flag_on_load():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane, table = await _open_items_with_seeded_item(pilot, screen, app, db)
+        pane = await _open_items_with_seeded_item(pilot, screen, app, db)
 
         assert pane.items[0].get("queued_for_briefing") is True, (
             "the normalized item handed to the pane must already carry the "
             "flag -- the read path, not a write this test performs"
         )
         row_key = str(pane.items[0]["id"])
-        assert table.get_row(row_key)[4] == ItemsPane._QUEUED_GLYPH, (
+        assert _queued_indicator_shown(pane, row_key), (
             "a pre-queued item must show the glyph as soon as it loads"
         )
 

--- a/Tests/UI/test_watchlists_item_actions.py
+++ b/Tests/UI/test_watchlists_item_actions.py
@@ -38,7 +38,7 @@ from tldw_chatbook.Subscriptions.watchlist_normalizers import (
     normalize_watchlist_run,
 )
 from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
-from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 
 # Whole-branch review (Important): without this, CI's `pytest -m unit` run
 # DESELECTS this entire module, so every assertion here -- including the ones
@@ -79,7 +79,7 @@ async def test_selected_item_reports_type_item_and_offers_item_actions():
         screen.active_section = "items"
         await pilot.pause(0.2)
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         pane.items = [dict(REAL_ITEM)]
         await pilot.pause(0.2)
         pane.select_item_by_id(str(REAL_ITEM["id"]))

--- a/Tests/UI/test_watchlists_items_status_filter.py
+++ b/Tests/UI/test_watchlists_items_status_filter.py
@@ -13,18 +13,29 @@ get_new_items` applied its status predicate unconditionally, and
 incapable of returning anything but `new` rows, and the pane's "All statuses"
 option had nothing else to filter. The tests here run bottom-up: the two data
 layers first, then the pane, then the user gesture.
+
+TASK-3072 changed the filter's vocabulary: the five per-status options became
+the reader's Unread/All pair. "Unread" is `status="new"` pushed into the
+query; "All" is the reader set `new`/`reviewed`/`ingested` -- `ignored` stays
+hidden (the user hid it on purpose) and `error` stays in Runs. Tests below
+that predate the swap assert against the reader set, not the full status
+vocabulary; the data-layer tests (`status=None` returns every status) are
+untouched, because the narrowing lives in the screen's query, not the DB.
 """
 
 from __future__ import annotations
 
 import pytest
-from textual.widgets import DataTable
+from textual.widgets import ListView
 
 from Tests.UI.test_destination_shells import DestinationHarness
 from Tests.UI.app_factory import _build_test_app
 from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
+from tldw_chatbook.UI.Watchlists_Modules.article_list import (
+    ArticleListPane,
+    _ArticleRow,
+)
 from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import IngestRequested
-from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
 
 pytestmark = pytest.mark.unit
 
@@ -36,6 +47,14 @@ SEEDED = {
     "ingested": "Filed into the library",
     "ignored": "Deliberately dismissed",
     "error": "Failed to fetch",
+}
+
+#: The subset of SEEDED the reader's "All" shows (TASK-3072): ignored stays
+#: hidden, error stays in Runs. Every pane-level count expectation uses this.
+READER_SEEDED = {
+    status: title
+    for status, title in SEEDED.items()
+    if status in ArticleListPane._READER_STATUSES
 }
 
 
@@ -71,69 +90,52 @@ def _seed_one_item_per_status(db) -> dict[str, int]:
     return raw_ids
 
 
-async def _settled_items_pane(screen, pilot, expected: int) -> ItemsPane:
-    """The mounted `ItemsPane` once its loader has delivered `expected` rows."""
+async def _settled_items_pane(screen, pilot, expected: int) -> ArticleListPane:
+    """The mounted `ArticleListPane` once its loader has delivered `expected` rows."""
     screen.active_section = "items"
     await pilot.pause(0.3)
-    pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+    pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
     for _ in range(60):
         await pilot.pause()
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         if len(pane.items) >= expected:
             break
     return pane
 
 
-def _status_column(pane: ItemsPane) -> list[str]:
-    """The Status column as the LIVE table holds it, row by row.
+def _row_texts_by_id(pane: ArticleListPane) -> dict[str, str]:
+    """The rendered row text for each item, keyed by item id.
 
-    Read off the mounted `DataTable`, not off `pane.items`: the pane's
+    Read off the mounted `ListView`, not off `pane.items`: the pane's
     reactive is what the loader handed it, while this is what the user is
-    looking at, and TASK-2301's whole subject is those two disagreeing.
-
-    The cells carry the USER-FACING labels, not the stored values (review
-    wave, Minor 1) -- the filter above the table has always offered "Read"
-    while the column wrote the raw `reviewed`, and TASK-2301 is what first put
-    the two in the same frame.
+    looking at, and TASK-2301's whole subject is those two disagreeing. The
+    rows are `Text` objects built by appending, never markup-parsed
+    (`_render_row`), so plain text comparison is exact.
     """
-    table = pane.query_one("#items-table", DataTable)
-    status_key = pane._column_keys[2]
-    return [
-        str(table.get_cell(str(item["id"]), status_key))
-        for item in pane.displayed_items()
+    list_view = pane.query_one("#items-table", ListView)
+    out: dict[str, str] = {}
+    for node in list_view.children:
+        if isinstance(node, _ArticleRow):
+            static = node.children[0]
+            out[node.item_id_key] = static.render().plain
+    return out
+
+
+def test_the_filter_speaks_the_readers_vocabulary():
+    """TASK-3072. The contract the rest of this file asserts against.
+
+    Written out literally rather than derived, for the same vacuity reason
+    the old STATUS_LABELS table documented: a test that asks production code
+    what it displays cannot tell the display from the mapping.
+    """
+    assert ArticleListPane._FILTER_OPTIONS == [
+        ("Unread", "unread"),
+        ("All", "all"),
     ]
-
-
-#: The word the Status column must show for each stored value, written out
-#: rather than derived from `ItemsPane._status_label`. A helper that asks
-#: production code what it displays cannot tell "the column shows the label"
-#: from "the column shows the raw value" -- both sides move together. Caught
-#: by mutation: making `_status_label` return its input left the first version
-#: of this helper green.
-STATUS_LABELS = {
-    "new": "New",
-    "reviewed": "Read",
-    "ingested": "Ingested",
-    "ignored": "Ignored",
-    "error": "Error",
-}
-
-
-def _labels_for(statuses) -> set[str]:
-    """The words the Status column shows for a set of stored status values."""
-    return {STATUS_LABELS[status] for status in statuses}
-
-
-def test_the_status_column_speaks_the_filters_vocabulary():
-    """Review wave, Minor 1. One vocabulary, and unknown values still show."""
-    assert ItemsPane._status_label("reviewed") == "Read"
-    assert ItemsPane._status_label("ingested") == "Ingested"
-    assert {label for label, _v in ItemsPane._STATUS_OPTIONS} >= set(
-        STATUS_LABELS.values()
-    ), "every column label must be a word the filter also offers"
-    assert ItemsPane._status_label("a-status-from-the-future") == (
-        "a-status-from-the-future"
-    ), "an unmapped status must stay readable rather than blank"
+    assert ArticleListPane._READER_STATUSES == {"new", "reviewed", "ingested"}
+    assert ArticleListPane._UNREAD_DOT == "●"
+    assert ArticleListPane._STAR_GLYPH == "★"
+    assert ArticleListPane._QUEUED_GLYPH == "◆"
 
 
 # --- data layers -----------------------------------------------------------
@@ -192,8 +194,10 @@ async def test_list_items_no_longer_collapses_none_to_new():
 
 
 @pytest.mark.asyncio
-async def test_every_status_appears_in_the_list_and_is_distinguishable():
-    """AC#1. All statuses present under "All statuses", each labelled."""
+async def test_every_reader_status_appears_in_the_list_and_is_distinguishable():
+    """AC#1, reader vocabulary. The reader set is present under "All", each
+    status visibly told apart: unread rows carry the dot, ingested rows the
+    marker, reviewed rows neither."""
     app = _build_test_app()
     db = app.local_watchlists_service._db()
     _seed_one_item_per_status(db)
@@ -202,20 +206,40 @@ async def test_every_status_appears_in_the_list_and_is_distinguishable():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane = await _settled_items_pane(screen, pilot, len(SEEDED))
+        pane = await _settled_items_pane(screen, pilot, len(READER_SEEDED))
 
         assert pane.status_filter == "all"
-        assert len(pane.displayed_items()) == len(SEEDED)
-        assert set(_status_column(pane)) == _labels_for(SEEDED), (
-            "the Status column must tell the statuses apart on screen, not "
-            "only in the pane's own data"
+        displayed = pane.displayed_items()
+        assert {row["status"] for row in displayed} == set(READER_SEEDED)
+        texts = _row_texts_by_id(pane)
+        assert set(texts) == {str(row["id"]) for row in displayed}, (
+            "every displayed item must have exactly one rendered row"
+        )
+        by_status = {
+            row["status"]: texts[str(row["id"])] for row in displayed
+        }
+        assert by_status["new"].startswith("● "), (
+            f"the unread row must lead with the unread dot; got {by_status['new']!r}"
+        )
+        assert "· ingested" in by_status["ingested"], (
+            f"the ingested row must carry its marker; got {by_status['ingested']!r}"
+        )
+        reviewed = by_status["reviewed"]
+        assert not reviewed.startswith("●") and "· ingested" not in reviewed, (
+            f"the read row must carry neither mark; got {reviewed!r}"
         )
 
 
 @pytest.mark.asyncio
-async def test_a_triaged_item_is_findable_under_its_own_status_filter():
+async def test_a_triaged_item_is_findable_under_the_readers_filters():
     """AC#4. The regression test the task asks for, stated as the user's
-    question: "where did my ingested item go?"."""
+    question: "where did my ingested item go?".
+
+    TASK-3072 answer: under "All", right where it was -- ingested and read
+    items stay listed. Unread narrows to the unread bucket. What deliberately
+    does NOT come back is the ignored item (the user hid it) and the error
+    row (a Runs-tab concern), and that exclusion is pinned here too.
+    """
     app = _build_test_app()
     db = app.local_watchlists_service._db()
     _seed_one_item_per_status(db)
@@ -224,17 +248,23 @@ async def test_a_triaged_item_is_findable_under_its_own_status_filter():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane = await _settled_items_pane(screen, pilot, len(SEEDED))
+        pane = await _settled_items_pane(screen, pilot, len(READER_SEEDED))
 
-        for status, title in SEEDED.items():
-            pane.status_filter = status
-            await pilot.pause()
-            pane = screen.query_one("#watchlists-items-pane", ItemsPane)
-            titles = [row["title"] for row in pane.displayed_items()]
-            assert titles == [title], (
-                f"filtering to {status!r} must show exactly that item; showed "
-                f"{titles!r}"
-            )
+        titles = [row["title"] for row in pane.displayed_items()]
+        assert set(titles) == set(READER_SEEDED.values()), (
+            f"All must show exactly the reader set; showed {titles!r}"
+        )
+
+        pane.status_filter = "unread"
+        for _ in range(60):
+            await pilot.pause(0.05)
+            pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+            if [row for row in pane.items if row.get("status") == "new"]:
+                break
+        titles = [row["title"] for row in pane.displayed_items()]
+        assert titles == [SEEDED["new"]], (
+            f"Unread must show exactly the unread item; showed {titles!r}"
+        )
 
 
 # --- the user gesture ------------------------------------------------------
@@ -258,7 +288,7 @@ async def test_ingest_repaints_the_live_row_instead_of_removing_it():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane = await _settled_items_pane(screen, pilot, len(SEEDED))
+        pane = await _settled_items_pane(screen, pilot, len(READER_SEEDED))
 
         target = next(
             item for item in pane.items if item["title"] == SEEDED["new"]
@@ -276,20 +306,16 @@ async def test_ingest_repaints_the_live_row_instead_of_removing_it():
             if db.get_item_status(int(target["item_id"])) == "ingested":
                 break
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
-        table = pane.query_one("#items-table", DataTable)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         assert len(pane.displayed_items()) == rows_before, (
             "ingesting must not remove the row from a view whose filter "
             "includes it"
         )
-        assert (
-            # Literal, not `_status_label("ingested")` (round 2, O3): a
-            # helper that asks production code what it displays stays green
-            # when production code stops mapping at all -- the same vacuity
-            # the m1 mutation caught in this file's other assertions.
-            str(table.get_cell(str(target["id"]), pane._column_keys[2]))
-            == STATUS_LABELS["ingested"]
-        ), "the row the user acted on must show its new status immediately"
+        row_text = _row_texts_by_id(pane).get(str(target["id"]), "")
+        assert "· ingested" in row_text, (
+            "the row the user acted on must show its new status immediately; "
+            f"rendered {row_text!r}"
+        )
 
 
 @pytest.mark.asyncio
@@ -306,7 +332,7 @@ async def test_ingest_feedback_toast_never_parses_markup():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane = await _settled_items_pane(screen, pilot, len(SEEDED))
+        pane = await _settled_items_pane(screen, pilot, len(READER_SEEDED))
 
         toasts: list[tuple[str, dict]] = []
         screen.app_instance.notify = lambda message, **kwargs: toasts.append(
@@ -338,7 +364,7 @@ async def test_an_ingested_item_survives_the_reload_that_follows():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane = await _settled_items_pane(screen, pilot, len(SEEDED))
+        pane = await _settled_items_pane(screen, pilot, len(READER_SEEDED))
 
         target = next(item for item in pane.items if item["title"] == SEEDED["new"])
         screen.post_message(IngestRequested(dict(target)))
@@ -349,13 +375,15 @@ async def test_an_ingested_item_survives_the_reload_that_follows():
         for _ in range(40):
             await pilot.pause()
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
-        titles = [row["title"] for row in pane.displayed_items()]
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+        displayed = pane.displayed_items()
+        titles = [row["title"] for row in displayed]
         assert SEEDED["new"] in titles, (
             "the ingested item must still be in the list after the reload"
         )
-        assert set(_status_column(pane)) == _labels_for(
-            set(SEEDED) - {"new"} | {"ingested"}
+        assert {row["status"] for row in displayed} == {"reviewed", "ingested"}, (
+            "the reader's All still shows exactly its set, with the acted-on "
+            "item now ingested"
         )
 
 
@@ -415,12 +443,12 @@ async def test_unread_items_past_the_newest_page_are_still_reachable():
 
     TASK-2301 made `_load_items` ask for every status, which fixed "triaged
     items are unreachable" and quietly broke the other direction: the query
-    pages at 100 and `ItemsPane._filtered_items` only filters what arrived, so
+    pages at 100 and the pane's in-memory filter only filters what arrived, so
     the page went from "the newest 100 unread" to "the newest 100 of any
-    status". With 120 triaged items newer than every unread one, picking "New"
-    showed ZERO rows -- while the rail, which the same branch made accurate,
-    honestly reported the unread count. Two numbers on one screen disagreeing
-    about the same fact.
+    status". With 120 triaged items newer than every unread one, picking
+    "Unread" showed ZERO rows -- while the rail, which the same branch made
+    accurate, honestly reported the unread count. Two numbers on one screen
+    disagreeing about the same fact.
 
     The fixture is deliberately deeper than the 100-row page so nothing here
     can pass by accident of page size.
@@ -435,24 +463,24 @@ async def test_unread_items_past_the_newest_page_are_still_reachable():
         screen = host.screen_stack[-1]
         pane = await _settled_items_pane(screen, pilot, 100)
 
-        # The precondition that makes this a real test: under "All statuses"
-        # the page is entirely triaged, so an in-memory filter has nothing
-        # unread to find.
+        # The precondition that makes this a real test: under the reader's
+        # "All" the page is entirely triaged, so an in-memory filter has
+        # nothing unread to find.
         assert not [
             row for row in pane.items if row.get("status") == "new"
         ], "precondition: no unread item is inside the newest-100 page"
 
-        pane.status_filter = "new"
+        pane.status_filter = "unread"
         for _ in range(80):
             await pilot.pause(0.05)
-            pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+            pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
             if any(row.get("status") == "new" for row in pane.items):
                 break
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         titles = [row["title"] for row in pane.displayed_items()]
         assert set(titles) == set(unread_titles), (
-            "filtering to New must re-page against the unread bucket, not "
+            "filtering to Unread must re-page against the unread bucket, not "
             f"filter the mixed page in memory; showed {titles!r}"
         )
 
@@ -473,7 +501,7 @@ async def test_a_search_keystroke_does_not_re_page():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane = await _settled_items_pane(screen, pilot, len(SEEDED))
+        pane = await _settled_items_pane(screen, pilot, len(READER_SEEDED))
 
         calls: list[str | None] = []
         real_list_items = screen._controller.list_items
@@ -491,13 +519,14 @@ async def test_a_search_keystroke_does_not_re_page():
         await pilot.pause()
         assert calls == [], "a search keystroke must not re-query"
 
-        pane.status_filter = "ingested"
+        pane.status_filter = "unread"
         for _ in range(40):
             await pilot.pause(0.05)
             if calls:
                 break
-        assert calls == ["ingested"], (
-            "a status change must re-page for exactly that status"
+        assert calls == ["new"], (
+            "switching to Unread must re-page with status='new' pushed into "
+            "the query"
         )
 
 
@@ -524,7 +553,7 @@ async def test_the_delete_gesture_on_an_item_says_and_does_ignore():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane = await _settled_items_pane(screen, pilot, len(SEEDED))
+        pane = await _settled_items_pane(screen, pilot, len(READER_SEEDED))
 
         toasts: list[str] = []
         screen.app_instance.notify = lambda message, **kwargs: toasts.append(str(message))
@@ -537,7 +566,6 @@ async def test_the_delete_gesture_on_an_item_says_and_does_ignore():
             await pilot.pause(0.05)
             if db.get_item_status(raw_ids["new"]) == "ignored":
                 break
-
         assert dialogs == [], "an item must not be offered a delete dialog"
         assert db.get_item_status(raw_ids["new"]) == "ignored"
         assert any("ignored" in message.lower() for message in toasts), (
@@ -549,17 +577,17 @@ async def test_the_delete_gesture_on_an_item_says_and_does_ignore():
 async def test_the_open_item_survives_a_reload_under_a_narrow_filter():
     """Round 2, O2. The pin's guarantee must survive query-side filtering.
 
-    `ItemsPane._filtered_items` pins the open item into the list whatever the
-    filter says, because opening an item MARKS IT READ -- so under a "New"
-    filter it drops out of its own list the instant it is opened, and `j`/`k`
-    break for the rest of the session. That pin can only retain what the query
-    returned. Pushing the status filter into the query (I2) meant a reload
-    under `status="new"` came back without it, and the item the user was
-    reading vanished.
+    The pane's `_filtered_items` pins the open item into the list whatever the
+    filter says, because opening an item MARKS IT READ -- so under the
+    "Unread" filter it drops out of its own list the instant it is opened,
+    and `j`/`k` break for the rest of the session. That pin can only retain
+    what the query returned. Pushing the status filter into the query (I2)
+    meant a reload under `status="new"` came back without it, and the item
+    the user was reading vanished.
 
-    Driven through the real gesture: filter to New, open the only unread item
-    (which marks it `reviewed`), then force the reload that any deliberate
-    action would cause.
+    Driven through the real gesture: filter to Unread, open the only unread
+    item (which marks it `reviewed`), then force the reload that any
+    deliberate action would cause.
     """
     app = _build_test_app()
     db = app.local_watchlists_service._db()
@@ -569,12 +597,12 @@ async def test_the_open_item_survives_a_reload_under_a_narrow_filter():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        pane = await _settled_items_pane(screen, pilot, len(SEEDED))
+        pane = await _settled_items_pane(screen, pilot, len(READER_SEEDED))
 
-        pane.status_filter = "new"
+        pane.status_filter = "unread"
         for _ in range(60):
             await pilot.pause(0.05)
-            pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+            pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
             if [row for row in pane.items if row.get("status") == "new"]:
                 break
         assert [row["title"] for row in pane.displayed_items()] == [SEEDED["new"]]
@@ -586,7 +614,7 @@ async def test_the_open_item_survives_a_reload_under_a_narrow_filter():
             if db.get_item_status(raw_ids["new"]) == "reviewed":
                 break
         assert db.get_item_status(raw_ids["new"]) == "reviewed", (
-            "precondition: opening the item marked it read, so the New "
+            "precondition: opening the item marked it read, so the Unread "
             "filter no longer matches it"
         )
 
@@ -594,7 +622,7 @@ async def test_the_open_item_survives_a_reload_under_a_narrow_filter():
         await screen._load_items()
         await pilot.pause()
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         titles = [row["title"] for row in pane.displayed_items()]
         assert SEEDED["new"] in titles, (
             "the item the reader has open must survive a reload whose filter "
@@ -622,7 +650,7 @@ async def test_the_carried_open_item_keeps_the_pages_ordering():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.pause(0.2)
         screen = host.screen_stack[-1]
-        await _settled_items_pane(screen, pilot, len(SEEDED))
+        await _settled_items_pane(screen, pilot, len(READER_SEEDED))
 
         # An item older than every row of the page it will be carried into.
         screen._selected_content_item = {
@@ -631,6 +659,9 @@ async def test_the_carried_open_item_keeps_the_pages_ordering():
             "status": "ignored",
             "created_at": "2000-01-01T00:00:00+00:00",
         }
+        # The pre-reader per-status value, poked directly: TASK-3072's
+        # `_normalize_items_status_filter` maps it to "unread", so this also
+        # pins the legacy-value path -- the query below is `status="new"`.
         screen._items_status_filter = "new"
         await screen._load_items()
 

--- a/Tests/UI/test_watchlists_rail_counts_and_scope.py
+++ b/Tests/UI/test_watchlists_rail_counts_and_scope.py
@@ -174,7 +174,7 @@ async def test_a_check_that_produces_items_updates_the_rail_counts():
 async def test_ingesting_an_item_updates_the_rail_counts():
     """AC#1. Triage moves items out of the unread bucket the rail counts."""
     from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import IngestRequested
-    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+    from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 
     app = _build_test_app()
     watchlist_id, assigned_id, _unassigned = _seed_two_sources_one_assigned(app)
@@ -197,7 +197,7 @@ async def test_ingesting_an_item_updates_the_rail_counts():
         screen = await _mounted(host, pilot)
         screen.active_section = "items"
         await pilot.pause(0.3)
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         for _ in range(40):
             await pilot.pause()
             if pane.items:
@@ -493,7 +493,7 @@ async def test_opening_items_refreshes_the_rail_once_the_user_pauses():
     lag is removed with a debounce rather than the label weakened: a burst of
     opens costs one reload after the burst.
     """
-    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+    from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 
     app = _build_test_app()
     watchlist_id, assigned_id, _unassigned = _seed_two_sources_one_assigned(app)
@@ -517,7 +517,7 @@ async def test_opening_items_refreshes_the_rail_once_the_user_pauses():
         screen = await _mounted(host, pilot)
         screen.active_section = "items"
         await pilot.pause(0.3)
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         for _ in range(60):
             await pilot.pause()
             if len(pane.items) >= 3:

--- a/Tests/UI/test_watchlists_rail_counts_and_scope.py
+++ b/Tests/UI/test_watchlists_rail_counts_and_scope.py
@@ -583,3 +583,45 @@ async def test_a_check_that_is_only_queued_does_not_re_read_the_counts():
         await pilot.pause()
         assert reloads == ["x"], "a finished run must refresh the counts"
         screen._load_tree_data = real_load_tree
+
+
+# --- TASK-3072 plan task 6: the Starred root's badge -------------------------
+
+
+@pytest.mark.asyncio
+async def test_starred_root_badge_counts_flagged_items():
+    """The Starred root's badge is `get_flagged_items_count` -- global and
+    status-agnostic, refreshed through the same tree-data load as every
+    other node. Two flagged items on different sources read as one "2".
+    """
+    app = _build_test_app()
+    _watchlist_id, assigned_id, unassigned_id = _seed_two_sources_one_assigned(app)
+    db = app.local_watchlists_service._db()
+    with db.transaction() as conn:
+        for index, source_id in enumerate((assigned_id, unassigned_id, unassigned_id)):
+            persist_subscription_item(
+                conn,
+                source_id,
+                {
+                    "url": f"https://feed.test/post-{index}/",
+                    "title": f"Post {index}",
+                    "content_hash": f"hash-starred-{index}",
+                },
+                run_id=None,
+                now=f"2026-08-04T09:00:0{index}+00:00",
+            )
+    item_ids = [
+        row[0]
+        for row in db.conn.execute("SELECT id FROM subscription_items ORDER BY id")
+    ]
+    db.set_item_flagged(item_ids[0], True)
+    db.set_item_flagged(item_ids[1], True)
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = await _mounted(host, pilot)
+        for _ in range(40):
+            await pilot.pause()
+            if _rail_label(screen, "wl-tree-node-starred").endswith("2"):
+                break
+        assert _rail_label(screen, "wl-tree-node-starred") == "★ Starred  2"

--- a/Tests/UI/test_watchlists_read_status.py
+++ b/Tests/UI/test_watchlists_read_status.py
@@ -22,8 +22,9 @@ path, which calls `_refresh_overview_data()` -- and `overview_data` is
 recompose that replaced the mounted `ItemsPane`/`DataTable` wholesale and
 dropped keyboard focus. `_mark_item_read_on_open` now calls
 `_update_item_status(..., refresh=False, patch_item=item)` instead, patching
-the same dict object already held by `ItemsPane.items` in place rather than
-reloading and recomposing.
+the same dict object already held by `ArticleListPane.items` in place rather
+than reloading and recomposing. (TASK-3072 later swapped the pane itself:
+`ArticleListPane` + `ListView` now sit where `ItemsPane` + `DataTable` did.)
 """
 
 from __future__ import annotations
@@ -31,13 +32,13 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from textual.widgets import Button, DataTable
+from textual.widgets import Button, ListView
 
 from Tests.UI.test_destination_shells import DestinationHarness
 from Tests.UI.app_factory import _build_test_app
 from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
 from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
-from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 
 pytestmark = pytest.mark.unit
 
@@ -83,7 +84,7 @@ async def test_opening_an_item_marks_it_read():
         screen.active_section = "items"
         await pilot.pause(0.3)
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         for _ in range(40):
             await pilot.pause()
             if pane.items:
@@ -124,7 +125,7 @@ async def test_the_unread_toggle_restores_unread():
         screen.active_section = "items"
         await pilot.pause(0.3)
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         for _ in range(40):
             await pilot.pause()
             if pane.items:
@@ -208,7 +209,7 @@ async def test_read_status_is_global_across_watchlists():
         screen.active_section = "items"
         await pilot.pause(0.3)
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         for _ in range(40):
             await pilot.pause()
             if pane.items:
@@ -265,16 +266,23 @@ async def test_selecting_an_item_does_not_break_keyboard_navigation():
     `reactive({}, recompose=True)` on the screen. So EVERY single item
     selection (not just a deliberate button press) forced a full screen
     recompose, which rebuilds every region through its factory and replaces
-    the mounted `ItemsPane`/`DataTable` wholesale. Proven live: with the old
-    behaviour, one `down` press detached the `ItemsPane`, reset the cursor
+    the mounted `ItemsPane`/`DataTable` wholesale (today:
+    `ArticleListPane`/`ListView`, TASK-3072). Proven live: with the old
+    behaviour, one `down` press detached the pane, reset the cursor
     to row 0, cleared screen focus, and a SECOND `down` press did nothing at
     all -- the list became unusable by keyboard after the very first
     selection.
 
-    Drives the real keyboard path (`pilot.press`, a focused `DataTable`)
+    Drives the real keyboard path (`pilot.press`, a focused `ListView`)
     rather than `select_item_by_id` directly, since the bug is specifically
     about what selecting a row does to the table hosting it, not about
     selection itself (already covered by the other tests in this file).
+
+    ListView shape note (TASK-3072): the four seeded items share one
+    `created_at`, so they render under a single date-group header -- child 0
+    is the disabled header, the rows are children 1-4. `_ArticleListView`
+    starts the cursor at the first enabled row, so the first `down` selects
+    "Item 0" (index 1) and the second "Item 1" (index 2).
     """
     app = _build_test_app()
     db = app.local_watchlists_service._db()
@@ -303,15 +311,15 @@ async def test_selecting_an_item_does_not_break_keyboard_navigation():
         screen.active_section = "items"
         await pilot.pause(0.3)
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         for _ in range(40):
             await pilot.pause()
             if len(pane.items) >= 4:
                 break
         assert len(pane.items) == 4, "all four seeded items must reach the Items pane"
 
-        table = pane.query_one("#items-table", DataTable)
-        table.focus()
+        list_view = pane.query_one("#items-table", ListView)
+        list_view.focus()
         await pilot.pause(0.2)
 
         await pilot.press("down")
@@ -322,29 +330,29 @@ async def test_selecting_an_item_does_not_break_keyboard_navigation():
             await pilot.pause()
 
         assert pane.is_attached, (
-            "selecting a row must not detach the mounted ItemsPane via a "
+            "selecting a row must not detach the mounted ArticleListPane via a "
             "screen-level recompose"
         )
-        assert screen.query_one("#watchlists-items-pane", ItemsPane) is pane, (
-            "the screen must still be hosting the SAME ItemsPane instance, "
+        assert screen.query_one("#watchlists-items-pane", ArticleListPane) is pane, (
+            "the screen must still be hosting the SAME ArticleListPane instance, "
             "not one rebuilt from scratch"
         )
-        current_table = pane.query_one("#items-table", DataTable)
-        assert current_table is table, "the DataTable itself must survive too"
-        assert current_table.has_focus, (
-            "a recompose drops focus entirely -- the table must still be "
+        current_list = pane.query_one("#items-table", ListView)
+        assert current_list is list_view, "the ListView itself must survive too"
+        assert current_list.has_focus, (
+            "a recompose drops focus entirely -- the list must still be "
             "focused after a plain row selection"
         )
-        assert current_table.cursor_row == 1, "the cursor must stay where the user put it"
+        assert current_list.index == 1, "the cursor must stay where the user put it"
 
         await pilot.press("down")
         await pilot.pause(0.3)
-        assert current_table.cursor_row == 2, (
+        assert current_list.index == 2, (
             "a SECOND arrow key must still move the cursor -- before the fix "
-            "this did nothing at all once the table had been replaced"
+            "this did nothing at all once the list had been replaced"
         )
         assert pane.selected_item is not None
-        assert pane.selected_item.get("title") == "Item 2"
+        assert pane.selected_item.get("title") == "Item 1"
 
 
 @pytest.mark.asyncio
@@ -404,7 +412,7 @@ async def test_a_cancelled_mark_read_still_leaves_the_cached_dict_coherent():
         screen.active_section = "items"
         await pilot.pause(0.3)
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         for _ in range(40):
             await pilot.pause()
             if pane.items:
@@ -458,9 +466,16 @@ async def test_a_cancelled_mark_read_still_leaves_the_cached_dict_coherent():
         # `status="new"`, so a triaged item fell out of the cache entirely
         # and "coherent" could only mean "no longer here". That collapse WAS
         # the defect (the Items tab could not show a triaged item at all), so
-        # the cache now carries every status and this can name the status the
-        # item must hold: `ignored` -- the last dispatched action, not the
-        # superseded Ingest's `ingested`, not the pre-write `new`.
+        # the cache then carried every status and this named the status the
+        # item must hold: `ignored`.
+        #
+        # TASK-3072 changes the contract once more, deliberately: the
+        # reader's "all" is `_READER_ALL_STATUSES` (new/reviewed/ingested) --
+        # an item the user just told the reader to hide does not belong in
+        # the article list, so the reloaded cache legitimately drops it, and
+        # "coherent" is absence again. The DB assertion above is what pins
+        # the write itself landing on `ignored` (the last dispatched action,
+        # not the superseded Ingest's `ingested`, not the pre-write `new`).
         def _cached_status():
             return next(
                 (
@@ -473,13 +488,13 @@ async def test_a_cancelled_mark_read_still_leaves_the_cached_dict_coherent():
 
         for _ in range(40):
             await pilot.pause(0.05)
-            if _cached_status() == "ignored":
+            if screen._loaded_items and _cached_status() is None:
                 break
-        assert _cached_status() == "ignored", (
-            "the reloaded Items cache must agree with the database's final "
-            "('ignored') status -- not the superseded Ingest's write, not "
-            "the original pre-write 'new', and not missing from the cache "
-            "altogether"
+        assert _cached_status() is None, (
+            "the reloaded reader cache must NOT carry the just-ignored item: "
+            "TASK-3072's 'all' is the reader set (new/reviewed/ingested), "
+            "and an item the user hid leaves the article list immediately -- "
+            "the database assertion above is what pins the ignored write"
         )
 
 
@@ -523,7 +538,7 @@ async def test_mark_read_on_open_does_not_overwrite_an_item_ingested_behind_the_
         screen.active_section = "items"
         await pilot.pause(0.3)
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         for _ in range(40):
             await pilot.pause()
             if pane.items:
@@ -587,7 +602,7 @@ async def test_a_failed_item_status_write_toasts_an_error_and_leaves_the_cache_u
         screen.active_section = "items"
         await pilot.pause(0.3)
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         for _ in range(40):
             await pilot.pause()
             if pane.items:

--- a/Tests/UI/test_watchlists_select_option_overlays.py
+++ b/Tests/UI/test_watchlists_select_option_overlays.py
@@ -37,7 +37,7 @@ from Tests.UI.test_settings_configuration_hub import (
     StyledSettingsDestinationHarness,
     _open_settings_category,
 )
-from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
 from tldw_chatbook.UI.Watchlists_Modules.rules_pane import RulesPane
 
 pytestmark = pytest.mark.asyncio
@@ -108,10 +108,10 @@ async def test_items_status_filter_paints_every_status_option():
         await pilot.pause()
 
         assert select.query_one(SelectOverlay).option_count == len(
-            ItemsPane._STATUS_OPTIONS
+            ArticleListPane._FILTER_OPTIONS
         )
         painted = _painted_option_labels(screen, select)
-        expected = [label for label, _value in ItemsPane._STATUS_OPTIONS]
+        expected = [label for label, _value in ArticleListPane._FILTER_OPTIONS]
         assert painted == expected, (
             "every status option must reach the screen intact; the overlay "
             f"painted {painted!r}"
@@ -138,7 +138,7 @@ async def test_the_status_filter_still_shows_its_value_when_focused_or_hovered()
         select = screen.query_one("#items-status-select", Select)
 
         blurred = _painted_rows(screen, select.region)[0]
-        assert "All statuses" in blurred, "precondition: the value is readable at rest"
+        assert "All" in blurred, "precondition: the value is readable at rest"
 
         # Hover FIRST, on a blurred control -- which is the order a user meets
         # them in, and the only order that measures hover at all. Round 2, O1
@@ -146,7 +146,7 @@ async def test_the_status_filter_still_shows_its_value_when_focused_or_hovered()
         # outranks hover, so hovering an already-focused Select correctly
         # shows the focus colour and says nothing about the hover rule.
         current, rest_background = await _hover(pilot, screen, select)
-        assert "All statuses" in _painted_rows(screen, select.region)[0], (
+        assert "All" in _painted_rows(screen, select.region)[0], (
             "a hovered one-row Select must still say what it is set to"
         )
         assert current.styles.background != rest_background, (
@@ -158,7 +158,7 @@ async def test_the_status_filter_still_shows_its_value_when_focused_or_hovered()
         select.focus()
         await pilot.pause()
         await pilot.pause()
-        assert "All statuses" in _painted_rows(screen, select.region)[0], (
+        assert "All" in _painted_rows(screen, select.region)[0], (
             "and so must a focused one"
         )
 
@@ -195,20 +195,27 @@ async def _hover(pilot, screen, select: Select):
     return current, rest_background
 
 
-async def test_items_status_filter_covers_every_status_the_backend_produces():
-    """AC#1's other half: the vocabulary is the backend's, not a subset.
+async def test_items_status_filter_covers_the_reader_set_the_backend_produces():
+    """AC#1's other half, TASK-3072: the reader set is the backend's
+    vocabulary minus the two statuses a reader deliberately hides.
 
-    Pinned against `LocalWatchlistsService.ITEM_STATUSES` so adding a status
-    to the backend without adding it to the filter fails here rather than
-    silently making those items unreachable (which is TASK-2301's harm).
+    Still pinned against `LocalWatchlistsService.ITEM_STATUSES`, so adding a
+    status to the backend without deciding whether a reader should see it
+    fails here rather than silently making those items unreachable (which is
+    TASK-2301's harm). The exclusions are named literally, not computed:
+    `ignored` was hidden by the user on purpose, `error` belongs to Runs.
     """
     from tldw_chatbook.Subscriptions.local_watchlists_service import (
         LocalWatchlistsService,
     )
 
-    filter_values = {value for _label, value in ItemsPane._STATUS_OPTIONS}
-    assert "all" in filter_values, "the filter must offer an unfiltered view"
-    assert filter_values - {"all"} == set(LocalWatchlistsService.ITEM_STATUSES)
+    filter_values = {value for _label, value in ArticleListPane._FILTER_OPTIONS}
+    assert filter_values == {"unread", "all"}, (
+        "the reader's filter is exactly the Unread/All pair"
+    )
+    assert ArticleListPane._READER_STATUSES == (
+        set(LocalWatchlistsService.ITEM_STATUSES) - {"ignored", "error"}
+    )
 
 
 async def test_picking_a_status_filters_the_items_list():
@@ -220,7 +227,7 @@ async def test_picking_a_status_filters_the_items_list():
         await pilot.pause()
         await _wait_for_selector(screen, pilot, "#items-status-select", timeout=5.0)
 
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         pane.items = [
             {"id": "1", "title": "Fresh", "status": "new", "source_name": "F"},
             {"id": "2", "title": "Filed", "status": "ingested", "source_name": "F"},
@@ -229,12 +236,12 @@ async def test_picking_a_status_filters_the_items_list():
         assert len(pane.displayed_items()) == 2
 
         select = screen.query_one("#items-status-select", Select)
-        select.value = "ingested"
+        select.value = "unread"
         await pilot.pause()
         await pilot.pause()
 
-        displayed = screen.query_one("#watchlists-items-pane", ItemsPane).displayed_items()
-        assert [row["id"] for row in displayed] == ["2"]
+        displayed = screen.query_one("#watchlists-items-pane", ArticleListPane).displayed_items()
+        assert [row["id"] for row in displayed] == ["1"]
 
 
 async def test_new_rule_condition_select_paints_the_real_vocabulary():

--- a/Tests/UI/test_watchlists_source_row_click_selects.py
+++ b/Tests/UI/test_watchlists_source_row_click_selects.py
@@ -37,7 +37,10 @@ from Tests.UI.full_app_destination_context import (
     full_app_destination_context as _visual_destination_harness,
 )
 from Tests.UI.app_factory import _build_test_app
-from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+from tldw_chatbook.UI.Watchlists_Modules.article_list import (
+    ArticleListPane,
+    _ArticleRow,
+)
 from tldw_chatbook.UI.Watchlists_Modules.notifications_pane import NotificationsPane
 from tldw_chatbook.UI.Watchlists_Modules.rules_pane import RulesPane
 from tldw_chatbook.UI.Watchlists_Modules.runs_pane import RunsPane
@@ -232,21 +235,11 @@ async def test_focused_table_keeps_click_metadata_on_its_last_row():
 
 # Every centre section that lists rows. Each is populated with TWO rows and
 # the SECOND is clicked, for the same reason the Sources fixture has two.
+# The items pane is absent: TASK-3072 replaced its DataTable with a ListView
+# (`ArticleListPane`), whose highlight event carries the ListItem itself --
+# a different shape this DataTable-parametrized test cannot fabricate, so it
+# has its own test right below.
 OTHER_TABLES = (
-    (
-        "items",
-        "#watchlists-items-pane",
-        ItemsPane,
-        "items",
-        "#items-table",
-        "selected_item",
-        [
-            {"id": "local:watchlist_item:1", "item_id": 1, "title": "First post",
-             "source_name": "Summit Route", "status": "new"},
-            {"id": "local:watchlist_item:2", "item_id": 2, "title": "Second post",
-             "source_name": "Summit Route", "status": "new"},
-        ],
-    ),
     (
         "runs",
         "#watchlists-runs-pane",
@@ -302,7 +295,6 @@ def test_every_watchlists_highlight_handler_selects_requested_row(
 ):
     """AC#5: every pane maps a focused row highlight to that stable row id."""
     select_methods = {
-        ItemsPane: ("select_item_by_id", ItemsPane.select_item_by_id),
         RunsPane: ("select_run_by_id", RunsPane.select_run_by_id),
         RulesPane: ("select_rule_by_id", RulesPane.select_rule_by_id),
         NotificationsPane: (
@@ -330,4 +322,41 @@ def test_every_watchlists_highlight_handler_selects_requested_row(
     assert selected is not None, f"{section}: highlighting a row selected nothing"
     assert str(selected["id"]) == str(rows[1]["id"]), (
         f"{section}: the highlight must select the requested stable row id"
+    )
+
+
+ITEM_ROWS = [
+    {"id": "local:watchlist_item:1", "item_id": 1, "title": "First post",
+     "source_name": "Summit Route", "status": "new"},
+    {"id": "local:watchlist_item:2", "item_id": 2, "title": "Second post",
+     "source_name": "Summit Route", "status": "new"},
+]
+
+
+def test_article_list_highlight_selects_requested_row():
+    """AC#5's items case, TASK-3072 shape: the ListView highlight event.
+
+    Same contract as the DataTable panes above -- a focused highlight of the
+    SECOND row selects that row's stable id -- fabricated against
+    `ListView.Highlighted`'s own payload (the `ListItem`, not a row key),
+    with the focus gate satisfied by a stubbed `query_one`.
+    """
+    pane = SimpleNamespace(
+        items=list(ITEM_ROWS),
+        selected_item=None,
+        query_one=lambda *a, **k: SimpleNamespace(has_focus=True),
+    )
+    pane.select_item_by_id = MethodType(ArticleListPane.select_item_by_id, pane)
+    stopped = []
+    event = SimpleNamespace(
+        item=_ArticleRow(ITEM_ROWS[1]),
+        stop=lambda: stopped.append(True),
+    )
+
+    ArticleListPane.on_list_view_highlighted(pane, event)
+
+    assert stopped == [True]
+    assert pane.selected_item is not None, "items: highlighting a row selected nothing"
+    assert str(pane.selected_item["id"]) == str(ITEM_ROWS[1]["id"]), (
+        "items: the highlight must select the requested stable row id"
     )

--- a/Tests/Watchlists/test_watchlist_scope_service.py
+++ b/Tests/Watchlists/test_watchlist_scope_service.py
@@ -244,3 +244,33 @@ async def test_restore_items_new_server_backend_rejected():
             runtime_backend=WatchlistBackend.SERVER, item_ids=[1]
         )
     local_service.restore_items_new.assert_not_awaited()
+
+
+# --- TASK-3072 plan task 7: the star write ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_item_flagged_forwards_denamespaced_id_to_local_service():
+    scope_service, local_service, _ = make_scope_service()
+    local_service.set_item_flagged = AsyncMock(return_value=None)
+
+    await scope_service.set_item_flagged(
+        runtime_backend=WatchlistBackend.LOCAL,
+        item_id="local:watchlist_item:7",
+        flagged=True,
+    )
+
+    # `_source_id_from_item_id` strips the display namespace, exactly as
+    # `update_item` and `restore_items_new` already do.
+    local_service.set_item_flagged.assert_awaited_once_with(item_id="7", flagged=True)
+
+
+@pytest.mark.asyncio
+async def test_set_item_flagged_server_backend_rejected():
+    scope_service, local_service, _ = make_scope_service()
+    local_service.set_item_flagged = AsyncMock(return_value=None)
+    with pytest.raises(ValueError, match="only supported for the local backend"):
+        await scope_service.set_item_flagged(
+            runtime_backend=WatchlistBackend.SERVER, item_id=7, flagged=True
+        )
+    local_service.set_item_flagged.assert_not_awaited()

--- a/Tests/Watchlists/test_watchlist_scope_service.py
+++ b/Tests/Watchlists/test_watchlist_scope_service.py
@@ -107,6 +107,7 @@ async def test_list_items_delegates_to_local_service():
     local_service.list_items.assert_awaited_once_with(
         source_id=None, status="new", limit=100, offset=0, run_id=None,
         watchlist_id=None, unassigned_only=False, statuses=None,
+        is_flagged=None,
     )
     assert len(result) == 1
 
@@ -125,6 +126,7 @@ async def test_list_items_forwards_watchlist_scope():
     local_service.list_items.assert_awaited_once_with(
         source_id=None, status=None, limit=100, offset=0, run_id=None,
         watchlist_id=3, unassigned_only=False, statuses=["new", "reviewed"],
+        is_flagged=None,
     )
 
 

--- a/Tests/Watchlists/test_watchlist_tree.py
+++ b/Tests/Watchlists/test_watchlist_tree.py
@@ -4,6 +4,7 @@ from textual.message import Message
 from textual.widgets import Button, Static
 
 from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import (
+    STARRED_BUCKET,
     AddSourceToWatchlistRequested,
     CreateWatchlistRequested,
     DeleteWatchlistRequested,
@@ -602,3 +603,71 @@ async def test_a_blocked_verb_posts_nothing_even_if_it_is_pressed_directly():
         )
         await pilot.pause()
         assert app.write_requests == []
+
+
+# --- TASK-3072 plan task 6: the Starred smart feed ---------------------------
+#
+# NNW's first-class smart feed: one root above the watchlists whose badge is
+# `SubscriptionsDB.get_flagged_items_count` (starred items, status-agnostic)
+# and whose scope maps to `{"is_flagged": True}` in the items query.
+
+
+def _starred_data(flagged: int):
+    data = _tree_data()
+    data["counts"][STARRED_BUCKET] = {"total": flagged, "unread": flagged}
+    return data
+
+
+@pytest.mark.asyncio
+async def test_starred_root_renders_above_the_watchlists_with_its_count():
+    app = _TreeApp(_starred_data(5))
+    async with app.run_test():
+        starred = app.query_one("#wl-tree-node-starred", Button)
+        assert str(starred.label) == "★ Starred  5"
+        # DOM order is the rail's reading order: starred sits with the roots,
+        # above every watchlist node.
+        ids = [node.id for node in app.query(Button)]
+        assert ids.index("wl-tree-node-starred") < ids.index(
+            "wl-tree-node-watchlist-1"
+        )
+
+
+@pytest.mark.asyncio
+async def test_starred_root_without_a_count_renders_zero():
+    """Before any item is starred there is no STARRED_BUCKET entry at all --
+    the badge must read 0, not crash the rail."""
+    app = _TreeApp(_tree_data())
+    async with app.run_test():
+        starred = app.query_one("#wl-tree-node-starred", Button)
+        assert str(starred.label) == "★ Starred  0"
+
+
+@pytest.mark.asyncio
+async def test_starred_root_tooltip_says_starred_not_unread():
+    """The legend row labels the rail's numbers "unread items"; the starred
+    badge counts STARRED items, so its own tooltip must say the true word --
+    the TASK-2304 AC#3 honesty rule applied to the one node the legend does
+    not describe."""
+    app = _TreeApp(_starred_data(5))
+    async with app.run_test():
+        starred = app.query_one("#wl-tree-node-starred", Button)
+        tooltip = starred.tooltip or ""
+        assert "5 starred items" in tooltip
+        assert "unread" not in tooltip
+
+
+@pytest.mark.asyncio
+async def test_selecting_starred_posts_the_starred_scope():
+    app = _TreeApp(_starred_data(5))
+    async with app.run_test() as pilot:
+        await pilot.click("#wl-tree-node-starred")
+        await pilot.pause()
+        assert app.scopes[-1] == TreeScope(kind="starred")
+
+
+@pytest.mark.asyncio
+async def test_active_scope_starred_marks_the_starred_root_active():
+    app = _TreeApp(_starred_data(5), active_scope=TreeScope(kind="starred"))
+    async with app.run_test():
+        assert app.query_one("#wl-tree-node-starred", Button).has_class("is-active")
+        assert not app.query_one("#wl-tree-node-all", Button).has_class("is-active")

--- a/Tests/Watchlists/test_watchlists_article_list.py
+++ b/Tests/Watchlists/test_watchlists_article_list.py
@@ -1,0 +1,481 @@
+"""Tests for the Watchlists article list (task-3072, plan Task 5).
+
+The ListView-based reader-rows replacement for ItemsPane's DataTable, in
+the Read section only: multi-line rows with group headers, glyphs, and the
+carried-over pane contracts (`displayed_items`, `select_and_reveal`,
+in-place row repaints, open-item pinning).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.widgets import Input, ListView, Select, Static
+
+from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
+from tldw_chatbook.UI.Watchlists_Modules.items_pane import (
+    ItemSelected,
+    ItemsFilterChanged,
+    NextUnreadRequested,
+    RefreshItemsRequested,
+)
+
+# Same CI-visibility convention as `test_watchlists_items_pane.py`.
+pytestmark = pytest.mark.unit
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _item(
+    item_id: int,
+    *,
+    title: str | None = None,
+    source_name: str = "Feed",
+    status: str = "new",
+    published_offset_hours: float = 1.0,
+    created_offset_hours: float = 0.5,
+    **flags,
+) -> dict:
+    published = _now() - timedelta(hours=published_offset_hours)
+    created = _now() - timedelta(hours=created_offset_hours)
+    return {
+        "id": f"local:watchlist_item:{item_id}",
+        "item_id": item_id,
+        "title": title or f"Article {item_id}",
+        "source_name": source_name,
+        "status": status,
+        "published_date": published.isoformat() if published_offset_hours >= 0 else None,
+        "created_at": created.isoformat(),
+        "content": f"Body of article {item_id} with enough text to snippet.",
+        "queued_for_briefing": False,
+        "is_flagged": False,
+        **flags,
+    }
+
+
+class ArticleListHarness(App):
+    def __init__(self):
+        super().__init__()
+        self.captured_messages = []
+
+    def compose(self) -> ComposeResult:
+        yield ArticleListPane()
+
+    def on_item_selected(self, message: ItemSelected) -> None:
+        self.captured_messages.append(("item_selected", message.item))
+
+    def on_refresh_items_requested(self, message: RefreshItemsRequested) -> None:
+        self.captured_messages.append(("refresh_items_requested", None))
+
+    def on_next_unread_requested(self, message: NextUnreadRequested) -> None:
+        self.captured_messages.append(("next_unread_requested", None))
+
+    def on_items_filter_changed(self, message: ItemsFilterChanged) -> None:
+        self.captured_messages.append(("filter_changed", message.status_filter))
+
+
+def _row_texts(pane: ArticleListPane) -> list[str]:
+    """One plain-text string per ListView node (headers included)."""
+    list_view = pane.query_one("#items-table", ListView)
+    return [str(node.query_one(Static).renderable) for node in list_view.children]
+
+
+def _item_rows(pane: ArticleListPane) -> list:
+    """The ListView nodes that are real rows (headers are disabled)."""
+    list_view = pane.query_one("#items-table", ListView)
+    return [node for node in list_view.children if not node.disabled]
+
+
+def _header_texts(pane: ArticleListPane) -> list[str]:
+    list_view = pane.query_one("#items-table", ListView)
+    return [
+        str(node.query_one(Static).renderable)
+        for node in list_view.children
+        if node.disabled
+    ]
+
+
+async def test_unread_row_is_bold_with_dot_and_read_row_is_plain():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [
+            _item(1, status="new", published_offset_hours=1),
+            _item(2, status="reviewed", published_offset_hours=2),
+        ]
+        await pilot.pause()
+
+        rows = _item_rows(pane)
+        unread_renderable = rows[0].query_one(Static).renderable
+        read_renderable = rows[1].query_one(Static).renderable
+
+        assert isinstance(unread_renderable, Text)
+        assert pane._UNREAD_DOT in str(unread_renderable)
+        bold_spans = [
+            str(unread_renderable)[span.start : span.end]
+            for span in unread_renderable.spans
+            if "bold" in str(span.style)
+        ]
+        assert any("Article 1" in covered for covered in bold_spans), (
+            "the unread title must be bold"
+        )
+        assert pane._UNREAD_DOT not in str(read_renderable)
+        read_bold = [
+            span for span in read_renderable.spans if "bold" in str(span.style)
+        ]
+        assert not read_bold
+
+
+async def test_starred_and_queued_rows_show_their_glyphs():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [
+            _item(1, is_flagged=True, published_offset_hours=1),
+            _item(2, queued_for_briefing=True, published_offset_hours=2),
+            _item(3, published_offset_hours=3),
+        ]
+        await pilot.pause()
+
+        texts = [str(row.query_one(Static).renderable) for row in _item_rows(pane)]
+        assert pane._STAR_GLYPH in texts[0]
+        assert pane._QUEUED_GLYPH not in texts[0]
+        assert pane._QUEUED_GLYPH in texts[1]
+        assert pane._STAR_GLYPH not in texts[2]
+        assert pane._QUEUED_GLYPH not in texts[2]
+
+
+async def test_ingested_row_renders_read_styled_with_a_marker():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1, status="ingested")]
+        await pilot.pause()
+
+        renderable = _item_rows(pane)[0].query_one(Static).renderable
+        assert "ingested" in str(renderable)
+        assert pane._UNREAD_DOT not in str(renderable)
+        assert not [span for span in renderable.spans if "bold" in str(span.style)]
+
+
+async def test_hostile_title_renders_as_literal_text():
+    """Remote-derived row text is appended to a `Text`, never parsed: a
+    markup-shaped title comes out as those exact characters."""
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1, title="[bold red]x[/]\x1b[31m")]
+        await pilot.pause()
+
+        rendered = str(_item_rows(pane)[0].query_one(Static).renderable)
+        assert "[bold red]x[/]" in rendered
+        assert "\x1b" not in rendered
+
+
+async def test_rows_group_under_day_headers_in_effective_date_order():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [
+            # Deliberately scrambled: the pane sorts by effective date desc.
+            _item(1, title="Older", published_offset_hours=5 * 24),
+            _item(2, title="Today B", published_offset_hours=3),
+            _item(3, title="Yesterday", published_offset_hours=26),
+            _item(4, title="Today A", published_offset_hours=1),
+        ]
+        await pilot.pause()
+
+        texts = _row_texts(pane)
+        assert texts[0] == "Today"
+        assert "Today A" in texts[1]
+        assert "Today B" in texts[2]
+        assert texts[3] == "Yesterday"
+        assert "Yesterday" in texts[4]
+        headers = _header_texts(pane)
+        assert headers[0] == "Today"
+        assert headers[1] == "Yesterday"
+        assert headers[2] not in ("Today", "Yesterday")
+        assert "Older" in texts[-1]
+
+
+async def test_future_dated_item_lands_under_today():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [
+            _item(1, title="Clock skew", published_offset_hours=-48),
+            _item(2, title="Normal", published_offset_hours=2),
+        ]
+        await pilot.pause()
+
+        headers = _header_texts(pane)
+        assert headers == ["Today"]
+
+
+async def test_displayed_items_excludes_headers_and_preserves_order():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [
+            _item(1, published_offset_hours=1),
+            _item(2, published_offset_hours=26),
+        ]
+        await pilot.pause()
+
+        displayed = pane.displayed_items()
+        assert [item["item_id"] for item in displayed] == [1, 2]
+
+
+async def test_headers_are_not_highlightable():
+    """A disabled header cannot take the ListView cursor: moving down from
+    the first row skips straight past one."""
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [
+            _item(1, published_offset_hours=1),
+            _item(2, published_offset_hours=2),
+            _item(3, published_offset_hours=26),
+        ]
+        await pilot.pause()
+        list_view = pane.query_one("#items-table", ListView)
+        list_view.focus()
+        await pilot.pause()
+        # Node order: header("Today"), row1, row2, header("Yesterday"), row3.
+        list_view.index = 1
+        await pilot.pause()
+
+        list_view.action_cursor_down()
+        await pilot.pause()
+        list_view.action_cursor_down()
+        await pilot.pause()
+
+        # Two downs from row1: row2, then past the "Yesterday" header to
+        # row3 -- the disabled header never takes the cursor.
+        assert list_view.index == 4
+        assert not list_view.children[list_view.index].disabled
+
+
+async def test_selecting_a_row_posts_item_selected():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1), _item(2)]
+        await pilot.pause()
+        list_view = pane.query_one("#items-table", ListView)
+        list_view.focus()
+        await pilot.pause()
+
+        list_view.index = 1
+        await pilot.pause()
+
+        selected = [m for m in app.captured_messages if m[0] == "item_selected"]
+        assert selected, "highlighting a row must post ItemSelected"
+        assert selected[-1][1]["item_id"] == 2
+
+
+async def test_unread_filter_hides_read_items_but_pins_the_open_one():
+    """The ItemsPane pin, verbatim: opening an item marks it read, and the
+    open item must not drop out of the Unread view mid-read."""
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        items = [_item(1, status="new"), _item(2, status="reviewed")]
+        pane.items = items
+        await pilot.pause()
+        pane.status_filter = "unread"
+        await pilot.pause()
+
+        assert [item["item_id"] for item in pane.displayed_items()] == [1]
+
+        # The user opens item 1; the screen's mark-read-on-open mutates the
+        # dict in place. The pin keeps it displayed under the Unread filter.
+        items[0]["status"] = "reviewed"
+        pane.selected_item = items[0]
+        await pilot.pause()
+        assert [item["item_id"] for item in pane.displayed_items()] == [1]
+
+
+async def test_all_filter_shows_triage_statuses_but_not_ignored_or_error():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [
+            _item(1, status="new", published_offset_hours=1),
+            _item(2, status="reviewed", published_offset_hours=2),
+            _item(3, status="ingested", published_offset_hours=3),
+            _item(4, status="ignored", published_offset_hours=4),
+            _item(5, status="error", published_offset_hours=5),
+        ]
+        await pilot.pause()
+        pane.status_filter = "all"
+        await pilot.pause()
+
+        assert [item["item_id"] for item in pane.displayed_items()] == [1, 2, 3]
+
+
+async def test_search_query_narrows_rows():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1, title="Krebs on security"), _item(2, title="ArXiv digest")]
+        await pilot.pause()
+
+        search = pane.query_one("#items-search-input", Input)
+        assert search.select_on_focus is False, "TASK-3071 property must carry over"
+        search.value = "krebs"
+        await pilot.pause(0.2)
+
+        assert [item["item_id"] for item in pane.displayed_items()] == [1]
+
+
+async def test_update_item_status_cell_repaints_in_place_without_recompose():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        items = [_item(1, status="new")]
+        pane.items = items
+        await pilot.pause()
+        list_view_before = pane.query_one("#items-table", ListView)
+
+        items[0]["status"] = "reviewed"
+        pane.update_item_status_cell(items[0]["id"], "reviewed")
+        await pilot.pause()
+
+        assert pane.query_one("#items-table", ListView) is list_view_before, (
+            "a status repaint must never recompose the list"
+        )
+        rendered = str(_item_rows(pane)[0].query_one(Static).renderable)
+        assert pane._UNREAD_DOT not in rendered
+
+
+async def test_update_item_queued_cell_toggles_the_glyph_in_place():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        items = [_item(1)]
+        pane.items = items
+        await pilot.pause()
+
+        pane.update_item_queued_cell(items[0]["id"], True)
+        await pilot.pause()
+        assert pane._QUEUED_GLYPH in str(_item_rows(pane)[0].query_one(Static).renderable)
+
+        pane.update_item_queued_cell(items[0]["id"], False)
+        await pilot.pause()
+        assert pane._QUEUED_GLYPH not in str(_item_rows(pane)[0].query_one(Static).renderable)
+
+
+async def test_repaints_never_write_back_to_the_stored_item_dict():
+    """The staleness invariant the mark-unread guard relies on.
+
+    `ItemsPane.update_item_status_cell` repainted the cell and left the item
+    dict alone, and the port must keep that exactly: the dicts in
+    `pane.items` are shared with the screen's `_selected_content_item` and
+    `ContentPane.item`, whose staleness between a triage write and its reload
+    is what makes the mark-unread guard's backend re-check necessary (pinned
+    end to end by
+    `test_mark_unread_refuses_to_overwrite_an_item_ingested_by_the_real_gesture`).
+    A repaint that freshened the shared dict would silently close that gap --
+    and hide real races the guard exists to catch.
+    """
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        items = [_item(1, status="new")]
+        pane.items = items
+        await pilot.pause()
+
+        pane.update_item_status_cell(items[0]["id"], "ingested")
+        pane.update_item_queued_cell(items[0]["id"], True)
+        await pilot.pause()
+
+        assert items[0]["status"] == "new", (
+            "the repaint must render the new status without writing it back"
+        )
+        assert not items[0].get("queued_for_briefing"), (
+            "same for the queued flag"
+        )
+        rendered = str(_item_rows(pane)[0].query_one(Static).renderable)
+        assert "· ingested" in rendered and pane._QUEUED_GLYPH in rendered, (
+            "and the row itself must still show both"
+        )
+
+
+async def test_select_and_reveal_selects_and_moves_the_cursor():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1), _item(2), _item(3)]
+        await pilot.pause()
+
+        pane.select_and_reveal(pane.items[2])
+        await pilot.pause()
+
+        assert pane.selected_item["item_id"] == 3
+        list_view = pane.query_one("#items-table", ListView)
+        highlighted = list_view.children[list_view.index]
+        assert not highlighted.disabled
+        assert "Article 3" in str(highlighted.query_one(Static).renderable)
+
+
+async def test_filter_change_is_mirrored_for_the_screen():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1)]
+        await pilot.pause()
+
+        pane.query_one("#items-status-select", Select).value = "unread"
+        await pilot.pause(0.2)
+
+        changes = [m for m in app.captured_messages if m[0] == "filter_changed"]
+        assert changes and changes[-1][1] == "unread"
+
+
+async def test_refresh_button_posts_refresh_requested():
+    from textual.widgets import Button
+
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1)]
+        await pilot.pause()
+
+        pane.query_one("#items-refresh-button", Button).press()
+        await pilot.pause()
+
+        assert any(m[0] == "refresh_items_requested" for m in app.captured_messages)
+
+
+async def test_space_posts_next_unread_requested():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1)]
+        await pilot.pause()
+        pane.query_one("#items-table", ListView).focus()
+        await pilot.pause()
+
+        await pilot.press("space")
+        await pilot.pause()
+
+        assert any(m[0] == "next_unread_requested" for m in app.captured_messages)
+
+
+async def test_unread_filter_with_nothing_unread_says_all_caught_up():
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1, status="reviewed")]
+        await pilot.pause()
+        pane.status_filter = "unread"
+        await pilot.pause()
+
+        assert pane.query_one("#items-empty-state", Static)
+        assert "caught up" in str(pane.query_one("#items-empty-state", Static).renderable)

--- a/Tests/Watchlists/test_watchlists_article_list.py
+++ b/Tests/Watchlists/test_watchlists_article_list.py
@@ -479,3 +479,27 @@ async def test_unread_filter_with_nothing_unread_says_all_caught_up():
 
         assert pane.query_one("#items-empty-state", Static)
         assert "caught up" in str(pane.query_one("#items-empty-state", Static).renderable)
+
+
+async def test_update_item_starred_cell_toggles_the_glyph_in_place():
+    """TASK-3072 plan task 7: the star repaint composes with the other
+    per-row repaints and -- like them -- never writes the shared dict."""
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        items = [_item(1)]
+        pane.items = items
+        await pilot.pause()
+
+        pane.update_item_starred_cell(items[0]["id"], True)
+        await pilot.pause()
+        assert pane._STAR_GLYPH in str(_item_rows(pane)[0].query_one(Static).renderable)
+
+        pane.update_item_starred_cell(items[0]["id"], False)
+        await pilot.pause()
+        assert pane._STAR_GLYPH not in str(_item_rows(pane)[0].query_one(Static).renderable)
+
+        assert not items[0].get("is_flagged"), (
+            "display-only: the repaint must not freshen the shared dict "
+            "(the mark-unread guard's staleness invariant)"
+        )

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -963,6 +963,107 @@ async def test_the_next_unread_footer_button_opens_the_next_unread():
         )
 
 
+# --- TASK-3072 plan task 10: the hostile-HTML end-to-end pin ------------------
+
+
+@pytest.mark.asyncio
+async def test_a_hostile_item_stars_queues_and_still_renders_inert():
+    """The phase-2 DoD, end to end: an item whose title and body carry
+    `<script>`, `[bold red]` and control bytes renders as INERT TEXT in the
+    row and the reader body while the star and queue verbs work on it --
+    and both flags survive a re-persist (Task 3's pin, at the surface)."""
+    from textual.widgets import Static
+
+    from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
+
+    hostile_title = "[bold red]x[/]<script>alert('TITLE_LITERAL')</script>\x1b[31m"
+    hostile_body = "<script>alert('BODY_PAYLOAD')</script> [bold red]injected[/]\x00\x07"
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        source_id = db.add_subscription(
+            name="Evil Feed", type="rss", source="https://evil.example/f"
+        )
+        with db.transaction() as conn:
+            item_id = persist_subscription_item(
+                conn,
+                source_id,
+                {
+                    "url": "https://evil.example/post",
+                    "title": hostile_title,
+                    "content": hostile_body,
+                    "content_hash": "hash-hostile",
+                },
+                run_id=None,
+                now="2026-08-06T09:00:00+00:00",
+            )
+        await screen._load_items()
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+        await _wait_for_items(pilot, pane)
+
+        pane.select_item_by_id(str(pane.items[0]["id"]))
+        await pilot.pause(0.3)
+        assert screen._selected_content_item is not None, "precondition: item open"
+
+        # The verbs work on the hostile item exactly as on any other.
+        await pilot.press("s")
+        for _ in range(60):
+            await pilot.pause()
+            if _flagged_value(db, item_id) == 1:
+                break
+        assert _flagged_value(db, item_id) == 1, "the star write must land"
+        db.set_item_briefing_queued(item_id, True)
+
+        # The row renders the attacks as literal characters, control-stripped.
+        row_widget = pane._find_row(str(pane.items[0]["id"]))
+        row_text = str(row_widget.query_one(Static).renderable)
+        assert "[bold red]x[/]" in row_text, "markup-shaped text stays literal"
+        assert "\x1b" not in row_text, "no escape sequence survives into a row"
+
+        # The reader defends each field at its own layer. The TITLE is
+        # documented plain text (render_article appends, never parses), so
+        # its script-shaped characters render literally and inertly. The
+        # BODY goes through `readable_body_text`, which drops script tags
+        # AND their payloads. Bracket text stays literal; control bytes die.
+        body = screen.query_one("#content-body", Static).renderable
+        body_plain = getattr(body, "plain", str(body))
+        assert "[bold red]injected[/]" in body_plain
+        assert "TITLE_LITERAL" in body_plain, (
+            "the title renders -- as inert literal characters"
+        )
+        assert "BODY_PAYLOAD" not in body_plain, (
+            "the body's script payload is dropped, not shown"
+        )
+        assert "\x00" not in body_plain and "\x07" not in body_plain
+        assert "\x1b" not in body_plain
+
+        # Re-persist the same item (same url + content_hash, the re-fetch
+        # shape): neither flag is touched by the upsert.
+        with db.transaction() as conn:
+            persist_subscription_item(
+                conn,
+                source_id,
+                {
+                    "url": "https://evil.example/post",
+                    "title": hostile_title,
+                    "content": hostile_body,
+                    "content_hash": "hash-hostile",
+                },
+                run_id=None,
+                now="2026-08-06T09:05:00+00:00",
+            )
+        assert _flagged_value(db, item_id) == 1, "the star survives a re-persist"
+        queued = db.conn.execute(
+            "SELECT queued_for_briefing FROM subscription_items WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        assert int(queued[0]) == 1, "the queue flag survives a re-persist"
+
+
 @pytest.mark.asyncio
 async def test_space_opens_next_unread():
     """`space` walks to the next UNREAD item, skipping reviewed rows."""

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -451,6 +451,41 @@ async def test_items_reload_scopes_to_source():
 
 
 @pytest.mark.asyncio
+async def test_items_reload_scopes_to_starred():
+    """TASK-3072 plan task 6: the Starred smart feed lists flagged items from
+    every source -- membership is irrelevant, the flag is global (ADR-018
+    semantics, same as the briefing queue)."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        service = app.watchlist_bundle_service
+        db = service._db
+
+        arxiv = db.add_subscription(
+            name="ArXiv", type="rss", source="https://a.example/f"
+        )
+        krebs = db.add_subscription(
+            name="Krebs", type="rss", source="https://b.example/f"
+        )
+        starred_a = _seed_item(db, arxiv, "Starred from ArXiv")
+        starred_b = _seed_item(db, krebs, "Starred from Krebs")
+        _seed_item(db, arxiv, "Plain ArXiv item")
+        db.set_item_flagged(starred_a, True)
+        db.set_item_flagged(starred_b, True)
+
+        screen._apply_tree_scope(TreeScope(kind="starred"))
+        await screen._load_items()
+
+        assert screen._loaded_items, "precondition: two items are starred"
+        assert {item["title"] for item in screen._loaded_items} == {
+            "Starred from ArXiv",
+            "Starred from Krebs",
+        }
+
+
+@pytest.mark.asyncio
 async def test_tree_move_triggers_items_reload_on_read_tab():
     """Moving the tree while on the Read tab re-fetches the items list.
 

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -614,6 +614,129 @@ async def test_m_refuses_on_ingested_item():
         )
 
 
+# --- TASK-3072 plan task 7: `s` and the reader's Star button -------------------
+
+
+def _flagged_value(db, item_id: int) -> int:
+    row = db.conn.execute(
+        "SELECT is_flagged FROM subscription_items WHERE id = ?", (item_id,)
+    ).fetchone()
+    return int(row[0]) if row else -1
+
+
+@pytest.mark.asyncio
+async def test_s_toggles_star_on_the_open_item():
+    """`s` stars, then unstars, the open item through the service; the row's
+    star repaints in place and the Starred badge catches up through the
+    debounced counts path."""
+    from textual.widgets import Static
+
+    from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import STARRED_BUCKET
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        source_id = db.add_subscription(
+            name="ArXiv", type="rss", source="https://a.example/f"
+        )
+        item_id = _seed_item(db, source_id, "Star me")
+        await screen._load_items()
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+        await _wait_for_items(pilot, pane)
+
+        pane.select_item_by_id(str(pane.items[0]["id"]))
+        await pilot.pause(0.3)
+        assert screen._selected_content_item is not None, "precondition: item open"
+
+        await pilot.press("s")
+        for _ in range(60):
+            await pilot.pause()
+            if _flagged_value(db, item_id) == 1:
+                break
+        assert _flagged_value(db, item_id) == 1, "`s` must star the open item"
+
+        row_widget = pane._find_row(str(pane.items[0]["id"]))
+        assert pane._STAR_GLYPH in str(row_widget.query_one(Static).renderable), (
+            "the row's star repaints in place -- no recompose"
+        )
+
+        for _ in range(80):
+            await pilot.pause(0.05)
+            if screen._tree_counts.get(STARRED_BUCKET, {}).get("unread") == 1:
+                break
+        assert screen._tree_counts[STARRED_BUCKET]["unread"] == 1, (
+            "the Starred badge must refresh through the debounced counts path"
+        )
+
+        # The open dict was patched, so the second press unstars rather than
+        # re-deriving from a stale flag.
+        await pilot.press("s")
+        for _ in range(60):
+            await pilot.pause()
+            if _flagged_value(db, item_id) == 0:
+                break
+        assert _flagged_value(db, item_id) == 0, "a second `s` must unstar"
+
+
+@pytest.mark.asyncio
+async def test_s_with_no_open_item_is_a_noop():
+    """`s` with nothing open writes nothing and raises nothing."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        source_id = db.add_subscription(
+            name="ArXiv", type="rss", source="https://a.example/f"
+        )
+        item_id = _seed_item(db, source_id, "Never opened")
+        await screen._load_items()
+        assert screen._selected_content_item is None, "precondition: nothing open"
+
+        await pilot.press("s")
+        await pilot.pause(0.3)
+        assert _flagged_value(db, item_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_star_toggle_requested_toggles_the_same_path():
+    """The reader's Star button and the `s` key share one handler."""
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import StarToggleRequested
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        source_id = db.add_subscription(
+            name="ArXiv", type="rss", source="https://a.example/f"
+        )
+        item_id = _seed_item(db, source_id, "Button-starred")
+        await screen._load_items()
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+        await _wait_for_items(pilot, pane)
+
+        pane.select_item_by_id(str(pane.items[0]["id"]))
+        await pilot.pause(0.3)
+        assert screen._selected_content_item is not None, "precondition: item open"
+
+        screen.post_message(
+            StarToggleRequested(dict(screen._selected_content_item))
+        )
+        for _ in range(60):
+            await pilot.pause()
+            if _flagged_value(db, item_id) == 1:
+                break
+        assert _flagged_value(db, item_id) == 1, (
+            "the button's message must reach the same write the `s` key does"
+        )
+
+
 @pytest.mark.asyncio
 async def test_space_opens_next_unread():
     """`space` walks to the next UNREAD item, skipping reviewed rows."""

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -865,6 +865,104 @@ async def test_open_in_browser_requested_takes_the_same_path(monkeypatch):
         assert opened == ["https://example.com/via-button"]
 
 
+# --- TASK-3072 plan task 9: the reader's position footer ----------------------
+
+
+@pytest.mark.asyncio
+async def test_the_reader_footer_numbers_the_open_item():
+    """"N of M": M is the displayed list, N the open item's 1-based place in
+    it; `j` advances the reader and the footer together."""
+    from textual.widgets import Static
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        source_id = db.add_subscription(
+            name="ArXiv", type="rss", source="https://a.example/f"
+        )
+        # Newest-first display: [c (09:02), b (09:01), a (09:00)].
+        _seed_item(db, source_id, "a", created_at="2026-08-06 09:00:00")
+        _seed_item(db, source_id, "b", created_at="2026-08-06 09:01:00")
+        _seed_item(db, source_id, "c", created_at="2026-08-06 09:02:00")
+        await screen._load_items()
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+        await _wait_for_items(pilot, pane)
+        assert len(pane.displayed_items()) == 3, "precondition: all three listed"
+
+        pane.select_item_by_id(str(pane.displayed_items()[1]["id"]))
+        for _ in range(40):
+            await pilot.pause()
+            if screen._selected_content_item is not None:
+                break
+        assert screen._selected_content_item["title"] == "b", "precondition"
+        assert str(screen.query_one("#content-position", Static).renderable) == "2 of 3"
+
+        await pilot.press("j")
+        for _ in range(40):
+            await pilot.pause()
+            if screen._selected_content_item.get("title") == "a":
+                break
+        assert screen._selected_content_item["title"] == "a", "precondition: j moved"
+        assert str(screen.query_one("#content-position", Static).renderable) == "3 of 3", (
+            "the footer must walk with the reader"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_reader_footer_is_empty_with_nothing_open():
+    """Nothing open: no footer at all, and definitely not "0 of 0"."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        assert screen._selected_content_item is None, "precondition"
+        assert not screen.query("#content-position")
+
+
+@pytest.mark.asyncio
+async def test_the_next_unread_footer_button_opens_the_next_unread():
+    """The footer's Next Unread control drives the same handler `space` does."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        source_id = db.add_subscription(
+            name="ArXiv", type="rss", source="https://a.example/f"
+        )
+        _seed_item(db, source_id, "a", created_at="2026-08-06 09:00:00")
+        b_id = _seed_item(db, source_id, "b", created_at="2026-08-06 09:01:00")
+        _seed_item(db, source_id, "c", created_at="2026-08-06 09:02:00")
+        db.mark_item_status(b_id, "reviewed")
+        # Nothing open yet, so no footer exists -- open any item first.
+        await screen._load_items()
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+        await _wait_for_items(pilot, pane)
+        pane.select_item_by_id(str(pane.displayed_items()[1]["id"]))
+        for _ in range(40):
+            await pilot.pause()
+            if screen._selected_content_item is not None:
+                break
+        assert screen._selected_content_item["title"] == "b", "precondition"
+
+        from textual.widgets import Button
+
+        screen.query_one("#content-next-unread-button", Button).press()
+        for _ in range(40):
+            await pilot.pause()
+            if screen._selected_content_item.get("title") == "a":
+                break
+        assert screen._selected_content_item["title"] == "a", (
+            "from b, next unread walks the displayed sequence forward, "
+            "past nothing, to a -- the only unread item after it"
+        )
+
+
 @pytest.mark.asyncio
 async def test_space_opens_next_unread():
     """`space` walks to the next UNREAD item, skipping reviewed rows."""

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -663,6 +663,12 @@ async def test_s_toggles_star_on_the_open_item():
             "the row's star repaints in place -- no recompose"
         )
 
+        from textual.widgets import Button
+
+        assert str(screen.query_one("#content-star-button", Button).label) == (
+            "★ Starred"
+        ), "the reader's button flips on the success path, never optimistically"
+
         for _ in range(80):
             await pilot.pause(0.05)
             if screen._tree_counts.get(STARRED_BUCKET, {}).get("unread") == 1:
@@ -679,6 +685,7 @@ async def test_s_toggles_star_on_the_open_item():
             if _flagged_value(db, item_id) == 0:
                 break
         assert _flagged_value(db, item_id) == 0, "a second `s` must unstar"
+        assert str(screen.query_one("#content-star-button", Button).label) == "☆ Star"
 
 
 @pytest.mark.asyncio
@@ -810,6 +817,31 @@ async def test_o_refuses_a_non_http_url(monkeypatch):
         assert app.notify.called, "a refusal must say so"
         _args, kwargs = app.notify.call_args
         assert kwargs.get("severity") == "warning"
+
+
+@pytest.mark.asyncio
+async def test_o_strips_control_bytes_from_the_url_before_opening(monkeypatch):
+    """A feed URL is remote-derived text: control bytes are stripped before
+    the (already scheme- and host-validated) string reaches the OS."""
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", opened.append)
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        await _open_item_and_get_url(
+            pilot, screen, db, "Control bytes", "https://example.com/po\x07st"
+        )
+
+        await pilot.press("o")
+        for _ in range(20):
+            await pilot.pause()
+            if opened:
+                break
+        assert opened == ["https://example.com/post"]
 
 
 @pytest.mark.asyncio

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -737,6 +737,134 @@ async def test_star_toggle_requested_toggles_the_same_path():
         )
 
 
+# --- TASK-3072 plan task 8: `o` opens the item in the browser -----------------
+
+
+async def _open_item_and_get_url(pilot, screen, db, title: str, url: str) -> int:
+    """Seed one item carrying exactly `url`, open it in the reader."""
+    source_id = db.add_subscription(
+        name="ArXiv", type="rss", source="https://a.example/f"
+    )
+    item_id = _seed_item(db, source_id, title)
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE subscription_items SET url = ? WHERE id = ?", (url, item_id)
+        )
+    await screen._load_items()
+    pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
+    await _wait_for_items(pilot, pane)
+    pane.select_item_by_id(str(pane.items[0]["id"]))
+    await pilot.pause(0.3)
+    assert screen._selected_content_item is not None, "precondition: item open"
+    return item_id
+
+
+@pytest.mark.asyncio
+async def test_o_opens_the_open_items_url(monkeypatch):
+    """`o` hands the open item's http URL to the system browser."""
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", opened.append)
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        await _open_item_and_get_url(
+            pilot, screen, db, "Readable", "https://example.com/post"
+        )
+
+        await pilot.press("o")
+        await pilot.pause(0.2)
+        assert opened == ["https://example.com/post"]
+
+
+@pytest.mark.asyncio
+async def test_o_refuses_a_non_http_url(monkeypatch):
+    """A `javascript:`/`file:`/empty URL is a remote-derived string reaching
+    an OS primitive: it is refused with a notification, never passed on."""
+    from unittest.mock import Mock
+
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", opened.append)
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        app.notify = Mock()
+        await _open_item_and_get_url(
+            pilot, screen, db, "Hostile", "javascript:alert(1)"
+        )
+
+        await pilot.press("o")
+        for _ in range(20):
+            await pilot.pause()
+            if app.notify.called:
+                break
+
+        assert opened == [], "a non-http(s) scheme must never reach webbrowser"
+        assert app.notify.called, "a refusal must say so"
+        _args, kwargs = app.notify.call_args
+        assert kwargs.get("severity") == "warning"
+
+
+@pytest.mark.asyncio
+async def test_o_with_no_open_item_is_a_noop(monkeypatch):
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", opened.append)
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        source_id = db.add_subscription(
+            name="ArXiv", type="rss", source="https://a.example/f"
+        )
+        _seed_item(db, source_id, "Never opened")
+        await screen._load_items()
+        assert screen._selected_content_item is None, "precondition: nothing open"
+
+        await pilot.press("o")
+        await pilot.pause(0.2)
+        assert opened == []
+
+
+@pytest.mark.asyncio
+async def test_open_in_browser_requested_takes_the_same_path(monkeypatch):
+    """The reader's Open button and the `o` key share one handler."""
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import (
+        OpenInBrowserRequested,
+    )
+
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", opened.append)
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        await _open_item_and_get_url(
+            pilot, screen, db, "Button-opened", "https://example.com/via-button"
+        )
+
+        screen.post_message(
+            OpenInBrowserRequested(dict(screen._selected_content_item))
+        )
+        for _ in range(20):
+            await pilot.pause()
+            if opened:
+                break
+        assert opened == ["https://example.com/via-button"]
+
+
 @pytest.mark.asyncio
 async def test_space_opens_next_unread():
     """`space` walks to the next UNREAD item, skipping reviewed rows."""

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -18,7 +18,8 @@ from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
     InspectorPane,
     PreviewRequested,
 )
-from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemSelected, ItemsPane
+from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
+from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemSelected
 from tldw_chatbook.UI.Watchlists_Modules.opml_dialogs import (
     OpmlExportDialog,
     OpmlImportDialog,
@@ -508,7 +509,7 @@ async def test_m_toggles_read_state_on_open_item():
         )
         item_id = _seed_item(db, source_id, "Toggle me")
         await screen._load_items()
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         await _wait_for_items(pilot, pane)
         assert pane.items, "precondition: the seeded item reaches the pane"
 
@@ -556,7 +557,7 @@ async def test_m_refuses_on_ingested_item():
         item_id = _seed_item(db, source_id, "Ingested one")
         db.mark_item_status(item_id, "ingested")
         await screen._load_items()
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         await _wait_for_items(pilot, pane)
         assert pane.items, "precondition: the ingested item is listed (filter: all)"
 
@@ -596,7 +597,7 @@ async def test_space_opens_next_unread():
         _seed_item(db, source_id, "c", created_at="2026-08-06 09:02:00")
         db.mark_item_status(b_id, "reviewed")
         await screen._load_items()
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         await _wait_for_items(pilot, pane)
         assert len(pane.displayed_items()) == 3, "precondition: all three listed"
         displayed = pane.displayed_items()
@@ -636,7 +637,7 @@ async def test_space_at_end_notifies_all_caught_up():
         )
         _seed_item(db, source_id, "only one")
         await screen._load_items()
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         await _wait_for_items(pilot, pane)
         pane.select_item_by_id(str(pane.items[0]["id"]))
         await pilot.pause(0.3)
@@ -674,7 +675,7 @@ async def test_space_with_rail_focused_does_not_navigate():
         )
         _seed_item(db, source_id, "unread one")
         await screen._load_items()
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         await _wait_for_items(pilot, pane)
         screen.query_one("#wl-tree-node-all", Button).focus()
         await pilot.press("space")
@@ -706,7 +707,7 @@ async def test_space_in_items_search_input_still_types():
         )
         _seed_item(db, source_id, "f o matcher")
         await screen._load_items()
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         await _wait_for_items(pilot, pane)
         pane.query_one("#items-search-input", Input).focus()
         await pilot.press("f", "space", "o")
@@ -807,7 +808,7 @@ async def test_mark_all_read_then_undo_roundtrip():
                 created_at=f"2026-08-06 09:0{minute}:00",
             )
         await screen._load_items()
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         await _wait_for_items(pilot, pane)
         assert len(pane.displayed_items()) == 3, "precondition"
 
@@ -849,7 +850,7 @@ async def test_undo_failure_keeps_the_batch_for_retry(monkeypatch):
         )
         _seed_item(db, source_id, "item 0", created_at="2026-08-06 09:00:00")
         await screen._load_items()
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         await _wait_for_items(pilot, pane)
 
         await pilot.press("a")
@@ -920,7 +921,7 @@ async def test_mark_all_read_scoped_to_watchlist():
         _seed_item(db, outsider, "outsider", created_at="2026-08-06 09:02:00")
 
         screen._apply_tree_scope(TreeScope(kind="watchlist", watchlist_id=watchlist["id"]))
-        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        pane = screen.query_one("#watchlists-items-pane", ArticleListPane)
         for _ in range(60):
             await pilot.pause()
             if len(pane.displayed_items()) == 2:

--- a/backlog/tasks/task-3072 - Watchlists-reader-first-re-IA-phase-2-list-and-reader-quality.md
+++ b/backlog/tasks/task-3072 - Watchlists-reader-first-re-IA-phase-2-list-and-reader-quality.md
@@ -19,8 +19,29 @@ Implement phase 2 of the reader-first design (Docs/superpowers/specs/2026-08-05-
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Article list rows show source+relative time, bold-when-unread title, 1-2 line snippet, unread dot, star/queued/ingested markers, and Today/Yesterday/locale-date group headers,s toggles star and a Starred smart feed with count appears in the rail; flags persist across re-fetch,Reading-pane action row (Star/Mark unread/Open in browser/Ingest/Queue) calls the same shared helpers as the inspector,o opens the item in the browser,Item body renders via content_render.py with stdlib fallback; hostile HTML renders safely as text and failure never blanks the pane,Position footer shows N of M within the displayed list plus a Next Unread control,Tests/Watchlists green
+- [x] #1 Article list rows show source+relative time, bold-when-unread title, 1-2 line snippet, unread dot, star/queued/ingested markers, and Today/Yesterday/locale-date group headers,s toggles star and a Starred smart feed with count appears in the rail; flags persist across re-fetch,Reading-pane action row (Star/Mark unread/Open in browser/Ingest/Queue) calls the same shared helpers as the inspector,o opens the item in the browser,Item body renders via content_render.py with stdlib fallback; hostile HTML renders safely as text and failure never blanks the pane,Position footer shows N of M within the displayed list plus a Next Unread control,Tests/Watchlists green
 <!-- AC:END -->
+
+## Implementation Notes
+
+Phase 2 executed TDD per the plan (Docs/superpowers/plans/2026-08-07-watchlists-reader-first-phase-2-list-reader-quality.md), one commit per plan task, following the phase-1 playbook.
+
+**Per task:** af2b1ca97 docs (plan + this task); 89ff11856 item_dates helper (effective date, relative time, local-day buckets, reusing humane_time's parse); 3a9a353b6 is_flagged plumbing (Subscriptions_DB.set_item_flagged / get_flagged_items_count, get_new_items predicate, list_items forwarding, normalizer key); af0ea888b effective-date ordering (COALESCE published/created DESC) + html_text.body_snippet; b96060e63 ArticleListPane (ListView reader rows under disabled day-header rows, Unread/All filter pushed into the query, glyphs); cd1fee027 drive-by fixture fix; cb1e8ece5 Starred rail feed (TreeScope "starred", badge via the existing counts path, {"is_flagged": True} scope mapping); 60d6b0c00 `s` star toggle + reader Star button (controller→scope→local→DB set_item_flagged chain, local-only like every item write); b4c524835 `o` open-in-browser + reader action row; 1e3f31855 position footer with Next Unread; plus the help-text/hostile-pin/docs commit closing this task.
+
+**Key decisions:**
+- The spec's `Subscriptions/content_render.py` was recorded as ALREADY satisfied by `Subscriptions/html_text.py` (TASK-2307): dependency-free stdlib HTMLParser, `readable_body_text` in `render_article` today, html2text an optional extra that is not required. No new renderer module; phase 2 added only `body_snippet`.
+- `_repaint_row(item_id, **writes)` is display-only (per-row `display_overrides`, never written back to the shared item dict) — exact ItemsPane parity, and load-bearing: the dicts are shared with `_selected_content_item`/`ContentPane.item` and their staleness is the mark-unread guard's pinned invariant.
+- Queued glyph diverges from ItemsPane (◆ not ●) because ● is the unread dot in the reader rows.
+- Legacy filter values ("new"/"all statuses") are normalized to the reader vocabulary (Unread/All) at the pane-seed and filter-changed boundaries.
+- The Starred badge rides the existing debounced counts path (STARRED_BUCKET in the counts mapping) — no new refresh plumbing; it is status-agnostic so it never shrinks as starred items are read (which would read as data loss).
+- The reader's verbs share the Inspector's at the message layer (same `IngestRequested`/`ToggleBriefingQueueRequested` classes) — the no-drift mechanism the spec asked a "shared module" for, without a new module.
+- `o` validates the scheme (http/https only) before `webbrowser.open`: the URL is a remote-derived string reaching an OS primitive.
+
+**Disclosure (pre-existing on origin/dev, not from this branch):** the briefing overflow test had aged out of its hard-coded 7-day fixture window — fixed here as cd1fee027 (now-relative date); 6 other parity failures (schedules/mcp/main-nav) and 43 CI environment failures (42 Notes git-SSH + 1 real-server flake) reproduce on origin/dev unchanged.
+
+**Tests:** Tests/Watchlists/ and Tests/Subscriptions/ green; coupled Tests/UI watchlists files green; ruff clean on every touched file. New coverage includes per-layer star-write routing, the reader filter's literal vocabulary contract, display-only repaint invariants, scheme-refusal for `o`, footer position tracking, and the hostile-HTML end-to-end pin (star + queue + inert render + flags survive re-persist).
+
+**Files:** new `UI/Watchlists_Modules/article_list.py`, `Subscriptions/item_dates.py`, `Tests/Watchlists/test_watchlists_article_list.py`, `Tests/Subscriptions/test_item_dates.py`; modified `UI/Watchlists_Modules/{watchlist_tree,content_pane,watchlists_backend_controller,humane_time}.py`, `UI/Screens/watchlists_collections_screen.py`, `Subscriptions/{watchlist_bundle_service,local_watchlists_service,watchlist_scope_service,html_text}.py`, `DB/Subscriptions_DB.py`, `Subscriptions/watchlist_normalizers.py`, and the migrated Tests/{Watchlists,UI}/ suites listed in the per-task commits.
 
 ## Implementation Plan
 

--- a/backlog/tasks/task-3072 - Watchlists-reader-first-re-IA-phase-2-list-and-reader-quality.md
+++ b/backlog/tasks/task-3072 - Watchlists-reader-first-re-IA-phase-2-list-and-reader-quality.md
@@ -1,0 +1,33 @@
+---
+id: TASK-3072
+title: 'Watchlists reader-first re-IA, phase 2: list and reader quality'
+status: In Progress
+assignee: []
+created_date: '2026-08-07 17:50'
+updated_date: '2026-08-07 18:11'
+labels:
+  - watchlists
+  - ux
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement phase 2 of the reader-first design (Docs/superpowers/specs/2026-08-05-watchlists-reader-first-design.md, ADR-042): reader rows with snippet/relative-date/date-groups/unread-bold/star/ingested+queued markers, s key + Starred smart feed, Subscriptions/content_render.py, o open-in-browser, reading-pane action row via shared helpers, position footer, Subscriptions/item_dates.py date helper.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Article list rows show source+relative time, bold-when-unread title, 1-2 line snippet, unread dot, star/queued/ingested markers, and Today/Yesterday/locale-date group headers,s toggles star and a Starred smart feed with count appears in the rail; flags persist across re-fetch,Reading-pane action row (Star/Mark unread/Open in browser/Ingest/Queue) calls the same shared helpers as the inspector,o opens the item in the browser,Item body renders via content_render.py with stdlib fallback; hostile HTML renders safely as text and failure never blanks the pane,Position footer shows N of M within the displayed list plus a Next Unread control,Tests/Watchlists green
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Execute Docs/superpowers/plans/2026-08-07-watchlists-reader-first-phase-2-list-reader-quality.md
+
+ADR required: no (already exists)
+ADR path: backlog/decisions/042-watchlists-reader-first-ia.md
+Reason: ADR-042 covers the re-IA; phase 2 is a direct implementation of it.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-3072 - Watchlists-reader-first-re-IA-phase-2-list-and-reader-quality.md
+++ b/backlog/tasks/task-3072 - Watchlists-reader-first-re-IA-phase-2-list-and-reader-quality.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-3072
 title: 'Watchlists reader-first re-IA, phase 2: list and reader quality'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-07 17:50'
-updated_date: '2026-08-07 18:11'
+updated_date: '2026-08-08 04:49'
 labels:
   - watchlists
   - ux
@@ -22,8 +22,19 @@ Implement phase 2 of the reader-first design (Docs/superpowers/specs/2026-08-05-
 - [x] #1 Article list rows show source+relative time, bold-when-unread title, 1-2 line snippet, unread dot, star/queued/ingested markers, and Today/Yesterday/locale-date group headers,s toggles star and a Starred smart feed with count appears in the rail; flags persist across re-fetch,Reading-pane action row (Star/Mark unread/Open in browser/Ingest/Queue) calls the same shared helpers as the inspector,o opens the item in the browser,Item body renders via content_render.py with stdlib fallback; hostile HTML renders safely as text and failure never blanks the pane,Position footer shows N of M within the displayed list plus a Next Unread control,Tests/Watchlists green
 <!-- AC:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Execute Docs/superpowers/plans/2026-08-07-watchlists-reader-first-phase-2-list-reader-quality.md
+
+ADR required: no (already exists)
+ADR path: backlog/decisions/042-watchlists-reader-first-ia.md
+Reason: ADR-042 covers the re-IA; phase 2 is a direct implementation of it.
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 Phase 2 executed TDD per the plan (Docs/superpowers/plans/2026-08-07-watchlists-reader-first-phase-2-list-reader-quality.md), one commit per plan task, following the phase-1 playbook.
 
 **Per task:** af2b1ca97 docs (plan + this task); 89ff11856 item_dates helper (effective date, relative time, local-day buckets, reusing humane_time's parse); 3a9a353b6 is_flagged plumbing (Subscriptions_DB.set_item_flagged / get_flagged_items_count, get_new_items predicate, list_items forwarding, normalizer key); af0ea888b effective-date ordering (COALESCE published/created DESC) + html_text.body_snippet; b96060e63 ArticleListPane (ListView reader rows under disabled day-header rows, Unread/All filter pushed into the query, glyphs); cd1fee027 drive-by fixture fix; cb1e8ece5 Starred rail feed (TreeScope "starred", badge via the existing counts path, {"is_flagged": True} scope mapping); 60d6b0c00 `s` star toggle + reader Star button (controller→scope→local→DB set_item_flagged chain, local-only like every item write); b4c524835 `o` open-in-browser + reader action row; 1e3f31855 position footer with Next Unread; plus the help-text/hostile-pin/docs commit closing this task.
@@ -42,13 +53,4 @@ Phase 2 executed TDD per the plan (Docs/superpowers/plans/2026-08-07-watchlists-
 **Tests:** Tests/Watchlists/ and Tests/Subscriptions/ green; coupled Tests/UI watchlists files green; ruff clean on every touched file. New coverage includes per-layer star-write routing, the reader filter's literal vocabulary contract, display-only repaint invariants, scheme-refusal for `o`, footer position tracking, and the hostile-HTML end-to-end pin (star + queue + inert render + flags survive re-persist).
 
 **Files:** new `UI/Watchlists_Modules/article_list.py`, `Subscriptions/item_dates.py`, `Tests/Watchlists/test_watchlists_article_list.py`, `Tests/Subscriptions/test_item_dates.py`; modified `UI/Watchlists_Modules/{watchlist_tree,content_pane,watchlists_backend_controller,humane_time}.py`, `UI/Screens/watchlists_collections_screen.py`, `Subscriptions/{watchlist_bundle_service,local_watchlists_service,watchlist_scope_service,html_text}.py`, `DB/Subscriptions_DB.py`, `Subscriptions/watchlist_normalizers.py`, and the migrated Tests/{Watchlists,UI}/ suites listed in the per-task commits.
-
-## Implementation Plan
-
-<!-- SECTION:PLAN:BEGIN -->
-Execute Docs/superpowers/plans/2026-08-07-watchlists-reader-first-phase-2-list-reader-quality.md
-
-ADR required: no (already exists)
-ADR path: backlog/decisions/042-watchlists-reader-first-ia.md
-Reason: ADR-042 covers the re-IA; phase 2 is a direct implementation of it.
-<!-- SECTION:PLAN:END -->
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -2156,10 +2156,14 @@ class SubscriptionsDB(BaseDB):
         The Starred rail node's badge (TASK-3072). Status-agnostic on
         purpose: starring is orthogonal to triage, and a badge that shrank
         as the user read their starred items would read as data loss.
+
+        Returns:
+            The count of rows with ``is_flagged = 1``.
         """
-        row = self.conn.execute(
-            "SELECT COUNT(*) FROM subscription_items WHERE is_flagged = 1"
-        ).fetchone()
+        with self.transaction() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM subscription_items WHERE is_flagged = 1"
+            ).fetchone()
         return int(row[0]) if row else 0
 
     def insert_briefing(self, watchlist_id: int, status: str = "generating") -> int:

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -1848,7 +1848,13 @@ class SubscriptionsDB(BaseDB):
 
         Returns:
             One dict per item row, joined to its subscription's name and type,
-            ordered by `created_at` descending.
+            ordered by EFFECTIVE date descending (`published_date`, falling
+            back to `created_at` when the feed supplied none -- TASK-3072).
+            The COALESCE compares stored strings, which is exact for
+            same-shape ISO and approximate across mixed offsets; the reader
+            re-sorts its displayed page precisely in Python
+            (`Subscriptions/item_dates.py`), so this clause's job is picking
+            the right PAGE, not the final row order.
 
         Raises:
             ValueError: If both `status` and `statuses` are passed.
@@ -1898,7 +1904,7 @@ class SubscriptionsDB(BaseDB):
                 FROM subscription_items i
                 JOIN subscriptions s ON i.subscription_id = s.id
                 {where_clause}
-                ORDER BY i.created_at DESC
+                ORDER BY COALESCE(i.published_date, i.created_at) DESC
                 LIMIT ?
                 """,
                 tuple(params),

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -1799,6 +1799,7 @@ class SubscriptionsDB(BaseDB):
         watchlist_id: Optional[int] = None,
         unassigned_only: bool = False,
         statuses: Optional[List[str]] = None,
+        is_flagged: Optional[bool] = None,
     ) -> List[Dict[str, Any]]:
         """Items for a subscription (or all of them), newest first.
 
@@ -1840,6 +1841,10 @@ class SubscriptionsDB(BaseDB):
                 bucket by name passes `status="new"`, or names `"new"` in
                 `statuses`); passing both is rejected rather than silently
                 intersected.
+            is_flagged: Restrict to starred rows (`True`) or unstarred rows
+                (`False`), or `None` to not filter by the flag at all
+                (TASK-3072 -- the Starred feed's page). Composes with every
+                other predicate, the same as the membership scopes.
 
         Returns:
             One dict per item row, joined to its subscription's name and type,
@@ -1880,6 +1885,9 @@ class SubscriptionsDB(BaseDB):
             placeholders = ", ".join("?" for _ in statuses)
             predicates.append(f"i.status IN ({placeholders})")
             params.extend(statuses)
+        if is_flagged is not None:
+            predicates.append("i.is_flagged = ?")
+            params.append(1 if is_flagged else 0)
         where_clause = f"WHERE {' AND '.join(predicates)}" if predicates else ""
         params.append(limit)
 
@@ -2115,6 +2123,38 @@ class SubscriptionsDB(BaseDB):
                 "UPDATE subscription_items SET queued_for_briefing = ? WHERE id = ?",
                 (1 if queued else 0, item_id),
             )
+
+    def set_item_flagged(self, item_id: int, flagged: bool) -> None:
+        """Set or clear the global "starred" flag on one item (TASK-3072).
+
+        Same shape and same global semantics as `set_item_briefing_queued`:
+        one row, one flag -- an item starred through any scope reads starred
+        in all of them, and nothing but this explicit call changes it.
+        `persist_subscription_item` never writes the column, so the flag
+        survives re-fetches (pinned in
+        `Tests/DB/test_subscriptions_db_watchlists.py`).
+
+        Args:
+            item_id: `subscription_items.id` to update.
+            flagged: `True` to star the item, `False` to unstar it.
+        """
+        with self.transaction() as conn:
+            conn.execute(
+                "UPDATE subscription_items SET is_flagged = ? WHERE id = ?",
+                (1 if flagged else 0, item_id),
+            )
+
+    def get_flagged_items_count(self) -> int:
+        """How many items are starred, across every source and status.
+
+        The Starred rail node's badge (TASK-3072). Status-agnostic on
+        purpose: starring is orthogonal to triage, and a badge that shrank
+        as the user read their starred items would read as data loss.
+        """
+        row = self.conn.execute(
+            "SELECT COUNT(*) FROM subscription_items WHERE is_flagged = 1"
+        ).fetchone()
+        return int(row[0]) if row else 0
 
     def insert_briefing(self, watchlist_id: int, status: str = "generating") -> int:
         """Create a new `briefings` row for a watchlist.

--- a/tldw_chatbook/Subscriptions/html_text.py
+++ b/tldw_chatbook/Subscriptions/html_text.py
@@ -368,3 +368,36 @@ def readable_body_text(value: Any) -> str:
     if looks_like_html(value):
         return html_to_display_text(value)
     return strip_control_characters(value)
+
+
+def body_snippet(value: Any, *, max_chars: int = 160) -> str:
+    """The one-line preview an article-list row shows under its title.
+
+    task-3072. Built ON `readable_body_text`, so the whole hostile-input
+    discipline of this module comes along for free: tags and script/style
+    bodies are stripped, control characters removed, plain-text feeds pass
+    through. What remains is collapsed to a single line (a row has no room
+    for the block structure `html_to_display_text` preserves) and truncated
+    on a word boundary with an ellipsis.
+
+    Args:
+        value: The stored item body; may be None.
+        max_chars: Budget for the whole snippet, ellipsis included.
+
+    Returns:
+        At most `max_chars` of inert plain text ("" for empty input). The
+        output is TEXT, not markup: if the row renders it through a
+        markup-parsing widget, escaping is that boundary's job, the same
+        rule `content_pane.render_article` states for the reader body.
+    """
+    text = " ".join(readable_body_text(value).split())
+    if not text or len(text) <= max_chars:
+        return text
+    if max_chars <= 1:
+        return "…"[:max_chars]
+    # Cut at the last space inside the budget so the ellipsis never lands
+    # mid-word; a text with no space in range is cut hard instead.
+    cut = text.rfind(" ", 0, max_chars)
+    if cut <= 0:
+        cut = max_chars - 1
+    return text[:cut] + "…"

--- a/tldw_chatbook/Subscriptions/item_dates.py
+++ b/tldw_chatbook/Subscriptions/item_dates.py
@@ -1,0 +1,155 @@
+"""Stored-date reading for the Watchlists reader (task-3072).
+
+The article list renders two things from an item's dates: a relative time
+on the row ("9:41 AM", "Yesterday") and a local-day group header ("Today",
+"Yesterday", "August 01, 2026"). Both need the same three decisions made
+in exactly one place:
+
+**One parser rule: naive means UTC.** `published_date` is stored ISO-8601
+but mixed naive/aware -- `monitoring_engine._parse_date` returns
+timezone-less strings for several feed formats while URL monitors store
+aware UTC. Attaching naive values to the local zone would silently shift
+every such row by the user's offset. This parser is MOVED OUT of
+`UI/Watchlists_Modules/humane_time.py` (TASK-2308), where it was born:
+parsing a stored value is a data-layer concern, and the layer direction is
+UI -> Subscriptions, never the reverse -- a helper in `Subscriptions/`
+cannot import from `UI/`. `humane_time` re-exports this function as
+`parse_timestamp`; its public API is unchanged.
+
+**The effective date.** `created_at` is INGEST time -- every item one
+check produces carries the same value to the microsecond. TASK-2308
+already showed that presenting it under a "Published" heading is how a
+reader loses trust in the list, so a row sorts and renders by
+`published_date`, falling back to `created_at` only when the feed itself
+omitted a date (feed parsing returns `None` rather than defaulting to
+"now").
+
+**Bucketing is Python-side, not SQL.** Group headers and "Today" semantics
+are computed over displayed rows in the viewer's local zone. The stored
+tz strings cannot be trusted to SQL date functions (the mixed
+naive/aware problem above), and the row set is page-bounded, so the Python
+pass costs nothing.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+__all__ = [
+    "parse_stored_datetime",
+    "effective_date",
+    "relative_time",
+    "day_bucket",
+]
+
+#: Group header for rows whose effective date could not be determined at
+#: all. Rendering a labelled group over a real item is honest; dropping the
+#: row or inventing a date would not be.
+UNKNOWN_DATE_HEADER = "Unknown date"
+
+
+def parse_stored_datetime(value: Any) -> datetime | None:
+    """Parse the timestamp shapes this app actually stores.
+
+    Args:
+        value: A `datetime`, a `date`, or a string. ISO-8601 with or without
+            microseconds, with a `T` or a space separator, with a `Z` suffix,
+            a numeric offset, or nothing at all.
+
+    Returns:
+        A timezone-aware `datetime` in UTC, or `None` when the value is empty
+        or cannot be read. A date with no time component is returned as
+        midnight UTC -- callers that care about the distinction should check
+        the input, not the result.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+    text = str(value).strip()
+    if not text:
+        return None
+    # `fromisoformat` accepts `Z` from 3.11, but normalizing it here keeps this
+    # working if the minimum ever moves back down, and costs one comparison.
+    if text.endswith(("Z", "z")):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def effective_date(item: dict[str, Any]) -> datetime | None:
+    """The instant an item is sorted and rendered by.
+
+    `published_date` when the feed supplied one (and it parses), otherwise
+    `created_at` -- ingest time, used but never *presented* as a publish
+    date (see the module docstring). `None` when the item carries neither
+    or neither parses.
+    """
+    published = parse_stored_datetime(item.get("published_date"))
+    if published is not None:
+        return published
+    return parse_stored_datetime(item.get("created_at"))
+
+
+def _localize(dt: datetime) -> datetime:
+    """`dt` in the viewer's local zone, naive attached to UTC first."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone()
+
+
+def _reference(now: datetime | None) -> datetime:
+    """The injected or current instant, as a local-zone datetime."""
+    reference = now if now is not None else datetime.now(timezone.utc)
+    return _localize(reference)
+
+
+def relative_time(dt: datetime | None, *, now: datetime | None = None) -> str:
+    """Render an effective date for line 1 of an article row.
+
+    Clock time for today ("9:41 AM"), "Yesterday", a month-day for another
+    day this year ("Aug 04"), ISO for older ("2025-12-31"), "-" for a
+    missing date. Distinct from `humane_time.humane_timestamp`, which is the
+    house style for table CELLS ("Today 18:15"): the row already sits under
+    a day-group header, so repeating "Today" on every row is noise, and a
+    24-hour clock is not how the reference readers render times.
+    """
+    if dt is None:
+        return "-"
+    local = _localize(dt)
+    reference_local = _reference(now)
+    today = reference_local.date()
+    if local.date() >= today:
+        # `>=` deliberately: future-dated items (bad feed clocks) render as
+        # now-ish rather than a negative countdown.
+        return local.strftime("%I:%M %p").lstrip("0")
+    if local.date() == today - timedelta(days=1):
+        return "Yesterday"
+    if local.year == reference_local.year:
+        return local.strftime("%b %d")
+    return local.strftime("%Y-%m-%d")
+
+
+def day_bucket(dt: datetime | None, *, now: datetime | None = None) -> str:
+    """The group-header label for an effective date, in the viewer's zone.
+
+    "Today" / "Yesterday" / a full date ("August 01, 2026"). Future-dated
+    items (bad feed clocks) bucket into Today rather than floating above
+    the list under a header of their own. `None` buckets into
+    `UNKNOWN_DATE_HEADER` so a dateless item still has a group to live in.
+    """
+    if dt is None:
+        return UNKNOWN_DATE_HEADER
+    local = _localize(dt)
+    today = _reference(now).date()
+    if local.date() >= today:
+        return "Today"
+    if local.date() == today - timedelta(days=1):
+        return "Yesterday"
+    return local.strftime("%B %d, %Y")

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -635,6 +635,28 @@ class LocalWatchlistsService:
                 raise ValueError(f"Invalid watchlist item id: {item_id!r}") from exc
         return self._db().restore_items_new(row_ids)
 
+    async def set_item_flagged(self, *, item_id: Any, flagged: bool) -> None:
+        """Star or unstar one item (TASK-3072 plan task 7).
+
+        The write behind the reader's `s` key and Star button. Thin delegate
+        to `SubscriptionsDB.set_item_flagged` -- one row, one global flag,
+        with the same ``int(...)`` id normalization `restore_items_new`
+        applies to its ids.
+
+        Args:
+            item_id: The local row id (bare, already denamespaced by the
+                scope service).
+            flagged: `True` to star the item, `False` to unstar it.
+
+        Raises:
+            ValueError: If the id is not an integer id.
+        """
+        try:
+            row_id = int(item_id)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid watchlist item id: {item_id!r}") from exc
+        self._db().set_item_flagged(row_id, bool(flagged))
+
     async def delete_source(self, source_id: Any) -> dict[str, Any]:
         success = self._db().delete_subscription(int(source_id))
         return {

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -363,6 +363,7 @@ class LocalWatchlistsService:
         watchlist_id: Any = None,
         unassigned_only: bool = False,
         statuses: list[str] | None = None,
+        is_flagged: bool | None = None,
     ) -> list[dict[str, Any]]:
         """List watchlist items from the local subscriptions database.
 
@@ -404,6 +405,9 @@ class LocalWatchlistsService:
                 `None` to defer to `status`. Safe to combine with the default
                 falsey `status` only -- `get_new_items` rejects passing both
                 a truthy `status` and `statuses`.
+            is_flagged: Restrict to starred rows (`True`) or unstarred rows
+                (`False`), or `None` -- the default -- to not filter by the
+                flag at all (TASK-3072).
 
         Returns:
             Normalized item dicts for the requested window.
@@ -420,6 +424,7 @@ class LocalWatchlistsService:
             watchlist_id=int(watchlist_id) if watchlist_id is not None else None,
             unassigned_only=bool(unassigned_only),
             statuses=list(statuses) if statuses is not None else None,
+            is_flagged=is_flagged,
         )
         normalized = [normalize_watchlist_item("local", row) for row in rows]
         return normalized[int(offset) : int(offset) + int(limit)]

--- a/tldw_chatbook/Subscriptions/watchlist_bundle_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_bundle_service.py
@@ -374,3 +374,16 @@ class WatchlistBundleService:
             sources with no items are absent.
         """
         return self._db.get_source_item_counts()
+
+    def get_flagged_items_count(self) -> int:
+        """Global starred-item count, for the Starred root's badge (TASK-3072).
+
+        Thin delegation, same contract as `get_watchlist_item_counts` above:
+        the tree's loader reaches every one of its inputs through this
+        service rather than holding a second accessor onto
+        ``SubscriptionsDB`` directly.
+
+        Returns:
+            How many items are starred, across every source and status.
+        """
+        return self._db.get_flagged_items_count()

--- a/tldw_chatbook/Subscriptions/watchlist_normalizers.py
+++ b/tldw_chatbook/Subscriptions/watchlist_normalizers.py
@@ -590,6 +590,8 @@ def normalize_watchlist_item(source: str, row: Mapping[str, Any]) -> dict[str, A
         # column -- coerce SQLite's 0/1 to an actual bool, or every
         # downstream consumer sees a truthy int instead of a real flag.
         "queued_for_briefing": bool(row.get("queued_for_briefing")),
+        # task-3072: same column-present/bool-coercion shape for the star.
+        "is_flagged": bool(row.get("is_flagged")),
         # `canonical_url` is deliberately NOT re-exported as its own key: it
         # is already folded into `url` two lines above (`row.get("url") or
         # row.get("canonical_url")`), and a second copy under a second name

--- a/tldw_chatbook/Subscriptions/watchlist_scope_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_scope_service.py
@@ -224,6 +224,7 @@ class WatchlistScopeService:
         watchlist_id: Any = None,
         unassigned_only: bool = False,
         statuses: list[str] | None = None,
+        is_flagged: bool | None = None,
     ) -> list[dict[str, Any]]:
         """List content items for watchlist sources.
 
@@ -243,6 +244,9 @@ class WatchlistScopeService:
                 watchlist (TASK-2513).
             statuses: Optional list of statuses to match any of (TASK-2513);
                 combine only with a falsey ``status``.
+            is_flagged: Restrict to starred rows (``True``) or unstarred
+                rows (``False``), or ``None`` to not filter by the flag
+                (TASK-3072 -- the Starred feed's scope).
 
         Returns:
             List of normalized watchlist item dicts.
@@ -266,6 +270,7 @@ class WatchlistScopeService:
                 watchlist_id=watchlist_id,
                 unassigned_only=unassigned_only,
                 statuses=statuses,
+                is_flagged=is_flagged,
             )
         )
 

--- a/tldw_chatbook/Subscriptions/watchlist_scope_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_scope_service.py
@@ -445,6 +445,45 @@ class WatchlistScopeService:
             await self._maybe_await(service.restore_items_new(item_ids=row_ids))
         )
 
+    async def set_item_flagged(
+        self,
+        *,
+        runtime_backend: WatchlistBackend | str | None = None,
+        item_id: Any,
+        flagged: bool,
+    ) -> None:
+        """Star or unstar one item (TASK-3072 plan task 7).
+
+        Routed as ``items.update`` like `update_item`/`mark_all_read`: it is
+        the same kind of write -- one flag on one `subscription_items` row.
+
+        Args:
+            runtime_backend: Target backend (``local`` or ``server``).
+            item_id: Item identifier, namespaced
+                (``local:watchlist_item:7``) or bare -- denamespaced exactly
+                as `update_item` does.
+            flagged: `True` to star the item, `False` to unstar it.
+
+        Raises:
+            ValueError: If the server backend is requested; item writes are
+                local-only, mirroring `update_item` -- the server API carries
+                no item-flag route.
+        """
+        backend = self._normalize_backend(runtime_backend)
+        self._enforce_policy(backend, "items.update")
+        if backend == WatchlistBackend.SERVER:
+            raise ValueError(
+                "Item star updates are only supported for the local backend "
+                "in this slice."
+            )
+        service = self._service_for_backend(backend)
+        await self._maybe_await(
+            service.set_item_flagged(
+                item_id=self._source_id_from_item_id(item_id),
+                flagged=bool(flagged),
+            )
+        )
+
     async def get_watch_item_detail(
         self,
         item_id: Any,

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -134,10 +134,10 @@ from ..Watchlists_Modules.content_pane import (
     UnreadToggleRequested,
     ViewSnapshotRequested,
 )
+from ..Watchlists_Modules.article_list import ArticleListPane
 from ..Watchlists_Modules.items_pane import (
     ItemSelected,
     ItemsFilterChanged,
-    ItemsPane,
     NextUnreadRequested,
     RefreshItemsRequested,
 )
@@ -273,6 +273,26 @@ _ITEM_STATUS_DRAIN_GROUP_PREFIX = "wl-item-status-drain:"
 #: A frozenset, since `_blocking_status_for` now asks the backend for the
 #: item's one status and only has to decide whether it is in this set.
 _NON_READ_STATE_STATUSES: frozenset[str] = frozenset({"ingested", "ignored", "error"})
+
+#: Statuses the reader's "All" filter actually queries (TASK-3072). "All" in
+#: a reader means "everything I might still want to read", not "every row in
+#: the table": `ignored` items were explicitly triaged away and `error` rows
+#: are a Runs-tab concern, so neither belongs in the article list.
+_READER_ALL_STATUSES: tuple[str, ...] = ("new", "reviewed", "ingested")
+
+
+def _normalize_items_status_filter(value: Any) -> str:
+    """Map any stored items-filter value onto the reader's Unread/All pair.
+
+    TASK-3072. `ArticleListPane`'s Select only offers `unread`/`all`, but the
+    screen mirrors the filter across workbench rebuilds and the pre-reader
+    `ItemsPane` used per-status values (`new`, `reviewed`, `ignored`, ...).
+    Seeding one of those into the two-option Select would raise, so every
+    read of the mirrored value goes through here: legacy `new` is exactly
+    the reader's `unread`; everything else falls back to `all`.
+    """
+    text = str(value or "").strip().lower()
+    return "unread" if text in {"unread", "new"} else "all"
 
 
 @dataclass(frozen=True)
@@ -1982,15 +2002,20 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         elif self.active_section == "items":
             # Seed the last-loaded rows (Finding 2, fix round 2) — see the
             # note on `sources_pane.sources` above; same rebuild, same gap.
-            items_pane = ItemsPane(id="watchlists-items-pane")
+            items_pane = ArticleListPane(id="watchlists-items-pane")
             items_pane.items = self._loaded_items
             # Seed the filter, the search box and the selection too
             # (whole-branch review, Important) -- the sibling Sources/Runs/
             # Notifications panes above and below already re-seed their
             # selection, and this one seeded only `.items`, so every rebuild
             # silently reset the user's filtered view to "all items, nothing
-            # selected". See `_items_status_filter` in `__init__`.
-            items_pane.status_filter = self._items_status_filter
+            # selected". See `_items_status_filter` in `__init__`. The value
+            # goes through `_normalize_items_status_filter` (TASK-3072): the
+            # mirror can still hold a pre-reader per-status value, which the
+            # two-option Select would reject.
+            items_pane.status_filter = _normalize_items_status_filter(
+                self._items_status_filter
+            )
             items_pane.search_query = self._items_search_query
             items_pane.selected_item = self._selected_content_item
             children.append(items_pane)
@@ -6175,7 +6200,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             if not self.is_mounted:
                 return
             try:
-                items_pane = self.query_one("#watchlists-items-pane", ItemsPane)
+                items_pane = self.query_one("#watchlists-items-pane", ArticleListPane)
             except NoMatches:
                 return
             items_pane.select_and_reveal(item)
@@ -8383,8 +8408,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
         stop_audio_playback_if_current(Path(str(file_path)))
 
-    def _items_status_query(self) -> str | None:
-        """The status the item PAGE should be fetched for, or `None` for all.
+    def _items_status_kwargs(self) -> dict[str, Any]:
+        """The status predicate the item PAGE should be fetched with.
 
         Review wave, I2. TASK-2301 made `_load_items` ask for every status,
         which fixed "triaged items are unreachable" and quietly broke a
@@ -8398,16 +8423,22 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         which is the defect class this batch exists to remove.
 
         Pushing the active filter into the query makes a page 100 rows OF THE
-        FILTERED STATUS, so "New" can reach unread items however deep they sit.
-        "All statuses" is unchanged: it genuinely wants a mixed page.
+        FILTERED STATUS, so "Unread" can reach unread items however deep they
+        sit. TASK-3072 renames the filter vocabulary to the reader's
+        Unread/All pair (`_normalize_items_status_filter`): "unread" queries
+        `status="new"`; "all" queries `_READER_ALL_STATUSES` -- every status
+        a reader can still act on, excluding `ignored` (triaged away on
+        purpose) and `error` (a Runs-tab concern), which the pre-reader
+        pane's literal "all statuses" mixed in.
 
         The pane keeps its own in-memory filter as well. That is not redundant
         -- it is what pins the currently-open item into a view its status no
         longer matches (see `_filtered_items`), and it is what makes the list
         correct in the window between a filter change and its reload landing.
         """
-        status = str(self._items_status_filter or "all")
-        return None if status == "all" else status
+        if _normalize_items_status_filter(self._items_status_filter) == "unread":
+            return {"status": "new"}
+        return {"statuses": list(_READER_ALL_STATUSES)}
 
     def _items_scope_query(self) -> dict[str, Any]:
         """The tree scope as `list_items` kwargs.
@@ -8460,16 +8491,24 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         this sequence, and an item teleporting to the top of the list when its
         status changed would be its own small lie.
 
+        TASK-3072 removed the old "All statuses covers everything" skip: the
+        reader's "all" is itself a restricted query (`_READER_ALL_STATUSES`),
+        so BOTH filters can now return a page without the open item, and the
+        pin applies unconditionally. Under "all" the common case still
+        short-circuits on the open item being present; the pin only fires
+        when the item genuinely fell out of the query -- e.g. it was ignored
+        while open, which is exactly the "the article I'm reading vanished"
+        moment this method exists to prevent.
+
         Args:
             page: The rows the backend returned for the current filter.
 
         Returns:
-            `page` unchanged when no item is open, when the filter is "All
-            statuses" (the page already covers every status), or when the open
-            item is in it already; otherwise `page` plus that one item.
+            `page` unchanged when no item is open or when the open item is
+            in it already; otherwise `page` plus that one item.
         """
         open_item = self._selected_content_item
-        if open_item is None or self._items_status_query() is None:
+        if open_item is None:
             return page
         open_id = str(open_item.get("id") or "")
         if not open_id or any(str(row.get("id")) == open_id for row in page):
@@ -8486,9 +8525,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         try:
             items = await self._controller.list_items(
                 runtime_backend=self.runtime_backend,
-                status=self._items_status_query(),
                 limit=100,
                 offset=0,
+                **self._items_status_kwargs(),
                 **self._items_scope_query(),
             )
             # Mirror to screen state (Finding 2, fix round 2) — see the note
@@ -8499,7 +8538,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             )
             if self._dom_is_live:
                 try:
-                    items_pane = self.query_one("#watchlists-items-pane", ItemsPane)
+                    items_pane = self.query_one("#watchlists-items-pane", ArticleListPane)
                     items_pane.items = self._loaded_items
                 except Exception:
                     pass
@@ -9013,18 +9052,24 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         """Mirror the Items filter/search, and re-page when the STATUS moves.
 
         Review wave, I2. The status is now part of the query
-        (`_items_status_query`), so changing it has to re-fetch or the pane is
+        (`_items_status_kwargs`), so changing it has to re-fetch or the pane is
         left filtering the previous status's page in memory -- which is exactly
         the "the filter can only narrow what was already fetched" defect this
         fix removes.
 
         Gated on the status ACTUALLY changing. This message also fires on every
         keystroke in the search box, which is a purely in-memory filter and
-        must not cost a query per character.
+        must not cost a query per character. Both sides are compared through
+        `_normalize_items_status_filter` (TASK-3072): a pre-reader `new`
+        still sitting in the mirror IS the reader's `unread`, and must not
+        trigger a spurious reload when the pane first posts it.
         """
         event.stop()
-        status_changed = event.status_filter != self._items_status_filter
-        self._items_status_filter = event.status_filter
+        incoming = _normalize_items_status_filter(event.status_filter)
+        status_changed = incoming != _normalize_items_status_filter(
+            self._items_status_filter
+        )
+        self._items_status_filter = incoming
         self._items_search_query = event.search_query
         if status_changed:
             # Own group, as in `watch_tree_scope`: an exclusive reload in
@@ -9384,7 +9429,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     row_key = entity.get("id")
         if row_key is not None:
             try:
-                pane = self.query_one("#watchlists-items-pane", ItemsPane)
+                pane = self.query_one("#watchlists-items-pane", ArticleListPane)
                 pane.update_item_queued_cell(row_key, queued)
             except NoMatches:
                 pass
@@ -9601,7 +9646,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def _repaint_item_status_cell(self, item_id: Any, status: str) -> None:
         """Push a patched status into the mounted Items table's Status cell."""
         try:
-            pane = self.query_one("#watchlists-items-pane", ItemsPane)
+            pane = self.query_one("#watchlists-items-pane", ArticleListPane)
         except NoMatches:
             return
         pane.update_item_status_cell(item_id, status)
@@ -9913,7 +9958,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if self.active_section != "items":
             return
         try:
-            pane = self.query_one("#watchlists-items-pane", ItemsPane)
+            pane = self.query_one("#watchlists-items-pane", ArticleListPane)
         except NoMatches:
             return
         items = pane.displayed_items()
@@ -10016,7 +10061,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if self.active_section != "items":
             return
         try:
-            pane = self.query_one("#watchlists-items-pane", ItemsPane)
+            pane = self.query_one("#watchlists-items-pane", ArticleListPane)
         except NoMatches:
             return
         items = pane.displayed_items()
@@ -10126,7 +10171,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         currently rendered are skipped inside `update_item_status_cell`.
         """
         try:
-            pane = self.query_one("#watchlists-items-pane", ItemsPane)
+            pane = self.query_one("#watchlists-items-pane", ArticleListPane)
         except NoMatches:
             return
         for item in pane.displayed_items():

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -131,6 +131,7 @@ from ..Watchlists_Modules.briefing_preset_modal import BriefingPresetModal
 from ..Watchlists_Modules.content_pane import (
     ContentPane,
     ExpandReaderRequested,
+    StarToggleRequested,
     UnreadToggleRequested,
     ViewSnapshotRequested,
 )
@@ -436,6 +437,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # deliberately NOT here — it is bound on ItemsPane so it cannot fire
         # from the rail (see `NextUnreadRequested`).
         ("m", "toggle_read_selected", "Read/Unread"),
+        # TASK-3072 plan task 7: NNW's one-key star. Same resolution and
+        # gating as `m` (`_reader_verb_blocked`, the open item), one shared
+        # handler with the reader's Star button.
+        ("s", "toggle_star_selected", "Star"),
         ("a", "mark_all_read", "Mark all read"),
         ("u", "undo_mark_all_read", "Undo mark-all-read"),
         ("z", "toggle_region", "Collapse"),
@@ -10058,6 +10063,72 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             item_id,
             _ItemStatusIntent(status=target, gate=True, refresh=False, patch_item=item),
         )
+        self._request_tree_counts_refresh()
+
+    def action_toggle_star_selected(self) -> None:
+        """`s`: star or unstar the open item (TASK-3072 plan task 7).
+
+        Resolves the item and gates exactly like `action_toggle_read_selected`
+        (typing in an Input is typing, and the verb is scoped to the Read
+        tab), then shares `_toggle_item_star` with the reader's Star button.
+        """
+        if self._reader_verb_blocked():
+            return
+        item = self._selected_content_item
+        if item is None:
+            return
+        self._toggle_item_star(item)
+
+    @on(StarToggleRequested)
+    def handle_star_toggle_requested(self, event: StarToggleRequested) -> None:
+        """The reader's Star button takes the same path as `s`."""
+        event.stop()
+        item = event.item or self._selected_content_item
+        if item is None:
+            return
+        self._toggle_item_star(item)
+
+    def _toggle_item_star(self, item: dict[str, Any]) -> None:
+        """Flip one item's star: write, patch, repaint, badge refresh.
+
+        The target reads from the live dict, which the worker patches after
+        a successful write -- so a second toggle unstars instead of
+        re-deriving from a stale flag (`patch_item`'s contract on the
+        read/unread side, restated for a flag there is no gate on: starring
+        is orthogonal to status, so an ingested item can be starred).
+        """
+        item_id = item.get("id")
+        if item_id is None:
+            return
+        target = not bool(item.get("is_flagged"))
+        self.run_worker(
+            self._toggle_star_worker(item_id, item, target),
+            exclusive=True,
+            group="wl-star-toggle",
+        )
+
+    async def _toggle_star_worker(
+        self, item_id: Any, item: dict[str, Any], target: bool
+    ) -> None:
+        """The write half of a star toggle, mirroring every other write
+        handler on this screen (a worker, never a render-path query)."""
+        notify = getattr(self.app_instance, "notify", None)
+        try:
+            await self._controller.set_item_flagged(
+                runtime_backend=self.runtime_backend, item_id=item_id, flagged=target
+            )
+        except Exception:
+            logger.opt(exception=True).debug("Failed to toggle an item's star.")
+            if callable(notify):
+                notify("Could not update the star.", severity="error")
+            return
+        item["is_flagged"] = target
+        try:
+            pane = self.query_one("#watchlists-items-pane", ArticleListPane)
+        except NoMatches:
+            pane = None
+        if pane is not None:
+            pane.update_item_starred_cell(item_id, target)
         self._request_tree_counts_refresh()
 
     @on(NextUnreadRequested)

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -186,6 +186,7 @@ from ..Watchlists_Modules.sources_pane import (
 )
 from ..Watchlists_Modules.watchlist_tree import (
     ALL_SOURCES_BUCKET,
+    STARRED_BUCKET,
     AddSourceToWatchlistRequested,
     CreateWatchlistRequested,
     DeleteWatchlistRequested,
@@ -1126,7 +1127,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         try:
             service = self._watchlist_bundle_service()
             self._tree_watchlists = service.list_watchlists()
-            self._tree_counts = service.get_watchlist_item_counts()
+            # Copy before inserting: the service's own mapping is its
+            # return-value contract, and the Starred smart feed's badge
+            # (TASK-3072) is a tree-only bucket -- it rides this mapping so
+            # every existing counts refresh updates it too.
+            counts = dict(service.get_watchlist_item_counts())
+            starred = service.get_flagged_items_count()
+            counts[STARRED_BUCKET] = {"total": starred, "unread": starred}
+            self._tree_counts = counts
             self._tree_source_counts = service.get_source_item_counts()
         except Exception:
             logger.opt(exception=True).debug("Failed to load watchlists tree data.")
@@ -1752,6 +1760,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             The scope's display name, unescaped.
         """
         scope = self.tree_scope
+        if scope.kind == "starred":
+            return "Starred"
         if scope.kind == "unassigned":
             return "Unassigned"
         if scope.kind == "watchlist" and scope.watchlist_id is not None:
@@ -5082,7 +5092,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             backend listing's own order. Every loaded source when the scope is
             `all`, or when the runtime backend is not `local`.
         """
-        if self.tree_scope.kind == "all" or self.runtime_backend != "local":
+        if self.tree_scope.kind in ("all", "starred") or self.runtime_backend != "local":
+            # `starred` scopes the ITEMS list (a flag predicate), not the
+            # Sources table -- every source can hold a starred item, so the
+            # truthful listing here is the same unscoped one `all` gets.
             return list(self._loaded_sources)
         allowed = {
             str(row.get("id")) for row in self.scoped_source_rows() if row.get("id") is not None
@@ -8450,6 +8463,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         regardless of the rail selection.
         """
         scope = self.tree_scope
+        if scope.kind == "starred":
+            # TASK-3072 plan task 6: the Starred smart feed. The flag is
+            # global (same ADR-018 semantics as the briefing queue), so no
+            # membership predicate -- just the flag itself.
+            return {"is_flagged": True}
         if scope.kind == "source" and scope.source_id is not None:
             return {"source_id": scope.source_id}
         if scope.kind == "watchlist" and scope.watchlist_id is not None:

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -2129,6 +2129,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         pane = ContentPane(id="watchlists-content-pane")
         pane.item = self._selected_content_item
         pane.expanded = self.region_layout.solo_region == Region.CONTENT
+        # TASK-3072 plan task 9: re-seed the footer the same way `item` is
+        # re-seeded just above, so a region rebuild re-renders the same
+        # position. Guarded inside `_reader_position_text` for the build
+        # order where the items pane is not mounted yet ("" then; the first
+        # selection pushes the real value).
+        pane.position = self._reader_position_text()
         return pane
 
     def _watchlists_are_empty(self) -> bool:
@@ -8593,10 +8599,37 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # `selected_entity` — see that seeding note above.
         self._selected_content_item = event.item
         try:
-            self.query_one("#watchlists-content-pane", ContentPane).item = event.item
+            content = self.query_one("#watchlists-content-pane", ContentPane)
+            content.item = event.item
+            content.position = self._reader_position_text()
         except NoMatches:
             pass
         self._mark_item_read_on_open(event.item)
+
+    def _reader_position_text(self) -> str:
+        """The reader footer's "N of M" (TASK-3072 plan task 9).
+
+        M is the article list's `displayed_items()` -- the list the user is
+        actually looking at, filter applied -- and N the open item's 1-based
+        place in it, so `j` and the footer walk the same sequence. The pane
+        holds no list state, which is why this is computed here and pushed
+        into its `position` reactive (the `_selected_content_item` re-seed
+        pattern). Empty when nothing is open (the footer is absent then,
+        never "0 of 0") or when the open item is not in the displayed list.
+        """
+        item = self._selected_content_item
+        if item is None:
+            return ""
+        try:
+            pane = self.query_one("#watchlists-items-pane", ArticleListPane)
+        except NoMatches:
+            return ""
+        items = pane.displayed_items()
+        open_id = str(item.get("id") or "")
+        for index, candidate in enumerate(items):
+            if str(candidate.get("id")) == open_id:
+                return f"{index + 1} of {len(items)}"
+        return ""
 
     def _mark_item_read_on_open(self, item: dict[str, Any] | None) -> None:
         """Opening an item in the reader marks it read (Task 5).

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 import asyncio
 import re
 import threading
+import webbrowser
 from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from loguru import logger
 from rich.markup import escape as escape_markup
@@ -131,6 +133,7 @@ from ..Watchlists_Modules.briefing_preset_modal import BriefingPresetModal
 from ..Watchlists_Modules.content_pane import (
     ContentPane,
     ExpandReaderRequested,
+    OpenInBrowserRequested,
     StarToggleRequested,
     UnreadToggleRequested,
     ViewSnapshotRequested,
@@ -441,6 +444,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # gating as `m` (`_reader_verb_blocked`, the open item), one shared
         # handler with the reader's Star button.
         ("s", "toggle_star_selected", "Star"),
+        # TASK-3072 plan task 8: open the item in the system browser,
+        # http/https only (the URL is a remote-derived string reaching an OS
+        # primitive, so the scheme check lives in the handler, not here).
+        ("o", "open_in_browser", "Open in browser"),
         ("a", "mark_all_read", "Mark all read"),
         ("u", "undo_mark_all_read", "Undo mark-all-read"),
         ("z", "toggle_region", "Collapse"),
@@ -10130,6 +10137,45 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if pane is not None:
             pane.update_item_starred_cell(item_id, target)
         self._request_tree_counts_refresh()
+
+    def action_open_in_browser(self) -> None:
+        """`o`: open the open item's URL in the system browser (TASK-3072 plan
+        task 8). Gated and resolved exactly like `m`/`s`."""
+        if self._reader_verb_blocked():
+            return
+        item = self._selected_content_item
+        if item is None:
+            return
+        self._open_item_in_browser(item)
+
+    @on(OpenInBrowserRequested)
+    def handle_open_in_browser_requested(self, event: OpenInBrowserRequested) -> None:
+        """The reader's Open button takes the same path as `o`."""
+        event.stop()
+        item = event.item or self._selected_content_item
+        if item is None:
+            return
+        self._open_item_in_browser(item)
+
+    def _open_item_in_browser(self, item: dict[str, Any]) -> None:
+        """`webbrowser.open`, http/https only.
+
+        A feed item's `url` is a REMOTE-derived string and `webbrowser.open`
+        hands it to the OS: a `javascript:`/`file:`/empty URL is refused
+        with a notification, never passed on -- validate at this boundary,
+        per `input_validation`'s convention that the sink's own contract
+        decides what is acceptable.
+        """
+        notify = getattr(self.app_instance, "notify", None)
+        url = str(item.get("url") or "").strip()
+        if not url or urlsplit(url).scheme.lower() not in ("http", "https"):
+            if callable(notify):
+                notify(
+                    "This item has no web URL to open (http/https only).",
+                    severity="warning",
+                )
+            return
+        webbrowser.open(url)
 
     @on(NextUnreadRequested)
     def handle_next_unread_requested(self, event: NextUnreadRequested) -> None:

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -9873,9 +9873,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
     def action_show_help(self) -> None:
         """Show a notification with available keyboard shortcuts."""
+        # TASK-3072 plan task 10: the reading-loop verbs join the help line.
+        # Decision 031: advertise only implemented actions -- every verb
+        # named here is bound above and covered by tests.
         self.app_instance.notify(
             "1=Read 2=Sources 3=Runs 4=Rules 5=Notifications 6=Artifacts "
-            "7=Overview | n=new d=delete/ignore c=check p=preview ?=help",
+            "7=Overview | n=new d=delete/ignore c=check p=preview ?=help | "
+            "j/k=move space=next-unread m=read/unread s=star o=open "
+            "a=mark-all-read u=undo",
             severity="information",
             timeout=8,
         )

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit
 
 from loguru import logger
 from rich.markup import escape as escape_markup
@@ -77,11 +76,12 @@ from ...Subscriptions.feed_server import (
     configured_bind_and_port,
     is_loopback_bind,
 )
+from ...Subscriptions.html_text import strip_control_characters
 from ...Subscriptions.watchlist_bundle_service import WatchlistBundleService
 from ...Subscriptions.watchlist_normalizers import normalize_watchlist_item
 from ...Third_Party.textual_fspicker import FileSave, SelectDirectory
 from ...TTS.audio_player import play_audio_file
-from ...Utils.input_validation import sanitize_string, validate_text_input
+from ...Utils.input_validation import sanitize_string, validate_text_input, validate_url
 from ...Utils.path_validation import validate_path_simple
 from ...Widgets.confirmation_dialog import ConfirmationDialog
 from ...Widgets.prune_safe_select import PruneSafeSelect
@@ -10174,6 +10174,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             pane = None
         if pane is not None:
             pane.update_item_starred_cell(item_id, target)
+        # The reader's Star button flips HERE, on the success path only --
+        # never optimistically in the pane (PR #1430 review): after a failed
+        # write there is no patch and no flip, so the label can never show
+        # the opposite of `item["is_flagged"]` until the next open.
+        try:
+            star_button = self.query_one("#content-star-button", Button)
+        except NoMatches:
+            star_button = None
+        if star_button is not None:
+            star_button.label = "★ Starred" if target else "☆ Star"
         self._request_tree_counts_refresh()
 
     def action_open_in_browser(self) -> None:
@@ -10196,17 +10206,21 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._open_item_in_browser(item)
 
     def _open_item_in_browser(self, item: dict[str, Any]) -> None:
-        """`webbrowser.open`, http/https only.
+        """`webbrowser.open`, gated by the shared URL validator.
 
         A feed item's `url` is a REMOTE-derived string and `webbrowser.open`
-        hands it to the OS: a `javascript:`/`file:`/empty URL is refused
-        with a notification, never passed on -- validate at this boundary,
-        per `input_validation`'s convention that the sink's own contract
-        decides what is acceptable.
+        hands it to the OS, so validation runs at this boundary through
+        `input_validation.validate_url` -- the centralized validator: only
+        well-formed http/https URLs with a valid host pass, and
+        whitespace/backslash/credential/malformed-host shapes are refused
+        with a notification, never passed on.
         """
         notify = getattr(self.app_instance, "notify", None)
-        url = str(item.get("url") or "").strip()
-        if not url or urlsplit(url).scheme.lower() not in ("http", "https"):
+        # Control characters first (a feed URL is remote-derived text, and
+        # the OS open is a shell-shaped sink on some platforms), then the
+        # centralized validator decides what is openable.
+        url = strip_control_characters(str(item.get("url") or "")).strip()
+        if not url or not validate_url(url):
             if callable(notify):
                 notify(
                     "This item has no web URL to open (http/https only).",

--- a/tldw_chatbook/UI/Watchlists_Modules/article_list.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/article_list.py
@@ -428,6 +428,14 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
         self._repaint_row(item_id, is_flagged=starred)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Route the strip's one button; stop every press from bubbling.
+
+        Args:
+            event: The button press; only `#items-refresh-button` carries a
+                meaning here (it posts `RefreshItemsRequested`), and every
+                id is stopped so a stray press cannot reach the screen's own
+                `Button.Pressed` handlers.
+        """
         button_id = str(event.button.id)
         if button_id == "items-refresh-button":
             self.post_message(RefreshItemsRequested())
@@ -506,6 +514,16 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
                 break
 
     def watch_selected_item(self, item: dict[str, Any] | None) -> None:
+        """Mirror a selection change to the screen as `ItemSelected`.
+
+        `is_mounted`-gated for the same reason as `_post_filter_changed`:
+        the screen seeds this reactive on a pane it has only just built, and
+        echoing the seed straight back is noise.
+
+        Args:
+            item: The newly selected normalized item dict, or `None` when
+                the selection cleared.
+        """
         if self.is_mounted:
             self.post_message(ItemSelected(item))
 

--- a/tldw_chatbook/UI/Watchlists_Modules/article_list.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/article_list.py
@@ -418,6 +418,15 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
         """
         self._repaint_row(item_id, queued_for_briefing=queued)
 
+    def update_item_starred_cell(self, item_id: Any, starred: bool) -> None:
+        """Repaint one row after a star write (TASK-3072 plan task 7).
+
+        Same naming note as `update_item_status_cell`. The star composes
+        with the status and queue repaints through the per-row overrides,
+        and -- like them -- never writes the shared dict back.
+        """
+        self._repaint_row(item_id, is_flagged=starred)
+
     def on_button_pressed(self, event: Button.Pressed) -> None:
         button_id = str(event.button.id)
         if button_id == "items-refresh-button":

--- a/tldw_chatbook/UI/Watchlists_Modules/article_list.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/article_list.py
@@ -1,0 +1,505 @@
+"""The Read tab's article list (task-3072).
+
+The reader-rows replacement for `ItemsPane`'s `DataTable`, in the Read
+section only (the spec's "Article list" section). One row is three lines --
+source · relative effective time, the title (bold while unread), a one-line
+snippet -- with a leading unread dot, trailing star/queued glyphs, an
+ingested marker, and locale day-group headers (Today / Yesterday / date)
+computed in Python over the displayed rows.
+
+Everything `ItemsPane` taught the hard way carries over, deliberately:
+`displayed_items()` / `select_and_reveal()`, the `_rendered_items`
+rendered-sequence authority, open-item pinning in the filter, the
+`ItemsFilterChanged` mirror, in-place single-row repaints (a recompose
+destroys the live list and drops focus), the search box's
+`select_on_focus=False` + recompose focus restore (TASK-3071), and the
+pane-bound `space` binding. The screen-facing API and message set are
+unchanged on purpose -- the construction-site swap is one line.
+
+Remote text is APPENDED to a `Text`, never parsed (the
+`content_pane.render_article` rule): a markup-shaped title renders as those
+literal characters, so there is no `escape_markup` here to corrupt ordinary
+brackets either.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from rich.text import Text
+from textual.containers import Horizontal, Vertical
+from textual.css.query import NoMatches
+from textual.reactive import reactive
+from textual.widgets import Button, Input, ListItem, ListView, Select, Static
+
+from ...Subscriptions.html_text import body_snippet, strip_control_characters
+from ...Subscriptions.item_dates import day_bucket, effective_date, relative_time
+from ...Widgets.prune_safe_select import PruneSafeSelect
+from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
+from .items_pane import (
+    ItemSelected,
+    ItemsFilterChanged,
+    NextUnreadRequested,
+    RefreshItemsRequested,
+)
+
+_EPOCH = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _sort_key(item: dict[str, Any]) -> datetime:
+    """Effective-date sort key; dateless items sink to the bottom."""
+    return effective_date(item) or _EPOCH
+
+
+def _render_row(item: dict[str, Any]) -> Text:
+    """One item as a three-line `Text`: meta, title, snippet.
+
+    Appended, never parsed -- see the module docstring. The status-derived
+    vocabulary is the filter's own (`_FILTER_OPTIONS`): `new` is "unread",
+    `reviewed` is "read", `ingested` renders read-styled with a marker.
+    """
+    status = str(item.get("status") or "new").lower()
+    unread = status == "new"
+    ingested = status == "ingested"
+
+    out = Text()
+    if unread:
+        out.append(f"{ArticleListPane._UNREAD_DOT} ", style="bold blue")
+    source = strip_control_characters(str(item.get("source_name") or "unknown source"))
+    out.append(source, style="dim")
+    stamp = relative_time(effective_date(item))
+    if stamp != "-":
+        out.append(f" · {stamp}", style="dim")
+    if item.get("is_flagged"):
+        out.append(f" {ArticleListPane._STAR_GLYPH}", style="yellow")
+    if item.get("queued_for_briefing"):
+        out.append(f" {ArticleListPane._QUEUED_GLYPH}", style="cyan")
+    if ingested:
+        # The spec's "small marker": read-styled rows plus a word, which is
+        # self-explaining in a way a third bare glyph could never be.
+        out.append(" · ingested", style="dim italic")
+    out.append("\n")
+
+    title = strip_control_characters(str(item.get("title") or "Untitled"))
+    if unread:
+        out.append(title, style="bold")
+    elif ingested:
+        out.append(title, style="dim")
+    else:
+        out.append(title)
+
+    snippet = body_snippet(item.get("content"))
+    if snippet:
+        out.append("\n")
+        out.append(snippet, style="dim")
+    return out
+
+
+class _DayHeader(ListItem):
+    """A date-group label row: display only, never selectable.
+
+    `disabled=True` is load-bearing, not cosmetic: Textual's ListView cursor
+    movement skips disabled children (`action_cursor_down` loops to the next
+    enabled node), so `j`/`k` and the arrow keys walk ITEMS only while the
+    headers stay visually interleaved.
+    """
+
+    def __init__(self, label: str) -> None:
+        super().__init__(Static(label, classes="article-day-header"), disabled=True)
+
+
+class _ArticleRow(ListItem):
+    """One displayed item. `item_id_key` is the row's stable identity for
+    selection and in-place repaints (the pane's `update_item_*_cell` API).
+
+    `display_overrides` accumulates the transient writes of every repaint so
+    far: a status repaint followed by a queued repaint must show BOTH, the
+    way ItemsPane's independent cells did, without either one writing back
+    to the shared item dict (see `_repaint_row`). Recomposes rebuild rows
+    from the dicts, which is precisely when the reload has made them fresh.
+    """
+
+    def __init__(self, item: dict[str, Any]) -> None:
+        self.item_id_key = str(item.get("id") or "")
+        self.display_overrides: dict[str, Any] = {}
+        super().__init__(Static(_render_row(item), classes="article-row"))
+
+
+class _ArticleListView(ListView):
+    """The rows' ListView, with the one cursor fix the headers require.
+
+    Stock `action_cursor_down` from `index=None` lands on child 0 blindly --
+    and child 0 here is a disabled day header, so the reader's FIRST arrow
+    press would visibly do nothing (Textual's disabled-skipping loop only
+    runs from a non-`None` index). From `None`, start at the first (down) or
+    last (up) ENABLED row instead, which is also what NetNewsWire does: the
+    first `j` selects the first article.
+    """
+
+    def action_cursor_down(self) -> None:
+        if self.index is None:
+            for index, node in enumerate(self._nodes):
+                if not node.disabled:
+                    self.index = index
+                    break
+        else:
+            super().action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        if self.index is None:
+            for index in range(len(self._nodes) - 1, -1, -1):
+                if not self._nodes[index].disabled:
+                    self.index = index
+                    break
+        else:
+            super().action_cursor_up()
+
+
+class ArticleListPane(RecomposeCaptureGuard, Vertical):
+    """Reader rows and filter for the watchlists Read tab.
+
+    Follows `ItemsPane`'s conventions verbatim (see the module docstring);
+    `RecomposeCaptureGuard` first for the same reason `ContentPane`
+    documents.
+    """
+
+    BINDINGS = [("space", "next_unread", "Next unread")]
+
+    #: App-controlled glyphs -- never item-derived text -- so no markup sink
+    #: can ever interpret them (the `ItemsPane._QUEUED_GLYPH` rule).
+    _UNREAD_DOT = "●"
+    _STAR_GLYPH = "★"
+    _QUEUED_GLYPH = "◆"
+
+    #: The spec's Unread / All toggle. "All" is the reader set: ignored
+    #: items stay hidden (the user hid them) and error items stay in Runs,
+    #: where they belong. The screen's `_load_items` pushes the same mapping
+    #: into the query, so a 100-row page is a page OF THIS FILTER.
+    _FILTER_OPTIONS = [
+        ("Unread", "unread"),
+        ("All", "all"),
+    ]
+    _READER_STATUSES = frozenset({"new", "reviewed", "ingested"})
+
+    items = reactive[list[dict[str, Any]]]([], recompose=True)
+    selected_item = reactive[dict[str, Any] | None](None)
+    status_filter = reactive("all", recompose=True)
+    search_query = reactive("", recompose=True)
+    runtime_backend = reactive("local", recompose=True)
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        #: The exact sequence `compose()` last turned into rows, headers
+        #: excluded. Same authority argument as `ItemsPane._rendered_items`:
+        #: rows are built once and status/queued repaints mutate item dicts
+        #: in place WITHOUT recomposing, so re-deriving the displayed
+        #: sequence afterwards can disagree with what is on screen.
+        self._rendered_items: list[dict[str, Any]] = []
+
+    def compose(self):
+        """Build the toolbar and the grouped rows, once per recompose.
+
+        Rows are sorted by effective date descending IN PYTHON over the
+        displayed set (the SQL COALESCE picks the page; mixed stored tz
+        shapes make it only approximate -- see `get_new_items`), with a
+        `_DayHeader` inserted wherever the bucket changes.
+        """
+        with Horizontal(id="items-toolbar", classes="destination-filter-strip"):
+            yield Button(
+                "Refresh",
+                id="items-refresh-button",
+                variant="primary",
+                tooltip="Reload the items list.",
+            )
+            yield Input(
+                placeholder="Search items...",
+                id="items-search-input",
+                value=self.search_query,
+                # `select_on_focus=False` is load-bearing (TASK-3071): this
+                # pane recomposes on every keystroke and recompose restores
+                # focus to the fresh input; with Textual's default the
+                # refocus would select-all and the next keystroke would
+                # REPLACE the query. See `ItemsPane.compose`'s full note.
+                select_on_focus=False,
+                compact=True,
+            )
+            yield PruneSafeSelect(
+                self._FILTER_OPTIONS,
+                value=self.status_filter,
+                id="items-status-select",
+                allow_blank=False,
+                compact=True,
+            )
+
+        filtered = self._filtered_items()
+        self._rendered_items = filtered
+        if not filtered:
+            yield Static(self._empty_text(), id="items-empty-state")
+        else:
+            rows: list[ListItem] = []
+            last_bucket: str | None = None
+            for item in filtered:
+                bucket = day_bucket(effective_date(item))
+                if bucket != last_bucket:
+                    rows.append(_DayHeader(bucket))
+                    last_bucket = bucket
+                rows.append(_ArticleRow(item))
+            # `initial_index=None`: no opening row-0 highlight announcement
+            # for a rebuilt list to fire -- the rebuilt-table highlight is
+            # exactly what `ItemsPane`'s focus gate existed to filter.
+            yield _ArticleListView(*rows, id="items-table", initial_index=None)
+        yield Static(
+            f"{self._UNREAD_DOT} unread · {self._STAR_GLYPH} starred · "
+            f"{self._QUEUED_GLYPH} queued for briefing",
+            id="items-queued-legend",
+            classes="watchlists-hint-line",
+        )
+
+    def _empty_text(self) -> str:
+        """What the list says when there is nothing to show."""
+        if self.status_filter == "unread" and not self.search_query.strip():
+            return "✓ All caught up"
+        return "No matching items"
+
+    def _filtered_items(self) -> list[dict[str, Any]]:
+        """Apply the Unread/All filter and search query, pinning the open
+        item, sorted by effective date descending.
+
+        The pin is verbatim `ItemsPane._filtered_items`: opening an item
+        marks it read, that write mutates the very dict this list is built
+        from, and the open item must not drop out of its own list mid-read.
+        Pinned by id rather than object identity (reloads rebuild the
+        dicts).
+        """
+        status_filter = self.status_filter
+        query = self.search_query.strip().lower()
+        selected = self.selected_item
+        selected_id: str | None = None
+        if isinstance(selected, dict) and selected.get("id") is not None:
+            selected_id = str(selected["id"])
+        results: list[dict[str, Any]] = []
+        for item in self.items:
+            if selected_id is not None and str(item.get("id")) == selected_id:
+                results.append(item)
+                continue
+            status = str(item.get("status") or "").lower()
+            if status_filter == "unread":
+                if status != "new":
+                    continue
+            elif status not in self._READER_STATUSES:
+                continue
+            if query:
+                text = " ".join(
+                    str(item.get(key) or "") for key in ("title", "url", "source_name", "status")
+                ).lower()
+                if query not in text:
+                    continue
+            results.append(item)
+        results.sort(key=_sort_key, reverse=True)
+        return results
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "items-search-input":
+            self.search_query = event.value
+        event.stop()
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if event.select.id == "items-status-select":
+            self.status_filter = str(event.value or "all")
+        event.stop()
+
+    def watch_status_filter(self, status_filter: str) -> None:
+        self._post_filter_changed()
+
+    def watch_search_query(self, search_query: str) -> None:
+        self._post_filter_changed()
+
+    async def recompose(self) -> None:
+        """Preserve search-box focus across the recompose typing triggers.
+
+        Verbatim port of `ItemsPane.recompose` (TASK-3071's shape): capture
+        WHO was focused before the teardown, restore it to the fresh input
+        after the `await`, and leave any other focus exactly as Textual
+        leaves it. `self.screen.focused`, never `self.app.focused` -- see
+        the original's `ScreenStackError` note.
+        """
+        try:
+            focused = self.screen.focused if self.is_mounted else None
+        except Exception:
+            focused = None
+        refocus_search = focused is not None and focused.id == "items-search-input"
+        await super().recompose()
+        if refocus_search and self.is_running:
+            self.call_after_refresh(self._restore_search_focus)
+
+    def _restore_search_focus(self) -> None:
+        """Focus the freshly recomposed search input, caret at end of query."""
+        try:
+            search = self.query_one("#items-search-input", Input)
+        except NoMatches:
+            return
+        search.focus()
+        search.cursor_position = len(search.value)
+
+    def _post_filter_changed(self) -> None:
+        """Mirror the filter state to the screen so a rebuild can restore it.
+
+        `is_mounted`-gated exactly like `ItemsPane._post_filter_changed`:
+        `_build_detail_pane` seeds these reactives on a pane it has only
+        just constructed, and echoing the seed straight back is noise.
+        """
+        if self.is_mounted:
+            self.post_message(ItemsFilterChanged(self.status_filter, self.search_query))
+
+    def _find_row(self, item_id: Any) -> _ArticleRow | None:
+        """The live row for one item id, or None when it is not rendered."""
+        if item_id is None:
+            return None
+        key = str(item_id)
+        for row in self.query(_ArticleRow):
+            if row.item_id_key == key:
+                return row
+        return None
+
+    def _repaint_row(self, item_id: Any, **writes: Any) -> None:
+        """Re-render one row's content in place, without a recompose.
+
+        The ListView shape of `ItemsPane`'s single-cell repaints: a status
+        or queue write must never recompose the list (a recompose destroys
+        the live rows and drops focus). The row is rendered from a merge of
+        its accumulated `display_overrides` over the stored dict, and the
+        overrides are deliberately NOT written back -- exact
+        `ItemsPane.update_item_status_cell` parity, and load-bearing: the
+        dicts in `self.items` are shared with the screen's
+        `_selected_content_item` and `ContentPane.item`, and the staleness of
+        that cache between a triage write and its reload is a documented
+        invariant the mark-unread guard tests pin
+        (`test_mark_unread_refuses_to_overwrite_an_item_ingested_by_the_real_gesture`).
+        Mutating the dict here would silently freshen that cache. The
+        mark-read-on-open path already mutates the dict screen-side via
+        `patch_item`, so its repaint is idempotent either way; every other
+        path is followed by a `_load_items()` reload that rebuilds the
+        dicts for real. Per-row accumulation (not a per-call merge) is what
+        lets a status repaint and a queued repaint compose the way
+        ItemsPane's independent cells did.
+        """
+        row = self._find_row(item_id)
+        if row is None:
+            return
+        item = next(
+            (candidate for candidate in self.items if str(candidate.get("id")) == row.item_id_key),
+            None,
+        )
+        if item is None:
+            return
+        row.display_overrides.update(writes)
+        try:
+            row.query_one(Static).update(
+                _render_row({**item, **row.display_overrides})
+            )
+        except NoMatches:
+            return
+
+    def update_item_status_cell(self, item_id: Any, status: str) -> None:
+        """Repaint one row after a status write.
+
+        Named for the `ItemsPane` method it replaces -- the screen's call
+        sites are the compatibility surface, and "cell" is one word of
+        drift nobody has to re-audit. The row re-bolds/un-bolds itself from
+        the new status.
+        """
+        self._repaint_row(item_id, status=status)
+
+    def update_item_queued_cell(self, item_id: Any, queued: bool) -> None:
+        """Repaint one row after a queued-for-briefing write.
+
+        Same naming note as `update_item_status_cell`.
+        """
+        self._repaint_row(item_id, queued_for_briefing=queued)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = str(event.button.id)
+        if button_id == "items-refresh-button":
+            self.post_message(RefreshItemsRequested())
+        event.stop()
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        event.stop()
+        if isinstance(event.item, _ArticleRow):
+            self.select_item_by_id(event.item.item_id_key)
+
+    def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
+        """Select on cursor movement, which is what a mouse click produces.
+
+        TASK-1105's rule, ported from `ItemsPane`: `Selected` fires only on
+        activation (Enter, second click), so a single click on any other row
+        would move the cursor and select nothing. The focus gate is the same
+        honest discriminator `highlight_is_user_driven` documents for
+        DataTable: programmatic index changes (a rebuild's opening
+        announcement, `select_and_reveal`) arrive at an UNFOCUSED list,
+        while every mouse- or keyboard-driven move arrives at a focused one.
+        """
+        event.stop()
+        if not isinstance(event.item, _ArticleRow):
+            return
+        try:
+            list_view = self.query_one("#items-table", ListView)
+        except NoMatches:
+            return
+        if not list_view.has_focus:
+            return
+        self.select_item_by_id(event.item.item_id_key)
+
+    def select_item_by_id(self, item_id: str) -> None:
+        """Select the item with the given id and notify listeners."""
+        item = None
+        for candidate in self.items:
+            if str(candidate.get("id") or "") == item_id:
+                item = candidate
+                break
+        self.selected_item = item
+
+    def displayed_items(self) -> list[dict[str, Any]]:
+        """The items actually rendered as rows right now (headers excluded).
+
+        Same authority argument as `ItemsPane.displayed_items`: returns the
+        sequence `compose()` actually turned into rows, not a fresh
+        `_filtered_items()` call -- the two diverge as soon as an item's
+        status is patched in place, and it is the rendered list the user is
+        looking at. The screen's `j`/`k` navigation walks THIS sequence.
+        """
+        if self.is_mounted and self._rendered_items:
+            return list(self._rendered_items)
+        return self._filtered_items()
+
+    def select_and_reveal(self, item: dict[str, Any] | None) -> None:
+        """Programmatic selection driven by the screen (`j`/`k` navigation).
+
+        Verbatim port of `ItemsPane.select_and_reveal`: keep
+        `selected_item`, the list's cursor, and its scroll position pointing
+        at the same item, and route the selection through the same
+        `watch_selected_item` -> `ItemSelected` path a click uses, so the
+        reader update and mark-read-on-open come along for free. Setting
+        `ListView.index` scrolls the row into view (`watch_index`).
+        """
+        self.selected_item = item
+        if item is None:
+            return
+        item_id = str(item.get("id") or "")
+        try:
+            list_view = self.query_one("#items-table", ListView)
+        except NoMatches:
+            return
+        for index, node in enumerate(list_view.children):
+            if isinstance(node, _ArticleRow) and node.item_id_key == item_id:
+                list_view.index = index
+                break
+
+    def watch_selected_item(self, item: dict[str, Any] | None) -> None:
+        if self.is_mounted:
+            self.post_message(ItemSelected(item))
+
+    def action_next_unread(self) -> None:
+        """`space`: ask the screen to open the next unread item."""
+        self.post_message(NextUnreadRequested())

--- a/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
@@ -39,6 +39,14 @@ _GLOBAL_STATUS_NOTE = (
     "everywhere it appears, in every watchlist that includes its source."
 )
 
+# The star is the same shape of fact as the read status (TASK-3072): one
+# global flag on the `subscription_items` row, not a per-watchlist copy, so
+# the tooltip says its scope the same way `_GLOBAL_STATUS_NOTE` does.
+_GLOBAL_STAR_NOTE = (
+    "Starring is shared: the star shows on this item everywhere it appears, "
+    "and feeds the Starred smart feed in the rail."
+)
+
 # Remote markdown bodies must not produce real terminal hyperlinks (PR #1091
 # review, F3; TASK-1348 AC#2 -- this is that decision, recorded).
 #
@@ -272,6 +280,18 @@ class ViewSnapshotRequested(Message):
         super().__init__()
 
 
+class StarToggleRequested(Message):
+    """Posted when the reader's Star button is pressed (TASK-3072 plan task 7).
+
+    Carries the full item dict (not just an id), same as
+    `UnreadToggleRequested`, so the screen's one star handler serves both
+    this button and the `s` key without a second lookup.
+    """
+
+    def __init__(self, item: dict[str, Any] | None) -> None:
+        self.item = item
+        super().__init__()
+
 class ExpandReaderRequested(Message):
     """Posted when the reader asks for (or gives back) the whole centre stack.
 
@@ -354,6 +374,17 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
                 tooltip=_GLOBAL_STATUS_NOTE,
                 compact=True,
             )
+            # TASK-3072 plan task 7: the same star the `s` key toggles, as a
+            # button. The label reflects the open item's state on compose;
+            # the press flips it optimistically in `on_button_pressed` (the
+            # authoritative dict patch lands screen-side, and the next open
+            # re-seeds from it).
+            yield Button(
+                "★ Starred" if self.item.get("is_flagged") else "☆ Star",
+                id="content-star-button",
+                tooltip=_GLOBAL_STAR_NOTE,
+                compact=True,
+            )
             # AC#2. `Z` does the same thing from the keyboard, and the tooltip
             # says so -- but only once the user knows the region has to be
             # focused first, which is exactly the knowledge F27 says nothing
@@ -392,6 +423,17 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
         if event.button.id == "content-mark-unread-button":
             event.stop()
             self.post_message(UnreadToggleRequested(self.item))
+        elif event.button.id == "content-star-button":
+            event.stop()
+            self.post_message(StarToggleRequested(self.item))
+            # Optimistic flip: no recompose (the reader must not tear down
+            # mid-press), and the shared item dict is patched screen-side on
+            # success -- the next open re-seeds the label from it.
+            event.button.label = (
+                "☆ Star"
+                if str(event.button.label).startswith("★")
+                else "★ Starred"
+            )
         elif event.button.id == "content-full-page-button":
             event.stop()
             self.post_message(ViewSnapshotRequested(self.item, "full_page"))

--- a/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
@@ -361,7 +361,12 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
     position: reactive[str] = reactive("")
 
     def watch_position(self, position: str) -> None:
-        """Re-render the footer Static in place -- never a reader recompose."""
+        """Re-render the footer Static in place -- never a reader recompose.
+
+        Args:
+            position: The screen-computed "N of M" string ("" clears the
+                footer); pushed by the screen on every selection change.
+        """
         try:
             self.query_one("#content-position", Static).update(position)
         except NoMatches:
@@ -411,10 +416,9 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
                 compact=True,
             )
             # TASK-3072 plan task 7: the same star the `s` key toggles, as a
-            # button. The label reflects the open item's state on compose;
-            # the press flips it optimistically in `on_button_pressed` (the
-            # authoritative dict patch lands screen-side, and the next open
-            # re-seeds from it).
+            # button. The label reflects the open item's state on compose and
+            # flips on the screen's SUCCESS path (see `on_button_pressed` --
+            # no optimistic flip, so it can never lie after a failed write).
             yield Button(
                 "★ Starred" if self.item.get("is_flagged") else "☆ Star",
                 id="content-star-button",
@@ -506,15 +510,11 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
             self.post_message(UnreadToggleRequested(self.item))
         elif event.button.id == "content-star-button":
             event.stop()
+            # No optimistic label flip (PR #1430 review): the write is async
+            # and can fail, and a label flipped on hope would then lie until
+            # the next open. The screen flips the label on the SUCCESS path
+            # (`_toggle_star_worker`), after the shared item dict is patched.
             self.post_message(StarToggleRequested(self.item))
-            # Optimistic flip: no recompose (the reader must not tear down
-            # mid-press), and the shared item dict is patched screen-side on
-            # success -- the next open re-seeds the label from it.
-            event.button.label = (
-                "☆ Star"
-                if str(event.button.label).startswith("★")
-                else "★ Starred"
-            )
         elif event.button.id == "content-open-button":
             event.stop()
             self.post_message(OpenInBrowserRequested(self.item))

--- a/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
@@ -12,6 +12,7 @@ from rich.console import Group, RenderableType
 from rich.markdown import Markdown
 from rich.text import Text
 from textual.containers import Horizontal, Vertical
+from textual.css.query import NoMatches
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Button, Static
@@ -21,6 +22,7 @@ from ...Subscriptions.item_persist import CONTENT_KIND_CHANGE
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
 from .humane_time import humane_timestamp
 from .inspector_pane import IngestRequested, ToggleBriefingQueueRequested
+from .items_pane import NextUnreadRequested
 
 # Every item persisted before Phase A carries `content = NULL`, and it cannot
 # be recovered without re-fetching the source. Say so rather than rendering an
@@ -347,6 +349,26 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
     #: second recompose would be pure churn.
     expanded: reactive[bool] = reactive(False)
 
+    #: The reader footer's "N of M" (TASK-3072 plan task 9).
+    #:
+    #: Screen-pushed, exactly like `expanded` above and for the same reason:
+    #: this pane holds no list state, so it cannot number the open item
+    #: itself -- the screen computes the position from the article list's
+    #: `displayed_items()` on every selection and pushes the string here
+    #: (and re-seeds it in `_build_content_pane`, so a region rebuild
+    #: re-renders the same footer). A plain reactive, not `recompose=True`:
+    #: `watch_position` updates the one Static in place.
+    position: reactive[str] = reactive("")
+
+    def watch_position(self, position: str) -> None:
+        """Re-render the footer Static in place -- never a reader recompose."""
+        try:
+            self.query_one("#content-position", Static).update(position)
+        except NoMatches:
+            # Pre-mount seeding (`_build_content_pane`) or the empty state,
+            # which has no footer at all; compose reads the reactive itself.
+            pass
+
     def compose(self):
         """Build the reader for `item`, or the empty-state placeholder.
 
@@ -463,6 +485,20 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
                     tooltip="Open the page as it was before this change.",
                 )
         yield Static(render_for(self.item), id="content-body")
+        # TASK-3072 plan task 9: the position footer. "N of M" is seeded and
+        # pushed by the screen (`position` above -- the pane holds no list
+        # state); Next Unread posts the pane's existing message, so the one
+        # screen handler that serves `space` serves this button too. Only
+        # rendered with an item open -- with nothing open the footer is
+        # absent entirely, never "0 of 0".
+        with Horizontal(id="content-footer", classes="destination-filter-strip"):
+            yield Static(self.position, id="content-position")
+            yield Button(
+                "Next unread",
+                id="content-next-unread-button",
+                compact=True,
+                tooltip="Open the next unread item (keyboard: space).",
+            )
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "content-mark-unread-button":
@@ -497,6 +533,9 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
                         item_id, not bool(item.get("queued_for_briefing"))
                     )
                 )
+        elif event.button.id == "content-next-unread-button":
+            event.stop()
+            self.post_message(NextUnreadRequested())
         elif event.button.id == "content-full-page-button":
             event.stop()
             self.post_message(ViewSnapshotRequested(self.item, "full_page"))

--- a/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
@@ -20,6 +20,7 @@ from ...Subscriptions.html_text import readable_body_text, strip_control_charact
 from ...Subscriptions.item_persist import CONTENT_KIND_CHANGE
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
 from .humane_time import humane_timestamp
+from .inspector_pane import IngestRequested, ToggleBriefingQueueRequested
 
 # Every item persisted before Phase A carries `content = NULL`, and it cannot
 # be recovered without re-fetching the source. Say so rather than rendering an
@@ -292,6 +293,19 @@ class StarToggleRequested(Message):
         self.item = item
         super().__init__()
 
+class OpenInBrowserRequested(Message):
+    """Posted when the reader's Open button is pressed (TASK-3072 plan task 8).
+
+    Carries the full item dict, same as `StarToggleRequested`: the screen's
+    one open-in-browser handler serves both this button and the `o` key,
+    and the URL scheme check lives screen-side (this pane holds no handle
+    on any OS primitive -- see `ContentPane`'s own docstring).
+    """
+
+    def __init__(self, item: dict[str, Any] | None) -> None:
+        self.item = item
+        super().__init__()
+
 class ExpandReaderRequested(Message):
     """Posted when the reader asks for (or gives back) the whole centre stack.
 
@@ -385,6 +399,37 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
                 tooltip=_GLOBAL_STAR_NOTE,
                 compact=True,
             )
+            # TASK-3072 plan task 8: the rest of the reader's verbs. Open is
+            # the `o` key's button half; Ingest and Queue/Unqueue post the
+            # Inspector's OWN message classes, so one screen handler serves
+            # both surfaces (the queue label states the CURRENT value, the
+            # Inspector's own `_queue_briefing_button` rule). Buttons only --
+            # the spec assigns no keys to these two.
+            yield Button(
+                "Open",
+                id="content-open-button",
+                tooltip="Open this item in your browser (keyboard: o).",
+                compact=True,
+            )
+            yield Button(
+                "Ingest",
+                id="content-ingest-button",
+                tooltip=(
+                    "File this item into the library. Ingesting is shared: "
+                    "it shows as ingested everywhere it appears."
+                ),
+                compact=True,
+            )
+            yield Button(
+                "Unqueue" if self.item.get("queued_for_briefing") else "Queue",
+                id="content-queue-button",
+                tooltip=(
+                    "Remove this item from the pool the next briefing draws from."
+                    if self.item.get("queued_for_briefing")
+                    else "Add this item to the pool the next briefing draws from."
+                ),
+                compact=True,
+            )
             # AC#2. `Z` does the same thing from the keyboard, and the tooltip
             # says so -- but only once the user knows the region has to be
             # focused first, which is exactly the knowledge F27 says nothing
@@ -434,6 +479,24 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
                 if str(event.button.label).startswith("★")
                 else "★ Starred"
             )
+        elif event.button.id == "content-open-button":
+            event.stop()
+            self.post_message(OpenInBrowserRequested(self.item))
+        elif event.button.id == "content-ingest-button":
+            event.stop()
+            self.post_message(IngestRequested(self.item))
+        elif event.button.id == "content-queue-button":
+            event.stop()
+            # The Inspector's own press-site shape: the raw row id, and the
+            # value to set the flag TO (the flip of the current one).
+            item = self.item or {}
+            item_id = item.get("item_id")
+            if item_id is not None:
+                self.post_message(
+                    ToggleBriefingQueueRequested(
+                        item_id, not bool(item.get("queued_for_briefing"))
+                    )
+                )
         elif event.button.id == "content-full-page-button":
             event.stop()
             self.post_message(ViewSnapshotRequested(self.item, "full_page"))

--- a/tldw_chatbook/UI/Watchlists_Modules/humane_time.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/humane_time.py
@@ -28,45 +28,19 @@ from __future__ import annotations
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
+# task-3072: the parser LIVES in `Subscriptions/item_dates.py` now, moved
+# there so the Subscriptions layer can parse stored dates without importing
+# from `UI/` (the layer direction is UI -> Subscriptions, never the
+# reverse). Re-exported here under its original name: this module's public
+# API (`__all__`) and every caller are unchanged. See item_dates' module
+# docstring for the full rationale.
+from ...Subscriptions.item_dates import parse_stored_datetime as parse_timestamp
+
 __all__ = ["humane_timestamp", "parse_timestamp"]
 
 #: What an empty cell says. The dash every Watchlists table already used for
 #: "no value", kept so this change cannot be mistaken for a new empty state.
 EMPTY_TIMESTAMP = "-"
-
-
-def parse_timestamp(value: Any) -> datetime | None:
-    """Parse the timestamp shapes this app actually stores.
-
-    Args:
-        value: A `datetime`, a `date`, or a string. ISO-8601 with or without
-            microseconds, with a `T` or a space separator, with a `Z` suffix,
-            a numeric offset, or nothing at all.
-
-    Returns:
-        A timezone-aware `datetime` in UTC, or `None` when the value is empty
-        or cannot be read. A date with no time component is returned as
-        midnight UTC -- callers that care about the distinction should check
-        the input, not the result.
-    """
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
-    if isinstance(value, date):
-        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
-    text = str(value).strip()
-    if not text:
-        return None
-    # `fromisoformat` accepts `Z` from 3.11, but normalizing it here keeps this
-    # working if the minimum ever moves back down, and costs one comparison.
-    if text.endswith(("Z", "z")):
-        text = f"{text[:-1]}+00:00"
-    try:
-        parsed = datetime.fromisoformat(text)
-    except ValueError:
-        return None
-    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
 
 
 def _is_date_only(value: Any) -> bool:

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlist_tree.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlist_tree.py
@@ -23,13 +23,23 @@ from textual.widgets import Button, Static
 
 ALL_SOURCES_BUCKET = -2
 UNASSIGNED_BUCKET = -1
+# The Starred smart feed (TASK-3072 plan task 6). Its badge rides the same
+# `counts` mapping as every other node -- the screen inserts this bucket
+# from `get_flagged_items_count()` on every tree-data load, so the badge
+# refreshes through the existing debounced counts path.
+STARRED_BUCKET = -3
+
+# App-controlled constant, never user data: the same markup rule as the
+# article list's glyphs (`_STAR_GLYPH` there) -- a remote feed title never
+# supplies this string.
+_STARRED_LABEL = "★ Starred"
 
 
 @dataclass(frozen=True)
 class TreeScope:
     """What the user has selected, as the panes need to understand it."""
 
-    kind: Literal["all", "unassigned", "watchlist", "source"]
+    kind: Literal["all", "unassigned", "watchlist", "source", "starred"]
     watchlist_id: int | None = None
     source_id: int | None = None
 
@@ -207,6 +217,12 @@ class WatchlistTree(Vertical):
         )
         yield self._root_node("all", "All sources", ALL_SOURCES_BUCKET)
         yield self._root_node("unassigned", "Unassigned", UNASSIGNED_BUCKET)
+        yield self._root_node(
+            "starred",
+            _STARRED_LABEL,
+            STARRED_BUCKET,
+            phrase=self._starred_phrase,
+        )
 
         for watchlist in self._visible_watchlists():
             yield from self._watchlist_node(watchlist)
@@ -374,17 +390,40 @@ class WatchlistTree(Vertical):
         noun = "item" if unread == 1 else "items"
         return f"{unread} unread {noun}"
 
-    def _root_node(self, key: str, label: str, bucket: int) -> Button:
-        unread = self._counts.get(bucket, {}).get("unread", 0)
+    @staticmethod
+    def _starred_phrase(starred: int) -> str:
+        """The Starred root's hover phrase (TASK-3072).
+
+        The legend row labels the rail's numbers "unread items"; this one
+        badge counts STARRED items instead, so the node's own tooltip must
+        say the true word -- the same TASK-2304 AC#3 honesty rule, applied
+        to the one node the legend does not describe.
+        """
+        if starred == 0:
+            return "No starred items"
+        noun = "item" if starred == 1 else "items"
+        return f"{starred} starred {noun}"
+
+    def _root_node(
+        self,
+        key: str,
+        label: str,
+        bucket: int,
+        *,
+        phrase: Callable[[int], str] | None = None,
+    ) -> Button:
+        count = self._counts.get(bucket, {}).get("unread", 0)
+        phrase_fn = phrase if phrase is not None else self._unread_phrase
         button = Button(
-            f"{label}  {unread}",
+            f"{label}  {count}",
             id=f"wl-tree-node-{key}",
             compact=True,
-            tooltip=f"Show {label.lower()}. {self._unread_phrase(unread)}.",
+            tooltip=f"Show {label.lower()}. {phrase_fn(count)}.",
         )
         button.add_class("watchlist-tree-root")
-        # `key` is always "all" or "unassigned" here (the only two callers,
-        # in `compose()`), which are also valid `TreeScope.kind` values.
+        # `key` is a root kind -- "all", "unassigned" or "starred" (the only
+        # three callers, in `compose()`) -- each also a valid
+        # `TreeScope.kind` value.
         if self.active_scope == TreeScope(kind=key):
             button.add_class("is-active")
         return button
@@ -523,6 +562,8 @@ class WatchlistTree(Vertical):
             scope = TreeScope(kind="all")
         elif button_id == "wl-tree-node-unassigned":
             scope = TreeScope(kind="unassigned")
+        elif button_id == "wl-tree-node-starred":
+            scope = TreeScope(kind="starred")
         elif button_id.startswith("wl-tree-node-watchlist-"):
             scope = TreeScope(kind="watchlist", watchlist_id=int(button_id.rsplit("-", 1)[1]))
         elif button_id.startswith("wl-tree-node-source-"):

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py
@@ -314,6 +314,20 @@ class WatchlistsBackendController:
         )
         return int(result)
 
+    async def set_item_flagged(self, *, runtime_backend: str | None = None, item_id: Any, flagged: bool) -> None:
+        """Star or unstar one item (TASK-3072 plan task 7).
+
+        The write behind the reader's `s` key and Star button; the id
+        forwards untouched (the scope service denamespaces it, exactly as
+        `update_item_status`'s does).
+        """
+        backend = self._normalize_backend(runtime_backend)
+        await self._maybe_await(
+            self.scope_service.set_item_flagged(
+                runtime_backend=backend, item_id=item_id, flagged=bool(flagged)
+            )
+        )
+
     async def _safe_list(self, method_name: str, **kwargs: Any) -> list[dict[str, Any]]:
         """Call a scope-service list method if it exists, otherwise return []."""
         if self.scope_service is None:

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py
@@ -320,6 +320,13 @@ class WatchlistsBackendController:
         The write behind the reader's `s` key and Star button; the id
         forwards untouched (the scope service denamespaces it, exactly as
         `update_item_status`'s does).
+
+        Args:
+            runtime_backend: Target backend, or `None` for the configured
+                default; normalized by `_normalize_backend`.
+            item_id: Item identifier, namespaced
+                (``local:watchlist_item:7``) or bare.
+            flagged: `True` to star the item, `False` to unstar it.
         """
         backend = self._normalize_backend(runtime_backend)
         await self._maybe_await(


### PR DESCRIPTION
Phase 2 of the Watchlists reader-first re-IA (ADR-042; phase 1 shipped in PR #1383), executed TDD per `Docs/superpowers/plans/2026-08-07-watchlists-reader-first-phase-2-list-reader-quality.md`, one commit per plan task.

## What ships

- **Reader rows** (`article_list.py`, replacing ItemsPane on the Read tab): ListView of multi-line rows under disabled day-group headers (Today / Yesterday / weekday / locale date), source + relative time, 1-line snippet, bold-when-unread with unread dot, star ★ / queued ◆ / ingested markers. Hostile input is appended-never-parsed and control-stripped.
- **Unread/All filter** in the readers vocabulary, pushed into the items query (`status=new` vs the bounded reader status set); the open-item pin is now unconditional.
- **Starred smart feed** in the rail with a global, status-agnostic count badge that rides the existing debounced counts refresh path; selecting it scopes items to `{"is_flagged": True}`.
- **`s` star toggle** on the open item + a Star button in the reader (one shared handler; new `set_item_flagged` chain controller → scope service → local service → DB, local-only like every item write). Row repaints are display-only, preserving the mark-unread guards staleness invariant.
- **`o` opens the item in the browser**, http/https only — `javascript:`/`file:`/empty URLs are refused with a notification, never passed to the OS.
- **Reader action row**: Open / Ingest / Queue-Unqueue buttons posting the Inspectors own `IngestRequested` / `ToggleBriefingQueueRequested` — the no-drift verb sharing at the message layer.
- **Position footer** ("N of M" within the displayed list) with a Next Unread control posting the panes existing `NextUnreadRequested`.
- **Help text** gains the reading-loop verbs (decision 031: only implemented actions advertised).

The specs `Subscriptions/content_render.py` is recorded as already satisfied by `Subscriptions/html_text.py` (TASK-2307): stdlib HTMLParser, `readable_body_text` in `render_article`, `html2text` optional and not required.

## Tests

- `Tests/Watchlists/` 533/533 and `Tests/Subscriptions/` 755/755 (+1 pre-existing skip) green; coupled `Tests/UI/` watchlists files green; ruff clean.
- New pins: per-layer star-write routing, reader filter vocabulary contract, display-only repaint invariants, `o` scheme refusal, footer position tracking, and a hostile-HTML end-to-end test (star + queue + inert render + flags survive re-persist).
- Drive-by: `cd1fee027` de-time-bombs a briefing fixture that had aged out of its hard-coded 7-day window (was failing on dev).
- Pre-existing on origin/dev (verified on a pristine checkout, unrelated to this branch): 5 schedules/mcp parity tests and the known CI-environment failures.

Closes TASK-3072 (backlog task marked Done with full Implementation Notes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the Read tab with multi‑line article rows, a simple Unread/All filter, and a Starred smart feed to improve scanning and reading flow. Completes TASK-3072 and polishes review items: Star button label now updates only after a successful write, and “Open in browser” uses centralized URL validation with control‑char stripping.

- **New Features**
  - New `ArticleListPane` replaces `ItemsPane` on Read: multi‑line rows with Today/Yesterday/date headers, bold‑when‑unread titles, 1‑line snippet, and unread/star/queued/ingested glyphs.
  - Unread/All filter: Unread → `status="new"`, All → `statuses=("new","reviewed","ingested")`; open‑item pin is always on.
  - Starred smart feed in the rail with a global count; selecting it lists items with `{"is_flagged": True}`.
  - Star toggle from reader (`s`) and a Star button; write via `set_item_flagged`; Star button label flips after the write succeeds.
  - Open in browser (`o`), http/https only; URL is validated by `validate_url` and control characters are stripped before opening.
  - Reader action row (Open, Ingest, Queue/Unqueue) shares the Inspector’s verbs; Next Unread button and a position footer (“N of M”); help text includes new keys.

- **Refactors**
  - Global `is_flagged` plumbing: DB `set_item_flagged` + `get_flagged_items_count`, `get_new_items(is_flagged=…)`, threaded through `LocalWatchlistsService`, `WatchlistScopeService`, and the backend controller; items normalize `is_flagged` to bool.
  - Date foundations in `Subscriptions/item_dates.py`: `parse_stored_datetime` (naive=UTC), `effective_date`, relative time, local day buckets; `humane_time.parse_timestamp` re‑exports; item queries sort by effective date.
  - New `html_text.body_snippet` builds a safe one‑line preview (tags/scripts stripped, controls removed, whitespace collapsed, word‑boundary ellipsis).
  - `get_flagged_items_count` now reads inside a DB transaction for consistency.
  - Hostile input is appended and never parsed; search focus behavior preserved; tests updated to the new reader vocabulary and list view.

<sup>Written for commit a23faab1332a820647e8ee4759617942b33fa788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

