### PR TITLE
fix(security): key diagnostic-inventory digests on content, not line numbers (task-3750)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -20,3262 +20,3283 @@
   "owners": [
     {
       "call_count": 3,
-      "diagnostic_digest": "0d78b70c928606dd32fe",
+      "diagnostic_digest": "c4532646d0265b71ec47",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Agents/agent_runtime.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "e5adb9327f53b73e91c4",
+      "diagnostic_digest": "81a172ef8dadc288b9bf",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Agents/builtin_tool_gate.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 1,
+      "diagnostic_digest": "00e3fd66f1b0a1863b64",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Agents/library_rag_tool_provider.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "b1cbdcf3a0a107beb4dd",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Agents/library_tool_provider.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 8,
-      "diagnostic_digest": "1ad2b3c48099f41bb550",
+      "diagnostic_digest": "fc49fca551481bbfbda4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Agents/local_tool_provider.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "2b0933285c5088d0abb6",
+      "diagnostic_digest": "ab541538fe3668a31294",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Agents/mcp_tool_provider.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 16,
-      "diagnostic_digest": "a250ad214780f0903951",
+      "diagnostic_digest": "10b283947607979eb8f4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Agents/run_log.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "37257c13ab8cf9046937",
+      "diagnostic_digest": "56d0d1710429e5fea3ce",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Agents/run_log_eviction.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "b547f728d15657568d9c",
+      "diagnostic_digest": "6cb45cc26f8523cd58da",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Agents/tool_catalog.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "0a6bfc9ae5537aa81a41",
+      "diagnostic_digest": "ebd5049a714019fa236d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Audio/console_dictation.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "c94ef3e280a003272e6d",
+      "diagnostic_digest": "a5dd63999ebb7d778ddb",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Audio/dictation_metrics.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 24,
-      "diagnostic_digest": "6be7a393b1e53db172d1",
+      "diagnostic_digest": "07505149c53f66c453a3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Audio/dictation_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 51,
-      "diagnostic_digest": "89dcd208a5502b9253e5",
+      "diagnostic_digest": "6cd4cf4bc4a833dc7445",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Audio/dictation_service_lazy.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "044807afb5e00c736b53",
+      "diagnostic_digest": "6f9e5b0b90e7a8c34e26",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Audio/realtime_mic_tap.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 35,
-      "diagnostic_digest": "b29e7026f52db22d58ef",
+      "diagnostic_digest": "62eda56c590eb6d82b4d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Audio/recording_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "12b32fd9769343fcf169",
+      "diagnostic_digest": "fc439bf3a6c4b9804c32",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Audio/streaming_sink.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 208,
-      "diagnostic_digest": "afc4ef6386cede7dd9fc",
+      "diagnostic_digest": "7ef22848bfba9a98ca61",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Character_Chat/Character_Chat_Lib.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 62,
-      "diagnostic_digest": "bf3c1125a405f309fc25",
+      "diagnostic_digest": "8460858ed563a61c36f8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Character_Chat/Chat_Dictionary_Lib.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "5cf76cb863b4a3c0ce42",
+      "diagnostic_digest": "413a9a0e003e7cc5e7a2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Character_Chat/character_card_formats.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "7d9e7a8b640a0d9c156d",
+      "diagnostic_digest": "ab6f18e87a4dbe5ad6c6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Character_Chat/character_generation_controller.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "917ba335660b2595f959",
+      "diagnostic_digest": "57a76b9c87e1a1155d9c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Character_Chat/local_chat_dictionary_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "832332ee12c25ac07794",
+      "diagnostic_digest": "b520edfafc91d3ca90c3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Character_Chat/world_book_import.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "f3ddfd9fe4021caabe72",
+      "diagnostic_digest": "e98f5f7d2aee8da3983b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Character_Chat/world_book_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "8cc0f61b88e3b6d141b1",
+      "diagnostic_digest": "c30e87bd82f2c8248e72",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Character_Chat/world_info_processor.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "7bfef1ffdedb832fe9dd",
+      "diagnostic_digest": "8310d7823c435ae1044a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Character_Chat/world_info_resolver.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 107,
-      "diagnostic_digest": "f017eaf38022f2d4017f",
+      "diagnostic_digest": "1b029f970d97ef59815a",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/Chat_Functions.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "09ed7cad0a9b79d2ba05",
+      "diagnostic_digest": "a52ef0ac63c3c795a214",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/attachment_core.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "432bb445939054b4268f",
+      "diagnostic_digest": "8c430d7a6ec3b9978fe2",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/chat_persistence_service.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 11,
-      "diagnostic_digest": "4b42a3b31aa661a5fd6c",
+      "diagnostic_digest": "5629431827da74716537",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_agent_bridge.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 26,
-      "diagnostic_digest": "7a8cf9d9cbd9e1b43260",
+      "call_count": 27,
+      "diagnostic_digest": "333bd79e0c0cd80eaf4b",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_controller.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 28,
-      "diagnostic_digest": "fa6b389ea336fd21ba35",
+      "diagnostic_digest": "191bcc4d3c417d015e03",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_store.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "1f054629636436316e8c",
+      "diagnostic_digest": "99780cd67ef9bc88a3ae",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_cost_tracker.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "f97e26df70c1f051a84c",
+      "diagnostic_digest": "13af102fa53c0557e423",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_generate_image.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "1fc2609e7284eeb509a8",
+      "diagnostic_digest": "f602a8dcefad367cf5d3",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_image_view.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "35d18a5b75aad8c5dd5f",
+      "diagnostic_digest": "6543b19fdcdba343b210",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_paste_attach.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "fceb9b02434e5f03f179",
+      "diagnostic_digest": "b362235b226680b9f911",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_provider_gateway.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "1bd472da16512dd9d742",
+      "diagnostic_digest": "b1328139e2f452650977",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_realtime_loop.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 32,
-      "diagnostic_digest": "bc6587000cac4f289dae",
+      "diagnostic_digest": "5c2b6b3f49f18d1ca29a",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_voice_input.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "ab12097c78278c1b41bf",
+      "diagnostic_digest": "5aff9e2969a0fb5e4116",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/document_generator.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "815a71a149eaa4458865",
+      "diagnostic_digest": "03545a096e7446d89956",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/prompt_history.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "f0d7da84a1620d81f420",
+      "diagnostic_digest": "ad66bd982c28b6447299",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/prompt_template_manager.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "82764920d87a6701a4d1",
+      "diagnostic_digest": "b8951a9cd27f98c41a87",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/rag_scope.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "74cd77fd68a0141b4ec1",
+      "diagnostic_digest": "df383cb2ba0b9d2a3378",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/reply_sentence_sequencer.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 53,
-      "diagnostic_digest": "d823cf346455b65c53d7",
+      "diagnostic_digest": "aa99179dbf8e33fec662",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Chatbooks/chatbook_creator.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 58,
-      "diagnostic_digest": "41bb5e0ba248f01f7fff",
+      "diagnostic_digest": "da368eec354a9f4d6750",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Chatbooks/chatbook_importer.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "62fa361804d9bd869b60",
+      "diagnostic_digest": "32cdf7328e86b024918c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Chatbooks/error_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 100,
-      "diagnostic_digest": "8ba4544b3dffc50a01d2",
+      "diagnostic_digest": "4032494883893d8593ec",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Chunking/Chunk_Lib.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 18,
-      "diagnostic_digest": "c4bc4a3d36c3dfddc676",
+      "diagnostic_digest": "002389197abd65ddfec9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Chunking/chunking_interop_library.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 17,
-      "diagnostic_digest": "42b7a79a183a50389428",
+      "diagnostic_digest": "f98a98c58c9a6a2ae297",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Chunking/chunking_templates.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 13,
-      "diagnostic_digest": "fe66954f07c38ef256e3",
+      "diagnostic_digest": "64154f1d06e52dd3f378",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Chunking/language_chunkers.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "de1ef9d777f406926079",
+      "diagnostic_digest": "1093a5debab2087069b6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Chunking/token_chunker.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "f697411000f491a2bf36",
+      "diagnostic_digest": "6862742d4db6f7d1ab2d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/AgentRuns_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 317,
-      "diagnostic_digest": "0a5ab8bdc834da4a37d2",
+      "call_count": 323,
+      "diagnostic_digest": "68e92c49a8aa4214183a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/ChaChaNotes_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 351,
-      "diagnostic_digest": "a1c7da3494bc44a2f034",
+      "call_count": 354,
+      "diagnostic_digest": "ad4cce914616f4e3ae16",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Client_Media_DB_v2.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 16,
-      "diagnostic_digest": "3d49e4ec10297371101e",
+      "diagnostic_digest": "a1f9e93d62d4e30e8724",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Evals_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "f68b831a6945125920d5",
+      "diagnostic_digest": "02456a73e53fe74bd045",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Library_Ingest_Jobs_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "e67201b8e3ced737b1ae",
+      "diagnostic_digest": "7dbcf7c5501018f4021e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Mindmap_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 120,
-      "diagnostic_digest": "15e26a5f1df0fd8482ef",
+      "call_count": 124,
+      "diagnostic_digest": "62daeb3aa49bebadc3ca",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Prompts_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "9528aade1bbd988d4d29",
+      "diagnostic_digest": "a3a495d2b9d1d5654746",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/RAG_Indexing_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 4,
-      "diagnostic_digest": "bcf988531779a4c2f0a6",
+      "call_count": 5,
+      "diagnostic_digest": "73c70bbddfdddee71e2a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Subscriptions_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 88,
-      "diagnostic_digest": "49ec2ffbd26d3b862b9b",
+      "diagnostic_digest": "5f1171abc376167e4455",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Sync_Client.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "a8de11edc707714545cf",
+      "diagnostic_digest": "4cfa696605e6da43ebfa",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Writing_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "8acb3baecbe067749d2e",
+      "diagnostic_digest": "602cf3b68ca3fcb2f23b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/base_db.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 14,
-      "diagnostic_digest": "470770c00d5d39155dc9",
+      "diagnostic_digest": "fb685ef0fc3dc6ef91a6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/search_history_db.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "9c6a147fb7be504b8dd9",
+      "diagnostic_digest": "82466a1be1e8c1f35d41",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/sql_validation.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 42,
-      "diagnostic_digest": "64a4cd3cc1bbed2b3e49",
+      "diagnostic_digest": "3ac51c99f2c7322fd050",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Embeddings/Embeddings_Lib.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "1ae2ffca415f3b89f7b7",
+      "diagnostic_digest": "63f72f33b948a32addb0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/ab_testing.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "94ea7b4a40886ac67495",
+      "diagnostic_digest": "f4a46f2bbea1d40f8a2e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/base_runner.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "c804f1f64bef9d43a421",
+      "diagnostic_digest": "e5b2547e13da8324ea12",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/character_probe/runner.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "a75b7e464e8c597c7818",
+      "diagnostic_digest": "4aaa944eb440ba5b2d33",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/concurrency_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "a47f8413bf99f17955ad",
+      "diagnostic_digest": "6621cf5b4a09183793f2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/config_loader.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "87ebc9a5ce4d075f79ce",
+      "diagnostic_digest": "0e60a8a7754e824373ad",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/dataset_loader.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "8092560ce81f50c6ee13",
+      "diagnostic_digest": "b1319c642022b18495bd",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/dataset_validator.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "47c95d83694067981cbd",
+      "diagnostic_digest": "dbd5d47ed147bad54ae1",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/eval_errors.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 24,
-      "diagnostic_digest": "a85c81e3ee7e3018d052",
+      "diagnostic_digest": "3aba2e1d17f5e28d44e8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/eval_orchestrator.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 42,
-      "diagnostic_digest": "bcb2a2ea04bbd22c1399",
+      "diagnostic_digest": "73c34745b16542f4541c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/eval_runner.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "155a44491bd53ea84832",
+      "diagnostic_digest": "fd4eb2de6093bc7e2e33",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/exporters.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 14,
-      "diagnostic_digest": "953dc4ddd0690ec85cc9",
+      "diagnostic_digest": "418e2c0c1b685a44cb7c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/specialized_runners.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "2e62ffa2678fa1de0ede",
+      "diagnostic_digest": "7186969a69b1ca8cfb2b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/task_loader.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "a1ce427f446291d12115",
+      "diagnostic_digest": "9d0aaa85f72424800ff1",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/word_bench/capture_client.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "e9a1d1227899b0180926",
+      "diagnostic_digest": "4b04060b9d033c1d369b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Evals/word_bench/runner.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "469103ae0a0ee189c322",
+      "diagnostic_digest": "812299f743afbfb840bd",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/Chat_Events/chat_events_console_dictionaries.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "cbdcdb4ab32623a553eb",
+      "diagnostic_digest": "a8c140f93a228475a0de",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/Chat_Events/chat_image_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 50,
-      "diagnostic_digest": "cec7f49635119a91b88d",
+      "diagnostic_digest": "523ef1735443c688a925",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "4afc1c1d6caa3845f7f3",
+      "diagnostic_digest": "898f98b5ab676b4bd9dd",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "446b8fb56f0e9524d420",
+      "diagnostic_digest": "c63803ee6a70b10bed13",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "bd7e904b10cf681cb3de",
+      "diagnostic_digest": "9927c366b89ecb10fb9d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_mlx_lm.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 37,
-      "diagnostic_digest": "442cf21914e477fba654",
+      "diagnostic_digest": "d7f0ee9a1d21b063ae04",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_ollama.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "e859591b94f475614594",
+      "diagnostic_digest": "a230f66c5cc26e83c2f8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_onnx.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "fd43210a342ce95d3a1f",
+      "diagnostic_digest": "1b5da708617d0e62ea05",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_transformers.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "6ddd8c26327e6bc2a46c",
+      "diagnostic_digest": "3b4ea58937576f43ce31",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events_vllm.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "8863a56f158f10b4d469",
+      "diagnostic_digest": "f41baa1a718b2a3da3be",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/Media_Creation_Events/swarmui_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 29,
-      "diagnostic_digest": "cc7b67f21ce2960b036d",
+      "diagnostic_digest": "9d8c5b42732a5672d788",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 23,
-      "diagnostic_digest": "915282994799753977ec",
+      "diagnostic_digest": "ad3f73e751e8b61a08fd",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/Study_Events/study_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 44,
-      "diagnostic_digest": "e78768aab6f1a215d98d",
+      "diagnostic_digest": "27241702710f01af78b7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 16,
-      "diagnostic_digest": "40377b6d8384acbd1688",
+      "diagnostic_digest": "eca063b8bc9c7768812d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/app_lifecycle.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "bc8ca9076081cfc90200",
+      "diagnostic_digest": "131ef39f5e96239ecc9d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/collections_tag_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "5e32493bf7b953295329",
+      "diagnostic_digest": "77776fe18b4a34a2910d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/eval_db_operations.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "5a0d5e6a94c8975450d3",
+      "diagnostic_digest": "f569ee256b356ddb4b93",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/ingest_status_helper.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "4e2d646d9397fbb13fef",
+      "diagnostic_digest": "a28e2522873c4b164b74",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/multi_item_review_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 28,
-      "diagnostic_digest": "411224ae1c19b9b33678",
+      "diagnostic_digest": "fb1ecf5235817bff6709",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/note_ingest_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "571a34b04531e8f0cc5f",
+      "diagnostic_digest": "817c52c6edaa8c619633",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/notes_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "19056bd032a4ad066f13",
+      "diagnostic_digest": "e2b0d663e718b53b6478",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/tab_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "d67fe3d037167624529a",
+      "diagnostic_digest": "19dc8bf5880fda1dc258",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/worker_handlers/base_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "d2271c87b4acc94fde61",
+      "diagnostic_digest": "f210ede649f35804db2b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/worker_handlers/misc_worker_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "52522f5499038b1a313b",
+      "diagnostic_digest": "69a5911c5c26e9658c4e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Home/active_work_adapter.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "d3a581ffb058b88c8272",
+      "diagnostic_digest": "aa25edebdd55eed09103",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Image_Generation/adapter_registry.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "dafa47b377631ca6393e",
+      "diagnostic_digest": "eaf1c9e5d2ab81ed8081",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Image_Generation/adapters/gemini_image_adapter.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "38fced3020fefde07f60",
+      "diagnostic_digest": "5bf019ef964a1c9b116f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Image_Generation/adapters/modelstudio_image_adapter.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "7a453b5715df7b41a6bf",
+      "diagnostic_digest": "87fed602cf5e579f82ab",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Image_Generation/adapters/stable_diffusion_cpp_adapter.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "5ae8c733182282d3fd62",
+      "diagnostic_digest": "98d9cdf9e8040be70a2b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Image_Generation/adapters/swarmui_adapter.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "a6f0aea4404d5147e3f3",
+      "diagnostic_digest": "b781a60e6d2b066d80bc",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Image_Generation/config.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "283d02221bcddf4044c1",
+      "diagnostic_digest": "21e17e226531ac145797",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Image_Generation/listing.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "5803c10f917675b1d443",
+      "diagnostic_digest": "085e0b9d6620ce2e9866",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Internal_Prompts/resolver.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 171,
-      "diagnostic_digest": "11e67575fe67376d7561",
+      "diagnostic_digest": "dc16bf5efed6e22426f0",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/LLM_API_Calls.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 41,
-      "diagnostic_digest": "bc790fe8d2f3544203bf",
+      "diagnostic_digest": "92d71de4efddebe2d16b",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 242,
-      "diagnostic_digest": "7116dc3d306135972131",
+      "diagnostic_digest": "57a407b4a573f4d946bf",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 279,
-      "diagnostic_digest": "db0bcd0e6c3a6abf68c3",
+      "diagnostic_digest": "e36a1454caea2b8a60a5",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/Summarization_General_Lib.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "d64ebb536846c4132cd8",
+      "diagnostic_digest": "583ecdd288aa9e490b0f",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/huggingface_api.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "ed2a62c9cb0e756c7768",
+      "diagnostic_digest": "00c4b3d6c8a727c71364",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/pricing_catalog.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 13,
-      "diagnostic_digest": "7837515d6f56319779c1",
+      "diagnostic_digest": "35a04207568c21f59764",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/realtime/openai_session.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "1a6204c6f07943aad764",
+      "diagnostic_digest": "03445f3598a93d1da939",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/realtime/transport.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "211e68ecc8c6e816b301",
+      "diagnostic_digest": "3df1b482fa5a7ee25456",
       "owner": "TASK-494",
       "path": "tldw_chatbook/LLM_Provider_Catalog/local_llm_provider_catalog_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "8926513199ef69888572",
+      "diagnostic_digest": "cd1b6cd15fa8b8f6584f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/LLM_Provider_Catalog/model_discovery_disk_cache.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "885d2bd87811d7842eb5",
+      "diagnostic_digest": "33e92c6d69ff96bfa5be",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/library_ingest_jobs.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 7,
-      "diagnostic_digest": "c0c481a8ae10d7f6983d",
+      "call_count": 6,
+      "diagnostic_digest": "e43355a220e62d5f778f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/library_local_rag_search_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "985544e334c8cd37376c",
+      "diagnostic_digest": "e76895f6c55063aea3db",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/library_rag_answer_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "a6eb74106180836d016a",
+      "diagnostic_digest": "d2f4d7f38ccc626b6009",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/library_rag_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "3363d728db5c3d1a8804",
+      "diagnostic_digest": "4804298a66c80175d602",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/server_ingest_reconcile.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 17,
-      "diagnostic_digest": "f20aa10be570c3a43c46",
+      "diagnostic_digest": "f8f0062da6fd1da6d222",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Inference/mlx_lm_inference_local.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "0b9d98fe1c7a9a961107",
+      "diagnostic_digest": "c8b81627ab9effb1c9f7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Inference/ollama_model_mgmt.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 30,
-      "diagnostic_digest": "35030dcfbf7f3bbf8d85",
+      "diagnostic_digest": "c8cc5fc4bd9cdad1751b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/API_Endpoint_Sample.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 88,
-      "diagnostic_digest": "5cd4668c48898f1b4a0e",
+      "diagnostic_digest": "5ff1d27c66a8638bf9ed",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/Book_Ingestion_Lib.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 15,
-      "diagnostic_digest": "86d2e5cd4489b32cfa89",
+      "diagnostic_digest": "e145e4ebd30937115537",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/Document_Processing_Lib.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 18,
-      "diagnostic_digest": "f29618ad5ad3edec7f93",
+      "diagnostic_digest": "39511c5c0a1346a55c90",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/Image_Processing_Lib.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 27,
-      "diagnostic_digest": "5b186425b0b79832123f",
+      "diagnostic_digest": "9054023a291c5f97922d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/OCR_Backends.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 74,
-      "diagnostic_digest": "b0d3d3aef9601c9ed864",
+      "diagnostic_digest": "03ed1214dcc7b7dcfd3c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/PDF_Processing_Lib.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "c3a28f42e225d7c10202",
+      "diagnostic_digest": "0743b0340d9d0591dfb6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/XML_Ingestion.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 50,
-      "diagnostic_digest": "57ba18fd92fa92b7a77f",
+      "diagnostic_digest": "9ec490e34d31769583c5",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/audio_processing.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 53,
-      "diagnostic_digest": "21fee50f1ed93fef04b7",
+      "diagnostic_digest": "ee7daccfca14ca6796d3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/diarization_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "7efc96ac41a3d8afe09f",
+      "diagnostic_digest": "bd552970166a4551d1f3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/local_file_ingestion.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 284,
-      "diagnostic_digest": "8949dc806e9c08e58ba1",
+      "diagnostic_digest": "28552320cc26e548150e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/transcription_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 80,
-      "diagnostic_digest": "e5b7513e62bea5155e19",
+      "diagnostic_digest": "5f25d2ba2684eccd8c14",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/video_processing.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 31,
-      "diagnostic_digest": "3cda2240450d542faf5e",
+      "diagnostic_digest": "910a12548228248eaee2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Logging_Config.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 21,
-      "diagnostic_digest": "018c6ae810412d1a182d",
+      "diagnostic_digest": "7f2a3278fd6885a43c15",
       "owner": "TASK-492",
       "path": "tldw_chatbook/MCP/client.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "e4c3738bcd16fd5d8d80",
+      "diagnostic_digest": "b836a17484abae8e1c7b",
       "owner": "TASK-492",
       "path": "tldw_chatbook/MCP/execution_log.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "947e0a2773722856b07b",
+      "diagnostic_digest": "ab24796a5735dc371001",
       "owner": "TASK-492",
       "path": "tldw_chatbook/MCP/local_server_tools.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "060f087c10d98dac2477",
+      "diagnostic_digest": "fa39f89cad5148e6a567",
       "owner": "TASK-492",
       "path": "tldw_chatbook/MCP/permission_store.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "61ef30cfd2a82abcd959",
+      "diagnostic_digest": "eae8af5d48bbf7c4ae0f",
       "owner": "TASK-492",
       "path": "tldw_chatbook/MCP/prompts.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "f21ad6533c3d830ca3b0",
+      "diagnostic_digest": "4c1f26aa1a1648ccbd67",
       "owner": "TASK-492",
       "path": "tldw_chatbook/MCP/resources.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 10,
-      "diagnostic_digest": "36e8d74b32cb4390f906",
+      "call_count": 11,
+      "diagnostic_digest": "017dcf53b2345c1b74a9",
       "owner": "TASK-492",
       "path": "tldw_chatbook/MCP/server.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "5cb47f0d4a6fa4ac3cb3",
+      "diagnostic_digest": "1a2a8849794056774339",
       "owner": "TASK-492",
       "path": "tldw_chatbook/MCP/server_unified_service.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "77861415062225b6cc43",
+      "diagnostic_digest": "1bdcc6f23a777936c352",
       "owner": "TASK-492",
       "path": "tldw_chatbook/MCP/tools.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "38bb2bc83c33d78dd5e3",
+      "diagnostic_digest": "97259efe73f0e537d3db",
       "owner": "TASK-492",
       "path": "tldw_chatbook/MCP/unified_context_store.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "ac00ce138f370a3ecc9f",
+      "diagnostic_digest": "ccdfad143cafc52894c5",
       "owner": "TASK-492",
       "path": "tldw_chatbook/MCP/unified_control_plane_service.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "4ba6c25c2282d0a4428d",
+      "diagnostic_digest": "be9d5941fa82f503e7f8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Media_Creation/generation_templates.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 15,
-      "diagnostic_digest": "8b56c0405f77fe4de138",
+      "diagnostic_digest": "bd84c9d24b6ebb7948ba",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Media_Creation/image_generation_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 21,
-      "diagnostic_digest": "327e49568945326ee25d",
+      "diagnostic_digest": "2f298504c205bd991348",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Media_Creation/swarmui_client.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "40fba3715cee292f7c80",
+      "diagnostic_digest": "f0d967cb3496aec94cce",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Metrics/Otel_Metrics.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "ee60092754dbda81de34",
+      "diagnostic_digest": "4229a493a1811939c41d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Metrics/metrics.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "73de2f739a758c0d8047",
+      "diagnostic_digest": "0ef1d5026ba8af329ad1",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Metrics/metrics_logger.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "077b5f2dbcbe736b4819",
+      "diagnostic_digest": "bb642fb676c466eb5aa0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Models/evaluation_state.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 32,
-      "diagnostic_digest": "dd0d7ccf37d37a5ae20c",
+      "diagnostic_digest": "cb31cdd6c99fa28d8c2e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Notes/Notes_Library.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "490337e5097148ef2db0",
+      "diagnostic_digest": "031cdd6ec934ff91afa6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Notes/auto_sync_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "964856e269b21d9f521b",
+      "diagnostic_digest": "8933a6273f741587703c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Notes/file_notes_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "17af213524c83580a09f",
+      "diagnostic_digest": "fd52ab3f664b86181725",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Notes/notes_scope_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 18,
-      "diagnostic_digest": "286f54932876fbdf4bf4",
+      "diagnostic_digest": "051847e5abc212136e80",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Notes/sync_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "383587c7e88d83573e83",
+      "diagnostic_digest": "e50e7020a8d57e03f3db",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Notes/sync_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "8878fd2bc21401210b77",
+      "diagnostic_digest": "8f71e7a1b3c45701e66f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Prompt_Management/Prompt_Engineering.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 93,
-      "diagnostic_digest": "d7ca19fa44acdf1e5289",
+      "diagnostic_digest": "3c444723b540359b7db5",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Prompt_Management/Prompts_Interop.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "f7a441595550015f240a",
+      "diagnostic_digest": "a2e8564226953a842e33",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Prompt_Management/prompt_improvement_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "8744fc7b31f358d58187",
+      "diagnostic_digest": "fbea65e22de6943a1c69",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/__init__.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "2939371dde31aca0f542",
+      "diagnostic_digest": "f69926a6d905e46a5b67",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/chunking_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 16,
-      "diagnostic_digest": "c85e3602f16ecbb43e9b",
+      "diagnostic_digest": "48de569e66d28ea95375",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/config_profiles.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "7ae9a0bf13b0439138d5",
+      "diagnostic_digest": "137e6bedad997559a63c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/enhanced_chunking_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "0e19c5209537e2bfccd3",
+      "diagnostic_digest": "d10dae06955a4fcb81d4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/fusion.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 40,
-      "diagnostic_digest": "43b101c66e6b77ec2de8",
+      "diagnostic_digest": "0d734273e94cd3f5d478",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/ingestion_indexing.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 13,
-      "diagnostic_digest": "3683c659d56b60639797",
+      "diagnostic_digest": "a7257cdee4615878f370",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/parallel_processor.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 13,
-      "diagnostic_digest": "5d9128903323ebb479fd",
+      "diagnostic_digest": "7436b3b38be007177218",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/pipeline_builder_simple.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "b2e9d1c6ed0b5243f46b",
+      "diagnostic_digest": "e236a20d3bba2a9c9a06",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/pipeline_functions_simple.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "ef78faa155cb5ffc37f3",
+      "diagnostic_digest": "48d4bbeb2a5c196ff625",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/pipeline_integration.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 26,
-      "diagnostic_digest": "cb61381235e01b3a5015",
+      "diagnostic_digest": "c5c0612b8ce0f33c3d58",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/pipeline_loader.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "6ce9d821defeecdea5f6",
+      "diagnostic_digest": "6bfe02642d1975cf6ed5",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/reranker.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 3,
-      "diagnostic_digest": "3e1a86f7ada72fbc009d",
+      "call_count": 5,
+      "diagnostic_digest": "f67f0fda0a6085c51807",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/semantic_availability.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "2fe54793500bedc4a83d",
+      "diagnostic_digest": "9e6afd171d864f87f936",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/active_config.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "f2901d241dd790691b2e",
+      "diagnostic_digest": "d6ff8dbb1efe0e545c33",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/circuit_breaker.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "355b2fcc39da995958bd",
+      "diagnostic_digest": "9c294a7a0858921f86de",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/collection_indexes.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "572183ac2905bef73eda",
+      "diagnostic_digest": "9510006ebfbc08596319",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/config.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 2,
-      "diagnostic_digest": "11682f57a6841d396d3f",
+      "call_count": 3,
+      "diagnostic_digest": "a80c0d70ec3b41c65d8b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/db_connection_pool.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 47,
-      "diagnostic_digest": "603136399284fff62f86",
+      "diagnostic_digest": "08bf9e5d2481cc30f355",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/embeddings_wrapper.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "69764351512fb5d765cd",
+      "diagnostic_digest": "3830c39d6831eb9a0a4e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/enhanced_indexing_helpers.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 11,
-      "diagnostic_digest": "c6a8260df2d8b1e4900e",
+      "diagnostic_digest": "1147d51137ac236d6d45",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/enhanced_rag_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 7,
-      "diagnostic_digest": "51f2440bc5ae3ca0b97e",
+      "call_count": 11,
+      "diagnostic_digest": "f33b5d06f2923d93b32c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "76684ac6274399c95caa",
+      "diagnostic_digest": "f334c8b6b9a51b2958b6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/health_check.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 13,
-      "diagnostic_digest": "016254b5e70d6a4b2e6e",
+      "diagnostic_digest": "9a06797eb230d295260e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/indexing_helpers.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "1fd6fa5f3e29dea7d8fa",
+      "diagnostic_digest": "ccbb744fc5a841d3b3e3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/rag_factory.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 48,
-      "diagnostic_digest": "858066772917007eea24",
+      "call_count": 43,
+      "diagnostic_digest": "7bc4f03e99c2746eec04",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/rag_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "4f661d95f2ca085dd43d",
+      "diagnostic_digest": "0ba21e54e0a25997af61",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/search_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 19,
-      "diagnostic_digest": "1392f801f0b56abb2069",
+      "diagnostic_digest": "ae73af1d1b8304ed2445",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/simple_cache.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 37,
-      "diagnostic_digest": "7f174425b47030373460",
+      "diagnostic_digest": "c6ba86ce69b5030903de",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/vector_store.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "240634ae975ff06a68a1",
+      "diagnostic_digest": "85e66862b3067b19f4e8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/table_serializer.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "58987e95f9c2cdce9866",
+      "diagnostic_digest": "2c0a87947d6065c00575",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/db/scheduled_tasks_db.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "29641db5477a9b61c918",
+      "diagnostic_digest": "52679127ce38295e85e9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/scheduler/handlers/briefing_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 15,
-      "diagnostic_digest": "e02a2bca25d9c10edc9c",
+      "diagnostic_digest": "1d1ac7fd3ae1ebfd1c2e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/scheduler/handlers/watchlist_check_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "cefe236a94d9a095f4e0",
+      "diagnostic_digest": "cf29ada6dae092debc36",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/scheduler/loop.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "fc0fe817da11767536fe",
+      "diagnostic_digest": "67cc7787adc013da495a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/scheduling_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "40e5cda7ad5605c0b168",
+      "diagnostic_digest": "ea51505e1926a730b29a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/sync_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "836ab74937bff5181d73",
+      "diagnostic_digest": "3480f25bc62eedb8af36",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Skills_Interop/local_skills_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "eab93ea994ea08229beb",
+      "diagnostic_digest": "689688365cbee84f20ee",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Skills_Interop/skill_script_runner.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "0fae9623ec09fa5f1242",
+      "diagnostic_digest": "66e92f600d3330195029",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Skills_Interop/skill_trust_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "c7b1eacd086ee92f2175",
+      "diagnostic_digest": "a8d57155e12b6f41e84c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Skills_Interop/skill_trust_store.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 19,
-      "diagnostic_digest": "2da68a5bc0ed55afc540",
+      "diagnostic_digest": "1fbb0d43a32a05f83b51",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Stats/user_statistics.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "05450a019294b70fcabd",
+      "diagnostic_digest": "ae2f658bb2c411dc6f8f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/baseline_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "479bee10109f937c61a0",
+      "diagnostic_digest": "9f06dc80ac038a55e1f0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/briefing_audio.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "f6e1995153dafa024816",
+      "diagnostic_digest": "27999cf13323baf87d6f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/briefing_cast.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "fc75282689a70bc70e1d",
+      "diagnostic_digest": "81f5ac3f0e0f37927fce",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/briefing_export.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "98fb1e8994049cbb2e90",
+      "diagnostic_digest": "faccd16703f691fc8920",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/briefing_keep.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "c34ba4a81103d1537b76",
+      "diagnostic_digest": "e472bd64c97a64919e08",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/briefing_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "a3c501827a663e3196b8",
+      "diagnostic_digest": "b6846286318a41aaadb5",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/feed_server.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "f504ca73838015b95e23",
+      "diagnostic_digest": "769552c703844018c3aa",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/fts_backfill.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "ff85ac96bb09e225665e",
+      "diagnostic_digest": "f3ae993d81531f7ad193",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/local_watchlists_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 16,
-      "diagnostic_digest": "f9ccee6989b39da1333b",
+      "diagnostic_digest": "65f3a0c1be12db1830f4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/monitoring_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "8dec1a3be0e9b78b3715",
+      "diagnostic_digest": "ceee9852ba290622d396",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/scrapers/custom_scraper.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "62e046f5b7f29d45ef2b",
+      "diagnostic_digest": "96c92dde856c27af60c9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/scrapers/generic_scraper.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "b529dff16a6eda5d3964",
+      "diagnostic_digest": "6ed0f4d7307be143d97d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/scrapers/github_scraper.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "ecc26ba291658577fae1",
+      "diagnostic_digest": "a3f2b54c8b9d3942c658",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/scrapers/hackernews_scraper.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "5e15a0bef413f66f27b5",
+      "diagnostic_digest": "6964df164bfd00f2812c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/scrapers/reddit_scraper.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "208c9c5d1e994f5dc6f6",
+      "diagnostic_digest": "3d2a01a18c454b0deac9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/scrapers/youtube_scraper.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "37be5474a2a15f91b5c3",
+      "diagnostic_digest": "342d9878452d2cf33e7d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/security.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "f62deb50cecadaba1659",
+      "diagnostic_digest": "3b2bcd0d82a09b3bab05",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/site_config_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "72cd9b263de6d21e69ea",
+      "diagnostic_digest": "0fdd9d782b560419f426",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/token_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "0974bb46164426026a11",
+      "diagnostic_digest": "f1450766e60d1fea5632",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/watchlist_scope_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "7df6a5c8f04f38210779",
+      "diagnostic_digest": "45af7eb4e97d0e9e39a2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/web_scraping_pipelines.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "92dd60af1658f3d50346",
+      "diagnostic_digest": "ccc06cbf037328baa078",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/TTS_Backends.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "861a83c322e4af456038",
+      "diagnostic_digest": "f0efee22ff46a7b596b2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/TTS_Generation.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 31,
-      "diagnostic_digest": "12d8ea56470a0db5196c",
+      "diagnostic_digest": "9fe57d979b3f9ac82ffd",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/audio_player.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "1b5f4544507ebb9cf9c8",
+      "diagnostic_digest": "edc356a942387df5b313",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/audio_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "8fc73e0cf312456090db",
+      "diagnostic_digest": "f2398649dd2448fd5dc5",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/audio_stitch.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "da0d460c371873327baf",
+      "diagnostic_digest": "1204230383fd6a4b994d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/audiobook_generator.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 18,
-      "diagnostic_digest": "1d4406258dd91bac374f",
+      "diagnostic_digest": "cf4611138239f6557284",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/alltalk.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 62,
-      "diagnostic_digest": "33aae0a47896076d56eb",
+      "diagnostic_digest": "7cb62ef6e2c77f418f78",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/chatterbox.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "319d7d236183c78ce2f0",
+      "diagnostic_digest": "e63b6cea99e7b9216d38",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/chatterbox_isolated.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 14,
-      "diagnostic_digest": "a321b98d72c20afcbd64",
+      "diagnostic_digest": "cde0f127e10a919d55a0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/chatterbox_voice_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "9cffedbef74da12ea824",
+      "diagnostic_digest": "6da58b15f9129a18c9e2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/elevenlabs.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 97,
-      "diagnostic_digest": "afa13262c88cb0061ea7",
+      "diagnostic_digest": "add1172bc1bb0571dce6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/higgs.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 15,
-      "diagnostic_digest": "4dfb1bdb9dcc9412260a",
+      "diagnostic_digest": "8e8f330f55b0f7712dc0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/higgs_voice_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 68,
-      "diagnostic_digest": "fd929100a041cb5e4ef4",
+      "diagnostic_digest": "897c0fb55b833c93ff73",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/kokoro.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 21,
-      "diagnostic_digest": "68c29933b9704cdfcdec",
+      "diagnostic_digest": "2c2bc705123ebe21789f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/openai.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "9e2792fa2f4b7be408a8",
+      "diagnostic_digest": "e6d6bfa44e50662eac3f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/base_backends.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "0f8d532da5ce6187ba7e",
+      "diagnostic_digest": "298daaebc60e261db43b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/character_request_resolver.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "61d9a86e78817360019d",
+      "diagnostic_digest": "b55ea00700a888b3229a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/default_profile_request_resolver.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "63385d1cf26d021dfa5f",
+      "diagnostic_digest": "6082bcd632c2111c3074",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/kokoro_pytorch.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "f18d5e2407dee2646c29",
+      "diagnostic_digest": "89f989fd9ebd956da889",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/legacy_bridge.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "ab87ab8813d8ed73295d",
+      "diagnostic_digest": "4a1fb0024fa568cc2a67",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/studio_preferences.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "aba026f4d03c5866ac32",
+      "diagnostic_digest": "5a001d0f54c1944d439f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/utils/download_models.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "f93a4255a563ff422f70",
+      "diagnostic_digest": "d2ca5bc002c608627a78",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/utils/performance.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "30b46086fe05b4521040",
+      "diagnostic_digest": "817195c667f92a6e9b85",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/Mind_Map/jsoncanvas_handler.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "fb472a56519e07a4e973",
+      "diagnostic_digest": "41797b8f9db3b8dbcb9d",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/Mind_Map/mermaid_parser.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "6c0b9668c1b89f426689",
+      "diagnostic_digest": "887c0aac42287ec319bd",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/Mind_Map/mindmap_exporter.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "b73e31be5b00caaafcca",
+      "diagnostic_digest": "5de4d80001ef93450480",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/Mind_Map/mindmap_integration.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "d67f144a69a7c23a1a68",
+      "diagnostic_digest": "8c63d70d823e21b4aba6",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/Mind_Map/mindmap_model.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "e202f602405d1eb54a1d",
+      "diagnostic_digest": "44b65efe1068de4682d4",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/Mind_Map/mindmap_renderer.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "6113fac5d6b23b58875a",
+      "diagnostic_digest": "1ace6c7573a9c080a918",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/__init__.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "f364c051e465b17a827c",
+      "diagnostic_digest": "83f1b779d094de50a859",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/code_audit_tool.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "ca121ab518fdfa20284c",
+      "diagnostic_digest": "d7edcfc2db545e361801",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/file_operation_hooks.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "bd98f67916a6f15f0e32",
+      "diagnostic_digest": "6617ce6c76c5f836ff40",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/file_operation_tools.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "d79e21fa1994ecb41008",
+      "diagnostic_digest": "b63bdf30a148572156db",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/note_management_tools.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "ab20d5bc8e80605198b2",
+      "diagnostic_digest": "67a11620e21e3b573980",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/rag_search_tool.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "c680f3c2439ef2f4ff93",
+      "diagnostic_digest": "9bca8bb9b31f3e507ac9",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/web_search_tool.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 2,
-      "diagnostic_digest": "50373138e89affab38d3",
+      "call_count": 9,
+      "diagnostic_digest": "2b7594873a6489dbd72e",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/web_tool_impls.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "122ab2feccfd622a2e42",
+      "diagnostic_digest": "821bf0239383bfab9a20",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/workspace_file_roots.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 63,
-      "diagnostic_digest": "8b071699011bb9b3e428",
+      "diagnostic_digest": "ed2dc4f7b0ba4bac7199",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/CCP_Modules/ccp_character_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 26,
-      "diagnostic_digest": "16945aa06372234849a4",
+      "diagnostic_digest": "73d0f80d355a3cb94b1d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/CCP_Modules/ccp_conversation_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 46,
-      "diagnostic_digest": "37974053338718daec65",
+      "diagnostic_digest": "e9cac8b6937addcf734c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/CCP_Modules/ccp_dictionary_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "960c314385747962bbc5",
+      "diagnostic_digest": "72b6304a742eb3aa93ac",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/CCP_Modules/ccp_enhanced_handlers.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "a665040f45ca11ec16ad",
+      "diagnostic_digest": "0f893eca362382d267b6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/CCP_Modules/ccp_loading_indicators.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 21,
-      "diagnostic_digest": "6717d27a5e1a985cb444",
+      "diagnostic_digest": "313fd196f0b95cd54eda",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/CCP_Modules/ccp_message_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 22,
-      "diagnostic_digest": "a86c7caf966f8d574a53",
+      "diagnostic_digest": "92f142d768647c11ee86",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/CCP_Modules/ccp_persona_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "58d1843f5b9730782ecf",
+      "diagnostic_digest": "60cdb25024a06b89e748",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/CCP_Modules/ccp_validation_decorators.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "80e0a3a1cc968c2181d1",
+      "diagnostic_digest": "88c22afb88298e9b5dde",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/ChatbookCreationWindow.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 11,
-      "diagnostic_digest": "7ccf1875ea59a58cc6fb",
+      "diagnostic_digest": "d22e427a54424dd28e4a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/ChatbookExportManagementWindow.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 20,
-      "diagnostic_digest": "50ee810db80310e8b1a6",
+      "diagnostic_digest": "73178f58eed9a314cb52",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Chatbooks_Window.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "4518abb4fef5c44026da",
+      "diagnostic_digest": "992293a7aa9f2c2a4c09",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Chatbooks_Window_Improved.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 13,
-      "diagnostic_digest": "edd8c3a5299aec3be2d7",
+      "diagnostic_digest": "c7801a64ad499dad6330",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/CodeRepoCopyPasteWindow.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "937588979668a002c8ce",
+      "diagnostic_digest": "25150ea798b2261edac8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/agent.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "275bcaf906f91b46a1e6",
+      "diagnostic_digest": "bd2ed1a7a885866fb113",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/dictation.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "8f34eb47c52e1dbf710b",
+      "diagnostic_digest": "307f1b2174c1754ed210",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/hands_free.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 13,
-      "diagnostic_digest": "ee2c749db4e92186a25a",
+      "diagnostic_digest": "9374a45c1305592bced2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/message.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "2fee300efb749f9af99f",
+      "diagnostic_digest": "989e5f27ed48bec1ac98",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/prompts.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "6d2e3941c4301ff12352",
+      "diagnostic_digest": "aed8e64cf697ed8ae07e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/session.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 25,
-      "diagnostic_digest": "42068712614c8ccafd81",
+      "diagnostic_digest": "3e0b6ec16af729849d5c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/workspace.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 11,
-      "diagnostic_digest": "dca5b45de6234dfab5ec",
+      "diagnostic_digest": "76bbd2e604615186a34f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Dictation_Window_Improved.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "e468123a9a65f709c4d3",
+      "diagnostic_digest": "24cb6123a942290d6ac5",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Evals/inspector.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "77c863fbfb6aac99f233",
+      "diagnostic_digest": "3a50094be42d48983929",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Evals/results_grid.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "ba4a663ebbb041f0177f",
+      "diagnostic_digest": "de5a16835c9d4e4900b4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Evals/sample_bench.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 14,
-      "diagnostic_digest": "bf9bcf23cdebdb750d8a",
+      "diagnostic_digest": "9c1df9e9680e4003527f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/LLM_Management_Window.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "0285487e085753dc2689",
+      "diagnostic_digest": "51d0333a3ae21d458de7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Lab_Modules/lab_rail_store.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "9fc8fbd1c0ae4b1e712a",
+      "diagnostic_digest": "3a5b6f853b80b99069a6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/MCP_Modules/mcp_inspector.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 36,
-      "diagnostic_digest": "6c91bb5e94f050b2dc67",
+      "call_count": 37,
+      "diagnostic_digest": "c71e2386891b689809bb",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/MCP_Modules/mcp_workbench.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 67,
-      "diagnostic_digest": "943b74fa4d8285c78187",
+      "diagnostic_digest": "69d27c0993049a2130fa",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/MediaWindow_v2.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "2752ae404d6fb6a4a7cc",
+      "diagnostic_digest": "7e4aacbed20eb01de8c1",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Navigation/base_app_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "a2de4f95142b69d8f9b2",
+      "diagnostic_digest": "9c9eef7f2b82c5812f48",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Navigation/main_navigation.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "e1f547ad94cc7a62ce16",
+      "diagnostic_digest": "0c3d1d25098f69b745e3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Navigation/screen_registry.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "f5ae6bc61b1bc0f342d0",
+      "diagnostic_digest": "16f2683516d8854e3f66",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Outputs_Panel.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "3caa0452caf255c0b9da",
+      "diagnostic_digest": "6f0982f3f9db9883e88c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Persona_Modules/personas_conversations_controller.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "67fa3249791bce020bf8",
+      "diagnostic_digest": "9ad8c5664859f95de896",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 27,
-      "diagnostic_digest": "2fbc1bae7c7ba3784141",
+      "diagnostic_digest": "29ef6683d53f4df410e3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/STTS_Window.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "dee24b0d9dd876fe9af0",
+      "diagnostic_digest": "e409e601317c772b9182",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/ScraperBuilderWindow.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "20cf84b35167718cc0d2",
+      "diagnostic_digest": "b527247e67c2560ea0ac",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/artifacts_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "1877d8fb2610dfd81032",
+      "diagnostic_digest": "ce8b76c5a9ec33bfbb28",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/change_review_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 142,
-      "diagnostic_digest": "ba22d3ff40d6a5b2699d",
+      "call_count": 148,
+      "diagnostic_digest": "82556b5b835701ee6253",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/chat_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "8545dfeb7d7c1d3f5336",
+      "diagnostic_digest": "8b9c0fde125d4ffe187d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/chatbooks_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "f7c5172ad0fb1c9740e7",
+      "diagnostic_digest": "1122ca839e4609cb1bb8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/evals_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "a88891277cd7262ea074",
+      "diagnostic_digest": "3169cdab4d1ca4b07f95",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/home_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "527b2be14653d857d596",
+      "diagnostic_digest": "3342e56640d40ff07c40",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/image_gen_demo_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "ce2271246aa4efc6c254",
+      "diagnostic_digest": "da1523b65ce4d4ff32ea",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/lab_frame.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 83,
-      "diagnostic_digest": "f8f8ae64639f6d12119a",
+      "call_count": 82,
+      "diagnostic_digest": "e17bca547a51f96897d0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "9fe9b07d7a7ee11159f4",
+      "diagnostic_digest": "8d9200ac0225b9b6c3b7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/llm_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "7064f8c738a36c64bf67",
+      "diagnostic_digest": "0ca00ffe261d79d538de",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/logs_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "a6769ad8e25c807d515d",
+      "diagnostic_digest": "41dd89d7e41e68289f6e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/media_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "efb67c3050b23f826e0d",
+      "diagnostic_digest": "c997f31d798cea52851e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/model_installed_view.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 154,
-      "diagnostic_digest": "137cf648af5010311d51",
+      "diagnostic_digest": "40a3aece7c14a5ffaf31",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/personas_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 1,
+      "diagnostic_digest": "26f6f8f7f2cb830921f7",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Screens/provider_model_resolution.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 2,
-      "diagnostic_digest": "f3fd950f851023dd7d29",
+      "diagnostic_digest": "de8fb75df30e5c0cbc97",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/schedules_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "bff452bc46292dd1f696",
+      "diagnostic_digest": "f72efc28255a399ae000",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/scheduling/conflicts_tab.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "9fc44f5cd258d786a08c",
+      "diagnostic_digest": "ec77a2d70a78b6d9a9ac",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "a0ed0e636c2f32286894",
+      "diagnostic_digest": "0d03ea7b0e2092a1e742",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/settings_image_gen_defaults.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "2d7a9d9ff4c2d71d537a",
+      "diagnostic_digest": "d588eb5d3aeb724abe99",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/settings_rag_profile_adapter.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 29,
-      "diagnostic_digest": "ca54986a35e61e1a8be2",
+      "diagnostic_digest": "e77dce56c6f5a8115a3d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/settings_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "5ebe2a69441ebf107cb3",
+      "diagnostic_digest": "3e5a48897028892f1aef",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/skills_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 14,
-      "diagnostic_digest": "0a3ea2979a7751883bd3",
+      "diagnostic_digest": "0f5542cc54bddaa67463",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/stats_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "622c2dd215858f545010",
+      "diagnostic_digest": "d7c320391b05b0157264",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/stts_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 13,
-      "diagnostic_digest": "a937e1d896d1aeb53f85",
+      "diagnostic_digest": "5fbdf030a4346e29a25f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/study_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 76,
-      "diagnostic_digest": "d498d812740b0720adbc",
+      "call_count": 78,
+      "diagnostic_digest": "febcae24a59565708296",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/watchlists_collections_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "1e6e3d8e1277e5028abf",
+      "diagnostic_digest": "2ab02afa9cb484044feb",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/workflows_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "870a530195c4af336501",
+      "diagnostic_digest": "a063ccab9a0de255126a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/writing_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "63feade1d9bb7ecc3668",
+      "diagnostic_digest": "f3c85b1c458f83706500",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Sharing_Panel.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "ded9c510b3b092cc2321",
+      "diagnostic_digest": "3d6c3c560f6c2af1389f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/SiteConfigSettings.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "79a67d489b973e1a2810",
+      "diagnostic_digest": "535e6d31e3eb9ab4527a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Speech/speech_catalog_mixin.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 50,
-      "diagnostic_digest": "c601bf39936ea21383ef",
+      "diagnostic_digest": "b22d44b38be1d0759cca",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Speech/speech_playback_mixin.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 24,
-      "diagnostic_digest": "29ecd4ee4918358bcbf9",
+      "diagnostic_digest": "b64ffd9a8d460cb3f72e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Speech/speech_settings_mixin.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "340421cc5761435dfbad",
+      "diagnostic_digest": "af504913b4457dfaf3a7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Speech/speech_settings_pane.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "ed98e719e517376e7460",
+      "diagnostic_digest": "490dc7223fc7b4709208",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Speech/speech_synthesis_mixin.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "67fe534dd7fcce549b73",
+      "diagnostic_digest": "104665e875f77b4f829b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Study_Modules/flashcards_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "aa98da8a4b23cbc31af5",
+      "diagnostic_digest": "eaa9b043104df3d0903d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Study_Modules/quizzes_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 26,
-      "diagnostic_digest": "4ab60669bb18f87b7de3",
+      "diagnostic_digest": "6ccff0ae55132f6df003",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Tools_Settings_Window.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "4abc40612c24634bd076",
+      "diagnostic_digest": "5c71845147cd18aba5a6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Voice_Cloning_Window.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "437a12c74e5a4cd724fe",
+      "diagnostic_digest": "62bc8dbe7b089ffdb5ce",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/briefing_preset_modal.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "1ba91a70c975405587a6",
+      "diagnostic_digest": "d9ac2032633bc1968736",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "5c557b948b114ba1717e",
+      "diagnostic_digest": "054312e527412288cbea",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/kept_briefings_modal.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "354e7cd7d03377aa506f",
+      "diagnostic_digest": "1f268634dc34652fddfc",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/region_layout_store.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "5bd2699d21547839f79c",
+      "diagnostic_digest": "1b753664cbb1a06e0f0d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/sources_pane.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 1,
-      "diagnostic_digest": "dc9cee9441ed5a1f5245",
+      "call_count": 2,
+      "diagnostic_digest": "277ebb5162ea85ebb0f7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "a85d0c8d78c73439a60d",
+      "diagnostic_digest": "ec6895803bf0f3090586",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/watchlists_console_handoff.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "587fb5f16e8105bc3b6b",
+      "diagnostic_digest": "f969a5e2074331ed224c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Widgets/MindmapViewer.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "2374a91769cac0ba77f2",
+      "diagnostic_digest": "79438ba03fa0b785e937",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Widgets/SmartContentTree.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 24,
-      "diagnostic_digest": "ebd508e20f891ac6e5c3",
+      "diagnostic_digest": "77344707fa6e9023516a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Wizards/BaseWizard.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 27,
-      "diagnostic_digest": "461e448555438d48ba9d",
+      "diagnostic_digest": "9b4de0b13e89169d5ffe",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "82523dd2cf8ac635e316",
+      "diagnostic_digest": "95ddcc4ddede6c0a1d8a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Wizards/ChatbookImportWizard.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 21,
-      "diagnostic_digest": "80c84b4a5b6633483520",
+      "diagnostic_digest": "ee4bc30bfbfd38b0ebb1",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "5baa5683f776f34de54b",
+      "diagnostic_digest": "cfcc86bd69d1deb760c5",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/Splash_Screens/__init__.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "e58973f7fb35657c6c0e",
+      "diagnostic_digest": "7e2adbc825eb37f572cb",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/Splash_Screens/base_effect.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 20,
-      "diagnostic_digest": "584eee182f6bcaba8d70",
+      "diagnostic_digest": "6328a4cc13b605e2e3b1",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/Utils.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "d140f9a3ae77fcd206a0",
+      "diagnostic_digest": "19bb63f9e8210cae9406",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/atomic_file_ops.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "c6d38981044a56fd5168",
+      "diagnostic_digest": "96e658422c7dd0444843",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/config_encryption.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "d9dea578830ad927df41",
+      "diagnostic_digest": "1fa0254f098f74f8a88e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/custom_tokenizers.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "c38f8f56617e5dc3e531",
+      "diagnostic_digest": "72df2e9624c9cce20301",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/db_status_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "d9bcd5c5eea98c7521ae",
+      "diagnostic_digest": "a674e6d483b3efde56e9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/debug_helpers.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "5be7005eddf92462cb04",
+      "diagnostic_digest": "a588b00ee09271441ef7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/egress.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "7bafbce78aa5ef5093e8",
+      "diagnostic_digest": "1135fc2441791e89afce",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/embedding_templates.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "10ccee9fd047e7d44171",
+      "diagnostic_digest": "bb7db7541551c0fedb59",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/file_extraction.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "1b67fe24e3f8f98d7a30",
+      "diagnostic_digest": "c293b2298d8ca732b52a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/file_handlers.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "5c06eb6291001d83afa4",
+      "diagnostic_digest": "876052bd926f9f3f907c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/github_api_client.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "501535d259657dfad9c9",
+      "diagnostic_digest": "51c7bcb594144faf708b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/ingestion_preferences.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "1a79d5fbc6b980652a1b",
+      "diagnostic_digest": "f9766f73fb7c2e82fe73",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/instance_lock.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "8b6f63656dfde20a20f1",
+      "diagnostic_digest": "63f85d7fb4dc4819c85f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/log_widget_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "5b897d5afb8b3059703e",
+      "diagnostic_digest": "c29454180dad9f581a54",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/note_importers.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 66,
-      "diagnostic_digest": "3b05526881688472a833",
+      "diagnostic_digest": "200520a8c1cc673d5653",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/optional_deps.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "673fa6a119aa44e11b14",
+      "diagnostic_digest": "de03f4abf99521311647",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/pagination.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "ccb8e318fa56e4ab4ec0",
+      "diagnostic_digest": "5c87aa034fdb12365052",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/path_validation.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "a5cf9869b686d12bb88f",
+      "diagnostic_digest": "8baad40748260b87df44",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/paths.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "3145cf37d980c8a2872b",
+      "diagnostic_digest": "f284de2bc41b0d856b70",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/persistent_diagnostics.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "dda9473c7ea2012fb89d",
+      "diagnostic_digest": "0b22a6c7f27764ac0500",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/secure_temp_files.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "7c984831009e27811be3",
+      "diagnostic_digest": "5e1f7cc53ac0791f1349",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/sensitive_paths.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "7f6048192601a89fe4a6",
+      "diagnostic_digest": "291c235f26ff797f6c34",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/terminal_utils.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "5d0b2db32054df1768bb",
+      "diagnostic_digest": "d7b790428d23da7450dc",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/text.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "bb1f35c036f302abf3c6",
+      "diagnostic_digest": "d2df6a8a07164aa52b50",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/token_counter.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "2f9c6a1fe8990456c3b4",
+      "diagnostic_digest": "b7919db0194c407f200a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/ui_helpers.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 73,
-      "diagnostic_digest": "ae034e4bae1e095adcc7",
+      "diagnostic_digest": "936612801a4092f7a624",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "f171571560fad0fb8023",
+      "diagnostic_digest": "3fd650261707d8e41214",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/Article_Scraper/crawler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 13,
-      "diagnostic_digest": "c8e479425935256f5c99",
+      "diagnostic_digest": "cc368bdbbc0761b1a11d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/Article_Scraper/importers.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "89d511f29a0fd89cb8a0",
+      "diagnostic_digest": "9495bd789e0691cb1d71",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/Article_Scraper/processors.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "ff4ab5d2ef7768c69eb9",
+      "diagnostic_digest": "10e747e73c438c756df1",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/Article_Scraper/scraper.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 11,
-      "diagnostic_digest": "27c34cad71591ef9ee52",
+      "diagnostic_digest": "f78eeb27ae11dadbfcb3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/Confluence/confluence_auth.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "b39b386e5a69c21f2c39",
+      "diagnostic_digest": "ce9b301017da2f2319f4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/Confluence/confluence_crawler.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "4c204b663e40e369d827",
+      "diagnostic_digest": "39790e88e8315ecec831",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/Confluence/confluence_main.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 13,
-      "diagnostic_digest": "b1cd68ad2ffab1c5380e",
+      "diagnostic_digest": "463590984cf0c01ef2e1",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/Confluence/confluence_scraper.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "762078a9139e14fcd5ab",
+      "diagnostic_digest": "dd199c45c477610f1339",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/Confluence/confluence_utils.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 100,
-      "diagnostic_digest": "24479f334089dc086e9d",
+      "diagnostic_digest": "d2232c700a34c05300ad",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/WebSearch_APIs.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "d437278e7221ee7ed548",
+      "diagnostic_digest": "ee16590d46f23a45c76e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/cookie_scraping/cookie_cloner.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "9236fa7f0d8158dba4a3",
+      "diagnostic_digest": "6d2198e75947eeae43a7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Server/serve.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "2dbebaf09e6dd9731f6d",
+      "diagnostic_digest": "5e52e2245dcd0198893a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/CCP_Widgets/ccp_dictionary_editor_widget.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "99c161bc84d25ce7dd7e",
+      "diagnostic_digest": "ac1d4832307e6fa84819",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/CCP_Widgets/ccp_prompt_editor_widget.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "982842560d677fc0116c",
+      "diagnostic_digest": "6320c2f9385c3abf2dd8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Chat_Widgets/chat_message.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 14,
-      "diagnostic_digest": "3ee992e27a61f441db0f",
+      "diagnostic_digest": "a11ca42c75621f29542d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Chat_Widgets/chat_message_enhanced.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "4935632bc27563f1baa3",
+      "diagnostic_digest": "073af2d6a9e12fbf65a4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Console/console_command_popup.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "c48ffd42bf1d0f27f374",
+      "diagnostic_digest": "9788f180d63aa7939014",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Console/console_context_modal.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "a057db9dd1b5e29e9c48",
+      "diagnostic_digest": "bb3f1238b881eb24b15d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Console/console_generation_card.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "1c95bab3e669f8ce1af9",
+      "diagnostic_digest": "4511017923f7af6001cc",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Console/console_transcript.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 27,
-      "diagnostic_digest": "713daef845845bb12577",
+      "diagnostic_digest": "a0e4c329925f064d2e66",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/HuggingFace/download_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 11,
-      "diagnostic_digest": "398e80e6b81a8471272c",
+      "diagnostic_digest": "1d59b3a2bc1ecf3d5310",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/HuggingFace/local_models_widget.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "082d01ccfd31477f0994",
+      "diagnostic_digest": "995ab81578ba43566e18",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/HuggingFace/model_browser_widget.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 24,
-      "diagnostic_digest": "78cfe692a8b6deffd0b7",
+      "diagnostic_digest": "18d8e52c40de3a04a3a0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/HuggingFace/model_card_viewer.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "1dc9846b3a512e63cc92",
+      "diagnostic_digest": "81c5b631c734100c0fe4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/HuggingFace/model_search_widget.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "2e77c057734c53b446a1",
+      "diagnostic_digest": "c9c4f277ff1d4c6679a1",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Media/media_list_panel.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 45,
-      "diagnostic_digest": "1c7a319b7db36a681547",
+      "diagnostic_digest": "25179ecd98c3d933f64b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Media/media_viewer_panel.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "7c7ef721404d5f6bd05b",
+      "diagnostic_digest": "230966e1200324c0e4d9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Note_Widgets/note_creation_modal.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "cf491b586aec5e9f9cd5",
+      "diagnostic_digest": "d7918d5975a414eac6e4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Persona_Widgets/personas_dictionary_detail.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "087a9455eb34e92f4c3b",
+      "diagnostic_digest": "03b18636e35b7d16137b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "0ba084b9d8a1663e7314",
+      "diagnostic_digest": "d20a0ff3057a8fb4d44d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "b8b2ce979806f021c0ee",
+      "diagnostic_digest": "ba763caa1483c704e4b6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/TTS/chapter_editor_widget.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "5e9ad66a66547db07865",
+      "diagnostic_digest": "9e1cce317e0967b0a0ce",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/TTS/character_voice_widget.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "af9d855c0391827a9ae5",
+      "diagnostic_digest": "9f85114d24a74e869906",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Tamagotchi/base_tamagotchi.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "8ebc38006ab3132b9f48",
+      "diagnostic_digest": "434ecf2762482db1deca",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Tamagotchi/tamagotchi_storage.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "c6b56cd80e0fbd37a7db",
+      "diagnostic_digest": "2d6884d6cd30f477cf58",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/activity_log.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "7094459fa7db012fa64d",
+      "diagnostic_digest": "42978bfdb31332cb1783",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/audio_troubleshooting_dialog.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "a6b931abd95e53177914",
+      "diagnostic_digest": "f51ca871d0281549ed86",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/base_components.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "bc8af952099104b2eb09",
+      "diagnostic_digest": "d96391a0cd2d8dabc444",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/chunk_preview_modal.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "9dac0b373389e0a6b085",
+      "diagnostic_digest": "2ac93bd77a2a2f7e5bd7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/collections_tag_window.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "dd7409e24f63f663b873",
+      "diagnostic_digest": "a246a965163ea839ff7c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/compact_model_bar.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "6b6b2adf63c4fa9718bc",
+      "diagnostic_digest": "4b29c8efa4c4c70e4e96",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/conversation_selection_dialog.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "9de41a5398a62ec82e20",
+      "diagnostic_digest": "42f808a769e4a2341d1b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/detailed_progress.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 10,
-      "diagnostic_digest": "f3730bdc98b0453b9c3f",
+      "diagnostic_digest": "d89d8a75e39824ecb46c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/document_generation_modal.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "9d8d8afa38d3084bc7a8",
+      "diagnostic_digest": "1906da842e64f788c468",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/embedding_template_selector.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "a7ca0822d5f5979645ae",
+      "diagnostic_digest": "ad8c2ca31a5a45a15dec",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/enhanced_file_picker.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "9fa05f2b5994e51a46f7",
+      "diagnostic_digest": "d308efa03f623393b6bf",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/enhanced_sidebar.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "ce6bebdae077db3ba9c4",
+      "diagnostic_digest": "08c8c4faf6845e7ed787",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/feedback_dialog.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "8e1f8275a482db531314",
+      "diagnostic_digest": "5f2abe0ae80b7a3a5c1f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/file_extraction_dialog.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "ba11afa16546ae12cb6a",
+      "diagnostic_digest": "1e67452b57a601b52aaa",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/file_list_item_enhanced.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "92fd9a749ce1e5de188b",
+      "diagnostic_digest": "886acbd53a6db54b57e1",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/file_picker_dialog.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 9,
-      "diagnostic_digest": "9f60e52f3f35f9b38d85",
+      "diagnostic_digest": "9781ad97e8c13f80ba44",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/lazy_widgets.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "2f5db3e89491a9a68ac1",
+      "diagnostic_digest": "d9eb796a0674c400d0d6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/loading_states.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 22,
-      "diagnostic_digest": "12206f60905543fac1ad",
+      "diagnostic_digest": "4462244f55936fa4e376",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/media_details_widget.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "f66cf7671eacddfc221f",
+      "diagnostic_digest": "b9884cee12b1eeae597e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/password_dialog.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 20,
-      "diagnostic_digest": "b4c7075a96a8d7418960",
+      "diagnostic_digest": "369d82e2b1661519bddf",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/prompt_selector.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "8e7584a79578f1aaa791",
+      "diagnostic_digest": "214f26cc3efe3bbc1cd8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/recompose_capture_guard.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "db5defbf541dba11dad8",
+      "diagnostic_digest": "a7b8e8cd3c4ad70622ce",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/settings_splash_screen_viewer.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "70ffaec9d5e20f2a0ea1",
+      "diagnostic_digest": "e5f5b8a3dad70ab963ad",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/settings_theme_editor.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 18,
-      "diagnostic_digest": "881f04afdc1bbdefb510",
+      "call_count": 19,
+      "diagnostic_digest": "626a1d6fd29003f958fc",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/splash_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "3470941d9b435cd2751b",
+      "diagnostic_digest": "5a49ccd8eaff36263256",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/status_dashboard.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "1686f90502a996d3e119",
+      "diagnostic_digest": "598e53cfec73196e2f16",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/template_selector.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "c1c10acda45629852fea",
+      "diagnostic_digest": "5394f055a68330f96f3c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/toast_notification.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "86dd92ab5d9b14a52b16",
+      "diagnostic_digest": "1745a4f82a28ff938c0b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/tool_message_widgets.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "409718196b014241641a",
+      "diagnostic_digest": "0dccab848f33dcd93e4b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/voice_blend_dialog.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "7c6201cd8cce52f03887",
+      "diagnostic_digest": "131f76ca88d5a531b059",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/voice_input_widget.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "5beb792371aed4f9eb76",
+      "diagnostic_digest": "7fb350eb8720967cf40b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/change_bounds.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "303871fdb52cb0798907",
+      "diagnostic_digest": "2d919935304e9b0f1b3c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/change_retention.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "2c290c7704b2a652f70b",
+      "diagnostic_digest": "307959d4869a5299046d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/change_revert.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "a729fc5f9bab7ce46228",
+      "diagnostic_digest": "d1bc191b82d44a33bfc0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/change_tracking.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "733d830aa2dd2070ddad",
+      "diagnostic_digest": "ebe4dbc9a3fba2384e21",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/change_turn_tracker.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "3480e9be98483397ac86",
+      "diagnostic_digest": "2c9e9e570dc79bd60b81",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/display_state.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "cda7280a1b1d9c5c39e2",
+      "diagnostic_digest": "57cd98b5b30e53dba161",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/registry_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 293,
-      "diagnostic_digest": "99d7182713249c79cb04",
+      "call_count": 298,
+      "diagnostic_digest": "114f37c1a1bcc7efe5ae",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 103,
-      "diagnostic_digest": "8609ce33f470b5506c05",
+      "diagnostic_digest": "aabf6d16c333bfdf89d4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/config.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "ffd31b020ca4b6f7828d",
+      "diagnostic_digest": "e14e3417728164c72c04",
       "owner": "TASK-494",
       "path": "tldw_chatbook/model_capabilities.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "7557ccaa98905ad76458",
+      "diagnostic_digest": "f7160f57fbaa22b52b54",
       "owner": "TASK-494",
       "path": "tldw_chatbook/runtime_policy/bootstrap.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "ba91536f8ee2432ec832",
+      "diagnostic_digest": "7f946a6f79f8eec9b795",
       "owner": "TASK-494",
       "path": "tldw_chatbook/runtime_policy/server_context.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "198443eafa305a254c08",
+      "diagnostic_digest": "43415f77e75973362156",
       "owner": "TASK-494",
       "path": "tldw_chatbook/runtime_policy/source_state.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "feda5e1dd273f2a9ab45",
+      "diagnostic_digest": "0be11f47b5dcf19f995d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/tldw_api/utils.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3288,8 +3309,8 @@
         {
           "digest": "f3f48a9cf32cb9a3",
           "kind": "addHandler",
-          "line": 103,
-          "method": "addHandler"
+          "method": "addHandler",
+          "scope": "silence_ingest_worker_import_noise"
         }
       ]
     },
@@ -3299,44 +3320,44 @@
         {
           "digest": "56b5792fdabbf41f",
           "kind": "open_private_text_append_stream",
-          "line": 250,
-          "method": "open_private_text_append_stream"
+          "method": "open_private_text_append_stream",
+          "scope": "PrivateRotatingFileHandler._open"
         },
         {
           "digest": "5e6ab9333644517d",
           "kind": "PrivateRotatingFileHandler",
-          "line": 299,
-          "method": "PrivateRotatingFileHandler"
+          "method": "PrivateRotatingFileHandler",
+          "scope": "_configure_private_file_logging"
         },
         {
           "digest": "6873d362f90a7843",
           "kind": "addHandler",
-          "line": 313,
-          "method": "addHandler"
+          "method": "addHandler",
+          "scope": "_configure_private_file_logging"
         },
         {
           "digest": "564e6ba00dec45c0",
           "kind": "addHandler",
-          "line": 407,
-          "method": "addHandler"
-        },
-        {
-          "digest": "9fce73a232622dc7",
-          "kind": "loguru_sink",
-          "line": 419,
-          "method": "add"
+          "method": "addHandler",
+          "scope": "configure_application_logging"
         },
         {
           "digest": "7907c11f3c5927cc",
           "kind": "addHandler",
-          "line": 508,
-          "method": "addHandler"
+          "method": "addHandler",
+          "scope": "configure_application_logging"
         },
         {
           "digest": "f32845c700525187",
           "kind": "addHandler",
-          "line": 543,
-          "method": "addHandler"
+          "method": "addHandler",
+          "scope": "configure_application_logging"
+        },
+        {
+          "digest": "9fce73a232622dc7",
+          "kind": "loguru_sink",
+          "method": "add",
+          "scope": "configure_application_logging"
         }
       ]
     },
@@ -3344,28 +3365,28 @@
       "path": "tldw_chatbook/MCP/execution_log.py",
       "sinks": [
         {
+          "digest": "56f25223a6b15e31",
+          "kind": "atomic_private_write_bytes",
+          "method": "atomic_private_write_bytes",
+          "scope": "MCPExecutionLog._migrate_generation"
+        },
+        {
           "digest": "6f3fa8858b867a5d",
           "kind": "atomic_private_write_bytes",
-          "line": 178,
-          "method": "atomic_private_write_bytes"
+          "method": "atomic_private_write_bytes",
+          "scope": "MCPExecutionLog.append"
         },
         {
           "digest": "ada430ac35802bc3",
           "kind": "atomic_private_write_bytes",
-          "line": 183,
-          "method": "atomic_private_write_bytes"
+          "method": "atomic_private_write_bytes",
+          "scope": "MCPExecutionLog.append"
         },
         {
           "digest": "78a896a27803ea08",
           "kind": "open_private_text_append",
-          "line": 189,
-          "method": "open_private_text_append"
-        },
-        {
-          "digest": "56f25223a6b15e31",
-          "kind": "atomic_private_write_bytes",
-          "line": 362,
-          "method": "atomic_private_write_bytes"
+          "method": "open_private_text_append",
+          "scope": "MCPExecutionLog.append"
         }
       ]
     },
@@ -3375,14 +3396,14 @@
         {
           "digest": "d75d7181a3fd5bda",
           "kind": "atomic_private_write_bytes",
-          "line": 738,
-          "method": "atomic_private_write_bytes"
+          "method": "atomic_private_write_bytes",
+          "scope": "atomic_private_write_text"
         },
         {
           "digest": "eb6b6c3fa9d61328",
           "kind": "open_private_text_append_stream",
-          "line": 755,
-          "method": "open_private_text_append_stream"
+          "method": "open_private_text_append_stream",
+          "scope": "open_private_text_append"
         }
       ]
     },
@@ -3392,26 +3413,26 @@
         {
           "digest": "9edec43a81cb22b9",
           "kind": "addHandler",
-          "line": 42,
-          "method": "addHandler"
+          "method": "addHandler",
+          "scope": "<module>"
         },
         {
           "digest": "567455f2495e9603",
           "kind": "addHandler",
-          "line": 6063,
-          "method": "addHandler"
+          "method": "addHandler",
+          "scope": "TldwCli._setup_buffered_logging"
         },
         {
           "digest": "004b99881aa5dff2",
           "kind": "loguru_sink",
-          "line": 6091,
-          "method": "add"
+          "method": "add",
+          "scope": "TldwCli._setup_buffered_logging"
         },
         {
           "digest": "928f6c554daaf493",
           "kind": "addHandler",
-          "line": 6148,
-          "method": "addHandler"
+          "method": "addHandler",
+          "scope": "TldwCli._setup_logging"
         }
       ]
     },
@@ -3421,8 +3442,8 @@
         {
           "digest": "79153c35e06865c1",
           "kind": "open_private_text_append_stream",
-          "line": 4339,
-          "method": "open_private_text_append_stream"
+          "method": "open_private_text_append_stream",
+          "scope": "_config_interprocess_lock"
         }
       ]
     }
@@ -3444,12 +3465,12 @@
       "reason": "not Chatbook-owned; persistent filtering is tested separately"
     }
   ],
-  "schema_version": 1,
+  "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 466,
+    "owner_files": 469,
     "persistent_sink_files": 6,
-    "task_492_calls": 1144,
-    "task_494_calls": 6851
+    "task_492_calls": 1153,
+    "task_494_calls": 6884
   }
 }

--- a/Tests/Architecture/test_persistent_diagnostic_inventory.py
+++ b/Tests/Architecture/test_persistent_diagnostic_inventory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -38,6 +39,149 @@ def test_persistent_metadata_marker_cannot_be_forged_outside_its_owner() -> None
         "persistent metadata admission marker used outside its sole owner: "
         + ", ".join(offenders)
     )
+
+
+def _digest(source: str) -> str:
+    diagnostics, _sinks = diagnostic_inventory.scan_source(source)
+    return diagnostic_inventory.diagnostic_digest(diagnostics)
+
+
+BASE_MODULE = (
+    "from loguru import logger\n"
+    "\n"
+    "\n"
+    "def alpha() -> None:\n"
+    "    value = 1\n"
+    "    logger.info('alpha ran')\n"
+    "    return value\n"
+    "\n"
+    "\n"
+    "def beta() -> None:\n"
+    "    logger.error('beta failed')\n"
+)
+
+
+def test_moving_a_logger_call_within_a_file_does_not_change_the_digest() -> None:
+    """AC1: pure movement is not a review event."""
+    moved_down = (
+        "from loguru import logger\n"
+        "\n"
+        "\n"
+        "def alpha() -> None:\n"
+        "    value = 1\n"
+        "    # a comment inserted above the call shifts every line below it\n"
+        "\n"
+        "    logger.info('alpha ran')\n"
+        "    return value\n"
+        "\n"
+        "\n"
+        "def beta() -> None:\n"
+        "    logger.error('beta failed')\n"
+    )
+    # Relocating a call into the *other* function, and swapping the order of
+    # the two diagnostics, is still pure movement: the statements themselves
+    # are untouched.
+    relocated = (
+        "from loguru import logger\n"
+        "\n"
+        "\n"
+        "def alpha() -> None:\n"
+        "    value = 1\n"
+        "    return value\n"
+        "\n"
+        "\n"
+        "def beta() -> None:\n"
+        "    logger.error('beta failed')\n"
+        "    logger.info('alpha ran')\n"
+    )
+
+    assert _digest(moved_down) == _digest(BASE_MODULE)
+    assert _digest(relocated) == _digest(BASE_MODULE)
+
+
+def test_editing_a_diagnostic_changes_the_digest() -> None:
+    """AC2: reword, re-level, add, and remove all remain review events."""
+    reworded = BASE_MODULE.replace("'alpha ran'", "'alpha ran with 3 items'")
+    downgraded = BASE_MODULE.replace("logger.error(", "logger.debug(")
+    added = BASE_MODULE + "    logger.warning('beta warned')\n"
+    removed = BASE_MODULE.replace("    logger.error('beta failed')\n", "    pass\n")
+
+    baseline = _digest(BASE_MODULE)
+    for label, mutated in (
+        ("reworded message", reworded),
+        ("level downgraded to debug", downgraded),
+        ("diagnostic added", added),
+        ("diagnostic removed", removed),
+    ):
+        assert _digest(mutated) != baseline, f"{label} did not change the digest"
+
+
+def test_duplicate_diagnostics_are_digested_with_multiplicity() -> None:
+    """Two identical calls are not one: deleting a twin must still be caught."""
+    twice = (
+        "from loguru import logger\n"
+        "\n"
+        "\n"
+        "def alpha() -> None:\n"
+        "    logger.info('same text')\n"
+        "    logger.info('same text')\n"
+    )
+    once = (
+        "from loguru import logger\n"
+        "\n"
+        "\n"
+        "def alpha() -> None:\n"
+        "    logger.info('same text')\n"
+    )
+
+    assert _digest(twice) != _digest(once)
+
+
+def test_sink_entries_are_position_independent_but_still_content_sensitive() -> None:
+    """Sinks carry a scope, not a line: they move quietly, change loudly."""
+    base = (
+        "import logging\n"
+        "\n"
+        "\n"
+        "def configure() -> None:\n"
+        "    root = logging.getLogger()\n"
+        "    root.addHandler(logging.FileHandler('/var/log/app.log'))\n"
+    )
+    moved = base.replace(
+        "    root = logging.getLogger()\n",
+        "    root = logging.getLogger()\n    root.setLevel(logging.INFO)\n",
+    )
+    retargeted = base.replace("/var/log/app.log", "/tmp/app.log")
+
+    _diagnostics, base_sinks = diagnostic_inventory.scan_source(base)
+    _diagnostics, moved_sinks = diagnostic_inventory.scan_source(moved)
+    _diagnostics, retargeted_sinks = diagnostic_inventory.scan_source(retargeted)
+
+    assert base_sinks == moved_sinks
+    assert base_sinks != retargeted_sinks
+    assert all("line" not in entry for entry in base_sinks)
+    assert {entry["scope"] for entry in base_sinks} == {"configure"}
+
+
+def test_shifting_a_real_inventory_file_leaves_its_digest_unchanged() -> None:
+    """End-to-end on shipped source, not just a synthetic fixture."""
+    inventory = json.loads(
+        (REPO_ROOT / "Docs/security/production-diagnostic-inventory.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    entry = next(
+        item for item in inventory["owners"] if item["call_count"] >= 3
+    )
+    source = (REPO_ROOT / entry["path"]).read_text(encoding="utf-8")
+    diagnostics, _sinks = diagnostic_inventory.scan_source(source)
+
+    assert len(diagnostics) == entry["call_count"]
+    assert diagnostic_inventory.diagnostic_digest(diagnostics) == (
+        entry["diagnostic_digest"]
+    )
+    # Prepending blank lines shifts every line number in the file.
+    assert _digest("\n\n\n" + source) == entry["diagnostic_digest"]
 
 
 def test_inventory_counts_chained_logger_diagnostic_calls() -> None:

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1208,3 +1208,33 @@ shape (Edit-based, unique marker strings) and READ the red result before
 trusting the green one. Both of these were caught only because the review
 step re-ran the pre-fix code against the new test; neither red-check had been
 done by the author, and both tests were the SOLE pin for their spec clause.
+
+## A regenerated gate artifact is stale the moment something merges ahead of it
+
+**Incident (task-3750, 2026-08-08).** `Docs/security/production-diagnostic-inventory.json`
+is a checked-in artifact that a test regenerates and byte-compares. Its most recent
+regeneration was commit `f990464ed` — and `f990464ed` was `origin/dev`'s tip, where the
+test **failed**. The commit that regenerated the file left it stale on arrival: the
+author ran `--write` on a branch, and the PRs that merged ahead of theirs moved line
+numbers and added diagnostics. Green on the branch, red on dev, nobody at fault.
+
+Two things follow.
+
+1. **"The gate passed on my branch" is not evidence the gate passes on dev** for any
+   test that compares against a regenerated whole-tree artifact. The only honest check
+   is after the final rebase/merge — `test_screen_size_ratchet.py` already says exactly
+   this in a comment ("a budget derived from a stale base fails the moment it merges"),
+   which is how you know it is a repo-wide pattern and not one script's quirk.
+2. **Design these artifacts so unrelated churn cannot invalidate them.** The inventory
+   hashed each logger call's *line number* alongside its text, so any refactor that
+   shifted lines failed a security gate with the call count unchanged and the sink
+   topology byte-identical. Measured on dev: of 47 drifted entries, 28 were pure line
+   movement. A gate that fires on no-ops trains reviewers to regenerate without reading,
+   which destroys exactly the review it exists to force. Key such artifacts on content,
+   and keep multiplicity (a sorted list, never a set) so deletions still register.
+
+**What to do.** Before blessing a regenerated artifact, classify the drift instead of
+running `--write` and staring at a 1,000-line diff: walk each file's history for the
+revision whose digest reproduces the checked-in value, and diff content-vs-position.
+That is what separated the 28 no-ops from the 19 real changes here, and it is what made
+it cheap to actually read the diagnostics being newly blessed.

--- a/backlog/tasks/task-3750 - Diagnostic-inventory-digests-key-on-logger-line-numbers.md
+++ b/backlog/tasks/task-3750 - Diagnostic-inventory-digests-key-on-logger-line-numbers.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-3750
 title: Diagnostic inventory digests key on logger line numbers
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-08 21:06'
+updated_date: '2026-08-08 23:13'
 labels:
   - tech-debt
 dependencies: []
@@ -17,7 +19,68 @@ Docs/security/production-diagnostic-inventory.json stores a per-file digest that
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Moving a logger call within a file without changing it does not change its digest
-- [ ] #2 Adding, removing, or editing a diagnostic still changes the digest and fails the test
-- [ ] #3 The existing reviewed inventory is migrated to the new keying in one deliberate commit
+- [x] #1 Moving a logger call within a file without changing it does not change its digest
+- [x] #2 Adding, removing, or editing a diagnostic still changes the digest and fails the test
+- [x] #3 The existing reviewed inventory is migrated to the new keying in one deliberate commit
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read the script and identify exactly what feeds diagnostic_digest
+2. Re-key the digest on content (log method + statement source text), dropping line numbers
+3. Decide the sink question on evidence, not taste
+4. Write unit tests for AC1/AC2 incl. multiplicity, plus a real-file end-to-end
+5. Migrate the checked-in inventory in a separate deliberate commit
+6. Prove both arms by mutating real production source
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Re-keyed the per-file diagnostic_digest on CONTENT instead of position.
+
+**Approach.** The digest hashed a list of {line, method, digest} per logger call, so
+line numbers were a hash input and any refactor that shifted lines failed the gate.
+It is now a sorted list of (log method, statement source-text digest). Sorted, so
+reordering or relocating calls is invisible; a LIST and not a set, so multiplicity
+counts and deleting one of two identical calls is still caught.
+
+**Sinks: line: dropped, replaced by scope:.** Decided on evidence found while doing
+this task, not on taste. The entire sink drift sitting on dev was pure line movement
+-- all 5 drifted entries had byte-identical digest and kind, with only line: changed
+(app.py 6063 -> 6656). Sinks live in app.py and config.py, two of the churniest files
+in the repo, so the same false-positive engine runs there. Entries now carry the
+enclosing qualified scope (TldwCli._setup_buffered_logging rather than 6063), which
+navigates better than a line number and does not go stale. The rejected middle option
+-- print line: but exclude it from the comparison -- would let the number rot and send
+a reviewer to the wrong place, which is worse than a chore.
+
+**Diagnostics deliberately do NOT carry scope,** though sinks do. Moving a logger call
+into an extracted method is the single most common refactor in this repo (decomposition
+waves 4/5) and must stay silent; sinks are 19 entries that essentially never move
+between functions, and there the scope is the only navigation handle a reviewer has.
+Owner entries never had a line number to lose -- they are only path/count/digest.
+
+**schema_version 1 -> 2.** Every digest changes because the keying changed, not because
+code did; the version is the only signal that a mismatch across the bump is a semantics
+change rather than a new diagnostic.
+
+**Sensitivity is unchanged.** Proven on real production source, six arms, each run
+against the real checker: a moved logger call passes (exit 0); reworded message fails;
+level debug -> error fails; a moved sink passes; a retargeted sink fails; full restore
+passes. Plus unit tests for add/remove/reword/re-level/duplicate-multiplicity.
+
+**The migration commit absorbs pre-existing dev drift, reviewed rather than rubber-
+stamped.** The inventory was last regenerated in f990464ed (HEAD) and was ALREADY
+stale there -- a branch that regenerates before merge is re-staled by whatever merges
+ahead of it. Of 47 drifted owner entries, 28 were pure line movement and 19 were real
+content changes (3 files new). The added diagnostics in the high-risk TASK-492 paths
+were read: a Library factory warning, an MCP backend-unavailable exception, and 7
+robots.txt debug lines in web_tool_impls.py that log cache_key -- which is
+scheme://host[:port] only, no path or query, so no token can leak.
+
+**Files:** scripts/check_persistent_diagnostic_inventory.py,
+Tests/Architecture/test_persistent_diagnostic_inventory.py,
+Docs/security/production-diagnostic-inventory.json (migration in its own commit).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3750 - Diagnostic-inventory-digests-key-on-logger-line-numbers.md
+++ b/backlog/tasks/task-3750 - Diagnostic-inventory-digests-key-on-logger-line-numbers.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-3750
 title: Diagnostic inventory digests key on logger line numbers
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-08 21:06'
-updated_date: '2026-08-08 23:13'
+updated_date: '2026-08-08 23:14'
 labels:
   - tech-debt
 dependencies: []

--- a/scripts/check_persistent_diagnostic_inventory.py
+++ b/scripts/check_persistent_diagnostic_inventory.py
@@ -112,11 +112,24 @@ def _scope_names(tree: ast.Module) -> dict[int, str]:
     """Map every node to the dotted name of its enclosing def/class scope.
 
     Used to give persistent-sink entries a human navigation handle that, unlike
-    a line number, survives unrelated edits elsewhere in the file.
+    a line number, survives unrelated edits elsewhere in the file. Iterative
+    (explicit worklist) rather than recursive, so a pathologically nested
+    expression cannot raise ``RecursionError`` and crash the gate itself --
+    the gate failing for a reason unrelated to diagnostics would train people
+    to bypass it.
+
+    Args:
+        tree: Parsed module to walk.
+
+    Returns:
+        dict[int, str]: ``id(node)`` -> dotted scope name (`""` at module
+            scope). Keyed by identity because AST nodes are unhashable by
+            value and identity is stable for the lifetime of ``tree``.
     """
     names: dict[int, str] = {}
-
-    def visit(node: ast.AST, prefix: str) -> None:
+    stack: list[tuple[ast.AST, str]] = [(tree, "")]
+    while stack:
+        node, prefix = stack.pop()
         for child in ast.iter_child_nodes(node):
             if isinstance(
                 child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
@@ -125,9 +138,7 @@ def _scope_names(tree: ast.Module) -> dict[int, str]:
             else:
                 child_prefix = prefix
             names[id(child)] = child_prefix
-            visit(child, child_prefix)
-
-    visit(tree, "")
+            stack.append((child, child_prefix))
     return names
 
 
@@ -164,6 +175,14 @@ def diagnostic_digest(diagnostics: list[dict[str, Any]]) -> str:
 
     The projection is a sorted LIST, never a set, so multiplicity is part of
     the digest: deleting one of two identical logger calls still changes it.
+
+    Args:
+        diagnostics: Entries from `scan_source` for one file; only `method`
+            and the per-call source `digest` participate -- deliberately not
+            `line`, which is the whole point of task-3750.
+
+    Returns:
+        str: 20-hex-char content digest for the file's diagnostics.
     """
     content = sorted(
         (entry["method"], entry["digest"]) for entry in diagnostics

--- a/scripts/check_persistent_diagnostic_inventory.py
+++ b/scripts/check_persistent_diagnostic_inventory.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""Check the reviewed inventory of production diagnostics and disk sinks."""
+"""Check the reviewed inventory of production diagnostics and disk sinks.
+
+The inventory is keyed on the CONTENT of each diagnostic and sink -- the
+statement's own source text plus its log method -- and never on where in the
+file it sits.  Moving a logger call is therefore not a review event, while
+adding, deleting, rewording, or re-levelling one still is.  See task-3750: a
+digest that fires on pure line movement trains reviewers to regenerate this
+file without reading it, which is the one failure mode it exists to prevent.
+"""
 
 from __future__ import annotations
 
@@ -100,16 +108,44 @@ def _is_diagnostic_call(node: ast.Call, logger_symbols: set[str]) -> bool:
     )
 
 
+def _scope_names(tree: ast.Module) -> dict[int, str]:
+    """Map every node to the dotted name of its enclosing def/class scope.
+
+    Used to give persistent-sink entries a human navigation handle that, unlike
+    a line number, survives unrelated edits elsewhere in the file.
+    """
+    names: dict[int, str] = {}
+
+    def visit(node: ast.AST, prefix: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(
+                child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                child_prefix = f"{prefix}.{child.name}" if prefix else child.name
+            else:
+                child_prefix = prefix
+            names[id(child)] = child_prefix
+            visit(child, child_prefix)
+
+    visit(tree, "")
+    return names
+
+
 def _call_entry(
-    path: Path,
     source: str,
     node: ast.Call,
     *,
     kind: str | None = None,
+    scope: str | None = None,
 ) -> dict[str, Any]:
+    """Describe one call by its CONTENT.
+
+    The entry deliberately carries no line number or byte offset: a call that
+    moves within a file is not a review event, while any change to the
+    statement's own text (message, level, arguments) changes ``digest``.
+    """
     segment = ast.get_source_segment(source, node) or ""
     return {
-        "line": node.lineno,
         "method": (
             node.func.attr
             if isinstance(node.func, ast.Attribute)
@@ -119,7 +155,22 @@ def _call_entry(
         ),
         "digest": hashlib.sha256(segment.encode("utf-8")).hexdigest()[:16],
         **({"kind": kind} if kind else {}),
+        **({"scope": scope or "<module>"} if scope is not None else {}),
     }
+
+
+def diagnostic_digest(diagnostics: list[dict[str, Any]]) -> str:
+    """Digest a file's diagnostics by content, independently of their order.
+
+    The projection is a sorted LIST, never a set, so multiplicity is part of
+    the digest: deleting one of two identical logger calls still changes it.
+    """
+    content = sorted(
+        (entry["method"], entry["digest"]) for entry in diagnostics
+    )
+    return hashlib.sha256(
+        json.dumps(content, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:20]
 
 
 def _owner(path_text: str) -> tuple[str, str]:
@@ -134,17 +185,20 @@ def _owner(path_text: str) -> tuple[str, str]:
     )
 
 
-def _scan_file(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    source = path.read_text(encoding="utf-8")
-    tree = ast.parse(source, filename=str(path))
+def scan_source(
+    source: str, *, filename: str = "<source>"
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return the (diagnostics, sinks) content entries for one module's source."""
+    tree = ast.parse(source, filename=filename)
     symbols = _logger_symbols(tree)
+    scopes = _scope_names(tree)
     diagnostics: list[dict[str, Any]] = []
     sinks: list[dict[str, Any]] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         if _is_diagnostic_call(node, symbols):
-            diagnostics.append(_call_entry(path, source, node))
+            diagnostics.append(_call_entry(source, node))
         parts = _attribute_parts(node.func)
         call_name = parts[-1] if parts else ""
         is_loguru_add = call_name == "add" and any(
@@ -160,15 +214,26 @@ def _scan_file(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         ):
             sinks.append(
                 _call_entry(
-                    path,
                     source,
                     node,
                     kind="loguru_sink" if is_loguru_add else call_name,
+                    scope=scopes.get(id(node), ""),
                 )
             )
-    diagnostics.sort(key=lambda entry: (entry["line"], entry["method"]))
-    sinks.sort(key=lambda entry: (entry["line"], entry["method"]))
+    diagnostics.sort(key=lambda entry: (entry["method"], entry["digest"]))
+    sinks.sort(
+        key=lambda entry: (
+            entry["scope"],
+            entry["kind"],
+            entry["method"],
+            entry["digest"],
+        )
+    )
     return diagnostics, sinks
+
+
+def _scan_file(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    return scan_source(path.read_text(encoding="utf-8"), filename=str(path))
 
 
 def build_inventory() -> dict[str, Any]:
@@ -179,16 +244,13 @@ def build_inventory() -> dict[str, Any]:
         diagnostics, sinks = _scan_file(path)
         if diagnostics:
             owner, reason = _owner(relative)
-            diagnostic_digest = hashlib.sha256(
-                json.dumps(diagnostics, sort_keys=True).encode("utf-8")
-            ).hexdigest()[:20]
             owners.append(
                 {
                     "path": relative,
                     "owner": owner,
                     "reason": reason,
                     "call_count": len(diagnostics),
-                    "diagnostic_digest": diagnostic_digest,
+                    "diagnostic_digest": diagnostic_digest(diagnostics),
                 }
             )
         if sinks:
@@ -201,7 +263,10 @@ def build_inventory() -> dict[str, Any]:
         entry["call_count"] for entry in owners if entry["owner"] == "TASK-494"
     )
     return {
-        "schema_version": 1,
+        # 2: digests and sink entries are keyed on diagnostic CONTENT only.
+        # Line numbers are no longer an input, so v1 and v2 digests for an
+        # unchanged file differ and must never be compared across the bump.
+        "schema_version": 2,
         "scope": "tldw_chatbook/**/*.py",
         "classification_rules": {
             "TASK-492": {


### PR DESCRIPTION
## Why

`Docs/security/production-diagnostic-inventory.json` exists to force a human to review every new production diagnostic and disk sink. Its per-file `diagnostic_digest` hashed each logger call's **line number** alongside its text, so any refactor that shifted lines failed the gate with `call_count` unchanged and the sink topology byte-identical — one review-and-regenerate cycle per task across decomposition waves 4 and 5. A gate that fires on no-ops trains people to regenerate without reading, which destroys the review it exists to force.

Measured on this tree: of the 47 drifted owner entries, **28 (60%) were pure line movement**, and **all 5 drifted sink entries** had byte-identical `digest` and `kind` with only `line:` changed (app.py 6063 → 6656).

## What changed

The digest is now a **sorted list of (log method, statement source-text digest)** — sorted, so relocation and reordering are invisible; a *list* and never a set, so multiplicity counts and deleting one of two identical calls is still caught.

**Sinks trade `line:` for `scope:`** (`TldwCli._setup_buffered_logging` rather than `6063`). Decided on the evidence above, not taste: sinks live in `app.py` and `config.py`, two of the churniest files in the repo, so the same false-positive engine runs there. A scope name navigates better than a line number and does not go stale. The middle option — print `line:` but exclude it from the comparison — was rejected: the number would rot and send a reviewer to the wrong place, which is worse than a chore.

**Diagnostics deliberately do NOT carry scope**, though sinks do. Moving a logger call into an extracted method is this repo's most common refactor and must stay silent; sinks are 19 entries that essentially never change function, and there the scope is a reviewer's only navigation handle. Owner entries never had a line number to lose — they are only path/count/digest.

`schema_version` 1 → 2: every digest changes because the keying changed, not because code did, and the version is the only signal that a mismatch across the bump is a semantics change rather than a new diagnostic.

## Sensitivity is not weakened

Six arms, each run against the real checker on real production source:

| mutation | expected | result |
|---|---|---|
| logger call moved down 3 lines | pass | exit 0 |
| message reworded | **fail** | exit 1 |
| level `debug` → `error` | **fail** | exit 1 |
| sink moved down 2 lines | pass | exit 0 |
| sink retargeted to another path | **fail** | exit 1 |
| everything restored | pass | exit 0 |

Plus unit tests for add / remove / reword / re-level / relocate-across-functions / duplicate-multiplicity, and an end-to-end check that shifting every line in a real inventory file leaves its digest byte-identical.

## The migration commit was reviewed, not rubber-stamped

The inventory was last regenerated in `f990464ed` — which is `origin/dev`'s tip, **where the test already failed**. A branch that regenerates before merge is re-staled by whatever merges ahead of it. Rather than run `--write` and stare at a 1,000-line diff, each file's history was walked for the revision reproducing its checked-in digest: 28 no-ops, 19 real content changes, 3 new files. The diagnostics newly blessed in the high-risk TASK-492 paths were read — a Library factory warning, an MCP backend-unavailable exception, and 7 robots.txt debug lines in `web_tool_impls.py` that log `cache_key`, which is `scheme://host[:port]` only, no path or query, so no token can leak.

## Tests

`Tests/Architecture/test_persistent_diagnostic_inventory.py` — **8 passed** (was 1 failed / 2 passed on dev before this branch, from the pre-existing drift).

Two other failures in `Tests/Architecture/` (`test_profile_owned_path_inventory.py`, `test_screen_size_ratchet.py`) are **pre-existing on dev and not caused by this branch**: this branch touches exactly three files, and neither test reads any of them — they read `check_profile_owned_path_inventory.py` and `chat_screen.py`. `test_screen_size_ratchet.py` is the same disease as this task, and its own comments already warn that "a budget derived from a stale base fails the moment it merges".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch diagnostic-inventory digests to content-based hashing and make sink entries line-independent to stop false-positive gates when lines move. Bumps schema to v2 and migrates the inventory; implements TASK-3750.

- **Bug Fixes**
  - Digest is now a sorted list of (log method, statement source digest); ignores position and preserves multiplicity.
  - Sink entries use scope (e.g., TldwCli._setup_buffered_logging) instead of line; moves are silent, retargets still fail.
  - Scope-name walk is iterative to avoid RecursionError on deeply nested code; output is unchanged.
  - Added tests for move/add/remove/reword/relevel, multiplicity, and an end-to-end digest stability check.

- **Migration**
  - Inventory regenerated under schema_version 2; v1 and v2 digests are not comparable.

<sup>Written for commit 186f6507df8f6407aff76f773c2fc6d36bffbdd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

