### PR TITLE
docs(library): clarify prompt action contracts

### DIFF
--- a/Tests/UI/test_prompt_review_docstrings.py
+++ b/Tests/UI/test_prompt_review_docstrings.py
@@ -1,0 +1,38 @@
+"""Documentation contracts for public Prompt Library UI handlers."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Widgets.Library.prompt_delete_confirmation_modal import (
+    PromptDeleteConfirmationModal,
+)
+from tldw_chatbook.Widgets.Prompts.prompt_block_editor import PromptBlockEditor
+
+
+@pytest.mark.parametrize(
+    "handler",
+    (
+        PromptDeleteConfirmationModal.on_button_pressed,
+        LibraryScreen.handle_library_prompt_copy,
+        LibraryScreen.handle_library_prompt_delete,
+    ),
+)
+def test_prompt_library_button_handlers_document_event_argument(
+    handler: object,
+) -> None:
+    docstring = inspect.getdoc(handler) or ""
+
+    assert "Args:" in docstring
+    assert "event:" in docstring
+
+
+def test_prompt_block_editor_compose_documents_embedded_layout_contract() -> None:
+    docstring = inspect.getdoc(PromptBlockEditor.compose) or ""
+
+    assert "embedded" in docstring.lower()
+    assert "scroll" in docstring.lower()
+    assert "Yields:" in docstring

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -15866,7 +15866,11 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-prompt-copy")
     def handle_library_prompt_copy(self, event: Button.Pressed) -> None:
-        """Copy the live Prompt/Recipe working copy as canonical Markdown."""
+        """Copy the live Prompt/Recipe working copy as canonical Markdown.
+
+        Args:
+            event: Button press emitted by the Prompt editor's Copy action.
+        """
         event.stop()
         if self._library_prompts_view != "editor":
             return
@@ -16256,7 +16260,11 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-prompt-delete")
     def handle_library_prompt_delete(self, event: Button.Pressed) -> None:
-        """Open a confirmation for the current Prompt/Recipe identity."""
+        """Open a confirmation for the current Prompt/Recipe identity.
+
+        Args:
+            event: Button press emitted by the Prompt editor's Delete action.
+        """
         event.stop()
         if self._library_prompts_view != "editor" or not self._selected_prompt_id:
             return

--- a/tldw_chatbook/Widgets/Library/prompt_delete_confirmation_modal.py
+++ b/tldw_chatbook/Widgets/Library/prompt_delete_confirmation_modal.py
@@ -187,7 +187,11 @@ class PromptDeleteConfirmationModal(ModalScreen[PromptDeleteDecision]):
         self.dismiss(PromptDeleteDecision(False, self.request.fingerprint))
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        """Return a typed decision without invoking deletion infrastructure."""
+        """Return a typed decision without invoking deletion infrastructure.
+
+        Args:
+            event: Button press emitted by the modal's Cancel or Delete action.
+        """
         if event.button.id == "prompt-delete-cancel":
             event.stop()
             self.action_cancel()

--- a/tldw_chatbook/Widgets/Prompts/prompt_block_editor.py
+++ b/tldw_chatbook/Widgets/Prompts/prompt_block_editor.py
@@ -479,6 +479,14 @@ class PromptBlockEditor(Vertical):
         return f"encoded-{block_id.encode('utf-8').hex()}"
 
     def compose(self) -> ComposeResult:
+        """Compose the block editor with the layout required by its host.
+
+        Embedded editors yield a natural-height body so the parent owns vertical
+        scrolling. Standalone editors yield their own vertical scroll container.
+
+        Yields:
+            Widgets for each editable Prompt or Recipe lane and block.
+        """
         body_class = Vertical if self._embedded else VerticalScroll
         body_id = "prompt-editor-body" if self._embedded else "prompt-editor-scroll"
         with body_class(id=body_id):


### PR DESCRIPTION
## Summary

Addresses the two late Qodo review findings on merged PR #1449:

- adds Google-style `Args:` documentation to the Prompt Library Copy/Delete handlers and deletion modal button handler
- documents the embedded-versus-standalone scrolling contract for `PromptBlockEditor.compose()`
- adds focused regression coverage for both documentation contracts

Original discussions:
- https://github.com/rmusser01/tldw_chatbook/pull/1449#discussion_r3742208908
- https://github.com/rmusser01/tldw_chatbook/pull/1449#discussion_r3742208913

## Verification

- RED: 4 focused documentation-contract failures before the fix
- GREEN: 4 focused tests passed
- affected Prompt Library UI suite: 161 passed, 2 warnings
- Ruff lint, py_compile, formatting for changed ranges, and `git diff --check` passed
- independent review approved with no remaining findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified Prompt Library action handler contracts by documenting the `event` Args for copy/delete and modal button handlers, and documented embedded vs standalone scrolling behavior in `PromptBlockEditor.compose()`. Added focused tests to enforce these docstrings and the scrolling contract.

<sup>Written for commit 63e0322ce63e8d0857b9d24df2c5389a438454a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

