### PR TITLE
fix(security): activate credential redaction at diagnostic boundaries

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -838,8 +838,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 279,
-      "diagnostic_digest": "e36a1454caea2b8a60a5",
+      "call_count": 281,
+      "diagnostic_digest": "ce012f70f7dd05c403ef",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/Summarization_General_Lib.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -884,6 +884,13 @@
       "diagnostic_digest": "cd1b6cd15fa8b8f6584f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/LLM_Provider_Catalog/model_discovery_disk_cache.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 2,
+      "diagnostic_digest": "6df67f334af25efefb64",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Library/ingest_preflight.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -972,7 +979,7 @@
     },
     {
       "call_count": 74,
-      "diagnostic_digest": "03ed1214dcc7b7dcfd3c",
+      "diagnostic_digest": "175deb80bbf453370c6c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/PDF_Processing_Lib.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -999,8 +1006,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 8,
-      "diagnostic_digest": "bd552970166a4551d1f3",
+      "call_count": 10,
+      "diagnostic_digest": "6842e55e39bcc505548e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/local_file_ingestion.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3468,9 +3475,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 469,
+    "owner_files": 470,
     "persistent_sink_files": 6,
-    "task_492_calls": 1153,
-    "task_494_calls": 6886
+    "task_492_calls": 1155,
+    "task_494_calls": 6890
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1567,7 +1567,7 @@
     },
     {
       "call_count": 16,
-      "diagnostic_digest": "65f3a0c1be12db1830f4",
+      "diagnostic_digest": "28b1354fcd730b42d311",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/monitoring_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -1,0 +1,773 @@
+# Active Credential Redaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repair the active credential sanitizer, separate credential redaction from model-name display validation, and remove the monitored URL from subscription diagnostics without breaking the existing public sanitizer imports.
+
+**Architecture:** `Utils/log_sanitizer.py` composes the canonical sensitive-config-key predicate with an exact log/protocol field set, then applies a classify-first assignment scanner followed by bounded standalone rules. Ollama and Transformers model names move to bounded single-line input validation, while the subscription diagnostic omits its URL entirely. Tests exercise direct production functions and the full production app only; the existing installed-wheel probe verifies the packaged import path.
+
+**Tech Stack:** Python 3.11+, `re`, `tomllib`, Textual production helpers, Loguru, pytest, Ruff, Backlog.md
+
+**ADR required:** yes
+
+**ADR path:** `backlog/decisions/029-local-private-data-boundary.md`
+
+**Reason:** This task changes credential/privacy behavior at rendering and diagnostic boundaries. ADR-029 already forbids credentials and private values in persistent diagnostics and requires omission at the producer boundary; this plan implements that accepted decision without creating a new ADR.
+
+**Approved design:** `Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md`
+
+---
+
+## File responsibility map
+
+- `tldw_chatbook/Utils/log_sanitizer.py`: public credential-redaction functions, private structured-field classifier, assignment scanner, and standalone credential rules.
+- `tldw_chatbook/Utils/sensitive_config_keys.py`: unchanged canonical owner of shipped config-key sensitivity.
+- `tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_ollama.py`: keep structured payload redaction; validate model names for one-line display.
+- `tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_transformers.py`: validate discovered model names for one-line display.
+- `tldw_chatbook/Subscriptions/monitoring_engine.py`: retain snapshot-pruning metadata while omitting the URL.
+- `Tests/Utils/test_log_sanitizer.py`: dedicated sanitizer public-contract, structured-classification, scanner, false-positive, and idempotence tests.
+- `Tests/Utils/test_security_enhancements.py`: retain only path-validation tests after moving the unrelated sanitizer class.
+- `Tests/Utils/test_sensitive_config_keys.py`: unchanged canonical predicate tests; run as a regression owner.
+- `Tests/ProductionApp/test_llm_destination_actions.py`: direct production helper and mounted-production-app model display/payload behavior.
+- `Tests/Subscriptions/test_watchlist_snapshot_pruning.py`: real `URLMonitor._store_snapshot()` diagnostic omission proof.
+- `Tests/Packaging/test_installed_distribution.py`: extend the existing isolated-wheel probe; do not add another wheel builder.
+- `Docs/security/production-diagnostic-inventory.json`: update only the reviewed `monitoring_engine.py` digest.
+- `backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md`: implementation evidence, checked acceptance criteria, ADR link, and closeout notes.
+
+No reduced, fake, simplified, or test-only application may be created. Use direct functions where that is the sharper boundary and the real `TldwCli` tests already present in `Tests/ProductionApp` where mounted behavior matters.
+
+---
+
+### Task 1: Rebase, record baselines, and implement structured-field classification
+
+**Files:**
+
+- Create: `Tests/Utils/test_log_sanitizer.py`
+- Modify: `Tests/Utils/test_security_enhancements.py`
+- Modify: `tldw_chatbook/Utils/log_sanitizer.py`
+- Reference: `tldw_chatbook/Utils/sensitive_config_keys.py`
+- Reference: `backlog/decisions/029-local-private-data-boundary.md`
+
+- [ ] **Step 1: Refresh and verify the implementation base before code**
+
+Run:
+
+```bash
+git fetch origin dev
+git rebase origin/dev
+git status --short --branch
+git diff --stat origin/dev...HEAD -- \
+  tldw_chatbook/Utils/log_sanitizer.py \
+  tldw_chatbook/Utils/sensitive_config_keys.py \
+  tldw_chatbook/Utils/input_validation.py \
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_ollama.py \
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_transformers.py \
+  tldw_chatbook/Subscriptions/monitoring_engine.py \
+  Tests/Utils/test_security_enhancements.py \
+  Tests/Utils/test_sensitive_config_keys.py \
+  Tests/ProductionApp/test_llm_destination_actions.py \
+  Tests/Subscriptions/test_watchlist_snapshot_pruning.py \
+  Tests/Packaging/test_installed_distribution.py
+```
+
+Expected: the worktree is clean except for committed task/spec/plan documents. If latest `dev` changed any listed file, stop and reconcile the spec and plan before writing tests.
+
+- [ ] **Step 2: Re-run the focused behavioral baseline**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Utils/test_security_enhancements.py \
+  Tests/Utils/test_sensitive_config_keys.py \
+  Tests/ProductionApp/test_llm_destination_actions.py::test_ollama_success_payloads_are_bounded_and_redacted \
+  -q
+```
+
+Expected: 26 tests pass. If the latest-dev count changes, record the new green count; do not proceed through a failure.
+
+- [ ] **Step 3: Capture the diagnostic-inventory no-regression fingerprint**
+
+Run this read-only command before production edits:
+
+```bash
+../../.venv/bin/python -c 'import hashlib, importlib.util, json; spec=importlib.util.spec_from_file_location("inventory_check", "scripts/check_persistent_diagnostic_inventory.py"); module=importlib.util.module_from_spec(spec); spec.loader.exec_module(module); inventory=module.build_inventory(); path="tldw_chatbook/Subscriptions/monitoring_engine.py"; monitoring=next(entry for entry in inventory["owners"] if entry["path"] == path); inventory["owners"]=[entry for entry in inventory["owners"] if entry["path"] != path]; print(json.dumps(monitoring, sort_keys=True)); print(hashlib.sha256(json.dumps(inventory, sort_keys=True).encode()).hexdigest())'
+```
+
+Expected monitoring entry on the currently approved base:
+
+```json
+{"call_count": 16, "diagnostic_digest": "5bd6f2dfc3a7c56e9aea", "owner": "TASK-494", "path": "tldw_chatbook/Subscriptions/monitoring_engine.py", "reason": "remaining Chatbook production diagnostic owner"}
+```
+
+Record the printed non-monitoring SHA-256 in the plan execution notes. If latest `dev` changes the entry, reconcile it before proceeding.
+
+- [ ] **Step 4: Move the existing sanitizer tests to their dedicated owner**
+
+Create `Tests/Utils/test_log_sanitizer.py` with the existing `TestLogSanitizer` imports and test methods from `Tests/Utils/test_security_enhancements.py`. Remove only that class and its sanitizer imports from `test_security_enhancements.py`; keep every path-validation test unchanged.
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Utils/test_security_enhancements.py \
+  Tests/Utils/test_log_sanitizer.py \
+  -q
+```
+
+Expected: all relocated baseline tests pass before new assertions are added.
+
+- [ ] **Step 5: Write failing structured-redaction tests**
+
+Add imports for `tomllib`, `CONFIG_TOML_CONTENT`, `DEFAULT_APP_TTS_CONFIG`, and `is_sensitive_config_key`. Add a local recursive leaf-key iterator rather than importing a helper from another test module.
+
+Add these tests:
+
+```python
+def test_real_shipped_sensitive_key_names_are_redacted() -> None:
+    default_config = tomllib.loads(CONFIG_TOML_CONTENT)
+    key_names = {
+        str(key)
+        for key in _iter_leaf_key_names(default_config)
+        if is_sensitive_config_key(key)
+    }
+    key_names.update(
+        key
+        for key in DEFAULT_APP_TTS_CONFIG
+        if is_sensitive_config_key(key)
+    )
+    assert {"api_key", "auth_token", "api_token"} <= key_names
+
+    sentinels = {key: f"PRIVATE_CONFIG_{index}" for index, key in enumerate(sorted(key_names))}
+    result = sanitize_dict(sentinels)
+
+    assert set(result) == set(sentinels)
+    assert all(value == "***REDACTED***" for value in result.values())
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "Authorization",
+        "Proxy-Authorization",
+        "cookie",
+        "Set-Cookie",
+        "credential",
+        "credentials",
+        "database_url",
+        "connection-string",
+        "dsn",
+    ],
+)
+def test_log_protocol_fields_are_redacted_without_expanding_config_policy(key: str) -> None:
+    assert not is_sensitive_config_key(key)
+    assert sanitize_dict({key: "PRIVATE_PROTOCOL_VALUE"})[key] == "***REDACTED***"
+```
+
+Also add direct tests proving:
+
+- `sanitize_dict({1: "safe", "x-api-key": "PRIVATE"})` does not raise and redacts only the sensitive value;
+- the input dictionary/list and nested containers are not mutated;
+- `deep=False` returns a new outer container, preserves nested dictionary/list identity, and still sanitizes a direct string value;
+- `api_key_env_var`, `max_tokens`, and an ordinary key remain unchanged; and
+- a sensitive key whose value is a dictionary or list replaces the entire container with the marker before recursion.
+
+- [ ] **Step 6: Run the structured tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest Tests/Utils/test_log_sanitizer.py -k 'real_shipped or protocol_fields or non_string or deep_false or non_mutating or sensitive_container' -q
+```
+
+Expected: failures show missing real config/log fields and the current non-string-key `.lower()` exception. Ensure each new test reaches the intended assertion rather than failing during setup.
+
+- [ ] **Step 7: Implement the exact structured classifier**
+
+In `tldw_chatbook/Utils/log_sanitizer.py`:
+
+```python
+from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
+
+REDACTION_MARKER = "***REDACTED***"
+_LOG_ONLY_SENSITIVE_FIELDS = frozenset(
+    {
+        "authorization",
+        "proxy_authorization",
+        "cookie",
+        "set_cookie",
+        "credential",
+        "credentials",
+        "database_url",
+        "connection_string",
+        "dsn",
+    }
+)
+
+
+def _is_sensitive_log_key(key: object) -> bool:
+    normalized = str(key).strip().lower().replace("-", "_")
+    return is_sensitive_config_key(key) or normalized in _LOG_ONLY_SENSITIVE_FIELDS
+```
+
+Delete the drifting `SENSITIVE_FIELDS` set. Change `sanitize_dict()` to call `_is_sensitive_log_key(key)` and use `REDACTION_MARKER`. Preserve the existing type fallback, `deep` branching order, direct-string sanitization, and list recursion exactly. Do not broaden the public functions to tuples, arbitrary mappings, or new container types.
+
+- [ ] **Step 8: Run structured and canonical-predicate tests GREEN**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Utils/test_log_sanitizer.py \
+  Tests/Utils/test_sensitive_config_keys.py \
+  Tests/Utils/test_security_enhancements.py \
+  -q
+```
+
+Expected: all structured and relocated baseline tests pass; string tests that have not yet been added are not part of this checkpoint.
+
+- [ ] **Step 9: Commit the structured classifier**
+
+```bash
+git add \
+  Tests/Utils/test_log_sanitizer.py \
+  Tests/Utils/test_security_enhancements.py \
+  tldw_chatbook/Utils/log_sanitizer.py
+git commit -m "fix(security): centralize structured credential fields"
+```
+
+---
+
+### Task 2: Implement the classify-first string scanner and installed-wheel proof
+
+**Files:**
+
+- Modify: `Tests/Utils/test_log_sanitizer.py`
+- Modify: `Tests/Packaging/test_installed_distribution.py`
+- Modify: `tldw_chatbook/Utils/log_sanitizer.py`
+
+- [ ] **Step 1: Add failing assignment-scanner and standalone-rule tests**
+
+Add parameterized and focused cases with conspicuous fake sentinels:
+
+```python
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('api_key="PRIVATE_QUOTED", safe="visible"', 'api_key="***REDACTED***", safe="visible"'),
+        ("password=correct horse battery staple", "password=***REDACTED***"),
+        ("max_tokens=42 api_key=PRIVATE_LATER", "max_tokens=42 api_key=***REDACTED***"),
+        ("api_key=PRIVATE_QUERY&safe=visible", "api_key=***REDACTED***"),
+        ("api_key=\nrefresh_token=PRIVATE_NEXT", "api_key=\nrefresh_token=***REDACTED***"),
+    ],
+)
+def test_assignment_scanner_contract(raw: str, expected: str) -> None:
+    assert sanitize_string(raw) == expected
+```
+
+Add separate tests proving:
+
+- two quoted secrets on one line are both redacted while the safe field remains;
+- an escaped quote does not close a quoted secret;
+- an unterminated quoted value is redacted to the line boundary and scanning resumes on the next line;
+- `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and every config-derived sensitive provider label redact both quoted and unquoted opaque sentinels;
+- `api_key_env_var`, `max_tokens`, `claude-opus-4-20250514`, ordinary `Basic model configuration`, `NotBearer token`, and `not-bearer token` remain unchanged;
+- standalone `Bearer PRIVATE_BEARER` retains `Bearer` but removes the complete credential;
+- `https://user:PRIVATE_PASSWORD@example.test/private` contains neither username nor password afterward;
+- full, case-sensitive fake `sk-proj-`, `sk-ant-api03-`, legacy `sk-`, and `AIza` values become the neutral marker with no surviving prefix/suffix;
+- uppercase variants of those credential prefixes are not newly recognized as standalone shapes;
+- a standalone-shaped key inside a quoted labeled value produces one marker and remains idempotent;
+- already-redacted strings, dictionaries, and lists are idempotent;
+- non-string input retains the current `str()` fallback;
+- `create_safe_log_message()` formatting failure returns the sanitized template and never interpolates raw arguments; and
+- a 100,000-character non-matching string completes and remains unchanged without a wall-clock timing assertion.
+
+- [ ] **Step 2: Extend the existing installed-wheel probe before implementation**
+
+Inside `INSTALLED_PROBE` in `Tests/Packaging/test_installed_distribution.py`, import from the installed target only:
+
+```python
+from tldw_chatbook.Utils.log_sanitizer import sanitize_dict, sanitize_string
+
+assert sanitize_string("claude-opus-4-20250514") == "claude-opus-4-20250514"
+assert sanitize_dict({"x-api-key": "PRIVATE_INSTALLED_SENTINEL"}) == {
+    "x-api-key": "***REDACTED***"
+}
+assert "PRIVATE_INSTALLED_SENTINEL" not in sanitize_string(
+    'x-api-key="PRIVATE_INSTALLED_SENTINEL"'
+)
+```
+
+Do not add a test application, editable install, second builder, or source-root fallback. The existing probe already excludes checkout/build roots and imports the real `TldwCli` from the installed wheel.
+
+- [ ] **Step 3: Run the new source and installed tests RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest Tests/Utils/test_log_sanitizer.py -q
+```
+
+Expected: scanner/false-positive tests fail against the old `SENSITIVE_PATTERNS` loop.
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Packaging/test_installed_distribution.py::test_installed_wheel_loaders_entry_points_and_assets_are_immutable \
+  -q
+```
+
+Expected: FAIL in the isolated child because the installed sanitizer rewrites `claude-*` and/or misses a required labeled value. Confirm the failure is behavioral, not a build/network/environment failure.
+
+- [ ] **Step 4: Implement the monotonic assignment scanner**
+
+Replace `SENSITIVE_PATTERNS` with private compiled rules. Use a prefix-only assignment pattern so classification happens before value consumption:
+
+```python
+_ASSIGNMENT_PREFIX = re.compile(
+    r"""
+    (?<![A-Za-z0-9_.-])
+    (?:
+        (?P<quote>["'])(?P<quoted_key>[A-Za-z0-9_.-]+)(?P=quote)
+        |
+        (?P<plain_key>[A-Za-z0-9_.-]+)
+    )
+    [ \t]*[:=][ \t]*
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+```
+
+Implement private helpers with these exact responsibilities:
+
+```python
+def _line_end(text: str, start: int) -> int:
+    """Return the first CR/LF index at or after start, or len(text)."""
+
+
+def _after_line_break(text: str, index: int) -> int:
+    """Advance over LF, CR, or one CRLF pair; end stays at len(text)."""
+
+
+def _find_quoted_end(text: str, value_start: int, quote: str) -> tuple[int, bool]:
+    """Return the closing-quote/line-end index and whether it closed."""
+
+
+def _apply_replacements(text: str, spans: list[tuple[int, int]]) -> str:
+    """Build one output from sorted non-overlapping spans and REDACTION_MARKER."""
+
+
+def _redact_assignments(text: str) -> str:
+    """Classify label prefixes first, collect replacement spans, and always advance."""
+```
+
+`_redact_assignments()` must:
+
+1. search from a monotonic cursor;
+2. resume at `match.end()` for non-sensitive labels;
+3. skip horizontal whitespace already consumed by the prefix pattern;
+4. leave an empty assignment unchanged and resume after its line break;
+5. replace only contents between a matching quoted pair, respecting backslash escapes, then resume after the closing quote;
+6. replace an unterminated quote from after the opening quote to the line boundary;
+7. replace an unquoted sensitive value through the line boundary; and
+8. resume after CR/LF/CRLF and continue until no candidate remains.
+
+Do not use repeated whole-string concatenation in the scan loop. Collect spans and build once.
+
+- [ ] **Step 5: Implement standalone passes in the specified order**
+
+Add:
+
+```python
+_URL_USERINFO = re.compile(r"(https?://)[^/?#\s\r\n]*@", re.IGNORECASE)
+_BEARER = re.compile(
+    r"(?<![A-Za-z0-9_-])(Bearer\s+)(\S+)",
+    re.IGNORECASE,
+)
+_STANDALONE_CREDENTIALS = (
+    re.compile(r"(?<![A-Za-z0-9_-])sk-proj-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])"),
+    re.compile(r"(?<![A-Za-z0-9_-])sk-ant-api03-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])"),
+    re.compile(r"(?<![A-Za-z0-9_-])sk-[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])"),
+    re.compile(r"(?<![A-Za-z0-9_-])AIza[A-Za-z0-9_-]{35}(?![A-Za-z0-9_-])"),
+)
+```
+
+`sanitize_string()` retains its non-string `str()` fallback, then applies:
+
+1. `_redact_assignments()`;
+2. URL-userinfo replacement preserving only scheme, marker, `@`, and authority;
+3. Bearer replacement preserving the scheme and replacing its credential; and
+4. each case-sensitive standalone family with `REDACTION_MARKER`.
+
+No pattern recognizes `claude-*`. Do not add standalone Basic matching or speculative opaque-provider formats.
+
+- [ ] **Step 6: Run source tests GREEN**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Utils/test_log_sanitizer.py \
+  Tests/Utils/test_sensitive_config_keys.py \
+  Tests/Utils/test_security_enhancements.py \
+  -q
+```
+
+Expected: all pass. Inspect exact outputs, not only absence assertions, for quoted/unquoted syntax and false-positive cases.
+
+- [ ] **Step 7: Run the installed-wheel proof GREEN**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Packaging/test_installed_distribution.py::test_installed_wheel_loaders_entry_points_and_assets_are_immutable \
+  -q
+```
+
+Expected: PASS from the isolated installed target, with source/build roots excluded and the target hash unchanged.
+
+- [ ] **Step 8: Commit the scanner and wheel proof**
+
+```bash
+git add \
+  Tests/Utils/test_log_sanitizer.py \
+  Tests/Packaging/test_installed_distribution.py \
+  tldw_chatbook/Utils/log_sanitizer.py
+git commit -m "fix(security): redact labeled credentials without model false positives"
+```
+
+---
+
+### Task 3: Correct production consumer boundaries and inventory ownership
+
+**Files:**
+
+- Modify: `Tests/ProductionApp/test_llm_destination_actions.py`
+- Modify: `Tests/Subscriptions/test_watchlist_snapshot_pruning.py`
+- Modify: `tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_ollama.py`
+- Modify: `tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_transformers.py`
+- Modify: `tldw_chatbook/Subscriptions/monitoring_engine.py`
+- Modify: `Docs/security/production-diagnostic-inventory.json`
+
+- [ ] **Step 1: Write failing direct production-helper tests**
+
+In `test_ollama_success_payloads_are_bounded_and_redacted`, strengthen the payload to include nested `x-api-key`/authorization fields and replace the credential-like model-name assertion with:
+
+```python
+names = ollama_events._safe_ollama_model_names(
+    [
+        {"name": "claude-opus-4-20250514"},
+        {"name": "org/model\r\ninjected"},
+    ]
+)
+assert names == ["claude-opus-4-20250514", "org/model injected"]
+```
+
+Add a direct Transformers filesystem test using `tmp_path`:
+
+```python
+def test_transformers_model_scan_preserves_claude_ids_as_one_line(tmp_path: Path) -> None:
+    model_root = tmp_path / "models--anthropic--claude-opus-4-20250514"
+    model_root.mkdir()
+    (model_root / "config.json").write_text("{}", encoding="utf-8")
+    (model_root / "model.safetensors").touch()
+
+    assert transformers_events.scan_transformers_local_models(tmp_path) == [
+        "anthropic/claude-opus-4-20250514"
+    ]
+```
+
+Use direct production functions; do not construct a test app.
+
+- [ ] **Step 2: Write the failing real snapshot-pruning diagnostic test**
+
+In `Tests/Subscriptions/test_watchlist_snapshot_pruning.py`, use the existing real DB/source helpers and `URLMonitor._store_snapshot()`:
+
+```python
+@pytest.mark.asyncio
+async def test_prune_diagnostic_omits_the_monitored_url(monkeypatch) -> None:
+    from types import SimpleNamespace
+    from tldw_chatbook.Subscriptions import monitoring_engine
+
+    db, _service, source_id = await _site_source(monkeypatch, [_page("seed")])
+    private_url = (
+        "https://PRIVATE_USER:PRIVATE_PASSWORD@example.test/PRIVATE_PATH"
+        "?api_key=PRIVATE_QUERY#PRIVATE_FRAGMENT"
+    )
+    captured: list[str] = []
+
+    def capture(message: str, *args) -> None:
+        captured.append(message.format(*args))
+
+    monkeypatch.setattr(
+        monitoring_engine,
+        "logger",
+        SimpleNamespace(debug=capture),
+    )
+    monitor = monitoring_engine.URLMonitor(db)
+    for index in range(_cap() + 1):
+        await monitor._store_snapshot(
+            source_id,
+            private_url,
+            {"text": f"revision {index}", "html": "", "headers": {}},
+            fingerprint="fp",
+        )
+
+    message = next(text for text in captured if text.startswith("Pruned "))
+    assert message == (
+        f"Pruned 1 snapshot(s) for subscription {source_id}, "
+        f"keeping the newest {_cap()}"
+    )
+    for forbidden in (
+        private_url,
+        "PRIVATE_USER",
+        "PRIVATE_PASSWORD",
+        "PRIVATE_PATH",
+        "PRIVATE_QUERY",
+        "PRIVATE_FRAGMENT",
+    ):
+        assert forbidden not in message
+```
+
+If the real logger is used by another `_store_snapshot()` branch during this test, give the replacement object only the methods actually observed; do not replace `URLMonitor` or the database with a simplified test implementation.
+
+- [ ] **Step 3: Run consumer tests RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/ProductionApp/test_llm_destination_actions.py::test_ollama_success_payloads_are_bounded_and_redacted \
+  Tests/ProductionApp/test_llm_destination_actions.py::test_transformers_model_scan_preserves_claude_ids_as_one_line \
+  Tests/Subscriptions/test_watchlist_snapshot_pruning.py::test_prune_diagnostic_omits_the_monitored_url \
+  -q
+```
+
+Expected: Ollama/Transformers fail because model names still use credential redaction or retain multiple lines; the subscription test fails because the full sanitized URL is still present.
+
+- [ ] **Step 4: Split Ollama and Transformers display validation from redaction**
+
+In Ollama:
+
+```python
+from tldw_chatbook.Utils.input_validation import (
+    sanitize_string as sanitize_input_string,
+)
+from tldw_chatbook.Utils.log_sanitizer import sanitize_dict
+```
+
+In both model-name paths, replace log sanitization and manual newline slicing with:
+
+```python
+validated_name = sanitize_input_string(display_name, max_length=256)
+safe_name = " ".join(validated_name.split())
+```
+
+Use `name` in the Ollama helper and `display_name` in Transformers. Preserve the current invalid/empty checks and result caps. Do not route displayed names back through `log_sanitizer`.
+
+- [ ] **Step 5: Omit the subscription URL at the producer boundary**
+
+Delete the dynamic log-sanitizer import and its stale Qodo comment. Change only the message and arguments:
+
+```python
+logger.debug(
+    "Pruned {} snapshot(s) for subscription {}, keeping the newest {}",
+    pruned,
+    subscription_id,
+    _SNAPSHOTS_KEPT_PER_URL,
+)
+```
+
+Do not import `_log_origin()` from `Utils.egress`; the origin is unnecessary for this diagnostic.
+
+- [ ] **Step 6: Run the direct consumer tests GREEN**
+
+Run the exact command from Step 3.
+
+Expected: 3 tests pass using production helpers and the real snapshot producer.
+
+- [ ] **Step 7: Prove the branch changes only the monitoring inventory entry**
+
+Re-run the read-only fingerprint command from Task 1, Step 3.
+
+Expected:
+
+- the non-monitoring SHA-256 exactly matches the recorded base hash;
+- `owner`, `reason`, and `call_count: 16` remain unchanged; and
+- only `diagnostic_digest` differs for `monitoring_engine.py`.
+
+Patch only that digest in `Docs/security/production-diagnostic-inventory.json` with `apply_patch`. Do not run the checker's blanket `--write` mode.
+
+Inspect:
+
+```bash
+git diff -- Docs/security/production-diagnostic-inventory.json
+```
+
+Expected: one digest line changes.
+
+- [ ] **Step 8: Re-run the known-red global inventory gate without misreporting it**
+
+Run:
+
+```bash
+../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py
+```
+
+Expected on the currently approved base: exit 1 with the same pre-existing global drift.
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Architecture/test_persistent_diagnostic_inventory.py \
+  -q
+```
+
+Expected on the currently approved base: the inventory-equality test remains the one known failure; the persistent-metadata-marker and chained-logger-call sentinels pass. Record this as a base/head-equivalent limitation, not a task pass.
+
+- [ ] **Step 9: Commit the corrected consumers**
+
+```bash
+git add \
+  Docs/security/production-diagnostic-inventory.json \
+  Tests/ProductionApp/test_llm_destination_actions.py \
+  Tests/Subscriptions/test_watchlist_snapshot_pruning.py \
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_ollama.py \
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_transformers.py \
+  tldw_chatbook/Subscriptions/monitoring_engine.py
+git commit -m "fix(privacy): separate display validation from diagnostics"
+```
+
+---
+
+### Task 4: Run complete verification, review, and close TASK-856
+
+**Files:**
+
+- Modify: `Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md`
+- Modify: `Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md`
+- Modify: `backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md`
+- Review: every file changed by Tasks 1–3
+
+- [ ] **Step 1: Run the complete focused sanitizer/security suite**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Utils/test_log_sanitizer.py \
+  Tests/Utils/test_security_enhancements.py \
+  Tests/Utils/test_sensitive_config_keys.py \
+  -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run the full affected production-app and subscription modules**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/ProductionApp/test_llm_destination_actions.py \
+  Tests/Subscriptions/test_watchlist_snapshot_pruning.py \
+  -q
+```
+
+Expected: all pass. These are the real production app/direct producer owners; do not substitute a reduced app.
+
+- [ ] **Step 3: Re-run the installed-wheel test from a clean build**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/Packaging/test_installed_distribution.py::test_installed_wheel_loaders_entry_points_and_assets_are_immutable \
+  -q
+```
+
+Expected: pass from the isolated installed target with target hashes unchanged.
+
+- [ ] **Step 4: Run static and syntax checks on every changed Python file**
+
+```bash
+../../.venv/bin/python -m ruff check \
+  tldw_chatbook/Utils/log_sanitizer.py \
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_ollama.py \
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_transformers.py \
+  tldw_chatbook/Subscriptions/monitoring_engine.py \
+  Tests/Utils/test_log_sanitizer.py \
+  Tests/Utils/test_security_enhancements.py \
+  Tests/ProductionApp/test_llm_destination_actions.py \
+  Tests/Subscriptions/test_watchlist_snapshot_pruning.py \
+  Tests/Packaging/test_installed_distribution.py
+
+../../.venv/bin/python -m ruff format --check \
+  tldw_chatbook/Utils/log_sanitizer.py \
+  Tests/Utils/test_log_sanitizer.py
+
+../../.venv/bin/python -m py_compile \
+  tldw_chatbook/Utils/log_sanitizer.py \
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_ollama.py \
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_transformers.py \
+  tldw_chatbook/Subscriptions/monitoring_engine.py
+```
+
+Expected: all commands pass. If whole-file Ruff format is pre-existingly red for a changed legacy file, prove the base revision has the same result and format only the edited region/file when safe; do not mass-format unrelated code.
+
+- [ ] **Step 5: Run hygiene and scope review**
+
+```bash
+git diff --check
+git status --short
+git diff --stat origin/dev...HEAD
+git diff origin/dev...HEAD -- \
+  tldw_chatbook/Utils/log_sanitizer.py \
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_ollama.py \
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_transformers.py \
+  tldw_chatbook/Subscriptions/monitoring_engine.py
+```
+
+Review every changed line for:
+
+- no secret fragment survives a marker;
+- no `claude-*` or ordinary Basic prose false positive;
+- scanner cursor always advances;
+- no global logging hook or new config dependency;
+- no URL value remains in the pruning diagnostic;
+- no simplified/test-only app exists; and
+- no unrelated inventory entry or user change is included.
+
+- [ ] **Step 6: Request independent code review and address verified findings**
+
+Use `superpowers:requesting-code-review` with TASK-856, ADR-029, the approved spec/plan, the exact base/head inventory evidence, and all verification output. Apply `superpowers:receiving-code-review` before accepting any suggestion. Re-run affected tests after each correction and repeat review until no Critical or Important issue remains.
+
+- [ ] **Step 7: Complete Backlog and design/plan documentation**
+
+Update TASK-856 only after code and reviews are complete:
+
+- check all six acceptance criteria;
+- add concise `## Implementation Notes` covering the classifier/scanner, consumer boundary changes, installed-wheel proof, exact inventory limitation, changed files, and ADR-029;
+- record every verification count and the known base/head-equivalent inventory failure;
+- change the design status to `Implemented and verified`;
+- check completed plan steps and document any deviation; and
+- run `backlog task edit 856 -s Done` only after all other Definition-of-Done items are satisfied.
+
+Run:
+
+```bash
+backlog task 856 --plain
+```
+
+Expected: status Done, all acceptance criteria checked, Implementation Plan and Implementation Notes present, and ADR-029 linked.
+
+- [ ] **Step 8: Commit closeout documentation**
+
+```bash
+git add \
+  Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md \
+  Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md \
+  'backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md'
+git commit -m "docs(security): close TASK-856 sanitizer repair"
+```
+
+- [ ] **Step 9: Run final verification after the closeout commit**
+
+Re-run the complete focused commands from Steps 1–5 plus the installed-wheel test. Confirm the worktree is clean, every implementation commit is based on the current `origin/dev`, and the only known red gate is identical to the recorded latest-dev diagnostic-inventory baseline. Do not describe that gate as passing.

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -812,6 +812,44 @@ git commit -m "fix(privacy): separate display validation from diagnostics"
 - Modify: `backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md`
 - Review: every file changed by Tasks 1–3
 
+#### Latest-dev rebase amendment
+
+After Tasks 1–3 passed their task-scoped reviews, `origin/dev` advanced and the
+branch rebased cleanly onto `85a46bea8704d076fd6b544e56bead760fd3e9d9`.
+None of TASK-856's scoped production/test files changed upstream, but five STT
+executor diagnostics landed without an inventory update. The checked manifest
+records `467/1151/6854/6`; generated state is `467/1151/6859/6` for owner
+files/TASK-492 calls/TASK-494 calls/sink files.
+
+The reviewed current-dev delta is exactly:
+
+| Path suffix | Calls | Generated digest |
+| --- | ---: | --- |
+| `Local_Ingestion/audio_processing.py` | 50 | `e161bcc2fa635027a846` |
+| `Local_Ingestion/local_file_ingestion.py` | 8 | `23248608ccde923a2339` |
+| `Local_Ingestion/video_processing.py` | 80 | `1e6bc554c059b1bbb859` |
+| `UI/Screens/library_screen.py` | 83 | `8a3d52f62abfd4600f79` |
+| `app.py` | 298 | `e64f633a5515b2ad809f` |
+
+Semantic AST call-multiset comparison shows the first four files have no added
+or removed diagnostics. `app.py` adds five metadata/constant-only error calls:
+callback marshal failure by callback name; dispatch failure by job ID and error
+type; dispatch failure by job ID/provider/error type; and two constant shutdown
+messages with exception context. Persistent-sink call shapes/digests are
+unchanged; only the three later `app.py` sink lines move to 6635, 6663, and
+6720. Existing admission tests remain the proof that these ordinary errors do
+not reach persistent diagnostic storage.
+
+Patch only those reviewed owner/summary/sink-line entries without `--write`,
+commit them separately, and place that reconciliation immediately before the
+Task 3 consumer commit. At that boundary `monitoring_engine.py` still has digest
+`f9ccee6989b39da1333b`; the current non-monitoring fingerprint is
+`a927b4bc7a229d3c3328a5336054c410aabdedfe5fd40219ab1152a9880763eb`.
+Task 3 then changes only the monitoring digest to
+`3826b76482fd484ff194`, preserving the same non-monitoring fingerprint. The
+final checker must report 467 owners, 1,151 TASK-492 calls, 6,859 TASK-494
+calls, and six sink files.
+
 - [ ] **Step 1: Run the complete focused sanitizer/security suite**
 
 ```bash
@@ -924,9 +962,9 @@ Review every changed line for:
 - no global logging hook or new config dependency;
 - no URL value remains in the pruning diagnostic;
 - no simplified/test-only app exists; and
-- no inventory entry beyond the separately reviewed latest-dev reconciliation
-  and the TASK-856 monitoring digest is included, and no user change is
-  disturbed.
+- no inventory entry beyond the two separately reviewed latest-dev
+  reconciliations and the TASK-856 monitoring digest is included, and no user
+  change is disturbed.
 
 - [ ] **Step 6: Request independent code review and address verified findings**
 
@@ -941,8 +979,8 @@ Update TASK-856 only after code and reviews are complete:
   reconciliation, classifier/scanner, consumer boundary changes,
   installed-wheel proof, subsequent one-digest TASK-856 inventory update,
   changed files, and ADR-029;
-- record every verification count, the initial latest-dev inventory mismatch,
-  the reconciliation commit, and the reconciled base/head fingerprints;
+- record every verification count, both latest-dev inventory mismatches, both
+  reconciliation commits, and the current reconciled base/head fingerprints;
 - change the design status to `Implemented and verified`;
 - check completed plan steps and document any deviation; and
 - run `backlog task edit 856 -s Done` only after all other Definition-of-Done items are satisfied.

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -134,9 +134,12 @@ At that pinned commit the exact generated owner values are:
 Review the semantic diagnostic-call delta, not only digests. The accepted delta
 must still be: metadata-safe LLM helpers instead of payload/error previews;
 prompt-improvement request/provider/model/count metadata without prompt text;
-two constant change-revert warnings; the Prompts DB v2-to-v3 migration pair;
-and otherwise only line movement/formatting. If latest `dev` differs, stop and
-reconcile the new delta before patching anything.
+two constant-message change-revert warnings with exception context that remain
+ordinary, non-admitted records; the Prompts DB v2-to-v3 migration pair; and
+otherwise only line movement/formatting. Persistent-sink topology is unchanged,
+and the existing admission tests remain the proof that ordinary records do not
+reach disk. If latest `dev` differs, stop and reconcile the new delta before
+patching anything.
 
 Use `apply_patch` to change exactly the reviewed summary and owner entries.
 Then run:
@@ -678,20 +681,34 @@ non-portable Transformers filename case is skipped.
 In Ollama:
 
 ```python
-from tldw_chatbook.Utils.input_validation import (
-    sanitize_string as sanitize_input_string,
-)
-from tldw_chatbook.Utils.log_sanitizer import sanitize_dict
+from tldw_chatbook.Utils import input_validation as input_safety, log_sanitizer
+
+# In _format_ollama_success_payload():
+log_sanitizer.sanitize_dict(data)
+
+# In _safe_ollama_model_names():
+safe_name = " ".join(input_safety.sanitize_string(name, max_length=256).split())
 ```
 
-In both model-name paths, replace log sanitization and manual newline slicing with:
+In Transformers use one line for the import and one for the replacement:
 
 ```python
-validated_name = sanitize_input_string(display_name, max_length=256)
-safe_name = " ".join(validated_name.split())
+from tldw_chatbook.Utils.input_validation import sanitize_string as sanitize_input
+
+display_name = " ".join(sanitize_input(display_name, max_length=256).split())
 ```
 
-Use `name` in the Ollama helper and `display_name` in Transformers. Preserve the current invalid/empty checks and result caps. Do not route displayed names back through `log_sanitizer`.
+These line-count-neutral edits are deliberate: the inventory digest includes
+diagnostic line numbers, and both modules contain logger calls after the edited
+helpers. Preserve the existing logger line numbers so a presentation-only
+change cannot manufacture unrelated owner-digest drift. Preserve the current
+invalid/empty checks and result caps. Do not route displayed names back through
+`log_sanitizer`.
+
+Before changing `monitoring_engine.py`, re-run the fingerprint command from
+Task 1, Step 4. Expected: both the non-monitoring SHA-256 and the monitoring
+entry still exactly match the reconciled baseline. If they do not, fix the
+line-count/scope error before proceeding.
 
 - [ ] **Step 5: Omit the subscription URL at the producer boundary**
 
@@ -712,9 +729,9 @@ Do not import `_log_origin()` from `Utils.egress`; the origin is unnecessary for
 
 Run the exact command from Step 3.
 
-Expected: 4 tests pass using production helpers and the real snapshot producer
-(three on Windows because the non-portable filename case is explicitly
-skipped).
+Expected: four selected tests pass using production helpers and the real
+snapshot producer on POSIX. Windows reports three passed and the one explicitly
+non-portable filename case skipped.
 
 - [ ] **Step 7: Prove TASK-856 changes only the monitoring inventory entry after reconciliation**
 
@@ -734,7 +751,7 @@ TASK-856's inventory delta.
 Inspect:
 
 ```bash
-git diff <reconciliation-commit>...HEAD -- \
+git diff <reconciliation-commit> -- \
   Docs/security/production-diagnostic-inventory.json
 ```
 

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -915,7 +915,9 @@ Review every changed line for:
 - no global logging hook or new config dependency;
 - no URL value remains in the pruning diagnostic;
 - no simplified/test-only app exists; and
-- no unrelated inventory entry or user change is included.
+- no inventory entry beyond the separately reviewed latest-dev reconciliation
+  and the TASK-856 monitoring digest is included, and no user change is
+  disturbed.
 
 - [ ] **Step 6: Request independent code review and address verified findings**
 
@@ -925,9 +927,13 @@ Use `superpowers:requesting-code-review` with TASK-856, ADR-029, the approved sp
 
 Update TASK-856 only after code and reviews are complete:
 
-- check all six acceptance criteria;
-- add concise `## Implementation Notes` covering the classifier/scanner, consumer boundary changes, installed-wheel proof, one-digest inventory update, changed files, and ADR-029;
-- record every verification count and the known base/head-equivalent inventory failure;
+- check all seven acceptance criteria;
+- add concise `## Implementation Notes` covering the reviewed baseline
+  reconciliation, classifier/scanner, consumer boundary changes,
+  installed-wheel proof, subsequent one-digest TASK-856 inventory update,
+  changed files, and ADR-029;
+- record every verification count, the initial latest-dev inventory mismatch,
+  the reconciliation commit, and the reconciled base/head fingerprints;
 - change the design status to `Implemented and verified`;
 - check completed plan steps and document any deviation; and
 - run `backlog task edit 856 -s Done` only after all other Definition-of-Done items are satisfied.

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -31,20 +31,25 @@
 - `Tests/ProductionApp/test_llm_destination_actions.py`: direct production helper and mounted-production-app model display/payload behavior.
 - `Tests/Subscriptions/test_watchlist_snapshot_pruning.py`: real `URLMonitor._store_snapshot()` diagnostic omission proof.
 - `Tests/Packaging/test_installed_distribution.py`: extend the existing isolated-wheel probe; do not add another wheel builder.
-- `Docs/security/production-diagnostic-inventory.json`: update only the reviewed `monitoring_engine.py` digest.
+- `Docs/security/production-diagnostic-inventory.json`: first reconcile only
+  the reviewed latest-dev owner/summary drift in a separate baseline commit;
+  later update only the reviewed `monitoring_engine.py` digest relative to that
+  commit.
 - `backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md`: implementation evidence, checked acceptance criteria, ADR link, and closeout notes.
 
 No reduced, fake, simplified, or test-only application may be created. Use direct functions where that is the sharper boundary and the real `TldwCli` tests already present in `Tests/ProductionApp` where mounted behavior matters.
 
 ---
 
-### Task 1: Rebase, record baselines, and implement structured-field classification
+### Task 1: Rebase, reconcile inventory, and implement structured-field classification
 
 **Files:**
 
 - Create: `Tests/Utils/test_log_sanitizer.py`
 - Modify: `Tests/Utils/test_security_enhancements.py`
 - Modify: `tldw_chatbook/Utils/log_sanitizer.py`
+- Modify: `Docs/security/production-diagnostic-inventory.json` (reviewed
+  latest-dev baseline reconciliation only)
 - Reference: `tldw_chatbook/Utils/sensitive_config_keys.py`
 - Reference: `backlog/decisions/029-local-private-data-boundary.md`
 
@@ -67,7 +72,8 @@ git diff --stat origin/dev...HEAD -- \
   Tests/Utils/test_sensitive_config_keys.py \
   Tests/ProductionApp/test_llm_destination_actions.py \
   Tests/Subscriptions/test_watchlist_snapshot_pruning.py \
-  Tests/Packaging/test_installed_distribution.py
+  Tests/Packaging/test_installed_distribution.py \
+  Docs/security/production-diagnostic-inventory.json
 ```
 
 Expected: the worktree is clean except for committed task/spec/plan documents. If latest `dev` changed any listed file, stop and reconcile the spec and plan before writing tests.
@@ -86,7 +92,74 @@ Run:
 
 Expected: 26 tests pass. If the latest-dev count changes, record the new green count; do not proceed through a failure.
 
-- [ ] **Step 3: Capture the diagnostic-inventory no-regression fingerprint**
+- [ ] **Step 3: Reconcile the reviewed latest-dev inventory baseline before production edits**
+
+Run the checker before editing the manifest:
+
+```bash
+../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py
+```
+
+At latest-dev commit `c4599b8b1`, expected: exit 1 because the Prompt Workbench
+and Change Review merges changed production diagnostics without committing the
+generated inventory. Compare committed and generated inventories in memory;
+do not run `--write`. The reviewed drift is exactly:
+
+- summary `442/1089/6769/5` becomes `444/1102/6774/5` for
+  owner files/TASK-492 calls/TASK-494 calls/sink files;
+- add `Prompt_Management/prompt_improvement_service.py` with one TASK-494 call;
+- add `Workspaces/change_revert.py` with two TASK-494 calls;
+- update the owner entries for `Chat_Functions.py`,
+  `console_provider_gateway.py`, `Prompts_DB.py`, `LLM_API_Calls.py`,
+  `LLM_API_Calls_Local.py`, `local_llm_provider_catalog_service.py`,
+  `Prompts_Interop.py`, `chat_screen.py`, and `library_screen.py`; and
+- leave persistent-sink topology and `monitoring_engine.py` unchanged.
+
+At that pinned commit the exact generated owner values are:
+
+| Path suffix | Calls | Digest |
+| --- | ---: | --- |
+| `Chat/Chat_Functions.py` | 107 | `f017eaf38022f2d4017f` |
+| `Chat/console_provider_gateway.py` | 1 | `8c26198aaec0ad29e749` |
+| `DB/Prompts_DB.py` | 120 | `15e26a5f1df0fd8482ef` |
+| `LLM_Calls/LLM_API_Calls.py` | 171 | `e5991075a75d934a7e42` |
+| `LLM_Calls/LLM_API_Calls_Local.py` | 41 | `bc790fe8d2f3544203bf` |
+| `LLM_Provider_Catalog/local_llm_provider_catalog_service.py` | 5 | `211e68ecc8c6e816b301` |
+| `Prompt_Management/Prompts_Interop.py` | 93 | `d7ca19fa44acdf1e5289` |
+| `Prompt_Management/prompt_improvement_service.py` | 1 | `f7a441595550015f240a` |
+| `UI/Screens/chat_screen.py` | 148 | `569dd419f351b767b1d4` |
+| `UI/Screens/library_screen.py` | 77 | `35bdc0279c8ae277f42d` |
+| `Workspaces/change_revert.py` | 2 | `2c290c7704b2a652f70b` |
+
+Review the semantic diagnostic-call delta, not only digests. The accepted delta
+must still be: metadata-safe LLM helpers instead of payload/error previews;
+prompt-improvement request/provider/model/count metadata without prompt text;
+two constant change-revert warnings; the Prompts DB v2-to-v3 migration pair;
+and otherwise only line movement/formatting. If latest `dev` differs, stop and
+reconcile the new delta before patching anything.
+
+Use `apply_patch` to change exactly the reviewed summary and owner entries.
+Then run:
+
+```bash
+../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py
+../../.venv/bin/python -m pytest \
+  Tests/Architecture/test_persistent_diagnostic_inventory.py \
+  -q
+```
+
+Expected: checker exit 0 with 444 owners, 1,102 TASK-492 calls, 6,774
+TASK-494 calls, and five sink files; all three architecture tests pass.
+
+Commit this prerequisite separately before any sanitizer production edit and
+record the commit ID as the TASK-856 inventory reconciliation boundary:
+
+```bash
+git add Docs/security/production-diagnostic-inventory.json
+git commit -m "chore(security): reconcile diagnostic inventory baseline"
+```
+
+- [ ] **Step 4: Capture the reconciled diagnostic-inventory no-regression fingerprint**
 
 Run this read-only command before production edits:
 
@@ -100,17 +173,17 @@ Expected monitoring entry on the currently approved base:
 {"call_count": 16, "diagnostic_digest": "5bd6f2dfc3a7c56e9aea", "owner": "TASK-494", "path": "tldw_chatbook/Subscriptions/monitoring_engine.py", "reason": "remaining Chatbook production diagnostic owner"}
 ```
 
-Expected non-monitoring SHA-256 at `f5ca03d42`:
+Expected non-monitoring SHA-256 after the reviewed `c4599b8b1` reconciliation:
 
 ```text
-15f2e147c842ca5958ae14f53eeec3081966ba0ec8163f415088c02ad225d455
+854ea4cb694d8849b3f38ae473ca42df5bacbdc61ab5478eebea2b88294f2b6f
 ```
 
 Record the actual output in the plan execution notes. If latest `dev` changes
 either value, reconcile it before proceeding rather than forcing the old
 baseline.
 
-- [ ] **Step 4: Move the existing sanitizer tests to their dedicated owner**
+- [ ] **Step 5: Move the existing sanitizer tests to their dedicated owner**
 
 Create `Tests/Utils/test_log_sanitizer.py` with the existing `TestLogSanitizer` imports and test methods from `Tests/Utils/test_security_enhancements.py`. Remove only that class and its sanitizer imports from `test_security_enhancements.py`; keep every path-validation test unchanged.
 
@@ -125,7 +198,7 @@ Run:
 
 Expected: all relocated baseline tests pass before new assertions are added.
 
-- [ ] **Step 5: Write failing structured-redaction tests**
+- [ ] **Step 6: Write failing structured-redaction tests**
 
 Add imports for `tomllib`, `CONFIG_TOML_CONTENT`, `DEFAULT_APP_TTS_CONFIG`, and `is_sensitive_config_key`. Add a local recursive leaf-key iterator rather than importing a helper from another test module.
 
@@ -180,7 +253,7 @@ Also add direct tests proving:
 - `api_key_env_var`, `max_tokens`, and an ordinary key remain unchanged; and
 - a sensitive key whose value is a dictionary or list replaces the entire container with the marker before recursion.
 
-- [ ] **Step 6: Run the structured tests and verify RED**
+- [ ] **Step 7: Run the structured tests and verify RED**
 
 Run:
 
@@ -190,7 +263,7 @@ Run:
 
 Expected: failures show missing real config/log fields and the current non-string-key `.lower()` exception. Ensure each new test reaches the intended assertion rather than failing during setup.
 
-- [ ] **Step 7: Implement the exact structured classifier**
+- [ ] **Step 8: Implement the exact structured classifier**
 
 In `tldw_chatbook/Utils/log_sanitizer.py`:
 
@@ -220,7 +293,7 @@ def _is_sensitive_log_key(key: object) -> bool:
 
 Delete the drifting `SENSITIVE_FIELDS` set. Change `sanitize_dict()` to call `_is_sensitive_log_key(key)` and use `REDACTION_MARKER`. Preserve the existing type fallback, `deep` branching order, direct-string sanitization, and list recursion exactly. Do not broaden the public functions to tuples, arbitrary mappings, or new container types.
 
-- [ ] **Step 8: Run structured and canonical-predicate tests GREEN**
+- [ ] **Step 9: Run structured and canonical-predicate tests GREEN**
 
 Run:
 
@@ -234,7 +307,7 @@ Run:
 
 Expected: all structured and relocated baseline tests pass; string tests that have not yet been added are not part of this checkpoint.
 
-- [ ] **Step 9: Commit the structured classifier**
+- [ ] **Step 10: Commit the structured classifier**
 
 ```bash
 git add \
@@ -639,11 +712,13 @@ Do not import `_log_origin()` from `Utils.egress`; the origin is unnecessary for
 
 Run the exact command from Step 3.
 
-Expected: 3 tests pass using production helpers and the real snapshot producer.
+Expected: 4 tests pass using production helpers and the real snapshot producer
+(three on Windows because the non-portable filename case is explicitly
+skipped).
 
-- [ ] **Step 7: Prove the branch changes only the monitoring inventory entry**
+- [ ] **Step 7: Prove TASK-856 changes only the monitoring inventory entry after reconciliation**
 
-Re-run the read-only fingerprint command from Task 1, Step 3.
+Re-run the read-only fingerprint command from Task 1, Step 4.
 
 Expected:
 
@@ -651,15 +726,21 @@ Expected:
 - `owner`, `reason`, and `call_count: 16` remain unchanged; and
 - only `diagnostic_digest` differs for `monitoring_engine.py`.
 
-Patch only that digest in `Docs/security/production-diagnostic-inventory.json` with `apply_patch`. Do not run the checker's blanket `--write` mode.
+Patch only that digest in `Docs/security/production-diagnostic-inventory.json`
+with `apply_patch`. Do not run the checker's blanket `--write` mode. Use the
+recorded reconciliation commit—not `origin/dev`—as the comparison boundary for
+TASK-856's inventory delta.
 
 Inspect:
 
 ```bash
-git diff -- Docs/security/production-diagnostic-inventory.json
+git diff <reconciliation-commit>...HEAD -- \
+  Docs/security/production-diagnostic-inventory.json
 ```
 
-Expected: one digest line changes.
+Expected: one digest line changes. The whole branch diff against `origin/dev`
+also contains the separately reviewed upstream reconciliation and must not be
+misreported as a TASK-856 sanitizer change.
 
 - [ ] **Step 8: Run the complete diagnostic-inventory gate GREEN**
 

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -122,7 +122,7 @@ At that pinned commit the exact generated owner values are:
 | `Subscriptions/local_watchlists_service.py` | 3 | `db76c859421cc0197208` |
 | `Subscriptions/watchlist_scope_service.py` | 2 | `8dc49325dd2b17b0a7f5` |
 | `Tools/web_tool_impls.py` | 9 | `5130bcf118362c078f60` |
-| `UI/Console_Modules/dictation.py` | 10 | `44188d4d417a8174a0a` |
+| `UI/Console_Modules/dictation.py` | 10 | `44188d4d4174a8174a0a` |
 | `UI/Console_Modules/message.py` | 13 | `ee1a310018bae09826e6` |
 | `UI/Navigation/main_navigation.py` | 1 | `5041017946de31086ddb` |
 | `UI/Screens/chat_screen.py` | 142 | `3547979b9158631d0066` |

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -850,6 +850,30 @@ Task 3 then changes only the monitoring digest to
 final checker must report 467 owners, 1,151 TASK-492 calls, 6,859 TASK-494
 calls, and six sink files.
 
+#### Final-dev rebase amendment
+
+After verified closeout, `origin/dev` advanced again and the branch rebased
+cleanly onto `b030b0b73f217b955b298a45fce3a0256403447c`. The upstream Console
+rail work did not modify any TASK-856 production/test file and did not add or
+remove any diagnostic call. It moved existing calls in three owners, so the
+generated counts remain `467/1151/6859/6` while these line-sensitive entries
+change:
+
+| Path suffix | Calls | Generated digest |
+| --- | ---: | --- |
+| `UI/Screens/chat_screen.py` | 142 | `35ccde87405a6c405f14` |
+| `UI/Screens/settings_screen.py` | 29 | `0c5906f0cf31d049ca2b` |
+| `config.py` | 103 | `97bc4277a86ca26bb903` |
+
+AST call-multiset comparison is identical for all three files. Persistent-sink
+shapes/digests are unchanged; only the `config.py` private append sink moves
+from line 4352 to 4357. Reconcile exactly those entries in a third baseline
+commit placed immediately before the Task 3 consumer commit. At that boundary
+the monitoring digest remains `f9ccee6989b39da1333b`; TASK-856's head changes
+only that digest to `911bf9d65817bf259923`. Both sides share the current
+non-monitoring fingerprint
+`5ce06a13eb48f8007eddfa92a0616b41e5122b89e6b2b7d494d4c81fb48723ac`.
+
 - [ ] **Step 1: Run the complete focused sanitizer/security suite**
 
 ```bash

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -256,6 +256,21 @@ git commit -m "fix(security): centralize structured credential fields"
 
 - [ ] **Step 1: Add failing assignment-scanner and standalone-rule tests**
 
+First update the relocated baseline assertions to the approved neutral-marker
+contract before adding the new RED cases:
+
+- `Bearer sk-...` expects `Bearer ***REDACTED***`, not
+  `Bearer ***OPENAI_KEY***`;
+- standalone `sk-...` in `create_safe_log_message()` expects
+  `***REDACTED***`, not `***OPENAI_KEY***`; and
+- URL userinfo expects `https://***REDACTED***@example.com`, not the legacy
+  `https://***:***@example.com` split marker.
+
+Replace any other provider-specific marker expectation carried over from
+`TestLogSanitizer` with `***REDACTED***`. These assertion changes are part of
+the approved contract and must happen before the RED run, so a later GREEN run
+cannot be blocked by stale expectations from the implementation being removed.
+
 Add parameterized and focused cases with conspicuous fake sentinels:
 
 ```python
@@ -288,6 +303,10 @@ Add separate tests proving:
 - already-redacted strings, dictionaries, and lists are idempotent;
 - non-string input retains the current `str()` fallback;
 - `create_safe_log_message()` formatting failure returns the sanitized template and never interpolates raw arguments; and
+- `safe_log()` invokes its supplied callback exactly once with only the fully
+  sanitized final message, for example by collecting calls from
+  `safe_log(calls.append, "api_key={}", "PRIVATE_CALLBACK")` and asserting
+  `calls == ["api_key=***REDACTED***"]`; and
 - a 100,000-character non-matching string completes and remains unchanged without a wall-clock timing assertion.
 
 - [ ] **Step 2: Extend the existing installed-wheel probe before implementation**
@@ -467,7 +486,7 @@ In `test_ollama_success_payloads_are_bounded_and_redacted`, strengthen the paylo
 names = ollama_events._safe_ollama_model_names(
     [
         {"name": "claude-opus-4-20250514"},
-        {"name": "org/model\r\ninjected"},
+        {"name": "org/model\r\n\tinjected"},
     ]
 )
 assert names == ["claude-opus-4-20250514", "org/model injected"]
@@ -487,11 +506,33 @@ def test_transformers_model_scan_preserves_claude_ids_as_one_line(tmp_path: Path
     ]
 ```
 
+Add a second direct Transformers filesystem test for single-line normalization.
+Because CR/LF/tab characters in a directory name are not portable to Windows,
+skip only this test there with `@pytest.mark.skipif(os.name == "nt", ...)`:
+
+```python
+@pytest.mark.skipif(os.name == "nt", reason="Windows filenames reject CR/LF/tab")
+def test_transformers_model_scan_normalizes_multiline_names(tmp_path: Path) -> None:
+    model_root = tmp_path / "models--org--line\r\n\tname"
+    model_root.mkdir()
+    (model_root / "config.json").write_text("{}", encoding="utf-8")
+    (model_root / "model.safetensors").touch()
+
+    assert transformers_events.scan_transformers_local_models(tmp_path) == [
+        "org/line name"
+    ]
+```
+
 Use direct production functions; do not construct a test app.
 
 - [ ] **Step 2: Write the failing real snapshot-pruning diagnostic test**
 
 In `Tests/Subscriptions/test_watchlist_snapshot_pruning.py`, use the existing real DB/source helpers and `URLMonitor._store_snapshot()`:
+
+While touching this file, remove its pre-existing unused `_serve` import. A
+latest-dev scoped Ruff baseline reports that single `F401`; `_serve` has no
+references in the module, so removal is mechanical test hygiene rather than a
+behavioral change.
 
 ```python
 @pytest.mark.asyncio
@@ -549,11 +590,15 @@ Run:
 ../../.venv/bin/python -m pytest \
   Tests/ProductionApp/test_llm_destination_actions.py::test_ollama_success_payloads_are_bounded_and_redacted \
   Tests/ProductionApp/test_llm_destination_actions.py::test_transformers_model_scan_preserves_claude_ids_as_one_line \
+  Tests/ProductionApp/test_llm_destination_actions.py::test_transformers_model_scan_normalizes_multiline_names \
   Tests/Subscriptions/test_watchlist_snapshot_pruning.py::test_prune_diagnostic_omits_the_monitored_url \
   -q
 ```
 
-Expected: Ollama/Transformers fail because model names still use credential redaction or retain multiple lines; the subscription test fails because the full sanitized URL is still present.
+Expected: Ollama/Transformers fail because model names still use credential
+redaction or retain CR/LF/tab whitespace; the subscription test fails because
+the full sanitized URL is still present. On Windows only the explicitly
+non-portable Transformers filename case is skipped.
 
 - [ ] **Step 4: Split Ollama and Transformers display validation from redaction**
 
@@ -709,7 +754,12 @@ Expected: pass from the isolated installed target with target hashes unchanged.
 
 ../../.venv/bin/python -m ruff format --check \
   tldw_chatbook/Utils/log_sanitizer.py \
-  Tests/Utils/test_log_sanitizer.py
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_ollama.py \
+  tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_transformers.py \
+  Tests/Utils/test_log_sanitizer.py \
+  Tests/Utils/test_security_enhancements.py \
+  Tests/ProductionApp/test_llm_destination_actions.py \
+  Tests/Packaging/test_installed_distribution.py
 
 ../../.venv/bin/python -m py_compile \
   tldw_chatbook/Utils/log_sanitizer.py \
@@ -718,7 +768,33 @@ Expected: pass from the isolated installed target with target hashes unchanged.
   tldw_chatbook/Subscriptions/monitoring_engine.py
 ```
 
-Expected: all commands pass. If whole-file Ruff format is pre-existingly red for a changed legacy file, prove the base revision has the same result and format only the edited region/file when safe; do not mass-format unrelated code.
+For each edited hunk in the two legacy files with recorded whole-file format
+drift, derive the enclosing post-edit logical block from
+`git diff --unified=0 origin/dev...HEAD -- <file>`, then run one range check per
+edited block (Ruff accepts one range per invocation):
+
+```bash
+../../.venv/bin/python -m ruff format --check --range=<start>-<end> \
+  tldw_chatbook/Subscriptions/monitoring_engine.py
+../../.venv/bin/python -m ruff format --check --range=<start>-<end> \
+  Tests/Subscriptions/test_watchlist_snapshot_pruning.py
+```
+
+Include the import block and the new test as separate snapshot-test ranges if
+they are separate hunks. Record the exact ranges and passing output in the
+execution notes.
+
+Expected: lint, every full-file format check, every edited-range format check,
+and syntax compilation pass. Do not accept a new formatting failure merely
+because a file had unrelated baseline drift.
+
+Recorded latest-dev format baseline: Ruff would reformat
+`Tests/Subscriptions/test_watchlist_snapshot_pruning.py` and
+`tldw_chatbook/Subscriptions/monitoring_engine.py` before TASK-856. Do not
+mass-format either legacy file in this task; scoped lint must be green after the
+unused import is removed. Every currently formatted changed Python file must
+pass a full-file format check, and every edited block in the two legacy files
+must pass an explicit range check.
 
 - [ ] **Step 5: Run hygiene and scope review**
 

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -392,7 +392,11 @@ Add separate tests proving:
   sanitized final message, for example by collecting calls from
   `safe_log(calls.append, "api_key={}", "PRIVATE_CALLBACK")` and asserting
   `calls == ["api_key=***REDACTED***"]`; and
-- a 100,000-character non-matching string completes and remains unchanged without a wall-clock timing assertion.
+- a 100,000-character non-matching string completes and remains unchanged without a wall-clock timing assertion; and
+- a long line containing many quoted sensitive assignments produces the exact
+  redacted output without repeatedly scanning the remainder of the line. Prove
+  this with deterministic CR/LF search-work accounting on the real scanner,
+  not a wall-clock threshold.
 
 - [ ] **Step 2: Extend the existing installed-wheel probe before implementation**
 
@@ -484,6 +488,12 @@ def _redact_assignments(text: str) -> str:
 6. replace an unterminated quote from after the opening quote to the line boundary;
 7. replace an unquoted sensitive value through the line boundary; and
 8. resume after CR/LF/CRLF and continue until no candidate remains.
+
+After a sensitive prefix, inspect the immediate value character for EOF or a
+CR/LF boundary before any line search. Parse quoted values directly with
+`_find_quoted_end()`; call `_line_end()` only for unquoted values. Dense quoted
+assignments must therefore remain single-pass rather than rescanning the line
+suffix for every value.
 
 Do not use repeated whole-string concatenation in the scan loop. Collect spans and build once.
 

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -1030,7 +1030,7 @@ backlog task 856 --plain
 
 Expected: status Done, all acceptance criteria checked, Implementation Plan and Implementation Notes present, and ADR-029 linked.
 
-- [ ] **Step 8: Commit closeout documentation**
+- [x] **Step 8: Commit closeout documentation**
 
 ```bash
 git add \
@@ -1040,7 +1040,7 @@ git add \
 git commit -m "docs(security): close TASK-856 sanitizer repair"
 ```
 
-- [ ] **Step 9: Run final verification after the closeout commit**
+- [x] **Step 9: Run final verification after the closeout commit**
 
 Re-run the complete focused commands from Steps 1–5 plus the installed-wheel test. Confirm the worktree is clean, every implementation commit is based on the current `origin/dev`, and every required gate is green.
 

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -100,7 +100,15 @@ Expected monitoring entry on the currently approved base:
 {"call_count": 16, "diagnostic_digest": "5bd6f2dfc3a7c56e9aea", "owner": "TASK-494", "path": "tldw_chatbook/Subscriptions/monitoring_engine.py", "reason": "remaining Chatbook production diagnostic owner"}
 ```
 
-Record the printed non-monitoring SHA-256 in the plan execution notes. If latest `dev` changes the entry, reconcile it before proceeding.
+Expected non-monitoring SHA-256 at `f5ca03d42`:
+
+```text
+15f2e147c842ca5958ae14f53eeec3081966ba0ec8163f415088c02ad225d455
+```
+
+Record the actual output in the plan execution notes. If latest `dev` changes
+either value, reconcile it before proceeding rather than forcing the old
+baseline.
 
 - [ ] **Step 4: Move the existing sanitizer tests to their dedicated owner**
 
@@ -608,7 +616,7 @@ git diff -- Docs/security/production-diagnostic-inventory.json
 
 Expected: one digest line changes.
 
-- [ ] **Step 8: Re-run the known-red global inventory gate without misreporting it**
+- [ ] **Step 8: Run the complete diagnostic-inventory gate GREEN**
 
 Run:
 
@@ -616,7 +624,7 @@ Run:
 ../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py
 ```
 
-Expected on the currently approved base: exit 1 with the same pre-existing global drift.
+Expected: exit 0 with the reviewed owner/sink summary.
 
 Run:
 
@@ -626,7 +634,7 @@ Run:
   -q
 ```
 
-Expected on the currently approved base: the inventory-equality test remains the one known failure; the persistent-metadata-marker and chained-logger-call sentinels pass. Record this as a base/head-equivalent limitation, not a task pass.
+Expected: all three architecture tests pass.
 
 - [ ] **Step 9: Commit the corrected consumers**
 
@@ -744,7 +752,7 @@ Use `superpowers:requesting-code-review` with TASK-856, ADR-029, the approved sp
 Update TASK-856 only after code and reviews are complete:
 
 - check all six acceptance criteria;
-- add concise `## Implementation Notes` covering the classifier/scanner, consumer boundary changes, installed-wheel proof, exact inventory limitation, changed files, and ADR-029;
+- add concise `## Implementation Notes` covering the classifier/scanner, consumer boundary changes, installed-wheel proof, one-digest inventory update, changed files, and ADR-029;
 - record every verification count and the known base/head-equivalent inventory failure;
 - change the design status to `Implemented and verified`;
 - check completed plan steps and document any deviation; and
@@ -770,4 +778,4 @@ git commit -m "docs(security): close TASK-856 sanitizer repair"
 
 - [ ] **Step 9: Run final verification after the closeout commit**
 
-Re-run the complete focused commands from Steps 1–5 plus the installed-wheel test. Confirm the worktree is clean, every implementation commit is based on the current `origin/dev`, and the only known red gate is identical to the recorded latest-dev diagnostic-inventory baseline. Do not describe that gate as passing.
+Re-run the complete focused commands from Steps 1–5 plus the installed-wheel test. Confirm the worktree is clean, every implementation commit is based on the current `origin/dev`, and every required gate is green.

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -53,7 +53,7 @@ No reduced, fake, simplified, or test-only application may be created. Use direc
 - Reference: `tldw_chatbook/Utils/sensitive_config_keys.py`
 - Reference: `backlog/decisions/029-local-private-data-boundary.md`
 
-- [ ] **Step 1: Refresh and verify the implementation base before code**
+- [x] **Step 1: Refresh and verify the implementation base before code**
 
 Run:
 
@@ -78,7 +78,7 @@ git diff --stat origin/dev...HEAD -- \
 
 Expected: the worktree is clean except for committed task/spec/plan documents. If latest `dev` changed any listed file, stop and reconcile the spec and plan before writing tests.
 
-- [ ] **Step 2: Re-run the focused behavioral baseline**
+- [x] **Step 2: Re-run the focused behavioral baseline**
 
 Run:
 
@@ -92,7 +92,7 @@ Run:
 
 Expected: 26 tests pass. If the latest-dev count changes, record the new green count; do not proceed through a failure.
 
-- [ ] **Step 3: Reconcile the reviewed latest-dev inventory baseline before production edits**
+- [x] **Step 3: Reconcile the reviewed latest-dev inventory baseline before production edits**
 
 Run the checker before editing the manifest:
 
@@ -170,7 +170,7 @@ git add Docs/security/production-diagnostic-inventory.json
 git commit -m "chore(security): reconcile diagnostic inventory baseline"
 ```
 
-- [ ] **Step 4: Capture the reconciled diagnostic-inventory no-regression fingerprint**
+- [x] **Step 4: Capture the reconciled diagnostic-inventory no-regression fingerprint**
 
 Run this read-only command before production edits:
 
@@ -195,7 +195,7 @@ Record the actual output in the plan execution notes. If latest `dev` changes
 either value, reconcile it before proceeding rather than forcing the old
 baseline.
 
-- [ ] **Step 5: Move the existing sanitizer tests to their dedicated owner**
+- [x] **Step 5: Move the existing sanitizer tests to their dedicated owner**
 
 Create `Tests/Utils/test_log_sanitizer.py` with the existing `TestLogSanitizer` imports and test methods from `Tests/Utils/test_security_enhancements.py`. Remove only that class and its sanitizer imports from `test_security_enhancements.py`; keep every path-validation test unchanged.
 
@@ -210,7 +210,7 @@ Run:
 
 Expected: all relocated baseline tests pass before new assertions are added.
 
-- [ ] **Step 6: Write failing structured-redaction tests**
+- [x] **Step 6: Write failing structured-redaction tests**
 
 Add imports for `tomllib`, `CONFIG_TOML_CONTENT`, `DEFAULT_APP_TTS_CONFIG`, and `is_sensitive_config_key`. Add a local recursive leaf-key iterator rather than importing a helper from another test module.
 
@@ -265,7 +265,7 @@ Also add direct tests proving:
 - `api_key_env_var`, `max_tokens`, and an ordinary key remain unchanged; and
 - a sensitive key whose value is a dictionary or list replaces the entire container with the marker before recursion.
 
-- [ ] **Step 7: Run the structured tests and verify RED**
+- [x] **Step 7: Run the structured tests and verify RED**
 
 Run:
 
@@ -275,7 +275,7 @@ Run:
 
 Expected: failures show missing real config/log fields and the current non-string-key `.lower()` exception. Ensure each new test reaches the intended assertion rather than failing during setup.
 
-- [ ] **Step 8: Implement the exact structured classifier**
+- [x] **Step 8: Implement the exact structured classifier**
 
 In `tldw_chatbook/Utils/log_sanitizer.py`:
 
@@ -305,7 +305,7 @@ def _is_sensitive_log_key(key: object) -> bool:
 
 Delete the drifting `SENSITIVE_FIELDS` set. Change `sanitize_dict()` to call `_is_sensitive_log_key(key)` and use `REDACTION_MARKER`. Preserve the existing type fallback, `deep` branching order, direct-string sanitization, and list recursion exactly. Do not broaden the public functions to tuples, arbitrary mappings, or new container types.
 
-- [ ] **Step 9: Run structured and canonical-predicate tests GREEN**
+- [x] **Step 9: Run structured and canonical-predicate tests GREEN**
 
 Run:
 
@@ -319,7 +319,7 @@ Run:
 
 Expected: all structured and relocated baseline tests pass; string tests that have not yet been added are not part of this checkpoint.
 
-- [ ] **Step 10: Commit the structured classifier**
+- [x] **Step 10: Commit the structured classifier**
 
 ```bash
 git add \
@@ -339,7 +339,7 @@ git commit -m "fix(security): centralize structured credential fields"
 - Modify: `Tests/Packaging/test_installed_distribution.py`
 - Modify: `tldw_chatbook/Utils/log_sanitizer.py`
 
-- [ ] **Step 1: Add failing assignment-scanner and standalone-rule tests**
+- [x] **Step 1: Add failing assignment-scanner and standalone-rule tests**
 
 First update the relocated baseline assertions to the approved neutral-marker
 contract before adding the new RED cases:
@@ -398,7 +398,7 @@ Add separate tests proving:
   this with deterministic CR/LF search-work accounting on the real scanner,
   not a wall-clock threshold.
 
-- [ ] **Step 2: Extend the existing installed-wheel probe before implementation**
+- [x] **Step 2: Extend the existing installed-wheel probe before implementation**
 
 Inside `INSTALLED_PROBE` in `Tests/Packaging/test_installed_distribution.py`, import from the installed target only:
 
@@ -416,7 +416,7 @@ assert "PRIVATE_INSTALLED_SENTINEL" not in sanitize_string(
 
 Do not add a test application, editable install, second builder, or source-root fallback. The existing probe already excludes checkout/build roots and imports the real `TldwCli` from the installed wheel.
 
-- [ ] **Step 3: Run the new source and installed tests RED**
+- [x] **Step 3: Run the new source and installed tests RED**
 
 Run:
 
@@ -436,7 +436,7 @@ Run:
 
 Expected: FAIL in the isolated child because the installed sanitizer rewrites `claude-*` and/or misses a required labeled value. Confirm the failure is behavioral, not a build/network/environment failure.
 
-- [ ] **Step 4: Implement the monotonic assignment scanner**
+- [x] **Step 4: Implement the monotonic assignment scanner**
 
 Replace `SENSITIVE_PATTERNS` with private compiled rules. Use a prefix-only assignment pattern so classification happens before value consumption:
 
@@ -497,7 +497,7 @@ suffix for every value.
 
 Do not use repeated whole-string concatenation in the scan loop. Collect spans and build once.
 
-- [ ] **Step 5: Implement standalone passes in the specified order**
+- [x] **Step 5: Implement standalone passes in the specified order**
 
 Add:
 
@@ -524,7 +524,7 @@ _STANDALONE_CREDENTIALS = (
 
 No pattern recognizes `claude-*`. Do not add standalone Basic matching or speculative opaque-provider formats.
 
-- [ ] **Step 6: Run source tests GREEN**
+- [x] **Step 6: Run source tests GREEN**
 
 Run:
 
@@ -538,7 +538,7 @@ Run:
 
 Expected: all pass. Inspect exact outputs, not only absence assertions, for quoted/unquoted syntax and false-positive cases.
 
-- [ ] **Step 7: Run the installed-wheel proof GREEN**
+- [x] **Step 7: Run the installed-wheel proof GREEN**
 
 Run:
 
@@ -550,7 +550,7 @@ Run:
 
 Expected: PASS from the isolated installed target, with source/build roots excluded and the target hash unchanged.
 
-- [ ] **Step 8: Commit the scanner and wheel proof**
+- [x] **Step 8: Commit the scanner and wheel proof**
 
 ```bash
 git add \
@@ -573,7 +573,7 @@ git commit -m "fix(security): redact labeled credentials without model false pos
 - Modify: `tldw_chatbook/Subscriptions/monitoring_engine.py`
 - Modify: `Docs/security/production-diagnostic-inventory.json`
 
-- [ ] **Step 1: Write failing direct production-helper tests**
+- [x] **Step 1: Write failing direct production-helper tests**
 
 In `test_ollama_success_payloads_are_bounded_and_redacted`, strengthen the payload to include nested `x-api-key`/authorization fields and replace the credential-like model-name assertion with:
 
@@ -620,7 +620,7 @@ def test_transformers_model_scan_normalizes_multiline_names(tmp_path: Path) -> N
 
 Use direct production functions; do not construct a test app.
 
-- [ ] **Step 2: Write the failing real snapshot-pruning diagnostic test**
+- [x] **Step 2: Write the failing real snapshot-pruning diagnostic test**
 
 In `Tests/Subscriptions/test_watchlist_snapshot_pruning.py`, use the existing real DB/source helpers and `URLMonitor._store_snapshot()`:
 
@@ -677,7 +677,7 @@ async def test_prune_diagnostic_omits_the_monitored_url(monkeypatch) -> None:
 
 If the real logger is used by another `_store_snapshot()` branch during this test, give the replacement object only the methods actually observed; do not replace `URLMonitor` or the database with a simplified test implementation.
 
-- [ ] **Step 3: Run consumer tests RED**
+- [x] **Step 3: Run consumer tests RED**
 
 Run:
 
@@ -695,7 +695,7 @@ redaction or retain CR/LF/tab whitespace; the subscription test fails because
 the full sanitized URL is still present. On Windows only the explicitly
 non-portable Transformers filename case is skipped.
 
-- [ ] **Step 4: Split Ollama and Transformers display validation from redaction**
+- [x] **Step 4: Split Ollama and Transformers display validation from redaction**
 
 In Ollama:
 
@@ -729,7 +729,7 @@ Task 1, Step 4. Expected: both the non-monitoring SHA-256 and the monitoring
 entry still exactly match the reconciled baseline. If they do not, fix the
 line-count/scope error before proceeding.
 
-- [ ] **Step 5: Omit the subscription URL at the producer boundary**
+- [x] **Step 5: Omit the subscription URL at the producer boundary**
 
 Delete the dynamic log-sanitizer import and its stale Qodo comment. Change only the message and arguments:
 
@@ -744,7 +744,7 @@ logger.debug(
 
 Do not import `_log_origin()` from `Utils.egress`; the origin is unnecessary for this diagnostic.
 
-- [ ] **Step 6: Run the direct consumer tests GREEN**
+- [x] **Step 6: Run the direct consumer tests GREEN**
 
 Run the exact command from Step 3.
 
@@ -752,7 +752,7 @@ Expected: four selected tests pass using production helpers and the real
 snapshot producer on POSIX. Windows reports three passed and the one explicitly
 non-portable filename case skipped.
 
-- [ ] **Step 7: Prove TASK-856 changes only the monitoring inventory entry after reconciliation**
+- [x] **Step 7: Prove TASK-856 changes only the monitoring inventory entry after reconciliation**
 
 Re-run the read-only fingerprint command from Task 1, Step 4.
 
@@ -778,7 +778,7 @@ Expected: one digest line changes. The whole branch diff against `origin/dev`
 also contains the separately reviewed upstream reconciliation and must not be
 misreported as a TASK-856 sanitizer change.
 
-- [ ] **Step 8: Run the complete diagnostic-inventory gate GREEN**
+- [x] **Step 8: Run the complete diagnostic-inventory gate GREEN**
 
 Run:
 
@@ -798,7 +798,7 @@ Run:
 
 Expected: all three architecture tests pass.
 
-- [ ] **Step 9: Commit the corrected consumers**
+- [x] **Step 9: Commit the corrected consumers**
 
 ```bash
 git add \
@@ -855,9 +855,12 @@ commit them separately, and place that reconciliation immediately before the
 Task 3 consumer commit. At that boundary `monitoring_engine.py` still has digest
 `f9ccee6989b39da1333b`; the current non-monitoring fingerprint is
 `a927b4bc7a229d3c3328a5336054c410aabdedfe5fd40219ab1152a9880763eb`.
-Task 3 then changes only the monitoring digest to
+Task 3 initially changed only the monitoring digest to
 `3826b76482fd484ff194`, preserving the same non-monitoring fingerprint. The
-final checker must report 467 owners, 1,151 TASK-492 calls, 6,859 TASK-494
+scoped Ruff format repair subsequently changed only that source-sensitive
+monitoring digest to the current `911bf9d65817bf259923`; owner, reason,
+16-call count, sink topology, and non-monitoring fingerprint remain unchanged.
+The final checker must report 467 owners, 1,151 TASK-492 calls, 6,859 TASK-494
 calls, and six sink files.
 
 #### Final-dev rebase amendment
@@ -884,7 +887,7 @@ only that digest to `911bf9d65817bf259923`. Both sides share the current
 non-monitoring fingerprint
 `5ce06a13eb48f8007eddfa92a0616b41e5122b89e6b2b7d494d4c81fb48723ac`.
 
-- [ ] **Step 1: Run the complete focused sanitizer/security suite**
+- [x] **Step 1: Run the complete focused sanitizer/security suite**
 
 ```bash
 ../../.venv/bin/python -m pytest \
@@ -896,7 +899,7 @@ non-monitoring fingerprint
 
 Expected: all pass.
 
-- [ ] **Step 2: Run the full affected production-app and subscription modules**
+- [x] **Step 2: Run the full affected production-app and subscription modules**
 
 ```bash
 ../../.venv/bin/python -m pytest \
@@ -907,7 +910,7 @@ Expected: all pass.
 
 Expected: all pass. These are the real production app/direct producer owners; do not substitute a reduced app.
 
-- [ ] **Step 3: Re-run the installed-wheel test from a clean build**
+- [x] **Step 3: Re-run the installed-wheel test from a clean build**
 
 ```bash
 ../../.venv/bin/python -m pytest \
@@ -917,7 +920,7 @@ Expected: all pass. These are the real production app/direct producer owners; do
 
 Expected: pass from the isolated installed target with target hashes unchanged.
 
-- [ ] **Step 4: Run static and syntax checks on every changed Python file**
+- [x] **Step 4: Run static and syntax checks on every changed Python file**
 
 ```bash
 ../../.venv/bin/python -m ruff check \
@@ -975,7 +978,7 @@ unused import is removed. Every currently formatted changed Python file must
 pass a full-file format check, and every edited block in the two legacy files
 must pass an explicit range check.
 
-- [ ] **Step 5: Run hygiene and scope review**
+- [x] **Step 5: Run hygiene and scope review**
 
 ```bash
 git diff --check
@@ -1000,11 +1003,11 @@ Review every changed line for:
   reconciliations and the TASK-856 monitoring digest is included, and no user
   change is disturbed.
 
-- [ ] **Step 6: Request independent code review and address verified findings**
+- [x] **Step 6: Request independent code review and address verified findings**
 
 Use `superpowers:requesting-code-review` with TASK-856, ADR-029, the approved spec/plan, the exact base/head inventory evidence, and all verification output. Apply `superpowers:receiving-code-review` before accepting any suggestion. Re-run affected tests after each correction and repeat review until no Critical or Important issue remains.
 
-- [ ] **Step 7: Complete Backlog and design/plan documentation**
+- [x] **Step 7: Complete Backlog and design/plan documentation**
 
 Update TASK-856 only after code and reviews are complete:
 
@@ -1040,3 +1043,49 @@ git commit -m "docs(security): close TASK-856 sanitizer repair"
 - [ ] **Step 9: Run final verification after the closeout commit**
 
 Re-run the complete focused commands from Steps 1–5 plus the installed-wheel test. Confirm the worktree is clean, every implementation commit is based on the current `origin/dev`, and every required gate is green.
+
+## Execution and deviations
+
+- The first latest-dev diagnostic mismatch was reviewed at
+  `ceede62fe46d7aa090df4a36307077e097d8c044`: checked
+  `466/1144/6851/6` versus generated `467/1151/6854/6`. Commit
+  `3305befb9` records only that reviewed pre-existing inventory reconciliation.
+- After Tasks 1–3 reviewed cleanly, `origin/dev` advanced to
+  `85a46bea8704d076fd6b544e56bead760fd3e9d9`. Scoped TASK-856 files were
+  unchanged, but five upstream `app.py` diagnostics and related line movement
+  changed the generated repository-wide manifest from checked
+  `467/1151/6854/6` to `467/1151/6859/6`. Commit `f44b5ff01` records the
+  separately reviewed rebase boundary immediately before the Task 3 consumer
+  commit.
+- At `f44b5ff01`, the monitoring owner is TASK-494 with 16 calls, digest
+  `f9ccee6989b39da1333b`, and non-monitoring SHA-256
+  `a927b4bc7a229d3c3328a5336054c410aabdedfe5fd40219ab1152a9880763eb`.
+  Final generated state retains the owner, reason, count, fingerprint, and six
+  sinks while changing only that digest to `911bf9d65817bf259923`.
+- The first Task 4 verification exposed four branch-introduced Ruff format
+  failures. Commit `7e1462300` applied deterministic formatting only to the
+  approved full files and edited legacy range, then patched only the resulting
+  monitoring digest.
+- Whole-branch review reported no Critical issues, two related Important
+  scanner-complexity issues, and one Minor annotation mismatch. The added dense
+  matched-input test deterministically measured 94,996,790 CR/LF-search work
+  characters for 46,888 input characters before the fix. Commit `b847da509`
+  routes quoted values directly to their quote scanner; scoped re-review found
+  both Important issues resolved and no new Critical/Important issue. The
+  compatible `sanitize_dict` non-string-key annotation Minor is explicitly
+  deferred.
+- Final pre-closeout gates had 77 sanitizer/security tests, four selected
+  TASK-856 consumers, one isolated installed-wheel test, and three diagnostic
+  architecture tests passing. Inventory was `467/1151/6859/6`; Ruff lint,
+  full-file format, three legacy ranges, `py_compile`, and diff hygiene were
+  green.
+- The prescribed full affected-module command is not reported as passing. It
+  returned **2 failed, 26 passed** on the branch, with exactly
+  `test_llm_destination_action_census_is_complete_and_removed_controls_are_absent`
+  and `test_production_llm_destination_owns_navigation_actions_and_recovery`.
+  The identical clean-`origin/dev` command returned the same failure set at
+  **2 failed, 23 passed**; the branch adds three passing TASK-856 tests.
+- Task 4 Steps 8 and 9 remain unchecked in this closeout document because the
+  commit and its post-commit verification are necessarily performed after the
+  document is staged. Their exact results are recorded in the ignored SDD
+  `task-4-report.md` ledger rather than falsified pre-commit.

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -1049,31 +1049,37 @@ Re-run the complete focused commands from Steps 1–5 plus the installed-wheel t
 - The first latest-dev diagnostic mismatch was reviewed at
   `ceede62fe46d7aa090df4a36307077e097d8c044`: checked
   `466/1144/6851/6` versus generated `467/1151/6854/6`. Commit
-  `3305befb9` records only that reviewed pre-existing inventory reconciliation.
+  rebased commit `2299da555` records only that reviewed pre-existing inventory
+  reconciliation.
 - After Tasks 1–3 reviewed cleanly, `origin/dev` advanced to
   `85a46bea8704d076fd6b544e56bead760fd3e9d9`. Scoped TASK-856 files were
   unchanged, but five upstream `app.py` diagnostics and related line movement
   changed the generated repository-wide manifest from checked
-  `467/1151/6854/6` to `467/1151/6859/6`. Commit `f44b5ff01` records the
+  `467/1151/6854/6` to `467/1151/6859/6`. Rebased commit `a25f5c792` records the
   separately reviewed rebase boundary immediately before the Task 3 consumer
   commit.
-- At `f44b5ff01`, the monitoring owner is TASK-494 with 16 calls, digest
+- After verified closeout, `origin/dev` advanced again to
+  `b030b0b73f217b955b298a45fce3a0256403447c`. No TASK-856 file or diagnostic
+  call changed, but Console rail line movement changed three owner digests and
+  the `config.py` sink line. Rebased commit `2862505e7` records that third
+  reviewed boundary immediately before the Task 3 consumer commit.
+- At `2862505e7`, the monitoring owner is TASK-494 with 16 calls, digest
   `f9ccee6989b39da1333b`, and non-monitoring SHA-256
-  `a927b4bc7a229d3c3328a5336054c410aabdedfe5fd40219ab1152a9880763eb`.
+  `5ce06a13eb48f8007eddfa92a0616b41e5122b89e6b2b7d494d4c81fb48723ac`.
   Final generated state retains the owner, reason, count, fingerprint, and six
   sinks while changing only that digest to `911bf9d65817bf259923`.
 - The first Task 4 verification exposed four branch-introduced Ruff format
-  failures. Commit `7e1462300` applied deterministic formatting only to the
-  approved full files and edited legacy range, then patched only the resulting
-  monitoring digest.
+  failures. Rebased commit `dce39f0d2` applied deterministic formatting only
+  to the approved full files and edited legacy range, then patched only the
+  resulting monitoring digest.
 - Whole-branch review reported no Critical issues, two related Important
   scanner-complexity issues, and one Minor annotation mismatch. The added dense
   matched-input test deterministically measured 94,996,790 CR/LF-search work
-  characters for 46,888 input characters before the fix. Commit `b847da509`
-  routes quoted values directly to their quote scanner; scoped re-review found
-  both Important issues resolved and no new Critical/Important issue. The
-  compatible `sanitize_dict` non-string-key annotation Minor is explicitly
-  deferred.
+  characters for 46,888 input characters before the fix. Rebased commit
+  `1c1686cfa` routes quoted values directly to their quote scanner; scoped
+  re-review found both Important issues resolved and no new Critical/Important
+  issue. The compatible `sanitize_dict` non-string-key annotation Minor is
+  explicitly deferred.
 - Final pre-closeout gates had 77 sanitizer/security tests, four selected
   TASK-856 consumers, one isolated installed-wheel test, and three diagnostic
   architecture tests passing. Inventory was `467/1151/6859/6`; Ruff lint,
@@ -1085,7 +1091,6 @@ Re-run the complete focused commands from Steps 1–5 plus the installed-wheel t
   and `test_production_llm_destination_owns_navigation_actions_and_recovery`.
   The identical clean-`origin/dev` command returned the same failure set at
   **2 failed, 23 passed**; the branch adds three passing TASK-856 tests.
-- Task 4 Steps 8 and 9 remain unchecked in this closeout document because the
-  commit and its post-commit verification are necessarily performed after the
-  document is staged. Their exact results are recorded in the ignored SDD
-  `task-4-report.md` ledger rather than falsified pre-commit.
+- Rebased closeout commit `d70bd448f` recorded the verified design/task/lesson
+  state. Follow-up commit `15d6d4b0c` checked completed Steps 8 and 9 after the
+  post-commit gates; scoped re-review found the marker-only correction clean.

--- a/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+++ b/Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
@@ -100,46 +100,54 @@ Run the checker before editing the manifest:
 ../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py
 ```
 
-At latest-dev commit `c4599b8b1`, expected: exit 1 because the Prompt Workbench
-and Change Review merges changed production diagnostics without committing the
-generated inventory. Compare committed and generated inventories in memory;
-do not run `--write`. The reviewed drift is exactly:
+At latest-dev commit `ceede62fe46d7aa090df4a36307077e097d8c044`, expected:
+exit 1 because subsequent production changes updated diagnostic owners without
+committing the generated inventory. Compare committed and generated inventories
+in memory; do not run `--write`. The reviewed drift is exactly:
 
-- summary `442/1089/6769/5` becomes `444/1102/6774/5` for
+- summary `466/1144/6851/6` becomes `467/1151/6854/6` for
   owner files/TASK-492 calls/TASK-494 calls/sink files;
-- add `Prompt_Management/prompt_improvement_service.py` with one TASK-494 call;
-- add `Workspaces/change_revert.py` with two TASK-494 calls;
-- update the owner entries for `Chat_Functions.py`,
-  `console_provider_gateway.py`, `Prompts_DB.py`, `LLM_API_Calls.py`,
-  `LLM_API_Calls_Local.py`, `local_llm_provider_catalog_service.py`,
-  `Prompts_Interop.py`, `chat_screen.py`, and `library_screen.py`; and
+- add `UI/Screens/provider_model_resolution.py` with one TASK-494 call;
+- update the twenty existing owner entries listed below; and
 - leave persistent-sink topology and `monitoring_engine.py` unchanged.
 
 At that pinned commit the exact generated owner values are:
 
 | Path suffix | Calls | Digest |
 | --- | ---: | --- |
-| `Chat/Chat_Functions.py` | 107 | `f017eaf38022f2d4017f` |
-| `Chat/console_provider_gateway.py` | 1 | `8c26198aaec0ad29e749` |
-| `DB/Prompts_DB.py` | 120 | `15e26a5f1df0fd8482ef` |
-| `LLM_Calls/LLM_API_Calls.py` | 171 | `e5991075a75d934a7e42` |
-| `LLM_Calls/LLM_API_Calls_Local.py` | 41 | `bc790fe8d2f3544203bf` |
-| `LLM_Provider_Catalog/local_llm_provider_catalog_service.py` | 5 | `211e68ecc8c6e816b301` |
-| `Prompt_Management/Prompts_Interop.py` | 93 | `d7ca19fa44acdf1e5289` |
-| `Prompt_Management/prompt_improvement_service.py` | 1 | `f7a441595550015f240a` |
-| `UI/Screens/chat_screen.py` | 148 | `569dd419f351b767b1d4` |
-| `UI/Screens/library_screen.py` | 77 | `35bdc0279c8ae277f42d` |
-| `Workspaces/change_revert.py` | 2 | `2c290c7704b2a652f70b` |
+| `Chat/console_chat_controller.py` | 26 | `9c82b5bacfb585cb2344` |
+| `Chat/rag_scope.py` | 4 | `c8311dec8573efc15c1a` |
+| `DB/Subscriptions_DB.py` | 4 | `aeadec9e82211a3c903c` |
+| `Event_Handlers/Chat_Events/chat_rag_events.py` | 50 | `52dfbbbb9df89723c853` |
+| `Subscriptions/local_watchlists_service.py` | 3 | `db76c859421cc0197208` |
+| `Subscriptions/watchlist_scope_service.py` | 2 | `8dc49325dd2b17b0a7f5` |
+| `Tools/web_tool_impls.py` | 9 | `5130bcf118362c078f60` |
+| `UI/Console_Modules/dictation.py` | 10 | `44188d4d417a8174a0a` |
+| `UI/Console_Modules/message.py` | 13 | `ee1a310018bae09826e6` |
+| `UI/Navigation/main_navigation.py` | 1 | `5041017946de31086ddb` |
+| `UI/Screens/chat_screen.py` | 142 | `3547979b9158631d0066` |
+| `UI/Screens/provider_model_resolution.py` | 1 | `e5ceaaaff067fd372196` |
+| `UI/Screens/settings_screen.py` | 29 | `877b708b259829710f8a` |
+| `UI/Screens/watchlists_collections_screen.py` | 77 | `79ef1df299f4a6131333` |
+| `UI/Watchlists_Modules/watchlists_backend_controller.py` | 1 | `f137bb3f8055907a77b7` |
+| `UI/Wizards/FirstRunSetupWizard.py` | 21 | `79833587abfc0d80e29b` |
+| `Widgets/Console/console_context_modal.py` | 3 | `f20db7c68f2499dcc7a2` |
+| `Widgets/Console/console_transcript.py` | 7 | `c54d9ebc99f1d6f1baec` |
+| `Widgets/splash_screen.py` | 19 | `08e9790faf88858630ea` |
+| `app.py` | 293 | `8cee8c672b033ec6b723` |
+| `config.py` | 103 | `5026476db34a50876706` |
 
 Review the semantic diagnostic-call delta, not only digests. The accepted delta
-must still be: metadata-safe LLM helpers instead of payload/error previews;
-prompt-improvement request/provider/model/count metadata without prompt text;
-two constant-message change-revert warnings with exception context that remain
-ordinary, non-admitted records; the Prompts DB v2-to-v3 migration pair; and
+must still be: seven metadata-only `Tools/web_tool_impls.py` debug calls for
+robots.txt redirect and parsing failures; one provider/model-only catalog debug
+call in `provider_model_resolution.py`; one constant-message watchlist-star
+debug call with exception context; one reduced-motion card-name info call; and
 otherwise only line movement/formatting. Persistent-sink topology is unchanged,
-and the existing admission tests remain the proof that ordinary records do not
-reach disk. If latest `dev` differs, stop and reconcile the new delta before
-patching anything.
+and the existing admission tests remain the proof that these ordinary records
+do not reach disk. The `app.py` sink line numbers move from 6063/6091/6148 to
+6064/6092/6149, and the `config.py` private append sink moves from line 4339 to
+4352, without semantic sink changes. If latest `dev` differs, stop and
+reconcile the new delta before patching anything.
 
 Use `apply_patch` to change exactly the reviewed summary and owner entries.
 Then run:
@@ -151,8 +159,8 @@ Then run:
   -q
 ```
 
-Expected: checker exit 0 with 444 owners, 1,102 TASK-492 calls, 6,774
-TASK-494 calls, and five sink files; all three architecture tests pass.
+Expected: checker exit 0 with 467 owners, 1,151 TASK-492 calls, 6,854
+TASK-494 calls, and six sink files; all three architecture tests pass.
 
 Commit this prerequisite separately before any sanitizer production edit and
 record the commit ID as the TASK-856 inventory reconciliation boundary:
@@ -173,13 +181,14 @@ Run this read-only command before production edits:
 Expected monitoring entry on the currently approved base:
 
 ```json
-{"call_count": 16, "diagnostic_digest": "5bd6f2dfc3a7c56e9aea", "owner": "TASK-494", "path": "tldw_chatbook/Subscriptions/monitoring_engine.py", "reason": "remaining Chatbook production diagnostic owner"}
+{"call_count": 16, "diagnostic_digest": "f9ccee6989b39da1333b", "owner": "TASK-494", "path": "tldw_chatbook/Subscriptions/monitoring_engine.py", "reason": "remaining Chatbook production diagnostic owner"}
 ```
 
-Expected non-monitoring SHA-256 after the reviewed `c4599b8b1` reconciliation:
+Expected non-monitoring SHA-256 after the reviewed
+`ceede62fe46d7aa090df4a36307077e097d8c044` reconciliation:
 
 ```text
-854ea4cb694d8849b3f38ae473ca42df5bacbdc61ab5478eebea2b88294f2b6f
+8fbd4266f14a51b9645626ba6f5ea624b00db65ac0baae0e4b98de1eaabc0fab
 ```
 
 Record the actual output in the plan execution notes. If latest `dev` changes

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -398,28 +398,26 @@ The subscription diagnostic change necessarily changes the reviewed
 `monitoring_engine.py` digest in
 `Docs/security/production-diagnostic-inventory.json`.
 
-The inventory was green at `f5ca03d42`, but latest `dev` was rechecked again at
-`c4599b8b1` after the Prompt Workbench and Change Review merges. Those merges
-did not update the checked inventory: generated state has 444 owner files,
-1,102 TASK-492 calls, 6,774 TASK-494 calls, and five sink files, while the
-committed manifest still records 442/1,089/6,769/5. The drift consists of two
-new owner files and nine changed existing owner entries; sink topology is
-unchanged. Semantic call review confirms that the LLM changes replace unsafe
-payload/error diagnostics with the accepted metadata-safe helpers, prompt
-improvement emits request/provider/model/count metadata without prompt text,
-change-revert adds two constant-message warnings with exception context that
-remain outside persistent admission, the prompts DB adds its v2-to-v3 migration
-diagnostics, and the remaining digest changes are caused by moved or reformatted
-calls. Persistent-sink topology is unchanged, and the existing admission tests
-remain the proof that ordinary diagnostic records do not reach disk.
+Latest `dev` was rechecked at
+`ceede62fe46d7aa090df4a36307077e097d8c044`. Its production changes did not
+update the checked inventory: generated state has 467 owner files, 1,151
+TASK-492 calls, 6,854 TASK-494 calls, and six sink files, while the committed
+manifest records 466/1,144/6,851/6. The drift consists of one new owner file and
+twenty changed existing owner entries; sink topology is unchanged. Semantic
+call review confirms seven metadata-only robots.txt failure diagnostics, one
+provider/model-only catalog diagnostic, one constant-message watchlist-star
+diagnostic with exception context, and one reduced-motion card-name diagnostic.
+The remaining owner digest changes are caused by moved or reformatted calls.
+Persistent-sink topology is unchanged, and the existing admission tests remain
+the proof that ordinary diagnostic records do not reach disk.
 
 Implementation first patches only those reviewed pre-existing owner and
 summary entries and commits that reconciliation separately, without running
 the checker's blanket `--write` mode. The expected reconciled generated state
 has non-monitoring SHA-256
-`854ea4cb694d8849b3f38ae473ca42df5bacbdc61ab5478eebea2b88294f2b6f`.
+`8fbd4266f14a51b9645626ba6f5ea624b00db65ac0baae0e4b98de1eaabc0fab`.
 The checked and generated `monitoring_engine.py` entry remains TASK-494, 16
-calls, digest `5bd6f2dfc3a7c56e9aea` at that boundary.
+calls, digest `f9ccee6989b39da1333b` at that boundary.
 
 TASK-856 then captures the reconciliation commit and generated base inventory,
 and proves that every entry except `monitoring_engine.py` is identical at its

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -1,6 +1,6 @@
 # Active Credential Redaction and Display Validation (TASK-856)
 
-**Status:** Approved in conversation; pending written-spec review
+**Status:** Independently reviewed; awaiting user approval
 
 **Task:** TASK-856
 

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -1,6 +1,6 @@
 # Active Credential Redaction and Display Validation (TASK-856)
 
-**Status:** Revised after user-requested audit; pending independent re-review
+**Status:** Third-review issue corrected; awaiting user approval
 
 **Task:** TASK-856
 
@@ -201,6 +201,32 @@ The normative matching contract is:
    `sk-` rule is considered. This prevents partial `sk-proj`/`sk-ant` matches.
    No rule recognizes `claude-*`.
 
+Scanner progress is explicit and monotonic:
+
+- after a non-sensitive candidate, the cursor resumes at the end of its
+  separator;
+- after a closed quoted sensitive value, it resumes immediately after the
+  closing quote;
+- after an empty sensitive assignment, it resumes after the CR/LF when present
+  or terminates at end of string;
+- after an unterminated quoted or unquoted sensitive value, it resumes after
+  the CR/LF that bounded the replacement or terminates at end of string; and
+- every iteration advances at least past a separator or line boundary, and
+  scanning continues until no candidate remains.
+
+This permits multiple quoted sensitive assignments on one line and sensitive
+assignments on later lines to be redacted independently. An unquoted sensitive
+assignment intentionally consumes the rest of its own line, so later values on
+that line are removed as part of the same fail-closed replacement rather than
+individually parsed.
+
+After the assignment scanner builds its output, standalone transformations run
+against that output in this exact order: URL userinfo, independent Bearer, then
+the case-sensitive credential families from rule 9. They do not participate in
+the assignment span set. Consequently a standalone-shaped token already
+removed as part of a labeled value cannot create an overlapping replacement;
+subsequent passes only see `***REDACTED***`.
+
 For quoted assignment values, surrounding label syntax, separators, and quotes
 are preserved; only the scalar contents become `***REDACTED***`. For unquoted
 values, the label and separator are preserved and the remainder of the line is
@@ -315,6 +341,12 @@ Focused tests will prove:
   assignment before a sensitive assignment, standalone `Bearer` boundaries,
   including hyphenated larger identifiers, and ordinary standalone `Basic`
   prose;
+- multiple quoted sensitive assignments on one line, sensitive assignments on
+  later lines, empty assignments followed by later secrets, and an unquoted
+  sensitive assignment that fail-closes over the remainder of its line;
+- a standalone-format token inside a labeled sensitive value, proving the
+  assignment scan and subsequent standalone passes do not overlap and remain
+  idempotent;
 - no leakage of fixed sentinel values or credential fragments;
 - preservation of `claude-*`, `max_tokens`, `api_key_env_var`, and ordinary
   identifiers;

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -1,6 +1,6 @@
 # Active Credential Redaction and Display Validation (TASK-856)
 
-**Status:** Independently reviewed; awaiting user approval
+**Status:** Revised after user-requested audit; pending independent re-review
 
 **Task:** TASK-856
 
@@ -126,49 +126,66 @@ recursive traversal. Otherwise nested dictionaries/lists follow the existing
 
 ### String redaction
 
-String redaction uses an ordered set of precompiled patterns without nested
-ambiguous quantifiers. Each pattern replaces a complete value; partial
-credential fragments must not be left behind.
+String redaction combines a deterministic assignment scanner with a small
+ordered set of precompiled standalone patterns. The scanner classifies a label
+before deciding how much value text to consume. This ordering is load-bearing:
+a regex that first consumes a non-sensitive assignment such as
+`max_tokens=42 api_key=PRIVATE_SENTINEL` could skip the later sensitive label,
+while a rule that stops every unquoted value at whitespace could expose the
+remainder of a multi-word password.
+
+The scanner records non-overlapping replacement spans and constructs the output
+once. It does not repeatedly slice and concatenate the whole input. Standalone
+patterns contain no nested ambiguous quantifiers. Label, HTTP scheme, URL
+scheme, and Bearer matching is case-insensitive. Standalone credential-family
+prefixes are case-sensitive (`sk-`, `sk-proj-`, `sk-ant-api03-`, and `AIza`)
+to avoid expanding their false-positive surface.
 
 The normative matching contract is:
 
-1. A candidate scalar assignment has an unquoted label matching
+1. A precompiled candidate-prefix pattern finds an unquoted label matching
    `[A-Za-z0-9_.-]+` or that same label surrounded by one matching pair of
    single or double quotes. Optional ASCII horizontal whitespace may surround
    a `:` or `=` separator. The label starts at the beginning of the string or
    after a character outside `[A-Za-z0-9_.-]`, so matching cannot begin halfway
    through a larger label. The label is unquoted and passed to the same private
-   log-field classifier used by `sanitize_dict()`. Non-sensitive labels leave
-   the complete match unchanged.
-2. A quoted scalar value starts with `'` or `"` and consumes through the same
-   unescaped quote. Backslash plus the following character is part of the value
-   and cannot close it. The quotes are preserved and only their contents are
-   replaced. If a sensitive label starts a quoted value without a closing
-   quote, sanitization fails closed through the first CR, LF, mapping delimiter
-   (`,`/`}`/`]`), query delimiter (`&`/`#`), or end of string.
-3. An ordinary unquoted scalar value consumes at least one character and stops
-   before ASCII whitespace, a quote, `,`, `;`, `}`, `]`, `&`, `#`, CR, LF, or
-   end of string. These terminators are preserved. This covers environment
-   assignments and URL query parameters without consuming the next field.
-4. For the exact normalized protocol labels `authorization`,
-   `proxy_authorization`, `cookie`, and `set_cookie`, an unquoted value may
-   contain horizontal whitespace and semicolons. It stops before `,`, `}`, `]`,
-   CR, LF, or end of string. This consumes a complete `Bearer value`,
-   `Basic value`, or cookie header rather than redacting only its first word.
-   Quoted mapping values still follow rule 2 and therefore do not consume an
-   adjacent mapping entry.
-5. Assignment matching is for scalar text only. Serialized nested containers
+   log-field classifier used by `sanitize_dict()`.
+2. A non-sensitive candidate consumes no value text. Scanning resumes at the
+   end of its separator, so a later sensitive assignment—including one nested
+   inside a quoted descriptive value—remains discoverable.
+3. For a sensitive candidate, a quoted scalar value starts with `'` or `"` and
+   consumes through the same unescaped quote. Backslash plus the following
+   character is part of the value and cannot close it. The quotes are preserved
+   and only their contents are replaced. If a sensitive label starts a quoted
+   value without a closing quote, sanitization fails closed through the first
+   CR, LF, or end of string.
+4. For a sensitive candidate, an unquoted scalar value consumes from the first
+   non-horizontal-whitespace character through the first CR, LF, or end of
+   string. Spaces, quotes, commas, semicolons, mapping punctuation, query
+   separators, and fragments inside that span are redacted too. This
+   deliberately prefers over-redacting the remainder of one diagnostic line to
+   leaking an unquoted multi-word or punctuation-bearing credential. Callers
+   that need adjacent fields preserved must pass structured data or quote the
+   scalar value.
+5. If a sensitive candidate has no value before CR, LF, or end of string, it is
+   left unchanged; an empty assignment contains no credential bytes to expose.
+6. Assignment matching is for scalar text only. Serialized nested containers
    are not parsed with regex; callers holding structured data use
    `sanitize_dict()`/`sanitize_list()` so a sensitive container value is
    replaced as a unit.
-6. Independent Basic and Bearer scheme matches consume the scheme plus its
-   following non-whitespace credential when those values appear without a
-   label. The scheme may be retained, but the complete credential is replaced.
-7. HTTP(S) URL userinfo matches from immediately after `://` through the last
+7. An independent Bearer match begins at the start of the string or after a
+   character outside `[A-Za-z0-9_-]`, requires one or more whitespace
+   characters after `Bearer`, and consumes the following non-whitespace
+   credential. The scheme is retained and the complete credential is replaced.
+   Matching cannot begin inside `NotBearer` or `not-bearer`. `Basic` is
+   recognized only as part of a sensitive authorization assignment/header;
+   treating the common English adjective as an independent scheme would
+   corrupt ordinary log prose.
+8. HTTP(S) URL userinfo matches from immediately after `://` through the last
    `@` before the next `/`, `?`, `#`, ASCII whitespace, CR, or LF. The userinfo
    is replaced as a unit; scheme and authority remain only when the caller is
    otherwise allowed to render the URL.
-8. Standalone recognizable tokens use these exact families, evaluated from
+9. Standalone recognizable tokens use these exact families, evaluated from
    most specific to least specific:
 
    ```text
@@ -184,13 +201,15 @@ The normative matching contract is:
    `sk-` rule is considered. This prevents partial `sk-proj`/`sk-ant` matches.
    No rule recognizes `claude-*`.
 
-For assignment rules, surrounding label syntax, separators, quotes, and the
-terminating delimiter are preserved; only the scalar value becomes
-`***REDACTED***`. Tests instantiate every sensitive provider label derived from
+For quoted assignment values, surrounding label syntax, separators, and quotes
+are preserved; only the scalar contents become `***REDACTED***`. For unquoted
+values, the label and separator are preserved and the remainder of the line is
+replaced. Tests instantiate every sensitive provider label derived from
 `CONFIG_TOML_CONTENT` and `DEFAULT_APP_TTS_CONFIG` in both a structured mapping
-and representative quoted/unquoted assignment text. Therefore the structured
-classifier and independent string parser cannot drift while still satisfying
-AC #3.
+and representative quoted/unquoted assignment text. They also place a
+non-sensitive assignment before a sensitive one on the same line. Therefore
+the structured classifier and independent string scanner cannot drift or skip
+a later secret while still satisfying AC #3.
 
 Ambiguous provider keys are guaranteed to be redacted when accompanied by a
 sensitive field name, environment-variable assignment, header, or structured
@@ -241,7 +260,7 @@ Credential-bearing renderable text follows:
 
 ```text
 caller-approved string/structure
-  -> structured log-field classification or ordered string rules
+  -> structured log-field classification or assignment scanner/standalone rules
   -> complete values replaced with ***REDACTED***
   -> current UI or caller-owned logger callback
 ```
@@ -269,8 +288,9 @@ snapshot prune result
   supported input types.
 - Sensitive structured fields fail closed by replacing the complete value,
   regardless of its type.
-- Regexes avoid nested ambiguous quantifiers and are exercised with long input
-  to guard against pathological backtracking.
+- The assignment scanner advances monotonically, builds output once, and is
+  exercised with long input; standalone regexes avoid nested ambiguous
+  quantifiers.
 - Redaction markers contain no original prefix or suffix from the secret.
 - Formatting errors never fall back to interpolating raw arguments.
 - Consumer display validation retains current invalid-result behavior rather
@@ -291,6 +311,10 @@ Focused tests will prove:
 - contextual redaction for opaque fake provider values;
 - authorization, proxy-authorization, cookie, URL-userinfo, JSON-like,
   environment-style, and URL-query cases;
+- unquoted multi-word/punctuation-bearing credentials, a non-sensitive
+  assignment before a sensitive assignment, standalone `Bearer` boundaries,
+  including hyphenated larger identifiers, and ordinary standalone `Basic`
+  prose;
 - no leakage of fixed sentinel values or credential fragments;
 - preservation of `claude-*`, `max_tokens`, `api_key_env_var`, and ordinary
   identifiers;
@@ -334,10 +358,19 @@ builder.
 
 Closeout runs the focused sanitizer, sensitive-key, LLM destination,
 subscription-pruning, and installed-distribution tests; scoped Ruff and format
-checks; the persistent-diagnostic inventory gate if the diagnostic call shape
-changes its reviewed digest; `git diff --check`; and a broader relevant suite
-selected from the final diff. Any unrelated full-suite baseline failures are
-reported separately and never represented as TASK-856 passes.
+checks; `git diff --check`; and a broader relevant suite selected from the
+final diff. Any unrelated full-suite baseline failures are reported separately
+and never represented as TASK-856 passes.
+
+The subscription diagnostic change necessarily changes the reviewed
+`monitoring_engine.py` digest in
+`Docs/security/production-diagnostic-inventory.json`. Before implementation,
+the inventory checker and its architecture test must establish the current
+baseline. After the call changes, regeneration is mandatory and the diff must
+change only `monitoring_engine.py`'s diagnostic digest: its call count, owner,
+reason, and every other inventory entry remain fixed. If the pre-change
+baseline is already stale, this task must not absorb unrelated drift under a
+blanket `--write`; that drift is reported and handled separately.
 
 ## Architecture decision record
 

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -76,7 +76,9 @@ The public container behavior remains:
   value, with the marker;
 - `deep=True` recursively handles nested dictionaries and lists;
 - `deep=False` leaves nested containers untouched but still sanitizes direct
-  string values/items, matching the current contract;
+  string values/items, matching the current contract; the returned outer
+  dictionary/list is new while each untouched nested container retains its
+  original identity;
 - non-string dictionary keys do not raise;
 - non-string input to `sanitize_string()` retains the current `str()` fallback;
 - formatting failure in `create_safe_log_message()` retains the current safe
@@ -91,21 +93,32 @@ behavior harder to reason about.
 
 `sanitize_dict()` must not maintain another copy of the app's config-key
 inventory. A private log-field classifier will delegate config-shaped names to
-`Utils.sensitive_config_keys.is_sensitive_config_key()` and add a deliberately
-small set of log/protocol fields that are outside that predicate's config
-contract:
+`Utils.sensitive_config_keys.is_sensitive_config_key()` and add one exact set
+of log/protocol names that are outside that predicate's config contract.
+Log-only names are normalized with
+`str(key).strip().lower().replace("-", "_")` and compared to:
 
-- authorization and proxy-authorization headers;
-- cookie and set-cookie headers;
-- credential containers;
-- database URLs, connection strings, and DSNs.
+```text
+authorization
+proxy_authorization
+cookie
+set_cookie
+credential
+credentials
+database_url
+connection_string
+dsn
+```
 
-The log-only comparison is case-insensitive and treats hyphen/underscore header
-spellings equivalently. This composition is intentional: the canonical
-predicate owns shipped configuration names, while the sanitizer owns protocol
-fields that may appear in response or header dictionaries. Extending the
-config predicate with HTTP-only concepts would incorrectly change encryption
-and Settings privacy-posture behavior.
+There are no substring or suffix rules for these log-only names. A future name
+requires an explicit contract and regression rather than silently broadening
+the set. Config-shaped names are passed to the canonical predicate in their
+original spelling, so that predicate continues to own its `_env_var` exclusion
+and other rules. This composition is intentional: shipped configuration names
+belong to the canonical predicate, while the sanitizer owns protocol fields
+that may appear in response or header dictionaries. Extending the config
+predicate with HTTP-only concepts would incorrectly change encryption and
+Settings privacy-posture behavior.
 
 When a structured key is sensitive, its complete value is replaced before any
 recursive traversal. Otherwise nested dictionaries/lists follow the existing
@@ -113,28 +126,71 @@ recursive traversal. Otherwise nested dictionaries/lists follow the existing
 
 ### String redaction
 
-String redaction uses an ordered set of precompiled, linear-time patterns. Each
-pattern replaces a complete value; partial credential fragments must not be
-left behind.
+String redaction uses an ordered set of precompiled patterns without nested
+ambiguous quantifiers. Each pattern replaces a complete value; partial
+credential fragments must not be left behind.
 
-The supported categories are:
+The normative matching contract is:
 
-1. Candidate key/value assignments in environment, mapping-repr, JSON-like,
-   header-like, and URL-query text. A replacement callback normalizes the
-   candidate key and applies the same private log-field classifier used by
-   `sanitize_dict()`. Non-sensitive labels such as `max_tokens` and
-   `api_key_env_var` remain unchanged. Value matching stops at the appropriate
-   quote, whitespace, mapping, query, or fragment delimiter so adjacent text is
-   not swallowed.
-2. Authorization schemes and authentication/cookie header values, including
-   opaque Basic or Bearer values.
-3. HTTP(S) URL userinfo. The full userinfo portion before `@` is removed; the
-   scheme and host remain available only when the caller is otherwise allowed
-   to render the URL.
-4. Standalone credential families with a high-confidence, distinctive syntax,
-   including the reproduced hyphenated OpenAI/Anthropic forms and existing
-   Google-style form. Matching is bounded so a rule consumes the full token and
-   does not reclassify `claude-*` model IDs.
+1. A candidate scalar assignment has an unquoted label matching
+   `[A-Za-z0-9_.-]+` or that same label surrounded by one matching pair of
+   single or double quotes. Optional ASCII horizontal whitespace may surround
+   a `:` or `=` separator. The label starts at the beginning of the string or
+   after a character outside `[A-Za-z0-9_.-]`, so matching cannot begin halfway
+   through a larger label. The label is unquoted and passed to the same private
+   log-field classifier used by `sanitize_dict()`. Non-sensitive labels leave
+   the complete match unchanged.
+2. A quoted scalar value starts with `'` or `"` and consumes through the same
+   unescaped quote. Backslash plus the following character is part of the value
+   and cannot close it. The quotes are preserved and only their contents are
+   replaced. If a sensitive label starts a quoted value without a closing
+   quote, sanitization fails closed through the first CR, LF, mapping delimiter
+   (`,`/`}`/`]`), query delimiter (`&`/`#`), or end of string.
+3. An ordinary unquoted scalar value consumes at least one character and stops
+   before ASCII whitespace, a quote, `,`, `;`, `}`, `]`, `&`, `#`, CR, LF, or
+   end of string. These terminators are preserved. This covers environment
+   assignments and URL query parameters without consuming the next field.
+4. For the exact normalized protocol labels `authorization`,
+   `proxy_authorization`, `cookie`, and `set_cookie`, an unquoted value may
+   contain horizontal whitespace and semicolons. It stops before `,`, `}`, `]`,
+   CR, LF, or end of string. This consumes a complete `Bearer value`,
+   `Basic value`, or cookie header rather than redacting only its first word.
+   Quoted mapping values still follow rule 2 and therefore do not consume an
+   adjacent mapping entry.
+5. Assignment matching is for scalar text only. Serialized nested containers
+   are not parsed with regex; callers holding structured data use
+   `sanitize_dict()`/`sanitize_list()` so a sensitive container value is
+   replaced as a unit.
+6. Independent Basic and Bearer scheme matches consume the scheme plus its
+   following non-whitespace credential when those values appear without a
+   label. The scheme may be retained, but the complete credential is replaced.
+7. HTTP(S) URL userinfo matches from immediately after `://` through the last
+   `@` before the next `/`, `?`, `#`, ASCII whitespace, CR, or LF. The userinfo
+   is replaced as a unit; scheme and authority remain only when the caller is
+   otherwise allowed to render the URL.
+8. Standalone recognizable tokens use these exact families, evaluated from
+   most specific to least specific:
+
+   ```text
+   sk-proj-     + at least 20 characters from [A-Za-z0-9_-]
+   sk-ant-api03- + at least 20 characters from [A-Za-z0-9_-]
+   sk-          + at least 20 characters from [A-Za-z0-9]
+   AIza         + exactly 35 characters from [A-Za-z0-9_-]
+   ```
+
+   A standalone match requires both the preceding and following character, if
+   present, not to be in `[A-Za-z0-9_-]`. The specific `sk-proj-` and
+   `sk-ant-api03-` rules consume the maximal allowed run before the legacy
+   `sk-` rule is considered. This prevents partial `sk-proj`/`sk-ant` matches.
+   No rule recognizes `claude-*`.
+
+For assignment rules, surrounding label syntax, separators, quotes, and the
+terminating delimiter are preserved; only the scalar value becomes
+`***REDACTED***`. Tests instantiate every sensitive provider label derived from
+`CONFIG_TOML_CONTENT` and `DEFAULT_APP_TTS_CONFIG` in both a structured mapping
+and representative quoted/unquoted assignment text. Therefore the structured
+classifier and independent string parser cannot drift while still satisfying
+AC #3.
 
 Ambiguous provider keys are guaranteed to be redacted when accompanied by a
 sensitive field name, environment-variable assignment, header, or structured

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -1,0 +1,325 @@
+# Active Credential Redaction and Display Validation (TASK-856)
+
+**Status:** Approved in conversation; pending written-spec review
+
+**Task:** TASK-856
+
+## Context
+
+`tldw_chatbook.Utils.log_sanitizer` was originally recorded as dead code. That
+is no longer true on current `dev`. It has three production consumers:
+
+1. Ollama renders successful API payloads through `sanitize_dict()` and also
+   passes model names through `sanitize_string()` before displaying them.
+2. Transformers passes locally discovered model names through
+   `sanitize_string()` before displaying them.
+3. The subscription monitor passes a monitored URL through `sanitize_string()`
+   before including the URL in a snapshot-pruning debug message.
+
+The active sanitizer is incorrect in both directions. It classifies every
+`claude-*` model ID as an Anthropic credential while failing to consume the
+hyphenated portions of real-shaped `sk-ant-api03-*` and `sk-proj-*`
+credentials. Its private `SENSITIVE_FIELDS` set also disagrees with the
+canonical `is_sensitive_config_key()` predicate introduced by TASK-852 and
+misses real shipped configuration names.
+
+The three consumers expose a boundary error as well as regex defects:
+credential redaction, untrusted display-name validation, and metadata-only
+diagnostics are different operations. A single function must not be used as a
+generic notion of "safe text."
+
+## Goals
+
+- Keep the sanitizer's existing public function imports stable.
+- Reliably remove complete credential values from structured and labeled text.
+- Avoid treating model identifiers or arbitrary opaque strings as credentials.
+- Make display-name and diagnostic consumers use the boundary appropriate to
+  their purpose.
+- Preserve the sanitizer's recursive, non-mutating container contracts.
+- Verify the installed package, not only the source checkout.
+
+## Non-goals
+
+- This task does not install a process-wide logging filter.
+- It does not authorize payloads, URLs, or other private values to be written to
+  persistent diagnostics merely because a redaction helper exists.
+- It does not attempt to identify every unlabeled opaque provider token. Some
+  providers issue values with no stable syntax that distinguishes them from an
+  ordinary identifier.
+- It does not rename the module or its existing public functions.
+- It does not change provider configuration, credential storage, encryption,
+  or application logging topology.
+
+## Decision
+
+Keep `Utils/log_sanitizer.py` as an explicit credential-redaction utility, but
+narrow its claimed purpose. It is defense-in-depth for strings and structures
+that a caller has already decided may be rendered. It is not a global privacy
+policy and it is not a substitute for omitting private data at a diagnostic
+boundary.
+
+### Public compatibility
+
+The following functions remain importable under their current names:
+
+- `sanitize_string`
+- `sanitize_dict`
+- `sanitize_list`
+- `sanitize_log_params`
+- `create_safe_log_message`
+- `safe_log`
+
+The public container behavior remains:
+
+- sanitization produces new dictionaries and lists rather than mutating input;
+- a sensitive dictionary key replaces its entire value, including a container
+  value, with the marker;
+- `deep=True` recursively handles nested dictionaries and lists;
+- `deep=False` leaves nested containers untouched but still sanitizes direct
+  string values/items, matching the current contract;
+- non-string dictionary keys do not raise;
+- non-string input to `sanitize_string()` retains the current `str()` fallback;
+- formatting failure in `create_safe_log_message()` retains the current safe
+  fallback to the sanitized template; and
+- `safe_log()` retains its one-rendered-message callback behavior.
+
+All redactions use the single neutral marker `***REDACTED***`. Provider-specific
+markers are removed because they add no protection and make sequential rule
+behavior harder to reason about.
+
+### Structured secret classification
+
+`sanitize_dict()` must not maintain another copy of the app's config-key
+inventory. A private log-field classifier will delegate config-shaped names to
+`Utils.sensitive_config_keys.is_sensitive_config_key()` and add a deliberately
+small set of log/protocol fields that are outside that predicate's config
+contract:
+
+- authorization and proxy-authorization headers;
+- cookie and set-cookie headers;
+- credential containers;
+- database URLs, connection strings, and DSNs.
+
+The log-only comparison is case-insensitive and treats hyphen/underscore header
+spellings equivalently. This composition is intentional: the canonical
+predicate owns shipped configuration names, while the sanitizer owns protocol
+fields that may appear in response or header dictionaries. Extending the
+config predicate with HTTP-only concepts would incorrectly change encryption
+and Settings privacy-posture behavior.
+
+When a structured key is sensitive, its complete value is replaced before any
+recursive traversal. Otherwise nested dictionaries/lists follow the existing
+`deep` contract and direct strings pass through `sanitize_string()`.
+
+### String redaction
+
+String redaction uses an ordered set of precompiled, linear-time patterns. Each
+pattern replaces a complete value; partial credential fragments must not be
+left behind.
+
+The supported categories are:
+
+1. Candidate key/value assignments in environment, mapping-repr, JSON-like,
+   header-like, and URL-query text. A replacement callback normalizes the
+   candidate key and applies the same private log-field classifier used by
+   `sanitize_dict()`. Non-sensitive labels such as `max_tokens` and
+   `api_key_env_var` remain unchanged. Value matching stops at the appropriate
+   quote, whitespace, mapping, query, or fragment delimiter so adjacent text is
+   not swallowed.
+2. Authorization schemes and authentication/cookie header values, including
+   opaque Basic or Bearer values.
+3. HTTP(S) URL userinfo. The full userinfo portion before `@` is removed; the
+   scheme and host remain available only when the caller is otherwise allowed
+   to render the URL.
+4. Standalone credential families with a high-confidence, distinctive syntax,
+   including the reproduced hyphenated OpenAI/Anthropic forms and existing
+   Google-style form. Matching is bounded so a rule consumes the full token and
+   does not reclassify `claude-*` model IDs.
+
+Ambiguous provider keys are guaranteed to be redacted when accompanied by a
+sensitive field name, environment-variable assignment, header, or structured
+key. They are intentionally not guessed from arbitrary standalone alphanumeric
+text. This replaces TASK-856's previous impossible requirement to recognize
+every provider's opaque token without context.
+
+The output must be idempotent: sanitizing an already sanitized string or
+structure produces the same result.
+
+### Consumer corrections
+
+#### Ollama successful payloads
+
+`_format_ollama_success_payload()` continues using `sanitize_dict()` before
+rendering the bounded JSON shown in the current production UI. This is a true
+credential-redaction boundary. The sanitizer does not make provider payloads
+eligible for persistent logging; the output remains mounted-UI content only.
+
+#### Ollama and Transformers model names
+
+`_safe_ollama_model_names()` and `scan_transformers_local_models()` stop using
+the log sanitizer. They use `Utils.input_validation.sanitize_string()` under an
+explicitly named import, with the existing 256-character display bound, then
+normalize retained tabs, carriage returns, newlines, and other whitespace to a
+single display line.
+
+This preserves legitimate names such as `claude-opus-4-20250514`. It also makes
+the contract honest: these values are being validated for a RichLog display,
+not prepared for a persistent diagnostic. Both paths continue to reject empty
+or structurally invalid model entries and retain their existing result caps.
+
+#### Subscription snapshot pruning
+
+The snapshot-pruning diagnostic stops including the monitored URL. The message
+retains the pruned count, subscription ID, and retention count, which are the
+useful operational metadata. The dynamic log-sanitizer import is removed.
+
+Using a sanitized full URL would still expose private paths and nonstandard
+query values. Importing the private origin-only helper from
+`Utils.egress` would create a cross-module dependency without adding useful
+information to this message. Omission is the smallest boundary consistent with
+ADR-029 and the precedent established by TASK-1722.
+
+## Data flow
+
+Credential-bearing renderable text follows:
+
+```text
+caller-approved string/structure
+  -> structured log-field classification or ordered string rules
+  -> complete values replaced with ***REDACTED***
+  -> current UI or caller-owned logger callback
+```
+
+Model display text follows:
+
+```text
+provider/path model name
+  -> bounded input validation
+  -> single-line whitespace normalization
+  -> current mounted RichLog
+```
+
+Subscription diagnostics follow:
+
+```text
+snapshot prune result
+  -> retain count + subscription ID + retention count
+  -> debug diagnostic (URL never enters the message)
+```
+
+## Error and safety behavior
+
+- Redaction remains best-effort for strings but must not raise for ordinary
+  supported input types.
+- Sensitive structured fields fail closed by replacing the complete value,
+  regardless of its type.
+- Regexes avoid nested ambiguous quantifiers and are exercised with long input
+  to guard against pathological backtracking.
+- Redaction markers contain no original prefix or suffix from the secret.
+- Formatting errors never fall back to interpolating raw arguments.
+- Consumer display validation retains current invalid-result behavior rather
+  than inventing replacement model names.
+- No test or implementation logs live credentials; all values are conspicuous
+  fixed sentinels or fake format-shaped strings.
+
+## Verification strategy
+
+Tests use direct production functions and the full production app only. No
+reduced, fake, or test-only application is introduced.
+
+### Sanitizer unit contract
+
+Focused tests will prove:
+
+- complete redaction of reproduced `sk-proj-*` and `sk-ant-api03-*` values;
+- contextual redaction for opaque fake provider values;
+- authorization, proxy-authorization, cookie, URL-userinfo, JSON-like,
+  environment-style, and URL-query cases;
+- no leakage of fixed sentinel values or credential fragments;
+- preservation of `claude-*`, `max_tokens`, `api_key_env_var`, and ordinary
+  identifiers;
+- config-derived coverage by parsing `CONFIG_TOML_CONTENT` and
+  `DEFAULT_APP_TTS_CONFIG`, constructing a structure from the actual sensitive
+  key names, and asserting that every sentinel value is removed;
+- log-specific fields not owned by the config predicate;
+- nested dictionaries/lists, non-string keys, new-container identity,
+  `deep=False`, non-string fallback, formatting fallback, and idempotence; and
+- bounded behavior on long non-matching input.
+
+Expected config key names come from the shipped configuration sources and the
+canonical predicate, not from sanitizer constants. Tests also retain negative
+sentinels for real environment-variable-name settings so a future change does
+not redact or encrypt the name of an environment variable.
+
+### Production consumer contract
+
+Direct production helper tests prove that:
+
+- Ollama payload rendering removes nested structured credentials;
+- Ollama and Transformers display real `claude-*` model identifiers unchanged,
+  bound length, and cannot inject a second display line;
+- invalid model structures retain current failure behavior; and
+- a real snapshot-pruning path emits its diagnostic without the monitored URL
+  or any sentinel component from that URL.
+
+The existing full-production-app LLM destination tests remain the integration
+owner for mounted RichLog behavior. They are extended only where mounted
+behavior adds coverage beyond the direct helper contract.
+
+### Installed distribution
+
+The existing installed-wheel probe imports the public log-sanitizer functions
+from the isolated installed target and verifies both config-key delegation and
+the `claude-*` false-positive regression. This catches a source-checkout-only
+success or a missing packaged dependency without introducing another wheel
+builder.
+
+### Gates
+
+Closeout runs the focused sanitizer, sensitive-key, LLM destination,
+subscription-pruning, and installed-distribution tests; scoped Ruff and format
+checks; the persistent-diagnostic inventory gate if the diagnostic call shape
+changes its reviewed digest; `git diff --check`; and a broader relevant suite
+selected from the final diff. Any unrelated full-suite baseline failures are
+reported separately and never represented as TASK-856 passes.
+
+## Architecture decision record
+
+ADR required: yes
+
+ADR path: `backlog/decisions/029-local-private-data-boundary.md`
+
+Reason: TASK-856 changes behavior at a credential/privacy logging boundary, so
+an ADR check is mandatory. ADR-029 already establishes that credentials and
+private values are excluded from persistent diagnostics and that payload
+redaction does not authorize payload logging. This task directly implements
+that accepted boundary and does not introduce a new decision, so no duplicate
+ADR is created.
+
+## Alternatives considered
+
+### Delete the sanitizer
+
+Rejected because current `dev` has an active structured-payload redaction
+consumer. Deletion would either expose credential values in the Ollama result
+view or require an inline duplicate.
+
+### Install a process-wide logging filter
+
+Rejected because it is broader than the task, would interact with the accepted
+persistent-sink policy, and could encourage callers to send private payloads to
+logs under the assumption that the filter will repair them. ADR-029 requires
+privacy at the producer boundary.
+
+### Treat every provider-looking opaque token as a standalone secret
+
+Rejected because opaque credentials are not distinguishable from ordinary
+model IDs, content hashes, or user identifiers. Contextual field classification
+provides reliable protection without destructive false positives.
+
+### Extend the config-key predicate with HTTP header concepts
+
+Rejected because that predicate is also used for configuration encryption and
+Settings privacy posture. Authorization and cookie headers are valid log/payload
+concepts but are not shipped configuration fields. The sanitizer composes the
+canonical config predicate with its own small protocol-specific set instead.

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -439,6 +439,18 @@ The current boundary has `467/1151/6859/6`, monitoring digest
 The Task 3 head retains that fingerprint and changes only the monitoring digest
 to `3826b76482fd484ff194`.
 
+After closeout, the branch rebased once more onto
+`b030b0b73f217b955b298a45fce3a0256403447c`. The upstream Console rail
+changes left every TASK-856 file and diagnostic call multiset unchanged but
+moved calls in `chat_screen.py`, `settings_screen.py`, and `config.py`, plus the
+existing private append sink line in `config.py`. A third reviewed inventory
+reconciliation is placed immediately before the Task 3 consumer commit. Counts
+remain `467/1151/6859/6`; the current non-monitoring fingerprint on both sides
+of the TASK-856 monitoring change is
+`5ce06a13eb48f8007eddfa92a0616b41e5122b89e6b2b7d494d4c81fb48723ac`.
+Monitoring still changes only from `f9ccee6989b39da1333b` at that boundary to
+`911bf9d65817bf259923` at the head.
+
 ## Architecture decision record
 
 ADR required: yes

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -407,9 +407,11 @@ new owner files and nine changed existing owner entries; sink topology is
 unchanged. Semantic call review confirms that the LLM changes replace unsafe
 payload/error diagnostics with the accepted metadata-safe helpers, prompt
 improvement emits request/provider/model/count metadata without prompt text,
-change-revert adds two constant warnings, the prompts DB adds its v2-to-v3
-migration diagnostics, and the remaining digest changes are caused by moved or
-reformatted calls.
+change-revert adds two constant-message warnings with exception context that
+remain outside persistent admission, the prompts DB adds its v2-to-v3 migration
+diagnostics, and the remaining digest changes are caused by moved or reformatted
+calls. Persistent-sink topology is unchanged, and the existing admission tests
+remain the proof that ordinary diagnostic records do not reach disk.
 
 Implementation first patches only those reviewed pre-existing owner and
 summary entries and commits that reconciliation separately, without running

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -1,6 +1,6 @@
 # Active Credential Redaction and Display Validation (TASK-856)
 
-**Status:** Approved
+**Status:** Implemented and verified
 
 **Task:** TASK-856
 
@@ -441,8 +441,11 @@ reconciled in its own commit immediately before the Task 3 consumer commit.
 The current boundary has `467/1151/6859/6`, monitoring digest
 `f9ccee6989b39da1333b`, and non-monitoring fingerprint
 `a927b4bc7a229d3c3328a5336054c410aabdedfe5fd40219ab1152a9880763eb`.
-The Task 3 head retains that fingerprint and changes only the monitoring digest
-to `3826b76482fd484ff194`.
+The Task 3 consumer commit retained that fingerprint and initially changed only
+the monitoring digest to `3826b76482fd484ff194`. The subsequent scoped Ruff
+format repair changed only the source-sensitive monitoring digest again, to the
+current `911bf9d65817bf259923`; the owner, reason, 16-call count, sink topology,
+and non-monitoring fingerprint remain unchanged.
 
 After closeout, the branch rebased once more onto
 `b030b0b73f217b955b298a45fce3a0256403447c`. The upstream Console rail

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -1,6 +1,6 @@
 # Active Credential Redaction and Display Validation (TASK-856)
 
-**Status:** Third-review issue corrected; awaiting user approval
+**Status:** Approved
 
 **Task:** TASK-856
 

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -398,32 +398,19 @@ The subscription diagnostic change necessarily changes the reviewed
 `monitoring_engine.py` digest in
 `Docs/security/production-diagnostic-inventory.json`.
 
-The latest-dev baseline was checked explicitly at `db493a89d` and is already
-stale outside TASK-856:
+The latest-dev baseline was rechecked after its reviewed inventory refresh at
+`f5ca03d42`. The checker is green with 442 owner files, 1,089 TASK-492
+calls, 6,769 TASK-494 calls, and five sink files; all three inventory
+architecture tests pass. The checked and generated `monitoring_engine.py`
+entries are identical before this task: TASK-494, 16 calls, digest
+`5bd6f2dfc3a7c56e9aea`.
 
-- checked summary: 434 owner files, 1,073 TASK-492 calls, 6,684 TASK-494 calls,
-  and four sink files;
-- generated summary: 441 owner files, 1,088 TASK-492 calls, 6,746 TASK-494
-  calls, and four sink files;
-- eight owner paths exist only in generated output, one only in the checked
-  artifact, and 41 common owner entries differ; and
-- the checked and generated `monitoring_engine.py` entries are identical before
-  this task: TASK-494, 16 calls, digest `5bd6f2dfc3a7c56e9aea`.
-
-Consequently the unmodified checker and one of its three architecture tests
-fail on the base revision; the persistent-marker and chained-call tests pass.
-TASK-856 must not claim that global gate is green and must not absorb unrelated
-drift with a blanket `--write`.
-
-Instead, implementation captures generated base and head inventories in memory
-and proves that every entry except `monitoring_engine.py` is identical between
+Implementation captures generated base and head inventories in memory and
+proves that every entry except `monitoring_engine.py` is identical between
 them. The monitoring entry must retain its owner, reason, and 16-call count;
 only its digest may change. The checked JSON is patched only for that one digest
-so TASK-856 introduces no additional inventory mismatch. Closeout reruns the
-checker and architecture tests, records the same pre-existing failure, and
-requires the two unaffected architecture sentinels to remain green. This is a
-base-to-head no-regression proof, not a waiver or silent re-baseline of the
-repository-wide drift.
+rather than accepting unrelated changes through a blanket `--write`.
+Closeout requires the checker and all three architecture tests to remain green.
 
 ## Architecture decision record
 

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -396,13 +396,34 @@ and never represented as TASK-856 passes.
 
 The subscription diagnostic change necessarily changes the reviewed
 `monitoring_engine.py` digest in
-`Docs/security/production-diagnostic-inventory.json`. Before implementation,
-the inventory checker and its architecture test must establish the current
-baseline. After the call changes, regeneration is mandatory and the diff must
-change only `monitoring_engine.py`'s diagnostic digest: its call count, owner,
-reason, and every other inventory entry remain fixed. If the pre-change
-baseline is already stale, this task must not absorb unrelated drift under a
-blanket `--write`; that drift is reported and handled separately.
+`Docs/security/production-diagnostic-inventory.json`.
+
+The latest-dev baseline was checked explicitly at `db493a89d` and is already
+stale outside TASK-856:
+
+- checked summary: 434 owner files, 1,073 TASK-492 calls, 6,684 TASK-494 calls,
+  and four sink files;
+- generated summary: 441 owner files, 1,088 TASK-492 calls, 6,746 TASK-494
+  calls, and four sink files;
+- eight owner paths exist only in generated output, one only in the checked
+  artifact, and 41 common owner entries differ; and
+- the checked and generated `monitoring_engine.py` entries are identical before
+  this task: TASK-494, 16 calls, digest `5bd6f2dfc3a7c56e9aea`.
+
+Consequently the unmodified checker and one of its three architecture tests
+fail on the base revision; the persistent-marker and chained-call tests pass.
+TASK-856 must not claim that global gate is green and must not absorb unrelated
+drift with a blanket `--write`.
+
+Instead, implementation captures generated base and head inventories in memory
+and proves that every entry except `monitoring_engine.py` is identical between
+them. The monitoring entry must retain its owner, reason, and 16-call count;
+only its digest may change. The checked JSON is patched only for that one digest
+so TASK-856 introduces no additional inventory mismatch. Closeout reruns the
+checker and architecture tests, records the same pre-existing failure, and
+requires the two unaffected architecture sentinels to remain green. This is a
+base-to-head no-regression proof, not a waiver or silent re-baseline of the
+repository-wide drift.
 
 ## Architecture decision record
 

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -398,19 +398,32 @@ The subscription diagnostic change necessarily changes the reviewed
 `monitoring_engine.py` digest in
 `Docs/security/production-diagnostic-inventory.json`.
 
-The latest-dev baseline was rechecked after its reviewed inventory refresh at
-`f5ca03d42`. The checker is green with 442 owner files, 1,089 TASK-492
-calls, 6,769 TASK-494 calls, and five sink files; all three inventory
-architecture tests pass. The checked and generated `monitoring_engine.py`
-entries are identical before this task: TASK-494, 16 calls, digest
-`5bd6f2dfc3a7c56e9aea`.
+The inventory was green at `f5ca03d42`, but latest `dev` was rechecked again at
+`c4599b8b1` after the Prompt Workbench and Change Review merges. Those merges
+did not update the checked inventory: generated state has 444 owner files,
+1,102 TASK-492 calls, 6,774 TASK-494 calls, and five sink files, while the
+committed manifest still records 442/1,089/6,769/5. The drift consists of two
+new owner files and nine changed existing owner entries; sink topology is
+unchanged. Semantic call review confirms that the LLM changes replace unsafe
+payload/error diagnostics with the accepted metadata-safe helpers, prompt
+improvement emits request/provider/model/count metadata without prompt text,
+change-revert adds two constant warnings, the prompts DB adds its v2-to-v3
+migration diagnostics, and the remaining digest changes are caused by moved or
+reformatted calls.
 
-Implementation captures generated base and head inventories in memory and
-proves that every entry except `monitoring_engine.py` is identical between
-them. The monitoring entry must retain its owner, reason, and 16-call count;
-only its digest may change. The checked JSON is patched only for that one digest
-rather than accepting unrelated changes through a blanket `--write`.
-Closeout requires the checker and all three architecture tests to remain green.
+Implementation first patches only those reviewed pre-existing owner and
+summary entries and commits that reconciliation separately, without running
+the checker's blanket `--write` mode. The expected reconciled generated state
+has non-monitoring SHA-256
+`854ea4cb694d8849b3f38ae473ca42df5bacbdc61ab5478eebea2b88294f2b6f`.
+The checked and generated `monitoring_engine.py` entry remains TASK-494, 16
+calls, digest `5bd6f2dfc3a7c56e9aea` at that boundary.
+
+TASK-856 then captures the reconciliation commit and generated base inventory,
+and proves that every entry except `monitoring_engine.py` is identical at its
+head. The monitoring entry must retain its owner, reason, and 16-call count;
+only its digest may change. Closeout requires the checker and all three
+architecture tests to be green.
 
 ## Architecture decision record
 

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -425,6 +425,20 @@ head. The monitoring entry must retain its owner, reason, and 16-call count;
 only its digest may change. Closeout requires the checker and all three
 architecture tests to be green.
 
+After Tasks 1–3 were reviewed, `origin/dev` advanced to
+`85a46bea8704d076fd6b544e56bead760fd3e9d9`. The rebase left every TASK-856
+production/test file unchanged but exposed a second red upstream inventory
+baseline: five metadata/constant-only STT executor diagnostics in `app.py`,
+line-only digest changes in four related ingestion/library owners, and line-only
+movement of three existing `app.py` sinks. The semantic diagnostic multiset and
+sink-shape review found no additional payload/private-value sink. This drift is
+reconciled in its own commit immediately before the Task 3 consumer commit.
+The current boundary has `467/1151/6859/6`, monitoring digest
+`f9ccee6989b39da1333b`, and non-monitoring fingerprint
+`a927b4bc7a229d3c3328a5336054c410aabdedfe5fd40219ab1152a9880763eb`.
+The Task 3 head retains that fingerprint and changes only the monitoring digest
+to `3826b76482fd484ff194`.
+
 ## Architecture decision record
 
 ADR required: yes

--- a/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
@@ -314,8 +314,10 @@ snapshot prune result
   supported input types.
 - Sensitive structured fields fail closed by replacing the complete value,
   regardless of its type.
-- The assignment scanner advances monotonically, builds output once, and is
-  exercised with long input; standalone regexes avoid nested ambiguous
+- The assignment scanner advances monotonically, builds output once, and parses
+  quoted values without first searching the remaining line for a boundary.
+  Long non-matching and dense quoted matched inputs deterministically exercise
+  the intended single-pass bound; standalone regexes avoid nested ambiguous
   quantifiers.
 - Redaction markers contain no original prefix or suffix from the secret.
 - Formatting errors never fall back to interpolating raw arguments.
@@ -356,7 +358,10 @@ Focused tests will prove:
 - log-specific fields not owned by the config predicate;
 - nested dictionaries/lists, non-string keys, new-container identity,
   `deep=False`, non-string fallback, formatting fallback, and idempotence; and
-- bounded behavior on long non-matching input.
+- bounded behavior on long non-matching input; and
+- exact redaction plus deterministic single-pass scan-work accounting on a long
+  line containing many quoted sensitive assignments, without a wall-clock
+  threshold.
 
 Expected config key names come from the shipped configuration sources and the
 canonical predicate, not from sanitizer constants. Tests also retain negative

--- a/Tests/Packaging/test_installed_distribution.py
+++ b/Tests/Packaging/test_installed_distribution.py
@@ -152,6 +152,15 @@ from tldw_chatbook.Constants import TAB_CHAT, TAB_HOME
 from tldw_chatbook.Evals.config_loader import EvalConfigLoader
 from tldw_chatbook.RAG_Search.pipeline_loader import PipelineLoader
 from tldw_chatbook.runtime_policy.server_context import RuntimeServerContextProvider
+from tldw_chatbook.Utils.log_sanitizer import sanitize_dict, sanitize_string
+
+assert sanitize_string("claude-opus-4-20250514") == "claude-opus-4-20250514"
+assert sanitize_dict({"x-api-key": "PRIVATE_INSTALLED_SENTINEL"}) == {
+    "x-api-key": "***REDACTED***"
+}
+assert "PRIVATE_INSTALLED_SENTINEL" not in sanitize_string(
+    'x-api-key="PRIVATE_INSTALLED_SENTINEL"'
+)
 
 
 def deny_server_client_construction(_self):

--- a/Tests/ProductionApp/test_llm_destination_actions.py
+++ b/Tests/ProductionApp/test_llm_destination_actions.py
@@ -667,7 +667,9 @@ def test_ollama_success_payloads_are_bounded_and_redacted() -> None:
     assert names == ["claude-opus-4-20250514", "org/model injected"]
 
 
-def test_transformers_model_scan_preserves_claude_ids_as_one_line(tmp_path: Path) -> None:
+def test_transformers_model_scan_preserves_claude_ids_as_one_line(
+    tmp_path: Path,
+) -> None:
     model_root = tmp_path / "models--anthropic--claude-opus-4-20250514"
     model_root.mkdir()
     (model_root / "config.json").write_text("{}", encoding="utf-8")
@@ -685,7 +687,9 @@ def test_transformers_model_scan_normalizes_multiline_names(tmp_path: Path) -> N
     (model_root / "config.json").write_text("{}", encoding="utf-8")
     (model_root / "model.safetensors").touch()
 
-    assert transformers_events.scan_transformers_local_models(tmp_path) == ["org/line name"]
+    assert transformers_events.scan_transformers_local_models(tmp_path) == [
+        "org/line name"
+    ]
 
 
 def test_transformers_download_has_no_root_worker_completion_owner() -> None:

--- a/Tests/ProductionApp/test_llm_destination_actions.py
+++ b/Tests/ProductionApp/test_llm_destination_actions.py
@@ -5,6 +5,7 @@ import ast
 import io
 import inspect
 import logging
+import os
 from pathlib import Path
 import subprocess
 import textwrap
@@ -641,25 +642,50 @@ def test_ollama_success_payloads_are_bounded_and_redacted() -> None:
         {
             "family": "llama",
             "api_key": "PRIVATE_API_KEY",
-            "details": {"format": "gguf"},
+            "details": {
+                "format": "gguf",
+                "x-api-key": "PRIVATE_NESTED_API_KEY",
+                "authorization": "Bearer PRIVATE_AUTHORIZATION",
+            },
         }
     )
 
     assert '"family": "llama"' in rendered
     assert '"format": "gguf"' in rendered
     assert "PRIVATE_API_KEY" not in rendered
+    assert "PRIVATE_NESTED_API_KEY" not in rendered
+    assert "PRIVATE_AUTHORIZATION" not in rendered
     assert "REDACTED" in rendered
     assert len(rendered) <= ollama_events.MAX_OLLAMA_SUCCESS_OUTPUT_CHARS
 
     names = ollama_events._safe_ollama_model_names(
         [
-            {"name": "org/model:latest"},
-            {"name": "token=PRIVATE_MODEL_TOKEN"},
+            {"name": "claude-opus-4-20250514"},
+            {"name": "org/model\r\n\tinjected"},
         ]
     )
-    assert names is not None
-    assert names[0] == "org/model:latest"
-    assert "PRIVATE_MODEL_TOKEN" not in names[1]
+    assert names == ["claude-opus-4-20250514", "org/model injected"]
+
+
+def test_transformers_model_scan_preserves_claude_ids_as_one_line(tmp_path: Path) -> None:
+    model_root = tmp_path / "models--anthropic--claude-opus-4-20250514"
+    model_root.mkdir()
+    (model_root / "config.json").write_text("{}", encoding="utf-8")
+    (model_root / "model.safetensors").touch()
+
+    assert transformers_events.scan_transformers_local_models(tmp_path) == [
+        "anthropic/claude-opus-4-20250514"
+    ]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows filenames reject CR/LF/tab")
+def test_transformers_model_scan_normalizes_multiline_names(tmp_path: Path) -> None:
+    model_root = tmp_path / "models--org--line\r\n\tname"
+    model_root.mkdir()
+    (model_root / "config.json").write_text("{}", encoding="utf-8")
+    (model_root / "model.safetensors").touch()
+
+    assert transformers_events.scan_transformers_local_models(tmp_path) == ["org/line name"]
 
 
 def test_transformers_download_has_no_root_worker_completion_owner() -> None:

--- a/Tests/Subscriptions/test_watchlist_snapshot_pruning.py
+++ b/Tests/Subscriptions/test_watchlist_snapshot_pruning.py
@@ -25,7 +25,6 @@ import pytest
 
 from Tests.Subscriptions.test_watchlist_content_kind_producer import (
     _check,
-    _serve,
     _site_source,
     _stored_items,
 )
@@ -591,3 +590,49 @@ async def test_the_tie_break_decides_which_tied_row_is_pruned(monkeypatch):
     assert all(row["id"] > min(seeded) for row in survivors), (
         "the oldest tied rows are the ones pruned"
     )
+
+
+@pytest.mark.asyncio
+async def test_prune_diagnostic_omits_the_monitored_url(monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Subscriptions import monitoring_engine
+
+    db, _service, source_id = await _site_source(monkeypatch, [_page("seed")])
+    private_url = (
+        "https://PRIVATE_USER:PRIVATE_PASSWORD@example.test/PRIVATE_PATH"
+        "?api_key=PRIVATE_QUERY#PRIVATE_FRAGMENT"
+    )
+    captured: list[str] = []
+
+    def capture(message: str, *args) -> None:
+        captured.append(message.format(*args))
+
+    monkeypatch.setattr(
+        monitoring_engine,
+        "logger",
+        SimpleNamespace(debug=capture),
+    )
+    monitor = monitoring_engine.URLMonitor(db)
+    for index in range(_cap() + 1):
+        await monitor._store_snapshot(
+            source_id,
+            private_url,
+            {"text": f"revision {index}", "html": "", "headers": {}},
+            fingerprint="fp",
+        )
+
+    message = next(text for text in captured if text.startswith("Pruned "))
+    assert message == (
+        f"Pruned 1 snapshot(s) for subscription {source_id}, "
+        f"keeping the newest {_cap()}"
+    )
+    for forbidden in (
+        private_url,
+        "PRIVATE_USER",
+        "PRIVATE_PASSWORD",
+        "PRIVATE_PATH",
+        "PRIVATE_QUERY",
+        "PRIVATE_FRAGMENT",
+    ):
+        assert forbidden not in message

--- a/Tests/Utils/test_log_sanitizer.py
+++ b/Tests/Utils/test_log_sanitizer.py
@@ -229,10 +229,10 @@ def test_url_userinfo_removes_both_username_and_password() -> None:
 @pytest.mark.parametrize(
     "raw",
     [
-        "sk-proj-abcdefghijklmnopqrst",
-        "sk-ant-api03-abcdefghijklmnopqrst",
-        "sk-abcdefghijklmnopqrst",
-        "AIza" + "a" * 35,
+        "sk-proj-DO_NOT_USE_EXAMPLE_123456",
+        "sk-ant-api03-DO_NOT_USE_EXAMPLE_123456",
+        "sk-DONOTUSEEXAMPLEONLY1234567890",
+        "AIza" + "DO_NOT_USE_EXAMPLE_ONLY_" + "0" * 11,
     ],
 )
 def test_standalone_credential_shapes_are_replaced_wholly(raw: str) -> None:
@@ -243,10 +243,10 @@ def test_standalone_credential_shapes_are_replaced_wholly(raw: str) -> None:
 @pytest.mark.parametrize(
     "raw",
     [
-        "SK-PROJ-ABCDEFGHIJKLMNOPQRST",
-        "SK-ANT-API03-ABCDEFGHIJKLMNOPQRST",
-        "SK-ABCDEFGHIJKLMNOPQRST",
-        "AIZA" + "A" * 35,
+        "SK-PROJ-DO_NOT_USE_EXAMPLE_123456",
+        "SK-ANT-API03-DO_NOT_USE_EXAMPLE_123456",
+        "SK-DONOTUSEEXAMPLEONLY1234567890",
+        "AIZA" + "DO_NOT_USE_EXAMPLE_ONLY_" + "0" * 11,
     ],
 )
 def test_uppercase_standalone_credential_shapes_are_not_recognized(raw: str) -> None:
@@ -256,7 +256,7 @@ def test_uppercase_standalone_credential_shapes_are_not_recognized(raw: str) -> 
 
 def test_labeled_standalone_shaped_value_has_one_idempotent_marker() -> None:
     """Assignment redaction consumes a key-shaped quoted secret only once."""
-    raw = 'api_key="sk-proj-abcdefghijklmnopqrst"'
+    raw = 'api_key="sk-proj-DO_NOT_USE_EXAMPLE_123456"'
     sanitized = sanitize_string(raw)
 
     assert sanitized == 'api_key="***REDACTED***"'
@@ -340,12 +340,12 @@ class TestLogSanitizer:
     def test_sanitize_string_api_keys(self):
         """Test that API keys are sanitized from strings."""
         test_cases = [
-            ("api_key=sk-1234567890abcdef", "api_key=***REDACTED***"),
+            ("api_key=PRIVATE_API_KEY", "api_key=***REDACTED***"),
             (
-                "Bearer sk-abcdefghijklmnopqrstuvwxyz123456789012345678",
+                "Bearer PRIVATE_BEARER_TOKEN",
                 "Bearer ***REDACTED***",
             ),
-            ("OPENAI_API_KEY=sk-test123", "OPENAI_API_KEY=***REDACTED***"),
+            ("OPENAI_API_KEY=PRIVATE_OPENAI_KEY", "OPENAI_API_KEY=***REDACTED***"),
             ('{"api_key": "secret123"}', '{"api_key": "***REDACTED***"}'),
             ("password: mypassword123", "password: ***REDACTED***"),
             ("https://user:pass@example.com", "https://***REDACTED***@example.com"),
@@ -359,7 +359,7 @@ class TestLogSanitizer:
         """Test dictionary sanitization."""
         test_dict = {
             "name": "test",
-            "api_key": "sk-123456",
+            "api_key": "PRIVATE_API_KEY",
             "password": "secret",
             "nested": {"token": "bearer123", "safe": "value"},
             "config": "api_key=embedded_secret",
@@ -396,7 +396,7 @@ class TestLogSanitizer:
         msg = create_safe_log_message(
             "User {} logged in with key {}",
             "john",
-            "sk-abcdefghijklmnopqrstuvwxyz123456",
+            "sk-DONOTUSEEXAMPLEONLY1234567890",
         )
         assert msg == "User john logged in with key ***REDACTED***"
 

--- a/Tests/Utils/test_log_sanitizer.py
+++ b/Tests/Utils/test_log_sanitizer.py
@@ -1,0 +1,201 @@
+"""Tests for log sanitization utilities."""
+
+import tomllib
+
+import pytest
+
+from tldw_chatbook.config import CONFIG_TOML_CONTENT, DEFAULT_APP_TTS_CONFIG
+from tldw_chatbook.Utils.log_sanitizer import (
+    create_safe_log_message,
+    sanitize_dict,
+    sanitize_list,
+    sanitize_log_params,
+    sanitize_string,
+)
+from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
+
+
+def _iter_leaf_key_names(mapping):
+    """Yield leaf mapping keys from the shipped configuration structure."""
+    for key, value in mapping.items():
+        if isinstance(value, dict):
+            yield from _iter_leaf_key_names(value)
+        else:
+            yield key
+
+
+def test_real_shipped_sensitive_key_names_are_redacted() -> None:
+    """Redact every real secret-bearing default key using the shared policy."""
+    default_config = tomllib.loads(CONFIG_TOML_CONTENT)
+    key_names = {
+        str(key)
+        for key in _iter_leaf_key_names(default_config)
+        if is_sensitive_config_key(key)
+    }
+    key_names.update(
+        key for key in DEFAULT_APP_TTS_CONFIG if is_sensitive_config_key(key)
+    )
+    assert {"api_key", "auth_token", "api_token"} <= key_names
+
+    sentinels = {
+        key: f"PRIVATE_CONFIG_{index}" for index, key in enumerate(sorted(key_names))
+    }
+    result = sanitize_dict(sentinels)
+
+    assert set(result) == set(sentinels)
+    assert all(value == "***REDACTED***" for value in result.values())
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "Authorization",
+        "Proxy-Authorization",
+        "cookie",
+        "Set-Cookie",
+        "credential",
+        "credentials",
+        "database_url",
+        "connection-string",
+        "dsn",
+    ],
+)
+def test_log_protocol_fields_are_redacted_without_expanding_config_policy(key: str) -> None:
+    """Redact protocol-only fields while keeping config policy intentionally narrow."""
+    assert not is_sensitive_config_key(key)
+    assert sanitize_dict({key: "PRIVATE_PROTOCOL_VALUE"})[key] == "***REDACTED***"
+
+
+def test_non_string_mapping_key_is_safe_and_sensitive_values_are_redacted() -> None:
+    """Avoid lower() failures for non-string mapping keys."""
+    result = sanitize_dict({1: "safe", "x-api-key": "PRIVATE"})
+
+    assert result == {1: "safe", "x-api-key": "***REDACTED***"}
+
+
+def test_non_mutating_sanitization_preserves_input_containers() -> None:
+    """Return copies without changing supplied nested dictionaries or lists."""
+    nested = {"token": "PRIVATE_NESTED"}
+    items = [{"api_key": "PRIVATE_LIST"}]
+    source = {"nested": nested, "items": items}
+
+    result = sanitize_dict(source)
+
+    assert source == {
+        "nested": {"token": "PRIVATE_NESTED"},
+        "items": [{"api_key": "PRIVATE_LIST"}],
+    }
+    assert result == {
+        "nested": {"token": "***REDACTED***"},
+        "items": [{"api_key": "***REDACTED***"}],
+    }
+
+
+def test_deep_false_returns_new_outer_container_and_sanitizes_direct_strings() -> None:
+    """Skip nested traversal without sharing the outer mapping."""
+    nested = {"token": "PRIVATE_NESTED"}
+    items = ["token=PRIVATE_LIST"]
+    source = {"nested": nested, "items": items, "message": "api_key=PRIVATE"}
+
+    result = sanitize_dict(source, deep=False)
+
+    assert result is not source
+    assert result["nested"] is nested
+    assert result["items"] is items
+    assert result["message"] == "api_key=***REDACTED***"
+
+
+@pytest.mark.parametrize("key", ["api_key_env_var", "max_tokens", "ordinary"])
+def test_non_sensitive_keys_remain_unchanged(key: str) -> None:
+    """Keep known non-secret configuration names and ordinary data intact."""
+    assert sanitize_dict({key: "safe-value"}) == {key: "safe-value"}
+
+
+@pytest.mark.parametrize("value", [{"nested": "PRIVATE"}, ["PRIVATE"]])
+def test_sensitive_container_value_is_redacted_before_recursion(value) -> None:
+    """Replace a sensitive container wholly instead of traversing its contents."""
+    assert sanitize_dict({"api_key": value}) == {"api_key": "***REDACTED***"}
+
+
+class TestLogSanitizer:
+    """Test the log sanitization utilities."""
+
+    def test_sanitize_string_api_keys(self):
+        """Test that API keys are sanitized from strings."""
+        test_cases = [
+            ("api_key=sk-1234567890abcdef", "api_key=***REDACTED***"),
+            (
+                "Bearer sk-abcdefghijklmnopqrstuvwxyz123456789012345678",
+                "Bearer ***OPENAI_KEY***",
+            ),
+            ("OPENAI_API_KEY=sk-test123", "OPENAI_API_KEY=***REDACTED***"),
+            ('{"api_key": "secret123"}', '{"api_key": "***REDACTED***"}'),
+            ("password: mypassword123", "password=***REDACTED***"),
+            ("https://user:pass@example.com", "https://***:***@example.com"),
+        ]
+
+        for input_str, expected in test_cases:
+            result = sanitize_string(input_str)
+            assert result == expected
+
+    def test_sanitize_dict(self):
+        """Test dictionary sanitization."""
+        test_dict = {
+            "name": "test",
+            "api_key": "sk-123456",
+            "password": "secret",
+            "nested": {"token": "bearer123", "safe": "value"},
+            "config": "api_key=embedded_secret",
+        }
+
+        result = sanitize_dict(test_dict)
+
+        assert result["name"] == "test"
+        assert result["api_key"] == "***REDACTED***"
+        assert result["password"] == "***REDACTED***"
+        assert result["nested"]["token"] == "***REDACTED***"
+        assert result["nested"]["safe"] == "value"
+        assert "***REDACTED***" in result["config"]
+
+    def test_sanitize_list(self):
+        """Test list sanitization."""
+        test_list = [
+            "safe value",
+            "api_key=secret",
+            {"password": "hidden"},
+            ["nested", "token=abc123"],
+        ]
+
+        result = sanitize_list(test_list)
+
+        assert result[0] == "safe value"
+        assert "***REDACTED***" in result[1]
+        assert result[2]["password"] == "***REDACTED***"
+        assert "***REDACTED***" in result[3][1]
+
+    def test_create_safe_log_message(self):
+        """Test safe log message creation."""
+        # Test with positional args (OpenAI keys need 20+ chars after sk-)
+        msg = create_safe_log_message(
+            "User {} logged in with key {}",
+            "john",
+            "sk-abcdefghijklmnopqrstuvwxyz123456",
+        )
+        assert msg == "User john logged in with key ***OPENAI_KEY***"
+
+        # Test with keyword args
+        msg = create_safe_log_message("Config: {config}", config={"api_key": "secret"})
+        assert "***REDACTED***" in msg
+
+    def test_sanitize_log_params(self):
+        """Test parameter sanitization."""
+        args = ("test", {"api_key": "secret"}, "password=123")
+        kwargs = {"token": "bearer123", "safe": "value"}
+
+        clean_args, clean_kwargs = sanitize_log_params(*args, **kwargs)
+
+        assert clean_args[0] == "test"
+        assert clean_args[1]["api_key"] == "***REDACTED***"
+        assert "***REDACTED***" in clean_args[2]
+        assert clean_kwargs["token"] == "***REDACTED***"
+        assert clean_kwargs["safe"] == "value"

--- a/Tests/Utils/test_log_sanitizer.py
+++ b/Tests/Utils/test_log_sanitizer.py
@@ -61,7 +61,9 @@ def test_real_shipped_sensitive_key_names_are_redacted() -> None:
         "dsn",
     ],
 )
-def test_log_protocol_fields_are_redacted_without_expanding_config_policy(key: str) -> None:
+def test_log_protocol_fields_are_redacted_without_expanding_config_policy(
+    key: str,
+) -> None:
     """Redact protocol-only fields while keeping config policy intentionally narrow."""
     assert not is_sensitive_config_key(key)
     assert sanitize_dict({key: "PRIVATE_PROTOCOL_VALUE"})[key] == "***REDACTED***"
@@ -174,7 +176,9 @@ def test_explicit_provider_labels_redact_quoted_and_unquoted_values(label: str) 
     assert sanitize_string(f"{label}=PRIVATE_UNQUOTED") == f"{label}=***REDACTED***"
 
 
-def test_all_config_derived_sensitive_labels_redact_quoted_and_unquoted_values() -> None:
+def test_all_config_derived_sensitive_labels_redact_quoted_and_unquoted_values() -> (
+    None
+):
     """Keep string logging aligned with the shared sensitive-key policy."""
     default_config = tomllib.loads(CONFIG_TOML_CONTENT)
     labels = {
@@ -182,9 +186,7 @@ def test_all_config_derived_sensitive_labels_redact_quoted_and_unquoted_values()
         for key in _iter_leaf_key_names(default_config)
         if is_sensitive_config_key(key)
     }
-    labels.update(
-        key for key in DEFAULT_APP_TTS_CONFIG if is_sensitive_config_key(key)
-    )
+    labels.update(key for key in DEFAULT_APP_TTS_CONFIG if is_sensitive_config_key(key))
 
     for index, label in enumerate(sorted(labels)):
         quoted = f'{label}="PRIVATE_QUOTED_{index}"'
@@ -277,7 +279,9 @@ def test_sanitize_string_keeps_non_string_str_fallback() -> None:
     assert sanitize_string(1234) == "1234"
 
 
-def test_formatting_failure_sanitizes_template_without_interpolating_raw_arguments() -> None:
+def test_formatting_failure_sanitizes_template_without_interpolating_raw_arguments() -> (
+    None
+):
     """Do not leak raw arguments when formatting falls back to its template."""
     result = create_safe_log_message("api_key={missing}", "PRIVATE_ARGUMENT")
 

--- a/Tests/Utils/test_log_sanitizer.py
+++ b/Tests/Utils/test_log_sanitizer.py
@@ -7,6 +7,7 @@ import pytest
 from tldw_chatbook.config import CONFIG_TOML_CONTENT, DEFAULT_APP_TTS_CONFIG
 from tldw_chatbook.Utils.log_sanitizer import (
     create_safe_log_message,
+    safe_log,
     sanitize_dict,
     sanitize_list,
     sanitize_log_params,
@@ -117,6 +118,189 @@ def test_sensitive_container_value_is_redacted_before_recursion(value) -> None:
     assert sanitize_dict({"api_key": value}) == {"api_key": "***REDACTED***"}
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            'api_key="PRIVATE_QUOTED", safe="visible"',
+            'api_key="***REDACTED***", safe="visible"',
+        ),
+        ("password=correct horse battery staple", "password=***REDACTED***"),
+        (
+            "max_tokens=42 api_key=PRIVATE_LATER",
+            "max_tokens=42 api_key=***REDACTED***",
+        ),
+        ("api_key=PRIVATE_QUERY&safe=visible", "api_key=***REDACTED***"),
+        (
+            "api_key=\nrefresh_token=PRIVATE_NEXT",
+            "api_key=\nrefresh_token=***REDACTED***",
+        ),
+    ],
+)
+def test_assignment_scanner_contract(raw: str, expected: str) -> None:
+    """Redact classified assignments without consuming later candidates."""
+    assert sanitize_string(raw) == expected
+
+
+def test_assignment_scanner_redacts_two_quoted_secrets_on_one_line() -> None:
+    """Keep syntax and safe fields while finding each quoted sensitive value."""
+    raw = 'api_key="PRIVATE_FIRST", safe="visible", password="PRIVATE_SECOND"'
+
+    assert sanitize_string(raw) == (
+        'api_key="***REDACTED***", safe="visible", password="***REDACTED***"'
+    )
+
+
+def test_assignment_scanner_ignores_escaped_quotes_inside_secret() -> None:
+    """Treat an escaped quote as part of the quoted secret value."""
+    assert sanitize_string('api_key="PRIVATE\\"QUOTED", safe=visible') == (
+        'api_key="***REDACTED***", safe=visible'
+    )
+
+
+def test_assignment_scanner_resumes_after_unterminated_quoted_value() -> None:
+    """Redact an unterminated line then continue at the next assignment line."""
+    raw = 'api_key="PRIVATE_UNTERMINATED\nrefresh_token=PRIVATE_NEXT'
+
+    assert sanitize_string(raw) == (
+        'api_key="***REDACTED***\nrefresh_token=***REDACTED***'
+    )
+
+
+@pytest.mark.parametrize("label", ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"])
+def test_explicit_provider_labels_redact_quoted_and_unquoted_values(label: str) -> None:
+    """Classify explicit provider labels before consuming either value syntax."""
+    assert sanitize_string(f'{label}="PRIVATE_QUOTED"') == f'{label}="***REDACTED***"'
+    assert sanitize_string(f"{label}=PRIVATE_UNQUOTED") == f"{label}=***REDACTED***"
+
+
+def test_all_config_derived_sensitive_labels_redact_quoted_and_unquoted_values() -> None:
+    """Keep string logging aligned with the shared sensitive-key policy."""
+    default_config = tomllib.loads(CONFIG_TOML_CONTENT)
+    labels = {
+        str(key)
+        for key in _iter_leaf_key_names(default_config)
+        if is_sensitive_config_key(key)
+    }
+    labels.update(
+        key for key in DEFAULT_APP_TTS_CONFIG if is_sensitive_config_key(key)
+    )
+
+    for index, label in enumerate(sorted(labels)):
+        quoted = f'{label}="PRIVATE_QUOTED_{index}"'
+        unquoted = f"{label}=PRIVATE_UNQUOTED_{index}"
+
+        assert sanitize_string(quoted) == f'{label}="***REDACTED***"'
+        assert sanitize_string(unquoted) == f"{label}=***REDACTED***"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "api_key_env_var",
+        "max_tokens",
+        "claude-opus-4-20250514",
+        "Basic model configuration",
+        "NotBearer token",
+        "not-bearer token",
+    ],
+)
+def test_false_positive_shapes_remain_unchanged(raw: str) -> None:
+    """Avoid treating model names and near-schemes as credentials."""
+    assert sanitize_string(raw) == raw
+
+
+def test_standalone_bearer_credential_preserves_scheme_only() -> None:
+    """Remove a full bearer credential without rewriting its scheme."""
+    assert sanitize_string("Bearer PRIVATE_BEARER") == "Bearer ***REDACTED***"
+
+
+def test_url_userinfo_removes_both_username_and_password() -> None:
+    """Redact URL credentials as one neutral marker."""
+    result = sanitize_string("https://user:PRIVATE_PASSWORD@example.test/private")
+
+    assert result == "https://***REDACTED***@example.test/private"
+    assert "user" not in result
+    assert "PRIVATE_PASSWORD" not in result
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "sk-proj-abcdefghijklmnopqrst",
+        "sk-ant-api03-abcdefghijklmnopqrst",
+        "sk-abcdefghijklmnopqrst",
+        "AIza" + "a" * 35,
+    ],
+)
+def test_standalone_credential_shapes_are_replaced_wholly(raw: str) -> None:
+    """Replace every recognized standalone key shape with exactly one marker."""
+    assert sanitize_string(raw) == "***REDACTED***"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "SK-PROJ-ABCDEFGHIJKLMNOPQRST",
+        "SK-ANT-API03-ABCDEFGHIJKLMNOPQRST",
+        "SK-ABCDEFGHIJKLMNOPQRST",
+        "AIZA" + "A" * 35,
+    ],
+)
+def test_uppercase_standalone_credential_shapes_are_not_recognized(raw: str) -> None:
+    """Keep standalone credential family recognition intentionally case-sensitive."""
+    assert sanitize_string(raw) == raw
+
+
+def test_labeled_standalone_shaped_value_has_one_idempotent_marker() -> None:
+    """Assignment redaction consumes a key-shaped quoted secret only once."""
+    raw = 'api_key="sk-proj-abcdefghijklmnopqrst"'
+    sanitized = sanitize_string(raw)
+
+    assert sanitized == 'api_key="***REDACTED***"'
+    assert sanitize_string(sanitized) == sanitized
+
+
+def test_sanitization_is_idempotent_for_strings_and_containers() -> None:
+    """Repeated sanitization must not further alter redacted data."""
+    already_redacted = 'api_key="***REDACTED***" Bearer ***REDACTED***'
+    dictionary = {"api_key": "PRIVATE", "nested": {"password": "PRIVATE"}}
+    values = ["token=PRIVATE", {"api_key": "PRIVATE"}]
+
+    assert sanitize_string(sanitize_string(already_redacted)) == already_redacted
+    assert sanitize_dict(sanitize_dict(dictionary)) == sanitize_dict(dictionary)
+    assert sanitize_list(sanitize_list(values)) == sanitize_list(values)
+
+
+def test_sanitize_string_keeps_non_string_str_fallback() -> None:
+    """Preserve the established permissive fallback for non-string values."""
+    assert sanitize_string(1234) == "1234"
+
+
+def test_formatting_failure_sanitizes_template_without_interpolating_raw_arguments() -> None:
+    """Do not leak raw arguments when formatting falls back to its template."""
+    result = create_safe_log_message("api_key={missing}", "PRIVATE_ARGUMENT")
+
+    assert result == "api_key=***REDACTED***"
+    assert "PRIVATE_ARGUMENT" not in result
+
+
+def test_safe_log_calls_callback_once_with_sanitized_final_message() -> None:
+    """Send one fully sanitized message to the provided logging callback."""
+    calls: list[str] = []
+
+    safe_log(calls.append, "api_key={}", "PRIVATE_CALLBACK")
+
+    assert calls == ["api_key=***REDACTED***"]
+
+
+def test_long_non_matching_text_remains_unchanged() -> None:
+    """Exercise the scanner's linear no-match path without timing assertions."""
+    raw = "x" * 100_000
+
+    assert sanitize_string(raw) == raw
+
+
 class TestLogSanitizer:
     """Test the log sanitization utilities."""
 
@@ -126,12 +310,12 @@ class TestLogSanitizer:
             ("api_key=sk-1234567890abcdef", "api_key=***REDACTED***"),
             (
                 "Bearer sk-abcdefghijklmnopqrstuvwxyz123456789012345678",
-                "Bearer ***OPENAI_KEY***",
+                "Bearer ***REDACTED***",
             ),
             ("OPENAI_API_KEY=sk-test123", "OPENAI_API_KEY=***REDACTED***"),
             ('{"api_key": "secret123"}', '{"api_key": "***REDACTED***"}'),
-            ("password: mypassword123", "password=***REDACTED***"),
-            ("https://user:pass@example.com", "https://***:***@example.com"),
+            ("password: mypassword123", "password: ***REDACTED***"),
+            ("https://user:pass@example.com", "https://***REDACTED***@example.com"),
         ]
 
         for input_str, expected in test_cases:
@@ -181,7 +365,7 @@ class TestLogSanitizer:
             "john",
             "sk-abcdefghijklmnopqrstuvwxyz123456",
         )
-        assert msg == "User john logged in with key ***OPENAI_KEY***"
+        assert msg == "User john logged in with key ***REDACTED***"
 
         # Test with keyword args
         msg = create_safe_log_message("Config: {config}", config={"api_key": "secret"})

--- a/Tests/Utils/test_log_sanitizer.py
+++ b/Tests/Utils/test_log_sanitizer.py
@@ -305,6 +305,35 @@ def test_long_non_matching_text_remains_unchanged() -> None:
     assert sanitize_string(raw) == raw
 
 
+def test_dense_quoted_assignments_do_not_repeat_line_end_scans() -> None:
+    """Keep matched quoted input single-pass without a wall-clock assertion."""
+
+    class LineScanAccountingText(str):
+        line_scan_work = 0
+
+        def find(
+            self,
+            substring: str,
+            start: int = 0,
+            end: int | None = None,
+        ) -> int:
+            if substring in {"\r", "\n"}:
+                scan_end = len(self) if end is None else end
+                self.line_scan_work += scan_end - start
+            if end is None:
+                return super().find(substring, start)
+            return super().find(substring, start, end)
+
+    assignment_count = 2_000
+    raw = LineScanAccountingText(
+        ", ".join(f'api_key="PRIVATE_{index}"' for index in range(assignment_count))
+    )
+    expected = ", ".join('api_key="***REDACTED***"' for _ in range(assignment_count))
+
+    assert sanitize_string(raw) == expected
+    assert raw.line_scan_work == 0
+
+
 class TestLogSanitizer:
     """Test the log sanitization utilities."""
 

--- a/Tests/Utils/test_security_enhancements.py
+++ b/Tests/Utils/test_security_enhancements.py
@@ -3,13 +3,6 @@
 import pytest
 from pathlib import Path
 from tldw_chatbook.Utils.path_validation import validate_path_simple
-from tldw_chatbook.Utils.log_sanitizer import (
-    sanitize_string,
-    sanitize_dict,
-    sanitize_list,
-    create_safe_log_message,
-    sanitize_log_params,
-)
 
 
 class TestValidatePathSimple:
@@ -94,90 +87,6 @@ class TestValidatePathSimple:
         # constructs this exact shape for a lock root beneath ``tmp_path``.
         with pytest.raises(ValueError, match="dangerous pattern"):
             validate_path_simple("C:\\Temp\\cache\\..\\..")
-
-
-class TestLogSanitizer:
-    """Test the log sanitization utilities."""
-
-    def test_sanitize_string_api_keys(self):
-        """Test that API keys are sanitized from strings."""
-        test_cases = [
-            ("api_key=sk-1234567890abcdef", "api_key=***REDACTED***"),
-            (
-                "Bearer sk-abcdefghijklmnopqrstuvwxyz123456789012345678",
-                "Bearer ***OPENAI_KEY***",
-            ),
-            ("OPENAI_API_KEY=sk-test123", "OPENAI_API_KEY=***REDACTED***"),
-            ('{"api_key": "secret123"}', '{"api_key": "***REDACTED***"}'),
-            ("password: mypassword123", "password=***REDACTED***"),
-            ("https://user:pass@example.com", "https://***:***@example.com"),
-        ]
-
-        for input_str, expected in test_cases:
-            result = sanitize_string(input_str)
-            assert result == expected
-
-    def test_sanitize_dict(self):
-        """Test dictionary sanitization."""
-        test_dict = {
-            "name": "test",
-            "api_key": "sk-123456",
-            "password": "secret",
-            "nested": {"token": "bearer123", "safe": "value"},
-            "config": "api_key=embedded_secret",
-        }
-
-        result = sanitize_dict(test_dict)
-
-        assert result["name"] == "test"
-        assert result["api_key"] == "***REDACTED***"
-        assert result["password"] == "***REDACTED***"
-        assert result["nested"]["token"] == "***REDACTED***"
-        assert result["nested"]["safe"] == "value"
-        assert "***REDACTED***" in result["config"]
-
-    def test_sanitize_list(self):
-        """Test list sanitization."""
-        test_list = [
-            "safe value",
-            "api_key=secret",
-            {"password": "hidden"},
-            ["nested", "token=abc123"],
-        ]
-
-        result = sanitize_list(test_list)
-
-        assert result[0] == "safe value"
-        assert "***REDACTED***" in result[1]
-        assert result[2]["password"] == "***REDACTED***"
-        assert "***REDACTED***" in result[3][1]
-
-    def test_create_safe_log_message(self):
-        """Test safe log message creation."""
-        # Test with positional args (OpenAI keys need 20+ chars after sk-)
-        msg = create_safe_log_message(
-            "User {} logged in with key {}",
-            "john",
-            "sk-abcdefghijklmnopqrstuvwxyz123456",
-        )
-        assert msg == "User john logged in with key ***OPENAI_KEY***"
-
-        # Test with keyword args
-        msg = create_safe_log_message("Config: {config}", config={"api_key": "secret"})
-        assert "***REDACTED***" in msg
-
-    def test_sanitize_log_params(self):
-        """Test parameter sanitization."""
-        args = ("test", {"api_key": "secret"}, "password=123")
-        kwargs = {"token": "bearer123", "safe": "value"}
-
-        clean_args, clean_kwargs = sanitize_log_params(*args, **kwargs)
-
-        assert clean_args[0] == "test"
-        assert clean_args[1]["api_key"] == "***REDACTED***"
-        assert "***REDACTED***" in clean_args[2]
-        assert clean_kwargs["token"] == "***REDACTED***"
-        assert clean_kwargs["safe"] == "value"
 
 
 if __name__ == "__main__":

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -110,6 +110,21 @@ diff your tree's task filenames against dev's.
 
 ---
 
+## A clean scoped rebase can still invalidate a repository-wide manifest
+
+**TASK-856, 2026-08-08.** Tasks 1–3 and their scoped reviews were clean when the
+branch rebased onto a newer `dev`. None of TASK-856's scoped production or test
+files had changed upstream, yet the cross-cutting diagnostic inventory turned
+red: five new `app.py` diagnostics plus related owner and sink line movement
+made the generated manifest differ from the checked one.
+
+**What to do.** After every rebase, rerun repository-wide generated-manifest and
+architecture gates even when the scoped file diff is unchanged. Review the
+upstream semantic delta and commit it as a separate boundary before claiming
+that the feature branch changes only its intended inventory entry.
+
+---
+
 ## Regenerate the CSS bundle; never hand-merge it
 
 **What happened.** `tldw_cli_modular.tcss` is generated and conflicts on essentially

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1071,6 +1071,23 @@ only thing that reliably exposes the preemption.
 
 ---
 
+## A long no-match input does not prove a matched scanner is linear
+
+**TASK-856, 2026-08-08.** The sanitizer's long-input regression used only a
+string with no credential labels. It therefore exercised the scanner's cheap
+no-match path while completely missing repeated suffix scans after successful
+quoted-label matches. The final whole-branch review added a dense matched-input
+probe and measured the old quoted path performing **94,996,790 characters** of
+CR/LF search work on only **46,888 input characters**.
+
+**What to do.** A complexity claim about a scanner needs adversarial input that
+repeatedly takes the expensive matched branch. Count deterministic work—such as
+characters searched or cursor visits—and assert a structural bound alongside
+the exact output. Do not use wall-clock thresholds: they are noisy and can pass
+a superlinear implementation on a fast machine.
+
+---
+
 ## A button's region width proves nothing about whether its label renders
 
 **Incident.** TASK-2154.14 (DS-01) relabeled the Console composer's `☰`

--- a/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
+++ b/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-27 04:35'
-updated_date: '2026-08-02 23:50'
+updated_date: '2026-08-02 23:52'
 labels:
   - security
   - config
@@ -60,8 +60,8 @@ to log them.
 2. Move sanitizer tests to a dedicated module and use TDD to compose structured redaction from the canonical sensitive-config-key predicate plus exact log/protocol fields.
 3. Use TDD to replace regex-first assignment handling with the monotonic classify-first scanner and bounded standalone rules; extend the existing installed-wheel probe.
 4. Use direct production functions and the full production app to separate Ollama/Transformers display validation and omit the subscription URL at its diagnostic producer.
-5. Prove only monitoring_engine.py’s reviewed diagnostic digest changes relative to base; do not absorb the known unrelated global inventory drift.
-6. Run focused, production-app, subscription, installed-wheel, lint, format, syntax, hygiene, and independent-review gates; complete task notes and status only after verified closeout.
+5. Prove only monitoring_engine.py’s reviewed diagnostic digest changes relative to the green latest-dev inventory; do not use a blanket inventory rewrite.
+6. Run focused, production-app, subscription, installed-wheel, diagnostic-inventory, lint, format, syntax, hygiene, and independent-review gates; complete task notes and status only after verified closeout.
 
 ADR required: yes
 ADR path: backlog/decisions/029-local-private-data-boundary.md

--- a/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
+++ b/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-27 04:35'
-updated_date: '2026-08-02 23:14'
+updated_date: '2026-08-02 23:50'
 labels:
   - security
   - config
@@ -52,3 +52,21 @@ to log them.
 - [ ] #5 Subscription snapshot-pruning diagnostics contain useful non-private metadata but omit the monitored URL and all URL credentials, paths, queries, and fragments
 - [ ] #6 Recursive, non-mutating dictionary/list behavior, non-string mapping keys, `deep=False`, formatting fallback, and the installed-wheel import path are covered without introducing a reduced or test-only application
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rebase onto current origin/dev, rerun the focused baseline, and capture the non-monitoring diagnostic-inventory fingerprint.
+2. Move sanitizer tests to a dedicated module and use TDD to compose structured redaction from the canonical sensitive-config-key predicate plus exact log/protocol fields.
+3. Use TDD to replace regex-first assignment handling with the monotonic classify-first scanner and bounded standalone rules; extend the existing installed-wheel probe.
+4. Use direct production functions and the full production app to separate Ollama/Transformers display validation and omit the subscription URL at its diagnostic producer.
+5. Prove only monitoring_engine.py’s reviewed diagnostic digest changes relative to base; do not absorb the known unrelated global inventory drift.
+6. Run focused, production-app, subscription, installed-wheel, lint, format, syntax, hygiene, and independent-review gates; complete task notes and status only after verified closeout.
+
+ADR required: yes
+ADR path: backlog/decisions/029-local-private-data-boundary.md
+Reason: Implements ADR-029’s credential/privacy diagnostic boundary without introducing a new architectural decision.
+
+Approved design: Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
+Detailed plan: Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
+++ b/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
@@ -94,18 +94,20 @@ recursive/non-mutating containers, contextual and standalone credentials,
 false-positive model identifiers, formatting fallback, installed-wheel imports,
 and deterministic matched-input scan work. The final review caught a superlinear
 quoted-match path: the pre-fix implementation searched 94,996,790 CR/LF characters
-for 46,888 input characters. Commit `b847da509` made quoted values bypass repeated
-line-end scans and the scoped re-review found no remaining Critical or Important
-issue. The compatible `sanitize_dict` non-string-key annotation mismatch remains
-an explicitly deferred Minor.
+for 46,888 input characters. Rebased commit `1c1686cfa` made quoted values bypass
+repeated line-end scans; the scoped re-review found no remaining Critical or
+Important issue. The compatible `sanitize_dict`
+non-string-key annotation mismatch remains an explicitly deferred Minor.
 
-Diagnostic drift was reconciled without checker `--write` at two reviewed
-boundaries: `3305befb9` for the first latest-dev mismatch and `f44b5ff01` after
-the later rebase. At `f44b5ff01`, `monitoring_engine.py` was TASK-494 with 16
-calls and digest `f9ccee6989b39da1333b`; the final head changes only that digest
-to `911bf9d65817bf259923`. The non-monitoring SHA-256 remains
-`a927b4bc7a229d3c3328a5336054c410aabdedfe5fd40219ab1152a9880763eb`,
-with inventory `467/1151/6859/6` and unchanged sink topology.
+Diagnostic drift was reconciled without checker `--write` at three reviewed
+boundaries: rebased commits `2299da555`, `a25f5c792`, and `2862505e7`. The last
+boundary follows the final rebase onto
+`b030b0b73f217b955b298a45fce3a0256403447c`. At `2862505e7`,
+`monitoring_engine.py` was TASK-494 with 16 calls and digest
+`f9ccee6989b39da1333b`; the final head changes only that digest to
+`911bf9d65817bf259923`. The current non-monitoring SHA-256 remains
+`5ce06a13eb48f8007eddfa92a0616b41e5122b89e6b2b7d494d4c81fb48723ac`, with
+inventory `467/1151/6859/6` and unchanged sink topology.
 
 ADR-029 is the governing privacy boundary; no new ADR was required. Changed
 areas are the sanitizer and its focused/packaging tests, Ollama/Transformers

--- a/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
+++ b/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
@@ -124,6 +124,17 @@ failure set as clean `origin/dev` at 2 failed/23 passed
 (`test_llm_destination_action_census_is_complete_and_removed_controls_are_absent`
 and `test_production_llm_destination_owns_navigation_actions_and_recovery`).
 
+Final PR refresh: the branch was rebased again onto `origin/dev` at
+`ebeae144042c744d1639df2f192bda8d63aa78b6`. Exact generated comparison with
+that base records inventory `470/1155/6890/6`; the base and branch differ only
+in `monitoring_engine.py`'s digest (`65f3a0c1be12db1830f4` to
+`28b1354fcd730b42d311`). Both retain 16 calls, the same owner/reason, six sink
+files, and non-monitoring SHA-256
+`284f2c81631ff4b06b67971e996258b2b831b731f097b05dae46fd11aea0e2f3`.
+Fresh post-rebase verification retained 77 sanitizer/security passes, one
+installed-wheel pass, eight inventory architecture passes, green static/range/
+syntax/diff checks, and only the same two known full affected-module failures.
+
 Lessons recorded: no-match input does not prove matched-scanner linearity; and a
 rebase must rerun cross-cutting generated-manifest gates even when scoped files
 are unchanged.

--- a/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
+++ b/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
@@ -42,12 +42,12 @@ credential would corrupt ordinary identifiers. URL-bearing diagnostics must
 omit private URL components instead of treating regex redaction as permission
 to log them.
 
-The latest `dev` baseline also contains reviewed diagnostic changes from the
-Prompt Workbench and Change Review merges whose generated inventory was not
-committed. TASK-856 must reconcile those exact pre-existing owner entries in a
-separate baseline commit before changing sanitizer production code. Its own
-inventory proof is then measured from that reconciled commit, so upstream drift
-cannot be mistaken for or hidden inside the subscription diagnostic change.
+The latest `dev` baseline also contains reviewed diagnostic changes whose
+generated inventory was not committed. TASK-856 must reconcile those exact
+pre-existing owner entries in a separate baseline commit before changing
+sanitizer production code. Its own inventory proof is then measured from that
+reconciled commit, so upstream drift cannot be mistaken for or hidden inside
+the subscription diagnostic change.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
+++ b/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-856
 title: 'Decide the fate of Utils/log_sanitizer.py: wire it in fixed, or delete it'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-27 04:35'
+updated_date: '2026-08-02 23:14'
 labels:
   - security
   - config
@@ -13,14 +15,40 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Utils/log_sanitizer.py has zero production importers -- a repo-wide grep for log_sanitizer under tldw_chatbook/ and Tests/ finds only Tests/Utils/test_security_enhancements.py. The 40+ sanitize_string call sites elsewhere in the app resolve to a different function in Utils/input_validation.py. So every literal in this module protects nothing at runtime today; only the test file exercises it, making that test green and vacuous.
+The original audit found no production importers, but that premise is stale on
+current `dev`: `Utils/log_sanitizer.py` now has three production consumers.
+Ollama uses it both to redact successful API payloads and to transform model
+names, Transformers uses it to transform local model display names, and the
+subscription monitor uses it before interpolating a URL into a pruning
+diagnostic. The module therefore needs an explicit, correct runtime boundary
+rather than deletion.
 
-Independent of the dead-import problem, the module's rules are wrong in both directions. log_sanitizer.py:16 labels the pattern claude-[a-zA-Z0-9-]+ as matching "Anthropic keys", but claude-* is the model-id prefix (e.g. claude-opus-4-20250514), not a key format; a reproduction showed a log line naming the model claude-opus-4-20250514 gets its model name destroyed (replaced with ***ANTHROPIC_KEY***) while a real Anthropic key (sk-ant-api03-...) and a real OpenAI key (sk-proj-...) both survive sanitize_string unredacted, because :15's sk-[a-zA-Z0-9]{20,} character class excludes "-" and stops at "sk-ant"/"sk-proj". sanitize_dict() similarly redacts openai_api_key and auth_token but passes x-api-key, cohere_api_key, api_token, secret_key, and refresh_token through untouched. SENSITIVE_FIELDS also names ten literals that appear nowhere in this codebase (aws_access_key_id, connection_string, private_key, etc.) and misses roughly 30 real ones. If this module is ever wired in as-is, it will strip model names from logs while letting real credentials through.
+Its rules remain wrong in both directions. The `claude-*` pattern treats an
+Anthropic model-ID prefix as a credential, so
+`claude-opus-4-20250514` becomes `***ANTHROPIC_KEY***`. Meanwhile real-shaped
+`sk-ant-api03-*` and `sk-proj-*` credentials are only partially matched or
+survive because the generic `sk-` character class stops at their embedded
+hyphens. `sanitize_dict()` also has a second, drifting secret-field list that
+misses real shipped names such as `x-api-key`, `cohere_api_key`, `api_token`,
+`secret_key`, and `refresh_token`.
+
+Credential redaction and display-name validation are separate operations.
+Model names must receive bounded single-line input validation without being
+rewritten as secrets. Structured and labeled credential values must use the
+shared sensitive-config-key classification plus HTTP/log-specific secret
+fields. Ambiguous opaque provider tokens can only be safely recognized from
+that context; attempting to identify every opaque token as a standalone
+credential would corrupt ordinary identifiers. URL-bearing diagnostics must
+omit private URL components instead of treating regex redaction as permission
+to log them.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A decision is made and implemented: either log_sanitizer.py is deleted (along with its now-vacuous test), or it is fixed (correct key-format regexes, a field list that matches the app's real key names, an inverted Anthropic-key rule corrected) and wired into at least the log paths that currently rely on Utils/input_validation.sanitize_string for secret redaction
-- [ ] #2 If kept, a test builds its expected-redacted-field list from the app's real config key names (not the module's own literal list) and confirms every real provider key format (openai, anthropic, cohere, etc.) is actually redacted from a sample log line
-- [ ] #3 If deleted, its test file is removed and no remaining code references the module
+- [ ] #1 `Utils/log_sanitizer.py` remains importable under its existing public function names and redacts complete credential values without rewriting ordinary model identifiers such as `claude-opus-4-20250514`
+- [ ] #2 Structured redaction covers the app's real sensitive config key names, sourced in tests from shipped configuration rather than a duplicate sanitizer-owned list, plus authentication headers, cookies, credential containers, and connection-secret fields
+- [ ] #3 Labeled credentials from every configured provider are redacted even when their opaque value has no safely recognizable standalone format; high-confidence standalone key families are fully redacted rather than partially matched
+- [ ] #4 Ollama and Transformers model names use bounded single-line input validation, preserve legitimate `claude-*` identifiers, and do not rely on credential redaction for display safety
+- [ ] #5 Subscription snapshot-pruning diagnostics contain useful non-private metadata but omit the monitored URL and all URL credentials, paths, queries, and fragments
+- [ ] #6 Recursive, non-mutating dictionary/list behavior, non-string mapping keys, `deep=False`, formatting fallback, and the installed-wheel import path are covered without introducing a reduced or test-only application
 <!-- AC:END -->

--- a/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
+++ b/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
@@ -41,6 +41,13 @@ that context; attempting to identify every opaque token as a standalone
 credential would corrupt ordinary identifiers. URL-bearing diagnostics must
 omit private URL components instead of treating regex redaction as permission
 to log them.
+
+The latest `dev` baseline also contains reviewed diagnostic changes from the
+Prompt Workbench and Change Review merges whose generated inventory was not
+committed. TASK-856 must reconcile those exact pre-existing owner entries in a
+separate baseline commit before changing sanitizer production code. Its own
+inventory proof is then measured from that reconciled commit, so upstream drift
+cannot be mistaken for or hidden inside the subscription diagnostic change.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -51,16 +58,17 @@ to log them.
 - [ ] #4 Ollama and Transformers model names use bounded single-line input validation, preserve legitimate `claude-*` identifiers, and do not rely on credential redaction for display safety
 - [ ] #5 Subscription snapshot-pruning diagnostics contain useful non-private metadata but omit the monitored URL and all URL credentials, paths, queries, and fragments
 - [ ] #6 Recursive, non-mutating dictionary/list behavior, non-string mapping keys, `deep=False`, formatting fallback, and the installed-wheel import path are covered without introducing a reduced or test-only application
+- [ ] #7 Pre-existing latest-dev diagnostic-inventory drift is reviewed and reconciled in a separate baseline commit, after which TASK-856 changes only `monitoring_engine.py`'s diagnostic digest while preserving every other generated inventory entry and the persistent-sink topology
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Rebase onto current origin/dev, rerun the focused baseline, and capture the non-monitoring diagnostic-inventory fingerprint.
-2. Move sanitizer tests to a dedicated module and use TDD to compose structured redaction from the canonical sensitive-config-key predicate plus exact log/protocol fields.
+1. Rebase onto current origin/dev, rerun the focused baseline, review the exact pre-existing diagnostic-inventory drift, and reconcile only those entries in a separate baseline commit without using blanket write mode.
+2. Capture the reconciled non-monitoring fingerprint, then move sanitizer tests to a dedicated module and use TDD to compose structured redaction from the canonical sensitive-config-key predicate plus exact log/protocol fields.
 3. Use TDD to replace regex-first assignment handling with the monotonic classify-first scanner and bounded standalone rules; extend the existing installed-wheel probe.
 4. Use direct production functions and the full production app to separate Ollama/Transformers display validation and omit the subscription URL at its diagnostic producer.
-5. Prove only monitoring_engine.py’s reviewed diagnostic digest changes relative to the green latest-dev inventory; do not use a blanket inventory rewrite.
+5. Prove only monitoring_engine.py’s reviewed diagnostic digest changes relative to the recorded reconciliation commit; do not use a blanket inventory rewrite.
 6. Run focused, production-app, subscription, installed-wheel, diagnostic-inventory, lint, format, syntax, hygiene, and independent-review gates; complete task notes and status only after verified closeout.
 
 ADR required: yes

--- a/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
+++ b/backlog/tasks/task-856 - Decide-the-fate-of-Utils-log_sanitizer.py-wire-it-in-fixed-or-delete-it.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-856
 title: 'Decide the fate of Utils/log_sanitizer.py: wire it in fixed, or delete it'
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-27 04:35'
-updated_date: '2026-08-02 23:52'
+updated_date: '2026-08-08 16:29'
 labels:
   - security
   - config
@@ -52,13 +52,13 @@ the subscription diagnostic change.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `Utils/log_sanitizer.py` remains importable under its existing public function names and redacts complete credential values without rewriting ordinary model identifiers such as `claude-opus-4-20250514`
-- [ ] #2 Structured redaction covers the app's real sensitive config key names, sourced in tests from shipped configuration rather than a duplicate sanitizer-owned list, plus authentication headers, cookies, credential containers, and connection-secret fields
-- [ ] #3 Labeled credentials from every configured provider are redacted even when their opaque value has no safely recognizable standalone format; high-confidence standalone key families are fully redacted rather than partially matched
-- [ ] #4 Ollama and Transformers model names use bounded single-line input validation, preserve legitimate `claude-*` identifiers, and do not rely on credential redaction for display safety
-- [ ] #5 Subscription snapshot-pruning diagnostics contain useful non-private metadata but omit the monitored URL and all URL credentials, paths, queries, and fragments
-- [ ] #6 Recursive, non-mutating dictionary/list behavior, non-string mapping keys, `deep=False`, formatting fallback, and the installed-wheel import path are covered without introducing a reduced or test-only application
-- [ ] #7 Pre-existing latest-dev diagnostic-inventory drift is reviewed and reconciled in a separate baseline commit, after which TASK-856 changes only `monitoring_engine.py`'s diagnostic digest while preserving every other generated inventory entry and the persistent-sink topology
+- [x] #1 `Utils/log_sanitizer.py` remains importable under its existing public function names and redacts complete credential values without rewriting ordinary model identifiers such as `claude-opus-4-20250514`
+- [x] #2 Structured redaction covers the app's real sensitive config key names, sourced in tests from shipped configuration rather than a duplicate sanitizer-owned list, plus authentication headers, cookies, credential containers, and connection-secret fields
+- [x] #3 Labeled credentials from every configured provider are redacted even when their opaque value has no safely recognizable standalone format; high-confidence standalone key families are fully redacted rather than partially matched
+- [x] #4 Ollama and Transformers model names use bounded single-line input validation, preserve legitimate `claude-*` identifiers, and do not rely on credential redaction for display safety
+- [x] #5 Subscription snapshot-pruning diagnostics contain useful non-private metadata but omit the monitored URL and all URL credentials, paths, queries, and fragments
+- [x] #6 Recursive, non-mutating dictionary/list behavior, non-string mapping keys, `deep=False`, formatting fallback, and the installed-wheel import path are covered without introducing a reduced or test-only application
+- [x] #7 Pre-existing latest-dev diagnostic-inventory drift is reviewed and reconciled in a separate baseline commit, after which TASK-856 changes only `monitoring_engine.py`'s diagnostic digest while preserving every other generated inventory entry and the persistent-sink topology
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -78,3 +78,51 @@ Reason: Implements ADR-029’s credential/privacy diagnostic boundary without in
 Approved design: Docs/superpowers/specs/2026-08-02-log-sanitizer-active-redaction-design.md
 Detailed plan: Docs/superpowers/plans/2026-08-02-log-sanitizer-active-redaction.md
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented and independently reviewed the active sanitizer rather than deleting
+it. Structured redaction delegates shipped config-key classification to the
+canonical predicate, composes the narrow HTTP/log-only field set, and uses a
+classify-first scanner plus bounded standalone credential families. Ollama and
+Transformers model names use bounded single-line display validation, while the
+snapshot-pruning producer omits the monitored URL entirely.
+
+Tests moved to `Tests/Utils/test_log_sanitizer.py` and cover public compatibility,
+recursive/non-mutating containers, contextual and standalone credentials,
+false-positive model identifiers, formatting fallback, installed-wheel imports,
+and deterministic matched-input scan work. The final review caught a superlinear
+quoted-match path: the pre-fix implementation searched 94,996,790 CR/LF characters
+for 46,888 input characters. Commit `b847da509` made quoted values bypass repeated
+line-end scans and the scoped re-review found no remaining Critical or Important
+issue. The compatible `sanitize_dict` non-string-key annotation mismatch remains
+an explicitly deferred Minor.
+
+Diagnostic drift was reconciled without checker `--write` at two reviewed
+boundaries: `3305befb9` for the first latest-dev mismatch and `f44b5ff01` after
+the later rebase. At `f44b5ff01`, `monitoring_engine.py` was TASK-494 with 16
+calls and digest `f9ccee6989b39da1333b`; the final head changes only that digest
+to `911bf9d65817bf259923`. The non-monitoring SHA-256 remains
+`a927b4bc7a229d3c3328a5336054c410aabdedfe5fd40219ab1152a9880763eb`,
+with inventory `467/1151/6859/6` and unchanged sink topology.
+
+ADR-029 is the governing privacy boundary; no new ADR was required. Changed
+areas are the sanitizer and its focused/packaging tests, Ollama/Transformers
+display helpers and production tests, subscription diagnostic/test, reviewed
+inventory, approved design/plan, task closeout, and the two generalized lesson
+entries.
+
+Verification before closeout: 77 sanitizer/security tests, four selected
+TASK-856 consumers, one installed-wheel test, and three inventory architecture
+tests passed; Ruff lint, full-file format, three legacy ranges, `py_compile`,
+inventory checker, and diff hygiene were green. The full affected-module command
+is not claimed green: branch result was 2 failed/26 passed, exactly the same
+failure set as clean `origin/dev` at 2 failed/23 passed
+(`test_llm_destination_action_census_is_complete_and_removed_controls_are_absent`
+and `test_production_llm_destination_owns_navigation_actions_and_recovery`).
+
+Lessons recorded: no-match input does not prove matched-scanner linearity; and a
+rebase must rerun cross-cutting generated-manifest gates even when scoped files
+are unchanged.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_ollama.py
+++ b/tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_ollama.py
@@ -42,7 +42,7 @@ from tldw_chatbook.Local_Inference.ollama_model_mgmt import (
     ollama_list_running_models,
     ollama_generate_embeddings,
 )
-from tldw_chatbook.Utils.log_sanitizer import sanitize_dict, sanitize_string
+from tldw_chatbook.Utils import input_validation as input_safety, log_sanitizer
 from tldw_chatbook.Widgets.enhanced_file_picker import EnhancedFileOpen as FileOpen
 from tldw_chatbook.Third_Party.textual_fspicker import Filters
 
@@ -79,7 +79,7 @@ def _format_ollama_success_payload(data: dict[str, Any]) -> str:
     """Render a bounded successful API result with credential fields redacted."""
 
     rendered = json.dumps(
-        sanitize_dict(data),
+        log_sanitizer.sanitize_dict(data),
         ensure_ascii=False,
         indent=2,
         sort_keys=True,
@@ -110,7 +110,7 @@ def _safe_ollama_model_names(models: object) -> list[str] | None:
         name = item.get("name") or item.get("model")
         if not isinstance(name, str):
             return None
-        safe_name = sanitize_string(name).replace("\n", " ").strip()[:256]
+        safe_name = " ".join(input_safety.sanitize_string(name, max_length=256).split())
         if not safe_name:
             return None
         safe_names.append(safe_name)

--- a/tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_transformers.py
+++ b/tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_transformers.py
@@ -14,7 +14,7 @@ from tldw_chatbook.Event_Handlers.LLM_Management_Events.server_lifecycle import 
     current_llm_destination,
     terminate_process_bounded,
 )
-from tldw_chatbook.Utils.log_sanitizer import sanitize_string
+from tldw_chatbook.Utils.input_validation import sanitize_string as sanitize_input
 from tldw_chatbook.Utils.log_widget_manager import LogWidgetManager
 
 # For listing local models, you might need to interact with huggingface_hub or scan directories
@@ -185,7 +185,7 @@ def scan_transformers_local_models(models_path: Path) -> list[str]:
             display_name = (
                 models_path.name if model_root == models_path else model_root.name
             )
-        display_name = sanitize_string(display_name).replace("\n", " ").strip()[:256]
+        display_name = " ".join(sanitize_input(display_name, max_length=256).split())
         if display_name and display_name not in seen:
             seen.add(display_name)
             found_models.append(display_name)

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -1605,18 +1605,11 @@ class URLMonitor:
             )
             pruned = cursor.rowcount
             if pruned > 0:
-                # Qodo/PR #1100: URLs can embed credentials
-                # (https://user:pass@host); the repo's log sanitizer redacts
-                # exactly that, so route the value through it rather than
-                # logging it raw.
-                from ..Utils.log_sanitizer import sanitize_string as _sanitize_log
-
                 logger.debug(
-                    "Pruned {} snapshot(s) for subscription {} url {}, "
+                    "Pruned {} snapshot(s) for subscription {}, "
                     "keeping the newest {}",
                     pruned,
                     subscription_id,
-                    _sanitize_log(url),
                     _SNAPSHOTS_KEPT_PER_URL,
                 )
 

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -1606,8 +1606,7 @@ class URLMonitor:
             pruned = cursor.rowcount
             if pruned > 0:
                 logger.debug(
-                    "Pruned {} snapshot(s) for subscription {}, "
-                    "keeping the newest {}",
+                    "Pruned {} snapshot(s) for subscription {}, keeping the newest {}",
                     pruned,
                     subscription_id,
                     _SNAPSHOTS_KEPT_PER_URL,

--- a/tldw_chatbook/Utils/log_sanitizer.py
+++ b/tldw_chatbook/Utils/log_sanitizer.py
@@ -121,9 +121,11 @@ def _redact_assignments(text: str) -> str:
             continue
 
         value_start = match.end()
-        line_end = _line_end(text, value_start)
-        if value_start == line_end:
-            cursor = _after_line_break(text, line_end)
+        if value_start == len(text):
+            cursor = value_start
+            continue
+        if text[value_start] in "\r\n":
+            cursor = _after_line_break(text, value_start)
             continue
 
         if text[value_start] in "\"'":
@@ -134,6 +136,7 @@ def _redact_assignments(text: str) -> str:
             cursor = value_end + 1 if closed else _after_line_break(text, value_end)
             continue
 
+        line_end = _line_end(text, value_start)
         spans.append((value_start, line_end))
         cursor = _after_line_break(text, line_end)
 

--- a/tldw_chatbook/Utils/log_sanitizer.py
+++ b/tldw_chatbook/Utils/log_sanitizer.py
@@ -8,6 +8,29 @@ sensitive information from log messages.
 import re
 from typing import Any, Dict, List
 
+from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
+
+
+REDACTION_MARKER = "***REDACTED***"
+_LOG_ONLY_SENSITIVE_FIELDS = frozenset(
+    {
+        "authorization",
+        "proxy_authorization",
+        "cookie",
+        "set_cookie",
+        "credential",
+        "credentials",
+        "database_url",
+        "connection_string",
+        "dsn",
+    }
+)
+
+
+def _is_sensitive_log_key(key: object) -> bool:
+    normalized = str(key).strip().lower().replace("-", "_")
+    return is_sensitive_config_key(key) or normalized in _LOG_ONLY_SENSITIVE_FIELDS
+
 
 # Patterns for common sensitive data
 SENSITIVE_PATTERNS = [
@@ -44,34 +67,6 @@ SENSITIVE_PATTERNS = [
         r"\1=***REDACTED***",
     ),
 ]
-
-# Fields to redact in dictionaries
-SENSITIVE_FIELDS = {
-    "api_key",
-    "apikey",
-    "api-key",
-    "api_secret",
-    "api-secret",
-    "password",
-    "passwd",
-    "pwd",
-    "secret",
-    "token",
-    "auth_token",
-    "access_token",
-    "bearer_token",
-    "client_secret",
-    "private_key",
-    "openai_api_key",
-    "anthropic_api_key",
-    "google_api_key",
-    "aws_access_key_id",
-    "aws_secret_access_key",
-    "database_url",
-    "connection_string",
-    "credentials",
-}
-
 
 def sanitize_string(text: str) -> str:
     """
@@ -110,8 +105,8 @@ def sanitize_dict(data: Dict[str, Any], deep: bool = True) -> Dict[str, Any]:
     result = {}
     for key, value in data.items():
         # Check if key is sensitive
-        if key.lower() in SENSITIVE_FIELDS:
-            result[key] = "***REDACTED***"
+        if _is_sensitive_log_key(key):
+            result[key] = REDACTION_MARKER
         elif deep and isinstance(value, dict):
             result[key] = sanitize_dict(value, deep=True)
         elif deep and isinstance(value, list):

--- a/tldw_chatbook/Utils/log_sanitizer.py
+++ b/tldw_chatbook/Utils/log_sanitizer.py
@@ -139,6 +139,7 @@ def _redact_assignments(text: str) -> str:
 
     return _apply_replacements(text, spans)
 
+
 def sanitize_string(text: str) -> str:
     """
     Sanitize a string by removing sensitive data patterns.

--- a/tldw_chatbook/Utils/log_sanitizer.py
+++ b/tldw_chatbook/Utils/log_sanitizer.py
@@ -32,41 +32,112 @@ def _is_sensitive_log_key(key: object) -> bool:
     return is_sensitive_config_key(key) or normalized in _LOG_ONLY_SENSITIVE_FIELDS
 
 
-# Patterns for common sensitive data
-SENSITIVE_PATTERNS = [
-    # Specific API key formats first (more specific patterns before general ones)
-    (r"sk-[a-zA-Z0-9]{20,}", "***OPENAI_KEY***"),  # OpenAI keys
-    (r"claude-[a-zA-Z0-9-]+", "***ANTHROPIC_KEY***"),  # Anthropic keys
-    (r"AIza[0-9A-Za-z-_]{35}", "***GOOGLE_KEY***"),  # Google API keys
-    # API Keys and tokens
-    (
-        r'(api[_-]?key|apikey|api_secret|access[_-]?token|auth[_-]?token|bearer)\s*[:=]\s*["\']?([^\s"\']+)',
-        r"\1=***REDACTED***",
-    ),
-    # Bearer tokens in headers
-    (
-        r"(Bearer\s+)(sk-[a-zA-Z0-9]{20,})",
-        r"\1***OPENAI_KEY***",
-    ),  # Specific OpenAI bearer
-    (r"(Bearer\s+)([a-zA-Z0-9\-._~+/]+=*)", r"\1***REDACTED***"),
-    (r"(Authorization:\s*)(Bearer\s+)?([^\s]+)", r"\1\2***REDACTED***"),
-    # Token patterns
-    (r'(token)\s*[:=]\s*["\']?([^\s"\']+)', r"\1=***REDACTED***"),
-    # Password patterns
-    (r'(password|passwd|pwd)\s*[:=]\s*["\']?([^\s"\']+)', r"\1=***REDACTED***"),
-    # URLs with embedded credentials
-    (r"(https?://)([^:]+):([^@]+)@", r"\1***:***@"),
-    # JSON/Dict API keys
-    (
-        r'["\']?(api[_-]?key|apikey|api_secret|password|secret|token)["\']?\s*:\s*["\']([^"\']+)["\']',
-        r'"\1": "***REDACTED***"',
-    ),
-    # Environment variable style
-    (
-        r"(OPENAI_API_KEY|ANTHROPIC_API_KEY|GOOGLE_API_KEY|API_KEY|SECRET_KEY|DATABASE_URL)\s*=\s*([^\s]+)",
-        r"\1=***REDACTED***",
-    ),
-]
+_ASSIGNMENT_PREFIX = re.compile(
+    r"""
+    (?<![A-Za-z0-9_.-])
+    (?:
+        (?P<quote>["'])(?P<quoted_key>[A-Za-z0-9_.-]+)(?P=quote)
+        |
+        (?P<plain_key>[A-Za-z0-9_.-]+)
+    )
+    [ \t]*[:=][ \t]*
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_URL_USERINFO = re.compile(r"(https?://)[^/?#\s\r\n]*@", re.IGNORECASE)
+_BEARER = re.compile(
+    r"(?<![A-Za-z0-9_-])(Bearer\s+)(\S+)",
+    re.IGNORECASE,
+)
+_STANDALONE_CREDENTIALS = (
+    re.compile(r"(?<![A-Za-z0-9_-])sk-proj-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])"),
+    re.compile(r"(?<![A-Za-z0-9_-])sk-ant-api03-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])"),
+    re.compile(r"(?<![A-Za-z0-9_-])sk-[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])"),
+    re.compile(r"(?<![A-Za-z0-9_-])AIza[A-Za-z0-9_-]{35}(?![A-Za-z0-9_-])"),
+)
+
+
+def _line_end(text: str, start: int) -> int:
+    """Return the first CR/LF index at or after start, or len(text)."""
+    line_feed = text.find("\n", start)
+    carriage_return = text.find("\r", start)
+    endings = (index for index in (line_feed, carriage_return) if index != -1)
+    return min(endings, default=len(text))
+
+
+def _after_line_break(text: str, index: int) -> int:
+    """Advance over LF, CR, or one CRLF pair; end stays at len(text)."""
+    if index >= len(text):
+        return len(text)
+    if text[index] == "\r" and index + 1 < len(text) and text[index + 1] == "\n":
+        return index + 2
+    if text[index] in "\r\n":
+        return index + 1
+    return index
+
+
+def _find_quoted_end(text: str, value_start: int, quote: str) -> tuple[int, bool]:
+    """Return the closing-quote/line-end index and whether it closed."""
+    index = value_start
+    while index < len(text):
+        character = text[index]
+        if character in "\r\n":
+            return index, False
+        if character == quote:
+            return index, True
+        if (
+            character == "\\"
+            and index + 1 < len(text)
+            and text[index + 1] not in "\r\n"
+        ):
+            index += 2
+            continue
+        index += 1
+    return len(text), False
+
+
+def _apply_replacements(text: str, spans: list[tuple[int, int]]) -> str:
+    """Build one output from sorted non-overlapping spans and REDACTION_MARKER."""
+    if not spans:
+        return text
+
+    parts: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        parts.extend((text[cursor:start], REDACTION_MARKER))
+        cursor = end
+    parts.append(text[cursor:])
+    return "".join(parts)
+
+
+def _redact_assignments(text: str) -> str:
+    """Classify label prefixes first, collect replacement spans, and always advance."""
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    while match := _ASSIGNMENT_PREFIX.search(text, cursor):
+        key = match.group("quoted_key") or match.group("plain_key")
+        if not _is_sensitive_log_key(key):
+            cursor = match.end()
+            continue
+
+        value_start = match.end()
+        line_end = _line_end(text, value_start)
+        if value_start == line_end:
+            cursor = _after_line_break(text, line_end)
+            continue
+
+        if text[value_start] in "\"'":
+            quote = text[value_start]
+            value_end, closed = _find_quoted_end(text, value_start + 1, quote)
+            if value_end > value_start + 1:
+                spans.append((value_start + 1, value_end))
+            cursor = value_end + 1 if closed else _after_line_break(text, value_end)
+            continue
+
+        spans.append((value_start, line_end))
+        cursor = _after_line_break(text, line_end)
+
+    return _apply_replacements(text, spans)
 
 def sanitize_string(text: str) -> str:
     """
@@ -81,10 +152,11 @@ def sanitize_string(text: str) -> str:
     if not isinstance(text, str):
         return str(text)
 
-    result = text
-    for pattern, replacement in SENSITIVE_PATTERNS:
-        result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
-
+    result = _redact_assignments(text)
+    result = _URL_USERINFO.sub(r"\1" + REDACTION_MARKER + "@", result)
+    result = _BEARER.sub(r"\1" + REDACTION_MARKER, result)
+    for pattern in _STANDALONE_CREDENTIALS:
+        result = pattern.sub(REDACTION_MARKER, result)
     return result
 
 


### PR DESCRIPTION
## Summary

- activate recursive structured credential redaction through the canonical sensitive-key classifier
- add bounded, monotonic string redaction for labeled credentials while preserving model and display identifiers
- separate Ollama and Transformers display validation from diagnostic privacy handling, and omit monitored subscription URLs
- extend the existing isolated installed-wheel proof and reconcile the governed diagnostic inventory
- close TASK-856 with ADR-029, implementation evidence, and incident-based lessons

## Verification

- sanitizer and security tests: 77 passed
- selected consumer-boundary tests: 4 passed
- installed-wheel proof: 1 passed
- diagnostic inventory architecture tests: 3 passed
- inventory checker: 467 owners, 1,151 TASK-492 calls, 6,859 TASK-494 calls, 6 sink files
- Ruff lint and format, legacy edited ranges, py_compile, and diff checks: passed
- definitive review: no Critical or Important findings

## Known baseline failures

The full affected-module command has the same two LLM-destination failures on this branch and exact current dev: branch 2 failed / 26 passed; dev 2 failed / 23 passed.

The broad project suite was interrupted after the integration gate was already red at 7 percent: 2,534 passed, 58 skipped, 8 failed. Seven failures are the existing ingest fixture/state contract missing _ingest_local_stt_jobs; one is the Console size ratchet at 18,224 lines versus 17,727. This branch changes none of app.py, chat_screen.py, the ingest test, or the size-ratchet test; current dev has the same 18,224-line chat_screen.py.

## Tracking

- Backlog TASK-856: Done, 7 of 7 acceptance criteria
- Base: dev at b030b0b73
- Head: 69dddf4bf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates recursive credential redaction at diagnostic boundaries, fixes false positives/negatives, and cleanly separates display validation from diagnostics; also removes monitored URLs from debug logs and makes the redaction grammar normative with linear scanning. Closes TASK-856 by hardening `Utils/log_sanitizer.py`, updating LLM handlers, adding targeted tests (incl. installed-wheel proof), and shipping design/spec docs.

- **Bug Fixes**
  - Redact labeled secrets recursively via the shared sensitive-key policy; masks nested fields like `api_key`, `x-api-key`, and `authorization` while preserving non-secret values.
  - Replace fragile scans with bounded, linear redaction and record scanner progress; avoid model-name false positives (`claude-*` stays visible).
  - Ollama: render success payloads with `log_sanitizer.sanitize_dict`; validate and normalize model names using `input_validation.sanitize_string`.
  - Transformers: validate display names with bounded `input_validation.sanitize_string` and normalize whitespace.
  - Subscriptions: prune diagnostic omits the monitored URL entirely.
  - Tests/Docs: add dedicated sanitizer tests and installed-wheel proof, move legacy cases, publish a normative redaction grammar/spec, and reconcile diagnostic-inventory drift.

<sup>Written for commit 2d1caa7a43fea2bfc686c126f18ef2260bfd047f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

