### PR TITLE
refactor(console): move the composer keymap to the composer (wave 5, partial)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2176,7 +2176,7 @@
     },
     {
       "call_count": 142,
-      "diagnostic_digest": "3645673c07350d130c62",
+      "diagnostic_digest": "ba22d3ff40d6a5b2699d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/chat_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Docs/superpowers/plans/2026-08-07-console-decomposition-wave5.md
+++ b/Docs/superpowers/plans/2026-08-07-console-decomposition-wave5.md
@@ -1,0 +1,156 @@
+# Console Decomposition — Wave 5 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Put the composer's keymap with the widget that already implements every operation it maps to, extract the two largest remaining feature clusters, and lower the size ratchet.
+
+**Architecture:** Per `Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md` and the eleven controllers/regions in `UI/Console_Modules/`. Task 1 is unusual and is the wave's most interesting change: it moves code **into an existing widget**, not into a new module, because the ownership is already there and only the mapping is misplaced.
+
+**Tech Stack:** Python ≥3.11, Textual 8.x, pytest.
+
+**Measured on dev at `fdaf1379f` (post-wave-4 + follow-ups) — re-locate by anchor, never by line number:**
+- `chat_screen.py` **17,727 lines**, `ChatScreen` **593 methods**. Ratchet budget 17727/593.
+- Largest methods: `compose_content` (314), `on_key` (309), `__init__` (285 — down from 782, wave 4 did its job), `on_button_pressed` (206).
+- **`on_key`'s 24 top-level branches, classified by what they touch: 18 touch ONLY the composer** (~120 lines: arrows, home/end, backspace/delete, ctrl+w/u/z/y, shift+enter, select-all). The other 6 reach further: `enter` (72 lines, composer + `query_one` + store), `pageup/pagedown` (17), the hands-free branch (23), the realtime branch (8), the command-popup branch (16), and the setup-modal guard (4).
+- **image: 638 lines / 21 methods.** Largest: `_console_command_generate_image` (162), `_paste_console_clipboard_image` (76), `_console_generate_image_llm_context_options` (68), `_extend_specs_with_remote_images` (59).
+- **character: 412 / 12.** Largest: `_refresh_active_character_avatar_if_scope_changed` (108), `_build_character_avatar_widget` (74), `_apply_console_character_choice_async` (65), `_render_character_avatar_into_section` (33).
+
+**The finding that shapes Task 1.** `tldw_chatbook/Widgets/Console/console_composer_bar.py` is 4,231 lines and **already implements every operation those 18 branches call**: `insert_text`, `delete_left`, `delete_right`, `delete_word_left`, `move_cursor_left/right/up/down/home/end`, `undo`, `redo`, `select_all_draft`. It defines **no `on_key` and no `BINDINGS`**. So the screen holds a key→method table for methods the widget owns. That is not a switch worth relocating for its own sake — it is a mapping living apart from the thing it maps to.
+
+## Global Constraints
+
+The spec's six migration rules bind every task. Plus, hard-won across waves 1–4:
+
+**THE CONTROLLER BINDING RULE** — canonical example is `ConsoleDictationController.__init__`'s docstring in `Console_Modules/dictation.py`:
+- Framework services (`run_worker`, `set_timer`, `post_message`, `push_screen`, `call_after_refresh`, `is_mounted`) — live-read from the screen via `@property`.
+- App-level dependencies — **named keyword-only callable parameters**, wired as late-binding lambdas **in `Console_Modules/wiring.py`** (wave 4 moved construction there; a new controller is added to `wiring.py`, never back into `__init__`).
+- `app_instance` — snapshot only, justified in the docstring.
+- Workers — preserve pre-move group names. `Tests/UI/test_chat_screen_worker_groups.py` scans `chat_screen.py` **and** `Console_Modules/*.py`; a new module is in scope automatically.
+- Controller↔controller traffic through named callables resolved at **CALL time**.
+- **Zero `query_one`/DOM access in a controller.** Every existing controller has zero. Regions and widgets are the opposite — DOM is theirs.
+- **A proxy property standing in for a baseline plain attribute must be read-WRITE and write THROUGH to the controller** (DESIGN.md §7). Wave 3 shipped a getter-only one and turned **41 tests red in a file the branch never touched**.
+- **A region owns its behaviour, not its children's API** (DESIGN.md, wave-5 rule from task-2767): route through a region only when the invariant is the region's; querying a child widget by id is idiomatic in Textual, not a boundary violation.
+- `action_*` and `@on` handlers Textual resolves **by name on the Screen** stay on the Screen. Their bodies may move; their definitions may not. **`on_key` itself stays on the screen** — it is the focus-routing policy ("treat the composer as the default printable text target"), which is a screen concern.
+
+**Process rules, each paid for:**
+- **`git push` after EVERY commit.** An entire unpushed wave was destroyed by the `/private/tmp` cleaner. Work lives in `.worktrees/wave5`; the interpreter is `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python`.
+- **Never `git stash`** — the stash stack is shared across 100+ worktrees.
+- **Never `cd` to the parent repo.** A wave-3 implementer's compound `cd <root> && … git commit` swept another session's ~500 uncommitted files into a commit on their branch.
+- **Characterise BEFORE extracting**, always. Retroactive characterisation is count-level evidence only.
+- **Commit the extraction the moment it exists**, before any sweep.
+- Tests FOREGROUND with Bash `timeout: 600000`. A backgrounded pytest strands the implementer — it has done so six times on this programme.
+- **`pytest` reporting "no tests ran" is a FAILED gate, not a pass.** Verify every path exists before trusting a green line; two paths were mistyped in wave 3 and produced a silent no-op.
+- **If a test fails, run BOTH arms — with and without the change — before calling it causal.** A correct deletion looked causal across three signals in wave 4 and nearly got reverted; a two-arm A/B showed the test was nondeterministic on its own.
+- **Scope verification to every file REFERENCING what you move, not the files you edited.** That error let a wave-3 task ship 42 failing tests past a green run. A plain diff CANNOT see moved-but-delegated methods — intersect `defs(new module)` with `defs(baseline screen)` instead.
+- Rebase onto `origin/dev` before each task, and **re-measure the ratchet after the FINAL rebase** — wave 3 set its budget twice from a stale base and both landed red.
+
+**Four defect classes that have bitten this programme:**
+1. **Dead bodies / over-deletion** — every moved method gone, or a ≤14-line pure-forwarding delegation **with a real caller** (`ast`, not grep). An `ast`-lineno delete misses decorator lines AND can take the first line of the *next* declaration's comment block; both have happened.
+2. **Silent drops outside the hunks** — orphaned imports causing runtime `NameError`. pyflakes both files, compare to baseline (currently **25** on `chat_screen.py`).
+3. **Imports that look unused but are load-bearing for tests.** Tests reach symbols as `chat_screen_module.X` or `setattr(chat_screen_module, "X", ...)` — invisible to any import-grep, and the quoted form is not even an identifier. Wave 4 deleted five such imports and turned 28 tests red. task-3023 repointed the known set, but **check before deleting any import your extraction orphans**.
+4. **Hand-built screen fixtures.** Every wave has shipped exactly one to dev. Sweep `grep -rl 'ChatScreen.__new__\|spec=ChatScreen' Tests/`. `Tests/UI/console_controller_stubs.py` exists — reuse or extend it, and note its `NO_APP` sentinel, which exists because an inferred `app_instance=None` is a silent-default hole.
+
+## File Structure
+
+- `tldw_chatbook/Widgets/Console/console_composer_bar.py` — gains the keymap it already has the operations for.
+- `tldw_chatbook/UI/Console_Modules/image.py` (new) — `ConsoleImageController`.
+- `tldw_chatbook/UI/Console_Modules/character.py` (new) — `ConsoleCharacterController`.
+- `tldw_chatbook/UI/Console_Modules/wiring.py` — two more constructions.
+- `tldw_chatbook/UI/Screens/chat_screen.py` — `on_key` and both clusters shrink.
+- `Tests/Architecture/test_screen_size_ratchet.py` — budget lowered in Task 4.
+
+---
+
+### Task 1: The composer keymap moves to the composer
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Console/console_composer_bar.py`, `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/UI/test_console_composer_keymap.py` (new)
+
+**Interfaces:**
+- Produces: a single public entry point on `ConsoleComposerBar` — `handle_console_key(event: Key) -> bool` — returning True when it consumed the key. The screen's `on_key` calls it and returns on True.
+- Consumes: nothing from later tasks.
+
+**The split is ownership, not line count.** The composer takes the 18 branches that touch **only** the composer, because each maps to a method it already implements. The screen keeps everything that is *routing policy* or reaches beyond the composer: the setup-modal guard, the hands-free branch, the realtime branch, the command-popup branch, `_should_capture_console_input`, `enter` (72 lines — it sends, touching the store and the DOM), and `pageup/pagedown` (it scrolls the transcript, not the composer).
+
+- [ ] **Step 1: Map all 24 branches** — key(s), line count, every method called, and a per-branch verdict (moves to the composer / stays with reason). **If a branch you expect to move calls anything other than a `ConsoleComposerBar` method, it stays** — report it rather than widening the widget's API to accommodate it. Confirm from the source that every operation the moving branches call already exists on the widget; **if any does not, that branch stays too** (adding operations is a feature change, forbidden in an extraction).
+- [ ] **Step 2: Characterise first.** Mount `ConsoleComposerBar` in a minimal host app and drive REAL key presses through `pilot`, asserting the resulting `draft_text` and cursor position — not internal calls. Cover at minimum: backspace, delete, ctrl+w, ctrl+u, arrows, home/end, undo/redo, select-all. Also pin the SCREEN-level routing that must not change: a printable key typed while the composer is not focused still reaches it. Commit separately, push, green pre-move.
+- [ ] **Step 3: Move** the 18 branch bodies into `handle_console_key`, verbatim. `on_key` keeps its own definition, its docstring's stated policy, and every branch that stays, and gains one call to the composer.
+- [ ] **Step 4: Commit, push, then verify** in one foreground call (`timeout: 600000`): the new test file + `Tests/UI/test_console_composer_undo.py` + `Tests/UI/test_console_command_composer.py` + `Tests/Architecture/`. Then a second call for every other file your referencing sweep flags.
+- [ ] **Step 5: Report** the branch table, the stays-list with reasons, whether any operation had to be added to the widget (it should not), the four audits, and before/after line counts.
+
+Commit: `refactor(console): move the composer keymap to the composer (wave 5)`
+
+---
+
+### Task 2: The image controller
+
+**Files:**
+- Create: `tldw_chatbook/UI/Console_Modules/image.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`, `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Test: `Tests/UI/test_console_image_controller.py` (new)
+
+**Interfaces:**
+- Produces: `ConsoleImageController` owning the image cluster (638 lines / 21 methods), constructed in `wiring.py`.
+
+- [ ] **Step 1: Map the cluster**, per-method verdicts, and the image↔message/session traffic in both directions. Waves 2, 3 and 4 all found `*name*`-matched methods that were **false positives**; check each of the 21 against what it actually touches and report any you exclude, plus any image-cluster method whose name lacks "image".
+- [ ] **Step 2: Characterise first** — drive a real generate-image path and assert the persisted result (message rows / stored specs), not widget state. `Tests/Chat/test_console_generation_actions.py` and `Tests/Chat/test_console_generation_card.py` already cover parts of this cluster: run them pre-move and record counts. Commit separately, push, green pre-move.
+- [ ] **Step 3: Extract** per the binding rule; construct in `wiring.py`.
+- [ ] **Step 4: Commit, push, verify** (two calls; include both generation test files).
+- [ ] **Step 5: Report** as above.
+
+Commit: `refactor(console): image controller (wave 5)`
+
+---
+
+### Task 3: The character controller
+
+**Files:**
+- Create: `tldw_chatbook/UI/Console_Modules/character.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`, `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Test: `Tests/UI/test_console_character_controller.py` (new)
+
+**Interfaces:**
+- Produces: `ConsoleCharacterController` owning the character cluster (412 lines / 12 methods), constructed in `wiring.py`.
+
+**One boundary is already known.** `_build_character_avatar_widget` (74) and `_render_character_avatar_into_section` (33) build and mount a widget into `ConsoleLeftRail`, which takes it as a zero-arg builder (`character_avatar_widget_builder`, DESIGN.md §7). **Widget construction is DOM work and must not enter the controller.** Expect the avatar builders to stay on the screen with the controller owning the *decision* (which character, whether the scope changed) — but map it and say what you found rather than assuming this shape.
+
+- [ ] **Step 1: Map the cluster**, per-method verdicts with reasons, and the character↔session/message traffic. Note that `{{char}}`/`{{persona}}` refer to the CHARACTER and `{{user}}` to the human — do not "fix" any copy that uses them.
+- [ ] **Step 2: Characterise first** — drive a real character choice and assert the persisted selection; committed, pushed, green pre-move.
+- [ ] **Step 3: Extract** per the binding rule; construct in `wiring.py`.
+- [ ] **Step 4: Commit, push, verify** (two calls).
+- [ ] **Step 5: Report** as above, including the avatar-builder boundary decision.
+
+Commit: `refactor(console): character controller (wave 5)`
+
+---
+
+### Task 4: Close the wave and lower the ratchet
+
+**Files:**
+- Modify: `Tests/Architecture/test_screen_size_ratchet.py`, `Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md`, `DESIGN.md` if the wave established a new rule
+
+- [ ] **Step 1: Rebase onto `origin/dev` FIRST, then measure** `chat_screen.py`'s line count and `ChatScreen`'s method count with `ast`. Wave 3 measured before its final rebase twice and both budgets landed red.
+- [ ] **Step 2: Lower the ratchet** in `_BUDGETS` to exactly those numbers. This is the step the whole wave exists to earn; the second ratchet test fails if you skip it, by design.
+- [ ] **Step 3: Annotate the spec** — mark the composer keymap, image and character done, update the Progress numbers honestly, and record what the wave did NOT achieve as well as what it did.
+- [ ] **Step 4: `DESIGN.md`** — Task 1 likely establishes a rule worth recording (a keymap belongs with the operations it maps to, not with the focus policy that routes to it). Add it if the wave earned it; **if not, say so in the report rather than inventing one.**
+- [ ] **Step 5: Serial gate**, at most two foreground calls (`timeout: 600000`), then commit and push.
+
+Commit: `refactor(console): wave 5 closed — ratchet lowered, honest numbers`
+
+---
+
+## Wave 5 exit criteria
+
+- The composer's key→operation mapping lives on `ConsoleComposerBar`; `on_key` keeps only routing policy and the branches that reach beyond the composer.
+- The image and character clusters live in `UI/Console_Modules/`, constructed in `wiring.py`.
+- Zero DOM access in any controller; the geometry baseline is byte-identical and green.
+- No behaviour change; every pre-existing DOM-driven test passes unchanged.
+- **The ratchet is lowered to the post-rebase measurement.**
+
+## Not in wave 5 (deliberate)
+
+- **`compose_content`'s workbench header.** Measured: ~62 composed lines plus a 230-line/15-method sync cluster of which several are `action_*` handlers that must stay on the Screen by name. That is the shape that made wave 3's transcript region net **+1 line**; extracting it would buy structure at no size cost, and this wave has better targets. Revisit only with a reason beyond "it is still inline".
+- `on_button_pressed` (206) — wave 4 already routed its six worthwhile branches; the remaining thirteen were judged coordination or event-passing, with reasons recorded.
+- The rail (515/27), rag (405/17), skill (339/16) and citation (333/9) clusters.
+- Settings and Library screens remain their own future efforts under the same spec.

--- a/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
+++ b/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
@@ -326,6 +326,43 @@ of the small ones pass the `Button.Pressed` event itself — moving those would
 breach the no-DOM-and-no-events-in-a-controller invariant. An honest stays-list
 is worth more than a flattering diff.
 
+**Wave 5 (partial — the composer keymap only)** — `ConsoleComposerBar` gained
+`handle_console_key`; `chat_screen.py` **17,727 -> 17,685**, `ChatScreen` 593
+methods (unchanged: this moved branch bodies, not methods).
+
+The wave's remaining tasks (image and character controllers) are **deferred with
+tasks filed**, not abandoned. What landed is complete and reviewed on its own.
+
+**The planning lesson is the durable part.** The plan predicted 18 of `on_key`'s
+24 branches would move; **seven did**. The premise was verified only half-way:
+all 17 composer *operations* those branches call were confirmed to already exist
+on `ConsoleComposerBar` (by AST, not assumption) — but nobody checked whether the
+branches ALSO call *screen* methods. Eleven do:
+`_sync_console_workbench_actions_from_draft` (workbench state + slash-command
+popup), `_dismiss_console_guidance` (repaints the transcript),
+`_console_composer_undo`/`_redo` (session-settle gate + chat-store persistence),
+and `ctrl+c` (the app clipboard). The task's own rule sent them back, so it
+netted −42 lines rather than ~−120.
+
+**When scoping a move, verify BOTH directions of the seam** — what the moving
+code needs from its destination, and what it still needs from its source. A
+"does the body mention X" filter answers only the first, and screen-method calls
+like `self._sync_console_workbench_actions_from_draft(...)` match no obvious
+token.
+
+What did move is right, and is a different shape from the earlier waves: the
+keymap now lives with the operations it maps to. `on_key` stays on the screen
+because it is *focus-routing policy* — "treat the composer as the default
+printable text target" — which is a screen concern, and Textual resolves it by
+name there anyway. The composer's return value tells the screen whether the key
+was consumed, so unconsumed keys still fall through; seven tests pin that
+contract, including the up/down fall-through.
+
+Task-3749 records the unblock: a composer `DraftChanged` message the screen
+subscribes to would free six of the eleven. It is a design change, not an
+extraction, and an extraction that also changes how components communicate gives
+a regression two candidate causes — so it is filed rather than smuggled in.
+
 ## Migration safety
 
 This is the section that matters most, because this refactor walks directly through this

--- a/Tests/Architecture/test_screen_size_ratchet.py
+++ b/Tests/Architecture/test_screen_size_ratchet.py
@@ -48,11 +48,12 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 #: patched controllers through this module's namespace and so freed the
 #: wave-4 re-export imports for deletion: 17,749 -> 17,727 lines (methods
 #: unchanged at 593 — only imports went).
-#: Lowered 2026-08-08 for wave 5's composer-keymap task: 17,727/593 ->
-#: 17,685/593. Wave 5 shipped only that task; its image and character
-#: extractions are deferred (tasks filed), so this is a partial-wave budget --
-#: which is exactly what the ratchet is for: lock in what was earned.
-#: Previously lowered 2026-08-07 at the wave-4 close (controller wiring out of
+#: NOT lowered by wave 5's composer-keymap task, deliberately. That task
+#: earned 42 lines, but between its start and its merge ~540 lines of feature
+#: work landed in `chat_screen.py` on dev and this budget was ALREADY exceeded
+#: (see task-3751). Lowering to the earned number would have been meaningless
+#: and raising it to the measured number would have defeated the mechanism, so
+#: the number is left exactly as dev has it. Lowered 2026-08-07 at the wave-4 close (controller wiring out of
 #: `__init__`, button-dispatch routing, the agent cluster): 18,930/600 ->
 #: 17,749/593. Wave 3 recorded 18,909/598; dev grew the screen by 21 lines
 #: and 2 methods while wave 4 was in flight, which is the whole reason this
@@ -62,7 +63,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 #: pre-rebase measurement and both landed red, because dev moved underneath
 #: it -- a budget derived from a stale base fails the moment it merges.
 _BUDGETS: dict[str, tuple[str, int, int]] = {
-    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 17685, 593),
+    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 17727, 593),
 }
 
 

--- a/Tests/Architecture/test_screen_size_ratchet.py
+++ b/Tests/Architecture/test_screen_size_ratchet.py
@@ -48,7 +48,11 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 #: patched controllers through this module's namespace and so freed the
 #: wave-4 re-export imports for deletion: 17,749 -> 17,727 lines (methods
 #: unchanged at 593 — only imports went).
-#: Lowered 2026-08-07 at the wave-4 close (controller wiring out of
+#: Lowered 2026-08-08 for wave 5's composer-keymap task: 17,727/593 ->
+#: 17,685/593. Wave 5 shipped only that task; its image and character
+#: extractions are deferred (tasks filed), so this is a partial-wave budget --
+#: which is exactly what the ratchet is for: lock in what was earned.
+#: Previously lowered 2026-08-07 at the wave-4 close (controller wiring out of
 #: `__init__`, button-dispatch routing, the agent cluster): 18,930/600 ->
 #: 17,749/593. Wave 3 recorded 18,909/598; dev grew the screen by 21 lines
 #: and 2 methods while wave 4 was in flight, which is the whole reason this
@@ -58,7 +62,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 #: pre-rebase measurement and both landed red, because dev moved underneath
 #: it -- a budget derived from a stale base fails the moment it merges.
 _BUDGETS: dict[str, tuple[str, int, int]] = {
-    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 17727, 593),
+    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 17685, 593),
 }
 
 

--- a/Tests/UI/test_console_composer_keymap.py
+++ b/Tests/UI/test_console_composer_keymap.py
@@ -1,0 +1,266 @@
+"""Characterisation of the Console composer keymap (decomposition wave 5).
+
+These tests exist to pin the *observable* behaviour of the composer key
+table -- the resulting `draft_text()` and `cursor_index` after a REAL key
+press driven through `pilot` -- so that moving the composer-only branches
+out of `ChatScreen.on_key` and into `ConsoleComposerBar.handle_console_key`
+can be proven byte-for-byte behaviour-preserving. They deliberately assert
+end state, never internal calls: a characterisation test that asserts
+"`delete_left` was called" would pass just as happily against a broken
+move.
+
+The screen-level routing is pinned here too, because it is exactly what the
+move must NOT change: `ChatScreen.on_key`'s stated policy is to "treat the
+Console composer as the default printable text target", so a printable key
+pressed while *nothing* is focused still has to land in the composer. That
+policy stays on the screen (`_should_capture_console_input` is the gate);
+only the per-key branch bodies move.
+
+The host is the real Console screen (`test_console_dictation._ready_host`),
+not a hand-built screen fixture -- the keymap is only observable through
+the screen's `on_key` before the move, so anything lighter would be
+characterising a reimplementation of the thing under test rather than the
+thing itself.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from Tests.UI.test_console_dictation import _mounted_console, _ready_host
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+
+APP_SIZE = (140, 42)
+
+
+async def _focused_composer(host, pilot, text: str = "") -> ConsoleComposerBar:
+    """Mount the ready Console, load `text`, and focus the composer."""
+    console = await _mounted_console(host, pilot)
+    composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+    if text:
+        composer.load_draft(text)
+    composer.focus()
+    await pilot.pause()
+    return composer
+
+
+# ---------------------------------------------------------------------------
+# Deletion keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backspace_deletes_the_character_left_of_the_caret():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        composer = await _focused_composer(host, pilot, "hello")
+        assert composer.cursor_index == 5
+
+        await pilot.press("backspace")
+        await pilot.pause()
+
+        assert composer.draft_text() == "hell"
+        assert composer.cursor_index == 4
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_the_character_right_of_the_caret():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        composer = await _focused_composer(host, pilot, "hello")
+        composer.position_cursor_from_display_index(2)
+        await pilot.pause()
+        assert composer.cursor_index == 2
+
+        await pilot.press("delete")
+        await pilot.pause()
+
+        assert composer.draft_text() == "helo"
+        assert composer.cursor_index == 2
+
+
+@pytest.mark.asyncio
+async def test_ctrl_w_deletes_the_word_left_of_the_caret():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        composer = await _focused_composer(host, pilot, "hello world")
+
+        await pilot.press("ctrl+w")
+        await pilot.pause()
+
+        assert composer.draft_text() == "hello "
+        assert composer.cursor_index == len("hello ")
+
+
+@pytest.mark.asyncio
+async def test_ctrl_u_clears_the_whole_draft():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        composer = await _focused_composer(host, pilot, "throw me away")
+
+        await pilot.press("ctrl+u")
+        await pilot.pause()
+
+        assert composer.draft_text() == ""
+        assert composer.cursor_index == 0
+
+
+# ---------------------------------------------------------------------------
+# Caret movement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_left_and_right_step_the_caret_without_changing_the_draft():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        composer = await _focused_composer(host, pilot, "abcdef")
+
+        await pilot.press("left")
+        await pilot.press("left")
+        await pilot.pause()
+        assert composer.cursor_index == 4
+
+        await pilot.press("right")
+        await pilot.pause()
+        assert composer.cursor_index == 5
+        assert composer.draft_text() == "abcdef"
+
+
+@pytest.mark.asyncio
+async def test_home_and_end_jump_the_caret_to_the_draft_bounds():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        composer = await _focused_composer(host, pilot, "abcdef")
+
+        await pilot.press("home")
+        await pilot.pause()
+        assert composer.cursor_index == 0
+
+        await pilot.press("end")
+        await pilot.pause()
+        assert composer.cursor_index == 6
+        assert composer.draft_text() == "abcdef"
+
+
+@pytest.mark.asyncio
+async def test_up_and_down_step_visual_rows_inside_a_multiline_draft():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        composer = await _focused_composer(host, pilot, "first\nsecond\nthird")
+        # rows: "first" [0,5)  "second" [6,12)  "third" [13,18)
+        composer.position_cursor_from_display_index(13 + 2)
+        await pilot.pause()
+        assert composer.cursor_index == 15
+
+        # Not on the last visual row after the first Up, so history recall
+        # declines and ordinary caret movement gets its chance.
+        await pilot.press("up")
+        await pilot.pause()
+        assert composer.cursor_index == 6 + 2
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert composer.cursor_index == 13 + 2
+        assert composer.draft_text() == "first\nsecond\nthird"
+
+
+@pytest.mark.asyncio
+async def test_up_on_the_first_visual_row_never_moves_the_caret():
+    """Row 0 hands Up to prompt-history recall, which never moves the caret."""
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        composer = await _focused_composer(host, pilot, "first\nsecond")
+        composer.position_cursor_from_display_index(3)
+        await pilot.pause()
+
+        await pilot.press("up")
+        await pilot.pause()
+
+        assert composer.cursor_index == 3
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ctrl_a_selects_the_entire_draft():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        composer = await _focused_composer(host, pilot, "select all of me")
+        assert composer.has_full_draft_selection() is False
+
+        await pilot.press("ctrl+a")
+        await pilot.pause()
+
+        assert composer.has_full_draft_selection() is True
+        assert composer.draft_text() == "select all of me"
+
+
+# ---------------------------------------------------------------------------
+# Undo / redo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ctrl_z_undoes_a_typed_run_and_ctrl_shift_z_redoes_it():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        composer = await _focused_composer(host, pilot)
+
+        await pilot.press("h", "i")
+        await pilot.pause()
+        assert composer.draft_text() == "hi"
+
+        await pilot.press("ctrl+z")
+        await pilot.pause()
+        assert composer.draft_text() == ""
+
+        await pilot.press("ctrl+shift+z")
+        await pilot.pause()
+        assert composer.draft_text() == "hi"
+
+
+# ---------------------------------------------------------------------------
+# Screen-level routing that the move must NOT change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_printable_key_reaches_the_composer_while_nothing_is_focused():
+    """`on_key`'s policy: the composer is the default printable text target."""
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        host.set_focus(None)
+        await pilot.pause()
+        assert host.focused is None
+
+        await pilot.press("z")
+        await pilot.pause()
+
+        assert composer.draft_text() == "z"
+        assert composer.cursor_index == 1
+
+
+@pytest.mark.asyncio
+async def test_an_edit_key_reaches_the_composer_while_nothing_is_focused():
+    """The same default-target policy covers the edit keys, not just typing."""
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("abc")
+        host.set_focus(None)
+        await pilot.pause()
+        assert host.focused is None
+
+        await pilot.press("left")
+        await pilot.press("backspace")
+        await pilot.pause()
+
+        assert composer.draft_text() == "ac"
+        assert composer.cursor_index == 1

--- a/backlog/tasks/task-3070 - chat_screen size ratchet red on dev after console decomposition wave 3.md
+++ b/backlog/tasks/task-3070 - chat_screen size ratchet red on dev after console decomposition wave 3.md
@@ -32,3 +32,35 @@ decomposition stream's owner explicitly decides the budget is wrong.
 - [ ] #1 The chat_screen size-ratchet test passes on dev
 - [ ] #2 The resolution shrinks the screen (or an explicit, documented owner decision adjusts the budget)
 <!-- AC:END -->
+
+## Addendum 2026-08-08 — the overage is now 540 lines, and its cause changed
+
+When filed, this was a 21-line transitional overage from wave 3 itself. It is now
+**18,267 lines against a budget of 17,727 (+540)**, and the cause is no longer the
+decomposition stream: waves 4 and 5 both LOWERED the screen (18,930 -> 17,727 ->
+17,685). The growth arrived from feature work merging past a red gate — six commits,
+chiefly the TASK-2154 UX remediation and the collapsed-rail work.
+
+**The budget was never raised**, which matters: the mechanism refused correctly and
+the refusal was merged past rather than defeated. So this is the first time the
+ratchet has fired against real feature growth rather than a wave, which is exactly
+what it was built for.
+
+Measured inventory of the growth (`ast`, dev at the wave-5 rebase):
+
+- **11 new `ChatScreen` methods, 221 lines.** Most have an obvious existing home:
+  `_stack_collapsed_rail_labels` (10) and `_reveal_console_inspector_rail` (15) ->
+  the rail regions; `_adapt_console_workspace_to_width` (23) and
+  `_console_tab_region_selector` (28) -> `workspace.py`; `_console_run_chip_activated`
+  (6), `_console_tools_chip_activated` (6), `_console_sources_chip_activated` (11),
+  `_console_active_run_copy` (17), `_notify_console_run_failure` (16) -> the agent or
+  session controllers. `_sync_console_compact_status_marker` (48) and
+  `_console_library_provider_factory` (41) need a judgement call.
+- **+251 lines in existing methods**, led by `compose_content` (314 -> 357),
+  `_sync_console_rail_visibility` (42 -> 64), `action_focus_next` (14 -> 31),
+  `_sync_console_mode_bar` (12 -> 28), `on_key` (309 -> 325).
+
+Wave 5 deliberately did NOT touch the budget: lowering it to the 42 lines its
+composer-keymap task earned would have been meaningless against a +540 overage, and
+raising it to the measured number would have defeated the mechanism. The number is
+left exactly as dev has it.

--- a/backlog/tasks/task-3749 - Composer-DraftChanged-message-would-unblock-six-on_key-branches.md
+++ b/backlog/tasks/task-3749 - Composer-DraftChanged-message-would-unblock-six-on_key-branches.md
@@ -1,0 +1,24 @@
+---
+id: TASK-3749
+title: Composer DraftChanged message would unblock six on_key branches
+status: To Do
+assignee: []
+created_date: '2026-08-08 21:06'
+labels:
+  - refactor
+  - console
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Wave 5 task 1 moved 7 of on_key's composer branches into ConsoleComposerBar. Eleven more could not move because they call screen methods after editing the draft: six of those call _sync_console_workbench_actions_from_draft (workbench state + slash-command popup) and _dismiss_console_guidance (repaints the transcript). If the composer posted a DraftChanged message that the screen subscribed to, those six branches would become composer-only and could move, taking the keymap with them. This is a DESIGN change, not an extraction, which is why wave 5 did not do it: an extraction that also changes how components communicate gives a regression two candidate causes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The composer notifies the screen of draft changes rather than the screen calling back after each edit
+- [ ] #2 The six blocked branches move to ConsoleComposerBar.handle_console_key
+- [ ] #3 No behaviour change: the workbench actions, slash-command popup and guidance repaint still update on every draft edit
+<!-- AC:END -->

--- a/backlog/tasks/task-3750 - Diagnostic-inventory-digests-key-on-logger-line-numbers.md
+++ b/backlog/tasks/task-3750 - Diagnostic-inventory-digests-key-on-logger-line-numbers.md
@@ -1,0 +1,23 @@
+---
+id: TASK-3750
+title: Diagnostic inventory digests key on logger line numbers
+status: To Do
+assignee: []
+created_date: '2026-08-08 21:06'
+labels:
+  - tech-debt
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Docs/security/production-diagnostic-inventory.json stores a per-file digest that changes when logger call LINE NUMBERS move, not only when the diagnostics themselves change. Any refactor that shifts lines in a file containing logging therefore fails Tests/Architecture/test_persistent_diagnostic_inventory.py and needs a review-and-regenerate cycle -- this cost one cycle per task across decomposition waves 4 and 5, every time with call_count unchanged and the sink topology byte-identical. Keying the digest on diagnostic CONTENT (message, level, owner) rather than position would keep the security signal the file exists for while removing a per-refactor chore that trains people to regenerate it without reading the diff.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Moving a logger call within a file without changing it does not change its digest
+- [ ] #2 Adding, removing, or editing a diagnostic still changes the digest and fails the test
+- [ ] #3 The existing reviewed inventory is migrated to the new keying in one deliberate commit
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -17389,10 +17389,14 @@ class ChatScreen(BaseAppScreen):
                 event.stop()
                 event.prevent_default()
                 return
-        if event.key in {"ctrl+a", "super+a", "cmd+a", "meta+a"}:
-            composer.select_all_draft()
-            event.stop()
-            event.prevent_default()
+        # Decomposition wave 5: the keys whose whole handling is a composer
+        # operation (select-all and caret movement, including Up/Down's
+        # history-recall-first shape, which still falls through UNCONSUMED
+        # on a boundary row where nothing moved) now live on the composer
+        # itself. Everything below stays because it reaches past the
+        # composer -- Workbench/guidance resync, the clipboard, undo/redo's
+        # store persistence, send, transcript paging.
+        if composer.handle_console_key(event):
             return
         if (
             event.key in {"ctrl+c", "super+c", "cmd+c", "meta+c"}
@@ -17413,52 +17417,6 @@ class ChatScreen(BaseAppScreen):
         if event.key == "delete":
             composer.delete_right()
             self._sync_console_workbench_actions_from_draft()
-            event.stop()
-            event.prevent_default()
-            return
-        if event.key == "left":
-            composer.move_cursor_left()
-            event.stop()
-            event.prevent_default()
-            return
-        if event.key == "right":
-            # TASK-1364: with a ghost-text suggestion visible (caret at end,
-            # live draft), Right accepts it instead of moving the caret.
-            if not composer.accept_ghost_text():
-                composer.move_cursor_right()
-            event.stop()
-            event.prevent_default()
-            return
-        # Vertical caret movement differs from every neighbor above: those
-        # always consume the key (there is always somewhere to move -- even
-        # at a boundary, left/right/home/end land on a valid, if unchanged,
-        # offset). `move_cursor_up`/`move_cursor_down` instead return False
-        # on the first/last visual row, and the composer moves nothing at
-        # all -- so the event must fall through UNCONSUMED in that case,
-        # preserving whatever up/down would otherwise do on this screen
-        # (nothing today; a future transcript scroll or default focus
-        # behavior must not be silently swallowed by a no-op composer move).
-        # TASK-1364: on exactly those boundary rows, Up/Down first offer
-        # prompt-history recall (the composer gates on first/last visual row
-        # of the wrapped draft); only when recall declines does ordinary
-        # caret movement get its chance.
-        if event.key == "up":
-            if composer.recall_history_previous() or composer.move_cursor_up():
-                event.stop()
-                event.prevent_default()
-                return
-        if event.key == "down":
-            if composer.recall_history_next() or composer.move_cursor_down():
-                event.stop()
-                event.prevent_default()
-                return
-        if event.key == "home":
-            composer.move_cursor_home()
-            event.stop()
-            event.prevent_default()
-            return
-        if event.key == "end":
-            composer.move_cursor_end()
             event.stop()
             event.prevent_default()
             return

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -41,7 +41,7 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.content import Content
 from textual.css.query import NoMatches
-from textual.events import Click, DescendantBlur, DescendantFocus, MouseUp
+from textual.events import Click, DescendantBlur, DescendantFocus, Key, MouseUp
 from textual.geometry import Region
 from textual.widget import Widget
 from textual.widgets import Button, Input, Static
@@ -2733,6 +2733,88 @@ class ConsoleComposerBar(Horizontal):
         self._evict_to_char_budget(self._undo_stack)
         self._evict_to_char_budget(self._redo_stack)
         self._coalescing_active = False
+
+    def handle_console_key(self, event: Key) -> bool:
+        """Consume a Console key that maps onto a composer-only operation.
+
+        Decomposition wave 5: the composer already owned every operation
+        these keys invoke -- only the key->method mapping lived on
+        `ChatScreen.on_key`. The branches below are the ones that call
+        *nothing but* composer methods, so they move here verbatim; the
+        screen keeps `on_key` itself (Textual resolves it by name, and its
+        "the Console composer is the default printable text target" policy
+        is routing, not composer behaviour) along with every branch that
+        reaches past the composer -- Workbench/guidance resync, the
+        clipboard, undo/redo's store persistence, send, transcript paging.
+
+        This is NOT a Textual handler (no `on_`/`_on_` prefix, no
+        `BINDINGS`): the composer must not start consuming keys on its own
+        the moment it happens to be focused. The screen decides whether the
+        keystroke belongs to the composer at all (`_should_capture_console_
+        input`, the setup-modal guard, the hands-free/realtime loops, the
+        slash-command popup) and only then delegates here.
+
+        Args:
+            event: The key event the screen is offering to the composer.
+
+        Returns:
+            True when the key was consumed (the event has already been
+            stopped and default-prevented); False when the screen should
+            keep looking -- which includes Up/Down on a boundary row where
+            neither history recall nor caret movement had anything to do.
+        """
+        if event.key in {"ctrl+a", "super+a", "cmd+a", "meta+a"}:
+            self.select_all_draft()
+            event.stop()
+            event.prevent_default()
+            return True
+        if event.key == "left":
+            self.move_cursor_left()
+            event.stop()
+            event.prevent_default()
+            return True
+        if event.key == "right":
+            # TASK-1364: with a ghost-text suggestion visible (caret at end,
+            # live draft), Right accepts it instead of moving the caret.
+            if not self.accept_ghost_text():
+                self.move_cursor_right()
+            event.stop()
+            event.prevent_default()
+            return True
+        # Vertical caret movement differs from every neighbor above: those
+        # always consume the key (there is always somewhere to move -- even
+        # at a boundary, left/right/home/end land on a valid, if unchanged,
+        # offset). `move_cursor_up`/`move_cursor_down` instead return False
+        # on the first/last visual row, and the composer moves nothing at
+        # all -- so the event must fall through UNCONSUMED in that case,
+        # preserving whatever up/down would otherwise do on this screen
+        # (nothing today; a future transcript scroll or default focus
+        # behavior must not be silently swallowed by a no-op composer move).
+        # TASK-1364: on exactly those boundary rows, Up/Down first offer
+        # prompt-history recall (the composer gates on first/last visual row
+        # of the wrapped draft); only when recall declines does ordinary
+        # caret movement get its chance.
+        if event.key == "up":
+            if self.recall_history_previous() or self.move_cursor_up():
+                event.stop()
+                event.prevent_default()
+                return True
+        if event.key == "down":
+            if self.recall_history_next() or self.move_cursor_down():
+                event.stop()
+                event.prevent_default()
+                return True
+        if event.key == "home":
+            self.move_cursor_home()
+            event.stop()
+            event.prevent_default()
+            return True
+        if event.key == "end":
+            self.move_cursor_end()
+            event.stop()
+            event.prevent_default()
+            return True
+        return False
 
     def select_all_draft(self) -> bool:
         """Mark the full visible Console draft as selected without mutating it.


### PR DESCRIPTION
Wave 5's first task, shipped on its own. The wave's image and character extractions are **deferred with tasks filed**, not abandoned — see "Why partial" below.

`chat_screen.py` **−42 lines**; `ConsoleComposerBar` gains `handle_console_key`.

## What lands

`ChatScreen.on_key` held a key→method table for methods `ConsoleComposerBar` already implements. The widget is 4,231 lines, already has all 17 operations (`insert_text`, `delete_left`, `delete_word_left`, `move_cursor_*`, `select_all_draft`, `undo`, `redo`, …), and defined **no `on_key` and no `BINDINGS`**. So the mapping lived apart from the thing it maps to.

Seven branches moved — `ctrl+a`, the four arrows, `home`, `end` — all pure cursor/selection, all byte-identical after the expected `composer.` → `self.` rewrite.

**`on_key` stays on the screen.** It is focus-routing policy — "treat the composer as the default printable text target", i.e. keys reach the composer even when it isn't focused — which is a screen concern, and Textual resolves it by name there. The composer returns `bool`; unconsumed keys fall through. Seven tests pin that contract, including the up/down fall-through in `test_console_composer_caret_nav.py`.

## The plan predicted 18 branches. Seven moved. That miss is the plan's.

The premise was verified only half-way: all 17 composer *operations* were confirmed present on the widget by AST — but nobody checked whether those branches **also call screen methods**. Eleven do:

| Branch | Reaches |
|---|---|
| backspace, delete, ctrl+w, ctrl+u, shift+enter, printable | `_sync_console_workbench_actions_from_draft` — workbench state + slash-command popup |
| shift+enter, printable | `_dismiss_console_guidance` — repaints the **transcript** |
| ctrl+z, ctrl+shift+z, ctrl+y | `_console_composer_undo`/`_redo` — session-settle gate + chat-store persistence |
| ctrl+c | the app clipboard |

The task's own rule ("if a branch calls anything other than a `ConsoleComposerBar` method, it stays") sent them back, so this netted −42 rather than ~−120. Nothing was forced and no operation was added to the widget to accommodate a move.

**The generalisable lesson, now in the spec: when scoping a move, verify BOTH directions of the seam** — what the moving code needs from its destination *and* what it still needs from its source. A "does the body mention X" filter answers only the first; `self._sync_console_workbench_actions_from_draft(...)` matches no obvious token.

**task-3749** records the unblock: a composer `DraftChanged` message the screen subscribes to would free six of the eleven. That is a design change, not an extraction, and an extraction that also changes how components communicate gives a regression two candidate causes — so it is filed, not smuggled in.

## The ratchet is red on `dev`, and this PR deliberately does not fix it

`Tests/Architecture/test_screen_size_ratchet.py` fails on clean `dev`: **18,267 lines against a budget of 17,727 (+540)**. The budget was **never raised** — the mechanism refused correctly and six PRs merged past the refusal.

This PR **leaves the number exactly as `dev` has it**. Lowering it to the 42 lines this task earned would be meaningless against a +540 overage; raising it to the measured number would defeat the mechanism its own docstring forbids defeating.

Measured inventory is on **task-3070** (updated, not duplicated — it was filed yesterday for what was then a 21-line overage): 11 new `ChatScreen` methods (221 lines) plus 251 added to existing ones, chiefly from the TASK-2154 UX remediation and the collapsed-rail work. Most of the new methods point at an existing home — `_stack_collapsed_rail_labels` and `_reveal_console_inspector_rail` at the rail regions, `_adapt_console_workspace_to_width` and `_console_tab_region_selector` at `workspace.py`, the run/tools/sources chips at the agent/session controllers. Worth noting waves 4 and 5 both *lowered* the screen (18,930 → 17,727 → 17,685); the growth is feature work, which is precisely the case the ratchet exists to surface.

## Why partial

Subagent capacity hit a weekly limit mid-wave, so the image (638/21) and character (412/12) extractions are deferred rather than half-built — a large extraction abandoned mid-flight is worse than one not started. What landed here is complete and independently reviewed.

## Verification

- Task 1 reviewed in full: the 24-branch split independently re-derived and confirmed; the 7 moved bodies AST-verified byte-identical; the `bool` contract mutation-tested (forcing `return False` breaks 7 tests); characterisation committed **before** the move (`26364f237`, absent from both later commits); pyflakes unchanged at **25** on the screen, **0** on the composer, message sets byte-identical; dead-body and hand-built-fixture sweeps clean.
- **135 passed** across the composer keymap/caret-nav/undo suites, `test_console_command_composer.py` and `Tests/Architecture/`; **73 passed** post-rebase on the composer suites.
- The implementer's own run: 1,879 passed, 0 failed across four batches.

Follow-ups filed: **3749** (composer `DraftChanged`), **3750** (the diagnostic inventory keys digests on logger *line numbers*, costing a review-and-regenerate cycle per refactor). Both renumbered into a safe block after an ID collision — the CLI assigns from a stale local view and the true max across worktrees was 3709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved Console composer key handling from `ChatScreen.on_key` to `ConsoleComposerBar` via a new `handle_console_key(event: Key) -> bool`. Behavior is unchanged; `on_key` still routes focus, and unconsumed keys (e.g., Up/Down on boundary rows) fall through.

- **Refactors**
  - Added `ConsoleComposerBar.handle_console_key(event) -> bool` and delegate from `on_key`.
  - Moved seven composer-only branches: `ctrl/cmd/super/meta+a`, `left/right` (ghost-text accept), `up/down` (history-first, boundary fall-through), `home/end` (bodies unchanged).
  - Kept branches that touch screen concerns (clipboard, workbench/guidance sync, undo/redo persistence, send, transcript paging).
  - `chat_screen.py` −42 lines; no controller or communication changes.

- **Tests/Docs**
  - Added `Tests/UI/test_console_composer_keymap.py` to pin draft/caret behavior and default routing.
  - Added `Docs/superpowers/plans/2026-08-07-console-decomposition-wave5.md`; updated the spec with the wave‑5 partial; filed follow-ups `TASK-3749` and `TASK-3750`; expanded `task-3070` with the +540 overage analysis (ratchet budget left unchanged).
  - Refreshed `Docs/security/production-diagnostic-inventory.json` digest due to line shifts only.

<sup>Written for commit cbf6884c44e08013d62589b3ccaa23b7958a675e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

