### PR TITLE
feat(console): composer DraftChanged message — six more on_key branches move (task-3749)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2805,8 +2805,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 100,
-      "diagnostic_digest": "d2232c700a34c05300ad",
+      "call_count": 102,
+      "diagnostic_digest": "0d3c1f71cc686fbd50c9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/WebSearch_APIs.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3471,6 +3471,6 @@
     "owner_files": 469,
     "persistent_sink_files": 6,
     "task_492_calls": 1153,
-    "task_494_calls": 6884
+    "task_494_calls": 6886
   }
 }

--- a/Tests/UI/test_console_composer_draft_changed.py
+++ b/Tests/UI/test_console_composer_draft_changed.py
@@ -1,0 +1,254 @@
+"""Characterisation of what a Console composer draft edit must still trigger.
+
+TASK-3749 moves six more `ChatScreen.on_key` branches into
+`ConsoleComposerBar.handle_console_key` by replacing the screen's
+"edit the draft, then call back into me" pattern with a
+`ConsoleComposerBar.DraftChanged` message the screen subscribes to.
+
+These tests are written and committed BEFORE that change, against the
+current callback shape, and pin the three things it must not disturb:
+
+1. **The Workbench actions row.** `#console-send-message` is a Workbench
+   action whose `disabled` state is derived from the draft by
+   `_sync_console_workbench_actions_from_draft`; every one of the six keys
+   that edits the draft has to leave it correct.
+2. **The slash-command popup**, which is opened by that same sync -- and
+   opened *in the same key turn*, so that a following arrow key already
+   finds it open. That timing is asserted adversarially (two keys queued
+   with no event-loop drain between them), because a message-based
+   notification is delivered asynchronously and would be free to arrive
+   after the next key otherwise.
+3. **The first-run guidance**, which is dismissed by the two keys that
+   ADD text (a printable character, Shift+Enter's newline) and NOT by the
+   four that remove it -- a distinction a naive "dismiss on every draft
+   change" would erase.
+
+They assert observable end state through a REAL key press on the real
+Console screen, never that a particular method was called.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual import events
+from textual.widgets import Button
+
+from Tests.UI.test_console_dictation import _mounted_console, _ready_host
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+
+APP_SIZE = (140, 42)
+
+
+async def _console(host, pilot, text: str = ""):
+    """Mount the ready Console, optionally seed the draft, focus the composer.
+
+    `load_draft` is deliberately used to seed text: it is not one of the
+    six branches under test, and (unlike typing the text) it does not
+    itself dismiss the guidance, which the guidance tests below depend on.
+    """
+    console = await _mounted_console(host, pilot)
+    composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+    if text:
+        composer.load_draft(text)
+    composer.focus()
+    await pilot.pause()
+    return console, composer
+
+
+def _send_action(console) -> Button:
+    """The Workbench actions row's Send action."""
+    return console.query_one("#console-send-message", Button)
+
+
+# ---------------------------------------------------------------------------
+# 1. The Workbench actions row tracks the draft across all six edit keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("seed", "keys", "expected_draft"),
+    [
+        ("x", ("backspace",), ""),
+        ("x", ("ctrl+h",), ""),
+        ("x", ("delete",), ""),
+        ("hello", ("ctrl+w",), ""),
+        ("hello there", ("ctrl+u",), ""),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_draft_emptying_key_disables_the_workbench_send_action(
+    seed, keys, expected_draft
+):
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot, seed)
+        if "delete" in keys:
+            composer.position_cursor_from_display_index(0)
+            await pilot.pause()
+        assert _send_action(console).disabled is False
+
+        await pilot.press(*keys)
+        await pilot.pause()
+
+        assert composer.draft_text() == expected_draft
+        assert _send_action(console).disabled is True
+
+
+@pytest.mark.asyncio
+async def test_a_printable_key_enables_the_workbench_send_action():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot)
+        assert _send_action(console).disabled is True
+
+        await pilot.press("a")
+        await pilot.pause()
+
+        assert composer.draft_text() == "a"
+        assert _send_action(console).disabled is False
+
+
+@pytest.mark.parametrize("key", ["shift+enter", "ctrl+j"])
+@pytest.mark.asyncio
+async def test_a_newline_key_resyncs_the_send_action_without_enabling_it(key):
+    """A newline-only draft is still "nothing to send" -- and stays that way.
+
+    Worth pinning precisely because it is the counter-example to "the sync
+    just mirrors `draft_text() != ''`": the draft is non-empty here and the
+    action stays disabled, so the sync really is re-deriving Workbench
+    readiness, not flipping a boolean off the draft length.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot)
+        assert _send_action(console).disabled is True
+
+        await pilot.press(key)
+        await pilot.pause()
+
+        assert composer.draft_text() == "\n"
+        assert _send_action(console).disabled is True
+
+
+@pytest.mark.parametrize("key", ["shift+enter", "ctrl+j"])
+@pytest.mark.asyncio
+async def test_a_newline_after_real_text_leaves_the_send_action_enabled(key):
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot, "hi")
+        assert _send_action(console).disabled is False
+
+        await pilot.press(key)
+        await pilot.pause()
+
+        assert composer.draft_text() == "hi\n"
+        assert _send_action(console).disabled is False
+
+
+@pytest.mark.asyncio
+async def test_a_partial_deletion_leaves_the_send_action_enabled():
+    """The sync is not just an empty/non-empty flip -- it runs every edit."""
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot, "hello world")
+
+        await pilot.press("ctrl+w")
+        await pilot.pause()
+
+        assert composer.draft_text() == "hello "
+        assert _send_action(console).disabled is False
+
+
+# ---------------------------------------------------------------------------
+# 2. The slash-command popup opens on the keystroke that types "/"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_typing_a_slash_opens_the_command_popup():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot)
+        popup = console.query_one("#console-command-popup")
+        assert popup.is_open is False
+
+        await pilot.press("/")
+        await pilot.pause()
+
+        assert composer.draft_text() == "/"
+        assert popup.is_open is True
+
+
+@pytest.mark.asyncio
+async def test_an_arrow_queued_behind_the_slash_still_navigates_the_popup():
+    """The popup must be open by the time the NEXT key is handled.
+
+    Both keys are posted to the focused composer's queue with no
+    event-loop drain between them -- exactly how `App.on_event` routes two
+    keystrokes that arrive in a single driver read (fast typing, a key
+    macro, `tmux send-keys`). At baseline the popup is opened
+    synchronously inside the "/" key turn, so the Down that follows finds
+    `popup.is_open` already True and moves the highlight instead of
+    falling through to the composer's own caret/history handling.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot)
+        popup = console.query_one("#console-command-popup")
+
+        composer.post_message(events.Key("slash", "/"))
+        composer.post_message(events.Key("down", None))
+        await pilot.pause()
+        await pilot.pause()
+
+        assert composer.draft_text() == "/"
+        assert popup.is_open is True
+        first, second = popup._suggestions[0], popup._suggestions[1]
+        assert first.label != second.label
+        # Down was consumed by the popup, not by the composer.
+        assert popup.accept_selected().label == second.label
+
+
+# ---------------------------------------------------------------------------
+# 3. Guidance is dismissed by insertions only, never by deletions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("keys", [("a",), ("shift+enter",), ("ctrl+j",)])
+@pytest.mark.asyncio
+async def test_an_insertion_key_dismisses_the_first_run_guidance(keys):
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, _composer = await _console(host, pilot)
+        assert console._console_guidance_dismissed is False
+
+        await pilot.press(*keys)
+        await pilot.pause()
+
+        assert console._console_guidance_dismissed is True
+
+
+@pytest.mark.parametrize(
+    ("seed", "keys"),
+    [
+        ("x", ("backspace",)),
+        ("x", ("ctrl+h",)),
+        ("x", ("delete",)),
+        ("hello", ("ctrl+w",)),
+        ("hello", ("ctrl+u",)),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_deletion_key_leaves_the_first_run_guidance_alone(seed, keys):
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot, seed)
+        if "delete" in keys:
+            composer.position_cursor_from_display_index(0)
+            await pilot.pause()
+        assert console._console_guidance_dismissed is False
+
+        await pilot.press(*keys)
+        await pilot.pause()
+
+        assert console._console_guidance_dismissed is False

--- a/Tests/UI/test_console_composer_draft_changed.py
+++ b/Tests/UI/test_console_composer_draft_changed.py
@@ -179,17 +179,35 @@ async def test_typing_a_slash_opens_the_command_popup():
         assert popup.is_open is True
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "TASK-3749 known, filed ordering gap: `DraftChanged` is delivered "
+        "through the message pump, so a key already queued behind the "
+        "slash is handled before the popup has been opened and is lost. "
+        "Kept as a strict xfail rather than deleted -- it is the exact "
+        "probe for the gap, and it will fail loudly (prompting this "
+        "marker's removal) the day the ordering is restored."
+    ),
+)
 @pytest.mark.asyncio
 async def test_an_arrow_queued_behind_the_slash_still_navigates_the_popup():
     """The popup must be open by the time the NEXT key is handled.
 
     Both keys are posted to the focused composer's queue with no
     event-loop drain between them -- exactly how `App.on_event` routes two
-    keystrokes that arrive in a single driver read (fast typing, a key
-    macro, `tmux send-keys`). At baseline the popup is opened
-    synchronously inside the "/" key turn, so the Down that follows finds
-    `popup.is_open` already True and moves the highlight instead of
+    keystrokes that arrive in a single driver read (a key macro, a text
+    expander, `tmux send-keys`; human typing is three orders of magnitude
+    too slow to reach it). Before TASK-3749 the popup was opened
+    synchronously inside the "/" key turn, so the Down that followed found
+    `popup.is_open` already True and moved the highlight instead of
     falling through to the composer's own caret/history handling.
+
+    The blast radius of the gap is one ignored arrow key: the popup still
+    opens, the draft is untouched, and the next arrow works. A batched
+    "/"+Enter was checked too and does NOT send -- Enter's own path
+    re-reads the Send action AFTER stashing the draft, so it is unaffected
+    by when this sync runs.
     """
     _, host = _ready_host()
     async with host.run_test(size=APP_SIZE) as pilot:

--- a/Tests/UI/test_console_composer_draft_changed.py
+++ b/Tests/UI/test_console_composer_draft_changed.py
@@ -79,6 +79,7 @@ def _send_action(console) -> Button:
 async def test_a_draft_emptying_key_disables_the_workbench_send_action(
     seed, keys, expected_draft
 ):
+    """A key that empties the draft must disable the Workbench Send action."""
     _, host = _ready_host()
     async with host.run_test(size=APP_SIZE) as pilot:
         console, composer = await _console(host, pilot, seed)
@@ -96,6 +97,7 @@ async def test_a_draft_emptying_key_disables_the_workbench_send_action(
 
 @pytest.mark.asyncio
 async def test_a_printable_key_enables_the_workbench_send_action():
+    """A printable key that adds text must enable the Workbench Send action."""
     _, host = _ready_host()
     async with host.run_test(size=APP_SIZE) as pilot:
         console, composer = await _console(host, pilot)
@@ -133,6 +135,7 @@ async def test_a_newline_key_resyncs_the_send_action_without_enabling_it(key):
 @pytest.mark.parametrize("key", ["shift+enter", "ctrl+j"])
 @pytest.mark.asyncio
 async def test_a_newline_after_real_text_leaves_the_send_action_enabled(key):
+    """shift+enter after real text keeps Send enabled (still a non-empty draft)."""
     _, host = _ready_host()
     async with host.run_test(size=APP_SIZE) as pilot:
         console, composer = await _console(host, pilot, "hi")
@@ -166,6 +169,7 @@ async def test_a_partial_deletion_leaves_the_send_action_enabled():
 
 @pytest.mark.asyncio
 async def test_typing_a_slash_opens_the_command_popup():
+    """A lone '/' opens the slash-command popup once its DraftChanged lands."""
     _, host = _ready_host()
     async with host.run_test(size=APP_SIZE) as pilot:
         console, composer = await _console(host, pilot)
@@ -235,6 +239,7 @@ async def test_an_arrow_queued_behind_the_slash_still_navigates_the_popup():
 @pytest.mark.parametrize("keys", [("a",), ("shift+enter",), ("ctrl+j",)])
 @pytest.mark.asyncio
 async def test_an_insertion_key_dismisses_the_first_run_guidance(keys):
+    """Text-ADDING keys retire the first-run guidance (is_insertion=True)."""
     _, host = _ready_host()
     async with host.run_test(size=APP_SIZE) as pilot:
         console, _composer = await _console(host, pilot)
@@ -258,6 +263,7 @@ async def test_an_insertion_key_dismisses_the_first_run_guidance(keys):
 )
 @pytest.mark.asyncio
 async def test_a_deletion_key_leaves_the_first_run_guidance_alone(seed, keys):
+    """Deletions never dismiss guidance: only an insertion claims composing."""
     _, host = _ready_host()
     async with host.run_test(size=APP_SIZE) as pilot:
         console, composer = await _console(host, pilot, seed)

--- a/Tests/UI/test_console_composer_draft_changed.py
+++ b/Tests/UI/test_console_composer_draft_changed.py
@@ -179,20 +179,16 @@ async def test_typing_a_slash_opens_the_command_popup():
         assert popup.is_open is True
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "TASK-3749 known, filed ordering gap: `DraftChanged` is delivered "
-        "through the message pump, so a key already queued behind the "
-        "slash is handled before the popup has been opened and is lost. "
-        "Kept as a strict xfail rather than deleted -- it is the exact "
-        "probe for the gap, and it will fail loudly (prompting this "
-        "marker's removal) the day the ordering is restored."
-    ),
-)
 @pytest.mark.asyncio
 async def test_an_arrow_queued_behind_the_slash_still_navigates_the_popup():
     """The popup must be open by the time the NEXT key is handled.
+
+    Was a strict xfail (the TASK-3790 ordering gap); un-xfailed by the
+    generation-gated `_ensure_console_command_popup_current`, which
+    re-derives the popup at the routing point ONLY when the draft moved
+    since the last sync -- so a key queued behind the slash in the same
+    driver read now finds the popup open, while an Escape-dismissed popup
+    (no edit, no generation movement) stays dismissed.
 
     Both keys are posted to the focused composer's queue with no
     event-loop drain between them -- exactly how `App.on_event` routes two
@@ -274,3 +270,70 @@ async def test_a_deletion_key_leaves_the_first_run_guidance_alone(seed, keys):
         await pilot.pause()
 
         assert console._console_guidance_dismissed is False
+
+
+@pytest.mark.asyncio
+async def test_escape_dismissal_survives_a_following_arrow_key():
+    """An Escape-dismissed popup must NOT be re-opened by mere navigation.
+
+    The guard that makes `_ensure_console_command_popup_current` safe: it is
+    generation-gated, and Escape edits nothing. An UNGATED re-sync at the
+    routing point would re-derive suggestions from the still-slash draft and
+    re-open the popup the user just closed -- turning the task-3790 fix into
+    a worse regression than the one it fixes. This is the test that fails if
+    anyone "simplifies" the gate away.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot)
+        popup = console.query_one("#console-command-popup")
+
+        composer.post_message(events.Key("slash", "/"))
+        await pilot.pause()
+        await pilot.pause()
+        assert popup.is_open is True
+
+        # Escape reaches the popup through the screen's binding action, not
+        # on_key (the popup branch never sees it), so invoke the real dismiss
+        # route the Escape binding calls -- a synthetic Key posted to the
+        # composer does not resolve screen bindings under this harness.
+        console.action_focus_console_composer_home()
+        await pilot.pause()
+        assert popup.is_open is False
+
+        composer.post_message(events.Key("down", None))
+        await pilot.pause()
+        await pilot.pause()
+        assert popup.is_open is False, (
+            "navigation re-opened a popup the user dismissed with Escape"
+        )
+        assert composer.draft_text() == "/"
+
+
+@pytest.mark.asyncio
+async def test_deferred_draft_changed_does_not_yank_the_moved_highlight():
+    """The queued `DraftChanged` must not reset a highlight Down just moved.
+
+    Same-read `/`+Down: the routing-point ensure opens the popup and Down
+    moves the highlight to row 1 -- then the deferred `DraftChanged` finally
+    delivers and re-runs the sync. `show_suggestions` is idempotent for an
+    identical suggestion list precisely so that second run leaves the
+    highlight alone; without it the user's Down would be silently undone a
+    frame later.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot)
+        popup = console.query_one("#console-command-popup")
+
+        composer.post_message(events.Key("slash", "/"))
+        composer.post_message(events.Key("down", None))
+        # Drain until the deferred DraftChanged has definitely delivered.
+        for _ in range(4):
+            await pilot.pause()
+
+        assert popup.is_open is True
+        second = popup._suggestions[1]
+        assert popup.accept_selected().label == second.label, (
+            "the deferred sync reset the highlight the Down had moved"
+        )

--- a/Tests/UI/test_console_composer_draft_changed.py
+++ b/Tests/UI/test_console_composer_draft_changed.py
@@ -203,11 +203,15 @@ async def test_an_arrow_queued_behind_the_slash_still_navigates_the_popup():
     `popup.is_open` already True and moved the highlight instead of
     falling through to the composer's own caret/history handling.
 
-    The blast radius of the gap is one ignored arrow key: the popup still
-    opens, the draft is untouched, and the next arrow works. A batched
-    "/"+Enter was checked too and does NOT send -- Enter's own path
-    re-reads the Send action AFTER stashing the draft, so it is unaffected
-    by when this sync runs.
+    Blast radius, measured as a two-arm A/B (this code vs. the baseline
+    callback restored synchronously in its place): exactly one ignored
+    keystroke. Batched "/"+Down -- baseline highlights the second entry,
+    this ignores the Down. Batched "/"+Enter -- baseline accepts the
+    highlighted suggestion into the draft, this ignores the Enter. In both
+    arms the popup ends up open and the draft is "/", and in neither does
+    the stray key send anything: Enter's own path re-reads the Send action
+    AFTER stashing the draft, so it never depended on this sync's timing.
+    The next keypress behaves normally.
     """
     _, host = _ready_host()
     async with host.run_test(size=APP_SIZE) as pilot:

--- a/backlog/tasks/task-3749 - Composer-DraftChanged-message-would-unblock-six-on_key-branches.md
+++ b/backlog/tasks/task-3749 - Composer-DraftChanged-message-would-unblock-six-on_key-branches.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-3749
 title: Composer DraftChanged message would unblock six on_key branches
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-08 21:06'
+updated_date: '2026-08-08 23:37'
 labels:
   - refactor
   - console
@@ -18,7 +19,25 @@ Wave 5 task 1 moved 7 of on_key's composer branches into ConsoleComposerBar. Ele
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The composer notifies the screen of draft changes rather than the screen calling back after each edit
-- [ ] #2 The six blocked branches move to ConsoleComposerBar.handle_console_key
-- [ ] #3 No behaviour change: the workbench actions, slash-command popup and guidance repaint still update on every draft edit
+- [x] #1 The composer notifies the screen of draft changes rather than the screen calling back after each edit
+- [x] #2 The six blocked branches move to ConsoleComposerBar.handle_console_key
+- [x] #3 No behaviour change: the workbench actions, slash-command popup and guidance repaint still update on every draft edit
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`ConsoleComposerBar` now posts a `DraftChanged` message; `ChatScreen._handle_console_composer_draft_edit` subscribes and does the Workbench resync (and, for insertions, the guidance dismissal) the six branches used to do inline. Those six -- backspace/ctrl+h, delete, ctrl+w, shift+enter/ctrl+j, ctrl+u, printable fallthrough -- moved into `handle_console_key`, taking `_is_modified_chord` with them. `chat_screen.py` sheds ~85 lines (the six branch bodies plus the `_is_modified_chord` block) and gains a ~53-line subscriber: net -32 lines, 18,595 -> 18,563. The commit message for 87a9d4bca says "~90", which was the gross removal, not the net; `on_key` keeps only the branches that genuinely reach past the composer (clipboard, send, paging, undo/redo's store persistence).
+
+Three design decisions, each settled from measured baseline behaviour:
+
+1. **One message with an `is_insertion` flag**, not two messages and not a bare notification. Guidance is dismissed at baseline by the two keys that ADD text and by none of the four that remove it; "dismiss on every DraftChanged" would have silently changed backspace/delete/ctrl+w/ctrl+u. The flag names the cause (the edit added text) rather than the effect, so the "insertions retire the first-run guidance" policy stays on the screen.
+2. **Posted from the moved branches only**, never from `insert_text`/`delete_left`/`clear_draft`. Verified those helpers have other callers -- `Console_Modules/dictation.py`, `Console_Modules/session.py`, `/prompt`, paste -- each with its own different follow-up (dictation also re-persists to the chat store; the session restore deliberately does not dismiss guidance), so posting from the helpers would have changed all of them.
+3. **Ordering: async delivery is a real, measured difference** -- scoped, not papered over. No existing test and no human-speed input depends on the old synchronous timing (471 composer/popup/dictation tests green). A key arriving in the SAME driver read as the slash that opens the popup does: two-arm A/B (this code vs. the baseline callback restored synchronously in its place) shows batched slash+Down used to highlight the second entry and now ignores the Down, and batched slash+Enter used to accept the highlighted suggestion and now ignores the Enter. In both arms the popup still opens, the draft is untouched and nothing is sent -- one lost keystroke under programmatic input (tmux send-keys, macros), never a wrong send. Kept as a strict xfail that will fail loudly when fixed, and filed as TASK-3790. AC #3 therefore holds for every drained observation and for all human-speed input, with that one batched-input exception documented rather than hidden.
+
+Defect found and fixed en route, caught by the existing suite: the new handler was first named `_on_console_composer_draft_changed`, which is ALREADY a `ChatScreen` method (`@on(Input.Changed, "#console-command-input")`, disarming the unknown-command Enter escape). The later definition silently replaced the earlier one and killed that subscription -- two `test_console_command_composer.py` tests caught it. Renamed to `_handle_console_composer_draft_edit`, with both docstrings now cross-referencing each other and explaining why the broader `Input.Changed` signal is deliberately NOT reused here (it fires on load_draft/paste/dictation/session-restore, which do not sync the Workbench or dismiss guidance today).
+
+Verification: 21 characterisation tests written and committed GREEN before the change (`Tests/UI/test_console_composer_draft_changed.py`, real pilot key presses on the real Console screen, asserting end state). After: 471 passed + 1 xfailed across the composer, popup, command-composer, dictation and decomposition suites; 411 passed across the workbench/guidance/send-state suites. Two `test_console_native_chat_flow.py` toast failures were A/B'd against a pre-change worktree and are pre-existing on dev. pyflakes unchanged (26 = 26, identical message set) on `chat_screen.py`, 0 on the composer and the new test. AST duplicate-method audit clean. No hand-built `ChatScreen` fixtures (`ChatScreen.__new__`/`spec=ChatScreen`) exist. Full-suite `--collect-only`: 33,536 tests, no import breakage.
+
+Files: `tldw_chatbook/Widgets/Console/console_composer_bar.py`, `tldw_chatbook/UI/Screens/chat_screen.py`, `Tests/UI/test_console_composer_draft_changed.py` (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3790 - Console-a-key-batched-behind-the-slash-misses-the-command-popup-DraftChanged-ordering.md
+++ b/backlog/tasks/task-3790 - Console-a-key-batched-behind-the-slash-misses-the-command-popup-DraftChanged-ordering.md
@@ -3,9 +3,10 @@ id: TASK-3790
 title: >-
   Console: a key batched behind the slash misses the command popup (DraftChanged
   ordering)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-08 23:36'
+updated_date: '2026-08-09 02:34'
 labels:
   - console
   - refactor
@@ -21,7 +22,30 @@ TASK-3749 replaced the screen's after-the-edit callbacks with a ConsoleComposerB
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A key delivered in the same driver read as the slash that opens the command popup is handled against the popup's post-edit state, as it was before TASK-3749
-- [ ] #2 The strict xfail on test_an_arrow_queued_behind_the_slash_still_navigates_the_popup (Tests/UI/test_console_composer_draft_changed.py) is removed and the test passes
-- [ ] #3 The fix does not reintroduce a screen-to-composer callback inside on_key as the primary notification path
+- [x] #1 A key delivered in the same driver read as the slash that opens the command popup is handled against the popup's post-edit state, as it was before TASK-3749
+- [x] #2 The strict xfail on test_an_arrow_queued_behind_the_slash_still_navigates_the_popup (Tests/UI/test_console_composer_draft_changed.py) is removed and the test passes
+- [x] #3 The fix does not reintroduce a screen-to-composer callback inside on_key as the primary notification path
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed on the task-3749 branch itself rather than deferred. The gap: `DraftChanged`
+delivers through the message pump, so a key queued behind the slash in the same
+driver read consulted a popup whose sync had not run. Fix, two halves, both
+mutation-verified:
+
+1. `_ensure_console_command_popup_current` at the on_key routing point,
+   **gated on the synced draft TEXT** -- an Escape-dismissed popup (no edit, no
+   text movement) stays dismissed; removing the gate fails
+   `test_escape_dismissal_survives_a_following_arrow_key`.
+2. `show_suggestions` is idempotent for an identical suggestion list, so the
+   deferred `DraftChanged` re-sync cannot yank the highlight a routed Down just
+   moved; removing that fails
+   `test_deferred_draft_changed_does_not_yank_the_moved_highlight`.
+
+The first gate attempt used the composer's `_draft_generation` and no-oped on
+every keystroke: that counter is an undo-checkpoint marker `insert_text` never
+advances -- measured with an on_key entry probe, not assumed. The text compare
+is the honest signal because the sync is a pure function of the draft.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3790 - Console-a-key-batched-behind-the-slash-misses-the-command-popup-DraftChanged-ordering.md
+++ b/backlog/tasks/task-3790 - Console-a-key-batched-behind-the-slash-misses-the-command-popup-DraftChanged-ordering.md
@@ -1,0 +1,27 @@
+---
+id: TASK-3790
+title: >-
+  Console: a key batched behind the slash misses the command popup (DraftChanged
+  ordering)
+status: To Do
+assignee: []
+created_date: '2026-08-08 23:36'
+labels:
+  - console
+  - refactor
+  - defect
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-3749 replaced the screen's after-the-edit callbacks with a ConsoleComposerBar.DraftChanged message. Textual delivers that message through the pump, so when two keystrokes arrive in a SINGLE driver read (a key macro, a text expander, tmux send-keys -- human typing is orders of magnitude too slow), the second key is handled before the screen has opened the slash-command popup, and that key is ignored. Measured as a two-arm A/B: batched slash+Down used to highlight the second entry and now ignores the Down; batched slash+Enter used to accept the highlighted suggestion and now ignores the Enter. In both cases the popup still opens, the draft is untouched, nothing is sent, and the next keypress behaves normally -- so this is a lost keystroke under programmatic input, not a data-loss or wrong-send bug. It matters mainly because this repo drives live TUI verification with tmux send-keys.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A key delivered in the same driver read as the slash that opens the command popup is handled against the popup's post-edit state, as it was before TASK-3749
+- [ ] #2 The strict xfail on test_an_arrow_queued_behind_the_slash_still_navigates_the_popup (Tests/UI/test_console_composer_draft_changed.py) is removed and the test passes
+- [ ] #3 The fix does not reintroduce a screen-to-composer callback inside on_key as the primary notification path
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -16917,14 +16917,32 @@ class ChatScreen(BaseAppScreen):
         except QueryError:
             return None
 
+    #: Draft text `_sync_console_command_popup` last ran against, or
+    #: None before the first sync. A CLASS attribute, deliberately: the
+    #: hand-built `ChatScreen.__new__()` test fixtures never run `__init__`,
+    #: and this programme has shipped one fixture AttributeError per wave.
+    _console_popup_synced_draft: str | None = None
+
     def _sync_console_command_popup(self) -> None:
-        """Show/hide the slash-command popup from the current composer draft."""
+        """Show/hide the slash-command popup from the current composer draft.
+
+        Records the draft text it ran against (NOT the composer's
+        `_draft_generation` -- that is an undo-checkpoint counter that
+        `insert_text` never advances; a gate on it no-oped on every
+        keystroke, measured), so
+        `_ensure_console_command_popup_current` can tell a popup that is
+        merely CLOSED (Escape) from one that is STALE (an edit happened but
+        its `DraftChanged` has not been delivered yet). Recorded on every
+        path, including the hide paths -- "synced" means "reflects this
+        draft", not "open".
+        """
         popup = self._console_command_popup_or_none()
         if popup is None:
             return
         composer = self._console_composer_or_none()
         if composer is None:
             return
+        self._console_popup_synced_draft = composer.draft_text()
         if composer.has_paste_segments():
             popup.hide()
             return
@@ -16937,6 +16955,26 @@ class ChatScreen(BaseAppScreen):
             popup.hide()
             return
         popup.show_suggestions(suggestions)
+
+    def _ensure_console_command_popup_current(self) -> None:
+        """Re-sync the popup only if the draft moved since the last sync.
+
+        Closes the same-driver-read window (task-3790): when `/`+Down or
+        `/`+Enter arrive in one read, the second key's routing used to
+        consult a popup whose `DraftChanged` was still queued. Re-deriving
+        here is safe ONLY because it is gated on the synced draft text -- an ungated
+        re-sync would re-open a popup the user just dismissed with Escape
+        (dismissal edits nothing, so the text does not move, so this
+        is a no-op for it). The queued `DraftChanged` still delivers and
+        re-runs the full sync; by then the generation matches and
+        `show_suggestions` is idempotent for identical rows, so the
+        highlight a routed Down moved is not yanked back.
+        """
+        composer = self._console_composer_or_none()
+        if composer is None:
+            return
+        if composer.draft_text() != self._console_popup_synced_draft:
+            self._sync_console_command_popup()
 
     def _dismiss_console_command_popup(self) -> bool:
         """Hide the popup if open. Returns True when it was open."""
@@ -17365,6 +17403,7 @@ class ChatScreen(BaseAppScreen):
             realtime.controller.on_keypress()
         if not self._should_capture_console_input(composer):
             return
+        self._ensure_console_command_popup_current()
         popup = self._console_command_popup_or_none()
         if popup is not None and popup.is_open:
             if event.key == "up":

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1453,37 +1453,6 @@ def _run_dictionary_summary_off_thread(
     )
 
 
-#: Modifier prefixes that make a key a CHORD rather than text input, even
-#: when it carries a printable ``character``. Textual's terminal parser
-#: renames the key (``alt+m``) but passes the bare letter through as the
-#: character (``_xterm_parser.py``), so ``is_printable`` is True for every
-#: ``alt+<letter>``. Without this check ``ChatScreen.on_key``'s
-#: printable-capture branch swallowed the chord as typing -- pressing Alt+M
-#: inserted a literal "m" into the draft and the screen's own
-#: ``Binding("alt+m", ...)`` never ran (TASK-1800).
-#:
-#: ``ctrl+``/``super+``/``meta+`` are listed for completeness, not because
-#: they leak today: their characters are C0 control bytes, which are not
-#: printable, so they never reached that branch. ``alt`` is the one that
-#: does. Listing all four keeps the rule "a modified key is not text" true
-#: by construction rather than by accident of the control-byte encoding.
-_CHORD_MODIFIER_PREFIXES = ("alt+", "ctrl+", "super+", "meta+")
-
-
-def _is_modified_chord(key: str) -> bool:
-    """Return whether ``key`` names a modifier chord rather than plain text.
-
-    Args:
-        key: Textual key name, e.g. ``"m"``, ``"alt+m"``, ``"shift+alt+m"``.
-
-    Returns:
-        True when any modifier prefix appears in the name. ``shift+`` alone
-        is deliberately NOT a chord -- ``shift+a`` is how a capital letter
-        arrives, and treating it as a chord would break typing.
-    """
-    return any(prefix in key for prefix in _CHORD_MODIFIER_PREFIXES)
-
-
 class ChatScreen(BaseAppScreen):
     """
     Chat screen with comprehensive state management.
@@ -17417,9 +17386,14 @@ class ChatScreen(BaseAppScreen):
         # operation (select-all and caret movement, including Up/Down's
         # history-recall-first shape, which still falls through UNCONSUMED
         # on a boundary row where nothing moved) now live on the composer
-        # itself. Everything below stays because it reaches past the
-        # composer -- Workbench/guidance resync, the clipboard, undo/redo's
-        # store persistence, send, transcript paging.
+        # itself. TASK-3749 added the draft-EDITING keys to that set -- they
+        # post `ConsoleComposerBar.DraftChanged`, which
+        # `_handle_console_composer_draft_edit` below turns back into the
+        # Workbench/guidance resync this method used to do inline. That
+        # includes the printable fallthrough, so this delegation is now also
+        # where ordinary typing lands. Everything below stays because it
+        # reaches past the composer -- the clipboard, undo/redo's store
+        # persistence, send, transcript paging.
         if composer.handle_console_key(event):
             return
         if (
@@ -17429,34 +17403,6 @@ class ChatScreen(BaseAppScreen):
             copy_to_clipboard = getattr(self.app_instance, "copy_to_clipboard", None)
             if callable(copy_to_clipboard):
                 copy_to_clipboard(composer.draft_text())
-            event.stop()
-            event.prevent_default()
-            return
-        if event.key in {"backspace", "ctrl+h"}:
-            composer.delete_left()
-            self._sync_console_workbench_actions_from_draft()
-            event.stop()
-            event.prevent_default()
-            return
-        if event.key == "delete":
-            composer.delete_right()
-            self._sync_console_workbench_actions_from_draft()
-            event.stop()
-            event.prevent_default()
-            return
-        if event.key == "ctrl+w":
-            composer.delete_word_left()
-            self._sync_console_workbench_actions_from_draft()
-            event.stop()
-            event.prevent_default()
-            return
-        # TASK-381: Shift+Enter is the natural newline chord, but terminals
-        # deliver it as a plain CR (which sends), so also accept Ctrl+J -- a
-        # control code that survives every terminal -- as a portable newline.
-        if event.key in ("shift+enter", "ctrl+j"):
-            composer.insert_text("\n")
-            self._sync_console_workbench_actions_from_draft()
-            self._dismiss_console_guidance()
             event.stop()
             event.prevent_default()
             return
@@ -17565,14 +17511,6 @@ class ChatScreen(BaseAppScreen):
             event.stop()
             event.prevent_default()
             return
-        if event.key == "ctrl+u":
-            # TASK-1281: this is the one call site that opts into undo --
-            # an accidental full clear is exactly what undo exists for.
-            composer.clear_draft(record_history=True)
-            self._sync_console_workbench_actions_from_draft()
-            event.stop()
-            event.prevent_default()
-            return
         if event.key == "ctrl+z":
             self._console_composer_undo()
             event.stop()
@@ -17607,16 +17545,46 @@ class ChatScreen(BaseAppScreen):
             event.stop()
             event.prevent_default()
             return
-        if (
-            event.is_printable
-            and event.character is not None
-            and not _is_modified_chord(event.key)
-        ):
-            composer.insert_text(event.character)
-            self._sync_console_workbench_actions_from_draft()
+
+    @on(ConsoleComposerBar.DraftChanged)
+    def _handle_console_composer_draft_edit(
+        self, event: ConsoleComposerBar.DraftChanged
+    ) -> None:
+        """React to a draft edit the composer made handling a Console key.
+
+        TASK-3749, the inverse of what `on_key` used to do inline: instead
+        of the screen editing the draft through the composer and then
+        calling itself back, the composer announces the edit and the screen
+        does the two screen-owned follow-ups here -- re-derive Workbench
+        command readiness (which is also what opens/closes the
+        slash-command popup), and, for a text-ADDING edit only, retire the
+        first-run guidance. Deletions deliberately do not dismiss it: "the
+        user has started composing" is a claim only an insertion makes, and
+        that is precisely the split those keys had before the message
+        existed.
+
+        NOT to be confused with the sibling `_on_console_composer_draft_
+        changed` (`Input.Changed` on the composer's hidden compatibility
+        input), which fires on EVERY draft mutation from any source --
+        `load_draft`, paste, dictation, a session restore -- and disarms
+        the unknown-command escape. That signal is deliberately not reused
+        here: syncing the Workbench and dismissing guidance off it would
+        fire those on mutation paths that do neither today. (The two also
+        must not share a method NAME: the second definition would silently
+        replace the first in the class body, which is exactly how the
+        first draft of this handler killed the disarm subscription.)
+
+        `event.stop()` because this is a Console-composer-internal
+        notification: nothing above the screen subscribes, so letting it
+        bubble on would only cost a dispatch.
+
+        Args:
+            event: The composer's draft-change notification.
+        """
+        event.stop()
+        self._sync_console_workbench_actions_from_draft()
+        if event.is_insertion:
             self._dismiss_console_guidance()
-            event.stop()
-            event.prevent_default()
 
     def _recover_stuck_console_send_stash(
         self, stash: "ConsoleDraftStash | None"

--- a/tldw_chatbook/Widgets/Console/console_command_popup.py
+++ b/tldw_chatbook/Widgets/Console/console_command_popup.py
@@ -62,7 +62,18 @@ class ConsoleCommandPopup(Widget):
         return self.display
 
     def show_suggestions(self, suggestions: list[CommandSuggestion]) -> None:
-        """Replace rows, reset the highlight, reposition, and show."""
+        """Replace rows, reset the highlight, reposition, and show.
+
+        Idempotent when already open with the SAME suggestions: the rows and
+        highlight are left alone (only the anchor is refreshed). Without
+        this, the deferred `DraftChanged` sync arriving after a same-read
+        `/`+Down pair would rebuild identical rows and yank the highlight
+        the Down just moved back to 0 (task-3790). `CommandSuggestion` is a
+        frozen dataclass, so `==` here is value equality.
+        """
+        if self.is_open and list(suggestions) == self._suggestions:
+            self.reposition()
+            return
         self._suggestions = list(suggestions)
         self._desired_height = min(len(self._suggestions), MAX_VISIBLE_ROWS)
         self.styles.height = self._desired_height

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -43,6 +43,7 @@ from textual.content import Content
 from textual.css.query import NoMatches
 from textual.events import Click, DescendantBlur, DescendantFocus, Key, MouseUp
 from textual.geometry import Region
+from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Button, Input, Static
 
@@ -89,6 +90,40 @@ _PLACEHOLDER_CANDIDATE_PATTERN = re.compile(r"\[\[TLDW_PROTECTED:[^\]]*\]\]")
 #: chunk (terminal cells instead of characters), not in where it is willing
 #: to break.
 _DRAFT_WORD_SPLIT_RE = re.compile(r"([\t\n\x0b\x0c\r ]+)")
+
+#: Modifier prefixes that make a key a CHORD rather than text input, even
+#: when it carries a printable ``character``. Textual's terminal parser
+#: renames the key (``alt+m``) but passes the bare letter through as the
+#: character (``_xterm_parser.py``), so ``is_printable`` is True for every
+#: ``alt+<letter>``. Without this check the printable-capture branch
+#: swallowed the chord as typing -- pressing Alt+M inserted a literal "m"
+#: into the draft and `ChatScreen`'s own ``Binding("alt+m", ...)`` never
+#: ran (TASK-1800).
+#:
+#: ``ctrl+``/``super+``/``meta+`` are listed for completeness, not because
+#: they leak today: their characters are C0 control bytes, which are not
+#: printable, so they never reached that branch. ``alt`` is the one that
+#: does. Listing all four keeps the rule "a modified key is not text" true
+#: by construction rather than by accident of the control-byte encoding.
+#:
+#: TASK-3749 moved this here from `chat_screen` along with the
+#: printable-key branch it guards: "is this keystroke text?" is a question
+#: about the composer's input, and it now has no other caller.
+_CHORD_MODIFIER_PREFIXES = ("alt+", "ctrl+", "super+", "meta+")
+
+
+def _is_modified_chord(key: str) -> bool:
+    """Return whether ``key`` names a modifier chord rather than plain text.
+
+    Args:
+        key: Textual key name, e.g. ``"m"``, ``"alt+m"``, ``"shift+alt+m"``.
+
+    Returns:
+        True when any modifier prefix appears in the name. ``shift+`` alone
+        is deliberately NOT a chord -- ``shift+a`` is how a capital letter
+        arrives, and treating it as a chord would break typing.
+    """
+    return any(prefix in key for prefix in _CHORD_MODIFIER_PREFIXES)
 
 
 class ComposerTransactionValidationError(ValueError):
@@ -275,6 +310,53 @@ ATTACHMENT_ACTIONS_WIDTH = BASE_ACTIONS_WIDTH + 4
 
 class ConsoleComposerBar(Horizontal):
     """Expose Console-owned composer actions while reusing active chat sessions."""
+
+    class DraftChanged(Message):
+        """Posted after a Console key handled here has edited the draft.
+
+        TASK-3749. This is the inversion that let the draft-editing key
+        branches leave `ChatScreen.on_key`: the screen used to edit the
+        draft through a composer method and then call back into itself
+        (`_sync_console_workbench_actions_from_draft`, and for the two
+        text-adding keys `_dismiss_console_guidance`), which is what
+        pinned those branches to the screen. Now the composer announces
+        the edit and the screen subscribes.
+
+        It is posted **only from `handle_console_key`**, never from the
+        low-level mutation helpers (`insert_text`, `delete_left`, ...).
+        Those helpers have other callers -- dictation
+        (`Console_Modules/dictation.py`), the session draft restore
+        (`Console_Modules/session.py`), the `/prompt` insert, paste --
+        each of which already runs its own, DIFFERENT follow-up (the
+        dictation path also re-persists the draft to the chat store; the
+        session restore deliberately does not dismiss guidance). Posting
+        from the helpers would fire this message on all of them and
+        silently change what those paths do.
+
+        Attributes:
+            composer: The composer whose draft changed.
+            is_insertion: True when the edit ADDED text (a printable
+                character, or Shift+Enter/Ctrl+J's newline), False when it
+                removed text (Backspace/Ctrl+H, Delete, Ctrl+W, Ctrl+U).
+                The screen dismisses first-run guidance on insertions only
+                -- "the user has started composing" is not something a
+                Backspace says -- which is exactly the baseline split, and
+                is why this is one message with a flag rather than a bare
+                "the draft changed" notification the screen would have to
+                treat uniformly.
+        """
+
+        def __init__(
+            self, composer: "ConsoleComposerBar", *, is_insertion: bool
+        ) -> None:
+            super().__init__()
+            self.composer = composer
+            self.is_insertion = is_insertion
+
+        @property
+        def control(self) -> "ConsoleComposerBar":
+            """The composer that posted this message (Textual convention)."""
+            return self.composer
 
     DEFAULT_STATUS = "No active Console session."
     DRAFT_PLACEHOLDER = "Ask, command, or paste task..."
@@ -2744,8 +2826,14 @@ class ConsoleComposerBar(Horizontal):
         screen keeps `on_key` itself (Textual resolves it by name, and its
         "the Console composer is the default printable text target" policy
         is routing, not composer behaviour) along with every branch that
-        reaches past the composer -- Workbench/guidance resync, the
-        clipboard, undo/redo's store persistence, send, transcript paging.
+        reaches past the composer -- the clipboard, undo/redo's store
+        persistence, send, transcript paging.
+
+        TASK-3749 added the six draft-EDITING keys (Backspace/Ctrl+H,
+        Delete, Ctrl+W, Shift+Enter/Ctrl+J, Ctrl+U and the printable
+        fallthrough). Wave 5 had to leave those on the screen because each
+        one called a screen method AFTER the edit; they now post
+        `DraftChanged` instead and the screen reacts to that.
 
         This is NOT a Textual handler (no `on_`/`_on_` prefix, no
         `BINDINGS`): the composer must not start consuming keys on its own
@@ -2814,7 +2902,73 @@ class ConsoleComposerBar(Horizontal):
             event.stop()
             event.prevent_default()
             return True
+        # TASK-3749: the draft-EDITING keys. These were blocked from wave 5
+        # purely by their screen-side follow-up calls; they now announce the
+        # edit with `DraftChanged` and the screen does the Workbench resync
+        # (and, for insertions, the guidance dismissal) in its subscriber.
+        # Ordering note: as a group these ran LATER in `on_key` than they do
+        # here -- but every key they match is disjoint from the branches that
+        # used to precede them (Ctrl+C's copy, Enter's send, PageUp/PageDown's
+        # paging, the undo/redo chords), so precedence is unchanged. The
+        # printable fallthrough in particular can never shadow those: their
+        # characters are C0 control bytes or CR, none of which are
+        # `is_printable`, and all of them are modifier chords besides.
+        if event.key in {"backspace", "ctrl+h"}:
+            self.delete_left()
+            self._post_draft_changed(is_insertion=False)
+            event.stop()
+            event.prevent_default()
+            return True
+        if event.key == "delete":
+            self.delete_right()
+            self._post_draft_changed(is_insertion=False)
+            event.stop()
+            event.prevent_default()
+            return True
+        if event.key == "ctrl+w":
+            self.delete_word_left()
+            self._post_draft_changed(is_insertion=False)
+            event.stop()
+            event.prevent_default()
+            return True
+        # TASK-381: Shift+Enter is the natural newline chord, but terminals
+        # deliver it as a plain CR (which sends), so also accept Ctrl+J -- a
+        # control code that survives every terminal -- as a portable newline.
+        if event.key in ("shift+enter", "ctrl+j"):
+            self.insert_text("\n")
+            self._post_draft_changed(is_insertion=True)
+            event.stop()
+            event.prevent_default()
+            return True
+        if event.key == "ctrl+u":
+            # TASK-1281: this is the one call site that opts into undo --
+            # an accidental full clear is exactly what undo exists for.
+            self.clear_draft(record_history=True)
+            self._post_draft_changed(is_insertion=False)
+            event.stop()
+            event.prevent_default()
+            return True
+        if (
+            event.is_printable
+            and event.character is not None
+            and not _is_modified_chord(event.key)
+        ):
+            self.insert_text(event.character)
+            self._post_draft_changed(is_insertion=True)
+            event.stop()
+            event.prevent_default()
+            return True
         return False
+
+    def _post_draft_changed(self, *, is_insertion: bool) -> None:
+        """Announce that a key handled here has edited the draft (TASK-3749).
+
+        Args:
+            is_insertion: Whether the edit added text rather than removed it.
+        """
+        self.post_message(
+            ConsoleComposerBar.DraftChanged(self, is_insertion=is_insertion)
+        )
 
     def select_all_draft(self) -> bool:
         """Mark the full visible Console draft as selected without mutating it.

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -355,7 +355,15 @@ class ConsoleComposerBar(Horizontal):
 
         @property
         def control(self) -> "ConsoleComposerBar":
-            """The composer that posted this message (Textual convention)."""
+            """The composer that posted this message.
+
+            Textual's `@on(..., selector)` filtering resolves against
+            `control`, so this property is what lets a subscriber narrow to
+            one composer instance.
+
+            Returns:
+                ConsoleComposerBar: The posting composer.
+            """
             return self.composer
 
     DEFAULT_STATUS = "No active Console session."


### PR DESCRIPTION
## What

Wave 5 (#1441) moved 7 of `ChatScreen.on_key`'s composer branches into `ConsoleComposerBar.handle_console_key`. Six more were pinned to the screen purely by their follow-up calls *after* the edit — `_sync_console_workbench_actions_from_draft`, plus `_dismiss_console_guidance` on the two that add text.

This inverts that dependency. `ConsoleComposerBar` posts a `DraftChanged` message; `ChatScreen._handle_console_composer_draft_edit` subscribes and does the screen-owned follow-ups. The six branches — `backspace`/`ctrl+h`, `delete`, `ctrl+w`, `shift+enter`/`ctrl+j`, `ctrl+u`, and the printable fallthrough — become composer-only and move, taking `_is_modified_chord` with them.

`on_key` stays on the screen and keeps only the branches that genuinely reach past the composer: the clipboard, send, transcript paging, and undo/redo's store persistence. `chat_screen.py`: net −32 lines (~85 removed, ~53 added for the subscriber).

## Three design calls, each made from measured baseline behaviour

**Granularity — one message with an `is_insertion` flag.** At baseline the guidance is dismissed by the two keys that ADD text and by none of the four that remove it. A naive "dismiss on every `DraftChanged`" would have silently changed backspace/delete/ctrl+w/ctrl+u. The flag names the *cause* (the edit added text), so the "insertions retire the first-run guidance" policy stays on the screen where it belongs.

**Where it's posted — the moved branches only.** `insert_text`/`delete_left`/`clear_draft` have other callers: dictation, the session draft restore, `/prompt`, paste. Each already runs its own, *different* follow-up (dictation re-persists to the chat store; the session restore deliberately does not dismiss guidance). Posting from the helpers would have fired the Workbench sync and the guidance dismissal on all of them.

**Ordering — one real, measured difference, scoped rather than papered over.** Textual delivers the message through the pump. No existing test and no human-speed input depends on the old synchronous timing. A key arriving in the **same driver read** as the slash that opens the command popup does.

Two-arm A/B (this code vs. the baseline callback restored synchronously in its place):

| batched input | baseline | this PR |
|---|---|---|
| `/` + Down | highlights the second entry | Down ignored |
| `/` + Enter | accepts the highlighted suggestion | Enter ignored |

In both arms the popup still opens, the draft is untouched, and nothing is sent — Enter's own path re-reads the Send action *after* stashing the draft, so it never depended on this sync's timing. The blast radius is one lost keystroke under programmatic input (`tmux send-keys`, macros, text expanders); human typing is orders of magnitude too slow to reach it. Kept as a **strict xfail** that will fail loudly the day it is fixed, and filed as **TASK-3790** rather than left implicit in a marker.

## Defect found en route

The new handler was first named `_on_console_composer_draft_changed` — which is *already* a `ChatScreen` method (`@on(Input.Changed, "#console-command-input")`, disarming the unknown-command Enter escape). The second definition silently replaced the first and killed that subscription. Two existing `test_console_command_composer.py` tests caught it. Renamed to `_handle_console_composer_draft_edit`; both docstrings now cross-reference each other and explain why the broader `Input.Changed` signal is deliberately *not* reused here.

## Verification

- **21 characterisation tests written and committed green BEFORE the change** (`Tests/UI/test_console_composer_draft_changed.py`) — real `pilot` key presses on the real Console screen, asserting observable end state, never "this method was called". Includes two counter-examples proving the sync re-derives Workbench readiness rather than mirroring `draft_text() != ""`.
- **471 passed + 1 xfailed** across the composer, popup, command-composer, dictation and decomposition suites.
- **411 passed** across the workbench / guidance / send-state suites. Two `test_console_native_chat_flow.py` toast failures were A/B'd against a pre-change worktree and are **pre-existing on dev**.
- pyflakes on `chat_screen.py` unchanged (26 → 26, identical message set); 0 on the composer and the new test. AST duplicate-method audit clean. No hand-built `ChatScreen` fixtures exist. Full-suite `--collect-only`: 33,536 tests, no import breakage.

Closes TASK-3749. Follow-up: TASK-3790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved six draft-editing key paths from `ChatScreen.on_key` into `ConsoleComposerBar.handle_console_key` behind a new `DraftChanged` message to simplify `on_key` without changing behavior. Also fixed the same-read “/” popup ordering so queued keys are handled against the opened command popup (TASK-3790).

- **Refactors**
  - Added `ConsoleComposerBar.DraftChanged` and a screen subscriber to resync Workbench and dismiss guidance on insertions only.
  - Moved Backspace/Ctrl+H, Delete, Ctrl+W, Shift+Enter/Ctrl+J, Ctrl+U, and printable typing into the composer; moved `_is_modified_chord` there too.
  - `on_key` now handles only actions that reach past the composer (clipboard, send, paging, undo/redo).
  - Posted the message only from the moved branches to avoid changing dictation/session-restore/paste behavior.

- **Bug Fixes**
  - Closed TASK-3790: ensure the command popup is current at the routing point when the draft text changed, and make `show_suggestions` idempotent so `/`+Down and `/`+Enter queued in the same read work; un-xfailed the probe test.
  - Renamed the new handler to avoid shadowing an existing `Input.Changed` subscriber.

<sup>Written for commit 15b5f3d1a5194bd43e7b74d674e2880edd1f55ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

