### PR TITLE
feat(notes): add adaptive 60x20 knowledge workbench

### DIFF
--- a/Tests/Library/test_library_notes_session.py
+++ b/Tests/Library/test_library_notes_session.py
@@ -1,0 +1,461 @@
+"""Portable Database Note session and serialized-save contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+from collections import deque
+from datetime import datetime, timezone
+from typing import Callable
+
+import pytest
+
+from tldw_chatbook.Library.library_notes_session import (
+    DatabaseNotePortLoadReply,
+    DatabaseNotePortSaveReply,
+    DatabaseNoteSessionCoordinator,
+    NoteLoadOutcomeKind,
+    NoteSaveOutcomeKind,
+    PortLoadKind,
+)
+from tldw_chatbook.Library.library_notes_state import NormalizedDatabaseNote
+
+
+NOW = datetime(2026, 7, 31, 12, 34, tzinfo=timezone.utc)
+
+
+def _detail(
+    note_id: str = "n-1",
+    *,
+    title: str = "Original",
+    body: str = "Original body",
+    keywords: tuple[str, ...] = ("one",),
+    version: int = 1,
+) -> NormalizedDatabaseNote:
+    return NormalizedDatabaseNote(
+        note_id=note_id,
+        title=title,
+        body=body,
+        keywords=keywords,
+        version=version,
+        created_at="2026-07-01T00:00:00+00:00",
+        modified_at="2026-07-02T00:00:00+00:00",
+    )
+
+
+class FakeDatabaseNotePort:
+    """Controllable async session port with bounded save-concurrency evidence."""
+
+    def __init__(self, detail: NormalizedDatabaseNote | None = None) -> None:
+        self.load_calls: list[str] = []
+        self.load_replies: deque[DatabaseNotePortLoadReply] = deque(
+            [DatabaseNotePortLoadReply.loaded(detail or _detail())]
+        )
+        self.load_gates: deque[asyncio.Event | None] = deque()
+        self.save_calls = []
+        self.save_replies: deque[DatabaseNotePortSaveReply] = deque()
+        self.save_gates: deque[asyncio.Event | None] = deque()
+        self.active_saves = 0
+        self.max_active_saves = 0
+
+    async def load_note(self, note_id: str) -> DatabaseNotePortLoadReply:
+        self.load_calls.append(note_id)
+        reply = self.load_replies.popleft()
+        gate = self.load_gates.popleft() if self.load_gates else None
+        if gate is not None:
+            await gate.wait()
+        return reply
+
+    async def save_note(self, note_id, expected_version, payload):
+        self.save_calls.append((note_id, expected_version, payload))
+        reply = self.save_replies.popleft()
+        gate = self.save_gates.popleft() if self.save_gates else None
+        self.active_saves += 1
+        self.max_active_saves = max(self.max_active_saves, self.active_saves)
+        try:
+            if gate is not None:
+                await gate.wait()
+            return reply
+        finally:
+            self.active_saves -= 1
+
+
+def _coordinator(
+    port: FakeDatabaseNotePort,
+    *,
+    clock: Callable[[], datetime] = lambda: NOW,
+) -> DatabaseNoteSessionCoordinator:
+    return DatabaseNoteSessionCoordinator(port, clock=clock)
+
+
+async def _wait_for_call_count(calls: list, expected: int) -> None:
+    async def wait() -> None:
+        while len(calls) < expected:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_open_session_seeds_one_coherent_baseline_and_exact_draft():
+    detail = _detail(
+        title="[draft] <plan>",
+        body="line 1\nline 2",
+        keywords=("Alpha", "βeta"),
+        version=7,
+    )
+    port = FakeDatabaseNotePort(detail)
+    coordinator = _coordinator(port)
+
+    outcome = await coordinator.open_session("n-1")
+
+    assert outcome.kind is NoteLoadOutcomeKind.LOADED
+    assert port.load_calls == ["n-1"]
+    snapshot = coordinator.snapshot
+    assert snapshot is not None
+    assert snapshot.baseline == detail
+    assert snapshot.note_id == "n-1"
+    assert snapshot.title == "[draft] <plan>"
+    assert snapshot.body == "line 1\nline 2"
+    assert snapshot.keywords_text == "Alpha, βeta"
+    assert snapshot.version == 7
+    assert snapshot.draft_revision == 0
+    assert snapshot.saved_revision == 0
+    assert snapshot.dirty is False
+
+
+@pytest.mark.asyncio
+async def test_stale_open_session_cannot_replace_a_newer_loaded_session():
+    first_gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    port.load_replies = deque(
+        [
+            DatabaseNotePortLoadReply.loaded(_detail("n-1", title="First")),
+            DatabaseNotePortLoadReply.loaded(_detail("n-2", title="Second")),
+        ]
+    )
+    port.load_gates = deque([first_gate, None])
+    coordinator = _coordinator(port)
+
+    first = asyncio.create_task(coordinator.open_session("n-1"))
+    await _wait_for_call_count(port.load_calls, 1)
+    second = await coordinator.open_session("n-2")
+    first_gate.set()
+    stale = await first
+
+    assert second.kind is NoteLoadOutcomeKind.LOADED
+    assert stale.kind is NoteLoadOutcomeKind.STALE
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.note_id == "n-2"
+    assert coordinator.snapshot.title == "Second"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reply", "expected_kind"),
+    (
+        (DatabaseNotePortLoadReply.missing("Gone"), NoteLoadOutcomeKind.MISSING),
+        (DatabaseNotePortLoadReply.failed("Offline"), NoteLoadOutcomeKind.FAILED),
+    ),
+)
+async def test_missing_and_failed_loads_do_not_seed_a_false_session(
+    reply, expected_kind
+):
+    port = FakeDatabaseNotePort()
+    port.load_replies = deque([reply])
+    coordinator = _coordinator(port)
+
+    outcome = await coordinator.open_session("missing")
+
+    assert outcome.kind is expected_kind
+    assert outcome.message
+    assert coordinator.snapshot is None
+
+
+def test_load_reply_requires_detail_only_for_loaded_kind():
+    with pytest.raises(ValueError, match="requires detail"):
+        DatabaseNotePortLoadReply(kind=PortLoadKind.LOADED)
+    with pytest.raises(ValueError, match="cannot carry detail"):
+        DatabaseNotePortLoadReply(
+            kind=PortLoadKind.MISSING,
+            detail=_detail(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_loaded_detail_with_wrong_identity_is_a_failure_not_a_session():
+    port = FakeDatabaseNotePort(_detail("n-2"))
+    coordinator = _coordinator(port)
+
+    outcome = await coordinator.open_session("n-1")
+
+    assert outcome.kind is NoteLoadOutcomeKind.FAILED
+    assert "identity" in outcome.message.lower()
+    assert coordinator.snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_invalidating_a_pending_open_makes_its_completion_stale():
+    gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    port.load_gates = deque([gate])
+    coordinator = _coordinator(port)
+
+    pending = asyncio.create_task(coordinator.open_session("n-1"))
+    await _wait_for_call_count(port.load_calls, 1)
+    coordinator.invalidate_session_request()
+    gate.set()
+
+    assert (await pending).kind is NoteLoadOutcomeKind.STALE
+    assert coordinator.snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_genuine_mutation_increments_revision_once_and_marks_dirty():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+
+    assert coordinator.mutate(body="Changed") is True
+    snapshot = coordinator.snapshot
+    assert snapshot is not None
+    assert snapshot.body == "Changed"
+    assert snapshot.draft_revision == 1
+    assert snapshot.saved_revision == 0
+    assert snapshot.dirty is True
+    assert coordinator.mutate(body="Changed") is False
+    assert coordinator.snapshot is snapshot
+
+
+@pytest.mark.asyncio
+async def test_snapshot_reads_are_programmatic_and_do_not_mutate_revision():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+
+    first = coordinator.snapshot
+    second = coordinator.snapshot
+
+    assert first is second
+    assert first is not None and first.draft_revision == 0
+
+
+@pytest.mark.asyncio
+async def test_construction_load_and_save_do_not_import_textual(monkeypatch):
+    real_import = builtins.__import__
+
+    def reject_textual(name, *args, **kwargs):
+        if name == "textual" or name.startswith("textual."):
+            raise AssertionError(f"Portable coordinator imported {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_textual)
+    port = FakeDatabaseNotePort()
+    port.save_replies.append(DatabaseNotePortSaveReply.saved(version=2))
+    coordinator = _coordinator(port)
+
+    await coordinator.open_session("n-1")
+    coordinator.mutate(body="Changed")
+    outcome = await coordinator.request_save(explicit=True)
+
+    assert outcome.kind is NoteSaveOutcomeKind.SAVED
+
+
+@pytest.mark.asyncio
+async def test_invalid_payload_vetoes_without_calling_the_port():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    coordinator.mutate(title="x" * 301)
+
+    outcome = await coordinator.request_save(explicit=True)
+
+    assert outcome.kind is NoteSaveOutcomeKind.VALIDATION_VETO
+    assert outcome.veto is not None and outcome.veto.field == "title"
+    assert port.save_calls == []
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.dirty is True
+    assert coordinator.snapshot.saving is False
+    assert coordinator.snapshot.title == "x" * 301
+
+
+@pytest.mark.asyncio
+async def test_explicit_noop_save_is_acknowledged_without_a_port_call():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1", untouched_create_token="create-7")
+
+    outcome = await coordinator.request_save(explicit=True)
+
+    assert outcome.kind is NoteSaveOutcomeKind.ACKNOWLEDGED
+    assert port.save_calls == []
+    assert coordinator.untouched_create_token is None
+
+
+@pytest.mark.asyncio
+async def test_three_edits_while_first_save_runs_coalesce_to_latest_revision():
+    first_gate = asyncio.Event()
+    second_gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    port.save_gates = deque([first_gate, second_gate])
+    port.save_replies = deque(
+        [
+            DatabaseNotePortSaveReply.saved(version=2),
+            DatabaseNotePortSaveReply.saved(version=3),
+        ]
+    )
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    coordinator.mutate(body="revision 1")
+
+    save = asyncio.create_task(coordinator.request_save(explicit=False))
+    await _wait_for_call_count(port.save_calls, 1)
+    coordinator.mutate(body="revision 2")
+    coordinator.mutate(body="revision 3")
+    coordinator.mutate(body="revision 4")
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.status_message == "Saving…"
+    first_gate.set()
+    await _wait_for_call_count(port.save_calls, 2)
+
+    assert [call[2].revision for call in port.save_calls] == [1, 4]
+    assert port.save_calls[1][1] == 2
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.baseline.body == "revision 1"
+    assert coordinator.snapshot.body == "revision 4"
+    assert coordinator.snapshot.saved_revision == 1
+    assert coordinator.snapshot.dirty is True
+    assert coordinator.snapshot.saving is True
+    second_gate.set()
+    outcome = await save
+
+    assert outcome.kind is NoteSaveOutcomeKind.SAVED
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.saved_revision == 4
+    assert coordinator.snapshot.draft_revision == 4
+    assert coordinator.snapshot.dirty is False
+    assert coordinator.snapshot.version == 3
+    assert port.max_active_saves == 1
+
+
+@pytest.mark.asyncio
+async def test_edit_during_followup_attempt_continues_without_a_two_save_limit():
+    gates = [asyncio.Event() for _ in range(3)]
+    port = FakeDatabaseNotePort()
+    port.save_gates = deque(gates)
+    port.save_replies = deque(
+        DatabaseNotePortSaveReply.saved(version=version) for version in (2, 3, 4)
+    )
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    coordinator.mutate(body="revision 1")
+
+    save = asyncio.create_task(coordinator.request_save(explicit=False))
+    await _wait_for_call_count(port.save_calls, 1)
+    coordinator.mutate(body="revision 2")
+    gates[0].set()
+    await _wait_for_call_count(port.save_calls, 2)
+    coordinator.mutate(body="revision 3")
+    gates[1].set()
+    await _wait_for_call_count(port.save_calls, 3)
+    gates[2].set()
+    await save
+
+    assert [call[2].revision for call in port.save_calls] == [1, 2, 3]
+    assert port.max_active_saves == 1
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.saved_revision == 3
+    assert coordinator.snapshot.dirty is False
+
+
+@pytest.mark.asyncio
+async def test_same_revision_save_request_joins_the_active_attempt():
+    gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    port.save_gates = deque([gate])
+    port.save_replies = deque([DatabaseNotePortSaveReply.saved(version=2)])
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    coordinator.mutate(body="revision 1")
+
+    first = asyncio.create_task(coordinator.request_save(explicit=False))
+    await _wait_for_call_count(port.save_calls, 1)
+    second = asyncio.create_task(coordinator.request_save(explicit=True))
+    await asyncio.sleep(0)
+    gate.set()
+    outcomes = await asyncio.gather(first, second)
+
+    assert [outcome.kind for outcome in outcomes] == [
+        NoteSaveOutcomeKind.SAVED,
+        NoteSaveOutcomeKind.SAVED,
+    ]
+    assert len(port.save_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_failure_stops_chaining_and_explicit_retry_saves_latest_revision():
+    failure_gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    port.save_gates = deque([failure_gate, None])
+    port.save_replies = deque(
+        [
+            DatabaseNotePortSaveReply.failed("Offline"),
+            DatabaseNotePortSaveReply.saved(version=2),
+        ]
+    )
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    coordinator.mutate(body="revision 1")
+
+    first = asyncio.create_task(coordinator.request_save(explicit=False))
+    await _wait_for_call_count(port.save_calls, 1)
+    coordinator.mutate(body="revision 2")
+    failure_gate.set()
+    failed = await first
+
+    assert failed.kind is NoteSaveOutcomeKind.FAILED
+    assert len(port.save_calls) == 1
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.body == "revision 2"
+    assert coordinator.snapshot.saved_revision == 0
+    assert coordinator.snapshot.dirty is True
+    assert coordinator.snapshot.saving is False
+    assert "Press Save to retry" in coordinator.snapshot.status_message
+
+    retried = await coordinator.request_save(explicit=True)
+
+    assert retried.kind is NoteSaveOutcomeKind.SAVED
+    assert [call[2].revision for call in port.save_calls] == [1, 2]
+    assert coordinator.snapshot.saved_revision == 2
+    assert coordinator.snapshot.dirty is False
+
+
+@pytest.mark.asyncio
+async def test_conflict_stops_chaining_and_preserves_the_newest_draft():
+    gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    port.save_gates = deque([gate])
+    port.save_replies = deque([DatabaseNotePortSaveReply.conflict()])
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    coordinator.mutate(body="revision 1")
+
+    save = asyncio.create_task(coordinator.request_save(explicit=False))
+    await _wait_for_call_count(port.save_calls, 1)
+    coordinator.mutate(body="revision 2")
+    gate.set()
+    outcome = await save
+
+    assert outcome.kind is NoteSaveOutcomeKind.CONFLICTED
+    assert len(port.save_calls) == 1
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.body == "revision 2"
+    assert coordinator.snapshot.saved_revision == 0
+    assert coordinator.snapshot.dirty is True
+    assert coordinator.snapshot.saving is False
+    assert coordinator.snapshot.in_conflict is True
+
+    coordinator.mutate(body="revision 3")
+
+    assert coordinator.snapshot.in_conflict is True
+    assert coordinator.snapshot.status_message == "Conflict — review the choices below."

--- a/Tests/Library/test_library_notes_session.py
+++ b/Tests/Library/test_library_notes_session.py
@@ -24,7 +24,10 @@ from tldw_chatbook.Library.library_notes_session import (
     NoteSaveOutcomeKind,
     PortLoadKind,
 )
-from tldw_chatbook.Library.library_notes_state import NormalizedDatabaseNote
+from tldw_chatbook.Library.library_notes_state import (
+    DatabaseNoteSavePayload,
+    NormalizedDatabaseNote,
+)
 
 
 NOW = datetime(2026, 7, 31, 12, 34, tzinfo=timezone.utc)
@@ -58,7 +61,7 @@ class FakeDatabaseNotePort:
             [DatabaseNotePortLoadReply.loaded(detail or _detail())]
         )
         self.load_gates: deque[asyncio.Event | None] = deque()
-        self.save_calls = []
+        self.save_calls: list[tuple[str, int, DatabaseNoteSavePayload]] = []
         self.save_replies: deque[DatabaseNotePortSaveReply] = deque()
         self.save_gates: deque[asyncio.Event | None] = deque()
         self.active_saves = 0
@@ -72,7 +75,12 @@ class FakeDatabaseNotePort:
             await gate.wait()
         return reply
 
-    async def save_note(self, note_id, expected_version, payload):
+    async def save_note(
+        self,
+        note_id: str,
+        expected_version: int,
+        payload: DatabaseNoteSavePayload,
+    ) -> DatabaseNotePortSaveReply:
         self.save_calls.append((note_id, expected_version, payload))
         reply = self.save_replies.popleft()
         gate = self.save_gates.popleft() if self.save_gates else None

--- a/Tests/Library/test_library_notes_session.py
+++ b/Tests/Library/test_library_notes_session.py
@@ -217,6 +217,20 @@ async def test_invalidating_a_pending_open_makes_its_completion_stale():
 
 
 @pytest.mark.asyncio
+async def test_close_session_clears_loaded_state_and_create_token():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1", untouched_create_token="create-1")
+
+    assert coordinator.untouched_create_token == "create-1"
+
+    coordinator.close_session()
+
+    assert coordinator.snapshot is None
+    assert coordinator.untouched_create_token is None
+
+
+@pytest.mark.asyncio
 async def test_genuine_mutation_increments_revision_once_and_marks_dirty():
     port = FakeDatabaseNotePort()
     coordinator = _coordinator(port)
@@ -596,6 +610,29 @@ async def test_duplicate_or_opposite_conflict_action_is_ignored():
     assert port.load_calls == ["n-1", "n-1"]
     gate.set()
     assert (await first).kind is ConflictOutcomeKind.RELOADED
+
+
+@pytest.mark.asyncio
+async def test_cancelled_conflict_refresh_releases_the_operation_gate():
+    gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+    port.load_replies.append(
+        DatabaseNotePortLoadReply.loaded(_detail(body="remote", version=8))
+    )
+    port.load_gates.append(gate)
+
+    operation = asyncio.create_task(coordinator.resolve_conflict(ConflictAction.RELOAD))
+    await _wait_for_call_count(port.load_calls, 2)
+    operation.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await operation
+
+    assert coordinator.conflict_resolution_running is False
+    assert (await coordinator.flush()).kind is NoteFlushOutcomeKind.CONFLICTED
 
 
 @pytest.mark.asyncio

--- a/Tests/Library/test_library_notes_session.py
+++ b/Tests/Library/test_library_notes_session.py
@@ -5,15 +5,21 @@ from __future__ import annotations
 import asyncio
 import builtins
 from collections import deque
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Callable
 
 import pytest
 
 from tldw_chatbook.Library.library_notes_session import (
+    ConflictAction,
+    ConflictOutcomeKind,
     DatabaseNotePortLoadReply,
     DatabaseNotePortSaveReply,
     DatabaseNoteSessionCoordinator,
+    DestructiveAdmissionOutcomeKind,
+    DestructiveKind,
+    NoteFlushOutcomeKind,
     NoteLoadOutcomeKind,
     NoteSaveOutcomeKind,
     PortLoadKind,
@@ -459,3 +465,544 @@ async def test_conflict_stops_chaining_and_preserves_the_newest_draft():
 
     assert coordinator.snapshot.in_conflict is True
     assert coordinator.snapshot.status_message == "Conflict — review the choices below."
+
+
+async def _seed_conflict(
+    coordinator: DatabaseNoteSessionCoordinator,
+    port: FakeDatabaseNotePort,
+    *,
+    body: str = "local revision 1",
+) -> None:
+    port.save_replies.append(DatabaseNotePortSaveReply.conflict())
+    coordinator.mutate(body=body)
+    outcome = await coordinator.request_save(explicit=True)
+    assert outcome.kind is NoteSaveOutcomeKind.CONFLICTED
+
+
+@pytest.mark.asyncio
+async def test_reload_applies_only_when_captured_revision_is_still_current():
+    gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+    port.load_replies.append(
+        DatabaseNotePortLoadReply.loaded(_detail(body="remote revision", version=8))
+    )
+    port.load_gates.append(gate)
+
+    reload_task = asyncio.create_task(
+        coordinator.resolve_conflict(ConflictAction.RELOAD)
+    )
+    await _wait_for_call_count(port.load_calls, 2)
+    coordinator.mutate(body="local revision 2")
+    gate.set()
+    outcome = await reload_task
+
+    assert outcome.kind is ConflictOutcomeKind.DRAFT_CHANGED
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.body == "local revision 2"
+    assert coordinator.snapshot.in_conflict is True
+    assert coordinator.conflict_resolution_running is False
+
+
+@pytest.mark.asyncio
+async def test_reload_replaces_an_unchanged_conflicted_draft_atomically():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+    port.load_replies.append(
+        DatabaseNotePortLoadReply.loaded(
+            _detail(body="remote revision", keywords=("remote",), version=8)
+        )
+    )
+
+    outcome = await coordinator.resolve_conflict(ConflictAction.RELOAD)
+
+    assert outcome.kind is ConflictOutcomeKind.RELOADED
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.body == "remote revision"
+    assert coordinator.snapshot.keywords_text == "remote"
+    assert coordinator.snapshot.version == 8
+    assert coordinator.snapshot.dirty is False
+    assert coordinator.snapshot.in_conflict is False
+    assert coordinator.snapshot.saved_revision == coordinator.snapshot.draft_revision
+
+
+@pytest.mark.asyncio
+async def test_overwrite_rebases_and_keeps_edits_during_fetch_and_save():
+    load_gate = asyncio.Event()
+    first_save_gate = asyncio.Event()
+    second_save_gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+    port.load_replies.append(
+        DatabaseNotePortLoadReply.loaded(_detail(body="remote", version=8))
+    )
+    port.load_gates.append(load_gate)
+    port.save_replies.extend(
+        (
+            DatabaseNotePortSaveReply.saved(version=9),
+            DatabaseNotePortSaveReply.saved(version=10),
+        )
+    )
+    port.save_gates.extend((first_save_gate, second_save_gate))
+
+    overwrite = asyncio.create_task(
+        coordinator.resolve_conflict(ConflictAction.OVERWRITE)
+    )
+    await _wait_for_call_count(port.load_calls, 2)
+    coordinator.mutate(body="edit during fetch")
+    load_gate.set()
+    await _wait_for_call_count(port.save_calls, 2)
+    assert port.save_calls[1][1] == 8
+    assert port.save_calls[1][2].body == "edit during fetch"
+    coordinator.mutate(body="edit during save")
+    first_save_gate.set()
+    await _wait_for_call_count(port.save_calls, 3)
+    assert port.save_calls[2][1] == 9
+    assert port.save_calls[2][2].body == "edit during save"
+    second_save_gate.set()
+    outcome = await overwrite
+
+    assert outcome.kind is ConflictOutcomeKind.OVERWRITTEN
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.body == "edit during save"
+    assert coordinator.snapshot.version == 10
+    assert coordinator.snapshot.dirty is False
+    assert port.max_active_saves == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_or_opposite_conflict_action_is_ignored():
+    gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+    port.load_replies.append(
+        DatabaseNotePortLoadReply.loaded(_detail(body="remote", version=8))
+    )
+    port.load_gates.append(gate)
+
+    first = asyncio.create_task(coordinator.resolve_conflict(ConflictAction.RELOAD))
+    await _wait_for_call_count(port.load_calls, 2)
+    duplicate = await coordinator.resolve_conflict(ConflictAction.OVERWRITE)
+
+    assert duplicate.kind is ConflictOutcomeKind.ALREADY_RUNNING
+    assert port.load_calls == ["n-1", "n-1"]
+    gate.set()
+    assert (await first).kind is ConflictOutcomeKind.RELOADED
+
+
+@pytest.mark.asyncio
+async def test_flush_is_vetoed_until_overwrite_publishes_its_terminal_outcome():
+    load_gate = asyncio.Event()
+    save_gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+    port.load_replies.append(
+        DatabaseNotePortLoadReply.loaded(_detail(body="remote", version=8))
+    )
+    port.load_gates.append(load_gate)
+    port.save_replies.append(DatabaseNotePortSaveReply.saved(version=9))
+    port.save_gates.append(save_gate)
+    overwrite = asyncio.create_task(
+        coordinator.resolve_conflict(ConflictAction.OVERWRITE)
+    )
+    await _wait_for_call_count(port.load_calls, 2)
+    load_gate.set()
+    await _wait_for_call_count(port.save_calls, 2)
+
+    blocked = await coordinator.flush()
+
+    assert blocked.kind is NoteFlushOutcomeKind.BLOCKED
+    assert coordinator.conflict_resolution_running is True
+    save_gate.set()
+    assert (await overwrite).kind is ConflictOutcomeKind.OVERWRITTEN
+    assert (await coordinator.flush()).kind is NoteFlushOutcomeKind.PERMITTED
+
+
+@pytest.mark.asyncio
+async def test_overwrite_that_conflicts_again_returns_renewed_conflict():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+    port.load_replies.append(
+        DatabaseNotePortLoadReply.loaded(_detail(body="remote", version=8))
+    )
+    port.save_replies.append(DatabaseNotePortSaveReply.conflict())
+
+    outcome = await coordinator.resolve_conflict(ConflictAction.OVERWRITE)
+
+    assert outcome.kind is ConflictOutcomeKind.RENEWED_CONFLICT
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.in_conflict is True
+    assert coordinator.snapshot.conflict_generation == 2
+    assert coordinator.snapshot.body == "local revision 1"
+
+
+@pytest.mark.asyncio
+async def test_missing_overwrite_keeps_draft_but_missing_reload_discards_it():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+    port.load_replies.append(DatabaseNotePortLoadReply.missing())
+
+    overwrite = await coordinator.resolve_conflict(ConflictAction.OVERWRITE)
+
+    assert overwrite.kind is ConflictOutcomeKind.MISSING
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.body == "local revision 1"
+    assert coordinator.snapshot.in_conflict is True
+
+    port.load_replies.append(DatabaseNotePortLoadReply.missing())
+    reload_outcome = await coordinator.resolve_conflict(ConflictAction.RELOAD)
+
+    assert reload_outcome.kind is ConflictOutcomeKind.MISSING
+    assert coordinator.snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_missing_reload_does_not_discard_a_draft_changed_during_fetch():
+    gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+    port.load_replies.append(DatabaseNotePortLoadReply.missing())
+    port.load_gates.append(gate)
+
+    reload_task = asyncio.create_task(
+        coordinator.resolve_conflict(ConflictAction.RELOAD)
+    )
+    await _wait_for_call_count(port.load_calls, 2)
+    coordinator.mutate(body="newer local draft")
+    gate.set()
+    outcome = await reload_task
+
+    assert outcome.kind is ConflictOutcomeKind.DRAFT_CHANGED
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.body == "newer local draft"
+    assert coordinator.snapshot.in_conflict is True
+
+
+@pytest.mark.asyncio
+async def test_conflict_fetch_failure_retains_conflict_and_draft():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+    port.load_replies.append(DatabaseNotePortLoadReply.failed("Offline"))
+
+    outcome = await coordinator.resolve_conflict(ConflictAction.RELOAD)
+
+    assert outcome.kind is ConflictOutcomeKind.FAILED
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.body == "local revision 1"
+    assert coordinator.snapshot.in_conflict is True
+    assert "again" in coordinator.snapshot.status_message.lower()
+
+
+@pytest.mark.asyncio
+async def test_conflict_completion_cannot_apply_to_a_newer_session():
+    gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+    port.load_replies.extend(
+        (
+            DatabaseNotePortLoadReply.loaded(_detail("n-1", version=8)),
+            DatabaseNotePortLoadReply.loaded(_detail("n-2", title="Second")),
+        )
+    )
+    port.load_gates.extend((gate, None))
+
+    reload_task = asyncio.create_task(
+        coordinator.resolve_conflict(ConflictAction.RELOAD)
+    )
+    await _wait_for_call_count(port.load_calls, 2)
+    assert (await coordinator.open_session("n-2")).kind is NoteLoadOutcomeKind.LOADED
+    gate.set()
+    outcome = await reload_task
+
+    assert outcome.kind is ConflictOutcomeKind.STALE
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.note_id == "n-2"
+    assert coordinator.snapshot.title == "Second"
+
+
+@pytest.mark.asyncio
+async def test_conflict_fetch_exception_is_stale_after_session_replacement():
+    gate = asyncio.Event()
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    await _seed_conflict(coordinator, port)
+
+    async def load_with_stale_failure(note_id: str):
+        port.load_calls.append(note_id)
+        if note_id == "n-1":
+            await gate.wait()
+            raise RuntimeError("late failure")
+        return DatabaseNotePortLoadReply.loaded(_detail("n-2", title="Second"))
+
+    port.load_note = load_with_stale_failure
+    reload_task = asyncio.create_task(
+        coordinator.resolve_conflict(ConflictAction.RELOAD)
+    )
+    await _wait_for_call_count(port.load_calls, 2)
+    assert (await coordinator.open_session("n-2")).kind is NoteLoadOutcomeKind.LOADED
+    gate.set()
+    outcome = await reload_task
+
+    assert outcome.kind is ConflictOutcomeKind.STALE
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.note_id == "n-2"
+
+
+@pytest.mark.asyncio
+async def test_flush_waits_for_the_complete_coalesced_save_chain():
+    gates = (asyncio.Event(), asyncio.Event())
+    port = FakeDatabaseNotePort()
+    port.save_gates.extend(gates)
+    port.save_replies.extend(
+        (
+            DatabaseNotePortSaveReply.saved(version=2),
+            DatabaseNotePortSaveReply.saved(version=3),
+        )
+    )
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    coordinator.mutate(body="revision 1")
+    save = asyncio.create_task(coordinator.request_save(explicit=False))
+    await _wait_for_call_count(port.save_calls, 1)
+    coordinator.mutate(body="revision 2")
+
+    flush = asyncio.create_task(coordinator.flush())
+    await asyncio.sleep(0)
+    assert flush.done() is False
+    gates[0].set()
+    await _wait_for_call_count(port.save_calls, 2)
+    assert flush.done() is False
+    gates[1].set()
+    await save
+    outcome = await flush
+
+    assert outcome.kind is NoteFlushOutcomeKind.PERMITTED
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.saved_revision == 2
+    assert coordinator.snapshot.dirty is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reply", "expected_kind"),
+    (
+        (
+            DatabaseNotePortSaveReply.failed("Offline"),
+            NoteFlushOutcomeKind.FAILED,
+        ),
+        (
+            DatabaseNotePortSaveReply.conflict(),
+            NoteFlushOutcomeKind.CONFLICTED,
+        ),
+    ),
+)
+async def test_flush_failure_and_conflict_veto_navigation(reply, expected_kind):
+    port = FakeDatabaseNotePort()
+    port.save_replies.append(reply)
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    coordinator.mutate(body="dirty")
+
+    outcome = await coordinator.flush()
+
+    assert outcome.kind is expected_kind
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.dirty is True
+
+
+@pytest.mark.asyncio
+async def test_flush_validation_veto_retains_invalid_dirty_draft():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    coordinator.mutate(title="x" * 301)
+
+    outcome = await coordinator.flush()
+
+    assert outcome.kind is NoteFlushOutcomeKind.VALIDATION_VETO
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.title == "x" * 301
+    assert coordinator.snapshot.dirty is True
+    assert port.save_calls == []
+
+
+def _session_tokens(coordinator: DatabaseNoteSessionCoordinator):
+    snapshot = coordinator.snapshot
+    assert snapshot is not None
+    return {
+        "note_id": snapshot.note_id,
+        "session_generation": snapshot.session_generation,
+        "expected_version": snapshot.version,
+    }
+
+
+@pytest.mark.asyncio
+async def test_discard_admission_blocks_mutation_save_duplicate_and_preserves_token():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1", untouched_create_token="create-7")
+
+    outcome = await coordinator.request_destructive_admission(
+        DestructiveKind.DISCARD_NEW_NOTE,
+        create_token="create-7",
+        **_session_tokens(coordinator),
+    )
+
+    assert outcome.kind is DestructiveAdmissionOutcomeKind.ADMITTED
+    assert outcome.admission is not None
+    assert coordinator.mutate(body="blocked") is False
+    blocked_save = await coordinator.request_save(explicit=True)
+    assert blocked_save.kind is NoteSaveOutcomeKind.BLOCKED
+    assert coordinator.untouched_create_token == "create-7"
+    duplicate = await coordinator.request_destructive_admission(
+        DestructiveKind.DISCARD_NEW_NOTE,
+        create_token="create-7",
+        **_session_tokens(coordinator),
+    )
+    assert duplicate.kind is DestructiveAdmissionOutcomeKind.ALREADY_RUNNING
+    assert coordinator.cancel_destructive(outcome.admission) is True
+    assert coordinator.mutate(body="now editable") is True
+    assert coordinator.untouched_create_token is None
+
+
+@pytest.mark.asyncio
+async def test_stale_or_ineligible_destructive_tokens_never_enter_the_gate():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1", untouched_create_token="create-7")
+    tokens = _session_tokens(coordinator)
+
+    stale = await coordinator.request_destructive_admission(
+        DestructiveKind.DELETE,
+        **{**tokens, "expected_version": tokens["expected_version"] + 1},
+    )
+    ineligible = await coordinator.request_destructive_admission(
+        DestructiveKind.DISCARD_NEW_NOTE,
+        create_token="wrong-token",
+        **tokens,
+    )
+
+    assert stale.kind is DestructiveAdmissionOutcomeKind.STALE
+    assert ineligible.kind is DestructiveAdmissionOutcomeKind.NOT_ELIGIBLE
+    assert coordinator.destructive_admission is None
+    assert coordinator.mutate(body="still editable") is True
+
+
+@pytest.mark.asyncio
+async def test_running_destructive_action_cannot_cancel_and_failure_unlocks_draft():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    admitted = await coordinator.request_destructive_admission(
+        DestructiveKind.DELETE,
+        **_session_tokens(coordinator),
+    )
+    assert admitted.admission is not None
+
+    assert coordinator.mark_destructive_running(admitted.admission) is True
+    assert coordinator.cancel_destructive(admitted.admission) is False
+    assert coordinator.mutate(body="blocked") is False
+    assert (
+        await coordinator.request_save(explicit=True)
+    ).kind is NoteSaveOutcomeKind.BLOCKED
+    assert coordinator.finish_destructive(admitted.admission, success=False) is True
+    assert coordinator.snapshot is not None
+    assert coordinator.mutate(body="editable after failure") is True
+
+
+@pytest.mark.asyncio
+async def test_successful_destructive_action_closes_session_and_stales_old_admission():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    admitted = await coordinator.request_destructive_admission(
+        DestructiveKind.DELETE,
+        **_session_tokens(coordinator),
+    )
+    assert admitted.admission is not None
+    assert coordinator.mark_destructive_running(admitted.admission) is True
+
+    stale_copy = replace(admitted.admission, operation_token=999)
+    assert coordinator.mark_destructive_running(stale_copy) is False
+    assert coordinator.finish_destructive(admitted.admission, success=True) is True
+    assert coordinator.snapshot is None
+    assert coordinator.destructive_admission is None
+    assert coordinator.finish_destructive(admitted.admission, success=True) is False
+
+
+@pytest.mark.asyncio
+async def test_failed_flush_never_opens_a_destructive_gate():
+    port = FakeDatabaseNotePort()
+    port.save_replies.append(DatabaseNotePortSaveReply.failed("Offline"))
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    coordinator.mutate(body="dirty")
+
+    outcome = await coordinator.request_destructive_admission(
+        DestructiveKind.DELETE,
+        **_session_tokens(coordinator),
+    )
+
+    assert outcome.kind is DestructiveAdmissionOutcomeKind.FLUSH_VETOED
+    assert coordinator.destructive_admission is None
+    assert coordinator.mutate(body="still editable") is True
+
+
+@pytest.mark.asyncio
+async def test_destructive_admission_uses_version_advanced_by_its_own_flush():
+    port = FakeDatabaseNotePort()
+    port.save_replies.append(DatabaseNotePortSaveReply.saved(version=2))
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1")
+    tokens_before_edit = _session_tokens(coordinator)
+    coordinator.mutate(body="dirty before delete")
+
+    outcome = await coordinator.request_destructive_admission(
+        DestructiveKind.DELETE,
+        **tokens_before_edit,
+    )
+
+    assert outcome.kind is DestructiveAdmissionOutcomeKind.ADMITTED
+    assert outcome.admission is not None
+    assert outcome.admission.expected_version == 2
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.dirty is False
+    assert coordinator.cancel_destructive(outcome.admission) is True
+
+
+@pytest.mark.asyncio
+async def test_explicit_noop_save_removes_discard_eligibility():
+    port = FakeDatabaseNotePort()
+    coordinator = _coordinator(port)
+    await coordinator.open_session("n-1", untouched_create_token="create-7")
+    await coordinator.request_save(explicit=True)
+
+    outcome = await coordinator.request_destructive_admission(
+        DestructiveKind.DISCARD_NEW_NOTE,
+        create_token="create-7",
+        **_session_tokens(coordinator),
+    )
+
+    assert outcome.kind is DestructiveAdmissionOutcomeKind.NOT_ELIGIBLE
+    assert coordinator.destructive_admission is None

--- a/Tests/Library/test_library_notes_state.py
+++ b/Tests/Library/test_library_notes_state.py
@@ -1,16 +1,31 @@
-"""Pure display-state contracts for the Library notes canvas."""
+"""Pure display and lossless-session contracts for Library Database Notes."""
 
+from dataclasses import FrozenInstanceError
 from datetime import datetime, timezone
 
+import pytest
+from rich.cells import cell_len
+
 from tldw_chatbook.Library.library_notes_state import (
+    DATABASE_NOTE_BODY_MAX_CHARS,
+    DATABASE_NOTE_KEYWORD_MAX_CHARS,
+    DATABASE_NOTE_TITLE_MAX_CHARS,
+    DatabaseNoteDraft,
+    DatabaseNoteSavePayload,
+    LibraryNoteSessionSnapshot,
+    LibraryNotesFocusIdentity,
     LibraryNotesListRow,
+    NormalizedDatabaseNote,
+    NoteValidationVeto,
     build_library_note_editor_state,
     build_library_notes_list_state,
     build_note_export_content,
+    ellipsize_note_title_cells,
     next_notes_sort_mode,
     notes_autosave_status_text,
     patch_note_records_after_save,
     sort_notes_records,
+    validate_database_note_draft,
 )
 
 NOW = datetime(2026, 7, 7, 12, 0, tzinfo=timezone.utc)
@@ -42,9 +57,19 @@ def test_list_state_builds_rows_with_age_and_header():
 
 
 def test_list_state_empty_uses_quiet_copy():
-    state = build_library_notes_list_state([], now=NOW)
+    state = build_library_notes_list_state([], total_count=0, now=NOW)
     assert state.rows == ()
-    assert state.empty_copy == "No notes yet. Create one to see it here."
+    assert state.empty_copy == "No notes yet. Create your first note."
+
+
+def test_list_state_filtered_empty_does_not_claim_the_source_is_empty():
+    state = build_library_notes_list_state(
+        [], filter_note="[draft] <plan>", total_count=2, now=NOW
+    )
+
+    assert state.header_copy == "Notes (2)"
+    assert state.status_copy == "filter: [draft] <plan> · 0 results"
+    assert state.empty_copy == "No notes match “[draft] <plan>”. Clear the filter."
 
 
 def test_list_state_filter_note_reflects_active_filter():
@@ -321,3 +346,174 @@ def test_patch_note_records_after_save_leaves_unknown_ids_and_shapes_alone():
 
     assert patched == (NOTE_A, "not-a-mapping")
     assert patch_note_records_after_save(None, "n-1", title="X", modified_at="s") == ()
+
+
+def test_save_payload_preserves_valid_raw_content_exactly():
+    draft = DatabaseNoteDraft(
+        note_id="n-1",
+        title="[draft] <plan>",
+        body="line 1\n<script example>\x3c/script>",
+        keywords_text="alpha, βeta",
+        revision=7,
+    )
+
+    result = validate_database_note_draft(draft)
+
+    assert result == DatabaseNoteSavePayload(
+        title="[draft] <plan>",
+        body="line 1\n<script example>\x3c/script>",
+        keywords=("alpha", "βeta"),
+        revision=7,
+    )
+
+
+@pytest.mark.parametrize(
+    ("draft", "field"),
+    (
+        (
+            DatabaseNoteDraft(
+                "n", "x" * (DATABASE_NOTE_TITLE_MAX_CHARS + 1), "", "", 1
+            ),
+            "title",
+        ),
+        (
+            DatabaseNoteDraft(
+                "n", "ok", "x" * (DATABASE_NOTE_BODY_MAX_CHARS + 1), "", 1
+            ),
+            "body",
+        ),
+        (
+            DatabaseNoteDraft(
+                "n",
+                "ok",
+                "",
+                "x" * (DATABASE_NOTE_KEYWORD_MAX_CHARS + 1),
+                1,
+            ),
+            "keywords",
+        ),
+        (DatabaseNoteDraft("n", "bad\x00title", "", "", 1), "title"),
+        (DatabaseNoteDraft("n", " spaced ", "", "", 1), "title"),
+        (DatabaseNoteDraft("n", "ok", "bad\x00body", "", 1), "body"),
+    ),
+)
+def test_invalid_or_transforming_payload_is_a_typed_veto(draft, field):
+    result = validate_database_note_draft(draft)
+
+    assert isinstance(result, NoteValidationVeto)
+    assert result.field == field
+    assert result.revision == draft.revision
+    assert result.message
+
+
+def test_keyword_delimiter_whitespace_is_syntax_not_content():
+    draft = DatabaseNoteDraft("n", "ok", "", " alpha , , βeta ", 1)
+
+    result = validate_database_note_draft(draft)
+
+    assert isinstance(result, DatabaseNoteSavePayload)
+    assert result.keywords == ("alpha", "βeta")
+
+
+def test_keyword_limit_is_per_semantic_token_not_aggregate_field():
+    keywords = ", ".join(f"topic-{index:02d}" for index in range(20))
+    assert len(keywords) > DATABASE_NOTE_KEYWORD_MAX_CHARS
+
+    result = validate_database_note_draft(DatabaseNoteDraft("n", "ok", "", keywords, 1))
+
+    assert isinstance(result, DatabaseNoteSavePayload)
+    assert result.keywords == tuple(f"topic-{index:02d}" for index in range(20))
+
+
+def test_casefold_duplicate_keywords_are_vetoed_not_silently_deduplicated():
+    result = validate_database_note_draft(
+        DatabaseNoteDraft("n", "ok", "", "Straße, STRASSE", 1)
+    )
+
+    assert isinstance(result, NoteValidationVeto)
+    assert result.field == "keywords"
+
+
+def test_cell_ellipsis_honors_wide_unicode_and_keeps_raw_title():
+    raw = "研究計画 [draft] roadmap"
+
+    visible = ellipsize_note_title_cells(raw, 10)
+
+    assert cell_len(visible) <= 10
+    assert visible.endswith("…")
+    assert raw == "研究計画 [draft] roadmap"
+
+
+def test_cell_ellipsis_keeps_persisted_line_separators_out_of_one_row_header():
+    raw = "first line\nsecond\tline"
+
+    visible = ellipsize_note_title_cells(raw, 40)
+
+    assert visible == "first line second line"
+    assert "\n" not in visible and "\t" not in visible
+    assert raw == "first line\nsecond\tline"
+
+
+@pytest.mark.parametrize(
+    ("budget", "expected"),
+    ((0, ""), (1, "…"), (20, "short title")),
+)
+def test_cell_ellipsis_handles_zero_tiny_and_untruncated_budgets(budget, expected):
+    assert ellipsize_note_title_cells("short title", budget) == expected
+
+
+def test_session_snapshot_is_immutable_and_exposes_canonical_draft_values():
+    baseline = NormalizedDatabaseNote(
+        note_id="n-1",
+        title="Original",
+        body="baseline body",
+        keywords=("one",),
+        version=4,
+        created_at="2026-07-01T00:00:00+00:00",
+        modified_at="2026-07-02T00:00:00+00:00",
+    )
+    draft = DatabaseNoteDraft("n-1", "Draft", "new body", "one, two", 3)
+    snapshot = LibraryNoteSessionSnapshot(
+        baseline=baseline,
+        draft=draft,
+        session_generation=9,
+        saved_revision=2,
+        dirty=True,
+        saving=False,
+        in_conflict=False,
+        conflict_generation=0,
+        status_message="Unsaved changes",
+    )
+
+    assert snapshot.note_id == "n-1"
+    assert snapshot.title == "Draft"
+    assert snapshot.body == "new body"
+    assert snapshot.keywords_text == "one, two"
+    assert snapshot.draft_revision == 3
+    assert snapshot.version == 4
+    with pytest.raises(FrozenInstanceError):
+        snapshot.dirty = False
+
+
+def test_focus_identity_is_portable_immutable_value_state():
+    identity = LibraryNotesFocusIdentity(
+        stage="notes",
+        region="editor",
+        note_id="n-1",
+        semantic_role="body",
+        body_selection_start=(3, 4),
+        body_selection_end=(5, 6),
+        scroll_offset=(0, 7),
+    )
+
+    assert identity == LibraryNotesFocusIdentity(
+        stage="notes",
+        region="editor",
+        note_id="n-1",
+        semantic_role="body",
+        body_selection_start=(3, 4),
+        body_selection_end=(5, 6),
+        scroll_offset=(0, 7),
+    )
+    with pytest.raises(FrozenInstanceError):
+        identity.semantic_role = "title"

--- a/Tests/Library/test_library_notes_state.py
+++ b/Tests/Library/test_library_notes_state.py
@@ -15,6 +15,7 @@ from tldw_chatbook.Library.library_notes_state import (
     LibraryNoteSessionSnapshot,
     LibraryNotesFocusIdentity,
     LibraryNotesListRow,
+    LibraryNotesOperationState,
     NormalizedDatabaseNote,
     NoteValidationVeto,
     build_library_note_editor_state,
@@ -60,6 +61,9 @@ def test_list_state_empty_uses_quiet_copy():
     state = build_library_notes_list_state([], total_count=0, now=NOW)
     assert state.rows == ()
     assert state.empty_copy == "No notes yet. Create your first note."
+    assert state.empty_kind == "source-empty"
+    assert state.total_count == 0
+    assert state.result_count == 0
 
 
 def test_list_state_filtered_empty_does_not_claim_the_source_is_empty():
@@ -70,6 +74,9 @@ def test_list_state_filtered_empty_does_not_claim_the_source_is_empty():
     assert state.header_copy == "Notes (2)"
     assert state.status_copy == "filter: [draft] <plan> · 0 results"
     assert state.empty_copy == "No notes match “[draft] <plan>”. Clear the filter."
+    assert state.empty_kind == "filter-empty"
+    assert state.total_count == 2
+    assert state.result_count == 0
 
 
 def test_list_state_filter_note_reflects_active_filter():
@@ -77,10 +84,102 @@ def test_list_state_filter_note_reflects_active_filter():
     assert state.status_copy == "filter: retro · 1 result"
 
 
+def test_list_state_filter_status_is_one_row_cell_bounded_and_plain():
+    state = build_library_notes_list_state(
+        [],
+        filter_note="[draft]\n" + "界" * 80,
+        total_count=2,
+        now=NOW,
+    )
+
+    assert "\n" not in state.status_copy
+    assert cell_len(state.status_copy) <= 52
+    assert state.status_copy.endswith("…")
+
+
+def test_list_state_exposes_sort_chooser_and_active_operation_status():
+    state = build_library_notes_list_state(
+        [NOTE_A],
+        sort_choices_visible=True,
+        operation_status="Import note…",
+        now=NOW,
+    )
+
+    assert state.sort_choices_visible is True
+    assert state.operation_status == "Import note…"
+    assert state.status_copy == "Import note…"
+    assert state.empty_kind == "populated"
+
+
+@pytest.mark.parametrize(
+    ("phase", "expected"),
+    (
+        ("running", "Import…"),
+        ("complete", "Import complete."),
+        ("failed", "Import failed — choose another file."),
+    ),
+)
+def test_note_operation_state_formats_typed_status(phase, expected):
+    state = LibraryNotesOperationState(
+        kind="import",
+        token=7,
+        phase=phase,
+        region="navigator",
+        failure_next_action="choose another file",
+    )
+
+    assert state.status_line == expected
+    assert state.running is (phase == "running")
+
+
+def test_note_operation_state_formats_committed_recovery_status():
+    state = LibraryNotesOperationState(
+        kind="import",
+        token=8,
+        phase="complete",
+        region="navigator",
+        completion_next_action="select the new note from Notes to open",
+    )
+
+    assert (
+        state.status_line == "Import complete — select the new note from Notes to open."
+    )
+
+
 def test_list_state_tolerates_missing_fields():
     state = build_library_notes_list_state([{"id": "x"}], now=NOW)
     assert state.rows[0].title == "Untitled"
     assert state.rows[0].age_label == ""
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("title", 7),
+        ("body", {"not": "text"}),
+        ("keywords", ["valid", 7]),
+    ),
+)
+def test_database_note_validation_vetoes_non_text_field_shapes(field, value):
+    values = {
+        "title": "Valid title",
+        "body": "Valid body",
+        "keywords": "valid, keywords",
+    }
+    values[field] = value
+    draft = DatabaseNoteDraft(
+        note_id="",
+        title=values["title"],
+        body=values["body"],
+        keywords_text=values["keywords"],
+        revision=1,
+    )
+
+    outcome = validate_database_note_draft(draft)
+
+    assert isinstance(outcome, NoteValidationVeto)
+    assert outcome.field == field
+    assert "must be text" in outcome.message.lower()
 
 
 def test_sort_mode_cycles_and_wraps():

--- a/Tests/UI/test_css_build_integrity.py
+++ b/Tests/UI/test_css_build_integrity.py
@@ -1,5 +1,6 @@
 """Regression coverage for deterministic, complete modular CSS builds."""
 
+import ast
 from contextlib import suppress
 from pathlib import Path
 import re
@@ -15,12 +16,356 @@ _AGENTIC_SOURCE = _CSS_ROOT / "components/_agentic_terminal.tcss"
 _SETTINGS_SOURCE = _CSS_ROOT / "components/_settings_splash_theme.tcss"
 _SHARED_SOURCE = _CSS_ROOT / "components/_shared_components.tcss"
 _BUNDLED_STYLESHEET = _CSS_ROOT / "tldw_cli_modular.tcss"
+_LIBRARY_SCREEN_SOURCE = _REPO_ROOT / "tldw_chatbook/UI/Screens/library_screen.py"
+
+_LIBRARY_NOTES_COMPACT_GEOMETRY = {
+    "#library-shell-grid.library-notes-compact": {
+        "padding": "0",
+        "margin": "0",
+        "border": "none",
+    },
+    "#library-canvas.library-notes-compact": {
+        "padding": "0",
+        "margin": "0",
+        "border": "none",
+    },
+    "#library-canvas.library-notes-compact #library-notes-canvas": {
+        "height": "100%",
+        "min-height": "0",
+        "padding": "0",
+        "margin": "0",
+    },
+    "#library-canvas.library-notes-compact #library-notes-header": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "text-wrap": "nowrap",
+        "text-overflow": "ellipsis",
+    },
+    "#library-canvas.library-notes-compact #library-notes-filter-row": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+    },
+    "#library-canvas.library-notes-compact #library-notes-browse-actions": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-sort-choices": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-transfer-actions": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-selection-actions": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-status-row": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+    },
+    "#library-canvas.library-notes-compact #library-notes-selection-status": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+    },
+    "#library-canvas.library-notes-compact #library-notes-list": {
+        "height": "1fr",
+        "min-height": "0",
+        "overflow-y": "auto",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-note-heading": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+    },
+    "#library-canvas.library-notes-compact #library-note-title-row": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+    },
+    "#library-canvas.library-notes-compact #library-note-editor-region": {
+        "height": "1fr",
+        "min-height": "0",
+        "overflow-y": "hidden",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-note-body": {
+        "height": "1fr",
+        "min-height": "0",
+        "max-height": "100%",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-note-preview-region": {
+        "height": "1fr",
+        "min-height": "0",
+        "max-height": "100%",
+        "overflow-y": "auto",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-note-preview-body": {
+        "height": "auto",
+        "min-height": "0",
+        "border": "none",
+        "overflow-y": "hidden",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-note-status": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "text-wrap": "nowrap",
+        "text-overflow": "ellipsis",
+    },
+    "#library-canvas.library-notes-compact #library-notes-canvas.library-note-validation #library-note-status": {
+        "height": "2",
+        "min-height": "2",
+        "max-height": "2",
+        "text-wrap": "wrap",
+    },
+    "#library-canvas.library-notes-compact #library-note-primary-actions": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-note-conflict-region": {
+        "height": "3",
+        "min-height": "3",
+        "max-height": "3",
+    },
+    "#library-canvas.library-notes-compact #library-note-conflict-copy": {
+        "height": "2",
+        "min-height": "2",
+        "max-height": "2",
+    },
+    "#library-canvas.library-notes-compact #library-note-conflict-actions": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-note-delete-confirmation": {
+        "height": "2",
+        "min-height": "2",
+        "max-height": "2",
+    },
+    "#library-canvas.library-notes-compact #library-note-delete-confirm-copy": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "text-wrap": "nowrap",
+        "text-overflow": "ellipsis",
+    },
+    "#library-canvas.library-notes-compact #library-note-delete-actions": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-note-context-region": {
+        "height": "1fr",
+        "min-height": "0",
+        "overflow-y": "auto",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-note-context-status": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "text-wrap": "nowrap",
+        "text-overflow": "ellipsis",
+    },
+    "#library-canvas.library-notes-compact #library-notes-create-heading": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+    },
+    "#library-canvas.library-notes-compact #library-notes-create-viewport": {
+        "height": "1fr",
+        "min-height": "0",
+        "overflow-y": "auto",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-sync-heading": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+    },
+    "#library-canvas.library-notes-compact #library-notes-sync-viewport": {
+        "height": "1fr",
+        "min-height": "0",
+        "overflow-y": "auto",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-sync-purpose": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "margin": "0",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-sync-folder-row": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "margin": "0",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-sync-direction-row": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "margin": "0",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-sync-conflict-row": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "margin": "0",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-sync-actions": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "margin": "0",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-sync-status": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "margin": "0",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-notes-sync-activity": {
+        "height": "auto",
+        "min-height": "1",
+        "overflow-x": "hidden",
+    },
+    "#library-canvas.library-notes-compact #library-note-load-heading": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+    },
+    "#library-canvas.library-notes-compact #library-note-loading": {
+        "height": "1",
+        "min-height": "1",
+        "max-height": "1",
+        "text-wrap": "nowrap",
+        "text-overflow": "ellipsis",
+    },
+    "#library-canvas.library-notes-compact #library-note-loading-viewport": {
+        "height": "1fr",
+        "min-height": "0",
+        "overflow-y": "auto",
+        "overflow-x": "hidden",
+    },
+}
 
 
 def _rule_body(css: str, selector: str) -> str:
-    match = re.search(rf"{re.escape(selector)}\s*\{{(?P<body>[^{{}}]*)\}}", css)
-    assert match is not None, f"Missing CSS rule for {selector}"
-    return match.group("body")
+    without_comments = re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
+    body = None
+    for match in re.finditer(
+        r"(?P<selectors>[^{}]+)\{(?P<body>[^{}]*)\}", without_comments
+    ):
+        selectors = tuple(
+            candidate.strip() for candidate in match.group("selectors").split(",")
+        )
+        if selector in selectors:
+            body = match.group("body")
+    if body is None:
+        raise AssertionError(f"Missing CSS rule for {selector}")
+    return body
+
+
+def _declarations(css: str, selector: str) -> dict[str, str]:
+    """Return cascaded declarations for one literal selector."""
+    without_comments = re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
+    declarations = {}
+    matched = False
+    for match in re.finditer(
+        r"(?P<selectors>[^{}]+)\{(?P<body>[^{}]*)\}", without_comments
+    ):
+        selectors = tuple(
+            candidate.strip() for candidate in match.group("selectors").split(",")
+        )
+        if selector not in selectors:
+            continue
+        matched = True
+        for raw in match.group("body").split(";"):
+            if ":" not in raw:
+                continue
+            name, value = raw.split(":", 1)
+            declarations[name.strip()] = value.strip()
+    if not matched:
+        raise AssertionError(f"Missing CSS rule for {selector}")
+    return declarations
+
+
+def _library_screen_default_css() -> str:
+    """Read LibraryScreen.DEFAULT_CSS without importing the application."""
+    module = ast.parse(_LIBRARY_SCREEN_SOURCE.read_text(encoding="utf-8"))
+    for node in module.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "LibraryScreen":
+            continue
+        for statement in node.body:
+            if not isinstance(statement, ast.Assign):
+                continue
+            if any(
+                isinstance(target, ast.Name) and target.id == "DEFAULT_CSS"
+                for target in statement.targets
+            ):
+                value = ast.literal_eval(statement.value)
+                assert isinstance(value, str)
+                return value
+    raise AssertionError("LibraryScreen.DEFAULT_CSS not found")
+
+
+def _bundled_module(bundle: str, module_path: str) -> str:
+    marker = f"/* ===== MODULE: {module_path} ===== */"
+    assert marker in bundle
+    return bundle.split(marker, 1)[1].split("/* ===== MODULE:", 1)[0].strip()
+
+
+def test_library_notes_compact_source_module_is_exactly_bundled() -> None:
+    source = _AGENTIC_SOURCE.read_text(encoding="utf-8").strip()
+    bundle = _BUNDLED_STYLESHEET.read_text(encoding="utf-8")
+
+    assert _bundled_module(bundle, "components/_agentic_terminal.tcss") == source
+
+
+def test_library_notes_compact_geometry_matches_fallback_source_and_bundle() -> None:
+    stylesheets = (
+        _library_screen_default_css(),
+        _AGENTIC_SOURCE.read_text(encoding="utf-8"),
+        _BUNDLED_STYLESHEET.read_text(encoding="utf-8"),
+    )
+
+    for selector, expected in _LIBRARY_NOTES_COMPACT_GEOMETRY.items():
+        declarations = [_declarations(css, selector) for css in stylesheets]
+        for name, value in expected.items():
+            assert [declaration.get(name) for declaration in declarations] == [
+                value,
+                value,
+                value,
+            ], (selector, name, declarations)
 
 
 def _missing_fixture(

--- a/Tests/UI/test_library_multiselect_notes.py
+++ b/Tests/UI/test_library_multiselect_notes.py
@@ -12,6 +12,10 @@ from tldw_chatbook.Library.library_notes_state import (
     LibraryNotesListState,
 )
 from tldw_chatbook.Widgets.Library.library_notes_canvas import LibraryNotesCanvas
+from tldw_chatbook.Library.library_notes_session import (
+    NoteFlushOutcome,
+    NoteFlushOutcomeKind,
+)
 
 
 def _fake(select_mode):
@@ -34,6 +38,7 @@ async def test_notes_row_select_mode_toggles_and_does_not_open_editor():
 
     async def _flush():
         fake._flushed += 1
+        return NoteFlushOutcome(NoteFlushOutcomeKind.PERMITTED)
 
     fake._flush_library_note_save = _flush
     ev = SimpleNamespace(button=SimpleNamespace(note_id="n9"), stop=lambda: None)

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -11609,6 +11609,595 @@ async def test_library_note_failed_discard_clears_shortcut_lock_status() -> None
             message="Failed discard did not release its destructive admission.",
         )
         assert screen._library_note_shortcut_status == ""
+
+
+# ---------------------------------------------------------------------------
+# TASK-1333 Task 8: exact compact Notes geometry and dynamic-state budgets.
+
+
+def _assert_task8_compact_chrome(screen: LibraryScreen) -> None:
+    """Pin the terminal-level 3 + 1 + 15 + 1 row allocation."""
+    navigation = screen.query_one("MainNavigationBar")
+    header = screen.query_one("#library-header-line")
+    shell = screen.query_one("#library-shell-grid")
+    canvas = screen.query_one("#library-canvas")
+    notes = (
+        screen.query("#library-notes-canvas").first()
+        if screen.query("#library-notes-canvas")
+        else screen.query_one("#library-note-load-state")
+    )
+    footer = screen.query_one("#screen-footer-status")
+
+    assert screen.region.height == 20
+    assert navigation.region.height == 3
+    assert header.region.height == 1
+    assert shell.region.height == 15
+    assert shell.content_region.height == 15
+    assert canvas.region.height == 15
+    assert canvas.content_region.height == 15
+    assert notes.region.height == 15
+    assert footer.region.height == 1
+    assert (
+        navigation.region.height
+        + header.region.height
+        + shell.region.height
+        + footer.region.height
+        == 20
+    )
+    assert screen.query_one("#screen-content").virtual_size.width <= screen.region.width
+    assert shell.virtual_size.width <= shell.region.width
+    assert canvas.virtual_size.width <= canvas.region.width
+
+
+async def _assert_task8_rows(
+    screen: LibraryScreen,
+    pilot,
+    expected: dict[str, int],
+    *,
+    focused_selector: str,
+) -> None:
+    """Assert exact visible row heights, bounds, and focus visibility."""
+    _assert_task8_compact_chrome(screen)
+    for selector, height in expected.items():
+        widget = screen.query_one(selector)
+        assert widget.display is True, selector
+        assert widget.region.height == height, (selector, widget.region)
+        assert widget.region.width > 0, (selector, widget.region)
+        assert widget.region.x >= 0, (selector, widget.region)
+        assert widget.region.y >= 0, (selector, widget.region)
+        assert widget.region.right <= screen.region.right, (selector, widget.region)
+        assert widget.region.bottom <= screen.region.bottom - 1, (
+            selector,
+            widget.region,
+        )
+
+    notes_root = (
+        screen.query("#library-notes-canvas").first()
+        if screen.query("#library-notes-canvas")
+        else screen.query_one("#library-note-load-state")
+    )
+    for control in notes_root.query("*"):
+        if not control.can_focus or not control.is_on_screen:
+            continue
+        assert control.region.width > 0 and control.region.height > 0, control
+        assert control.region.x >= 0 and control.region.right <= screen.region.right, (
+            control,
+            control.region,
+        )
+    focused = screen.query_one(focused_selector)
+    focused.focus(scroll_visible=True)
+    await pilot.pause()
+    assert screen.focused is focused
+    assert focused.region.width > 0 and focused.region.height > 0
+    assert focused.region.x >= 0 and focused.region.right <= screen.region.right
+    assert focused.region.y >= 0 and focused.region.bottom <= screen.region.bottom - 1
+
+
+async def _enter_task8_navigator_state(screen, pilot, state: str) -> None:
+    screen.query_one("#library-row-browse-notes").press()
+    await _wait_for_selector(screen, pilot, "#library-notes-filter")
+    if state == "normal":
+        return
+    if state == "filtered-empty":
+        screen._library_notes_filter = "[none] Ω very long filter query"
+        screen._library_notes_filter_records = []
+    elif state == "sort-choice":
+        screen._library_notes_sort_choices_visible = True
+    elif state == "selection":
+        screen._library_notes_select_mode = True
+    else:
+        raise AssertionError(f"Unsupported Navigator state: {state}")
+    screen.refresh(recompose=True)
+    await _wait_for_selector(screen, pilot, "#library-notes-canvas")
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "expected", "focused_selector"),
+    (
+        (
+            "normal",
+            {
+                "#library-notes-header": 1,
+                "#library-notes-filter-row": 1,
+                "#library-notes-browse-actions": 1,
+                "#library-notes-transfer-actions": 1,
+                "#library-notes-status-row": 1,
+                "#library-notes-list": 10,
+            },
+            "#library-notes-filter",
+        ),
+        (
+            "filtered-empty",
+            {
+                "#library-notes-header": 1,
+                "#library-notes-filter-row": 1,
+                "#library-notes-browse-actions": 1,
+                "#library-notes-transfer-actions": 1,
+                "#library-notes-status-row": 1,
+                "#library-notes-empty": 10,
+            },
+            "#library-notes-filter-clear",
+        ),
+        (
+            "sort-choice",
+            {
+                "#library-notes-header": 1,
+                "#library-notes-filter-row": 1,
+                "#library-notes-sort-choices": 1,
+                "#library-notes-transfer-actions": 1,
+                "#library-notes-status-row": 1,
+                "#library-notes-list": 10,
+            },
+            "#library-notes-sort-newest",
+        ),
+        (
+            "selection",
+            {
+                "#library-notes-header": 1,
+                "#library-notes-filter-row": 1,
+                "#library-notes-selection-actions": 1,
+                "#library-notes-selection-status": 1,
+                "#library-notes-list": 11,
+            },
+            "#library-notes-select-toggle",
+        ),
+    ),
+)
+async def test_library_note_60x20_navigator_state_allocation(
+    state: str, expected: dict[str, int], focused_selector: str
+) -> None:
+    app = _build_test_app()
+    notes = _two_notes() + [
+        {
+            "id": f"geometry-{index}",
+            "title": f"Geometry note {index}",
+            "content": f"Body {index}",
+            "last_modified": f"2026-06-{30 - index:02d}T12:00:00+00:00",
+            "version": 1,
+            "keywords": [],
+        }
+        for index in range(3, 18)
+    ]
+    _seed_conversations(app, _two_conversations(), notes=notes)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        await _enter_task8_navigator_state(screen, pilot, state)
+
+        await _assert_task8_rows(
+            screen,
+            pilot,
+            expected,
+            focused_selector=focused_selector,
+        )
+        if state == "selection":
+            assert screen.query_one("#library-notes-status").display is False
+        if state == "sort-choice":
+            assert screen.query_one("#library-notes-browse-actions").display is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ("create", "sync"))
+async def test_library_note_60x20_temporary_region_allocation(state: str) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        if state == "create":
+            screen.query_one("#library-row-create-note").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+            heading = "#library-notes-create-heading"
+            viewport = "#library-notes-create-viewport"
+            focus = "#library-notes-create-blank"
+        else:
+            screen.query_one("#library-row-browse-notes").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-sync-open")
+            screen.query_one("#library-notes-sync-open").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-sync-folder")
+            heading = "#library-notes-sync-heading"
+            viewport = "#library-notes-sync-viewport"
+            focus = "#library-notes-sync-folder"
+
+        _assert_task8_compact_chrome(screen)
+        owner = screen.query_one("#library-notes-canvas")
+        header = screen.query_one(heading)
+        assert header.region.height == 1
+        await _assert_task8_rows(
+            screen,
+            pilot,
+            {heading: 1, viewport: 14, "#library-notes-canvas": 15},
+            focused_selector=focus,
+        )
+        scroll_owner = screen.query_one(viewport)
+        assert str(owner.styles.overflow_y) == "hidden"
+        assert str(scroll_owner.styles.overflow_y) == "auto"
+        heading_y = header.region.y
+        scroll_owner.scroll_end(animate=False, immediate=True)
+        await pilot.pause()
+        assert header.region.y == heading_y
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("region", "selector", "compact_label", "wide_label"),
+    (
+        (
+            "selection",
+            "#library-notes-select-all",
+            "All 2",
+            "Select all 2 shown",
+        ),
+        (
+            "sync",
+            "#library-notes-sync-direction-bidirectional",
+            "✓ Both",
+            "✓ Bidirectional",
+        ),
+    ),
+)
+async def test_library_note_compact_labels_round_trip_without_recompose(
+    region: str, selector: str, compact_label: str, wide_label: str
+) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        if region == "selection":
+            await _enter_task8_navigator_state(screen, pilot, "selection")
+        else:
+            screen.query_one("#library-row-browse-notes").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-sync-open")
+            screen.query_one("#library-notes-sync-open").press()
+            await _wait_for_selector(screen, pilot, selector)
+
+        control = screen.query_one(selector, Button)
+        canvas = screen.query_one("#library-notes-canvas")
+        assert str(control.label) == compact_label
+
+        await pilot.resize_terminal(170, 48)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        assert screen.query_one("#library-notes-canvas") is canvas
+        assert str(control.label) == wide_label
+
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        assert screen.query_one("#library-notes-canvas") is canvas
+        assert str(control.label) == compact_label
+
+
+@pytest.mark.asyncio
+async def test_library_note_60x20_sync_activity_scrolls_below_fixed_heading() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-sync-open")
+        screen.query_one("#library-notes-sync-open").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-sync-run")
+        screen._library_notes_sync_activity = tuple(
+            f"Activity line {index}" for index in range(20)
+        )
+        screen.refresh(recompose=True)
+        await _wait_for_selector(screen, pilot, "#library-notes-sync-viewport")
+        await pilot.pause()
+
+        heading = screen.query_one("#library-notes-sync-heading")
+        viewport = screen.query_one("#library-notes-sync-viewport")
+        activity = screen.query_one("#library-notes-sync-activity")
+        assert heading.region.height == 1
+        assert viewport.region.height == 14
+        assert activity.region.height >= 20
+        assert int(viewport.max_scroll_y) > 0
+        heading_y = heading.region.y
+        viewport.scroll_end(animate=False, immediate=True)
+        await pilot.pause()
+        assert heading.region.y == heading_y
+        assert viewport.scroll_y > 0
+
+
+@pytest.mark.asyncio
+async def test_library_note_wide_preview_has_one_focusable_scroll_owner() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        screen.query_one("#library-note-body", TextArea).text = "\n\n".join(
+            f"## Section {index}\nLong preview content {index}" for index in range(80)
+        )
+        await pilot.pause()
+        screen.query_one("#library-note-preview").press()
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
+        outer = screen.query_one("#library-note-preview-region")
+        markdown = screen.query_one("#library-note-preview-body", Markdown)
+        await _wait_for_condition(
+            pilot,
+            lambda: int(outer.max_scroll_y) > 10,
+            message="Wide Preview never assigned long content to its viewport.",
+        )
+
+        assert outer.can_focus is True
+        assert int(markdown.max_scroll_y) == 0
+        outer.focus()
+        before = outer.scroll_y
+        await pilot.press("pagedown")
+        await pilot.pause()
+        assert outer.scroll_y > before
+
+
+@pytest.mark.asyncio
+async def test_library_note_60x20_loading_allocation_keeps_back_visible() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    detail_service = _GatedLibraryNoteDetailService(_two_notes())
+    app.notes_scope_service = detail_service
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-row-0")
+        screen.query_one("#library-notes-row-0").press()
+        try:
+            await _wait_for_condition(
+                pilot,
+                detail_service.started.is_set,
+                message="Detail service never entered its gated load.",
+            )
+            await _wait_for_selector(screen, pilot, "#library-note-load-state")
+            _assert_task8_compact_chrome(screen)
+            assert screen.query_one("#library-note-load-heading").region.height == 1
+            assert screen.query_one("#library-note-loading").region.height == 1
+            assert (
+                screen.query_one("#library-note-loading-viewport").region.height == 13
+            )
+            back = screen.query_one("#library-note-back")
+            back.focus()
+            await pilot.pause()
+            assert screen.focused is back
+            assert back.region.height == 1
+        finally:
+            detail_service.release.set()
+
+
+@pytest.mark.asyncio
+async def test_library_note_60x20_untouched_new_allocation_keeps_discard_visible() -> (
+    None
+):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        screen.query_one("#library-row-create-note").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        screen.query_one("#library-notes-create-blank").press()
+        await _wait_for_selector(screen, pilot, "#library-note-discard-new")
+
+        await _assert_task8_rows(
+            screen,
+            pilot,
+            {
+                "#library-note-heading": 1,
+                "#library-note-title-row": 1,
+                "#library-note-body-label": 1,
+                "#library-note-body": 10,
+                "#library-note-status": 1,
+                "#library-note-primary-actions": 1,
+            },
+            focused_selector="#library-note-discard-new",
+        )
+        assert screen.query_one("#library-note-discard-new").display is True
+
+
+@pytest.mark.asyncio
+async def test_library_note_60x20_long_title_header_is_plain_one_row_and_lossless() -> (
+    None
+):
+    raw_title = "Ω [bold]literal[/bold] 👩🏽‍💻 " + "界" * 80
+    notes = [dict(_two_notes()[0], title=raw_title), _two_notes()[1]]
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=notes)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        await _open_note_editor(screen, pilot)
+        screen.query_one("#library-note-preview").press()
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
+
+        heading = screen.query_one("#library-note-preview-title", Static)
+        rendered = getattr(heading.renderable, "plain", str(heading.renderable))
+        assert heading.region.height == 1
+        assert "[bold]literal[/bold]" in rendered
+        assert rendered.endswith("…")
+        assert screen.query_one("#library-note-title", Input).value == raw_title
+        assert screen._library_note_session.snapshot.title == raw_title
+
+
+async def _enter_task8_editor_state(screen, pilot, state: str) -> None:
+    await _open_note_editor(screen, pilot)
+    body = screen.query_one("#library-note-body", TextArea)
+    body.text = "\n".join(f"geometry body line {index}" for index in range(80))
+    await pilot.pause()
+    if state == "normal":
+        return
+    if state == "validation":
+        screen.query_one("#library-note-title", Input).value = "x" * 301
+        screen.query_one("#library-note-save").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_autosave_state == "validation",
+            message="Validation geometry state never appeared.",
+        )
+    elif state == "conflict":
+        _bump_note_version_externally(screen.app_instance.notes_scope_service, "n-1")
+        body.text += "\nnew local edit"
+        await pilot.pause()
+        screen.query_one("#library-note-save").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_session.snapshot.in_conflict,
+            message="Conflict geometry state never appeared.",
+        )
+    elif state == "delete-confirmation":
+        screen.query_one("#library-note-context").press()
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one("#library-note-context-delete").press()
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
+    elif state == "preview":
+        screen.query_one("#library-note-preview").press()
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
+    elif state == "context":
+        screen.query_one("#library-note-context").press()
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+    else:
+        raise AssertionError(f"Unsupported Editor state: {state}")
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "expected", "focused_selector"),
+    (
+        (
+            "normal",
+            {
+                "#library-note-heading": 1,
+                "#library-note-title-row": 1,
+                "#library-note-body-label": 1,
+                "#library-note-body": 10,
+                "#library-note-status": 1,
+                "#library-note-primary-actions": 1,
+            },
+            "#library-note-body",
+        ),
+        (
+            "validation",
+            {
+                "#library-note-heading": 1,
+                "#library-note-title-row": 1,
+                "#library-note-body-label": 1,
+                "#library-note-body": 9,
+                "#library-note-status": 2,
+                "#library-note-primary-actions": 1,
+            },
+            "#library-note-title",
+        ),
+        (
+            "conflict",
+            {
+                "#library-note-heading": 1,
+                "#library-note-title-row": 1,
+                "#library-note-body-label": 1,
+                "#library-note-body": 8,
+                "#library-note-status": 1,
+                "#library-note-conflict-copy": 2,
+                "#library-note-conflict-actions": 1,
+            },
+            "#library-note-conflict-copy",
+        ),
+        (
+            "delete-confirmation",
+            {
+                "#library-note-heading": 1,
+                "#library-note-title-row": 1,
+                "#library-note-body-label": 1,
+                "#library-note-body": 9,
+                "#library-note-status": 1,
+                "#library-note-delete-confirm-copy": 1,
+                "#library-note-delete-actions": 1,
+            },
+            "#library-note-delete-cancel",
+        ),
+        (
+            "preview",
+            {
+                "#library-note-heading": 1,
+                "#library-note-preview-region": 12,
+                "#library-note-status": 1,
+                "#library-note-primary-actions": 1,
+            },
+            "#library-note-preview-region",
+        ),
+        (
+            "context",
+            {
+                "#library-note-heading": 1,
+                "#library-note-context-status": 1,
+                "#library-note-context-region": 13,
+            },
+            "#library-note-context-keywords",
+        ),
+    ),
+)
+async def test_library_note_60x20_editor_state_allocation(
+    state: str, expected: dict[str, int], focused_selector: str
+) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        await _enter_task8_editor_state(screen, pilot, state)
+
+        await _assert_task8_rows(
+            screen,
+            pilot,
+            expected,
+            focused_selector=focused_selector,
+        )
         assert screen._library_note_session.snapshot is not None
 
 
@@ -18589,22 +19178,55 @@ async def test_library_note_same_side_resize_does_no_presentation_work(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("region", "owner_selector", "fixed_selectors"),
+    (
+        "region",
+        "owner_selector",
+        "fixed_selectors",
+        "owner_height_at_80x24",
+        "owner_height_at_100x30",
+    ),
     (
         (
             "navigator",
             "#library-notes-list",
-            ("#library-notes-filter", "#library-notes-new"),
+            (
+                "#library-notes-header",
+                "#library-notes-filter-row",
+                "#library-notes-browse-actions",
+                "#library-notes-transfer-actions",
+                "#library-notes-status-row",
+            ),
+            14,
+            20,
         ),
         (
             "editor",
             "#library-note-body",
-            ("#library-note-title", "#library-note-save"),
+            (
+                "#library-note-heading",
+                "#library-note-title-row",
+                "#library-note-body-label",
+                "#library-note-status",
+                "#library-note-primary-actions",
+            ),
+            14,
+            20,
+        ),
+        (
+            "context",
+            "#library-note-context-region",
+            ("#library-note-heading", "#library-note-context-status"),
+            17,
+            23,
         ),
     ),
 )
-async def test_library_note_compact_surplus_rows_expand_only_named_owner(
-    region: str, owner_selector: str, fixed_selectors: tuple[str, ...]
+async def test_library_note_compact_surplus_allocation_expands_only_named_owner(
+    region: str,
+    owner_selector: str,
+    fixed_selectors: tuple[str, ...],
+    owner_height_at_80x24: int,
+    owner_height_at_100x30: int,
 ) -> None:
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
@@ -18616,9 +19238,12 @@ async def test_library_note_compact_surplus_rows_expand_only_named_owner(
         await _wait_for_library_notes_compact(screen, pilot, True)
         screen.query_one(f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}").press()
         await _wait_for_selector(screen, pilot, "#library-notes-filter")
-        if region == "editor":
+        if region in {"editor", "context"}:
             screen.query_one("#library-notes-row-0").press()
             await _wait_for_selector(screen, pilot, "#library-note-body")
+        if region == "context":
+            screen.query_one("#library-note-context").press()
+            await _wait_for_display(screen, pilot, "#library-note-context-region")
 
         owner = screen.query_one(owner_selector)
         owner_height = owner.region.height
@@ -18630,8 +19255,10 @@ async def test_library_note_compact_surplus_rows_expand_only_named_owner(
         await _wait_for_library_notes_compact(screen, pilot, True)
         await pilot.pause()
 
+        assert owner_height == owner_height_at_80x24
+        assert fixed_heights == tuple(1 for _ in fixed_selectors)
         assert screen.query_one(owner_selector) is owner
-        assert owner.region.height > owner_height
+        assert owner.region.height == owner_height_at_100x30
         assert (
             tuple(
                 screen.query_one(selector).region.height for selector in fixed_selectors
@@ -18695,6 +19322,11 @@ async def test_library_note_deliberate_scroll_override_replaces_responsive_memor
         screen.query_one("#library-note-preview").press()
         await _wait_for_display(screen, pilot, "#library-note-preview-region")
         preview = screen.query_one("#library-note-preview-region")
+        await _wait_for_condition(
+            pilot,
+            lambda: int(preview.max_scroll_y) > 2,
+            message="Long Preview content never produced a scroll range.",
+        )
         preview.focus()
         screen._mark_library_notes_user_interaction()
         preview.scroll_to(y=2, animate=False, force=True, immediate=True)
@@ -18871,7 +19503,10 @@ async def test_library_note_breakpoint_round_trips_restore_every_region_focus_ro
         await _wait_for_selector(screen, pilot, "#library-notes-sync-run")
         sync_owner = screen._library_notes_scroll_owner("sync")
         assert sync_owner is not None
-        assert int(sync_owner.max_scroll_y) > 0
+        # Task 8's exact compact allocation fits the complete default Sync
+        # workflow in its 14-row viewport. Focus-role restoration must work
+        # without depending on accidental chrome overflow.
+        assert int(sync_owner.max_scroll_y) == 0
         screen._library_notes_sync_status = "running · 2 files"
         screen._library_notes_sync_activity = ("Scanned notes", "Writing changes")
         screen.refresh(recompose=True)
@@ -19115,7 +19750,10 @@ async def test_library_note_user_focus_vetoes_stale_deferred_restore() -> None:
         await _wait_for_library_shell(screen, pilot)
         await _open_note_editor(screen, pilot)
         body = screen.query_one("#library-note-body", TextArea)
-        body.text = "\n".join(f"focus guard line {index}" for index in range(100))
+        body.text = "\n\n".join(
+            f"## focus guard {index}\ncontent for section {index}"
+            for index in range(100)
+        )
         await pilot.pause()
         body.scroll_to(y=9, animate=False, force=True, immediate=True)
         body.focus()
@@ -19132,6 +19770,11 @@ async def test_library_note_user_focus_vetoes_stale_deferred_restore() -> None:
         preview = screen.query_one("#library-note-preview-region")
         screen._mark_library_notes_user_interaction()
         preview.focus()
+        await _wait_for_condition(
+            pilot,
+            lambda: int(preview.max_scroll_y) > 2,
+            message="Preview content never produced the expected scroll range.",
+        )
         preview.scroll_to(y=2, animate=False, force=True, immediate=True)
         await _wait_for_condition(
             pilot,

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -1,5 +1,6 @@
 """Library shell (L1) rail + conversations canvas pilot contracts."""
 
+import ast
 import asyncio
 import dataclasses
 import json
@@ -92,7 +93,10 @@ from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
 from tldw_chatbook.Widgets.Library.library_ingest_canvas import LibraryIngestCanvas
 from tldw_chatbook.Widgets.Library.library_notes_canvas import LibraryNotesCanvas
-from tldw_chatbook.Widgets.Library.library_rail import LIBRARY_RAIL_ROW_PREFIX
+from tldw_chatbook.Widgets.Library.library_rail import (
+    LIBRARY_RAIL_ROW_PREFIX,
+    LibraryRail,
+)
 from Tests.UI.test_destination_shells import (
     PolicyDeniedLibraryNotesScopeService,
     StaticLibraryConversationScopeService,
@@ -804,6 +808,38 @@ def test_library_dead_hub_helpers_are_removed():
     assert not hasattr(library_screen_module, "LIBRARY_EMPTY_NEXT_ACTION_COPY")
 
 
+def test_library_screen_has_one_canonical_cross_cutting_handler_per_event():
+    """Notes integration must augment, not shadow, screen-wide handlers."""
+    source = Path(library_screen_module.__file__).read_text(encoding="utf-8")
+    module = ast.parse(source)
+    screen_class = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "LibraryScreen"
+    )
+
+    method_names = [
+        node.name
+        for node in screen_class.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    for handler_name in ("on_key", "on_descendant_focus", "check_action"):
+        assert method_names.count(handler_name) == 1, handler_name
+
+
+def test_library_notes_bindings_are_inactive_outside_notes_workflow():
+    """Notes-only bindings do not leak through the screen-wide action gate."""
+    screen = LibraryScreen(_open_source_test_app())
+
+    for action in (
+        "library_notes_new",
+        "library_notes_focus_filter",
+        "library_notes_save",
+        "library_notes_escape",
+    ):
+        assert screen.check_action(action, ()) is False, action
+
+
 def test_library_dead_inspector_copy_is_removed():
     """F-021: the retired inspector pane's empty-state copy is gone. The
     review flagged the next-action line as architecture-talk in user
@@ -860,6 +896,49 @@ async def test_rail_rows_are_one_line_by_default_with_meta_only_for_handoffs():
 
 
 @pytest.mark.asyncio
+async def test_rail_apply_selection_preserves_canonical_row_metadata():
+    """Selection-only updates retain canonical count, gloss, and handoff copy."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        rail = screen.query_one("#library-rail", LibraryRail)
+
+        row_ids = (
+            "browse-conversations",
+            "browse-search",
+            "create-study",
+        )
+        original_labels = {
+            row_id: screen.query_one(
+                f"#{LIBRARY_RAIL_ROW_PREFIX}{row_id}", Button
+            ).label.plain
+            for row_id in row_ids
+        }
+
+        previous_row_id = ""
+        for row_id in row_ids:
+            rail.apply_selection(
+                dataclasses.replace(rail.shell, selected_row_id=row_id)
+            )
+
+            selected_label = screen.query_one(
+                f"#{LIBRARY_RAIL_ROW_PREFIX}{row_id}", Button
+            ).label.plain
+            assert selected_label == f"▸{original_labels[row_id][1:]}"
+
+            if previous_row_id:
+                previous_label = screen.query_one(
+                    f"#{LIBRARY_RAIL_ROW_PREFIX}{previous_row_id}", Button
+                ).label.plain
+                assert previous_label == original_labels[previous_row_id]
+            previous_row_id = row_id
+
+
+@pytest.mark.asyncio
 async def test_rail_create_section_and_details_reachable_at_100x30():
     """F-011: the regression the stutter caused -- at 100x30 the Create
     section is inside the viewport without scrolling (it was pushed out of
@@ -889,7 +968,9 @@ async def test_rail_create_section_and_details_reachable_at_100x30():
         # Details toggle: one scroll to the bottom of the rail.
         rail.scroll_end(animate=False)
         await pilot.pause()
-        toggle = screen.query_one("#console-rail-section-toggle-library-details", Button)
+        toggle = screen.query_one(
+            "#console-rail-section-toggle-library-details", Button
+        )
         assert toggle.region.y + toggle.region.height <= fold, (
             f"details toggle unreachable after scroll_end: {toggle.region}"
         )
@@ -939,9 +1020,7 @@ async def test_jargon_rail_rows_render_a_dim_subtitle_on_the_same_line():
 
         plain_row = screen.query_one("#library-row-browse-notes", Button)
         assert "—" not in plain_row.label.plain
-        assert not [
-            s for s in plain_row.label.spans if "dim" in str(s.style)
-        ]
+        assert not [s for s in plain_row.label.spans if "dim" in str(s.style)]
 
 
 @pytest.mark.asyncio
@@ -1819,9 +1898,7 @@ async def test_library_shell_search_rag_mode_blocks_run_when_endpoint_named_but_
         settings["api_settings"] = api_settings
         return settings
 
-    monkeypatch.setattr(
-        app_config, "load_settings", _load_settings_with_no_openai_key
-    )
+    monkeypatch.setattr(app_config, "load_settings", _load_settings_with_no_openai_key)
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())
     host = LibraryHarness(app)
@@ -6265,9 +6342,7 @@ async def test_library_open_source_context_uses_dirty_note_flush_and_veto(
         async def flush_note() -> NoteFlushOutcome:
             await flush()
             return NoteFlushOutcome(
-                NoteFlushOutcomeKind.BLOCKED
-                if veto
-                else NoteFlushOutcomeKind.PERMITTED
+                NoteFlushOutcomeKind.BLOCKED if veto else NoteFlushOutcomeKind.PERMITTED
             )
 
         monkeypatch.setattr(screen, "_open_library_item_by_id", opener)
@@ -9187,7 +9262,6 @@ async def test_library_shell_note_save_result_after_switch_is_discarded():
         # Force a replacement session while n-1's save is still sleeping.
         # The late save result must be typed STALE by the coordinator and
         # ignored by the screen presentation.
-        n1_meta_widget = screen.query_one("#library-note-meta", Static)
         screen._begin_library_note_load("n-2")
         screen.refresh(recompose=True)
 
@@ -9630,6 +9704,7 @@ async def test_library_shell_note_conflict_reload_discards_local_edits():
                 f"title_text={getattr(title_widget, 'value', '')!r}). "
                 f"Visible text: {_visible_text(screen)}"
             )
+
         await _wait_for_condition(
             pilot,
             lambda: (
@@ -16780,9 +16855,7 @@ async def test_library_shell_export_orphaned_run_completion_cannot_corrupt_a_lat
 
         # The orphaned export genuinely completed -- still notified...
         assert len(notified) == 1
-        assert (
-            notified[0][0] == f"Exported bundle to {tmp_path / 'orphaned_dest.zip'}"
-        )
+        assert notified[0][0] == f"Exported bundle to {tmp_path / 'orphaned_dest.zip'}"
         # ...but the CURRENT (fresh, second) visit is completely
         # undisturbed: still not running, still no error/status, the
         # SAME submit button instance, still correctly disabled (no
@@ -16928,8 +17001,7 @@ async def test_library_shell_export_submit_missing_service_surfaces_error_and_re
         for _ in range(150):
             if (
                 screen._library_export_running is False
-                and screen._library_export_error
-                == "Bundle export service unavailable."
+                and screen._library_export_error == "Bundle export service unavailable."
             ):
                 break
             await pilot.pause(0.02)
@@ -17383,9 +17455,9 @@ async def test_library_ingest_intro_lines_hide_while_typing(tmp_path):
         await pilot.pause()
         path_input.value = "/tmp/somewhere.txt"
         await pilot.pause()
-        assert all(
-            not w.display for w in screen.query(".library-ingest-intro")
-        ), "intro lines must hide once a path is typed"
+        assert all(not w.display for w in screen.query(".library-ingest-intro")), (
+            "intro lines must hide once a path is typed"
+        )
 
         path_input.value = ""
         await pilot.pause()
@@ -17418,18 +17490,18 @@ async def test_library_search_typed_text_survives_registry_recompose(tmp_path):
         screen._handle_library_ingest_registry_changed()
         await pilot.pause()
         await _wait_for_selector(screen, pilot, "#library-search-input")
-        assert (
-            screen.query_one("#library-search-input", Input).value == "cake"
-        ), "typed search text vanished on recompose"
+        assert screen.query_one("#library-search-input", Input).value == "cake", (
+            "typed search text vanished on recompose"
+        )
 
         screen.query_one("#library-search-input", Input).value = ""
         await pilot.pause()
         screen._handle_library_ingest_registry_changed()
         await pilot.pause()
         await _wait_for_selector(screen, pilot, "#library-search-input")
-        assert (
-            screen.query_one("#library-search-input", Input).value == ""
-        ), "deleted search text resurrected on recompose"
+        assert screen.query_one("#library-search-input", Input).value == "", (
+            "deleted search text resurrected on recompose"
+        )
 
 
 @pytest.mark.asyncio
@@ -17594,8 +17666,7 @@ async def test_library_search_rag_canvas_survives_ingest_done_count_growth(tmp_p
         # snapshot-driven sync never touches results/history.
         results_after = list(screen.query_one("#library-rag-results").children)
         assert len(results_after) == len(results_before) and all(
-            before is after
-            for before, after in zip(results_before, results_after)
+            before is after for before, after in zip(results_before, results_after)
         ), (
             "Evidence result widgets were rebuilt -- the snapshot-driven "
             "sync must never touch results/history"
@@ -17977,9 +18048,7 @@ async def test_clear_path_button_empties_the_widget_for_real(tmp_path):
         await _wait_for_selector(screen, pilot, "#library-ingest-path")
 
         widget = screen.query_one("#library-ingest-path", Input)
-        assert widget.value == "", (
-            f"Clear left the widget holding {widget.value!r}"
-        )
+        assert widget.value == "", f"Clear left the widget holding {widget.value!r}"
         assert screen._library_ingest_form.path == ""
 
         # Refocus + one more recompose: the emptiness must survive both.
@@ -18033,9 +18102,9 @@ async def test_completion_toast_reports_dedup_as_already_in_library(tmp_path):
             for call in harness.notify.call_args_list
             if call.args and str(call.args[0]).startswith("Import finished")
         ]
-        assert summaries and summaries[-1] == (
-            "Import finished — 1 matched"
-        ), f"dedup batch misreported: {summaries}"
+        assert summaries and summaries[-1] == ("Import finished — 1 matched"), (
+            f"dedup batch misreported: {summaries}"
+        )
         assert summaries[0] == "Import finished — 1 imported"
 
 
@@ -18243,23 +18312,17 @@ async def test_details_toggle_renders_and_hides_inline_lines(tmp_path):
         await _wait_for_selector(
             screen, pilot, f"#library-ingest-details-{failing.job_id}"
         )
-        screen.query_one(
-            f"#library-ingest-details-{failing.job_id}", Button
-        ).press()
+        screen.query_one(f"#library-ingest-details-{failing.job_id}", Button).press()
         await pilot.pause()
         await _wait_for_selector(
             screen, pilot, f"#library-ingest-detail-{failing.job_id}-0"
         )
-        button = screen.query_one(
-            f"#library-ingest-details-{failing.job_id}", Button
-        )
+        button = screen.query_one(f"#library-ingest-details-{failing.job_id}", Button)
         assert str(button.label) == "Hide details"
 
         button.press()
         for _ in range(_INGEST_POLL_ATTEMPTS):
-            if not list(
-                screen.query(f"#library-ingest-detail-{failing.job_id}-0")
-            ):
+            if not list(screen.query(f"#library-ingest-detail-{failing.job_id}-0")):
                 break
             await pilot.pause(_INGEST_POLL_INTERVAL)
         else:
@@ -18341,9 +18404,7 @@ async def test_options_loader_never_calls_get_cli_setting_without_default(
 
         import unittest.mock as _mock
 
-        with _mock.patch.object(
-            screen_module, "get_cli_setting", _two_shape_stub
-        ):
+        with _mock.patch.object(screen_module, "get_cli_setting", _two_shape_stub):
             screen._library_ingest_form = LibraryIngestFormState()
             screen._load_library_ingest_options_from_config()
 
@@ -18385,14 +18446,10 @@ async def test_retry_press_updates_queue_in_place(tmp_path):
         )
         start_before = screen.query_one("#library-ingest-start", Button)
 
-        screen.query_one(
-            f"#library-ingest-retry-{failing.job_id}", Button
-        ).press()
+        screen.query_one(f"#library-ingest-retry-{failing.job_id}", Button).press()
         await pilot.pause()
         for _ in range(_INGEST_POLL_ATTEMPTS):
-            if any(
-                j.retry_count for j in harness.library_ingest_jobs.jobs()
-            ):
+            if any(j.retry_count for j in harness.library_ingest_jobs.jobs()):
                 break
             await pilot.pause(_INGEST_POLL_INTERVAL)
 
@@ -18414,8 +18471,6 @@ async def test_focused_panel_title_keeps_its_label(tmp_path):
         await _wait_for_library_shell(screen, pilot)
         await _open_library_ingest_canvas(screen, pilot)
         await _wait_for_selector(screen, pilot, "#type-group-generic")
-
-        from textual.widgets._collapsible import CollapsibleTitle
 
         title = screen.query_one("#type-group-generic CollapsibleTitle")
         title.focus()
@@ -18505,17 +18560,13 @@ async def test_server_mode_line_requires_configured_server(tmp_path):
             submit_ingest_jobs=lambda **kwargs: None
         )
         harness.runtime_policy = SimpleNamespace(
-            state=SimpleNamespace(
-                active_source="local", server_configured=False
-            )
+            state=SimpleNamespace(active_source="local", server_configured=False)
         )
         state = screen._build_library_ingest_state()
         assert state.server_quiet_line == ""
 
         harness.runtime_policy = SimpleNamespace(
-            state=SimpleNamespace(
-                active_source="local", server_configured=True
-            )
+            state=SimpleNamespace(active_source="local", server_configured=True)
         )
         configured = screen._build_library_ingest_state()
         assert "server mode" in configured.server_quiet_line
@@ -18631,9 +18682,9 @@ async def test_option_input_edit_updates_receipt_error_and_gate(tmp_path):
         assert "Chunk size: 1500" in str(
             screen.query_one("#type-group-generic", Collapsible).title
         )
-        assert screen.query_one(
-            "#opt-generic-chunk_size-error", Static
-        ).display is False
+        assert (
+            screen.query_one("#opt-generic-chunk_size-error", Static).display is False
+        )
         assert screen.query_one("#library-ingest-start", Button).disabled is False
 
 
@@ -18805,9 +18856,7 @@ async def test_dismiss_preserves_failure_in_recent_ledger(tmp_path):
         await _wait_for_selector(
             screen, pilot, f"#library-ingest-dismiss-{failing.job_id}"
         )
-        screen.query_one(
-            f"#library-ingest-dismiss-{failing.job_id}", Button
-        ).press()
+        screen.query_one(f"#library-ingest-dismiss-{failing.job_id}", Button).press()
         await pilot.pause()
         await pilot.pause()
 

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -6262,13 +6262,21 @@ async def test_library_open_source_context_uses_dirty_note_flush_and_veto(
         opener = AsyncMock()
         flush = AsyncMock()
 
-        async def flush_note() -> None:
+        async def flush_note() -> NoteFlushOutcome:
             await flush()
-            screen._library_note_dirty = veto
+            return NoteFlushOutcome(
+                NoteFlushOutcomeKind.BLOCKED
+                if veto
+                else NoteFlushOutcomeKind.PERMITTED
+            )
 
         monkeypatch.setattr(screen, "_open_library_item_by_id", opener)
         monkeypatch.setattr(screen, "_flush_library_note_save", flush_note)
-        screen._library_note_dirty = True
+        monkeypatch.setattr(
+            type(screen),
+            "_library_note_dirty",
+            property(lambda _screen: True),
+        )
 
         screen.apply_navigation_context(
             {

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -47,6 +47,7 @@ from tldw_chatbook.Library.library_rag_state import (
     LIBRARY_RAG_SCOPE_ALL_LOCAL_COPY,
     LibraryRagPanelState,
 )
+from tldw_chatbook.Library.library_notes_state import LibraryNotesFocusIdentity
 from tldw_chatbook.Widgets.Library.library_search_rag_panel import (
     results_heading_text,
 )
@@ -6823,6 +6824,20 @@ def _two_notes():
     ]
 
 
+async def _wait_for_library_notes_compact(screen, pilot, expected: bool) -> None:
+    """Wait until the measured Library workbench breakpoint settles."""
+    await _wait_for_condition(
+        pilot,
+        lambda: screen._library_notes_compact is expected,
+        message=lambda: (
+            "Library Notes compact state did not settle to "
+            f"{expected!r}; shell width="
+            f"{screen.query_one('#library-shell-grid').region.width!r}, "
+            f"actual={screen._library_notes_compact!r}."
+        ),
+    )
+
+
 class _CountSeamLibraryNotesScopeService(StaticLibraryNotesListScopeService):
     """Local notes fake mirroring the real production shape: ``list_notes``
     returns a bare list with no total (like ``NotesInteropService.list_notes``),
@@ -10238,6 +10253,17 @@ async def test_library_shell_note_preview_focus_and_editor_position_survive_togg
             f"max_y={preview_region.max_scroll_y!r}, "
             f"body size={preview.size!r}, virtual={preview.virtual_size!r}"
         )
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_last_user_scroll_focus is not None
+                and screen._library_notes_last_user_scroll_focus.semantic_role
+                == "preview-body"
+                and screen._library_notes_last_user_scroll_focus.scroll_offset
+                == (0, int(preview_region.scroll_y))
+            ),
+            message="Keyboard preview scroll did not reach responsive memory.",
+        )
 
         screen.query_one("#library-note-preview").press()
         await pilot.pause()
@@ -10844,6 +10870,18 @@ async def test_library_shell_create_is_single_flight_and_disables_all_choices():
                 message="Create service never entered its gated call.",
             )
             assert screen._library_note_create_running is True
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    bool(screen.query("#library-notes-create-blank"))
+                    and screen.query("#library-notes-create-blank").first().disabled
+                    and all(
+                        button.disabled
+                        for button in screen.query(".library-notes-template-row")
+                    )
+                ),
+                message="Create choices never settled into their disabled state.",
+            )
             assert (
                 screen.query_one("#library-notes-create-blank", Button).disabled is True
             )
@@ -11522,6 +11560,59 @@ async def test_library_shell_discard_new_note_deletes_untouched_create():
 
 
 @pytest.mark.asyncio
+async def test_library_note_failed_discard_clears_shortcut_lock_status() -> None:
+    """A failed discard releases both its destructive gate and refusal copy."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+    discard_started = threading.Event()
+    discard_release = threading.Event()
+
+    async def gated_failed_delete(**kwargs):
+        app.notes_scope_service.delete_calls.append(dict(kwargs))
+        discard_started.set()
+        await asyncio.to_thread(discard_release.wait, _GATED_RELEASE_TIMEOUT_SECONDS)
+        return False
+
+    app.notes_scope_service.delete_note = gated_failed_delete
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-create-note").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        screen.query_one("#library-notes-create-blank").press()
+        discard = await _wait_for_selector(screen, pilot, "#library-note-discard-new")
+
+        discard.press()
+        try:
+            await _wait_for_condition(
+                pilot,
+                discard_started.is_set,
+                message="Discard never reached its gated delete service.",
+            )
+            await pilot.press("ctrl+s")
+            await _wait_for_condition(
+                pilot,
+                lambda: "Save locked" in screen._library_note_shortcut_status,
+                message="Destructive shortcut refusal did not become visible.",
+            )
+        finally:
+            discard_release.set()
+
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                not screen._library_note_session.destructive_running
+                and screen._library_note_session.destructive_admission is None
+            ),
+            message="Failed discard did not release its destructive admission.",
+        )
+        assert screen._library_note_shortcut_status == ""
+        assert screen._library_note_session.snapshot is not None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("acknowledge", ["edit", "save"])
 async def test_library_shell_discard_new_note_disappears_after_edit_or_noop_save(
     acknowledge,
@@ -11970,6 +12061,7 @@ async def test_library_shell_late_import_failure_after_navigation_releases_trans
             ),
             message="Late import completion retained an invisible running claim.",
         )
+        await _wait_for_selector(screen, pilot, "#library-row-browse-notes")
         screen.query_one("#library-row-browse-notes").press()
         await _wait_for_selector(screen, pilot, "#library-notes-import")
         assert screen.query_one("#library-notes-import", Button).disabled is False
@@ -12081,6 +12173,7 @@ async def test_library_shell_import_leave_and_return_does_not_restore_authority(
                 ),
                 message="Navigation did not leave Notes during import.",
             )
+            await _wait_for_selector(screen, pilot, "#library-row-browse-notes")
             screen.query_one("#library-row-browse-notes").press()
             await _wait_for_selector(screen, pilot, "#library-notes-import")
         finally:
@@ -12703,6 +12796,7 @@ async def test_library_shell_sync_running_claim_survives_rail_navigation(
             )
             assert screen._library_notes_sync_running is True
 
+            await _wait_for_selector(screen, pilot, "#library-row-browse-notes")
             screen.query_one("#library-row-browse-notes").press()
             await _wait_for_selector(screen, pilot, "#library-notes-sync-open")
             screen.query_one("#library-notes-sync-open").press()
@@ -18273,3 +18367,1326 @@ async def test_invalid_marker_toggles_with_the_in_place_validation(
         assert not chunk.has_class("-ingest-option-invalid"), (
             "becoming valid must clear the marker in place"
         )
+
+
+# ---------------------------------------------------------------------------
+# TASK-1333 Task 7: compact Notes stages, portable focus, and local shortcuts.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("terminal_width", "expected_compact"), ((119, True), (120, False))
+)
+async def test_library_note_measured_breakpoint_is_exact_and_stable(
+    terminal_width: int, expected_compact: bool
+) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(terminal_width, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, expected_compact)
+
+        shell_width = screen.query_one("#library-shell-grid").region.width
+        assert shell_width == terminal_width
+        assert screen._library_notes_compact is expected_compact
+
+        for _ in range(4):
+            crossing_width = 120 if expected_compact else 119
+            await pilot.resize_terminal(crossing_width, 30)
+            await _wait_for_library_notes_compact(screen, pilot, not expected_compact)
+            assert (
+                screen.query_one("#library-shell-grid").region.width == crossing_width
+            )
+            await pilot.resize_terminal(terminal_width, 30)
+            await _wait_for_library_notes_compact(screen, pilot, expected_compact)
+            assert (
+                screen.query_one("#library-shell-grid").region.width == terminal_width
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("context", "selector", "expected_region"),
+    (
+        ({"mode": "notes"}, "#library-notes-filter", "navigator"),
+        (
+            {LIBRARY_NAV_CONTEXT_NOTES_CREATE: True},
+            "#library-notes-create-blank",
+            "create",
+        ),
+        (
+            {LIBRARY_NAV_CONTEXT_NOTE_ID: "n-1"},
+            "#library-note-body",
+            "editor",
+        ),
+    ),
+)
+async def test_library_note_compact_deep_link_intent_opens_notes_stage(
+    context: dict[str, object], selector: str, expected_region: str
+) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    screen = LibraryScreen(app)
+    screen.apply_navigation_context(context)
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        await _wait_for_selector(screen, pilot, selector)
+
+        assert screen._library_notes_stage == "notes"
+        assert screen._library_notes_focus_region() == expected_region
+        assert screen.query_one("#library-rail").display is False
+        assert screen.query_one("#library-canvas").display is True
+
+
+@pytest.mark.asyncio
+async def test_library_note_wide_deep_link_back_clears_future_compact_intent() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    screen = LibraryScreen(app)
+    screen.apply_navigation_context({"mode": "notes"})
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen._library_notes_stage == "rail"
+        assert screen._library_notes_explicit_stage_intent is False
+
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        assert screen._library_notes_stage == "rail"
+        assert screen.query_one("#library-rail").display is True
+        assert screen.query_one("#library-canvas").display is False
+
+
+@pytest.mark.asyncio
+async def test_library_note_compact_stage_drills_in_and_back_without_losing_origin() -> (
+    None
+):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+
+        rail = screen.query_one("#library-rail")
+        canvas = screen.query_one("#library-canvas")
+        assert rail.display is True
+        assert canvas.display is False
+
+        screen.query_one(f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        assert screen._library_notes_stage == "notes"
+        assert screen.query_one("#library-rail").display is False
+        assert screen.query_one("#library-canvas").display is True
+
+        screen.query_one("#library-notes-row-0").press()
+        await _wait_for_selector(screen, pilot, "#library-note-body")
+        await pilot.pause()
+        assert screen._library_notes_active_region() == "editor"
+
+        screen.query_one("#library-note-back").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        assert screen._library_notes_active_region() == "navigator"
+        await _wait_for_condition(
+            pilot,
+            lambda: getattr(screen.focused, "note_id", None) == "n-1",
+            message=lambda: (
+                "Editor Back did not restore the originating note row: "
+                f"focused={screen.focused!r}, "
+                f"pending={screen._library_notes_pending_focus_identity!r}, "
+                "rows="
+                f"{[getattr(row, 'note_id', None) for row in screen.query('.library-notes-row')]}"
+            ),
+        )
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen._library_notes_stage == "rail"
+        assert screen.query_one("#library-rail").display is True
+        assert screen.query_one("#library-canvas").display is False
+        assert getattr(screen.focused, "row_id", None) == LIBRARY_ROW_BROWSE_NOTES
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("initial_size", "same_side_sizes", "expected_compact"),
+    (
+        ((80, 24), ((100, 30), (60, 20), (80, 24)), True),
+        ((120, 30), ((170, 48), (140, 36), (120, 30)), False),
+    ),
+)
+async def test_library_note_same_side_resize_does_no_presentation_work(
+    initial_size: tuple[int, int],
+    same_side_sizes: tuple[tuple[int, int], ...],
+    expected_compact: bool,
+) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=initial_size) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, expected_compact)
+        await _open_note_editor(screen, pilot)
+
+        transition = getattr(screen, "_transition_library_notes_presentation", None)
+        assert callable(transition), "Task 7 requires one measured transition seam."
+        screen._transition_library_notes_presentation = Mock(wraps=transition)
+        capture = getattr(screen, "_capture_library_notes_focus_identity", None)
+        assert callable(capture), "Task 7 requires one portable focus capture seam."
+        screen._capture_library_notes_focus_identity = Mock(wraps=capture)
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "\n".join(f"line {index}" for index in range(80))
+        body.move_cursor((12, 1))
+        body.move_cursor((16, 3), select=True)
+        body.scroll_to(y=8, animate=False, immediate=True)
+        body.focus()
+        await pilot.pause()
+        before = (
+            screen._library_notes_stage,
+            screen._library_notes_active_region(),
+            screen._library_note_session.snapshot,
+            body.selection,
+            body.scroll_y,
+            screen.focused,
+        )
+        screen._transition_library_notes_presentation.reset_mock()
+        screen._capture_library_notes_focus_identity.reset_mock()
+
+        for width, height in same_side_sizes:
+            await pilot.resize_terminal(width, height)
+            await pilot.pause()
+
+        after = (
+            screen._library_notes_stage,
+            screen._library_notes_active_region(),
+            screen._library_note_session.snapshot,
+            body.selection,
+            body.scroll_y,
+            screen.focused,
+        )
+        assert screen._transition_library_notes_presentation.call_count == 0
+        assert screen._capture_library_notes_focus_identity.call_count == 0
+        assert after == before
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("region", "owner_selector", "fixed_selectors"),
+    (
+        (
+            "navigator",
+            "#library-notes-list",
+            ("#library-notes-filter", "#library-notes-new"),
+        ),
+        (
+            "editor",
+            "#library-note-body",
+            ("#library-note-title", "#library-note-save"),
+        ),
+    ),
+)
+async def test_library_note_compact_surplus_rows_expand_only_named_owner(
+    region: str, owner_selector: str, fixed_selectors: tuple[str, ...]
+) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(80, 24)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        screen.query_one(f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        if region == "editor":
+            screen.query_one("#library-notes-row-0").press()
+            await _wait_for_selector(screen, pilot, "#library-note-body")
+
+        owner = screen.query_one(owner_selector)
+        owner_height = owner.region.height
+        fixed_heights = tuple(
+            screen.query_one(selector).region.height for selector in fixed_selectors
+        )
+
+        await pilot.resize_terminal(100, 30)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        await pilot.pause()
+
+        assert screen.query_one(owner_selector) is owner
+        assert owner.region.height > owner_height
+        assert (
+            tuple(
+                screen.query_one(selector).region.height for selector in fixed_selectors
+            )
+            == fixed_heights
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_note_breakpoint_round_trip_restores_editor_focus_tuple() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "\n".join(f"paragraph {index}" for index in range(120))
+        body.move_cursor((18, 2))
+        body.move_cursor((24, 5), select=True)
+        body.scroll_to(y=12, animate=False, immediate=True)
+        body.focus()
+        await pilot.pause()
+        selection = body.selection
+        scroll_y = body.scroll_y
+        coordinator = screen._library_note_session
+
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        await pilot.resize_terminal(170, 48)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+
+        restored = screen.query_one("#library-note-body", TextArea)
+        assert screen._library_note_session is coordinator
+        assert screen.focused is restored
+        assert restored.selection == selection
+        assert restored.scroll_y == scroll_y
+        assert screen._library_note_session.snapshot.body == body.text
+
+
+@pytest.mark.asyncio
+async def test_library_note_deliberate_scroll_override_replaces_responsive_memory() -> (
+    None
+):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        await _open_note_editor(screen, pilot)
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "\n\n".join(
+            f"## section {index}\ncontent for section {index}" for index in range(60)
+        )
+        await pilot.pause()
+        screen.query_one("#library-note-preview").press()
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
+        preview = screen.query_one("#library-note-preview-region")
+        preview.focus()
+        screen._mark_library_notes_user_interaction()
+        preview.scroll_to(y=2, animate=False, force=True, immediate=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_last_user_scroll_focus is not None
+                and screen._library_notes_last_user_scroll_focus.semantic_role
+                == "preview-body"
+                and screen._library_notes_last_user_scroll_focus.scroll_offset == (0, 2)
+            ),
+            message="Preview scroll did not reach event-driven responsive memory.",
+        )
+
+        await pilot.resize_terminal(170, 48)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        assert screen.query_one("#library-note-preview-region").scroll_y == 2
+
+        await pilot.resize_terminal(170, 48)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        await pilot.pause()
+        preview = screen.query_one("#library-note-preview-region")
+        screen._mark_library_notes_user_interaction()
+        preview.scroll_to(y=0, animate=False, force=True, immediate=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_last_user_scroll_focus is not None
+                and screen._library_notes_last_user_scroll_focus.scroll_offset == (0, 0)
+            ),
+            message="Deliberate wide-layout scroll did not reach stable memory.",
+        )
+
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        assert screen.query_one("#library-note-preview-region").scroll_y == 0
+
+
+@pytest.mark.asyncio
+async def test_library_note_breakpoint_round_trips_restore_every_region_focus_role() -> (
+    None
+):
+    """Portable roles survive compact→wide→compact across the full workflow."""
+    notes = _two_notes() + [
+        {
+            "id": f"n-{index}",
+            "title": f"Archive note {index}",
+            "content": f"archived body {index}",
+            "last_modified": f"2026-06-{30 - index:02d}T12:00:00+00:00",
+            "version": 1,
+            "keywords": [],
+        }
+        for index in range(3, 18)
+    ]
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=notes)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+
+        async def round_trip(
+            selector: str, semantic_role: str, owner_region: str
+        ) -> None:
+            target = screen.query_one(selector)
+            owner = screen._library_notes_scroll_owner(owner_region)
+            screen._mark_library_notes_user_interaction()
+            target.focus(scroll_visible=False)
+            if owner is not None and int(owner.max_scroll_y) > 0:
+                owner.scroll_to(
+                    y=min(2, int(owner.max_scroll_y)),
+                    animate=False,
+                    force=True,
+                    immediate=True,
+                )
+            await pilot.pause()
+            await pilot.pause()
+            before = screen._capture_library_notes_focus_identity()
+            assert before.semantic_role == semantic_role
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_notes_interaction_focus is not None
+                    and screen._library_notes_interaction_focus.semantic_role
+                    == before.semantic_role
+                    and screen._library_notes_interaction_focus.scroll_offset
+                    == before.scroll_offset
+                ),
+                message=(
+                    f"{semantic_role} did not reach responsive interaction memory."
+                ),
+            )
+
+            await pilot.resize_terminal(170, 48)
+            await _wait_for_library_notes_compact(screen, pilot, False)
+            await pilot.pause()
+            await pilot.resize_terminal(60, 20)
+            await _wait_for_library_notes_compact(screen, pilot, True)
+            await pilot.pause()
+
+            after = screen._capture_library_notes_focus_identity()
+            assert after.semantic_role == semantic_role
+            assert screen.focused is screen._library_notes_role_target(before)
+            assert after.scroll_offset == before.scroll_offset, semantic_role
+
+        rail_row = screen.query_one(f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}")
+        await round_trip(
+            f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}",
+            f"library-row:{rail_row.row_id}",
+            "rail",
+        )
+        screen.query_one(f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        await round_trip("#library-notes-filter", "filter", "navigator")
+        note_row = screen.query_one("#library-notes-row-0")
+        await round_trip(
+            "#library-notes-row-0", f"note-row:{note_row.note_id}", "navigator"
+        )
+
+        note_row.press()
+        await _wait_for_selector(screen, pilot, "#library-note-body")
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "\n\n".join(
+            f"## section {index}\ncontent for section {index}" for index in range(60)
+        )
+        await pilot.pause()
+        await round_trip("#library-note-title", "title", "editor")
+
+        screen.query_one("#library-note-preview").press()
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
+        await round_trip("#library-note-preview-region", "preview-body", "preview")
+        await pilot.resize_terminal(170, 48)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        preview_region = screen.query_one("#library-note-preview-region")
+        screen._mark_library_notes_user_interaction()
+        preview_region.scroll_to(y=0, animate=False, force=True, immediate=True)
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        await pilot.pause()
+        assert screen.query_one("#library-note-preview-region").scroll_y == 0
+
+        screen.query_one("#library-note-context").press()
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+        await round_trip(
+            "#library-note-context-copy",
+            "context-action:library-note-context-copy",
+            "context",
+        )
+
+        await pilot.press("escape")
+        await pilot.press("escape")
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        await pilot.press("ctrl+n")
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        create_owner = screen._library_notes_scroll_owner("create")
+        assert create_owner is not None
+        assert int(create_owner.max_scroll_y) > 0
+        template = screen.query_one("#library-notes-template-0")
+        await round_trip(
+            "#library-notes-template-0",
+            f"create-template:{template.template_key}",
+            "create",
+        )
+
+        await pilot.press("escape")
+        await _wait_for_selector(screen, pilot, "#library-notes-sync-open")
+        screen.query_one("#library-notes-sync-open").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-sync-run")
+        sync_owner = screen._library_notes_scroll_owner("sync")
+        assert sync_owner is not None
+        assert int(sync_owner.max_scroll_y) > 0
+        screen._library_notes_sync_status = "running · 2 files"
+        screen._library_notes_sync_activity = ("Scanned notes", "Writing changes")
+        screen.refresh(recompose=True)
+        await _wait_for_selector(screen, pilot, "#library-notes-sync-run")
+
+        for selector, role in (
+            ("#library-notes-sync-folder", "sync-folder"),
+            (
+                "#library-notes-sync-direction-disk_to_db",
+                "sync-direction:disk_to_db",
+            ),
+            (
+                "#library-notes-sync-conflict-db_wins",
+                "sync-conflict-policy:db_wins",
+            ),
+            ("#library-notes-sync-auto", "sync-auto"),
+            ("#library-notes-sync-run", "sync-run"),
+        ):
+            await round_trip(selector, role, "sync")
+
+        status = str(screen.query_one("#library-notes-sync-status").renderable)
+        activity = str(screen.query_one("#library-notes-sync-activity").renderable)
+        assert status == "running · 2 files"
+        assert activity == "Scanned notes\nWriting changes"
+
+
+@pytest.mark.asyncio
+async def test_library_note_unsafe_session_outranks_rail_focus_on_compact_entry() -> (
+    None
+):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "dirty draft that must stay visible"
+        await pilot.pause()
+        screen.query_one(f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}").focus()
+
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+
+        assert screen._library_notes_stage == "notes"
+        assert screen.query_one("#library-canvas").display is True
+        assert screen.query_one("#library-rail").display is False
+        assert screen._library_note_session.snapshot.body == (
+            "dirty draft that must stay visible"
+        )
+        assert getattr(screen.focused, "id", None) == "library-note-body"
+
+
+@pytest.mark.asyncio
+async def test_library_note_delete_confirmation_outranks_rail_focus_on_compact_entry() -> (
+    None
+):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        screen.query_one("#library-note-delete").press()
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
+        screen.query_one(f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}").focus()
+
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+
+        assert screen._library_notes_stage == "notes"
+        assert screen._library_note_confirming_delete is True
+        assert screen.query_one("#library-note-delete-confirmation").display is True
+        assert getattr(screen.focused, "id", None) == "library-note-delete-cancel"
+
+
+@pytest.mark.asyncio
+async def test_library_note_load_failure_outranks_rail_focus_on_compact_entry() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = _FailingLibraryNoteDetailService(_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-row-0")
+        screen.query_one("#library-notes-row-0").press()
+        await _wait_for_selector(screen, pilot, "#library-note-load-retry")
+        screen.query_one(f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}").focus()
+
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+
+        assert screen._library_notes_stage == "notes"
+        assert screen._library_note_load_state == "failed"
+        assert screen.query_one("#library-canvas").display is True
+        assert screen.query_one("#library-rail").display is False
+        assert screen.query_one("#library-note-load-retry").display is True
+        assert getattr(screen.focused, "id", None) == "library-note-load-retry"
+
+
+@pytest.mark.asyncio
+async def test_library_note_newer_selection_cancels_pending_back_focus() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-row-0")
+        screen._library_notes_pending_focus_identity = LibraryNotesFocusIdentity(
+            stage="notes",
+            region="navigator",
+            note_id="n-1",
+            semantic_role="note-row:n-1",
+        )
+        screen._library_notes_pending_focus_waits_for_snapshot = True
+
+        screen.query_one("#library-notes-row-1").press()
+        await _wait_for_selector(screen, pilot, "#library-note-body")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_note_session.snapshot is not None
+                and screen._library_note_session.snapshot.note_id == "n-2"
+            ),
+            message="Newer note selection did not open its editor session.",
+        )
+        screen._release_library_notes_focus_after_snapshot()
+        await pilot.pause()
+
+        assert screen._library_notes_pending_focus_identity is None
+        assert screen._library_note_session.snapshot.note_id == "n-2"
+        assert screen._library_notes_focus_region() == "editor"
+        assert getattr(screen.focused, "id", None) == "library-note-body"
+
+
+@pytest.mark.asyncio
+async def test_library_note_sync_routes_cancel_pending_navigator_focus() -> None:
+    """Sync open/back supersede a late note-row focus from an older Back."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-sync-open")
+
+        def seed_pending_back_focus() -> None:
+            screen._library_notes_pending_focus_identity = LibraryNotesFocusIdentity(
+                stage="notes",
+                region="navigator",
+                note_id="n-1",
+                semantic_role="note-row:n-1",
+            )
+            screen._library_notes_pending_focus_waits_for_snapshot = True
+            screen._library_notes_pending_focus_generation = (
+                screen._library_notes_navigation_generation
+            )
+
+        seed_pending_back_focus()
+        screen.query_one("#library-notes-sync-open").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-sync-back")
+        assert screen._library_notes_pending_focus_identity is None
+
+        seed_pending_back_focus()
+        screen.query_one("#library-notes-sync-back").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        screen._release_library_notes_focus_after_snapshot()
+        await pilot.pause()
+
+        assert screen._library_notes_pending_focus_identity is None
+        assert screen._library_notes_view == "list"
+        assert getattr(screen.focused, "id", None) == "library-notes-filter"
+
+
+@pytest.mark.asyncio
+async def test_library_note_wide_rail_recompose_restores_rail_focus_and_scroll() -> (
+    None
+):
+    """Wide rail tuples keep their own scroll owner across whole recomposes."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 24)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+
+        rail = screen.query_one("#library-rail")
+        assert int(rail.max_scroll_y) > 0
+        row = screen.query_one("#library-row-browse-notes")
+        screen._mark_library_notes_user_interaction()
+        row.focus(scroll_visible=False)
+        rail.scroll_to(y=2, animate=False, force=True, immediate=True)
+        await pilot.pause()
+        before = screen._capture_library_notes_focus_identity()
+        assert before.stage == "rail"
+        assert before.scroll_offset == (0, 2)
+
+        screen.refresh(recompose=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                bool(screen.query("#library-rail"))
+                and screen.query("#library-rail").first() is not rail
+                and screen._library_notes_semantic_role(screen.focused)
+                == "library-row:browse-notes"
+            ),
+            message="Wide rail recompose did not restore its semantic focus.",
+        )
+        await pilot.pause()
+
+        restored = screen._capture_library_notes_focus_identity()
+        assert restored.stage == "rail"
+        assert restored.scroll_offset == before.scroll_offset
+
+
+@pytest.mark.asyncio
+async def test_library_note_user_focus_vetoes_stale_deferred_restore() -> None:
+    """A later Tab/click intent cannot be stolen by an older restore turn."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "\n".join(f"focus guard line {index}" for index in range(100))
+        await pilot.pause()
+        body.scroll_to(y=9, animate=False, force=True, immediate=True)
+        body.focus()
+        await pilot.pause()
+        stale_identity = screen._capture_library_notes_focus_identity()
+        assert stale_identity.scroll_offset == (0, 9)
+        stale_generation = screen._library_notes_focus_intent_generation
+        guard = library_screen_module._LibraryNotesRestoreGuard(
+            focus_generation=stale_generation
+        )
+
+        screen.query_one("#library-note-preview").press()
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
+        preview = screen.query_one("#library-note-preview-region")
+        screen._mark_library_notes_user_interaction()
+        preview.focus()
+        preview.scroll_to(y=2, animate=False, force=True, immediate=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen.focused is preview
+                and screen._library_notes_focus_intent_generation > stale_generation
+            ),
+            message="User focus intent did not advance its generation.",
+        )
+
+        screen._restore_library_notes_settled_focus(stale_identity, guard)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen.focused is preview
+        assert screen._library_notes_semantic_role(screen.focused) == "preview-body"
+        assert preview.scroll_y == 2
+
+
+@pytest.mark.asyncio
+async def test_library_note_whole_screen_recompose_restores_canonical_draft_and_focus() -> (
+    None
+):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        coordinator = screen._library_note_session
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "\n".join(f"recompose line {index}" for index in range(100))
+        body.move_cursor((14, 1))
+        body.move_cursor((20, 4), select=True)
+        body.scroll_to(y=9, animate=False, immediate=True)
+        body.focus()
+        await pilot.pause()
+        revision = coordinator.snapshot.draft_revision
+        selection = body.selection
+        scroll_y = body.scroll_y
+
+        screen.refresh(recompose=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                bool(list(screen.query("#library-note-body")))
+                and list(screen.query("#library-note-body"))[0] is not body
+            ),
+            message="Whole-screen recompose did not replace the Notes canvas.",
+        )
+        await pilot.pause()
+
+        restored = screen.query_one("#library-note-body", TextArea)
+        assert screen._library_note_session is coordinator
+        assert coordinator.snapshot.draft_revision == revision
+        assert restored.text == coordinator.snapshot.body
+        assert restored.selection == selection
+        assert restored.scroll_y == scroll_y
+        assert screen.focused is restored
+
+
+@pytest.mark.asyncio
+async def test_library_note_stale_recompose_capture_cannot_rewind_newer_presentation() -> (
+    None
+):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        stale = screen._capture_library_notes_recompose_state()
+        assert stale is not None
+
+        screen.query_one("#library-note-body", TextArea).text = "newer draft"
+        await pilot.pause()
+        screen.query_one("#library-note-preview").press()
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
+        newer_revision = screen._library_note_session.snapshot.draft_revision
+        assert newer_revision > stale.draft_revision
+
+        screen._library_note_editor_armed = False
+        body = screen.query_one("#library-note-body", TextArea)
+        with body.prevent(TextArea.Changed):
+            body.text = "stale rendered draft"
+        screen._rehydrate_library_notes_after_recompose(stale)
+        await pilot.pause()
+
+        assert screen._library_note_session.snapshot.body == "newer draft"
+        assert screen._library_note_session.snapshot.draft_revision == newer_revision
+        assert screen.query_one("#library-note-body", TextArea).text == "newer draft"
+        assert screen._library_note_editor_armed is True
+        assert screen._library_note_preview is True
+        assert screen.query_one("#library-note-preview-region").display is True
+
+
+@pytest.mark.asyncio
+async def test_library_note_recompose_captures_queued_widget_change_before_disarm() -> (
+    None
+):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "queued draft before recompose"
+
+        screen.refresh(recompose=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                bool(list(screen.query("#library-note-body")))
+                and list(screen.query("#library-note-body"))[0] is not body
+            ),
+            message="Whole-screen recompose did not replace the Notes editor.",
+        )
+        await pilot.pause()
+
+        snapshot = screen._library_note_session.snapshot
+        assert snapshot is not None
+        assert snapshot.body == "queued draft before recompose"
+        assert screen.query_one("#library-note-body", TextArea).text == snapshot.body
+        assert screen._library_note_editor_armed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("presentation", "focus_selector", "semantic_role"),
+    (
+        ("editor", "#library-note-title", "title"),
+        ("editor", "#library-note-save", "save"),
+        ("preview", "#library-note-preview-region", "preview-body"),
+        (
+            "context",
+            "#library-note-context-copy",
+            "context-action:library-note-context-copy",
+        ),
+    ),
+)
+async def test_library_note_recompose_preserves_body_selection_off_body_focus(
+    presentation: str, focus_selector: str, semantic_role: str
+) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "\n".join(f"selection line {index}" for index in range(30))
+        body.move_cursor((5, 2))
+        body.move_cursor((9, 7), select=True)
+        await pilot.pause()
+        selection = body.selection
+
+        if presentation == "preview":
+            screen.query_one("#library-note-preview").press()
+            await _wait_for_display(screen, pilot, "#library-note-preview-region")
+        elif presentation == "context":
+            screen.query_one("#library-note-context").press()
+            await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one(focus_selector).focus()
+        await pilot.pause()
+
+        screen.refresh(recompose=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                bool(list(screen.query("#library-note-body")))
+                and list(screen.query("#library-note-body"))[0] is not body
+            ),
+            message="Whole-screen recompose did not replace the Notes editor.",
+        )
+        await pilot.pause()
+
+        assert screen.query_one("#library-note-body", TextArea).selection == selection
+        assert screen._library_notes_semantic_role(screen.focused) == semantic_role
+
+
+@pytest.mark.asyncio
+async def test_library_note_local_shortcuts_are_region_scoped_and_flush_guarded() -> (
+    None
+):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+
+        selected_before = screen._library_selected_row_id
+        await pilot.press("ctrl+n")
+        await pilot.pause()
+        assert screen._library_selected_row_id == selected_before
+
+        screen.query_one(f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        screen.query_one("#library-notes-new").focus()
+        await pilot.press("/")
+        await pilot.pause()
+        assert getattr(screen.focused, "id", None) == "library-notes-filter"
+
+        filter_input = screen.query_one("#library-notes-filter", Input)
+        await pilot.press("/")
+        await pilot.pause()
+        assert filter_input.value == "/"
+
+        filter_input.value = ""
+        screen.query_one("#library-notes-row-0").press()
+        await _wait_for_selector(screen, pilot, "#library-note-body")
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "save before opening Create"
+        await pilot.pause()
+        saves_before = len(app.notes_scope_service.save_calls)
+
+        await pilot.press("ctrl+n")
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        assert len(app.notes_scope_service.save_calls) == saves_before + 1
+        assert screen._library_selected_row_id == LIBRARY_ROW_CREATE_NOTE
+
+
+@pytest.mark.asyncio
+async def test_library_note_shortcut_navigation_cannot_bypass_failed_flush() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "unsaved shortcut draft"
+        await pilot.pause()
+
+        async def failing_save(**kwargs):
+            del kwargs
+            raise RuntimeError("shortcut flush outage")
+
+        app.notes_scope_service.save_note = failing_save
+
+        await pilot.press("ctrl+n")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_autosave_state == "error",
+            message="Ctrl+N did not surface its failed flush.",
+        )
+        assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+        assert screen._library_notes_view == "editor"
+        assert screen._library_note_session.snapshot.body == "unsaved shortcut draft"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+        assert screen._library_notes_view == "editor"
+        assert screen._library_note_session.snapshot.dirty is True
+
+
+@pytest.mark.asyncio
+async def test_library_note_footer_tracks_editor_states_and_ancillary_contents() -> (
+    None
+):
+    """Compact local help follows editor state without erasing footer metrics."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+
+        def footer_shortcuts() -> str:
+            footers = list(screen.query(AppFooterStatus))
+            return footers[0].shortcut_text if footers else ""
+
+        async def wait_footer(expected: str) -> None:
+            await _wait_for_condition(
+                pilot,
+                lambda: footer_shortcuts() == expected,
+                message=f"Footer did not settle to {expected!r}.",
+            )
+
+        await _open_note_editor(screen, pilot)
+        await wait_footer("Ctrl+S Save · Esc Notes")
+        footer = screen.query_one(AppFooterStatus)
+        footer.update_word_count(12)
+        footer.update_token_count("Tokens: 34")
+        footer.update_db_sizes_display("DB 2 MB")
+        ancillary = (
+            screen.query_one("#footer-word-count", Static),
+            screen.query_one("#footer-token-count", Static),
+            screen.query_one("#internal-db-size-indicator", Static),
+        )
+        contents = tuple(
+            getattr(widget.renderable, "plain", str(widget.renderable))
+            for widget in ancillary
+        )
+        assert all(widget.display is False for widget in ancillary)
+
+        screen.query_one("#library-note-preview").press()
+        await wait_footer("Pg Scroll · Esc Notes")
+        screen.query_one("#library-note-context").press()
+        await wait_footer("Enter Act · Esc Note")
+
+        await pilot.resize_terminal(170, 48)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        assert all(widget.display is True for widget in ancillary)
+        assert (
+            tuple(
+                getattr(widget.renderable, "plain", str(widget.renderable))
+                for widget in ancillary
+            )
+            == contents
+        )
+
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        screen.query_one("#library-note-context-delete").press()
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
+        await wait_footer("Enter Confirm · Esc Cancel")
+        await pilot.press("escape")
+        await wait_footer("Enter Act · Esc Note")
+        await pilot.press("escape")
+        await wait_footer("Pg Scroll · Esc Notes")
+        screen.query_one("#library-note-preview").press()
+        await wait_footer("Ctrl+S Save · Esc Notes")
+
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "local conflict text"
+        await pilot.pause()
+        _bump_note_version_externally(app.notes_scope_service, "n-1")
+        await pilot.press("ctrl+s")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_session.snapshot.in_conflict,
+            message="Ctrl+S did not surface the expected conflict.",
+        )
+        await wait_footer("Enter Choose · Esc Locked")
+        await pilot.press("ctrl+s")
+        await _wait_for_condition(
+            pilot,
+            lambda: "Save locked" in screen._library_note_shortcut_status,
+            message="Conflict shortcut refusal did not become visible.",
+        )
+
+        screen.query_one("#library-note-conflict-reload").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                not screen._library_note_session.snapshot.in_conflict
+                and not screen._library_note_session.conflict_resolution_running
+            ),
+            message="Reload did not resolve the conflict.",
+        )
+        await wait_footer("Ctrl+S Save · Esc Notes")
+        assert screen._library_note_shortcut_status == ""
+
+
+@pytest.mark.asyncio
+async def test_library_note_footer_covers_navigator_create_sync_and_exit() -> None:
+    """Navigator substates and sibling Notes stages publish exact local help."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+
+        def footer_shortcuts() -> str:
+            footers = list(screen.query(AppFooterStatus))
+            return footers[0].shortcut_text if footers else ""
+
+        async def wait_footer(expected: str) -> None:
+            await _wait_for_condition(
+                pilot,
+                lambda: footer_shortcuts() == expected,
+                message=f"Footer did not settle to {expected!r}.",
+            )
+
+        screen.query_one(f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        await wait_footer("Ctrl+N New · / Find · Esc Library")
+
+        screen.query_one("#library-notes-select-toggle").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-selection-actions")
+        await wait_footer("Enter Select · Esc Done")
+        await pilot.press("escape")
+        await wait_footer("Ctrl+N New · / Find · Esc Library")
+
+        screen.query_one("#library-notes-sort").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-sort-choices")
+        await wait_footer("Enter Choose · Esc Cancel")
+        await pilot.press("escape")
+        await wait_footer("Ctrl+N New · / Find · Esc Library")
+
+        await pilot.press("ctrl+n")
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        await wait_footer("Enter Create · Esc Notes")
+        await pilot.press("escape")
+        await _wait_for_selector(screen, pilot, "#library-notes-sync-open")
+        await wait_footer("Ctrl+N New · / Find · Esc Library")
+
+        screen.query_one("#library-notes-sync-open").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-sync-run")
+        await wait_footer("Enter Act · Esc Notes")
+        await pilot.press("escape")
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        await wait_footer("Ctrl+N New · / Find · Esc Library")
+
+        await pilot.press("escape")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_notes_stage == "rail",
+            message="Navigator Escape did not return to the Library rail.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: "use Library context in Console" in footer_shortcuts(),
+            message="Library footer guidance did not restore after Notes exit.",
+        )
+        assert all(
+            screen.query_one(selector).display is True
+            for selector in (
+                "#footer-word-count",
+                "#footer-token-count",
+                "#internal-db-size-indicator",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_note_ctrl_s_saves_from_editor_preview_and_context() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "saved from editor"
+        await pilot.pause()
+        saves = len(app.notes_scope_service.save_calls)
+        await pilot.press("ctrl+s")
+        await _wait_for_condition(
+            pilot,
+            lambda: len(app.notes_scope_service.save_calls) == saves + 1,
+            message="Ctrl+S did not save from Editor.",
+        )
+
+        body.text = "saved from preview"
+        await pilot.pause()
+        screen.query_one("#library-note-preview").press()
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
+        saves = len(app.notes_scope_service.save_calls)
+        await pilot.press("ctrl+s")
+        await _wait_for_condition(
+            pilot,
+            lambda: len(app.notes_scope_service.save_calls) == saves + 1,
+            message="Ctrl+S did not save from Preview.",
+        )
+
+        screen.query_one("#library-note-context").press()
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one(
+            "#library-note-context-keywords", Input
+        ).value = "shortcut, context"
+        await pilot.pause()
+        saves = len(app.notes_scope_service.save_calls)
+        await pilot.press("ctrl+s")
+        await _wait_for_condition(
+            pilot,
+            lambda: len(app.notes_scope_service.save_calls) == saves + 1,
+            message="Ctrl+S did not save from Context.",
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_note_escape_hierarchy_cannot_bypass_conflict() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        screen.query_one("#library-note-context").press()
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen.query_one("#library-note-context-region").display is False
+        assert screen._library_notes_view == "editor"
+
+        screen.query_one("#library-note-context").press()
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one("#library-note-context-delete").press()
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        assert "Save locked" in screen._library_note_shortcut_status
+        assert screen._library_note_confirming_delete is True
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen._library_note_confirming_delete is False
+        assert screen._library_note_context is True
+        assert screen._library_note_shortcut_status == ""
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen._library_note_context is False
+
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "local conflict text"
+        await pilot.pause()
+        _bump_note_version_externally(app.notes_scope_service, "n-1")
+        await pilot.press("ctrl+s")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_session.snapshot.in_conflict,
+            message="Ctrl+S did not surface the expected conflict.",
+        )
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen._library_notes_view == "editor"
+        assert screen._library_notes_stage == "notes"
+        assert screen._library_note_session.snapshot.in_conflict is True
+        assert screen.query_one("#library-note-conflict-region").display is True
+        assert "Conflict locked" in screen._library_note_shortcut_status
+
+        screen.query_one("#library-note-conflict-reload").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                not screen._library_note_session.snapshot.in_conflict
+                and not screen._library_note_session.conflict_resolution_running
+            ),
+            message="Reload did not resolve the conflict after Escape refusal.",
+        )
+        assert screen._library_note_shortcut_status == ""

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -7201,11 +7201,8 @@ async def test_library_shell_notes_row_opens_notes_list_canvas():
 
 
 @pytest.mark.asyncio
-async def test_library_shell_notes_list_toolbar_is_one_horizontal_row():
-    """(task-184) sort/Sync/Import note/Export… share a single horizontal
-    ds-toolbar row -- the previous bare stacked Buttons rendered as an
-    overlapped vertical pile eating into the first list row (2026-07 UAT
-    capture notes-list-toolbar-stack-markup-eaten)."""
+async def test_library_shell_notes_list_actions_use_two_named_horizontal_rows():
+    """Navigator actions stay grouped without overlapping the note list."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
     host = LibraryHarness(app)
@@ -7216,24 +7213,39 @@ async def test_library_shell_notes_list_toolbar_is_one_horizontal_row():
         screen.query_one("#library-row-browse-notes").press()
         await _wait_for_selector(screen, pilot, "#library-notes-row-0")
 
-        toolbar = screen.query_one("#library-notes-sort").parent
-        assert toolbar is not None and toolbar.has_class("ds-toolbar")
-        selectors = (
+        browse_toolbar = screen.query_one("#library-notes-browse-actions")
+        transfer_toolbar = screen.query_one("#library-notes-transfer-actions")
+        assert browse_toolbar.has_class("ds-toolbar")
+        assert transfer_toolbar.has_class("ds-toolbar")
+
+        browse_selectors = (
+            "#library-notes-new",
             "#library-notes-sort",
+            "#library-notes-select-toggle",
+        )
+        transfer_selectors = (
             "#library-notes-sync-open",
             "#library-notes-import",
             "#library-notes-export",
         )
-        for selector in selectors:
-            assert screen.query_one(selector).parent is toolbar
-        # All four occupy the same single row (real app CSS is loaded by
-        # this harness): no vertical stacking, no overlap with each other
-        # or the first list row below.
-        rows = {screen.query_one(selector).region.y for selector in selectors}
-        assert len(rows) == 1
-        toolbar_y = rows.pop()
+        for selector in browse_selectors:
+            assert screen.query_one(selector).parent is browse_toolbar
+        for selector in transfer_selectors:
+            assert screen.query_one(selector).parent is transfer_toolbar
+
+        browse_rows = {
+            screen.query_one(selector).region.y for selector in browse_selectors
+        }
+        transfer_rows = {
+            screen.query_one(selector).region.y for selector in transfer_selectors
+        }
+        assert len(browse_rows) == 1
+        assert len(transfer_rows) == 1
+        browse_y = browse_rows.pop()
+        transfer_y = transfer_rows.pop()
+        assert transfer_y > browse_y
         first_row_y = screen.query_one("#library-notes-row-0").region.y
-        assert first_row_y > toolbar_y
+        assert first_row_y > transfer_y
 
 
 @pytest.mark.asyncio
@@ -7279,7 +7291,7 @@ async def test_library_shell_notes_list_renders_bracketed_titles_verbatim():
 
 
 @pytest.mark.asyncio
-async def test_library_shell_notes_sort_button_cycles():
+async def test_library_shell_notes_sort_opens_direct_choices_and_applies_one_value():
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
     host = LibraryHarness(app)
@@ -7290,8 +7302,116 @@ async def test_library_shell_notes_sort_button_cycles():
         await _wait_for_selector(screen, pilot, "#library-notes-sort")
         assert screen._library_notes_sort == "newest"
         screen.query_one("#library-notes-sort").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-sort-oldest")
+        assert {
+            button.id for button in screen.query("#library-notes-sort-choices Button")
+        } == {
+            "library-notes-sort-newest",
+            "library-notes-sort-oldest",
+            "library-notes-sort-title",
+        }
+        screen.query_one("#library-notes-sort-oldest").press()
         await pilot.pause()
         assert screen._library_notes_sort == "oldest"
+        assert not screen.query("#library-notes-sort-choices")
+
+
+@pytest.mark.asyncio
+async def test_library_shell_notes_navigator_has_named_action_groups_and_filter_label():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-browse-actions")
+
+        assert (
+            str(screen.query_one("#library-notes-filter-label", Static).renderable)
+            == "Filter"
+        )
+        assert {
+            button.id for button in screen.query("#library-notes-browse-actions Button")
+        } == {
+            "library-notes-new",
+            "library-notes-sort",
+            "library-notes-select-toggle",
+        }
+        assert {
+            button.id
+            for button in screen.query("#library-notes-transfer-actions Button")
+        } == {
+            "library-notes-sync-open",
+            "library-notes-import",
+            "library-notes-export",
+        }
+
+
+@pytest.mark.asyncio
+async def test_library_shell_notes_empty_source_keeps_new_action_visible():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=[])
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        empty = await _wait_for_selector(screen, pilot, "#library-notes-empty")
+
+        assert str(empty.renderable) == "No notes yet. Create your first note."
+        assert screen.query_one("#library-notes-new", Button).disabled is False
+
+
+@pytest.mark.asyncio
+async def test_library_shell_notes_filtered_empty_keeps_clear_and_source_truth():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        box = await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        box.value = "no such note"
+        box.focus()
+        await pilot.press("enter")
+        empty = await _wait_for_selector(screen, pilot, "#library-notes-empty")
+
+        assert str(empty.renderable) == (
+            "No notes match “no such note”. Clear the filter."
+        )
+        assert "No notes yet" not in _visible_text(screen)
+        screen.query_one("#library-notes-filter-clear", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-notes-row-0")
+        assert screen._library_notes_filter == ""
+
+
+@pytest.mark.asyncio
+async def test_library_shell_notes_multiselect_replaces_normal_action_groups():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-select-toggle")
+        screen.query_one("#library-notes-select-toggle").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-selection-actions")
+
+        assert not screen.query("#library-notes-browse-actions")
+        assert not screen.query("#library-notes-transfer-actions")
+        assert len(list(screen.query("#library-notes-selection-actions"))) == 1
+        assert len(list(screen.query("#library-notes-selection-status"))) == 1
+        assert (
+            str(screen.query_one("#library-notes-selection-status", Static).renderable)
+            == "0 selected"
+        )
 
 
 @pytest.mark.asyncio
@@ -10341,6 +10461,21 @@ async def test_library_shell_note_export_pushes_file_save_dialog(
 
         dialog = host.screen_stack[-1]
         assert dialog._default_file == expected_file
+        assert screen._library_notes_operation is not None
+        assert screen._library_notes_operation.running is True
+        status_selector = (
+            "#library-note-context-transfer-status"
+            if "context" in action_selector
+            else "#library-note-transfer-status"
+        )
+        assert str(screen.query_one(status_selector, Static).renderable) == "Export…"
+        for selector in (
+            "#library-note-use-in-console",
+            "#library-note-export-md",
+            "#library-note-export-txt",
+            "#library-note-copy",
+        ):
+            assert screen.query_one(selector, Button).disabled is True
 
         await host.pop_screen()
         await pilot.pause()
@@ -10383,6 +10518,10 @@ async def test_library_shell_note_write_export_file_writes_expected_content(tmp_
         assert written.endswith("alpha budget line")
         app.notify.assert_called_once()
         assert "exported successfully" in app.notify.call_args.args[0]
+        assert (
+            str(screen.query_one("#library-note-transfer-status", Static).renderable)
+            == "Export complete."
+        )
 
 
 @pytest.mark.asyncio
@@ -10423,6 +10562,10 @@ async def test_library_shell_note_write_export_file_rejects_invalid_path(
         args, kwargs = app.notify.call_args
         assert "Rejected export path" in args[0]
         assert kwargs.get("severity") == "warning"
+        assert (
+            str(screen.query_one("#library-note-transfer-status", Static).renderable)
+            == "Export failed — choose another destination and try again."
+        )
 
 
 @pytest.mark.asyncio
@@ -10449,6 +10592,15 @@ async def test_library_shell_note_copy_calls_clipboard_seam(action_selector):
         screen.query_one(action_selector).press()
         await pilot.pause()
 
+        status_selector = (
+            "#library-note-context-transfer-status"
+            if "context" in action_selector
+            else "#library-note-transfer-status"
+        )
+        assert str(screen.query_one(status_selector, Static).renderable) == (
+            "Copy complete."
+        )
+
     app.copy_to_clipboard.assert_called_once()
     copied = app.copy_to_clipboard.call_args.args[0]
     assert copied.startswith("---\n")
@@ -10456,6 +10608,30 @@ async def test_library_shell_note_copy_calls_clipboard_seam(action_selector):
     assert "alpha budget line" in copied
     app.notify.assert_called_once()
     assert "copied to clipboard" in app.notify.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_library_shell_note_copy_failure_stays_visible_with_recovery():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.copy_to_clipboard = Mock(side_effect=RuntimeError("clipboard unavailable"))
+    app.notify = Mock()
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        screen.query_one("#library-note-copy").press()
+        await pilot.pause()
+
+        assert (
+            str(screen.query_one("#library-note-transfer-status", Static).renderable)
+            == "Copy failed — check clipboard access and try again."
+        )
+        assert screen._library_notes_operation is not None
+        assert screen._library_notes_operation.running is False
 
 
 @pytest.mark.asyncio
@@ -10489,6 +10665,15 @@ async def test_library_shell_note_use_in_console_triggers_handoff(action_selecto
         await pilot.pause()
         await pilot.pause()
 
+        status_selector = (
+            "#library-note-context-transfer-status"
+            if "context" in action_selector
+            else "#library-note-transfer-status"
+        )
+        assert str(screen.query_one(status_selector, Static).renderable) == (
+            "Use in Console complete."
+        )
+
     app.open_chat_with_handoff.assert_called_once()
     payload = app.open_chat_with_handoff.call_args.args[0]
     assert payload.source == "notes"
@@ -10497,6 +10682,34 @@ async def test_library_shell_note_use_in_console_triggers_handoff(action_selecto
     assert payload.title == "Q3 retro"
     assert "alpha budget line" in payload.body
     assert payload.metadata["note_version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_library_shell_note_console_failure_stays_visible_with_recovery():
+    app = _build_test_app()
+    _seed_conversations(app, [], notes=_two_notes()[:1])
+    app.open_chat_with_handoff = Mock(side_effect=RuntimeError("Console unavailable"))
+    app.notify = Mock()
+    _link_library_items_to_active_workspace(
+        app,
+        (("note", "n-1", "Q3 retro"),),
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        screen.query_one("#library-note-use-in-console").press()
+        await pilot.pause()
+
+        assert (
+            str(screen.query_one("#library-note-transfer-status", Static).renderable)
+            == "Use in Console failed — check Console readiness and try again."
+        )
+        assert screen._library_notes_operation is not None
+        assert screen._library_notes_operation.running is False
 
 
 @pytest.mark.asyncio
@@ -10570,6 +10783,312 @@ async def test_library_shell_create_note_row_renders_blank_and_template_rows():
 
 
 @pytest.mark.asyncio
+async def test_library_shell_create_back_returns_to_notes_navigator():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-new")
+        screen.query_one("#library-notes-new").press()
+        back = await _wait_for_selector(screen, pilot, "#library-notes-create-back")
+
+        back.press()
+        await _wait_for_selector(screen, pilot, "#library-notes-browse-actions")
+        assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+
+
+class _GatedCreateLibraryNotesScopeService(StaticLibraryNotesScopeService):
+    def __init__(self, notes):
+        super().__init__(notes)
+        self.create_attempts = 0
+        self.create_started = threading.Event()
+        self.create_release = threading.Event()
+
+    async def save_note(self, **kwargs):
+        if kwargs.get("note_id") is None:
+            self.create_attempts += 1
+            self.create_started.set()
+            await asyncio.to_thread(
+                self.create_release.wait, _GATED_RELEASE_TIMEOUT_SECONDS
+            )
+        return await super().save_note(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_library_shell_create_is_single_flight_and_disables_all_choices():
+    app = _build_test_app()
+    service = _GatedCreateLibraryNotesScopeService(_two_notes())
+    app.notes_scope_service = service
+    app.notes_service = StaticLibraryNotesKeywordsService({})
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        _two_conversations()
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-create-note").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+
+        screen.query_one("#library-notes-create-blank").press()
+        try:
+            await _wait_for_condition(
+                pilot,
+                service.create_started.is_set,
+                message="Create service never entered its gated call.",
+            )
+            assert screen._library_note_create_running is True
+            assert (
+                screen.query_one("#library-notes-create-blank", Button).disabled is True
+            )
+            assert all(
+                button.disabled
+                for button in screen.query(".library-notes-template-row")
+            )
+            screen.query_one("#library-notes-create-blank").press()
+            await pilot.pause()
+            assert service.create_attempts == 1
+        finally:
+            service.create_release.set()
+
+        await _wait_for_selector(screen, pilot, "#library-note-title")
+
+
+class _FailingCreateLibraryNotesScopeService(StaticLibraryNotesScopeService):
+    async def save_note(self, **kwargs):
+        if kwargs.get("note_id") is None:
+            self.save_calls.append(dict(kwargs))
+            raise RuntimeError("database unavailable")
+        return await super().save_note(**kwargs)
+
+
+class _CreateThenFailFirstOpenLibraryNotesScopeService(StaticLibraryNotesScopeService):
+    """Persist a create, then make only its first detail load unavailable."""
+
+    def __init__(self, notes):
+        super().__init__(notes)
+        self.failed_created_load = False
+
+    async def get_note_detail(self, *, scope, note_id, user_id=None, **kwargs):
+        if (
+            self.save_calls
+            and str(note_id) == str(self.notes[-1].get("id"))
+            and not self.failed_created_load
+        ):
+            self.failed_created_load = True
+            self.detail_calls.append(
+                {"scope": scope, "note_id": note_id, "user_id": user_id, **kwargs}
+            )
+            return None
+        return await super().get_note_detail(
+            scope=scope, note_id=note_id, user_id=user_id, **kwargs
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_shell_failed_create_stays_create_with_actionable_status():
+    app = _build_test_app()
+    service = _FailingCreateLibraryNotesScopeService(_two_notes())
+    app.notes_scope_service = service
+    app.notes_service = StaticLibraryNotesKeywordsService({})
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        _two_conversations()
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-create-note").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        screen.query_one("#library-notes-create-blank").press()
+
+        await _wait_for_selector(screen, pilot, "#library-notes-create-status")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                "failed"
+                in str(
+                    screen.query_one("#library-notes-create-status", Static).renderable
+                ).lower()
+            ),
+            message="Create failure never reached the visible status line.",
+        )
+        status = screen.query_one("#library-notes-create-status", Static)
+        assert screen._library_selected_row_id == LIBRARY_ROW_CREATE_NOTE
+        assert "try again" in str(status.renderable).lower()
+        assert screen.query_one("#library-notes-create-blank", Button).disabled is False
+
+
+@pytest.mark.asyncio
+async def test_library_shell_persisted_create_with_open_failure_recovers_from_navigator():
+    app = _build_test_app()
+    service = _CreateThenFailFirstOpenLibraryNotesScopeService(_two_notes())
+    app.notes_scope_service = service
+    app.notes_service = StaticLibraryNotesKeywordsService({})
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        _two_conversations()
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-create-note").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+
+        screen.query_one("#library-notes-create-blank").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-browse-actions")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                "Note created"
+                in str(screen.query_one("#library-notes-status", Static).renderable)
+            ),
+            message="Persisted create did not expose honest Navigator recovery.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._local_source_counts.get("notes") == 3,
+            message="Persisted create was not refreshed into Navigator.",
+        )
+
+        assert len(service.save_calls) == 1
+        created_id = str(service.notes[-1]["id"])
+        created_row = next(
+            row
+            for row in screen.query(".library-notes-row")
+            if str(getattr(row, "note_id", "")) == created_id
+        )
+        created_row.press()
+        await _wait_for_selector(screen, pilot, "#library-note-title")
+
+        assert screen._selected_note_id == created_id
+        assert len(service.save_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_library_shell_transforming_template_is_vetoed_before_create_service(
+    monkeypatch,
+):
+    from tldw_chatbook.Event_Handlers import notes_events
+
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    monkeypatch.setitem(
+        notes_events.NOTE_TEMPLATES,
+        "invalid-transforming",
+        {
+            "name": "Invalid transforming payload",
+            "title": " padded title ",
+            "content": "raw body",
+            "keywords": "one, two",
+        },
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-create-note").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        invalid = next(
+            button
+            for button in screen.query(".library-notes-template-row")
+            if getattr(button, "template_key", "") == "invalid-transforming"
+        )
+        invalid.press()
+
+        await _wait_for_selector(screen, pilot, "#library-notes-create-status")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                "whitespace"
+                in str(
+                    screen.query_one("#library-notes-create-status", Static).renderable
+                ).lower()
+            ),
+            message="Raw template validation veto never became visible.",
+        )
+        assert app.notes_scope_service.save_calls == []
+        assert screen._library_selected_row_id == LIBRARY_ROW_CREATE_NOTE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("template_key", "template"),
+    (
+        (
+            "missing-title",
+            {"description": "Missing title", "content": "body", "keywords": ""},
+        ),
+        (
+            "non-text-title",
+            {"title": 7, "content": "body", "keywords": ""},
+        ),
+        (
+            "missing-content",
+            {"title": "Title", "keywords": ""},
+        ),
+        (
+            "non-text-content",
+            {"title": "Title", "content": {"body": "value"}, "keywords": ""},
+        ),
+        (
+            "non-text-keywords",
+            {"title": "Title", "content": "body", "keywords": ["valid", 7]},
+        ),
+    ),
+)
+async def test_library_shell_malformed_template_shapes_never_reach_create_service(
+    monkeypatch, template_key, template
+):
+    from tldw_chatbook.Event_Handlers import notes_events
+
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    monkeypatch.setitem(notes_events.NOTE_TEMPLATES, template_key, template)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-create-note").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        malformed = next(
+            button
+            for button in screen.query(".library-notes-template-row")
+            if getattr(button, "template_key", "") == template_key
+        )
+
+        malformed.press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                bool(app.notes_scope_service.save_calls)
+                or any(
+                    "must be text" in str(status.renderable).lower()
+                    for status in screen.query("#library-notes-create-status")
+                )
+            ),
+            message="Malformed template produced neither a veto nor a service call.",
+        )
+
+        assert app.notes_scope_service.save_calls == []
+        assert screen._library_selected_row_id == LIBRARY_ROW_CREATE_NOTE
+        status = screen.query_one("#library-notes-create-status", Static)
+        assert "must be text" in str(status.renderable).lower()
+
+
+@pytest.mark.asyncio
 async def test_library_shell_create_blank_note_lands_in_editor():
     """Pressing Blank note calls ``save_note`` with ``note_id=None`` and
     ``title="Untitled"`` (the row still commits immediately -- LIB-14's
@@ -10609,6 +11128,12 @@ async def test_library_shell_create_blank_note_lands_in_editor():
         title_input = screen.query_one("#library-note-title", Input)
         assert title_input.value == ""
         assert title_input.placeholder == "Untitled"
+        await _wait_for_condition(
+            pilot,
+            lambda: getattr(screen.focused, "id", None) == "library-note-title",
+            message="Successful Create never focused the title field.",
+        )
+        assert screen.query_one("#library-note-discard-new", Button).display is True
 
         for _ in range(150):
             if screen._local_source_counts.get("notes") == 3:
@@ -10972,6 +11497,60 @@ async def test_library_shell_blank_note_autosaved_then_emptied_still_gcs_on_back
 
 
 @pytest.mark.asyncio
+async def test_library_shell_discard_new_note_deletes_untouched_create():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-create-note").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        screen.query_one("#library-notes-create-blank").press()
+        discard = await _wait_for_selector(screen, pilot, "#library-note-discard-new")
+        created_id = screen._selected_note_id
+
+        discard.press()
+        await _wait_for_selector(screen, pilot, "#library-notes-browse-actions")
+
+        assert app.notes_scope_service.delete_calls[-1]["note_id"] == created_id
+        assert all(
+            str(note.get("id")) != created_id for note in app.notes_scope_service.notes
+        )
+        assert screen._library_note_session.snapshot is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("acknowledge", ["edit", "save"])
+async def test_library_shell_discard_new_note_disappears_after_edit_or_noop_save(
+    acknowledge,
+):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-create-note").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        screen.query_one("#library-notes-create-blank").press()
+        discard = await _wait_for_selector(screen, pilot, "#library-note-discard-new")
+        assert discard.display is True
+
+        if acknowledge == "edit":
+            screen.query_one("#library-note-title", Input).value = "Kept note"
+        else:
+            screen.query_one("#library-note-save", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen.query_one("#library-note-discard-new", Button).display,
+            message="Discard new note remained visible after keep intent.",
+        )
+
+
+@pytest.mark.asyncio
 async def test_library_shell_create_from_template_uses_template_fields():
     """Pressing a template row creates a note using that template's title/
     content with ``{date}``/``{time}``/``{datetime}`` placeholders resolved
@@ -11085,6 +11664,10 @@ async def test_library_shell_import_note_lands_in_editor(tmp_path):
             n for n in service.notes if n["title"] == "Imported from disk"
         )
         assert screen._selected_note_id == created_note["id"]
+        assert (
+            str(screen.query_one("#library-note-transfer-status", Static).renderable)
+            == "Import complete."
+        )
 
         for _ in range(150):
             if screen._local_source_counts.get("notes") == 3:
@@ -11094,6 +11677,88 @@ async def test_library_shell_import_note_lands_in_editor(tmp_path):
             raise AssertionError(
                 "The notes snapshot/rail count never refreshed after import."
             )
+
+
+@pytest.mark.asyncio
+async def test_library_shell_import_created_but_not_opened_has_persistent_recovery(
+    tmp_path,
+):
+    app = _build_test_app()
+    service = _CreateThenFailFirstOpenLibraryNotesScopeService(_two_notes())
+    app.notes_scope_service = service
+    app.notes_service = StaticLibraryNotesKeywordsService({})
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        _two_conversations()
+    )
+    host = LibraryHarness(app)
+    note_file = tmp_path / "committed.md"
+    note_file.write_text("imported body", encoding="utf-8")
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-import")
+        _fake_import_dialog_result(screen, note_file)
+
+        screen.query_one("#library-notes-import").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: any(
+                "Import complete" in str(status.renderable)
+                for status in screen.query("#library-notes-status")
+            ),
+            message="Committed import never reached persistent Navigator status.",
+        )
+
+        assert len(service.save_calls) == 1
+        assert screen._library_notes_view == "list"
+        assert (
+            str(screen.query_one("#library-notes-status", Static).renderable)
+            == "Import complete — select the new note below to open."
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_shell_new_create_clears_stale_import_create_status(tmp_path):
+    app = _build_test_app()
+    service = _FailingCreateLibraryNotesScopeService(_two_notes())
+    app.notes_scope_service = service
+    app.notes_service = StaticLibraryNotesKeywordsService({})
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        _two_conversations()
+    )
+    host = LibraryHarness(app)
+    note_file = tmp_path / "failed.md"
+    note_file.write_text("imported body", encoding="utf-8")
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-import")
+        _fake_import_dialog_result(screen, note_file)
+        screen.query_one("#library-notes-import").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: any(
+                "Import failed" in str(status.renderable)
+                for status in screen.query("#library-notes-status")
+            ),
+            message="Import service failure never reached Navigator status.",
+        )
+        assert "Create failed" in screen._library_note_create_status
+
+        await _wait_for_selector(screen, pilot, "#library-notes-new")
+        screen.query_one("#library-notes-new").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-create-status")
+
+        assert (
+            str(screen.query_one("#library-notes-create-status", Static).renderable)
+            == ""
+        )
 
 
 @pytest.mark.asyncio
@@ -11128,6 +11793,14 @@ async def test_library_shell_import_note_oversize_file_rejected(tmp_path, monkey
         args, kwargs = app.notify.call_args
         assert "import" in args[0].lower()
         assert kwargs.get("severity") == "warning"
+        rendered_status = str(
+            screen.query_one("#library-notes-status", Static).renderable
+        )
+        assert rendered_status.startswith("Import failed — choose a valid UTF-8")
+        assert rendered_status.endswith("…")
+        assert screen._library_notes_operation.status_line == (
+            "Import failed — choose a valid UTF-8 note file and try again."
+        )
 
 
 @pytest.mark.asyncio
@@ -11236,6 +11909,196 @@ async def test_library_shell_import_note_cancelled_dialog_is_noop():
 
         assert not service.save_calls
         assert screen._library_notes_view != "editor"
+
+
+@pytest.mark.asyncio
+async def test_library_shell_late_import_failure_after_navigation_releases_transfer(
+    tmp_path, monkeypatch
+):
+    """A hidden late completion cannot leave Navigator permanently gated."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+    note_file = tmp_path / "unreadable.md"
+    note_file.write_text("body", encoding="utf-8")
+    read_started = threading.Event()
+    read_release = threading.Event()
+    real_read_text = Path.read_text
+
+    def _gated_failed_read(path, *args, **kwargs):
+        if path == note_file:
+            read_started.set()
+            read_release.wait(_GATED_RELEASE_TIMEOUT_SECONDS)
+            raise OSError("file disappeared")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _gated_failed_read)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-import")
+        _fake_import_dialog_result(screen, note_file)
+
+        screen.query_one("#library-notes-import").press()
+        try:
+            await _wait_for_condition(
+                pilot,
+                read_started.is_set,
+                message="Import never entered its gated read.",
+            )
+            await _wait_for_selector(screen, pilot, "#library-row-browse-conversations")
+            screen.query_one("#library-row-browse-conversations").press()
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+                ),
+                message="Navigation did not leave Notes during import.",
+            )
+        finally:
+            read_release.set()
+
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                not (
+                    screen._library_notes_operation
+                    and screen._library_notes_operation.running
+                )
+            ),
+            message="Late import completion retained an invisible running claim.",
+        )
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-import")
+        assert screen.query_one("#library-notes-import", Button).disabled is False
+
+
+@pytest.mark.asyncio
+async def test_library_shell_late_valid_import_after_navigation_has_no_side_effect(
+    tmp_path, monkeypatch
+):
+    """Leaving the initiating region invalidates import before persistence."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+    note_file = tmp_path / "slow.md"
+    note_file.write_text("valid imported body", encoding="utf-8")
+    read_started = threading.Event()
+    read_release = threading.Event()
+    real_read_text = Path.read_text
+
+    def _gated_read(path, *args, **kwargs):
+        if path == note_file:
+            read_started.set()
+            read_release.wait(_GATED_RELEASE_TIMEOUT_SECONDS)
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _gated_read)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-import")
+        _fake_import_dialog_result(screen, note_file)
+
+        screen.query_one("#library-notes-import").press()
+        try:
+            await _wait_for_condition(
+                pilot,
+                read_started.is_set,
+                message="Import never entered its gated read.",
+            )
+            await _wait_for_selector(screen, pilot, "#library-row-browse-conversations")
+            screen.query_one("#library-row-browse-conversations").press()
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+                ),
+                message="Navigation did not leave Notes during import.",
+            )
+        finally:
+            read_release.set()
+
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                not (
+                    screen._library_notes_operation
+                    and screen._library_notes_operation.running
+                )
+            ),
+            message="Late valid import did not terminalize its claim.",
+        )
+        assert app.notes_scope_service.save_calls == []
+        assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+
+
+@pytest.mark.asyncio
+async def test_library_shell_import_leave_and_return_does_not_restore_authority(
+    tmp_path, monkeypatch
+):
+    """Returning to Navigator cannot revive an import invalidated on exit."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+    note_file = tmp_path / "aba.md"
+    note_file.write_text("valid imported body", encoding="utf-8")
+    read_started = threading.Event()
+    read_release = threading.Event()
+    real_read_text = Path.read_text
+
+    def _gated_read(path, *args, **kwargs):
+        if path == note_file:
+            read_started.set()
+            read_release.wait(_GATED_RELEASE_TIMEOUT_SECONDS)
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _gated_read)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-import")
+        _fake_import_dialog_result(screen, note_file)
+        screen.query_one("#library-notes-import").press()
+        try:
+            await _wait_for_condition(
+                pilot,
+                read_started.is_set,
+                message="Import never entered its gated read.",
+            )
+            await _wait_for_selector(screen, pilot, "#library-row-browse-conversations")
+            screen.query_one("#library-row-browse-conversations").press()
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+                ),
+                message="Navigation did not leave Notes during import.",
+            )
+            screen.query_one("#library-row-browse-notes").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-import")
+        finally:
+            read_release.set()
+
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                not (
+                    screen._library_notes_operation
+                    and screen._library_notes_operation.running
+                )
+            ),
+            message="Invalidated import retained a running claim.",
+        )
+        assert app.notes_scope_service.save_calls == []
+        assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+        assert screen._library_notes_view == "list"
 
 
 @pytest.mark.asyncio
@@ -11369,7 +12232,7 @@ def _prepare_library_notes_sync_app(app, *, notes=None):
     # session-shared CLI config file (under the isolated test HOME) -- a
     # previous test in this same session may have persisted a non-default
     # value there. Reset to known starting values so every sync test's
-    # cycling assertions are deterministic regardless of run order.
+    # direct-choice assertions are deterministic regardless of run order.
     from tldw_chatbook.config import save_setting_to_cli_config
 
     save_setting_to_cli_config("notes", "sync_direction", "bidirectional")
@@ -11405,8 +12268,8 @@ async def test_library_shell_notes_sync_button_opens_sync_mode():
             "#library-notes-sync-folder-label",
             "#library-notes-sync-folder",
             "#library-notes-sync-browse",
-            "#library-notes-sync-direction",
-            "#library-notes-sync-conflict",
+            "#library-notes-sync-direction-choices",
+            "#library-notes-sync-conflict-choices",
             "#library-notes-sync-auto",
             "#library-notes-sync-run",
             "#library-notes-sync-status",
@@ -11430,7 +12293,7 @@ async def test_library_shell_notes_sync_button_opens_sync_mode():
 
 
 @pytest.mark.asyncio
-async def test_library_shell_notes_sync_direction_cycles_and_persists():
+async def test_library_shell_notes_sync_direction_choices_are_direct_and_persist():
     app = _build_test_app()
     _prepare_library_notes_sync_app(app)
     host = LibraryHarness(app)
@@ -11441,21 +12304,22 @@ async def test_library_shell_notes_sync_direction_cycles_and_persists():
         await _open_library_notes_sync_panel(screen, pilot)
 
         assert screen._library_notes_sync_direction == "bidirectional"
-        button = screen.query_one("#library-notes-sync-direction", Button)
-        assert "Bidirectional" in str(button.label)
+        assert len(list(screen.query(".library-notes-sync-direction-choice"))) == 3
+        button = screen.query_one("#library-notes-sync-direction-bidirectional", Button)
+        assert str(button.label).startswith("✓ ")
 
-        button.press()
+        screen.query_one("#library-notes-sync-direction-disk_to_db").press()
         await pilot.pause()
         assert screen._library_notes_sync_direction == "disk_to_db"
         from tldw_chatbook.config import get_cli_setting
 
         assert get_cli_setting("notes", "sync_direction", None) == "disk_to_db"
-        button = screen.query_one("#library-notes-sync-direction", Button)
-        assert "Disk" in str(button.label)
+        button = screen.query_one("#library-notes-sync-direction-disk_to_db", Button)
+        assert str(button.label).startswith("✓ ")
 
 
 @pytest.mark.asyncio
-async def test_library_shell_notes_sync_conflict_cycles_and_persists():
+async def test_library_shell_notes_sync_conflict_choices_are_direct_and_persist():
     app = _build_test_app()
     _prepare_library_notes_sync_app(app)
     host = LibraryHarness(app)
@@ -11466,29 +12330,22 @@ async def test_library_shell_notes_sync_conflict_cycles_and_persists():
         await _open_library_notes_sync_panel(screen, pilot)
 
         assert screen._library_notes_sync_conflict == "newer_wins"
-        screen.query_one("#library-notes-sync-conflict").press()
+        assert len(list(screen.query(".library-notes-sync-conflict-choice"))) == 3
+        screen.query_one("#library-notes-sync-conflict-disk_wins").press()
         await pilot.pause()
         assert screen._library_notes_sync_conflict == "disk_wins"
         from tldw_chatbook.config import get_cli_setting
 
         assert get_cli_setting("notes", "sync_conflict_resolution", None) == "disk_wins"
 
-        # A1: the cycle is 3 modes long with "ask" removed entirely -- one
-        # more press reaches "Library wins" (B2's de-jargoned "db_wins"
-        # label), and a third press wraps back to "newer_wins" rather than
-        # ever landing on "ask". Each press recomposes the panel (see
-        # handle_library_notes_sync_conflict), so the Button must be
-        # re-queried after every press rather than reusing a stale
-        # reference to the pre-recompose instance.
-        screen.query_one("#library-notes-sync-conflict").press()
+        # Every supported policy is visible directly; the removed "ask"
+        # policy cannot render or be reached.
+        screen.query_one("#library-notes-sync-conflict-db_wins").press()
         await pilot.pause()
         assert screen._library_notes_sync_conflict == "db_wins"
-        button = screen.query_one("#library-notes-sync-conflict", Button)
+        button = screen.query_one("#library-notes-sync-conflict-db_wins", Button)
         assert "Library wins" in str(button.label)
-
-        screen.query_one("#library-notes-sync-conflict").press()
-        await pilot.pause()
-        assert screen._library_notes_sync_conflict == "newer_wins"
+        assert "ask" not in _visible_text(screen).lower()
 
 
 @pytest.mark.asyncio
@@ -11552,9 +12409,9 @@ async def test_library_shell_notes_sync_folder_typing_does_not_write_config(tmp_
 
         # Typed but not committed: config untouched...
         assert get_cli_setting("notes", "sync_directory", None) == "~/Documents/Notes"
-        # ...but the typed value survives a recompose (cycling any setting
+        # ...but the typed value survives a recompose (choosing any setting
         # rebuilds the canvas) instead of snapping back to the config value.
-        screen.query_one("#library-notes-sync-direction").press()
+        screen.query_one("#library-notes-sync-direction-disk_to_db").press()
         await pilot.pause()
         folder_input = screen.query_one("#library-notes-sync-folder", Input)
         assert folder_input.value == str(tmp_path)
@@ -11657,20 +12514,20 @@ async def test_library_shell_notes_sync_now_calls_recording_service_with_chosen_
         folder_input.focus()
         await pilot.pause()
 
-        # Cycle direction/conflict once each so the recorded call proves the
-        # *chosen* enums (not just the defaults) are threaded through. Each
+        # Choose direction/conflict explicitly so the recorded call proves the
+        # selected enums (not just the defaults) are threaded through. Each
         # press triggers a full canvas recompose (`refresh(recompose=True)`)
-        # that re-mounts these two toggle buttons -- poll for the
+        # that re-mounts these choice buttons -- poll for the
         # re-mounted button to actually show the newly-chosen enum's label
         # before the next press, instead of a fixed pause, so the second
         # press can't land mid-recompose and get lost/target a stale
         # instance.
         expected_direction_label = (
-            f"direction: {sync_direction_label(SyncDirection.DISK_TO_DB.value)} ▸"
+            f"✓ {sync_direction_label(SyncDirection.DISK_TO_DB.value)}"
         )
-        screen.query_one("#library-notes-sync-direction").press()
+        screen.query_one("#library-notes-sync-direction-disk_to_db").press()
         for _ in range(150):
-            direction_buttons = screen.query("#library-notes-sync-direction")
+            direction_buttons = screen.query("#library-notes-sync-direction-disk_to_db")
             if direction_buttons and str(direction_buttons.first().label) == (
                 expected_direction_label
             ):
@@ -11678,16 +12535,16 @@ async def test_library_shell_notes_sync_now_calls_recording_service_with_chosen_
             await pilot.pause(0.02)
         else:
             raise AssertionError(
-                "Direction toggle never re-mounted with the cycled label "
+                "Direction choice never re-mounted with the selected label "
                 f"(wanted {expected_direction_label!r})."
             )
 
         expected_conflict_label = (
-            f"conflicts: {sync_conflict_label(ConflictResolution.DISK_WINS.value)} ▸"
+            f"✓ {sync_conflict_label(ConflictResolution.DISK_WINS.value)}"
         )
-        screen.query_one("#library-notes-sync-conflict").press()
+        screen.query_one("#library-notes-sync-conflict-disk_wins").press()
         for _ in range(150):
-            conflict_buttons = screen.query("#library-notes-sync-conflict")
+            conflict_buttons = screen.query("#library-notes-sync-conflict-disk_wins")
             if conflict_buttons and str(conflict_buttons.first().label) == (
                 expected_conflict_label
             ):
@@ -11695,7 +12552,7 @@ async def test_library_shell_notes_sync_now_calls_recording_service_with_chosen_
             await pilot.pause(0.02)
         else:
             raise AssertionError(
-                "Conflict toggle never re-mounted with the cycled label "
+                "Conflict choice never re-mounted with the selected label "
                 f"(wanted {expected_conflict_label!r})."
             )
 
@@ -11708,8 +12565,8 @@ async def test_library_shell_notes_sync_now_calls_recording_service_with_chosen_
             raise AssertionError("Sync-now never started.")
 
         # A3: the run handler flips the running flag then recomposes; the
-        # flag is set synchronously at the top of the worker coroutine, so
-        # poll until the start-of-run recompose has landed the disabled
+        # token/flag is claimed synchronously before worker dispatch, so poll
+        # until the start-of-run recompose has landed the disabled
         # "Syncing…" button (querying the instant the flag flips can race
         # the mid-recompose teardown -> NoMatches).
         for _ in range(150):
@@ -11783,6 +12640,85 @@ async def test_library_shell_notes_sync_now_calls_recording_service_with_chosen_
         run_button_after = screen.query_one("#library-notes-sync-run", Button)
         assert "Sync now" in str(run_button_after.label)
         assert not run_button_after.disabled
+
+
+@pytest.mark.asyncio
+async def test_library_shell_sync_running_claim_survives_rail_navigation(
+    monkeypatch, tmp_path
+):
+    """Navigation cannot clear a thread-backed sync's single-flight claim."""
+    from tldw_chatbook.Notes import sync_service as sync_service_module
+
+    _RecordingNotesSyncService.instances.clear()
+    monkeypatch.setattr(
+        sync_service_module, "NotesSyncService", _RecordingNotesSyncService
+    )
+    app = _build_test_app()
+    _prepare_library_notes_sync_app(app)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_library_notes_sync_panel(screen, pilot)
+        screen.query_one("#library-notes-sync-folder", Input).value = str(tmp_path)
+        await pilot.pause()
+        screen.query_one("#library-notes-sync-run").press()
+
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(
+                _RecordingNotesSyncService.instances
+                and _RecordingNotesSyncService.instances[0].calls
+            ),
+            message="Sync never reached its gated service.",
+        )
+        service = _RecordingNotesSyncService.instances[0]
+        try:
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    bool(screen.query("#library-notes-sync-back"))
+                    and screen.query("#library-notes-sync-back").first().disabled
+                ),
+                message="Sync controls never entered their disabled running state.",
+            )
+            for selector in (
+                "#library-notes-sync-back",
+                "#library-notes-sync-folder",
+                "#library-notes-sync-browse",
+                "#library-notes-sync-auto",
+                "#library-notes-sync-run",
+            ):
+                assert screen.query_one(selector).disabled is True
+
+            await _wait_for_selector(screen, pilot, "#library-row-browse-conversations")
+            screen.query_one("#library-row-browse-conversations").press()
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+                ),
+                message="Rail navigation did not leave Sync.",
+            )
+            assert screen._library_notes_sync_running is True
+
+            screen.query_one("#library-row-browse-notes").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-sync-open")
+            screen.query_one("#library-notes-sync-open").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-sync-run")
+
+            assert screen._library_notes_sync_running is True
+            assert screen.query_one("#library-notes-sync-run", Button).disabled is True
+            assert len(_RecordingNotesSyncService.instances) == 1
+        finally:
+            service.release_event.set()
+
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen._library_notes_sync_running,
+            message="Released sync did not relinquish its running claim.",
+        )
 
 
 @pytest.mark.asyncio
@@ -11871,8 +12807,8 @@ async def test_library_shell_notes_sync_stale_ask_conflict_coerces_to_newer_wins
         await _open_library_notes_sync_panel(screen, pilot)
 
         assert screen._library_notes_sync_conflict == "newer_wins"
-        button = screen.query_one("#library-notes-sync-conflict", Button)
-        assert "Newer wins" in str(button.label)
+        button = screen.query_one("#library-notes-sync-conflict-newer_wins", Button)
+        assert str(button.label).startswith("✓ ")
 
 
 @pytest.mark.asyncio
@@ -11892,8 +12828,8 @@ async def test_library_shell_notes_sync_stale_direction_coerces_to_bidirectional
         await _open_library_notes_sync_panel(screen, pilot)
 
         assert screen._library_notes_sync_direction == "bidirectional"
-        button = screen.query_one("#library-notes-sync-direction", Button)
-        assert "Bidirectional" in str(button.label)
+        button = screen.query_one("#library-notes-sync-direction-bidirectional", Button)
+        assert str(button.label).startswith("✓ ")
 
 
 @pytest.mark.asyncio
@@ -14430,6 +15366,33 @@ async def test_library_shell_notes_export_action_opens_notes_scope():
 
         assert screen._library_selected_row_id == LIBRARY_ROW_INGEST_EXPORT
         assert screen._library_export_scope == ExportScope(kind="notes")
+
+
+@pytest.mark.asyncio
+async def test_library_shell_notes_selected_export_opens_exact_selection_scope():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.media_db = MediaDatabase(":memory:", client_id="notes-selected-export-media")
+    app.chachanotes_db = CharactersRAGDB(
+        ":memory:", client_id="notes-selected-export-ccn"
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-select-toggle")
+        screen.query_one("#library-notes-select-toggle").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-selection-actions")
+        screen.query_one("#library-notes-row-0").press()
+        await pilot.pause()
+
+        screen.query_one("#library-notes-export-selected").press()
+        await _wait_for_selector(screen, pilot, "#library-export-status-line")
+
+        assert screen._library_export_scope == ExportScope(kind="notes", ids=("n-1",))
+        assert screen.query_one("#library-export-status-line", Static)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -406,6 +406,19 @@ async def _wait_for_selector(screen, pilot, selector, *, attempts=120, timeout=1
     )
 
 
+async def _wait_for_display(screen, pilot, selector, *, attempts=120):
+    """Wait until an always-mounted stable-composition widget is visible."""
+    widget = await _wait_for_selector(screen, pilot, selector, attempts=attempts)
+    for _ in range(attempts):
+        if widget.display:
+            await pilot.pause()
+            return widget
+        await pilot.pause(0.02)
+    raise AssertionError(
+        f"{selector} never became visible. Visible text: {_visible_text(screen)}"
+    )
+
+
 async def _wait_for_condition(
     pilot, predicate, *, timeout=15.0, message, interval=0.02
 ) -> None:
@@ -2703,11 +2716,34 @@ async def test_library_shell_rail_search_submit_aborts_on_note_conflict():
         ).text = "kept text that must survive"
         await pilot.pause()
 
+        search_input_before = screen.query_one("#library-search-input", Input)
         screen.query_one("#library-note-save").press()
+
+        def conflict_search_input_ready() -> bool:
+            search_inputs = list(screen.query("#library-search-input"))
+            return (
+                screen._library_note_autosave_state == "conflict"
+                and screen.query_one("#library-note-conflict-region").display
+                and bool(search_inputs)
+                and search_inputs[0] is search_input_before
+            )
+
+        def conflict_search_input_timeout_message() -> str:
+            search_inputs = list(screen.query("#library-search-input"))
+            search_input = search_inputs[0] if search_inputs else None
+            return (
+                "The version conflict never stabilized the existing search input "
+                f"(autosave_state={screen._library_note_autosave_state!r}, "
+                f"search_input_mounted={search_input is not None!r}, "
+                f"search_input_stable="
+                f"{search_input is search_input_before!r}). "
+                f"Visible text: {_visible_text(screen)}"
+            )
+
         await _wait_for_condition(
             pilot,
-            lambda: screen._library_note_autosave_state == "conflict",
-            message="The version conflict was never reached.",
+            conflict_search_input_ready,
+            message=conflict_search_input_timeout_message,
         )
 
         history_before = screen._library_search_history
@@ -7821,6 +7857,76 @@ async def test_library_note_coordinator_validation_veto_keeps_raw_title_and_focu
 
 
 @pytest.mark.asyncio
+async def test_library_note_keyword_validation_routes_to_wide_inline_control(
+    monkeypatch,
+):
+    """A wide Context autosave veto returns focus to the inline keywords."""
+    monkeypatch.setattr(library_screen_module, "LIBRARY_NOTES_AUTOSAVE_SECONDS", 0.05)
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        screen.query_one("#library-note-context").press()
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one(
+            "#library-note-context-keywords", Input
+        ).value = "duplicate, Duplicate"
+
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_note_autosave_state == "validation"
+                and getattr(screen.focused, "id", None) == "library-note-keywords"
+            ),
+            message="Wide keyword veto did not focus the inline keyword control.",
+        )
+        assert screen.query_one("#library-note-context-region").display is False
+        assert screen.query_one("#library-note-wide-utilities").display is True
+
+
+@pytest.mark.asyncio
+async def test_library_note_keyword_validation_routes_to_compact_context():
+    """A compact keyword veto reopens Context and focuses its only editor."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        screen._library_notes_compact = True
+        screen._apply_library_note_presentation_state()
+
+        screen.query_one("#library-note-context").press()
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one(
+            "#library-note-context-keywords", Input
+        ).value = "duplicate, Duplicate"
+        await pilot.pause()
+        screen.query_one("#library-note-context-back").press()
+        await pilot.pause()
+        screen.query_one("#library-note-save").press()
+
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_note_autosave_state == "validation"
+                and getattr(screen.focused, "id", None)
+                == "library-note-context-keywords"
+            ),
+            message="Compact keyword veto did not reopen and focus Context.",
+        )
+        assert screen.query_one("#library-note-context-region").display is True
+        assert screen.query_one("#library-note-wide-utilities").display is False
+
+
+@pytest.mark.asyncio
 async def test_library_note_saved_outcome_does_not_mask_a_newer_dirty_revision():
     """Late host presentation must not relabel a newer coordinator draft saved."""
     app = _build_test_app()
@@ -7984,7 +8090,7 @@ def test_library_conflict_handlers_do_not_cancel_the_token_owner(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_library_conflict_opposite_button_cannot_cancel_active_owner():
+async def test_library_note_conflict_opposite_button_cannot_cancel_active_owner():
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
     service = _GatedConflictRefreshNotesService(_two_notes())
@@ -7999,7 +8105,7 @@ async def test_library_conflict_opposite_button_cannot_cancel_active_owner():
         screen.query_one("#library-note-body", TextArea).text = "kept draft"
         await pilot.pause()
         screen.query_one("#library-note-save").press()
-        overwrite = await _wait_for_selector(
+        overwrite = await _wait_for_display(
             screen, pilot, "#library-note-conflict-overwrite"
         )
         reload_button = screen.query_one("#library-note-conflict-reload")
@@ -8014,6 +8120,10 @@ async def test_library_conflict_opposite_button_cannot_cancel_active_owner():
             reload_button.press()
             await pilot.pause()
             assert screen._library_note_session.conflict_resolution_running is True
+            assert overwrite.disabled is True
+            assert reload_button.disabled is True
+            assert screen.query_one("#library-note-title", Input).disabled is False
+            assert screen.query_one("#library-note-body", TextArea).disabled is False
         finally:
             service.release_conflict_refresh.set()
 
@@ -8025,7 +8135,7 @@ async def test_library_conflict_opposite_button_cannot_cancel_active_owner():
             ),
             message="The original conflict action did not finish and release its gate.",
         )
-        assert not screen.query("#library-note-conflict-overwrite")
+        assert screen.query_one("#library-note-conflict-region").display is False
 
 
 @pytest.mark.asyncio
@@ -8243,21 +8353,13 @@ async def test_library_shell_note_explicit_save_calls_seam_and_bumps_version():
             )
 
         assert screen.query_one("#library-note-body", TextArea) is body_before_save
-        meta = str(screen.query_one("#library-note-meta").renderable)
-        assert "saved" in meta
+        status = str(screen.query_one("#library-note-status").renderable)
+        assert "Saved" in status
 
 
 @pytest.mark.asyncio
-async def test_library_shell_note_save_patches_detail_title_and_content_for_later_recompose():
-    """A save only ever updates the ``#library-note-meta`` ``Static`` in
-    place -- it never recomposes the editor itself. But a *later*
-    recompose (entering the delete-confirm state, in this test) rebuilds
-    the editor's ``TextArea``/``Input`` values fresh from
-    ``_library_note_detail``. If Save only patched the cached ``version``
-    there and left ``title``/``content`` stale, that later recompose would
-    silently revert the just-saved edit back to the pre-save text on
-    screen.
-    """
+async def test_library_shell_note_save_survives_stable_delete_confirmation():
+    """Delete confirmation preserves the coordinator-backed saved draft."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
     host = LibraryHarness(app)
@@ -8279,16 +8381,13 @@ async def test_library_shell_note_save_patches_detail_title_and_content_for_late
             raise AssertionError("Save never completed.")
 
         screen.query_one("#library-note-delete").press()
-        await _wait_for_selector(screen, pilot, "#library-note-delete-confirm-copy")
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
         screen.query_one("#library-note-delete-cancel").press()
         await pilot.pause()
 
         assert (
             screen.query_one("#library-note-body", TextArea).text == "edited body text"
-        ), (
-            "A later recompose reverted the saved edit -- the detail mirror "
-            "wasn't patched with the saved title/content."
-        )
+        ), "Stable delete confirmation reverted the saved coordinator draft."
 
 
 class _TouchingNotesScopeService(StaticLibraryNotesScopeService):
@@ -8377,7 +8476,7 @@ async def test_library_shell_note_save_then_back_refreshes_list_title_age_and_or
 @pytest.mark.asyncio
 async def test_library_shell_note_autosave_fires_after_debounce(monkeypatch):
     """Editing the body (no Save press) arms the autosave debounce; once it
-    fires, ``save_note`` was called and the meta line shows "saved".
+    fires, ``save_note`` was called and the status shows ``Saved HH:MM``.
     """
     monkeypatch.setattr(library_screen_module, "LIBRARY_NOTES_AUTOSAVE_SECONDS", 0.05)
     app = _build_test_app()
@@ -8406,13 +8505,13 @@ async def test_library_shell_note_autosave_fires_after_debounce(monkeypatch):
 
         assert service.save_calls[-1]["content"] == "alpha budget line, autosaved"
 
-        meta = ""
+        status = ""
         for _ in range(150):
-            meta = str(screen.query_one("#library-note-meta").renderable)
-            if "saved" in meta:
+            status = str(screen.query_one("#library-note-status").renderable)
+            if "Saved" in status:
                 break
             await pilot.pause(0.02)
-        assert "saved" in meta
+        assert "Saved" in status
 
 
 @pytest.mark.asyncio
@@ -8929,27 +9028,21 @@ async def test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user
             message="The version conflict was never reached.",
         )
 
-        # Wait for the WIDGET, not just the state. ``_wait_for_condition`` above
-        # returns as soon as ``_library_note_autosave_state`` flips to
-        # "conflict", but the buttons only exist after the screen recomposes --
-        # so asserting on the DOM immediately is a race, and it is the one that
-        # made this test fail intermittently in full-file runs while passing in
-        # isolation (task-699). Captured assertion:
-        #   assert screen.query("#library-note-conflict-overwrite")
-        #   AssertionError: assert <DOMQuery ...>   (an empty query is falsy)
-        await _wait_for_selector(screen, pilot, "#library-note-conflict-overwrite")
-        await _wait_for_selector(screen, pilot, "#library-note-conflict-reload")
+        # The recovery widgets are stable children. Wait for visibility rather
+        # than mount so an always-mounted hidden action cannot satisfy the test.
+        await _wait_for_display(screen, pilot, "#library-note-conflict-overwrite")
+        await _wait_for_display(screen, pilot, "#library-note-conflict-reload")
         await _wait_for_condition(
             pilot,
             lambda: getattr(screen.focused, "id", None) == "library-note-conflict-copy",
             message="Keyboard focus never moved to the note conflict callout.",
         )
         assert screen.query_one("#library-note-conflict-copy").can_focus is True
-        meta = str(screen.query_one("#library-note-meta").renderable)
-        assert "changed elsewhere" in meta
-        assert screen.query_one("#library-note-body", TextArea).text == (
-            "kept text that must survive"
-        )
+        status = str(screen.query_one("#library-note-status").renderable)
+        assert "Conflict" in status
+        conflict_body = screen.query_one("#library-note-body", TextArea)
+        assert conflict_body.text == "kept text that must survive"
+        assert conflict_body.disabled is False
 
 
 @pytest.mark.asyncio
@@ -9028,7 +9121,7 @@ async def test_library_shell_note_conflict_during_preview_reads_live_text():
         await pilot.pause()
 
         screen.query_one("#library-note-preview").press()
-        await _wait_for_selector(screen, pilot, "#library-note-preview-body")
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
         assert screen._library_note_preview is True
 
         _bump_note_version_externally(
@@ -9066,7 +9159,7 @@ async def test_library_shell_note_conflict_during_preview_reads_live_text():
             lambda: screen._library_note_autosave_state == "saved",
             message="Overwrite never saved the coordinator's latest conflict draft.",
         )
-        await _wait_for_selector(screen, pilot, "#library-note-body")
+        await _wait_for_display(screen, pilot, "#library-note-editor-region")
 
         assert service.save_calls[-1]["content"] == "T2", (
             "Overwrite sent stale pre-preview text to the seam: "
@@ -9109,16 +9202,36 @@ async def test_library_shell_note_conflict_overwrite_resaves_with_fresh_version(
             message="The version conflict was never reached.",
         )
 
-        (
-            await _wait_for_selector(screen, pilot, "#library-note-conflict-overwrite")
-        ).press()
+        overwrite_button = await _wait_for_display(
+            screen, pilot, "#library-note-conflict-overwrite"
+        )
+        conflict_body = screen.query_one("#library-note-body", TextArea)
+        overwrite_button.press()
+
+        def overwritten_editor_ready() -> bool:
+            body_widgets = list(screen.query("#library-note-body"))
+            return (
+                screen._library_note_autosave_state == "saved"
+                and not screen.query_one("#library-note-conflict-region").display
+                and bool(body_widgets)
+                and body_widgets[0] is conflict_body
+            )
+
         await _wait_for_condition(
             pilot,
-            lambda: screen._library_note_autosave_state == "saved",
-            message="Overwrite never completed.",
+            overwritten_editor_ready,
+            message=lambda: (
+                "Overwrite never rendered the saved replacement editor "
+                f"(autosave_state={screen._library_note_autosave_state!r}, "
+                f"conflict_visible="
+                f"{screen.query_one('#library-note-conflict-region').display!r}, "
+                f"body_stable="
+                f"{bool(screen.query('#library-note-body')) and screen.query('#library-note-body').first() is conflict_body!r}). "
+                f"Visible text: {_visible_text(screen)}"
+            ),
         )
 
-        assert not screen.query("#library-note-conflict-overwrite")
+        assert screen.query_one("#library-note-conflict-region").display is False
         stored = next(note for note in service.notes if note["id"] == "n-1")
         assert stored["content"] == "kept text that must survive"
         assert (
@@ -9143,7 +9256,7 @@ async def test_library_shell_note_conflict_overwrite_failure_exits_conflict_stat
         screen.query_one("#library-note-body", TextArea).text = "draft survives"
         await pilot.pause()
         screen.query_one("#library-note-save").press()
-        await _wait_for_selector(screen, pilot, "#library-note-conflict-overwrite")
+        await _wait_for_display(screen, pilot, "#library-note-conflict-overwrite")
 
         async def fail_overwrite(**kwargs):
             service.save_calls.append(kwargs)
@@ -9155,8 +9268,8 @@ async def test_library_shell_note_conflict_overwrite_failure_exits_conflict_stat
             pilot,
             lambda: (
                 screen._library_note_autosave_state == "error"
-                and not screen.query("#library-note-conflict-overwrite")
-                and bool(screen.query("#library-note-preview"))
+                and not screen.query_one("#library-note-conflict-region").display
+                and screen.query_one("#library-note-primary-actions").display
             ),
             message="Overwrite failure remained trapped in conflict presentation.",
         )
@@ -9168,7 +9281,7 @@ async def test_library_shell_note_conflict_overwrite_failure_exits_conflict_stat
         assert snapshot.body == "draft survives"
         assert "temporary overwrite outage" in _visible_text(screen)
         screen.query_one("#library-note-preview").press()
-        await _wait_for_selector(screen, pilot, "#library-note-preview-body")
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
 
 
 @pytest.mark.asyncio
@@ -9186,7 +9299,7 @@ async def test_library_shell_note_conflict_overwrite_validation_focuses_field():
         screen.query_one("#library-note-body", TextArea).text = "kept body"
         await pilot.pause()
         screen.query_one("#library-note-save").press()
-        await _wait_for_selector(screen, pilot, "#library-note-conflict-overwrite")
+        await _wait_for_display(screen, pilot, "#library-note-conflict-overwrite")
 
         raw_title = "x" * 301
         screen.query_one("#library-note-title", Input).value = raw_title
@@ -9237,9 +9350,57 @@ async def test_library_shell_note_conflict_reload_discards_local_edits():
             message="The version conflict was never reached.",
         )
 
-        (
-            await _wait_for_selector(screen, pilot, "#library-note-conflict-reload")
-        ).press()
+        reload_button = await _wait_for_display(
+            screen, pilot, "#library-note-conflict-reload"
+        )
+        conflict_body = screen.query_one("#library-note-body", TextArea)
+        conflict_title = screen.query_one("#library-note-title", Input)
+        reload_button.press()
+
+        def reloaded_editor_ready() -> bool:
+            detail = screen._library_note_detail
+            body_widgets = list(screen.query("#library-note-body"))
+            title_widgets = list(screen.query("#library-note-title"))
+            return (
+                screen._library_note_autosave_state == "idle"
+                and screen._library_notes_view == "editor"
+                and isinstance(detail, dict)
+                and str(detail.get("id")) == "n-1"
+                and detail.get("version") == 3
+                and screen._library_note_version == 3
+                and not screen.query_one("#library-note-conflict-region").display
+                and bool(body_widgets)
+                and body_widgets[0] is conflict_body
+                and bool(title_widgets)
+                and title_widgets[0] is conflict_title
+            )
+
+        def reloaded_editor_timeout_message() -> str:
+            detail = screen._library_note_detail
+            detail_id = detail.get("id") if isinstance(detail, dict) else None
+            detail_version = detail.get("version") if isinstance(detail, dict) else None
+            body_widgets = list(screen.query("#library-note-body"))
+            title_widgets = list(screen.query("#library-note-title"))
+            body_widget = body_widgets[0] if body_widgets else None
+            title_widget = title_widgets[0] if title_widgets else None
+            return (
+                "Reload never rendered the fresh server-backed editor "
+                f"(autosave_state={screen._library_note_autosave_state!r}, "
+                f"view={screen._library_notes_view!r}, detail_id={detail_id!r}, "
+                f"detail_version={detail_version!r}, "
+                f"note_version={screen._library_note_version!r}, "
+                f"conflict_visible="
+                f"{screen.query_one('#library-note-conflict-region').display!r}, "
+                f"body_mounted={body_widget is not None!r}, "
+                f"body_stable="
+                f"{body_widget is conflict_body!r}, "
+                f"title_mounted={title_widget is not None!r}, "
+                f"title_stable="
+                f"{title_widget is conflict_title!r}, "
+                f"body_text={getattr(body_widget, 'text', '')!r}, "
+                f"title_text={getattr(title_widget, 'value', '')!r}). "
+                f"Visible text: {_visible_text(screen)}"
+            )
         await _wait_for_condition(
             pilot,
             lambda: (
@@ -9249,7 +9410,7 @@ async def test_library_shell_note_conflict_reload_discards_local_edits():
             message="Reload never completed.",
         )
 
-        assert not screen.query("#library-note-conflict-reload")
+        assert screen.query_one("#library-note-conflict-region").display is False
         assert (
             screen.query_one("#library-note-body", TextArea).text
             == "Server-side content"
@@ -9296,7 +9457,7 @@ async def test_library_shell_note_conflict_reload_falls_back_to_list_when_note_m
         _remove_note_externally(service, "n-1")
 
         (
-            await _wait_for_selector(screen, pilot, "#library-note-conflict-reload")
+            await _wait_for_display(screen, pilot, "#library-note-conflict-reload")
         ).press()
         await _wait_for_condition(
             pilot,
@@ -9349,22 +9510,22 @@ async def test_library_shell_note_conflict_overwrite_retains_draft_when_note_mis
         _remove_note_externally(service, "n-1")
 
         (
-            await _wait_for_selector(screen, pilot, "#library-note-conflict-overwrite")
+            await _wait_for_display(screen, pilot, "#library-note-conflict-overwrite")
         ).press()
         await _wait_for_condition(
             pilot,
             lambda: (
                 screen._library_notes_view == "editor"
                 and screen._library_note_autosave_state == "conflict"
-                and bool(screen.query("#library-note-conflict-overwrite"))
+                and screen.query_one("#library-note-conflict-region").display
                 and "no longer exists" in _visible_text(screen)
             ),
             message=lambda: (
                 "Overwrite did not retain/report the missing target draft "
                 f"(stuck: view={screen._library_notes_view!r}, "
                 f"autosave_state={screen._library_note_autosave_state!r}, "
-                f"overwrite_mounted="
-                f"{bool(screen.query('#library-note-conflict-overwrite'))!r}). "
+                f"conflict_visible="
+                f"{screen.query_one('#library-note-conflict-region').display!r}). "
                 f"Visible text: {_visible_text(screen)}"
             ),
         )
@@ -9376,7 +9537,13 @@ async def test_library_shell_note_conflict_overwrite_retains_draft_when_note_mis
 
 
 @pytest.mark.asyncio
-async def test_library_shell_note_delete_shows_inline_confirm_without_deleting():
+@pytest.mark.parametrize(
+    "delete_selector",
+    ("#library-note-delete", "#library-note-context-delete"),
+)
+async def test_library_shell_note_delete_shows_inline_confirm_without_deleting(
+    delete_selector,
+):
     """Pressing Delete shows the inline confirm affordance, not an immediate delete."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
@@ -9387,18 +9554,35 @@ async def test_library_shell_note_delete_shows_inline_confirm_without_deleting()
         await _wait_for_library_shell(screen, pilot)
         await _open_note_editor(screen, pilot)
 
-        screen.query_one("#library-note-delete").press()
-        await _wait_for_selector(screen, pilot, "#library-note-delete-confirm-copy")
+        if "context" in delete_selector:
+            screen.query_one("#library-note-context").press()
+            await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one(delete_selector).press()
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
 
         assert screen._library_note_confirming_delete is True
         assert screen.query_one("#library-note-delete-confirm")
         assert screen.query_one("#library-note-delete-cancel")
-        assert not screen.query("#library-note-save")
-        assert not screen.query("#library-note-delete")
+        assert screen.query_one("#library-note-primary-actions").display is False
+        assert screen.query_one("#library-note-wide-utilities").display is False
+        assert getattr(screen.focused, "id", None) == "library-note-delete-cancel"
 
         service = app.notes_scope_service
         assert service.delete_calls == []
         assert screen._library_notes_view == "editor"
+
+        screen.query_one("#library-note-delete-cancel").press()
+        await pilot.pause()
+        if "context" in delete_selector:
+            assert screen.query_one("#library-note-context-region").display is True
+            assert getattr(screen.focused, "id", None) == delete_selector.removeprefix(
+                "#"
+            )
+        else:
+            assert screen.query_one("#library-note-editor-region").display is True
+            assert getattr(screen.focused, "id", None) == delete_selector.removeprefix(
+                "#"
+            )
 
 
 @pytest.mark.asyncio
@@ -9415,7 +9599,7 @@ async def test_library_shell_note_delete_confirm_removes_note_and_returns_to_lis
         await _open_note_editor(screen, pilot)
 
         screen.query_one("#library-note-delete").press()
-        await _wait_for_selector(screen, pilot, "#library-note-delete-confirm")
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
 
         screen.query_one("#library-note-delete-confirm").press()
 
@@ -9457,15 +9641,15 @@ async def test_library_shell_note_delete_cancel_leaves_note_intact():
         await _open_note_editor(screen, pilot)
 
         screen.query_one("#library-note-delete").press()
-        await _wait_for_selector(screen, pilot, "#library-note-delete-confirm")
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
 
         screen.query_one("#library-note-delete-cancel").press()
         await pilot.pause()
         await pilot.pause()
 
         assert screen._library_note_confirming_delete is False
-        assert not screen.query("#library-note-delete-confirm")
-        assert not screen.query("#library-note-delete-confirm-copy")
+        assert screen.query_one("#library-note-delete-confirmation").display is False
+        assert screen.query_one("#library-note-primary-actions").display is True
         assert screen.query_one("#library-note-delete")
         assert screen.query_one("#library-note-title", Input).value == "Q3 retro"
 
@@ -9475,15 +9659,7 @@ async def test_library_shell_note_delete_cancel_leaves_note_intact():
 
 @pytest.mark.asyncio
 async def test_library_shell_note_delete_confirm_does_not_arm_autosave(monkeypatch):
-    """Entering (and leaving) the delete-confirmation state recomposes the
-    editor, which remounts the Input/TextArea and re-fires their mount-time
-    ``Changed`` events. Those must never be mistaken for a real edit and
-    fire a background autosave while a destructive-action confirmation is
-    on screen -- the same armed-flag discipline every other note-editor
-    recompose site already follows (see ``_refresh_library_note_detail``,
-    ``_save_library_note``'s conflict branch, and
-    ``_resolve_library_note_conflict``).
-    """
+    """Stable delete-confirm visibility must not create a draft mutation."""
     monkeypatch.setattr(library_screen_module, "LIBRARY_NOTES_AUTOSAVE_SECONDS", 0.05)
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
@@ -9498,7 +9674,7 @@ async def test_library_shell_note_delete_confirm_does_not_arm_autosave(monkeypat
         calls_before_delete = len(service.save_calls)
 
         screen.query_one("#library-note-delete").press()
-        await _wait_for_selector(screen, pilot, "#library-note-delete-confirm-copy")
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
 
         # Wait well past the (monkeypatched) debounce window -- long enough
         # for a spurious autosave timer to have fired if the armed flag
@@ -9523,29 +9699,19 @@ async def test_library_shell_note_delete_confirm_does_not_arm_autosave(monkeypat
             "Cancelling delete-confirm must not trigger an autosave either."
         )
         assert screen._library_note_confirming_delete is False
-        assert not screen.query("#library-note-delete-confirm")
+        assert screen.query_one("#library-note-delete-confirmation").display is False
         assert screen.query_one("#library-note-delete")
 
 
 @pytest.mark.asyncio
-async def test_library_shell_note_delete_stale_version_rearms_the_editor():
-    """Task 7 regression rider: the delete confirm's stale-version failure
-    path must re-arm dirty-tracking around its recompose, the same
-    ``_library_note_editor_armed = False`` +
-    ``call_after_refresh(_arm_library_note_editor)`` dance every other
-    notes-editor recompose already uses (before this rider fix, this one
-    call site skipped it). Proven deterministically via a spy on
-    ``_arm_library_note_editor`` rather than by observing autosave timing:
-    a worker-triggered recompose racing its own mount-time
-    ``Input``/``TextArea`` ``Changed`` events against the re-arm is a
-    pre-existing characteristic of this mechanism (independently
-    reproducible today on the already-shipped save-conflict recompose in
-    ``_save_library_note``), so asserting "no autosave ever fires" around
-    the recompose itself would be asserting a guarantee this codebase
-    doesn't actually make -- not something introduced or fixable within
-    this rider's narrow scope (adding the same dance already used
-    elsewhere to 3 more call sites).
-    """
+@pytest.mark.parametrize(
+    "delete_selector",
+    ("#library-note-delete", "#library-note-context-delete"),
+)
+async def test_library_shell_note_delete_stale_version_keeps_editor_mounted(
+    delete_selector,
+):
+    """A stale delete hides confirmation without rearming/remounting fields."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
     host = LibraryHarness(app)
@@ -9560,13 +9726,15 @@ async def test_library_shell_note_delete_stale_version_rearms_the_editor():
         # bumping its stored version so the confirmed delete below is stale.
         _bump_note_version_externally(service, "n-1")
 
-        screen.query_one("#library-note-delete").press()
-        await _wait_for_selector(screen, pilot, "#library-note-delete-confirm")
+        if "context" in delete_selector:
+            screen.query_one("#library-note-context").press()
+            await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one(delete_selector).press()
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
         await pilot.pause()
+        body = screen.query_one("#library-note-body", TextArea)
 
-        # Spy on the re-arm hook from here on, so only calls triggered by
-        # the confirmed (stale) delete below count -- entering confirm mode
-        # already re-arms once on its own (a separate, already-covered path).
+        # Stable presentation must not need the legacy remount/re-arm dance.
         rearm_calls: list[bool] = []
         original_arm = screen._arm_library_note_editor
 
@@ -9600,11 +9768,12 @@ async def test_library_shell_note_delete_stale_version_rearms_the_editor():
         assert screen._library_notes_view == "editor"
         assert screen._selected_note_id == "n-1"
         assert screen.query_one("#library-note-delete")
-        assert rearm_calls, (
-            "The stale-version delete failure path never re-armed the "
-            "editor's dirty-tracking after its recompose."
-        )
+        assert screen.query_one("#library-note-body") is body
+        assert rearm_calls == []
         assert screen._library_note_editor_armed is True
+        if "context" in delete_selector:
+            assert screen.query_one("#library-note-context-region").display is True
+        assert getattr(screen.focused, "id", None) == delete_selector.removeprefix("#")
 
 
 @pytest.mark.asyncio
@@ -9643,7 +9812,7 @@ async def test_library_shell_filtered_delete_refreshes_list_without_ghost():
         assert screen._selected_note_id == "n-1"
 
         screen.query_one("#library-note-delete").press()
-        await _wait_for_selector(screen, pilot, "#library-note-delete-confirm")
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
         screen.query_one("#library-note-delete-confirm").press()
 
         service = app.notes_scope_service
@@ -9735,10 +9904,7 @@ async def test_library_shell_opening_missing_note_falls_back_to_list():
 
 @pytest.mark.asyncio
 async def test_library_shell_note_preview_toggle_shows_markdown_and_restores_edit():
-    """Preview swaps the body TextArea for a read-only Markdown widget
-    rendering the *current* (unsaved) text; toggling back to Edit restores
-    the TextArea with that same edit intact.
-    """
+    """Preview toggles stable regions and preserves the current draft."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
     host = LibraryHarness(app)
@@ -9753,9 +9919,9 @@ async def test_library_shell_note_preview_toggle_shows_markdown_and_restores_edi
         await pilot.pause()
 
         screen.query_one("#library-note-preview").press()
-        await _wait_for_selector(screen, pilot, "#library-note-preview-body")
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
 
-        assert not screen.query("#library-note-body")
+        assert screen.query_one("#library-note-editor-region").display is False
         preview = screen.query_one("#library-note-preview-body", Markdown)
         assert "alpha budget line, unsaved preview edit" in preview.source
         assert str(screen.query_one("#library-note-preview").label) == "Edit"
@@ -9763,25 +9929,278 @@ async def test_library_shell_note_preview_toggle_shows_markdown_and_restores_edi
         assert screen.query_one("#library-note-title", Input).value == "Q3 retro"
 
         screen.query_one("#library-note-preview").press()
-        await _wait_for_selector(screen, pilot, "#library-note-body")
+        await _wait_for_display(screen, pilot, "#library-note-editor-region")
 
-        assert not screen.query("#library-note-preview-body")
+        assert screen.query_one("#library-note-preview-region").display is False
         restored_body = screen.query_one("#library-note-body", TextArea)
+        assert restored_body is body
         assert restored_body.text == "alpha budget line, unsaved preview edit"
         assert str(screen.query_one("#library-note-preview").label) == "Preview"
+
+
+@pytest.mark.asyncio
+async def test_library_shell_note_presentation_surfaces_keep_widget_identity():
+    """Presentation toggles hide stable children instead of recomposing them."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        selectors = (
+            "#library-note-title",
+            "#library-note-body",
+            "#library-note-preview-body",
+            "#library-note-context-region",
+            "#library-note-conflict-copy",
+            "#library-note-delete-confirm-copy",
+            "#library-note-status",
+        )
+        mounted = {selector: screen.query_one(selector) for selector in selectors}
+
+        screen.query_one("#library-note-preview").press()
+        await pilot.pause()
+        assert screen.query_one("#library-note-preview-region").display is True
+        assert screen.query_one("#library-note-editor-region").display is False
+
+        screen.query_one("#library-note-context").press()
+        await pilot.pause()
+        assert screen.query_one("#library-note-context-region").display is True
+
+        screen.query_one("#library-note-context-back").press()
+        await pilot.pause()
+        assert screen.query_one("#library-note-preview-region").display is True
+
+        screen.query_one("#library-note-preview").press()
+        await pilot.pause()
+        screen.query_one("#library-note-delete").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.query_one("#library-note-delete-confirm-copy").display,
+            message="Delete confirmation did not become visible.",
+        )
+        screen.query_one("#library-note-delete-cancel").press()
+        await pilot.pause()
+
+        for selector, original in mounted.items():
+            assert screen.query_one(selector) is original
+
+
+@pytest.mark.asyncio
+async def test_library_shell_note_conflict_and_status_keep_widget_identity():
+    """Save status and conflict recovery update already-mounted surfaces."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        status = screen.query_one("#library-note-status")
+        conflict = screen.query_one("#library-note-conflict-copy")
+        title = screen.query_one("#library-note-title")
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "local text kept through a conflict"
+        await pilot.pause()
+
+        service = app.notes_scope_service
+        _bump_note_version_externally(service, "n-1")
+        screen.query_one("#library-note-save").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.query_one("#library-note-conflict-copy").display,
+            message="Conflict callout did not become visible.",
+        )
+
+        assert screen.query_one("#library-note-status") is status
+        assert screen.query_one("#library-note-conflict-copy") is conflict
+        assert screen.query_one("#library-note-title") is title
+        assert screen.query_one("#library-note-body") is body
+
+
+@pytest.mark.asyncio
+async def test_library_shell_note_presentation_sync_is_idempotent_and_guarded():
+    """Applying the same presentation cannot mutate or rearm the draft."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "one genuine user mutation"
+        await pilot.pause()
+        revision = screen._library_note_session.snapshot.draft_revision
+        timer = screen._library_notes_autosave_timer
+        canvas = screen.query_one("#library-notes-canvas")
+        state = screen._library_note_presentation_state()
+
+        canvas.apply_session_state(state)
+        canvas.apply_session_state(state)
+        await pilot.pause()
+
+        assert screen._library_note_session.snapshot.draft_revision == revision
+        assert screen._library_notes_autosave_timer is timer
+
+        canvas.apply_session_state(dataclasses.replace(state, validation=True))
+        assert canvas.has_class("library-note-validation")
+
+
+@pytest.mark.asyncio
+async def test_library_shell_note_hidden_preview_defers_markdown_parse_until_open():
+    """Editor keystrokes do not enqueue hidden Markdown render work."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        preview = screen.query_one("#library-note-preview-body", Markdown)
+        preview.update = Mock(wraps=preview.update)
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "first hidden preview revision"
+        await pilot.pause()
+        body.text = "second hidden preview revision"
+        await pilot.pause()
+
+        preview.update.assert_not_called()
+        screen.query_one("#library-note-preview").press()
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
+        preview.update.assert_called_once_with("second hidden preview revision")
+        assert preview.source == "second hidden preview revision"
+
+
+@pytest.mark.asyncio
+async def test_library_shell_note_preview_focus_and_editor_position_survive_toggle():
+    """Preview scroll is keyboard-owned while the hidden editor keeps position."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = "\n\n".join(
+            f"## section {index}\ncontent for section {index}" for index in range(80)
+        )
+        body.move_cursor((12, 2))
+        body.move_cursor((18, 4), select=True)
+        body.scroll_to(y=8, animate=False)
+        await pilot.pause()
+        selection = body.selection
+        scroll_y = body.scroll_y
+
+        screen.query_one("#library-note-preview").press()
+        await pilot.pause()
+        preview = screen.query_one("#library-note-preview-body", Markdown)
+        preview_region = screen.query_one("#library-note-preview-region")
+        preview_region.focus()
+        await pilot.press("pagedown")
+
+        assert screen.focused is preview_region
+        assert preview_region.scroll_y > 0, (
+            f"region size={preview_region.size!r}, "
+            f"virtual={preview_region.virtual_size!r}, "
+            f"max_y={preview_region.max_scroll_y!r}, "
+            f"body size={preview.size!r}, virtual={preview.virtual_size!r}"
+        )
+
+        screen.query_one("#library-note-preview").press()
+        await pilot.pause()
+        restored = screen.query_one("#library-note-body", TextArea)
+        assert restored is body
+        assert restored.selection == selection
+        assert restored.scroll_y == scroll_y
+
+
+@pytest.mark.asyncio
+async def test_library_shell_note_context_mutates_canonical_keywords():
+    """The Context properties field edits the one coordinator-owned draft."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        before = screen._library_note_session.snapshot.draft_revision
+        screen.query_one("#library-note-context").press()
+        await pilot.pause()
+        context_keywords = screen.query_one("#library-note-context-keywords", Input)
+        context_keywords.value = "planning, decisions"
+        await pilot.pause()
+
+        snapshot = screen._library_note_session.snapshot
+        assert snapshot.keywords_text == "planning, decisions"
+        assert snapshot.draft_revision == before + 1
+        assert screen._library_notes_autosave_timer is not None
+
+
+@pytest.mark.asyncio
+async def test_library_shell_note_wide_and_compact_utilities_remain_reachable():
+    """Wide keeps inline utilities; compact reaches the same actions in Context."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        canvas = screen.query_one("#library-notes-canvas")
+        assert screen.query_one("#library-note-wide-utilities").display is True
+        for selector in (
+            "#library-note-use-in-console",
+            "#library-note-copy",
+            "#library-note-export-md",
+            "#library-note-export-txt",
+            "#library-note-delete",
+        ):
+            assert screen.query_one(selector)
+
+        compact_context = dataclasses.replace(
+            screen._library_note_presentation_state(),
+            compact=True,
+            region="context",
+        )
+        canvas.apply_session_state(compact_context)
+        await pilot.pause()
+
+        assert screen.query_one("#library-note-wide-utilities").display is False
+        assert screen.query_one("#library-note-context-region").display is True
+        for selector in (
+            "#library-note-context-use-in-console",
+            "#library-note-context-copy",
+            "#library-note-context-export-md",
+            "#library-note-context-export-txt",
+            "#library-note-context-delete",
+        ):
+            assert screen.query_one(selector)
 
 
 @pytest.mark.asyncio
 async def test_library_shell_note_save_works_while_previewing():
     """Pressing Save while Preview is on must still persist the edit.
 
-    While Preview is showing, ``#library-note-body`` is a read-only
-    ``Markdown`` widget -- not the ``TextArea`` -- so a naive
-    ``query_one("#library-note-body", TextArea)`` raises ``NoMatches``.
-    ``_save_library_note`` must instead read through the preview-aware
-    ``_read_library_note_editor_fields`` helper (the same one Export/Copy/
-    Use-in-Console already rely on) so Save is not a silent no-op while
-    previewing.
+    The hidden TextArea stays mounted, but persistence must still read the
+    canonical coordinator draft rather than presentation visibility.
     """
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
@@ -9798,8 +10217,8 @@ async def test_library_shell_note_save_works_while_previewing():
         await pilot.pause()
 
         screen.query_one("#library-note-preview").press()
-        await _wait_for_selector(screen, pilot, "#library-note-preview-body")
-        assert not screen.query("#library-note-body")
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
+        assert screen.query_one("#library-note-editor-region").display is False
 
         screen.query_one("#library-note-save").press()
 
@@ -9854,8 +10273,8 @@ async def test_library_shell_note_back_flushes_while_previewing():
         await pilot.pause()
 
         screen.query_one("#library-note-preview").press()
-        await _wait_for_selector(screen, pilot, "#library-note-preview-body")
-        assert not screen.query("#library-note-body")
+        await _wait_for_display(screen, pilot, "#library-note-preview-region")
+        assert screen.query_one("#library-note-editor-region").display is False
 
         screen.query_one("#library-note-back").press()
         for _ in range(50):
@@ -9888,9 +10307,18 @@ async def test_library_shell_note_back_flushes_while_previewing():
 
 
 @pytest.mark.asyncio
-async def test_library_shell_note_export_markdown_pushes_file_save_dialog():
-    """Export .md pushes a ``FileSave`` dialog pre-filled with a sanitized
-    default filename derived from the note's current title."""
+@pytest.mark.parametrize(
+    ("action_selector", "expected_file"),
+    (
+        ("#library-note-export-md", "Q3 retro.md"),
+        ("#library-note-context-export-md", "Q3 retro.md"),
+        ("#library-note-context-export-txt", "Q3 retro.txt"),
+    ),
+)
+async def test_library_shell_note_export_pushes_file_save_dialog(
+    action_selector, expected_file
+):
+    """Wide and Context exports use the canonical note draft."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
     host = LibraryHarness(app)
@@ -9900,16 +10328,19 @@ async def test_library_shell_note_export_markdown_pushes_file_save_dialog():
         await _wait_for_library_shell(screen, pilot)
         await _open_note_editor(screen, pilot)
 
-        screen.query_one("#library-note-export-md").press()
+        if "context" in action_selector:
+            screen.query_one("#library-note-context").press()
+            await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one(action_selector).press()
         for _ in range(150):
             if isinstance(host.screen_stack[-1], FileSave):
                 break
             await pilot.pause(0.02)
         else:
-            raise AssertionError("Export .md never pushed a FileSave dialog.")
+            raise AssertionError("Note export never pushed a FileSave dialog.")
 
         dialog = host.screen_stack[-1]
-        assert dialog._default_file == "Q3 retro.md"
+        assert dialog._default_file == expected_file
 
         await host.pop_screen()
         await pilot.pause()
@@ -9995,7 +10426,10 @@ async def test_library_shell_note_write_export_file_rejects_invalid_path(
 
 
 @pytest.mark.asyncio
-async def test_library_shell_note_copy_calls_clipboard_seam():
+@pytest.mark.parametrize(
+    "action_selector", ("#library-note-copy", "#library-note-context-copy")
+)
+async def test_library_shell_note_copy_calls_clipboard_seam(action_selector):
     """Copy calls the app's ``copy_to_clipboard`` seam with the markdown
     export shape and notifies on success."""
     app = _build_test_app()
@@ -10009,7 +10443,10 @@ async def test_library_shell_note_copy_calls_clipboard_seam():
         await _wait_for_library_shell(screen, pilot)
         await _open_note_editor(screen, pilot)
 
-        screen.query_one("#library-note-copy").press()
+        if "context" in action_selector:
+            screen.query_one("#library-note-context").press()
+            await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one(action_selector).press()
         await pilot.pause()
 
     app.copy_to_clipboard.assert_called_once()
@@ -10022,7 +10459,11 @@ async def test_library_shell_note_copy_calls_clipboard_seam():
 
 
 @pytest.mark.asyncio
-async def test_library_shell_note_use_in_console_triggers_handoff():
+@pytest.mark.parametrize(
+    "action_selector",
+    ("#library-note-use-in-console", "#library-note-context-use-in-console"),
+)
+async def test_library_shell_note_use_in_console_triggers_handoff(action_selector):
     """ "Use in Console" stages the open note as Console context, mirroring
     the media viewer's "Use in Chat" handoff test.
     """
@@ -10041,7 +10482,10 @@ async def test_library_shell_note_use_in_console_triggers_handoff():
         await _wait_for_library_shell(screen, pilot)
         await _open_note_editor(screen, pilot)
 
-        screen.query_one("#library-note-use-in-console").press()
+        if "context" in action_selector:
+            screen.query_one("#library-note-context").press()
+            await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one(action_selector).press()
         await pilot.pause()
         await pilot.pause()
 

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -8406,6 +8406,91 @@ class _DelayedSaveLibraryNotesScopeService(StaticLibraryNotesScopeService):
         return await super().save_note(**kwargs)
 
 
+class _GatedInteractionLibraryNotesScopeService(StaticLibraryNotesScopeService):
+    """Bound real service seams with per-call OS-thread release gates.
+
+    The screen offloads these async methods into executor threads.  Each gate
+    is therefore a ``threading.Event`` and every wait is bounded by the shared
+    shutdown-safe timeout.  ``None`` consumes one call without blocking, which
+    lets a test gate only a later conflict refresh or overwrite save.
+    """
+
+    def __init__(
+        self,
+        notes,
+        *,
+        detail_gates: tuple[threading.Event | None, ...] = (),
+        save_gates: tuple[threading.Event | None, ...] = (),
+        create_gates: tuple[threading.Event | None, ...] = (),
+        delete_gates: tuple[threading.Event | None, ...] = (),
+        force_delete_result: bool | None = None,
+    ) -> None:
+        super().__init__(notes)
+        self._detail_gates = list(detail_gates)
+        self._save_gates = list(save_gates)
+        self._create_gates = list(create_gates)
+        self._delete_gates = list(delete_gates)
+        self._gate_lock = threading.Lock()
+        self._active_save_calls = 0
+        self.max_concurrent_save_calls = 0
+        self.force_delete_result = force_delete_result
+        self.detail_attempts: list[dict] = []
+        self.save_attempts: list[dict] = []
+        self.create_attempts: list[dict] = []
+        self.delete_attempts: list[dict] = []
+
+    def _claim_gate(
+        self, gates: list[threading.Event | None]
+    ) -> threading.Event | None:
+        with self._gate_lock:
+            return gates.pop(0) if gates else None
+
+    @staticmethod
+    async def _wait_for_gate(gate: threading.Event | None, operation: str) -> None:
+        if gate is None:
+            return
+        released = await asyncio.to_thread(gate.wait, _GATED_RELEASE_TIMEOUT_SECONDS)
+        if not released:
+            raise TimeoutError(f"Timed out waiting to release {operation} gate.")
+
+    async def get_note_detail(self, **kwargs):
+        self.detail_attempts.append(dict(kwargs))
+        gate = self._claim_gate(self._detail_gates)
+        await self._wait_for_gate(gate, "detail")
+        return await super().get_note_detail(**kwargs)
+
+    async def save_note(self, **kwargs):
+        is_create = not kwargs.get("note_id")
+        attempts = self.create_attempts if is_create else self.save_attempts
+        gates = self._create_gates if is_create else self._save_gates
+        attempts.append(dict(kwargs))
+        gate = self._claim_gate(gates)
+        if is_create:
+            await self._wait_for_gate(gate, "create")
+            return await super().save_note(**kwargs)
+
+        with self._gate_lock:
+            self._active_save_calls += 1
+            self.max_concurrent_save_calls = max(
+                self.max_concurrent_save_calls, self._active_save_calls
+            )
+        try:
+            await self._wait_for_gate(gate, "save")
+            return await super().save_note(**kwargs)
+        finally:
+            with self._gate_lock:
+                self._active_save_calls -= 1
+
+    async def delete_note(self, **kwargs):
+        self.delete_attempts.append(dict(kwargs))
+        gate = self._claim_gate(self._delete_gates)
+        await self._wait_for_gate(gate, "delete")
+        if self.force_delete_result is False:
+            self.delete_calls.append(dict(kwargs))
+            return False
+        return await super().delete_note(**kwargs)
+
+
 async def _open_note_editor(screen, pilot, note_id_suffix: str = "n-1"):
     """Drive the shared path to the in-canvas note editor for ``_two_notes()``'s
     first row, then let the mount-time armed-flag callback settle.
@@ -20333,3 +20418,615 @@ async def test_library_note_escape_hierarchy_cannot_bypass_conflict() -> None:
             message="Reload did not resolve the conflict after Escape refusal.",
         )
         assert screen._library_note_shortcut_status == ""
+
+
+# ---------------------------------------------------------------------------
+# TASK-1333 Task 9: destructive and concurrent interaction safety in Pilot.
+
+
+async def _scroll_task9_context_to_nonzero_offset(context, pilot):
+    """Add bounded synthetic overflow and return a real nonzero scroll offset."""
+    await context.mount(
+        Static(
+            "Additional context evidence\n" * 12,
+            markup=False,
+        )
+    )
+    await pilot.pause()
+    context.scroll_to(y=context.max_scroll_y, animate=False)
+    await pilot.pause()
+    assert context.max_scroll_y > 0
+    assert context.scroll_y > 0
+    return context.scroll_y
+
+
+@pytest.mark.asyncio
+async def test_library_note_pilot_coalesces_three_edits_and_back_waits_for_chain() -> (
+    None
+):
+    first_save_release = threading.Event()
+    latest_save_release = threading.Event()
+    service = _GatedInteractionLibraryNotesScopeService(
+        _two_notes(), save_gates=(first_save_release, latest_save_release)
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = service
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            await _open_note_editor(screen, pilot)
+            body = screen.query_one("#library-note-body", TextArea)
+
+            body.text = "revision one"
+            await pilot.pause()
+            screen.query_one("#library-note-save").press()
+            await _wait_for_condition(
+                pilot,
+                lambda: len(service.save_attempts) == 1,
+                message="The first save never reached its gate.",
+            )
+
+            body.text = "revision two"
+            await pilot.pause()
+            screen.query_one("#library-note-save").press()
+            body.text = "revision three"
+            await pilot.pause()
+            screen.query_one("#library-note-back").press()
+
+            await asyncio.sleep(0.05)
+            assert screen._library_notes_view == "editor"
+            assert len(service.save_attempts) == 1
+
+            first_save_release.set()
+            for _ in range(200):
+                if len(service.save_attempts) == 2:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("The coalesced latest save never started.")
+            assert screen._library_notes_view == "editor"
+
+            latest_save_release.set()
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_notes_view == "list",
+                message="Back did not wait for the complete save chain.",
+            )
+
+            assert [call["content"] for call in service.save_attempts] == [
+                "revision one",
+                "revision three",
+            ]
+            assert service.max_concurrent_save_calls == 1
+            stored = next(note for note in service.notes if note["id"] == "n-1")
+            assert stored["content"] == "revision three"
+    finally:
+        first_save_release.set()
+        latest_save_release.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("origin", ("editor", "preview", "context"))
+async def test_library_note_pilot_conflict_can_originate_from_every_region(
+    origin: str,
+) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        body = screen.query_one("#library-note-body", TextArea)
+        body.text = f"{origin} conflict draft"
+        await pilot.pause()
+
+        if origin == "preview":
+            screen.query_one("#library-note-preview").press()
+            await _wait_for_display(screen, pilot, "#library-note-preview-region")
+        elif origin == "context":
+            screen.query_one("#library-note-context").press()
+            await _wait_for_display(screen, pilot, "#library-note-context-region")
+
+        _bump_note_version_externally(app.notes_scope_service, "n-1")
+        await pilot.press("ctrl+s")
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(
+                screen._library_note_session.snapshot
+                and screen._library_note_session.snapshot.in_conflict
+            ),
+            message=f"{origin} did not surface its save conflict.",
+        )
+
+        snapshot = screen._library_note_session.snapshot
+        assert snapshot is not None
+        assert snapshot.body == f"{origin} conflict draft"
+        assert screen.query_one("#library-note-conflict-region").display is True
+
+
+@pytest.mark.asyncio
+async def test_library_note_pilot_overwrite_keeps_edits_from_fetch_and_save() -> None:
+    refresh_release = threading.Event()
+    overwrite_save_release = threading.Event()
+    service = _GatedInteractionLibraryNotesScopeService(
+        _two_notes(),
+        detail_gates=(None, refresh_release),
+        save_gates=(None, overwrite_save_release, None),
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = service
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            await _open_note_editor(screen, pilot)
+            body = screen.query_one("#library-note-body", TextArea)
+            body.text = "conflicted local draft"
+            await pilot.pause()
+            _bump_note_version_externally(service, "n-1")
+            screen.query_one("#library-note-save").press()
+            await _wait_for_display(screen, pilot, "#library-note-conflict-overwrite")
+
+            overwrite = screen.query_one("#library-note-conflict-overwrite")
+            reload_button = screen.query_one("#library-note-conflict-reload")
+            overwrite.press()
+            overwrite.press()
+            reload_button.press()
+            for _ in range(200):
+                if len(service.detail_attempts) == 2:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("Overwrite refresh never reached its gate.")
+
+            body.text = "edit during overwrite fetch"
+            await pilot.pause()
+            refresh_release.set()
+            for _ in range(200):
+                if len(service.save_attempts) == 2:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("Overwrite save never reached its gate.")
+
+            body.text = "edit during overwrite save"
+            await pilot.pause()
+            overwrite_save_release.set()
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_note_autosave_state == "saved",
+                message="Overwrite did not save the newest canonical draft.",
+            )
+
+            assert len(service.detail_attempts) == 2
+            assert [call["content"] for call in service.save_attempts] == [
+                "conflicted local draft",
+                "edit during overwrite fetch",
+                "edit during overwrite save",
+            ]
+            assert service.max_concurrent_save_calls == 1
+            snapshot = screen._library_note_session.snapshot
+            assert snapshot is not None
+            assert snapshot.body == "edit during overwrite save"
+            assert snapshot.dirty is False
+    finally:
+        refresh_release.set()
+        overwrite_save_release.set()
+
+
+@pytest.mark.asyncio
+async def test_library_note_pilot_reload_rejects_edit_during_fetch_and_duplicates() -> (
+    None
+):
+    refresh_release = threading.Event()
+    service = _GatedInteractionLibraryNotesScopeService(
+        _two_notes(), detail_gates=(None, refresh_release)
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = service
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            await _open_note_editor(screen, pilot)
+            body = screen.query_one("#library-note-body", TextArea)
+            body.text = "conflicted local draft"
+            await pilot.pause()
+            _bump_note_version_externally(service, "n-1", content="server replacement")
+            screen.query_one("#library-note-save").press()
+            await _wait_for_display(screen, pilot, "#library-note-conflict-reload")
+
+            reload_button = screen.query_one("#library-note-conflict-reload")
+            overwrite = screen.query_one("#library-note-conflict-overwrite")
+            reload_button.press()
+            reload_button.press()
+            overwrite.press()
+            for _ in range(200):
+                if len(service.detail_attempts) == 2:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("Reload refresh never reached its gate.")
+
+            body.text = "newer edit during reload"
+            await pilot.pause()
+            refresh_release.set()
+            await _wait_for_condition(
+                pilot,
+                lambda: not screen._library_note_session.conflict_resolution_running,
+                message="Reload conflict operation never completed.",
+            )
+
+            snapshot = screen._library_note_session.snapshot
+            assert snapshot is not None
+            assert snapshot.body == "newer edit during reload"
+            assert snapshot.in_conflict is True
+            assert "Reload not applied" in snapshot.status_message
+            assert len(service.detail_attempts) == 2
+            assert len(service.save_attempts) == 1
+    finally:
+        refresh_release.set()
+
+
+@pytest.mark.asyncio
+async def test_library_note_pilot_delete_pending_locks_and_cancel_restores_context() -> (
+    None
+):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        screen.query_one("#library-note-context").press()
+        context = await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one("#library-note-context-delete").focus()
+        origin_scroll = await _scroll_task9_context_to_nonzero_offset(context, pilot)
+        snapshot_before = screen._library_note_session.snapshot
+        assert snapshot_before is not None
+        save_calls_before = len(app.notes_scope_service.save_calls)
+
+        delete_action = screen.query_one("#library-note-context-delete")
+        delete_action.press()
+        delete_action.press()
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
+
+        admission = screen._library_note_session.destructive_admission
+        assert admission is not None
+        assert screen._library_note_session.destructive_running is False
+        assert screen._library_note_context is False
+        assert screen.query_one("#library-note-editor-region").display is True
+        delete_action.press()
+        await pilot.pause()
+        assert screen._library_note_session.destructive_admission == admission
+        title = screen.query_one("#library-note-title", Input)
+        body = screen.query_one("#library-note-body", TextArea)
+        keywords = screen.query_one("#library-note-context-keywords", Input)
+        assert title.disabled is True
+        assert body.disabled is True
+        assert keywords.disabled is True
+        for widget, key in ((title, "x"), (body, "y"), (keywords, "z")):
+            widget.focus()
+            await pilot.press(key)
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        assert len(app.notes_scope_service.save_calls) == save_calls_before
+        assert "Save locked" in screen._library_note_shortcut_status
+        assert screen._library_note_session.snapshot == snapshot_before
+
+        await pilot.press("escape")
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+        assert screen._library_note_session.destructive_admission is None
+        assert screen._library_note_confirming_delete is False
+        assert screen._library_note_context is True
+        assert getattr(screen.focused, "id", None) == "library-note-context-delete"
+        assert context.scroll_y == origin_scroll
+
+
+@pytest.mark.asyncio
+async def test_library_note_delete_captures_context_origin_before_gated_flush() -> None:
+    save_release = threading.Event()
+    service = _GatedInteractionLibraryNotesScopeService(
+        _two_notes(), save_gates=(save_release,)
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = service
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=(60, 20)) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            await _open_note_editor(screen, pilot)
+            screen.query_one("#library-note-context").press()
+            context = await _wait_for_display(
+                screen, pilot, "#library-note-context-region"
+            )
+            origin_scroll = await _scroll_task9_context_to_nonzero_offset(
+                context, pilot
+            )
+            screen.query_one(
+                "#library-note-context-keywords", Input
+            ).value = "alpha, gated-delete"
+            await pilot.pause()
+
+            screen.query_one("#library-note-context-delete").press()
+            for _ in range(200):
+                if len(service.save_attempts) == 1:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("Delete's pre-admission flush never started.")
+
+            # Invoke the same bound Escape action while the Textual handler is
+            # suspended at the real threaded save seam. The initiating origin
+            # must remain Context even though current presentation changes.
+            await screen.action_library_notes_escape()
+            assert screen._library_note_context is False
+            save_release.set()
+            await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
+
+            await pilot.press("escape")
+            await _wait_for_display(screen, pilot, "#library-note-context-region")
+            assert screen._library_note_context is True
+            assert getattr(screen.focused, "id", None) == (
+                "library-note-context-delete"
+            )
+            assert context.scroll_y == origin_scroll
+    finally:
+        save_release.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("delete_succeeds", (False, True))
+async def test_library_note_pilot_delete_running_blocks_duplicate_escape_and_save(
+    delete_succeeds: bool,
+) -> None:
+    delete_release = threading.Event()
+    service = _GatedInteractionLibraryNotesScopeService(
+        _two_notes(),
+        delete_gates=(delete_release,),
+        force_delete_result=None if delete_succeeds else False,
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = service
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=(60, 20)) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            await _open_note_editor(screen, pilot)
+            screen.query_one("#library-note-context").press()
+            context = await _wait_for_display(
+                screen, pilot, "#library-note-context-region"
+            )
+            origin_scroll = await _scroll_task9_context_to_nonzero_offset(
+                context, pilot
+            )
+            screen.query_one("#library-note-context-delete").press()
+            await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
+            snapshot_before = screen._library_note_session.snapshot
+            assert snapshot_before is not None
+
+            confirm = screen.query_one("#library-note-delete-confirm", Button)
+            confirm.press()
+            confirm.press()
+            await _wait_for_condition(
+                pilot,
+                lambda: len(service.delete_attempts) == 1,
+                message="Delete never reached its service gate.",
+            )
+            assert screen._library_note_session.destructive_running is True
+
+            confirm.press()
+            for selector, widget_type, key in (
+                ("#library-note-title", Input, "x"),
+                ("#library-note-body", TextArea, "y"),
+                ("#library-note-context-keywords", Input, "z"),
+            ):
+                widget = screen.query_one(selector, widget_type)
+                assert widget.disabled is True
+                widget.focus()
+                await pilot.press(key)
+            await pilot.press("ctrl+s")
+            await pilot.press("escape")
+            await pilot.pause()
+            assert len(service.delete_attempts) == 1
+            assert screen._library_note_confirming_delete is True
+            assert screen._library_note_session.snapshot == snapshot_before
+            assert "running" in screen._library_note_shortcut_status.lower()
+
+            delete_release.set()
+            if delete_succeeds:
+                await _wait_for_selector(screen, pilot, "#library-notes-list")
+                assert screen._library_notes_view == "list"
+                assert screen._library_note_session.snapshot is None
+            else:
+                await _wait_for_display(screen, pilot, "#library-note-context-region")
+                assert screen._library_note_session.destructive_admission is None
+                snapshot_after = screen._library_note_session.snapshot
+                assert snapshot_after is not None
+                assert snapshot_after.draft == snapshot_before.draft
+                assert snapshot_after.baseline == snapshot_before.baseline
+                assert snapshot_after.dirty == snapshot_before.dirty
+                assert "Delete failed" in snapshot_after.status_message
+                assert getattr(screen.focused, "id", None) == (
+                    "library-note-context-delete"
+                )
+                assert context.scroll_y == origin_scroll
+    finally:
+        delete_release.set()
+
+
+@pytest.mark.asyncio
+async def test_library_note_pilot_stale_session_admission_cannot_reach_delete() -> None:
+    service = _GatedInteractionLibraryNotesScopeService(_two_notes())
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = service
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        screen.query_one("#library-note-delete").press()
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
+        stale_admission = screen._library_note_session.destructive_admission
+        assert stale_admission is not None
+
+        outcome = await screen._library_note_session.open_session("n-2")
+        assert outcome.kind is NoteLoadOutcomeKind.LOADED
+        assert screen._library_note_session.destructive_admission is None
+        screen.query_one("#library-note-delete-confirm").press()
+        await pilot.pause()
+
+        assert service.delete_attempts == []
+        assert screen._library_note_session.snapshot is not None
+        assert screen._library_note_session.snapshot.note_id == "n-2"
+        assert screen._library_note_session.snapshot.session_generation != (
+            stale_admission.session_generation
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_note_pilot_stale_version_fails_without_deleting_newer_note() -> (
+    None
+):
+    service = _GatedInteractionLibraryNotesScopeService(_two_notes())
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = service
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        screen.query_one("#library-note-context").press()
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+        screen.query_one("#library-note-context-delete").press()
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
+        admission = screen._library_note_session.destructive_admission
+        assert admission is not None
+
+        _bump_note_version_externally(service, "n-1", content="newer server body")
+        screen.query_one("#library-note-delete-confirm").press()
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+
+        assert len(service.delete_attempts) == 1
+        assert service.delete_attempts[0]["version"] == admission.expected_version
+        stored = next(note for note in service.notes if note["id"] == "n-1")
+        assert stored["version"] == admission.expected_version + 1
+        assert stored["content"] == "newer server body"
+        assert screen._library_note_session.destructive_admission is None
+        assert screen._library_note_session.snapshot is not None
+
+
+@pytest.mark.asyncio
+async def test_library_note_pilot_duplicate_discard_runs_one_delete_and_blocks_exit() -> (
+    None
+):
+    delete_release = threading.Event()
+    service = _GatedInteractionLibraryNotesScopeService(
+        _two_notes(), delete_gates=(delete_release,)
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = service
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=(60, 20)) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            screen.query_one("#library-row-create-note").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+            screen.query_one("#library-notes-create-blank").press()
+            discard = await _wait_for_selector(
+                screen, pilot, "#library-note-discard-new"
+            )
+            await _wait_for_condition(
+                pilot,
+                lambda: discard.display,
+                message="Untouched create never exposed Discard.",
+            )
+
+            discard.press()
+            discard.press()
+            await _wait_for_condition(
+                pilot,
+                lambda: len(service.delete_attempts) == 1,
+                message="Discard never reached its service gate.",
+            )
+            assert screen._library_note_session.destructive_running is True
+            await pilot.press("ctrl+s")
+            await pilot.press("escape")
+            await pilot.pause()
+            assert len(service.delete_attempts) == 1
+            assert screen._library_notes_view == "editor"
+
+            delete_release.set()
+            await _wait_for_selector(screen, pilot, "#library-notes-list")
+            assert screen._library_notes_view == "list"
+            assert screen._library_note_session.snapshot is None
+    finally:
+        delete_release.set()
+
+
+@pytest.mark.asyncio
+async def test_library_note_pilot_stale_create_token_blocks_discard_activation() -> (
+    None
+):
+    service = _GatedInteractionLibraryNotesScopeService(_two_notes())
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = service
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-create-note").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        screen.query_one("#library-notes-create-blank").press()
+        discard = await _wait_for_selector(screen, pilot, "#library-note-discard-new")
+        await _wait_for_condition(
+            pilot,
+            lambda: discard.display,
+            message="Untouched create never exposed Discard.",
+        )
+
+        title = screen.query_one("#library-note-title", Input)
+        title.focus()
+        await pilot.press("end")
+        await pilot.press("space", "k", "e", "p", "t")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_session.untouched_create_token is None,
+            message="A genuine edit did not revoke the create token.",
+        )
+        discard.press()
+        await pilot.pause()
+
+        assert service.delete_attempts == []
+        snapshot = screen._library_note_session.snapshot
+        assert snapshot is not None
+        assert snapshot.title.endswith(" kept")

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -91,6 +91,7 @@ from tldw_chatbook.UI.Screens import library_screen as library_screen_module
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
 from tldw_chatbook.Widgets.Library.library_ingest_canvas import LibraryIngestCanvas
+from tldw_chatbook.Widgets.Library.library_notes_canvas import LibraryNotesCanvas
 from tldw_chatbook.Widgets.Library.library_rail import LIBRARY_RAIL_ROW_PREFIX
 from Tests.UI.test_destination_shells import (
     PolicyDeniedLibraryNotesScopeService,
@@ -19344,12 +19345,23 @@ async def test_library_note_compact_surplus_allocation_expands_only_named_owner(
         assert fixed_heights == tuple(1 for _ in fixed_selectors)
         assert screen.query_one(owner_selector) is owner
         assert owner.region.height == owner_height_at_100x30
-        assert (
-            tuple(
-                screen.query_one(selector).region.height for selector in fixed_selectors
-            )
-            == fixed_heights
+        resized_fixed_heights = tuple(
+            screen.query_one(selector).region.height for selector in fixed_selectors
         )
+        assert resized_fixed_heights == fixed_heights
+        growth_by_named_region = {
+            owner_selector: owner.region.height - owner_height,
+            **{
+                selector: resized - initial
+                for selector, resized, initial in zip(
+                    fixed_selectors, resized_fixed_heights, fixed_heights, strict=True
+                )
+            },
+        }
+        assert growth_by_named_region[owner_selector] == 6
+        assert [
+            selector for selector, growth in growth_by_named_region.items() if growth
+        ] == [owner_selector]
 
 
 @pytest.mark.asyncio
@@ -21030,3 +21042,1072 @@ async def test_library_note_pilot_stale_create_token_blocks_discard_activation()
         snapshot = screen._library_note_session.snapshot
         assert snapshot is not None
         assert snapshot.title.endswith(" kept")
+
+
+# ---------------------------------------------------------------------------
+# TASK-1333 Task 10: keyboard accessibility and lifecycle stability gates.
+
+
+async def _task10_focus_with_keyboard(
+    screen,
+    pilot,
+    selector: str,
+    *,
+    reverse: bool = False,
+    limit: int = 120,
+):
+    """Reach one visible control using Tab/Shift+Tab only."""
+    target = screen.query_one(selector)
+    assert target.display is True, f"Keyboard target is hidden: {selector}"
+    await _wait_for_condition(
+        pilot,
+        lambda: target.region.width > 0 and target.region.height > 0,
+        message=lambda: (
+            "Keyboard target never received visible geometry: "
+            f"{selector} -> {target.region!r}"
+        ),
+    )
+    key = "shift+tab" if reverse else "tab"
+    for _ in range(limit):
+        if screen.focused is target:
+            return target
+        await pilot.press(key)
+        await pilot.pause()
+    raise AssertionError(
+        f"{selector} was not reachable with {key}; focused={screen.focused!r}."
+    )
+
+
+async def _task10_activate_with_keyboard(screen, pilot, selector: str):
+    """Reach a visible control with Tab and activate it with Enter."""
+    target = await _task10_focus_with_keyboard(screen, pilot, selector)
+    if isinstance(target, Button):
+        await _wait_for_condition(
+            pilot,
+            lambda: not target.has_class("-active"),
+            message=f"{selector} never released its prior key-active state.",
+        )
+    await pilot.press("enter")
+    await pilot.pause()
+    return target
+
+
+async def _task10_open_notes_navigator(screen, pilot) -> None:
+    # Capability gates begin from a quiet shell so an unrelated first-load
+    # recompose cannot replace the rail button between Tab focus and Enter.
+    await screen.workers.wait_for_complete()
+    await pilot.pause()
+    await _task10_activate_with_keyboard(
+        screen,
+        pilot,
+        f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}",
+    )
+    await _wait_for_condition(
+        pilot,
+        lambda: (
+            screen._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+            and (
+                not screen._library_notes_compact
+                or screen._library_notes_stage == "notes"
+            )
+        ),
+        message=lambda: (
+            "Keyboard activation did not enter Notes Navigator: "
+            f"selected={screen._library_selected_row_id!r}, "
+            f"stage={screen._library_notes_stage!r}."
+        ),
+    )
+    await _wait_for_selector(screen, pilot, "#library-notes-filter")
+    await pilot.pause()
+
+
+async def _task10_open_note_editor_with_keyboard(screen, pilot) -> None:
+    await _task10_open_notes_navigator(screen, pilot)
+    await _task10_activate_with_keyboard(screen, pilot, "#library-notes-row-0")
+    await _wait_for_selector(screen, pilot, "#library-note-body")
+    await pilot.pause()
+
+
+_TASK10_NOTE_CAPABILITIES = (
+    "filter_sort",
+    "create_discard",
+    "sync",
+    "import_whole_export",
+    "multi_select_export",
+    "edit_title_body",
+    "edit_keywords",
+    "save_autosave",
+    "preview_edit",
+    "metadata",
+    "use_in_console",
+    "copy",
+    "export_markdown_text",
+    "delete_cancel_confirm",
+    "conflict_overwrite_reload",
+)
+
+
+async def _task10_open_note_utilities(screen, pilot, compact: bool) -> str:
+    """Expose the parity utility surface and return its selector prefix."""
+    if compact:
+        await _task10_activate_with_keyboard(screen, pilot, "#library-note-context")
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+        return "#library-note-context-"
+    assert screen.query_one("#library-note-wide-utilities").display is True
+    return "#library-note-"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_size", ((60, 20), (170, 48)))
+@pytest.mark.parametrize("capability", _TASK10_NOTE_CAPABILITIES)
+async def test_library_note_keyboard_capability_matrix(
+    terminal_size: tuple[int, int],
+    capability: str,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Every specified Notes capability is operable without pointer or Space."""
+    compact = terminal_size[0] < 120
+    if capability == "save_autosave":
+        monkeypatch.setattr(
+            library_screen_module, "LIBRARY_NOTES_AUTOSAVE_SECONDS", 0.05
+        )
+    if capability == "sync":
+        from tldw_chatbook.Notes import sync_service as sync_service_module
+
+        _RecordingNotesSyncService.instances.clear()
+        monkeypatch.setattr(
+            sync_service_module, "NotesSyncService", _RecordingNotesSyncService
+        )
+
+        def task10_sync_setting(section, key, default=None):
+            if (section, key) == ("notes", "sync_directory"):
+                return str(tmp_path)
+            return default
+
+        monkeypatch.setattr(
+            library_screen_module, "get_cli_setting", task10_sync_setting
+        )
+    app = _build_test_app()
+    _seed_conversations(app, [], notes=_two_notes())
+    if capability == "sync":
+        app.notes_service = Mock()
+        app.chachanotes_db = Mock()
+    app.notify = Mock()
+    app.copy_to_clipboard = Mock()
+    app.open_chat_with_handoff = Mock()
+    _link_library_items_to_active_workspace(
+        app,
+        (
+            ("note", "n-1", "Q3 retro"),
+            ("note", "n-2", "Reading list"),
+        ),
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=terminal_size) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, compact)
+
+        if capability == "filter_sort":
+            await _task10_open_notes_navigator(screen, pilot)
+            filter_input = await _task10_focus_with_keyboard(
+                screen, pilot, "#library-notes-filter"
+            )
+            await pilot.press("r", "e", "t", "r", "o", "enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: bool(app.notes_scope_service.search_calls),
+                message="Keyboard filter submit never reached search_notes.",
+            )
+            assert filter_input.value == "retro"
+            await _task10_activate_with_keyboard(screen, pilot, "#library-notes-sort")
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-sort-oldest"
+            )
+            assert screen._library_notes_sort == "oldest"
+            return
+
+        if capability == "create_discard":
+            await _task10_open_notes_navigator(screen, pilot)
+            await _task10_activate_with_keyboard(screen, pilot, "#library-notes-new")
+            await _wait_for_selector(screen, pilot, "#library-notes-template-0")
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-template-0"
+            )
+            await _wait_for_selector(screen, pilot, "#library-note-discard-new")
+            template_note_id = screen._library_note_session.snapshot.note_id
+            assert any(
+                str(note.get("id")) == template_note_id
+                for note in app.notes_scope_service.notes
+            )
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-note-discard-new"
+            )
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    len(app.notes_scope_service.delete_calls) == 1
+                    and bool(screen.query("#library-notes-new"))
+                ),
+                message="Template discard never deleted the created note.",
+            )
+            assert all(
+                str(note.get("id")) != template_note_id
+                for note in app.notes_scope_service.notes
+            )
+            await _task10_activate_with_keyboard(screen, pilot, "#library-notes-new")
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-create-blank"
+            )
+            await _wait_for_selector(screen, pilot, "#library-note-discard-new")
+            blank_note_id = screen._library_note_session.snapshot.note_id
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-note-discard-new"
+            )
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    len(app.notes_scope_service.delete_calls) == 2
+                    and bool(screen.query("#library-notes-new"))
+                ),
+                message="Blank-note discard never deleted the created note.",
+            )
+            assert all(
+                str(note.get("id")) != blank_note_id
+                for note in app.notes_scope_service.notes
+            )
+            assert len(app.notes_scope_service.save_calls) == 2
+            return
+
+        if capability == "sync":
+            await _task10_open_notes_navigator(screen, pilot)
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-sync-open"
+            )
+            await _wait_for_selector(screen, pilot, "#library-notes-sync-run")
+            direction_before = screen._library_notes_sync_direction
+            conflict_before = screen._library_notes_sync_conflict
+            auto_before = screen._library_notes_sync_auto
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-sync-direction-disk_to_db"
+            )
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-sync-conflict-db_wins"
+            )
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-sync-auto"
+            )
+            assert screen._library_notes_sync_direction != direction_before
+            assert screen._library_notes_sync_conflict != conflict_before
+            assert screen._library_notes_sync_auto != auto_before
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-sync-run"
+            )
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    bool(_RecordingNotesSyncService.instances)
+                    and bool(_RecordingNotesSyncService.instances[0].calls)
+                ),
+                message="Keyboard Sync now never reached the sync service.",
+            )
+            sync_service = _RecordingNotesSyncService.instances[0]
+            assert sync_service.calls[0]["root_folder"] == tmp_path
+            sync_service.release_event.set()
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    not screen._library_notes_sync_running
+                    and screen._library_notes_sync_status.startswith("done")
+                ),
+                message="Keyboard Sync now never rendered its completed status.",
+            )
+            return
+
+        if capability == "import_whole_export":
+            await _task10_open_notes_navigator(screen, pilot)
+            await _task10_activate_with_keyboard(screen, pilot, "#library-notes-import")
+            await _wait_for_condition(
+                pilot,
+                lambda: isinstance(host.screen_stack[-1], FileOpen),
+                message="Keyboard Import never opened FileOpen.",
+            )
+            operation = screen._library_notes_operation
+            assert operation is not None and operation.kind == "import"
+            await pilot.press("escape")
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    host.screen_stack[-1] is screen
+                    and screen._library_notes_operation is not None
+                    and not screen._library_notes_operation.running
+                ),
+                message="FileOpen Escape did not cancel the import callback.",
+            )
+            assert screen._library_notes_operation.token == operation.token
+            assert screen._library_notes_operation.status_line == (
+                "Import failed — choose a file and try again."
+            )
+            assert not app.notes_scope_service.save_calls
+            await _task10_activate_with_keyboard(screen, pilot, "#library-notes-export")
+            await _wait_for_selector(screen, pilot, "#library-export-destination")
+            assert screen._library_export_scope == ExportScope(kind="notes")
+            return
+
+        if capability == "multi_select_export":
+            await _task10_open_notes_navigator(screen, pilot)
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-select-toggle"
+            )
+            await _task10_activate_with_keyboard(screen, pilot, "#library-notes-row-0")
+            assert screen._library_notes_row_selection.count == 1
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-select-all"
+            )
+            assert screen._library_notes_row_selection.count == 2
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-select-clear"
+            )
+            assert screen._library_notes_row_selection.count == 0
+            await _task10_activate_with_keyboard(screen, pilot, "#library-notes-row-0")
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-notes-export-selected"
+            )
+            await _wait_for_selector(screen, pilot, "#library-export-destination")
+            assert screen._library_export_scope == ExportScope(
+                kind="notes", ids=("n-1",)
+            )
+            return
+
+        await _task10_open_note_editor_with_keyboard(screen, pilot)
+
+        if capability == "edit_title_body":
+            title = await _task10_focus_with_keyboard(
+                screen, pilot, "#library-note-title"
+            )
+            await pilot.press("end", "x")
+            body = await _task10_focus_with_keyboard(
+                screen, pilot, "#library-note-body"
+            )
+            await pilot.press("end", "y")
+            await pilot.pause()
+            assert title.value.endswith("x")
+            assert body.text.endswith("y")
+            assert screen._library_note_session.snapshot.dirty is True
+            return
+
+        if capability == "edit_keywords":
+            prefix = await _task10_open_note_utilities(screen, pilot, compact)
+            keywords = await _task10_focus_with_keyboard(
+                screen,
+                pilot,
+                f"{prefix}keywords",
+            )
+            await pilot.press("end", "k")
+            await pilot.pause()
+            assert keywords.value.endswith("k")
+            assert screen._library_note_session.snapshot.dirty is True
+            return
+
+        if capability == "save_autosave":
+            body = await _task10_focus_with_keyboard(
+                screen, pilot, "#library-note-body"
+            )
+            saves_before = len(app.notes_scope_service.save_calls)
+            await pilot.press("end", "s")
+            await _wait_for_condition(
+                pilot,
+                lambda: len(app.notes_scope_service.save_calls) == saves_before + 1,
+                message="The debounce timer never autosaved the keyboard edit.",
+            )
+            assert body.text.endswith("s")
+            assert screen._library_notes_autosave_timer is None
+            assert screen._library_note_autosave_state == "saved"
+
+            monkeypatch.setattr(
+                library_screen_module, "LIBRARY_NOTES_AUTOSAVE_SECONDS", 3600
+            )
+            body = await _task10_focus_with_keyboard(
+                screen, pilot, "#library-note-body"
+            )
+            await pilot.press("end", "e")
+            await pilot.pause()
+            assert screen._library_notes_autosave_timer is not None
+            await _task10_activate_with_keyboard(screen, pilot, "#library-note-save")
+            await _wait_for_condition(
+                pilot,
+                lambda: len(app.notes_scope_service.save_calls) == saves_before + 2,
+                message="Keyboard Save never reached save_note.",
+            )
+            return
+
+        if capability == "preview_edit":
+            await _task10_activate_with_keyboard(screen, pilot, "#library-note-preview")
+            await _wait_for_display(screen, pilot, "#library-note-preview-region")
+            assert screen._library_note_preview is True
+            await _task10_activate_with_keyboard(screen, pilot, "#library-note-preview")
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_note_preview is False,
+                message="Keyboard Edit did not leave Preview.",
+            )
+            return
+
+        if capability == "metadata":
+            if compact:
+                await _task10_open_note_utilities(screen, pilot, compact)
+                metadata = screen.query_one("#library-note-context-meta")
+            else:
+                await _task10_focus_with_keyboard(
+                    screen, pilot, "#library-note-keywords"
+                )
+                metadata = screen.query_one("#library-note-meta")
+            assert metadata.display is True
+            assert "v2" in str(metadata.renderable)
+            return
+
+        if capability == "use_in_console":
+            prefix = await _task10_open_note_utilities(screen, pilot, compact)
+            await _task10_activate_with_keyboard(
+                screen, pilot, f"{prefix}use-in-console"
+            )
+            await _wait_for_condition(
+                pilot,
+                lambda: app.open_chat_with_handoff.call_count == 1,
+                message="Keyboard Use in Console never reached the handoff seam.",
+            )
+            return
+
+        if capability == "copy":
+            prefix = await _task10_open_note_utilities(screen, pilot, compact)
+            await _task10_activate_with_keyboard(screen, pilot, f"{prefix}copy")
+            app.copy_to_clipboard.assert_called_once()
+            return
+
+        if capability == "export_markdown_text":
+            prefix = await _task10_open_note_utilities(screen, pilot, compact)
+            for suffix, extension in (("export-md", ".md"), ("export-txt", ".txt")):
+                await _task10_activate_with_keyboard(screen, pilot, f"{prefix}{suffix}")
+                await _wait_for_condition(
+                    pilot,
+                    lambda: isinstance(host.screen_stack[-1], FileSave),
+                    message=f"Keyboard {suffix} never opened FileSave.",
+                )
+                dialog = host.screen_stack[-1]
+                assert dialog._default_file.endswith(extension)
+                await pilot.press("escape")
+                await _wait_for_condition(
+                    pilot,
+                    lambda: host.screen_stack[-1] is screen,
+                    message="FileSave Escape did not return to the note.",
+                )
+            return
+
+        if capability == "delete_cancel_confirm":
+            prefix = await _task10_open_note_utilities(screen, pilot, compact)
+            await _task10_activate_with_keyboard(screen, pilot, f"{prefix}delete")
+            await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-note-delete-cancel"
+            )
+            assert screen._library_note_confirming_delete is False
+            await _task10_activate_with_keyboard(screen, pilot, f"{prefix}delete")
+            await _task10_activate_with_keyboard(
+                screen, pilot, "#library-note-delete-confirm"
+            )
+            await _wait_for_condition(
+                pilot,
+                lambda: bool(app.notes_scope_service.delete_calls),
+                message="Keyboard delete confirmation never reached delete_note.",
+            )
+            return
+
+        assert capability == "conflict_overwrite_reload"
+        await _task10_focus_with_keyboard(screen, pilot, "#library-note-body")
+        await pilot.press("end", "r")
+        await pilot.pause()
+        _bump_note_version_externally(app.notes_scope_service, "n-1")
+        await _task10_activate_with_keyboard(screen, pilot, "#library-note-save")
+        await _wait_for_display(screen, pilot, "#library-note-conflict-region")
+        assert getattr(screen.focused, "id", None) == "library-note-conflict-copy"
+        await _task10_activate_with_keyboard(
+            screen, pilot, "#library-note-conflict-reload"
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen._library_note_session.snapshot.in_conflict,
+            message="Keyboard Reload did not resolve the conflict.",
+        )
+        await _task10_focus_with_keyboard(screen, pilot, "#library-note-body")
+        await pilot.press("end", "o")
+        await pilot.pause()
+        _bump_note_version_externally(app.notes_scope_service, "n-1")
+        await _task10_activate_with_keyboard(screen, pilot, "#library-note-save")
+        await _wait_for_display(screen, pilot, "#library-note-conflict-region")
+        await _task10_activate_with_keyboard(
+            screen, pilot, "#library-note-conflict-overwrite"
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen._library_note_session.snapshot.in_conflict,
+            message="Keyboard Overwrite did not resolve the conflict.",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_size", ((60, 20), (170, 48)))
+async def test_library_note_keyboard_focus_order_and_persistent_labels(
+    terminal_size: tuple[int, int],
+) -> None:
+    """Editor, Context, conflict, delete, and recompose retain exact order."""
+    compact = terminal_size[0] < 120
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=terminal_size) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, compact)
+        await _task10_open_notes_navigator(screen, pilot)
+
+        filter_label = screen.query_one("#library-notes-filter-label", Static)
+        assert str(filter_label.renderable) == "Filter"
+        assert filter_label.region.width > 0 and filter_label.region.height == 1
+        await _task10_activate_with_keyboard(screen, pilot, "#library-notes-row-0")
+        await _wait_for_selector(screen, pilot, "#library-note-body")
+        await pilot.pause()
+
+        for selector, copy in (
+            ("#library-note-title-label", "Title"),
+            ("#library-note-body-label", "Body"),
+        ):
+            label = screen.query_one(selector, Static)
+            assert str(label.renderable) == copy
+            assert label.region.width > 0 and label.region.height == 1
+
+        title = await _task10_focus_with_keyboard(screen, pilot, "#library-note-title")
+        await pilot.press("tab")
+        await pilot.pause()
+        body = screen.query_one("#library-note-body", TextArea)
+        assert screen.focused is body
+        await pilot.press("shift+tab")
+        await pilot.pause()
+        assert screen.focused is title
+        await pilot.press("tab")
+        await pilot.pause()
+        assert screen.focused is body
+        for expected in (
+            "library-note-save",
+            "library-note-preview",
+            "library-note-context",
+        ):
+            await pilot.press("tab")
+            await pilot.pause()
+            assert getattr(screen.focused, "id", None) == expected
+        if not compact:
+            await pilot.press("tab")
+            await pilot.pause()
+            assert getattr(screen.focused, "id", None) == "library-note-keywords"
+            label = screen.query_one("#library-note-keywords-label", Static)
+            assert str(label.renderable) == "Keywords"
+            assert label.region.height == 1
+
+        body = await _task10_focus_with_keyboard(screen, pilot, "#library-note-body")
+        screen.refresh(recompose=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.query_one("#library-note-body", TextArea) is not body,
+            message="Whole-screen recompose did not replace the editor widget.",
+        )
+        body = screen.query_one("#library-note-body", TextArea)
+        assert screen.focused is body
+        assert screen._library_notes_semantic_role(screen.focused) == "body"
+        await pilot.press("shift+tab")
+        await pilot.pause()
+        assert getattr(screen.focused, "id", None) == "library-note-title"
+        await pilot.press("tab")
+        await pilot.pause()
+        assert screen.focused is body
+        await pilot.press("tab")
+        await pilot.pause()
+        assert getattr(screen.focused, "id", None) == "library-note-save"
+
+        await _task10_activate_with_keyboard(screen, pilot, "#library-note-context")
+        await _wait_for_display(screen, pilot, "#library-note-context-region")
+        assert getattr(screen.focused, "id", None) == "library-note-context-region"
+        context_order = (
+            "library-note-context-keywords",
+            "library-note-context-use-in-console",
+            "library-note-context-copy",
+            "library-note-context-export-md",
+            "library-note-context-export-txt",
+            "library-note-context-delete",
+        )
+        for expected in context_order:
+            await pilot.press("tab")
+            await pilot.pause()
+            assert getattr(screen.focused, "id", None) == expected
+        await pilot.press("shift+tab")
+        await pilot.pause()
+        assert getattr(screen.focused, "id", None) == context_order[-2]
+        keywords_label = screen.query_one(
+            "#library-note-context-keywords-label", Static
+        )
+        assert str(keywords_label.renderable) == "Keywords"
+        assert keywords_label.region.height == 1
+
+        await _task10_activate_with_keyboard(
+            screen, pilot, "#library-note-context-delete"
+        )
+        await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
+        assert getattr(screen.focused, "id", None) == "library-note-delete-cancel"
+        await pilot.press("tab")
+        await pilot.pause()
+        assert getattr(screen.focused, "id", None) == "library-note-delete-confirm"
+        await pilot.press("shift+tab")
+        await pilot.pause()
+        assert getattr(screen.focused, "id", None) == "library-note-delete-cancel"
+        await pilot.press("escape")
+        await pilot.press("escape")
+        await pilot.pause()
+
+        body = await _task10_focus_with_keyboard(screen, pilot, "#library-note-body")
+        await pilot.press("end", "c")
+        await pilot.pause()
+        _bump_note_version_externally(app.notes_scope_service, "n-1")
+        await pilot.press("ctrl+s")
+        await _wait_for_display(screen, pilot, "#library-note-conflict-region")
+        assert getattr(screen.focused, "id", None) == "library-note-conflict-copy"
+        await pilot.press("tab")
+        await pilot.pause()
+        assert getattr(screen.focused, "id", None) == (
+            "library-note-conflict-overwrite"
+        )
+        await pilot.press("tab")
+        await pilot.pause()
+        assert getattr(screen.focused, "id", None) == "library-note-conflict-reload"
+        await pilot.press("shift+tab")
+        await pilot.pause()
+        assert getattr(screen.focused, "id", None) == (
+            "library-note-conflict-overwrite"
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_note_fifty_cycle_breakpoint_and_presentation_lifecycle() -> None:
+    """Fifty breakpoint/Preview/Context cycles retain one stable workbench."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(119, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        await _task10_open_note_editor_with_keyboard(screen, pilot)
+        coordinator = screen._library_note_session
+        stable = {
+            selector: screen.query_one(selector)
+            for selector in (
+                "#library-notes-canvas",
+                "#library-note-title",
+                "#library-note-body",
+                "#library-note-preview-region",
+                "#library-note-context-region",
+                "#library-note-conflict-copy",
+                "#library-note-delete-confirmation",
+                "#library-note-status",
+            )
+        }
+
+        for _ in range(50):
+            await pilot.resize_terminal(120, 30)
+            await _wait_for_library_notes_compact(screen, pilot, False)
+            await pilot.resize_terminal(119, 30)
+            await _wait_for_library_notes_compact(screen, pilot, True)
+
+            screen.query_one("#library-note-preview", Button).press()
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_note_preview,
+                message="Preview did not open during the 50-cycle gate.",
+            )
+            screen.query_one("#library-note-preview", Button).press()
+            await _wait_for_condition(
+                pilot,
+                lambda: not screen._library_note_preview,
+                message="Preview did not close during the 50-cycle gate.",
+            )
+            screen.query_one("#library-note-context", Button).press()
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_note_context,
+                message="Context did not open during the 50-cycle gate.",
+            )
+            screen.query_one("#library-note-context-back", Button).press()
+            await _wait_for_condition(
+                pilot,
+                lambda: not screen._library_note_context,
+                message="Context did not close during the 50-cycle gate.",
+            )
+
+        assert screen._library_note_session is coordinator
+        assert len(screen.query("#library-notes-canvas")) == 1
+        for selector, original in stable.items():
+            assert screen.query_one(selector) is original
+        assert screen._library_notes_autosave_timer is None
+        assert not any(
+            worker.node is screen and worker.group.startswith("library_note")
+            for worker in host.workers
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("initial_size", "sequence", "expected_compact"),
+    (
+        ((80, 24), ((100, 30), (60, 20), (80, 24)), True),
+        ((120, 30), ((170, 48), (140, 36), (120, 30)), False),
+    ),
+)
+async def test_library_note_fifty_same_side_resize_sequences_do_zero_notes_work(
+    initial_size: tuple[int, int],
+    sequence: tuple[tuple[int, int], ...],
+    expected_compact: bool,
+) -> None:
+    """Fifty same-side sequences never touch presentation or coordinator seams."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=initial_size) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, expected_compact)
+        await _open_note_editor(screen, pilot)
+        coordinator = screen._library_note_session
+        body = screen.query_one("#library-note-body", TextArea)
+        seams = {}
+        for name in (
+            "_transition_library_notes_presentation",
+            "_capture_library_notes_focus_identity",
+            "_rehydrate_library_notes_after_recompose",
+            "_apply_library_notes_stage_visibility",
+            "_apply_library_note_presentation_state",
+            "_restore_library_notes_focus_identity",
+            "_commit_library_note_widgets_before_recompose",
+        ):
+            wrapped = Mock(wraps=getattr(screen, name))
+            setattr(screen, name, wrapped)
+            seams[name] = wrapped
+
+        for wrapped in seams.values():
+            wrapped.reset_mock()
+        for _ in range(50):
+            for width, height in sequence:
+                await pilot.resize_terminal(width, height)
+                await pilot.pause()
+
+        assert screen._library_note_session is coordinator
+        assert screen.query_one("#library-note-body", TextArea) is body
+        for name, wrapped in seams.items():
+            assert wrapped.call_count == 0, name
+        if expected_compact:
+            assert screen.query_one("#library-note-body").region.height == 14
+            await pilot.resize_terminal(100, 30)
+            await pilot.pause()
+            assert screen.query_one("#library-note-body") is body
+            assert body.region.height == 20
+
+
+@pytest.mark.asyncio
+async def test_library_note_recompose_and_fifty_route_cycles_return_to_baseline(
+    monkeypatch,
+) -> None:
+    """Dirty recomposes and fifty flushed route loops retain bounded ownership."""
+    monkeypatch.setattr(library_screen_module, "LIBRARY_NOTES_AUTOSAVE_SECONDS", 3600)
+    canvas_lifecycle = {"mounted": 0, "removed": 0}
+    original_canvas_mount = LibraryNotesCanvas.on_mount
+
+    def counted_canvas_mount(canvas) -> None:
+        canvas_lifecycle["mounted"] += 1
+        original_canvas_mount(canvas)
+
+    def counted_canvas_unmount(canvas) -> None:
+        del canvas
+        canvas_lifecycle["removed"] += 1
+
+    monkeypatch.setattr(LibraryNotesCanvas, "on_mount", counted_canvas_mount)
+    monkeypatch.setattr(
+        LibraryNotesCanvas, "on_unmount", counted_canvas_unmount, raising=False
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        await _task10_open_note_editor_with_keyboard(screen, pilot)
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+        coordinator = screen._library_note_session
+        note_worker_groups = {
+            "library_note_save",
+            "library_note_conflict",
+            "library_note_create",
+            "library_note_delete",
+        }
+        baseline_active_groups = {
+            worker.group
+            for worker in host.workers
+            if worker.node is screen and worker.group in note_worker_groups
+        }
+        baseline_timer_refs = (
+            screen._library_notes_autosave_timer,
+            screen._library_notes_auto_sync_timer,
+        )
+        assert baseline_active_groups == set()
+        assert baseline_timer_refs == (None, None)
+
+        exercised_groups = set()
+        original_run_worker = screen.run_worker
+
+        def recording_run_worker(*args, **kwargs):
+            group = kwargs.get("group")
+            if group in note_worker_groups:
+                exercised_groups.add(group)
+            return original_run_worker(*args, **kwargs)
+
+        monkeypatch.setattr(screen, "run_worker", recording_run_worker)
+        await _task10_focus_with_keyboard(screen, pilot, "#library-note-body")
+        await pilot.press("end", "d")
+        await pilot.pause()
+        dirty_body = screen._library_note_session.snapshot.body
+        assert screen._library_note_session.snapshot.dirty is True
+
+        for _ in range(5):
+            prior = screen.query_one("#library-note-body", TextArea)
+            screen._apply_local_source_snapshot(
+                dict(screen._local_source_records),
+                dict(screen._local_source_counts),
+                dict(screen._local_source_total_known),
+                screen._library_lookup_error,
+                screen._library_lookup_recovery_state,
+                dict(screen._library_study_counts),
+            )
+            await _wait_for_condition(
+                pilot,
+                lambda: screen.query_one("#library-note-body", TextArea) is not prior,
+                message=(
+                    "Generic source-snapshot completion never recomposed the "
+                    "Notes workbench."
+                ),
+            )
+            assert screen._library_note_session is coordinator
+            assert screen._library_note_session.snapshot.body == dirty_body
+            assert screen._library_note_session.snapshot.dirty is True
+            assert len(screen.query("#library-notes-canvas")) == 1
+
+        saves_before = len(app.notes_scope_service.save_calls)
+        await _task10_activate_with_keyboard(screen, pilot, "#library-note-save")
+        await _wait_for_condition(
+            pilot,
+            lambda: len(app.notes_scope_service.save_calls) == saves_before + 1,
+            message="Pre-route explicit Save never completed.",
+        )
+        assert screen._library_notes_autosave_timer is None
+
+        await _task10_focus_with_keyboard(screen, pilot, "#library-note-body")
+        await pilot.press("end", "c")
+        await pilot.pause()
+        _bump_note_version_externally(app.notes_scope_service, "n-1")
+        await _task10_activate_with_keyboard(screen, pilot, "#library-note-save")
+        await _wait_for_display(screen, pilot, "#library-note-conflict-region")
+        await _task10_activate_with_keyboard(
+            screen, pilot, "#library-note-conflict-reload"
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                not screen._library_note_session.snapshot.in_conflict
+                and not screen._library_note_session.conflict_resolution_running
+            ),
+            message="Lifecycle conflict Reload never completed.",
+        )
+
+        await _task10_activate_with_keyboard(screen, pilot, "#library-note-back")
+        await _wait_for_selector(screen, pilot, "#library-notes-new")
+        await _task10_activate_with_keyboard(screen, pilot, "#library-notes-new")
+        await _task10_activate_with_keyboard(
+            screen, pilot, "#library-notes-create-blank"
+        )
+        await _wait_for_selector(screen, pilot, "#library-note-discard-new")
+        created_note_id = screen._library_note_session.snapshot.note_id
+        await _task10_activate_with_keyboard(screen, pilot, "#library-note-discard-new")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                bool(app.notes_scope_service.delete_calls)
+                and bool(screen.query("#library-notes-new"))
+            ),
+            message="Lifecycle create/discard operation never completed.",
+        )
+        assert all(
+            str(note.get("id")) != created_note_id
+            for note in app.notes_scope_service.notes
+        )
+
+        screen._arm_library_notes_auto_sync_timer()
+        assert screen._library_notes_auto_sync_timer is not None
+        screen._cancel_library_notes_auto_sync_timer()
+        assert screen._library_notes_auto_sync_timer is None
+
+        for _ in range(50):
+            await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+            await _wait_for_selector(screen, pilot, "#library-media-list")
+            assert len(screen.query("#library-notes-canvas")) == 0
+            await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+            await _wait_for_selector(screen, pilot, "#library-notes-filter")
+            assert len(screen.query("#library-notes-canvas")) == 1
+
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+        assert screen._library_note_session is coordinator
+        assert screen._library_notes_autosave_timer is None
+        assert screen._library_notes_auto_sync_timer is None
+        final_active_groups = {
+            worker.group
+            for worker in host.workers
+            if worker.node is screen and worker.group in note_worker_groups
+        }
+        assert exercised_groups == note_worker_groups
+        assert final_active_groups == baseline_active_groups
+        assert (
+            screen._library_notes_autosave_timer,
+            screen._library_notes_auto_sync_timer,
+        ) == baseline_timer_refs
+        assert canvas_lifecycle["mounted"] > 50
+        assert canvas_lifecycle["mounted"] == canvas_lifecycle["removed"] + 1
+
+    assert canvas_lifecycle["mounted"] == canvas_lifecycle["removed"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_size", ((60, 20), (170, 48)))
+async def test_library_note_remount_restores_only_persistent_view_state(
+    terminal_size: tuple[int, int],
+) -> None:
+    """Remount keeps route/filter/sort but excludes Context/Preview/confirm."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=terminal_size) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _task10_open_note_editor_with_keyboard(screen, pilot)
+        screen._library_notes_filter = "retro"
+        screen._library_notes_sort = "oldest"
+        screen._library_note_preview = True
+        screen._library_note_context = True
+        screen._library_note_confirming_delete = True
+        state = screen.save_state()
+
+    restored = LibraryScreen(app)
+    restored.restore_state(state)
+    assert restored._library_note_preview is False
+    assert restored._library_note_context is False
+    assert restored._library_note_confirming_delete is False
+    host2 = LibraryHarness(app, screen=restored)
+
+    async with host2.run_test(size=terminal_size) as pilot:
+        screen2 = _active_library_screen(host2)
+        await _wait_for_library_shell(screen2, pilot)
+        await _wait_for_selector(screen2, pilot, "#library-note-body")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen2._library_note_session.snapshot is not None,
+            message="Restored note session never loaded.",
+        )
+        assert screen2._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+        assert screen2._selected_note_id == "n-1"
+        assert screen2._library_notes_view == "editor"
+        assert screen2._library_notes_filter == "retro"
+        assert screen2._library_notes_sort == "oldest"
+        assert screen2._library_note_preview is False
+        assert screen2._library_note_context is False
+        assert screen2._library_note_confirming_delete is False
+        assert screen2.query_one("#library-note-editor-region").display is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_size", ((60, 20), (170, 48)))
+async def test_library_note_context_toggle_lands_on_visible_scroll_focus(
+    terminal_size: tuple[int, int],
+) -> None:
+    """Context opens at its scroll owner, with keywords next in Tab order."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=terminal_size) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, terminal_size[0] < 120)
+        await _task10_open_note_editor_with_keyboard(screen, pilot)
+        await _task10_activate_with_keyboard(screen, pilot, "#library-note-context")
+        context = await _wait_for_display(screen, pilot, "#library-note-context-region")
+
+        assert context.can_focus is True
+        assert screen.focused is context
+        assert context.has_focus is True
+        assert context.region.width > 0 and context.region.height > 0
+
+        await pilot.press("tab")
+        await pilot.pause()
+        assert getattr(screen.focused, "id", None) == ("library-note-context-keywords")
+        await pilot.press("shift+tab")
+        await pilot.pause()
+        assert screen.focused is context
+
+
+@pytest.mark.asyncio
+async def test_library_note_unmount_clears_notes_timers_and_workers() -> None:
+    """Unmount releases every screen-owned Notes timer and worker reference."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _task10_open_note_editor_with_keyboard(screen, pilot)
+        body = await _task10_focus_with_keyboard(screen, pilot, "#library-note-body")
+        body.text = "dirty draft with a pending autosave"
+        await pilot.pause()
+        assert screen._library_notes_autosave_timer is not None
+
+        screen._arm_library_notes_auto_sync_timer()
+        assert screen._library_notes_auto_sync_timer is not None
+        screen.run_worker(asyncio.sleep(30), group="library_note_create")
+        await pilot.pause()
+        assert any(
+            worker.node is screen and worker.group == "library_note_create"
+            for worker in host.workers
+        )
+
+        await host.pop_screen()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen._library_notes_autosave_timer is None
+        assert screen._library_notes_auto_sync_timer is None
+        assert not any(
+            worker.node is screen and worker.group.startswith("library_note")
+            for worker in host.workers
+        )

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -12302,8 +12302,17 @@ async def test_library_shell_discard_new_note_disappears_after_edit_or_noop_save
         screen.query_one("#library-row-create-note").press()
         await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
         screen.query_one("#library-notes-create-blank").press()
-        discard = await _wait_for_selector(screen, pilot, "#library-note-discard-new")
-        assert discard.display is True
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                bool(screen.query("#library-note-discard-new"))
+                and screen.query_one("#library-note-discard-new", Button).display
+            ),
+            message="Discard new note never became visible after create.",
+        )
+        assert screen.query_one("#library-note-discard-new", Button).display is True
 
         if acknowledge == "edit":
             screen.query_one("#library-note-title", Input).value = "Kept note"
@@ -21576,6 +21585,10 @@ async def test_library_note_keyboard_focus_order_and_persistent_labels(
         filter_label = screen.query_one("#library-notes-filter-label", Static)
         assert str(filter_label.renderable) == "Filter"
         assert filter_label.region.width > 0 and filter_label.region.height == 1
+        if compact:
+            # Width includes one cell of horizontal padding on each side.
+            # Six visible label cells therefore require at least eight cells.
+            assert filter_label.region.width >= 8
         await _task10_activate_with_keyboard(screen, pilot, "#library-notes-row-0")
         await _wait_for_selector(screen, pilot, "#library-note-body")
         await pilot.pause()
@@ -21821,6 +21834,75 @@ async def test_library_note_fifty_same_side_resize_sequences_do_zero_notes_work(
             await pilot.pause()
             assert screen.query_one("#library-note-body") is body
             assert body.region.height == 20
+
+
+@pytest.mark.asyncio
+async def test_library_note_stage_visibility_skips_redundant_class_work() -> None:
+    """An unchanged wide presentation does not re-run stylesheet matching."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(120, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        await _task10_open_notes_navigator(screen, pilot)
+
+        shell = screen.query_one("#library-shell-grid")
+        rail = screen.query_one("#library-rail")
+        canvas_host = screen.query_one("#library-canvas")
+        notes_canvas = screen.query_one("#library-notes-canvas", LibraryNotesCanvas)
+        class_mutators = []
+        for widget in (shell, rail, canvas_host):
+            wrapped = Mock(wraps=widget.set_class)
+            widget.set_class = wrapped
+            class_mutators.append(wrapped)
+        apply_compact = Mock(wraps=notes_canvas.apply_compact_presentation)
+        notes_canvas.apply_compact_presentation = apply_compact
+
+        screen._apply_library_notes_stage_visibility()
+
+        assert all(mutator.call_count == 0 for mutator in class_mutators)
+        apply_compact.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_library_note_media_route_switch_preserves_shell_surfaces() -> None:
+    """Notes/Media route changes replace only the active canvas subtree."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(120, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        await _task10_open_notes_navigator(screen, pilot)
+        await _task10_activate_with_keyboard(screen, pilot, "#library-notes-row-0")
+        await _wait_for_selector(screen, pilot, "#library-note-body")
+
+        header = screen.query_one("#library-header-line")
+        shell = screen.query_one("#library-shell-grid")
+        rail = screen.query_one("#library-rail")
+        canvas_host = screen.query_one("#library-canvas")
+
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+        await _wait_for_selector(screen, pilot, "#library-media-list")
+        assert screen.query_one("#library-header-line") is header
+        assert screen.query_one("#library-shell-grid") is shell
+        assert screen.query_one("#library-rail") is rail
+        assert screen.query_one("#library-canvas") is canvas_host
+
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        assert screen.query_one("#library-header-line") is header
+        assert screen.query_one("#library-shell-grid") is shell
+        assert screen.query_one("#library-rail") is rail
+        assert screen.query_one("#library-canvas") is canvas_host
+        assert screen.query_one("#library-row-browse-notes").has_class(
+            "library-rail-row-selected"
+        )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -6,6 +6,7 @@ import json
 import re
 import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -28,7 +29,7 @@ from tldw_chatbook.Constants import (
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE,
 )
-from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, ConflictError
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
 from tldw_chatbook.Library.ingest_capabilities import get_capabilities
@@ -48,6 +49,16 @@ from tldw_chatbook.Library.library_rag_state import (
 )
 from tldw_chatbook.Widgets.Library.library_search_rag_panel import (
     results_heading_text,
+)
+from tldw_chatbook.Library.library_notes_session import (
+    DatabaseNotePortLoadReply,
+    DatabaseNoteSavePayload,
+    NoteFlushOutcome,
+    NoteFlushOutcomeKind,
+    NoteLoadOutcomeKind,
+    NoteSaveOutcomeKind,
+    PortLoadKind,
+    PortSaveKind,
 )
 from tldw_chatbook.Library.library_export_scope import ExportScope
 from tldw_chatbook.Library.library_export_state import EMPTY_SCOPE_COPY
@@ -292,6 +303,10 @@ def _visible_text(screen) -> str:
 
 def _seed_conversations(app, conversations, *, notes=None, media=None, highlights=None):
     app.notes_scope_service = StaticLibraryNotesScopeService(notes or [])
+    # Production local-note detail obtains keywords from this separate service.
+    # Keep the fake contract coherent for notes created during a test, whose
+    # detail record intentionally carries no inline ``keywords`` field.
+    app.notes_service = StaticLibraryNotesKeywordsService({})
     app.media_reading_scope_service = StaticLibraryMediaScopeService(
         media or [], highlights=highlights
     )
@@ -6759,6 +6774,7 @@ def _two_notes():
             "content": "alpha budget line",
             "last_modified": "2026-07-07T11:57:00+00:00",
             "version": 2,
+            "keywords": [],
         },
         {
             "id": "n-2",
@@ -6766,6 +6782,7 @@ def _two_notes():
             "content": "bravo",
             "last_modified": "2026-07-06T12:00:00+00:00",
             "version": 1,
+            "keywords": [],
         },
     ]
 
@@ -7403,6 +7420,431 @@ class StaticLibraryNotesKeywordsService:
         ]
 
 
+def _library_note_session_port(
+    notes_scope_service,
+    *,
+    notes_service=None,
+):
+    """Build the screen-private adapter against deterministic test services."""
+    return library_screen_module._LibraryDatabaseNoteSessionPort(
+        run_service_call=LibraryScreen._run_library_service_call,
+        notes_scope_service=notes_scope_service,
+        notes_service=notes_service,
+        user_id="test-user",
+        clock=lambda: datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_library_note_normalized_adapter_combines_detail_and_keywords():
+    """The portable session receives one complete, lossless normalized note."""
+    scope_service = StaticLibraryNotesScopeService(
+        [
+            {
+                "id": "n-1",
+                "title": "  Exact [title]  ",
+                "content": "body\n<script>kept as note text</script>",
+                "version": "2",
+                "created_at": "2026-07-01T10:00:00+00:00",
+                "last_modified": "2026-07-02T11:00:00+00:00",
+            }
+        ]
+    )
+    keywords_service = StaticLibraryNotesKeywordsService(
+        {"n-1": ["First Tag", "second-tag"]}
+    )
+
+    reply = await _library_note_session_port(
+        scope_service, notes_service=keywords_service
+    ).load_note("n-1")
+
+    assert reply.kind is PortLoadKind.LOADED
+    assert reply.detail is not None
+    assert reply.detail.note_id == "n-1"
+    assert reply.detail.title == "  Exact [title]  "
+    assert reply.detail.body == "body\n<script>kept as note text</script>"
+    assert reply.detail.keywords == ("First Tag", "second-tag")
+    assert reply.detail.version == 2
+    assert reply.detail.created_at == "2026-07-01T10:00:00+00:00"
+    assert reply.detail.modified_at == "2026-07-02T11:00:00+00:00"
+
+
+class _FailingLibraryNoteDetailService(StaticLibraryNotesScopeService):
+    async def get_note_detail(self, **kwargs):
+        self.detail_calls.append(kwargs)
+        raise RuntimeError("temporary detail outage")
+
+
+class _RecoveringLibraryNoteDetailService(StaticLibraryNotesScopeService):
+    def __init__(self, notes):
+        super().__init__(notes)
+        self.failures_remaining = 1
+
+    async def get_note_detail(self, **kwargs):
+        if self.failures_remaining:
+            self.failures_remaining -= 1
+            raise RuntimeError("temporary detail outage")
+        return await super().get_note_detail(**kwargs)
+
+
+class _FailingLibraryNotesKeywordsService(StaticLibraryNotesKeywordsService):
+    def get_keywords_for_note(self, user_id, note_id):
+        raise RuntimeError("temporary keyword outage")
+
+
+@pytest.mark.asyncio
+async def test_library_note_normalized_adapter_distinguishes_missing_and_failed():
+    missing = await _library_note_session_port(
+        StaticLibraryNotesScopeService([])
+    ).load_note("absent")
+    failed = await _library_note_session_port(
+        _FailingLibraryNoteDetailService(_two_notes())
+    ).load_note("n-1")
+
+    assert missing == DatabaseNotePortLoadReply.missing()
+    assert failed.kind is PortLoadKind.FAILED
+    assert "temporary detail outage" in failed.message
+
+    keyword_failed = await _library_note_session_port(
+        StaticLibraryNotesScopeService(_two_notes()),
+        notes_service=_FailingLibraryNotesKeywordsService({}),
+    ).load_note("n-1")
+    assert keyword_failed.kind is PortLoadKind.FAILED
+    assert "temporary keyword outage" in keyword_failed.message
+
+
+class _FixedLibraryNoteSaveService:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    async def save_note(self, **kwargs):
+        self.calls.append(kwargs)
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("service_result", "expected_kind", "expected_version"),
+    (
+        (True, PortSaveKind.SAVED, 3),
+        ({"version": 4, "keywords": ["a"]}, PortSaveKind.SAVED, 4),
+        (False, PortSaveKind.CONFLICT, None),
+    ),
+)
+async def test_library_note_save_reply_normalization_matrix(
+    service_result,
+    expected_kind,
+    expected_version,
+):
+    service = _FixedLibraryNoteSaveService(service_result)
+    port = _library_note_session_port(service)
+    payload = DatabaseNoteSavePayload(
+        title="  Exact title  ",
+        body="exact\nbody",
+        keywords=("First Tag", "second-tag"),
+        revision=7,
+    )
+
+    reply = await port.save_note("n-1", 2, payload)
+
+    assert reply.kind is expected_kind
+    assert reply.version == expected_version
+    assert service.calls == [
+        {
+            "scope": "local_note",
+            "title": "  Exact title  ",
+            "content": "exact\nbody",
+            "note_id": "n-1",
+            "version": 2,
+            "user_id": "test-user",
+            "keywords": ["First Tag", "second-tag"],
+        }
+    ]
+    if isinstance(service_result, dict):
+        assert reply.keywords == ("a",)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected_kind"),
+    (
+        (ConflictError("version changed"), PortSaveKind.CONFLICT),
+        (RuntimeError("temporary save outage"), PortSaveKind.FAILED),
+    ),
+)
+async def test_library_note_save_reply_normalizes_service_exceptions(
+    error,
+    expected_kind,
+):
+    reply = await _library_note_session_port(
+        _FixedLibraryNoteSaveService(error)
+    ).save_note(
+        "n-1",
+        2,
+        DatabaseNoteSavePayload("title", "body", (), revision=1),
+    )
+
+    assert reply.kind is expected_kind
+    if expected_kind is PortSaveKind.FAILED:
+        assert "temporary save outage" in reply.message
+
+
+class _GatedLibraryNotesKeywordsService(StaticLibraryNotesKeywordsService):
+    def __init__(self, keywords_by_note_id):
+        super().__init__(keywords_by_note_id)
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def get_keywords_for_note(self, user_id, note_id):
+        if str(note_id) == "n-1":
+            self.started.set()
+            self.release.wait(_GATED_RELEASE_TIMEOUT_SECONDS)
+        return super().get_keywords_for_note(user_id, note_id)
+
+
+class _GatedLibraryNoteDetailService(StaticLibraryNotesScopeService):
+    def __init__(self, notes):
+        super().__init__(notes)
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def get_note_detail(self, *, note_id, **kwargs):
+        self.detail_calls.append({"note_id": note_id, **kwargs})
+        self.started.set()
+        self.release.wait(_GATED_RELEASE_TIMEOUT_SECONDS)
+        return next(
+            (dict(note) for note in self.notes if str(note.get("id")) == str(note_id)),
+            None,
+        )
+
+
+class _GatedConflictRefreshNotesService(StaticLibraryNotesScopeService):
+    """Block only the second detail call, which conflict recovery performs."""
+
+    def __init__(self, notes):
+        super().__init__(notes)
+        self.conflict_refresh_started = threading.Event()
+        self.release_conflict_refresh = threading.Event()
+
+    async def get_note_detail(self, **kwargs):
+        if self.detail_calls:
+            self.conflict_refresh_started.set()
+            self.release_conflict_refresh.wait(_GATED_RELEASE_TIMEOUT_SECONDS)
+        return await super().get_note_detail(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_library_note_coordinator_pending_detail_keeps_back_action():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    detail_service = _GatedLibraryNoteDetailService(_two_notes())
+    app.notes_scope_service = detail_service
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-row-0")
+        screen.query_one("#library-notes-row-0").press()
+        try:
+            await _wait_for_condition(
+                pilot,
+                detail_service.started.is_set,
+                message="Note detail never reached its gate.",
+            )
+            (await _wait_for_selector(screen, pilot, "#library-note-back")).press()
+            await _wait_for_selector(screen, pilot, "#library-notes-list")
+        finally:
+            detail_service.release.set()
+
+        await pilot.pause()
+        assert screen._library_note_session.snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_library_note_coordinator_pending_load_keeps_back_and_discards_late_reply():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    keywords_service = _GatedLibraryNotesKeywordsService({"n-1": ["slow"]})
+    app.notes_service = keywords_service
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-row-0")
+        screen.query_one("#library-notes-row-0").press()
+        try:
+            await _wait_for_condition(
+                pilot,
+                keywords_service.started.is_set,
+                message="Keyword enrichment never reached its gate.",
+            )
+            back = await _wait_for_selector(screen, pilot, "#library-note-back")
+            back.press()
+            await _wait_for_selector(screen, pilot, "#library-notes-list")
+        finally:
+            keywords_service.release.set()
+
+        await pilot.pause()
+        await pilot.pause()
+        assert screen._library_notes_view == "list"
+        assert screen._selected_note_id == ""
+        assert screen._library_note_session.snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_library_note_coordinator_new_open_wins_during_keyword_enrichment():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    keywords_service = _GatedLibraryNotesKeywordsService(
+        {"n-1": ["slow"], "n-2": ["new"]}
+    )
+    app.notes_service = keywords_service
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-row-0")
+        screen.query_one("#library-notes-row-0").press()
+        try:
+            await _wait_for_condition(
+                pilot,
+                keywords_service.started.is_set,
+                message="First note keyword enrichment never reached its gate.",
+            )
+            screen._begin_library_note_load("n-2")
+            screen.refresh(recompose=True)
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_note_session.snapshot is not None
+                    and screen._library_note_session.snapshot.note_id == "n-2"
+                ),
+                message="The newer note session never loaded.",
+            )
+        finally:
+            keywords_service.release.set()
+
+        await pilot.pause()
+        await pilot.pause()
+        snapshot = screen._library_note_session.snapshot
+        assert snapshot is not None
+        assert snapshot.note_id == "n-2"
+        assert snapshot.keywords_text == "new"
+
+
+@pytest.mark.asyncio
+async def test_library_note_coordinator_load_failure_keeps_back_and_retry():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = _FailingLibraryNoteDetailService(_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-row-0")
+        screen.query_one("#library-notes-row-0").press()
+
+        await _wait_for_selector(screen, pilot, "#library-note-load-retry")
+        assert screen.query("#library-note-back")
+        assert "temporary detail outage" in _visible_text(screen)
+        assert screen._library_notes_view == "editor"
+        assert screen._selected_note_id == "n-1"
+
+
+@pytest.mark.asyncio
+async def test_library_note_coordinator_retry_recovers_transient_load_failure():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_scope_service = _RecoveringLibraryNoteDetailService(_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-row-0")
+        screen.query_one("#library-notes-row-0").press()
+        await _wait_for_selector(screen, pilot, "#library-note-load-retry")
+
+        await pilot.click("#library-note-load-retry")
+
+        await _wait_for_selector(screen, pilot, "#library-note-title")
+        snapshot = screen._library_note_session.snapshot
+        assert snapshot is not None
+        assert snapshot.note_id == "n-1"
+        assert screen._library_note_load_state == "loaded"
+
+
+@pytest.mark.asyncio
+async def test_library_note_coordinator_validation_veto_keeps_raw_title_and_focus():
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        service = app.notes_scope_service
+        calls_before = len(service.save_calls)
+        raw_title = "x" * 301
+
+        screen.query_one("#library-note-title", Input).value = raw_title
+        await pilot.pause()
+        screen.query_one("#library-note-save").press()
+
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_note_autosave_state == "validation"
+                and getattr(screen.focused, "id", None) == "library-note-title"
+            ),
+            message="Title validation veto did not retain/restore field focus.",
+        )
+        snapshot = screen._library_note_session.snapshot
+        assert snapshot is not None
+        assert snapshot.title == raw_title
+        assert snapshot.dirty is True
+        assert len(service.save_calls) == calls_before
+        assert "shorten it to save" in _visible_text(screen)
+
+
+@pytest.mark.asyncio
+async def test_library_note_saved_outcome_does_not_mask_a_newer_dirty_revision():
+    """Late host presentation must not relabel a newer coordinator draft saved."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    app.notes_service = StaticLibraryNotesKeywordsService({"n-1": []})
+    screen = LibraryScreen(app)
+    screen._library_notes_view = "editor"
+    screen._selected_note_id = "n-1"
+    assert (
+        await screen._library_note_session.open_session("n-1")
+    ).kind is NoteLoadOutcomeKind.LOADED
+    assert screen._library_note_session.mutate(body="first revision")
+
+    outcome = await screen._library_note_session.request_save(explicit=True)
+    assert outcome.kind is NoteSaveOutcomeKind.SAVED
+    assert screen._library_note_session.mutate(body="newer unsaved revision")
+
+    screen._apply_library_note_save_outcome(outcome)
+
+    snapshot = screen._library_note_session.snapshot
+    assert snapshot is not None and snapshot.dirty is True
+    assert screen._library_note_autosave_state == "idle"
+
+
 @pytest.mark.asyncio
 async def test_library_shell_note_editor_shows_enriched_keywords():
     """``notes_scope_service.get_note_detail``'s local-scope shape is the
@@ -7438,22 +7880,152 @@ async def test_library_shell_note_editor_shows_enriched_keywords():
 
 
 @pytest.mark.asyncio
-async def test_library_shell_note_editor_keywords_empty_without_notes_service():
-    """Absent ``app.notes_service`` (or a service missing the method), the
-    editor still opens normally with an empty Keywords input -- the
-    enrichment is quiet-best-effort, never a hard requirement to open a
-    note (matches the current/pre-enrichment behavior).
-    """
+async def test_library_shell_note_editor_refuses_unknown_keywords_without_service():
+    """Unknown keywords must not be normalized to empty and erased on save."""
+    app = _build_test_app()
+    notes_without_keyword_authority = [
+        {key: value for key, value in note.items() if key != "keywords"}
+        for note in _two_notes()
+    ]
+    _seed_conversations(
+        app,
+        _two_conversations(),
+        notes=notes_without_keyword_authority,
+    )
+    app.notes_service = None
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-row-0")
+        screen.query_one("#library-notes-row-0").press()
+
+        await _wait_for_selector(screen, pilot, "#library-note-load-retry")
+        assert not screen.query("#library-note-keywords")
+        assert "keyword" in _visible_text(screen).lower()
+
+
+@pytest.mark.asyncio
+async def test_library_note_adapter_accepts_authoritative_detail_keywords():
+    """A detail payload that explicitly carries keywords is complete by itself."""
+    detail = dict(_two_notes()[0], keywords=["kept", "exact tag"])
+
+    reply = await _library_note_session_port(
+        StaticLibraryNotesScopeService([detail])
+    ).load_note("n-1")
+
+    assert reply.kind is PortLoadKind.LOADED
+    assert reply.detail is not None
+    assert reply.detail.keywords == ("kept", "exact tag")
+
+
+@pytest.mark.asyncio
+async def test_library_note_navigation_propagates_typed_flush_veto(monkeypatch):
+    """A clean-looking snapshot cannot bypass a coordinator BLOCKED outcome."""
+    app = _build_test_app()
+    screen = LibraryScreen(app)
+    screen._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
+
+    async def blocked_flush():
+        return NoteFlushOutcome(
+            NoteFlushOutcomeKind.BLOCKED,
+            "A conflict action is in progress.",
+        )
+
+    monkeypatch.setattr(screen._library_note_session, "flush", blocked_flush)
+    monkeypatch.setattr(screen, "refresh", Mock())
+
+    await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+
+    assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+    assert await screen.flush_pending_work() is False
+
+
+@pytest.mark.asyncio
+async def test_library_export_canvas_propagates_non_conflict_flush_veto(monkeypatch):
+    """Validation/failure flush outcomes must retain the editor route too."""
+    app = _build_test_app()
+    screen = LibraryScreen(app)
+    screen._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
+
+    async def vetoed_flush():
+        return NoteFlushOutcome(
+            NoteFlushOutcomeKind.VALIDATION_VETO,
+            "Title is too long.",
+        )
+
+    monkeypatch.setattr(screen._library_note_session, "flush", vetoed_flush)
+    monkeypatch.setattr(screen, "refresh", Mock())
+
+    await screen._open_library_export_canvas(ExportScope(kind="notes"))
+
+    assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+
+
+def test_library_conflict_handlers_do_not_cancel_the_token_owner(monkeypatch):
+    """Duplicate conflict actions must not create exclusive cancelling workers."""
+    screen = LibraryScreen(_build_test_app())
+    calls = []
+
+    def capture_worker(awaitable, **kwargs):
+        awaitable.close()
+        calls.append(kwargs)
+
+    monkeypatch.setattr(screen, "run_worker", capture_worker)
+    event = SimpleNamespace(stop=Mock())
+
+    screen.handle_library_note_conflict_overwrite(event)
+    screen.handle_library_note_conflict_reload(event)
+
+    assert all(call.get("exclusive", False) is False for call in calls)
+    assert {call["group"] for call in calls} == {"library_note_conflict"}
+
+
+@pytest.mark.asyncio
+async def test_library_conflict_opposite_button_cannot_cancel_active_owner():
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    service = _GatedConflictRefreshNotesService(_two_notes())
+    app.notes_scope_service = service
     host = LibraryHarness(app)
 
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         screen = _active_library_screen(host)
         await _wait_for_library_shell(screen, pilot)
         await _open_note_editor(screen, pilot)
+        _bump_note_version_externally(service, "n-1")
+        screen.query_one("#library-note-body", TextArea).text = "kept draft"
+        await pilot.pause()
+        screen.query_one("#library-note-save").press()
+        overwrite = await _wait_for_selector(
+            screen, pilot, "#library-note-conflict-overwrite"
+        )
+        reload_button = screen.query_one("#library-note-conflict-reload")
 
-        assert screen.query_one("#library-note-keywords", Input).value == ""
+        overwrite.press()
+        try:
+            await _wait_for_condition(
+                pilot,
+                service.conflict_refresh_started.is_set,
+                message="Conflict recovery never reached its detail gate.",
+            )
+            reload_button.press()
+            await pilot.pause()
+            assert screen._library_note_session.conflict_resolution_running is True
+        finally:
+            service.release_conflict_refresh.set()
+
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_note_autosave_state == "saved"
+                and not screen._library_note_session.conflict_resolution_running
+            ),
+            message="The original conflict action did not finish and release its gate.",
+        )
+        assert not screen.query("#library-note-conflict-overwrite")
 
 
 @pytest.mark.asyncio
@@ -7624,7 +8196,7 @@ def _remove_note_externally(service, note_id: str) -> None:
 
 @pytest.mark.asyncio
 async def test_library_shell_note_explicit_save_calls_seam_and_bumps_version():
-    """Pressing Save calls the seam with the sanitized fields/keywords list,
+    """Pressing Save calls the seam with exact validated fields/keywords,
     bumps the in-memory version from the seam's dict result, updates the
     meta line to show "saved", and never recomposes the editor -- the
     ``TextArea`` instance must be the exact same object before and after.
@@ -7914,39 +8486,34 @@ async def test_library_destructive_transitions_abort_when_failed_save_leaves_not
         save_calls.append(kwargs)
         raise RuntimeError("simulated save failure")
 
-    app.notes_scope_service = Mock(save_note=failing_save_note)
+    app.notes_scope_service = Mock(
+        save_note=failing_save_note,
+        get_note_detail=lambda **kwargs: {
+            "id": "n-current",
+            "title": "Current note",
+            "content": "persisted body",
+            "version": 4,
+        },
+    )
+    app.notes_service = Mock(get_keywords_for_note=lambda *args: [])
     screen = LibraryScreen(app)
     screen._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
     screen._library_notes_view = "editor"
     screen._selected_note_id = "n-current"
-    screen._library_note_detail = {
-        "id": "n-current",
-        "title": "Current note",
-        "content": "persisted body",
-        "version": 4,
-    }
-    screen._library_note_version = 4
-    screen._library_note_dirty = True
+    load_outcome = await screen._library_note_session.open_session("n-current")
+    assert load_outcome.kind is NoteLoadOutcomeKind.LOADED
+    assert screen._library_note_session.mutate(
+        body="unsaved body", keywords_text="alpha"
+    )
     screen._library_note_autosave_state = "idle"
     screen._library_note_editor_armed = True
     screen._selected_media_id = "media-current"
     screen._library_media_view = "list"
     screen._library_media_detail = {"id": "media-current"}
-    monkeypatch.setattr(
-        screen,
-        "_read_library_note_editor_fields",
-        lambda: ("Current note", "unsaved body", "alpha"),
-    )
     monkeypatch.setattr(screen, "refresh", Mock())
     monkeypatch.setattr(screen, "run_worker", Mock())
     monkeypatch.setattr(screen, "call_after_refresh", Mock())
 
-    # Keep the real save/error handling while omitting the unrelated worker
-    # drain from this direct, unmounted unit test.
-    async def flush_save():
-        await screen._save_library_note(explicit=False)
-
-    monkeypatch.setattr(screen, "_flush_library_note_save", flush_save)
     preserved_state = (
         screen._library_selected_row_id,
         screen._library_notes_view,
@@ -8275,11 +8842,12 @@ async def test_library_shell_note_save_result_after_switch_is_discarded():
         assert screen._selected_note_id == "n-1"
         assert screen._library_note_version == 2
 
-        # Arm a save for n-1 whose fake response is deliberately delayed, but
-        # never dirty the editor -- the save is triggered purely by the Save
-        # button so ``_library_note_dirty`` stays False and a subsequent row
-        # switch's flush is a no-op, letting the switch complete immediately
-        # while this save is still in flight.
+        # Arm a genuine save for n-1 whose fake response is deliberately
+        # delayed. Normal user navigation now waits at the coordinator flush
+        # barrier, so the forced session replacement below models a host-level
+        # route teardown rather than bypassing that safety through a no-op Save.
+        screen.query_one("#library-note-body", TextArea).text = "n-1 delayed edit"
+        await pilot.pause()
         screen.query_one("#library-note-save").press()
         for _ in range(50):
             if service.save_started:
@@ -8288,19 +8856,12 @@ async def test_library_shell_note_save_result_after_switch_is_discarded():
         else:
             raise AssertionError("Save never called the save_note seam.")
 
-        # Switch to n-2's editor while n-1's save is still sleeping. The
-        # notes canvas only renders row buttons in its list view, so this
-        # goes via Back (a no-op flush, since nothing is dirty) then a row
-        # press -- the same "row press" switch path a user takes.
-        screen.query_one("#library-note-back").press()
-        await _wait_for_selector(screen, pilot, "#library-notes-row-1")
-        screen.query_one("#library-notes-row-1").press()
-        for _ in range(150):
-            if screen._selected_note_id == "n-2":
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("Row switch to n-2 never completed.")
+        # Force a replacement session while n-1's save is still sleeping.
+        # The late save result must be typed STALE by the coordinator and
+        # ignored by the screen presentation.
+        n1_meta_widget = screen.query_one("#library-note-meta", Static)
+        screen._begin_library_note_load("n-2")
+        screen.refresh(recompose=True)
 
         for _ in range(150):
             detail = screen._library_note_detail
@@ -8378,6 +8939,12 @@ async def test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user
         #   AssertionError: assert <DOMQuery ...>   (an empty query is falsy)
         await _wait_for_selector(screen, pilot, "#library-note-conflict-overwrite")
         await _wait_for_selector(screen, pilot, "#library-note-conflict-reload")
+        await _wait_for_condition(
+            pilot,
+            lambda: getattr(screen.focused, "id", None) == "library-note-conflict-copy",
+            message="Keyboard focus never moved to the note conflict callout.",
+        )
+        assert screen.query_one("#library-note-conflict-copy").can_focus is True
         meta = str(screen.query_one("#library-note-meta").renderable)
         assert "changed elsewhere" in meta
         assert screen.query_one("#library-note-body", TextArea).text == (
@@ -8436,14 +9003,10 @@ async def test_library_shell_note_preview_toggle_never_bumps_version_or_autosave
 
 @pytest.mark.asyncio
 async def test_library_shell_note_conflict_during_preview_reads_live_text():
-    """A save conflict raised while Preview is toggled on must not leave a
-    stale ``_library_note_preview``/``_library_note_preview_snapshot`` behind:
-    the conflict UI always renders the live ``TextArea`` (``compose`` never
-    threads ``preview`` through for the conflict branch), so
-    ``_read_library_note_editor_fields`` still reading through the old
-    preview snapshot would send stale, pre-preview text to the seam on a
-    save from the conflict UI -- and visibly revert the user's on-screen
-    edits on the next recompose.
+    """Conflict resolution after Preview must save the coordinator's live draft.
+
+    The conflict UI always renders editable fields, so resolving a conflict must
+    use the canonical session draft rather than a presentation-time preview copy.
     """
     app = _build_test_app(configured_default="library")
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
@@ -8492,21 +9055,25 @@ async def test_library_shell_note_conflict_during_preview_reads_live_text():
 
         calls_before_second_save = len(service.save_calls)
         screen.query_one("#library-note-save").press()
+        await pilot.pause()
+        assert len(service.save_calls) == calls_before_second_save
+        assert screen._library_note_autosave_state == "conflict"
+        assert screen.query_one("#library-note-body", TextArea).text == "T2"
+
+        screen.query_one("#library-note-conflict-overwrite").press()
         await _wait_for_condition(
             pilot,
-            lambda: len(service.save_calls) > calls_before_second_save,
-            message="The second Save press never called the seam.",
+            lambda: screen._library_note_autosave_state == "saved",
+            message="Overwrite never saved the coordinator's latest conflict draft.",
         )
-        # Give the resulting conflict recompose a few cycles to settle.
-        for _ in range(10):
-            await pilot.pause(0.02)
+        await _wait_for_selector(screen, pilot, "#library-note-body")
 
         assert service.save_calls[-1]["content"] == "T2", (
-            "The conflict-UI save sent stale pre-preview text to the seam: "
+            "Overwrite sent stale pre-preview text to the seam: "
             f"{service.save_calls[-1]['content']!r}"
         )
         assert screen.query_one("#library-note-body", TextArea).text == "T2", (
-            "The second conflict recompose reverted the user's on-screen edit."
+            "Conflict recovery reverted the user's on-screen edit."
         )
 
 
@@ -8558,6 +9125,87 @@ async def test_library_shell_note_conflict_overwrite_resaves_with_fresh_version(
             stored["version"] == 4
         )  # v2 -> externally bumped to v3 -> overwrite saves to v4
         assert screen._library_note_version == 4
+
+
+@pytest.mark.asyncio
+async def test_library_shell_note_conflict_overwrite_failure_exits_conflict_state():
+    """A rebased overwrite failure keeps the draft retryable as an error."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        service = app.notes_scope_service
+        _bump_note_version_externally(service, "n-1")
+        screen.query_one("#library-note-body", TextArea).text = "draft survives"
+        await pilot.pause()
+        screen.query_one("#library-note-save").press()
+        await _wait_for_selector(screen, pilot, "#library-note-conflict-overwrite")
+
+        async def fail_overwrite(**kwargs):
+            service.save_calls.append(kwargs)
+            raise RuntimeError("temporary overwrite outage")
+
+        service.save_note = fail_overwrite
+        screen.query_one("#library-note-conflict-overwrite").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_note_autosave_state == "error"
+                and not screen.query("#library-note-conflict-overwrite")
+                and bool(screen.query("#library-note-preview"))
+            ),
+            message="Overwrite failure remained trapped in conflict presentation.",
+        )
+
+        snapshot = screen._library_note_session.snapshot
+        assert snapshot is not None
+        assert snapshot.in_conflict is False
+        assert snapshot.dirty is True
+        assert snapshot.body == "draft survives"
+        assert "temporary overwrite outage" in _visible_text(screen)
+        screen.query_one("#library-note-preview").press()
+        await _wait_for_selector(screen, pilot, "#library-note-preview-body")
+
+
+@pytest.mark.asyncio
+async def test_library_shell_note_conflict_overwrite_validation_focuses_field():
+    """Overwrite validation restores the exact draft and vetoed field focus."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+        _bump_note_version_externally(app.notes_scope_service, "n-1")
+        screen.query_one("#library-note-body", TextArea).text = "kept body"
+        await pilot.pause()
+        screen.query_one("#library-note-save").press()
+        await _wait_for_selector(screen, pilot, "#library-note-conflict-overwrite")
+
+        raw_title = "x" * 301
+        screen.query_one("#library-note-title", Input).value = raw_title
+        await pilot.pause()
+        screen.query_one("#library-note-conflict-overwrite").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_note_autosave_state == "validation"
+                and getattr(screen.focused, "id", None) == "library-note-title"
+            ),
+            message="Overwrite validation did not focus the vetoed title.",
+        )
+
+        snapshot = screen._library_note_session.snapshot
+        assert snapshot is not None
+        assert snapshot.title == raw_title
+        assert snapshot.dirty is True
+        assert snapshot.in_conflict is False
 
 
 @pytest.mark.asyncio
@@ -8672,12 +9320,8 @@ async def test_library_shell_note_conflict_reload_falls_back_to_list_when_note_m
 
 
 @pytest.mark.asyncio
-async def test_library_shell_note_conflict_overwrite_falls_back_to_list_when_note_missing():
-    """Same fallback as the Reload case above, but for Overwrite: it also
-    runs the same silent re-fetch first, so a note deleted elsewhere must
-    not leave Overwrite stuck silently no-op-ing against a conflict UI that
-    can never be resolved.
-    """
+async def test_library_shell_note_conflict_overwrite_retains_draft_when_note_missing():
+    """Overwrite cannot recreate a deleted target, so it retains the draft."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
     host = LibraryHarness(app)
@@ -8709,23 +9353,26 @@ async def test_library_shell_note_conflict_overwrite_falls_back_to_list_when_not
         ).press()
         await _wait_for_condition(
             pilot,
-            lambda: screen._library_notes_view == "list",
+            lambda: (
+                screen._library_notes_view == "editor"
+                and screen._library_note_autosave_state == "conflict"
+                and bool(screen.query("#library-note-conflict-overwrite"))
+                and "no longer exists" in _visible_text(screen)
+            ),
             message=lambda: (
-                "Overwrite never fell back to the list view for a missing note "
+                "Overwrite did not retain/report the missing target draft "
                 f"(stuck: view={screen._library_notes_view!r}, "
-                f"autosave_state={screen._library_note_autosave_state!r})."
+                f"autosave_state={screen._library_note_autosave_state!r}, "
+                f"overwrite_mounted="
+                f"{bool(screen.query('#library-note-conflict-overwrite'))!r}). "
+                f"Visible text: {_visible_text(screen)}"
             ),
         )
-        await _wait_for_condition(
-            pilot,
-            lambda: not screen.query("#library-note-conflict-overwrite"),
-            message="Overwrite remained mounted after the list-view recompose.",
-        )
 
-        assert screen._selected_note_id == ""
-        assert screen._library_note_detail is None
-        assert screen._library_note_autosave_state == "idle"
-        assert not screen.query("#library-note-conflict-overwrite")
+        assert screen._selected_note_id == "n-1"
+        assert screen._library_note_detail is not None
+        assert screen._library_note_dirty is True
+        assert screen.query_one("#library-note-body", TextArea).text == "kept text"
 
 
 @pytest.mark.asyncio
@@ -16219,4 +16866,3 @@ async def test_invalid_marker_toggles_with_the_in_place_validation(
         assert not chunk.has_class("-ingest-option-invalid"), (
             "becoming valid must clear the marker in place"
         )
-

--- a/Tests/UI/test_non_obscuring_focus_contract.py
+++ b/Tests/UI/test_non_obscuring_focus_contract.py
@@ -1829,7 +1829,6 @@ def test_library_notes_labeled_fields_keep_stable_non_semantic_focus_geometry():
     for selector in (
         "Input:focus",
         "TextArea:focus",
-        "Select:focus",
     ):
         assert_thin_input_focus(css_block(text, selector))
 

--- a/Tests/UI/test_non_obscuring_focus_contract.py
+++ b/Tests/UI/test_non_obscuring_focus_contract.py
@@ -1800,3 +1800,46 @@ def test_sidebar_hover_states_use_neutral_readable_surface(selector: str):
     bundled_blocks = css_blocks(BUNDLE.read_text(encoding="utf-8"), selector)
     assert bundled_blocks, f"tldw_cli_modular.tcss is missing {selector}"
     assert_native_row_hover_state_contract(bundled_blocks[-1])
+
+
+def test_library_notes_focus_cues_are_visible_without_obscuring_content():
+    """Database Notes gives scroll surfaces and conflict recovery real focus cues."""
+    for path in (AGENTIC, BUNDLE):
+        text = path.read_text(encoding="utf-8")
+
+        for selector in (
+            "#library-note-preview-region:focus",
+            "#library-note-context-region:focus",
+        ):
+            block = css_block(text, selector)
+            assert "outline: heavy" not in block
+            assert "reverse" not in block
+            assert "border: solid $ds-input-focus-accent;" in block
+            assert "background: $ds-input-focus-bg;" in block
+
+        conflict = css_block(text, "#library-note-conflict-copy:focus")
+        assert_non_obscuring_focus(conflict)
+        assert "background: $ds-focus-bg;" in conflict
+        assert "color: $ds-focus-fg;" in conflict
+
+
+def test_library_notes_labeled_fields_keep_stable_non_semantic_focus_geometry():
+    """Filter, title, body, and both keyword editors use the shared thin cue."""
+    text = BUNDLE.read_text(encoding="utf-8")
+    for selector in (
+        "Input:focus",
+        "TextArea:focus",
+        "Select:focus",
+    ):
+        assert_thin_input_focus(css_block(text, selector))
+
+    for selector in (
+        "#library-notes-filter:focus",
+        "#library-note-title:focus",
+        "#library-note-keywords:focus",
+    ):
+        block = css_block(text, selector)
+        assert "outline: heavy" not in block
+        assert "reverse" not in block
+        assert "background: $ds-input-focus-bg;" in block
+        assert "color: $ds-text-primary;" in block

--- a/Tests/UI/test_non_obscuring_focus_contract.py
+++ b/Tests/UI/test_non_obscuring_focus_contract.py
@@ -496,7 +496,6 @@ def test_shared_form_and_native_inputs_use_thin_non_semantic_focus():
     for selector in (
         "Input:focus",
         "TextArea:focus",
-        "Select:focus",
         ".form-input:focus",
         ".form-textarea:focus",
     ):
@@ -506,6 +505,17 @@ def test_shared_form_and_native_inputs_use_thin_non_semantic_focus():
         assert "border-bottom: solid $ds-input-focus-accent;" in block
         assert "$error" not in block
         assert "$warning" not in block
+
+    # TASK-2300: Select draws its visible focus border on SelectCurrent.
+    # Adding the shared parent border consumes the control's value row, so
+    # the parent keeps only the non-semantic colour cue.
+    select_focus = css_block(text, "Select:focus")
+    assert "outline: heavy" not in select_focus
+    assert "border:" not in select_focus
+    assert "background: $ds-input-focus-bg;" in select_focus
+    assert "color: $ds-text-primary;" in select_focus
+    assert "$error" not in select_focus
+    assert "$warning" not in select_focus
 
 
 def test_native_toggle_focus_states_use_non_obscuring_contracts():
@@ -1054,9 +1064,7 @@ def test_library_rag_collapsible_header_hover_uses_non_obscuring_surface_contrac
 def test_shared_collapsible_header_focus_is_underlined_and_non_heavy():
     text = WIDGETS.read_text(encoding="utf-8")
     block = css_block(text, "Collapsible > CollapsibleTitle:focus")
-    collapsed_focus = css_block(
-        text, "Collapsible.-collapsed > CollapsibleTitle:focus"
-    )
+    collapsed_focus = css_block(text, "Collapsible.-collapsed > CollapsibleTitle:focus")
     assert_non_obscuring_focus(block)
     assert "outline: heavy" not in block
     assert "border-bottom: solid $ds-focus-accent;" in collapsed_focus
@@ -1068,9 +1076,7 @@ def test_conversations_collapsible_active_header_uses_selected_contract():
         BUNDLE.read_text(encoding="utf-8"),
     ):
         blocks = css_blocks(text, "Collapsible.-active > CollapsibleTitle")
-        assert blocks, (
-            "Missing CSS block for Collapsible.-active > CollapsibleTitle"
-        )
+        assert blocks, "Missing CSS block for Collapsible.-active > CollapsibleTitle"
         active = blocks[-1]
         assert_readable_selected_state_contract(active)
         assert_no_dominant_selected_geometry(active)

--- a/Tests/UI/test_screen_footer_hints.py
+++ b/Tests/UI/test_screen_footer_hints.py
@@ -375,6 +375,27 @@ async def test_library_registration_updates_the_screens_own_footer():
         assert "u" in screen_footer.shortcut_text
 
 
+def test_library_note_footer_shortcut_contract_is_exact():
+    """Keep screen-owned Notes copy stable without cross-test private imports."""
+    from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+    assert LibraryScreen.LIBRARY_NOTES_NAVIGATOR_SHORTCUTS == (
+        ("Ctrl+N", "New · / Find · Esc Library"),
+    )
+    assert LibraryScreen.LIBRARY_NOTES_EDITOR_SHORTCUTS == (
+        ("Ctrl+S", "Save · Esc Notes"),
+    )
+    assert LibraryScreen.LIBRARY_NOTES_PREVIEW_SHORTCUTS == (
+        ("Pg", "Scroll · Esc Notes"),
+    )
+    assert LibraryScreen.LIBRARY_NOTES_CONTEXT_SHORTCUTS == (
+        ("Enter", "Act · Esc Note"),
+    )
+    assert LibraryScreen.LIBRARY_NOTES_CONFLICT_SHORTCUTS == (
+        ("Enter", "Choose · Esc Locked"),
+    )
+
+
 @pytest.mark.asyncio
 async def test_settings_registration_updates_the_screens_own_footer():
     """task-264 review Important: Settings' footer hints must reach its own

--- a/tldw_chatbook/Library/library_notes_session.py
+++ b/tldw_chatbook/Library/library_notes_session.py
@@ -332,6 +332,10 @@ class DatabaseNoteSessionCoordinator:
         """Make every currently pending detail-load completion stale."""
         self._session_request_token += 1
 
+    def close_session(self) -> None:
+        """End the active session and invalidate every pending completion."""
+        self._close_session()
+
     async def open_session(
         self,
         note_id: str,
@@ -738,6 +742,9 @@ class DatabaseNoteSessionCoordinator:
 
         try:
             reply = await self._port.load_note(operation.note_id)
+        except asyncio.CancelledError:
+            self._finish_conflict_operation(operation)
+            raise
         except Exception:
             if not self._conflict_operation_is_current(operation):
                 self._finish_conflict_operation(operation)
@@ -838,7 +845,11 @@ class DatabaseNoteSessionCoordinator:
             in_conflict=False,
             status_message="Unsaved changes",
         )
-        save_outcome = await self.request_save(explicit=True)
+        try:
+            save_outcome = await self.request_save(explicit=True)
+        except asyncio.CancelledError:
+            self._finish_conflict_operation(operation)
+            raise
         if not self._conflict_operation_matches_session(operation):
             self._finish_conflict_operation(operation)
             return ConflictOutcome(

--- a/tldw_chatbook/Library/library_notes_session.py
+++ b/tldw_chatbook/Library/library_notes_session.py
@@ -72,6 +72,56 @@ class NoteSaveOutcomeKind(StrEnum):
     STALE = "stale"
 
 
+class ConflictAction(StrEnum):
+    """User-selected optimistic-conflict recovery actions."""
+
+    OVERWRITE = "overwrite"
+    RELOAD = "reload"
+
+
+class ConflictOutcomeKind(StrEnum):
+    """Typed conflict-resolution result kinds."""
+
+    OVERWRITTEN = "overwritten"
+    RELOADED = "reloaded"
+    DRAFT_CHANGED = "draft_changed"
+    ALREADY_RUNNING = "already_running"
+    RENEWED_CONFLICT = "renewed_conflict"
+    VALIDATION_VETO = "validation_veto"
+    MISSING = "missing"
+    FAILED = "failed"
+    STALE = "stale"
+    NOT_IN_CONFLICT = "not_in_conflict"
+
+
+class NoteFlushOutcomeKind(StrEnum):
+    """Typed navigation-barrier result kinds."""
+
+    PERMITTED = "permitted"
+    VALIDATION_VETO = "validation_veto"
+    FAILED = "failed"
+    CONFLICTED = "conflicted"
+    BLOCKED = "blocked"
+    STALE = "stale"
+
+
+class DestructiveKind(StrEnum):
+    """Coordinator-gated destructive Database Note actions."""
+
+    DISCARD_NEW_NOTE = "discard_new_note"
+    DELETE = "delete"
+
+
+class DestructiveAdmissionOutcomeKind(StrEnum):
+    """Typed destructive-admission result kinds."""
+
+    ADMITTED = "admitted"
+    FLUSH_VETOED = "flush_vetoed"
+    ALREADY_RUNNING = "already_running"
+    NOT_ELIGIBLE = "not_eligible"
+    STALE = "stale"
+
+
 @dataclass(frozen=True)
 class DatabaseNotePortLoadReply:
     """Normalized result from the injected detail-fetch port."""
@@ -167,6 +217,64 @@ class NoteSaveOutcome:
     veto: NoteValidationVeto | None = None
 
 
+@dataclass(frozen=True)
+class ConflictOutcome:
+    """Typed public result of one gated conflict action."""
+
+    kind: ConflictOutcomeKind
+    action: ConflictAction
+    note_id: str = ""
+    message: str = ""
+    save_outcome: NoteSaveOutcome | None = None
+
+
+@dataclass(frozen=True)
+class NoteFlushOutcome:
+    """Typed public navigation-barrier result."""
+
+    kind: NoteFlushOutcomeKind
+    message: str = ""
+    save_outcome: NoteSaveOutcome | None = None
+
+
+@dataclass(frozen=True)
+class DestructiveAdmission:
+    """Immutable authority token revalidated immediately before deletion."""
+
+    kind: DestructiveKind
+    note_id: str
+    session_generation: int
+    expected_version: int
+    operation_token: int
+    create_token: str | None = None
+
+
+@dataclass(frozen=True)
+class DestructiveAdmissionOutcome:
+    """Typed public result of requesting destructive admission."""
+
+    kind: DestructiveAdmissionOutcomeKind
+    message: str = ""
+    admission: DestructiveAdmission | None = None
+    flush_outcome: NoteFlushOutcome | None = None
+
+
+@dataclass(frozen=True)
+class _ConflictOperation:
+    action: ConflictAction
+    note_id: str
+    session_generation: int
+    conflict_generation: int
+    draft_revision: int
+    operation_token: int
+
+
+@dataclass(frozen=True)
+class _DestructiveState:
+    admission: DestructiveAdmission
+    running: bool = False
+
+
 class DatabaseNoteSessionCoordinator:
     """Own one canonical draft and serialize all saves admitted for it."""
 
@@ -190,7 +298,10 @@ class DatabaseNoteSessionCoordinator:
         self._save_task: asyncio.Task[NoteSaveOutcome] | None = None
         self._pending_save_requested = False
         self._untouched_create_token: str | None = None
-        self._destructive: object | None = None
+        self._conflict_operation_counter = 0
+        self._active_conflict_operation: _ConflictOperation | None = None
+        self._destructive_operation_counter = 0
+        self._destructive: _DestructiveState | None = None
 
     @property
     def snapshot(self) -> LibraryNoteSessionSnapshot | None:
@@ -201,6 +312,21 @@ class DatabaseNoteSessionCoordinator:
     def untouched_create_token(self) -> str | None:
         """Return the active untouched-create token, if still eligible."""
         return self._untouched_create_token
+
+    @property
+    def conflict_resolution_running(self) -> bool:
+        """Return whether one conflict action currently owns the gate."""
+        return self._active_conflict_operation is not None
+
+    @property
+    def destructive_admission(self) -> DestructiveAdmission | None:
+        """Return the active destructive authority token, if admitted."""
+        return self._destructive.admission if self._destructive is not None else None
+
+    @property
+    def destructive_running(self) -> bool:
+        """Return whether the admitted destructive service call has begun."""
+        return self._destructive is not None and self._destructive.running
 
     def invalidate_session_request(self) -> None:
         """Make every currently pending detail-load completion stale."""
@@ -297,6 +423,7 @@ class DatabaseNoteSessionCoordinator:
         self._save_task = None
         self._pending_save_requested = False
         self._untouched_create_token = untouched_create_token
+        self._active_conflict_operation = None
         self._destructive = None
 
     def mutate(
@@ -572,3 +699,416 @@ class DatabaseNoteSessionCoordinator:
                 f"Save failed — {message.rstrip('.')}. Edits kept. Press Save to retry."
             )
         return "Save failed — edits kept. Press Save to retry."
+
+    async def resolve_conflict(self, action: ConflictAction) -> ConflictOutcome:
+        """Run one token-gated Reload or revision-safe Overwrite operation.
+
+        Args:
+            action: Recovery action selected by the user.
+
+        Returns:
+            A typed terminal or already-running conflict outcome.
+        """
+        snapshot = self._snapshot
+        if self._active_conflict_operation is not None:
+            return ConflictOutcome(
+                ConflictOutcomeKind.ALREADY_RUNNING,
+                action,
+                note_id=snapshot.note_id if snapshot is not None else "",
+                message="A conflict action is already running.",
+            )
+        if snapshot is None or not snapshot.in_conflict:
+            return ConflictOutcome(
+                ConflictOutcomeKind.NOT_IN_CONFLICT,
+                action,
+                note_id=snapshot.note_id if snapshot is not None else "",
+                message="No note conflict is active.",
+            )
+
+        self._conflict_operation_counter += 1
+        operation = _ConflictOperation(
+            action=action,
+            note_id=snapshot.note_id,
+            session_generation=snapshot.session_generation,
+            conflict_generation=snapshot.conflict_generation,
+            draft_revision=snapshot.draft_revision,
+            operation_token=self._conflict_operation_counter,
+        )
+        self._active_conflict_operation = operation
+
+        try:
+            reply = await self._port.load_note(operation.note_id)
+        except Exception:
+            if not self._conflict_operation_is_current(operation):
+                self._finish_conflict_operation(operation)
+                return ConflictOutcome(
+                    ConflictOutcomeKind.STALE,
+                    action,
+                    note_id=operation.note_id,
+                    message=(
+                        "The note session changed before conflict recovery completed."
+                    ),
+                )
+            return self._finish_conflict_failure(
+                operation,
+                "Conflict refresh failed — try again.",
+            )
+
+        if not self._conflict_operation_is_current(operation):
+            self._finish_conflict_operation(operation)
+            return ConflictOutcome(
+                ConflictOutcomeKind.STALE,
+                action,
+                note_id=operation.note_id,
+                message="The note session changed before conflict recovery completed.",
+            )
+
+        current = self._snapshot
+        assert current is not None
+        if reply.kind is PortLoadKind.FAILED:
+            failure_detail = reply.message.strip()
+            message = (
+                f"Conflict refresh failed — {failure_detail.rstrip('.')}. Try again."
+                if failure_detail
+                else "Conflict refresh failed — try again."
+            )
+            return self._finish_conflict_failure(operation, message)
+        if reply.kind is PortLoadKind.MISSING:
+            if action is ConflictAction.RELOAD:
+                if current.draft_revision != operation.draft_revision:
+                    return self._reload_draft_changed(operation)
+                self._close_session()
+                return ConflictOutcome(
+                    ConflictOutcomeKind.MISSING,
+                    action,
+                    note_id=operation.note_id,
+                    message="Note no longer exists; local conflict draft was discarded.",
+                )
+            message = "Note no longer exists — local draft kept."
+            self._snapshot = replace(current, status_message=message)
+            self._finish_conflict_operation(operation)
+            return ConflictOutcome(
+                ConflictOutcomeKind.MISSING,
+                action,
+                note_id=operation.note_id,
+                message=message,
+            )
+
+        detail = reply.detail
+        if detail is None or detail.note_id != operation.note_id:
+            return self._finish_conflict_failure(
+                operation,
+                "Conflict refresh returned the wrong note — try again.",
+            )
+
+        if action is ConflictAction.RELOAD:
+            if current.draft_revision != operation.draft_revision:
+                return self._reload_draft_changed(operation)
+            revision = current.draft_revision + 1
+            draft = DatabaseNoteDraft(
+                note_id=detail.note_id,
+                title=detail.title,
+                body=detail.body,
+                keywords_text=", ".join(detail.keywords),
+                revision=revision,
+            )
+            self._snapshot = replace(
+                current,
+                baseline=detail,
+                draft=draft,
+                saved_revision=revision,
+                dirty=False,
+                saving=False,
+                in_conflict=False,
+                status_message="Reloaded latest saved note.",
+            )
+            self._finish_conflict_operation(operation)
+            return ConflictOutcome(
+                ConflictOutcomeKind.RELOADED,
+                action,
+                note_id=operation.note_id,
+                message="Reloaded latest saved note.",
+            )
+
+        self._snapshot = replace(
+            current,
+            baseline=detail,
+            dirty=True,
+            saving=False,
+            in_conflict=False,
+            status_message="Unsaved changes",
+        )
+        save_outcome = await self.request_save(explicit=True)
+        if not self._conflict_operation_matches_session(operation):
+            self._finish_conflict_operation(operation)
+            return ConflictOutcome(
+                ConflictOutcomeKind.STALE,
+                action,
+                note_id=operation.note_id,
+                message="The note session changed before overwrite completed.",
+                save_outcome=save_outcome,
+            )
+
+        outcome_kind = {
+            NoteSaveOutcomeKind.SAVED: ConflictOutcomeKind.OVERWRITTEN,
+            NoteSaveOutcomeKind.ACKNOWLEDGED: ConflictOutcomeKind.OVERWRITTEN,
+            NoteSaveOutcomeKind.CONFLICTED: ConflictOutcomeKind.RENEWED_CONFLICT,
+            NoteSaveOutcomeKind.VALIDATION_VETO: ConflictOutcomeKind.VALIDATION_VETO,
+            NoteSaveOutcomeKind.FAILED: ConflictOutcomeKind.FAILED,
+            NoteSaveOutcomeKind.STALE: ConflictOutcomeKind.STALE,
+            NoteSaveOutcomeKind.BLOCKED: ConflictOutcomeKind.FAILED,
+        }[save_outcome.kind]
+        self._finish_conflict_operation(operation)
+        return ConflictOutcome(
+            outcome_kind,
+            action,
+            note_id=operation.note_id,
+            message=save_outcome.message,
+            save_outcome=save_outcome,
+        )
+
+    def _conflict_operation_is_current(self, operation: _ConflictOperation) -> bool:
+        snapshot = self._snapshot
+        return (
+            self._active_conflict_operation == operation
+            and snapshot is not None
+            and snapshot.note_id == operation.note_id
+            and snapshot.session_generation == operation.session_generation
+            and snapshot.in_conflict
+            and snapshot.conflict_generation == operation.conflict_generation
+        )
+
+    def _conflict_operation_matches_session(
+        self, operation: _ConflictOperation
+    ) -> bool:
+        snapshot = self._snapshot
+        return (
+            self._active_conflict_operation == operation
+            and snapshot is not None
+            and snapshot.note_id == operation.note_id
+            and snapshot.session_generation == operation.session_generation
+        )
+
+    def _finish_conflict_operation(self, operation: _ConflictOperation) -> None:
+        if self._active_conflict_operation == operation:
+            self._active_conflict_operation = None
+
+    def _finish_conflict_failure(
+        self,
+        operation: _ConflictOperation,
+        message: str,
+    ) -> ConflictOutcome:
+        if self._conflict_operation_is_current(operation):
+            assert self._snapshot is not None
+            self._snapshot = replace(self._snapshot, status_message=message)
+        self._finish_conflict_operation(operation)
+        return ConflictOutcome(
+            ConflictOutcomeKind.FAILED,
+            operation.action,
+            note_id=operation.note_id,
+            message=message,
+        )
+
+    def _reload_draft_changed(self, operation: _ConflictOperation) -> ConflictOutcome:
+        message = "Draft changed — Reload not applied. Choose again."
+        if self._conflict_operation_is_current(operation):
+            assert self._snapshot is not None
+            self._snapshot = replace(self._snapshot, status_message=message)
+        self._finish_conflict_operation(operation)
+        return ConflictOutcome(
+            ConflictOutcomeKind.DRAFT_CHANGED,
+            operation.action,
+            note_id=operation.note_id,
+            message=message,
+        )
+
+    async def flush(self) -> NoteFlushOutcome:
+        """Cross the pending-work barrier without inferring from widget state."""
+        while True:
+            snapshot = self._snapshot
+            if snapshot is None:
+                return NoteFlushOutcome(NoteFlushOutcomeKind.PERMITTED)
+            if self._destructive is not None:
+                return NoteFlushOutcome(
+                    NoteFlushOutcomeKind.BLOCKED,
+                    "A destructive action is in progress.",
+                )
+            if self._active_conflict_operation is not None:
+                return NoteFlushOutcome(
+                    NoteFlushOutcomeKind.BLOCKED,
+                    "A conflict action is in progress.",
+                )
+            if snapshot.in_conflict:
+                return NoteFlushOutcome(
+                    NoteFlushOutcomeKind.CONFLICTED,
+                    "Conflict — review the choices before leaving.",
+                )
+            if not snapshot.dirty and not snapshot.saving:
+                return NoteFlushOutcome(NoteFlushOutcomeKind.PERMITTED)
+
+            save_outcome = await self.request_save(explicit=False)
+            if save_outcome.kind in {
+                NoteSaveOutcomeKind.SAVED,
+                NoteSaveOutcomeKind.ACKNOWLEDGED,
+            }:
+                continue
+            outcome_kind = {
+                NoteSaveOutcomeKind.VALIDATION_VETO: NoteFlushOutcomeKind.VALIDATION_VETO,
+                NoteSaveOutcomeKind.FAILED: NoteFlushOutcomeKind.FAILED,
+                NoteSaveOutcomeKind.CONFLICTED: NoteFlushOutcomeKind.CONFLICTED,
+                NoteSaveOutcomeKind.BLOCKED: NoteFlushOutcomeKind.BLOCKED,
+                NoteSaveOutcomeKind.STALE: NoteFlushOutcomeKind.STALE,
+            }[save_outcome.kind]
+            return NoteFlushOutcome(
+                outcome_kind,
+                save_outcome.message,
+                save_outcome=save_outcome,
+            )
+
+    async def request_destructive_admission(
+        self,
+        kind: DestructiveKind,
+        *,
+        note_id: str,
+        session_generation: int,
+        expected_version: int,
+        create_token: str | None = None,
+    ) -> DestructiveAdmissionOutcome:
+        """Flush, revalidate, then atomically block mutation and save admission."""
+        if self._destructive is not None:
+            return DestructiveAdmissionOutcome(
+                DestructiveAdmissionOutcomeKind.ALREADY_RUNNING,
+                "A destructive action is already admitted.",
+            )
+
+        initial = self._snapshot
+        if (
+            initial is None
+            or initial.note_id != note_id
+            or initial.session_generation != session_generation
+            or initial.version != expected_version
+        ):
+            return DestructiveAdmissionOutcome(
+                DestructiveAdmissionOutcomeKind.STALE,
+                "The note changed before the destructive action was admitted.",
+            )
+        if kind is DestructiveKind.DISCARD_NEW_NOTE and (
+            create_token is None or create_token != self._untouched_create_token
+        ):
+            return DestructiveAdmissionOutcome(
+                DestructiveAdmissionOutcomeKind.NOT_ELIGIBLE,
+                "This note is no longer eligible for discard.",
+            )
+
+        flush_outcome = await self.flush()
+        if flush_outcome.kind is not NoteFlushOutcomeKind.PERMITTED:
+            return DestructiveAdmissionOutcome(
+                DestructiveAdmissionOutcomeKind.FLUSH_VETOED,
+                flush_outcome.message,
+                flush_outcome=flush_outcome,
+            )
+        if self._destructive is not None:
+            return DestructiveAdmissionOutcome(
+                DestructiveAdmissionOutcomeKind.ALREADY_RUNNING,
+                "A destructive action is already admitted.",
+            )
+
+        snapshot = self._snapshot
+        if (
+            snapshot is None
+            or snapshot.note_id != note_id
+            or snapshot.session_generation != session_generation
+        ):
+            return DestructiveAdmissionOutcome(
+                DestructiveAdmissionOutcomeKind.STALE,
+                "The note changed before the destructive action was admitted.",
+            )
+        if kind is DestructiveKind.DISCARD_NEW_NOTE and (
+            create_token is None or create_token != self._untouched_create_token
+        ):
+            return DestructiveAdmissionOutcome(
+                DestructiveAdmissionOutcomeKind.NOT_ELIGIBLE,
+                "This note is no longer eligible for discard.",
+            )
+
+        self._destructive_operation_counter += 1
+        admission = DestructiveAdmission(
+            kind=kind,
+            note_id=snapshot.note_id,
+            session_generation=snapshot.session_generation,
+            expected_version=snapshot.version,
+            operation_token=self._destructive_operation_counter,
+            create_token=create_token,
+        )
+        self._destructive = _DestructiveState(admission)
+        return DestructiveAdmissionOutcome(
+            DestructiveAdmissionOutcomeKind.ADMITTED,
+            admission=admission,
+        )
+
+    def mark_destructive_running(self, admission: DestructiveAdmission) -> bool:
+        """Revalidate the full admission immediately before the service call."""
+        state = self._destructive
+        snapshot = self._snapshot
+        if (
+            state is None
+            or state.running
+            or state.admission != admission
+            or snapshot is None
+            or snapshot.note_id != admission.note_id
+            or snapshot.session_generation != admission.session_generation
+            or snapshot.version != admission.expected_version
+            or (
+                admission.kind is DestructiveKind.DISCARD_NEW_NOTE
+                and admission.create_token != self._untouched_create_token
+            )
+        ):
+            return False
+        self._destructive = replace(state, running=True)
+        return True
+
+    def cancel_destructive(self, admission: DestructiveAdmission) -> bool:
+        """Cancel only an admitted operation whose service call has not begun."""
+        state = self._destructive
+        if state is None or state.running or state.admission != admission:
+            return False
+        self._destructive = None
+        return True
+
+    def finish_destructive(
+        self,
+        admission: DestructiveAdmission,
+        *,
+        success: bool,
+    ) -> bool:
+        """Finish a running destructive action, closing only on success."""
+        state = self._destructive
+        if state is None or not state.running or state.admission != admission:
+            return False
+        if success:
+            self._close_session()
+            return True
+
+        self._destructive = None
+        if self._snapshot is not None:
+            action = (
+                "Discard"
+                if admission.kind is DestructiveKind.DISCARD_NEW_NOTE
+                else "Delete"
+            )
+            self._snapshot = replace(
+                self._snapshot,
+                status_message=f"{action} failed — edits kept. Try again.",
+            )
+        return True
+
+    def _close_session(self) -> None:
+        """Invalidate all tokens and end the active in-memory session."""
+        self._session_request_token += 1
+        self._session_generation += 1
+        self._snapshot = None
+        self._save_task = None
+        self._pending_save_requested = False
+        self._untouched_create_token = None
+        self._active_conflict_operation = None
+        self._destructive = None

--- a/tldw_chatbook/Library/library_notes_session.py
+++ b/tldw_chatbook/Library/library_notes_session.py
@@ -1,0 +1,574 @@
+"""Host-independent Database Note session and serialized-save coordinator."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Callable, Protocol
+
+from tldw_chatbook.Library.library_notes_state import (
+    DatabaseNoteDraft,
+    DatabaseNoteSavePayload,
+    LibraryNoteSessionSnapshot,
+    NormalizedDatabaseNote,
+    NoteValidationVeto,
+    validate_database_note_draft,
+)
+
+
+class DatabaseNoteSessionPort(Protocol):
+    """Minimum asynchronous persistence boundary required by a session."""
+
+    async def load_note(self, note_id: str) -> DatabaseNotePortLoadReply:
+        """Load one complete normalized note detail."""
+        ...
+
+    async def save_note(
+        self,
+        note_id: str,
+        expected_version: int,
+        payload: DatabaseNoteSavePayload,
+    ) -> DatabaseNotePortSaveReply:
+        """Persist one exact payload against an optimistic-lock version."""
+        ...
+
+
+class PortLoadKind(StrEnum):
+    """Normalized port-level detail-fetch result kinds."""
+
+    LOADED = "loaded"
+    MISSING = "missing"
+    FAILED = "failed"
+
+
+class PortSaveKind(StrEnum):
+    """Normalized port-level versioned-save result kinds."""
+
+    SAVED = "saved"
+    CONFLICT = "conflict"
+    FAILED = "failed"
+
+
+class NoteLoadOutcomeKind(StrEnum):
+    """Public session-opening result kinds."""
+
+    LOADED = "loaded"
+    MISSING = "missing"
+    FAILED = "failed"
+    STALE = "stale"
+
+
+class NoteSaveOutcomeKind(StrEnum):
+    """Public save-request result kinds."""
+
+    SAVED = "saved"
+    ACKNOWLEDGED = "acknowledged"
+    VALIDATION_VETO = "validation_veto"
+    FAILED = "failed"
+    CONFLICTED = "conflicted"
+    BLOCKED = "blocked"
+    STALE = "stale"
+
+
+@dataclass(frozen=True)
+class DatabaseNotePortLoadReply:
+    """Normalized result from the injected detail-fetch port."""
+
+    kind: PortLoadKind
+    detail: NormalizedDatabaseNote | None = None
+    message: str = ""
+
+    def __post_init__(self) -> None:
+        """Reject ambiguous loaded/missing/failed reply shapes."""
+        if self.kind is PortLoadKind.LOADED and self.detail is None:
+            raise ValueError("A loaded Database Note reply requires detail.")
+        if self.kind is not PortLoadKind.LOADED and self.detail is not None:
+            raise ValueError("A non-loaded Database Note reply cannot carry detail.")
+
+    @classmethod
+    def loaded(cls, detail: NormalizedDatabaseNote) -> DatabaseNotePortLoadReply:
+        """Build a coherent loaded-detail reply."""
+        return cls(kind=PortLoadKind.LOADED, detail=detail)
+
+    @classmethod
+    def missing(
+        cls, message: str = "Note no longer exists."
+    ) -> DatabaseNotePortLoadReply:
+        """Build a genuinely missing-note reply."""
+        return cls(kind=PortLoadKind.MISSING, message=message)
+
+    @classmethod
+    def failed(cls, message: str = "Unable to load note.") -> DatabaseNotePortLoadReply:
+        """Build an ordinary load-failure reply."""
+        return cls(kind=PortLoadKind.FAILED, message=message)
+
+
+@dataclass(frozen=True)
+class DatabaseNotePortSaveReply:
+    """Normalized result from the injected versioned-save port."""
+
+    kind: PortSaveKind
+    version: int | None = None
+    modified_at: str = ""
+    keywords: tuple[str, ...] | None = None
+    message: str = ""
+
+    @classmethod
+    def saved(
+        cls,
+        *,
+        version: int,
+        modified_at: str = "",
+        keywords: tuple[str, ...] | None = None,
+    ) -> DatabaseNotePortSaveReply:
+        """Build a successful save reply."""
+        return cls(
+            kind=PortSaveKind.SAVED,
+            version=version,
+            modified_at=modified_at,
+            keywords=keywords,
+        )
+
+    @classmethod
+    def conflict(
+        cls, message: str = "Note changed elsewhere."
+    ) -> DatabaseNotePortSaveReply:
+        """Build an optimistic-lock conflict reply."""
+        return cls(kind=PortSaveKind.CONFLICT, message=message)
+
+    @classmethod
+    def failed(
+        cls, message: str = "Save failed — edits kept. Press Save to retry."
+    ) -> DatabaseNotePortSaveReply:
+        """Build an ordinary save-failure reply."""
+        return cls(kind=PortSaveKind.FAILED, message=message)
+
+
+@dataclass(frozen=True)
+class NoteLoadOutcome:
+    """Typed public result of opening a Database Note session."""
+
+    kind: NoteLoadOutcomeKind
+    note_id: str
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class NoteSaveOutcome:
+    """Typed public result of a serialized save request."""
+
+    kind: NoteSaveOutcomeKind
+    note_id: str = ""
+    revision: int | None = None
+    version: int | None = None
+    message: str = ""
+    veto: NoteValidationVeto | None = None
+
+
+class DatabaseNoteSessionCoordinator:
+    """Own one canonical draft and serialize all saves admitted for it."""
+
+    def __init__(
+        self,
+        port: DatabaseNoteSessionPort,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        """Initialize the coordinator with its minimal async port.
+
+        Args:
+            port: Complete-detail load and optimistic-version save boundary.
+            clock: Timestamp source used for saved status and baseline metadata.
+        """
+        self._port = port
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._snapshot: LibraryNoteSessionSnapshot | None = None
+        self._session_request_token = 0
+        self._session_generation = 0
+        self._save_task: asyncio.Task[NoteSaveOutcome] | None = None
+        self._pending_save_requested = False
+        self._untouched_create_token: str | None = None
+        self._destructive: object | None = None
+
+    @property
+    def snapshot(self) -> LibraryNoteSessionSnapshot | None:
+        """Return the current immutable session view, if one is active."""
+        return self._snapshot
+
+    @property
+    def untouched_create_token(self) -> str | None:
+        """Return the active untouched-create token, if still eligible."""
+        return self._untouched_create_token
+
+    def invalidate_session_request(self) -> None:
+        """Make every currently pending detail-load completion stale."""
+        self._session_request_token += 1
+
+    async def open_session(
+        self,
+        note_id: str,
+        *,
+        untouched_create_token: str | None = None,
+    ) -> NoteLoadOutcome:
+        """Load and start a session only if this request remains current.
+
+        Args:
+            note_id: Database Note identity to load.
+            untouched_create_token: Matching creation token for discard
+                eligibility until the first edit or explicit Save.
+
+        Returns:
+            A typed loaded, missing, failed, or stale outcome.
+        """
+        self._session_request_token += 1
+        request_token = self._session_request_token
+        try:
+            reply = await self._port.load_note(note_id)
+        except Exception as error:
+            if request_token != self._session_request_token:
+                return NoteLoadOutcome(NoteLoadOutcomeKind.STALE, note_id)
+            return NoteLoadOutcome(
+                NoteLoadOutcomeKind.FAILED,
+                note_id,
+                str(error) or "Unable to load note.",
+            )
+
+        if request_token != self._session_request_token:
+            return NoteLoadOutcome(NoteLoadOutcomeKind.STALE, note_id)
+        if reply.kind is PortLoadKind.MISSING:
+            return NoteLoadOutcome(
+                NoteLoadOutcomeKind.MISSING,
+                note_id,
+                reply.message or "Note no longer exists.",
+            )
+        if reply.kind is PortLoadKind.FAILED:
+            return NoteLoadOutcome(
+                NoteLoadOutcomeKind.FAILED,
+                note_id,
+                reply.message or "Unable to load note.",
+            )
+        if reply.detail is None:
+            return NoteLoadOutcome(
+                NoteLoadOutcomeKind.FAILED,
+                note_id,
+                "Note detail was incomplete.",
+            )
+        if reply.detail.note_id != note_id:
+            return NoteLoadOutcome(
+                NoteLoadOutcomeKind.FAILED,
+                note_id,
+                "Loaded note identity did not match the request.",
+            )
+
+        self._start_loaded_session(
+            reply.detail,
+            untouched_create_token=untouched_create_token,
+        )
+        return NoteLoadOutcome(NoteLoadOutcomeKind.LOADED, note_id)
+
+    def _start_loaded_session(
+        self,
+        detail: NormalizedDatabaseNote,
+        *,
+        untouched_create_token: str | None,
+    ) -> None:
+        """Replace the active session from one coherent normalized detail."""
+        self._session_generation += 1
+        draft = DatabaseNoteDraft(
+            note_id=detail.note_id,
+            title=detail.title,
+            body=detail.body,
+            keywords_text=", ".join(detail.keywords),
+            revision=0,
+        )
+        self._snapshot = LibraryNoteSessionSnapshot(
+            baseline=detail,
+            draft=draft,
+            session_generation=self._session_generation,
+            saved_revision=0,
+            dirty=False,
+            saving=False,
+            in_conflict=False,
+            conflict_generation=0,
+            status_message="",
+        )
+        self._save_task = None
+        self._pending_save_requested = False
+        self._untouched_create_token = untouched_create_token
+        self._destructive = None
+
+    def mutate(
+        self,
+        *,
+        title: str | None = None,
+        body: str | None = None,
+        keywords_text: str | None = None,
+    ) -> bool:
+        """Apply one genuine value change to the canonical raw draft.
+
+        Args:
+            title: Replacement raw title, or None to leave unchanged.
+            body: Replacement raw body, or None to leave unchanged.
+            keywords_text: Replacement raw keyword input, or None to leave
+                unchanged.
+
+        Returns:
+            True when at least one supplied value genuinely changed.
+        """
+        snapshot = self._snapshot
+        if snapshot is None or self._destructive is not None:
+            return False
+
+        draft = snapshot.draft
+        next_title = draft.title if title is None else title
+        next_body = draft.body if body is None else body
+        next_keywords = draft.keywords_text if keywords_text is None else keywords_text
+        if (
+            next_title == draft.title
+            and next_body == draft.body
+            and next_keywords == draft.keywords_text
+        ):
+            return False
+
+        next_draft = DatabaseNoteDraft(
+            note_id=draft.note_id,
+            title=next_title,
+            body=next_body,
+            keywords_text=next_keywords,
+            revision=draft.revision + 1,
+        )
+        self._snapshot = replace(
+            snapshot,
+            draft=next_draft,
+            dirty=True,
+            status_message=(
+                snapshot.status_message
+                if snapshot.saving or snapshot.in_conflict
+                else "Unsaved changes"
+            ),
+        )
+        self._untouched_create_token = None
+        if snapshot.saving:
+            self._pending_save_requested = True
+        return True
+
+    async def request_save(self, *, explicit: bool) -> NoteSaveOutcome:
+        """Request a serialized save and await the complete coalesced chain.
+
+        Args:
+            explicit: Whether the user explicitly acknowledged Save.
+
+        Returns:
+            A typed saved, acknowledged, vetoed, failed, conflicted, blocked,
+            or stale outcome.
+        """
+        snapshot = self._snapshot
+        if snapshot is None:
+            return NoteSaveOutcome(
+                NoteSaveOutcomeKind.BLOCKED,
+                message="No note is open.",
+            )
+        if self._destructive is not None:
+            return NoteSaveOutcome(
+                NoteSaveOutcomeKind.BLOCKED,
+                note_id=snapshot.note_id,
+                revision=snapshot.draft_revision,
+                message="A destructive action is in progress.",
+            )
+        if snapshot.in_conflict:
+            return NoteSaveOutcome(
+                NoteSaveOutcomeKind.CONFLICTED,
+                note_id=snapshot.note_id,
+                revision=snapshot.draft_revision,
+                version=snapshot.version,
+                message="Conflict — review the choices below.",
+            )
+        if not snapshot.dirty:
+            if explicit:
+                self._untouched_create_token = None
+            return NoteSaveOutcome(
+                NoteSaveOutcomeKind.ACKNOWLEDGED,
+                note_id=snapshot.note_id,
+                revision=snapshot.draft_revision,
+                version=snapshot.version,
+                message="Saved — no changes.",
+            )
+
+        self._pending_save_requested = True
+        task = self._save_task
+        if task is None or task.done():
+            task = asyncio.create_task(self._drive_saves())
+            self._save_task = task
+        return await asyncio.shield(task)
+
+    async def _drive_saves(self) -> NoteSaveOutcome:
+        """Persist successive latest revisions with one active port call."""
+        while True:
+            snapshot = self._snapshot
+            if snapshot is None:
+                return NoteSaveOutcome(
+                    NoteSaveOutcomeKind.STALE,
+                    message="The note session changed before save completed.",
+                )
+            if snapshot.in_conflict:
+                self._pending_save_requested = False
+                return NoteSaveOutcome(
+                    NoteSaveOutcomeKind.CONFLICTED,
+                    note_id=snapshot.note_id,
+                    revision=snapshot.draft_revision,
+                    version=snapshot.version,
+                    message="Conflict — review the choices below.",
+                )
+            if not snapshot.dirty:
+                self._pending_save_requested = False
+                return NoteSaveOutcome(
+                    NoteSaveOutcomeKind.ACKNOWLEDGED,
+                    note_id=snapshot.note_id,
+                    revision=snapshot.draft_revision,
+                    version=snapshot.version,
+                    message="Saved — no changes.",
+                )
+
+            note_id = snapshot.note_id
+            session_generation = snapshot.session_generation
+            expected_version = snapshot.version
+            draft_revision = snapshot.draft_revision
+            payload = validate_database_note_draft(snapshot.draft)
+            self._pending_save_requested = False
+            if isinstance(payload, NoteValidationVeto):
+                self._snapshot = replace(
+                    snapshot,
+                    saving=False,
+                    dirty=True,
+                    status_message=payload.message,
+                )
+                return NoteSaveOutcome(
+                    NoteSaveOutcomeKind.VALIDATION_VETO,
+                    note_id=note_id,
+                    revision=draft_revision,
+                    version=expected_version,
+                    message=payload.message,
+                    veto=payload,
+                )
+
+            self._snapshot = replace(
+                snapshot,
+                saving=True,
+                status_message="Saving…",
+            )
+            try:
+                reply = await self._port.save_note(
+                    note_id,
+                    expected_version,
+                    payload,
+                )
+            except Exception as error:
+                reply = DatabaseNotePortSaveReply.failed(
+                    str(error) or "Save failed — edits kept. Press Save to retry."
+                )
+
+            current = self._snapshot
+            if (
+                current is None
+                or current.note_id != note_id
+                or current.session_generation != session_generation
+            ):
+                return NoteSaveOutcome(
+                    NoteSaveOutcomeKind.STALE,
+                    note_id=note_id,
+                    revision=draft_revision,
+                    version=expected_version,
+                    message="The note session changed before save completed.",
+                )
+
+            if reply.kind is PortSaveKind.FAILED:
+                self._pending_save_requested = False
+                message = self._actionable_save_failure(reply.message)
+                self._snapshot = replace(
+                    current,
+                    saving=False,
+                    dirty=True,
+                    status_message=message,
+                )
+                return NoteSaveOutcome(
+                    NoteSaveOutcomeKind.FAILED,
+                    note_id=note_id,
+                    revision=current.draft_revision,
+                    version=current.version,
+                    message=message,
+                )
+
+            if reply.kind is PortSaveKind.CONFLICT:
+                self._pending_save_requested = False
+                message = "Conflict — review the choices below."
+                self._snapshot = replace(
+                    current,
+                    saving=False,
+                    dirty=True,
+                    in_conflict=True,
+                    conflict_generation=current.conflict_generation + 1,
+                    status_message=message,
+                )
+                return NoteSaveOutcome(
+                    NoteSaveOutcomeKind.CONFLICTED,
+                    note_id=note_id,
+                    revision=current.draft_revision,
+                    version=current.version,
+                    message=message,
+                )
+
+            saved_at = self._clock()
+            saved_version = (
+                reply.version if reply.version is not None else expected_version + 1
+            )
+            baseline = NormalizedDatabaseNote(
+                note_id=note_id,
+                title=payload.title,
+                body=payload.body,
+                keywords=(
+                    reply.keywords if reply.keywords is not None else payload.keywords
+                ),
+                version=saved_version,
+                created_at=current.baseline.created_at,
+                modified_at=reply.modified_at or saved_at.isoformat(),
+            )
+            has_newer_draft = current.draft_revision > draft_revision
+            self._snapshot = replace(
+                current,
+                baseline=baseline,
+                saved_revision=draft_revision,
+                dirty=has_newer_draft,
+                saving=False,
+                in_conflict=False,
+                status_message=(
+                    "Unsaved changes"
+                    if has_newer_draft
+                    else f"Saved {saved_at.strftime('%H:%M')}"
+                ),
+            )
+            if has_newer_draft:
+                self._pending_save_requested = True
+                continue
+
+            self._pending_save_requested = False
+            return NoteSaveOutcome(
+                NoteSaveOutcomeKind.SAVED,
+                note_id=note_id,
+                revision=draft_revision,
+                version=saved_version,
+                message=self._snapshot.status_message,
+            )
+
+    @staticmethod
+    def _actionable_save_failure(detail: str) -> str:
+        """Keep every ordinary save failure explicit about safe recovery."""
+        message = detail.strip()
+        if "Press Save to retry" in message:
+            return message
+        if message:
+            return (
+                f"Save failed — {message.rstrip('.')}. Edits kept. Press Save to retry."
+            )
+        return "Save failed — edits kept. Press Save to retry."

--- a/tldw_chatbook/Library/library_notes_state.py
+++ b/tldw_chatbook/Library/library_notes_state.py
@@ -172,6 +172,12 @@ def validate_database_note_draft(
         An exact persistence payload, or a typed actionable validation veto.
     """
     title = draft.title
+    if not isinstance(title, str):
+        return _validation_veto(
+            draft,
+            "title",
+            "Title must be text — fix the template or input to save.",
+        )
     if len(title) > DATABASE_NOTE_TITLE_MAX_CHARS:
         return _validation_veto(
             draft,
@@ -200,6 +206,12 @@ def validate_database_note_draft(
         )
 
     body = draft.body
+    if not isinstance(body, str):
+        return _validation_veto(
+            draft,
+            "body",
+            "Body must be text — fix the template or input to save.",
+        )
     if len(body) > DATABASE_NOTE_BODY_MAX_CHARS:
         return _validation_veto(
             draft,
@@ -215,7 +227,14 @@ def validate_database_note_draft(
 
     keywords: list[str] = []
     seen: set[str] = set()
-    for raw_token in draft.keywords_text.split(","):
+    keywords_text = draft.keywords_text
+    if not isinstance(keywords_text, str):
+        return _validation_veto(
+            draft,
+            "keywords",
+            "Keywords must be text — fix the template or input to save.",
+        )
+    for raw_token in keywords_text.split(","):
         token = raw_token.strip()
         if not token:
             continue
@@ -311,6 +330,68 @@ class LibraryNotesListRow:
     checked: bool = False
 
 
+_NOTE_OPERATION_LABELS = {
+    "import": "Import",
+    "export": "Export",
+    "copy": "Copy",
+    "console": "Use in Console",
+}
+
+
+@dataclass(frozen=True)
+class LibraryNotesOperationState:
+    """One token-gated transfer status owned by its initiating region.
+
+    Attributes:
+        kind: External action whose status is being reported.
+        token: Monotonic operation identity used to reject stale completion.
+        phase: Current operation lifecycle phase.
+        region: Notes surface that owns and displays this status.
+        completion_next_action: Optional recovery step after committed success.
+        failure_next_action: Recovery instruction rendered after failure.
+    """
+
+    kind: Literal["import", "export", "copy", "console"]
+    token: int
+    phase: Literal["running", "complete", "failed"]
+    region: Literal["navigator", "editor", "context"]
+    completion_next_action: str = ""
+    failure_next_action: str = "try again"
+
+    @property
+    def running(self) -> bool:
+        """Return whether the external side effect is still in flight."""
+        return self.phase == "running"
+
+    @property
+    def status_line(self) -> str:
+        """Render the compact active-region status contract."""
+        action = _NOTE_OPERATION_LABELS[self.kind]
+        if self.phase == "running":
+            return f"{action}…"
+        if self.phase == "complete":
+            if self.completion_next_action:
+                next_action = self.completion_next_action.rstrip(". ")
+                return f"{action} complete — {next_action}."
+            return f"{action} complete."
+        next_action = self.failure_next_action.rstrip(". ")
+        return f"{action} failed — {next_action}."
+
+
+@dataclass(frozen=True)
+class LibraryNoteCreateOutcome:
+    """Typed boundary between persistence and opening the created note.
+
+    Attributes:
+        kind: Whether persistence failed, committed without an editor, or
+            committed and opened successfully.
+        note_id: Persisted identity when ``kind`` is not ``"failed"``.
+    """
+
+    kind: Literal["failed", "created_not_opened", "opened"]
+    note_id: str = ""
+
+
 @dataclass(frozen=True)
 class LibraryNotesListState:
     """Display state for the Library notes canvas's list view.
@@ -324,6 +405,13 @@ class LibraryNotesListState:
             ``""`` when there are rows to render.
         select_mode: Whether multi-select mode is active.
         selected_count: Number of rendered rows currently checked.
+        total_count: Total notes in the unfiltered source.
+        result_count: Number of rows rendered after filtering.
+        empty_kind: Typed distinction between populated, source-empty, and
+            filter-empty states.
+        sort_choices_visible: Whether direct sort choices are expanded.
+        operation_status: Active Navigator transfer status, if any.
+        operation_running: Whether Navigator actions must be gated.
     """
 
     rows: tuple[LibraryNotesListRow, ...]
@@ -332,6 +420,12 @@ class LibraryNotesListState:
     empty_copy: str
     select_mode: bool = False
     selected_count: int = 0
+    total_count: int = 0
+    result_count: int = 0
+    empty_kind: Literal["populated", "source-empty", "filter-empty"] = "populated"
+    sort_choices_visible: bool = False
+    operation_status: str = ""
+    operation_running: bool = False
 
 
 @dataclass(frozen=True)
@@ -394,6 +488,9 @@ def build_library_notes_list_state(
     now: datetime | None = None,
     select_mode: bool = False,
     selected_ids: frozenset[str] = frozenset(),
+    sort_choices_visible: bool = False,
+    operation_status: str = "",
+    operation_running: bool = False,
 ) -> LibraryNotesListState:
     """Build the Library notes canvas's list-view display state.
 
@@ -425,15 +522,23 @@ def build_library_notes_list_state(
     status_copy = ""
     if filter_note:
         noun = "result" if len(rows) == 1 else "results"
-        status_copy = f"filter: {filter_note} · {len(rows)} {noun}"
+        status_copy = ellipsize_note_title_cells(
+            f"filter: {filter_note} · {len(rows)} {noun}", 52
+        )
+    if operation_status:
+        status_copy = ellipsize_note_title_cells(operation_status, 52)
     selected_count = sum(1 for r in rows if r.checked)
     source_total = len(rows) if total_count is None else max(total_count, 0)
     empty_copy = ""
+    empty_kind: Literal["populated", "source-empty", "filter-empty"] = "populated"
     if not rows:
         if source_total == 0:
             empty_copy = _EMPTY_NOTES_COPY
+            empty_kind = "source-empty"
         elif filter_note:
-            empty_copy = f"No notes match “{filter_note}”. Clear the filter."
+            filter_copy = ellipsize_note_title_cells(filter_note, 32)
+            empty_copy = f"No notes match “{filter_copy}”. Clear the filter."
+            empty_kind = "filter-empty"
     return LibraryNotesListState(
         rows=rows,
         header_copy=f"Notes ({source_total})",
@@ -441,6 +546,12 @@ def build_library_notes_list_state(
         empty_copy=empty_copy,
         select_mode=select_mode,
         selected_count=selected_count,
+        total_count=source_total,
+        result_count=len(rows),
+        empty_kind=empty_kind,
+        sort_choices_visible=sort_choices_visible,
+        operation_status=operation_status,
+        operation_running=operation_running,
     )
 
 
@@ -780,8 +891,8 @@ def build_library_note_template_rows(
     Excludes the ``blank`` template (it duplicates the dedicated Blank
     note action). Rows are sorted by key for a stable order. Malformed
     (non-mapping) template values degrade to a key-derived label with no
-    secondary line rather than being dropped -- the screen-side field
-    resolver already degrades their creation to a blank note.
+    secondary line rather than being dropped. Activating such a row lets the
+    screen's lossless validation boundary surface a typed, visible veto.
 
     Args:
         templates: The ``NOTE_TEMPLATES`` mapping (or None).

--- a/tldw_chatbook/Library/library_notes_state.py
+++ b/tldw_chatbook/Library/library_notes_state.py
@@ -18,6 +18,11 @@ NOTES_SORT_MODES = ("newest", "oldest", "title")
 _UPDATED_KEYS = ("last_modified", "updated_at", "created_at")
 _EMPTY_NOTES_COPY = "No notes yet. Create your first note."
 
+LibraryNotesStage = Literal["rail", "notes"]
+LibraryNotesRegion = Literal[
+    "", "navigator", "editor", "preview", "context", "create", "sync"
+]
+
 DATABASE_NOTE_TITLE_MAX_CHARS = 300
 DATABASE_NOTE_BODY_MAX_CHARS = 2_000_000
 DATABASE_NOTE_KEYWORD_MAX_CHARS = 100
@@ -138,8 +143,8 @@ class LibraryNoteSessionSnapshot:
 class LibraryNotesFocusIdentity:
     """Textual-free semantic focus, selection, and scroll restoration tuple."""
 
-    stage: str
-    region: str
+    stage: LibraryNotesStage
+    region: LibraryNotesRegion
     note_id: str | None
     semantic_role: str
     body_selection_start: tuple[int, int] | None = None

--- a/tldw_chatbook/Library/library_notes_state.py
+++ b/tldw_chatbook/Library/library_notes_state.py
@@ -5,20 +5,291 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Mapping, Sequence
+from typing import Any, Literal, Mapping, Sequence
 
+from rich.cells import get_character_cell_size
+
+from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
 from tldw_chatbook.Workspaces.conversation_browser_state import (
     format_console_relative_age,
 )
 
 NOTES_SORT_MODES = ("newest", "oldest", "title")
 _UPDATED_KEYS = ("last_modified", "updated_at", "created_at")
-_EMPTY_NOTES_COPY = "No notes yet. Create one to see it here."
+_EMPTY_NOTES_COPY = "No notes yet. Create your first note."
+
+DATABASE_NOTE_TITLE_MAX_CHARS = 300
+DATABASE_NOTE_BODY_MAX_CHARS = 2_000_000
+DATABASE_NOTE_KEYWORD_MAX_CHARS = 100
 
 # The "blank" template duplicates the dedicated Blank note action (with a
 # confusingly different default title), so the create view's template list
 # excludes it -- the button is the one canonical empty path.
 _BLANK_TEMPLATE_KEY = "blank"
+
+
+@dataclass(frozen=True)
+class NormalizedDatabaseNote:
+    """One coherent persisted Database Note detail returned by a session port.
+
+    Attributes:
+        note_id: Stable Database Note identity.
+        title: Exact persisted title.
+        body: Exact persisted body.
+        keywords: Semantic keyword tokens in persisted order.
+        version: Current optimistic-lock version.
+        created_at: Persisted creation timestamp text.
+        modified_at: Persisted modification timestamp text.
+    """
+
+    note_id: str
+    title: str
+    body: str
+    keywords: tuple[str, ...]
+    version: int
+    created_at: str
+    modified_at: str
+
+
+@dataclass(frozen=True)
+class DatabaseNoteDraft:
+    """Canonical raw in-memory Database Note draft.
+
+    Attributes:
+        note_id: Stable Database Note identity.
+        title: Raw, untransformed title text.
+        body: Raw, untransformed body text.
+        keywords_text: Raw comma-delimited keyword input.
+        revision: Monotonic draft revision.
+    """
+
+    note_id: str
+    title: str
+    body: str
+    keywords_text: str
+    revision: int
+
+
+@dataclass(frozen=True)
+class DatabaseNoteSavePayload:
+    """Losslessly validated values for one versioned save attempt."""
+
+    title: str
+    body: str
+    keywords: tuple[str, ...]
+    revision: int
+
+
+@dataclass(frozen=True)
+class NoteValidationVeto:
+    """Typed actionable reason that the current raw draft cannot be saved."""
+
+    field: Literal["title", "body", "keywords"]
+    message: str
+    revision: int
+
+
+@dataclass(frozen=True)
+class LibraryNoteSessionSnapshot:
+    """Portable immutable view of one active Database Note session."""
+
+    baseline: NormalizedDatabaseNote
+    draft: DatabaseNoteDraft
+    session_generation: int
+    saved_revision: int
+    dirty: bool
+    saving: bool
+    in_conflict: bool
+    conflict_generation: int
+    status_message: str
+
+    @property
+    def note_id(self) -> str:
+        """Return the active note identity."""
+        return self.draft.note_id
+
+    @property
+    def title(self) -> str:
+        """Return the canonical raw draft title."""
+        return self.draft.title
+
+    @property
+    def body(self) -> str:
+        """Return the canonical raw draft body."""
+        return self.draft.body
+
+    @property
+    def keywords_text(self) -> str:
+        """Return the canonical raw keyword input."""
+        return self.draft.keywords_text
+
+    @property
+    def draft_revision(self) -> int:
+        """Return the current canonical draft revision."""
+        return self.draft.revision
+
+    @property
+    def version(self) -> int:
+        """Return the last confirmed optimistic-lock version."""
+        return self.baseline.version
+
+
+@dataclass(frozen=True)
+class LibraryNotesFocusIdentity:
+    """Textual-free semantic focus, selection, and scroll restoration tuple."""
+
+    stage: str
+    region: str
+    note_id: str | None
+    semantic_role: str
+    body_selection_start: tuple[int, int] | None = None
+    body_selection_end: tuple[int, int] | None = None
+    scroll_offset: tuple[int, int] | None = None
+
+
+def _validation_veto(
+    draft: DatabaseNoteDraft,
+    field: Literal["title", "body", "keywords"],
+    message: str,
+) -> NoteValidationVeto:
+    return NoteValidationVeto(field=field, message=message, revision=draft.revision)
+
+
+def validate_database_note_draft(
+    draft: DatabaseNoteDraft,
+) -> DatabaseNoteSavePayload | NoteValidationVeto:
+    """Build an exact save payload or veto any transforming persistence path.
+
+    Delimiter-adjacent keyword whitespace and empty comma segments are syntax;
+    every remaining token preserves its spelling and order. Title, body, and
+    keyword content are never truncated, sanitized into replacement text, or
+    silently deduplicated.
+
+    Args:
+        draft: Canonical raw Database Note draft.
+
+    Returns:
+        An exact persistence payload, or a typed actionable validation veto.
+    """
+    title = draft.title
+    if len(title) > DATABASE_NOTE_TITLE_MAX_CHARS:
+        return _validation_veto(
+            draft,
+            "title",
+            f"Title is {len(title)}/{DATABASE_NOTE_TITLE_MAX_CHARS} characters — shorten it to save.",
+        )
+    if title != title.strip():
+        return _validation_veto(
+            draft,
+            "title",
+            "Title begins or ends with whitespace — remove it to save.",
+        )
+    if sanitize_string(title, max_length=DATABASE_NOTE_TITLE_MAX_CHARS) != title:
+        return _validation_veto(
+            draft,
+            "title",
+            "Title contains unsupported control characters — remove them to save.",
+        )
+    if not validate_text_input(
+        title, max_length=DATABASE_NOTE_TITLE_MAX_CHARS, allow_html=False
+    ):
+        return _validation_veto(
+            draft,
+            "title",
+            "Title contains unsafe markup — revise it to save.",
+        )
+
+    body = draft.body
+    if len(body) > DATABASE_NOTE_BODY_MAX_CHARS:
+        return _validation_veto(
+            draft,
+            "body",
+            f"Body is {len(body)}/{DATABASE_NOTE_BODY_MAX_CHARS} characters — shorten it to save.",
+        )
+    if sanitize_string(body, max_length=DATABASE_NOTE_BODY_MAX_CHARS) != body:
+        return _validation_veto(
+            draft,
+            "body",
+            "Body contains unsupported control characters — remove them to save.",
+        )
+
+    keywords: list[str] = []
+    seen: set[str] = set()
+    for raw_token in draft.keywords_text.split(","):
+        token = raw_token.strip()
+        if not token:
+            continue
+        if len(token) > DATABASE_NOTE_KEYWORD_MAX_CHARS:
+            return _validation_veto(
+                draft,
+                "keywords",
+                f"A keyword is {len(token)}/{DATABASE_NOTE_KEYWORD_MAX_CHARS} characters — shorten it to save.",
+            )
+        if sanitize_string(token, max_length=DATABASE_NOTE_KEYWORD_MAX_CHARS) != token:
+            return _validation_veto(
+                draft,
+                "keywords",
+                "A keyword contains unsupported control characters — revise it to save.",
+            )
+        if not validate_text_input(
+            token, max_length=DATABASE_NOTE_KEYWORD_MAX_CHARS, allow_html=False
+        ):
+            return _validation_veto(
+                draft,
+                "keywords",
+                "A keyword contains unsafe markup — revise it to save.",
+            )
+        identity = token.casefold()
+        if identity in seen:
+            return _validation_veto(
+                draft,
+                "keywords",
+                "Keywords contain a case-insensitive duplicate — remove one to save.",
+            )
+        seen.add(identity)
+        keywords.append(token)
+
+    return DatabaseNoteSavePayload(
+        title=title,
+        body=body,
+        keywords=tuple(keywords),
+        revision=draft.revision,
+    )
+
+
+def ellipsize_note_title_cells(title: str, max_cells: int) -> str:
+    """Return a plain one-row title no wider than ``max_cells`` terminal cells.
+
+    Args:
+        title: Raw title to format for display only.
+        max_cells: Maximum terminal-cell width, including an ellipsis.
+
+    Returns:
+        The original title when it fits, otherwise a cell-safe ellipsized copy.
+        The raw input is never modified.
+    """
+    if max_cells <= 0:
+        return ""
+
+    one_row_title = re.sub(r"[\r\n\t\x85\u2028\u2029]", " ", title)
+    width = sum(get_character_cell_size(character) for character in one_row_title)
+    if width <= max_cells:
+        return one_row_title
+
+    ellipsis = "…"
+    remaining = max_cells - get_character_cell_size(ellipsis)
+    if remaining <= 0:
+        return ellipsis if max_cells >= 1 else ""
+
+    visible: list[str] = []
+    used = 0
+    for character in one_row_title:
+        character_width = get_character_cell_size(character)
+        if used + character_width > remaining:
+            break
+        visible.append(character)
+        used += character_width
+    return "".join(visible) + ellipsis
 
 
 @dataclass(frozen=True)
@@ -119,6 +390,7 @@ def build_library_notes_list_state(
     records: Sequence[Mapping[str, Any]] | None,
     *,
     filter_note: str = "",
+    total_count: int | None = None,
     now: datetime | None = None,
     select_mode: bool = False,
     selected_ids: frozenset[str] = frozenset(),
@@ -134,6 +406,8 @@ def build_library_notes_list_state(
             caller), or ``None``.
         filter_note: The active filter text, used only to render the
             result-count status copy; ``""`` when no filter is active.
+        total_count: Total notes in the source before filtering. Defaults to
+            the rendered row count when the caller has no separate total.
         now: Reference time for relative-age labels; defaults to the
             current UTC time.
         select_mode: Whether multi-select mode is active.
@@ -153,11 +427,18 @@ def build_library_notes_list_state(
         noun = "result" if len(rows) == 1 else "results"
         status_copy = f"filter: {filter_note} · {len(rows)} {noun}"
     selected_count = sum(1 for r in rows if r.checked)
+    source_total = len(rows) if total_count is None else max(total_count, 0)
+    empty_copy = ""
+    if not rows:
+        if source_total == 0:
+            empty_copy = _EMPTY_NOTES_COPY
+        elif filter_note:
+            empty_copy = f"No notes match “{filter_note}”. Clear the filter."
     return LibraryNotesListState(
         rows=rows,
-        header_copy=f"Notes ({len(rows)})",
+        header_copy=f"Notes ({source_total})",
         status_copy=status_copy,
-        empty_copy="" if rows else _EMPTY_NOTES_COPY,
+        empty_copy=empty_copy,
         select_mode=select_mode,
         selected_count=selected_count,
     )

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1621,6 +1621,465 @@ class LibraryScreen(BaseAppScreen):
         min-height: 1;
         content-align: center middle;
     }
+
+    /* Presentation-only row wrappers keep the established wide stacked
+       workbench. Compact rules below switch only these wrappers to rows. */
+    #library-notes-filter-row,
+    #library-notes-status-row,
+    #library-note-heading,
+    #library-note-title-row,
+    #library-note-context-keywords-row,
+    #library-notes-create-heading,
+    #library-notes-sync-heading,
+    #library-notes-sync-folder-row,
+    #library-notes-sync-direction-row,
+    #library-notes-sync-conflict-row,
+    #library-notes-sync-actions {
+        layout: vertical;
+        height: auto;
+        min-height: 0;
+    }
+
+    #library-notes-create-viewport,
+    #library-notes-sync-viewport {
+        height: 1fr;
+        min-height: 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    /* Database Notes compact geometry: at the measured compact breakpoint,
+       the shell becomes a single 15-row workbench and every Notes state
+       assigns surplus height to exactly one scroll owner. */
+    #library-shell-grid.library-notes-compact {
+        padding: 0;
+        margin: 0;
+        border: none;
+    }
+
+    #library-canvas.library-notes-compact {
+        padding: 0;
+        margin: 0;
+        border: none;
+        overflow-x: hidden;
+        overflow-y: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-canvas {
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        padding: 0;
+        margin: 0;
+        overflow-x: hidden;
+        overflow-y: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-header {
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        padding: 0 1;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-filter-row {
+        layout: horizontal;
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-filter-label {
+        width: 7;
+        height: 1;
+        padding: 0 1;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-filter {
+        width: 1fr;
+        height: 1;
+        min-height: 1;
+        margin: 0;
+        padding: 0 1;
+        border: none;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-browse-actions,
+    #library-canvas.library-notes-compact #library-notes-sort-choices,
+    #library-canvas.library-notes-compact #library-notes-transfer-actions,
+    #library-canvas.library-notes-compact #library-notes-selection-actions,
+    #library-canvas.library-notes-compact #library-note-primary-actions,
+    #library-canvas.library-notes-compact #library-note-conflict-actions,
+    #library-canvas.library-notes-compact #library-note-delete-actions {
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact .library-canvas-action {
+        width: auto;
+        min-width: 0;
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0 1 0 0;
+        padding: 0 1;
+        border: none;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-status-row {
+        layout: horizontal;
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-status {
+        width: 1fr;
+        height: 1;
+        min-height: 1;
+        margin: 0;
+        padding: 0 1;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-filter-clear {
+        width: auto;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-selection-status {
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        padding: 0 1;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-list {
+        height: 1fr;
+        min-height: 0;
+        margin: 0;
+        padding: 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-empty {
+        height: 1fr;
+        min-height: 0;
+        margin: 0;
+        padding: 0 1;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-note-heading {
+        layout: horizontal;
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-note-editor-title,
+    #library-canvas.library-notes-compact #library-note-preview-title,
+    #library-canvas.library-notes-compact #library-note-context-title,
+    #library-canvas.library-notes-compact #library-note-loading-title,
+    #library-canvas.library-notes-compact #library-notes-create-header,
+    #library-canvas.library-notes-compact #library-notes-sync-header {
+        width: 1fr;
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        padding: 0 1;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    #library-canvas.library-notes-compact #library-note-editor-region {
+        height: 1fr;
+        min-height: 0;
+        margin: 0;
+        overflow-x: hidden;
+        overflow-y: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-note-title-row {
+        layout: horizontal;
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+    }
+
+    #library-canvas.library-notes-compact #library-note-title-label,
+    #library-canvas.library-notes-compact #library-note-context-keywords-label {
+        width: 10;
+        height: 1;
+        padding: 0 1;
+    }
+
+    #library-canvas.library-notes-compact #library-note-title,
+    #library-canvas.library-notes-compact #library-note-context-keywords,
+    #library-canvas.library-notes-compact #library-notes-sync-folder {
+        width: 1fr;
+        height: 1;
+        min-height: 1;
+        margin: 0;
+        padding: 0 1;
+        border: none;
+    }
+
+    #library-canvas.library-notes-compact #library-note-body-label {
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        padding: 0 1;
+    }
+
+    #library-canvas.library-notes-compact #library-note-body {
+        height: 1fr;
+        min-height: 0;
+        max-height: 100%;
+        margin: 0;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-note-preview-region {
+        height: 1fr;
+        min-height: 0;
+        max-height: 100%;
+        margin: 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-note-preview-body {
+        height: auto;
+        min-height: 0;
+        margin: 0;
+        padding: 0 1;
+        border: none;
+        overflow-y: hidden;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-note-context-status {
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        padding: 0 1;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    #library-canvas.library-notes-compact #library-note-context-region {
+        height: 1fr;
+        min-height: 0;
+        margin: 0;
+        padding: 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-note-context-region .destination-section,
+    #library-canvas.library-notes-compact #library-note-context-meta,
+    #library-canvas.library-notes-compact #library-note-context-region > .library-canvas-action {
+        height: 1;
+        min-height: 1;
+        margin: 0;
+    }
+
+    #library-canvas.library-notes-compact #library-note-context-keywords-row {
+        layout: horizontal;
+        height: 1;
+        min-height: 1;
+        margin: 0;
+    }
+
+    #library-canvas.library-notes-compact #library-note-status {
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        padding: 0 1;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-canvas.library-note-validation #library-note-status {
+        height: 2;
+        min-height: 2;
+        max-height: 2;
+        text-wrap: wrap;
+        text-overflow: clip;
+    }
+
+    #library-canvas.library-notes-compact #library-note-transfer-status,
+    #library-canvas.library-notes-compact #library-note-context-transfer-status {
+        display: none;
+        height: 0;
+        min-height: 0;
+        margin: 0;
+    }
+
+    #library-canvas.library-notes-compact #library-note-conflict-region {
+        height: 3;
+        min-height: 3;
+        max-height: 3;
+        margin: 0;
+    }
+
+    #library-canvas.library-notes-compact #library-note-conflict-copy {
+        height: 2;
+        min-height: 2;
+        max-height: 2;
+        margin: 0;
+        padding: 0 1;
+    }
+
+    #library-canvas.library-notes-compact #library-note-delete-confirmation {
+        height: 2;
+        min-height: 2;
+        max-height: 2;
+        margin: 0;
+    }
+
+    #library-canvas.library-notes-compact #library-note-delete-confirm-copy {
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        padding: 0 1;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-create-heading {
+        layout: horizontal;
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-create-viewport {
+        height: 1fr;
+        min-height: 0;
+        margin: 0;
+        padding: 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-sync-heading {
+        layout: horizontal;
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-sync-viewport {
+        height: 1fr;
+        min-height: 0;
+        margin: 0;
+        padding: 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-note-load-state {
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-note-load-heading {
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+    }
+
+    #library-canvas.library-notes-compact #library-note-loading {
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        padding: 0 1;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    #library-canvas.library-notes-compact #library-note-loading-viewport {
+        height: 1fr;
+        min-height: 0;
+        margin: 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-sync-purpose,
+    #library-canvas.library-notes-compact #library-notes-sync-folder-row,
+    #library-canvas.library-notes-compact #library-notes-sync-direction-row,
+    #library-canvas.library-notes-compact #library-notes-sync-conflict-row,
+    #library-canvas.library-notes-compact #library-notes-sync-actions,
+    #library-canvas.library-notes-compact #library-notes-sync-status {
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        margin: 0;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-sync-activity {
+        height: auto;
+        min-height: 1;
+        margin: 0;
+        overflow-x: hidden;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-sync-folder-row,
+    #library-canvas.library-notes-compact #library-notes-sync-direction-row,
+    #library-canvas.library-notes-compact #library-notes-sync-conflict-row,
+    #library-canvas.library-notes-compact #library-notes-sync-actions {
+        layout: horizontal;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-sync-folder-label,
+    #library-canvas.library-notes-compact #library-notes-sync-direction-label,
+    #library-canvas.library-notes-compact #library-notes-sync-conflict-label {
+        width: 11;
+        height: 1;
+        min-height: 1;
+        padding: 0 1;
+    }
+
+    #library-canvas.library-notes-compact #library-notes-sync-direction-choices,
+    #library-canvas.library-notes-compact #library-notes-sync-conflict-choices {
+        width: 1fr;
+        height: 1;
+        min-height: 1;
+        margin: 0;
+        overflow-x: hidden;
+    }
     """
 
     def __init__(
@@ -2548,15 +3007,6 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_presentation_syncing = True
         try:
             canvas.apply_session_state(self._library_note_presentation_state())
-            body = canvas.query_one("#library-note-body", TextArea)
-            if self._library_notes_compact:
-                body.styles.height = "1fr"
-                body.styles.min_height = 3
-                body.styles.max_height = None
-            else:
-                body.styles.height = "auto"
-                body.styles.min_height = 12
-                body.styles.max_height = 20
         finally:
             self._library_note_presentation_syncing = False
 
@@ -2668,8 +3118,8 @@ class LibraryScreen(BaseAppScreen):
             "editor": "#library-note-body",
             "preview": "#library-note-preview-region",
             "context": "#library-note-context-region",
-            "create": "#library-notes-canvas",
-            "sync": "#library-notes-canvas",
+            "create": "#library-notes-create-viewport",
+            "sync": "#library-notes-sync-viewport",
         }.get(region)
         if selector is None:
             return None
@@ -3066,6 +3516,12 @@ class LibraryScreen(BaseAppScreen):
             return
         for widget in (shell, rail, canvas):
             widget.set_class(self._library_notes_compact, "library-notes-compact")
+        try:
+            notes_canvas = canvas.query_one("#library-notes-canvas", LibraryNotesCanvas)
+        except (NoMatches, QueryError):
+            pass
+        else:
+            notes_canvas.apply_compact_presentation(self._library_notes_compact)
         single_stage = (
             self._library_notes_compact and self._library_notes_compact_stage_applies()
         )
@@ -6755,12 +7211,18 @@ class LibraryScreen(BaseAppScreen):
                     editor_state = self._library_note_editor_state()
                     if editor_state is None:
                         with Vertical(id="library-note-load-state"):
-                            yield Button(
-                                "‹ Back to list",
-                                id="library-note-back",
-                                classes="library-canvas-action",
-                                compact=True,
-                            )
+                            with Horizontal(id="library-note-load-heading"):
+                                yield Button(
+                                    "‹ Notes",
+                                    id="library-note-back",
+                                    classes="library-canvas-action",
+                                    compact=True,
+                                )
+                                yield Static(
+                                    "Edit note",
+                                    id="library-note-loading-title",
+                                    markup=False,
+                                )
                             load_copy = (
                                 self._library_note_load_message
                                 if self._library_note_load_state == "failed"
@@ -6772,17 +7234,19 @@ class LibraryScreen(BaseAppScreen):
                                 classes="destination-purpose",
                                 markup=False,
                             )
-                            if self._library_note_load_state == "failed":
-                                yield Button(
-                                    "Retry",
-                                    id="library-note-load-retry",
-                                    classes="library-canvas-action",
-                                    compact=True,
-                                )
+                            with Vertical(id="library-note-loading-viewport"):
+                                if self._library_note_load_state == "failed":
+                                    yield Button(
+                                        "Retry",
+                                        id="library-note-load-retry",
+                                        classes="library-canvas-action",
+                                        compact=True,
+                                    )
                     else:
                         yield LibraryNotesCanvas(
                             mode="editor",
                             presentation_state=self._library_note_presentation_state(),
+                            compact=self._library_notes_compact,
                             title_placeholder_only=(
                                 self._library_note_pending_blank_gc_id is not None
                                 and self._library_note_pending_blank_gc_id
@@ -6796,6 +7260,7 @@ class LibraryScreen(BaseAppScreen):
                     yield LibraryNotesCanvas(
                         mode="sync",
                         sync_state=self._build_library_notes_sync_state(),
+                        compact=self._library_notes_compact,
                         id="library-notes-canvas",
                     )
                 elif shell.canvas_kind == "notes":
@@ -6803,11 +7268,13 @@ class LibraryScreen(BaseAppScreen):
                         self._build_library_notes_state(),
                         sort_mode=self._library_notes_sort,
                         filter_value=self._library_notes_filter,
+                        compact=self._library_notes_compact,
                         id="library-notes-canvas",
                     )
                 elif shell.canvas_kind == "notes-create":
                     yield LibraryNotesCanvas(
                         mode="create",
+                        compact=self._library_notes_compact,
                         create_running=self._library_note_create_running,
                         create_status=self._library_note_create_status,
                         id="library-notes-canvas",

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1649,6 +1649,41 @@ class LibraryScreen(BaseAppScreen):
         overflow-x: hidden;
     }
 
+    #library-note-preview-region {
+        height: auto;
+        min-height: 12;
+        max-height: 20;
+        margin: 0 0 1 0;
+        border: solid $surface-lighten-1;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    #library-note-context-region {
+        border: solid $surface-lighten-1;
+    }
+
+    #library-note-preview-region:focus,
+    #library-note-context-region:focus {
+        border: solid $accent;
+        background: $boost;
+    }
+
+    #library-note-conflict-copy:focus {
+        background: $boost;
+        color: $text;
+        text-style: bold underline;
+    }
+
+    #library-note-preview-body {
+        height: auto;
+        min-height: 0;
+        margin: 0;
+        padding: 0 1;
+        border: none;
+        overflow-y: hidden;
+        overflow-x: hidden;
+    }
     /* Database Notes compact geometry: at the measured compact breakpoint,
        the shell becomes a single 15-row workbench and every Notes state
        assigns surplus height to exactly one scroll owner. */
@@ -3995,7 +4030,12 @@ class LibraryScreen(BaseAppScreen):
         )
         focus_identity = pending_focus or restore.focus
         may_restore_focus = pending_focus is not None or presentation_matches
-        if self._library_notes_compact and may_restore_focus:
+        explicit_stage_intent = self._library_notes_explicit_stage_intent
+        if (
+            self._library_notes_compact
+            and may_restore_focus
+            and not explicit_stage_intent
+        ):
             self._library_notes_stage = focus_identity.stage
         self._apply_library_notes_stage_visibility()
         if snapshot is not None and session_matches:
@@ -4024,6 +4064,8 @@ class LibraryScreen(BaseAppScreen):
                 focus_identity,
                 guard,
             )
+        if explicit_stage_intent:
+            self._library_notes_explicit_stage_intent = False
 
     def refresh(
         self,
@@ -4491,6 +4533,10 @@ class LibraryScreen(BaseAppScreen):
         workspace = self._library_file_notes_workspace
         if workspace is not None:
             await workspace.shutdown()
+        if self._library_notes_autosave_timer is not None:
+            self._library_notes_autosave_timer.stop()
+            self._library_notes_autosave_timer = None
+        self._cancel_library_notes_auto_sync_timer()
         super().on_unmount()
         registry = self._library_ingest_registry()
         if registry is not None:
@@ -10863,8 +10909,11 @@ class LibraryScreen(BaseAppScreen):
         self._library_selected_row_id = row_id
         # task-420: keep the footer's "u" hint in sync with the row gate.
         self._register_footer_shortcuts()
-        self._library_notes_explicit_stage_intent = False
-        if row_id in {LIBRARY_ROW_BROWSE_NOTES, LIBRARY_ROW_CREATE_NOTE}:
+        self._library_notes_explicit_stage_intent = row_id in {
+            LIBRARY_ROW_BROWSE_NOTES,
+            LIBRARY_ROW_CREATE_NOTE,
+        }
+        if self._library_notes_explicit_stage_intent:
             self._library_notes_stage = "notes"
         elif self._library_notes_compact and self._library_notes_stage == "rail":
             # Unrelated canvases retain their incumbent compact composition;

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -235,6 +235,7 @@ from ...Library.library_shell_state import (
     LIBRARY_ROW_INGEST_EXPORT,
     LIBRARY_ROW_INGEST_MEDIA,
     LibraryShellInput,
+    LibraryShellState,
     build_library_shell_state,
 )
 from ...Local_Ingestion.parakeet_v2_artifact import (
@@ -1730,7 +1731,7 @@ class LibraryScreen(BaseAppScreen):
     }
 
     #library-canvas.library-notes-compact #library-notes-filter-label {
-        width: 7;
+        width: 8;
         height: 1;
         padding: 0 1;
     }
@@ -3550,19 +3551,28 @@ class LibraryScreen(BaseAppScreen):
             canvas = self.query_one("#library-canvas", Widget)
         except (NoMatches, QueryError):
             return
-        for widget in (shell, rail, canvas):
-            widget.set_class(self._library_notes_compact, "library-notes-compact")
+        # Only the grid and canvas host participate in compact CSS selectors;
+        # tagging the rail and inner Notes canvas forced two needless global
+        # stylesheet matches on every breakpoint crossing.
+        for widget in (shell, canvas):
+            if widget.has_class("library-notes-compact") != self._library_notes_compact:
+                widget.set_class(self._library_notes_compact, "library-notes-compact")
         try:
             notes_canvas = canvas.query_one("#library-notes-canvas", LibraryNotesCanvas)
         except (NoMatches, QueryError):
             pass
         else:
-            notes_canvas.apply_compact_presentation(self._library_notes_compact)
+            if notes_canvas.compact != self._library_notes_compact:
+                notes_canvas.apply_compact_presentation(self._library_notes_compact)
         single_stage = (
             self._library_notes_compact and self._library_notes_compact_stage_applies()
         )
-        rail.display = not single_stage or self._library_notes_stage == "rail"
-        canvas.display = not single_stage or self._library_notes_stage == "notes"
+        rail_display = not single_stage or self._library_notes_stage == "rail"
+        canvas_display = not single_stage or self._library_notes_stage == "notes"
+        if rail.display != rail_display:
+            rail.display = rail_display
+        if canvas.display != canvas_display:
+            canvas.display = canvas_display
 
     def _transition_library_notes_presentation(
         self,
@@ -7147,7 +7157,6 @@ class LibraryScreen(BaseAppScreen):
                 classes="destination-workbench-pane",
             )
             rail.styles.height = "100%"
-            rail.set_class(self._library_notes_compact, "library-notes-compact")
             rail.display = not single_notes_stage or self._library_notes_stage == "rail"
             yield rail
             canvas_host = Vertical(
@@ -10856,6 +10865,78 @@ class LibraryScreen(BaseAppScreen):
         # Unknown target kind: select the row and recompose from selection.
         await self._select_library_rail_row(row_id)
 
+    async def _replace_library_browse_canvas(self, shell: LibraryShellState) -> bool:
+        """Replace a Notes/Media list canvas without rebuilding the shell.
+
+        Notes and Media are the high-frequency browse routes exercised by the
+        adaptive Notes workflow. Their list canvases can be rebuilt in the
+        existing canvas host while the header, rail, and workbench grid retain
+        identity. Other routes keep the central whole-screen recompose seam.
+
+        Args:
+            shell: Latest normalized Library shell state.
+
+        Returns:
+            True when the targeted update completed; False when the caller
+            should use the whole-screen fallback.
+        """
+        try:
+            if shell.canvas_kind == "notes":
+                if self._library_notes_view != "list":
+                    return False
+                canvas: Widget = LibraryNotesCanvas(
+                    self._build_library_notes_state(),
+                    sort_mode=self._library_notes_sort,
+                    filter_value=self._library_notes_filter,
+                    compact=self._library_notes_compact,
+                    id="library-notes-canvas",
+                )
+            elif shell.canvas_kind == "media":
+                if self._library_media_view != "list":
+                    return False
+                media_state = self._build_library_media_state()
+                self._selected_media_id = media_state.selected_id
+                canvas = LibraryMediaCanvas(
+                    media_state,
+                    id="library-media-canvas",
+                )
+            else:
+                return False
+
+            header = self.query_one("#library-header-line", Static)
+            rail = self.query_one("#library-rail", LibraryRail)
+            canvas_host = self.query_one("#library-canvas", Vertical)
+            if self.is_running:
+                try:
+                    self.app.capture_mouse(None)
+                except Exception:
+                    logger.debug(
+                        "Mouse-capture release before Library route update skipped.",
+                        exc_info=True,
+                    )
+            header.update(shell.header_line)
+            rail.apply_selection(shell)
+            # Hide the outgoing subtree before detaching it. Textual's
+            # compositor may still hold the previous geometry for one frame;
+            # without this guard a removed TextArea can be asked to render
+            # after its component-style context has already been released.
+            outgoing = tuple(canvas_host.children)
+            for child in outgoing:
+                child.display = False
+            await canvas_host.mount(canvas)
+            if outgoing:
+                await canvas_host.remove_children(outgoing)
+            self._apply_library_notes_stage_visibility()
+            self._apply_library_notes_footer_context()
+            return True
+        except Exception:
+            logger.debug(
+                "Targeted Library Notes/Media route update failed; falling back "
+                "to the central screen recompose seam.",
+                exc_info=True,
+            )
+            return False
+
     async def _select_library_rail_row(self, row_id: str) -> None:
         """Apply a rail-row selection and recompose the canvas from it.
 
@@ -10990,7 +11071,13 @@ class LibraryScreen(BaseAppScreen):
                 wait_for_recompose=True,
             )
             return
-        await self.recompose()
+        shell = build_library_shell_state(
+            self._build_library_shell_input(),
+            selected_row_id=self._library_selected_row_id,
+        )
+        self._library_selected_row_id = shell.selected_row_id
+        if not await self._replace_library_browse_canvas(shell):
+            self.refresh(recompose=True)
         # task-2856 AC1: a rail-row press landing on one of the four list
         # canvases focuses its primary list's first row -- the entry-point
         # half of the same seam ``_exit_library_skill_editor_guarded`` /

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -2449,7 +2449,6 @@ class LibraryScreen(BaseAppScreen):
         # both share this single flag/handler set since only one of the
         # two views is ever mounted at a time.
         self._library_skill_trust_confirming_reset: bool = False
-        self._library_note_detail: Mapping[str, Any] | None = None
         self._selected_note_id: str = ""
         note_session_port = _LibraryDatabaseNoteSessionPort(
             run_service_call=self._run_library_service_call,
@@ -3041,6 +3040,10 @@ class LibraryScreen(BaseAppScreen):
             canvas = self.query_one("#library-notes-canvas", LibraryNotesCanvas)
         except (NoMatches, QueryError):
             return
+        canvas.title_placeholder_only = bool(
+            self._library_note_pending_blank_gc_id
+            and self._library_note_pending_blank_gc_id == self._selected_note_id
+        )
         self._library_note_presentation_syncing = True
         try:
             canvas.apply_session_state(self._library_note_presentation_state())
@@ -3956,7 +3959,7 @@ class LibraryScreen(BaseAppScreen):
         if not self._library_notes_workflow_active() or (
             self._library_notes_compact and self._library_notes_stage != "notes"
         ):
-            return self.LIBRARY_SHORTCUTS
+            return self._library_footer_shortcuts_for_current_state()
         snapshot = self._library_note_session.snapshot
         if snapshot is not None and (
             snapshot.in_conflict
@@ -3990,7 +3993,7 @@ class LibraryScreen(BaseAppScreen):
                 if self._library_notes_sync_active_token is not None
                 else (("Enter", "Act · Esc Notes"),)
             )
-        return self.LIBRARY_SHORTCUTS
+        return self._library_footer_shortcuts_for_current_state()
 
     def _apply_library_notes_footer_context(self) -> None:
         """Persist region help and hide only compact Notes ancillary indicators."""
@@ -4327,6 +4330,7 @@ class LibraryScreen(BaseAppScreen):
         settle-window timer is only ever the LAST resort for a
         still-armed, still-idle request.
         """
+        self._mark_library_notes_user_interaction()
         if self._library_pending_list_entry_focus:
             self._disarm_library_list_entry_focus()
         if isinstance(self.focused, (Input, TextArea)):
@@ -9676,6 +9680,7 @@ class LibraryScreen(BaseAppScreen):
         ):
             return
         if self._library_note_session.mutate(title=event.value):
+            self._library_note_pending_blank_gc_id = None
             self._library_note_shortcut_status = ""
             self._schedule_library_note_autosave()
             self._apply_library_note_presentation_state()
@@ -9693,6 +9698,7 @@ class LibraryScreen(BaseAppScreen):
         ):
             return
         if self._library_note_session.mutate(body=event.text_area.text):
+            self._library_note_pending_blank_gc_id = None
             self._library_note_shortcut_status = ""
             self._schedule_library_note_autosave()
             self._apply_library_note_presentation_state()
@@ -9710,6 +9716,7 @@ class LibraryScreen(BaseAppScreen):
         ):
             return
         if self._library_note_session.mutate(keywords_text=event.value):
+            self._library_note_pending_blank_gc_id = None
             self._library_note_shortcut_status = ""
             self._schedule_library_note_autosave()
             self._apply_library_note_presentation_state()
@@ -9932,6 +9939,19 @@ class LibraryScreen(BaseAppScreen):
         if self._library_notes_autosave_timer is not None:
             self._library_notes_autosave_timer.stop()
             self._library_notes_autosave_timer = None
+        if (
+            self._library_note_session_blank_id
+            and self._library_note_session_blank_id == self._selected_note_id
+        ):
+            fields = self._read_library_note_editor_fields()
+            if fields is not None:
+                raw_title, raw_content, raw_keywords_text = fields
+                if not any(
+                    value.strip()
+                    for value in (raw_title, raw_content, raw_keywords_text)
+                ):
+                    await self._gc_pending_blank_note()
+                    return NoteFlushOutcome(NoteFlushOutcomeKind.PERMITTED)
         before = self._library_note_session.snapshot
         before_saved_revision = before.saved_revision if before is not None else None
         outcome = await self._library_note_session.flush()
@@ -10038,7 +10058,6 @@ class LibraryScreen(BaseAppScreen):
         current_version = self._library_note_version or 1
         self._library_note_session_blank_id = None
         self._library_note_pending_blank_gc_id = None
-        self._library_note_dirty = False
         if not note_id:
             return
         service = getattr(self.app_instance, "notes_scope_service", None)

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -315,6 +315,7 @@ from ...Widgets.Library import (
 from ...Widgets.Library.library_file_notes_workspace import (
     LibraryFileNotesWorkspace,
 )
+from ...Widgets.Library.library_notes_canvas import LibraryNotePresentationState
 from ...Widgets.ModelArtifacts import (
     InstallProgressed,
     ModelInstallModal,
@@ -1925,6 +1926,14 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_autosave_timer: Timer | None = None
         self._library_note_confirming_delete: bool = False
         self._library_note_preview: bool = False
+        self._library_note_context: bool = False
+        self._library_note_delete_origin_context: bool = False
+        self._library_note_delete_origin_preview: bool = False
+        # Task 7 owns measured breakpoint transitions. Task 5 consumes this
+        # explicit presentation input now so compact/wide utility grouping is
+        # testable without coupling the canvas to terminal geometry.
+        self._library_notes_compact: bool = False
+        self._library_note_presentation_syncing: bool = False
         # Guards against the spurious ``Input.Changed`` that Textual fires
         # when an ``Input(value=...)`` widget mounts with a non-empty
         # initial value: without this, opening a note (or leaving a
@@ -2277,6 +2286,57 @@ class LibraryScreen(BaseAppScreen):
             meta_line=meta_line,
             has_note=True,
         )
+
+    def _library_note_status_line(self) -> str:
+        """Return the persistent, text-labeled save state for both regions."""
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None:
+            return "No note open"
+        if self._library_note_autosave_state == "saving" or snapshot.saving:
+            return "Saving…"
+        if snapshot.in_conflict:
+            return snapshot.status_message or "Conflict — review the choices below."
+        if snapshot.status_message:
+            return snapshot.status_message
+        return "Unsaved changes" if snapshot.dirty else "Saved"
+
+    def _library_note_presentation_state(self) -> LibraryNotePresentationState:
+        """Project the canonical session into presentation-only canvas state."""
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None:
+            raise RuntimeError("A note presentation requires an active session.")
+        base_meta = self._library_note_meta_base_line()
+        word_count = self._note_word_count(snapshot.body)
+        word_copy = f"{word_count} words" if word_count != 1 else "1 word"
+        status_line = self._library_note_status_line()
+        metadata_line = " · ".join(part for part in (base_meta, word_copy) if part)
+        return LibraryNotePresentationState(
+            snapshot=snapshot,
+            metadata_line=metadata_line,
+            status_line=status_line,
+            region="context" if self._library_note_context else "editor",
+            presentation="preview" if self._library_note_preview else "edit",
+            compact=self._library_notes_compact,
+            validation=self._library_note_autosave_state == "validation",
+            conflict=snapshot.in_conflict,
+            conflict_running=self._library_note_session.conflict_resolution_running,
+            confirming_delete=self._library_note_confirming_delete,
+            destructive_running=self._library_note_session.destructive_running,
+        )
+
+    def _apply_library_note_presentation_state(self) -> None:
+        """Synchronize the mounted canvas without changing its composition."""
+        if not self.is_mounted or self._library_note_session.snapshot is None:
+            return
+        try:
+            canvas = self.query_one("#library-notes-canvas", LibraryNotesCanvas)
+        except (NoMatches, QueryError):
+            return
+        self._library_note_presentation_syncing = True
+        try:
+            canvas.apply_session_state(self._library_note_presentation_state())
+        finally:
+            self._library_note_presentation_syncing = False
 
     def _register_footer_shortcuts(self) -> None:
         """Register Library shortcuts via BaseAppScreen's persisting API.
@@ -5251,17 +5311,7 @@ class LibraryScreen(BaseAppScreen):
                     and self._library_notes_view == "editor"
                 ):
                     editor_state = self._library_note_editor_state()
-                    if (
-                        editor_state is not None
-                        and self._library_note_conflict_snapshot
-                    ):
-                        yield LibraryNotesCanvas(
-                            mode="editor",
-                            editor_state=editor_state,
-                            conflict=True,
-                            id="library-notes-canvas",
-                        )
-                    elif editor_state is None:
+                    if editor_state is None:
                         with Vertical(id="library-note-load-state"):
                             yield Button(
                                 "‹ Back to list",
@@ -5290,9 +5340,7 @@ class LibraryScreen(BaseAppScreen):
                     else:
                         yield LibraryNotesCanvas(
                             mode="editor",
-                            editor_state=editor_state,
-                            confirming_delete=self._library_note_confirming_delete,
-                            preview=self._library_note_preview,
+                            presentation_state=self._library_note_presentation_state(),
                             title_placeholder_only=(
                                 self._library_note_pending_blank_gc_id is not None
                                 and self._library_note_pending_blank_gc_id
@@ -6010,6 +6058,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_load_message = ""
         self._library_note_autosave_state = "idle"
         self._library_note_preview = False
+        self._library_note_context = False
         self._library_note_editor_armed = False
         if self.is_mounted:
             self.refresh(recompose=True)
@@ -6025,6 +6074,9 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_autosave_state = "idle"
         self._library_note_confirming_delete = False
         self._library_note_preview = False
+        self._library_note_context = False
+        self._library_note_delete_origin_context = False
+        self._library_note_delete_origin_preview = False
         self._library_note_editor_armed = False
         self.run_worker(
             self._refresh_library_note_detail(note_id),
@@ -6054,6 +6106,9 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_autosave_state = "idle"
         self._library_note_confirming_delete = False
         self._library_note_preview = False
+        self._library_note_context = False
+        self._library_note_delete_origin_context = False
+        self._library_note_delete_origin_preview = False
         self._library_note_editor_armed = False
         # Defense in depth: the normal exit path is ``_flush_library_note_
         # save`` (which GCs a still-pending blank note and clears both
@@ -7606,10 +7661,14 @@ class LibraryScreen(BaseAppScreen):
         Args:
             event: Input change event emitted by the editor's title field.
         """
-        if not self._library_note_editor_armed:
+        if (
+            self._library_note_presentation_syncing
+            or not self._library_note_editor_armed
+        ):
             return
         if self._library_note_session.mutate(title=event.value):
             self._schedule_library_note_autosave()
+            self._apply_library_note_presentation_state()
 
     @on(TextArea.Changed, "#library-note-body")
     def handle_library_note_body_changed(self, event: TextArea.Changed) -> None:
@@ -7618,10 +7677,14 @@ class LibraryScreen(BaseAppScreen):
         Args:
             event: Text change event emitted by the editor's body ``TextArea``.
         """
-        if not self._library_note_editor_armed:
+        if (
+            self._library_note_presentation_syncing
+            or not self._library_note_editor_armed
+        ):
             return
         if self._library_note_session.mutate(body=event.text_area.text):
             self._schedule_library_note_autosave()
+            self._apply_library_note_presentation_state()
 
     @on(Input.Changed, "#library-note-keywords")
     def handle_library_note_keywords_changed(self, event: Input.Changed) -> None:
@@ -7630,10 +7693,28 @@ class LibraryScreen(BaseAppScreen):
         Args:
             event: Input change event emitted by the editor's keywords field.
         """
-        if not self._library_note_editor_armed:
+        if (
+            self._library_note_presentation_syncing
+            or not self._library_note_editor_armed
+        ):
             return
         if self._library_note_session.mutate(keywords_text=event.value):
             self._schedule_library_note_autosave()
+            self._apply_library_note_presentation_state()
+
+    @on(Input.Changed, "#library-note-context-keywords")
+    def handle_library_note_context_keywords_changed(
+        self, event: Input.Changed
+    ) -> None:
+        """Mutate the canonical keyword draft from the Context properties field."""
+        if (
+            self._library_note_presentation_syncing
+            or not self._library_note_editor_armed
+        ):
+            return
+        if self._library_note_session.mutate(keywords_text=event.value):
+            self._schedule_library_note_autosave()
+            self._apply_library_note_presentation_state()
 
     def _fire_library_note_autosave(self) -> None:
         """Debounce-timer callback: kick the actual autosave worker."""
@@ -7681,40 +7762,14 @@ class LibraryScreen(BaseAppScreen):
         ).meta_line
 
     def _update_library_note_meta_static(self, *, content: str) -> None:
-        """Targeted update of the meta line's autosave status suffix.
-
-        Never recomposes: the ``#library-note-meta`` ``Static`` is updated
-        in place, composing its already-known base meta line with the
-        current autosave status text, so the ``TextArea``/``Input`` widget
-        instances are left untouched by a save.
+        """Synchronize persistent metadata and status without recomposition.
 
         Args:
-            content: The just-saved (or attempted) note body, used only to
-                compute the word count shown in the status text.
+            content: Compatibility input from save callers. Canonical content
+                is read from the coordinator snapshot.
         """
-        try:
-            meta_static = self.query_one("#library-note-meta", Static)
-        except (NoMatches, QueryError):
-            return
-        status_text = notes_autosave_status_text(
-            self._library_note_autosave_state, word_count=self._note_word_count(content)
-        )
-        snapshot = self._library_note_session.snapshot
-        if (
-            snapshot is not None
-            and snapshot.status_message
-            and (
-                snapshot.dirty
-                or self._library_note_autosave_state in {"error", "validation"}
-            )
-        ):
-            word_count = self._note_word_count(content)
-            word_copy = f"{word_count} words" if word_count != 1 else "1 word"
-            status_text = f"{word_copy} · {snapshot.status_message}"
-        base_meta_line = self._library_note_meta_base_line()
-        meta_static.update(
-            f"{base_meta_line} · {status_text}" if base_meta_line else status_text
-        )
+        del content
+        self._apply_library_note_presentation_state()
 
     def _patch_library_note_list_from_session(self) -> None:
         """Patch list caches from the payload the coordinator actually saved."""
@@ -7743,7 +7798,11 @@ class LibraryScreen(BaseAppScreen):
         selector = {
             "title": "#library-note-title",
             "body": "#library-note-body",
-            "keywords": "#library-note-keywords",
+            "keywords": (
+                "#library-note-context-keywords"
+                if self._library_notes_compact
+                else "#library-note-keywords"
+            ),
         }.get(field)
         if selector is None or not self.is_mounted:
             return
@@ -7755,6 +7814,17 @@ class LibraryScreen(BaseAppScreen):
                 return
 
         self.call_after_refresh(focus_field)
+
+    def _route_library_note_validation_field(self, field: str) -> None:
+        """Expose the region that owns a vetoed field without recomposing."""
+        if field in {"title", "body"}:
+            self._library_note_preview = False
+            self._library_note_context = False
+        elif field == "keywords":
+            # Compact has no inline utilities, while wide deliberately keeps
+            # the incumbent keyword field directly reachable from both Edit
+            # and Preview. Context therefore follows the measured ownership.
+            self._library_note_context = self._library_notes_compact
 
     def _focus_library_note_conflict_callout(self) -> None:
         """Move keyboard focus to the explanatory conflict callout."""
@@ -7801,13 +7871,12 @@ class LibraryScreen(BaseAppScreen):
         if outcome.kind is NoteSaveOutcomeKind.CONFLICTED:
             self._library_note_autosave_state = "conflict"
             self._library_note_preview = False
-            self._library_note_editor_armed = False
+            self._library_note_context = False
             if self._library_notes_autosave_timer is not None:
                 self._library_notes_autosave_timer.stop()
                 self._library_notes_autosave_timer = None
             if self.is_mounted:
-                self.refresh(recompose=True)
-                self.call_after_refresh(self._arm_library_note_editor)
+                self._apply_library_note_presentation_state()
                 self.call_after_refresh(self._focus_library_note_conflict_callout)
             return
         self._library_note_autosave_state = (
@@ -7816,14 +7885,10 @@ class LibraryScreen(BaseAppScreen):
             else "error"
         )
         validation_field = outcome.veto.field if outcome.veto is not None else ""
-        if self._library_note_preview:
+        if outcome.kind is NoteSaveOutcomeKind.VALIDATION_VETO:
+            self._route_library_note_validation_field(validation_field)
+        elif self._library_note_preview:
             self._library_note_preview = False
-            self._library_note_editor_armed = False
-            if self.is_mounted:
-                self.refresh(recompose=True)
-                self.call_after_refresh(self._arm_library_note_editor)
-                self._focus_library_note_validation_field(validation_field)
-            return
         self._update_library_note_meta_static(content=snapshot.body)
         self._focus_library_note_validation_field(validation_field)
 
@@ -7874,10 +7939,9 @@ class LibraryScreen(BaseAppScreen):
         if outcome.kind is NoteFlushOutcomeKind.CONFLICTED:
             self._library_note_autosave_state = "conflict"
             self._library_note_preview = False
-            self._library_note_editor_armed = False
+            self._library_note_context = False
             if self.is_mounted:
-                self.refresh(recompose=True)
-                self.call_after_refresh(self._arm_library_note_editor)
+                self._apply_library_note_presentation_state()
                 self.call_after_refresh(self._focus_library_note_conflict_callout)
             return outcome
         if outcome.kind is NoteFlushOutcomeKind.BLOCKED:
@@ -7887,19 +7951,14 @@ class LibraryScreen(BaseAppScreen):
             if outcome.kind is NoteFlushOutcomeKind.VALIDATION_VETO
             else "error"
         )
-        if (
-            outcome.kind is NoteFlushOutcomeKind.VALIDATION_VETO
-            and self._library_note_preview
-        ):
-            self._library_note_preview = False
-            self._library_note_editor_armed = False
-            if self.is_mounted:
-                self.refresh(recompose=True)
-                self.call_after_refresh(self._arm_library_note_editor)
-        else:
-            self._update_library_note_meta_static(content=snapshot.body)
+        validation_field = ""
         if outcome.save_outcome is not None and outcome.save_outcome.veto is not None:
-            self._focus_library_note_validation_field(outcome.save_outcome.veto.field)
+            validation_field = outcome.save_outcome.veto.field
+        if outcome.kind is NoteFlushOutcomeKind.VALIDATION_VETO:
+            self._route_library_note_validation_field(validation_field)
+        self._update_library_note_meta_static(content=snapshot.body)
+        if validation_field:
+            self._focus_library_note_validation_field(validation_field)
         return outcome
 
     async def _gc_pending_blank_note(self) -> None:
@@ -7996,7 +8055,22 @@ class LibraryScreen(BaseAppScreen):
             overwrite: ``True`` for Overwrite, ``False`` for Reload.
         """
         action = ConflictAction.OVERWRITE if overwrite else ConflictAction.RELOAD
-        outcome = await self._library_note_session.resolve_conflict(action)
+        operation = asyncio.create_task(
+            self._library_note_session.resolve_conflict(action)
+        )
+        try:
+            # Let the coordinator atomically claim its conflict token before
+            # reflecting the running state. The operation's first service
+            # boundary yields here; a synchronous rejection/finish needs no
+            # intermediate presentation.
+            await asyncio.sleep(0)
+            if self._library_note_session.conflict_resolution_running:
+                self._apply_library_note_presentation_state()
+            outcome = await operation
+        except asyncio.CancelledError:
+            operation.cancel()
+            await asyncio.gather(operation, return_exceptions=True)
+            raise
         if outcome.kind in {
             ConflictOutcomeKind.STALE,
             ConflictOutcomeKind.ALREADY_RUNNING,
@@ -8035,10 +8109,11 @@ class LibraryScreen(BaseAppScreen):
             ):
                 validation_field = outcome.save_outcome.veto.field
         self._library_note_preview = False
-        self._library_note_editor_armed = False
+        self._library_note_context = False
+        if outcome.kind is ConflictOutcomeKind.VALIDATION_VETO:
+            self._route_library_note_validation_field(validation_field)
         if self.is_mounted:
-            self.refresh(recompose=True)
-            self.call_after_refresh(self._arm_library_note_editor)
+            self._apply_library_note_presentation_state()
             if snapshot is not None and snapshot.in_conflict:
                 self.call_after_refresh(self._focus_library_note_conflict_callout)
             elif validation_field:
@@ -8106,9 +8181,40 @@ class LibraryScreen(BaseAppScreen):
         if self._library_note_session.snapshot is None:
             return
         self._library_note_preview = not self._library_note_preview
-        self._library_note_editor_armed = False
-        self.refresh(recompose=True)
-        self.call_after_refresh(self._arm_library_note_editor)
+        self._apply_library_note_presentation_state()
+
+    @on(Button.Pressed, "#library-note-context")
+    def handle_library_note_context_open(self, event: Button.Pressed) -> None:
+        """Show the stable Context region without replacing editor widgets."""
+        event.stop()
+        snapshot = self._library_note_session.snapshot
+        if (
+            self._library_notes_view != "editor"
+            or snapshot is None
+            or snapshot.in_conflict
+            or self._library_note_confirming_delete
+        ):
+            return
+        self._library_note_context = True
+        self._apply_library_note_presentation_state()
+        try:
+            context = self.query_one("#library-note-context-region")
+        except (NoMatches, QueryError):
+            return
+        context.focus()
+
+    @on(Button.Pressed, "#library-note-context-back")
+    def handle_library_note_context_back(self, event: Button.Pressed) -> None:
+        """Return Context to the Edit or Preview presentation that opened it."""
+        event.stop()
+        if not self._library_note_context:
+            return
+        self._library_note_context = False
+        self._apply_library_note_presentation_state()
+        try:
+            self.query_one("#library-note-context", Button).focus()
+        except (NoMatches, QueryError):
+            return
 
     async def _export_library_note(self, export_format: str) -> None:
         """Push the Export dialog for the open Library note.
@@ -8242,6 +8348,7 @@ class LibraryScreen(BaseAppScreen):
                 severity="information",
             )
 
+    @on(Button.Pressed, "#library-note-context-export-md")
     @on(Button.Pressed, "#library-note-export-md")
     async def handle_library_note_export_markdown(self, event: Button.Pressed) -> None:
         """Export the open note as Markdown via a ``FileSave`` dialog.
@@ -8252,6 +8359,7 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         await self._export_library_note("markdown")
 
+    @on(Button.Pressed, "#library-note-context-export-txt")
     @on(Button.Pressed, "#library-note-export-txt")
     async def handle_library_note_export_text(self, event: Button.Pressed) -> None:
         """Export the open note as plain text via a ``FileSave`` dialog.
@@ -8262,6 +8370,7 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         await self._export_library_note("text")
 
+    @on(Button.Pressed, "#library-note-context-copy")
     @on(Button.Pressed, "#library-note-copy")
     def handle_library_note_copy(self, event: Button.Pressed) -> None:
         """Copy the open Library note to the clipboard as markdown.
@@ -8377,6 +8486,7 @@ class LibraryScreen(BaseAppScreen):
             return
         open_chat_with_handoff(payload, action_label="Use in Console")
 
+    @on(Button.Pressed, "#library-note-context-use-in-console")
     @on(Button.Pressed, "#library-note-use-in-console")
     def handle_library_note_use_in_console(self, event: Button.Pressed) -> None:
         """Hand the open note off to Console as chat context.
@@ -16482,6 +16592,7 @@ class LibraryScreen(BaseAppScreen):
         )
         self.refresh(recompose=True)
 
+    @on(Button.Pressed, "#library-note-context-delete")
     @on(Button.Pressed, "#library-note-delete")
     async def handle_library_note_delete(self, event: Button.Pressed) -> None:
         """Enter the inline delete-confirmation state for the open note.
@@ -16511,10 +16622,35 @@ class LibraryScreen(BaseAppScreen):
         note_flush = await self._flush_library_note_save()
         if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
+        self._library_note_delete_origin_context = self._library_note_context
+        self._library_note_delete_origin_preview = self._library_note_preview
         self._library_note_confirming_delete = True
-        self._library_note_editor_armed = False
-        self.refresh(recompose=True)
-        self.call_after_refresh(self._arm_library_note_editor)
+        self._library_note_preview = False
+        self._library_note_context = False
+        self._apply_library_note_presentation_state()
+        self._focus_library_note_control("#library-note-delete-cancel")
+
+    def _focus_library_note_control(self, selector: str) -> None:
+        """Focus one stable note control when its presentation is visible."""
+        try:
+            self.query_one(selector, Button).focus()
+        except (NoMatches, QueryError):
+            return
+
+    def _restore_library_note_delete_origin(self) -> None:
+        """Leave confirmation and restore its stable source presentation."""
+        origin_context = self._library_note_delete_origin_context
+        origin_preview = self._library_note_delete_origin_preview
+        self._library_note_confirming_delete = False
+        self._library_note_context = origin_context
+        self._library_note_preview = origin_preview
+        self._apply_library_note_presentation_state()
+        selector = (
+            "#library-note-context-delete" if origin_context else "#library-note-delete"
+        )
+        self._focus_library_note_control(selector)
+        self._library_note_delete_origin_context = False
+        self._library_note_delete_origin_preview = False
 
     @on(Button.Pressed, "#library-note-delete-cancel")
     def handle_library_note_delete_cancel(self, event: Button.Pressed) -> None:
@@ -16525,10 +16661,7 @@ class LibraryScreen(BaseAppScreen):
                 "Cancel" action.
         """
         event.stop()
-        self._library_note_confirming_delete = False
-        self._library_note_editor_armed = False
-        self.refresh(recompose=True)
-        self.call_after_refresh(self._arm_library_note_editor)
+        self._restore_library_note_delete_origin()
 
     @on(Button.Pressed, "#library-note-delete-confirm")
     def handle_library_note_delete_confirm(self, event: Button.Pressed) -> None:
@@ -16546,8 +16679,7 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         note_id = self._selected_note_id
         if not note_id:
-            self._library_note_confirming_delete = False
-            self.refresh(recompose=True)
+            self._restore_library_note_delete_origin()
             return
         self.run_worker(
             self._delete_library_note(note_id, version=self._library_note_version),
@@ -16589,12 +16721,9 @@ class LibraryScreen(BaseAppScreen):
         service = getattr(self.app_instance, "notes_scope_service", None)
         delete_note = getattr(service, "delete_note", None)
         if not callable(delete_note):
-            self._library_note_confirming_delete = False
             self._notify_library_note_delete_warning("Note deletion is unavailable.")
-            self._library_note_editor_armed = False
             if self.is_mounted:
-                self.refresh(recompose=True)
-                self.call_after_refresh(self._arm_library_note_editor)
+                self._restore_library_note_delete_origin()
             return
 
         try:
@@ -16617,12 +16746,9 @@ class LibraryScreen(BaseAppScreen):
                 or self._library_notes_view != "editor"
             ):
                 return
-            self._library_note_confirming_delete = False
             self._notify_library_note_delete_warning("Could not delete this note.")
-            self._library_note_editor_armed = False
             if self.is_mounted:
-                self.refresh(recompose=True)
-                self.call_after_refresh(self._arm_library_note_editor)
+                self._restore_library_note_delete_origin()
             return
 
         # Discard a stale result: the user has since switched to a different
@@ -16631,14 +16757,11 @@ class LibraryScreen(BaseAppScreen):
             return
 
         if not deleted:
-            self._library_note_confirming_delete = False
             self._notify_library_note_delete_warning(
                 "This note changed elsewhere — refresh and try again."
             )
-            self._library_note_editor_armed = False
             if self.is_mounted:
-                self.refresh(recompose=True)
-                self.call_after_refresh(self._arm_library_note_editor)
+                self._restore_library_note_delete_origin()
             return
 
         self._reset_library_note_editor_state()

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -18,13 +18,14 @@ from typing import TYPE_CHECKING, Any, Literal
 from loguru import logger
 from rich.markup import escape as escape_markup
 from rich.text import Text
-from textual import on, work
+from textual import events, on, work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.events import DescendantFocus, Key
-from textual.screen import ModalScreen
 from textual.css.query import NoMatches, QueryError
+from textual.geometry import Region
+from textual.screen import ModalScreen
 from textual.timer import Timer
 from textual.widget import Widget
 from textual.worker import Worker
@@ -119,6 +120,7 @@ from ...Library.library_notes_state import (
     DatabaseNoteSavePayload,
     LibraryNoteCreateOutcome,
     LibraryNoteEditorState,
+    LibraryNotesFocusIdentity,
     LibraryNotesListState,
     LibraryNotesOperationState,
     NormalizedDatabaseNote,
@@ -487,6 +489,31 @@ LIBRARY_MEDIA_HANDOFF_EXCERPT_CHARS = 500
 # every row-level id (old flat widgets or the new card) was already being
 # removed and remounted here -- only the always-kept heading is listed.
 LIBRARY_RAG_RESULTS_STATIC_WIDGET_IDS = frozenset({"library-rag-results-heading"})
+LIBRARY_NOTES_COMPACT_BREAKPOINT = 120
+
+
+@dataclasses.dataclass(frozen=True)
+class _LibraryNotesRecomposeCapture:
+    """Portable identity needed to rehydrate a replaced Notes canvas."""
+
+    focus: LibraryNotesFocusIdentity
+    recompose_generation: int
+    scroll_generation: int
+    focus_generation: int
+    session_generation: int | None
+    draft_revision: int | None
+    preview: bool
+    context: bool
+    confirming_delete: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class _LibraryNotesRestoreGuard:
+    """Generations that keep deferred focus/scroll restoration current."""
+
+    recompose_generation: int | None = None
+    scroll_generation: int | None = None
+    focus_generation: int | None = None
 
 # PR-3 Task 4: the retrieval outcomes phase two runs on. `ready` is the
 # ordinary case; `empty` is answered too -- honestly, and without a provider
@@ -1276,6 +1303,10 @@ class LibraryScreen(BaseAppScreen):
 
     BINDINGS = [
         ("u", "library_rag_use_in_console", "Use Library context in Console"),
+        ("ctrl+n", "library_notes_new", "New note"),
+        ("/", "library_notes_focus_filter", "Find notes"),
+        ("ctrl+s", "library_notes_save", "Save note"),
+        ("escape", "library_notes_escape", "Back"),
         # task-424: skill-editor accelerators. ``check_action`` gates both
         # to the open skill editor, so the keys pass through untouched
         # everywhere else on the screen.
@@ -1429,6 +1460,11 @@ class LibraryScreen(BaseAppScreen):
             ("library-hub-action-import",),
         ),
     )
+    LIBRARY_NOTES_NAVIGATOR_SHORTCUTS = (("Ctrl+N", "New · / Find · Esc Library"),)
+    LIBRARY_NOTES_EDITOR_SHORTCUTS = (("Ctrl+S", "Save · Esc Notes"),)
+    LIBRARY_NOTES_PREVIEW_SHORTCUTS = (("Pg", "Scroll · Esc Notes"),)
+    LIBRARY_NOTES_CONTEXT_SHORTCUTS = (("Enter", "Act · Esc Note"),)
+    LIBRARY_NOTES_CONFLICT_SHORTCUTS = (("Enter", "Choose · Esc Locked"),)
 
     # Baseline workbench geometry so the screen renders correctly even without
     # the app stylesheet (e.g. harness tests). The agentic-terminal TCSS uses
@@ -1943,6 +1979,36 @@ class LibraryScreen(BaseAppScreen):
         # explicit presentation input now so compact/wide utility grouping is
         # testable without coupling the canvas to terminal geometry.
         self._library_notes_compact: bool = False
+        self._library_notes_stage: Literal["rail", "notes"] = "rail"
+        self._library_notes_explicit_stage_intent = False
+        self._library_notes_pending_focus_identity: LibraryNotesFocusIdentity | None = (
+            None
+        )
+        self._library_notes_pending_focus_waits_for_snapshot = False
+        self._library_notes_navigation_generation = 0
+        self._library_notes_pending_focus_generation: int | None = None
+        self._library_notes_responsive_focus_memory: (
+            LibraryNotesFocusIdentity | None
+        ) = None
+        self._library_notes_last_presented_focus: LibraryNotesFocusIdentity | None = (
+            None
+        )
+        self._library_notes_pre_resize_focus: LibraryNotesFocusIdentity | None = None
+        self._library_notes_interaction_focus: LibraryNotesFocusIdentity | None = None
+        self._library_notes_resize_epoch = 0
+        self._library_notes_resize_settling = False
+        self._library_notes_restoring_focus = False
+        self._library_notes_scroll_intent_generation = 0
+        self._library_notes_transition_scroll_generation = 0
+        self._library_notes_focus_intent_generation = 0
+        self._library_notes_transition_focus_generation = 0
+        self._library_notes_programmatic_focus_target: Widget | None = None
+        self._library_notes_last_user_scroll_focus: LibraryNotesFocusIdentity | None = (
+            None
+        )
+        self._library_notes_last_user_focus: LibraryNotesFocusIdentity | None = None
+        self._library_notes_recompose_generation = 0
+        self._library_note_shortcut_status: str = ""
         self._library_note_presentation_syncing: bool = False
         # Guards against the spurious ``Input.Changed`` that Textual fires
         # when an ``Input(value=...)`` widget mounts with a non-empty
@@ -2304,6 +2370,8 @@ class LibraryScreen(BaseAppScreen):
         snapshot = self._library_note_session.snapshot
         if snapshot is None:
             return "No note open"
+        if self._library_note_shortcut_status:
+            return self._library_note_shortcut_status
         if self._library_note_autosave_state == "saving" or snapshot.saving:
             return "Saving…"
         if snapshot.in_conflict:
@@ -2480,8 +2548,1216 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_presentation_syncing = True
         try:
             canvas.apply_session_state(self._library_note_presentation_state())
+            body = canvas.query_one("#library-note-body", TextArea)
+            if self._library_notes_compact:
+                body.styles.height = "1fr"
+                body.styles.min_height = 3
+                body.styles.max_height = None
+            else:
+                body.styles.height = "auto"
+                body.styles.min_height = 12
+                body.styles.max_height = 20
         finally:
             self._library_note_presentation_syncing = False
+
+        self._apply_library_notes_footer_context()
+
+    def _library_notes_workflow_active(self) -> bool:
+        """Return whether the current Library route is owned by Database Notes."""
+        return self._library_selected_row_id in {
+            LIBRARY_ROW_BROWSE_NOTES,
+            LIBRARY_ROW_CREATE_NOTE,
+        }
+
+    def _library_notes_focus_region(
+        self,
+    ) -> Literal["", "navigator", "editor", "preview", "context", "create", "sync"]:
+        """Return the semantic Notes region currently presented by the host."""
+        if self._library_selected_row_id == LIBRARY_ROW_CREATE_NOTE:
+            return "create"
+        if self._library_selected_row_id != LIBRARY_ROW_BROWSE_NOTES:
+            return ""
+        if self._library_notes_view == "sync":
+            return "sync"
+        if self._library_notes_view == "list":
+            return "navigator"
+        if self._library_note_context:
+            return "context"
+        if self._library_note_preview:
+            return "preview"
+        return "editor"
+
+    @staticmethod
+    def _library_notes_widget_is_within(widget: Widget, ancestor: Widget) -> bool:
+        """Return whether ``widget`` belongs to ``ancestor``'s live subtree."""
+        return ancestor in widget.ancestors_with_self
+
+    def _library_notes_focus_stage(
+        self, focused: Widget | None
+    ) -> Literal["rail", "notes"]:
+        """Map a live focused widget to the portable Library stage."""
+        if focused is None:
+            return self._library_notes_stage
+        try:
+            rail = self.query_one("#library-rail", Widget)
+            canvas = self.query_one("#library-canvas", Widget)
+        except (NoMatches, QueryError):
+            return self._library_notes_stage
+        if self._library_notes_widget_is_within(focused, rail):
+            return "rail"
+        if self._library_notes_widget_is_within(focused, canvas):
+            return "notes"
+        return self._library_notes_stage
+
+    def _library_notes_semantic_role(self, focused: Widget | None) -> str:
+        """Map one mounted control to its stable Notes semantic identity."""
+        if focused is None:
+            return ""
+        row_id = str(getattr(focused, "row_id", "") or "")
+        if row_id and focused.has_class("library-rail-row"):
+            return f"library-row:{row_id}"
+        note_id = str(getattr(focused, "note_id", "") or "")
+        if note_id and focused.has_class("library-notes-row"):
+            return f"note-row:{note_id}"
+        template_key = str(getattr(focused, "template_key", "") or "")
+        if template_key:
+            return f"create-template:{template_key}"
+
+        widget_id = focused.id or ""
+        direct_roles = {
+            "library-notes-filter": "filter",
+            "library-note-title": "title",
+            "library-note-body": "body",
+            "library-note-preview-region": "preview-body",
+            "library-note-preview-body": "preview-body",
+            "library-note-context-region": "context",
+            "library-note-context": "context",
+            "library-note-save": "save",
+            "library-note-load-retry": "load-retry",
+            "library-note-conflict-copy": "conflict-callout",
+            "library-note-delete-cancel": "delete-cancel",
+            "library-notes-sync-folder": "sync-folder",
+            "library-notes-sync-auto": "sync-auto",
+            "library-notes-sync-run": "sync-run",
+            "library-notes-create-blank": "create-template:blank",
+        }
+        if widget_id in direct_roles:
+            return direct_roles[widget_id]
+        if widget_id in {
+            "library-note-back",
+            "library-note-context-back",
+            "library-notes-create-back",
+            "library-notes-sync-back",
+        }:
+            return f"region-back:{self._library_notes_focus_region()}"
+        if widget_id.startswith("library-note-context-"):
+            return f"context-action:{widget_id}"
+        direction = "library-notes-sync-direction-"
+        if widget_id.startswith(direction):
+            return f"sync-direction:{widget_id.removeprefix(direction)}"
+        conflict = "library-notes-sync-conflict-"
+        if widget_id.startswith(conflict):
+            return f"sync-conflict-policy:{widget_id.removeprefix(conflict)}"
+        return ""
+
+    def _library_notes_scroll_owner(self, region: str) -> Widget | None:
+        """Resolve the one named scroll/content owner for a Notes region."""
+        selector = {
+            "rail": "#library-rail",
+            "navigator": "#library-notes-list",
+            "editor": "#library-note-body",
+            "preview": "#library-note-preview-region",
+            "context": "#library-note-context-region",
+            "create": "#library-notes-canvas",
+            "sync": "#library-notes-canvas",
+        }.get(region)
+        if selector is None:
+            return None
+        try:
+            return self.query_one(selector, Widget)
+        except (NoMatches, QueryError):
+            return None
+
+    def _capture_library_notes_focus_identity(
+        self, *, stage_from_focus: bool = True
+    ) -> LibraryNotesFocusIdentity:
+        """Capture only portable focus, selection, and scroll values."""
+        focused = self.focused
+        region = self._library_notes_focus_region()
+        stage = (
+            self._library_notes_focus_stage(focused)
+            if stage_from_focus
+            else self._library_notes_stage
+        )
+        role = self._library_notes_semantic_role(focused)
+        snapshot = self._library_note_session.snapshot
+        note_id = snapshot.note_id if snapshot is not None else None
+        selection_start: tuple[int, int] | None = None
+        selection_end: tuple[int, int] | None = None
+        if region in {"editor", "preview", "context"}:
+            try:
+                body = self.query_one("#library-note-body", TextArea)
+            except (NoMatches, QueryError):
+                pass
+            else:
+                selection_start = tuple(body.selection.start)
+                selection_end = tuple(body.selection.end)
+
+        owner_region = "rail" if stage == "rail" else region
+        scroll_owner = self._library_notes_scroll_owner(owner_region)
+        scroll_offset = (
+            (int(scroll_owner.scroll_x), int(scroll_owner.scroll_y))
+            if scroll_owner is not None
+            else None
+        )
+        return LibraryNotesFocusIdentity(
+            stage=stage,
+            region=region,
+            note_id=note_id,
+            semantic_role=role,
+            body_selection_start=selection_start,
+            body_selection_end=selection_end,
+            scroll_offset=scroll_offset,
+        )
+
+    def _capture_library_notes_recompose_state(
+        self,
+    ) -> _LibraryNotesRecomposeCapture | None:
+        """Capture coordinator identity and transient presentation, never draft text."""
+        if not self.is_mounted or not self._library_notes_workflow_active():
+            return None
+        snapshot = self._library_note_session.snapshot
+        return _LibraryNotesRecomposeCapture(
+            focus=self._capture_library_notes_focus_identity(stage_from_focus=True),
+            recompose_generation=self._library_notes_recompose_generation,
+            scroll_generation=self._library_notes_scroll_intent_generation,
+            focus_generation=self._library_notes_focus_intent_generation,
+            session_generation=(
+                snapshot.session_generation if snapshot is not None else None
+            ),
+            draft_revision=(snapshot.draft_revision if snapshot is not None else None),
+            preview=self._library_note_preview,
+            context=self._library_note_context,
+            confirming_delete=self._library_note_confirming_delete,
+        )
+
+    def _commit_library_note_widgets_before_recompose(self) -> None:
+        """Move queued editor values into the canonical coordinator before teardown."""
+        if (
+            not self.is_mounted
+            or not self._library_note_editor_armed
+            or self._library_note_presentation_syncing
+            or self._library_notes_focus_region()
+            not in {"editor", "preview", "context"}
+            or self._library_note_session.snapshot is None
+        ):
+            return
+        try:
+            title = self.query_one("#library-note-title", Input).value
+            body = self.query_one("#library-note-body", TextArea).text
+            keywords_selector = (
+                "#library-note-context-keywords"
+                if self._library_note_context
+                else "#library-note-keywords"
+            )
+            keywords_text = self.query_one(keywords_selector, Input).value
+        except (NoMatches, QueryError):
+            return
+        if self._library_note_session.mutate(
+            title=title,
+            body=body,
+            keywords_text=keywords_text,
+        ):
+            self._library_note_shortcut_status = ""
+            self._schedule_library_note_autosave()
+
+    def _library_notes_role_target(
+        self, identity: LibraryNotesFocusIdentity
+    ) -> Widget | None:
+        """Resolve one portable semantic role against the current widget tree."""
+        role = identity.semantic_role
+        selector = {
+            "filter": "#library-notes-filter",
+            "title": "#library-note-title",
+            "body": "#library-note-body",
+            "preview-body": "#library-note-preview-region",
+            "context": "#library-note-context-region",
+            "save": "#library-note-save",
+            "load-retry": "#library-note-load-retry",
+            "conflict-callout": "#library-note-conflict-copy",
+            "delete-cancel": "#library-note-delete-cancel",
+            "sync-folder": "#library-notes-sync-folder",
+            "sync-auto": "#library-notes-sync-auto",
+            "sync-run": "#library-notes-sync-run",
+            "create-template:blank": "#library-notes-create-blank",
+        }.get(role)
+        if role.startswith("context-action:"):
+            selector = f"#{role.removeprefix('context-action:')}"
+        elif role.startswith("sync-direction:"):
+            selector = (
+                f"#library-notes-sync-direction-{role.removeprefix('sync-direction:')}"
+            )
+        elif role.startswith("sync-conflict-policy:"):
+            selector = (
+                "#library-notes-sync-conflict-"
+                f"{role.removeprefix('sync-conflict-policy:')}"
+            )
+        elif role.startswith("region-back:"):
+            selector = {
+                "context": "#library-note-context-back",
+                "create": "#library-notes-create-back",
+                "sync": "#library-notes-sync-back",
+            }.get(role.removeprefix("region-back:"), "#library-note-back")
+        if selector is not None:
+            try:
+                return self.query_one(selector, Widget)
+            except (NoMatches, QueryError):
+                return None
+
+        if role.startswith("library-row:"):
+            row_id = role.removeprefix("library-row:")
+            for row in self.query(".library-rail-row"):
+                if str(getattr(row, "row_id", "") or "") == row_id:
+                    return row
+        elif role.startswith("note-row:"):
+            note_id = role.removeprefix("note-row:")
+            for row in self.query(".library-notes-row"):
+                if str(getattr(row, "note_id", "") or "") == note_id:
+                    return row
+        elif role.startswith("create-template:"):
+            template_key = role.removeprefix("create-template:")
+            for row in self.query(".library-notes-template-row"):
+                if str(getattr(row, "template_key", "") or "") == template_key:
+                    return row
+        return None
+
+    def _library_notes_fallback_focus_target(
+        self, identity: LibraryNotesFocusIdentity
+    ) -> Widget | None:
+        """Choose the safest visible focus target when an exact role vanished."""
+        if self._library_notes_compact and identity.stage != self._library_notes_stage:
+            identity = dataclasses.replace(
+                identity,
+                stage=self._library_notes_stage,
+                semantic_role="",
+            )
+        if identity.stage == "rail":
+            role = f"library-row:{self._library_selected_row_id}"
+            return self._library_notes_role_target(
+                dataclasses.replace(identity, semantic_role=role)
+            )
+        region = self._library_notes_focus_region()
+        if region == "navigator":
+            role = f"note-row:{identity.note_id}" if identity.note_id else "filter"
+            return self._library_notes_role_target(
+                dataclasses.replace(identity, semantic_role=role)
+            ) or self._library_notes_role_target(
+                dataclasses.replace(identity, semantic_role="filter")
+            )
+        if region == "context":
+            return self._library_notes_role_target(
+                dataclasses.replace(identity, semantic_role="context")
+            )
+        if region == "preview":
+            return self._library_notes_role_target(
+                dataclasses.replace(identity, semantic_role="preview-body")
+            )
+        if region == "editor":
+            snapshot = self._library_note_session.snapshot
+            role = "body"
+            if self._library_note_load_state == "failed":
+                role = "load-retry"
+            elif snapshot is not None and snapshot.in_conflict:
+                role = "conflict-callout"
+            elif self._library_note_confirming_delete:
+                role = "delete-cancel"
+            elif self._library_note_session.untouched_create_token is not None:
+                role = "title"
+            return self._library_notes_role_target(
+                dataclasses.replace(identity, semantic_role=role)
+            )
+        if region == "create":
+            return self._library_notes_role_target(
+                dataclasses.replace(identity, semantic_role="create-template:blank")
+            )
+        if region == "sync":
+            return self._library_notes_role_target(
+                dataclasses.replace(identity, semantic_role="sync-folder")
+            )
+        return None
+
+    def _restore_library_notes_focus_identity(
+        self,
+        identity: LibraryNotesFocusIdentity,
+        guard: _LibraryNotesRestoreGuard | None = None,
+    ) -> bool:
+        """Restore semantic focus, retaining pending intent until its exact target exists."""
+        if not self.is_mounted or not self._library_notes_restore_guard_is_current(
+            guard
+        ):
+            return False
+        target = None
+        if not (
+            self._library_notes_compact and identity.stage != self._library_notes_stage
+        ):
+            target = self._library_notes_role_target(identity)
+        restored_exact_target = target is not None
+        if target is None:
+            target = self._library_notes_fallback_focus_target(identity)
+        if target is None:
+            return False
+        if identity.semantic_role == "conflict-callout" and isinstance(target, Static):
+            target.can_focus = True
+        start = identity.body_selection_start
+        end = identity.body_selection_end
+        if start is not None and end is not None:
+            try:
+                body = self.query_one("#library-note-body", TextArea)
+            except (NoMatches, QueryError):
+                pass
+            else:
+                body.move_cursor(start)
+                body.move_cursor(end, select=start != end)
+        self._library_notes_restoring_focus = True
+        try:
+            if self.focused is not target:
+                exact_scroll = identity.scroll_offset is not None
+                self._library_notes_programmatic_focus_target = target
+                self.set_focus(target, scroll_visible=not exact_scroll)
+                if not exact_scroll:
+                    target.scroll_visible(animate=False, force=True, immediate=True)
+            self._restore_library_notes_scroll_offset(identity, guard)
+        finally:
+            self._library_notes_restoring_focus = False
+        if (
+            restored_exact_target
+            and not self._library_notes_pending_focus_waits_for_snapshot
+            and self._library_notes_pending_focus_identity == identity
+        ):
+            self._library_notes_pending_focus_identity = None
+            self._library_notes_pending_focus_generation = None
+        return restored_exact_target
+
+    def _restore_library_notes_scroll_offset(
+        self,
+        identity: LibraryNotesFocusIdentity,
+        guard: _LibraryNotesRestoreGuard | None = None,
+    ) -> None:
+        """Apply only the named owner's portable offset, without changing focus."""
+        if not self._library_notes_restore_guard_is_current(guard):
+            return
+        owner_region = (
+            "rail" if identity.stage == "rail" else self._library_notes_focus_region()
+        )
+        owner = self._library_notes_scroll_owner(owner_region)
+        if owner is not None and identity.scroll_offset is not None:
+            owner.scroll_to(
+                x=identity.scroll_offset[0],
+                y=identity.scroll_offset[1],
+                animate=False,
+                force=True,
+                immediate=True,
+            )
+
+    def _library_notes_restore_guard_is_current(
+        self, guard: _LibraryNotesRestoreGuard | None
+    ) -> bool:
+        """Treat focus, scroll, and recompose generations as one restore intent."""
+        if guard is None:
+            return True
+        return bool(
+            (
+                guard.recompose_generation is None
+                or guard.recompose_generation
+                == self._library_notes_recompose_generation
+            )
+            and (
+                guard.scroll_generation is None
+                or guard.scroll_generation
+                == self._library_notes_scroll_intent_generation
+            )
+            and (
+                guard.focus_generation is None
+                or guard.focus_generation == self._library_notes_focus_intent_generation
+            )
+        )
+
+    def _supersede_library_notes_navigation(self) -> int:
+        """Invalidate deferred focus owned by any older Notes route intent."""
+        self._library_notes_navigation_generation += 1
+        self._library_notes_pending_focus_identity = None
+        self._library_notes_pending_focus_waits_for_snapshot = False
+        self._library_notes_pending_focus_generation = None
+        return self._library_notes_navigation_generation
+
+    def _release_library_notes_focus_after_snapshot(self) -> None:
+        """Complete a Back focus handoff after its source refresh settles."""
+        if (
+            self._library_notes_pending_focus_generation
+            != self._library_notes_navigation_generation
+        ):
+            self._library_notes_pending_focus_identity = None
+            self._library_notes_pending_focus_waits_for_snapshot = False
+            self._library_notes_pending_focus_generation = None
+            return
+        identity = self._library_notes_pending_focus_identity
+        self._library_notes_pending_focus_waits_for_snapshot = False
+        if identity is not None:
+            self._restore_library_notes_focus_identity(identity)
+
+    def _library_note_session_is_unsafe(self) -> bool:
+        """Return whether rail focus must not hide the active note session."""
+        snapshot = self._library_note_session.snapshot
+        return bool(
+            self._library_note_load_state == "failed"
+            or self._library_note_confirming_delete
+            or self._library_note_session.destructive_running
+            or self._library_note_session.destructive_admission is not None
+            or (
+                snapshot is not None
+                and (
+                    snapshot.dirty
+                    or snapshot.saving
+                    or snapshot.in_conflict
+                    or self._library_note_autosave_state
+                    in {"saving", "error", "validation", "conflict"}
+                    or self._library_note_session.conflict_resolution_running
+                )
+            )
+        )
+
+    def _compact_library_notes_stage(
+        self, identity: LibraryNotesFocusIdentity
+    ) -> Literal["rail", "notes"]:
+        """Resolve compact stage precedence without consulting layout children."""
+        if self._library_note_session_is_unsafe():
+            return "notes"
+        if self._library_notes_explicit_stage_intent:
+            return "notes"
+        if identity.stage == "rail":
+            return "rail"
+        if identity.stage == "notes" and self._library_notes_workflow_active():
+            return "notes"
+        if self._library_notes_focus_region() in {
+            "editor",
+            "preview",
+            "context",
+            "create",
+            "sync",
+        }:
+            return "notes"
+        return "rail"
+
+    def _library_notes_compact_stage_applies(self) -> bool:
+        """Scope single-stage behavior to Library entry and active Notes routes."""
+        return (
+            self._library_notes_stage == "rail" or self._library_notes_workflow_active()
+        )
+
+    def _apply_library_notes_stage_visibility(self) -> None:
+        """Apply compact classes and mutually exclusive mounted stage visibility."""
+        if not self.is_mounted:
+            return
+        try:
+            shell = self.query_one("#library-shell-grid", Widget)
+            rail = self.query_one("#library-rail", Widget)
+            canvas = self.query_one("#library-canvas", Widget)
+        except (NoMatches, QueryError):
+            return
+        for widget in (shell, rail, canvas):
+            widget.set_class(self._library_notes_compact, "library-notes-compact")
+        single_stage = (
+            self._library_notes_compact and self._library_notes_compact_stage_applies()
+        )
+        rail.display = not single_stage or self._library_notes_stage == "rail"
+        canvas.display = not single_stage or self._library_notes_stage == "notes"
+
+    def _transition_library_notes_presentation(
+        self,
+        compact: bool,
+        identity: LibraryNotesFocusIdentity,
+    ) -> None:
+        """Cross the one measured compact/wide boundary losslessly."""
+        self._library_notes_compact = compact
+        if compact:
+            self._library_notes_stage = self._compact_library_notes_stage(identity)
+            self._library_notes_explicit_stage_intent = False
+        self._library_notes_transition_scroll_generation = (
+            self._library_notes_scroll_intent_generation
+        )
+        self._library_notes_transition_focus_generation = (
+            self._library_notes_focus_intent_generation
+        )
+        guard = _LibraryNotesRestoreGuard(
+            scroll_generation=self._library_notes_transition_scroll_generation,
+            focus_generation=self._library_notes_transition_focus_generation,
+        )
+        self._apply_library_notes_stage_visibility()
+        self._apply_library_note_presentation_state()
+        self._apply_library_notes_footer_context()
+        self.call_after_refresh(
+            self._restore_library_notes_focus_identity,
+            identity,
+            guard,
+        )
+        self.call_after_refresh(
+            self._queue_library_notes_settled_focus_restore,
+            identity,
+            guard,
+        )
+
+    def _queue_library_notes_settled_focus_restore(
+        self,
+        expected: LibraryNotesFocusIdentity,
+        guard: _LibraryNotesRestoreGuard | None = None,
+    ) -> None:
+        """Repeat restoration after resize layout settles, then sample it."""
+        self.call_later(
+            self._defer_library_notes_settled_focus_restore,
+            expected,
+            guard,
+        )
+
+    def _defer_library_notes_settled_focus_restore(
+        self,
+        expected: LibraryNotesFocusIdentity,
+        guard: _LibraryNotesRestoreGuard | None = None,
+    ) -> None:
+        """Cross the extra turn Textual may need to finish scrollbar layout."""
+        self.call_later(
+            self._restore_library_notes_settled_focus,
+            expected,
+            guard,
+        )
+
+    def _restore_library_notes_settled_focus(
+        self,
+        expected: LibraryNotesFocusIdentity,
+        guard: _LibraryNotesRestoreGuard | None = None,
+    ) -> None:
+        """Apply the tuple after geometry clamps and queue its actual position."""
+        if not self._library_notes_restore_guard_is_current(guard):
+            return
+        self._restore_library_notes_focus_identity(expected, guard)
+        self.call_later(
+            self._restore_library_notes_final_scroll,
+            expected,
+            guard,
+        )
+
+    def _restore_library_notes_final_scroll(
+        self,
+        expected: LibraryNotesFocusIdentity,
+        guard: _LibraryNotesRestoreGuard | None = None,
+    ) -> None:
+        """Reapply the exact offset after deferred focus visibility has settled."""
+        if not self._library_notes_restore_guard_is_current(guard):
+            return
+        self._library_notes_restoring_focus = True
+        try:
+            self._restore_library_notes_scroll_offset(expected, guard)
+        finally:
+            self._library_notes_restoring_focus = False
+        self.call_later(
+            self._settle_library_notes_final_scroll,
+            expected,
+            guard,
+        )
+
+    def _settle_library_notes_final_scroll(
+        self,
+        expected: LibraryNotesFocusIdentity,
+        guard: _LibraryNotesRestoreGuard | None = None,
+    ) -> None:
+        """Win the last focus-visibility clamp before recording the tuple."""
+        if not self._library_notes_restore_guard_is_current(guard):
+            return
+        self._library_notes_restoring_focus = True
+        try:
+            self._restore_library_notes_scroll_offset(expected, guard)
+        finally:
+            self._library_notes_restoring_focus = False
+        self.call_later(
+            self._record_library_notes_presented_focus,
+            expected,
+            guard,
+        )
+
+    def _record_library_notes_presented_focus(
+        self,
+        expected: LibraryNotesFocusIdentity,
+        guard: _LibraryNotesRestoreGuard | None = None,
+    ) -> None:
+        """Remember the actual clamped position for user-change detection."""
+        if not self._library_notes_restore_guard_is_current(guard):
+            return
+        self._install_library_notes_scroll_observers()
+        current = self._capture_library_notes_focus_identity()
+        if (
+            current.region == expected.region
+            and current.note_id == expected.note_id
+            and current.semantic_role == expected.semantic_role
+        ):
+            self._library_notes_last_presented_focus = current
+            self._library_notes_interaction_focus = current
+
+    def _install_library_notes_scroll_observers(self) -> None:
+        """Watch current named scroll owners only while their mounted tree lives."""
+        owners: dict[int, Widget] = {}
+        for region in (
+            "rail",
+            "navigator",
+            "editor",
+            "preview",
+            "context",
+            "create",
+            "sync",
+        ):
+            owner = self._library_notes_scroll_owner(region)
+            if owner is not None:
+                owners[id(owner)] = owner
+        for owner in owners.values():
+            if getattr(owner, "_library_notes_scroll_observed", False):
+                continue
+            owner._library_notes_scroll_observed = True
+            self.watch(
+                owner,
+                "scroll_x",
+                partial(self._queue_library_notes_scroll_interaction, owner),
+                init=False,
+            )
+            self.watch(
+                owner,
+                "scroll_y",
+                partial(self._queue_library_notes_scroll_interaction, owner),
+                init=False,
+            )
+
+    def _queue_library_notes_scroll_interaction(
+        self, owner: Widget, old_value: float, new_value: float
+    ) -> None:
+        """Defer scroll intent so a resize epoch can reject layout clamping."""
+        del old_value, new_value
+        epoch = self._library_notes_resize_epoch
+        programmatic = bool(
+            self._library_notes_restoring_focus or self._library_notes_resize_settling
+        )
+        stage = self._library_notes_focus_stage(self.focused)
+        region = "rail" if stage == "rail" else self._library_notes_focus_region()
+        relevant = self._library_notes_workflow_active() or stage == "rail"
+        user_intent = bool(
+            not programmatic
+            and relevant
+            and self._library_notes_scroll_owner(region) is owner
+        )
+        if user_intent:
+            # Invalidate any older deferred resize/recompose restore before
+            # its callback can overwrite this explicit scroll interaction.
+            self._library_notes_scroll_intent_generation += 1
+        self.call_later(
+            self._record_library_notes_scroll_interaction,
+            owner,
+            epoch,
+            user_intent,
+        )
+
+    def _record_library_notes_scroll_interaction(
+        self, owner: Widget, epoch: int, user_intent: bool
+    ) -> None:
+        """Cache one settled user scroll without a global Idle hot path."""
+        if epoch != self._library_notes_resize_epoch or not self.is_mounted:
+            return
+        stage = self._library_notes_focus_stage(self.focused)
+        if not self._library_notes_workflow_active() and stage != "rail":
+            return
+        region = "rail" if stage == "rail" else self._library_notes_focus_region()
+        if self._library_notes_scroll_owner(region) is not owner:
+            return
+        identity = self._capture_library_notes_focus_identity(stage_from_focus=True)
+        self._library_notes_interaction_focus = identity
+        if user_intent:
+            self._library_notes_last_user_scroll_focus = identity
+
+    def on_descendant_focus(self, event: events.DescendantFocus) -> None:
+        """Cache meaningful semantic focus changes for the next crossing."""
+        if not self.is_mounted:
+            return
+        focused = event.widget
+        stage = self._library_notes_focus_stage(focused)
+        relevant = self._library_notes_workflow_active() or stage == "rail"
+        target_restore = self._library_notes_programmatic_focus_target is focused
+        if target_restore:
+            self._library_notes_programmatic_focus_target = None
+        programmatic = bool(
+            target_restore
+            or self._library_notes_restoring_focus
+            or self._library_notes_resize_settling
+        )
+        user_intent = relevant and not programmatic
+        if user_intent:
+            # Veto every older deferred focus restore synchronously, before
+            # its next call_later turn can steal the newly chosen control.
+            self._library_notes_focus_intent_generation += 1
+        self.call_after_refresh(
+            self._record_library_notes_focus_interaction,
+            focused,
+            user_intent,
+        )
+
+    def _record_library_notes_focus_interaction(
+        self, expected: Widget, user_intent: bool
+    ) -> None:
+        """Capture a settled focus change and attach its current scroll owner."""
+        if not self.is_mounted or self.focused is not expected:
+            return
+        if (
+            not self._library_notes_workflow_active()
+            and self._library_notes_focus_stage(self.focused) != "rail"
+        ):
+            return
+        self._install_library_notes_scroll_observers()
+        identity = self._capture_library_notes_focus_identity(stage_from_focus=True)
+        self._library_notes_interaction_focus = identity
+        if user_intent:
+            self._library_notes_last_user_focus = identity
+
+    def _remember_library_notes_responsive_focus(
+        self, identity: LibraryNotesFocusIdentity
+    ) -> LibraryNotesFocusIdentity:
+        """Keep offsets that an expanded viewport temporarily clamps away."""
+        previous = self._library_notes_responsive_focus_memory
+        same_target = bool(
+            previous is not None
+            and previous.region == identity.region
+            and previous.note_id == identity.note_id
+            and previous.semantic_role == identity.semantic_role
+        )
+        if (
+            same_target
+            and previous is not None
+            and previous.scroll_offset is not None
+            and identity.scroll_offset is not None
+        ):
+            user_scroll = self._library_notes_last_user_scroll_focus
+            user_changed_since_transition = bool(
+                self._library_notes_scroll_intent_generation
+                != self._library_notes_transition_scroll_generation
+                and user_scroll is not None
+                and user_scroll.region == identity.region
+                and user_scroll.note_id == identity.note_id
+                and user_scroll.semantic_role == identity.semantic_role
+            )
+            current_x, current_y = identity.scroll_offset
+            previous_x, previous_y = previous.scroll_offset
+            if not user_changed_since_transition:
+                current_x, current_y = previous_x, previous_y
+            identity = dataclasses.replace(
+                identity, scroll_offset=(current_x, current_y)
+            )
+        self._library_notes_responsive_focus_memory = identity
+        return identity
+
+    def _update_library_notes_responsive_state(self) -> None:
+        """Measure the invariant shell allocation and transition only on crossing."""
+        if not self.is_mounted:
+            return
+        try:
+            width = self.query_one("#library-shell-grid").region.width
+        except (NoMatches, QueryError):
+            return
+        if width <= 0:
+            return
+        compact = width < LIBRARY_NOTES_COMPACT_BREAKPOINT
+        if compact == self._library_notes_compact:
+            self._library_notes_pre_resize_focus = None
+            return
+        identity = self._library_notes_pre_resize_focus or (
+            self._capture_library_notes_focus_identity(stage_from_focus=True)
+        )
+        self._library_notes_pre_resize_focus = None
+        identity = self._remember_library_notes_responsive_focus(identity)
+        self._transition_library_notes_presentation(compact, identity)
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Capture only a crossing, decided by the measured invariant grid."""
+        del event
+        self._library_notes_resize_epoch += 1
+        self._library_notes_resize_settling = True
+        try:
+            width = self.query_one("#library-shell-grid").region.width
+        except (NoMatches, QueryError):
+            return
+        if width <= 0:
+            return
+        compact = width < LIBRARY_NOTES_COMPACT_BREAKPOINT
+        if compact == self._library_notes_compact:
+            self._library_notes_pre_resize_focus = None
+            return
+        current = self._capture_library_notes_focus_identity(stage_from_focus=True)
+        identity = current
+        for cached in (
+            self._library_notes_last_user_focus,
+            self._library_notes_interaction_focus,
+            self._library_notes_last_presented_focus,
+        ):
+            if (
+                cached is not None
+                and cached.region == current.region
+                and cached.note_id == current.note_id
+            ):
+                identity = dataclasses.replace(
+                    cached,
+                    stage=current.stage,
+                    body_selection_start=current.body_selection_start,
+                    body_selection_end=current.body_selection_end,
+                )
+                break
+        user_scroll = self._library_notes_last_user_scroll_focus
+        if (
+            user_scroll is not None
+            and user_scroll.region == current.region
+            and user_scroll.note_id == current.note_id
+        ):
+            identity = dataclasses.replace(
+                identity,
+                scroll_offset=user_scroll.scroll_offset,
+            )
+        self._library_notes_pre_resize_focus = identity
+        self.call_after_refresh(self._update_library_notes_responsive_state)
+
+    def _mark_library_notes_user_interaction(self) -> None:
+        """End resize suppression only when a real input event can own changes."""
+        self._library_notes_resize_settling = False
+
+    def on_key(self, event: events.Key) -> None:
+        """Let keyboard-driven focus/scroll changes supersede resize memory."""
+        del event
+        self._mark_library_notes_user_interaction()
+
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+        """Let click-driven focus changes supersede resize memory."""
+        del event
+        self._mark_library_notes_user_interaction()
+
+    def on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
+        """Let wheel scrolling supersede resize memory."""
+        del event
+        self._mark_library_notes_user_interaction()
+
+    def on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
+        """Let wheel scrolling supersede resize memory."""
+        del event
+        self._mark_library_notes_user_interaction()
+
+    def _library_notes_footer_shortcuts(self) -> tuple[tuple[str, str], ...]:
+        """Return exact one-row local help for the visible Notes state."""
+        if not self._library_notes_workflow_active() or (
+            self._library_notes_compact and self._library_notes_stage != "notes"
+        ):
+            return self.LIBRARY_SHORTCUTS
+        snapshot = self._library_note_session.snapshot
+        if snapshot is not None and (
+            snapshot.in_conflict
+            or self._library_note_session.conflict_resolution_running
+        ):
+            return self.LIBRARY_NOTES_CONFLICT_SHORTCUTS
+        if self._library_note_confirming_delete:
+            return (("Enter", "Confirm · Esc Cancel"),)
+        region = self._library_notes_focus_region()
+        if region == "navigator":
+            if self._library_notes_select_mode:
+                return (("Enter", "Select · Esc Done"),)
+            if self._library_notes_sort_choices_visible:
+                return (("Enter", "Choose · Esc Cancel"),)
+            return self.LIBRARY_NOTES_NAVIGATOR_SHORTCUTS
+        if region == "preview":
+            return self.LIBRARY_NOTES_PREVIEW_SHORTCUTS
+        if region == "context":
+            return self.LIBRARY_NOTES_CONTEXT_SHORTCUTS
+        if region == "editor":
+            return self.LIBRARY_NOTES_EDITOR_SHORTCUTS
+        if region == "create":
+            return (
+                (("Enter", "Create · Esc Locked"),)
+                if self._library_note_create_running
+                else (("Enter", "Create · Esc Notes"),)
+            )
+        if region == "sync":
+            return (
+                (("Enter", "Syncing · Esc Locked"),)
+                if self._library_notes_sync_active_token is not None
+                else (("Enter", "Act · Esc Notes"),)
+            )
+        return self.LIBRARY_SHORTCUTS
+
+    def _apply_library_notes_footer_context(self) -> None:
+        """Persist region help and hide only compact Notes ancillary indicators."""
+        shortcuts = self._library_notes_footer_shortcuts()
+        registration = ("library", tuple(shortcuts))
+        if self._footer_shortcut_registration != registration:
+            self.register_footer_shortcuts(source="library", shortcuts=shortcuts)
+        hide_ancillary = bool(
+            self._library_notes_compact
+            and self._library_notes_stage == "notes"
+            and self._library_notes_workflow_active()
+        )
+        for selector in (
+            "#footer-word-count",
+            "#footer-token-count",
+            "#internal-db-size-indicator",
+        ):
+            try:
+                self.query_one(selector, Widget).display = not hide_ancillary
+            except (NoMatches, QueryError):
+                continue
+
+    def _rehydrate_library_notes_after_recompose(
+        self, restore: _LibraryNotesRecomposeCapture
+    ) -> None:
+        """Reapply the live coordinator snapshot and portable presentation tuple."""
+        if (
+            not self.is_mounted
+            or restore.recompose_generation != self._library_notes_recompose_generation
+        ):
+            return
+        snapshot = self._library_note_session.snapshot
+        session_matches = restore.session_generation is None or bool(
+            snapshot is not None
+            and snapshot.note_id == restore.focus.note_id
+            and snapshot.session_generation == restore.session_generation
+        )
+        revision_matches = restore.draft_revision is None or bool(
+            snapshot is not None and snapshot.draft_revision == restore.draft_revision
+        )
+        presentation_matches = session_matches and revision_matches
+        pending_focus = (
+            self._library_notes_pending_focus_identity
+            if self._library_notes_pending_focus_generation
+            == self._library_notes_navigation_generation
+            else None
+        )
+        focus_identity = pending_focus or restore.focus
+        may_restore_focus = pending_focus is not None or presentation_matches
+        if self._library_notes_compact and may_restore_focus:
+            self._library_notes_stage = focus_identity.stage
+        self._apply_library_notes_stage_visibility()
+        if snapshot is not None and session_matches:
+            if snapshot.in_conflict:
+                self._library_note_preview = False
+                self._library_note_context = False
+            elif presentation_matches:
+                self._library_note_preview = restore.preview
+                self._library_note_context = restore.context
+            if presentation_matches:
+                self._library_note_confirming_delete = restore.confirming_delete
+            self._apply_library_note_presentation_state()
+            self.call_after_refresh(
+                self._arm_library_note_editor, restore.recompose_generation
+            )
+        self._apply_library_notes_footer_context()
+        if may_restore_focus:
+            guard = _LibraryNotesRestoreGuard(
+                recompose_generation=restore.recompose_generation,
+                scroll_generation=restore.scroll_generation,
+                focus_generation=restore.focus_generation,
+            )
+            self._restore_library_notes_focus_identity(focus_identity, guard)
+            self.call_after_refresh(
+                self._queue_library_notes_settled_focus_restore,
+                focus_identity,
+                guard,
+            )
+
+    def refresh(
+        self,
+        *regions: Region,
+        repaint: bool = True,
+        layout: bool = False,
+        recompose: bool = False,
+    ) -> "LibraryScreen":
+        """Capture one coordinator-safe seam around every screen recompose."""
+        if recompose:
+            self._commit_library_note_widgets_before_recompose()
+        restore = self._capture_library_notes_recompose_state() if recompose else None
+        if restore is not None:
+            self._library_notes_recompose_generation += 1
+            restore = dataclasses.replace(
+                restore,
+                recompose_generation=self._library_notes_recompose_generation,
+            )
+        self._apply_library_notes_footer_context()
+        result = super().refresh(
+            *regions,
+            repaint=repaint,
+            layout=layout,
+            recompose=recompose,
+        )
+        if restore is not None:
+            self.call_after_refresh(
+                self._rehydrate_library_notes_after_recompose, restore
+            )
+        elif recompose:
+            self.call_after_refresh(self._apply_library_notes_stage_visibility)
+            self.call_after_refresh(self._apply_library_notes_footer_context)
+        return result
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        """Expose Notes accelerators only on their exact local surfaces."""
+        visible_notes = self._library_notes_workflow_active() and not (
+            self._library_notes_compact and self._library_notes_stage != "notes"
+        )
+        region = self._library_notes_focus_region()
+        if action == "library_notes_new":
+            return visible_notes and region in {
+                "navigator",
+                "editor",
+                "preview",
+                "context",
+            }
+        if action == "library_notes_focus_filter":
+            return bool(
+                visible_notes
+                and region == "navigator"
+                and not isinstance(self.focused, (Input, TextArea))
+            )
+        if action == "library_notes_save":
+            return visible_notes and region in {"editor", "preview", "context"}
+        if action == "library_notes_escape":
+            return visible_notes
+        return super().check_action(action, parameters)
+
+    async def action_library_notes_new(self) -> None:
+        """Open Create only after the active canonical draft flushes."""
+        await self._select_library_rail_row(LIBRARY_ROW_CREATE_NOTE)
+
+    def action_library_notes_focus_filter(self) -> None:
+        """Focus Navigator Filter without claiming literal input keystrokes."""
+        self._focus_library_notes_filter_input()
+        try:
+            self.query_one("#library-notes-filter", Input).scroll_visible(
+                animate=False, force=True, immediate=True
+            )
+        except (NoMatches, QueryError):
+            return
+
+    def _show_library_note_shortcut_refusal(self, message: str) -> None:
+        """Keep a blocked local action visible in status and notification."""
+        self._library_note_shortcut_status = message
+        self._apply_library_note_presentation_state()
+        notify = getattr(self.app_instance, "notify", None)
+        if callable(notify):
+            notify(message, severity="warning")
+
+    async def action_library_notes_save(self) -> None:
+        """Request an immediate save or explain the owning safety gate."""
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None:
+            return
+        if (
+            self._library_note_confirming_delete
+            or self._library_note_session.destructive_running
+            or self._library_note_session.destructive_admission is not None
+        ):
+            self._show_library_note_shortcut_refusal(
+                "Save locked — finish or cancel the destructive action."
+            )
+            if self._library_note_confirming_delete:
+                self._focus_library_note_control("#library-note-delete-cancel")
+            return
+        if (
+            snapshot.in_conflict
+            or self._library_note_session.conflict_resolution_running
+        ):
+            self._show_library_note_shortcut_refusal(
+                "Save locked — resolve the note conflict below."
+            )
+            self._focus_library_note_conflict_callout()
+            return
+        if self._library_notes_autosave_timer is not None:
+            self._library_notes_autosave_timer.stop()
+            self._library_notes_autosave_timer = None
+        await self._save_library_note(explicit=True)
+
+    async def action_library_notes_escape(self) -> None:
+        """Follow the visible Notes Back hierarchy without bypassing vetoes."""
+        snapshot = self._library_note_session.snapshot
+        if self._library_note_confirming_delete:
+            if self._library_note_session.destructive_running:
+                self._show_library_note_shortcut_refusal(
+                    "Delete is running — wait for it to finish."
+                )
+                return
+            self._restore_library_note_delete_origin()
+            return
+        if snapshot is not None and (
+            snapshot.in_conflict
+            or self._library_note_session.conflict_resolution_running
+        ):
+            self._show_library_note_shortcut_refusal(
+                "Conflict locked — choose Overwrite or Reload before leaving."
+            )
+            self._focus_library_note_conflict_callout()
+            return
+        if self._library_note_context:
+            self._library_note_context = False
+            self._apply_library_note_presentation_state()
+            self._focus_library_note_control("#library-note-context")
+            return
+        if self._library_notes_view == "editor":
+            await self._back_from_library_note_editor()
+            return
+        if self._library_selected_row_id == LIBRARY_ROW_CREATE_NOTE:
+            if self._library_note_create_running:
+                notify = getattr(self.app_instance, "notify", None)
+                if callable(notify):
+                    notify(
+                        "Create is running — wait for it to finish.", severity="warning"
+                    )
+                return
+            self._library_note_create_status = ""
+            await self._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+            return
+        if self._library_notes_view == "sync":
+            if self._library_notes_sync_active_token is not None:
+                notify = getattr(self.app_instance, "notify", None)
+                if callable(notify):
+                    notify(
+                        "Sync is running — wait for it to finish.", severity="warning"
+                    )
+                return
+            self._supersede_library_notes_navigation()
+            self._library_notes_view = "list"
+            self._reset_library_notes_sync_transient_state()
+            self.refresh(recompose=True)
+            self.call_after_refresh(self._focus_library_notes_filter_input)
+            return
+        if self._library_notes_select_mode:
+            self._library_notes_select_mode = False
+            self._library_notes_row_selection.clear()
+            self.refresh(recompose=True)
+            self.call_after_refresh(
+                self._focus_library_note_control, "#library-notes-select-toggle"
+            )
+            return
+        if self._library_notes_sort_choices_visible:
+            self._library_notes_sort_choices_visible = False
+            self.refresh(recompose=True)
+            self.call_after_refresh(
+                self._focus_library_note_control, "#library-notes-sort"
+            )
+            return
+        self._library_notes_stage = "rail"
+        self._library_notes_explicit_stage_intent = False
+        self._supersede_library_notes_navigation()
+        self._apply_library_notes_stage_visibility()
+        self._apply_library_notes_footer_context()
+        identity = LibraryNotesFocusIdentity(
+            stage="rail",
+            region="navigator",
+            note_id=None,
+            semantic_role=f"library-row:{self._library_selected_row_id}",
+        )
+        self.call_after_refresh(self._restore_library_notes_focus_identity, identity)
 
     def _register_footer_shortcuts(self) -> None:
         """Register Library shortcuts via BaseAppScreen's persisting API.
@@ -2603,6 +3879,7 @@ class LibraryScreen(BaseAppScreen):
         self._register_footer_shortcuts()
         # No super().on_mount(): the dispatcher already invokes
         # BaseAppScreen.on_mount separately for this Mount event.
+        self.call_after_refresh(self._update_library_notes_responsive_state)
         self._load_library_ingest_options_from_config()
         self.set_timer(
             LIBRARY_SOURCE_SNAPSHOT_TIMEOUT_SECONDS,
@@ -3309,6 +4586,7 @@ class LibraryScreen(BaseAppScreen):
         ``_apply_navigation_context_after_flush``) while the pre-mount and
         clean-editor paths apply directly.
         """
+        self._supersede_library_notes_navigation()
         raw_open_source_type = context.get(LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE)
         raw_open_source_id = context.get(LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID)
         open_source_type = ""
@@ -3429,6 +4707,11 @@ class LibraryScreen(BaseAppScreen):
         # without a rail-row press -- the footer's `u` hint must follow the
         # canvas, not just the rail switch, or the key works unadvertised.
         self._register_footer_shortcuts()
+        if self._library_notes_workflow_active():
+            self._library_notes_stage = "notes"
+            self._library_notes_explicit_stage_intent = not self.is_mounted
+        else:
+            self._library_notes_explicit_stage_intent = False
         if self.is_mounted:
             if (
                 self._library_selected_row_id == LIBRARY_ROW_BROWSE_COLLECTIONS
@@ -3634,6 +4917,10 @@ class LibraryScreen(BaseAppScreen):
                     self._sync_library_rag_scope_toggle_and_run_gate_widgets()
                 return
             self.refresh(recompose=True)
+            if self._library_notes_pending_focus_waits_for_snapshot:
+                self.call_after_refresh(
+                    self._release_library_notes_focus_after_snapshot
+                )
 
     def _apply_source_snapshot_timeout(self) -> None:
         """Avoid leaving Library in an indefinite loading state."""
@@ -5332,6 +6619,10 @@ class LibraryScreen(BaseAppScreen):
         )
         shell_grid.styles.height = "1fr"
         shell_grid.styles.min_height = 12
+        shell_grid.set_class(self._library_notes_compact, "library-notes-compact")
+        single_notes_stage = (
+            self._library_notes_compact and self._library_notes_compact_stage_applies()
+        )
         with shell_grid:
             rail = LibraryRail(
                 shell,
@@ -5344,6 +6635,8 @@ class LibraryScreen(BaseAppScreen):
                 classes="destination-workbench-pane",
             )
             rail.styles.height = "100%"
+            rail.set_class(self._library_notes_compact, "library-notes-compact")
+            rail.display = not single_notes_stage or self._library_notes_stage == "rail"
             yield rail
             canvas_host = Vertical(
                 id="library-canvas", classes="destination-workbench-pane"
@@ -5351,6 +6644,10 @@ class LibraryScreen(BaseAppScreen):
             canvas_host.styles.width = "13fr"
             canvas_host.styles.min_width = 40
             canvas_host.styles.height = "100%"
+            canvas_host.set_class(self._library_notes_compact, "library-notes-compact")
+            canvas_host.display = (
+                not single_notes_stage or self._library_notes_stage == "notes"
+            )
             with canvas_host:
                 # Only the conversations, media, and notes canvases read the
                 # local source snapshot directly, so only they can show a
@@ -6219,15 +7516,26 @@ class LibraryScreen(BaseAppScreen):
         if self.is_mounted:
             self.refresh(recompose=True)
             self.call_after_refresh(self._arm_library_note_editor)
+            self.call_after_refresh(
+                self._restore_library_notes_focus_identity,
+                LibraryNotesFocusIdentity(
+                    stage="notes",
+                    region="editor",
+                    note_id=note_id,
+                    semantic_role="body",
+                ),
+            )
 
     def _begin_library_note_load(self, note_id: str) -> None:
         """Reset presentation, invalidate old work, and start one editor load."""
+        self._supersede_library_notes_navigation()
         self._library_note_session.close_session()
         self._selected_note_id = note_id
         self._library_notes_view = "editor"
         self._library_note_load_state = "loading"
         self._library_note_load_message = ""
         self._library_note_autosave_state = "idle"
+        self._library_note_shortcut_status = ""
         self._library_note_confirming_delete = False
         self._library_note_preview = False
         self._library_note_context = False
@@ -6240,11 +7548,16 @@ class LibraryScreen(BaseAppScreen):
             group="library_note_detail",
         )
 
-    def _arm_library_note_editor(self) -> None:
+    def _arm_library_note_editor(self, recompose_generation: int | None = None) -> None:
         """Enable dirty-tracking once the notes editor's mount-time
         ``Input.Changed`` (fired for the non-empty ``value=`` kwarg) has
         already been delivered, so it is never mistaken for a real edit.
         """
+        if (
+            recompose_generation is not None
+            and recompose_generation != self._library_notes_recompose_generation
+        ):
+            return
         self._library_note_editor_armed = True
 
     def _reset_library_note_editor_state(self) -> None:
@@ -6260,6 +7573,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_load_state = "idle"
         self._library_note_load_message = ""
         self._library_note_autosave_state = "idle"
+        self._library_note_shortcut_status = ""
         self._library_note_confirming_delete = False
         self._library_note_preview = False
         self._library_note_context = False
@@ -7830,6 +9144,7 @@ class LibraryScreen(BaseAppScreen):
         ):
             return
         if self._library_note_session.mutate(title=event.value):
+            self._library_note_shortcut_status = ""
             self._schedule_library_note_autosave()
             self._apply_library_note_presentation_state()
 
@@ -7846,6 +9161,7 @@ class LibraryScreen(BaseAppScreen):
         ):
             return
         if self._library_note_session.mutate(body=event.text_area.text):
+            self._library_note_shortcut_status = ""
             self._schedule_library_note_autosave()
             self._apply_library_note_presentation_state()
 
@@ -7862,6 +9178,7 @@ class LibraryScreen(BaseAppScreen):
         ):
             return
         if self._library_note_session.mutate(keywords_text=event.value):
+            self._library_note_shortcut_status = ""
             self._schedule_library_note_autosave()
             self._apply_library_note_presentation_state()
 
@@ -7876,6 +9193,7 @@ class LibraryScreen(BaseAppScreen):
         ):
             return
         if self._library_note_session.mutate(keywords_text=event.value):
+            self._library_note_shortcut_status = ""
             self._schedule_library_note_autosave()
             self._apply_library_note_presentation_state()
 
@@ -8071,6 +9389,7 @@ class LibraryScreen(BaseAppScreen):
             or snapshot.note_id != self._selected_note_id
         ):
             return
+        self._library_note_shortcut_status = ""
         self._library_note_autosave_state = "saving"
         self._update_library_note_meta_static(content=snapshot.body)
         outcome = await self._library_note_session.request_save(explicit=explicit)
@@ -8217,6 +9536,7 @@ class LibraryScreen(BaseAppScreen):
         Args:
             overwrite: ``True`` for Overwrite, ``False`` for Reload.
         """
+        self._library_note_shortcut_status = ""
         action = ConflictAction.OVERWRITE if overwrite else ConflictAction.RELOAD
         operation = asyncio.create_task(
             self._library_note_session.resolve_conflict(action)
@@ -9057,6 +10377,7 @@ class LibraryScreen(BaseAppScreen):
         # later returns to the same visual Notes region. Invalidate the token
         # now so leave→return cannot recreate authority by region equality.
         self._library_notes_operation = None
+        self._supersede_library_notes_navigation()
         if row_id == LIBRARY_ROW_CREATE_NOTE and not self._library_note_create_running:
             # Create status belongs to one visible Create attempt. Import
             # reuses the persistence seam from Navigator, so its internal
@@ -9065,6 +10386,13 @@ class LibraryScreen(BaseAppScreen):
         self._library_selected_row_id = row_id
         # task-420: keep the footer's "u" hint in sync with the row gate.
         self._register_footer_shortcuts()
+        self._library_notes_explicit_stage_intent = False
+        if row_id in {LIBRARY_ROW_BROWSE_NOTES, LIBRARY_ROW_CREATE_NOTE}:
+            self._library_notes_stage = "notes"
+        elif self._library_notes_compact and self._library_notes_stage == "rail":
+            # Unrelated canvases retain their incumbent compact composition;
+            # moving off the entry rail merely releases the Notes-only stage.
+            self._library_notes_stage = "notes"
         # A rail-row press is always a fresh entry into a content type, so
         # the media canvas must never resume a previously opened viewer
         # (e.g. Browse Media -> open item -> Browse Conversations -> Browse
@@ -14769,6 +16097,7 @@ class LibraryScreen(BaseAppScreen):
         note_flush = await self._flush_library_note_save()
         if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
+        self._supersede_library_notes_navigation()
         self._ensure_library_notes_sync_config_loaded()
         self._library_notes_view = "sync"
         self.refresh(recompose=True)
@@ -14786,6 +16115,7 @@ class LibraryScreen(BaseAppScreen):
         note_flush = await self._flush_library_note_save()
         if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
+        self._supersede_library_notes_navigation()
         self._library_notes_view = "list"
         self._reset_library_notes_sync_transient_state()
         self.refresh(recompose=True)
@@ -16910,25 +18240,28 @@ class LibraryScreen(BaseAppScreen):
         Returns:
             ``True`` when the editor was exited; ``False`` on a dirty veto.
         """
+        note_id = self._selected_note_id
         note_flush = await self._flush_library_note_save()
         if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return False
+        navigation_generation = self._supersede_library_notes_navigation()
+        identity = LibraryNotesFocusIdentity(
+            stage="notes",
+            region="navigator",
+            note_id=note_id or None,
+            semantic_role=f"note-row:{note_id}" if note_id else "filter",
+        )
+        self._library_notes_pending_focus_identity = identity
+        self._library_notes_pending_focus_waits_for_snapshot = True
+        self._library_notes_pending_focus_generation = navigation_generation
         self._reset_library_note_editor_state()
         self._refresh_local_source_snapshot()
         self.refresh(recompose=True)
-        # task-2856 AC1: every "back to list" exit re-focuses the list's
-        # first row so Up/Down/Enter work immediately.
-        self._arm_library_list_entry_focus()
+        self.call_after_refresh(self._restore_library_notes_focus_identity, identity)
         return True
 
     async def action_library_note_editor_back(self) -> None:
-        """Escape: leave the note editor for its list, honoring the dirty
-        guard (task-2856 AC2).
-
-        ``check_action`` gates this to ``_library_note_editor_active()``,
-        so it only ever fires while the DATABASE note editor genuinely owns
-        the Notes canvas.
-        """
+        """Escape: leave the note editor while honoring the dirty guard."""
         await self._exit_library_note_editor_guarded()
 
     @on(Button.Pressed, "#library-note-load-retry")
@@ -16996,6 +18329,7 @@ class LibraryScreen(BaseAppScreen):
         """Leave confirmation and restore its stable source presentation."""
         origin_context = self._library_note_delete_origin_context
         origin_preview = self._library_note_delete_origin_preview
+        self._library_note_shortcut_status = ""
         self._library_note_confirming_delete = False
         self._library_note_context = origin_context
         self._library_note_preview = origin_preview
@@ -17496,12 +18830,14 @@ class LibraryScreen(BaseAppScreen):
             admission_outcome.kind is not DestructiveAdmissionOutcomeKind.ADMITTED
             or admission_outcome.admission is None
         ):
+            self._library_note_shortcut_status = ""
             self._apply_library_note_presentation_state()
             return
         admission = admission_outcome.admission
         self._apply_library_note_presentation_state()
         if not self._library_note_session.mark_destructive_running(admission):
             self._library_note_session.cancel_destructive(admission)
+            self._library_note_shortcut_status = ""
             self._apply_library_note_presentation_state()
             return
         self._apply_library_note_presentation_state()
@@ -17526,6 +18862,7 @@ class LibraryScreen(BaseAppScreen):
                     f"Failed to discard new Library note {admission.note_id!r}."
                 )
         self._library_note_session.finish_destructive(admission, success=deleted)
+        self._library_note_shortcut_status = ""
         if not deleted:
             self._notify_library_note_delete_warning(
                 "Could not discard this new note. Try again."

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -268,7 +268,6 @@ from ...Workspaces import (
 )
 from ...Workspaces.registry_service import next_local_workspace_identity
 from ...Widgets.destination_rail import (
-
     RAIL_SECTION_TOGGLE_PREFIX,
     DestinationRailSectionHeader,
 )
@@ -517,6 +516,7 @@ class _LibraryNotesRestoreGuard:
     scroll_generation: int | None = None
     focus_generation: int | None = None
 
+
 # PR-3 Task 4: the retrieval outcomes phase two runs on. `ready` is the
 # ordinary case; `empty` is answered too -- honestly, and without a provider
 # call (`generate_library_rag_answer` refuses to hand a model an evidence
@@ -524,6 +524,7 @@ class _LibraryNotesRestoreGuard:
 # retrieval did not run, so there is nothing to be grounded in and the
 # recovery copy those statuses already render is the honest answer.
 LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES = frozenset({"ready", "empty"})
+
 
 class _LibraryDatabaseNoteSessionPort:
     """Adapt the existing Library note services to the portable session port."""
@@ -697,6 +698,7 @@ class _LibraryDatabaseNoteSessionPort:
         return DatabaseNotePortSaveReply.failed(
             "Save returned an unexpected result — edits kept. Press Save to retry."
         )
+
 
 LIBRARY_STUDY_HANDOFF_MODES = {
     "study": {
@@ -1113,9 +1115,7 @@ def _apply_library_row_toggle(
         # through to the same full-recompose fallback as every other
         # failure here.
         if kind == "media":
-            delete_button = screen.query_one(
-                "#library-media-delete-selected", Button
-            )
+            delete_button = screen.query_one("#library-media-delete-selected", Button)
             delete_button.disabled = selection.count == 0
             delete_button.tooltip = (
                 LIBRARY_DELETE_SELECTED_DISABLED_TOOLTIP
@@ -3783,32 +3783,6 @@ class LibraryScreen(BaseAppScreen):
         if user_intent:
             self._library_notes_last_user_scroll_focus = identity
 
-    def on_descendant_focus(self, event: events.DescendantFocus) -> None:
-        """Cache meaningful semantic focus changes for the next crossing."""
-        if not self.is_mounted:
-            return
-        focused = event.widget
-        stage = self._library_notes_focus_stage(focused)
-        relevant = self._library_notes_workflow_active() or stage == "rail"
-        target_restore = self._library_notes_programmatic_focus_target is focused
-        if target_restore:
-            self._library_notes_programmatic_focus_target = None
-        programmatic = bool(
-            target_restore
-            or self._library_notes_restoring_focus
-            or self._library_notes_resize_settling
-        )
-        user_intent = relevant and not programmatic
-        if user_intent:
-            # Veto every older deferred focus restore synchronously, before
-            # its next call_later turn can steal the newly chosen control.
-            self._library_notes_focus_intent_generation += 1
-        self.call_after_refresh(
-            self._record_library_notes_focus_interaction,
-            focused,
-            user_intent,
-        )
-
     def _record_library_notes_focus_interaction(
         self, expected: Widget, user_intent: bool
     ) -> None:
@@ -3933,11 +3907,6 @@ class LibraryScreen(BaseAppScreen):
     def _mark_library_notes_user_interaction(self) -> None:
         """End resize suppression only when a real input event can own changes."""
         self._library_notes_resize_settling = False
-
-    def on_key(self, event: events.Key) -> None:
-        """Let keyboard-driven focus/scroll changes supersede resize memory."""
-        del event
-        self._mark_library_notes_user_interaction()
 
     def on_mouse_down(self, event: events.MouseDown) -> None:
         """Let click-driven focus changes supersede resize memory."""
@@ -4112,31 +4081,6 @@ class LibraryScreen(BaseAppScreen):
             self.call_after_refresh(self._apply_library_notes_stage_visibility)
             self.call_after_refresh(self._apply_library_notes_footer_context)
         return result
-
-    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        """Expose Notes accelerators only on their exact local surfaces."""
-        visible_notes = self._library_notes_workflow_active() and not (
-            self._library_notes_compact and self._library_notes_stage != "notes"
-        )
-        region = self._library_notes_focus_region()
-        if action == "library_notes_new":
-            return visible_notes and region in {
-                "navigator",
-                "editor",
-                "preview",
-                "context",
-            }
-        if action == "library_notes_focus_filter":
-            return bool(
-                visible_notes
-                and region == "navigator"
-                and not isinstance(self.focused, (Input, TextArea))
-            )
-        if action == "library_notes_save":
-            return visible_notes and region in {"editor", "preview", "context"}
-        if action == "library_notes_escape":
-            return visible_notes
-        return super().check_action(action, parameters)
 
     async def action_library_notes_new(self) -> None:
         """Open Create only after the active canonical draft flushes."""
@@ -4342,8 +4286,7 @@ class LibraryScreen(BaseAppScreen):
             event.prevent_default()
             return
         is_slash = (
-            event.key in {"/", "slash"}
-            or getattr(event, "character", None) == "/"
+            event.key in {"/", "slash"} or getattr(event, "character", None) == "/"
         )
         if is_slash:
             try:
@@ -4928,8 +4871,12 @@ class LibraryScreen(BaseAppScreen):
             self._library_list_entry_focus_timer = None
 
     def on_descendant_focus(self, event: DescendantFocus) -> None:
-        """Disarm a pending entry-focus request on any FOREIGN focus change
-        (task-2856 review round 2).
+        """Record Notes focus intent and disarm foreign list-entry focus.
+
+        The Notes workbench caches meaningful semantic focus changes so a
+        breakpoint crossing can restore the same control and scroll owner.
+        Independently, task-2856's list-entry settle window is disarmed as
+        soon as focus leaves the list rows it owns.
 
         Textual posts ``DescendantFocus`` for every focus change, including
         the system's OWN ``_focus_library_list_entry()`` call -- that case
@@ -4943,11 +4890,32 @@ class LibraryScreen(BaseAppScreen):
         ``on_key`` -- this hook is what also covers mouse clicks, which
         never reach ``on_key`` at all.
         """
+        focused = event.widget
+        if self.is_mounted:
+            stage = self._library_notes_focus_stage(focused)
+            relevant = self._library_notes_workflow_active() or stage == "rail"
+            target_restore = self._library_notes_programmatic_focus_target is focused
+            if target_restore:
+                self._library_notes_programmatic_focus_target = None
+            programmatic = bool(
+                target_restore
+                or self._library_notes_restoring_focus
+                or self._library_notes_resize_settling
+            )
+            user_intent = relevant and not programmatic
+            if user_intent:
+                # Veto every older deferred restore before its next turn can
+                # steal the control the user just chose.
+                self._library_notes_focus_intent_generation += 1
+            self.call_after_refresh(
+                self._record_library_notes_focus_interaction,
+                focused,
+                user_intent,
+            )
+
         if not self._library_pending_list_entry_focus:
             return
-        row_class = _LIBRARY_LIST_ROW_CLASS_BY_ROW_ID.get(
-            self._library_selected_row_id
-        )
+        row_class = _LIBRARY_LIST_ROW_CLASS_BY_ROW_ID.get(self._library_selected_row_id)
         widget = event.widget
         if row_class is not None and widget is not None and widget.has_class(row_class):
             return
@@ -4960,9 +4928,7 @@ class LibraryScreen(BaseAppScreen):
         (nothing to focus), the list is empty, or the query can't resolve
         (e.g. a recompose still in flight).
         """
-        row_class = _LIBRARY_LIST_ROW_CLASS_BY_ROW_ID.get(
-            self._library_selected_row_id
-        )
+        row_class = _LIBRARY_LIST_ROW_CLASS_BY_ROW_ID.get(self._library_selected_row_id)
         if row_class is None:
             return
         try:
@@ -5401,11 +5367,15 @@ class LibraryScreen(BaseAppScreen):
         self._library_loaded = True
         self._invalidate_library_workspace_depth_state()
         if self.is_mounted and not self._file_notes_active():
-            if self._library_selected_row_id == LIBRARY_ROW_INGEST_MEDIA or (
-                self._library_selected_row_id
-                in {LIBRARY_ROW_BROWSE_PROMPTS, LIBRARY_ROW_CREATE_PROMPT}
-                and self._library_prompts_view == "editor"
-            ) or self._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH:
+            if (
+                self._library_selected_row_id == LIBRARY_ROW_INGEST_MEDIA
+                or (
+                    self._library_selected_row_id
+                    in {LIBRARY_ROW_BROWSE_PROMPTS, LIBRARY_ROW_CREATE_PROMPT}
+                    and self._library_prompts_view == "editor"
+                )
+                or self._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH
+            ):
                 # A source refresh may update the Prompts count while a newly
                 # created Prompt remains open. Recompose only the rail so the
                 # shared block editor keeps its TextAreas, cursor, selection,
@@ -7232,9 +7202,7 @@ class LibraryScreen(BaseAppScreen):
                         yield LibraryMediaViewer(
                             build_library_media_viewer_state(
                                 self._library_media_detail,
-                                arrival_note=(
-                                    self._pop_library_media_arrival_note()
-                                ),
+                                arrival_note=(self._pop_library_media_arrival_note()),
                             ),
                             editing=self._library_media_editing,
                             confirming_delete=self._library_media_confirming_delete,
@@ -7551,15 +7519,27 @@ class LibraryScreen(BaseAppScreen):
                             # and tooltip match the rail-top primary button.
                             # task-2857: relabeled "Import…" for consistency
                             # with the canvas header/Start button/toast.
-                            ("Import…", "Add files, links, and transcripts to your Library.",
-                             LIBRARY_ROW_INGEST_MEDIA, "ingest-media",
-                             "library-hub-action-import"),
-                            ("Search", "Search everything in the Library.",
-                             LIBRARY_ROW_BROWSE_SEARCH, "search",
-                             "library-hub-action-search"),
-                            ("New note", "Create a new note.",
-                             LIBRARY_ROW_CREATE_NOTE, "notes-create",
-                             "library-hub-action-new-note"),
+                            (
+                                "Import…",
+                                "Add files, links, and transcripts to your Library.",
+                                LIBRARY_ROW_INGEST_MEDIA,
+                                "ingest-media",
+                                "library-hub-action-import",
+                            ),
+                            (
+                                "Search",
+                                "Search everything in the Library.",
+                                LIBRARY_ROW_BROWSE_SEARCH,
+                                "search",
+                                "library-hub-action-search",
+                            ),
+                            (
+                                "New note",
+                                "Create a new note.",
+                                LIBRARY_ROW_CREATE_NOTE,
+                                "notes-create",
+                                "library-hub-action-new-note",
+                            ),
                         ):
                             action = Button(
                                 label,
@@ -7576,9 +7556,12 @@ class LibraryScreen(BaseAppScreen):
                             yield action
                     # task-2238 (R2): the triad stays on top; the recents
                     # follow as clickable rows, not one dim text line.
-                    for source_type, record_id, title, source_label in (
-                        self._hub_recent_items()
-                    ):
+                    for (
+                        source_type,
+                        record_id,
+                        title,
+                        source_label,
+                    ) in self._hub_recent_items():
                         recent = Button(
                             f"{source_label} · {escape_markup(title)}",
                             id=f"library-hub-recent-{source_type}",
@@ -9338,9 +9321,7 @@ class LibraryScreen(BaseAppScreen):
         if cursor is not None and isinstance(widget, Input):
             widget.cursor_position = min(cursor, len(widget.value))
 
-    def _update_library_ingest_gate(
-        self, new_state: LibraryIngestCanvasState
-    ) -> None:
+    def _update_library_ingest_gate(self, new_state: LibraryIngestCanvasState) -> None:
         """Sync the Start button + gate line in place (never a recompose).
 
         Args:
@@ -9354,9 +9335,7 @@ class LibraryScreen(BaseAppScreen):
             return
         start_button.disabled = not new_state.start_enabled
         try:
-            quiet_line = self.query_one(
-                "#library-ingest-start-quiet-line", Static
-            )
+            quiet_line = self.query_one("#library-ingest-start-quiet-line", Static)
         except (NoMatches, QueryError):
             return
         quiet_line.update(new_state.start_quiet_line)
@@ -9411,18 +9390,14 @@ class LibraryScreen(BaseAppScreen):
         # non-structural pre-flight apply (or a Clear) can never leave it
         # unmounted or stale.
         try:
-            commit_summary = canvas.query_one(
-                "#library-ingest-commit-summary", Static
-            )
+            commit_summary = canvas.query_one("#library-ingest-commit-summary", Static)
         except (NoMatches, QueryError):
             pass
         else:
             commit_summary.update(new_state.commit_summary_line)
             commit_summary.display = bool(new_state.commit_summary_line)
         try:
-            clear_button = canvas.query_one(
-                "#library-ingest-clear-path", Button
-            )
+            clear_button = canvas.query_one("#library-ingest-clear-path", Button)
         except (NoMatches, QueryError):
             pass
         else:
@@ -9515,9 +9490,7 @@ class LibraryScreen(BaseAppScreen):
         server_ingest_available = (
             (
                 callable(getattr(server_service, "submit_ingest_jobs", None))
-                or callable(
-                    getattr(server_service, "submit_media_ingest_jobs", None)
-                )
+                or callable(getattr(server_service, "submit_media_ingest_jobs", None))
             )
             and bool(getattr(runtime_state, "server_configured", False))
             and not self._server_binding_is_shipped_placeholder()
@@ -10219,7 +10192,14 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-note-context")
     def handle_library_note_context_open(self, event: Button.Pressed) -> None:
-        """Show the stable Context region without replacing editor widgets."""
+        """Show the stable Context region without replacing editor widgets.
+
+        Args:
+            event: Button press emitted by the editor's Context action.
+
+        Returns:
+            None.
+        """
         event.stop()
         snapshot = self._library_note_session.snapshot
         if (
@@ -10239,7 +10219,14 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-note-context-back")
     def handle_library_note_context_back(self, event: Button.Pressed) -> None:
-        """Return Context to the Edit or Preview presentation that opened it."""
+        """Return to the Edit or Preview presentation that opened Context.
+
+        Args:
+            event: Button press emitted by the Context region's Back action.
+
+        Returns:
+            None.
+        """
         event.stop()
         if not self._library_note_context:
             return
@@ -11417,9 +11404,7 @@ class LibraryScreen(BaseAppScreen):
             return
         self.run_worker(self._delete_library_media_selection(media_ids))
 
-    async def _delete_library_media_selection(
-        self, media_ids: tuple[str, ...]
-    ) -> None:
+    async def _delete_library_media_selection(self, media_ids: tuple[str, ...]) -> None:
         """Soft-delete every selected Library media item (task-2853 AC3).
 
         Reuses the exact seam ``_delete_library_media_item`` uses for the
@@ -13136,7 +13121,9 @@ class LibraryScreen(BaseAppScreen):
                 # `disabled` (this patcher exists precisely to avoid a
                 # recompose, so the compose-time tooltip would go stale).
                 button.tooltip = (
-                    SKILL_DISCARD_TOOLTIP_DIRTY if enabled else SKILL_DISCARD_TOOLTIP_CLEAN
+                    SKILL_DISCARD_TOOLTIP_DIRTY
+                    if enabled
+                    else SKILL_DISCARD_TOOLTIP_CLEAN
                 )
 
     def _library_skill_editor_active(self) -> bool:
@@ -13148,8 +13135,7 @@ class LibraryScreen(BaseAppScreen):
         )
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        """Gate the skill-editor, Files-mode, list/detail Escape, and
-        Search/RAG evidence-card bindings (task-424/2850/2856/2858).
+        """Gate Notes, Skills, Files, list/detail, and Search/RAG bindings.
 
         Returning ``False`` deactivates the binding entirely, so Escape /
         Ctrl+S behave as if unbound anywhere else on the Library screen.
@@ -13170,6 +13156,32 @@ class LibraryScreen(BaseAppScreen):
         ``BINDINGS`` now has an explicit branch here; see
         ``test_library_screen_bindings_are_all_gated_or_universal``.
         """
+        if action in {
+            "library_notes_new",
+            "library_notes_focus_filter",
+            "library_notes_save",
+            "library_notes_escape",
+        }:
+            visible_notes = self._library_notes_workflow_active() and not (
+                self._library_notes_compact and self._library_notes_stage != "notes"
+            )
+            region = self._library_notes_focus_region()
+            if action == "library_notes_new":
+                return visible_notes and region in {
+                    "navigator",
+                    "editor",
+                    "preview",
+                    "context",
+                }
+            if action == "library_notes_focus_filter":
+                return bool(
+                    visible_notes
+                    and region == "navigator"
+                    and not isinstance(self.focused, (Input, TextArea))
+                )
+            if action == "library_notes_save":
+                return visible_notes and region in {"editor", "preview", "context"}
+            return visible_notes
         if action in ("library_skill_save", "library_skill_back"):
             return self._library_skill_editor_active()
         if action == "library_notes_files_back":
@@ -17171,8 +17183,7 @@ class LibraryScreen(BaseAppScreen):
         # but this handler avoids recomposing while typing -- hide/show them
         # in place so they track the field's content live.
         show_intros = (
-            not event.value.strip()
-            and self._library_ingest_form.preflight is None
+            not event.value.strip() and self._library_ingest_form.preflight is None
         )
         for intro in self.query(".library-ingest-intro"):
             intro.display = show_intros
@@ -17416,15 +17427,11 @@ class LibraryScreen(BaseAppScreen):
             # invalid), which is exactly the unreliable "highlighted" the
             # marker was added to fix.
             try:
-                field_input = self.query_one(
-                    f"#opt-{event.group}-{event.name}", Input
-                )
+                field_input = self.query_one(f"#opt-{event.group}-{event.name}", Input)
             except (NoMatches, QueryError):
                 pass
             else:
-                field_input.set_class(
-                    bool(message), "-ingest-option-invalid"
-                )
+                field_input.set_class(bool(message), "-ingest-option-invalid")
             self._update_library_ingest_gate(self._build_library_ingest_state())
 
     @on(LibraryIngestCanvas.ParakeetInstallRequested)
@@ -17738,16 +17745,12 @@ class LibraryScreen(BaseAppScreen):
                     or candidate_path.stat().st_size > 8 * 1024 * 1024
                 ):
                     continue
-                text = candidate_path.read_text(
-                    encoding="utf-8", errors="replace"
-                )
+                text = candidate_path.read_text(encoding="utf-8", errors="replace")
                 digest = hashlib.sha256(text.encode()).hexdigest()
                 if media_db.get_media_by_hash(digest) is not None:
                     already += 1
             except Exception as exc:
-                logger.debug(
-                    f"Pre-flight duplicate check skipped {candidate!r}: {exc}"
-                )
+                logger.debug(f"Pre-flight duplicate check skipped {candidate!r}: {exc}")
                 continue
         if not already:
             return result
@@ -18013,9 +18016,7 @@ class LibraryScreen(BaseAppScreen):
         """
         form = self._library_ingest_form
         self._transcribe_cpp_configured = bool(
-            get_cli_setting(
-                "transcription.transcribe_cpp", "model_path", None
-            )
+            get_cli_setting("transcription.transcribe_cpp", "model_path", None)
         )
         for group in list_type_groups():
             cap = get_capabilities(group)
@@ -18260,9 +18261,7 @@ class LibraryScreen(BaseAppScreen):
             self._open_transcribe_cpp_gguf_picker(retry_job_id=job_id)
 
     @on(Button.Pressed, ".library-ingest-retry-faster-whisper")
-    def handle_library_ingest_retry_faster_whisper(
-        self, event: Button.Pressed
-    ) -> None:
+    def handle_library_ingest_retry_faster_whisper(self, event: Button.Pressed) -> None:
         """Explicitly retry a direct-local failure with faster-whisper."""
         event.stop()
         job_id = self._ingest_job_id_from_button(
@@ -18377,10 +18376,7 @@ class LibraryScreen(BaseAppScreen):
             # dismissed record now survives in the Recent-ingests ledger,
             # marked as dismissed.
             if dismissed_job is not None:
-                known = {
-                    job.job_id
-                    for job in self._library_ingest_recent_ledger
-                }
+                known = {job.job_id for job in self._library_ingest_recent_ledger}
                 if dismissed_job.job_id not in known:
                     self._library_ingest_recent_ledger = [
                         dismissed_job,
@@ -18447,14 +18443,13 @@ class LibraryScreen(BaseAppScreen):
             # cure is to not disturb layout at all: no recompose, no
             # scroll, the confirm appears under the finger that armed it.
             try:
-                armed_button = self.query_one(
-                    "#library-ingest-clear-finished", Button
-                )
+                armed_button = self.query_one("#library-ingest-clear-finished", Button)
             except (NoMatches, QueryError):
                 self._update_library_ingest_dynamic_regions()
             else:
-                armed_button.label = self._build_library_ingest_state(
-                ).queue_clear_finished_label
+                armed_button.label = (
+                    self._build_library_ingest_state().queue_clear_finished_label
+                )
                 # The label got longer; without a layout pass the
                 # auto-width compact button keeps its old width and clips
                 # the confirm copy (live-caught: "Press again to").
@@ -18463,13 +18458,8 @@ class LibraryScreen(BaseAppScreen):
         # (task-2160) Double-click protection: a press landing within the
         # dead zone of the arming press is the same gesture, not a
         # decision -- ignore it (stays armed).
-        armed_at = getattr(
-            self, "_library_ingest_clear_finished_armed_at", 0.0
-        )
-        if (
-            time.monotonic() - armed_at
-            < self._CLEAR_FINISHED_DEAD_ZONE_SECONDS
-        ):
+        armed_at = getattr(self, "_library_ingest_clear_finished_armed_at", 0.0)
+        if time.monotonic() - armed_at < self._CLEAR_FINISHED_DEAD_ZONE_SECONDS:
             return
         self._library_ingest_clear_finished_armed = False
         self._library_ingest_expanded_details.clear()
@@ -18576,8 +18566,7 @@ class LibraryScreen(BaseAppScreen):
             values["chunk"] = form.chunk
             values["chunk_size"] = form.chunk_size
         summary = ", ".join(
-            _summarise_option(f, values.get(f.name, f.default))
-            for f in cap.fields
+            _summarise_option(f, values.get(f.name, f.default)) for f in cap.fields
         )
         try:
             panel = self.query_one(f"#type-group-{group}", Collapsible)
@@ -20196,7 +20185,10 @@ class LibraryScreen(BaseAppScreen):
         Args:
             mode: ``"rendered"`` or ``"raw"``.
         """
-        if self._library_media_view != "viewer" or self._library_media_content_mode == mode:
+        if (
+            self._library_media_view != "viewer"
+            or self._library_media_content_mode == mode
+        ):
             return
         self._library_media_content_mode = mode
         self.refresh(recompose=True)
@@ -20677,8 +20669,7 @@ class LibraryScreen(BaseAppScreen):
             return
 
         guidance_text = (
-            create_action.disabled_reason
-            or "Enter a Collection name to enable Create."
+            create_action.disabled_reason or "Enter a Collection name to enable Create."
         )
         if guidance_widgets:
             guidance_widgets[0].update(guidance_text)

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -139,6 +139,7 @@ from ...Library.library_notes_session import (
     DatabaseNotePortLoadReply,
     DatabaseNotePortSaveReply,
     DatabaseNoteSessionCoordinator,
+    DestructiveAdmission,
     DestructiveAdmissionOutcomeKind,
     DestructiveKind,
     NoteFlushOutcome,
@@ -4139,6 +4140,15 @@ class LibraryScreen(BaseAppScreen):
         snapshot = self._library_note_session.snapshot
         if self._library_note_confirming_delete:
             if self._library_note_session.destructive_running:
+                self._show_library_note_shortcut_refusal(
+                    "Delete is running — wait for it to finish."
+                )
+                return
+            admission = self._library_note_session.destructive_admission
+            if (
+                admission is not None
+                and not self._library_note_session.cancel_destructive(admission)
+            ):
                 self._show_library_note_shortcut_refusal(
                     "Delete is running — wait for it to finish."
                 )
@@ -18756,7 +18766,9 @@ class LibraryScreen(BaseAppScreen):
         action row for a "Delete" / "Cancel" confirm affordance (mirroring
         ``handle_library_media_delete``); the actual service call only
         happens once the confirm button (``#library-note-delete-confirm``)
-        is pressed.
+        is pressed. Before confirmation is shown, the coordinator atomically
+        admits this exact note/session/version tuple so typing, Save, and a
+        duplicate destructive action cannot race the user's decision.
 
         Flushes a dirty edit first (awaited) so the version the confirmed
         delete sends is never stale; an unsaved edit surviving the flush
@@ -18766,19 +18778,60 @@ class LibraryScreen(BaseAppScreen):
             event: Button press event emitted by the editor's "Delete" action.
         """
         event.stop()
-        # LIB-14: the user is now explicitly managing this note's deletion
-        # themselves via the normal confirm-then-delete flow below -- clear
-        # any pending blank-note GC state first so ``_flush_library_note_
-        # save`` (called next) does not delete it out from under that flow
-        # (which would otherwise make the confirm button's own delete call
-        # fail against an already-gone row and surface a spurious warning).
+        initiating_snapshot = self._library_note_session.snapshot
+        if (
+            initiating_snapshot is None
+            or initiating_snapshot.note_id != self._selected_note_id
+        ):
+            return
+        initiating_note_id = initiating_snapshot.note_id
+        initiating_session_generation = initiating_snapshot.session_generation
+        origin_context = self._library_note_context
+        origin_preview = self._library_note_preview
+        # The user is explicitly managing deletion now; disarm the legacy
+        # blank-note GC path so it cannot race the admitted destructive flow.
         self._library_note_pending_blank_gc_id = None
         self._library_note_session_blank_id = None
         note_flush = await self._flush_library_note_save()
         if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
-        self._library_note_delete_origin_context = self._library_note_context
-        self._library_note_delete_origin_preview = self._library_note_preview
+        snapshot = self._library_note_session.snapshot
+        if (
+            snapshot is None
+            or snapshot.note_id != initiating_note_id
+            or snapshot.session_generation != initiating_session_generation
+            or snapshot.note_id != self._selected_note_id
+            or self._library_notes_view != "editor"
+        ):
+            return
+        admission_outcome = (
+            await self._library_note_session.request_destructive_admission(
+                DestructiveKind.DELETE,
+                note_id=snapshot.note_id,
+                session_generation=snapshot.session_generation,
+                expected_version=snapshot.version,
+            )
+        )
+        if (
+            admission_outcome.kind is not DestructiveAdmissionOutcomeKind.ADMITTED
+            or admission_outcome.admission is None
+        ):
+            self._library_note_shortcut_status = admission_outcome.message
+            self._apply_library_note_presentation_state()
+            return
+        admission = admission_outcome.admission
+        current = self._library_note_session.snapshot
+        if (
+            current is None
+            or current.note_id != initiating_note_id
+            or current.session_generation != initiating_session_generation
+            or current.note_id != self._selected_note_id
+            or self._library_notes_view != "editor"
+        ):
+            self._library_note_session.cancel_destructive(admission)
+            return
+        self._library_note_delete_origin_context = origin_context
+        self._library_note_delete_origin_preview = origin_preview
         self._library_note_confirming_delete = True
         self._library_note_preview = False
         self._library_note_context = False
@@ -18817,33 +18870,40 @@ class LibraryScreen(BaseAppScreen):
                 "Cancel" action.
         """
         event.stop()
+        admission = self._library_note_session.destructive_admission
+        if admission is not None and not self._library_note_session.cancel_destructive(
+            admission
+        ):
+            self._show_library_note_shortcut_refusal(
+                "Delete is running — wait for it to finish."
+            )
+            return
         self._restore_library_note_delete_origin()
 
     @on(Button.Pressed, "#library-note-delete-confirm")
     def handle_library_note_delete_confirm(self, event: Button.Pressed) -> None:
         """Hand the confirmed delete off to a worker that removes the note.
 
-        Reads the currently selected note id/version synchronously (before
-        any recompose can clear them) and defers the actual service call
-        and state mutation to ``_delete_library_note`` -- mirroring
-        ``handle_library_media_delete_confirm``.
+        Reads the coordinator-issued admission synchronously and defers its
+        final revalidation plus the actual service call to
+        ``_delete_library_note``. Duplicate workers may be scheduled, but
+        only one can mark that admission running and reach the service.
 
         Args:
             event: Button press event emitted by the confirm affordance's
                 "Delete" action.
         """
         event.stop()
-        note_id = self._selected_note_id
-        if not note_id:
+        admission = self._library_note_session.destructive_admission
+        if admission is None or admission.kind is not DestructiveKind.DELETE:
             self._restore_library_note_delete_origin()
             return
         self.run_worker(
-            self._delete_library_note(note_id, version=self._library_note_version),
-            exclusive=True,
+            self._delete_library_note(admission),
             group="library_note_delete",
         )
 
-    async def _delete_library_note(self, note_id: str, *, version: int | None) -> None:
+    async def _delete_library_note(self, admission: DestructiveAdmission) -> None:
         """Delete the selected Library note, then return to the list view.
 
         Calls ``delete_note`` through the offloaded service seam. The real
@@ -18871,50 +18931,63 @@ class LibraryScreen(BaseAppScreen):
         ``_save_library_note``.
 
         Args:
-            note_id: The Library note id to delete.
-            version: The note's in-memory version at confirm time.
+            admission: Coordinator-issued authority for this exact session.
         """
-        service = getattr(self.app_instance, "notes_scope_service", None)
-        delete_note = getattr(service, "delete_note", None)
-        if not callable(delete_note):
-            self._notify_library_note_delete_warning("Note deletion is unavailable.")
-            if self.is_mounted:
+        if not self._library_note_session.mark_destructive_running(admission):
+            cancelled = self._library_note_session.cancel_destructive(admission)
+            if (
+                cancelled
+                and self.is_mounted
+                and self._library_note_session.snapshot is not None
+            ):
                 self._restore_library_note_delete_origin()
             return
+        self._apply_library_note_presentation_state()
 
-        try:
-            deleted = await self._run_library_service_call(
-                delete_note,
-                scope="local_note",
-                note_id=note_id,
-                version=version,
-                user_id=self._library_notes_user_id(),
-                isolate_in_worker=True,
-            )
-        except ConflictError:
-            deleted = False
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Failed to delete Library note {note_id!r}."
-            )
-            if (
-                note_id != self._selected_note_id
-                or self._library_notes_view != "editor"
-            ):
-                return
-            self._notify_library_note_delete_warning("Could not delete this note.")
-            if self.is_mounted:
-                self._restore_library_note_delete_origin()
+        service = getattr(self.app_instance, "notes_scope_service", None)
+        delete_note = getattr(service, "delete_note", None)
+        deleted = False
+        failure_message = ""
+        if not callable(delete_note):
+            failure_message = "Note deletion is unavailable."
+        else:
+            try:
+                deleted = bool(
+                    await self._run_library_service_call(
+                        delete_note,
+                        scope="local_note",
+                        note_id=admission.note_id,
+                        version=admission.expected_version,
+                        user_id=self._library_notes_user_id(),
+                        isolate_in_worker=True,
+                    )
+                )
+            except ConflictError:
+                failure_message = "This note changed elsewhere — refresh and try again."
+            except Exception:
+                logger.opt(exception=True).warning(
+                    f"Failed to delete Library note {admission.note_id!r}."
+                )
+                failure_message = "Could not delete this note."
+
+        finished = self._library_note_session.finish_destructive(
+            admission, success=deleted
+        )
+        if not finished:
             return
 
         # Discard a stale result: the user has since switched to a different
         # note (or left the editor) while this delete was in flight.
-        if note_id != self._selected_note_id or self._library_notes_view != "editor":
+        if (
+            admission.note_id != self._selected_note_id
+            or self._library_notes_view != "editor"
+        ):
             return
 
         if not deleted:
             self._notify_library_note_delete_warning(
-                "This note changed elsewhere — refresh and try again."
+                failure_message
+                or "This note changed elsewhere — refresh and try again."
             )
             if self.is_mounted:
                 self._restore_library_note_delete_origin()

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -115,19 +115,21 @@ from ...Library.library_media_viewer_state import (
     find_content_matches,
 )
 from ...Library.library_notes_state import (
+    DatabaseNoteDraft,
     DatabaseNoteSavePayload,
+    LibraryNoteCreateOutcome,
     LibraryNoteEditorState,
     LibraryNotesListState,
+    LibraryNotesOperationState,
     NormalizedDatabaseNote,
     build_library_note_editor_state,
     build_library_notes_list_state,
     build_note_export_content,
-    next_notes_sort_mode,
-    note_template_keywords,
     notes_autosave_status_text,
     patch_note_records_after_save,
     resolve_note_template_placeholders,
     sort_notes_records,
+    validate_database_note_draft,
 )
 from ...Library.library_notes_session import (
     ConflictAction,
@@ -135,6 +137,8 @@ from ...Library.library_notes_session import (
     DatabaseNotePortLoadReply,
     DatabaseNotePortSaveReply,
     DatabaseNoteSessionCoordinator,
+    DestructiveAdmissionOutcomeKind,
+    DestructiveKind,
     NoteFlushOutcome,
     NoteFlushOutcomeKind,
     NoteLoadOutcomeKind,
@@ -148,8 +152,6 @@ from ...Library.library_notes_sync_state import (
     LibraryNotesSyncState,
     append_activity,
     count_noun,
-    next_sync_conflict,
-    next_sync_direction,
     sync_conflict_label,
     sync_status_line,
 )
@@ -1791,8 +1793,16 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_select_mode: bool = False
         self._library_notes_row_selection = RowSelection("notes")
         self._library_notes_sort: str = "newest"
+        self._library_notes_sort_choices_visible: bool = False
         self._library_notes_filter: str = ""
         self._library_notes_filter_records: list | None = None
+        self._library_notes_notice: str = ""
+        self._library_note_create_counter: int = 0
+        self._library_note_create_token: str | None = None
+        self._library_note_create_running: bool = False
+        self._library_note_create_status: str = ""
+        self._library_notes_operation_counter: int = 0
+        self._library_notes_operation: LibraryNotesOperationState | None = None
         self._library_prompts_sort: str = "newest"
         self._library_prompts_filter: str = ""
         self._selected_prompt_id: int | None = None
@@ -1994,6 +2004,8 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_sync_auto: bool = False
         self._library_notes_sync_status: str = "idle"
         self._library_notes_sync_activity: tuple[str, ...] = ()
+        self._library_notes_sync_counter: int = 0
+        self._library_notes_sync_active_token: int | None = None
         self._library_notes_sync_running: bool = False
         self._library_notes_auto_sync_timer: Timer | None = None
         # The folder box's live (possibly uncommitted) text. Typing updates
@@ -2310,6 +2322,7 @@ class LibraryScreen(BaseAppScreen):
         word_copy = f"{word_count} words" if word_count != 1 else "1 word"
         status_line = self._library_note_status_line()
         metadata_line = " · ".join(part for part in (base_meta, word_copy) if part)
+        operation = self._library_notes_operation_for_active_region()
         return LibraryNotePresentationState(
             snapshot=snapshot,
             metadata_line=metadata_line,
@@ -2322,7 +2335,139 @@ class LibraryScreen(BaseAppScreen):
             conflict_running=self._library_note_session.conflict_resolution_running,
             confirming_delete=self._library_note_confirming_delete,
             destructive_running=self._library_note_session.destructive_running,
+            discard_new_note=(
+                self._library_note_session.untouched_create_token is not None
+            ),
+            transfer_status=operation.status_line if operation is not None else "",
+            transfer_running=bool(operation and operation.running),
         )
+
+    def _library_notes_active_region(
+        self,
+    ) -> Literal["navigator", "editor", "context", ""]:
+        """Return the currently visible Notes operation-status region."""
+        if (
+            self._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+            and self._library_notes_view == "editor"
+        ):
+            return "context" if self._library_note_context else "editor"
+        if (
+            self._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+            and self._library_notes_view == "list"
+        ):
+            return "navigator"
+        return ""
+
+    def _library_notes_operation_for_active_region(
+        self,
+    ) -> LibraryNotesOperationState | None:
+        operation = self._library_notes_operation
+        if operation is None or operation.region != self._library_notes_active_region():
+            return None
+        return operation
+
+    def _library_notes_operation_is_current_and_active(
+        self, operation: LibraryNotesOperationState
+    ) -> bool:
+        """Return whether a running token still owns the visible region."""
+        current = self._library_notes_operation
+        return bool(
+            current is not None
+            and current.running
+            and current.token == operation.token
+            and current.kind == operation.kind
+            and current.region == self._library_notes_active_region()
+        )
+
+    def _apply_library_notes_operation_state(self) -> None:
+        """Synchronize the one active Notes operation status surface."""
+        if not self.is_mounted:
+            return
+        if self._library_notes_active_region() == "navigator":
+            self.refresh(recompose=True)
+            return
+        if self._library_notes_active_region() in {"editor", "context"}:
+            try:
+                canvas = self.query_one("#library-notes-canvas", LibraryNotesCanvas)
+            except (NoMatches, QueryError):
+                return
+            if canvas.mode != "editor":
+                self.call_after_refresh(self._apply_library_notes_operation_state)
+                return
+            self._apply_library_note_presentation_state()
+
+    def _begin_library_notes_operation(
+        self, kind: Literal["import", "export", "copy", "console"]
+    ) -> LibraryNotesOperationState | None:
+        """Claim one typed transfer token before invoking an external seam."""
+        current = self._library_notes_operation
+        if current is not None and current.running:
+            return None
+        region = self._library_notes_active_region()
+        if region not in {"navigator", "editor", "context"}:
+            return None
+        if kind not in {"import", "export", "copy", "console"}:
+            return None
+        self._library_notes_notice = ""
+        self._library_notes_operation_counter += 1
+        operation = LibraryNotesOperationState(
+            kind=kind,
+            token=self._library_notes_operation_counter,
+            phase="running",
+            region=region,
+        )
+        self._library_notes_operation = operation
+        self._apply_library_notes_operation_state()
+        return operation
+
+    def _move_library_notes_operation(
+        self,
+        token: int,
+        region: Literal["navigator", "editor", "context"],
+    ) -> bool:
+        """Move a current operation to the region its success opened."""
+        operation = self._library_notes_operation
+        if (
+            operation is None
+            or operation.token != token
+            or region not in {"navigator", "editor", "context"}
+        ):
+            return False
+        self._library_notes_operation = dataclasses.replace(operation, region=region)
+        return True
+
+    def _finish_library_notes_operation(
+        self,
+        operation: LibraryNotesOperationState,
+        *,
+        success: bool,
+        completion_next_action: str = "",
+        failure_next_action: str = "try again",
+    ) -> bool:
+        """Terminalize the current token and render only in its active region."""
+        current = self._library_notes_operation
+        active_region = self._library_notes_active_region()
+        if (
+            current is None
+            or current.token != operation.token
+            or current.kind != operation.kind
+        ):
+            return False
+        terminal = dataclasses.replace(
+            current,
+            phase="complete" if success else "failed",
+            completion_next_action=completion_next_action,
+            failure_next_action=failure_next_action,
+        )
+        if current.region != active_region:
+            # The side effect belongs to the matching token, but its former
+            # status surface is no longer visible. Release the global claim
+            # without leaking completion copy into the user's new region.
+            self._library_notes_operation = None
+            return False
+        self._library_notes_operation = terminal
+        self._apply_library_notes_operation_state()
+        return True
 
     def _apply_library_note_presentation_state(self) -> None:
         """Synchronize the mounted canvas without changing its composition."""
@@ -5366,6 +5511,8 @@ class LibraryScreen(BaseAppScreen):
                 elif shell.canvas_kind == "notes-create":
                     yield LibraryNotesCanvas(
                         mode="create",
+                        create_running=self._library_note_create_running,
+                        create_status=self._library_note_create_status,
                         id="library-notes-canvas",
                     )
                 elif (
@@ -5772,11 +5919,20 @@ class LibraryScreen(BaseAppScreen):
             if self._library_notes_filter_records is not None
             else self._local_source_records.get("notes", ())
         )
+        operation = self._library_notes_operation_for_active_region()
         state = build_library_notes_list_state(
             sort_notes_records(source_records, self._library_notes_sort),
             filter_note=self._library_notes_filter,
+            total_count=self._local_source_counts.get("notes"),
             select_mode=self._library_notes_select_mode,
             selected_ids=self._library_notes_row_selection.ids,
+            sort_choices_visible=self._library_notes_sort_choices_visible,
+            operation_status=(
+                operation.status_line
+                if operation is not None
+                else self._library_notes_notice
+            ),
+            operation_running=bool(operation and operation.running),
         )
         if self._library_notes_select_mode:
             self._library_notes_row_selection.reconcile(r.note_id for r in state.rows)
@@ -6133,6 +6289,11 @@ class LibraryScreen(BaseAppScreen):
         the whole Library screen's, not a single sync-panel visit (see
         ``handle_library_notes_sync_auto_toggle``).
         """
+        if self._library_notes_sync_active_token is not None:
+            # A thread-backed run owns this state until its matching finally
+            # block releases the token. Navigation may hide the panel, but it
+            # cannot make a still-running filesystem/DB side effect restartable.
+            return
         self._library_notes_sync_status = "idle"
         self._library_notes_sync_activity = ()
         self._library_notes_sync_running = False
@@ -7530,7 +7691,7 @@ class LibraryScreen(BaseAppScreen):
 
         Idempotent: only reads config once per screen lifetime
         (``_library_notes_sync_config_loaded`` guards re-entry), so
-        in-session cycling/toggling is never clobbered by a later sync-mode
+        in-session choices/toggling are never clobbered by a later sync-mode
         re-entry re-reading stale config.
 
         A stale persisted conflict value not in ``SYNC_CONFLICTS`` (e.g. an
@@ -7621,7 +7782,7 @@ class LibraryScreen(BaseAppScreen):
 
     def _library_notes_auto_sync_tick(self) -> None:
         """Auto-sync timer callback: skip quietly when busy or misconfigured."""
-        if self._library_notes_sync_running:
+        if self._library_notes_sync_active_token is not None:
             return
         folder_value = self._library_notes_sync_folder()
         if not folder_value:
@@ -7634,9 +7795,11 @@ class LibraryScreen(BaseAppScreen):
             return
         if not folder.is_dir():
             return
+        token = self._begin_library_notes_sync_run(folder)
+        if token is None:
+            return
         self.run_worker(
-            self._run_library_notes_sync(folder),
-            exclusive=True,
+            self._run_library_notes_sync(folder, token),
             group="library_notes_sync",
         )
 
@@ -8242,6 +8405,9 @@ class LibraryScreen(BaseAppScreen):
         fields = self._read_library_note_editor_fields()
         if fields is None:
             return
+        operation = self._begin_library_notes_operation("export")
+        if operation is None:
+            return
         title, content, keywords_text = fields
         note_id = self._selected_note_id
         safe_title = (
@@ -8274,6 +8440,7 @@ class LibraryScreen(BaseAppScreen):
                 content,
                 keywords_text,
                 note_id,
+                operation,
             ),
         )
 
@@ -8285,6 +8452,7 @@ class LibraryScreen(BaseAppScreen):
         content: str,
         keywords_text: str,
         note_id: str,
+        operation: LibraryNotesOperationState | None = None,
     ) -> None:
         """Write the exported note content to the path chosen via ``FileSave``.
 
@@ -8314,10 +8482,18 @@ class LibraryScreen(BaseAppScreen):
             keywords_text: The note's keywords, as a comma-separated string.
             note_id: The note's id.
         """
+        active_operation = operation or self._begin_library_notes_operation("export")
+        if active_operation is None:
+            return
         notify = getattr(self.app_instance, "notify", None)
         if not selected_path:
             if callable(notify):
                 notify("Note export cancelled.", severity="information")
+            self._finish_library_notes_operation(
+                active_operation,
+                success=False,
+                failure_next_action="choose another destination and try again",
+            )
             return
         try:
             validated_path = validate_path_simple(selected_path, require_exists=False)
@@ -8327,6 +8503,11 @@ class LibraryScreen(BaseAppScreen):
             )
             if callable(notify):
                 notify(f"Rejected export path: {exc}", severity="warning")
+            self._finish_library_notes_operation(
+                active_operation,
+                success=False,
+                failure_next_action="choose another destination and try again",
+            )
             return
         try:
             validated_path.write_text(
@@ -8341,12 +8522,18 @@ class LibraryScreen(BaseAppScreen):
             )
             if callable(notify):
                 notify(f"Error exporting note: {type(exc).__name__}", severity="error")
+            self._finish_library_notes_operation(
+                active_operation,
+                success=False,
+                failure_next_action="check the destination and try again",
+            )
             return
         if callable(notify):
             notify(
                 f"Note exported successfully to {validated_path.name}",
                 severity="information",
             )
+        self._finish_library_notes_operation(active_operation, success=True)
 
     @on(Button.Pressed, "#library-note-context-export-md")
     @on(Button.Pressed, "#library-note-export-md")
@@ -8393,6 +8580,9 @@ class LibraryScreen(BaseAppScreen):
         fields = self._read_library_note_editor_fields()
         if fields is None:
             return
+        operation = self._begin_library_notes_operation("copy")
+        if operation is None:
+            return
         title, content, keywords_text = fields
         note_id = self._selected_note_id
         export_content = build_note_export_content(
@@ -8404,6 +8594,11 @@ class LibraryScreen(BaseAppScreen):
                 notify(
                     "Clipboard copy is unavailable in this runtime.", severity="warning"
                 )
+            self._finish_library_notes_operation(
+                operation,
+                success=False,
+                failure_next_action="enable clipboard access and try again",
+            )
             return
         try:
             copy_to_clipboard(export_content)
@@ -8413,9 +8608,15 @@ class LibraryScreen(BaseAppScreen):
             )
             if callable(notify):
                 notify(f"Error copying note: {type(exc).__name__}", severity="error")
+            self._finish_library_notes_operation(
+                operation,
+                success=False,
+                failure_next_action="check clipboard access and try again",
+            )
             return
         if callable(notify):
             notify("Note copied to clipboard as markdown!", severity="information")
+        self._finish_library_notes_operation(operation, success=True)
 
     def _selected_library_note_handoff_payload(self) -> ChatHandoffPayload | None:
         """Build the Console handoff payload for the open Library note.
@@ -8456,7 +8657,7 @@ class LibraryScreen(BaseAppScreen):
             },
         )
 
-    def _open_selected_library_note_handoff(self) -> None:
+    def _open_selected_library_note_handoff(self) -> bool:
         """Stage the note open in the editor into Console via the shared handoff.
 
         Mirrors ``_open_selected_media_handoff``: builds the payload, then
@@ -8469,11 +8670,11 @@ class LibraryScreen(BaseAppScreen):
         if payload is None:
             if callable(notify):
                 notify("Open a note before using it in Console.", severity="warning")
-            return
+            return False
         if not workspace_state.context_handoff_enabled:
             if callable(notify):
                 notify(workspace_state.context_handoff_tooltip, severity="warning")
-            return
+            return False
         open_chat_with_handoff = getattr(
             self.app_instance, "open_chat_with_handoff", None
         )
@@ -8483,8 +8684,15 @@ class LibraryScreen(BaseAppScreen):
                     "Console handoff is unavailable for Library Notes.",
                     severity="warning",
                 )
-            return
-        open_chat_with_handoff(payload, action_label="Use in Console")
+            return False
+        try:
+            open_chat_with_handoff(payload, action_label="Use in Console")
+        except Exception:
+            logger.opt(exception=True).warning("Library note Console handoff failed.")
+            if callable(notify):
+                notify("Could not use this note in Console.", severity="warning")
+            return False
+        return True
 
     @on(Button.Pressed, "#library-note-context-use-in-console")
     @on(Button.Pressed, "#library-note-use-in-console")
@@ -8496,7 +8704,15 @@ class LibraryScreen(BaseAppScreen):
                 "Use in Console" action.
         """
         event.stop()
-        self._open_selected_library_note_handoff()
+        operation = self._begin_library_notes_operation("console")
+        if operation is None:
+            return
+        handed_off = self._open_selected_library_note_handoff()
+        self._finish_library_notes_operation(
+            operation,
+            success=handed_off,
+            failure_next_action="check Console readiness and try again",
+        )
 
     def _library_rail_preferences(self):
         """Read persisted Library rail section preferences, defensively.
@@ -8837,6 +9053,15 @@ class LibraryScreen(BaseAppScreen):
         if not await self._flush_library_skill_save():
             self._notify_skill_dirty_veto()
             return
+        # A rail selection is an explicit route boundary, even when the user
+        # later returns to the same visual Notes region. Invalidate the token
+        # now so leave→return cannot recreate authority by region equality.
+        self._library_notes_operation = None
+        if row_id == LIBRARY_ROW_CREATE_NOTE and not self._library_note_create_running:
+            # Create status belongs to one visible Create attempt. Import
+            # reuses the persistence seam from Navigator, so its internal
+            # failure must not leak into a later fresh Create entry.
+            self._library_note_create_status = ""
         self._library_selected_row_id = row_id
         # task-420: keep the footer's "u" hint in sync with the row gate.
         self._register_footer_shortcuts()
@@ -9397,16 +9622,47 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-notes-sort")
     def handle_library_notes_sort(self, event: Button.Pressed) -> None:
-        """Cycle the Library notes canvas sort mode (newest/oldest/title).
+        """Toggle the direct Library notes sort chooser.
 
         Args:
             event: Button press event emitted by the notes sort control.
         """
         event.stop()
-        self._library_notes_sort = next_notes_sort_mode(self._library_notes_sort)
+        self._library_notes_sort_choices_visible = (
+            not self._library_notes_sort_choices_visible
+        )
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, ".library-notes-sort-choice")
+    def handle_library_notes_sort_choice(self, event: Button.Pressed) -> None:
+        """Apply the exact sort value carried by one direct choice."""
+        event.stop()
+        requested = str(getattr(event.button, "sort_mode", "") or "")
+        if requested not in {"newest", "oldest", "title"}:
+            return
+        self._library_notes_sort = requested
+        self._library_notes_sort_choices_visible = False
         self._library_notes_select_mode = False
         self._library_notes_row_selection.clear()
         self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-notes-new")
+    async def handle_library_notes_new(self, event: Button.Pressed) -> None:
+        """Open the in-Library Create surface from Navigator."""
+        event.stop()
+        await self._select_library_rail_row(LIBRARY_ROW_CREATE_NOTE)
+
+    @on(Button.Pressed, "#library-notes-filter-clear")
+    def handle_library_notes_filter_clear(self, event: Button.Pressed) -> None:
+        """Clear the active filter without requiring an empty Enter submit."""
+        event.stop()
+        self._library_notes_filter = ""
+        self._library_notes_filter_records = None
+        self._library_notes_sort_choices_visible = False
+        self._library_notes_select_mode = False
+        self._library_notes_row_selection.clear()
+        self.refresh(recompose=True)
+        self.call_after_refresh(self._focus_library_notes_filter_input)
 
     @on(Input.Submitted, "#library-notes-filter")
     def handle_library_notes_filter(self, event: Input.Submitted) -> None:
@@ -14361,24 +14617,28 @@ class LibraryScreen(BaseAppScreen):
             event: Button press event emitted by the "Import note" action.
         """
         event.stop()
+        operation = self._begin_library_notes_operation("import")
+        if operation is None:
+            return
 
         async def import_callback(selected_path: Path | None) -> None:
-            await self._import_library_note_from_path(selected_path)
+            await self._import_library_note_from_path(selected_path, operation)
 
         self.app.push_screen(
             FileOpen(title="Import Note (TXT, MD, JSON, YAML)"),
             import_callback,
         )
 
-    async def _import_library_note_from_path(self, selected_path: Path | None) -> None:
+    async def _import_library_note_from_path(
+        self,
+        selected_path: Path | None,
+        operation: LibraryNotesOperationState,
+    ) -> None:
         """Validate, read, and parse a chosen file, then create a note from it.
 
-        Cancelling the dialog (``selected_path is None``) is a silent no-op.
-        Every other failure mode -- a path ``validate_path_simple`` rejects,
-        a file that cannot be read/decoded, or one larger than
-        ``LIBRARY_NOTE_CONTENT_MAX_CHARS`` -- is a quiet warning notice with
-        no note created, matching every other Library note failure path in
-        this screen. The file read is offloaded to a thread (mirroring the
+        Cancelling the dialog or encountering a path/read/size failure creates
+        no note and leaves an actionable failure line in Navigator. The file
+        read is offloaded to a thread (mirroring the
         retired standalone Notes screen's import) and is memory-bounded by a
         pre-read ``st_size`` guard: UTF-8 chars are at most 4 bytes, so any
         file over ``4 * LIBRARY_NOTE_CONTENT_MAX_CHARS`` bytes is guaranteed
@@ -14391,6 +14651,11 @@ class LibraryScreen(BaseAppScreen):
                 ``None`` if the dialog was cancelled.
         """
         if selected_path is None:
+            self._finish_library_notes_operation(
+                operation,
+                success=False,
+                failure_next_action="choose a file and try again",
+            )
             return
 
         from tldw_chatbook.Event_Handlers.notes_events import (
@@ -14403,7 +14668,7 @@ class LibraryScreen(BaseAppScreen):
             logger.opt(exception=True).warning(
                 f"Rejected Library note import path {selected_path!r}."
             )
-            self._notify_library_note_create_warning("Could not import that file.")
+            self._fail_library_note_import(operation)
             return
 
         try:
@@ -14412,14 +14677,14 @@ class LibraryScreen(BaseAppScreen):
             logger.opt(exception=True).warning(
                 f"Could not stat Library note import file '{note_path}'."
             )
-            self._notify_library_note_create_warning("Could not import that file.")
+            self._fail_library_note_import(operation)
             return
         if file_size > LIBRARY_NOTE_CONTENT_MAX_CHARS * 4:
             # See docstring: st_size > 4x the char cap proves the decoded
             # text exceeds the cap (UTF-8 is <= 4 bytes/char), so reject
             # BEFORE reading -- the char check below would otherwise slurp
             # an arbitrarily large file into memory first.
-            self._notify_library_note_create_warning("Could not import that file.")
+            self._fail_library_note_import(operation)
             return
 
         try:
@@ -14430,11 +14695,11 @@ class LibraryScreen(BaseAppScreen):
             logger.opt(exception=True).warning(
                 f"Could not read Library note import file '{note_path}'."
             )
-            self._notify_library_note_create_warning("Could not import that file.")
+            self._fail_library_note_import(operation)
             return
 
         if len(file_content) > LIBRARY_NOTE_CONTENT_MAX_CHARS:
-            self._notify_library_note_create_warning("Could not import that file.")
+            self._fail_library_note_import(operation)
             return
 
         title, content = _parse_note_from_file_content(note_path, file_content)
@@ -14445,7 +14710,47 @@ class LibraryScreen(BaseAppScreen):
             title = note_path.stem or "Imported note"
         content = (content or "").replace("\x00", "")
 
-        await self._create_library_note(title=title, content=content)
+        if not self._library_notes_operation_is_current_and_active(operation):
+            # Reading is reversible; creating the parsed note is not. A user
+            # who left Navigator while the read was in flight has withdrawn
+            # this operation's authority to cross the persistence boundary.
+            self._finish_library_notes_operation(
+                operation,
+                success=False,
+                failure_next_action="return to Notes and try again",
+            )
+            return
+
+        create_outcome = await self._create_library_note(title=title, content=content)
+        if create_outcome.kind == "failed":
+            self._fail_library_note_import(operation)
+            return
+        if create_outcome.kind == "created_not_opened":
+            recovery = "select the new note below to open"
+            self._library_notes_notice = f"Import complete — {recovery}."
+            notify = getattr(self.app_instance, "notify", None)
+            if callable(notify):
+                notify(
+                    "Note imported. Select it from Notes to open.",
+                    severity="information",
+                )
+            self._finish_library_notes_operation(
+                operation,
+                success=True,
+                completion_next_action=recovery,
+            )
+            return
+        self._move_library_notes_operation(operation.token, "editor")
+        self._finish_library_notes_operation(operation, success=True)
+
+    def _fail_library_note_import(self, operation: LibraryNotesOperationState) -> None:
+        """Keep import failure visible in Navigator with one recovery step."""
+        self._notify_library_note_create_warning("Could not import that file.")
+        self._finish_library_notes_operation(
+            operation,
+            success=False,
+            failure_next_action="choose a valid UTF-8 note file and try again",
+        )
 
     # ----- Notes sync panel ------------------------------------------------
 
@@ -14476,6 +14781,8 @@ class LibraryScreen(BaseAppScreen):
             event: Button press event emitted by the "‹ Back to notes" action.
         """
         event.stop()
+        if self._library_notes_sync_active_token is not None:
+            return
         note_flush = await self._flush_library_note_save()
         if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
@@ -14497,6 +14804,8 @@ class LibraryScreen(BaseAppScreen):
             event: Input change event emitted by the sync folder box.
         """
         event.stop()
+        if self._library_notes_sync_active_token is not None:
+            return
         self._library_notes_sync_folder_text = event.value
 
     @on(Input.Submitted, "#library-notes-sync-folder")
@@ -14509,6 +14818,8 @@ class LibraryScreen(BaseAppScreen):
             event: Input submit event emitted by the sync folder box.
         """
         event.stop()
+        if self._library_notes_sync_active_token is not None:
+            return
         self._library_notes_sync_folder_text = event.value
         save_setting_to_cli_config("notes", "sync_directory", event.value)
 
@@ -14520,6 +14831,8 @@ class LibraryScreen(BaseAppScreen):
             event: Button press event emitted by the "Browse…" action.
         """
         event.stop()
+        if self._library_notes_sync_active_token is not None:
+            return
         from ...Third_Party.textual_fspicker import SelectDirectory
 
         current = Path(self._library_notes_sync_folder()).expanduser()
@@ -14532,40 +14845,46 @@ class LibraryScreen(BaseAppScreen):
 
     def _apply_library_notes_sync_folder(self, path: Path | None) -> None:
         """Persist and render the folder chosen via ``SelectDirectory``."""
-        if not path:
+        if not path or self._library_notes_sync_active_token is not None:
             return
         self._library_notes_sync_folder_text = str(path)
         save_setting_to_cli_config("notes", "sync_directory", str(path))
         if self._library_notes_view == "sync":
             self.refresh(recompose=True)
 
-    @on(Button.Pressed, "#library-notes-sync-direction")
+    @on(Button.Pressed, ".library-notes-sync-direction-choice")
     def handle_library_notes_sync_direction(self, event: Button.Pressed) -> None:
-        """Cycle the sync direction and persist the new value.
+        """Apply and persist one explicitly chosen sync direction.
 
         Args:
-            event: Button press event emitted by the direction cycler.
+            event: Button press event emitted by a direction choice.
         """
         event.stop()
-        self._library_notes_sync_direction = next_sync_direction(
-            self._library_notes_sync_direction
-        )
+        if self._library_notes_sync_active_token is not None:
+            return
+        value = str(getattr(event.button, "choice_value", "") or "")
+        if value not in SYNC_DIRECTIONS:
+            return
+        self._library_notes_sync_direction = value
         save_setting_to_cli_config(
             "notes", "sync_direction", self._library_notes_sync_direction
         )
         self.refresh(recompose=True)
 
-    @on(Button.Pressed, "#library-notes-sync-conflict")
+    @on(Button.Pressed, ".library-notes-sync-conflict-choice")
     def handle_library_notes_sync_conflict(self, event: Button.Pressed) -> None:
-        """Cycle the conflict-resolution mode and persist the new value.
+        """Apply and persist one explicitly chosen conflict policy.
 
         Args:
-            event: Button press event emitted by the conflict cycler.
+            event: Button press event emitted by a conflict choice.
         """
         event.stop()
-        self._library_notes_sync_conflict = next_sync_conflict(
-            self._library_notes_sync_conflict
-        )
+        if self._library_notes_sync_active_token is not None:
+            return
+        value = str(getattr(event.button, "choice_value", "") or "")
+        if value not in SYNC_CONFLICTS:
+            return
+        self._library_notes_sync_conflict = value
         save_setting_to_cli_config(
             "notes", "sync_conflict_resolution", self._library_notes_sync_conflict
         )
@@ -14586,6 +14905,8 @@ class LibraryScreen(BaseAppScreen):
             event: Button press event emitted by the auto-sync toggle.
         """
         event.stop()
+        if self._library_notes_sync_active_token is not None:
+            return
         self._library_notes_sync_auto = not self._library_notes_sync_auto
         save_setting_to_cli_config("notes", "auto_sync", self._library_notes_sync_auto)
         if self._library_notes_sync_auto:
@@ -14596,13 +14917,13 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-notes-sync-run")
     def handle_library_notes_sync_run(self, event: Button.Pressed) -> None:
-        """Validate the folder and kick off a sync run as an exclusive worker.
+        """Validate the folder, claim single-flight ownership, and run sync.
 
         Args:
             event: Button press event emitted by the "Sync now" action.
         """
         event.stop()
-        if self._library_notes_sync_running:
+        if self._library_notes_sync_active_token is not None:
             return
         folder_value = self._library_notes_sync_folder()
         if not folder_value:
@@ -14624,18 +14945,48 @@ class LibraryScreen(BaseAppScreen):
         # folder (see handle_library_notes_sync_folder_changed): the folder
         # a run actually used is always the one that persists.
         save_setting_to_cli_config("notes", "sync_directory", folder_value)
+        token = self._begin_library_notes_sync_run(folder)
+        if token is None:
+            return
         self.run_worker(
-            self._run_library_notes_sync(folder),
-            exclusive=True,
+            self._run_library_notes_sync(folder, token),
             group="library_notes_sync",
         )
+
+    def _begin_library_notes_sync_run(self, folder: Path) -> int | None:
+        """Claim one sync token synchronously before worker dispatch."""
+        if self._library_notes_sync_active_token is not None:
+            return None
+        self._library_notes_sync_counter += 1
+        token = self._library_notes_sync_counter
+        self._library_notes_sync_active_token = token
+        self._library_notes_sync_running = True
+        self._library_notes_sync_status = sync_status_line(
+            "syncing", processed=0, total=0
+        )
+        self._library_notes_sync_activity = append_activity(
+            self._library_notes_sync_activity, f"Starting sync: {folder.name}"
+        )
+        if self._library_notes_view == "sync" and self.is_mounted:
+            self.refresh(recompose=True)
+        return token
+
+    def _finish_library_notes_sync_run(self, token: int) -> bool:
+        """Release only the matching thread-backed sync claim."""
+        if token != self._library_notes_sync_active_token:
+            return False
+        self._library_notes_sync_active_token = None
+        self._library_notes_sync_running = False
+        if self._library_notes_view == "sync" and self.is_mounted:
+            self.refresh(recompose=True)
+        return True
 
     def _notify_library_notes_sync_warning(self, message: str) -> None:
         notify = getattr(self.app_instance, "notify", None)
         if callable(notify):
             notify(message, severity="warning")
 
-    async def _run_library_notes_sync(self, folder: Path) -> None:
+    async def _run_library_notes_sync(self, folder: Path, token: int) -> None:
         """Run one notes sync pass against ``folder`` and report the outcome.
 
         Builds a fresh ``NotesSyncService`` per run (mirroring the retired
@@ -14656,7 +15007,12 @@ class LibraryScreen(BaseAppScreen):
         ever performs targeted ``query_one(...).update(...)`` calls,
         guarded against the user having navigated away mid-run. Only the
         start and the final outcome trigger a recompose (also
-        freshness-guarded).
+        freshness-guarded). Only the matching token's ``finally`` block can
+        release the running claim, including after rail navigation.
+
+        Args:
+            folder: Validated root folder for this sync pass.
+            token: Monotonic run identity claimed before worker dispatch.
         """
         from ...Notes.sync_engine import ConflictResolution, SyncDirection
         from ...Notes.sync_service import NotesSyncService
@@ -14667,6 +15023,11 @@ class LibraryScreen(BaseAppScreen):
             self._notify_library_notes_sync_warning(
                 "Sync service is unavailable in this runtime."
             )
+            if token == self._library_notes_sync_active_token:
+                self._library_notes_sync_status = sync_status_line(
+                    "failed", error="Sync service unavailable"
+                )
+            self._finish_library_notes_sync_run(token)
             return
 
         try:
@@ -14678,18 +15039,13 @@ class LibraryScreen(BaseAppScreen):
         except ValueError:
             resolution = ConflictResolution.NEWER_WINS
 
-        self._library_notes_sync_running = True
-        self._library_notes_sync_status = sync_status_line(
-            "syncing", processed=0, total=0
-        )
-        self._library_notes_sync_activity = append_activity(
-            self._library_notes_sync_activity, f"Starting sync: {folder.name}"
-        )
-        self.refresh(recompose=True)
-
         def progress_callback(sync_progress: Any) -> None:
             def apply() -> None:
-                if self._library_notes_view != "sync" or not self.is_mounted:
+                if (
+                    token != self._library_notes_sync_active_token
+                    or self._library_notes_view != "sync"
+                    or not self.is_mounted
+                ):
                     return
                 total = getattr(sync_progress, "total_files", 0)
                 processed = getattr(sync_progress, "processed_files", 0)
@@ -14786,9 +15142,7 @@ class LibraryScreen(BaseAppScreen):
                 self._library_notes_sync_activity, f"Sync failed: {exc}"
             )
         finally:
-            self._library_notes_sync_running = False
-            if self._library_notes_view == "sync" and self.is_mounted:
-                self.refresh(recompose=True)
+            self._finish_library_notes_sync_run(token)
 
     # ----- Ingest canvas -----------------------------------------------
 
@@ -16446,6 +16800,7 @@ class LibraryScreen(BaseAppScreen):
             self._library_notes_row_selection.toggle(note_id)
             _apply_library_row_toggle(self, "notes", event.button, note_id)
             return
+        self._library_notes_notice = ""
         self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
         # A normal row switch never carries the blank-note GC identity.
         self._library_note_pending_blank_gc_id = None
@@ -16633,7 +16988,7 @@ class LibraryScreen(BaseAppScreen):
     def _focus_library_note_control(self, selector: str) -> None:
         """Focus one stable note control when its presentation is visible."""
         try:
-            self.query_one(selector, Button).focus()
+            self.query_one(selector, Widget).focus()
         except (NoMatches, QueryError):
             return
 
@@ -16807,9 +17162,16 @@ class LibraryScreen(BaseAppScreen):
             event: Button press event emitted by the "Blank note" action.
         """
         event.stop()
+        create_token = self._begin_library_note_create()
+        if create_token is None:
+            return
         self.run_worker(
-            self._create_library_note(title="Untitled", content="", blank=True),
-            exclusive=True,
+            self._create_library_note(
+                title="Untitled",
+                content="",
+                create_token=create_token,
+                blank=True,
+            ),
             group="library_note_create",
         )
 
@@ -16827,27 +17189,65 @@ class LibraryScreen(BaseAppScreen):
         template = NOTE_TEMPLATES.get(template_key)
         title, content = self._library_note_template_fields(template)
         # Templates carry keywords ("meeting, notes") that the standalone
-        # screen applies on create -- parity requires passing them through.
-        keywords = list(note_template_keywords(template))
+        # screen applies on create. Preserve the raw shape until the shared
+        # lossless validator can either accept it or surface a typed veto.
+        keywords: Any = ""
+        if isinstance(template, Mapping):
+            keywords = template.get("keywords", "")
+        create_token = self._begin_library_note_create()
+        if create_token is None:
+            return
         self.run_worker(
-            self._create_library_note(title=title, content=content, keywords=keywords),
-            exclusive=True,
+            self._create_library_note(
+                title=title,
+                content=content,
+                keywords=keywords,
+                create_token=create_token,
+            ),
             group="library_note_create",
         )
 
+    @on(Button.Pressed, "#library-notes-create-back")
+    async def handle_library_notes_create_back(self, event: Button.Pressed) -> None:
+        """Leave Create without creating anything."""
+        event.stop()
+        if self._library_note_create_running:
+            return
+        self._library_note_create_status = ""
+        await self._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+
+    def _begin_library_note_create(self) -> str | None:
+        """Claim one monotonic Create token before a worker can be scheduled."""
+        if self._library_note_create_running:
+            return None
+        self._library_notes_notice = ""
+        self._library_note_create_counter += 1
+        token = f"create-{self._library_note_create_counter}"
+        self._library_note_create_token = token
+        self._library_note_create_running = True
+        self._library_note_create_status = "Create…"
+        if self.is_mounted:
+            self.refresh(recompose=True)
+        return token
+
+    def _finish_library_note_create(
+        self, create_token: str, *, status: str = ""
+    ) -> bool:
+        """Finish only the still-current Create attempt."""
+        if create_token != self._library_note_create_token:
+            return False
+        self._library_note_create_running = False
+        self._library_note_create_status = status
+        return True
+
     @staticmethod
-    def _library_note_template_fields(template: Any) -> tuple[str, str]:
+    def _library_note_template_fields(template: Any) -> tuple[Any, Any]:
         """Resolve a note template's title/content for the create flow.
 
-        Malformed or unknown templates (not a mapping, or missing/non-string
-        ``title``) degrade to the same "Untitled" / empty-body defaults the
-        Blank note button uses. The real ``NOTE_TEMPLATES`` shape (bundled
-        ``Config_Files/note_templates.json`` or a user override) always
-        carries plain-string ``title``/``content`` values -- callables/
-        "content builders" never occur in practice -- but a non-string,
-        non-``None`` ``content`` is still coerced on a best-effort basis
-        (calling it first if it is callable) rather than raising, so one
-        odd template can never break the create view for the others.
+        Valid string fields receive placeholder substitution. Malformed or
+        missing fields remain unmodified so the shared lossless validator can
+        veto them visibly; this adapter must never default, call, or stringify
+        user template values into a different persisted note.
 
         ``{date}``/``{time}``/``{datetime}`` placeholders are resolved
         against the current time, mirroring the retired standalone Notes
@@ -16865,72 +17265,55 @@ class LibraryScreen(BaseAppScreen):
                 when the key is unknown.
 
         Returns:
-            A ``(title, content)`` tuple, always ``str``.
+            The raw ``(title, content)`` values, with placeholders resolved
+            only for valid strings.
         """
         if not isinstance(template, Mapping):
-            return "Untitled", ""
-        raw_title = template.get("title")
-        title = (
-            raw_title
-            if isinstance(raw_title, str) and raw_title.strip()
-            else "Untitled"
-        )
-        raw_content = template.get("content")
-        if isinstance(raw_content, str):
-            content = raw_content
-        elif raw_content is None:
-            content = ""
-        else:
-            candidate = raw_content
-            if callable(candidate):
-                try:
-                    candidate = candidate()
-                except Exception:
-                    candidate = ""
-            try:
-                content = str(candidate)
-            except Exception:
-                content = ""
-
-        # Shared pure resolver (also drives the create view's row secondary
-        # lines) -- per-field, so a title-only malformation still gets the
-        # content substituted.
-        title = resolve_note_template_placeholders(title)
-        content = resolve_note_template_placeholders(content)
+            return None, None
+        title = template.get("title")
+        content = template.get("content")
+        if isinstance(title, str):
+            title = resolve_note_template_placeholders(title)
+        if isinstance(content, str):
+            content = resolve_note_template_placeholders(content)
         return title, content
 
     async def _create_library_note(
         self,
         *,
-        title: str,
-        content: str,
-        keywords: list[str] | None = None,
+        title: Any,
+        content: Any,
+        keywords: Any = None,
+        create_token: str | None = None,
         blank: bool = False,
-    ) -> None:
+    ) -> LibraryNoteCreateOutcome:
         """Create a new local note from the in-canvas Create view and open it.
 
         Shared by the Blank note button and every template row: both
         resolve their title/content synchronously (see
         ``_library_note_template_fields``) and hand off to this single
-        creation seam. Sanitizes the fields through the same Task 5
-        boundary helpers ``_save_library_note`` uses, then calls
-        ``save_note`` with ``note_id=None`` (the create path) offloaded via
-        ``_run_library_service_call``.
+        creation seam. Validates the lossless draft through the same typed
+        boundary used by editor Save, then calls ``save_note`` with
+        ``note_id=None`` (the create path) offloaded via
+        ``_run_library_service_call``. Invalid input remains visible in
+        Create and is never silently truncated or transformed.
 
         On success, switches straight into the editor for the newly
         created note: selects the Browse > Notes rail row, refreshes the
         local source snapshot (so the new note appears in both the notes
         list and the rail's count -- the same full-refresh the initial
         mount load uses, since there is no existing "append one record"
-        mutation path for notes to reuse) and kicks the existing
-        ``_refresh_library_note_detail`` worker.
+        mutation path for notes to reuse). The coordinator must first return
+        a typed loaded session for the new identity.
 
         A missing/failed save leaves the create view in place with a quiet
         warning notice, mirroring ``_notify_library_media_edit_warning``.
 
         Args:
-            title: The note's title (already resolved; not yet sanitized).
-            content: The note's body (already resolved; not yet sanitized).
+            title: The note's exact resolved title.
+            content: The note's exact resolved body.
+            keywords: Exact resolved template keywords, if any.
+            create_token: Preclaimed monotonic token for a UI activation.
             blank: Whether this is the "Blank note" creation path (as
                 opposed to a template row, which already carries real
                 content the user likely wants kept even unedited). LIB-14:
@@ -16940,55 +17323,221 @@ class LibraryScreen(BaseAppScreen):
                 but a blank-note row that is never touched is armed for
                 quiet deletion on exit instead of surviving as a permanent
                 literal "Untitled" row.
+
+        Returns:
+            Typed distinction between pre-commit failure, committed recovery,
+            and a successfully opened editor session.
         """
-        sanitized_title = self._sanitize_media_field(title, max_length=300)
-        sanitized_content = self._sanitize_note_content(
-            content, max_length=LIBRARY_NOTE_CONTENT_MAX_CHARS
+        origin_row = self._library_selected_row_id
+        origin_view = self._library_notes_view
+        active_token = create_token or self._begin_library_note_create()
+        if active_token is None:
+            return LibraryNoteCreateOutcome("failed")
+        if keywords is None:
+            keywords_text: Any = ""
+        elif isinstance(keywords, str):
+            keywords_text = keywords
+        elif (
+            isinstance(keywords, Sequence)
+            and not isinstance(keywords, (bytes, bytearray))
+            and all(isinstance(keyword, str) for keyword in keywords)
+        ):
+            keywords_text = ", ".join(keywords)
+        else:
+            keywords_text = keywords
+        draft = DatabaseNoteDraft(
+            note_id="",
+            title=title,
+            body=content,
+            keywords_text=keywords_text,
+            revision=0,
         )
-        sanitized_keywords = [
-            sanitized
-            for keyword in (keywords or [])
-            if (sanitized := self._sanitize_media_field(keyword, max_length=100))
-        ] or None
+        payload = validate_database_note_draft(draft)
+        if not isinstance(payload, DatabaseNoteSavePayload):
+            status = f"Create failed — {payload.message}"
+            if self._finish_library_note_create(active_token, status=status):
+                self.refresh(recompose=True)
+            return LibraryNoteCreateOutcome("failed")
 
         service = getattr(self.app_instance, "notes_scope_service", None)
         save_note = getattr(service, "save_note", None)
         if not callable(save_note):
             self._notify_library_note_create_warning("Note creation is unavailable.")
-            return
+            if self._finish_library_note_create(
+                active_token,
+                status="Create failed — creation is unavailable. Try again.",
+            ):
+                self.refresh(recompose=True)
+            return LibraryNoteCreateOutcome("failed")
         try:
             result = await self._run_library_service_call(
                 save_note,
                 scope="local_note",
-                title=sanitized_title,
-                content=sanitized_content,
+                title=payload.title,
+                content=payload.body,
                 note_id=None,
                 user_id=self._library_notes_user_id(),
-                keywords=sanitized_keywords,
+                keywords=list(payload.keywords) if payload.keywords else None,
                 isolate_in_worker=True,
             )
         except Exception:
             logger.opt(exception=True).warning("Library note create failed.")
             self._notify_library_note_create_warning("Could not create the note.")
-            return
+            if self._finish_library_note_create(
+                active_token,
+                status="Create failed — check the service and try again.",
+            ):
+                self.refresh(recompose=True)
+            return LibraryNoteCreateOutcome("failed")
+
+        if active_token != self._library_note_create_token:
+            return LibraryNoteCreateOutcome("failed")
 
         created_id = result.get("id") if isinstance(result, Mapping) else result
         created_id = str(created_id) if created_id else ""
         if not created_id:
             self._notify_library_note_create_warning("Could not create the note.")
-            return
+            if self._finish_library_note_create(
+                active_token,
+                status="Create failed — no note was returned. Try again.",
+            ):
+                self.refresh(recompose=True)
+            return LibraryNoteCreateOutcome("failed")
 
+        # The returned identity is the irreversible commit point. Refresh the
+        # source immediately; every later load/route failure must preserve the
+        # created note and must never expose a create-retry path.
+        self._refresh_local_source_snapshot()
+        route_is_current = (
+            self._library_selected_row_id == origin_row
+            and self._library_notes_view == origin_view
+        )
+        if not route_is_current:
+            self._finish_library_note_create(active_token)
+            self._library_notes_notice = "Note created — select it from Notes to open."
+            return LibraryNoteCreateOutcome("created_not_opened", created_id)
+
+        outcome = await self._library_note_session.open_session(
+            created_id, untouched_create_token=active_token
+        )
+        if active_token != self._library_note_create_token:
+            return LibraryNoteCreateOutcome("created_not_opened", created_id)
+        route_is_current = (
+            self._library_selected_row_id == origin_row
+            and self._library_notes_view == origin_view
+        )
+        if outcome.kind is not NoteLoadOutcomeKind.LOADED or not route_is_current:
+            if outcome.kind is NoteLoadOutcomeKind.LOADED:
+                self._library_note_session.close_session()
+            self._finish_library_note_create(active_token)
+            self._library_notes_notice = "Note created — select it from Notes to open."
+            if route_is_current:
+                self._reset_library_note_editor_state()
+                self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
+                self._library_notes_filter = ""
+                self._library_notes_filter_records = None
+            if self.is_mounted:
+                self.refresh(recompose=True)
+            return LibraryNoteCreateOutcome("created_not_opened", created_id)
+
+        self._library_notes_notice = ""
         self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
         self._library_notes_filter = ""
         self._library_notes_filter_records = None
-        # Reuses the same full local-source reload the initial mount load
-        # runs (already its own exclusive worker via @work) rather than a
-        # targeted append, since notes have no existing "patch the cached
-        # snapshot" mutation path the way media edits/deletes do.
-        self._refresh_local_source_snapshot()
-        self._begin_library_note_load(created_id)
+        self._selected_note_id = created_id
+        self._library_notes_view = "editor"
+        self._library_note_load_state = "loaded"
+        self._library_note_load_message = ""
+        self._library_note_autosave_state = "idle"
+        self._library_note_confirming_delete = False
+        self._library_note_preview = False
+        self._library_note_context = False
+        self._library_note_delete_origin_context = False
+        self._library_note_delete_origin_preview = False
+        self._library_note_editor_armed = False
         self._library_note_pending_blank_gc_id = created_id if blank else None
         self._library_note_session_blank_id = created_id if blank else None
+        self._finish_library_note_create(active_token)
+        if self.is_mounted:
+            self.refresh(recompose=True)
+            self.call_after_refresh(self._arm_library_note_editor)
+            self.call_after_refresh(
+                self._focus_library_note_control, "#library-note-title"
+            )
+        return LibraryNoteCreateOutcome("opened", created_id)
+
+    @on(Button.Pressed, "#library-note-discard-new")
+    def handle_library_note_discard_new(self, event: Button.Pressed) -> None:
+        """Discard only the coordinator-certified untouched new note."""
+        event.stop()
+        create_token = self._library_note_session.untouched_create_token
+        if create_token is None:
+            return
+        self.run_worker(
+            self._discard_new_library_note(create_token),
+            group="library_note_delete",
+        )
+
+    async def _discard_new_library_note(self, create_token: str) -> None:
+        """Delete one untouched create through typed destructive admission."""
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None:
+            return
+        admission_outcome = (
+            await self._library_note_session.request_destructive_admission(
+                DestructiveKind.DISCARD_NEW_NOTE,
+                note_id=snapshot.note_id,
+                session_generation=snapshot.session_generation,
+                expected_version=snapshot.version,
+                create_token=create_token,
+            )
+        )
+        if (
+            admission_outcome.kind is not DestructiveAdmissionOutcomeKind.ADMITTED
+            or admission_outcome.admission is None
+        ):
+            self._apply_library_note_presentation_state()
+            return
+        admission = admission_outcome.admission
+        self._apply_library_note_presentation_state()
+        if not self._library_note_session.mark_destructive_running(admission):
+            self._library_note_session.cancel_destructive(admission)
+            self._apply_library_note_presentation_state()
+            return
+        self._apply_library_note_presentation_state()
+
+        service = getattr(self.app_instance, "notes_scope_service", None)
+        delete_note = getattr(service, "delete_note", None)
+        deleted = False
+        if callable(delete_note):
+            try:
+                deleted = bool(
+                    await self._run_library_service_call(
+                        delete_note,
+                        scope="local_note",
+                        note_id=admission.note_id,
+                        version=admission.expected_version,
+                        user_id=self._library_notes_user_id(),
+                        isolate_in_worker=True,
+                    )
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    f"Failed to discard new Library note {admission.note_id!r}."
+                )
+        self._library_note_session.finish_destructive(admission, success=deleted)
+        if not deleted:
+            self._notify_library_note_delete_warning(
+                "Could not discard this new note. Try again."
+            )
+            self._apply_library_note_presentation_state()
+            return
+
+        self._reset_library_note_editor_state()
+        self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
+        self._library_notes_filter = ""
+        self._library_notes_filter_records = None
+        self._refresh_local_source_snapshot()
         if self.is_mounted:
             self.refresh(recompose=True)
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -115,8 +115,10 @@ from ...Library.library_media_viewer_state import (
     find_content_matches,
 )
 from ...Library.library_notes_state import (
+    DatabaseNoteSavePayload,
     LibraryNoteEditorState,
     LibraryNotesListState,
+    NormalizedDatabaseNote,
     build_library_note_editor_state,
     build_library_notes_list_state,
     build_note_export_content,
@@ -126,6 +128,18 @@ from ...Library.library_notes_state import (
     patch_note_records_after_save,
     resolve_note_template_placeholders,
     sort_notes_records,
+)
+from ...Library.library_notes_session import (
+    ConflictAction,
+    ConflictOutcomeKind,
+    DatabaseNotePortLoadReply,
+    DatabaseNotePortSaveReply,
+    DatabaseNoteSessionCoordinator,
+    NoteFlushOutcome,
+    NoteFlushOutcomeKind,
+    NoteLoadOutcomeKind,
+    NoteSaveOutcome,
+    NoteSaveOutcomeKind,
 )
 from ...Library.library_notes_sync_state import (
     AUTO_SYNC_INTERVAL_SECONDS,
@@ -478,6 +492,179 @@ LIBRARY_RAG_RESULTS_STATIC_WIDGET_IDS = frozenset({"library-rag-results-heading"
 # retrieval did not run, so there is nothing to be grounded in and the
 # recovery copy those statuses already render is the honest answer.
 LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES = frozenset({"ready", "empty"})
+
+class _LibraryDatabaseNoteSessionPort:
+    """Adapt the existing Library note services to the portable session port."""
+
+    def __init__(
+        self,
+        *,
+        run_service_call: Any,
+        notes_scope_service: Any,
+        notes_service: Any,
+        user_id: str,
+        clock: Any,
+    ) -> None:
+        self._run_service_call = run_service_call
+        self._notes_scope_service = notes_scope_service
+        self._notes_service = notes_service
+        self._user_id = user_id
+        self._clock = clock
+
+    @staticmethod
+    def _keyword_strings(records: Any) -> tuple[str, ...]:
+        """Return semantic keyword strings in their service-provided order."""
+        if records is None:
+            return ()
+        if isinstance(records, (str, bytes)) or not isinstance(records, Sequence):
+            raise TypeError("Keyword detail was not a sequence.")
+        keywords: list[str] = []
+        for record in records:
+            value = record.get("keyword") if isinstance(record, Mapping) else record
+            if value is None:
+                continue
+            keyword = value if isinstance(value, str) else str(value)
+            if keyword:
+                keywords.append(keyword)
+        return tuple(keywords)
+
+    async def load_note(self, note_id: str) -> DatabaseNotePortLoadReply:
+        """Fetch detail plus keywords and return one coherent typed reply."""
+        get_note_detail = getattr(self._notes_scope_service, "get_note_detail", None)
+        if not callable(get_note_detail):
+            return DatabaseNotePortLoadReply.failed("Note loading is unavailable.")
+        try:
+            detail = await self._run_service_call(
+                get_note_detail,
+                scope="local_note",
+                note_id=note_id,
+                user_id=self._user_id,
+                isolate_in_worker=True,
+            )
+            if detail is None:
+                return DatabaseNotePortLoadReply.missing()
+            if not isinstance(detail, Mapping):
+                return DatabaseNotePortLoadReply.failed(
+                    "Note detail was incomplete. Press Retry."
+                )
+
+            get_keywords = getattr(self._notes_service, "get_keywords_for_note", None)
+            if callable(get_keywords):
+                keyword_records = await self._run_service_call(
+                    get_keywords,
+                    self._user_id,
+                    note_id,
+                    isolate_in_worker=True,
+                )
+            elif "keywords" in detail:
+                keyword_records = detail["keywords"]
+            else:
+                return DatabaseNotePortLoadReply.failed(
+                    "Keyword loading is unavailable. Press Retry."
+                )
+            keywords = self._keyword_strings(keyword_records)
+            raw_note_id = detail.get("id", detail.get("note_id", note_id))
+            raw_title = detail.get("title", "")
+            raw_body = detail.get("content", detail.get("body", ""))
+            created_at = detail.get("created_at", "")
+            modified_at = detail.get(
+                "last_modified", detail.get("updated_at", created_at)
+            )
+            normalized = NormalizedDatabaseNote(
+                note_id=str(raw_note_id),
+                title=raw_title if isinstance(raw_title, str) else str(raw_title or ""),
+                body=raw_body if isinstance(raw_body, str) else str(raw_body or ""),
+                keywords=keywords,
+                version=int(detail.get("version", 0)),
+                created_at=(
+                    created_at if isinstance(created_at, str) else str(created_at or "")
+                ),
+                modified_at=(
+                    modified_at
+                    if isinstance(modified_at, str)
+                    else str(modified_at or "")
+                ),
+            )
+        except Exception as error:
+            logger.opt(exception=True).warning(
+                f"Failed to load Library note session for {note_id!r}."
+            )
+            failure_detail = str(error).strip()
+            return DatabaseNotePortLoadReply.failed(
+                (
+                    f"Unable to load note — {failure_detail.rstrip('.')}. Press Retry."
+                    if failure_detail
+                    else "Unable to load note. Press Retry."
+                )
+            )
+        return DatabaseNotePortLoadReply.loaded(normalized)
+
+    async def save_note(
+        self,
+        note_id: str,
+        expected_version: int,
+        payload: DatabaseNoteSavePayload,
+    ) -> DatabaseNotePortSaveReply:
+        """Persist one exact versioned payload and normalize the service reply."""
+        save_note = getattr(self._notes_scope_service, "save_note", None)
+        if not callable(save_note):
+            return DatabaseNotePortSaveReply.failed("Note saving is unavailable.")
+        try:
+            result = await self._run_service_call(
+                save_note,
+                scope="local_note",
+                title=payload.title,
+                content=payload.body,
+                note_id=note_id,
+                version=expected_version,
+                user_id=self._user_id,
+                keywords=list(payload.keywords),
+                isolate_in_worker=True,
+            )
+        except ConflictError:
+            return DatabaseNotePortSaveReply.conflict()
+        except Exception as error:
+            logger.opt(exception=True).warning(
+                f"Library note save failed for {note_id!r}."
+            )
+            return DatabaseNotePortSaveReply.failed(str(error))
+
+        if result is False:
+            return DatabaseNotePortSaveReply.conflict()
+        modified_at = self._clock().isoformat()
+        if result is True:
+            return DatabaseNotePortSaveReply.saved(
+                version=expected_version + 1,
+                modified_at=modified_at,
+                keywords=payload.keywords,
+            )
+        if isinstance(result, Mapping):
+            try:
+                version = int(result.get("version", expected_version + 1))
+                keywords = (
+                    self._keyword_strings(result["keywords"])
+                    if "keywords" in result
+                    else payload.keywords
+                )
+            except (TypeError, ValueError) as error:
+                return DatabaseNotePortSaveReply.failed(
+                    f"Save returned invalid note metadata: {error}"
+                )
+            returned_modified = result.get(
+                "last_modified", result.get("updated_at", modified_at)
+            )
+            return DatabaseNotePortSaveReply.saved(
+                version=version,
+                modified_at=(
+                    returned_modified
+                    if isinstance(returned_modified, str)
+                    else str(returned_modified or modified_at)
+                ),
+                keywords=keywords,
+            )
+        return DatabaseNotePortSaveReply.failed(
+            "Save returned an unexpected result — edits kept. Press Save to retry."
+        )
 
 LIBRARY_STUDY_HANDOFF_MODES = {
     "study": {
@@ -1721,18 +1908,23 @@ class LibraryScreen(BaseAppScreen):
         self._library_skill_trust_confirming_reset: bool = False
         self._library_note_detail: Mapping[str, Any] | None = None
         self._selected_note_id: str = ""
-        self._library_note_version: int | None = None
-        self._library_note_dirty: bool = False
+        note_session_port = _LibraryDatabaseNoteSessionPort(
+            run_service_call=self._run_library_service_call,
+            notes_scope_service=getattr(app_instance, "notes_scope_service", None),
+            notes_service=getattr(app_instance, "notes_service", None),
+            user_id=getattr(app_instance, "notes_user_id", None) or "default_user",
+            clock=lambda: datetime.now(timezone.utc),
+        )
+        self._library_note_session = DatabaseNoteSessionCoordinator(
+            note_session_port,
+            clock=lambda: datetime.now(timezone.utc),
+        )
+        self._library_note_load_state: str = "idle"
+        self._library_note_load_message: str = ""
         self._library_note_autosave_state: str = "idle"
         self._library_notes_autosave_timer: Timer | None = None
-        self._library_note_conflict_snapshot: LibraryNoteEditorState | None = None
         self._library_note_confirming_delete: bool = False
         self._library_note_preview: bool = False
-        # Live-capture snapshot seeded whenever the Preview toggle fires, so
-        # neither entering nor leaving preview drops unsaved edits (the
-        # Markdown widget shown in preview mode has no widget text of its
-        # own to read back). See ``handle_library_note_preview_toggle``.
-        self._library_note_preview_snapshot: LibraryNoteEditorState | None = None
         # Guards against the spurious ``Input.Changed`` that Textual fires
         # when an ``Input(value=...)`` widget mounts with a non-empty
         # initial value: without this, opening a note (or leaving a
@@ -2005,6 +2197,86 @@ class LibraryScreen(BaseAppScreen):
         if self._library_list_canvas_showing_list():
             return self.LIBRARY_LIST_SHORTCUTS
         return self.LIBRARY_GENERAL_SHORTCUTS
+
+    @property
+    def _library_note_detail(self) -> Mapping[str, Any] | None:
+        """Return a read-only compatibility projection of the session snapshot."""
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None:
+            return None
+        return {
+            "id": snapshot.note_id,
+            "title": snapshot.title,
+            "content": snapshot.body,
+            "keywords": snapshot.keywords_text,
+            "version": snapshot.version,
+            "created_at": snapshot.baseline.created_at,
+            "last_modified": snapshot.baseline.modified_at,
+        }
+
+    @property
+    def _library_note_version(self) -> int | None:
+        """Return the coordinator-owned optimistic-lock version."""
+        snapshot = self._library_note_session.snapshot
+        return snapshot.version if snapshot is not None else None
+
+    @property
+    def _library_note_dirty(self) -> bool:
+        """Return whether the canonical coordinator draft has unsaved edits."""
+        snapshot = self._library_note_session.snapshot
+        return snapshot.dirty if snapshot is not None else False
+
+    @property
+    def _library_note_conflict_snapshot(self) -> LibraryNoteEditorState | None:
+        """Return the canonical draft presentation while conflict is active."""
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None or not snapshot.in_conflict:
+            return None
+        return self._library_note_editor_state()
+
+    @property
+    def _library_note_preview_snapshot(self) -> LibraryNoteEditorState | None:
+        """Return the canonical draft presentation while preview is active."""
+        if not self._library_note_preview:
+            return None
+        return self._library_note_editor_state()
+
+    def _library_note_editor_state(self) -> LibraryNoteEditorState | None:
+        """Project the one canonical session snapshot into incumbent canvas state."""
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None:
+            return None
+        baseline_state = build_library_note_editor_state(
+            {
+                "id": snapshot.note_id,
+                "title": snapshot.baseline.title,
+                "content": snapshot.baseline.body,
+                "keywords": snapshot.baseline.keywords,
+                "version": snapshot.version,
+                "created_at": snapshot.baseline.created_at,
+                "last_modified": snapshot.baseline.modified_at,
+            }
+        )
+        if snapshot.in_conflict:
+            status = notes_autosave_status_text(
+                "conflict", word_count=self._note_word_count(snapshot.body)
+            )
+            if snapshot.status_message != "Conflict — review the choices below.":
+                status = f"{status} · {snapshot.status_message}"
+        else:
+            status = snapshot.status_message
+        meta_line = baseline_state.meta_line
+        if status:
+            meta_line = f"{meta_line} · {status}" if meta_line else status
+        return LibraryNoteEditorState(
+            note_id=snapshot.note_id,
+            title=snapshot.title,
+            content=snapshot.body,
+            keywords_text=snapshot.keywords_text,
+            version=snapshot.version,
+            meta_line=meta_line,
+            has_note=True,
+        )
 
     def _register_footer_shortcuts(self) -> None:
         """Register Library shortcuts via BaseAppScreen's persisting API.
@@ -2724,14 +2996,13 @@ class LibraryScreen(BaseAppScreen):
         tabs mid-edit.
 
         Returns:
-            False whenever unsaved edits survive the flush -- an unresolved
-            save conflict (the user must resolve the banner) or a failed
-            save (state "error"; the edits are still only in the editor).
-            Both veto the navigation so the screen instance holding the
-            edits is not discarded. True once nothing dirty remains.
+            True only for the coordinator's typed ``PERMITTED`` result and
+            successful prompt/skill barriers. Conflict, failure, validation,
+            blocked, and stale Notes outcomes all veto navigation even when a
+            presentation scalar or snapshot appears clean.
         """
         file_notes_flush_allowed = await self._flush_active_file_notes()
-        await self._flush_library_note_save()
+        note_flush = await self._flush_library_note_save()
         prompt_flush_allowed = await self._flush_library_prompt_save()
         skill_flush_allowed = await self._flush_library_skill_save()
         if not skill_flush_allowed:
@@ -2743,7 +3014,7 @@ class LibraryScreen(BaseAppScreen):
             self._notify_skill_dirty_veto()
         return (
             file_notes_flush_allowed
-            and not self._library_note_dirty
+            and note_flush.kind is NoteFlushOutcomeKind.PERMITTED
             and prompt_flush_allowed
             and skill_flush_allowed
         )
@@ -2813,8 +3084,8 @@ class LibraryScreen(BaseAppScreen):
         context: Mapping[str, Any],
     ) -> None:
         """Apply mounted navigation context while source admission is held."""
-        await self._flush_library_note_save()
-        if self._library_note_dirty:
+        note_flush = await self._flush_library_note_save()
+        if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
         self._apply_navigation_context_state(context, recompose=False)
         if self.is_mounted:
@@ -2928,29 +3199,21 @@ class LibraryScreen(BaseAppScreen):
             # this is exercised only by tests until such a producer is wired --
             # not orphaned wiring.
             self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
-            self._selected_note_id = note_id
-            self._library_notes_view = "editor"
-            self._library_note_detail = None
-            self._library_note_version = None
-            self._library_note_dirty = False
-            self._library_note_autosave_state = "idle"
-            self._library_note_conflict_snapshot = None
-            self._library_note_confirming_delete = False
-            self._library_note_preview = False
-            self._library_note_preview_snapshot = None
-            self._library_note_editor_armed = False
-            # LIB-14: a deep link always lands on a note by explicit id
-            # (never "Blank note"), so neither flag ever applies to it --
-            # clear both defensively in case a still-open session blank
-            # from a DIFFERENT note is left behind by this jump.
+            if self.is_mounted:
+                self._begin_library_note_load(note_id)
+            else:
+                self._library_note_session.close_session()
+                self._selected_note_id = note_id
+                self._library_notes_view = "editor"
+                self._library_note_load_state = "loading"
+                self._library_note_load_message = ""
+                self._library_note_autosave_state = "idle"
+                self._library_note_confirming_delete = False
+                self._library_note_preview = False
+                self._library_note_editor_armed = False
+            # A deep link never owns the current blank-note GC identity.
             self._library_note_pending_blank_gc_id = None
             self._library_note_session_blank_id = None
-            if self.is_mounted:
-                self.run_worker(
-                    self._refresh_library_note_detail(note_id),
-                    exclusive=True,
-                    group="library_note_detail",
-                )
         if open_source_type and open_source_id and self.is_mounted:
             self.run_worker(
                 self._open_pending_library_source(),
@@ -3477,8 +3740,8 @@ class LibraryScreen(BaseAppScreen):
         batched-join DB seam or N per-row ``fetch_keywords_for_prompt`` calls;
         the notes list canvas sets the precedent for skipping this (its own
         bulk ``list_notes`` fetch has never carried keywords either -- only
-        the single-note editor enriches, via
-        ``_fetch_library_note_keywords``), so this deliberately matches that
+        the single-note session port enriches in its normalized load reply),
+        so this deliberately matches that
         precedent rather than fetching keywords per row here. ``details``,
         unlike keywords, IS cheap to carry (a single extra column on the same
         query, Task 8b D2) -- ``build_prompts_list_state``'s filter/secondary-
@@ -4987,37 +5250,44 @@ class LibraryScreen(BaseAppScreen):
                     shell.canvas_kind == "notes"
                     and self._library_notes_view == "editor"
                 ):
-                    if self._library_note_conflict_snapshot is not None:
-                        # A save just lost an optimistic-lock race: recompose
-                        # from the user's own kept text (never the stale
-                        # ``_library_note_detail``) with the Overwrite/Reload
-                        # actions surfaced.
+                    editor_state = self._library_note_editor_state()
+                    if (
+                        editor_state is not None
+                        and self._library_note_conflict_snapshot
+                    ):
                         yield LibraryNotesCanvas(
                             mode="editor",
-                            editor_state=self._library_note_conflict_snapshot,
+                            editor_state=editor_state,
                             conflict=True,
                             id="library-notes-canvas",
                         )
-                    elif self._library_note_detail is None:
-                        yield Static(
-                            "Loading note…",
-                            id="library-note-loading",
-                            classes="destination-purpose",
-                            markup=False,
-                        )
-                    else:
-                        # The Preview snapshot (when present) carries the
-                        # live -- possibly unsaved -- text captured by the
-                        # last Preview toggle, so restoring from preview (or
-                        # any other recompose while it's live) never reverts
-                        # to the stale on-disk ``_library_note_detail``.
-                        editor_state = (
-                            self._library_note_preview_snapshot
-                            if self._library_note_preview_snapshot is not None
-                            else build_library_note_editor_state(
-                                self._library_note_detail
+                    elif editor_state is None:
+                        with Vertical(id="library-note-load-state"):
+                            yield Button(
+                                "‹ Back to list",
+                                id="library-note-back",
+                                classes="library-canvas-action",
+                                compact=True,
                             )
-                        )
+                            load_copy = (
+                                self._library_note_load_message
+                                if self._library_note_load_state == "failed"
+                                else "Loading note…"
+                            )
+                            yield Static(
+                                load_copy,
+                                id="library-note-loading",
+                                classes="destination-purpose",
+                                markup=False,
+                            )
+                            if self._library_note_load_state == "failed":
+                                yield Button(
+                                    "Retry",
+                                    id="library-note-load-retry",
+                                    classes="library-canvas-action",
+                                    compact=True,
+                                )
+                    else:
                         yield LibraryNotesCanvas(
                             mode="editor",
                             editor_state=editor_state,
@@ -5697,60 +5967,27 @@ class LibraryScreen(BaseAppScreen):
             self.refresh(recompose=True)
 
     async def _refresh_library_note_detail(self, note_id: str) -> None:
-        """Fetch and store the full detail for a selected Library note.
-
-        Mirrors ``_refresh_library_media_detail``: offloads the (possibly
-        blocking) ``get_note_detail`` service call via
-        ``_run_library_service_call`` and recomposes once the fetched detail
-        (or a cleared/failed state) has been stored.
-
-        Triggered by ``handle_library_notes_row`` on note-row selection;
-        ``compose_content`` renders the stored ``_library_note_detail`` via
-        ``build_library_note_editor_state`` once this worker completes.
+        """Open one normalized coordinator session and apply its typed outcome.
 
         Args:
             note_id: The Library note id to fetch full detail for.
         """
-        service = getattr(self.app_instance, "notes_scope_service", None)
-        get_note_detail = getattr(service, "get_note_detail", None)
-        if not callable(get_note_detail):
-            self._library_note_detail = None
-            self._library_note_version = None
-            if self.is_mounted:
-                self.refresh(recompose=True)
-            return
-        try:
-            detail = await self._run_library_service_call(
-                get_note_detail,
-                scope="local_note",
-                note_id=note_id,
-                user_id=getattr(self.app_instance, "notes_user_id", None)
-                or "default_user",
-                isolate_in_worker=True,
-            )
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Failed to load Library note detail for {note_id!r}."
-            )
-            detail = None
-        # Discard out-of-order results: if the user has since selected a
-        # different note (or left the editor), a slower in-flight fetch for
-        # the previous selection must not overwrite the current one -- the
-        # same stale-race guard as ``_refresh_library_media_detail``.
         if (
             note_id != self._selected_note_id
             or self._library_notes_view != "editor"
             or self._library_notes_source != "database"
         ):
             return
-        if not isinstance(detail, Mapping):
-            # The note no longer exists -- deleted elsewhere, or a stale
-            # ghost row from an already-out-of-date list snapshot. Leaving
-            # ``_library_note_detail`` at ``None`` here would strand the
-            # canvas on the "Loading note…" placeholder forever (it never
-            # becomes a real dict). Fall back to the list view instead of
-            # that dead end, mirroring the delete-success flow's full
-            # snapshot reload.
+        outcome = await self._library_note_session.open_session(note_id)
+        if outcome.kind is NoteLoadOutcomeKind.STALE:
+            return
+        if (
+            note_id != self._selected_note_id
+            or self._library_notes_view != "editor"
+            or self._library_notes_source != "database"
+        ):
+            return
+        if outcome.kind is NoteLoadOutcomeKind.MISSING:
             logger.info(
                 f"Library note {note_id!r} is no longer available; returning to list."
             )
@@ -5760,74 +5997,40 @@ class LibraryScreen(BaseAppScreen):
             if self.is_mounted:
                 self.refresh(recompose=True)
             return
-        self._library_note_detail = detail
-        keywords = await self._fetch_library_note_keywords(note_id)
-        # Fetching keywords is a second await point: re-check freshness the
-        # same way ``_refresh_library_media_detail`` re-checks after its own
-        # second (highlights) fetch, so a switch that happened during that
-        # fetch cannot land keywords for the wrong note.
-        if (
-            note_id != self._selected_note_id
-            or self._library_notes_view != "editor"
-            or self._library_notes_source != "database"
-        ):
+        if outcome.kind is NoteLoadOutcomeKind.FAILED:
+            self._library_note_load_state = "failed"
+            self._library_note_load_message = (
+                outcome.message or "Unable to load note. Press Retry."
+            )
+            if self.is_mounted:
+                self.refresh(recompose=True)
             return
-        if keywords is not None and isinstance(self._library_note_detail, Mapping):
-            enriched_detail = dict(self._library_note_detail)
-            enriched_detail["keywords"] = keywords
-            self._library_note_detail = enriched_detail
-        editor_state = build_library_note_editor_state(self._library_note_detail)
-        self._library_note_version = editor_state.version
-        self._library_note_dirty = False
+
+        self._library_note_load_state = "loaded"
+        self._library_note_load_message = ""
         self._library_note_autosave_state = "idle"
-        self._library_note_conflict_snapshot = None
         self._library_note_preview = False
-        self._library_note_preview_snapshot = None
         self._library_note_editor_armed = False
         if self.is_mounted:
             self.refresh(recompose=True)
             self.call_after_refresh(self._arm_library_note_editor)
 
-    async def _fetch_library_note_keywords(self, note_id: str) -> list[Any] | None:
-        """Fetch a Library note's keywords for the in-canvas editor.
-
-        ``notes_scope_service.get_note_detail``'s local-scope shape is the
-        raw ``notes`` table row and never carries a ``keywords`` field (see
-        ``NotesInteropService.get_note_by_id``) -- keywords live in a
-        separate join table. This fetches them through the standalone
-        Notes screen's own seam, ``app.notes_service.get_keywords_for_note``
-        (``NotesInteropService.get_keywords_for_note(user_id, note_id)``,
-        which returns the ``ChaChaNotes_DB.get_keywords_for_note`` row
-        shape -- each item a mapping with a ``keyword`` key), offloaded off
-        the UI loop the same way every other Library service call is.
-
-        Args:
-            note_id: The Library note id to fetch keywords for.
-
-        Returns:
-            The fetched keyword records, or ``None`` when
-            ``app.notes_service`` (or the method) is unavailable or the
-            fetch fails -- callers should leave the detail's keywords field
-            untouched in that case, the same quiet-absent behavior as
-            before this enrichment existed.
-        """
-        notes_service = getattr(self.app_instance, "notes_service", None)
-        get_keywords_for_note = getattr(notes_service, "get_keywords_for_note", None)
-        if not callable(get_keywords_for_note):
-            return None
-        try:
-            keywords = await self._run_library_service_call(
-                get_keywords_for_note,
-                self._library_notes_user_id(),
-                note_id,
-                isolate_in_worker=True,
-            )
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Failed to load keywords for Library note {note_id!r}."
-            )
-            return None
-        return list(keywords) if isinstance(keywords, list) else None
+    def _begin_library_note_load(self, note_id: str) -> None:
+        """Reset presentation, invalidate old work, and start one editor load."""
+        self._library_note_session.close_session()
+        self._selected_note_id = note_id
+        self._library_notes_view = "editor"
+        self._library_note_load_state = "loading"
+        self._library_note_load_message = ""
+        self._library_note_autosave_state = "idle"
+        self._library_note_confirming_delete = False
+        self._library_note_preview = False
+        self._library_note_editor_armed = False
+        self.run_worker(
+            self._refresh_library_note_detail(note_id),
+            exclusive=True,
+            group="library_note_detail",
+        )
 
     def _arm_library_note_editor(self) -> None:
         """Enable dirty-tracking once the notes editor's mount-time
@@ -5843,16 +6046,14 @@ class LibraryScreen(BaseAppScreen):
         selection so every exit from the editor leaves save/autosave/
         conflict tracking in a clean ``idle`` state for the next note.
         """
+        self._library_note_session.close_session()
         self._library_notes_view = "list"
-        self._library_note_detail = None
         self._selected_note_id = ""
-        self._library_note_version = None
-        self._library_note_dirty = False
+        self._library_note_load_state = "idle"
+        self._library_note_load_message = ""
         self._library_note_autosave_state = "idle"
-        self._library_note_conflict_snapshot = None
         self._library_note_confirming_delete = False
         self._library_note_preview = False
-        self._library_note_preview_snapshot = None
         self._library_note_editor_armed = False
         # Defense in depth: the normal exit path is ``_flush_library_note_
         # save`` (which GCs a still-pending blank note and clears both
@@ -6001,8 +6202,8 @@ class LibraryScreen(BaseAppScreen):
                 LIBRARY_EXPORT_SERVER_DISABLED_TOOLTIP, severity="warning"
             )
             return
-        await self._flush_library_note_save()
-        if self._library_note_autosave_state == "conflict":
+        note_flush = await self._flush_library_note_save()
+        if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
         self._library_selected_row_id = LIBRARY_ROW_INGEST_EXPORT
         self._reset_library_export_transient_state(scope)
@@ -7386,34 +7587,14 @@ class LibraryScreen(BaseAppScreen):
 
     # ----- Notes editor: save, autosave, conflict policy -----------------
 
-    def _mark_library_note_dirty(self) -> None:
-        """Record an in-progress edit and (re)arm the autosave debounce.
-
-        Ignored until ``_library_note_editor_armed`` is set (see that
-        flag's docstring) and while a save conflict is being shown --
-        autosaving against a version that is already known to be stale
-        would just recreate the same conflict on a timer.
-        """
-        if not self._library_note_editor_armed:
+    def _schedule_library_note_autosave(self) -> None:
+        """Rearm debounce after one genuine coordinator-owned draft mutation."""
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None or snapshot.in_conflict or snapshot.saving:
             return
-        self._library_note_dirty = True
-        # LIB-14: a real edit (this is only reached once armed, i.e. never
-        # for the mount-time phantom Input/TextArea.Changed) stops the
-        # title Input from showing the "Untitled" placeholder on the next
-        # recompose -- no recompose is forced here, matching this method's
-        # existing silent (no per-keystroke recompose) discipline; the
-        # mounted Input already shows whatever the user is typing
-        # regardless of this flag. Deliberately does NOT clear
-        # ``_library_note_session_blank_id`` -- that flag's whole purpose
-        # is to survive edits so a later "typed then deleted everything"
-        # exit still GCs (see that flag's own docstring).
-        self._library_note_pending_blank_gc_id = None
-        if self._library_note_autosave_state == "conflict":
-            return
+        self._library_note_autosave_state = "idle"
         if self._library_notes_autosave_timer is not None:
             self._library_notes_autosave_timer.stop()
-        # Read as a bare module global (not a captured default) so tests can
-        # monkeypatch LIBRARY_NOTES_AUTOSAVE_SECONDS to a short interval.
         self._library_notes_autosave_timer = self.set_timer(
             LIBRARY_NOTES_AUTOSAVE_SECONDS, self._fire_library_note_autosave
         )
@@ -7425,7 +7606,10 @@ class LibraryScreen(BaseAppScreen):
         Args:
             event: Input change event emitted by the editor's title field.
         """
-        self._mark_library_note_dirty()
+        if not self._library_note_editor_armed:
+            return
+        if self._library_note_session.mutate(title=event.value):
+            self._schedule_library_note_autosave()
 
     @on(TextArea.Changed, "#library-note-body")
     def handle_library_note_body_changed(self, event: TextArea.Changed) -> None:
@@ -7434,7 +7618,10 @@ class LibraryScreen(BaseAppScreen):
         Args:
             event: Text change event emitted by the editor's body ``TextArea``.
         """
-        self._mark_library_note_dirty()
+        if not self._library_note_editor_armed:
+            return
+        if self._library_note_session.mutate(body=event.text_area.text):
+            self._schedule_library_note_autosave()
 
     @on(Input.Changed, "#library-note-keywords")
     def handle_library_note_keywords_changed(self, event: Input.Changed) -> None:
@@ -7443,7 +7630,10 @@ class LibraryScreen(BaseAppScreen):
         Args:
             event: Input change event emitted by the editor's keywords field.
         """
-        self._mark_library_note_dirty()
+        if not self._library_note_editor_armed:
+            return
+        if self._library_note_session.mutate(keywords_text=event.value):
+            self._schedule_library_note_autosave()
 
     def _fire_library_note_autosave(self) -> None:
         """Debounce-timer callback: kick the actual autosave worker."""
@@ -7478,7 +7668,17 @@ class LibraryScreen(BaseAppScreen):
 
     def _library_note_meta_base_line(self) -> str:
         """The static Created/Modified/version portion of the meta line."""
-        return build_library_note_editor_state(self._library_note_detail).meta_line
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None:
+            return ""
+        return build_library_note_editor_state(
+            {
+                "id": snapshot.note_id,
+                "version": snapshot.version,
+                "created_at": snapshot.baseline.created_at,
+                "last_modified": snapshot.baseline.modified_at,
+            }
+        ).meta_line
 
     def _update_library_note_meta_static(self, *, content: str) -> None:
         """Targeted update of the meta line's autosave status suffix.
@@ -7499,272 +7699,208 @@ class LibraryScreen(BaseAppScreen):
         status_text = notes_autosave_status_text(
             self._library_note_autosave_state, word_count=self._note_word_count(content)
         )
+        snapshot = self._library_note_session.snapshot
+        if (
+            snapshot is not None
+            and snapshot.status_message
+            and (
+                snapshot.dirty
+                or self._library_note_autosave_state in {"error", "validation"}
+            )
+        ):
+            word_count = self._note_word_count(content)
+            word_copy = f"{word_count} words" if word_count != 1 else "1 word"
+            status_text = f"{word_copy} · {snapshot.status_message}"
         base_meta_line = self._library_note_meta_base_line()
         meta_static.update(
             f"{base_meta_line} · {status_text}" if base_meta_line else status_text
         )
 
+    def _patch_library_note_list_from_session(self) -> None:
+        """Patch list caches from the payload the coordinator actually saved."""
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None:
+            return
+        baseline = snapshot.baseline
+        self._local_source_records["notes"] = patch_note_records_after_save(
+            self._local_source_records.get("notes", ()),
+            baseline.note_id,
+            title=baseline.title,
+            modified_at=baseline.modified_at,
+        )
+        if self._library_notes_filter_records is not None:
+            self._library_notes_filter_records = list(
+                patch_note_records_after_save(
+                    self._library_notes_filter_records,
+                    baseline.note_id,
+                    title=baseline.title,
+                    modified_at=baseline.modified_at,
+                )
+            )
+
+    def _focus_library_note_validation_field(self, field: str) -> None:
+        """Restore keyboard focus to the field named by a validation veto."""
+        selector = {
+            "title": "#library-note-title",
+            "body": "#library-note-body",
+            "keywords": "#library-note-keywords",
+        }.get(field)
+        if selector is None or not self.is_mounted:
+            return
+
+        def focus_field() -> None:
+            try:
+                self.query_one(selector).focus()
+            except (NoMatches, QueryError):
+                return
+
+        self.call_after_refresh(focus_field)
+
+    def _focus_library_note_conflict_callout(self) -> None:
+        """Move keyboard focus to the explanatory conflict callout."""
+        try:
+            callout = self.query_one("#library-note-conflict-copy", Static)
+        except (NoMatches, QueryError):
+            return
+        callout.can_focus = True
+        callout.focus()
+
+    def _apply_library_note_saved_presentation(
+        self,
+        outcome: NoteSaveOutcome,
+    ) -> None:
+        """Present saved only when the outcome still covers the latest draft."""
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None or snapshot.note_id != self._selected_note_id:
+            return
+        if outcome.kind is NoteSaveOutcomeKind.SAVED:
+            self._patch_library_note_list_from_session()
+        is_current_clean_revision = (
+            not snapshot.dirty
+            and outcome.revision is not None
+            and outcome.revision == snapshot.saved_revision
+        )
+        self._library_note_autosave_state = (
+            "saved" if is_current_clean_revision else "idle"
+        )
+        self._update_library_note_meta_static(content=snapshot.body)
+
+    def _apply_library_note_save_outcome(self, outcome: NoteSaveOutcome) -> None:
+        """Translate one typed coordinator save outcome into screen presentation."""
+        snapshot = self._library_note_session.snapshot
+        if outcome.kind is NoteSaveOutcomeKind.STALE or snapshot is None:
+            return
+        if snapshot.note_id != self._selected_note_id:
+            return
+        if outcome.kind in {
+            NoteSaveOutcomeKind.SAVED,
+            NoteSaveOutcomeKind.ACKNOWLEDGED,
+        }:
+            self._apply_library_note_saved_presentation(outcome)
+            return
+        if outcome.kind is NoteSaveOutcomeKind.CONFLICTED:
+            self._library_note_autosave_state = "conflict"
+            self._library_note_preview = False
+            self._library_note_editor_armed = False
+            if self._library_notes_autosave_timer is not None:
+                self._library_notes_autosave_timer.stop()
+                self._library_notes_autosave_timer = None
+            if self.is_mounted:
+                self.refresh(recompose=True)
+                self.call_after_refresh(self._arm_library_note_editor)
+                self.call_after_refresh(self._focus_library_note_conflict_callout)
+            return
+        self._library_note_autosave_state = (
+            "validation"
+            if outcome.kind is NoteSaveOutcomeKind.VALIDATION_VETO
+            else "error"
+        )
+        validation_field = outcome.veto.field if outcome.veto is not None else ""
+        if self._library_note_preview:
+            self._library_note_preview = False
+            self._library_note_editor_armed = False
+            if self.is_mounted:
+                self.refresh(recompose=True)
+                self.call_after_refresh(self._arm_library_note_editor)
+                self._focus_library_note_validation_field(validation_field)
+            return
+        self._update_library_note_meta_static(content=snapshot.body)
+        self._focus_library_note_validation_field(validation_field)
+
     async def _save_library_note(self, *, explicit: bool) -> None:
-        """Save the open Library note's current editor text.
-
-        Reads title/content/keywords via ``_read_library_note_editor_fields``
-        (which tolerates the Preview toggle, falling back to the live-capture
-        snapshot for the body when ``#library-note-body`` isn't mounted),
-        sanitizes the fields, and calls ``save_note`` through the offloaded
-        service seam (``note_id``/``version`` supplied, so this is always the
-        update path). A successful save bumps ``_library_note_version`` in memory
-        and updates only the meta line -- it never recomposes, so the
-        ``TextArea``/``Input`` widget instances stay identical across a
-        save. A version conflict (a falsy result from the seam, or a
-        ``ConflictError`` raised by the real local notes service on a
-        stale ``expected_version``) cancels the autosave timer and
-        recomposes into the conflict UI, re-seeded from the user's live
-        widget text -- never from the stale ``_library_note_detail``.
-
-        The save is awaited inline (see ``_flush_library_note_save``, which
-        bypasses the exclusive ``library_note_save`` worker group), so
-        another note can become selected while this call is still in
-        flight. Every branch below therefore re-checks that the note this
-        save was *for* is still the selected one -- and the editor is still
-        showing -- before mutating any shared editor state, mirroring the
-        stale-result guard in ``_refresh_library_note_detail`` and
-        ``_resolve_library_note_conflict``.
+        """Ask the portable coordinator to serialize the canonical draft.
 
         Args:
             explicit: Whether this save was triggered by the Save button
-                (``True``) or the autosave debounce/flush (``False``). Not
-                currently used to vary behavior, but kept for call-site
-                clarity and future use (e.g. differentiated error copy).
+                (``True``) or the autosave debounce/flush (``False``). The
+                coordinator uses an explicit no-op Save to acknowledge an
+                untouched newly created note without calling persistence.
         """
-        if self._library_notes_view != "editor" or not self._selected_note_id:
-            return
-        note_id = self._selected_note_id
-        fields = self._read_library_note_editor_fields()
-        if fields is None:
-            return
-        raw_title, raw_content, raw_keywords_text = fields
-
-        # LIB-14: the title Input can now render genuinely empty (see
-        # ``title_placeholder_only``) for a pristine "Blank note" the user
-        # tabs/clicks past without typing a title -- a note otherwise
-        # always has a non-blank title, so an empty save falls back to the
-        # same "Untitled" default the create seam itself uses, rather than
-        # persisting a blank one.
-        title = self._sanitize_media_field(raw_title, max_length=300) or "Untitled"
-        content = self._sanitize_note_content(
-            raw_content, max_length=LIBRARY_NOTE_CONTENT_MAX_CHARS
-        )
-        keywords = self._library_note_keywords_from_input(raw_keywords_text)
-
-        service = getattr(self.app_instance, "notes_scope_service", None)
-        save_note = getattr(service, "save_note", None)
-        if not callable(save_note):
-            return
-
-        self._library_note_autosave_state = "saving"
-
-        try:
-            result = await self._run_library_service_call(
-                save_note,
-                scope="local_note",
-                title=title,
-                content=content,
-                note_id=note_id,
-                version=self._library_note_version,
-                user_id=self._library_notes_user_id(),
-                keywords=keywords,
-                isolate_in_worker=True,
-            )
-        except ConflictError:
-            result = False
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Library note save failed for {note_id!r}."
-            )
-            if (
-                note_id != self._selected_note_id
-                or self._library_notes_view != "editor"
-            ):
-                return
-            self._library_note_autosave_state = "error"
-            self._update_library_note_meta_static(content=raw_content)
-            return
-
-        # Discard a stale result: the user has since switched to a
-        # different note (or left the editor) while this save was in
-        # flight. Mutating shared state past this point would land this
-        # note's save result -- version bump, meta line, or conflict UI --
-        # on whatever note is now selected.
-        if note_id != self._selected_note_id or self._library_notes_view != "editor":
-            return
-
-        if result:
-            if isinstance(result, Mapping):
-                version = result.get("version")
-                if version is not None:
-                    self._library_note_version = version
-            else:
-                self._library_note_version = (self._library_note_version or 0) + 1
-            if isinstance(self._library_note_detail, dict):
-                # Patch the just-saved fields into the cached detail mirror
-                # too, not just ``version`` -- a save never recomposes the
-                # editor itself, but a *later* recompose (entering the
-                # delete-confirm state, toggling Preview, ...) rebuilds the
-                # editor's widgets fresh from this detail. Leaving
-                # title/content stale here would silently revert the
-                # just-saved edit back to its pre-save text on that
-                # recompose.
-                self._library_note_detail["version"] = self._library_note_version
-                self._library_note_detail["title"] = title
-                self._library_note_detail["content"] = content
-                if isinstance(result, Mapping) and "keywords" in result:
-                    self._library_note_detail["keywords"] = result["keywords"]
-                elif keywords is not None:
-                    self._library_note_detail["keywords"] = keywords
-            # Patch the cached notes-list snapshot too (title + a fresh
-            # last_modified), not just the detail mirror: the list view is
-            # rendered from these records on the next Back-to-list, and
-            # without this it kept showing the pre-save title, stale
-            # relative age, and stale Newest ordering until a full
-            # snapshot refetch landed (2026-07 UAT finding).
-            saved_stamp = datetime.now(timezone.utc).isoformat()
-            self._local_source_records["notes"] = patch_note_records_after_save(
-                self._local_source_records.get("notes", ()),
-                note_id,
-                title=title,
-                modified_at=saved_stamp,
-            )
-            if self._library_notes_filter_records is not None:
-                self._library_notes_filter_records = list(
-                    patch_note_records_after_save(
-                        self._library_notes_filter_records,
-                        note_id,
-                        title=title,
-                        modified_at=saved_stamp,
-                    )
-                )
-            self._library_note_dirty = False
-            self._library_note_autosave_state = "saved"
-            self._update_library_note_meta_static(content=raw_content)
-            return
-
-        # Falsy result: another writer changed the note first (an
-        # optimistic-lock version conflict). Stop any pending autosave and
-        # recompose into the conflict UI, re-seeded from the user's live
-        # widget text so nothing they typed is lost.
-        self._library_note_autosave_state = "conflict"
-        if self._library_notes_autosave_timer is not None:
-            self._library_notes_autosave_timer.stop()
-            self._library_notes_autosave_timer = None
-        base_meta_line = self._library_note_meta_base_line()
-        conflict_status = notes_autosave_status_text(
-            "conflict", word_count=self._note_word_count(raw_content)
-        )
-        self._library_note_conflict_snapshot = LibraryNoteEditorState(
-            note_id=note_id,
-            title=raw_title,
-            content=raw_content,
-            keywords_text=raw_keywords_text,
-            version=self._library_note_version,
-            meta_line=(
-                f"{base_meta_line} · {conflict_status}"
-                if base_meta_line
-                else conflict_status
-            ),
-            has_note=True,
-        )
-        self._library_note_preview = False
-        self._library_note_preview_snapshot = None
-        self._library_note_editor_armed = False
-        if self.is_mounted:
-            self.refresh(recompose=True)
-            self.call_after_refresh(self._arm_library_note_editor)
-
-    async def _flush_library_note_save(self) -> None:
-        """Save any pending edit before the notes editor is left.
-
-        Called at the top of the Back handler, note-row selection, and
-        rail-row selection so a dirty edit is never silently discarded by
-        navigating away.
-
-        Cancels the pending autosave timer, then WAITS for any save already
-        running in the ``library_note_save`` worker group (an autosave that
-        fired just before this navigation) before deciding whether an inline
-        save is still needed. Without the wait, this inline flush and the
-        in-flight autosave both call ``save_note`` with the same
-        not-yet-bumped version -- an optimistic-lock conflict that fires
-        against the note's *own* autosave and pops a spurious "changed
-        elsewhere" banner, aborting the navigation. After the in-flight save
-        finishes it has already persisted the text and cleared the dirty
-        flag, so the re-check below usually short-circuits; the inline save
-        only runs when edits genuinely remain, and then against the bumped
-        version.
-
-        LIB-14 (AC#5): this is also the single choke point every editor-exit
-        path already awaits before tearing the editor down, so it doubles
-        as the GC point for this session's "Blank note" whenever it ends
-        up empty -- see ``_gc_pending_blank_note``. The GC check runs
-        BEFORE the dirty check below and is gated on final live emptiness,
-        not on ``_library_note_dirty``, so it covers both a note that was
-        never touched (never dirty) AND one that was typed into and then
-        emptied back out again (dirty, but finally empty) -- the latter
-        being the case the first version of this fix (dirty-gated) missed.
-        A real in-progress edit that leaves genuine content behind is
-        never at risk of being mistaken for GC-eligible, since the
-        emptiness check reads the live fields, not the dirty flag.
-        """
-        if self._library_notes_autosave_timer is not None:
-            self._library_notes_autosave_timer.stop()
-            self._library_notes_autosave_timer = None
-        for worker in list(self.workers):
-            if worker.group == "library_note_save" and not worker.is_finished:
-                try:
-                    await worker.wait()
-                except Exception:
-                    logger.opt(exception=True).debug(
-                        "In-flight note-save worker errored while flushing; continuing.",
-                    )
-        # LIB-14 (review round 1 fix, task-2858 T3): decide GC-vs-save on
-        # this session's blank note (if any is open) from its FINAL live
-        # state, not from ``_library_note_dirty`` -- a dirty-gated check
-        # would route "typed then deleted everything back to empty"
-        # through the save branch below, persisting exactly the stray
-        # "Untitled" row AC#5 forbids. Reading live fields (never the
-        # stale ``_library_note_detail``) covers both "never touched"
-        # (fields are trivially empty) and "typed then emptied" (fields
-        # are empty again after edits) with the ONE check -- no separate
-        # not-dirty branch is needed any more. The scope guard is
-        # structural: ``_library_note_session_blank_id`` is only ever set
-        # by the "Blank note" create path, so a pre-existing note that the
-        # user empties out never matches here and always falls through to
-        # the normal save branch.
+        snapshot = self._library_note_session.snapshot
         if (
-            self._library_note_session_blank_id
-            and self._library_note_session_blank_id == self._selected_note_id
+            self._library_notes_view != "editor"
+            or snapshot is None
+            or snapshot.note_id != self._selected_note_id
         ):
-            fields = self._read_library_note_editor_fields()
-            if fields is not None:
-                raw_title, raw_content, raw_keywords_text = fields
-                # "Effectively empty" = title, body, AND keywords all blank
-                # -- keywords count too (a user-provided tag on an
-                # otherwise-blank note is still user content worth
-                # keeping, not noise). The title Input never actually
-                # holds the literal string "Untitled" unless the user
-                # typed it themselves (LIB-14a renders it as an empty
-                # value + a placeholder, never a real value) -- so a
-                # plain ``.strip()`` emptiness check already captures
-                # "still showing the placeholder" with no separate
-                # "Untitled"-string special case needed.
-                if (
-                    not raw_title.strip()
-                    and not raw_content.strip()
-                    and not raw_keywords_text.strip()
-                ):
-                    await self._gc_pending_blank_note()
-                    return
-        if not self._library_note_dirty:
             return
-        await self._save_library_note(explicit=False)
+        self._library_note_autosave_state = "saving"
+        self._update_library_note_meta_static(content=snapshot.body)
+        outcome = await self._library_note_session.request_save(explicit=explicit)
+        self._apply_library_note_save_outcome(outcome)
+
+    async def _flush_library_note_save(self) -> NoteFlushOutcome:
+        """Cross the coordinator's pending-work barrier before navigation."""
+        if self._library_notes_autosave_timer is not None:
+            self._library_notes_autosave_timer.stop()
+            self._library_notes_autosave_timer = None
+        before = self._library_note_session.snapshot
+        before_saved_revision = before.saved_revision if before is not None else None
+        outcome = await self._library_note_session.flush()
+        snapshot = self._library_note_session.snapshot
+        if outcome.kind is NoteFlushOutcomeKind.PERMITTED:
+            if (
+                snapshot is not None
+                and before_saved_revision is not None
+                and snapshot.saved_revision > before_saved_revision
+            ):
+                self._patch_library_note_list_from_session()
+                self._library_note_autosave_state = (
+                    "idle" if snapshot.dirty else "saved"
+                )
+                self._update_library_note_meta_static(content=snapshot.body)
+            return outcome
+        if snapshot is None:
+            return outcome
+        if outcome.kind is NoteFlushOutcomeKind.CONFLICTED:
+            self._library_note_autosave_state = "conflict"
+            self._library_note_preview = False
+            self._library_note_editor_armed = False
+            if self.is_mounted:
+                self.refresh(recompose=True)
+                self.call_after_refresh(self._arm_library_note_editor)
+                self.call_after_refresh(self._focus_library_note_conflict_callout)
+            return outcome
+        if outcome.kind is NoteFlushOutcomeKind.BLOCKED:
+            return outcome
+        self._library_note_autosave_state = (
+            "validation"
+            if outcome.kind is NoteFlushOutcomeKind.VALIDATION_VETO
+            else "error"
+        )
+        if (
+            outcome.kind is NoteFlushOutcomeKind.VALIDATION_VETO
+            and self._library_note_preview
+        ):
+            self._library_note_preview = False
+            self._library_note_editor_armed = False
+            if self.is_mounted:
+                self.refresh(recompose=True)
+                self.call_after_refresh(self._arm_library_note_editor)
+        else:
+            self._update_library_note_meta_static(content=snapshot.body)
+        if outcome.save_outcome is not None and outcome.save_outcome.veto is not None:
+            self._focus_library_note_validation_field(outcome.save_outcome.veto.field)
+        return outcome
 
     async def _gc_pending_blank_note(self) -> None:
         """Delete this session's now-empty "Blank note" row before it is left behind (LIB-14).
@@ -7854,162 +7990,59 @@ class LibraryScreen(BaseAppScreen):
             self._refresh_local_source_snapshot()
 
     async def _resolve_library_note_conflict(self, *, overwrite: bool) -> None:
-        """Resolve a shown save conflict via the Overwrite or Reload action.
-
-        Both paths silently re-fetch the note's current server-side detail
-        first (no "Loading…" placeholder -- the conflict UI stays put while
-        this happens).
-
-        * ``overwrite=True``: take only the fresh ``version`` from that
-          detail and re-save the user's *live* editor text (read fresh from
-          the widgets, not the recompose-time snapshot, so further edits
-          made while the conflict banner was showing are not lost) with
-          that version. On success, the local detail mirror is patched
-          (not fully reloaded) with the saved fields so a normal-mode
-          recompose renders the kept text, and the conflict state clears.
-        * ``overwrite=False``: discard the local edits and recompose the
-          editor from the freshly fetched detail.
-
-        Either path falls back to the list view (with the same "no longer
-        available" warning ``_refresh_library_note_detail`` shows) when the
-        re-fetch discovers the note was deleted elsewhere entirely -- not
-        just version-bumped again -- so neither action can strand the
-        canvas on a permanent "Loading…" placeholder (Reload) or a
-        conflict UI that can never be resolved (Overwrite).
+        """Resolve a conflict through the coordinator's token-gated action.
 
         Args:
             overwrite: ``True`` for Overwrite, ``False`` for Reload.
         """
-        note_id = self._selected_note_id
-        if not note_id or self._library_note_autosave_state != "conflict":
+        action = ConflictAction.OVERWRITE if overwrite else ConflictAction.RELOAD
+        outcome = await self._library_note_session.resolve_conflict(action)
+        if outcome.kind in {
+            ConflictOutcomeKind.STALE,
+            ConflictOutcomeKind.ALREADY_RUNNING,
+            ConflictOutcomeKind.NOT_IN_CONFLICT,
+        }:
             return
-        service = getattr(self.app_instance, "notes_scope_service", None)
-        get_note_detail = getattr(service, "get_note_detail", None)
-        if not callable(get_note_detail):
-            return
-        try:
-            detail = await self._run_library_service_call(
-                get_note_detail,
-                scope="local_note",
-                note_id=note_id,
-                user_id=self._library_notes_user_id(),
-                isolate_in_worker=True,
-            )
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Failed to reload Library note {note_id!r} after a save conflict.",
-            )
-            return
-        if note_id != self._selected_note_id:
-            return  # The user navigated away while the re-fetch was in flight.
-
-        if not isinstance(detail, Mapping):
-            # The note is gone entirely (deleted elsewhere) rather than
-            # merely changed again -- neither Reload nor Overwrite has
-            # anything left to reconcile against. Mirrors
-            # ``_refresh_library_note_detail``'s missing-note fallback so
-            # this never leaves the canvas stuck in the conflict UI or on
-            # an unresolvable "Loading…" placeholder.
-            logger.info(
-                f"Library note {note_id!r} is no longer available; returning to list."
-            )
+        if outcome.kind is ConflictOutcomeKind.MISSING and not overwrite:
             self._reset_library_note_editor_state()
             self._notify_library_note_missing_warning()
             self._refresh_local_source_snapshot()
             if self.is_mounted:
                 self.refresh(recompose=True)
             return
-
-        if not overwrite:
-            self._library_note_detail = detail
-            editor_state = build_library_note_editor_state(self._library_note_detail)
-            self._library_note_version = editor_state.version
-            self._library_note_conflict_snapshot = None
-            self._library_note_dirty = False
+        snapshot = self._library_note_session.snapshot
+        validation_field = ""
+        if outcome.kind is ConflictOutcomeKind.OVERWRITTEN:
+            if outcome.save_outcome is not None:
+                self._apply_library_note_saved_presentation(outcome.save_outcome)
+        elif outcome.kind is ConflictOutcomeKind.RELOADED:
             self._library_note_autosave_state = "idle"
-            self._library_note_preview = False
-            self._library_note_preview_snapshot = None
-            self._library_note_editor_armed = False
-            if self.is_mounted:
-                self.refresh(recompose=True)
-                self.call_after_refresh(self._arm_library_note_editor)
-            return
-
-        fresh_version = build_library_note_editor_state(detail).version
-        if fresh_version is None:
-            return
-        try:
-            title_widget = self.query_one("#library-note-title", Input)
-            body_widget = self.query_one("#library-note-body", TextArea)
-            keywords_widget = self.query_one("#library-note-keywords", Input)
-        except (NoMatches, QueryError):
-            return
-        title = self._sanitize_media_field(title_widget.value, max_length=300)
-        content = self._sanitize_note_content(
-            body_widget.text, max_length=LIBRARY_NOTE_CONTENT_MAX_CHARS
-        )
-        keywords = self._library_note_keywords_from_input(keywords_widget.value)
-
-        save_note = getattr(service, "save_note", None)
-        if not callable(save_note):
-            return
-        try:
-            result = await self._run_library_service_call(
-                save_note,
-                scope="local_note",
-                title=title,
-                content=content,
-                note_id=note_id,
-                version=fresh_version,
-                user_id=self._library_notes_user_id(),
-                keywords=keywords,
-                isolate_in_worker=True,
+        elif outcome.kind in {
+            ConflictOutcomeKind.RENEWED_CONFLICT,
+            ConflictOutcomeKind.DRAFT_CHANGED,
+            ConflictOutcomeKind.MISSING,
+        }:
+            self._library_note_autosave_state = "conflict"
+        elif outcome.kind is ConflictOutcomeKind.FAILED:
+            self._library_note_autosave_state = (
+                "conflict" if snapshot is not None and snapshot.in_conflict else "error"
             )
-        except ConflictError:
-            result = False
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Failed to overwrite Library note {note_id!r} after a save conflict.",
-            )
-            return
-        if note_id != self._selected_note_id:
-            return
-        if not result:
-            # Someone else won this race too; keep showing the conflict UI
-            # (still seeded with the user's text) so they can try again.
-            return
-
-        if isinstance(result, Mapping):
-            version = result.get("version")
-            self._library_note_version = (
-                version if version is not None else fresh_version + 1
-            )
-        else:
-            self._library_note_version = fresh_version + 1
-
-        patched_detail: dict[str, Any] = (
-            dict(self._library_note_detail)
-            if isinstance(self._library_note_detail, Mapping)
-            else {}
-        )
-        patched_detail["id"] = note_id
-        patched_detail["title"] = title
-        patched_detail["content"] = content
-        patched_detail["version"] = self._library_note_version
-        if isinstance(detail, Mapping):
-            for key in ("created_at", "last_modified", "updated_at"):
-                if key in detail:
-                    patched_detail[key] = detail[key]
-        self._library_note_detail = patched_detail
-        self._library_note_conflict_snapshot = None
-        self._library_note_dirty = False
-        self._library_note_autosave_state = "saved"
+        elif outcome.kind is ConflictOutcomeKind.VALIDATION_VETO:
+            self._library_note_autosave_state = "validation"
+            if (
+                outcome.save_outcome is not None
+                and outcome.save_outcome.veto is not None
+            ):
+                validation_field = outcome.save_outcome.veto.field
         self._library_note_preview = False
-        self._library_note_preview_snapshot = None
         self._library_note_editor_armed = False
         if self.is_mounted:
             self.refresh(recompose=True)
             self.call_after_refresh(self._arm_library_note_editor)
+            if snapshot is not None and snapshot.in_conflict:
+                self.call_after_refresh(self._focus_library_note_conflict_callout)
+            elif validation_field:
+                self._focus_library_note_validation_field(validation_field)
 
     @on(Button.Pressed, "#library-note-conflict-overwrite")
     def handle_library_note_conflict_overwrite(self, event: Button.Pressed) -> None:
@@ -8022,8 +8055,7 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         self.run_worker(
             self._resolve_library_note_conflict(overwrite=True),
-            exclusive=True,
-            group="library_note_save",
+            group="library_note_conflict",
         )
 
     @on(Button.Pressed, "#library-note-conflict-reload")
@@ -8037,57 +8069,29 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         self.run_worker(
             self._resolve_library_note_conflict(overwrite=False),
-            exclusive=True,
-            group="library_note_save",
+            group="library_note_conflict",
         )
 
     # ----- Notes editor: preview, export, copy, use-in-console -----------
 
     def _read_library_note_editor_fields(self) -> tuple[str, str, str] | None:
-        """Read the note editor's current (possibly unsaved) title/content/keywords.
-
-        Tolerates the Preview toggle: when ``#library-note-body`` is a
-        read-only ``Markdown`` widget (no live text of its own), the body
-        falls back to the live-capture snapshot taken when Preview was
-        entered (see ``handle_library_note_preview_toggle``) instead of the
-        stale ``_library_note_detail``.
+        """Project canonical draft fields for non-persistence utilities.
 
         Returns:
-            ``(title, content, keywords_text)`` read from the live widgets
-            (and/or the preview snapshot), or ``None`` if the editor isn't
-            mounted.
+            ``(title, content, keywords_text)`` from the coordinator snapshot,
+            or ``None`` when no Database Note session is active.
         """
-        try:
-            title = self.query_one("#library-note-title", Input).value
-            keywords_text = self.query_one("#library-note-keywords", Input).value
-        except (NoMatches, QueryError):
+        snapshot = self._library_note_session.snapshot
+        if snapshot is None:
             return None
-        if self._library_note_preview:
-            content = (
-                self._library_note_preview_snapshot.content
-                if self._library_note_preview_snapshot is not None
-                else ""
-            )
-        else:
-            try:
-                content = self.query_one("#library-note-body", TextArea).text
-            except (NoMatches, QueryError):
-                return None
-        return title, content, keywords_text
+        return snapshot.title, snapshot.body, snapshot.keywords_text
 
     @on(Button.Pressed, "#library-note-preview")
     def handle_library_note_preview_toggle(self, event: Button.Pressed) -> None:
         """Toggle the note editor between edit and read-only Markdown preview.
 
-        Captures the live editor text (via ``_read_library_note_editor_fields``,
-        which already knows how to read through a prior Preview toggle)
-        *before* flipping the flag and recomposing, so neither entering nor
-        leaving preview silently drops in-progress edits -- the same
-        live-widget-capture discipline ``_save_library_note``'s conflict
-        branch already uses. A no-op while a save conflict is showing: that
-        recompose branch ignores ``preview`` entirely (it always shows the
-        live conflict text), so toggling here would have no visible effect
-        beyond leaving a stale flag/snapshot behind.
+        The coordinator already owns every raw field, so recomposition can
+        switch presentation without taking a second mutable draft snapshot.
 
         Args:
             event: Button press event emitted by the editor's Preview/Edit
@@ -8099,19 +8103,8 @@ class LibraryScreen(BaseAppScreen):
             or self._library_note_autosave_state == "conflict"
         ):
             return
-        fields = self._read_library_note_editor_fields()
-        if fields is None:
+        if self._library_note_session.snapshot is None:
             return
-        title, content, keywords_text = fields
-        self._library_note_preview_snapshot = LibraryNoteEditorState(
-            note_id=self._selected_note_id,
-            title=title,
-            content=content,
-            keywords_text=keywords_text,
-            version=self._library_note_version,
-            meta_line=self._library_note_meta_base_line(),
-            has_note=True,
-        )
         self._library_note_preview = not self._library_note_preview
         self._library_note_editor_armed = False
         self.refresh(recompose=True)
@@ -8726,8 +8719,8 @@ class LibraryScreen(BaseAppScreen):
         row_id: str,
     ) -> None:
         """Recompose a rail destination while source admission is held."""
-        await self._flush_library_note_save()
-        if self._library_note_dirty:
+        note_flush = await self._flush_library_note_save()
+        if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
         if not await self._flush_library_prompt_save():
             return
@@ -12340,7 +12333,7 @@ class LibraryScreen(BaseAppScreen):
         been stored.
 
         Unlike notes' ``get_note_detail`` (which never carries keywords, so
-        the editor separately enriches via ``_fetch_library_note_keywords``),
+        its private session port enriches the normalized load reply),
         the local backend's ``get_prompt`` seam is backed by
         ``PromptsDatabase.fetch_prompt_details``, which already joins
         keywords into the returned mapping -- no second enrichment call is
@@ -14358,8 +14351,8 @@ class LibraryScreen(BaseAppScreen):
             event: Button press event emitted by the "Sync" action.
         """
         event.stop()
-        await self._flush_library_note_save()
-        if self._library_note_dirty:
+        note_flush = await self._flush_library_note_save()
+        if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
         self._ensure_library_notes_sync_config_loaded()
         self._library_notes_view = "sync"
@@ -14373,7 +14366,9 @@ class LibraryScreen(BaseAppScreen):
             event: Button press event emitted by the "‹ Back to notes" action.
         """
         event.stop()
-        await self._flush_library_note_save()
+        note_flush = await self._flush_library_note_save()
+        if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
+            return
         self._library_notes_view = "list"
         self._reset_library_notes_sync_transient_state()
         self.refresh(recompose=True)
@@ -16333,45 +16328,20 @@ class LibraryScreen(BaseAppScreen):
             event: Button press event emitted by a note row button.
         """
         event.stop()
-        await self._flush_library_note_save()
-        if self._library_note_dirty:
+        note_flush = await self._flush_library_note_save()
+        if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
         note_id = str(getattr(event.button, "note_id", "") or "")
         if self._library_notes_select_mode:
             self._library_notes_row_selection.toggle(note_id)
             _apply_library_row_toggle(self, "notes", event.button, note_id)
             return
-        if note_id:
-            self._selected_note_id = note_id
         self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
-        self._library_notes_view = "editor"
-        self._library_note_detail = None
-        self._library_note_version = None
-        self._library_note_dirty = False
-        self._library_note_autosave_state = "idle"
-        self._library_note_conflict_snapshot = None
-        self._library_note_confirming_delete = False
-        self._library_note_preview = False
-        self._library_note_preview_snapshot = None
-        self._library_note_editor_armed = False
-        # LIB-14: switching to a (possibly different) note by row press --
-        # the flush above already resolved the PREVIOUS note's own
-        # save-vs-GC decision by id equality before this reassigns
-        # ``_selected_note_id``, but clear both flags explicitly here too
-        # (rather than relying solely on the id-equality guard elsewhere
-        # never matching a future note) so neither can read as "this note"
-        # for whatever gets opened next.
+        # A normal row switch never carries the blank-note GC identity.
         self._library_note_pending_blank_gc_id = None
         self._library_note_session_blank_id = None
         if note_id:
-            # Exclusive in its own group so rapidly switching rows cancels the
-            # previous in-flight detail fetch instead of letting a slower older
-            # fetch finish and overwrite the newer selection's editor.
-            self.run_worker(
-                self._refresh_library_note_detail(note_id),
-                exclusive=True,
-                group="library_note_detail",
-            )
+            self._begin_library_note_load(note_id)
         self.refresh(recompose=True)
 
     @on(Button.Pressed, "#library-notes-select-toggle")
@@ -16397,7 +16367,9 @@ class LibraryScreen(BaseAppScreen):
                 Select/Done toggle.
         """
         event.stop()
-        await self._flush_library_note_save()
+        note_flush = await self._flush_library_note_save()
+        if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
+            return
         self._library_notes_select_mode = not self._library_notes_select_mode
         self._library_notes_row_selection.clear()
         self.refresh(recompose=True)
@@ -16473,8 +16445,8 @@ class LibraryScreen(BaseAppScreen):
         Returns:
             ``True`` when the editor was exited; ``False`` on a dirty veto.
         """
-        await self._flush_library_note_save()
-        if self._library_note_dirty:
+        note_flush = await self._flush_library_note_save()
+        if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return False
         self._reset_library_note_editor_state()
         self._refresh_local_source_snapshot()
@@ -16493,6 +16465,22 @@ class LibraryScreen(BaseAppScreen):
         the Notes canvas.
         """
         await self._exit_library_note_editor_guarded()
+
+    @on(Button.Pressed, "#library-note-load-retry")
+    def handle_library_note_load_retry(self, event: Button.Pressed) -> None:
+        """Retry the current typed note-load failure without leaving Editor."""
+        event.stop()
+        note_id = self._selected_note_id
+        if not note_id or self._library_notes_view != "editor":
+            return
+        self._library_note_load_state = "loading"
+        self._library_note_load_message = ""
+        self.run_worker(
+            self._refresh_library_note_detail(note_id),
+            exclusive=True,
+            group="library_note_detail",
+        )
+        self.refresh(recompose=True)
 
     @on(Button.Pressed, "#library-note-delete")
     async def handle_library_note_delete(self, event: Button.Pressed) -> None:
@@ -16520,8 +16508,8 @@ class LibraryScreen(BaseAppScreen):
         # fail against an already-gone row and surface a spurious warning).
         self._library_note_pending_blank_gc_id = None
         self._library_note_session_blank_id = None
-        await self._flush_library_note_save()
-        if self._library_note_dirty:
+        note_flush = await self._flush_library_note_save()
+        if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
         self._library_note_confirming_delete = True
         self._library_note_editor_armed = False
@@ -16867,20 +16855,7 @@ class LibraryScreen(BaseAppScreen):
             self._notify_library_note_create_warning("Could not create the note.")
             return
 
-        self._selected_note_id = created_id
         self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
-        self._library_notes_view = "editor"
-        self._library_note_detail = None
-        self._library_note_version = None
-        self._library_note_dirty = False
-        self._library_note_autosave_state = "idle"
-        self._library_note_conflict_snapshot = None
-        self._library_note_confirming_delete = False
-        self._library_note_preview = False
-        self._library_note_preview_snapshot = None
-        self._library_note_editor_armed = False
-        self._library_note_pending_blank_gc_id = created_id if blank else None
-        self._library_note_session_blank_id = created_id if blank else None
         self._library_notes_filter = ""
         self._library_notes_filter_records = None
         # Reuses the same full local-source reload the initial mount load
@@ -16888,11 +16863,9 @@ class LibraryScreen(BaseAppScreen):
         # targeted append, since notes have no existing "patch the cached
         # snapshot" mutation path the way media edits/deletes do.
         self._refresh_local_source_snapshot()
-        self.run_worker(
-            self._refresh_library_note_detail(created_id),
-            exclusive=True,
-            group="library_note_detail",
-        )
+        self._begin_library_note_load(created_id)
+        self._library_note_pending_blank_gc_id = created_id if blank else None
+        self._library_note_session_blank_id = created_id if blank else None
         if self.is_mounted:
             self.refresh(recompose=True)
 
@@ -18751,8 +18724,8 @@ class LibraryScreen(BaseAppScreen):
             return
 
         if source_type == "media":
-            await self._flush_library_note_save()
-            if self._library_note_dirty:
+            note_flush = await self._flush_library_note_save()
+            if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
                 return
             # Mirrors handle_library_media_row's full state-set EXACTLY so
             # the recomposed canvas lands on a clean viewer, never a stale
@@ -18778,22 +18751,11 @@ class LibraryScreen(BaseAppScreen):
             return
 
         if source_type == "notes":
-            await self._flush_library_note_save()
-            if self._library_note_dirty:
+            note_flush = await self._flush_library_note_save()
+            if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
                 return
-            # Reset first for a clean slate (also stops any autosave timer,
-            # clears dirty/conflict/preview state), then apply the actual
-            # open-target fields -- equivalent final state to the note_id
-            # navigation-context branch's inline field-by-field reset.
-            self._reset_library_note_editor_state()
-            self._library_notes_view = "editor"
-            self._selected_note_id = record_id
             self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
-            self.run_worker(
-                self._refresh_library_note_detail(record_id),
-                exclusive=True,
-                group="library_note_detail",
-            )
+            self._begin_library_note_load(record_id)
             self.refresh(recompose=True)
             return
 

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -119,6 +119,22 @@ class LibraryNotesCanvas(Vertical):
         create_status: str = "",
         **kwargs: Any,
     ) -> None:
+        """Initialize one list, editor, create, or sync canvas.
+
+        Args:
+            list_state: List-mode rows, counts, selection, and empty-state copy.
+            sort_mode: Active list sort key.
+            filter_value: Text prefilled into the list filter.
+            mode: Canvas surface to compose: list, editor, create, or sync.
+            presentation_state: Canonical editor snapshot and UI-only flags.
+            sync_state: Display state for the sync surface.
+            title_placeholder_only: Render an empty title with an Untitled
+                placeholder for a pristine newly-created note.
+            compact: Whether 60-column-safe controls and labels are active.
+            create_running: Whether note creation is in progress.
+            create_status: Visible creation completion or recovery status.
+            **kwargs: Additional keyword arguments forwarded to ``Vertical``.
+        """
         super().__init__(**kwargs)
         self.list_state = list_state
         self.sort_mode = sort_mode

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -695,9 +695,11 @@ class LibraryNotesCanvas(Vertical):
         body_input = self.query_one("#library-note-body", TextArea)
         wide_keywords = self.query_one("#library-note-keywords", Input)
         context_keywords = self.query_one("#library-note-context-keywords", Input)
-        if title_input.value != snapshot.title:
+        presented_title = "" if self.title_placeholder_only else snapshot.title
+        if title_input.value != presented_title:
             with title_input.prevent(Input.Changed):
-                title_input.value = snapshot.title
+                title_input.value = presented_title
+        title_input.placeholder = "Untitled" if self.title_placeholder_only else ""
         if body_input.text != snapshot.body:
             with body_input.prevent(TextArea.Changed):
                 body_input.text = snapshot.body

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -420,7 +420,7 @@ class LibraryNotesCanvas(Vertical):
             id="library-note-context-status",
             markup=False,
         )
-        with VerticalScroll(id="library-note-context-region"):
+        with VerticalScroll(id="library-note-context-region", can_focus=True):
             yield Static("Properties", classes="destination-section", markup=False)
             with Horizontal(id="library-note-context-keywords-row"):
                 yield Static(

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -29,6 +29,16 @@ from tldw_chatbook.Library.library_notes_sync_state import (
 )
 
 _SORT_LABELS = {"newest": "Newest", "oldest": "Oldest", "title": "Title"}
+_COMPACT_SYNC_DIRECTION_LABELS = {
+    "bidirectional": "Both",
+    "disk_to_db": "Disk → Lib",
+    "db_to_disk": "Lib → Disk",
+}
+_COMPACT_SYNC_CONFLICT_LABELS = {
+    "newer_wins": "Newest",
+    "disk_wins": "Disk",
+    "db_wins": "Library",
+}
 
 
 @dataclass(frozen=True)
@@ -89,6 +99,7 @@ class LibraryNotesCanvas(Vertical):
             ``_library_note_pending_blank_gc_id``); it never applies to a
             note whose title happens to equal the word "Untitled" by the
             user's own choice.
+        compact: Whether compact, 60-column-safe action labels are active.
         create_running: Whether a Create request is currently in flight.
         create_status: Visible Create completion or recovery status.
     """
@@ -103,6 +114,7 @@ class LibraryNotesCanvas(Vertical):
         presentation_state: LibraryNotePresentationState | None = None,
         sync_state: LibraryNotesSyncState | None = None,
         title_placeholder_only: bool = False,
+        compact: bool = False,
         create_running: bool = False,
         create_status: str = "",
         **kwargs: Any,
@@ -115,10 +127,13 @@ class LibraryNotesCanvas(Vertical):
         self.presentation_state = presentation_state
         self.sync_state = sync_state
         self.title_placeholder_only = title_placeholder_only
+        self.compact = compact
         self.create_running = create_running
         self.create_status = create_status
         self.styles.width = "1fr"
         self.styles.min_width = 40
+        self.add_class(f"library-notes-mode-{mode}")
+        self.set_class(compact, "library-notes-compact")
 
     def compose(self) -> ComposeResult:
         if self.mode == "editor":
@@ -142,10 +157,8 @@ class LibraryNotesCanvas(Vertical):
             classes="destination-section",
             markup=False,
         )
-        # LIB-19: Database mode (this view), Files mode, and the Sync
-        # sub-canvas are three distinct folder-notes concepts that were
-        # never related to each other anywhere in the UI -- one placement
-        # sentence per surface, cross-referencing the other two.
+        # Database mode persists notes in the Library; Files edits a folder
+        # directly, while Sync mirrors a folder into this database.
         yield Static(
             "These notes live in the Library's own database — for notes "
             "that live in a folder on disk, switch to Files, or use Sync "
@@ -153,18 +166,12 @@ class LibraryNotesCanvas(Vertical):
             id="library-notes-database-purpose",
             markup=False,
         )
-        yield Static("Filter", id="library-notes-filter-label", markup=False)
-        yield Input(
-            placeholder="Filter notes… (Enter)",
-            id="library-notes-filter",
-            value=self.filter_value,
-        )
-        if self.filter_value:
-            yield Button(
-                "Clear filter",
-                id="library-notes-filter-clear",
-                classes="library-canvas-action",
-                compact=True,
+        with Horizontal(id="library-notes-filter-row"):
+            yield Static("Filter", id="library-notes-filter-label", markup=False)
+            yield Input(
+                placeholder="Filter notes… (Enter)",
+                id="library-notes-filter",
+                value=self.filter_value,
             )
         select_mode = list_state.select_mode
         # Gate/label off the RENDERED rows, not any total-count field -- only
@@ -197,7 +204,11 @@ class LibraryNotesCanvas(Vertical):
                     compact=True,
                 )
                 yield Button(
-                    f"Select all {rendered_count} shown",
+                    (
+                        f"All {rendered_count}"
+                        if self.compact
+                        else f"Select all {rendered_count} shown"
+                    ),
                     id="library-notes-select-all",
                     classes="library-canvas-action",
                     compact=True,
@@ -209,7 +220,7 @@ class LibraryNotesCanvas(Vertical):
                     compact=True,
                 )
                 export_selected = Button(
-                    "Export selected",
+                    "Export" if self.compact else "Export selected",
                     id="library-notes-export-selected",
                     classes="library-canvas-action",
                     compact=True,
@@ -232,6 +243,7 @@ class LibraryNotesCanvas(Vertical):
                 id="library-notes-browse-actions", classes="ds-toolbar"
             )
             browse_actions.styles.height = "auto"
+            browse_actions.display = not list_state.sort_choices_visible
             with browse_actions:
                 yield Button(
                     "New",
@@ -254,6 +266,21 @@ class LibraryNotesCanvas(Vertical):
                     compact=True,
                     disabled=rendered_count == 0 or list_state.operation_running,
                 )
+            if list_state.sort_choices_visible:
+                sort_choices = Horizontal(
+                    id="library-notes-sort-choices", classes="ds-toolbar"
+                )
+                sort_choices.styles.height = "auto"
+                with sort_choices:
+                    for mode, label in _SORT_LABELS.items():
+                        button = Button(
+                            f"{'✓ ' if mode == self.sort_mode else ''}{label}",
+                            id=f"library-notes-sort-{mode}",
+                            classes="library-canvas-action library-notes-sort-choice",
+                            compact=True,
+                        )
+                        button.sort_mode = mode
+                        yield button
             transfer_actions = Horizontal(
                 id="library-notes-transfer-actions", classes="ds-toolbar"
             )
@@ -271,22 +298,24 @@ class LibraryNotesCanvas(Vertical):
                         compact=True,
                         disabled=list_state.operation_running,
                     )
-            if list_state.sort_choices_visible:
-                sort_choices = Horizontal(
-                    id="library-notes-sort-choices", classes="ds-toolbar"
+        status_row = Horizontal(id="library-notes-status-row")
+        status_row.styles.height = "auto"
+        status_row.display = not select_mode
+        with status_row:
+            status = Static(
+                list_state.status_copy,
+                id="library-notes-status",
+                markup=False,
+            )
+            status.display = not select_mode
+            yield status
+            if self.filter_value:
+                yield Button(
+                    "Clear filter",
+                    id="library-notes-filter-clear",
+                    classes="library-canvas-action",
+                    compact=True,
                 )
-                sort_choices.styles.height = "auto"
-                with sort_choices:
-                    for mode, label in _SORT_LABELS.items():
-                        button = Button(
-                            f"{'✓ ' if mode == self.sort_mode else ''}{label}",
-                            id=f"library-notes-sort-{mode}",
-                            classes="library-canvas-action library-notes-sort-choice",
-                            compact=True,
-                        )
-                        button.sort_mode = mode
-                        yield button
-        yield Static(list_state.status_copy, id="library-notes-status", markup=False)
         if not list_state.rows:
             yield Static(list_state.empty_copy, id="library-notes-empty", markup=False)
             return
@@ -337,37 +366,112 @@ class LibraryNotesCanvas(Vertical):
         metadata_line = presentation_state.metadata_line
         status_line = presentation_state.status_line
 
-        yield Button(
-            "‹ Back to list",
-            id="library-note-back",
-            classes="library-canvas-action",
-            compact=True,
-        )
-        with Vertical(id="library-note-editor-region"):
-            yield Static("Title", id="library-note-title-label", markup=False)
-            yield Input(
-                value="" if self.title_placeholder_only else title,
-                placeholder="Untitled" if self.title_placeholder_only else "",
-                id="library-note-title",
-            )
-            yield Static("Body", id="library-note-body-label", markup=False)
-            yield TextArea(content, id="library-note-body")
-
-        # TASK-1993: consume YAML front matter (file-synced notes carry it)
-        # instead of rendering the --- block as noise; None falls back to
-        # the default parser when mdit-py-plugins is absent.
+        # File-synced notes may carry YAML front matter; consume it instead
+        # of rendering the delimiter block as note content.
         from tldw_chatbook.Utils.markdown_parsing import front_matter_parser_factory
 
-        with VerticalScroll(id="library-note-preview-region", can_focus=True):
+        with Horizontal(id="library-note-heading"):
+            yield Button(
+                "‹ Notes",
+                id="library-note-back",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Button(
+                "‹ Note",
+                id="library-note-context-back",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Static(
+                "Edit note",
+                id="library-note-editor-title",
+                markup=False,
+            )
             yield Static(
                 ellipsize_note_title_cells(title, 72),
                 id="library-note-preview-title",
                 markup=False,
             )
+            yield Static(
+                ellipsize_note_title_cells(title, 72),
+                id="library-note-context-title",
+                markup=False,
+            )
+        with Vertical(id="library-note-editor-region"):
+            with Horizontal(id="library-note-title-row"):
+                yield Static("Title", id="library-note-title-label", markup=False)
+                yield Input(
+                    value="" if self.title_placeholder_only else title,
+                    placeholder="Untitled" if self.title_placeholder_only else "",
+                    id="library-note-title",
+                )
+            yield Static("Body", id="library-note-body-label", markup=False)
+            yield TextArea(content, id="library-note-body")
+
+        with VerticalScroll(id="library-note-preview-region", can_focus=True):
             yield Markdown(
                 content,
                 id="library-note-preview-body",
                 parser_factory=front_matter_parser_factory(),
+            )
+        yield Static(
+            status_line,
+            id="library-note-context-status",
+            markup=False,
+        )
+        with VerticalScroll(id="library-note-context-region"):
+            yield Static("Properties", classes="destination-section", markup=False)
+            with Horizontal(id="library-note-context-keywords-row"):
+                yield Static(
+                    "Keywords", id="library-note-context-keywords-label", markup=False
+                )
+                yield Input(
+                    value=keywords_text,
+                    placeholder="Comma-separated keywords",
+                    id="library-note-context-keywords",
+                )
+            yield Static("Metadata", classes="destination-section", markup=False)
+            yield Static(metadata_line, id="library-note-context-meta", markup=False)
+            yield Static("Chatbook", classes="destination-section", markup=False)
+            yield Button(
+                "Use in Console",
+                id="library-note-context-use-in-console",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Static("Utilities", classes="destination-section", markup=False)
+            yield Button(
+                "Copy",
+                id="library-note-context-copy",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Button(
+                "Export Markdown",
+                id="library-note-context-export-md",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Button(
+                "Export text",
+                id="library-note-context-export-txt",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Static(
+                presentation_state.transfer_status
+                if presentation_state is not None
+                else "",
+                id="library-note-context-transfer-status",
+                markup=False,
+            )
+            yield Static("Danger zone", classes="destination-section", markup=False)
+            yield Button(
+                "Delete",
+                id="library-note-context-delete",
+                classes="library-canvas-action library-media-action-danger",
+                compact=True,
             )
         yield Static(status_line, id="library-note-status", markup=False)
 
@@ -451,71 +555,6 @@ class LibraryNotesCanvas(Vertical):
                     compact=True,
                 )
 
-        with VerticalScroll(id="library-note-context-region"):
-            yield Button(
-                "‹ Note",
-                id="library-note-context-back",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            yield Static(
-                ellipsize_note_title_cells(title, 72),
-                id="library-note-context-title",
-                markup=False,
-            )
-            yield Static(status_line, id="library-note-context-status", markup=False)
-            yield Static("Properties", classes="destination-section", markup=False)
-            yield Static(
-                "Keywords", id="library-note-context-keywords-label", markup=False
-            )
-            yield Input(
-                value=keywords_text,
-                placeholder="Comma-separated keywords",
-                id="library-note-context-keywords",
-            )
-            yield Static("Metadata", classes="destination-section", markup=False)
-            yield Static(metadata_line, id="library-note-context-meta", markup=False)
-            yield Static("Chatbook", classes="destination-section", markup=False)
-            yield Button(
-                "Use in Console",
-                id="library-note-context-use-in-console",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            yield Static("Utilities", classes="destination-section", markup=False)
-            yield Button(
-                "Copy",
-                id="library-note-context-copy",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            yield Button(
-                "Export Markdown",
-                id="library-note-context-export-md",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            yield Button(
-                "Export text",
-                id="library-note-context-export-txt",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            yield Static(
-                presentation_state.transfer_status
-                if presentation_state is not None
-                else "",
-                id="library-note-context-transfer-status",
-                markup=False,
-            )
-            yield Static("Danger zone", classes="destination-section", markup=False)
-            yield Button(
-                "Delete",
-                id="library-note-context-delete",
-                classes="library-canvas-action library-media-action-danger",
-                compact=True,
-            )
-
         with Vertical(id="library-note-conflict-region"):
             yield Static(
                 "This note changed elsewhere — Overwrite saves your text; "
@@ -524,7 +563,9 @@ class LibraryNotesCanvas(Vertical):
                 classes="destination-purpose",
                 markup=False,
             )
-            conflict_actions = Horizontal(classes="ds-toolbar")
+            conflict_actions = Horizontal(
+                id="library-note-conflict-actions", classes="ds-toolbar"
+            )
             conflict_actions.styles.height = "auto"
             with conflict_actions:
                 yield Button(
@@ -546,7 +587,9 @@ class LibraryNotesCanvas(Vertical):
                 id="library-note-delete-confirm-copy",
                 markup=False,
             )
-            delete_actions = Horizontal(classes="ds-toolbar")
+            delete_actions = Horizontal(
+                id="library-note-delete-actions", classes="ds-toolbar"
+            )
             delete_actions.styles.height = "auto"
             with delete_actions:
                 yield Button(
@@ -564,8 +607,59 @@ class LibraryNotesCanvas(Vertical):
 
     def on_mount(self) -> None:
         """Apply initial visibility after the stable editor subtree mounts."""
+        self.apply_compact_presentation(self.compact)
         if self.mode == "editor" and self.presentation_state is not None:
             self.apply_session_state(self.presentation_state)
+
+    def apply_compact_presentation(self, compact: bool) -> None:
+        """Update responsive copy and classes without remounting the canvas."""
+        self.compact = compact
+        self.set_class(compact, "library-notes-compact")
+        if not self.is_mounted:
+            return
+        if self.mode == "list" and self.list_state is not None:
+            rendered_count = len(self.list_state.rows)
+            select_all = self.query("#library-notes-select-all")
+            if select_all:
+                select_all.first(Button).label = (
+                    f"All {rendered_count}"
+                    if compact
+                    else f"Select all {rendered_count} shown"
+                )
+            export_selected = self.query("#library-notes-export-selected")
+            if export_selected:
+                export_selected.first(Button).label = (
+                    "Export" if compact else "Export selected"
+                )
+            return
+        if self.mode != "sync" or self.sync_state is None:
+            return
+        for value in ("bidirectional", "disk_to_db", "db_to_disk"):
+            label = (
+                _COMPACT_SYNC_DIRECTION_LABELS[value]
+                if compact
+                else sync_direction_label(value)
+            )
+            prefix = "✓ " if value == self.sync_state.direction else ""
+            choices = self.query(f"#library-notes-sync-direction-{value}")
+            if choices:
+                choices.first(Button).label = f"{prefix}{label}"
+        for value in ("newer_wins", "disk_wins", "db_wins"):
+            label = (
+                _COMPACT_SYNC_CONFLICT_LABELS[value]
+                if compact
+                else sync_conflict_label(value)
+            )
+            prefix = "✓ " if value == self.sync_state.conflict else ""
+            choices = self.query(f"#library-notes-sync-conflict-{value}")
+            if choices:
+                choices.first(Button).label = f"{prefix}{label}"
+        auto_label = auto_sync_label(self.sync_state.auto_sync)
+        if compact:
+            auto_label = auto_label.replace("auto-sync: every ", "Auto ", 1)
+        auto = self.query("#library-notes-sync-auto")
+        if auto:
+            auto.first(Button).label = auto_label
 
     @staticmethod
     def _static_text(widget: Static) -> str:
@@ -581,8 +675,10 @@ class LibraryNotesCanvas(Vertical):
         """
         if self.mode != "editor" or not self.is_mounted:
             self.presentation_state = state
+            self.compact = state.compact
             return
         self.presentation_state = state
+        self.compact = state.compact
         snapshot = state.snapshot
         conflict = state.conflict
         confirming_delete = state.confirming_delete and not conflict
@@ -628,10 +724,15 @@ class LibraryNotesCanvas(Vertical):
         # unbounded hidden-render backlog.
         if show_preview and preview_body.source != snapshot.body:
             preview_body.update(snapshot.body)
+        compact_status = (
+            state.transfer_status
+            if state.compact and state.transfer_status
+            else state.status_line
+        )
         for selector in ("#library-note-status", "#library-note-context-status"):
             widget = self.query_one(selector, Static)
-            if self._static_text(widget) != state.status_line:
-                widget.update(state.status_line)
+            if self._static_text(widget) != compact_status:
+                widget.update(compact_status)
         for selector in ("#library-note-meta", "#library-note-context-meta"):
             widget = self.query_one(selector, Static)
             if self._static_text(widget) != state.metadata_line:
@@ -643,13 +744,20 @@ class LibraryNotesCanvas(Vertical):
             transfer = self.query_one(selector, Static)
             if self._static_text(transfer) != state.transfer_status:
                 transfer.update(state.transfer_status)
-            transfer.display = bool(state.transfer_status)
+            transfer.display = bool(state.transfer_status) and not state.compact
 
-        self.set_class(state.compact, "library-notes-compact")
+        self.apply_compact_presentation(state.compact)
         self.set_class(state.validation, "library-note-validation")
         self.query_one("#library-note-back").display = not show_context
+        self.query_one("#library-note-context-back").display = show_context
+        self.query_one("#library-note-editor-title").display = (
+            show_editor and state.compact
+        )
+        self.query_one("#library-note-preview-title").display = show_preview
+        self.query_one("#library-note-context-title").display = show_context
         self.query_one("#library-note-editor-region").display = show_editor
         self.query_one("#library-note-preview-region").display = show_preview
+        self.query_one("#library-note-context-status").display = show_context
         self.query_one("#library-note-context-region").display = show_context
         self.query_one("#library-note-status").display = not show_context
         self.query_one("#library-note-primary-actions").display = (
@@ -744,59 +852,61 @@ class LibraryNotesCanvas(Vertical):
         fields via ``_library_note_template_fields`` -- this widget only
         needs the key and a human label, never the raw title/content.
         """
-        yield Button(
-            "‹ Back to notes",
-            id="library-notes-create-back",
-            classes="library-canvas-action",
-            compact=True,
-            disabled=self.create_running,
-        )
-        yield Static(
-            "New note",
-            id="library-notes-create-header",
-            classes="destination-section",
-            markup=False,
-        )
-        yield Button(
-            "Blank note",
-            id="library-notes-create-blank",
-            classes="library-notes-create-row",
-            compact=True,
-            disabled=self.create_running,
-        )
-        from tldw_chatbook.Event_Handlers.notes_events import NOTE_TEMPLATES
-
-        # The pure builder excludes the "blank" template (it duplicates the
-        # Blank note action above) and pre-resolves each template's title so
-        # the row's muted secondary line shows the exact title the created
-        # note will get (date placeholders already substituted).
-        rows = build_library_note_template_rows(NOTE_TEMPLATES)
-        yield Static(
-            "From a template",
-            id="library-notes-template-section",
-            classes="destination-section",
-            markup=False,
-        )
-        for index, row in enumerate(rows):
-            label = (
-                f"{row.label}\n{row.resolved_title}"
-                if row.resolved_title
-                else row.label
-            )
-            button = Button(
-                label,
-                id=f"library-notes-template-{index}",
-                classes="library-notes-create-row library-notes-template-row",
+        with Horizontal(id="library-notes-create-heading"):
+            yield Button(
+                "‹ Notes",
+                id="library-notes-create-back",
+                classes="library-canvas-action",
                 compact=True,
+                disabled=self.create_running,
             )
-            button.template_key = row.template_key
-            button.disabled = self.create_running
-            yield button
-        yield Static(
-            self.create_status,
-            id="library-notes-create-status",
-            markup=False,
-        )
+            yield Static(
+                "New note",
+                id="library-notes-create-header",
+                classes="destination-section",
+                markup=False,
+            )
+        with VerticalScroll(id="library-notes-create-viewport"):
+            yield Button(
+                "Blank note",
+                id="library-notes-create-blank",
+                classes="library-notes-create-row",
+                compact=True,
+                disabled=self.create_running,
+            )
+            from tldw_chatbook.Event_Handlers.notes_events import NOTE_TEMPLATES
+
+            # The pure builder excludes the "blank" template (it duplicates the
+            # Blank note action above) and pre-resolves each template's title so
+            # the row's muted secondary line shows the exact title the created
+            # note will get (date placeholders already substituted).
+            rows = build_library_note_template_rows(NOTE_TEMPLATES)
+            yield Static(
+                "From a template",
+                id="library-notes-template-section",
+                classes="destination-section",
+                markup=False,
+            )
+            for index, row in enumerate(rows):
+                label = (
+                    f"{row.label}\n{row.resolved_title}"
+                    if row.resolved_title
+                    else row.label
+                )
+                button = Button(
+                    label,
+                    id=f"library-notes-template-{index}",
+                    classes="library-notes-create-row library-notes-template-row",
+                    compact=True,
+                )
+                button.template_key = row.template_key
+                button.disabled = self.create_running
+                yield button
+            yield Static(
+                self.create_status,
+                id="library-notes-create-status",
+                markup=False,
+            )
 
     def _compose_sync(self) -> ComposeResult:
         """Render the notes sync panel: folder, direction, conflicts, activity.
@@ -809,111 +919,132 @@ class LibraryNotesCanvas(Vertical):
         sync_state = self.sync_state
         if sync_state is None:
             return
-        yield Button(
-            "‹ Back to notes",
-            id="library-notes-sync-back",
-            classes="library-canvas-action",
-            compact=True,
-            disabled=sync_state.running,
-        )
-        yield Static(
-            "Notes sync",
-            id="library-notes-sync-header",
-            classes="destination-section",
-            markup=False,
-        )
-        # LIB-19: relates this surface to Database mode and Files mode --
-        # see library_notes_canvas.py's _compose_list and
-        # library_file_notes_workspace.py's compose() for their own
-        # placement sentences.
-        yield Static(
-            "Mirror notes between a folder on disk and the Library — "
-            "unlike Files mode, which edits that folder directly without "
-            "mirroring it in.",
-            id="library-notes-sync-purpose",
-            markup=False,
-        )
-        yield Static("folder", id="library-notes-sync-folder-label", markup=False)
-        yield Input(
-            value=sync_state.folder,
-            placeholder="Folder to sync…",
-            id="library-notes-sync-folder",
-            disabled=sync_state.running,
-        )
-        yield Button(
-            "Browse…",
-            id="library-notes-sync-browse",
-            classes="library-canvas-action",
-            compact=True,
-            disabled=sync_state.running,
-        )
-        yield Static("Direction", id="library-notes-sync-direction-label", markup=False)
-        direction_choices = Horizontal(
-            id="library-notes-sync-direction-choices", classes="ds-toolbar"
-        )
-        direction_choices.styles.height = "auto"
-        with direction_choices:
-            for value in ("bidirectional", "disk_to_db", "db_to_disk"):
-                button = Button(
-                    f"{'✓ ' if value == sync_state.direction else ''}"
-                    f"{sync_direction_label(value)}",
-                    id=f"library-notes-sync-direction-{value}",
-                    classes=(
-                        "library-canvas-action library-notes-sync-direction-choice"
-                    ),
+        with Horizontal(id="library-notes-sync-heading"):
+            yield Button(
+                "‹ Notes",
+                id="library-notes-sync-back",
+                classes="library-canvas-action",
+                compact=True,
+                disabled=sync_state.running,
+            )
+            yield Static(
+                "Notes sync",
+                id="library-notes-sync-header",
+                classes="destination-section",
+                markup=False,
+            )
+        with VerticalScroll(id="library-notes-sync-viewport"):
+            yield Static(
+                "Mirror notes between a folder on disk and the Library — "
+                "unlike Files mode, which edits that folder directly without "
+                "mirroring it in.",
+                id="library-notes-sync-purpose",
+                markup=False,
+            )
+            with Horizontal(id="library-notes-sync-folder-row"):
+                yield Static(
+                    "Folder", id="library-notes-sync-folder-label", markup=False
+                )
+                yield Input(
+                    value=sync_state.folder,
+                    placeholder="Folder to sync…",
+                    id="library-notes-sync-folder",
+                    disabled=sync_state.running,
+                )
+                yield Button(
+                    "Browse…",
+                    id="library-notes-sync-browse",
+                    classes="library-canvas-action",
                     compact=True,
                     disabled=sync_state.running,
                 )
-                button.choice_value = value
-                yield button
-        yield Static("Conflicts", id="library-notes-sync-conflict-label", markup=False)
-        conflict_choices = Horizontal(
-            id="library-notes-sync-conflict-choices", classes="ds-toolbar"
-        )
-        conflict_choices.styles.height = "auto"
-        with conflict_choices:
-            for value in ("newer_wins", "disk_wins", "db_wins"):
-                button = Button(
-                    f"{'✓ ' if value == sync_state.conflict else ''}"
-                    f"{sync_conflict_label(value)}",
-                    id=f"library-notes-sync-conflict-{value}",
-                    classes=(
-                        "library-canvas-action library-notes-sync-conflict-choice"
-                    ),
+            with Horizontal(id="library-notes-sync-direction-row"):
+                yield Static(
+                    "Direction", id="library-notes-sync-direction-label", markup=False
+                )
+                direction_choices = Horizontal(
+                    id="library-notes-sync-direction-choices", classes="ds-toolbar"
+                )
+                direction_choices.styles.height = "auto"
+                with direction_choices:
+                    for value in ("bidirectional", "disk_to_db", "db_to_disk"):
+                        label = (
+                            _COMPACT_SYNC_DIRECTION_LABELS[value]
+                            if self.compact
+                            else sync_direction_label(value)
+                        )
+                        button = Button(
+                            f"{'✓ ' if value == sync_state.direction else ''}{label}",
+                            id=f"library-notes-sync-direction-{value}",
+                            classes=(
+                                "library-canvas-action "
+                                "library-notes-sync-direction-choice"
+                            ),
+                            compact=True,
+                            disabled=sync_state.running,
+                        )
+                        button.choice_value = value
+                        yield button
+            with Horizontal(id="library-notes-sync-conflict-row"):
+                yield Static(
+                    "Conflicts", id="library-notes-sync-conflict-label", markup=False
+                )
+                conflict_choices = Horizontal(
+                    id="library-notes-sync-conflict-choices", classes="ds-toolbar"
+                )
+                conflict_choices.styles.height = "auto"
+                with conflict_choices:
+                    for value in ("newer_wins", "disk_wins", "db_wins"):
+                        label = (
+                            _COMPACT_SYNC_CONFLICT_LABELS[value]
+                            if self.compact
+                            else sync_conflict_label(value)
+                        )
+                        button = Button(
+                            f"{'✓ ' if value == sync_state.conflict else ''}{label}",
+                            id=f"library-notes-sync-conflict-{value}",
+                            classes=(
+                                "library-canvas-action "
+                                "library-notes-sync-conflict-choice"
+                            ),
+                            compact=True,
+                            disabled=sync_state.running,
+                        )
+                        button.choice_value = value
+                        yield button
+            with Horizontal(id="library-notes-sync-actions"):
+                auto_label = auto_sync_label(sync_state.auto_sync)
+                if self.compact:
+                    auto_label = auto_label.replace("auto-sync: every ", "Auto ", 1)
+                yield Button(
+                    auto_label,
+                    id="library-notes-sync-auto",
+                    classes="library-canvas-action",
                     compact=True,
                     disabled=sync_state.running,
                 )
-                button.choice_value = value
-                yield button
-        yield Button(
-            auto_sync_label(sync_state.auto_sync),
-            id="library-notes-sync-auto",
-            classes="library-canvas-action",
-            compact=True,
-            disabled=sync_state.running,
-        )
-        yield Button(
-            "Syncing…" if sync_state.running else "Sync now",
-            id="library-notes-sync-run",
-            classes="library-canvas-action",
-            compact=True,
-            disabled=sync_state.running,
-        )
-        # ``sync_status_line``'s own tested contract is that a failed status
-        # always starts with the literal prefix "failed" -- safe to key the
-        # error styling off that prefix here.
-        yield Static(
-            sync_state.status_line,
-            id="library-notes-sync-status",
-            classes=(
-                "library-notes-sync-status-failed"
-                if sync_state.status_line.startswith("failed")
-                else ""
-            ),
-            markup=False,
-        )
-        yield Static(
-            "\n".join(sync_state.activity_lines),
-            id="library-notes-sync-activity",
-            markup=False,
-        )
+                yield Button(
+                    "Syncing…" if sync_state.running else "Sync now",
+                    id="library-notes-sync-run",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=sync_state.running,
+                )
+            # ``sync_status_line``'s own tested contract is that a failed status
+            # always starts with the literal prefix "failed" -- safe to key the
+            # error styling off that prefix here.
+            yield Static(
+                sync_state.status_line,
+                id="library-notes-sync-status",
+                classes=(
+                    "library-notes-sync-status-failed"
+                    if sync_state.status_line.startswith("failed")
+                    else ""
+                ),
+                markup=False,
+            )
+            yield Static(
+                "\n".join(sync_state.activity_lines),
+                id="library-notes-sync-activity",
+                markup=False,
+            )

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -51,7 +51,9 @@ class LibraryNotePresentationState:
     conflict_running: bool = False
     confirming_delete: bool = False
     destructive_running: bool = False
+    discard_new_note: bool = False
     transfer_status: str = ""
+    transfer_running: bool = False
 
 
 class LibraryNotesCanvas(Vertical):
@@ -87,6 +89,8 @@ class LibraryNotesCanvas(Vertical):
             ``_library_note_pending_blank_gc_id``); it never applies to a
             note whose title happens to equal the word "Untitled" by the
             user's own choice.
+        create_running: Whether a Create request is currently in flight.
+        create_status: Visible Create completion or recovery status.
     """
 
     def __init__(
@@ -99,6 +103,8 @@ class LibraryNotesCanvas(Vertical):
         presentation_state: LibraryNotePresentationState | None = None,
         sync_state: LibraryNotesSyncState | None = None,
         title_placeholder_only: bool = False,
+        create_running: bool = False,
+        create_status: str = "",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -109,6 +115,8 @@ class LibraryNotesCanvas(Vertical):
         self.presentation_state = presentation_state
         self.sync_state = sync_state
         self.title_placeholder_only = title_placeholder_only
+        self.create_running = create_running
+        self.create_status = create_status
         self.styles.width = "1fr"
         self.styles.min_width = 40
 
@@ -145,65 +153,28 @@ class LibraryNotesCanvas(Vertical):
             id="library-notes-database-purpose",
             markup=False,
         )
+        yield Static("Filter", id="library-notes-filter-label", markup=False)
         yield Input(
             placeholder="Filter notes… (Enter)",
             id="library-notes-filter",
             value=self.filter_value,
         )
+        if self.filter_value:
+            yield Button(
+                "Clear filter",
+                id="library-notes-filter-clear",
+                classes="library-canvas-action",
+                compact=True,
+            )
         select_mode = list_state.select_mode
         # Gate/label off the RENDERED rows, not any total-count field -- only
         # rendered rows are selectable, matching the media/conversations
         # canvases' ``len(rows)`` convention.
         rendered_count = len(list_state.rows)
-        # One horizontal ds-toolbar row for sort/Sync/Import note/Export…/
-        # Select (2026-07 UAT: the previous bare stacked Buttons rendered as
-        # an overlapped vertical pile eating into the first list row). Safe
-        # here because every child is a fixed-width compact Button -- the
-        # known non-rendering failure mode for this canvas family is only
-        # a Horizontal mixing a 1fr sibling with fixed-width children,
-        # exactly the ds-toolbar shape `_compose_editor` already proves out.
-        toolbar = Horizontal(classes="ds-toolbar")
-        toolbar.styles.height = "auto"
-        with toolbar:
-            yield Button(
-                f"sort: {_SORT_LABELS.get(self.sort_mode, 'Newest')} ▸",
-                id="library-notes-sort",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            yield Button(
-                "Sync",
-                id="library-notes-sync-open",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            yield Button(
-                "Import note",
-                id="library-notes-import",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            export_btn = Button(
-                "Export…",
-                id="library-notes-export",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            export_btn.display = not select_mode
-            yield export_btn
-            select_btn = Button(
-                "Done" if select_mode else "Select",
-                id="library-notes-select-toggle",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            # Disable only when nothing to select AND not already in select mode
-            # -- in select mode "Done" must stay pressable so the user can exit
-            # even if the rows dropped to zero (e.g. a background refresh).
-            select_btn.disabled = rendered_count == 0 and not select_mode
-            yield select_btn
         if select_mode:
-            action_row = Horizontal(classes="ds-toolbar")
+            action_row = Horizontal(
+                id="library-notes-selection-actions", classes="ds-toolbar"
+            )
             action_row.styles.height = "auto"
             with action_row:
                 # task-2853 review round 2: the SAME unbounded-width defect
@@ -218,6 +189,12 @@ class LibraryNotesCanvas(Vertical):
                     id="library-notes-selected-count",
                     classes="library-toolbar-count",
                     markup=False,
+                )
+                yield Button(
+                    "Done",
+                    id="library-notes-select-toggle",
+                    classes="library-canvas-action",
+                    compact=True,
                 )
                 yield Button(
                     f"Select all {rendered_count} shown",
@@ -245,10 +222,71 @@ class LibraryNotesCanvas(Vertical):
                     else LIBRARY_EXPORT_SELECTED_TOOLTIP
                 )
                 yield export_selected
-        if list_state.status_copy:
             yield Static(
-                list_state.status_copy, id="library-notes-status", markup=False
+                f"{list_state.selected_count} selected",
+                id="library-notes-selection-status",
+                markup=False,
             )
+        else:
+            browse_actions = Horizontal(
+                id="library-notes-browse-actions", classes="ds-toolbar"
+            )
+            browse_actions.styles.height = "auto"
+            with browse_actions:
+                yield Button(
+                    "New",
+                    id="library-notes-new",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=list_state.operation_running,
+                )
+                yield Button(
+                    f"Sort: {_SORT_LABELS.get(self.sort_mode, 'Newest')}",
+                    id="library-notes-sort",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=list_state.operation_running,
+                )
+                yield Button(
+                    "Select",
+                    id="library-notes-select-toggle",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=rendered_count == 0 or list_state.operation_running,
+                )
+            transfer_actions = Horizontal(
+                id="library-notes-transfer-actions", classes="ds-toolbar"
+            )
+            transfer_actions.styles.height = "auto"
+            with transfer_actions:
+                for label, button_id in (
+                    ("Sync", "library-notes-sync-open"),
+                    ("Import", "library-notes-import"),
+                    ("Export", "library-notes-export"),
+                ):
+                    yield Button(
+                        label,
+                        id=button_id,
+                        classes="library-canvas-action",
+                        compact=True,
+                        disabled=list_state.operation_running,
+                    )
+            if list_state.sort_choices_visible:
+                sort_choices = Horizontal(
+                    id="library-notes-sort-choices", classes="ds-toolbar"
+                )
+                sort_choices.styles.height = "auto"
+                with sort_choices:
+                    for mode, label in _SORT_LABELS.items():
+                        button = Button(
+                            f"{'✓ ' if mode == self.sort_mode else ''}{label}",
+                            id=f"library-notes-sort-{mode}",
+                            classes="library-canvas-action library-notes-sort-choice",
+                            compact=True,
+                        )
+                        button.sort_mode = mode
+                        yield button
+        yield Static(list_state.status_copy, id="library-notes-status", markup=False)
         if not list_state.rows:
             yield Static(list_state.empty_copy, id="library-notes-empty", markup=False)
             return
@@ -356,6 +394,20 @@ class LibraryNotesCanvas(Vertical):
                 classes="library-canvas-action",
                 compact=True,
             )
+            discard_new = Button(
+                "Discard new note",
+                id="library-note-discard-new",
+                classes="library-canvas-action library-media-action-danger",
+                compact=True,
+            )
+            discard_new.display = presentation_state.discard_new_note
+            discard_new.disabled = presentation_state.destructive_running
+            yield discard_new
+        yield Static(
+            presentation_state.transfer_status,
+            id="library-note-transfer-status",
+            markup=False,
+        )
 
         with Vertical(id="library-note-wide-utilities"):
             yield Static("Keywords", id="library-note-keywords-label", markup=False)
@@ -584,10 +636,14 @@ class LibraryNotesCanvas(Vertical):
             widget = self.query_one(selector, Static)
             if self._static_text(widget) != state.metadata_line:
                 widget.update(state.metadata_line)
-        transfer = self.query_one("#library-note-context-transfer-status", Static)
-        if self._static_text(transfer) != state.transfer_status:
-            transfer.update(state.transfer_status)
-        transfer.display = bool(state.transfer_status)
+        for selector in (
+            "#library-note-transfer-status",
+            "#library-note-context-transfer-status",
+        ):
+            transfer = self.query_one(selector, Static)
+            if self._static_text(transfer) != state.transfer_status:
+                transfer.update(state.transfer_status)
+            transfer.display = bool(state.transfer_status)
 
         self.set_class(state.compact, "library-notes-compact")
         self.set_class(state.validation, "library-note-validation")
@@ -639,6 +695,22 @@ class LibraryNotesCanvas(Vertical):
         ):
             self.query_one(selector, Button).disabled = state.destructive_running
         for selector in (
+            "#library-note-use-in-console",
+            "#library-note-export-md",
+            "#library-note-export-txt",
+            "#library-note-copy",
+            "#library-note-context-use-in-console",
+            "#library-note-context-export-md",
+            "#library-note-context-export-txt",
+            "#library-note-context-copy",
+        ):
+            self.query_one(selector, Button).disabled = (
+                state.destructive_running or state.transfer_running
+            )
+        discard_new = self.query_one("#library-note-discard-new", Button)
+        discard_new.display = state.discard_new_note
+        discard_new.disabled = state.destructive_running
+        for selector in (
             "#library-note-conflict-overwrite",
             "#library-note-conflict-reload",
         ):
@@ -672,6 +744,13 @@ class LibraryNotesCanvas(Vertical):
         fields via ``_library_note_template_fields`` -- this widget only
         needs the key and a human label, never the raw title/content.
         """
+        yield Button(
+            "‹ Back to notes",
+            id="library-notes-create-back",
+            classes="library-canvas-action",
+            compact=True,
+            disabled=self.create_running,
+        )
         yield Static(
             "New note",
             id="library-notes-create-header",
@@ -683,6 +762,7 @@ class LibraryNotesCanvas(Vertical):
             id="library-notes-create-blank",
             classes="library-notes-create-row",
             compact=True,
+            disabled=self.create_running,
         )
         from tldw_chatbook.Event_Handlers.notes_events import NOTE_TEMPLATES
 
@@ -710,18 +790,21 @@ class LibraryNotesCanvas(Vertical):
                 compact=True,
             )
             button.template_key = row.template_key
+            button.disabled = self.create_running
             yield button
+        yield Static(
+            self.create_status,
+            id="library-notes-create-status",
+            markup=False,
+        )
 
     def _compose_sync(self) -> ComposeResult:
         """Render the notes sync panel: folder, direction, conflicts, activity.
 
-        Every control here is a plain, stacked, full-width Button/Input/
-        Static -- the render-safe shape already proven by list/editor/create
-        mode in this canvas. Notably absent: ``Select`` (the retired
-        standalone Notes screen's Direction/Conflict dropdowns) and ``Switch``
-        (its auto-sync toggle) -- neither renders reliably in this canvas,
-        so both become cycling/toggle Buttons instead, matching the
-        pattern the media type filter and notes sort control already use.
+        Direction and conflict policy use explicit compact choice groups so
+        every available value and the current selection remain visible.
+        Auto-sync stays a direct toggle button. All mutable controls are
+        disabled while a sync run is active.
         """
         sync_state = self.sync_state
         if sync_state is None:
@@ -731,6 +814,7 @@ class LibraryNotesCanvas(Vertical):
             id="library-notes-sync-back",
             classes="library-canvas-action",
             compact=True,
+            disabled=sync_state.running,
         )
         yield Static(
             "Notes sync",
@@ -754,30 +838,59 @@ class LibraryNotesCanvas(Vertical):
             value=sync_state.folder,
             placeholder="Folder to sync…",
             id="library-notes-sync-folder",
+            disabled=sync_state.running,
         )
         yield Button(
             "Browse…",
             id="library-notes-sync-browse",
             classes="library-canvas-action",
             compact=True,
+            disabled=sync_state.running,
         )
-        yield Button(
-            f"direction: {sync_direction_label(sync_state.direction)} ▸",
-            id="library-notes-sync-direction",
-            classes="library-canvas-action",
-            compact=True,
+        yield Static("Direction", id="library-notes-sync-direction-label", markup=False)
+        direction_choices = Horizontal(
+            id="library-notes-sync-direction-choices", classes="ds-toolbar"
         )
-        yield Button(
-            f"conflicts: {sync_conflict_label(sync_state.conflict)} ▸",
-            id="library-notes-sync-conflict",
-            classes="library-canvas-action",
-            compact=True,
+        direction_choices.styles.height = "auto"
+        with direction_choices:
+            for value in ("bidirectional", "disk_to_db", "db_to_disk"):
+                button = Button(
+                    f"{'✓ ' if value == sync_state.direction else ''}"
+                    f"{sync_direction_label(value)}",
+                    id=f"library-notes-sync-direction-{value}",
+                    classes=(
+                        "library-canvas-action library-notes-sync-direction-choice"
+                    ),
+                    compact=True,
+                    disabled=sync_state.running,
+                )
+                button.choice_value = value
+                yield button
+        yield Static("Conflicts", id="library-notes-sync-conflict-label", markup=False)
+        conflict_choices = Horizontal(
+            id="library-notes-sync-conflict-choices", classes="ds-toolbar"
         )
+        conflict_choices.styles.height = "auto"
+        with conflict_choices:
+            for value in ("newer_wins", "disk_wins", "db_wins"):
+                button = Button(
+                    f"{'✓ ' if value == sync_state.conflict else ''}"
+                    f"{sync_conflict_label(value)}",
+                    id=f"library-notes-sync-conflict-{value}",
+                    classes=(
+                        "library-canvas-action library-notes-sync-conflict-choice"
+                    ),
+                    compact=True,
+                    disabled=sync_state.running,
+                )
+                button.choice_value = value
+                yield button
         yield Button(
             auto_sync_label(sync_state.auto_sync),
             id="library-notes-sync-auto",
             classes="library-canvas-action",
             compact=True,
+            disabled=sync_state.running,
         )
         yield Button(
             "Syncing…" if sync_state.running else "Sync now",

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -3,17 +3,19 @@ create mode (Blank note + template rows)."""
 
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 from rich.markup import escape as escape_markup
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Button, Input, Markdown, Static, TextArea
 
 from tldw_chatbook.Library.library_notes_state import (
-    LibraryNoteEditorState,
+    LibraryNoteSessionSnapshot,
     LibraryNotesListState,
     build_library_note_template_rows,
+    ellipsize_note_title_cells,
 )
 from tldw_chatbook.Library.library_shell_state import (
     LIBRARY_EXPORT_SELECTED_DISABLED_TOOLTIP,
@@ -29,6 +31,29 @@ from tldw_chatbook.Library.library_notes_sync_state import (
 _SORT_LABELS = {"newest": "Newest", "oldest": "Oldest", "title": "Title"}
 
 
+@dataclass(frozen=True)
+class LibraryNotePresentationState:
+    """Immutable presentation input for one mounted Database Note canvas.
+
+    The coordinator snapshot is the only source of draft text. Everything
+    else describes how that draft is presented; applying this state must not
+    perform persistence, navigation, or draft mutation.
+    """
+
+    snapshot: LibraryNoteSessionSnapshot
+    metadata_line: str
+    status_line: str
+    region: Literal["editor", "context"] = "editor"
+    presentation: Literal["edit", "preview"] = "edit"
+    compact: bool = False
+    validation: bool = False
+    conflict: bool = False
+    conflict_running: bool = False
+    confirming_delete: bool = False
+    destructive_running: bool = False
+    transfer_status: str = ""
+
+
 class LibraryNotesCanvas(Vertical):
     """Render the Library notes canvas: the list view, or the note editor.
 
@@ -40,31 +65,14 @@ class LibraryNotesCanvas(Vertical):
         filter_value: Current notes filter text, prefilled into the filter
             ``Input``.
         mode: ``"list"`` renders the notes list; ``"editor"`` renders the
-            in-canvas note editor for ``editor_state``; ``"create"`` renders
+            in-canvas note editor for ``presentation_state``; ``"create"`` renders
             the Blank note / template picker reached from the rail's
             Create > New note row; ``"sync"`` renders the in-canvas notes
             sync panel for ``sync_state``.
-        editor_state: The note to render in editor mode. Required when
-            ``mode == "editor"``.
+        presentation_state: Canonical snapshot plus presentation-only state.
+            Required when ``mode == "editor"``.
         sync_state: The sync panel's display state. Required when
             ``mode == "sync"``.
-        preview: When ``True`` (editor mode only), renders ``editor_state``'s
-            content as read-only ``Markdown`` in place of the editable
-            ``TextArea`` -- the screen is responsible for threading the
-            live (possibly unsaved) body text into ``editor_state.content``
-            before toggling this on, so switching to preview never drops
-            in-progress edits. The Preview/Edit action button's label
-            reflects this flag.
-        conflict: When ``True`` (editor mode only), renders the save
-            conflict banner -- a quiet explanatory line plus Overwrite/
-            Reload actions -- in addition to the normal editor fields.
-            ``editor_state`` must already reflect the user's kept text
-            (never the server's stale detail) when this is set.
-        confirming_delete: When ``True`` (editor mode only, and only when
-            ``conflict`` is not also set), renders the inline delete
-            confirmation affordance -- a quiet explanatory line plus
-            Delete/Cancel actions -- in place of the normal action row.
-            Mirrors ``LibraryMediaViewer.confirming_delete``.
         title_placeholder_only: When ``True`` (editor mode only), the title
             ``Input`` renders empty with an "Untitled" placeholder instead
             of a literal editable "Untitled" value -- LIB-14's fix for a
@@ -88,10 +96,7 @@ class LibraryNotesCanvas(Vertical):
         sort_mode: str = "newest",
         filter_value: str = "",
         mode: str = "list",
-        editor_state: LibraryNoteEditorState | None = None,
-        preview: bool = False,
-        conflict: bool = False,
-        confirming_delete: bool = False,
+        presentation_state: LibraryNotePresentationState | None = None,
         sync_state: LibraryNotesSyncState | None = None,
         title_placeholder_only: bool = False,
         **kwargs: Any,
@@ -101,10 +106,7 @@ class LibraryNotesCanvas(Vertical):
         self.sort_mode = sort_mode
         self.filter_value = filter_value
         self.mode = mode
-        self.editor_state = editor_state
-        self.preview = preview
-        self.conflict = conflict
-        self.confirming_delete = confirming_delete
+        self.presentation_state = presentation_state
         self.sync_state = sync_state
         self.title_placeholder_only = title_placeholder_only
         self.styles.width = "1fr"
@@ -286,118 +288,86 @@ class LibraryNotesCanvas(Vertical):
                 yield button
 
     def _compose_editor(self) -> ComposeResult:
-        """Render the note editor: Back, title, body, keywords, meta, actions.
-
-        Stacked full-width widgets (mirroring ``LibraryMediaViewer.compose``)
-        plus a single plain ``ds-toolbar`` action row -- the render-safe
-        shape already proven by the media viewer canvas. All fields render
-        with their current values; the action buttons are wired with ids
-        only here (Save/Preview/Use in Console/Export/Copy/Delete stay
-        inert until later tasks add their handlers).
-        """
-        editor_state = self.editor_state
-        if editor_state is None:
+        """Mount every editor-session presentation surface exactly once."""
+        presentation_state = self.presentation_state
+        if presentation_state is None:
             return
+        snapshot = presentation_state.snapshot
+        title = snapshot.title
+        content = snapshot.body
+        keywords_text = snapshot.keywords_text
+        metadata_line = presentation_state.metadata_line
+        status_line = presentation_state.status_line
+
         yield Button(
             "‹ Back to list",
             id="library-note-back",
             classes="library-canvas-action",
             compact=True,
         )
-        yield Input(
-            value="" if self.title_placeholder_only else editor_state.title,
-            placeholder="Untitled" if self.title_placeholder_only else "",
-            id="library-note-title",
-        )
-        if self.preview:
-            # TASK-1993: consume YAML front matter (file-synced notes carry
-            # it) instead of rendering the --- block as noise; None falls
-            # back to the default parser when mdit-py-plugins is absent.
-            from tldw_chatbook.Utils.markdown_parsing import (
-                front_matter_parser_factory,
+        with Vertical(id="library-note-editor-region"):
+            yield Static("Title", id="library-note-title-label", markup=False)
+            yield Input(
+                value="" if self.title_placeholder_only else title,
+                placeholder="Untitled" if self.title_placeholder_only else "",
+                id="library-note-title",
             )
+            yield Static("Body", id="library-note-body-label", markup=False)
+            yield TextArea(content, id="library-note-body")
 
+        # TASK-1993: consume YAML front matter (file-synced notes carry it)
+        # instead of rendering the --- block as noise; None falls back to
+        # the default parser when mdit-py-plugins is absent.
+        from tldw_chatbook.Utils.markdown_parsing import front_matter_parser_factory
+
+        with VerticalScroll(id="library-note-preview-region", can_focus=True):
+            yield Static(
+                ellipsize_note_title_cells(title, 72),
+                id="library-note-preview-title",
+                markup=False,
+            )
             yield Markdown(
-                editor_state.content,
+                content,
                 id="library-note-preview-body",
                 parser_factory=front_matter_parser_factory(),
             )
-        else:
-            yield TextArea(
-                editor_state.content,
-                id="library-note-body",
-            )
-        yield Input(
-            value=editor_state.keywords_text,
-            placeholder="Keywords (comma-separated)",
-            id="library-note-keywords",
+        yield Static(status_line, id="library-note-status", markup=False)
+
+        primary_actions = Horizontal(
+            id="library-note-primary-actions", classes="ds-toolbar"
         )
-        yield Static(
-            editor_state.meta_line,
-            id="library-note-meta",
-            markup=False,
-        )
-        if self.conflict:
-            yield Static(
-                "This note changed elsewhere — Overwrite saves your text; "
-                "Reload discards it.",
-                id="library-note-conflict-copy",
-                classes="destination-purpose",
-                markup=False,
+        primary_actions.styles.height = "auto"
+        with primary_actions:
+            yield Button(
+                "Save",
+                id="library-note-save",
+                classes="library-canvas-action",
+                compact=True,
             )
-        confirming_delete = self.confirming_delete and not self.conflict
-        if confirming_delete:
-            # A single full-width Static above the toolbar, not inside it --
-            # mixing a Static with the toolbar's Buttons is the known
-            # non-rendering failure mode called out on the media viewer's
-            # ``compose`` (the pattern this mirrors).
-            yield Static(
-                "Delete this note? This cannot be undone from Library.",
-                id="library-note-delete-confirm-copy",
-                markup=False,
+            yield Button(
+                "Edit" if presentation_state.presentation == "preview" else "Preview",
+                id="library-note-preview",
+                classes="library-canvas-action",
+                compact=True,
             )
-        toolbar = Horizontal(classes="ds-toolbar")
-        toolbar.styles.height = "auto"
-        with toolbar:
-            if confirming_delete:
-                yield Button(
-                    "Delete",
-                    id="library-note-delete-confirm",
-                    classes="library-canvas-action library-media-action-danger",
-                    compact=True,
-                )
-                yield Button(
-                    "Cancel",
-                    id="library-note-delete-cancel",
-                    classes="library-canvas-action",
-                    compact=True,
-                )
-            else:
-                if self.conflict:
-                    yield Button(
-                        "Overwrite",
-                        id="library-note-conflict-overwrite",
-                        classes="library-canvas-action",
-                        compact=True,
-                    )
-                    yield Button(
-                        "Reload",
-                        id="library-note-conflict-reload",
-                        classes="library-canvas-action",
-                        compact=True,
-                    )
-                yield Button(
-                    "Save",
-                    id="library-note-save",
-                    classes="library-canvas-action",
-                    compact=True,
-                )
-                yield Button(
-                    "Edit" if self.preview else "Preview",
-                    id="library-note-preview",
-                    classes="library-canvas-action",
-                    compact=True,
-                )
+            yield Button(
+                "Context",
+                id="library-note-context",
+                classes="library-canvas-action",
+                compact=True,
+            )
+
+        with Vertical(id="library-note-wide-utilities"):
+            yield Static("Keywords", id="library-note-keywords-label", markup=False)
+            yield Input(
+                value=keywords_text,
+                placeholder="Comma-separated keywords",
+                id="library-note-keywords",
+            )
+            yield Static(metadata_line, id="library-note-meta", markup=False)
+            wide_actions = Horizontal(classes="ds-toolbar")
+            wide_actions.styles.height = "auto"
+            with wide_actions:
                 yield Button(
                     "Use in Console",
                     id="library-note-use-in-console",
@@ -405,13 +375,13 @@ class LibraryNotesCanvas(Vertical):
                     compact=True,
                 )
                 yield Button(
-                    "Export .md",
+                    "Export Markdown",
                     id="library-note-export-md",
                     classes="library-canvas-action",
                     compact=True,
                 )
                 yield Button(
-                    "Export .txt",
+                    "Export text",
                     id="library-note-export-txt",
                     classes="library-canvas-action",
                     compact=True,
@@ -428,6 +398,258 @@ class LibraryNotesCanvas(Vertical):
                     classes="library-canvas-action library-media-action-danger",
                     compact=True,
                 )
+
+        with VerticalScroll(id="library-note-context-region"):
+            yield Button(
+                "‹ Note",
+                id="library-note-context-back",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Static(
+                ellipsize_note_title_cells(title, 72),
+                id="library-note-context-title",
+                markup=False,
+            )
+            yield Static(status_line, id="library-note-context-status", markup=False)
+            yield Static("Properties", classes="destination-section", markup=False)
+            yield Static(
+                "Keywords", id="library-note-context-keywords-label", markup=False
+            )
+            yield Input(
+                value=keywords_text,
+                placeholder="Comma-separated keywords",
+                id="library-note-context-keywords",
+            )
+            yield Static("Metadata", classes="destination-section", markup=False)
+            yield Static(metadata_line, id="library-note-context-meta", markup=False)
+            yield Static("Chatbook", classes="destination-section", markup=False)
+            yield Button(
+                "Use in Console",
+                id="library-note-context-use-in-console",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Static("Utilities", classes="destination-section", markup=False)
+            yield Button(
+                "Copy",
+                id="library-note-context-copy",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Button(
+                "Export Markdown",
+                id="library-note-context-export-md",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Button(
+                "Export text",
+                id="library-note-context-export-txt",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Static(
+                presentation_state.transfer_status
+                if presentation_state is not None
+                else "",
+                id="library-note-context-transfer-status",
+                markup=False,
+            )
+            yield Static("Danger zone", classes="destination-section", markup=False)
+            yield Button(
+                "Delete",
+                id="library-note-context-delete",
+                classes="library-canvas-action library-media-action-danger",
+                compact=True,
+            )
+
+        with Vertical(id="library-note-conflict-region"):
+            yield Static(
+                "This note changed elsewhere — Overwrite saves your text; "
+                "Reload discards it.",
+                id="library-note-conflict-copy",
+                classes="destination-purpose",
+                markup=False,
+            )
+            conflict_actions = Horizontal(classes="ds-toolbar")
+            conflict_actions.styles.height = "auto"
+            with conflict_actions:
+                yield Button(
+                    "Overwrite",
+                    id="library-note-conflict-overwrite",
+                    classes="library-canvas-action",
+                    compact=True,
+                )
+                yield Button(
+                    "Reload",
+                    id="library-note-conflict-reload",
+                    classes="library-canvas-action",
+                    compact=True,
+                )
+
+        with Vertical(id="library-note-delete-confirmation"):
+            yield Static(
+                "Delete this note? This cannot be undone from Library.",
+                id="library-note-delete-confirm-copy",
+                markup=False,
+            )
+            delete_actions = Horizontal(classes="ds-toolbar")
+            delete_actions.styles.height = "auto"
+            with delete_actions:
+                yield Button(
+                    "Cancel",
+                    id="library-note-delete-cancel",
+                    classes="library-canvas-action",
+                    compact=True,
+                )
+                yield Button(
+                    "Delete",
+                    id="library-note-delete-confirm",
+                    classes="library-canvas-action library-media-action-danger",
+                    compact=True,
+                )
+
+    def on_mount(self) -> None:
+        """Apply initial visibility after the stable editor subtree mounts."""
+        if self.mode == "editor" and self.presentation_state is not None:
+            self.apply_session_state(self.presentation_state)
+
+    @staticmethod
+    def _static_text(widget: Static) -> str:
+        renderable = widget.renderable
+        return getattr(renderable, "plain", str(renderable))
+
+    def apply_session_state(self, state: LibraryNotePresentationState) -> None:
+        """Synchronize stable editor surfaces from one immutable snapshot.
+
+        Value assignments are difference-checked so repeated application is
+        idempotent. The screen owns the presentation-sync guard around calls
+        that may assign ``Input`` or ``TextArea`` values.
+        """
+        if self.mode != "editor" or not self.is_mounted:
+            self.presentation_state = state
+            return
+        self.presentation_state = state
+        snapshot = state.snapshot
+        conflict = state.conflict
+        confirming_delete = state.confirming_delete and not conflict
+        show_context = (
+            state.region == "context" and not conflict and not confirming_delete
+        )
+        show_preview = (
+            not show_context
+            and not conflict
+            and not confirming_delete
+            and state.presentation == "preview"
+        )
+        show_editor = not show_context and not show_preview
+
+        title_input = self.query_one("#library-note-title", Input)
+        body_input = self.query_one("#library-note-body", TextArea)
+        wide_keywords = self.query_one("#library-note-keywords", Input)
+        context_keywords = self.query_one("#library-note-context-keywords", Input)
+        if title_input.value != snapshot.title:
+            with title_input.prevent(Input.Changed):
+                title_input.value = snapshot.title
+        if body_input.text != snapshot.body:
+            with body_input.prevent(TextArea.Changed):
+                body_input.text = snapshot.body
+        if wide_keywords.value != snapshot.keywords_text:
+            with wide_keywords.prevent(Input.Changed):
+                wide_keywords.value = snapshot.keywords_text
+        if context_keywords.value != snapshot.keywords_text:
+            with context_keywords.prevent(Input.Changed):
+                context_keywords.value = snapshot.keywords_text
+
+        title_width = 52 if state.compact else 72
+        title = ellipsize_note_title_cells(snapshot.title, title_width)
+        for selector in ("#library-note-preview-title", "#library-note-context-title"):
+            widget = self.query_one(selector, Static)
+            if self._static_text(widget) != title:
+                widget.update(title)
+
+        preview_body = self.query_one("#library-note-preview-body", Markdown)
+        # Markdown.update() parses and remounts asynchronously. Keep the
+        # hidden Preview stale while typing, then perform one canonical update
+        # when Preview becomes the active surface so edits cannot queue an
+        # unbounded hidden-render backlog.
+        if show_preview and preview_body.source != snapshot.body:
+            preview_body.update(snapshot.body)
+        for selector in ("#library-note-status", "#library-note-context-status"):
+            widget = self.query_one(selector, Static)
+            if self._static_text(widget) != state.status_line:
+                widget.update(state.status_line)
+        for selector in ("#library-note-meta", "#library-note-context-meta"):
+            widget = self.query_one(selector, Static)
+            if self._static_text(widget) != state.metadata_line:
+                widget.update(state.metadata_line)
+        transfer = self.query_one("#library-note-context-transfer-status", Static)
+        if self._static_text(transfer) != state.transfer_status:
+            transfer.update(state.transfer_status)
+        transfer.display = bool(state.transfer_status)
+
+        self.set_class(state.compact, "library-notes-compact")
+        self.set_class(state.validation, "library-note-validation")
+        self.query_one("#library-note-back").display = not show_context
+        self.query_one("#library-note-editor-region").display = show_editor
+        self.query_one("#library-note-preview-region").display = show_preview
+        self.query_one("#library-note-context-region").display = show_context
+        self.query_one("#library-note-status").display = not show_context
+        self.query_one("#library-note-primary-actions").display = (
+            not show_context and not conflict and not confirming_delete
+        )
+        self.query_one("#library-note-wide-utilities").display = (
+            not state.compact
+            and not show_context
+            and not conflict
+            and not confirming_delete
+        )
+        self.query_one("#library-note-conflict-region").display = conflict
+        self.query_one("#library-note-delete-confirmation").display = confirming_delete
+
+        locked = confirming_delete or state.destructive_running
+        title_input.disabled = not show_editor or locked
+        body_input.disabled = not show_editor or locked
+        wide_keywords.disabled = state.compact or show_context or locked
+        context_keywords.disabled = not show_context or locked
+        preview_body.can_focus = False
+        self.query_one("#library-note-preview-region").can_focus = show_preview
+        self.query_one("#library-note-context-region").can_focus = show_context
+
+        preview_button = self.query_one("#library-note-preview", Button)
+        preview_label = "Edit" if state.presentation == "preview" else "Preview"
+        if str(preview_button.label) != preview_label:
+            preview_button.label = preview_label
+
+        for selector in (
+            "#library-note-save",
+            "#library-note-preview",
+            "#library-note-context",
+            "#library-note-use-in-console",
+            "#library-note-export-md",
+            "#library-note-export-txt",
+            "#library-note-copy",
+            "#library-note-delete",
+            "#library-note-context-use-in-console",
+            "#library-note-context-export-md",
+            "#library-note-context-export-txt",
+            "#library-note-context-copy",
+            "#library-note-context-delete",
+        ):
+            self.query_one(selector, Button).disabled = state.destructive_running
+        for selector in (
+            "#library-note-conflict-overwrite",
+            "#library-note-conflict-reload",
+        ):
+            self.query_one(selector, Button).disabled = (
+                state.destructive_running or state.conflict_running
+            )
+        for selector in (
+            "#library-note-delete-confirm",
+            "#library-note-delete-cancel",
+        ):
+            self.query_one(selector, Button).disabled = state.destructive_running
 
     def _compose_create(self) -> ComposeResult:
         """Render the notes canvas in create mode: Blank note + template rows.

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -133,7 +133,6 @@ class LibraryNotesCanvas(Vertical):
         self.styles.width = "1fr"
         self.styles.min_width = 40
         self.add_class(f"library-notes-mode-{mode}")
-        self.set_class(compact, "library-notes-compact")
 
     def compose(self) -> ComposeResult:
         if self.mode == "editor":
@@ -612,9 +611,8 @@ class LibraryNotesCanvas(Vertical):
             self.apply_session_state(self.presentation_state)
 
     def apply_compact_presentation(self, compact: bool) -> None:
-        """Update responsive copy and classes without remounting the canvas."""
+        """Update responsive copy without remounting the canvas."""
         self.compact = compact
-        self.set_class(compact, "library-notes-compact")
         if not self.is_mounted:
             return
         if self.mode == "list" and self.list_state is not None:

--- a/tldw_chatbook/Widgets/Library/library_rail.py
+++ b/tldw_chatbook/Widgets/Library/library_rail.py
@@ -322,18 +322,15 @@ class LibraryRail(RecomposeCaptureGuard, Vertical):
             if row.row_id in changed_row_ids
         }
         for row_id, row in rows.items():
-            button = self.query_one(f"#{LIBRARY_RAIL_ROW_PREFIX}{row_id}", Button)
+            button = self.query_one(
+                f"#{LIBRARY_RAIL_ROW_PREFIX}{row_id}", LibraryRailRowButton
+            )
             selected = row_id == shell.selected_row_id
-            marker = "▸" if selected else " "
-            count_suffix = row.count_display or self._count_suffix(
-                row.count, row.count_known
-            )
-            section_hint = (
-                "opens screen" if row.target_kind == "screen" else "in Library"
-            )
-            button.label = (
-                f"{marker} {_visible_row_title(row.title)}{count_suffix}"
-                f"\n    {section_hint}"
+            button.library_row = row
+            button.label = self._row_label(
+                row,
+                selected,
+                width=button.content_region.width,
             )
             if button.has_class("library-rail-row-selected") != selected:
                 button.set_class(selected, "library-rail-row-selected")

--- a/tldw_chatbook/Widgets/Library/library_rail.py
+++ b/tldw_chatbook/Widgets/Library/library_rail.py
@@ -298,6 +298,46 @@ class LibraryRail(RecomposeCaptureGuard, Vertical):
         self.query = query
         self.refresh(recompose=True)
 
+    def apply_selection(self, shell: LibraryShellState) -> None:
+        """Update route selection without recomposing the whole rail.
+
+        Route selection changes only the leading marker and selected class;
+        counts, sections, search state, and Details remain unchanged. Updating
+        the two affected rows in place avoids remounting the full Library rail
+        during a canvas-to-canvas route switch.
+
+        Args:
+            shell: Latest shell state carrying the new selected row.
+
+        Returns:
+            None.
+        """
+        previous_row_id = self.shell.selected_row_id
+        self.shell = shell
+        changed_row_ids = {previous_row_id, shell.selected_row_id} - {""}
+        rows = {
+            row.row_id: row
+            for section in shell.sections
+            for row in section.rows
+            if row.row_id in changed_row_ids
+        }
+        for row_id, row in rows.items():
+            button = self.query_one(f"#{LIBRARY_RAIL_ROW_PREFIX}{row_id}", Button)
+            selected = row_id == shell.selected_row_id
+            marker = "▸" if selected else " "
+            count_suffix = row.count_display or self._count_suffix(
+                row.count, row.count_known
+            )
+            section_hint = (
+                "opens screen" if row.target_kind == "screen" else "in Library"
+            )
+            button.label = (
+                f"{marker} {_visible_row_title(row.title)}{count_suffix}"
+                f"\n    {section_hint}"
+            )
+            if button.has_class("library-rail-row-selected") != selected:
+                button.set_class(selected, "library-rail-row-selected")
+
     def _section_open(self, section_id: str) -> bool:
         return bool(getattr(self.preferences, f"{section_id}_open", True))
 

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -1621,17 +1621,27 @@ with stray left-edge border fragments), and padding 0 1 so the full
     margin: 0 0 1 0;
 }
 
-/* The read-only Markdown preview takes the TextArea's place one-for-one
-   when Preview is toggled on, so it gets the same bounded footprint (plus
-   its own scroll region, since Markdown has no implicit one here). */
-#library-note-preview-body {
+/* The read-only Markdown preview takes the TextArea's place one-for-one.
+   The focusable wrapper is its sole scroll owner; Markdown grows naturally
+   inside it so keyboard paging can reach the complete document. */
+#library-note-preview-region {
     height: auto;
     min-height: 12;
     max-height: 20;
     margin: 0 0 1 0;
-    padding: 0 1;
     border: solid $ds-grid-line;
     overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-note-preview-body {
+    height: auto;
+    min-height: 0;
+    margin: 0;
+    padding: 0 1;
+    border: none;
+    overflow-y: hidden;
+    overflow-x: hidden;
 }
 
 /* Muted meta line: same tier as the media viewer's metadata block
@@ -6986,4 +6996,463 @@ LibraryIngestCanvas .library-ingest-batch-header {
 LibraryIngestCanvas #library-ingest-latest-batch {
     height: auto;
     text-style: bold;
+}
+
+/* Presentation-only row wrappers keep the established wide stacked
+   workbench. Compact rules below switch only these wrappers to rows. */
+#library-notes-filter-row,
+#library-notes-status-row,
+#library-note-heading,
+#library-note-title-row,
+#library-note-context-keywords-row,
+#library-notes-create-heading,
+#library-notes-sync-heading,
+#library-notes-sync-folder-row,
+#library-notes-sync-direction-row,
+#library-notes-sync-conflict-row,
+#library-notes-sync-actions {
+    layout: vertical;
+    height: auto;
+    min-height: 0;
+}
+
+#library-notes-create-viewport,
+#library-notes-sync-viewport {
+    height: 1fr;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+/* Database Notes compact geometry: at the measured compact breakpoint,
+   the shell becomes a single 15-row workbench and every Notes state
+   assigns surplus height to exactly one scroll owner. */
+#library-shell-grid.library-notes-compact {
+    padding: 0;
+    margin: 0;
+    border: none;
+}
+
+#library-canvas.library-notes-compact {
+    padding: 0;
+    margin: 0;
+    border: none;
+    overflow-x: hidden;
+    overflow-y: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-canvas {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    padding: 0;
+    margin: 0;
+    overflow-x: hidden;
+    overflow-y: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-header {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-notes-filter-row {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-notes-filter-label {
+    width: 7;
+    height: 1;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-notes-filter {
+    width: 1fr;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+    padding: 0 1;
+    border: none;
+}
+
+#library-canvas.library-notes-compact #library-notes-browse-actions,
+#library-canvas.library-notes-compact #library-notes-sort-choices,
+#library-canvas.library-notes-compact #library-notes-transfer-actions,
+#library-canvas.library-notes-compact #library-notes-selection-actions,
+#library-canvas.library-notes-compact #library-note-primary-actions,
+#library-canvas.library-notes-compact #library-note-conflict-actions,
+#library-canvas.library-notes-compact #library-note-delete-actions {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact .library-canvas-action {
+    width: auto;
+    min-width: 0;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0 1 0 0;
+    padding: 0 1;
+    border: none;
+}
+
+#library-canvas.library-notes-compact #library-notes-status-row {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-status {
+    width: 1fr;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-notes-filter-clear {
+    width: auto;
+}
+
+#library-canvas.library-notes-compact #library-notes-selection-status {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-notes-list {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-empty {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    padding: 0 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-heading {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-editor-title,
+#library-canvas.library-notes-compact #library-note-preview-title,
+#library-canvas.library-notes-compact #library-note-context-title,
+#library-canvas.library-notes-compact #library-note-loading-title,
+#library-canvas.library-notes-compact #library-notes-create-header,
+#library-canvas.library-notes-compact #library-notes-sync-header {
+    width: 1fr;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-note-editor-region {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    overflow-x: hidden;
+    overflow-y: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-title-row {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-title-label,
+#library-canvas.library-notes-compact #library-note-context-keywords-label {
+    width: 10;
+    height: 1;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-note-title,
+#library-canvas.library-notes-compact #library-note-context-keywords,
+#library-canvas.library-notes-compact #library-notes-sync-folder {
+    width: 1fr;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+    padding: 0 1;
+    border: none;
+}
+
+#library-canvas.library-notes-compact #library-note-body-label {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-note-body {
+    height: 1fr;
+    min-height: 0;
+    max-height: 100%;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-preview-region {
+    height: 1fr;
+    min-height: 0;
+    max-height: 100%;
+    margin: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-preview-body {
+    height: auto;
+    min-height: 0;
+    margin: 0;
+    padding: 0 1;
+    border: none;
+    overflow-y: hidden;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-context-status {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-note-context-region {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-context-region .destination-section,
+#library-canvas.library-notes-compact #library-note-context-meta,
+#library-canvas.library-notes-compact #library-note-context-region > .library-canvas-action {
+    height: 1;
+    min-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-context-keywords-row {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-status {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-notes-canvas.library-note-validation #library-note-status {
+    height: 2;
+    min-height: 2;
+    max-height: 2;
+    text-wrap: wrap;
+    text-overflow: clip;
+}
+
+#library-canvas.library-notes-compact #library-note-transfer-status,
+#library-canvas.library-notes-compact #library-note-context-transfer-status {
+    display: none;
+    height: 0;
+    min-height: 0;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-conflict-region {
+    height: 3;
+    min-height: 3;
+    max-height: 3;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-conflict-copy {
+    height: 2;
+    min-height: 2;
+    max-height: 2;
+    margin: 0;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-note-delete-confirmation {
+    height: 2;
+    min-height: 2;
+    max-height: 2;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-delete-confirm-copy {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-notes-create-heading {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-notes-create-viewport {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-heading {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-viewport {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-load-state {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-load-heading {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-loading {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-note-loading-viewport {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-purpose,
+#library-canvas.library-notes-compact #library-notes-sync-folder-row,
+#library-canvas.library-notes-compact #library-notes-sync-direction-row,
+#library-canvas.library-notes-compact #library-notes-sync-conflict-row,
+#library-canvas.library-notes-compact #library-notes-sync-actions,
+#library-canvas.library-notes-compact #library-notes-sync-status {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-activity {
+    height: auto;
+    min-height: 1;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-folder-row,
+#library-canvas.library-notes-compact #library-notes-sync-direction-row,
+#library-canvas.library-notes-compact #library-notes-sync-conflict-row,
+#library-canvas.library-notes-compact #library-notes-sync-actions {
+    layout: horizontal;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-folder-label,
+#library-canvas.library-notes-compact #library-notes-sync-direction-label,
+#library-canvas.library-notes-compact #library-notes-sync-conflict-label {
+    width: 11;
+    height: 1;
+    min-height: 1;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-direction-choices,
+#library-canvas.library-notes-compact #library-notes-sync-conflict-choices {
+    width: 1fr;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+    overflow-x: hidden;
 }

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -7087,7 +7087,7 @@ LibraryIngestCanvas #library-ingest-latest-batch {
 }
 
 #library-canvas.library-notes-compact #library-notes-filter-label {
-    width: 7;
+    width: 8;
     height: 1;
     padding: 0 1;
 }

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -1634,6 +1634,16 @@ with stray left-edge border fragments), and padding 0 1 so the full
     overflow-x: hidden;
 }
 
+#library-note-context-region {
+    border: solid $ds-grid-line;
+}
+
+#library-note-preview-region:focus,
+#library-note-context-region:focus {
+    border: solid $ds-input-focus-accent;
+    background: $ds-input-focus-bg;
+}
+
 #library-note-preview-body {
     height: auto;
     min-height: 0;
@@ -1658,6 +1668,13 @@ with stray left-edge border fragments), and padding 0 1 so the full
     height: auto;
     color: $ds-text-muted;
     margin: 0 0 1 0;
+}
+
+#library-note-conflict-copy:focus {
+    outline: none;
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
+    text-style: bold underline;
 }
 
 /* Prompt editor (library_prompts_canvas.py): same field/meta/conflict look

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -3462,6 +3462,16 @@ with stray left-edge border fragments), and padding 0 1 so the full
     overflow-x: hidden;
 }
 
+#library-note-context-region {
+    border: solid $ds-grid-line;
+}
+
+#library-note-preview-region:focus,
+#library-note-context-region:focus {
+    border: solid $ds-input-focus-accent;
+    background: $ds-input-focus-bg;
+}
+
 #library-note-preview-body {
     height: auto;
     min-height: 0;
@@ -3486,6 +3496,13 @@ with stray left-edge border fragments), and padding 0 1 so the full
     height: auto;
     color: $ds-text-muted;
     margin: 0 0 1 0;
+}
+
+#library-note-conflict-copy:focus {
+    outline: none;
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
+    text-style: bold underline;
 }
 
 /* Prompt editor (library_prompts_canvas.py): same field/meta/conflict look

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -8915,7 +8915,7 @@ LibraryIngestCanvas #library-ingest-latest-batch {
 }
 
 #library-canvas.library-notes-compact #library-notes-filter-label {
-    width: 7;
+    width: 8;
     height: 1;
     padding: 0 1;
 }

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -3449,17 +3449,27 @@ with stray left-edge border fragments), and padding 0 1 so the full
     margin: 0 0 1 0;
 }
 
-/* The read-only Markdown preview takes the TextArea's place one-for-one
-   when Preview is toggled on, so it gets the same bounded footprint (plus
-   its own scroll region, since Markdown has no implicit one here). */
-#library-note-preview-body {
+/* The read-only Markdown preview takes the TextArea's place one-for-one.
+   The focusable wrapper is its sole scroll owner; Markdown grows naturally
+   inside it so keyboard paging can reach the complete document. */
+#library-note-preview-region {
     height: auto;
     min-height: 12;
     max-height: 20;
     margin: 0 0 1 0;
-    padding: 0 1;
     border: solid $ds-grid-line;
     overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-note-preview-body {
+    height: auto;
+    min-height: 0;
+    margin: 0;
+    padding: 0 1;
+    border: none;
+    overflow-y: hidden;
+    overflow-x: hidden;
 }
 
 /* Muted meta line: same tier as the media viewer's metadata block
@@ -8814,6 +8824,465 @@ LibraryIngestCanvas .library-ingest-batch-header {
 LibraryIngestCanvas #library-ingest-latest-batch {
     height: auto;
     text-style: bold;
+}
+
+/* Presentation-only row wrappers keep the established wide stacked
+   workbench. Compact rules below switch only these wrappers to rows. */
+#library-notes-filter-row,
+#library-notes-status-row,
+#library-note-heading,
+#library-note-title-row,
+#library-note-context-keywords-row,
+#library-notes-create-heading,
+#library-notes-sync-heading,
+#library-notes-sync-folder-row,
+#library-notes-sync-direction-row,
+#library-notes-sync-conflict-row,
+#library-notes-sync-actions {
+    layout: vertical;
+    height: auto;
+    min-height: 0;
+}
+
+#library-notes-create-viewport,
+#library-notes-sync-viewport {
+    height: 1fr;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+/* Database Notes compact geometry: at the measured compact breakpoint,
+   the shell becomes a single 15-row workbench and every Notes state
+   assigns surplus height to exactly one scroll owner. */
+#library-shell-grid.library-notes-compact {
+    padding: 0;
+    margin: 0;
+    border: none;
+}
+
+#library-canvas.library-notes-compact {
+    padding: 0;
+    margin: 0;
+    border: none;
+    overflow-x: hidden;
+    overflow-y: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-canvas {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    padding: 0;
+    margin: 0;
+    overflow-x: hidden;
+    overflow-y: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-header {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-notes-filter-row {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-notes-filter-label {
+    width: 7;
+    height: 1;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-notes-filter {
+    width: 1fr;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+    padding: 0 1;
+    border: none;
+}
+
+#library-canvas.library-notes-compact #library-notes-browse-actions,
+#library-canvas.library-notes-compact #library-notes-sort-choices,
+#library-canvas.library-notes-compact #library-notes-transfer-actions,
+#library-canvas.library-notes-compact #library-notes-selection-actions,
+#library-canvas.library-notes-compact #library-note-primary-actions,
+#library-canvas.library-notes-compact #library-note-conflict-actions,
+#library-canvas.library-notes-compact #library-note-delete-actions {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact .library-canvas-action {
+    width: auto;
+    min-width: 0;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0 1 0 0;
+    padding: 0 1;
+    border: none;
+}
+
+#library-canvas.library-notes-compact #library-notes-status-row {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-status {
+    width: 1fr;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-notes-filter-clear {
+    width: auto;
+}
+
+#library-canvas.library-notes-compact #library-notes-selection-status {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-notes-list {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-empty {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    padding: 0 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-heading {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-editor-title,
+#library-canvas.library-notes-compact #library-note-preview-title,
+#library-canvas.library-notes-compact #library-note-context-title,
+#library-canvas.library-notes-compact #library-note-loading-title,
+#library-canvas.library-notes-compact #library-notes-create-header,
+#library-canvas.library-notes-compact #library-notes-sync-header {
+    width: 1fr;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-note-editor-region {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    overflow-x: hidden;
+    overflow-y: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-title-row {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-title-label,
+#library-canvas.library-notes-compact #library-note-context-keywords-label {
+    width: 10;
+    height: 1;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-note-title,
+#library-canvas.library-notes-compact #library-note-context-keywords,
+#library-canvas.library-notes-compact #library-notes-sync-folder {
+    width: 1fr;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+    padding: 0 1;
+    border: none;
+}
+
+#library-canvas.library-notes-compact #library-note-body-label {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-note-body {
+    height: 1fr;
+    min-height: 0;
+    max-height: 100%;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-preview-region {
+    height: 1fr;
+    min-height: 0;
+    max-height: 100%;
+    margin: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-preview-body {
+    height: auto;
+    min-height: 0;
+    margin: 0;
+    padding: 0 1;
+    border: none;
+    overflow-y: hidden;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-context-status {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-note-context-region {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-context-region .destination-section,
+#library-canvas.library-notes-compact #library-note-context-meta,
+#library-canvas.library-notes-compact #library-note-context-region > .library-canvas-action {
+    height: 1;
+    min-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-context-keywords-row {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-status {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-notes-canvas.library-note-validation #library-note-status {
+    height: 2;
+    min-height: 2;
+    max-height: 2;
+    text-wrap: wrap;
+    text-overflow: clip;
+}
+
+#library-canvas.library-notes-compact #library-note-transfer-status,
+#library-canvas.library-notes-compact #library-note-context-transfer-status {
+    display: none;
+    height: 0;
+    min-height: 0;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-conflict-region {
+    height: 3;
+    min-height: 3;
+    max-height: 3;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-conflict-copy {
+    height: 2;
+    min-height: 2;
+    max-height: 2;
+    margin: 0;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-note-delete-confirmation {
+    height: 2;
+    min-height: 2;
+    max-height: 2;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-delete-confirm-copy {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-notes-create-heading {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-notes-create-viewport {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-heading {
+    layout: horizontal;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-viewport {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-load-state {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+
+#library-canvas.library-notes-compact #library-note-load-heading {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+}
+
+#library-canvas.library-notes-compact #library-note-loading {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+#library-canvas.library-notes-compact #library-note-loading-viewport {
+    height: 1fr;
+    min-height: 0;
+    margin: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-purpose,
+#library-canvas.library-notes-compact #library-notes-sync-folder-row,
+#library-canvas.library-notes-compact #library-notes-sync-direction-row,
+#library-canvas.library-notes-compact #library-notes-sync-conflict-row,
+#library-canvas.library-notes-compact #library-notes-sync-actions,
+#library-canvas.library-notes-compact #library-notes-sync-status {
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-activity {
+    height: auto;
+    min-height: 1;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-folder-row,
+#library-canvas.library-notes-compact #library-notes-sync-direction-row,
+#library-canvas.library-notes-compact #library-notes-sync-conflict-row,
+#library-canvas.library-notes-compact #library-notes-sync-actions {
+    layout: horizontal;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-folder-label,
+#library-canvas.library-notes-compact #library-notes-sync-direction-label,
+#library-canvas.library-notes-compact #library-notes-sync-conflict-label {
+    width: 11;
+    height: 1;
+    min-height: 1;
+    padding: 0 1;
+}
+
+#library-canvas.library-notes-compact #library-notes-sync-direction-choices,
+#library-canvas.library-notes-compact #library-notes-sync-conflict-choices {
+    width: 1fr;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+    overflow-x: hidden;
 }
 
 /* ===== MODULE: components/_workbench.tcss ===== */


### PR DESCRIPTION
## Summary

- add a lossless, portable Notes session coordinator with serialized saves, autosave, conflict handling, and destructive-action gates
- make Notes fully usable at 60x20 through stateful Navigator, Editor, and explicit Context modes while preserving inline utilities at larger sizes
- preserve focus, selections, scroll state, note identity, and keyboard lifecycle across drill-in, back navigation, resize, and recompose
- add Chatbook-specific knowledge-loop behavior and regression coverage for concurrent edits, compact geometry, footer hints, focus safety, and responsive routing

## Design decisions

- phased hybrid: harden the current Notes screen now while keeping the coordinator portable for a later dedicated workbench
- Notes opens in Navigator; selecting a note drills into Editor; Back returns to Navigator; Context is an explicit toggle
- compact mode remains single-region and fully operable rather than a reduced read-only view

## Verification

- fast syntax compilation of the changed Notes screen and canvas passed
- git diff --check passed
- focused Notes state, session, canvas, CSS, keyboard, and compact-workflow coverage was exercised during implementation
- per the requested scope, unrelated and long-running broad test sweeps were not used as a PR gate

Tracks TASK-2818.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a host‑independent, lossless Notes session coordinator with autosave, serialized saves, and gated conflicts/destructive actions. Makes Notes fully operable at 60x20 with adaptive Navigator, Editor, Preview, Context, and Conflict modes while preserving focus, selection, scroll, and keyboard across navigation and resize. Addresses TASK‑2818.

- **New Features**
  - Portable session for Database Notes: protocol-based load/save, autosave, serialized saves, conflict gates, and destructive‑action admission.
  - Adaptive compact workflow: single‑region 60x20; Navigator → Editor with Back; explicit Preview, Context, and Conflict; keeps inline utilities at larger sizes.
  - Stable UX: preserves note identity/version and focus/selection/scroll across drill‑in/back/resize; non‑obscuring focus cues; rail selection updates without full recompose; Preview/Context own scrolling for reliable paging.
  - Footer and hints: exact mode‑specific shortcuts (Navigator/Editor/Preview/Context/Conflict); preview/context paging; ellipsized list titles; input validation and length limits for title/body/keywords.

- **Bug Fixes**
  - Hardened adaptive routing and responsiveness during size changes.
  - Multiselect save flush returns `NoteFlushOutcome` and no longer opens the editor.
  - Regression coverage for concurrent edits, compact geometry, focus safety, and deterministic modular CSS builds.

<sup>Written for commit 174dfc5eedd6af952c41bd3e5825b47254f83fd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

