### PR TITLE
docs(lessons): guard tests must be proven to discriminate (two same-day incidents from the web-tools arc)

### DIFF
--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1181,3 +1181,30 @@ because that path is testing the template, not the code. The read site's own
 literal default needs a separate, direct assertion (stub the accessor, assert
 the literal argument passed to it), not an inference from observed runtime
 behavior.
+
+## A guard test must be PROVEN to discriminate — twice in one day it wasn't (2026-08-08, tasks 1359/2832)
+
+Two review-verified tests, written by the same controller, both passed while
+guarding nothing:
+
+1. **`capsys` does not observe loguru.** The task-2832 log-privacy test
+   asserted a secret query never appears in `capsys.readouterr()`. The
+   reviewer emitted `logger.warning("… query=<the secret>")` DURING that
+   exact test via a plugin — **1 passed**. loguru's default handler binds
+   pytest's *global* stderr capture at import, so the per-test fixture sees
+   nothing (and `capfd` misses it too). The house pattern is a list-appending
+   sink: `sink_id = logger.add(lambda m: records.append(str(m)))` /
+   `logger.remove(sink_id)` in `finally` — ~15 files already use it.
+2. **A single-chunk MockTransport body makes any early-abort test vacuous.**
+   The task-1359 crawl regression test proved a body was "read in full past
+   the sniff window" — but `httpx.Response(200, content=bytes_blob)` delivers
+   ONE `iter_bytes()` chunk, which the read loop appends before any abort
+   check runs, so the whole body is captured even under the buggy predicate.
+   Only multi-chunk (generator) delivery lets an abort actually cut a body.
+
+**What to do.** For any test whose value is "this would catch the
+regression": run the regression. Mutate the guarded code back to the buggy
+shape (Edit-based, unique marker strings) and READ the red result before
+trusting the green one. Both of these were caught only because the review
+step re-ran the pre-fix code against the new test; neither red-check had been
+done by the author, and both tests were the SOLE pin for their spec clause.


### PR DESCRIPTION
Two review-verified vacuous guards from tasks 1359/2832, same day, same author: a capsys-based loguru privacy test that stayed green while the secret was actually logged (loguru binds pytest's global capture — the sink pattern is the only real observer), and a single-chunk MockTransport body making an early-abort regression test pass against the buggy predicate (only generator delivery lets an abort cut a body). Rule with incidents attached: mutate the guarded code back to the buggy shape and read the red before trusting the green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new lesson to the testing-evidence docs showing that guard tests must be proven to discriminate, based on two same-day incidents tied to tasks 1359 and 2832. It explains that `capsys` doesn’t observe `loguru` output and that a single-chunk `httpx`/`MockTransport` body makes early-abort tests pass, and sets a rule to rerun the buggy shape to see red before trusting green.

<sup>Written for commit f3b569f7097bb61b9db346aec36bf8c267850d7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

