### PR TITLE
chore(backlog): task-2512 FastMCP-retirement update — mcp 2.0 landmine + task-1337 scope reduction

### DIFF
--- a/backlog/tasks/task-2512 - Migrate-MCP-server-from-FastMCP-to-tldw_servers-mcp-unified-package.md
+++ b/backlog/tasks/task-2512 - Migrate-MCP-server-from-FastMCP-to-tldw_servers-mcp-unified-package.md
@@ -4,14 +4,23 @@ title: Migrate MCP server from FastMCP to tldw_server's mcp-unified package
 status: To Do
 assignee: []
 created_date: '2026-08-06 07:18'
-labels: []
+labels:
+  - mcp
+  - fastmcp
+  - migration
 dependencies: []
+references:
+  - backlog/tasks/task-1337 - Add-direct-local-Library-tools-for-Console-agents-and-MCP.md
+  - backlog/decisions/030-local-library-agent-tool-boundary.md
+priority: high
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 The MCP server (tldw_chatbook/MCP/server.py) currently uses the official SDK's FastMCP 1.x (optional mcp[cli] extra). It should instead use the standalone mcp-unified package from tldw_server (apps/mcp-unified, on PyPI, GPL-3.0-only — fine as a dependency for this AGPLv3+ project). Decisions (user, 2026-08-05): FULL migration — all 10 built-in tools, resources, prompts, and the phase-4 local agent tools (fs_*/git_*/web_*/fs_patch, permission-gated via LocalToolProvider) move to mcp-unified as modules served via its stdio gateway; dependency via PyPI optional extra. Research pointers: gateway in apps/mcp-unified/src/mcp_unified/gateway/{jsonrpc,fastapi,stdio}.py; modules subclass BaseModule (get_tools/execute_tool) loaded via ModuleRegistry (tldw_Server_API/app/core/MCP_unified/modules/base.py, registry.py); profiles/permission_rules.py + policy_grants/ for the permission layer. KEY UNKNOWN to resolve first: whether mcp-unified supports MCP resources and prompts (not just tools) — chatbook's server exposes both; if unsupported, the spec must decide the fallback. Also: protocol version compat with our hand-rolled client (2025-03-26), and whether serving stdio is programmatic or CLI-only. Refs: ADR-032/033, re-plan spec Docs/superpowers/specs/2026-08-05-local-agent-tools-phases-3-4-replan.md, task-2511 (FastMCP smoke — may become moot if this lands first).
+
+Update (2026-08-08, via task-1337 close-out / PR #1435): (1) LANDMINE — `mcp[cli]>=1.0.0` now resolves to mcp 2.0.0, which REMOVES `mcp.server.fastmcp`; a fresh install therefore breaks the legacy standalone server (`TldwMCPServer`, `MCP/__main__.py`) today, and the current dev venv ships with NO `mcp` installed (the in-app surface is unaffected). This makes the migration time-sensitive rather than cosmetic. (2) Scope reduction — the 18 descriptor-backed `library_*` tools (task-1337) are already FastMCP-free: they ride the capability manifest (`MCP/server.py::_describe_local_library_tools`) plus the direct runtime delegate (`LocalMCPRuntimeDelegate.execute_tool` via `asyncio.to_thread`) with the shared-service factory `build_local_library_tool_service`; they need NO migration. Remaining scope is the 10 legacy built-ins + resources + prompts + the phase-4 local agent tools. (3) Contract to preserve — the in-app direct runtime now refuses raw protocol `tools/call` for every tool with typed `RawToolCallRefusedError` (execution only via the gated, logged Execute Local Tool action); the migrated server must keep an equivalent policy-gated path, and `Tests/MCP/test_library_tools.py` (legacy-name/shape pinning) must stay green throughout.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria


### PR DESCRIPTION
Updates the existing FastMCP-migration task rather than filing a duplicate. Records three facts from the task-1337 close-out (PR #1435):

1. **Landmine:** `mcp[cli]>=1.0.0` now resolves to mcp 2.0.0, which removes `mcp.server.fastmcp` — the legacy standalone server (`TldwMCPServer`, `MCP/__main__.py`) breaks on fresh installs today; the current dev venv ships no `mcp` at all. Migration is time-sensitive, not cosmetic.
2. **Scope reduction:** the 18 descriptor-backed `library_*` tools are already FastMCP-free (manifest + direct delegate + shared-service factory) and need no migration — remaining scope is the 10 legacy built-ins + resources + prompts + phase-4 local agent tools.
3. **Contract to preserve:** raw protocol `tools/call` is refused for every tool with typed `RawToolCallRefusedError` (execution only via the gated Execute Local Tool action); the migrated server must keep the equivalent policy-gated path, and `Tests/MCP/test_library_tools.py` must stay green.

Backlog bookkeeping only — no code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated task-2512 to capture the MCP 2.0 landmine, narrow migration scope per task-1337, and specify the policy‑gated execution requirement.

- **Backlog updates**
  - Marked high priority; added `mcp`, `fastmcp`, `migration` labels and references to task-1337 and ADR-030.
  - Documented that `mcp[cli]>=1.0.0` resolves to 2.0.0 and removes `mcp.server.fastmcp`, breaking the legacy server on fresh installs.
  - Reduced scope: 18 `library_*` tools need no migration; remaining work is 10 built-ins, resources, prompts, and phase-4 local agent tools.
  - Locked the contract: refuse raw `tools/call`, keep the policy-gated Execute Local Tool path, and keep `Tests/MCP/test_library_tools.py` green.

<sup>Written for commit 9024a28e66fda427018c013ca89ac50364c826cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

