### PR TITLE
feat(stt): add bounded Parakeet ONNX Console dictation

### DIFF
--- a/.superpowers/sdd/2026-08-08-task-603-bounded-parakeet-dictation/task-6-report.md
+++ b/.superpowers/sdd/2026-08-08-task-603-bounded-parakeet-dictation/task-6-report.md
@@ -1,0 +1,216 @@
+# Task 6 report
+
+## RED evidence
+
+- Baseline focused gate: `156 passed, 2 warnings in 177.41s`.
+- App-factory/busy slice: the two new nodes failed (`2 failed in 6.83s`):
+  production sessions bypassed the app-owned factory, and the busy event was
+  not rendered.
+- Limit/explicit-resume slice: the three new nodes failed
+  (`3 failed in 24.79s`): the cap still included headroom and hands-free still
+  reopened/auto-sent.
+- Retry port slice: the new session-delegation node failed with
+  `AttributeError` before the retry methods were added.
+
+## Implementation
+
+- Late-bound Console construction through
+  `screen.app_instance._create_console_dictation_service(**kwargs)` while the
+  controller's new named factory dependency remains optional for existing
+  fakes.
+- Replaced the headroom cap with the canonical 60-second PCM calculation
+  (`1_920_000` bytes) and used `DICTATION_MAX_SECONDS` for the wall timer.
+- Routed `VoiceLocalSTTBusy` into the existing voice chip with exact busy copy.
+- Limit recovery now uses exact warning copy, stops/transcribes accepted PCM,
+  exits hands-free without send/reopen, and requires a physical Mic press.
+- Added one-shot Parakeet retry confirmation through the existing
+  `ConfirmationDialog`; decline/failure/cancellation leave the draft intact,
+  and accepted retry shares the normal success/insertion tail.
+- Cleanup clears retained retry state before mount/generation ownership guards;
+  prompt cancel, screen unmount, app shutdown, session discard, retry success,
+  retry failure, and a retry/new-generation race are covered.
+- One executor result carrying ordinary text plus `console stop` is still split
+  into one final and one command, with no command text inserted.
+
+## Verification
+
+- Final required five-file gate:
+  `168 passed, 2 warnings in 196.35s`.
+- Post-cleanup targeted production seams: `9 passed, 2 warnings in 10.37s`.
+- Real mounted retry confirm/decline: `2 passed, 2 warnings in 5.40s`.
+- Ruff check on the seven owned changed Python files: passed.
+- `git diff --check`: passed.
+- Ruff format check: `test_console_dictation.py` passed; six other owned files
+  remain reported as needing formatting. The same files at starting commit
+  `02fb2a3d4` also fail this formatter check. Applying Ruff caused broad
+  unrelated reflow, so that churn was removed and the baseline layout kept.
+- Known warnings: Requests dependency-version warning and Python 3.13
+  `audioop` deprecation through pydub.
+
+## Files and self-review
+
+- Production: `dictation.py`, `wiring.py`.
+- Tests: the five assigned Console UI test files that changed; no new widget,
+  button, modal type, retry queue, or hands-free paused state was added.
+- `console_composer_bar.py` required no production edit because its existing
+  preparing-message/status API already provides persistent busy copy and idle
+  cleanup.
+- Reviewed timer cancellation, recorder-thread callback marshalling, modal
+  cancellation, retry cleanup ordering, stale session identity, newer capture
+  generation, unmount/shutdown, no auto-send, and app-factory late binding.
+
+## Concerns
+
+- The formatter warning is pre-existing baseline debt as described above; no
+  behavioral or lint failure remains in the allowed gate.
+
+## Review fix round 1
+
+### RED evidence
+
+- Painted busy-copy node at `80x12`: `1 failed in 1.25s`; the chip painted only
+  `Local transcription busy — dictation will`.
+- Controller logical-boundary node: `1 failed in 0.23s` with missing
+  `retry_segments_with_faster_whisper`.
+- Session prefix/command node: `1 failed in 1.61s`; replay returned only
+  `recovered words Console, stop.` and dropped the finalized prefix.
+- Stale-generation replay node: `1 failed, 2 warnings in 1.46s`; an old replay
+  appended `stale recovered words` to a new capture.
+
+### Implementation and GREEN evidence
+
+- The retained retry now preserves logical segment texts internally while the
+  existing public `retry_with_faster_whisper() -> str` still returns their
+  space-joined compatibility value. PCM boundaries, `local_files_only=True`,
+  one-shot consumption, and sanitized retry failures are unchanged.
+- The streaming session snapshots the capture generation before blocking
+  replay, classifies each recovered logical segment through the ordinary
+  `classify_segment`/`_handle_event` route, and returns the complete accumulated
+  transcript. Earlier Parakeet finals survive; a retried `console stop` remains
+  a live command and is never inserted.
+- Focused session prefix/command, mounted real retry, and stale-generation
+  nodes: `3 passed, 2 warnings in 3.15s`. Controller retry boundary and
+  compatibility nodes: `4 passed in 0.20s`. Mounted real retry alone:
+  `1 passed in 3.49s`.
+- The existing voice chip ceiling is now 53 cells (51-cell message plus its
+  padding), so `Local transcription busy — dictation will run next.` is fully
+  painted at `80x12`; busy, narrow-terminal, and transcribing chip nodes:
+  `3 passed in 0.97s`.
+- Chat controller gate: `136 passed in 4.09s`.
+- Final five-file UI gate after all review fixes:
+  `171 passed, 2 warnings in 195.48s`.
+
+### Gate diagnosis and self-review
+
+- An intermediate UI gate reported `170 passed, 1 failed, 2 warnings in
+  192.93s` in the pre-existing rapid stop/restart test. Systematic isolation
+  showed dictation was already `idle`, the prior session was cleared, and mic
+  geometry was unchanged. Textual deliberately ignores a second Button click
+  during its 0.2-second `-active` press animation; the zero-work fake stop can
+  finish inside that interval. The test now waits for that explicit animation
+  class to clear, and the exact node passed before the final gate.
+- Ruff check on all six changed Python files passed. Ruff format check reports
+  four existing baseline-unformatted files; the two changed Chat files pass,
+  and review-added hunks in the four baseline files are formatter-compatible.
+  `git diff --check` passed.
+- Re-reviewed retry ownership and clearing, prefix merging, logical command
+  routing, stale generation during a blocking replay, unmount/new-capture
+  races, exact painted busy copy at a common width, and narrow-terminal chip
+  behavior. No new widget, modal, queue, state, dependency, or cross-module
+  interface break was introduced.
+
+### Concerns
+
+- Known warnings remain the Requests dependency-version warning and pydub's
+  Python 3.13 `audioop` deprecation. Formatter debt is unchanged from the
+  starting commit.
+- Review fix commit: `c1ecda33370bd26b94cf3995867008d086ea796f`.
+
+## Review fix round 2
+
+### RED evidence
+
+- Replaced the stylesheet-free busy-copy proof with a minimal composer harness
+  loading `tldw_chatbook/css/tldw_cli_modular.tcss`. At `80x12`, the exact node
+  failed `1 failed in 0.92s`: the 51-cell message painted as
+  `Local transcription busy — dictation will run nex…`.
+- The real CSS resolves the requested 53-cell chip to 52 cells and keeps two
+  horizontal padding cells, leaving only 50 content cells. The raw renderable
+  assertion had hidden that production geometry.
+
+### Implementation and GREEN evidence
+
+- For a full-width `STATE_PREPARING` message only, the existing chip now keeps
+  its leading pad and reclaims the single right padding cell needed by the
+  busy copy. Every ordinary state clears that inline override and falls back
+  to its existing stylesheet padding; no widget, state, surface, or composer/
+  action budget changed.
+- Real-CSS exact-80, narrow meaningful truncation, and ordinary preparing/
+  error/listening restoration nodes: `3 passed in 1.23s`.
+- Voice-chip file gate after correcting an initial stylesheet-free-listening
+  regression: `13 passed in 2.41s`.
+- Directly impacted mounted busy-capture node:
+  `1 passed, 2 warnings in 2.94s`.
+- Fresh combined completion gate (voice-chip file plus mounted busy capture):
+  `14 passed, 2 warnings in 6.53s`.
+
+### Self-review and concerns
+
+- Rechecked exact painted copy after a redundant `starting` refresh, idle
+  clearing, 48-column truncation/visibility, ordinary state padding, listening
+  partial/transcribing behavior, and the unchanged 24-cell action/mic budget.
+- Ruff check and `git diff --check` passed. Both changed files retain their
+  pre-existing Ruff format debt; review-added hunks are formatter-compatible.
+- Known warnings remain the Requests dependency-version warning and pydub's
+  Python 3.13 `audioop` deprecation.
+- Review fix commit: `703325619515a76ef6820f52e783ba167a19c306`.
+
+## Review fix round 3
+
+### RED evidence and mounted diagnosis
+
+- Real-production-CSS `80x12` chip assertions plus the mounted Console
+  `80x42` cancel regression initially produced `3 failed, 2 warnings in
+  3.22s`: the presentation controls remained visible and the mounted action
+  row ended at column 132 while the composer ended at column 80.
+- The mounted probe measured a 76-cell composer interior. With the exact
+  52-cell busy chip, ordinary left-side presentation chrome, reason strip,
+  and the unchanged 25-cell action row could not coexist. Hiding only the
+  reason still ended the actions at column 100; hiding collapse/Menu as well
+  ended them at 82. Temporarily hiding the draft mirror too placed the actions
+  at columns 55..80 while retaining the chip's normal right margin.
+- A toast/status alternative was rejected because the busy state must remain
+  persistent and exact. The selected presentation uses only existing composer
+  widgets and preserves their canonical state.
+
+### Implementation and GREEN evidence
+
+- Only for the full-width preparing copy, the composer now hides the existing
+  collapse button, Menu button, draft mirror, and disabled-reason strip. It
+  retains the round-2 trailing-padding override and the normal CSS margin, so
+  the exact copy, Send, and Mic all fit at 80 columns.
+- Every non-full-width repaint restores controls through the existing
+  expanded/collapsed presentation logic and restores the cached disabled
+  reason with its current muted/blocked semantics. Draft text, caret,
+  selection/history state, collapsed state, and action state are untouched.
+- Focused RED-to-GREEN nodes for exact busy geometry, draft/caret restoration,
+  and mounted Mic cancel: `3 passed, 2 warnings in 4.82s`.
+- Fresh scoped completion gate (`Tests/UI/test_console_voice_chip.py` plus the
+  mounted busy/cancel node): `15 passed, 2 warnings in 5.84s`.
+- The mounted test confirms the same Mic cell remains its hit-test target and
+  a physical second click cancels. An initially missed immediate click was
+  diagnosed as Textual deliberately suppressing Click while its stock
+  `-active` button animation is running; capture state and geometry were
+  already stable, and no production dispatch change was needed.
+
+### Static checks, self-review, and concerns
+
+- Ruff check passed on the three changed Python files and `git diff --check`
+  passed. Ruff format check reports all three as baseline-unformatted; the
+  same three files fail when their starting-commit contents are checked.
+- Rechecked busy-to-recording, busy-to-idle/cancel, redundant busy refresh,
+  narrow truncation, ordinary loading/error/listening padding and margin,
+  cached disabled-reason visibility, collapsed-presentation preservation,
+  and physical Mic reachability at real production CSS.
+- Known warnings remain the Requests dependency-version warning and pydub's
+  Python 3.13 `audioop` deprecation. No new runtime concern was found.

--- a/.superpowers/sdd/2026-08-08-task-603-bounded-parakeet-dictation/task-6-report.md
+++ b/.superpowers/sdd/2026-08-08-task-603-bounded-parakeet-dictation/task-6-report.md
@@ -214,3 +214,56 @@
   and physical Mic reachability at real production CSS.
 - Known warnings remain the Requests dependency-version warning and pydub's
   Python 3.13 `audioop` deprecation. No new runtime concern was found.
+
+## Review fix round 4
+
+### RED evidence
+
+- Added a real-production-CSS composer regression and an `80x42` mounted
+  Console regression with two real staged `PendingAttachment` values. Before
+  production changes the exact nodes reported `2 failed, 2 warnings in
+  3.15s`: `set_pending_attachment_label` reopened the attachment indicator
+  during the busy presentation, and the staged 29-cell action row pushed Mic
+  out of bounds.
+- The mounted test enters through the real Mic `Button.press()` message path,
+  re-runs the production control-bar refresh while deferred capture is busy,
+  then requires physical hit-testing/clicking for cancel. This isolates the
+  reviewed busy-state geometry from the pre-existing staged-idle 80-column
+  overflow described under Concerns.
+
+### Implementation and GREEN evidence
+
+- Extended the existing full-width presentation helper to hide the attachment
+  indicator and clear control and pin the action row to its 25-cell base width
+  while busy. No attachment content or control state is cleared.
+- On every ordinary repaint, the helper restores the indicator, clear control,
+  and 29-cell attachment action width only when the cached pending label still
+  exists; a cleared label stays hidden at the 25-cell base width.
+- `set_pending_attachment_label` still performs its normal cache, rendered
+  label, tooltip, and count updates first, then re-applies the existing busy
+  suppression when needed. It does not recurse or reconstruct lossy count/
+  total values during restore.
+- Focused direct and mounted nodes after the final assertion additions:
+  `2 passed, 2 warnings in 3.60s`.
+- Fresh scoped completion gate (voice-chip file plus both no-attachment and
+  staged-attachment mounted busy/cancel nodes):
+  `17 passed, 2 warnings in 7.95s`.
+
+### Static checks, self-review, and concerns
+
+- Ruff check and `git diff --check` passed on the three changed Python files.
+  Ruff format check reports the same three starting-commit files as already
+  unformatted; all three also fail when their `HEAD` contents are checked.
+- Rechecked exact busy paint, no-attachment and staged-attachment geometry,
+  repeated production refresh, physical Mic cancellation, attachment object/
+  label/tooltip retention, 25-to-29 width restoration, clearing back to base,
+  and collapsed-parent authority. Textual visibility assertions use the
+  composer's real `display` contract; physical hit-testing independently
+  proves user reachability.
+- Pre-existing out-of-scope observation: at production CSS and 80 columns, a
+  staged attachment already places the ordinary idle Mic outside the viewport
+  before dictation begins. This round deliberately does not alter ordinary
+  attachment layout; it verifies the requested busy-state cancel path by
+  entering through `Button.press()` and physically clicking Mic once busy.
+- Known warnings remain the Requests dependency-version warning and pydub's
+  Python 3.13 `audioop` deprecation.

--- a/Docs/STT_Evaluation/task-603/README.md
+++ b/Docs/STT_Evaluation/task-603/README.md
@@ -1,11 +1,11 @@
-# TASK-603 partial focused macOS implementation evidence
+# TASK-603 focused macOS Console dictation evidence
 
-Evidence label: `partial_focused_macos_implementation_evidence`.
+Evidence label: `partial_focused_macos_console_evidence`.
 
 This is focused implementation evidence for TASK-603 on one Apple-silicon
-macOS host. It is **not** live Console microphone acceptance evidence, a speech
-quality benchmark, cross-platform evidence, or completion of the release gate.
-Exact host, artifact, runtime, test, review, and limitation data is in
+macOS host. It includes a real Console Mic/capture/caret smoke, but it is not a
+speech quality benchmark, cross-platform evidence, or completion of the release
+gate. Exact host, artifact, runtime, test, review, and limitation data is in
 [`macos-evidence.json`](macos-evidence.json).
 
 ## What is evidenced
@@ -14,18 +14,30 @@ Exact host, artifact, runtime, test, review, and limitation data is in
   app-owned coordinator and executor to Parakeet v2 INT8 ONNX on CPU. The
   4.7025-second synthetic English fixture returned its expected sentence in
   4.407 seconds without network access or PCM disk staging.
+- At rebased commit `24a2ba3cf`, a physical Console Mic press opened the host
+  PyAudio device, captured playback of the same fixture, and sent 159,360 PCM
+  bytes through the app-owned coordinator/executor. The exact expected text was
+  inserted at the existing caret, the draft was not sent, Mic returned to idle,
+  and no user-visible failure was emitted.
+- The live smoke exposed and fixed two production blockers: deferred dictation
+  now honors `transcription.parakeet_onnx_model_dir`, and the first Python 3.12
+  STT worker spawn is protected from Textual's `stderr.fileno() == -1` capture.
 - The immutable TASK-602 artifact store was reused without acquisition or
   mutation. The pinned v2 INT8 root, Silero VAD dependency, readiness closure,
   file hashes, and a managed read lease were verified.
-- At final rebased commit `f8827ddff24b7415acc1b7f40dc40564b55a014d`,
+- At the earlier evidence commit `f8827ddff24b7415acc1b7f40dc40564b55a014d`,
   148 focused coordinator/executor/runtime/facade tests and ten exact
   app/Chat/UI contract nodes passed. The review-found oversized one-shot gap
   has focused red/green and full coordinator-file evidence.
 - Final changed-package `py_compile` and `git diff --check` passed. Changed-file
   Ruff reports only two proven pre-existing findings in the changed Library
   test file.
-- Whole-branch review found one Important boundedness defect, fixed it at the
-  final commit, and approved the focused re-review with no remaining finding.
+- Whole-branch review found one Important boundedness defect, fixed it before
+  the live Console follow-up, and approved the focused re-review with no
+  remaining finding.
+- Post-rebase follow-up verification passed 94 executor/facade tests and seven
+  exact limit/resume/batch-ordering nodes. Focused review of the two live-smoke
+  fixes found no Critical, Important, or Minor issues.
 
 ## Deliberate limitations and open gates
 
@@ -34,12 +46,14 @@ The mandated changed-test union is not green: its one permitted run reached
 Parakeet MLX native warm-up. The exact active node passed alone, which makes the
 abort load/order-sensitive but does not replace the missing union summary.
 
-The full Textual app mount produced no retained user-surface markers. This
-evidence therefore does not claim a real Mic press, microphone capture, caret
-insertion, unchanged message count, visible Library-busy ordering, live hard
-limit behavior, or a real retry failure. Windows and Linux remain untested, and
-the dead legacy implementation remains intentionally retained for TASK-605.
+The real Mic smoke establishes capture, exact caret insertion, unchanged
+message count, idle recovery, and shared executor ownership. Hard-limit/explicit
+resume and batch-to-dictation ordering are covered by focused mounted/contract
+tests rather than a 60-second physical capture. A destructive real retry failure
+was not induced. Windows and Linux remain untested, and the dead legacy
+implementation remains intentionally retained for TASK-605.
 
-TASK-603 remains **In Progress**. Only AC1–AC3 have direct implementation,
-runtime, focused-test, and review evidence; AC4–AC6 remain open. This is partial
-mergeable implementation evidence, not release-gate completion.
+TASK-603 remains **In Progress**. AC1–AC5 have direct implementation, runtime or
+focused user-surface/contract evidence. AC6 remains open for representative
+Windows/Linux evidence and the full release gate. This is partial mergeable
+implementation evidence, not release-gate completion.

--- a/Docs/STT_Evaluation/task-603/README.md
+++ b/Docs/STT_Evaluation/task-603/README.md
@@ -1,0 +1,45 @@
+# TASK-603 partial focused macOS implementation evidence
+
+Evidence label: `partial_focused_macos_implementation_evidence`.
+
+This is focused implementation evidence for TASK-603 on one Apple-silicon
+macOS host. It is **not** live Console microphone acceptance evidence, a speech
+quality benchmark, cross-platform evidence, or completion of the release gate.
+Exact host, artifact, runtime, test, review, and limitation data is in
+[`macos-evidence.json`](macos-evidence.json).
+
+## What is evidenced
+
+- A real `TldwCli` dictation factory routed in-memory PCM through the one
+  app-owned coordinator and executor to Parakeet v2 INT8 ONNX on CPU. The
+  4.7025-second synthetic English fixture returned its expected sentence in
+  4.407 seconds without network access or PCM disk staging.
+- The immutable TASK-602 artifact store was reused without acquisition or
+  mutation. The pinned v2 INT8 root, Silero VAD dependency, readiness closure,
+  file hashes, and a managed read lease were verified.
+- At final rebased commit `f8827ddff24b7415acc1b7f40dc40564b55a014d`,
+  148 focused coordinator/executor/runtime/facade tests and ten exact
+  app/Chat/UI contract nodes passed. The review-found oversized one-shot gap
+  has focused red/green and full coordinator-file evidence.
+- Final changed-package `py_compile` and `git diff --check` passed. Changed-file
+  Ruff reports only two proven pre-existing findings in the changed Library
+  test file.
+- Whole-branch review found one Important boundedness defect, fixed it at the
+  final commit, and approved the focused re-review with no remaining finding.
+
+## Deliberate limitations and open gates
+
+The mandated changed-test union is not green: its one permitted run reached
+96% and the interpreter aborted with exit 134 during a background retained
+Parakeet MLX native warm-up. The exact active node passed alone, which makes the
+abort load/order-sensitive but does not replace the missing union summary.
+
+The full Textual app mount produced no retained user-surface markers. This
+evidence therefore does not claim a real Mic press, microphone capture, caret
+insertion, unchanged message count, visible Library-busy ordering, live hard
+limit behavior, or a real retry failure. Windows and Linux remain untested, and
+the dead legacy implementation remains intentionally retained for TASK-605.
+
+TASK-603 remains **In Progress**. Only AC1–AC3 have direct implementation,
+runtime, focused-test, and review evidence; AC4–AC6 remain open. This is partial
+mergeable implementation evidence, not release-gate completion.

--- a/Docs/STT_Evaluation/task-603/macos-evidence.json
+++ b/Docs/STT_Evaluation/task-603/macos-evidence.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "evidence_label": "partial_focused_macos_implementation_evidence",
-  "generated_at": "2026-08-09T04:20:31Z",
-  "tested_commit": "f8827ddff24b7415acc1b7f40dc40564b55a014d",
-  "origin_dev": "48a54ed9c58f9bb8ce2cca6dce3e62b7084d5d6f",
+  "evidence_label": "partial_focused_macos_console_evidence",
+  "generated_at": "2026-08-09T05:28:20Z",
+  "tested_commit": "24a2ba3cf0b2856be5b5fe5ad52a1bf58405dbfc",
+  "origin_dev": "0cb70a95cbd52547a8b811c756ab40f0e5a68d59",
   "task_status": {
     "status": "In Progress",
-    "checked_acceptance_criteria": [1, 2, 3],
-    "open_acceptance_criteria": [4, 5, 6],
+    "checked_acceptance_criteria": [1, 2, 3, 4, 5],
+    "open_acceptance_criteria": [6],
     "release_gate_complete": false
   },
   "host": {
@@ -179,7 +179,74 @@
       "a real retry failure"
     ]
   },
+  "console_mic_smoke": {
+    "label": "real_console_mic_capture_and_caret_insertion",
+    "status": "passed",
+    "tested_commit": "24a2ba3cf0b2856be5b5fe5ad52a1bf58405dbfc",
+    "environment": "isolated scratch profile with network-disabled model resolution",
+    "input": {
+      "device": "MacBook Pro Microphone through PyAudio",
+      "stimulus": "verified 4.7025-second English fixture played through the host speakers",
+      "sample_rate_hz": 16000,
+      "channels": 1,
+      "sample_width_bytes": 2,
+      "captured_pcm_bytes": 159360
+    },
+    "ui": {
+      "physical_mic_start_clicked": true,
+      "state_after_click": "starting",
+      "recording_reached_seconds": 2.004,
+      "physical_mic_stop_clicked": true,
+      "final_state": "idle",
+      "final_mic_label": "Dictate",
+      "caret_insertion": true,
+      "message_count_before": 0,
+      "message_count_after": 0,
+      "user_visible_notices": []
+    },
+    "output": {
+      "text": "The local transcription stack is working on this Mac and does not need a network connection.",
+      "draft": "before The local transcription stack is working on this Mac and does not need a network connection. after"
+    },
+    "ownership": {
+      "app_owns_coordinator": true,
+      "app_owns_executor": true,
+      "provider_id": "parakeet-onnx",
+      "model_id": "nemo-parakeet-tdt-0.6b-v2",
+      "precision": "int8",
+      "effective_device": "cpu"
+    },
+    "live_blockers_fixed": [
+      "Deferred dictation now forwards the configured parakeet_onnx_model_dir to local-only dispatch resolution.",
+      "LocalSTTExecutor protects first-spawn multiprocessing primitives and Process.start from Textual's fileno-less stderr."
+    ],
+    "qualification": "This is an end-to-end wiring/runtime smoke using a known fixture, not a speech quality benchmark."
+  },
   "post_rebase_verification": {
+    "mounted_console_followup": {
+      "tested_commit": "24a2ba3cf0b2856be5b5fe5ad52a1bf58405dbfc",
+      "focused_executor_and_facade": {
+        "command": "/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/STT/test_local_stt_executor.py Tests/STT/test_transcription_service_facade.py",
+        "status": "passed",
+        "passed": 94,
+        "warnings": 1,
+        "duration_seconds": 5.94
+      },
+      "limit_resume_and_batch_ordering": {
+        "status": "passed",
+        "passed": 7,
+        "warnings": 2,
+        "duration_seconds": 7.1,
+        "coverage": [
+          "visible exact limit copy and non-blocking stop",
+          "retained caret insertion and explicit physical Mic resume",
+          "no hands-free auto-send or hidden reopen",
+          "dictation submission before the next batch callback",
+          "heavy Library work deferred while dictation is reserved"
+        ]
+      },
+      "review": "Focused review approved both follow-up fixes with no Critical, Important, or Minor findings."
+    },
     "focused_core": {
       "command": "/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/STT/test_dispatch_coordinator.py Tests/STT/test_local_stt_executor.py Tests/STT/test_parakeet_onnx.py Tests/STT/test_transcription_service_facade.py",
       "status": "passed",
@@ -256,10 +323,6 @@
   },
   "open_gates": [
     "normal terminal summary from the exact changed-test union at final HEAD",
-    "real Console Mic press and microphone capture",
-    "visible caret insertion with unchanged message count",
-    "live Library active-batch busy copy and batch-to-dictation ordering",
-    "live hard-limit retained transcription, idle transition, and explicit physical resume",
     "safe real retryable-failure evidence",
     "Windows representative-platform evidence",
     "Linux representative-platform evidence",
@@ -268,8 +331,8 @@
   "limitations": [
     "This is one Apple-silicon macOS host, not cross-platform evidence.",
     "Synthetic speech is a wiring/runtime smoke, not a quality benchmark.",
-    "The runtime smoke used in-memory PCM rather than a real microphone or verified Console surface.",
-    "The full app mount outcome was indeterminate because user-surface markers were not retained.",
+    "The real microphone captured controlled fixture playback rather than unconstrained human speech.",
+    "Hard-limit and batch-ordering outcomes are focused mounted/contract tests, not a 60-second physical capture.",
     "No artifact was corrupted and no destructive real retry was induced.",
     "Mergeable implementation evidence is partial and does not complete the release gate."
   ]

--- a/Docs/STT_Evaluation/task-603/macos-evidence.json
+++ b/Docs/STT_Evaluation/task-603/macos-evidence.json
@@ -1,0 +1,276 @@
+{
+  "schema_version": 1,
+  "evidence_label": "partial_focused_macos_implementation_evidence",
+  "generated_at": "2026-08-09T04:20:31Z",
+  "tested_commit": "f8827ddff24b7415acc1b7f40dc40564b55a014d",
+  "origin_dev": "48a54ed9c58f9bb8ce2cca6dce3e62b7084d5d6f",
+  "task_status": {
+    "status": "In Progress",
+    "checked_acceptance_criteria": [1, 2, 3],
+    "open_acceptance_criteria": [4, 5, 6],
+    "release_gate_complete": false
+  },
+  "host": {
+    "system": "Darwin",
+    "mac_version": "15.6",
+    "machine": "arm64",
+    "python": {
+      "implementation": "CPython",
+      "version": "3.12.11",
+      "executable": "/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python"
+    },
+    "packages": {
+      "tldw-chatbook": "0.1.8.0",
+      "textual": "8.2.7",
+      "onnx-asr": "0.12.0",
+      "onnxruntime": "1.27.0",
+      "numpy": "2.4.4",
+      "sounddevice": "0.5.5",
+      "webrtcvad": "2.0.10"
+    },
+    "onnxruntime_available_providers": [
+      "CoreMLExecutionProvider",
+      "AzureExecutionProvider",
+      "CPUExecutionProvider"
+    ],
+    "runtime_execution_provider": "CPUExecutionProvider"
+  },
+  "artifact_reuse": {
+    "source_task": "TASK-602",
+    "store_kind": "reused_temporary_immutable_evidence_store",
+    "store_root": "/private/tmp/tldw-task602-macos-models",
+    "network_used": false,
+    "download_or_acquisition_attempted": false,
+    "store_mutated": false,
+    "lease": {
+      "service": "ModelArtifactService",
+      "mode": "read acquire and release",
+      "status": "passed"
+    },
+    "root": {
+      "artifact_id": "parakeet-v2",
+      "model_id": "nemo-parakeet-tdt-0.6b-v2",
+      "revision": "0bbb45a3365852604aef28b538a8f066f4ccaa85-vad-b3e3ee3cce4c",
+      "variant": "int8",
+      "precision": "int8",
+      "expected_installed_bytes": 661191781,
+      "runtime_constraint": "onnx-asr==0.12.0",
+      "closure_fingerprint": "d52f16e6505c8efc3e5a9178f597e2414814ae44e677ea0cd75b317a240effc0",
+      "files": [
+        {
+          "path": "config.json",
+          "size_bytes": 97,
+          "sha256": "666903c76b9798caf2c210afd4f6cd60b08a8dbf9800ec8d7a3bc0d2148ac466"
+        },
+        {
+          "path": "vocab.txt",
+          "size_bytes": 9384,
+          "sha256": "ec182b70dd42113aff6c5372c75cac58c952443eb22322f57bbd7f53977d497d"
+        },
+        {
+          "path": "encoder-model.int8.onnx",
+          "size_bytes": 652184014,
+          "sha256": "3e0581fda6ab843888b51e56d7ee78b6d5bc3237ec113af1f732d1d5286aa155"
+        },
+        {
+          "path": "decoder_joint-model.int8.onnx",
+          "size_bytes": 8998286,
+          "sha256": "a449f49acd68979d418651dd2dcb737cc0f1bf0225e009e29ee326354edbf7d3"
+        }
+      ]
+    },
+    "dependency": {
+      "artifact_id": "silero-vad",
+      "model_id": "silero-vad-onnx",
+      "revision": "b3e3ee3cce4c11ceb63b1a0b229d916069c1ddf6",
+      "variant": "f32",
+      "size_bytes": 2327524,
+      "sha256": "1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3"
+    },
+    "active_selector_after_evidence": {
+      "variant": "f32",
+      "unchanged": true,
+      "sha256": "7868f0fe220b421ae667b62a8583b8cb40dcc963d0f9b499b2c0cdf68c708b37",
+      "qualification": "The runtime fallback explicitly selected the verified INT8 local snapshot; it did not promote or alter the global F32 active selector."
+    }
+  },
+  "profile_isolation": {
+    "status": "passed",
+    "established_before_app_import": true,
+    "scratch_path_redacted": true,
+    "variables_redirected": [
+      "HOME",
+      "XDG_CONFIG_HOME",
+      "XDG_DATA_HOME",
+      "TLDW_CONFIG_PATH"
+    ],
+    "explicit_scratch_data_dir": true,
+    "test_mode_set": false,
+    "credentials_added": false,
+    "real_profile_invariance": [
+      {
+        "path": "~/.config/tldw_cli/config.toml",
+        "size_bytes": 51270,
+        "mtime_epoch": 1786035601,
+        "sha256": "5e496b75a706c4693a4fbbc4d90933a05b0e3cb6ccc9f56ad6f7744cf0a7fb06"
+      },
+      {
+        "path": "~/.config/tldw_cli/runtime_policy.json",
+        "size_bytes": 299,
+        "mtime_epoch": 1781304897,
+        "sha256": "4197e7cca06ba6355543b2bd637db57dccafb4dac3fd14f16a951307eb4367f3"
+      },
+      {
+        "path": "~/.config/tldw_cli/ui_state.toml",
+        "size_bytes": 58,
+        "mtime_epoch": 1786242203,
+        "sha256": "92ed0c3dcba7b43610f0a867f255c09e921add3508b726216f043f211faaeb42"
+      }
+    ],
+    "real_data_tree_post_check": "No entry through depth two acquired an mtime after the pre-run snapshot."
+  },
+  "runtime_fallback": {
+    "label": "non_ui_in_memory_production_path_fallback",
+    "status": "passed",
+    "path": [
+      "TldwCli._create_console_dictation_service",
+      "TranscriptionService",
+      "app-owned LocalSTTDispatchCoordinator",
+      "app-owned LocalSTTExecutor",
+      "ParakeetOnnxRuntime CPU"
+    ],
+    "ownership": {
+      "uses_deferred_local_stt_dispatch": true,
+      "app_owns_coordinator": true,
+      "app_owns_executor": true
+    },
+    "input": {
+      "kind": "bounded in-memory PCM fixture",
+      "fixture_file_size_bytes": 150558,
+      "fixture_sha256": "8025642b1da904543a336b0239ceb51f241e8c7d0610060993f13dbea81d9f07",
+      "pcm_bytes": 150480,
+      "frames": 75240,
+      "sample_rate_hz": 16000,
+      "channels": 1,
+      "sample_width_bytes": 2,
+      "duration_seconds": 4.7025,
+      "disk_staged_by_runtime": false
+    },
+    "output": {
+      "text": "The local transcription stack is working on this Mac and does not need a network connection.",
+      "logical_segments": 1,
+      "elapsed_seconds": 4.407,
+      "provider_id": "parakeet-onnx",
+      "model_id": "nemo-parakeet-tdt-0.6b-v2",
+      "precision": "int8",
+      "requested_device": "cpu",
+      "effective_device": "cpu",
+      "job_id": null,
+      "warnings": []
+    },
+    "shutdown_thread_alive_after_bounded_join": false,
+    "known_probe_log": "The unmounted app could not marshal the final Library top-up callback; transcription and shutdown still completed.",
+    "does_not_prove": [
+      "microphone permission or capture",
+      "Console rendering or Mic state",
+      "caret insertion or unchanged message count",
+      "visible Library busy ordering",
+      "live hard-limit behavior",
+      "a real retry failure"
+    ]
+  },
+  "post_rebase_verification": {
+    "focused_core": {
+      "command": "/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/STT/test_dispatch_coordinator.py Tests/STT/test_local_stt_executor.py Tests/STT/test_parakeet_onnx.py Tests/STT/test_transcription_service_facade.py",
+      "status": "passed",
+      "passed": 148,
+      "warnings": 1,
+      "warning_kinds": [
+        "RequestsDependencyWarning"
+      ],
+      "duration_seconds": 7.31,
+      "source": "root-supplied fresh post-rebase evidence"
+    },
+    "exact_app_chat_ui_nodes": {
+      "command": "/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/App/test_submit_library_ingest_job.py::test_console_dictation_factory_injects_app_owned_coordinator Tests/Chat/test_console_voice_input.py::test_deferred_parakeet_reserves_before_warmup_and_opens_while_busy Tests/Chat/test_console_voice_input.py::test_retryable_parakeet_failure_exposes_one_bounded_faster_whisper_retry Tests/Chat/test_console_voice_input.py::test_retry_preserves_logical_segment_texts_for_the_console_adapter Tests/UI/test_console_controller_wiring.py::test_dictation_session_late_binds_the_app_owned_service_factory Tests/UI/test_console_voice_chip.py::test_busy_dictation_copy_uses_the_existing_chip_and_clears_at_idle Tests/UI/test_console_dictation_streaming.py::test_mounted_retry_keeps_prefix_and_routes_retried_stop_command Tests/UI/test_console_dictation_streaming.py::test_the_buffer_limit_callback_stops_the_capture_from_its_own_thread Tests/UI/test_console_hands_free_wiring.py::test_hands_free_limit_exits_without_reopen_until_a_physical_mic_press Tests/UI/test_console_hands_free_wiring.py::test_hands_free_limit_never_auto_sends_the_retained_text",
+      "status": "passed",
+      "passed": 10,
+      "warnings": 2,
+      "warning_kinds": [
+        "RequestsDependencyWarning",
+        "pydub audioop deprecation warning"
+      ],
+      "duration_seconds": 13.18,
+      "source": "root-supplied fresh post-rebase evidence"
+    },
+    "review_fix_boundary": {
+      "defect": "The blocking one-shot buffer path could admit more than the format-derived 60-second PCM limit.",
+      "red_on_old_code": true,
+      "green_boundary_nodes": 2,
+      "full_coordinator_test_file_passed": 38,
+      "focused_rereview": "approved with no new findings",
+      "source": "root-supplied review evidence"
+    },
+    "static": {
+      "changed_package_py_compile": "passed",
+      "changed_file_ruff": {
+        "status": "two pre-existing findings",
+        "findings": [
+          "F841 unused local job in Tests/Library/test_library_ingest_runner.py",
+          "F401 unused local import SimpleNamespace in Tests/Library/test_library_ingest_runner.py"
+        ],
+        "introduced_by_task_603": false
+      },
+      "git_diff_check_origin_dev_to_head": "passed"
+    }
+  },
+  "changed_test_union": {
+    "phase_1_target": "8de33a6f38a7066a3ce828f960601e0a440b6e4d",
+    "attempts": 1,
+    "status": "aborted",
+    "progress_percent": 96,
+    "exit_code": 134,
+    "real_seconds": 252.69,
+    "terminal_summary_available": false,
+    "fatal_context": "Background retained parakeet_mlx/MLX native warm-up import aborted the interpreter.",
+    "assertion_failure_reported_before_abort": false,
+    "exact_active_node_diagnosis": {
+      "node": "Tests/UI/test_console_hands_free_wiring.py::test_awaiting_reply_watchdog_disarms_at_row_creation_not_first_token",
+      "status": "passed",
+      "passed": 1,
+      "warnings": 2,
+      "duration_seconds": 3.29
+    },
+    "qualification": "The isolated node pass does not turn the changed-test union green; the abort remains a release gate."
+  },
+  "review": {
+    "scope": "origin/dev through final rebased HEAD",
+    "important_findings_found": 1,
+    "important_findings_fixed": 1,
+    "remaining_findings": {
+      "critical": 0,
+      "important": 0,
+      "minor": 0
+    },
+    "deferred_test_debt": "The Task-2 import-order assertion is test-isolation debt, not a production download defect."
+  },
+  "open_gates": [
+    "normal terminal summary from the exact changed-test union at final HEAD",
+    "real Console Mic press and microphone capture",
+    "visible caret insertion with unchanged message count",
+    "live Library active-batch busy copy and batch-to-dictation ordering",
+    "live hard-limit retained transcription, idle transition, and explicit physical resume",
+    "safe real retryable-failure evidence",
+    "Windows representative-platform evidence",
+    "Linux representative-platform evidence",
+    "TASK-605 legacy removal and semantic-default promotion"
+  ],
+  "limitations": [
+    "This is one Apple-silicon macOS host, not cross-platform evidence.",
+    "Synthetic speech is a wiring/runtime smoke, not a quality benchmark.",
+    "The runtime smoke used in-memory PCM rather than a real microphone or verified Console surface.",
+    "The full app mount outcome was indeterminate because user-surface markers were not retained.",
+    "No artifact was corrupted and no destructive real retry was induced.",
+    "Mergeable implementation evidence is partial and does not complete the release gate."
+  ]
+}

--- a/Docs/superpowers/plans/2026-08-08-task-603-bounded-parakeet-dictation.md
+++ b/Docs/superpowers/plans/2026-08-08-task-603-bounded-parakeet-dictation.md
@@ -1,0 +1,723 @@
+# TASK-603 Bounded Parakeet ONNX Dictation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route public and Console Parakeet ONNX PCM transcription through the one app-owned `LocalSTTExecutor`, with a bounded one-item dictation mailbox, dictation-next admission, explicit limit recovery, and faster-whisper retry while preserving current Console insertion and voice-command behavior.
+
+**Architecture:** Keep `LocalSTTExecutor` queue-less and add one small app-owned `LocalSTTDispatchCoordinator` in front of it. File jobs and bounded PCM requests share the same exact Parakeet model/artifact resolver and resident worker. Live Console capture seals silence-delimited segments into an asynchronous capture handle so its processing thread never blocks behind batch work; the handle coalesces at most one pending request and preserves segment boundaries. Existing retained providers remain behind `LegacyTranscriptionBridge`; only an explicit user-approved faster-whisper retry replays failed bounded PCM there.
+
+**Tech Stack:** Python 3.11+, Textual 8, existing `BufferAudioSource`/normalized STT contracts, existing `LocalSTTExecutor`, `onnx-asr[cpu]==0.12.0`, existing Console dictation controllers, pytest.
+
+## Global Constraints
+
+- ADR required: no new ADR.
+- ADR path: `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`.
+- Reason: ADR-025 already decides the shared executor boundary, bounded in-memory dictation, dictation-next/non-preemption policy, retained-provider fallback, and release gates. This task implements that decision without changing it.
+- Read `backlog/docs/lessons-testing-evidence.md`, `backlog/docs/lessons-live-verification.md`, and `backlog/docs/lessons-backlog-hygiene.md` before implementation or verification.
+- Do not create another executor, worker process, model cache, downloader, general priority queue, persisted audio queue, or temporary WAV for microphone PCM.
+- Keep `parakeet_defaults_enabled=False`; do not promote semantic defaults, delete legacy NeMo/MLX/faster-whisper code, or perform TASK-605 cleanup.
+- TASK-603.1 already shipped the Mic control, 60-second capture, off-loop stop,
+  caret insertion, and direct legacy Parakeet buffer vertical slice. Upgrade its
+  execution/admission seam; do not add a second Mic flow or reimplement the
+  established Console lifecycle.
+- English remains the Console default and resolves to Parakeet v2; precision
+  defaults to INT8. Do not alter `auto` or non-English routing owned by the
+  existing batch policy.
+- INT8 is the fallback only when `transcription.default_precision` is absent.
+  Honor the first-run wizard's persisted explicit `f32` selection for public
+  and Console Parakeet buffers; reject any other precision clearly. Do not read
+  the legacy MLX-only `transcription.parakeet_precision` key.
+- `LocalSTTExecutor` remains single-slot and queue-less. The coordinator may hold one dictation reservation and one pending same-capture PCM request only; Library ordering remains in `LibraryIngestJobRegistry`.
+- One canonical Console ceiling is 60 seconds. Derive bytes as `sample_rate * channels * sample_width * seconds`; do not preserve the current 1.5 headroom as a second behavioral limit.
+- An active native inference is never preempted. A Mic press gates only future local-STT heavy Library jobs; light parsing remains dispatchable.
+- The retained silence-transcription warm-up must be skipped for deferred shared-executor Parakeet capture, or an active batch will block the Mic before recording opens.
+- At the limit, stop and transcribe retained PCM, show `Limit reached — press Mic to continue.`, return to idle, and do not auto-reopen even from hands-free mode.
+- Retry copy is exactly `Parakeet failed. Retry this audio with faster-whisper?`; never expose native exception text and never retry automatically.
+- Run only tests covering modified functionality. Do not run the full repository suite or wait on unrelated CI.
+- macOS native evidence may be collected locally. Keep Windows/Linux release gates open and do not claim them without native evidence.
+
+---
+
+## Task 1: Extend the executor protocol from file-only to file-or-buffer
+
+**Files:**
+- Modify: `tldw_chatbook/STT/executor.py`
+- Modify: `tldw_chatbook/STT/executor_worker.py`
+- Modify: `tldw_chatbook/app.py`
+- Modify: `Tests/STT/executor_test_support.py`
+- Modify: `Tests/STT/test_local_stt_executor.py`
+- Modify: `Tests/STT/test_transcribe_cpp.py`
+- Modify: `Tests/Library/test_library_ingest_runner.py`
+
+**Interfaces:**
+- Consumes: existing `FileAudioSource`, `BufferAudioSource`, `ModelIdentity`, executor callbacks, and Library file requests.
+- Produces: a picklable `ExecutorRequest.source`, optional `job_id`, validated logical segment boundaries, and typed rejection for provider/source mismatches.
+- Invariant: exactly one source object per request; buffer boundaries are frame offsets, not byte offsets.
+
+Implement the request shape directly in the existing executor module:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ExecutorRequest:
+    generation: int
+    attempt_id: str
+    job_id: str | None
+    source: FileAudioSource | BufferAudioSource = field(repr=False)
+    identity: ModelIdentity
+    options: dict[str, Any] = field(repr=False)
+    segment_end_frames: tuple[int, ...] = ()
+    local_source: LocalSourceSnapshot | None = field(default=None, repr=False)
+    managed_store_root: Path | None = field(default=None, repr=False)
+    managed_artifact_ref: tuple[str, str, str] | None = None
+```
+
+Validation rules in `ExecutorRequest.__post_init__`:
+
+```python
+if self.job_id is not None:
+    _require_nonempty_text("job_id", self.job_id)
+if type(self.source) not in (FileAudioSource, BufferAudioSource):
+    raise TypeError("source must be a FileAudioSource or BufferAudioSource")
+if self.segment_end_frames:
+    if type(self.source) is not BufferAudioSource:
+        raise ValueError("segment_end_frames require a buffer source")
+    frame_bytes = self.source.channels * self.source.sample_width
+    total_frames = len(self.source.audio) // frame_bytes
+    if (
+        any(type(end) is not int or end <= 0 for end in self.segment_end_frames)
+        or any(a >= b for a, b in zip(self.segment_end_frames, self.segment_end_frames[1:]))
+        or self.segment_end_frames[-1] != total_frames
+    ):
+        raise ValueError("segment_end_frames must increase to the final PCM frame")
+```
+
+The executor submission seam becomes:
+
+```python
+def submit(
+    self,
+    *,
+    attempt_id: str,
+    job_id: str | None,
+    source: FileAudioSource | BufferAudioSource,
+    identity: ModelIdentity,
+    options: dict[str, Any],
+    segment_end_frames: tuple[int, ...] = (),
+    local_source: LocalSourceSnapshot | None = None,
+    managed_store_root: Path | None = None,
+    managed_artifact_ref: tuple[str, str, str] | None = None,
+    on_event: Callable[[ExecutorEvent], None] = _ignore_event,
+    on_result: Callable[[ExecutorResult], None] = _ignore_result,
+    on_failure: Callable[[ExecutorFailure], None] = _ignore_failure,
+    explicit_retry: bool = False,
+) -> int:
+```
+
+- [ ] Add failing protocol tests for file and buffer sources, `job_id=None`, invalid source types, boundaries on a file, non-increasing/zero/past-end boundaries, and a final boundary that does not equal the buffer frame count.
+- [ ] Update the pickling/redaction test to prove PCM bytes, paths, and snapshot tokens never appear in `repr` while both source variants round-trip through `pickle`.
+- [ ] Add a worker test proving `FileAudioSource` still calls the existing parser with the exact path/options/runner shape and unchanged payload.
+- [ ] Add a worker test proving a `BufferAudioSource` never calls `parse_job`; it calls a provider buffer runner and returns its bounded payload.
+- [ ] Add a worker test proving `BufferAudioSource` with `transcribe-cpp` or a provider without a buffer runner returns `UNSUPPORTED_CAPABILITY` plus the existing recovery actions.
+- [ ] Run `python -m pytest Tests/STT/test_local_stt_executor.py Tests/STT/test_transcribe_cpp.py Tests/Library/test_library_ingest_runner.py -q` and confirm the new tests fail for the intended missing contract/branch, not import or fixture errors.
+- [ ] Replace `source_path` with `source`, make `job_id` optional, and add boundary validation without changing executor admission, cancellation, recycling, containment, or callback delivery.
+- [ ] Extend `ProviderRuntime` minimally with `buffer_runner: Callable[..., dict[str, Any]] | None = None`; keep the existing `runner` field for file parsing and existing fake providers.
+- [ ] Branch once in `_run_executor_worker`: file -> the unchanged `parse_job` call using `source.path`; Parakeet buffer -> `buffer_runner(source, segment_end_frames=request.segment_end_frames)`; otherwise raise `_ProviderLoadFailure(UNSUPPORTED_CAPABILITY)`.
+- [ ] Update the app's existing Library call and direct request construction in the listed test/support files mechanically from `source_path=path` to `source=FileAudioSource(path)`. Update the Library fake executor assertion to the same source object so this commit leaves production file dispatch working; do not change admission policy yet.
+- [ ] Re-run `python -m pytest Tests/STT/test_local_stt_executor.py Tests/STT/test_transcribe_cpp.py Tests/Library/test_library_ingest_runner.py -q` and commit: `feat(stt): admit bounded executor buffers`.
+
+## Task 2: Share exact Parakeet dispatch identity and add in-memory recognition
+
+**Files:**
+- Create: `tldw_chatbook/STT/parakeet_dispatch.py`
+- Modify: `tldw_chatbook/STT/parakeet_onnx.py`
+- Modify: `tldw_chatbook/STT/executor_worker.py`
+- Create: `Tests/STT/test_parakeet_dispatch.py`
+- Modify: `Tests/STT/test_parakeet_onnx.py`
+- Modify: `Tests/STT/test_local_stt_executor.py`
+
+**Interfaces:**
+- Consumes: model ID, precision, optional configured model directory, existing managed/legacy artifact helpers, `BufferAudioSource`, and optional logical frame boundaries.
+- Produces: one `ParakeetDispatch` used by both Library and Console plus one normalized in-memory result with ordered logical segment text.
+- Invariant: resolving identity never downloads; recognizing PCM never writes it to disk.
+
+Create one immutable resolution result:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ParakeetDispatch:
+    identity: ModelIdentity
+    local_source: LocalSourceSnapshot | None
+    managed_store_root: Path | None
+    managed_artifact_ref: tuple[str, str, str] | None
+    option_updates: Mapping[str, Any]
+
+
+def resolve_parakeet_dispatch(
+    *,
+    model_id: str,
+    precision: str,
+    model_dir: str | Path | None,
+) -> ParakeetDispatch:
+    """Resolve an installed configured, managed, or verified legacy artifact."""
+```
+
+`option_updates` contains only the already-supported private worker options (`transcription_model_dir`, `_verify_legacy_parakeet_v2`) and is copied into each caller's own options dictionary. The function must not accept a Library job or invent an attempt/job ID.
+
+Add an internal normalized carrier in `parakeet_onnx.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ParakeetBufferResult:
+    normalized: TranscriptionResult
+    logical_segments: tuple[str, ...]
+
+
+def transcribe_buffer(
+    self,
+    *,
+    source: BufferAudioSource,
+    segment_end_frames: tuple[int, ...],
+    attempt_id: str,
+    language: str,
+    job_id: str | None = None,
+    is_cancelled: Callable[[], bool] | None = None,
+) -> ParakeetBufferResult:
+```
+
+PCM conversion is in memory and explicit:
+
+```python
+samples = np.frombuffer(source.audio, dtype="<i2").reshape(-1, source.channels)
+mono = samples.astype(np.float32).mean(axis=1) / 32768.0
+ends = segment_end_frames or (len(mono),)
+starts = (0, *ends[:-1])
+logical_waveforms = tuple(mono[start:end] for start, end in zip(starts, ends))
+```
+
+Only 16-bit PCM is admitted by Parakeet in this task; the provider boundary returns `UNSUPPORTED_CAPABILITY` for other widths rather than silently mis-decoding them. For total duration over 30 seconds, use the resident managed VAD when present and report `produced_capabilities.vad=True`. A configured or verified legacy v2 runtime without VAD recognizes each logical waveform directly up to the 60-second public/Console bound and reports `vad=False`.
+
+- [ ] Add failing resolver tests showing Library-style and Console-style calls
+  produce identical v2 INT8 and explicit v2 F32 `ModelIdentity`, local
+  snapshot/managed closure identity, and option updates from the same
+  configured, managed, and verified-legacy fixtures.
+- [ ] Add a failing resolver test proving it never imports or calls provision/download functions and fails clearly when no installed artifact is resolvable.
+- [ ] Add failing runtime tests for mono and stereo int16 PCM conversion, exact duration, `job_id=None` provenance, v2 English semantics, v3 warning semantics, and no filesystem/tempfile/wave staging.
+- [ ] Add failing boundary tests where two logical segments (`ordinary text`, `console stop`) return two ordered texts even when sent as one executor request.
+- [ ] Add a resident-reuse test with two buffer requests sharing one model identity but different attempt IDs; prove the second result uses the second request's attempt/language/job metadata (including `job_id=None`) rather than state captured when the runtime first loaded.
+- [ ] Add failing 30–60-second tests: managed closure invokes fake VAD in memory and reports `vad=True`; verified legacy v2 without VAD recognizes directly and reports `vad=False`.
+- [ ] Add cancellation coverage proving the token is checked before every logical/VAD inference and a cancellation before segment two prevents its native call.
+- [ ] Add worker coverage proving `buffer_runner` serializes `text`, `logical_segments`, `duration`, `transcription_model`, and validated normalized `transcription_provenance` without a synthetic job ID.
+- [ ] Run `python -m pytest Tests/STT/test_parakeet_dispatch.py Tests/STT/test_parakeet_onnx.py Tests/STT/test_local_stt_executor.py -q` and confirm intended failures.
+- [ ] Extract the Parakeet half of `LibraryIngestQueueMixin._build_local_stt_dispatch` into `resolve_parakeet_dispatch`; leave transcribe.cpp resolution exactly where it is.
+- [ ] Factor the runtime's result/provenance assembly so file and buffer methods cannot drift, while keeping `_prepared_wav` file-only.
+- [ ] Add the Parakeet provider's `buffer_runner`, mapping unexpected native errors to the existing sanitized `INFERENCE_FAILED` failure and preserving `retry_faster_whisper`.
+- [ ] Pass the current request's attempt/job/context/language into
+  `buffer_runner` on every worker loop iteration. The resident provider closure
+  may capture artifact/runtime identity only; it must not reuse the first
+  request's provenance metadata.
+- [ ] Re-run the three focused tests and commit: `feat(stt): transcribe Parakeet PCM in shared worker`.
+
+## Task 3: Add the bounded dictation-next dispatch coordinator
+
+**Files:**
+- Create: `tldw_chatbook/STT/dispatch_coordinator.py`
+- Create: `Tests/STT/test_dispatch_coordinator.py`
+
+**Interfaces:**
+- Consumes: the existing queue-less `LocalSTTExecutor`, a resolved `ParakeetDispatch`, bounded segment PCM, and existing executor callbacks.
+- Produces: `submit_library`, blocking one-shot `transcribe_buffer`, and asynchronous `begin_dictation`/`DictationCaptureHandle`.
+- Invariant: one native inference active; zero or one same-capture dictation request pending; no persisted Library queue duplicated here.
+
+Keep the public shape small. These are the complete public operations; private
+helpers may only support their locking and callback delivery:
+
+```python
+DICTATION_MAX_SECONDS = 60.0
+
+
+def pcm_byte_limit(*, sample_rate: int, channels: int, sample_width: int) -> int:
+    return int(sample_rate * channels * sample_width * DICTATION_MAX_SECONDS)
+```
+
+Coordinator operations are exactly:
+
+- `submit_library(**executor_kwargs) -> int`, where `executor_kwargs` is the
+  existing executor submission contract from Task 1;
+- `transcribe_buffer(*, source, dispatch, language) -> dict[str, Any]`;
+- `begin_dictation(*, capture_generation, dispatch, sample_rate, channels,
+  sample_width, language, on_logical_segment) -> DictationCaptureHandle`;
+- read-only `dictation_reserved -> bool`; and
+- idempotent `close() -> None`.
+
+Capture-handle operations are exactly read-only `waiting_for_executor -> bool`,
+`append_segment(audio) -> DictationAppendStatus`, `finish() -> None`, `wait()
+-> None`, `cancel(*, force=False) -> bool`, and `take_retry_buffer() ->
+RetryableDictationBuffer | None`.
+
+`DictationAppendStatus` has only `ACCEPTED` and `LIMIT_REACHED`. `RetryableDictationBuffer` contains one `BufferAudioSource` plus logical frame offsets; it is held only after a retryable Parakeet failure and released by `take_retry_buffer`, cancel, or close.
+
+The handle's blocking caller receives one sanitized typed failure:
+
+```python
+class RetryableDictationFailure(RuntimeError):
+    def __init__(self, retry_buffer: RetryableDictationBuffer) -> None:
+        self.retry_buffer = retry_buffer
+        super().__init__("Parakeet transcription failed.")
+```
+
+It contains no native exception text or private path. `wait()` raises it only
+after a retryable Parakeet terminal; non-retryable failure and cancellation use
+their existing normalized categories without a retry buffer.
+
+Coordinator state under one `threading.RLock`:
+
+```python
+self._active_kind: Literal["library", "dictation"] | None
+self._active_attempt_id: str | None
+self._reservation: _DictationCapture | None
+self._pending: _PendingDictation | None
+self._closed: bool
+```
+
+Admission order on every executor terminal callback is fixed:
+
+```python
+with self._lock:
+    clear_active_once()
+    if self._pending is not None:
+        next_request = snapshot_pending_locked()
+    elif self._reservation is finished:
+        clear_reservation_once()
+outside_lock_submit(next_request)
+outside_lock_deliver_original_callback()
+outside_lock_notify_library_top_up_if_gate_cleared()
+```
+
+Never invoke executor or user callbacks while holding the coordinator lock.
+The executor terminal callback itself runs on the executor reader thread, so it
+must not retire/re-submit a different resident identity inline: doing so can
+make worker retirement join its own reader thread. The terminal callback starts
+one bounded daemon dispatch thread whose body performs the three `outside_lock`
+operations above in order. There is never more than one such transition thread
+because the executor itself has only one active terminal guard.
+
+- [ ] Write a dependency-free fake executor that records submissions and exposes explicit `succeed`, `fail`, `cancel`, and `force_stop` terminal controls.
+- [ ] Add failing tests for idle dictation immediate dispatch; batch active -> one pending dictation; batch terminal -> dictation before a later Library submit; and dictation terminal -> gate clear/top-up callback.
+- [ ] Add a test proving a Mic reservation with no PCM blocks only `submit_library` heavy work, then cancellation clears the gate and wakes the waiter.
+- [ ] Add coalescing tests: several same-capture segments become one pending `BufferAudioSource`, frame boundaries stay ordered, and an active dictation permits exactly one next pending request.
+- [ ] Add mismatch tests for capture generation, identity, sample rate, channels, and width; each returns a visible busy failure and never combines audio.
+- [ ] Add exact-bound/one-frame-over tests proving frame-aligned accepted PCM is retained, `LIMIT_REACHED` is returned once, and no accepted sample disappears.
+- [ ] Add stale terminal, duplicate terminal, worker failure, pending cancel, active cooperative cancel, force-stop, and close tests; every path clears reservation/pending state exactly once.
+- [ ] Add retry-buffer tests proving a retryable active failure merges only
+  that failed request, its not-yet-run pending segments, and later same-capture
+  segments accepted before `finish`; earlier successful segments are excluded,
+  native details are absent, and `take_retry_buffer` transfers ownership once.
+- [ ] Add an identity-change regression where a v3 batch terminal callback runs on a named fake reader thread and pending v2 dictation is submitted by the bounded transition thread, never by that reader thread; assert callback/top-up ordering remains unchanged.
+- [ ] Add a real event-controlled delay test: hold a fake batch longer than a 50 ms processing-thread join bound, append dictation, finish capture, and prove the processing thread exits promptly while `handle.wait()` completes only after batch then dictation. Do not sleep 30 seconds.
+- [ ] Run `python -m pytest Tests/STT/test_dispatch_coordinator.py -q` and confirm intended failures.
+- [ ] Implement only the state above plus the single terminal-transition thread; do not add a standing scheduler thread, priorities, multiple pending entries, polling, timers, persistence, worker ownership, or model ownership.
+- [ ] Deliver logical-segment callbacks in monotonically increasing sequence order and ignore stale executor generations/attempt IDs.
+- [ ] Retain only failed+not-yet-run PCM for explicit retry; release successful request bytes immediately and release all bytes on cancel/close.
+- [ ] Re-run the focused coordinator test and commit: `feat(stt): coordinate dictation before batch top-up`.
+
+## Task 4: Put Library and Console on the same app-owned coordinator
+
+**Files:**
+- Modify: `tldw_chatbook/app.py`
+- Modify: `Tests/Library/test_library_ingest_runner.py`
+- Modify: `Tests/App/test_submit_library_ingest_job.py`
+
+**Interfaces:**
+- Consumes: app-owned `LocalSTTExecutor`, `LibraryIngestQueueMixin` heavy dispatch, and the new `LocalSTTDispatchCoordinator`.
+- Produces: one lazily constructed coordinator, one Console dictation service factory, and deterministic heavy-lane gating/top-up.
+- Invariant: shutdown detaches coordinator and executor once, off the Textual event loop.
+
+Add app ownership beside the existing executor fields:
+
+```python
+self._local_stt_executor_lock = threading.RLock()
+self._local_stt_executor: LocalSTTExecutor | None = None
+self._local_stt_dispatch_coordinator: LocalSTTDispatchCoordinator | None = None
+```
+
+The lazy accessor constructs both under the existing lock:
+
+```python
+def _ensure_local_stt_dispatch_coordinator(self) -> LocalSTTDispatchCoordinator:
+    with self._local_stt_executor_lock:
+        if self._ingest_shutdown:
+            raise ExecutorUnavailableError("Local STT is shutting down")
+        if self._local_stt_executor is None:
+            self._local_stt_executor = self._create_local_stt_executor()
+        if self._local_stt_dispatch_coordinator is None:
+            self._local_stt_dispatch_coordinator = LocalSTTDispatchCoordinator(
+                self._local_stt_executor,
+                on_dictation_idle=lambda: self._marshal_local_stt_call(
+                    self._top_up_ingest_parse_pool
+                ),
+            )
+        return self._local_stt_dispatch_coordinator
+```
+
+Use the `RLock` shown above because `_ensure_local_stt_dispatch_coordinator`
+reuses `_ensure_local_stt_executor`; this preserves one lazy-construction lock
+without a second lock-held helper or a self-deadlock.
+
+- [ ] Add failing Library tests proving `_build_local_stt_dispatch` delegates its Parakeet branch to `resolve_parakeet_dispatch` while transcribe.cpp output stays unchanged.
+- [ ] Add failing dispatch tests proving every Library `executor.submit` now goes through `coordinator.submit_library(source=FileAudioSource(Path(job.source_path)))` and preserves attempt/job/result callbacks.
+- [ ] Add a top-up test where `dictation_reserved=True`: queued audio/video remains queued, a queued document still enters the parse pool, and no synthetic `ExecutorBusyError` is produced.
+- [ ] Add a terminal-order test proving a batch callback cannot top up a second heavy job before pending dictation is submitted.
+- [ ] Add an accessor concurrency/reentrancy test proving simultaneous Library/Console callers receive the same coordinator and executor and the nested executor accessor cannot self-deadlock.
+- [ ] Add shutdown tests proving `coordinator.close()` is nonblocking and
+  process-agnostic: it marks admission closed, resolves pending dictation as
+  cancelled, and cooperatively cancels an active dictation without joining or
+  closing the executor. `_shutdown_ingest_parse_pool` then detaches coordinator
+  and executor, and the existing teardown thread closes the executor/process.
+- [ ] Run `python -m pytest Tests/Library/test_library_ingest_runner.py Tests/App/test_submit_library_ingest_job.py -q` and confirm intended failures.
+- [ ] Route Library submissions through the coordinator and add `coordinator.dictation_reserved` to the existing heavy-lane fullness condition; do not change the light parse pool or Library registry ordering.
+- [ ] Merge `option_updates` from the shared Parakeet resolver into the per-job options copy; never mutate global configuration.
+- [ ] Add `_create_console_dictation_service(**kwargs)` on the app. It returns
+  `LazyLiveDictationService(**kwargs,
+  transcription_service_factory=lambda: TranscriptionService(
+  local_stt_dispatcher=self._ensure_local_stt_dispatch_coordinator()))` and
+  performs both imports inside the method so importing/mounting Console does
+  not import native STT packages.
+- [ ] Update `_shutdown_ingest_parse_pool` to set `_ingest_shutdown`, call the
+  coordinator's nonblocking `close`, detach coordinator/executor under the
+  `RLock`, and pass the executor to the existing teardown thread; do not create
+  a second shutdown thread or let the coordinator close a process it does not
+  own.
+- [ ] Re-run the two focused test files and commit: `feat(stt): share app-owned dispatch across batch and dictation`.
+
+## Task 5: Adapt the public facade and live service without blocking its processing thread
+
+**Files:**
+- Modify: `tldw_chatbook/Local_Ingestion/transcription_service.py`
+- Modify: `tldw_chatbook/Audio/dictation_service_lazy.py`
+- Modify: `tldw_chatbook/Chat/console_voice_input.py`
+- Modify: `Tests/STT/test_transcription_service_facade.py`
+- Modify: `Tests/Audio/test_dictation_lazy_transcription.py`
+- Modify: `Tests/Audio/test_dictation_segment_finalization.py`
+- Modify: `Tests/Audio/test_dictation_stop_join.py`
+- Modify: `Tests/Chat/test_console_voice_input.py`
+
+**Interfaces:**
+- Consumes: explicit app-owned coordinator dependency, historical `transcribe_buffer` signature, current Lazy service callbacks, and `ConsoleVoiceInputController` generation fencing.
+- Produces: blocking public Parakeet buffer dispatch, async live capture dispatch, truthful streaming fallback, and a bounded retry token.
+- Invariant: retained providers keep their current bridge calls and Parakeet never silently falls back to an in-process legacy model.
+
+Change only the facade constructor, not the public method signatures:
+
+```python
+class TranscriptionService:
+    def __init__(
+        self,
+        *,
+        local_stt_dispatcher: LocalSTTDispatchCoordinator | None = None,
+    ) -> None:
+        self._bridge = LegacyTranscriptionBridge(_LegacyTranscriptionBackend)
+        self._local_stt_dispatcher = local_stt_dispatcher
+
+    @property
+    def uses_deferred_local_stt_dispatch(self) -> bool:
+        return self._local_stt_dispatcher is not None
+```
+
+`transcribe_buffer` behavior:
+
+```python
+effective_provider = provider or self.config["default_provider"]
+if effective_provider == "parakeet-onnx":
+    if self._local_stt_dispatcher is None:
+        raise TranscriptionError(
+            "Parakeet ONNX buffer transcription requires the shared local executor."
+        )
+    source = BufferAudioSource(audio_data, sample_rate, channels, sample_width)
+    dispatch = resolve_parakeet_dispatch(
+        model_id=model or PARAKEET_V2_MODEL,
+        precision=str(
+            kwargs.pop(
+                "precision",
+                get_cli_setting("transcription.default_precision", "int8"),
+            )
+            or "int8"
+        ).strip().lower(),
+        model_dir=kwargs.pop("model_dir", None),
+    )
+    return self._local_stt_dispatcher.transcribe_buffer(
+        source=source,
+        dispatch=dispatch,
+        language=language or "en",
+    )
+return self._bridge.transcribe_buffer_legacy(
+    audio_data,
+    sample_rate,
+    channels,
+    sample_width,
+    provider,
+    model,
+    language,
+    **kwargs,
+)
+```
+
+The retained bridge still receives the original `provider` argument for every
+non-Parakeet call. `create_streaming_transcriber` resolves the same effective
+provider and returns `None` before consulting the retained bridge when it is
+`parakeet-onnx`.
+
+Add one internal facade method used only by the live service:
+
+```python
+def begin_dictation_capture(
+    self,
+    *,
+    capture_generation: int,
+    model: str | None,
+    language: str,
+    sample_rate: int,
+    channels: int,
+    sample_width: int,
+    on_logical_segment: Callable[[int, str], None],
+) -> DictationCaptureHandle:
+    if self._local_stt_dispatcher is None:
+        raise TranscriptionError("The shared local executor is unavailable.")
+    dispatch = resolve_parakeet_dispatch(
+        model_id=model or PARAKEET_V2_MODEL,
+        precision=str(
+            get_cli_setting("transcription.default_precision", "int8") or "int8"
+        ).strip().lower(),
+        model_dir=None,
+    )
+    return self._local_stt_dispatcher.begin_dictation(
+        capture_generation=capture_generation,
+        dispatch=dispatch,
+        sample_rate=sample_rate,
+        channels=channels,
+        sample_width=sample_width,
+        language=language,
+        on_logical_segment=on_logical_segment,
+    )
+```
+
+`resolve_parakeet_dispatch(model_dir=None)` performs the existing configured-
+directory/managed/verified-legacy lookup and validates precision as `int8` or
+`f32`. The model fallback is the approved English v2 default; the precision
+fallback is INT8 only when the first-run/config value is absent.
+
+Inject the facade lazily into `LazyLiveDictationService`:
+
+```python
+def __init__(
+    self,
+    transcription_provider: str = "auto",
+    transcription_model: str | None = None,
+    language: str = "en",
+    enable_punctuation: bool = True,
+    enable_commands: bool = True,
+    audio_backend: str | None = None,
+    max_buffer_bytes: int | None = None,
+    on_buffer_limit: Callable[[], None] | None = None,
+    transcription_service_factory: Callable[[], Any] | None = None,
+) -> None:
+    self._transcription_service_factory = transcription_service_factory
+    self._dictation_handle = None
+
+@property
+def transcription_service(self):
+    if self._transcription_service is None:
+        factory = self._transcription_service_factory or TranscriptionService
+        self._transcription_service = factory()
+    return self._transcription_service
+```
+
+For Parakeet with an injected dispatcher,
+`LazyLiveDictationService.reserve_deferred_dictation(capture_generation)`
+creates the `DictationCaptureHandle`. `ConsoleVoiceInputController._run_begin`
+calls that method immediately after service construction and before
+`_prepare_speech_model`, so the reservation exists before any Library top-up
+can race the Mic press. A true `handle.waiting_for_executor` value emits the
+approved busy event. `_prepare_speech_model` then skips the retained silence
+warm-up for this exact deferred capability; `start_dictation` installs the
+ordinary transcript callbacks and opens the recorder using the already-
+reserved handle.
+
+`_transcribe_segment_audio` emits `done=False`, calls
+`handle.append_segment(audio_data)`, and returns without waiting. The handle's
+ordered callback performs the current `_handle_partial_text` -> `done=True` ->
+`_finalize_current_segment` flow for each logical segment; blank results still
+emit `done=True` and `on_segment_no_final`. `LIMIT_REACHED` invokes the existing
+one-shot buffer-limit callback, which posts onto the Console UI thread.
+
+On stop, the processing thread only drains/seals PCM, so its existing bounded join completes quickly. The same off-UI stop worker then calls `handle.finish()` and `handle.wait()`. `abandon()` cancels the handle without joining. Do not change retained-provider synchronous segment behavior.
+
+- [ ] Update facade signature tests for a keyword-only optional dispatcher while asserting every public method signature remains unchanged.
+- [ ] Add facade tests: explicit Parakeet and omitted-provider/configured-
+  Parakeet use the coordinator and return the compatibility dictionary;
+  omitted precision uses INT8, persisted explicit F32 selects the F32 artifact,
+  and an invalid configured precision fails without loading a model;
+  missing dispatcher fails clearly; retained faster-whisper/MLX calls are
+  byte-for-byte bridge forwards; Parakeet streaming returns `None` without
+  bridge/native calls; and facade cleanup never closes the app-owned
+  coordinator.
+- [ ] Add Lazy service tests proving Parakeet creates one capture handle, segment processing returns before the fake inference is released, ordered callbacks preserve final/no-final events, and retained providers still call synchronous `transcribe_buffer` once per segment.
+- [ ] Add a stop-join regression with a 50 ms join bound and a real event-delayed batch: processing thread completes within the bound, audio remains pending, and stop finishes after batch+dictation without `transcription_complete=False`.
+- [ ] Add generation/cancellation tests proving a stale handle callback cannot mutate a later capture and abandon cancels pending/active dispatch without inserting text.
+- [ ] Add Console controller tests proving the reservation exists before the warm-up decision, deferred Parakeet skips `warm_transcription_model` entirely, opens the microphone while batch is active, and emits `VoiceLocalSTTBusy("Local transcription busy — dictation will run next.")`.
+- [ ] Add a test proving `auto`/faster-whisper retains the current warm-before-capture behavior; the skip is exact-provider/capability based, not global.
+- [ ] Run `python -m pytest Tests/STT/test_transcription_service_facade.py Tests/Audio/test_dictation_lazy_transcription.py Tests/Audio/test_dictation_segment_finalization.py Tests/Audio/test_dictation_stop_join.py Tests/Chat/test_console_voice_input.py -q` and confirm intended failures.
+- [ ] Implement explicit facade dispatch and mark the legacy Parakeet buffer branch `retained until TASK-605; unreachable from production Parakeet facade` without deleting it.
+- [ ] Implement the async handle branch as a narrow alternative inside existing segment finalization/stop paths; do not rewrite the recorder or streaming regime.
+- [ ] Add a `VoiceLocalSTTBusy` event and a retry-availability boolean on the existing sanitized `VoiceFailed`; keep native error objects out of UI events. A retryable executor failure remains on the bounded handle until stop, where `handle.wait()` raises one sanitized retryable failure through the existing blocking-call path; do not add a parallel mid-capture failure event.
+- [ ] Store any retry callable/token only on the controller/session that owns the failed capture. The token replays the failed+not-yet-run logical segments through retained faster-whisper and excludes earlier successful Parakeet segments. Clear it on later start, discard, success, decline, cancellation, and abandon.
+- [ ] In `_run_finish`, catch `RetryableDictationFailure` before the generic
+  failure branch. When `faster-whisper` is installed, store one bounded retry
+  callable on the controller, emit sanitized `VoiceFailed(retry_available=True)`,
+  and release the stopped service; otherwise clear the retry buffer and use the
+  ordinary non-retryable failure path. `ConsoleStreamingDictationSession`
+  exposes read-only `retry_available`, `retry_with_faster_whisper()`, and
+  `clear_retry()` methods instead of adding a second event/error channel.
+- [ ] Re-run the five focused test files and commit: `feat(stt): defer live Parakeet buffers to shared executor`.
+
+## Task 6: Wire Console busy, limit, retry, and explicit-resume behavior
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Console_Modules/dictation.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify: `tldw_chatbook/Widgets/Console/console_composer_bar.py`
+- Modify: `Tests/UI/test_console_dictation_streaming.py`
+- Modify: `Tests/UI/test_console_dictation.py`
+- Modify: `Tests/UI/test_console_voice_chip.py`
+- Modify: `Tests/UI/test_console_controller_wiring.py`
+- Modify: `Tests/UI/test_console_hands_free_wiring.py`
+
+**Interfaces:**
+- Consumes: app-owned service factory, `VoiceLocalSTTBusy`, sanitized retry availability, current Mic/session state machine, and existing `ConfirmationDialog`.
+- Produces: visible busy and limit copy, one explicit retry confirmation, normal caret insertion after success/retry, and no automatic capture restart.
+- Invariant: UI loop never waits on executor/native inference and no success path sends automatically.
+
+Add one optional named dependency to `ConsoleDictationController` and pass it through the existing session port:
+
+```python
+def _create_console_dictation_session(self) -> ConsoleStreamingDictationSession:
+    return ConsoleStreamingDictationSession(
+        on_event=self._emit_console_dictation_event,
+        service_factory=self._dictation_service_factory,
+        max_buffer_bytes=pcm_byte_limit(
+            sample_rate=CONSOLE_DICTATION_SAMPLE_RATE,
+            channels=CONSOLE_DICTATION_CHANNELS,
+            sample_width=CONSOLE_DICTATION_SAMPLE_WIDTH,
+        ),
+    )
+```
+
+The constructor gains the keyword-only parameter
+`dictation_service_factory: Callable[..., Any] = default_service_factory` and
+stores it as `self._dictation_service_factory`; no other constructor dependency
+changes.
+
+`wiring.py` supplies a late-binding lambda to the app-owned factory so test monkeypatches and screen replacement remain valid:
+
+```python
+dictation_service_factory=lambda **kwargs: (
+    screen.app_instance._create_console_dictation_service(**kwargs)
+),
+```
+
+Retry stays inside `_stop_console_dictation`'s existing off-loop workflow. The
+session's normal failure is still an exception; its read-only retry state tells
+the UI whether to offer the bounded replay:
+
+```python
+except Exception as exc:
+    if not session.retry_available:
+        await asyncio.to_thread(session.discard)
+        if self._console_dictation_session is session:
+            self._notify_console_dictation_error(exc)
+        return
+    confirmed = await self.run_worker(
+        self.app_instance.push_screen_wait(
+            ConfirmationDialog(
+                title="Parakeet transcription failed",
+                message="Parakeet failed. Retry this audio with faster-whisper?",
+                confirm_label="Retry",
+                cancel_label="Keep draft",
+            )
+        ),
+        exclusive=False,
+        exit_on_error=False,
+    ).wait()
+    if not confirmed:
+        await asyncio.to_thread(session.clear_retry)
+        self._finish_failed_console_dictation(session)
+        return
+    transcript = await asyncio.to_thread(session.retry_with_faster_whisper)
+```
+
+Factor the existing successful transcript insertion/idle/pending-action tail into one private helper used by both the first Parakeet success and accepted retry. Do not duplicate caret spacing, realtime adoption, undo-history invalidation, hands-free routing, or no-auto-send logic.
+`_finish_failed_console_dictation(session)` clears the owning session, origin,
+partial text, timers, and retained retry state and returns the Mic to idle; it
+does not mutate the draft. Prompt cancellation, retry failure, or unmount uses
+that same cleanup rather than leaving the Console in `transcribing`.
+
+- [ ] Add a wiring test proving production sessions receive the app-owned factory and existing tests/fakes may omit it.
+- [ ] Add a mounted Console test with active batch: Mic reaches recording, chip/status shows `Local transcription busy — dictation will run next.`, batch completes, dictation runs, transcript inserts at the captured caret, and no message is sent.
+- [ ] Add a limit test at the exact derived byte cap: all accepted PCM is transcribed, warning copy is exactly `Limit reached — press Mic to continue.`, state returns to idle, timers are cancelled, and no new session starts until a second Mic press.
+- [ ] Add a hands-free limit regression proving the loop exits without `OpenCapture`/auto-send/reopen; retained text follows the ordinary insertion path and another physical Mic press is required.
+- [ ] Add a whole-segment command test where coalesced `ordinary text` + `console stop` arrives from one executor request and still produces one `VoiceFinal` plus one `VoiceCommand`, never dictated command text.
+- [ ] Add retry tests for confirm and decline: the prompt appears only for retryable Parakeet failures when faster-whisper is installed; confirm replays exact failed/pending boundaries once then inserts normally; decline leaves the draft unchanged.
+- [ ] Add teardown tests proving prompt cancel, screen unmount, app shutdown, session discard, retry success, and retry failure each clear retained PCM and cannot insert into a newer capture generation.
+- [ ] Add a non-retryable/missing-faster-whisper test proving the bounded normalized error is shown with no confirmation and no native exception detail.
+- [ ] Run `python -m pytest Tests/UI/test_console_dictation_streaming.py Tests/UI/test_console_dictation.py Tests/UI/test_console_voice_chip.py Tests/UI/test_console_controller_wiring.py Tests/UI/test_console_hands_free_wiring.py -q` and confirm intended failures.
+- [ ] Replace the current headroom-derived byte constant with
+  `pcm_byte_limit(sample_rate=CONSOLE_DICTATION_SAMPLE_RATE,
+  channels=CONSOLE_DICTATION_CHANNELS,
+  sample_width=CONSOLE_DICTATION_SAMPLE_WIDTH)` and use
+  `DICTATION_MAX_SECONDS` for the timer; keep one source of truth.
+- [ ] Display busy through the existing composer voice chip/status functions; do not add another widget or button.
+- [ ] Change limit handling to stop/transcribe and exit any hands-free auto-reopen path. This is the smallest implementation of the approved explicit-resume rule; do not add a new paused hands-free state.
+- [ ] Use the existing `ConfirmationDialog`; do not create a retry modal or persistent retry queue.
+- [ ] Re-run the five focused UI test files and commit: `feat(console): finish bounded shared-executor dictation`.
+
+## Task 7: Focused verification, macOS evidence, and honest open gates
+
+**Files:**
+- Modify: `backlog/tasks/task-603 - Restore-bounded-Parakeet-ONNX-dictation-buffers.md`
+- Create: `Docs/STT_Evaluation/task-603/README.md`
+- Create: `Docs/STT_Evaluation/task-603/macos-evidence.json`
+- Modify only directly affected STT/Console documentation if focused verification proves copy is stale.
+
+**Interfaces:**
+- Consumes: the focused tests above, installed macOS Parakeet v2 INT8 artifact, real Console Mic path, and the task's release-gate criteria.
+- Produces: reproducible focused verification evidence, concise implementation notes, and only truthfully completed acceptance criteria.
+- Invariant: no full suite, no unrelated CI wait, no Windows/Linux claim, no TASK-605 promotion/removal.
+
+- [ ] Run the union of only the test files changed in Tasks 1–6. Use exact file paths; do not run bare `pytest`.
+- [ ] Run Ruff only on changed Python files, `python -m compileall` only on changed package modules, and `git diff --check`.
+- [ ] Run a placeholder scan on the plan and changed code for `TBD|TODO|FIXME|pass  #|NotImplemented`; distinguish pre-existing retained markers from newly introduced placeholders.
+- [ ] Run a type/contract consistency review: `ExecutorRequest.source`, optional `job_id`, segment-frame units, callback sequence IDs, retry token ownership, and shutdown order must match across parent, worker, facade, Lazy service, and UI.
+- [ ] Using the repository virtual environment's absolute Python path and an isolated profile, run a macOS CPU smoke with the real installed Parakeet v2 INT8 bundle: open Console, press Mic, dictate English, stop, and confirm insertion without send.
+- [ ] During the same smoke, start one real local Parakeet Library batch item first, press Mic while it is active, confirm the busy copy, dictate, verify batch -> dictation -> batch ordering, then hit/induce the bounded limit and confirm another Mic press is required.
+- [ ] If practical with bounded sample audio, induce one retryable Parakeet failure and confirm the faster-whisper prompt/replay. If not safely inducible without corrupting an installed artifact, record that exact limitation and rely on the focused injected-failure test rather than manufacturing a destructive live condition.
+- [ ] Record interpreter, OS/architecture, package versions, exact artifact lease/model/precision, timestamps, commands, observed UI states, and redacted outcomes in `macos-evidence.json`; validate it with `python -m json.tool`.
+- [ ] Self-review the complete diff for a second executor/model load, hidden download, PCM disk staging, unbounded references, callback-under-lock, Mic warm-up blocking, hands-free auto-reopen, native path/error leakage, accidental default promotion, and legacy deletion.
+- [ ] Request code review using `superpowers:requesting-code-review`; address only verified findings and rerun the focused tests covering each changed fix.
+- [ ] Rebase onto current `origin/dev`, resolve conflicts without discarding unrelated upstream work, and rerun only focused verification affected by the rebase.
+- [ ] Add concise Implementation Notes to TASK-603, including ADR-025, exact files/behavior, focused test commands, macOS evidence, retained legacy code, and open Windows/Linux/TASK-605 gates.
+- [ ] Check AC1–AC5 only when directly evidenced. Keep AC6 and TASK-603 status open if representative Windows/Linux release evidence remains unavailable; do not mark the task globally Done merely because the macOS implementation can merge.
+- [ ] Commit evidence/task hygiene: `docs(stt): record TASK-603 focused evidence`.
+
+## Plan self-review checklist
+
+- [x] Every approved behavior appears in at least one implementation step and one focused test: shared executor, no true streaming, one pending/coalescing, bounded overrun, dictation-next/no preemption, busy copy, exact limit copy, explicit Mic resume, faster-whisper confirmation, caret insertion, voice commands, cancellation, shutdown, and open platform gates.
+- [x] Every new type has one owner and one reason to exist:
+  `ParakeetDispatch` (artifact identity), `ParakeetBufferResult` (normalized
+  result plus logical boundaries), `LocalSTTDispatchCoordinator` (admission),
+  `DictationCaptureHandle` (one capture), `DictationAppendStatus` (typed bound
+  result), `RetryableDictationBuffer` (bounded explicit retry),
+  `RetryableDictationFailure` (sanitized ownership transfer to the blocking
+  caller), and `VoiceLocalSTTBusy` (existing Console event transport).
+- [x] No step creates a parallel queue, downloader, executor, model cache, recorder, dialog class, or persistence layer.
+- [x] File paths and test commands are exact; no `TBD`, `TODO`, ellipsis-only implementation instruction, or unspecified “add tests” remains.
+- [x] Public compatibility is explicit: only the facade constructor gains a keyword-only dependency; public method signatures remain stable; retained providers remain unchanged.
+- [x] The plan does not require a 30-second sleep, full-suite run, unrelated CI, Windows/Linux access, legacy deletion, or default promotion.

--- a/Docs/superpowers/specs/2026-08-08-task-603-bounded-parakeet-dictation-design.md
+++ b/Docs/superpowers/specs/2026-08-08-task-603-bounded-parakeet-dictation-design.md
@@ -22,7 +22,8 @@ next batch item, and then let the batch continue automatically.
 
 ## Confirmed product decisions
 
-- English remains the dictation default and routes to Parakeet v2 INT8.
+- English remains the dictation default and routes to Parakeet v2 with INT8 as
+  the default precision; an explicitly persisted F32 selection remains usable.
 - Parakeet ONNX is buffer transcription, not true streaming.
 - A Mic press reserves the next local-STT slot automatically. There is no extra
   pause prompt or separate batch-pause control.
@@ -253,6 +254,13 @@ Existing partial/final events, voice-command classification, hands-free state,
 caret insertion, draft preservation, and no-auto-send behavior remain owned by
 their current controllers.
 
+The retained silence-transcription warm-up is skipped for this deferred shared-
+executor path. Otherwise an active batch inference would block the Mic press
+before the recorder opens, contradicting the approved behavior that capture may
+continue while dictation waits for the next executor slot. Model loading occurs
+inside the reserved executor attempt and the existing preparing/busy states
+remain honest about that work.
+
 On a retryable Parakeet failure, the Console retains the exact bounded PCM and
 segment-boundary metadata long enough to offer one confirmation:
 **Parakeet failed. Retry this audio with faster-whisper?** Acceptance replays
@@ -295,6 +303,11 @@ The UI receives bounded categories, not native exception text:
 
 Failures leave the draft unchanged unless a prior, independently successful
 segment was already inserted. No error path starts a download.
+
+The explicit-resume rule also wins over the hands-free loop's historical
+limit-triggered reopen behavior: reaching the canonical capture ceiling exits
+that loop after preserving the captured transcript. It does not send or reopen
+the microphone automatically; another physical Mic press is required.
 
 ## Focused verification
 

--- a/Docs/superpowers/specs/2026-08-08-task-603-bounded-parakeet-dictation-design.md
+++ b/Docs/superpowers/specs/2026-08-08-task-603-bounded-parakeet-dictation-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-08
 
-**Status:** Approved direction; written-spec review pending
+**Status:** Approved direction; failure-oriented review corrections incorporated
 
 **Task:** TASK-603 — Restore bounded Parakeet ONNX dictation buffers
 
@@ -88,10 +88,22 @@ constructs it around the same lazily constructed `LocalSTTExecutor`. Individual
 `TranscriptionService` instances receive an explicit buffer-dispatch callable;
 they cannot create a private executor or reach the app through a module global.
 
+Parakeet model identity and artifact admission are not reimplemented in the
+coordinator. The existing Library-only identity construction is split so one
+provider-neutral Parakeet dispatch builder resolves the selected model,
+precision, configured/local/managed artifact source, snapshot, closure
+fingerprint, and lease reference. Library file requests and dictation buffer
+requests both call that builder. `transcribe-cpp` keeps its existing path.
+
 ### 2. Use the existing file-or-buffer source contract
 
 `ExecutorRequest` changes from a mandatory `source_path` to one mandatory
 `source: FileAudioSource | BufferAudioSource`.
+
+`job_id` becomes optional. Library requests continue supplying their persisted
+job ID; dictation requests supply `None` and use their capture generation plus
+attempt ID for ownership. A synthetic Library job ID must not appear in
+dictation provenance.
 
 - Library callers wrap their current path in `FileAudioSource`; their parse and
   persistence path remains unchanged.
@@ -103,6 +115,13 @@ they cannot create a private executor or reach the app through a module global.
   provider/source combinations fail with the existing typed
   `UNSUPPORTED_CAPABILITY` contract.
 
+An executor buffer request may also carry an optional, validated tuple of
+strictly increasing segment-end frame offsets. It is valid only for a
+`BufferAudioSource`; its final offset must equal the buffer's total frame
+count. No offsets means the whole buffer is one segment. This preserves the
+Console's silence-delimited logical segments while still sending one bounded
+executor request.
+
 The worker branches only at the source boundary:
 
 - file source: run the existing `parse_local_file_for_ingest` flow;
@@ -110,9 +129,20 @@ The worker branches only at the source boundary:
   the normalized transcription payload without invoking the Library parser.
 
 `ParakeetOnnxRuntime.transcribe_buffer()` converts validated interleaved PCM to
-mono float32 in memory, calls the resident model, computes duration from frame
-count, and returns the same `TranscriptionResult`/provenance shape as file
-transcription. No temporary file or second model load is permitted.
+mono float32 in memory, slices it at validated logical segment boundaries,
+recognizes those segments in order with the resident model, computes duration
+from frame count, and returns the same normalized result/provenance shape as
+file transcription. A one-shot public buffer call is one segment. A coalesced
+Console request returns ordered segment text so whole-segment voice-command
+classification remains correct. No temporary file or second model load is
+permitted.
+
+For buffers longer than 30 seconds, the runtime uses the resident managed VAD
+in memory when the artifact closure supplies it. A configured or verified
+legacy v2 bundle without VAD remains compatible for the Console's bounded
+60-second input and uses direct recognition, matching the existing public
+buffer behavior rather than turning an optional managed dependency into a new
+dictation requirement. Produced capabilities report whether VAD actually ran.
 
 The executor worker converts that normalized result into the existing bounded
 executor payload. The compatibility facade maps it to the historical public
@@ -120,10 +150,21 @@ dictionary keys while preserving normalized provenance.
 
 ### 3. One bounded dictation mailbox
 
-The coordinator exposes a dictation-specific blocking adapter to the existing
-dictation processing thread. Blocking is intentional: it happens off the
-Textual event loop and preserves the current `transcribe_buffer()` call
-contract.
+The coordinator exposes two views of the same admission path:
+
+- the public one-shot `transcribe_buffer()` compatibility call submits one
+  buffer and blocks its non-UI caller for the terminal result; and
+- live Console dictation submits through an asynchronous completion handle, so
+  its audio processing thread never sits blocked behind a long active batch.
+
+The second distinction is load-bearing. The existing live service gives its
+processing thread only 30 seconds to join on stop; blocking that thread behind
+a longer batch would trigger its documented incomplete-transcription path and
+drop audio. The processing thread instead drains captured audio into the
+mailbox and exits promptly. The Console's existing off-event-loop stop worker
+waits for the capture's ordered completion handles, with cancellation and
+force-stop available through the coordinator. The Textual event loop never
+blocks.
 
 The mailbox rules are:
 
@@ -134,21 +175,26 @@ The mailbox rules are:
    item and gates dispatch of later heavy Library jobs.
 4. Microphone frames that arrive while that item is waiting continue to
    coalesce in the dictation session's single pending PCM buffer; they do not
-   become one queued inference per frame or segment. The buffer is snapshotted
-   only when it is handed to the executor.
-5. Once a dictation inference is active, later frames coalesce into the one
-   next pending buffer. The coordinator never admits a second pending buffer.
+   become one queued inference per frame or segment. Silence finalization adds
+   a frame offset, not another request. The buffer and its ordered boundaries
+   are snapshotted only when handed to the executor.
+5. Once a dictation request is active, later frames and finalized segments
+   coalesce into the one next pending request. The coordinator never admits a
+   second pending request. Segment offsets preserve the boundary between
+   ordinary dictated text and whole-segment voice commands.
 6. Coalescing is allowed only for the same capture generation, model identity,
    sample rate, channel count, and sample width. A different capture receives a
    visible busy failure rather than having two users' audio combined.
 7. Pending PCM is memory-only and is released after success, failure,
    cancellation, or shutdown.
 
-The existing Console capture ceiling remains 60 seconds. The mailbox also
-checks explicit duration and byte ceilings so it remains bounded even when a
-caller bypasses the Console timer. Appending a frame-aligned chunk either
-retains the accepted portion or returns a typed overrun signal; it never drops
-audio without notifying the controller.
+There is one canonical Console capture ceiling: 60 seconds. Its byte ceiling is
+derived from sample rate, channel count, and sample width rather than restated
+as an independent magic number in the recorder, Console controller, and
+mailbox. The mailbox checks the duration and derived byte ceiling so it remains
+bounded even when a caller bypasses the Console timer. Appending a frame-aligned
+chunk either retains the accepted portion or returns a typed overrun signal; it
+never drops audio without notifying the controller.
 
 On overrun, the recorder is stopped, the retained PCM is sealed for
 transcription, and the Console enters its existing transcribing state with the
@@ -189,6 +235,12 @@ reservation immediately so it cannot stall later batch work.
 - A Parakeet ONNX call without an app-owned dispatcher fails clearly; it does
   not silently instantiate a model in the caller process.
 
+The optional dispatcher is an explicit constructor dependency. Direct callers
+that want Parakeet ONNX outside `TldwCli` may supply a dispatcher backed by
+their own `LocalSTTExecutor`; production app code always supplies the one
+app-owned instance. Absence is a typed unavailable error, never an implicit
+global singleton or hidden model load.
+
 `create_streaming_transcriber(provider="parakeet-onnx")` returns `None` through
 the existing fallback contract. The existing `LazyLiveDictationService` then
 uses bounded whole-segment buffer transcription, exactly as it does for every
@@ -200,6 +252,15 @@ factory. It does not replace the Mic button or fork another dictation UI.
 Existing partial/final events, voice-command classification, hands-free state,
 caret insertion, draft preservation, and no-auto-send behavior remain owned by
 their current controllers.
+
+On a retryable Parakeet failure, the Console retains the exact bounded PCM and
+segment-boundary metadata long enough to offer one confirmation:
+**Parakeet failed. Retry this audio with faster-whisper?** Acceptance replays
+the preserved segments through the retained faster-whisper buffer path and
+then follows the normal insertion/voice-command flow. Declining, cancelling,
+closing the Console, completing the retry, or app shutdown clears the retained
+audio. The retry never starts automatically and is not offered when
+faster-whisper is unavailable. Native exception text is not shown.
 
 ### 6. Cancellation, shutdown, and stale results
 
@@ -213,6 +274,11 @@ their current controllers.
 - Dictation attempts carry a capture generation as well as the executor
   generation/attempt ID. A result from a discarded capture cannot insert text
   into a later capture or keep the batch gate set.
+- Live completion handles carry monotonically increasing segment sequence
+  numbers. Results are delivered in capture order even if cancellation and
+  terminal callbacks arrive on different threads.
+- Retryable PCM retained for the faster-whisper offer is bounded by the same
+  capture limit and is cleared on every resolution and teardown path.
 - Every terminal path clears the pending buffer and reservation exactly once.
 
 ## Error and status behavior
@@ -223,8 +289,8 @@ The UI receives bounded categories, not native exception text:
 - capture bound: **Limit reached — press Mic to continue.**
 - unsupported streaming: internal `None` fallback, no false streaming claim;
 - missing/corrupt model, unavailable runtime, inference failure, or engine
-  crash: existing normalized STT failure copy plus **Retry with
-  faster-whisper** where the current action surface supports it;
+  crash: existing normalized STT failure copy followed by the explicit
+  **Retry this audio with faster-whisper?** confirmation when available;
 - cancelled capture: existing cancellation behavior, with no draft mutation.
 
 Failures leave the draft unchanged unless a prior, independently successful
@@ -237,9 +303,11 @@ Only tests covering modified functionality are in scope.
 ### Contract and worker tests
 
 - executor accepts file and bounded buffer sources and rejects invalid unions;
+- dictation requests preserve `job_id=None` in normalized provenance;
 - Library file requests retain their existing parse call shape;
 - Parakeet buffer requests stay in memory, reuse the resident model, and return
   normalized text, duration, provenance, and warnings;
+- ordered segment boundaries are validated and returned in order;
 - unsupported provider/buffer combinations fail with a typed code;
 - no facade or dictation session creates another executor/process.
 
@@ -250,6 +318,8 @@ Only tests covering modified functionality are in scope.
 - pending dictation is selected before the next heavy batch item;
 - light Library work remains dispatchable;
 - same-capture audio coalesces within byte/duration limits;
+- silence-delimited segments coalesce into one request without losing their
+  boundaries;
 - a second pending inference is never admitted;
 - overrun stops capture visibly and retains the accepted PCM;
 - cancelling before dispatch, cancelling active inference, worker failure,
@@ -257,16 +327,26 @@ Only tests covering modified functionality are in scope.
 - a stale callback cannot complete a newer capture.
 
 Latency fakes must include a real controllable delay; zero-latency fakes cannot
-prove the backpressure path.
+prove the backpressure path. One focused test sets a short join bound and holds
+an active batch behind a real event-controlled delay longer than that bound,
+proving the same failure shape without a 30-second test sleep: stop neither
+blocks the UI thread nor drops the pending audio.
 
 ### Console and compatibility tests
 
 - the mounted Console shows busy and limit states and returns to idle;
 - a successful transcript still inserts at the caret without sending;
 - pressing Mic again is required after a limit stop;
+- a coalesced whole-segment voice command is still classified as a command;
 - Parakeet streaming factory returns `None` and the buffer fallback is used;
 - public Parakeet buffer calls use the injected shared coordinator;
+- retryable Parakeet failure offers an explicit faster-whisper replay and
+  clears retained PCM after every answer/teardown path;
 - retained-provider calls remain unchanged pending TASK-605.
+
+Runtime-focused tests cover 30–60-second buffers with and without a managed VAD
+and assert that no disk staging occurs and produced capabilities report the
+actual VAD behavior.
 
 A macOS live smoke should use an isolated profile, the repository virtual
 environment's absolute Python path, a real installed Parakeet v2 INT8 bundle,

--- a/Docs/superpowers/specs/2026-08-08-task-603-bounded-parakeet-dictation-design.md
+++ b/Docs/superpowers/specs/2026-08-08-task-603-bounded-parakeet-dictation-design.md
@@ -1,0 +1,320 @@
+# TASK-603: Bounded Parakeet ONNX Dictation Design
+
+**Date:** 2026-08-08
+
+**Status:** Approved direction; written-spec review pending
+
+**Task:** TASK-603 — Restore bounded Parakeet ONNX dictation buffers
+
+**Architecture:** [ADR-025](../../../backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md)
+
+## Goal
+
+Route Parakeet ONNX microphone and public in-memory buffer transcription through
+the app's existing `LocalSTTExecutor`. Preserve the Console microphone,
+hands-free, voice-command, and caret-insertion behavior without creating a
+second native model process, staging microphone audio on disk, or claiming true
+streaming.
+
+This task also supplies the smallest scheduler needed to let interactive
+dictation wait behind the currently running batch inference, run before the
+next batch item, and then let the batch continue automatically.
+
+## Confirmed product decisions
+
+- English remains the dictation default and routes to Parakeet v2 INT8.
+- Parakeet ONNX is buffer transcription, not true streaming.
+- A Mic press reserves the next local-STT slot automatically. There is no extra
+  pause prompt or separate batch-pause control.
+- An active batch inference is never preempted.
+- While waiting, the Console shows **Local transcription busy — dictation will
+  run next.**
+- When the capture bound is reached, capture stops, every retained sample is
+  transcribed, and the Console shows **Limit reached — press Mic to continue.**
+  Recording never restarts automatically.
+- The existing Console interaction model remains intact: transcription inserts
+  into the draft and does not send automatically.
+
+## Non-goals
+
+- Do not implement token/audio streaming for Parakeet ONNX.
+- Do not change the global STT default promotion or remove retained providers;
+  those remain TASK-605 work after the release gates pass.
+- Do not add another process pool, worker process, general-purpose priority
+  queue, or persisted audio queue.
+- Do not write microphone PCM to a temporary WAV file.
+- Do not redesign the Console composer, hands-free loop, or voice commands.
+- Do not run the repository-wide test suite for this task.
+
+## Current state
+
+`LocalSTTExecutor` already owns a single spawn-context worker, one resident model
+identity, artifact leases, cancellation, generation fencing, descendant-process
+containment, and worker recycling. It deliberately accepts one request at a
+time and has no internal queue. Library Parakeet/transcribe.cpp jobs use it with
+file paths.
+
+The public `TranscriptionService.transcribe_buffer()` still sends Parakeet ONNX
+buffers to the retained in-process backend. The Console's non-streaming
+dictation regime calls this buffer API for whole speech segments. The recorder
+has a wall-clock bound and a PCM byte bound, but batch and dictation do not yet
+share admission to the executor.
+
+`BufferAudioSource` already defines the provider-neutral, bounded interleaved
+PCM contract. TASK-603 adopts that contract at the executor seam instead of
+inventing another buffer representation.
+
+## Design
+
+### 1. Keep process control and scheduling separate
+
+`LocalSTTExecutor` remains the process controller and remains queue-less. A
+small app-owned `LocalSTTDispatchCoordinator` sits immediately in front of it.
+The coordinator owns only admission state:
+
+- the active executor attempt, if any;
+- at most one pending dictation buffer;
+- whether that pending dictation has temporarily gated the next heavy Library
+  dispatch; and
+- the callback/future needed to return the result to the dictation caller.
+
+It is not a general job queue. Library jobs remain persisted and ordered by the
+existing Library ingest registry. Microphone frames remain owned by the
+dictation session. The coordinator never creates a process and never owns a
+model.
+
+Library and Console obtain the same coordinator from `TldwCli`, which lazily
+constructs it around the same lazily constructed `LocalSTTExecutor`. Individual
+`TranscriptionService` instances receive an explicit buffer-dispatch callable;
+they cannot create a private executor or reach the app through a module global.
+
+### 2. Use the existing file-or-buffer source contract
+
+`ExecutorRequest` changes from a mandatory `source_path` to one mandatory
+`source: FileAudioSource | BufferAudioSource`.
+
+- Library callers wrap their current path in `FileAudioSource`; their parse and
+  persistence path remains unchanged.
+- Dictation callers supply `BufferAudioSource` with bytes, sample rate,
+  channels, and sample width.
+- The parent validates the buffer and its size before IPC. The worker validates
+  the typed request again before native inference.
+- Only Parakeet ONNX accepts executor buffer requests in this task. Unsupported
+  provider/source combinations fail with the existing typed
+  `UNSUPPORTED_CAPABILITY` contract.
+
+The worker branches only at the source boundary:
+
+- file source: run the existing `parse_local_file_for_ingest` flow;
+- buffer source: call the already-resident Parakeet runtime directly and return
+  the normalized transcription payload without invoking the Library parser.
+
+`ParakeetOnnxRuntime.transcribe_buffer()` converts validated interleaved PCM to
+mono float32 in memory, calls the resident model, computes duration from frame
+count, and returns the same `TranscriptionResult`/provenance shape as file
+transcription. No temporary file or second model load is permitted.
+
+The executor worker converts that normalized result into the existing bounded
+executor payload. The compatibility facade maps it to the historical public
+dictionary keys while preserving normalized provenance.
+
+### 3. One bounded dictation mailbox
+
+The coordinator exposes a dictation-specific blocking adapter to the existing
+dictation processing thread. Blocking is intentional: it happens off the
+Textual event loop and preserves the current `transcribe_buffer()` call
+contract.
+
+The mailbox rules are:
+
+1. There may be one active native inference and at most one pending dictation
+   inference.
+2. If the executor is idle, a sealed dictation buffer dispatches immediately.
+3. If a batch inference is active, the dictation buffer becomes the one pending
+   item and gates dispatch of later heavy Library jobs.
+4. Microphone frames that arrive while that item is waiting continue to
+   coalesce in the dictation session's single pending PCM buffer; they do not
+   become one queued inference per frame or segment. The buffer is snapshotted
+   only when it is handed to the executor.
+5. Once a dictation inference is active, later frames coalesce into the one
+   next pending buffer. The coordinator never admits a second pending buffer.
+6. Coalescing is allowed only for the same capture generation, model identity,
+   sample rate, channel count, and sample width. A different capture receives a
+   visible busy failure rather than having two users' audio combined.
+7. Pending PCM is memory-only and is released after success, failure,
+   cancellation, or shutdown.
+
+The existing Console capture ceiling remains 60 seconds. The mailbox also
+checks explicit duration and byte ceilings so it remains bounded even when a
+caller bypasses the Console timer. Appending a frame-aligned chunk either
+retains the accepted portion or returns a typed overrun signal; it never drops
+audio without notifying the controller.
+
+On overrun, the recorder is stopped, the retained PCM is sealed for
+transcription, and the Console enters its existing transcribing state with the
+approved limit message. After the transcript is inserted, the control returns
+to idle. Only another Mic press starts a new capture.
+
+### 4. Dictation gets the next slot, not the current slot
+
+Starting dictation sets a coordinator reservation before capture can submit a
+buffer. `_top_up_ingest_parse_pool()` continues dispatching light work, but it
+skips new local-STT heavy jobs while a dictation reservation or pending buffer
+exists.
+
+If a heavy batch inference is already active:
+
+1. it continues to completion, failure, or cancellation;
+2. the Console reports that local transcription is busy;
+3. its terminal callback asks the coordinator to dispatch pending dictation
+   before calling the normal heavy-lane top-up; and
+4. after dictation reaches a terminal result, the coordinator clears the gate
+   and invokes the existing Library top-up.
+
+This ordering is explicit and deterministic. It does not poll `executor.busy`,
+retry on a timer, preempt a worker, or race two direct `submit()` calls.
+
+Starting and cancelling capture before any PCM is pending clears the
+reservation immediately so it cannot stall later batch work.
+
+### 5. Preserve the public and Console compatibility surfaces
+
+`TranscriptionService.transcribe_buffer()` keeps its public signature.
+
+- `provider="parakeet-onnx"` uses the injected app-owned dispatcher and returns
+  the compatibility dictionary built from the normalized executor result.
+- Retained providers continue through `LegacyTranscriptionBridge` until
+  TASK-605. Their code is left in place and marked as retained/dead-after-gate,
+  not deleted here.
+- A Parakeet ONNX call without an app-owned dispatcher fails clearly; it does
+  not silently instantiate a model in the caller process.
+
+`create_streaming_transcriber(provider="parakeet-onnx")` returns `None` through
+the existing fallback contract. The existing `LazyLiveDictationService` then
+uses bounded whole-segment buffer transcription, exactly as it does for every
+other non-streaming provider. No Parakeet object advertises `process_audio()` or
+another streaming API.
+
+Console wiring injects the app-owned dispatch adapter into the existing service
+factory. It does not replace the Mic button or fork another dictation UI.
+Existing partial/final events, voice-command classification, hands-free state,
+caret insertion, draft preservation, and no-auto-send behavior remain owned by
+their current controllers.
+
+### 6. Cancellation, shutdown, and stale results
+
+- Cancelling a pending dictation removes it, clears the Library gate, wakes its
+  waiting caller with `CANCELLED`, and resumes heavy dispatch.
+- Cancelling an active dictation uses the executor's exact attempt-id
+  cancellation path. Force-stop remains the existing explicit escalation.
+- App shutdown first rejects new coordinator submissions, then resolves any
+  pending dictation as cancelled, then closes the shared executor through the
+  existing shutdown path.
+- Dictation attempts carry a capture generation as well as the executor
+  generation/attempt ID. A result from a discarded capture cannot insert text
+  into a later capture or keep the batch gate set.
+- Every terminal path clears the pending buffer and reservation exactly once.
+
+## Error and status behavior
+
+The UI receives bounded categories, not native exception text:
+
+- active batch: **Local transcription busy — dictation will run next.**
+- capture bound: **Limit reached — press Mic to continue.**
+- unsupported streaming: internal `None` fallback, no false streaming claim;
+- missing/corrupt model, unavailable runtime, inference failure, or engine
+  crash: existing normalized STT failure copy plus **Retry with
+  faster-whisper** where the current action surface supports it;
+- cancelled capture: existing cancellation behavior, with no draft mutation.
+
+Failures leave the draft unchanged unless a prior, independently successful
+segment was already inserted. No error path starts a download.
+
+## Focused verification
+
+Only tests covering modified functionality are in scope.
+
+### Contract and worker tests
+
+- executor accepts file and bounded buffer sources and rejects invalid unions;
+- Library file requests retain their existing parse call shape;
+- Parakeet buffer requests stay in memory, reuse the resident model, and return
+  normalized text, duration, provenance, and warnings;
+- unsupported provider/buffer combinations fail with a typed code;
+- no facade or dictation session creates another executor/process.
+
+### Coordinator tests
+
+- idle dictation dispatches immediately;
+- an active batch is not preempted;
+- pending dictation is selected before the next heavy batch item;
+- light Library work remains dispatchable;
+- same-capture audio coalesces within byte/duration limits;
+- a second pending inference is never admitted;
+- overrun stops capture visibly and retains the accepted PCM;
+- cancelling before dispatch, cancelling active inference, worker failure,
+  force-stop, and shutdown each clear the gate once;
+- a stale callback cannot complete a newer capture.
+
+Latency fakes must include a real controllable delay; zero-latency fakes cannot
+prove the backpressure path.
+
+### Console and compatibility tests
+
+- the mounted Console shows busy and limit states and returns to idle;
+- a successful transcript still inserts at the caret without sending;
+- pressing Mic again is required after a limit stop;
+- Parakeet streaming factory returns `None` and the buffer fallback is used;
+- public Parakeet buffer calls use the injected shared coordinator;
+- retained-provider calls remain unchanged pending TASK-605.
+
+A macOS live smoke should use an isolated profile, the repository virtual
+environment's absolute Python path, a real installed Parakeet v2 INT8 bundle,
+and the real Console Mic affordance. Windows and Linux evidence remains an
+explicit release gate because those platforms are unavailable for immediate
+testing; their absence does not authorize legacy removal or default promotion.
+
+## Rollout and completion boundary
+
+This implementation may merge with focused tests and macOS evidence while the
+TASK-603/TASK-605 cross-platform release gate remains visibly open. It must not:
+
+- mark Windows/Linux parity as verified without evidence;
+- promote Parakeet ONNX as the global default;
+- delete the retained Parakeet/MLX paths; or
+- weaken the TASK-605 removal gate.
+
+## Alternatives rejected
+
+### Put a priority queue inside `LocalSTTExecutor`
+
+Rejected because it couples UI admission policy to process containment and
+turns a currently simple single-slot executor into a general scheduler.
+
+### Stage PCM as a temporary WAV
+
+Rejected because the existing buffer contract is explicitly memory-only for
+dictation and the resident Parakeet model already accepts NumPy audio.
+
+### Build a second dictation-specific executor
+
+Rejected because it can load a second multi-gigabyte model, violates ADR-025,
+and recreates the lifecycle problem the shared executor was built to solve.
+
+### Replace the current Console dictation UI with the old one-shot session
+
+Rejected because the current Console already owns microphone state, voice
+commands, hands-free behavior, generation fencing, and insertion semantics.
+The task should replace the execution seam, not regress those user-visible
+features.
+
+## ADR check
+
+**ADR required:** no new ADR
+
+**ADR path:** `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`
+
+**Reason:** ADR-025 already decides the shared executor boundary, bounded
+in-memory dictation, no true streaming, dictation-next priority, non-preemption,
+and release gates. This design implements that existing decision without
+changing its architecture.

--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -26,6 +29,87 @@ def _minimal_app(media_db: Any = None) -> TldwCli:
     app.media_db = media_db
     app._top_up_ingest_parse_pool = lambda: None  # type: ignore[method-assign]
     return app
+
+
+def _minimal_stt_app() -> TldwCli:
+    app = object.__new__(TldwCli)
+    app._ingest_shutdown = False
+    app._local_stt_executor_lock = threading.RLock()
+    app._local_stt_executor = None
+    app._local_stt_dispatch_coordinator = None
+    app._marshal_local_stt_call = lambda callback: callback()  # type: ignore[method-assign]
+    app._top_up_ingest_parse_pool = lambda: None  # type: ignore[method-assign]
+    return app
+
+
+def test_local_stt_accessors_share_one_executor_and_coordinator_without_deadlock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _minimal_stt_app()
+    created: list[object] = []
+
+    def create_executor() -> object:
+        executor = object()
+        created.append(executor)
+        return executor
+
+    monkeypatch.setattr(app, "_create_local_stt_executor", create_executor)
+    barrier = threading.Barrier(8)
+
+    def resolve(index: int) -> tuple[object, object]:
+        barrier.wait(timeout=2.0)
+        if index % 2:
+            coordinator = app._ensure_local_stt_dispatch_coordinator()
+            executor = app._ensure_local_stt_executor()
+        else:
+            executor = app._ensure_local_stt_executor()
+            coordinator = app._ensure_local_stt_dispatch_coordinator()
+        return executor, coordinator
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(resolve, index) for index in range(8)]
+        resolved = [future.result(timeout=2.0) for future in futures]
+
+    executors = {id(executor) for executor, _coordinator in resolved}
+    coordinators = {id(coordinator) for _executor, coordinator in resolved}
+    assert len(created) == 1
+    assert len(executors) == 1
+    assert len(coordinators) == 1
+    assert resolved[0][1]._executor is resolved[0][0]
+
+
+def test_console_dictation_factory_injects_app_owned_coordinator() -> None:
+    app = _minimal_stt_app()
+    coordinator = object()
+    app._ensure_local_stt_dispatch_coordinator = lambda: coordinator  # type: ignore[method-assign]
+
+    class _FakeTranscriptionService:
+        def __init__(self, *, local_stt_dispatcher: object) -> None:
+            self.local_stt_dispatcher = local_stt_dispatcher
+
+    class _FakeLazyService:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    with (
+        patch(
+            "tldw_chatbook.Audio.dictation_service_lazy.LazyLiveDictationService",
+            _FakeLazyService,
+        ),
+        patch(
+            "tldw_chatbook.Local_Ingestion.transcription_service.TranscriptionService",
+            _FakeTranscriptionService,
+        ),
+    ):
+        service = app._create_console_dictation_service(
+            transcription_provider="parakeet-onnx",
+            language="en",
+        )
+
+    assert service.kwargs["transcription_provider"] == "parakeet-onnx"
+    assert service.kwargs["language"] == "en"
+    transcription = service.kwargs["transcription_service_factory"]()
+    assert transcription.local_stt_dispatcher is coordinator
 
 
 def _make_job(

--- a/Tests/Audio/test_dictation_lazy_transcription.py
+++ b/Tests/Audio/test_dictation_lazy_transcription.py
@@ -105,6 +105,49 @@ class _FakeRecorder:
         self.callback(chunk)
 
 
+class _DeferredHandle:
+    """Asynchronous capture handle whose inference completion is test-driven."""
+
+    def __init__(
+        self, *, waiting: bool = False, append_status: str = "accepted"
+    ) -> None:
+        self.waiting_for_executor = waiting
+        self.append_status = append_status
+        self.appended: List[bytes] = []
+        self.finished = False
+        self.cancelled = False
+        self.wait_entered = threading.Event()
+        self.release = threading.Event()
+
+    def append_segment(self, audio: bytes) -> str:
+        self.appended.append(audio)
+        return self.append_status
+
+    def finish(self) -> None:
+        self.finished = True
+
+    def wait(self) -> None:
+        self.wait_entered.set()
+        self.release.wait(timeout=5)
+
+    def cancel(self, *, force: bool = False) -> bool:
+        self.cancelled = True
+        return True
+
+
+class _DeferredTranscriptionService(_FakeTranscriptionService):
+    uses_deferred_local_stt_dispatch = True
+
+    def __init__(self, handles: Optional[List[_DeferredHandle]] = None) -> None:
+        super().__init__()
+        self.handles = list(handles or [_DeferredHandle()])
+        self.capture_calls: List[Dict[str, Any]] = []
+
+    def begin_dictation_capture(self, **kwargs: Any) -> _DeferredHandle:
+        self.capture_calls.append(kwargs)
+        return self.handles[len(self.capture_calls) - 1]
+
+
 # --------------------------------------------------------------------------
 # Helpers
 # --------------------------------------------------------------------------
@@ -188,6 +231,144 @@ def _attach(service, sink: _Sink) -> None:
     service.on_partial_transcript = sink.partial
     service.on_final_transcript = sink.final
     service.on_error = sink.error
+
+
+# --------------------------------------------------------------------------
+# Shared-executor deferred Parakeet capture
+# --------------------------------------------------------------------------
+
+
+def test_transcription_factory_is_lazy_and_one_handle_is_reserved_per_capture(
+    monkeypatch,
+):
+    _stub_settings(monkeypatch)
+    from tldw_chatbook.Audio.dictation_service_lazy import LazyLiveDictationService
+
+    transcription = _DeferredTranscriptionService()
+    factory_calls: List[str] = []
+    service = LazyLiveDictationService(
+        transcription_provider="parakeet-onnx",
+        transcription_model=None,
+        language="en",
+        transcription_service_factory=lambda: (
+            factory_calls.append("built") or transcription
+        ),
+    )
+
+    assert factory_calls == []
+    first = service.reserve_deferred_dictation(9)
+    second = service.reserve_deferred_dictation(9)
+
+    assert first is second is transcription.handles[0]
+    assert factory_calls == ["built"]
+    assert len(transcription.capture_calls) == 1
+    assert transcription.capture_calls[0]["capture_generation"] == 9
+
+
+def test_deferred_segment_append_returns_without_waiting_for_inference(monkeypatch):
+    handle = _DeferredHandle()
+    transcription = _DeferredTranscriptionService([handle])
+    service = _build_service(
+        monkeypatch,
+        transcription,
+        provider="parakeet-onnx",
+        model=None,
+    )
+    service.reserve_deferred_dictation(3)
+    returned = threading.Event()
+
+    thread = threading.Thread(
+        target=lambda: (
+            service._transcribe_segment_audio([b"\x00\x01" * 16]),
+            returned.set(),
+        ),
+        daemon=True,
+    )
+    thread.start()
+
+    assert returned.wait(timeout=0.05), (
+        "segment processing waited for native inference instead of appending"
+    )
+    assert handle.appended == [b"\x00\x01" * 16]
+    assert handle.wait_entered.is_set() is False
+
+
+def test_deferred_ordered_callbacks_preserve_final_and_no_final_events(monkeypatch):
+    handle = _DeferredHandle()
+    transcription = _DeferredTranscriptionService([handle])
+    service = _build_service(
+        monkeypatch,
+        transcription,
+        provider="parakeet-onnx",
+        model=None,
+    )
+    sink = _Sink()
+    transcribing: List[bool] = []
+    no_final: List[str] = []
+    _attach(service, sink)
+    service.on_segment_transcribing = transcribing.append
+    service.on_segment_no_final = lambda: no_final.append("blank")
+    service.reserve_deferred_dictation(4)
+
+    service._transcribe_segment_audio([b"\x01\x00"])
+    service._transcribe_segment_audio([b"\x02\x00"])
+    callback = transcription.capture_calls[0]["on_logical_segment"]
+    callback(0, "first segment")
+    callback(1, "   ")
+
+    assert sink.partials == ["first segment"]
+    assert sink.finals == ["first segment"]
+    assert transcribing == [False, False, True, True]
+    assert no_final == ["blank"]
+
+
+def test_abandon_cancels_deferred_capture_and_stale_callback_is_fenced(
+    monkeypatch,
+):
+    first = _DeferredHandle()
+    second = _DeferredHandle()
+    transcription = _DeferredTranscriptionService([first, second])
+    recorder = _FakeRecorder()
+    service = _build_service(
+        monkeypatch,
+        transcription,
+        recorder,
+        provider="parakeet-onnx",
+        model=None,
+    )
+    sink = _Sink()
+    _attach(service, sink)
+
+    service.reserve_deferred_dictation(1)
+    stale_callback = transcription.capture_calls[0]["on_logical_segment"]
+    service.abandon()
+    service.reserve_deferred_dictation(2)
+    stale_callback(0, "stale text")
+
+    assert first.cancelled is True
+    assert first.wait_entered.is_set() is False
+    assert sink.partials == []
+    assert sink.finals == []
+    assert service.current_transcript == ""
+
+
+def test_deferred_limit_uses_the_existing_one_shot_buffer_callback(monkeypatch):
+    handle = _DeferredHandle(append_status="limit_reached")
+    transcription = _DeferredTranscriptionService([handle])
+    limits: List[str] = []
+    service = _build_service(
+        monkeypatch,
+        transcription,
+        provider="parakeet-onnx",
+        model=None,
+    )
+    service.on_buffer_limit = lambda: limits.append("limit")
+    service.reserve_deferred_dictation(5)
+
+    service._transcribe_segment_audio([b"\x01\x00"])
+    service._transcribe_segment_audio([b"\x02\x00"])
+
+    assert limits == ["limit"]
 
 
 # --------------------------------------------------------------------------
@@ -414,9 +595,7 @@ def test_parakeet_mlx_streams_finals_without_double_firing_and_drains_the_tail(
     whatever is left through that same `_process_audio_buffer` call the
     cadence uses, not a separate buffer-API mechanism.
     """
-    streaming = _FakeStreamingTranscriber(
-        results=[{"text": "hello", "partial": True}]
-    )
+    streaming = _FakeStreamingTranscriber(results=[{"text": "hello", "partial": True}])
     transcription = _FakeTranscriptionService(streaming_transcriber=streaming)
     recorder = _FakeRecorder()
     service = _build_service(
@@ -459,8 +638,7 @@ def test_parakeet_mlx_streams_finals_without_double_firing_and_drains_the_tail(
         time.sleep(0.01)
     assert sink.finals == ["hello"]
     assert transcription.buffer_calls == [], (
-        "the silence gate double-fired a buffer transcription in the "
-        "streaming regime"
+        "the silence gate double-fired a buffer transcription in the streaming regime"
     )
 
     service.stop_dictation()

--- a/Tests/Audio/test_dictation_lazy_transcription.py
+++ b/Tests/Audio/test_dictation_lazy_transcription.py
@@ -303,11 +303,21 @@ def test_deferred_ordered_callbacks_preserve_final_and_no_final_events(monkeypat
         model=None,
     )
     sink = _Sink()
-    transcribing: List[bool] = []
-    no_final: List[str] = []
-    _attach(service, sink)
-    service.on_segment_transcribing = transcribing.append
-    service.on_segment_no_final = lambda: no_final.append("blank")
+    events: List[tuple[str, object]] = []
+
+    def _partial(text: str) -> None:
+        sink.partial(text)
+        events.append(("partial", text))
+
+    def _final(text: str) -> None:
+        sink.final(text)
+        events.append(("final", text))
+
+    service.on_partial_transcript = _partial
+    service.on_final_transcript = _final
+    service.on_error = sink.error
+    service.on_segment_transcribing = lambda done: events.append(("done", done))
+    service.on_segment_no_final = lambda: events.append(("no-final", None))
     service.reserve_deferred_dictation(4)
 
     service._transcribe_segment_audio([b"\x01\x00"])
@@ -318,8 +328,15 @@ def test_deferred_ordered_callbacks_preserve_final_and_no_final_events(monkeypat
 
     assert sink.partials == ["first segment"]
     assert sink.finals == ["first segment"]
-    assert transcribing == [False, False, True, True]
-    assert no_final == ["blank"]
+    assert events == [
+        ("done", False),
+        ("done", False),
+        ("partial", "first segment"),
+        ("done", True),
+        ("final", "first segment"),
+        ("done", True),
+        ("no-final", None),
+    ]
 
 
 def test_abandon_cancels_deferred_capture_and_stale_callback_is_fenced(

--- a/Tests/Audio/test_dictation_stop_join.py
+++ b/Tests/Audio/test_dictation_stop_join.py
@@ -113,7 +113,8 @@ class _FakeRecorder:
 
     def feed(self, chunk: bytes) -> None:
         assert self.callback is not None, "recording was never started"
-        self.callback(chunk)
+        if self.is_recording:
+            self.callback(chunk)
 
 
 class _BatchDelayedHandle:
@@ -282,7 +283,10 @@ def test_deferred_stop_joins_only_the_processing_thread_then_waits_off_loop(
     assert handle.wait_entered.wait(timeout=1), "stop never reached deferred wait"
     assert service.processing_thread is not None
     assert service.processing_thread.is_alive() is False
+    assert recorder.is_recording is False
     assert handle.appended == [audio]
+    recorder.feed(b"\x02\x03" * 80)
+    assert service.captured_bytes == len(audio)
     assert stop_thread.is_alive() is True
     assert "result" not in result_box
 
@@ -293,6 +297,7 @@ def test_deferred_stop_joins_only_the_processing_thread_then_waits_off_loop(
     result = result_box["result"]
     assert result.transcription_complete is True
     assert result.transcript == "delayed dictation"
+    assert result.captured_bytes == len(audio)
 
 
 @pytest.mark.parametrize(

--- a/Tests/Audio/test_dictation_stop_join.py
+++ b/Tests/Audio/test_dictation_stop_join.py
@@ -116,6 +116,49 @@ class _FakeRecorder:
         self.callback(chunk)
 
 
+class _BatchDelayedHandle:
+    """Models dictation waiting behind an event-controlled active batch."""
+
+    waiting_for_executor = True
+
+    def __init__(self, batch_release: threading.Event) -> None:
+        self._batch_release = batch_release
+        self.appended: List[bytes] = []
+        self.finished = False
+        self.wait_entered = threading.Event()
+        self.callback: Optional[Callable[[int, str], None]] = None
+
+    def append_segment(self, audio: bytes) -> str:
+        self.appended.append(audio)
+        return "accepted"
+
+    def finish(self) -> None:
+        self.finished = True
+
+    def wait(self) -> None:
+        self.wait_entered.set()
+        assert self._batch_release.wait(timeout=5), "batch was never released"
+        assert self.callback is not None
+        self.callback(0, "delayed dictation")
+
+    def cancel(self, *, force: bool = False) -> bool:
+        return True
+
+
+class _DeferredFacade:
+    uses_deferred_local_stt_dispatch = True
+
+    def __init__(self, handle: _BatchDelayedHandle) -> None:
+        self.handle = handle
+
+    def begin_dictation_capture(self, **kwargs: Any) -> _BatchDelayedHandle:
+        self.handle.callback = kwargs["on_logical_segment"]
+        return self.handle
+
+    def create_streaming_transcriber(self, **kwargs: Any) -> None:
+        return None
+
+
 # --------------------------------------------------------------------------
 # Helpers
 # --------------------------------------------------------------------------
@@ -179,7 +222,9 @@ def test_join_timeout_defaults_to_the_class_default(monkeypatch):
     """No config key set: the default must be a real transcription budget."""
     from tldw_chatbook.Audio.dictation_service_lazy import LazyLiveDictationService
 
-    service = _build_service(monkeypatch, _InstantTranscriptionService(), _FakeRecorder())
+    service = _build_service(
+        monkeypatch, _InstantTranscriptionService(), _FakeRecorder()
+    )
 
     assert (
         service.stop_join_timeout_seconds
@@ -198,6 +243,56 @@ def test_join_timeout_is_read_from_config(monkeypatch):
     )
 
     assert service.stop_join_timeout_seconds == 7.5
+
+
+def test_deferred_stop_joins_only_the_processing_thread_then_waits_off_loop(
+    monkeypatch,
+):
+    """The 50ms processing join must not include queued/native inference."""
+    _stub_settings(
+        monkeypatch,
+        **{"dictation.stop_join_timeout_seconds": 0.05},
+    )
+    from tldw_chatbook.Audio.dictation_service_lazy import LazyLiveDictationService
+
+    batch_release = threading.Event()
+    handle = _BatchDelayedHandle(batch_release)
+    facade = _DeferredFacade(handle)
+    recorder = _FakeRecorder()
+    service = LazyLiveDictationService(
+        transcription_provider="parakeet-onnx",
+        transcription_model=None,
+        language="en",
+        enable_commands=False,
+        transcription_service_factory=lambda: facade,
+    )
+    service._audio_service = recorder
+    service.reserve_deferred_dictation(11)
+    _start(service)
+    audio = b"\x00\x01" * 320
+    recorder.feed(audio)
+    result_box: Dict[str, Any] = {}
+
+    stop_thread = threading.Thread(
+        target=lambda: result_box.setdefault("result", service.stop_dictation()),
+        daemon=True,
+    )
+    stop_thread.start()
+
+    assert handle.wait_entered.wait(timeout=1), "stop never reached deferred wait"
+    assert service.processing_thread is not None
+    assert service.processing_thread.is_alive() is False
+    assert handle.appended == [audio]
+    assert stop_thread.is_alive() is True
+    assert "result" not in result_box
+
+    batch_release.set()
+    stop_thread.join(timeout=1)
+
+    assert stop_thread.is_alive() is False
+    result = result_box["result"]
+    assert result.transcription_complete is True
+    assert result.transcript == "delayed dictation"
 
 
 @pytest.mark.parametrize(

--- a/Tests/Chat/test_console_voice_input.py
+++ b/Tests/Chat/test_console_voice_input.py
@@ -141,6 +141,7 @@ def test_capture_available_true_with_only_one_backend_installed(monkeypatch):
     deliberately left unresolved so this still proves any(), not all(), over
     `CAPTURE_MODULES` specifically.
     """
+
     def fake_find_spec(name, *args, **kwargs):
         return object() if name in {"sounddevice", "numpy"} else None
 
@@ -156,7 +157,9 @@ def test_capture_available_false_with_no_backend_installed(monkeypatch):
     assert cvi.capture_available() is False
 
 
-def test_capture_available_false_when_numpy_missing_even_with_backend_present(monkeypatch):
+def test_capture_available_false_when_numpy_missing_even_with_backend_present(
+    monkeypatch,
+):
     """A resolvable capture backend is not enough on its own.
 
     `AudioRecordingService.__init__` raises `AudioRecordingError` when NumPy
@@ -164,6 +167,7 @@ def test_capture_available_false_when_numpy_missing_even_with_backend_present(mo
     was chosen. Without this check, `probe()` would report OK and the Mic
     button would light up for a start that deterministically fails.
     """
+
     def fake_find_spec(name, *args, **kwargs):
         return object() if name == "pyaudio" else None  # numpy stays unresolved
 
@@ -179,6 +183,7 @@ def test_capture_available_true_when_backend_and_numpy_both_present(monkeypatch)
     "sounddevice", stays unresolved), proving both are genuinely consulted
     rather than the fake happening to resolve everything.
     """
+
     def fake_find_spec(name, *args, **kwargs):
         return object() if name in {"pyaudio", "numpy"} else None
 
@@ -193,6 +198,7 @@ def test_probe_reports_missing_capture_when_numpy_missing(monkeypatch):
     underlying failure (`AudioRecordingService` refuses to construct) is
     identical either way.
     """
+
     def fake_find_spec(name, *args, **kwargs):
         return object() if name == "sounddevice" else None  # numpy stays unresolved
 
@@ -231,6 +237,7 @@ def test_installed_local_providers_includes_parakeet_onnx_when_present(monkeypat
     """parakeet-onnx is the provider the shipping one-shot dictation used --
     the worst omission this task fixes. Cross-platform: no darwin gate.
     """
+
     def fake_find_spec(name, *args, **kwargs):
         return object() if name == "onnx_asr" else None
 
@@ -257,6 +264,7 @@ def test_installed_local_providers_detects_cross_platform_providers(
     monkeypatch, provider, module_name
 ):
     """Providers with no darwin gate are detected purely by find_spec."""
+
     def fake_find_spec(name, *args, **kwargs):
         return object() if name == module_name else None
 
@@ -267,6 +275,7 @@ def test_installed_local_providers_detects_cross_platform_providers(
 
 def test_parakeet_and_canary_both_come_from_nemo(monkeypatch):
     """A single NeMo install makes both NeMo-backed providers available."""
+
     def fake_find_spec(name, *args, **kwargs):
         return object() if name == "nemo" else None
 
@@ -287,8 +296,11 @@ def test_qwen2audio_requires_both_torch_and_transformers(monkeypatch):
 
 
 @pytest.mark.parametrize("present_module", ["torch", "transformers"])
-def test_qwen2audio_unavailable_with_only_one_of_two_modules(monkeypatch, present_module):
+def test_qwen2audio_unavailable_with_only_one_of_two_modules(
+    monkeypatch, present_module
+):
     """Present with only one of the two required modules -> not available."""
+
     def fake_find_spec(name, *args, **kwargs):
         return object() if name == present_module else None
 
@@ -299,7 +311,10 @@ def test_qwen2audio_unavailable_with_only_one_of_two_modules(monkeypatch, presen
 
 @pytest.mark.parametrize(
     ("provider", "module_name"),
-    [("parakeet-mlx", "parakeet_mlx"), ("lightning-whisper-mlx", "lightning_whisper_mlx")],
+    [
+        ("parakeet-mlx", "parakeet_mlx"),
+        ("lightning-whisper-mlx", "lightning_whisper_mlx"),
+    ],
 )
 def test_mlx_providers_require_darwin_even_if_module_resolves(
     monkeypatch, provider, module_name
@@ -309,7 +324,9 @@ def test_mlx_providers_require_darwin_even_if_module_resolves(
     capture time.
     """
     monkeypatch.setattr(
-        cvi.importlib.util, "find_spec", lambda name, *a, **k: object() if name == module_name else None
+        cvi.importlib.util,
+        "find_spec",
+        lambda name, *a, **k: object() if name == module_name else None,
     )
     monkeypatch.setattr(cvi.sys, "platform", "linux")
 
@@ -318,13 +335,18 @@ def test_mlx_providers_require_darwin_even_if_module_resolves(
 
 @pytest.mark.parametrize(
     ("provider", "module_name"),
-    [("parakeet-mlx", "parakeet_mlx"), ("lightning-whisper-mlx", "lightning_whisper_mlx")],
+    [
+        ("parakeet-mlx", "parakeet_mlx"),
+        ("lightning-whisper-mlx", "lightning_whisper_mlx"),
+    ],
 )
 def test_mlx_providers_available_on_darwin_when_module_resolves(
     monkeypatch, provider, module_name
 ):
     monkeypatch.setattr(
-        cvi.importlib.util, "find_spec", lambda name, *a, **k: object() if name == module_name else None
+        cvi.importlib.util,
+        "find_spec",
+        lambda name, *a, **k: object() if name == module_name else None,
     )
     monkeypatch.setattr(cvi.sys, "platform", "darwin")
 
@@ -349,6 +371,7 @@ def test_module_installed_returns_false_when_find_spec_raises(monkeypatch, exc):
     `find_spec`; `_module_installed` must swallow that and report False
     instead of propagating.
     """
+
     def fake_find_spec(name, *args, **kwargs):
         raise exc("broken namespace package")
 
@@ -418,7 +441,9 @@ def test_resolve_flags_override_instead_of_swapping_silently(monkeypatch):
 def test_resolve_never_returns_an_uninstalled_provider(monkeypatch):
     """This is the guard against the service's parakeet-mlx rewrite."""
     monkeypatch.setattr(cvi, "installed_local_providers", lambda: ("faster-whisper",))
-    _stub_settings(monkeypatch, {"transcription.default_provider": "lightning-whisper-mlx"})
+    _stub_settings(
+        monkeypatch, {"transcription.default_provider": "lightning-whisper-mlx"}
+    )
 
     effective = cvi.resolve()
 
@@ -507,9 +532,7 @@ def test_resolve_falls_back_to_stt_settings_section_name(monkeypatch):
     monkeypatch.setattr(
         cvi, "installed_local_providers", lambda: ("parakeet-mlx", "faster-whisper")
     )
-    _stub_settings(
-        monkeypatch, {"STT_settings.default_stt_provider": "faster-whisper"}
-    )
+    _stub_settings(monkeypatch, {"STT_settings.default_stt_provider": "faster-whisper"})
 
     effective = cvi.resolve()
 
@@ -811,12 +834,8 @@ def test_model_default_is_not_announced_for_a_non_fast_provider(monkeypatch):
     """Only the `DICTATION_FAST_MODEL_PROVIDER` branch can displace anything;
     every other provider keeps reading `transcription.default_model` as-is.
     """
-    controller, events, _ = _controller(
-        monkeypatch, spawn=lambda thunk: thunk()
-    )
-    monkeypatch.setattr(
-        cvi, "installed_local_providers", lambda: ("parakeet-mlx",)
-    )
+    controller, events, _ = _controller(monkeypatch, spawn=lambda thunk: thunk())
+    monkeypatch.setattr(cvi, "installed_local_providers", lambda: ("parakeet-mlx",))
     _stub_settings(
         monkeypatch,
         {
@@ -930,7 +949,9 @@ def test_fail_emits_voicefailed_before_voicestatechanged_idle(monkeypatch):
 
     controller.start()
 
-    failed_index = next(i for i, e in enumerate(events) if isinstance(e, cvi.VoiceFailed))
+    failed_index = next(
+        i for i, e in enumerate(events) if isinstance(e, cvi.VoiceFailed)
+    )
     idle_index = next(
         i
         for i, e in enumerate(events)
@@ -980,7 +1001,9 @@ def test_abandon_mid_preparing_releases_service_built_after_abandon(monkeypatch)
     audio = FakeAudioService()
     service = FakeDictationService()
     service._audio_service = audio
-    controller, events, _ = _controller(monkeypatch, service=service, spawn=pending.append)
+    controller, events, _ = _controller(
+        monkeypatch, service=service, spawn=pending.append
+    )
 
     controller.start()
     assert controller.state == cvi.STATE_PREPARING
@@ -1092,7 +1115,9 @@ def test_probe_failure_does_not_cascade_into_a_second_voicefailed(monkeypatch):
     assert failures[0].reason == cvi.CAPTURE_REASON
 
 
-def test_fail_emits_voicefailed_before_voicestatechanged_idle_after_restructure(monkeypatch):
+def test_fail_emits_voicefailed_before_voicestatechanged_idle_after_restructure(
+    monkeypatch,
+):
     """Re-confirms the Finding 2 invariant survives the try/except
     restructuring done for NEW BREAKAGE 1: state mutated first, then
     VoiceFailed, then VoiceStateChanged(idle)."""
@@ -1102,7 +1127,9 @@ def test_fail_emits_voicefailed_before_voicestatechanged_idle_after_restructure(
 
     controller.start()
 
-    failed_index = next(i for i, e in enumerate(events) if isinstance(e, cvi.VoiceFailed))
+    failed_index = next(
+        i for i, e in enumerate(events) if isinstance(e, cvi.VoiceFailed)
+    )
     idle_index = next(
         i
         for i, e in enumerate(events)
@@ -1149,7 +1176,9 @@ def test_ghost_listening_race_is_closed_by_the_atomic_recheck(monkeypatch):
         controller.abandon()
         real_enter_listening()
 
-    monkeypatch.setattr(controller, "_enter_listening", enter_listening_after_concurrent_abandon)
+    monkeypatch.setattr(
+        controller, "_enter_listening", enter_listening_after_concurrent_abandon
+    )
 
     controller.start()
 
@@ -1212,7 +1241,9 @@ def test_begin_when_start_dictation_returns_false(monkeypatch):
     assert controller._service is None
 
 
-def test_begin_not_started_failure_does_not_cascade_into_a_second_voicefailed(monkeypatch):
+def test_begin_not_started_failure_does_not_cascade_into_a_second_voicefailed(
+    monkeypatch,
+):
     """The S4 fix (wrapping `self._spawn(...)` in `start()`) reintroduced the
     N1 cascade one call frame deeper: with the default inline `spawn`, that
     try transitively covers all of `_begin()`, so `_begin()`'s own `_fail()`
@@ -1269,7 +1300,9 @@ def test_begin_not_started_stays_quiet_when_abandoned_in_the_gap(monkeypatch):
         controller.abandon()
         real_fail_not_started()
 
-    monkeypatch.setattr(controller, "_fail_not_started", fail_not_started_after_concurrent_abandon)
+    monkeypatch.setattr(
+        controller, "_fail_not_started", fail_not_started_after_concurrent_abandon
+    )
 
     controller.start()
 
@@ -1374,7 +1407,9 @@ def test_synchronous_on_error_is_the_only_failure_reported(monkeypatch):
     assert controller.state == cvi.STATE_IDLE
     assert controller._service is None
     # The load-bearing ordering still holds on this path too.
-    failed_index = next(i for i, e in enumerate(events) if isinstance(e, cvi.VoiceFailed))
+    failed_index = next(
+        i for i, e in enumerate(events) if isinstance(e, cvi.VoiceFailed)
+    )
     idle_index = next(
         i
         for i, e in enumerate(events)
@@ -1492,7 +1527,10 @@ def test_stop_does_not_wedge_finishing_when_the_finishing_emit_raises(monkeypatc
 
     def emit_raising_on_finishing(event):
         recorded.append(event)
-        if isinstance(event, cvi.VoiceStateChanged) and event.state == cvi.STATE_FINISHING:
+        if (
+            isinstance(event, cvi.VoiceStateChanged)
+            and event.state == cvi.STATE_FINISHING
+        ):
             raise RuntimeError("widget torn down")
 
     service = FakeDictationService()
@@ -1724,9 +1762,7 @@ class _WarmableService:
         self._transcriber = transcriber if transcriber is not None else _Transcriber()
         self._gate = gate
         self._build_error = build_error
-        self._audio_service = type(
-            "R", (), {"stop_recording": lambda s: None}
-        )()
+        self._audio_service = type("R", (), {"stop_recording": lambda s: None})()
 
     @property
     def transcription_service(self):
@@ -1744,6 +1780,25 @@ class _WarmableService:
 
     def stop_dictation(self):
         return None
+
+
+class _WaitingHandle:
+    waiting_for_executor = True
+
+
+class _DeferredWarmableService(_WarmableService):
+    """Parakeet service that reserves shared execution instead of warming."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.capture_generation = None
+        self.uses_deferred_dictation = False
+
+    def reserve_deferred_dictation(self, capture_generation):
+        self.calls.append("reserve_deferred_dictation")
+        self.capture_generation = capture_generation
+        self.uses_deferred_dictation = True
+        return _WaitingHandle()
 
 
 class _Transcriber:
@@ -1806,6 +1861,45 @@ def test_the_model_is_warmed_before_the_microphone_opens(monkeypatch):
     assert controller.state == cvi.STATE_LISTENING
 
 
+def test_deferred_parakeet_reserves_before_warmup_and_opens_while_busy(monkeypatch):
+    service = _DeferredWarmableService()
+    monkeypatch.setattr(
+        cvi,
+        "resolve",
+        lambda: cvi.EffectiveConfig(
+            provider="parakeet-onnx",
+            model=None,
+            language="en",
+            configured_provider="parakeet-onnx",
+            was_overridden=False,
+        ),
+    )
+    controller, events, _ = _controller(monkeypatch, service=service)
+
+    controller.start(capture_generation=17)
+
+    assert service.calls == ["reserve_deferred_dictation", "start_dictation"]
+    assert service.capture_generation == 17
+    assert service._transcriber.buffer_calls == []
+    assert service.started is True
+    busy = [event for event in events if isinstance(event, cvi.VoiceLocalSTTBusy)]
+    assert busy == [
+        cvi.VoiceLocalSTTBusy("Local transcription busy — dictation will run next.")
+    ]
+
+
+def test_faster_whisper_still_warms_when_service_has_no_deferred_reservation(
+    monkeypatch,
+):
+    service = _DeferredWarmableService()
+    controller, _events, _ = _controller(monkeypatch, service=service)
+
+    controller.start(capture_generation=18)
+
+    assert service.calls == ["build-transcriber", "start_dictation"]
+    assert len(service._transcriber.buffer_calls) == 1
+
+
 def test_the_warm_up_uses_the_resolved_provider_model_and_language(monkeypatch):
     """A warm-up against a different model warms the wrong cache entry."""
     service = _WarmableService()
@@ -1857,9 +1951,9 @@ def test_a_slow_warm_announces_itself_before_it_blocks(monkeypatch):
     transcriber = _Transcriber(gate=gate, entered=entered)
     service = _WarmableService(transcriber=transcriber)
     controller, events, _ = _controller(
-        monkeypatch, service=service, spawn=lambda thunk: threading.Thread(
-            target=thunk, daemon=True
-        ).start()
+        monkeypatch,
+        service=service,
+        spawn=lambda thunk: threading.Thread(target=thunk, daemon=True).start(),
     )
 
     controller.start()
@@ -1899,9 +1993,7 @@ def test_the_first_run_message_differs_from_later_presses(monkeypatch):
     assert second.detail == ""
 
 
-@pytest.mark.parametrize(
-    "message", [cvi.WARMUP_MESSAGE_FIRST_RUN, cvi.WARMUP_MESSAGE]
-)
+@pytest.mark.parametrize("message", [cvi.WARMUP_MESSAGE_FIRST_RUN, cvi.WARMUP_MESSAGE])
 def test_every_preparing_message_fits_the_one_row_chip(message):
     """The chip is 42 cells and one row; longer copy is cut mid-sentence.
 
@@ -2237,6 +2329,141 @@ def test_a_raising_stop_dictation_still_releases_the_microphone(monkeypatch):
     assert controller.state == cvi.STATE_IDLE
     failures = [e for e in events if isinstance(e, cvi.VoiceFailed)]
     assert len(failures) == 1
+
+
+class _RetryTranscriber(_Transcriber):
+    def __init__(self, texts):
+        super().__init__()
+        self._texts = list(texts)
+
+    def transcribe_buffer(self, *args, **kwargs):
+        super().transcribe_buffer(*args, **kwargs)
+        return {"text": self._texts.pop(0)}
+
+
+class _RetryableStopService(_DeferredWarmableService):
+    def __init__(self, failure, transcriber, **kwargs):
+        super().__init__(transcriber=transcriber, **kwargs)
+        self._failure = failure
+
+    def stop_dictation(self):
+        raise self._failure
+
+
+def _retryable_stop_service():
+    from tldw_chatbook.STT.contracts import BufferAudioSource
+    from tldw_chatbook.STT.dispatch_coordinator import (
+        RetryableDictationBuffer,
+        RetryableDictationFailure,
+    )
+
+    retry_buffer = RetryableDictationBuffer(
+        BufferAudioSource(b"\x01\x00\x02\x00\x03\x00\x04\x00", 16_000, 1, 2),
+        (2, 4),
+    )
+    transcriber = _RetryTranscriber(["failed segment", "pending segment"])
+    return _RetryableStopService(
+        RetryableDictationFailure(retry_buffer),
+        transcriber,
+    ), transcriber
+
+
+def test_retryable_parakeet_failure_exposes_one_bounded_faster_whisper_retry(
+    monkeypatch,
+):
+    service, transcriber = _retryable_stop_service()
+    monkeypatch.setattr(
+        cvi,
+        "resolve",
+        lambda: cvi.EffectiveConfig(
+            provider="parakeet-onnx",
+            model=None,
+            language="en",
+            configured_provider="parakeet-onnx",
+            was_overridden=False,
+        ),
+    )
+    controller, events, _ = _controller(monkeypatch, service=service)
+    controller.start(capture_generation=19)
+    events.clear()
+
+    controller.stop()
+
+    failures = [event for event in events if isinstance(event, cvi.VoiceFailed)]
+    assert failures == [
+        cvi.VoiceFailed(
+            reason="Parakeet transcription failed.",
+            retry_available=True,
+        )
+    ]
+    assert controller.retry_available is True
+    assert transcriber.buffer_calls == []
+
+    transcript = controller.retry_with_faster_whisper()
+
+    assert transcript == "failed segment pending segment"
+    assert [call["audio_data"] for call in transcriber.buffer_calls] == [
+        b"\x01\x00\x02\x00",
+        b"\x03\x00\x04\x00",
+    ]
+    assert all(
+        call["provider"] == "faster-whisper" for call in transcriber.buffer_calls
+    )
+    assert all(call["model"] == "base" for call in transcriber.buffer_calls)
+    assert controller.retry_available is False
+
+
+def test_retryable_failure_without_faster_whisper_is_not_offered(monkeypatch):
+    service, _transcriber = _retryable_stop_service()
+    monkeypatch.setattr(
+        cvi,
+        "resolve",
+        lambda: cvi.EffectiveConfig(
+            provider="parakeet-onnx",
+            model=None,
+            language="en",
+            configured_provider="parakeet-onnx",
+            was_overridden=False,
+        ),
+    )
+    controller, events, _ = _controller(monkeypatch, service=service)
+    controller.start(capture_generation=20)
+    monkeypatch.setattr(cvi, "installed_local_providers", lambda: ("parakeet-onnx",))
+    events.clear()
+
+    controller.stop()
+
+    failures = [event for event in events if isinstance(event, cvi.VoiceFailed)]
+    assert failures == [
+        cvi.VoiceFailed(
+            reason="Parakeet transcription failed.",
+            retry_available=False,
+        )
+    ]
+    assert controller.retry_available is False
+
+
+def test_a_later_start_clears_the_previous_capture_retry(monkeypatch):
+    service, _transcriber = _retryable_stop_service()
+    monkeypatch.setattr(
+        cvi,
+        "resolve",
+        lambda: cvi.EffectiveConfig(
+            provider="parakeet-onnx",
+            model=None,
+            language="en",
+            configured_provider="parakeet-onnx",
+            was_overridden=False,
+        ),
+    )
+    controller, _events, _ = _controller(monkeypatch, service=service)
+    controller.start(capture_generation=21)
+    controller.stop()
+    assert controller.retry_available is True
+
+    controller.start(capture_generation=22)
+
+    assert controller.retry_available is False
 
 
 # --------------------------------------------------------------------------

--- a/Tests/Chat/test_console_voice_input.py
+++ b/Tests/Chat/test_console_voice_input.py
@@ -2561,25 +2561,30 @@ def test_retry_is_not_offered_when_base_model_is_not_cached(monkeypatch):
 
 
 def test_faster_whisper_cache_probe_resolves_without_network(monkeypatch):
+    from tldw_chatbook.Utils import optional_deps
+
     calls = []
+    dependency_requests = []
 
     def _download_model(model, **kwargs):
         calls.append((model, kwargs))
         return "/cached/faster-whisper-base"
 
     monkeypatch.setattr(
-        cvi.importlib,
-        "import_module",
-        lambda name: (
-            SimpleNamespace(download_model=_download_model)
-            if name == "faster_whisper.utils"
-            else None
+        optional_deps,
+        "require_dependency",
+        lambda module_name, feature_name: (
+            dependency_requests.append((module_name, feature_name))
+            or SimpleNamespace(download_model=_download_model)
         ),
     )
     probe = getattr(cvi, "_faster_whisper_model_is_local", None)
 
     assert callable(probe)
     assert probe("base") is True
+    assert dependency_requests == [
+        ("faster_whisper", "transcription_faster_whisper")
+    ]
     assert calls == [("base", {"local_files_only": True})]
 
 

--- a/Tests/Chat/test_console_voice_input.py
+++ b/Tests/Chat/test_console_voice_input.py
@@ -2427,6 +2427,33 @@ def test_retryable_parakeet_failure_exposes_one_bounded_faster_whisper_retry(
     assert controller.retry_available is False
 
 
+def test_retry_preserves_logical_segment_texts_for_the_console_adapter(monkeypatch):
+    service, transcriber = _retryable_stop_service()
+    monkeypatch.setattr(
+        cvi,
+        "resolve",
+        lambda: cvi.EffectiveConfig(
+            provider="parakeet-onnx",
+            model=None,
+            language="en",
+            configured_provider="parakeet-onnx",
+            was_overridden=False,
+        ),
+    )
+    controller, _events, _ = _controller(monkeypatch, service=service)
+    controller.start(capture_generation=32)
+    controller.stop()
+
+    texts = controller.retry_segments_with_faster_whisper()
+
+    assert texts == ("failed segment", "pending segment")
+    assert [call["audio_data"] for call in transcriber.buffer_calls] == [
+        b"\x01\x00\x02\x00",
+        b"\x03\x00\x04\x00",
+    ]
+    assert controller.retry_available is False
+
+
 def test_retry_closure_does_not_retain_the_finished_dictation_service(monkeypatch):
     service, transcriber = _retryable_stop_service()
     service.language = "fr"

--- a/Tests/Chat/test_console_voice_input.py
+++ b/Tests/Chat/test_console_voice_input.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import gc
 import queue
 import subprocess
 import sys
 import threading
 import time
+import weakref
+from types import SimpleNamespace
 
 import pytest
 
@@ -622,6 +625,12 @@ def _controller(monkeypatch, service=None, spawn=None):
     """
     monkeypatch.setattr(cvi, "capture_available", lambda: True)
     monkeypatch.setattr(cvi, "installed_local_providers", lambda: ("faster-whisper",))
+    monkeypatch.setattr(
+        cvi,
+        "_faster_whisper_model_is_local",
+        lambda _model: True,
+        raising=False,
+    )
     _stub_settings(monkeypatch, {"transcription.default_provider": "faster-whisper"})
 
     service = service or FakeDictationService()
@@ -1830,6 +1839,7 @@ class _Transcriber:
                 "provider": provider,
                 "model": model,
                 "language": language,
+                "provider_kwargs": kwargs,
             }
         )
         if self.entered is not None:
@@ -2410,7 +2420,140 @@ def test_retryable_parakeet_failure_exposes_one_bounded_faster_whisper_retry(
         call["provider"] == "faster-whisper" for call in transcriber.buffer_calls
     )
     assert all(call["model"] == "base" for call in transcriber.buffer_calls)
+    assert all(
+        call["provider_kwargs"] == {"local_files_only": True}
+        for call in transcriber.buffer_calls
+    )
     assert controller.retry_available is False
+
+
+def test_retry_closure_does_not_retain_the_finished_dictation_service(monkeypatch):
+    service, transcriber = _retryable_stop_service()
+    service.language = "fr"
+    service_box = [service]
+    monkeypatch.setattr(cvi, "capture_available", lambda: True)
+    monkeypatch.setattr(cvi, "installed_local_providers", lambda: ("faster-whisper",))
+    monkeypatch.setattr(
+        cvi,
+        "_faster_whisper_model_is_local",
+        lambda _model: True,
+        raising=False,
+    )
+    _stub_settings(monkeypatch, {"transcription.default_provider": "parakeet-onnx"})
+
+    def _service_factory(**kwargs):
+        built = service_box.pop()
+        built.kwargs = kwargs
+        return built
+
+    controller = cvi.ConsoleVoiceInputController(
+        emit=lambda _event: None,
+        spawn=lambda thunk: thunk(),
+        service_factory=_service_factory,
+    )
+    monkeypatch.setattr(
+        cvi,
+        "resolve",
+        lambda: cvi.EffectiveConfig(
+            provider="parakeet-onnx",
+            model=None,
+            language="fr",
+            configured_provider="parakeet-onnx",
+            was_overridden=False,
+        ),
+    )
+    controller.start(capture_generation=29)
+    controller.stop()
+    service_ref = weakref.ref(service)
+
+    del service
+    gc.collect()
+
+    assert service_ref() is None
+    assert controller.retry_with_faster_whisper() == "failed segment pending segment"
+    assert all(call["language"] == "fr" for call in transcriber.buffer_calls)
+
+
+def test_retry_execution_failure_is_fixed_and_sanitized(monkeypatch):
+    service, transcriber = _retryable_stop_service()
+    transcriber._error = RuntimeError("native failure at /private/models/secret.bin")
+    monkeypatch.setattr(
+        cvi,
+        "resolve",
+        lambda: cvi.EffectiveConfig(
+            provider="parakeet-onnx",
+            model=None,
+            language="en",
+            configured_provider="parakeet-onnx",
+            was_overridden=False,
+        ),
+    )
+    controller, _events, _ = _controller(monkeypatch, service=service)
+    controller.start(capture_generation=30)
+    controller.stop()
+
+    with pytest.raises(RuntimeError) as caught:
+        controller.retry_with_faster_whisper()
+
+    assert str(caught.value) == "Dictation retry failed."
+    assert caught.value.__cause__ is None
+    assert caught.value.__suppress_context__ is True
+    assert "secret.bin" not in str(caught.value)
+    assert controller.retry_available is False
+
+
+def test_retry_is_not_offered_when_base_model_is_not_cached(monkeypatch):
+    service, transcriber = _retryable_stop_service()
+    monkeypatch.setattr(
+        cvi,
+        "resolve",
+        lambda: cvi.EffectiveConfig(
+            provider="parakeet-onnx",
+            model=None,
+            language="en",
+            configured_provider="parakeet-onnx",
+            was_overridden=False,
+        ),
+    )
+    controller, events, _ = _controller(monkeypatch, service=service)
+    monkeypatch.setattr(cvi, "_faster_whisper_model_is_local", lambda _model: False)
+    controller.start(capture_generation=31)
+    events.clear()
+
+    controller.stop()
+
+    failures = [event for event in events if isinstance(event, cvi.VoiceFailed)]
+    assert failures == [
+        cvi.VoiceFailed(
+            reason="Parakeet transcription failed.",
+            retry_available=False,
+        )
+    ]
+    assert transcriber.buffer_calls == []
+    assert controller.retry_available is False
+
+
+def test_faster_whisper_cache_probe_resolves_without_network(monkeypatch):
+    calls = []
+
+    def _download_model(model, **kwargs):
+        calls.append((model, kwargs))
+        return "/cached/faster-whisper-base"
+
+    monkeypatch.setattr(
+        cvi.importlib,
+        "import_module",
+        lambda name: (
+            SimpleNamespace(download_model=_download_model)
+            if name == "faster_whisper.utils"
+            else None
+        ),
+    )
+    probe = getattr(cvi, "_faster_whisper_model_is_local", None)
+
+    assert callable(probe)
+    assert probe("base") is True
+    assert calls == [("base", {"local_files_only": True})]
 
 
 def test_retryable_failure_without_faster_whisper_is_not_offered(monkeypatch):

--- a/Tests/Library/test_library_ingest_runner.py
+++ b/Tests/Library/test_library_ingest_runner.py
@@ -28,7 +28,8 @@ import subprocess
 import sys
 import textwrap
 import threading
-from types import SimpleNamespace
+import time
+from types import MappingProxyType, SimpleNamespace
 from pathlib import Path
 from typing import Any, Callable, Optional
 from unittest.mock import patch
@@ -37,6 +38,7 @@ import pytest
 from textual.app import App
 
 import tldw_chatbook.app as _app_module
+import tldw_chatbook.STT.parakeet_dispatch as _parakeet_dispatch_module
 from tldw_chatbook.app import LibraryIngestQueueMixin
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.Library.library_ingest_jobs import (
@@ -57,6 +59,7 @@ from tldw_chatbook.STT.executor import (
     ModelIdentity,
     WorkerPhase,
 )
+from tldw_chatbook.STT.parakeet_dispatch import ParakeetDispatch
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -242,8 +245,9 @@ class _IngestRunnerHarness(LibraryIngestQueueMixin, App):
         self._ingest_parse_pool_stop_event: Optional[threading.Event] = None
         self._ingest_parsed_payloads: dict[str, dict] = {}
         self._ingest_shutdown = False
-        self._local_stt_executor_lock = threading.Lock()
+        self._local_stt_executor_lock = threading.RLock()
         self._local_stt_executor = local_stt_executor
+        self._local_stt_dispatch_coordinator = None
         self._ingest_local_stt_jobs: dict[str, tuple[int, str]] = {}
         self._pool_factory = pool_factory or (lambda: _FakeIngestParsePool())
         self._pool_create_count = 0
@@ -287,6 +291,23 @@ def _fake_local_stt_dispatch(job, options) -> dict[str, Any]:
         "managed_store_root": None,
         "managed_artifact_ref": None,
     }
+
+
+def _fake_parakeet_dispatch() -> ParakeetDispatch:
+    return ParakeetDispatch(
+        identity=ModelIdentity(
+            provider_id="parakeet-onnx",
+            model_id="nemo-parakeet-tdt-0.6b-v2",
+            root_revision=None,
+            closure_fingerprint=None,
+            precision="int8",
+            device=ExecutionDevice.CPU,
+        ),
+        local_source=None,
+        managed_store_root=None,
+        managed_artifact_ref=None,
+        option_updates=MappingProxyType({}),
+    )
 
 
 def _make_db(tmp_path: Path, name: str = "library_ingest.db") -> MediaDatabase:
@@ -1327,8 +1348,9 @@ async def test_explicit_parakeet_directory_uses_central_validated_path(
     ):
         (validated_dir / filename).write_bytes(filename.encode("utf-8"))
 
-    with patch(
-        "tldw_chatbook.Utils.path_validation.validate_path_simple",
+    with patch.object(
+        _parakeet_dispatch_module,
+        "validate_path_simple",
         return_value=validated_dir,
     ):
         async with app.run_test() as pilot:
@@ -1349,13 +1371,117 @@ async def test_explicit_parakeet_directory_uses_central_validated_path(
     assert executor.calls[0]["options"]["transcription_model_dir"] == str(validated_dir)
 
 
+def test_parakeet_dispatch_delegates_to_shared_resolver_and_copies_updates(
+    tmp_path: Path,
+) -> None:
+    app = _IngestRunnerHarness(None)
+    job = LibraryIngestJob(job_id="job-shared-resolver", source_path="speech.wav")
+    identity = ModelIdentity(
+        provider_id="parakeet-onnx",
+        model_id="fixture-model",
+        root_revision="fixture-revision",
+        closure_fingerprint="fixture-closure",
+        precision="f32",
+        device=ExecutionDevice.CPU,
+    )
+    resolved = ParakeetDispatch(
+        identity=identity,
+        local_source=None,
+        managed_store_root=tmp_path / "managed",
+        managed_artifact_ref=("artifact", "revision", "variant"),
+        option_updates=MappingProxyType(
+            {
+                "transcription_model_dir": str(tmp_path / "resolved"),
+                "_verify_legacy_parakeet_v2": True,
+            }
+        ),
+    )
+    requested = tmp_path / "requested"
+    requested.mkdir()
+    for filename in (
+        "config.json",
+        "vocab.txt",
+        "encoder-model.onnx",
+        "encoder-model.onnx.data",
+        "decoder_joint-model.onnx",
+    ):
+        (requested / filename).write_bytes(filename.encode())
+    options = {
+        "transcription_provider": "parakeet-onnx",
+        "transcription_model": "fixture-model",
+        "transcription_precision": "f32",
+        "transcription_model_dir": str(requested),
+    }
+
+    with patch.object(
+        _parakeet_dispatch_module,
+        "resolve_parakeet_dispatch",
+        autospec=True,
+        return_value=resolved,
+    ) as resolver:
+        dispatch = app._build_local_stt_dispatch(job, options)
+
+    resolver.assert_called_once_with(
+        model_id="fixture-model",
+        precision="f32",
+        model_dir=str(requested),
+    )
+    assert dispatch == {
+        "attempt_id": "job-shared-resolver-attempt-1",
+        "identity": identity,
+        "local_source": None,
+        "managed_store_root": tmp_path / "managed",
+        "managed_artifact_ref": ("artifact", "revision", "variant"),
+    }
+    assert options["transcription_model_dir"] == str(tmp_path / "resolved")
+    assert options["_verify_legacy_parakeet_v2"] is True
+
+
+def test_transcribe_cpp_dispatch_stays_on_gguf_resolution(
+    tmp_path: Path,
+) -> None:
+    model_path = tmp_path / "model.gguf"
+    model_path.write_bytes(b"gguf")
+    app = _IngestRunnerHarness(None)
+    options = {
+        "transcription_provider": "transcribe-cpp",
+        "transcription_precision": "native",
+        "transcription_context": {"model_path": str(model_path)},
+    }
+    admission = SimpleNamespace(
+        path=model_path,
+        metadata=SimpleNamespace(architecture="whisper"),
+    )
+
+    with (
+        patch(
+            "tldw_chatbook.Model_Artifacts.gguf_admission.validate_local_gguf",
+            return_value=admission,
+        ),
+        patch.object(
+            _parakeet_dispatch_module,
+            "resolve_parakeet_dispatch",
+            side_effect=AssertionError("Parakeet resolver used for transcribe.cpp"),
+        ),
+    ):
+        dispatch = app._build_local_stt_dispatch(
+            LibraryIngestJob(job_id="job-gguf", source_path="speech.wav"),
+            options,
+        )
+
+    assert dispatch["identity"].provider_id == "transcribe-cpp"
+    assert dispatch["identity"].model_id == "local-gguf:whisper"
+    assert dispatch["identity"].device is ExecutionDevice.AUTO
+    assert dispatch["local_source"].paths == (model_path,)
+    assert "transcription_model_dir" not in options
+
+
 def test_managed_parakeet_dispatch_selects_exact_model_and_precision(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from tldw_chatbook.Local_Ingestion import parakeet_v2_artifact as artifacts
     from tldw_chatbook.Local_Ingestion.stt_batch_routing import PARAKEET_V3_MODEL
-    from tldw_chatbook.Model_Artifacts import store as artifact_store
 
     reference = artifacts.parakeet_reference(PARAKEET_V3_MODEL, "f32")
     handle = SimpleNamespace(
@@ -1374,13 +1500,17 @@ def test_managed_parakeet_dispatch_selects_exact_model_and_precision(
     lease = _Lease()
     service = SimpleNamespace(acquire=lambda selected: lease)
     monkeypatch.setattr(
-        artifacts,
+        _parakeet_dispatch_module,
         "active_managed_parakeet_dir",
         lambda model, precision, service=None: tmp_path / "managed-root",
     )
-    monkeypatch.setattr(artifacts, "parakeet_v2_managed_service", lambda: service)
     monkeypatch.setattr(
-        artifact_store,
+        _parakeet_dispatch_module,
+        "parakeet_v2_managed_service",
+        lambda: service,
+    )
+    monkeypatch.setattr(
+        _parakeet_dispatch_module,
         "managed_model_artifact_root",
         lambda: tmp_path / "managed",
     )
@@ -1442,7 +1572,6 @@ def test_unqualified_legacy_v2_folder_cannot_satisfy_a_v3_dispatch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from tldw_chatbook.Local_Ingestion import parakeet_v2_artifact as artifacts
     from tldw_chatbook.Local_Ingestion.stt_batch_routing import PARAKEET_V3_MODEL
 
     legacy_v2 = tmp_path / "legacy-v2-int8"
@@ -1464,29 +1593,26 @@ def test_unqualified_legacy_v2_folder_cannot_satisfy_a_v3_dispatch(
         else None,
     )
     monkeypatch.setattr(
-        artifacts,
+        _parakeet_dispatch_module,
         "active_managed_parakeet_dir",
         lambda model, precision, service=None: None,
     )
     monkeypatch.setattr(
-        artifacts,
+        _parakeet_dispatch_module,
         "parakeet_v2_managed_service",
         lambda: SimpleNamespace(),
     )
     app = _IngestRunnerHarness(None)
 
-    dispatch = app._build_local_stt_dispatch(
-        LibraryIngestJob(job_id="job-v3", source_path="speech.wav"),
-        {
-            "transcription_provider": "parakeet-onnx",
-            "transcription_model": PARAKEET_V3_MODEL,
-            "transcription_precision": "int8",
-        },
-    )
-
-    assert dispatch["identity"].model_id == PARAKEET_V3_MODEL
-    assert dispatch["local_source"] is None
-    assert dispatch["managed_artifact_ref"] is None
+    with pytest.raises(FileNotFoundError, match="No installed Parakeet artifact"):
+        app._build_local_stt_dispatch(
+            LibraryIngestJob(job_id="job-v3", source_path="speech.wav"),
+            {
+                "transcription_provider": "parakeet-onnx",
+                "transcription_model": PARAKEET_V3_MODEL,
+                "transcription_precision": "int8",
+            },
+        )
 
 
 @pytest.mark.asyncio
@@ -1548,6 +1674,134 @@ async def test_executor_heavy_job_leaves_remaining_pool_slots_for_documents(
         assert len(executor.calls) == 1
         assert len(pool.calls) == 2
         assert app.library_ingest_jobs.counts()["parsing"] == 3
+
+
+@pytest.mark.asyncio
+async def test_dictation_reservation_gates_only_heavy_library_work(
+    tmp_path: Path,
+) -> None:
+    pool = _FakeIngestParsePool(auto_run=False)
+    executor = _FakeLocalSTTExecutor()
+    app = _IngestRunnerHarness(
+        _make_db(tmp_path),
+        pool_factory=lambda: pool,
+        worker_count=2,
+        heavy_lane=1,
+        local_stt_executor=executor,
+        local_stt_dispatch_factory=_fake_local_stt_dispatch,
+    )
+    coordinator = app._ensure_local_stt_dispatch_coordinator()
+    coordinator.begin_dictation(
+        capture_generation=1,
+        dispatch=_fake_parakeet_dispatch(),
+        sample_rate=16_000,
+        channels=1,
+        sample_width=2,
+        language="en",
+        on_logical_segment=lambda _sequence, _text: None,
+    )
+    audio = tmp_path / "reserved.wav"
+    audio.write_bytes(b"fixture")
+    document = _write_text_file(tmp_path, "document.txt", "document body")
+
+    async with app.run_test() as pilot:
+        audio_job = app.submit_library_ingest_job(
+            source_path=str(audio),
+            ingest_options={"audio_video": {"transcription_provider": "parakeet-onnx"}},
+        )
+        document_job = app.submit_library_ingest_job(source_path=str(document))
+        await pilot.pause()
+
+        states = {job.job_id: job.state for job in app.library_ingest_jobs.jobs()}
+        assert states[audio_job.job_id] is IngestJobState.QUEUED
+        assert states[document_job.job_id] is IngestJobState.PARSING
+        assert len(pool.calls) == 1
+        assert pool.calls[0]["args"][0] == document_job.source_path
+        assert executor.calls == []
+        reserved_audio = app.library_ingest_jobs.get_job(audio_job.job_id)
+        assert reserved_audio is not None
+        assert reserved_audio.error == ""
+
+
+@pytest.mark.asyncio
+async def test_library_terminal_hands_executor_to_pending_dictation_before_top_up(
+    tmp_path: Path,
+) -> None:
+    executor = _FakeLocalSTTExecutor()
+    app = _IngestRunnerHarness(
+        _make_db(tmp_path),
+        worker_count=1,
+        heavy_lane=1,
+        local_stt_executor=executor,
+        local_stt_dispatch_factory=_fake_local_stt_dispatch,
+    )
+    first_path = tmp_path / "first.wav"
+    first_path.write_bytes(b"first")
+    second_path = tmp_path / "second.wav"
+    second_path.write_bytes(b"second")
+
+    async with app.run_test() as pilot:
+        first = app.submit_library_ingest_job(
+            source_path=str(first_path),
+            ingest_options={"audio_video": {"transcription_provider": "parakeet-onnx"}},
+        )
+        await pilot.pause()
+        coordinator = app._ensure_local_stt_dispatch_coordinator()
+        handle = coordinator.begin_dictation(
+            capture_generation=2,
+            dispatch=_fake_parakeet_dispatch(),
+            sample_rate=16_000,
+            channels=1,
+            sample_width=2,
+            language="en",
+            on_logical_segment=lambda _sequence, _text: None,
+        )
+        handle.append_segment(b"\x00\x00")
+        handle.finish()
+        second = app.submit_library_ingest_job(
+            source_path=str(second_path),
+            ingest_options={"audio_video": {"transcription_provider": "parakeet-onnx"}},
+        )
+        await pilot.pause()
+        first_attempt = executor.calls[0]["attempt_id"]
+
+        executor.trigger_failure(
+            0,
+            ExecutorFailure(
+                1,
+                first_attempt,
+                TranscriptionFailureCode.CANCELLED,
+            ),
+        )
+        for _ in range(_POLL_ATTEMPTS):
+            if len(executor.calls) >= 2:
+                break
+            await pilot.pause(_POLL_INTERVAL)
+
+        assert [call["job_id"] for call in executor.calls] == [first.job_id, None]
+        second_job = app.library_ingest_jobs.get_job(second.job_id)
+        assert second_job is not None
+        assert second_job.state is IngestJobState.QUEUED
+
+        dictation_attempt = executor.calls[1]["attempt_id"]
+        executor.trigger_result(
+            1,
+            ExecutorResult(
+                1,
+                dictation_attempt,
+                {"logical_segments": ["dictated"]},
+            ),
+        )
+        for _ in range(_POLL_ATTEMPTS):
+            if len(executor.calls) >= 3:
+                break
+            await pilot.pause(_POLL_INTERVAL)
+
+        assert [call["job_id"] for call in executor.calls] == [
+            first.job_id,
+            None,
+            second.job_id,
+        ]
 
 
 @pytest.mark.asyncio
@@ -1971,6 +2225,92 @@ def test_shutdown_closes_local_executor_off_caller_thread(tmp_path: Path) -> Non
     assert app._local_stt_executor is None
     assert executor.close_thread_ident is not None
     assert executor.close_thread_ident != caller_thread
+
+
+def test_shutdown_closes_and_detaches_coordinator_before_executor_teardown(
+    tmp_path: Path,
+) -> None:
+    class _BlockingExecutor(_FakeLocalSTTExecutor):
+        def __init__(self) -> None:
+            super().__init__()
+            self.close_started = threading.Event()
+            self.close_release = threading.Event()
+
+        def close(self) -> None:
+            self.close_started.set()
+            assert self.close_release.wait(5.0)
+            super().close()
+
+    executor = _BlockingExecutor()
+    app = _IngestRunnerHarness(_make_db(tmp_path), local_stt_executor=executor)
+    coordinator = app._ensure_local_stt_dispatch_coordinator()
+    handle = coordinator.begin_dictation(
+        capture_generation=3,
+        dispatch=_fake_parakeet_dispatch(),
+        sample_rate=16_000,
+        channels=1,
+        sample_width=2,
+        language="en",
+        on_logical_segment=lambda _sequence, _text: None,
+    )
+
+    started = time.monotonic()
+    teardown = app._shutdown_ingest_parse_pool()
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5
+    assert app._local_stt_dispatch_coordinator is None
+    assert app._local_stt_executor is None
+    with pytest.raises(RuntimeError, match="closed"):
+        coordinator.begin_dictation(
+            capture_generation=4,
+            dispatch=_fake_parakeet_dispatch(),
+            sample_rate=16_000,
+            channels=1,
+            sample_width=2,
+            language="en",
+            on_logical_segment=lambda _sequence, _text: None,
+        )
+    with pytest.raises(RuntimeError) as cancelled:
+        handle.wait()
+    assert cancelled.value.args == (TranscriptionFailureCode.CANCELLED,)
+    assert executor.cancel_calls == []
+    assert executor.close_started.wait(1.0)
+    assert executor.close_thread_ident is None
+
+    executor.close_release.set()
+    assert teardown is not None
+    teardown.join(timeout=5.0)
+    assert not teardown.is_alive()
+    assert executor.close_thread_ident is not None
+
+
+def test_shutdown_cooperatively_cancels_active_dictation_before_executor_close(
+    tmp_path: Path,
+) -> None:
+    executor = _FakeLocalSTTExecutor()
+    app = _IngestRunnerHarness(_make_db(tmp_path), local_stt_executor=executor)
+    coordinator = app._ensure_local_stt_dispatch_coordinator()
+    handle = coordinator.begin_dictation(
+        capture_generation=5,
+        dispatch=_fake_parakeet_dispatch(),
+        sample_rate=16_000,
+        channels=1,
+        sample_width=2,
+        language="en",
+        on_logical_segment=lambda _sequence, _text: None,
+    )
+    handle.append_segment(b"\x00\x00")
+    attempt_id = executor.calls[0]["attempt_id"]
+
+    teardown = app._shutdown_ingest_parse_pool()
+
+    assert executor.cancel_calls == [attempt_id]
+    assert app._local_stt_dispatch_coordinator is None
+    assert app._local_stt_executor is None
+    assert teardown is not None
+    teardown.join(timeout=5.0)
+    assert not teardown.is_alive()
 
 
 def test_shutdown_thread_waits_for_executor_and_parse_pool(tmp_path: Path) -> None:

--- a/Tests/Library/test_library_ingest_runner.py
+++ b/Tests/Library/test_library_ingest_runner.py
@@ -23,6 +23,7 @@ that a spawned process can run ``run_parse_job``.
 
 from __future__ import annotations
 
+import concurrent.futures
 import os
 import subprocess
 import sys
@@ -2654,6 +2655,55 @@ def test_pool_callbacks_short_circuit_without_marshaling_when_shutdown(
     assert len(marshaled) == 2
 
 
+@pytest.mark.parametrize(
+    ("callback_name", "callback_value"),
+    [
+        ("_ingest_pool_callback", {"ok": True, "payload": {}}),
+        ("_ingest_pool_error_callback", RuntimeError("pool failure")),
+    ],
+)
+def test_pool_callback_ignores_cancelled_marshal_only_during_shutdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    callback_name: str,
+    callback_value: Any,
+) -> None:
+    """A callback already past the shutdown check may lose its UI future."""
+
+    app = _IngestRunnerHarness(_make_db(tmp_path))
+    marshal_entered = threading.Event()
+    release_marshal = threading.Event()
+
+    def cancelled_marshal(*_args: Any, **_kwargs: Any) -> None:
+        marshal_entered.set()
+        assert release_marshal.wait(5.0)
+        raise concurrent.futures.CancelledError
+
+    monkeypatch.setattr(app, "call_from_thread", cancelled_marshal)
+    callback = getattr(app, callback_name)
+    callback_errors: list[BaseException] = []
+
+    def invoke_callback() -> None:
+        try:
+            callback(1, "ingest-job-1", callback_value)
+        except BaseException as exc:  # noqa: BLE001 - assert thread outcome below
+            callback_errors.append(exc)
+
+    callback_thread = threading.Thread(target=invoke_callback, daemon=True)
+    callback_thread.start()
+    assert marshal_entered.wait(1.0)
+    app._ingest_shutdown = True
+    release_marshal.set()
+    callback_thread.join(timeout=5.0)
+
+    assert not callback_thread.is_alive()
+    assert callback_errors == []
+
+    app._ingest_shutdown = False
+    with pytest.raises(concurrent.futures.CancelledError):
+        callback(1, "ingest-job-2", callback_value)
+
+
 def test_shutdown_terminates_pool_off_the_caller_thread(tmp_path: Path) -> None:
     """(Quit-deadlock guard, layer b) `_shutdown_ingest_parse_pool` must
     set the shutdown flag, detach the pool reference, and run
@@ -4376,4 +4426,11 @@ async def test_folder_submission_shares_one_batch_id(tmp_path: Path) -> None:
         assert jobs["solo.txt"].batch_id is None
         assert solo_job.batch_id is None
 
+        for submitted in jobs.values():
+            await _wait_for_job_state(
+                app,
+                pilot,
+                submitted.job_id,
+                IngestJobState.DONE,
+            )
         await _wait_for_runner_idle(app, pilot)

--- a/Tests/Library/test_library_ingest_runner.py
+++ b/Tests/Library/test_library_ingest_runner.py
@@ -46,6 +46,7 @@ from tldw_chatbook.Library.library_ingest_jobs import (
 )
 from tldw_chatbook.STT.contracts import (
     ExecutionDevice,
+    FileAudioSource,
     TranscriptionFailureCode,
 )
 from tldw_chatbook.STT.executor import (
@@ -1092,6 +1093,7 @@ async def test_eligible_local_stt_uses_executor_not_general_pool(
 
         assert len(executor.calls) == 1
         assert executor.calls[0]["job_id"] == job.job_id
+        assert executor.calls[0]["source"] == FileAudioSource(source)
         assert executor.calls[0]["options"]["transcription_provider"] == provider
         assert pool.calls == []
 

--- a/Tests/Library/test_library_ingest_runner.py
+++ b/Tests/Library/test_library_ingest_runner.py
@@ -1724,6 +1724,136 @@ async def test_dictation_reservation_gates_only_heavy_library_work(
 
 
 @pytest.mark.asyncio
+async def test_dictation_race_defers_claimed_library_job_without_failure(
+    tmp_path: Path,
+) -> None:
+    pool = _FakeIngestParsePool(auto_run=False)
+    executor = _FakeLocalSTTExecutor()
+    dispatch_started = threading.Event()
+    release_dispatch = threading.Event()
+    dispatch_count = 0
+
+    def build_dispatch(job, options):
+        nonlocal dispatch_count
+        dispatch_count += 1
+        if dispatch_count == 1:
+            dispatch_started.set()
+            assert release_dispatch.wait(5.0)
+        return _fake_local_stt_dispatch(job, options)
+
+    app = _IngestRunnerHarness(
+        _make_db(tmp_path),
+        pool_factory=lambda: pool,
+        worker_count=2,
+        heavy_lane=1,
+        local_stt_executor=executor,
+        local_stt_dispatch_factory=build_dispatch,
+    )
+    audio = tmp_path / "raced.wav"
+    audio.write_bytes(b"fixture")
+    document = _write_text_file(tmp_path, "ordered.txt", "document body")
+    later_document = _write_text_file(tmp_path, "later.txt", "later body")
+
+    async with app.run_test() as pilot:
+        job = app.submit_library_ingest_job(
+            source_path=str(audio),
+            ingest_options={"audio_video": {"transcription_provider": "parakeet-onnx"}},
+        )
+        assert dispatch_started.wait(1.0)
+        coordinator = app._ensure_local_stt_dispatch_coordinator()
+        handle = coordinator.begin_dictation(
+            capture_generation=11,
+            dispatch=_fake_parakeet_dispatch(),
+            sample_rate=16_000,
+            channels=1,
+            sample_width=2,
+            language="en",
+            on_logical_segment=lambda _sequence, _text: None,
+        )
+        document_job = app.submit_library_ingest_job(source_path=str(document))
+        later_document_job = app.submit_library_ingest_job(
+            source_path=str(later_document)
+        )
+        await pilot.pause()
+        current_document = app.library_ingest_jobs.get_job(document_job.job_id)
+        current_later_document = app.library_ingest_jobs.get_job(
+            later_document_job.job_id
+        )
+        assert current_document is not None
+        assert current_later_document is not None
+        assert current_document.state is IngestJobState.PARSING
+        assert current_later_document.state is IngestJobState.QUEUED
+        assert len(pool.calls) == 1
+        assert pool.calls[0]["args"][0] == document_job.source_path
+
+        release_dispatch.set()
+        for _ in range(_POLL_ATTEMPTS):
+            if job.job_id not in app._ingest_local_stt_jobs:
+                break
+            await pilot.pause(_POLL_INTERVAL)
+
+        deferred = app.library_ingest_jobs.get_job(job.job_id)
+        assert deferred is not None
+        assert deferred.state is IngestJobState.QUEUED
+        assert deferred.retry_count == 0
+        assert deferred.error == ""
+        assert deferred.error_detail is None
+        assert deferred.stt_failure_provenance is None
+        assert [item.job_id for item in app.library_ingest_jobs.jobs()] == [
+            later_document_job.job_id,
+            document_job.job_id,
+            job.job_id,
+        ]
+        assert executor.calls == []
+        assert coordinator.dictation_reserved is True
+        deferred_later_document = app.library_ingest_jobs.get_job(
+            later_document_job.job_id
+        )
+        assert deferred_later_document is not None
+        assert deferred_later_document.state is IngestJobState.PARSING
+        assert len(pool.calls) == 2
+
+        pool.trigger_success(
+            0,
+            {"ok": False, "error": "document failed", "permanent": False},
+        )
+        await _wait_for_job_state(
+            app,
+            pilot,
+            document_job.job_id,
+            IngestJobState.FAILED,
+        )
+
+        handle.append_segment(b"\x00\x00")
+        handle.finish()
+        assert [call["job_id"] for call in executor.calls] == [None]
+        dictation_attempt = executor.calls[0]["attempt_id"]
+        executor.trigger_result(
+            0,
+            ExecutorResult(
+                1,
+                dictation_attempt,
+                {"logical_segments": ["dictated"]},
+            ),
+        )
+        for _ in range(_POLL_ATTEMPTS):
+            if len(executor.calls) >= 2:
+                break
+            await pilot.pause(_POLL_INTERVAL)
+
+        resumed = app.library_ingest_jobs.get_job(job.job_id)
+        assert resumed is not None
+        assert resumed.state is IngestJobState.PARSING
+        assert resumed.retry_count == 0
+        assert resumed.error == ""
+        assert resumed.error_detail is None
+        assert [call["job_id"] for call in executor.calls] == [None, job.job_id]
+        still_parsing = app.library_ingest_jobs.get_job(later_document_job.job_id)
+        assert still_parsing is not None
+        assert still_parsing.state is IngestJobState.PARSING
+
+
+@pytest.mark.asyncio
 async def test_library_terminal_hands_executor_to_pending_dictation_before_top_up(
     tmp_path: Path,
 ) -> None:

--- a/Tests/STT/executor_test_support.py
+++ b/Tests/STT/executor_test_support.py
@@ -31,6 +31,75 @@ class _FakeResidentRuntime:
         return
 
 
+def _protocol_provider_builder(
+    request: Any,
+    _model_root: Path | None,
+    _managed_handle: Any | None,
+    _is_cancelled: Any,
+) -> Any:
+    """Build a deterministic runtime that exposes both executor source paths."""
+
+    from tldw_chatbook.STT.executor_worker import ProviderRuntime
+
+    def file_runner(audio_path: str, **kwargs: Any) -> dict[str, Any]:
+        return {"audio_path": audio_path, "kwargs": kwargs}
+
+    def buffer_runner(source: Any, *, segment_end_frames: tuple[int, ...]) -> dict[str, Any]:
+        return {
+            "audio_bytes": len(source.audio),
+            "sample_rate": source.sample_rate,
+            "segment_end_frames": segment_end_frames,
+        }
+
+    return ProviderRuntime(
+        runner=file_runner,
+        buffer_runner=(
+            None if request.options.get("test_no_buffer_runner") else buffer_runner
+        ),
+        close=lambda: None,
+    )
+
+
+def _protocol_parse_job(
+    file_path: str | Path,
+    options: dict[str, Any],
+    *,
+    transcription_runner: Any,
+) -> dict[str, Any]:
+    """Expose the exact file-parser inputs in a worker result payload."""
+
+    return {
+        "file_path": str(file_path),
+        "options": dict(options),
+        "runner_payload": transcription_runner(
+            str(file_path),
+            provider=options.get("transcription_provider"),
+        ),
+    }
+
+
+def protocol_executor_worker(
+    connection: Connection,
+    admission_event: Any,
+    cancellation_event: Any,
+    generation: int,
+    scratch_path: str,
+) -> None:
+    """Run the real worker loop with observable file and buffer seams."""
+
+    from tldw_chatbook.STT.executor_worker import _run_executor_worker
+
+    _run_executor_worker(
+        connection,
+        admission_event,
+        cancellation_event,
+        generation,
+        scratch_path,
+        provider_builder=_protocol_provider_builder,
+        parse_job=_protocol_parse_job,
+    )
+
+
 def _fake_provider_builder(
     _request: Any,
     _model_root: Path | None,

--- a/Tests/STT/test_dispatch_coordinator.py
+++ b/Tests/STT/test_dispatch_coordinator.py
@@ -18,10 +18,12 @@ from tldw_chatbook.STT.contracts import (
 )
 from tldw_chatbook.STT.executor import (
     ExecutorBusyError,
+    ExecutorEvent,
     ExecutorFailure,
     ExecutorResult,
     ExecutorUnavailableError,
     ModelIdentity,
+    WorkerPhase,
 )
 from tldw_chatbook.STT.parakeet_dispatch import ParakeetDispatch
 
@@ -178,6 +180,24 @@ class FakeExecutor:
             )
         )
 
+    def emit_event(
+        self,
+        generation: int,
+        *,
+        attempt_id: str | None = None,
+        phase: WorkerPhase = WorkerPhase.PREPARING,
+    ) -> None:
+        with self._condition:
+            assert self.active is not None
+            submission = self.active
+        submission["on_event"](
+            ExecutorEvent(
+                generation,
+                attempt_id or submission["attempt_id"],
+                phase,
+            )
+        )
+
     def _take_active(self) -> dict[str, Any]:
         with self._condition:
             assert self.active is not None
@@ -229,6 +249,7 @@ def _library_kwargs(
     *,
     attempt_id: str = "library-attempt",
     model_id: str = "parakeet-tdt-0.6b-v3",
+    on_event: Callable[[ExecutorEvent], None] = lambda _event: None,
     on_result: Callable[[ExecutorResult], None] = lambda _result: None,
     on_failure: Callable[[ExecutorFailure], None] = lambda _failure: None,
 ) -> dict[str, Any]:
@@ -238,6 +259,7 @@ def _library_kwargs(
         "source": FileAudioSource(Path(f"/tmp/{attempt_id}.wav")),
         "identity": _identity(model_id),
         "options": {"language": "en"},
+        "on_event": on_event,
         "on_result": on_result,
         "on_failure": on_failure,
     }
@@ -683,6 +705,54 @@ def test_stale_and_duplicate_terminals_are_ignored_once(
     executor.deliver_duplicate_result()
 
     assert delivered == ["real"]
+
+
+def test_current_preparing_event_advances_library_generation_once_outside_lock(
+    coordinator_module: Any,
+) -> None:
+    events: list[ExecutorEvent] = []
+    results: list[str] = []
+    result_delivered = threading.Event()
+    callback_blocked: list[bool] = []
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+
+    def on_event(event: ExecutorEvent) -> None:
+        reader = threading.Thread(
+            target=lambda: coordinator.dictation_reserved,
+            name="event-callback-lock-probe",
+        )
+        reader.start()
+        reader.join(0.05)
+        callback_blocked.append(reader.is_alive())
+        events.append(event)
+
+    def on_result(result: ExecutorResult) -> None:
+        results.append(result.payload["text"])
+        result_delivered.set()
+
+    assert coordinator.submit_library(
+        **_library_kwargs(on_event=on_event, on_result=on_result)
+    ) == 1
+    submission = executor.submissions[0]
+
+    executor.emit_event(3, attempt_id="different-attempt")
+    executor.emit_event(2)
+    submission["on_result"](
+        ExecutorResult(1, submission["attempt_id"], {"text": "stale"})
+    )
+    assert results == []
+    submission["on_result"](
+        ExecutorResult(2, submission["attempt_id"], {"text": "cpu retry"})
+    )
+    _wait_for(result_delivered)
+    executor.emit_event(2)
+
+    assert [(event.generation, event.phase) for event in events] == [
+        (2, WorkerPhase.PREPARING)
+    ]
+    assert callback_blocked == [False]
+    assert results == ["cpu retry"]
 
 
 def test_nonretryable_worker_failure_clears_capture_with_sanitized_category(

--- a/Tests/STT/test_dispatch_coordinator.py
+++ b/Tests/STT/test_dispatch_coordinator.py
@@ -1,0 +1,962 @@
+"""Behavior tests for the bounded dictation-next dispatch coordinator."""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.STT.contracts import (
+    BufferAudioSource,
+    ExecutionDevice,
+    FileAudioSource,
+    TranscriptionFailureCode,
+)
+from tldw_chatbook.STT.executor import (
+    ExecutorBusyError,
+    ExecutorFailure,
+    ExecutorResult,
+    ModelIdentity,
+)
+from tldw_chatbook.STT.parakeet_dispatch import ParakeetDispatch
+
+
+@pytest.fixture
+def coordinator_module() -> Any:
+    """Import inside the test so a missing implementation is an intentional RED."""
+
+    return importlib.import_module("tldw_chatbook.STT.dispatch_coordinator")
+
+
+class FakeExecutor:
+    """Queue-less executor fake with explicit, deterministic terminal controls."""
+
+    def __init__(self, order: list[str] | None = None) -> None:
+        self._condition = threading.Condition()
+        self._generation = 0
+        self.active: dict[str, Any] | None = None
+        self.submissions: list[dict[str, Any]] = []
+        self.cancelled_attempts: list[str] = []
+        self.force_stopped_attempts: list[str] = []
+        self.closed = False
+        self.order = order if order is not None else []
+
+    def submit(
+        self,
+        *,
+        attempt_id: str,
+        job_id: str | None,
+        source: FileAudioSource | BufferAudioSource,
+        identity: ModelIdentity,
+        options: dict[str, Any],
+        segment_end_frames: tuple[int, ...] = (),
+        local_source: Any = None,
+        managed_store_root: Path | None = None,
+        managed_artifact_ref: tuple[str, str, str] | None = None,
+        on_event: Callable[[Any], None] = lambda _event: None,
+        on_result: Callable[[ExecutorResult], None] = lambda _result: None,
+        on_failure: Callable[[ExecutorFailure], None] = lambda _failure: None,
+        explicit_retry: bool = False,
+    ) -> int:
+        with self._condition:
+            if self.active is not None:
+                raise ExecutorBusyError("fake executor already has active work")
+            self._generation += 1
+            submission = {
+                "generation": self._generation,
+                "attempt_id": attempt_id,
+                "job_id": job_id,
+                "source": source,
+                "identity": identity,
+                "options": dict(options),
+                "segment_end_frames": segment_end_frames,
+                "local_source": local_source,
+                "managed_store_root": managed_store_root,
+                "managed_artifact_ref": managed_artifact_ref,
+                "on_event": on_event,
+                "on_result": on_result,
+                "on_failure": on_failure,
+                "explicit_retry": explicit_retry,
+                "submit_thread": threading.current_thread().name,
+            }
+            self.active = submission
+            self.submissions.append(submission)
+            kind = "library" if job_id is not None else "dictation"
+            self.order.append(f"submit-{kind}")
+            self._condition.notify_all()
+            return self._generation
+
+    def wait_for_submissions(self, count: int, timeout: float = 1.0) -> bool:
+        with self._condition:
+            return self._condition.wait_for(
+                lambda: len(self.submissions) >= count,
+                timeout,
+            )
+
+    def succeed(
+        self,
+        payload: dict[str, Any] | None = None,
+        *,
+        thread_name: str | None = None,
+    ) -> None:
+        submission = self._take_active()
+        result = ExecutorResult(
+            submission["generation"],
+            submission["attempt_id"],
+            payload
+            or {
+                "text": "ok",
+                "logical_segments": ("ok",),
+                "duration": 0.1,
+                "transcription_model": submission["identity"].model_id,
+                "transcription_provenance": {},
+            },
+        )
+        self._deliver(submission["on_result"], result, thread_name)
+
+    def fail(
+        self,
+        code: TranscriptionFailureCode,
+        *,
+        recovery_actions: tuple[str, ...] = (),
+        failed_attempt: dict[str, Any] | None = None,
+        thread_name: str | None = None,
+    ) -> None:
+        submission = self._take_active()
+        failure = ExecutorFailure(
+            submission["generation"],
+            submission["attempt_id"],
+            code,
+            recovery_actions=recovery_actions,
+            failed_attempt=failed_attempt,
+        )
+        self._deliver(submission["on_failure"], failure, thread_name)
+
+    def cancel(self, attempt_id: str) -> bool:
+        with self._condition:
+            if self.active is None or self.active["attempt_id"] != attempt_id:
+                return False
+            self.cancelled_attempts.append(attempt_id)
+            return True
+
+    def force_stop(self, attempt_id: str) -> bool:
+        with self._condition:
+            if self.active is None or self.active["attempt_id"] != attempt_id:
+                return False
+            self.force_stopped_attempts.append(attempt_id)
+        self.fail(TranscriptionFailureCode.CANCELLED)
+        return True
+
+    def close(self) -> None:
+        self.closed = True
+
+    def deliver_duplicate_result(self, submission_index: int = -1) -> None:
+        submission = self.submissions[submission_index]
+        submission["on_result"](
+            ExecutorResult(
+                submission["generation"],
+                submission["attempt_id"],
+                {"text": "duplicate", "logical_segments": ("duplicate",)},
+            )
+        )
+
+    def deliver_stale_result(self, submission_index: int = -1) -> None:
+        submission = self.submissions[submission_index]
+        submission["on_result"](
+            ExecutorResult(
+                submission["generation"] + 100,
+                submission["attempt_id"],
+                {"text": "stale", "logical_segments": ("stale",)},
+            )
+        )
+
+    def _take_active(self) -> dict[str, Any]:
+        with self._condition:
+            assert self.active is not None
+            submission = self.active
+            self.active = None
+            return submission
+
+    @staticmethod
+    def _deliver(
+        callback: Callable[[Any], None],
+        envelope: Any,
+        thread_name: str | None,
+    ) -> None:
+        if thread_name is None:
+            callback(envelope)
+            return
+        thread = threading.Thread(
+            target=callback,
+            args=(envelope,),
+            name=thread_name,
+        )
+        thread.start()
+        thread.join(1.0)
+        assert not thread.is_alive()
+
+
+def _identity(model_id: str = "parakeet-tdt-0.6b-v2") -> ModelIdentity:
+    return ModelIdentity(
+        provider_id="parakeet-onnx",
+        model_id=model_id,
+        root_revision=f"revision-{model_id}",
+        closure_fingerprint=f"fingerprint-{model_id}",
+        precision="int8",
+        device=ExecutionDevice.CPU,
+    )
+
+
+def _dispatch(model_id: str = "parakeet-tdt-0.6b-v2") -> ParakeetDispatch:
+    return ParakeetDispatch(
+        identity=_identity(model_id),
+        local_source=None,
+        managed_store_root=None,
+        managed_artifact_ref=None,
+        option_updates={"provider_option": "copied"},
+    )
+
+
+def _library_kwargs(
+    *,
+    attempt_id: str = "library-attempt",
+    model_id: str = "parakeet-tdt-0.6b-v3",
+    on_result: Callable[[ExecutorResult], None] = lambda _result: None,
+    on_failure: Callable[[ExecutorFailure], None] = lambda _failure: None,
+) -> dict[str, Any]:
+    return {
+        "attempt_id": attempt_id,
+        "job_id": f"job-{attempt_id}",
+        "source": FileAudioSource(Path(f"/tmp/{attempt_id}.wav")),
+        "identity": _identity(model_id),
+        "options": {"language": "en"},
+        "on_result": on_result,
+        "on_failure": on_failure,
+    }
+
+
+def _begin(
+    module: Any,
+    coordinator: Any,
+    *,
+    capture_generation: int = 7,
+    dispatch: ParakeetDispatch | None = None,
+    sample_rate: int = 8_000,
+    channels: int = 1,
+    sample_width: int = 2,
+    callback: Callable[[int, str], None] = lambda _sequence, _text: None,
+) -> Any:
+    return coordinator.begin_dictation(
+        capture_generation=capture_generation,
+        dispatch=dispatch or _dispatch(),
+        sample_rate=sample_rate,
+        channels=channels,
+        sample_width=sample_width,
+        language="en",
+        on_logical_segment=callback,
+    )
+
+
+def _wait_for(event: threading.Event, timeout: float = 1.0) -> None:
+    assert event.wait(timeout), "timed out waiting for event-controlled transition"
+
+
+def test_pcm_byte_limit_is_derived_from_the_single_sixty_second_ceiling(
+    coordinator_module: Any,
+) -> None:
+    assert coordinator_module.DICTATION_MAX_SECONDS == 60.0
+    assert coordinator_module.pcm_byte_limit(
+        sample_rate=16_000,
+        channels=2,
+        sample_width=2,
+    ) == 3_840_000
+
+
+def test_idle_dictation_dispatches_immediately_and_delivers_ordered_text(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    delivered: list[tuple[int, str]] = []
+    handle = _begin(
+        coordinator_module,
+        coordinator,
+        callback=lambda sequence, text: delivered.append((sequence, text)),
+    )
+
+    assert handle.waiting_for_executor is False
+    assert handle.append_segment(b"\x01\x00\x02\x00") is coordinator_module.DictationAppendStatus.ACCEPTED
+    assert executor.wait_for_submissions(1)
+    assert executor.submissions[0]["source"].audio == b"\x01\x00\x02\x00"
+    assert executor.submissions[0]["segment_end_frames"] == (2,)
+    assert executor.submissions[0]["options"] == {
+        "provider_option": "copied",
+        "language": "en",
+    }
+
+    handle.finish()
+    executor.succeed({"text": "hello", "logical_segments": ("hello",)})
+    handle.wait()
+
+    assert delivered == [(0, "hello")]
+    assert coordinator.dictation_reserved is False
+
+
+def test_batch_terminal_submits_pending_dictation_before_original_callback(
+    coordinator_module: Any,
+) -> None:
+    order: list[str] = []
+    executor = FakeExecutor(order)
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    coordinator.submit_library(
+        **_library_kwargs(on_result=lambda _result: order.append("library-result"))
+    )
+    handle = _begin(coordinator_module, coordinator)
+    assert handle.waiting_for_executor is True
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+
+    with pytest.raises(ExecutorBusyError):
+        coordinator.submit_library(**_library_kwargs(attempt_id="later"))
+
+    executor.succeed()
+    assert executor.wait_for_submissions(2)
+
+    assert order[:3] == ["submit-library", "submit-dictation", "library-result"]
+    assert coordinator.dictation_reserved is True
+
+
+def test_batch_failure_also_submits_dictation_before_original_callback(
+    coordinator_module: Any,
+) -> None:
+    order: list[str] = []
+    failure_delivered = threading.Event()
+    executor = FakeExecutor(order)
+
+    def on_failure(_failure: ExecutorFailure) -> None:
+        order.append("library-failure")
+        failure_delivered.set()
+
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    coordinator.submit_library(**_library_kwargs(on_failure=on_failure))
+    handle = _begin(coordinator_module, coordinator)
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+
+    executor.fail(TranscriptionFailureCode.ENGINE_CRASHED)
+    assert executor.wait_for_submissions(2)
+    _wait_for(failure_delivered)
+
+    assert order[:3] == ["submit-library", "submit-dictation", "library-failure"]
+
+
+def test_dictation_terminal_delivers_callback_then_clears_gate_and_tops_up(
+    coordinator_module: Any,
+) -> None:
+    order: list[str] = []
+    idle = threading.Event()
+    executor = FakeExecutor(order)
+
+    def on_idle() -> None:
+        order.append("top-up")
+        idle.set()
+
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(
+        executor,
+        on_dictation_idle=on_idle,
+    )
+    handle = _begin(
+        coordinator_module,
+        coordinator,
+        callback=lambda sequence, text: order.append(f"segment-{sequence}-{text}"),
+    )
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+    executor.succeed({"text": "hello", "logical_segments": ("hello",)})
+    handle.wait()
+    _wait_for(idle)
+
+    assert order == ["submit-dictation", "segment-0-hello", "top-up"]
+    assert coordinator.dictation_reserved is False
+
+
+def test_user_terminal_callback_runs_outside_the_coordinator_lock(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    callback_finished = threading.Event()
+    blocked: list[bool] = []
+
+    def on_result(_result: ExecutorResult) -> None:
+        reader = threading.Thread(
+            target=lambda: coordinator.dictation_reserved,
+            name="callback-lock-probe",
+        )
+        reader.start()
+        reader.join(0.05)
+        blocked.append(reader.is_alive())
+        callback_finished.set()
+
+    coordinator.submit_library(**_library_kwargs(on_result=on_result))
+    executor.succeed()
+
+    _wait_for(callback_finished)
+    assert blocked == [False]
+
+
+def test_empty_mic_reservation_blocks_only_library_then_cancel_wakes_waiter(
+    coordinator_module: Any,
+) -> None:
+    idle = threading.Event()
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(
+        executor,
+        on_dictation_idle=idle.set,
+    )
+    handle = _begin(coordinator_module, coordinator)
+
+    assert coordinator.dictation_reserved is True
+    with pytest.raises(ExecutorBusyError):
+        coordinator.submit_library(**_library_kwargs())
+    assert handle.cancel() is True
+    with pytest.raises(RuntimeError) as caught:
+        handle.wait()
+    _wait_for(idle)
+
+    assert caught.value.args == (TranscriptionFailureCode.CANCELLED,)
+    assert coordinator.dictation_reserved is False
+    assert executor.submissions == []
+
+
+def test_waiting_segments_coalesce_into_one_source_with_ordered_boundaries(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    coordinator.submit_library(**_library_kwargs())
+    handle = _begin(coordinator_module, coordinator)
+
+    handle.append_segment(b"\x01\x00")
+    handle.append_segment(b"\x02\x00\x03\x00")
+    handle.append_segment(b"\x04\x00")
+    handle.finish()
+    assert len(executor.submissions) == 1
+
+    executor.succeed()
+    assert executor.wait_for_submissions(2)
+    pending = executor.submissions[1]
+    assert pending["source"].audio == b"\x01\x00\x02\x00\x03\x00\x04\x00"
+    assert pending["segment_end_frames"] == (1, 3, 4)
+
+
+def test_active_dictation_allows_exactly_one_coalesced_next_request(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    delivered: list[tuple[int, str]] = []
+    handle = _begin(
+        coordinator_module,
+        coordinator,
+        callback=lambda sequence, text: delivered.append((sequence, text)),
+    )
+
+    handle.append_segment(b"\x01\x00")
+    handle.append_segment(b"\x02\x00")
+    handle.append_segment(b"\x03\x00")
+    handle.finish()
+    assert len(executor.submissions) == 1
+
+    executor.succeed({"text": "one", "logical_segments": ("one",)})
+    assert executor.wait_for_submissions(2)
+    assert len(executor.submissions) == 2
+    assert executor.submissions[1]["source"].audio == b"\x02\x00\x03\x00"
+    assert executor.submissions[1]["segment_end_frames"] == (1, 2)
+    executor.succeed({"text": "two three", "logical_segments": ("two", "three")})
+    handle.wait()
+
+    assert delivered == [(0, "one"), (1, "two"), (2, "three")]
+
+
+def test_rapid_next_terminal_cannot_overtake_prior_segment_callback(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    first_callback_entered = threading.Event()
+    release_first_callback = threading.Event()
+    wait_done = threading.Event()
+    delivered: list[tuple[int, str, str]] = []
+
+    def on_segment(sequence: int, text: str) -> None:
+        if sequence == 0:
+            first_callback_entered.set()
+            release_first_callback.wait()
+        delivered.append((sequence, text, threading.current_thread().name))
+
+    handle = _begin(coordinator_module, coordinator, callback=on_segment)
+    handle.append_segment(b"\x01\x00")
+    handle.append_segment(b"\x02\x00")
+    handle.finish()
+    waiter = threading.Thread(
+        target=lambda: (handle.wait(), wait_done.set()),
+        name="ordered-callback-waiter",
+    )
+    waiter.start()
+
+    executor.succeed({"text": "first", "logical_segments": ("first",)})
+    assert executor.wait_for_submissions(2)
+    _wait_for(first_callback_entered)
+    executor.succeed({"text": "second", "logical_segments": ("second",)})
+
+    try:
+        assert delivered == []
+        assert not wait_done.is_set()
+    finally:
+        release_first_callback.set()
+    _wait_for(wait_done)
+    waiter.join(1.0)
+
+    assert [(sequence, text) for sequence, text, _thread in delivered] == [
+        (0, "first"),
+        (1, "second"),
+    ]
+    assert len({thread for _sequence, _text, thread in delivered}) == 1
+
+
+@pytest.mark.parametrize(
+    "changed",
+    ["capture_generation", "identity", "sample_rate", "channels", "sample_width"],
+)
+def test_mismatched_capture_is_visibly_busy_and_never_combines_pcm(
+    coordinator_module: Any,
+    changed: str,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    first = _begin(coordinator_module, coordinator)
+    first.append_segment(b"\x01\x00")
+    kwargs: dict[str, Any] = {}
+    if changed == "capture_generation":
+        kwargs[changed] = 8
+    elif changed == "identity":
+        kwargs["dispatch"] = _dispatch("parakeet-tdt-0.6b-v3")
+    elif changed == "sample_rate":
+        kwargs[changed] = 16_000
+    elif changed == "channels":
+        kwargs[changed] = 2
+    else:
+        kwargs[changed] = 1
+
+    with pytest.raises(ExecutorBusyError, match="dictation"):
+        _begin(coordinator_module, coordinator, **kwargs)
+
+    assert executor.submissions[0]["source"].audio == b"\x01\x00"
+
+
+def test_exact_limit_is_frame_aligned_retained_and_reported_once(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    handle = _begin(
+        coordinator_module,
+        coordinator,
+        sample_rate=2,
+        channels=1,
+        sample_width=2,
+    )
+    exact = b"\x01\x00" * 120
+
+    assert handle.append_segment(exact) is coordinator_module.DictationAppendStatus.LIMIT_REACHED
+    assert executor.wait_for_submissions(1)
+    assert executor.submissions[0]["source"].audio == exact
+    with pytest.raises(RuntimeError, match="finished"):
+        handle.append_segment(b"\x02\x00")
+
+
+def test_one_frame_over_limit_retains_every_accepted_complete_frame(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    handle = _begin(
+        coordinator_module,
+        coordinator,
+        sample_rate=2,
+        channels=1,
+        sample_width=2,
+    )
+    over = b"\x01\x00" * 121
+
+    assert handle.append_segment(over) is coordinator_module.DictationAppendStatus.LIMIT_REACHED
+    assert executor.wait_for_submissions(1)
+    assert executor.submissions[0]["source"].audio == over[:-2]
+    assert executor.submissions[0]["segment_end_frames"] == (120,)
+
+
+def test_append_rejects_partial_pcm_frames_without_retaining_them(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    handle = _begin(coordinator_module, coordinator, channels=2, sample_width=2)
+
+    with pytest.raises(ValueError, match="complete interleaved PCM frames"):
+        handle.append_segment(b"\x00\x00")
+    assert executor.submissions == []
+
+
+def test_stale_and_duplicate_terminals_are_ignored_once(
+    coordinator_module: Any,
+) -> None:
+    delivered: list[str] = []
+    delivered_event = threading.Event()
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    def on_result(result: ExecutorResult) -> None:
+        delivered.append(result.payload["text"])
+        delivered_event.set()
+
+    coordinator.submit_library(**_library_kwargs(on_result=on_result))
+
+    executor.deliver_stale_result()
+    assert delivered == []
+    executor.succeed({"text": "real"})
+    _wait_for(delivered_event)
+    executor.deliver_duplicate_result()
+
+    assert delivered == ["real"]
+
+
+def test_nonretryable_worker_failure_clears_capture_with_sanitized_category(
+    coordinator_module: Any,
+) -> None:
+    idle = threading.Event()
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(
+        executor,
+        on_dictation_idle=idle.set,
+    )
+    handle = _begin(coordinator_module, coordinator)
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+    executor.fail(
+        TranscriptionFailureCode.INFERENCE_FAILED,
+        failed_attempt={"private_path": "/Users/alice/secret/model.onnx"},
+    )
+
+    with pytest.raises(RuntimeError) as caught:
+        handle.wait()
+    _wait_for(idle)
+
+    assert caught.value.args == (TranscriptionFailureCode.INFERENCE_FAILED,)
+    assert "/Users/alice" not in str(caught.value)
+    assert handle.take_retry_buffer() is None
+    assert coordinator.dictation_reserved is False
+
+
+def test_pending_cancel_clears_gate_once_without_preempting_batch(
+    coordinator_module: Any,
+) -> None:
+    idle_count = 0
+    idle = threading.Event()
+
+    def on_idle() -> None:
+        nonlocal idle_count
+        idle_count += 1
+        idle.set()
+
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(
+        executor,
+        on_dictation_idle=on_idle,
+    )
+    coordinator.submit_library(**_library_kwargs())
+    handle = _begin(coordinator_module, coordinator)
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+
+    assert handle.cancel() is True
+    with pytest.raises(RuntimeError) as caught:
+        handle.wait()
+    _wait_for(idle)
+    assert handle.cancel() is False
+    executor.succeed()
+
+    assert executor.cancelled_attempts == []
+    assert caught.value.args == (TranscriptionFailureCode.CANCELLED,)
+    assert len(executor.submissions) == 1
+    assert idle_count == 1
+
+
+def test_active_cooperative_cancel_targets_attempt_and_waits_for_terminal(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    handle = _begin(coordinator_module, coordinator)
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+    attempt_id = executor.active["attempt_id"]
+
+    assert handle.cancel() is True
+    assert executor.cancelled_attempts == [attempt_id]
+    executor.fail(TranscriptionFailureCode.CANCELLED)
+    with pytest.raises(RuntimeError) as caught:
+        handle.wait()
+
+    assert caught.value.args == (TranscriptionFailureCode.CANCELLED,)
+    assert coordinator.dictation_reserved is False
+
+
+def test_force_cancel_uses_executor_force_stop_and_resolves_once(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    handle = _begin(coordinator_module, coordinator)
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+    attempt_id = executor.active["attempt_id"]
+
+    assert handle.cancel(force=True) is True
+    with pytest.raises(RuntimeError) as caught:
+        handle.wait()
+
+    assert caught.value.args == (TranscriptionFailureCode.CANCELLED,)
+    assert executor.force_stopped_attempts == [attempt_id]
+    assert coordinator.dictation_reserved is False
+
+
+def test_close_releases_pending_audio_without_closing_or_preempting_executor(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    coordinator.submit_library(**_library_kwargs())
+    handle = _begin(coordinator_module, coordinator)
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+
+    coordinator.close()
+    coordinator.close()
+    with pytest.raises(RuntimeError) as caught:
+        handle.wait()
+    executor.succeed()
+
+    assert caught.value.args == (TranscriptionFailureCode.CANCELLED,)
+    assert executor.closed is False
+    assert executor.cancelled_attempts == []
+    assert len(executor.submissions) == 1
+    assert coordinator.dictation_reserved is False
+    with pytest.raises(RuntimeError, match="closed"):
+        _begin(coordinator_module, coordinator, capture_generation=9)
+
+
+def test_close_cooperatively_cancels_active_dictation_without_owning_executor(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    handle = _begin(coordinator_module, coordinator)
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+    attempt_id = executor.active["attempt_id"]
+
+    coordinator.close()
+    assert executor.cancelled_attempts == [attempt_id]
+    assert executor.closed is False
+    executor.fail(TranscriptionFailureCode.CANCELLED)
+    with pytest.raises(RuntimeError) as caught:
+        handle.wait()
+
+    assert caught.value.args == (TranscriptionFailureCode.CANCELLED,)
+    assert coordinator.dictation_reserved is False
+
+
+def test_retry_retains_failed_pending_and_later_pcm_but_not_earlier_success(
+    coordinator_module: Any,
+) -> None:
+    delivered: list[tuple[int, str]] = []
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    handle = _begin(
+        coordinator_module,
+        coordinator,
+        callback=lambda sequence, text: delivered.append((sequence, text)),
+    )
+
+    handle.append_segment(b"\x01\x00")
+    executor.succeed({"text": "released", "logical_segments": ("released",)})
+    assert executor.wait_for_submissions(1)
+    handle.append_segment(b"\x02\x00")
+    assert executor.wait_for_submissions(2)
+    handle.append_segment(b"\x03\x00")
+    executor.fail(
+        TranscriptionFailureCode.INFERENCE_FAILED,
+        recovery_actions=("retry_faster_whisper",),
+        failed_attempt={"native": "secret /private/model.onnx"},
+    )
+    handle.append_segment(b"\x04\x00")
+    handle.finish()
+
+    with pytest.raises(coordinator_module.RetryableDictationFailure) as caught:
+        handle.wait()
+    retry = caught.value.retry_buffer
+
+    assert str(caught.value) == "Parakeet transcription failed."
+    assert "/private/model.onnx" not in repr(caught.value)
+    assert retry.source.audio == b"\x02\x00\x03\x00\x04\x00"
+    assert retry.segment_end_frames == (1, 2, 3)
+    assert delivered == [(0, "released")]
+    assert handle.take_retry_buffer() is retry
+    assert handle.take_retry_buffer() is None
+
+
+def test_cancel_releases_a_completed_retry_buffer(coordinator_module: Any) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    handle = _begin(coordinator_module, coordinator)
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+    executor.fail(
+        TranscriptionFailureCode.INFERENCE_FAILED,
+        recovery_actions=("retry_faster_whisper",),
+    )
+
+    with pytest.raises(coordinator_module.RetryableDictationFailure):
+        handle.wait()
+    assert handle.cancel() is True
+    assert handle.take_retry_buffer() is None
+    with pytest.raises(RuntimeError) as caught:
+        handle.wait()
+    assert caught.value.args == (TranscriptionFailureCode.CANCELLED,)
+
+
+def test_identity_change_resubmits_off_reader_then_preserves_callback_order(
+    coordinator_module: Any,
+) -> None:
+    order: list[str] = []
+    idle = threading.Event()
+    executor = FakeExecutor(order)
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(
+        executor,
+        on_dictation_idle=lambda: (order.append("top-up"), idle.set()),
+    )
+    coordinator.submit_library(
+        **_library_kwargs(
+            model_id="parakeet-tdt-0.6b-v3",
+            on_result=lambda _result: order.append("batch-callback"),
+        )
+    )
+    handle = _begin(
+        coordinator_module,
+        coordinator,
+        dispatch=_dispatch("parakeet-tdt-0.6b-v2"),
+        callback=lambda sequence, _text: order.append(f"dictation-callback-{sequence}"),
+    )
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+
+    executor.succeed(thread_name="fake-reader-v3")
+    assert executor.wait_for_submissions(2)
+    dictation_submission = executor.submissions[1]
+
+    assert dictation_submission["submit_thread"] != "fake-reader-v3"
+    assert dictation_submission["submit_thread"].startswith("local-stt-dispatch-")
+    assert order[:3] == ["submit-library", "submit-dictation", "batch-callback"]
+    executor.succeed({"text": "hello", "logical_segments": ("hello",)})
+    handle.wait()
+    _wait_for(idle)
+    assert order[-2:] == ["dictation-callback-0", "top-up"]
+
+
+def test_processing_thread_exits_within_join_bound_while_dictation_waits(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    coordinator.submit_library(**_library_kwargs())
+    handle = _begin(coordinator_module, coordinator)
+    processing_done = threading.Event()
+    release_batch = threading.Event()
+    batch_done = threading.Event()
+    wait_done = threading.Event()
+
+    def process_audio() -> None:
+        handle.append_segment(b"\x01\x00")
+        handle.finish()
+        processing_done.set()
+
+    processing = threading.Thread(target=process_audio, name="dictation-processing")
+    batch = threading.Thread(
+        target=lambda: (
+            release_batch.wait(),
+            executor.succeed(),
+            batch_done.set(),
+        ),
+        name="event-delayed-batch",
+    )
+    waiter = threading.Thread(
+        target=lambda: (handle.wait(), wait_done.set()),
+        name="dictation-waiter",
+    )
+    batch.start()
+    processing.start()
+    processing.join(0.05)
+    waiter.start()
+
+    assert processing_done.is_set()
+    assert not processing.is_alive()
+    assert len(executor.submissions) == 1
+    assert not batch_done.is_set()
+    assert not wait_done.is_set()
+
+    release_batch.set()
+    _wait_for(batch_done)
+    assert executor.wait_for_submissions(2)
+    assert not wait_done.is_set()
+    executor.succeed({"text": "kept", "logical_segments": ("kept",)})
+    _wait_for(wait_done)
+    batch.join(1.0)
+    waiter.join(1.0)
+
+
+def test_blocking_one_shot_returns_exact_executor_payload(coordinator_module: Any) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    expected = {
+        "text": "one shot",
+        "logical_segments": ("one shot",),
+        "duration": 0.25,
+        "transcription_model": "parakeet-tdt-0.6b-v2",
+        "transcription_provenance": {"schema_version": 1},
+    }
+    returned: list[dict[str, Any]] = []
+    completed = threading.Event()
+
+    def call() -> None:
+        returned.append(
+            coordinator.transcribe_buffer(
+                source=BufferAudioSource(b"\x01\x00", 8_000),
+                dispatch=_dispatch(),
+                language="en",
+            )
+        )
+        completed.set()
+
+    caller = threading.Thread(target=call, name="one-shot-caller")
+    caller.start()
+    assert executor.wait_for_submissions(1)
+    assert not completed.is_set()
+    executor.succeed(expected)
+    _wait_for(completed)
+    caller.join(1.0)
+
+    assert returned == [expected]

--- a/Tests/STT/test_dispatch_coordinator.py
+++ b/Tests/STT/test_dispatch_coordinator.py
@@ -1195,3 +1195,51 @@ def test_blocking_one_shot_returns_exact_executor_payload(coordinator_module: An
     caller.join(1.0)
 
     assert returned == [expected]
+
+
+def test_blocking_one_shot_accepts_exact_pcm_limit(coordinator_module: Any) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    exact = b"\x01\x00" * 120
+    expected = {"text": "exact", "logical_segments": ("exact",)}
+    returned: list[dict[str, Any]] = []
+    completed = threading.Event()
+
+    def call() -> None:
+        returned.append(
+            coordinator.transcribe_buffer(
+                source=BufferAudioSource(exact, 2),
+                dispatch=_dispatch(),
+                language="en",
+            )
+        )
+        completed.set()
+
+    caller = threading.Thread(target=call, name="exact-limit-one-shot-caller")
+    caller.start()
+    assert executor.wait_for_submissions(1)
+    assert executor.submissions[0]["source"].audio == exact
+    executor.succeed(expected)
+    _wait_for(completed)
+    caller.join(1.0)
+
+    assert returned == [expected]
+
+
+def test_blocking_one_shot_rejects_pcm_over_limit_before_submit(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+
+    def unexpected_submit(**_kwargs: Any) -> int:
+        raise AssertionError("oversized one-shot reached the executor")
+
+    executor.submit = unexpected_submit
+
+    with pytest.raises(ValueError, match="exceeds the 60-second PCM limit"):
+        coordinator.transcribe_buffer(
+            source=BufferAudioSource(b"\x01\x00" * 121, 2),
+            dispatch=_dispatch(),
+            language="en",
+        )

--- a/Tests/STT/test_dispatch_coordinator.py
+++ b/Tests/STT/test_dispatch_coordinator.py
@@ -948,6 +948,62 @@ def test_close_releases_a_completed_untransferred_retry_buffer(
     assert handle.take_retry_buffer() is None
 
 
+def test_second_retryable_capture_does_not_invalidate_first_retry_buffer(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    first = _begin(coordinator_module, coordinator, capture_generation=11)
+    first.append_segment(b"\x01\x00")
+    first.finish()
+    executor.fail(
+        TranscriptionFailureCode.INFERENCE_FAILED,
+        recovery_actions=("retry_faster_whisper",),
+    )
+    with pytest.raises(coordinator_module.RetryableDictationFailure) as first_error:
+        first.wait()
+
+    second = _begin(coordinator_module, coordinator, capture_generation=12)
+    second.append_segment(b"\x02\x00")
+    second.finish()
+    executor.fail(
+        TranscriptionFailureCode.INFERENCE_FAILED,
+        recovery_actions=("retry_faster_whisper",),
+    )
+    with pytest.raises(coordinator_module.RetryableDictationFailure) as second_error:
+        second.wait()
+
+    assert first.take_retry_buffer() is first_error.value.retry_buffer
+    assert second.take_retry_buffer() is second_error.value.retry_buffer
+
+
+def test_close_releases_all_live_handles_untransferred_retry_buffers(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    handles = []
+    for generation, audio in ((21, b"\x01\x00"), (22, b"\x02\x00")):
+        handle = _begin(
+            coordinator_module,
+            coordinator,
+            capture_generation=generation,
+        )
+        handle.append_segment(audio)
+        handle.finish()
+        executor.fail(
+            TranscriptionFailureCode.INFERENCE_FAILED,
+            recovery_actions=("retry_faster_whisper",),
+        )
+        with pytest.raises(coordinator_module.RetryableDictationFailure):
+            handle.wait()
+        handles.append(handle)
+
+    coordinator.close()
+
+    assert [handle.take_retry_buffer() for handle in handles] == [None, None]
+
+
 def test_identity_change_resubmits_off_reader_then_preserves_callback_order(
     coordinator_module: Any,
 ) -> None:

--- a/Tests/STT/test_dispatch_coordinator.py
+++ b/Tests/STT/test_dispatch_coordinator.py
@@ -994,7 +994,7 @@ def test_cancel_releases_a_completed_retry_buffer(coordinator_module: Any) -> No
     assert handle.take_retry_buffer() is None
     with pytest.raises(RuntimeError) as caught:
         handle.wait()
-    assert caught.value.args == (TranscriptionFailureCode.CANCELLED,)
+    assert caught.value.args == (TranscriptionFailureCode.CANCELLED.value,)
 
 
 def test_close_releases_a_completed_untransferred_retry_buffer(

--- a/Tests/STT/test_dispatch_coordinator.py
+++ b/Tests/STT/test_dispatch_coordinator.py
@@ -20,6 +20,7 @@ from tldw_chatbook.STT.executor import (
     ExecutorBusyError,
     ExecutorFailure,
     ExecutorResult,
+    ExecutorUnavailableError,
     ModelIdentity,
 )
 from tldw_chatbook.STT.parakeet_dispatch import ParakeetDispatch
@@ -44,6 +45,7 @@ class FakeExecutor:
         self.force_stopped_attempts: list[str] = []
         self.closed = False
         self.order = order if order is not None else []
+        self.before_submit: Callable[[str], None] | None = None
 
     def submit(
         self,
@@ -62,6 +64,9 @@ class FakeExecutor:
         on_failure: Callable[[ExecutorFailure], None] = lambda _failure: None,
         explicit_retry: bool = False,
     ) -> int:
+        kind = "library" if job_id is not None else "dictation"
+        if self.before_submit is not None:
+            self.before_submit(kind)
         with self._condition:
             if self.active is not None:
                 raise ExecutorBusyError("fake executor already has active work")
@@ -85,7 +90,6 @@ class FakeExecutor:
             }
             self.active = submission
             self.submissions.append(submission)
-            kind = "library" if job_id is not None else "dictation"
             self.order.append(f"submit-{kind}")
             self._condition.notify_all()
             return self._generation
@@ -352,6 +356,53 @@ def test_batch_failure_also_submits_dictation_before_original_callback(
     _wait_for(failure_delivered)
 
     assert order[:3] == ["submit-library", "submit-dictation", "library-failure"]
+
+
+def test_synchronous_library_submit_failure_still_dispatches_reserved_dictation(
+    coordinator_module: Any,
+) -> None:
+    submit_entered = threading.Event()
+    release_submit = threading.Event()
+    submit_finished = threading.Event()
+    caught: list[Exception] = []
+    executor = FakeExecutor()
+
+    def fail_library_submit(kind: str) -> None:
+        if kind != "library":
+            return
+        submit_entered.set()
+        release_submit.wait()
+        raise ExecutorUnavailableError("planned Library submit failure")
+
+    executor.before_submit = fail_library_submit
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+
+    def submit_library() -> None:
+        try:
+            coordinator.submit_library(**_library_kwargs())
+        except Exception as error:
+            caught.append(error)
+        finally:
+            submit_finished.set()
+
+    library_thread = threading.Thread(target=submit_library, name="failing-library")
+    library_thread.start()
+    _wait_for(submit_entered)
+    handle = _begin(coordinator_module, coordinator)
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+
+    release_submit.set()
+    _wait_for(submit_finished)
+    library_thread.join(1.0)
+
+    assert len(caught) == 1
+    assert isinstance(caught[0], ExecutorUnavailableError)
+    assert executor.wait_for_submissions(1)
+    assert executor.submissions[0]["job_id"] is None
+    executor.succeed({"text": "kept", "logical_segments": ("kept",)})
+    handle.wait()
+    assert coordinator.dictation_reserved is False
 
 
 def test_dictation_terminal_delivers_callback_then_clears_gate_and_tops_up(
@@ -734,6 +785,43 @@ def test_force_cancel_uses_executor_force_stop_and_resolves_once(
     assert coordinator.dictation_reserved is False
 
 
+def test_force_cancel_before_submit_residency_is_replayed_as_force_stop(
+    coordinator_module: Any,
+) -> None:
+    submit_entered = threading.Event()
+    release_submit = threading.Event()
+    append_finished = threading.Event()
+    executor = FakeExecutor()
+
+    def hold_dictation_submit(kind: str) -> None:
+        if kind == "dictation":
+            submit_entered.set()
+            release_submit.wait()
+
+    executor.before_submit = hold_dictation_submit
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    handle = _begin(coordinator_module, coordinator)
+    appender = threading.Thread(
+        target=lambda: (handle.append_segment(b"\x01\x00"), append_finished.set()),
+        name="dictation-submit-race",
+    )
+    appender.start()
+    _wait_for(submit_entered)
+
+    try:
+        assert handle.cancel(force=True) is True
+    finally:
+        release_submit.set()
+    _wait_for(append_finished)
+    appender.join(1.0)
+
+    with pytest.raises(RuntimeError) as caught:
+        handle.wait()
+    assert caught.value.args == (TranscriptionFailureCode.CANCELLED,)
+    assert len(executor.force_stopped_attempts) == 1
+    assert executor.cancelled_attempts == []
+
+
 def test_close_releases_pending_audio_without_closing_or_preempting_executor(
     coordinator_module: Any,
 ) -> None:
@@ -837,6 +925,27 @@ def test_cancel_releases_a_completed_retry_buffer(coordinator_module: Any) -> No
     with pytest.raises(RuntimeError) as caught:
         handle.wait()
     assert caught.value.args == (TranscriptionFailureCode.CANCELLED,)
+
+
+def test_close_releases_a_completed_untransferred_retry_buffer(
+    coordinator_module: Any,
+) -> None:
+    executor = FakeExecutor()
+    coordinator = coordinator_module.LocalSTTDispatchCoordinator(executor)
+    handle = _begin(coordinator_module, coordinator)
+    handle.append_segment(b"\x01\x00")
+    handle.finish()
+    executor.fail(
+        TranscriptionFailureCode.INFERENCE_FAILED,
+        recovery_actions=("retry_faster_whisper",),
+    )
+
+    with pytest.raises(coordinator_module.RetryableDictationFailure):
+        handle.wait()
+    assert coordinator.dictation_reserved is False
+    coordinator.close()
+
+    assert handle.take_retry_buffer() is None
 
 
 def test_identity_change_resubmits_off_reader_then_preserves_callback_order(

--- a/Tests/STT/test_local_stt_executor.py
+++ b/Tests/STT/test_local_stt_executor.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import os
 import pickle
+import subprocess
+import sys
+import textwrap
 import threading
 import time
 from dataclasses import FrozenInstanceError
@@ -430,6 +434,105 @@ def _wait_until(predicate: object, timeout: float = 10.0) -> None:
     while not predicate() and time.monotonic() < deadline:  # type: ignore[operator]
         time.sleep(0.01)
     assert predicate()  # type: ignore[operator]
+
+
+@pytest.mark.integration
+def test_executor_starts_under_textual_filenoless_stderr() -> None:
+    """The first real spawn must survive Textual's ``fileno() == -1`` stderr."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    environment = {**os.environ, "PYTHONPATH": str(repo_root)}
+    environment.pop("PYTEST_CURRENT_TEST", None)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                import sys
+                import threading
+
+
+                class TextualLikeStderr:
+                    def fileno(self):
+                        return -1
+
+                    def write(self, *_args, **_kwargs):
+                        return 0
+
+                    def flush(self):
+                        pass
+
+
+                if __name__ == "__main__":
+                    sys.stderr = TextualLikeStderr()
+
+                    from Tests.STT.executor_test_support import protocol_executor_worker
+                    from tldw_chatbook.STT.contracts import (
+                        BufferAudioSource,
+                        ExecutionDevice,
+                    )
+                    from tldw_chatbook.STT.executor import LocalSTTExecutor, ModelIdentity
+
+                    terminal = threading.Event()
+                    results = []
+                    failures = []
+
+                    def on_result(value):
+                        results.append(value)
+                        terminal.set()
+
+                    def on_failure(value):
+                        failures.append(value)
+                        terminal.set()
+
+                    executor = LocalSTTExecutor(
+                        worker_target=protocol_executor_worker,
+                        startup_timeout=5.0,
+                        graceful_shutdown_timeout=0.2,
+                        force_stop_timeout=2.0,
+                    )
+                    try:
+                        executor.submit(
+                            attempt_id="textual-stderr",
+                            job_id=None,
+                            source=BufferAudioSource(b"\\x00\\x00", 16_000),
+                            identity=ModelIdentity(
+                                provider_id="parakeet-onnx",
+                                model_id="nemo-parakeet-tdt-0.6b-v2",
+                                root_revision=None,
+                                closure_fingerprint=None,
+                                precision="int8",
+                                device=ExecutionDevice.CPU,
+                            ),
+                            options={},
+                            segment_end_frames=(1,),
+                            on_result=on_result,
+                            on_failure=on_failure,
+                        )
+                        assert terminal.wait(10.0)
+                        assert len(results) == 1, failures
+                    except BaseException:
+                        import traceback
+
+                        traceback.print_exc(file=sys.stdout)
+                        raise
+                    finally:
+                        executor.close()
+                    print("STT_WORKER_OK")
+                """
+            ),
+        ],
+        cwd=repo_root,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "STT_WORKER_OK" in completed.stdout
 
 
 def test_worker_file_source_uses_existing_parser_with_path_options_and_runner() -> None:

--- a/Tests/STT/test_local_stt_executor.py
+++ b/Tests/STT/test_local_stt_executor.py
@@ -42,9 +42,9 @@ from tldw_chatbook.STT.executor import (
     ExecutorRequest,
     ExecutorResult,
     ExecutorUnavailableError,
-    LocalSTTExecutor,
     LocalSourceChangedError,
     LocalSourceSnapshot,
+    LocalSTTExecutor,
     ModelIdentity,
     WorkerPhase,
     _AttemptTerminalGuard,
@@ -52,12 +52,14 @@ from tldw_chatbook.STT.executor import (
     validate_local_source_snapshot,
 )
 from tldw_chatbook.STT.executor_worker import (
-    _ProviderLoadFailure,
+    ProviderRuntime,
     _default_parse_job,
     _failure_from_exception,
     _failure_from_worker_exception,
     _load_resident,
     _parakeet_provider,
+    _ProviderLoadFailure,
+    _run_executor_worker,
 )
 
 
@@ -530,6 +532,336 @@ def test_worker_rejects_buffer_without_parakeet_buffer_capability(
     assert callbacks.results == []
     assert callbacks.failures[0].code is TranscriptionFailureCode.UNSUPPORTED_CAPABILITY
     assert callbacks.failures[0].recovery_actions == ("retry_faster_whisper",)
+
+
+def test_worker_passes_each_buffer_requests_current_provenance_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests = (
+        ExecutorRequest(
+            generation=1,
+            attempt_id="attempt-one",
+            job_id="job-one",
+            source=BufferAudioSource(b"\x00\x00", 16_000),
+            identity=_identity(root_revision=None, closure_fingerprint=None),
+            options={
+                "language": "en",
+                "transcription_context": {"batch_id": "batch-one"},
+            },
+            segment_end_frames=(1,),
+        ),
+        ExecutorRequest(
+            generation=1,
+            attempt_id="attempt-two",
+            job_id=None,
+            source=BufferAudioSource(b"\x01\x00", 16_000),
+            identity=_identity(root_revision=None, closure_fingerprint=None),
+            options={
+                "language": "fr",
+                "transcription_context": {"batch_id": "batch-two"},
+            },
+            segment_end_frames=(1,),
+        ),
+    )
+    received: list[dict[str, object]] = []
+
+    def provider_builder(*_args, **_kwargs) -> ProviderRuntime:
+        def buffer_runner(source, **kwargs):
+            received.append({"audio": source.audio, **kwargs})
+            return {
+                "attempt_id": kwargs["attempt_id"],
+                "job_id": kwargs["job_id"],
+                "language": kwargs["language"],
+            }
+
+        return ProviderRuntime(
+            runner=lambda *_args, **_kwargs: {},
+            buffer_runner=buffer_runner,
+            close=lambda: None,
+        )
+
+    class _Connection:
+        def __init__(self) -> None:
+            self.commands = iter((*requests, ("close", 1)))
+            self.sent: list[object] = []
+
+        def send(self, value: object) -> None:
+            self.sent.append(value)
+
+        def recv(self) -> object:
+            return next(self.commands)
+
+        def close(self) -> None:
+            return None
+
+    class _Event:
+        def wait(self, _timeout: float) -> bool:
+            return True
+
+        def is_set(self) -> bool:
+            return False
+
+    connection = _Connection()
+    monkeypatch.setattr(
+        "tldw_chatbook.STT.executor_worker.enter_worker_containment",
+        lambda: SimpleNamespace(pid=1),
+    )
+
+    _run_executor_worker(
+        connection,  # type: ignore[arg-type]
+        _Event(),
+        _Event(),
+        1,
+        str(tmp_path),
+        provider_builder=provider_builder,
+        parse_job=lambda *_args, **_kwargs: {},
+    )
+
+    assert received == [
+        {
+            "audio": b"\x00\x00",
+            "segment_end_frames": (1,),
+            "attempt_id": "attempt-one",
+            "job_id": "job-one",
+            "language": "en",
+            "transcription_context": {"batch_id": "batch-one"},
+        },
+        {
+            "audio": b"\x01\x00",
+            "segment_end_frames": (1,),
+            "attempt_id": "attempt-two",
+            "job_id": None,
+            "language": "fr",
+            "transcription_context": {"batch_id": "batch-two"},
+        },
+    ]
+    results = [item for item in connection.sent if type(item) is ExecutorResult]
+    assert [item.payload for item in results] == [
+        {"attempt_id": "attempt-one", "job_id": "job-one", "language": "en"},
+        {"attempt_id": "attempt-two", "job_id": None, "language": "fr"},
+    ]
+
+
+def test_parakeet_buffer_runner_serializes_normalized_result_without_synthetic_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.STT.parakeet_onnx import (
+        ParakeetBufferResult,
+        ParakeetOnnxRuntime,
+    )
+
+    captured: dict[str, object] = {}
+
+    class _Runtime:
+        def transcribe_buffer(self, **kwargs):
+            captured.update(kwargs)
+            normalized = TranscriptionResult(
+                text="ordinary text console stop",
+                segments=(),
+                provenance=TranscriptionProvenance(
+                    schema_version=1,
+                    attempt_id=kwargs["attempt_id"],
+                    batch_id=None,
+                    job_id=kwargs["job_id"],
+                    retry_of_attempt_id=None,
+                    retry_of_job_id=None,
+                    provider_id="parakeet-onnx",
+                    model_id=PARAKEET_V2_MODEL,
+                    artifact_root=None,
+                    artifact_dependencies=(),
+                    precision="int8",
+                    requested_device=ExecutionDevice.CPU,
+                    effective_device=ExecutionDevice.CPU,
+                    requested_language=kwargs["language"],
+                    effective_language="en",
+                    detected_language=None,
+                    task=TranscriptionTask.TRANSCRIBE,
+                ),
+                produced_capabilities=ProducedCapabilities(
+                    timestamps=TimestampGranularity.NONE,
+                    punctuation=True,
+                    capitalization=True,
+                    vad=False,
+                    diarization=False,
+                ),
+                duration_seconds=0.5,
+                timings=TranscriptionTimings(total_seconds=0.1),
+            )
+            return ParakeetBufferResult(
+                normalized=normalized,
+                logical_segments=("ordinary text", "console stop"),
+            )
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(ParakeetOnnxRuntime, "load", lambda **_kwargs: _Runtime())
+    request = ExecutorRequest(
+        generation=1,
+        attempt_id="first-load-attempt",
+        job_id="first-load-job",
+        source=BufferAudioSource(b"\x00\x00\x01\x00", 16_000),
+        identity=_identity(
+            root_revision=None,
+            closure_fingerprint=None,
+            local_snapshot_token=None,
+        ),
+        options={"language": "en"},
+        segment_end_frames=(2,),
+    )
+    provider = _parakeet_provider(request, tmp_path, None, lambda: False)
+
+    payload = provider.buffer_runner(
+        request.source,
+        segment_end_frames=(1, 2),
+        attempt_id="current-attempt",
+        job_id=None,
+        language="fr",
+        transcription_context={"batch_id": "current-batch"},
+    )
+
+    assert payload == {
+        "text": "ordinary text console stop",
+        "logical_segments": ("ordinary text", "console stop"),
+        "duration": 0.5,
+        "transcription_model": PARAKEET_V2_MODEL,
+        "transcription_provenance": {
+            "schema_version": 1,
+            "attempt_id": "current-attempt",
+            "batch_id": None,
+            "job_id": None,
+            "retry_of_attempt_id": None,
+            "retry_of_job_id": None,
+            "provider_id": "parakeet-onnx",
+            "model_id": PARAKEET_V2_MODEL,
+            "artifact_root": None,
+            "artifact_dependencies": [],
+            "precision": "int8",
+            "requested_device": "cpu",
+            "effective_device": "cpu",
+            "requested_language": "fr",
+            "effective_language": "en",
+            "detected_language": None,
+            "task": "transcribe",
+            "produced_capabilities": {
+                "timestamps": "none",
+                "punctuation": True,
+                "capitalization": True,
+                "vad": False,
+                "diarization": False,
+            },
+            "warnings": [],
+            "failed_attempt": None,
+        },
+    }
+    assert captured["attempt_id"] == "current-attempt"
+    assert captured["job_id"] is None
+    assert captured["language"] == "fr"
+
+
+def test_parakeet_buffer_runner_rejects_non_int16_pcm_as_unsupported_capability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.STT.parakeet_onnx import ParakeetOnnxRuntime
+
+    class _Runtime:
+        def transcribe_buffer(self, **_kwargs):
+            raise AssertionError("unsupported PCM must not reach native inference")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(ParakeetOnnxRuntime, "load", lambda **_kwargs: _Runtime())
+    request = ExecutorRequest(
+        generation=1,
+        attempt_id="unsupported-width",
+        job_id=None,
+        source=BufferAudioSource(b"\x00", 16_000, sample_width=1),
+        identity=_identity(
+            root_revision=None,
+            closure_fingerprint=None,
+            local_snapshot_token=None,
+        ),
+        options={"language": "en"},
+        segment_end_frames=(1,),
+    )
+    provider = _parakeet_provider(request, tmp_path, None, lambda: False)
+
+    with pytest.raises(_ProviderLoadFailure) as raised:
+        provider.buffer_runner(
+            request.source,
+            segment_end_frames=(1,),
+            attempt_id=request.attempt_id,
+            job_id=None,
+            language="en",
+            transcription_context={},
+        )
+
+    assert raised.value.code is TranscriptionFailureCode.UNSUPPORTED_CAPABILITY
+
+
+def test_parakeet_buffer_failure_uses_current_request_metadata_without_leakage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.STT.parakeet_onnx import (
+        ParakeetOnnxFailure,
+        ParakeetOnnxRuntime,
+    )
+
+    class _Runtime:
+        def transcribe_buffer(self, **_kwargs):
+            raise RuntimeError("private native inference detail")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(ParakeetOnnxRuntime, "load", lambda **_kwargs: _Runtime())
+    request = ExecutorRequest(
+        generation=1,
+        attempt_id="first-attempt",
+        job_id="first-job",
+        source=BufferAudioSource(b"\x00\x00", 16_000),
+        identity=_identity(
+            model_id=PARAKEET_V3_MODEL,
+            root_revision=None,
+            closure_fingerprint=None,
+            local_snapshot_token=None,
+        ),
+        options={
+            "language": "en",
+            "transcription_context": {"batch_id": "first-batch"},
+        },
+        segment_end_frames=(1,),
+    )
+    provider = _parakeet_provider(request, tmp_path, None, lambda: False)
+
+    try:
+        provider.buffer_runner(
+            request.source,
+            segment_end_frames=(1,),
+            attempt_id="current-attempt",
+            job_id=None,
+            language="fr",
+            transcription_context={},
+        )
+    except ParakeetOnnxFailure as error:
+        failure = _failure_from_exception(request, error)
+    else:
+        raise AssertionError("buffer inference failure was not raised")
+
+    assert failure.code is TranscriptionFailureCode.INFERENCE_FAILED
+    assert failure.recovery_actions == ("retry_faster_whisper",)
+    assert failure.failed_attempt is not None
+    assert failure.failed_attempt["attempt_id"] == "current-attempt"
+    assert failure.failed_attempt["batch_id"] is None
+    assert failure.failed_attempt["job_id"] is None
+    assert failure.failed_attempt["requested_language"] == "fr"
+    assert failure.failed_attempt["effective_language"] == "auto"
+    assert "private" not in str(failure)
 
 
 def test_controller_starts_lazily_and_reuses_same_worker_for_same_identity() -> None:

--- a/Tests/STT/test_local_stt_executor.py
+++ b/Tests/STT/test_local_stt_executor.py
@@ -14,6 +14,7 @@ from Tests.STT.executor_test_support import (
     device_retry_executor_worker,
     fake_executor_worker,
     private_log_executor_worker,
+    protocol_executor_worker,
     resident_executor_worker,
 )
 from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
@@ -22,8 +23,10 @@ from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
 )
 from tldw_chatbook.Model_Artifacts import ArtifactInUseError, ModelArtifactService
 from tldw_chatbook.STT.contracts import (
+    BufferAudioSource,
     DeviceFailureOrigin,
     ExecutionDevice,
+    FileAudioSource,
     ProducedCapabilities,
     TimestampGranularity,
     TranscriptionFailureCode,
@@ -77,7 +80,7 @@ def _request() -> ExecutorRequest:
         generation=3,
         attempt_id="attempt-1",
         job_id="job-1",
-        source_path=Path("/private/media/interview.wav"),
+        source=FileAudioSource(Path("/private/media/interview.wav")),
         identity=_identity(local_snapshot_token=None),
         options={"transcription_model_dir": "/private/models/parakeet"},
         managed_store_root=Path("/private/models/managed"),
@@ -105,6 +108,92 @@ def test_protocol_objects_are_frozen_slotted_and_picklable() -> None:
     assert all(hasattr(type(value), "__slots__") for value in envelopes)
     with pytest.raises(FrozenInstanceError):
         request.generation = 4  # type: ignore[misc]
+
+
+def test_executor_request_accepts_file_and_buffer_sources_without_a_job_id() -> None:
+    file_request = ExecutorRequest(
+        generation=3,
+        attempt_id="file-attempt",
+        job_id=None,
+        source=FileAudioSource(Path("/private/media/interview.wav")),
+        identity=_identity(),
+        options={},
+    )
+    buffer_request = ExecutorRequest(
+        generation=3,
+        attempt_id="buffer-attempt",
+        job_id=None,
+        source=BufferAudioSource(b"\x00\x00\x01\x00", 16_000),
+        identity=_identity(),
+        options={},
+        segment_end_frames=(2,),
+    )
+
+    assert file_request.job_id is None
+    assert type(file_request.source) is FileAudioSource
+    assert buffer_request.segment_end_frames == (2,)
+
+
+@pytest.mark.parametrize(
+    ("source", "segment_end_frames", "error"),
+    [
+        (Path("speech.wav"), (), TypeError),
+        (FileAudioSource(Path("speech.wav")), (1,), ValueError),
+        (BufferAudioSource(b"\x00\x00\x01\x00", 16_000), (0, 2), ValueError),
+        (BufferAudioSource(b"\x00\x00\x01\x00", 16_000), (2, 2), ValueError),
+        (BufferAudioSource(b"\x00\x00\x01\x00", 16_000), (3,), ValueError),
+        (BufferAudioSource(b"\x00\x00\x01\x00", 16_000), (1,), ValueError),
+    ],
+)
+def test_executor_request_rejects_invalid_source_or_buffer_boundaries(
+    source: object,
+    segment_end_frames: tuple[int, ...],
+    error: type[Exception],
+) -> None:
+    with pytest.raises(error):
+        ExecutorRequest(
+            generation=3,
+            attempt_id="attempt-1",
+            job_id=None,
+            source=source,  # type: ignore[arg-type]
+            identity=_identity(),
+            options={},
+            segment_end_frames=segment_end_frames,
+        )
+
+
+def test_executor_request_source_variants_pickle_without_leaking_private_inputs() -> None:
+    snapshot = LocalSourceSnapshot(
+        token="private-snapshot-token",
+        paths=(Path("/private/models/model.onnx"),),
+        identities=((7, 11, 1024, 123456),),
+    )
+    requests = (
+        ExecutorRequest(
+            generation=3,
+            attempt_id="file-attempt",
+            job_id=None,
+            source=FileAudioSource(Path("/private/media/interview.wav")),
+            identity=_identity(),
+            options={"private": "/private/options"},
+            local_source=snapshot,
+        ),
+        ExecutorRequest(
+            generation=3,
+            attempt_id="buffer-attempt",
+            job_id=None,
+            source=BufferAudioSource(b"private-pcm", 16_000, sample_width=1),
+            identity=_identity(),
+            options={},
+            segment_end_frames=(11,),
+        ),
+    )
+
+    assert all(pickle.loads(pickle.dumps(request)) == request for request in requests)
+    rendered = "".join(repr(request) for request in requests)
+    assert "/private/" not in rendered
+    assert "private-pcm" not in rendered
+    assert "private-snapshot-token" not in rendered
 
 
 def test_model_identity_equality_includes_every_residency_component() -> None:
@@ -149,7 +238,7 @@ def test_managed_artifact_reference_is_validated() -> None:
         "generation": 3,
         "attempt_id": "attempt-1",
         "job_id": "job-1",
-        "source_path": Path("media.wav"),
+        "source": FileAudioSource(Path("media.wav")),
         "identity": _identity(),
         "options": {},
         "managed_store_root": Path("store"),
@@ -182,7 +271,7 @@ def test_protocol_rejects_empty_or_invalid_required_identity(
         "generation": 3,
         "attempt_id": "attempt-1",
         "job_id": "job-1",
-        "source_path": Path("media.wav"),
+        "source": FileAudioSource(Path("media.wav")),
         "identity": _identity(),
         "options": {},
     }
@@ -236,7 +325,7 @@ def test_worker_generated_failures_always_offer_provider_recovery(
         generation=request.generation,
         attempt_id=request.attempt_id,
         job_id=request.job_id,
-        source_path=request.source_path,
+        source=request.source,
         identity=_identity(provider_id=provider_id, local_snapshot_token=None),
         options={},
     )
@@ -299,6 +388,15 @@ def _executor(*, completed_job_limit: int = 20) -> LocalSTTExecutor:
     )
 
 
+def _protocol_executor() -> LocalSTTExecutor:
+    return LocalSTTExecutor(
+        worker_target=protocol_executor_worker,
+        startup_timeout=5.0,
+        graceful_shutdown_timeout=0.2,
+        force_stop_timeout=2.0,
+    )
+
+
 def _submit(
     executor: LocalSTTExecutor,
     callbacks: _Callbacks,
@@ -311,7 +409,7 @@ def _submit(
     return executor.submit(
         attempt_id=attempt_id,
         job_id=f"job-{attempt_id}",
-        source_path=Path("fixture.wav"),
+        source=FileAudioSource(Path("fixture.wav")),
         identity=identity or _identity(root_revision=None, closure_fingerprint=None),
         options={"test_mode": mode},
         on_event=callbacks.on_event,
@@ -330,6 +428,108 @@ def _wait_until(predicate: object, timeout: float = 10.0) -> None:
     while not predicate() and time.monotonic() < deadline:  # type: ignore[operator]
         time.sleep(0.01)
     assert predicate()  # type: ignore[operator]
+
+
+def test_worker_file_source_uses_existing_parser_with_path_options_and_runner() -> None:
+    executor = _protocol_executor()
+    callbacks = _Callbacks()
+    source = FileAudioSource(Path("/private/audio/file.wav"))
+    options = {"transcription_provider": "parakeet-onnx", "timestamps": False}
+    try:
+        executor.submit(
+            attempt_id="file-attempt",
+            job_id="file-job",
+            source=source,
+            identity=_identity(root_revision=None, closure_fingerprint=None),
+            options=options,
+            on_result=callbacks.on_result,
+            on_failure=callbacks.on_failure,
+        )
+        _wait_for_terminal(callbacks)
+    finally:
+        executor.close()
+
+    assert callbacks.failures == []
+    assert callbacks.results[0].payload == {
+        "file_path": "/private/audio/file.wav",
+        "options": options,
+        "runner_payload": {
+            "audio_path": "/private/audio/file.wav",
+            "kwargs": {"provider": "parakeet-onnx"},
+        },
+    }
+
+
+def test_worker_buffer_source_bypasses_file_parser_and_returns_buffer_payload() -> None:
+    executor = _protocol_executor()
+    callbacks = _Callbacks()
+    source = BufferAudioSource(b"\x00\x00\x01\x00", 16_000)
+    try:
+        executor.submit(
+            attempt_id="buffer-attempt",
+            job_id=None,
+            source=source,
+            identity=_identity(root_revision=None, closure_fingerprint=None),
+            options={},
+            segment_end_frames=(2,),
+            on_result=callbacks.on_result,
+            on_failure=callbacks.on_failure,
+        )
+        _wait_for_terminal(callbacks)
+    finally:
+        executor.close()
+
+    assert callbacks.failures == []
+    assert callbacks.results[0].payload == {
+        "audio_bytes": 4,
+        "sample_rate": 16_000,
+        "segment_end_frames": (2,),
+    }
+
+
+@pytest.mark.parametrize(
+    ("identity", "options"),
+    [
+        (
+            _identity(
+                provider_id="transcribe-cpp",
+                model_id="local-gguf:whisper",
+                precision="native",
+                root_revision=None,
+                closure_fingerprint=None,
+            ),
+            {},
+        ),
+        (
+            _identity(root_revision=None, closure_fingerprint=None),
+            {"test_no_buffer_runner": True},
+        ),
+    ],
+)
+def test_worker_rejects_buffer_without_parakeet_buffer_capability(
+    identity: ModelIdentity,
+    options: dict[str, object],
+) -> None:
+    executor = _protocol_executor()
+    callbacks = _Callbacks()
+    try:
+        executor.submit(
+            attempt_id="unsupported-buffer",
+            job_id=None,
+            source=BufferAudioSource(b"\x00\x00", 16_000),
+            identity=identity,
+            options=options,
+            segment_end_frames=(1,),
+            on_result=callbacks.on_result,
+            on_failure=callbacks.on_failure,
+        )
+        _wait_for_terminal(callbacks)
+    finally:
+        executor.close()
+
+    assert callbacks.results == []
+    assert callbacks.failures[0].code is TranscriptionFailureCode.UNSUPPORTED_CAPABILITY
+    assert callbacks.failures[0].recovery_actions == ("retry_faster_whisper",)
 
 
 def test_controller_starts_lazily_and_reuses_same_worker_for_same_identity() -> None:
@@ -643,7 +843,7 @@ def test_cpu_retry_start_failure_delivers_one_terminal_instead_of_stranding(
         executor.submit(
             attempt_id="retry-start-fails",
             job_id="job-retry-start-fails",
-            source_path=Path("fixture.wav"),
+            source=FileAudioSource(Path("fixture.wav")),
             identity=accelerated,
             options={"test_mode": "device_failure"},
             on_event=hold_retry,
@@ -761,7 +961,7 @@ def test_worker_reuses_runtime_and_holds_managed_closure_lease_until_exit(
             executor.submit(
                 attempt_id=attempt_id,
                 job_id=f"job-{attempt_id}",
-                source_path=tmp_path / "fixture.wav",
+                source=FileAudioSource(tmp_path / "fixture.wav"),
                 identity=identity,
                 options={"transcription_provider": "parakeet-onnx"},
                 managed_store_root=tmp_path / "store",
@@ -796,7 +996,7 @@ def test_provider_builder_receives_the_full_verified_managed_handle(
         generation=1,
         attempt_id="managed-handle",
         job_id="job-managed-handle",
-        source_path=tmp_path / "speech.wav",
+        source=FileAudioSource(tmp_path / "speech.wav"),
         identity=identity,
         options={},
         managed_store_root=tmp_path / "store",
@@ -915,7 +1115,7 @@ def test_parakeet_provider_persists_normalized_managed_provenance(
         generation=1,
         attempt_id="attempt-managed",
         job_id="job-managed",
-        source_path=tmp_path / "speech.wav",
+        source=FileAudioSource(tmp_path / "speech.wav"),
         identity=_identity(
             root_revision=root.revision,
             closure_fingerprint="closure",
@@ -929,7 +1129,7 @@ def test_parakeet_provider_persists_normalized_managed_provenance(
     )
 
     provider = _parakeet_provider(request, model_root, handle, lambda: False)
-    payload = provider.runner(str(request.source_path))
+    payload = provider.runner(str(request.source.path))
 
     assert captured["load"]["model_root"] == model_root
     assert captured["load"]["vad_root"] == vad_root
@@ -1002,7 +1202,7 @@ def test_parakeet_failure_survives_media_parse_and_executor_envelope(
         generation=1,
         attempt_id="attempt-parakeet-failure",
         job_id="job-parakeet-failure",
-        source_path=source,
+        source=FileAudioSource(source),
         identity=_identity(
             root_revision=root.revision,
             closure_fingerprint="closure",
@@ -1134,7 +1334,7 @@ def test_parakeet_runtime_failures_preserve_normalized_failed_attempt(
         generation=1,
         attempt_id="attempt-failure",
         job_id="job-failure",
-        source_path=tmp_path / "speech.wav",
+        source=FileAudioSource(tmp_path / "speech.wav"),
         identity=_identity(
             model_id=model_id,
             root_revision=root.revision,
@@ -1150,7 +1350,7 @@ def test_parakeet_runtime_failures_preserve_normalized_failed_attempt(
     try:
         provider = _parakeet_provider(request, model_root, handle, lambda: False)
         provider.runner(
-            str(request.source_path),
+            str(request.source.path),
             attempt_id="attempt-current",
             batch_id="batch-current",
             job_id="job-current",
@@ -1200,7 +1400,7 @@ def test_loaded_residency_is_reported_before_first_parse_failure(
         first_generation = executor.submit(
             attempt_id="first-fails",
             job_id="job-first-fails",
-            source_path=tmp_path / "fixture.wav",
+            source=FileAudioSource(tmp_path / "fixture.wav"),
             identity=original,
             options={
                 "transcription_provider": "parakeet-onnx",
@@ -1216,7 +1416,7 @@ def test_loaded_residency_is_reported_before_first_parse_failure(
         second_generation = executor.submit(
             attempt_id="second-succeeds",
             job_id="job-second-succeeds",
-            source_path=tmp_path / "fixture.wav",
+            source=FileAudioSource(tmp_path / "fixture.wav"),
             identity=changed,
             options={"transcription_provider": "parakeet-onnx"},
             on_result=second.on_result,
@@ -1239,7 +1439,7 @@ def test_worker_crash_releases_managed_closure_lease(tmp_path: Path) -> None:
         executor.submit(
             attempt_id="crash",
             job_id="job-crash",
-            source_path=tmp_path / "fixture.wav",
+            source=FileAudioSource(tmp_path / "fixture.wav"),
             identity=identity,
             options={
                 "transcription_provider": "parakeet-onnx",
@@ -1271,7 +1471,7 @@ def test_force_stop_releases_managed_closure_lease(tmp_path: Path) -> None:
         executor.submit(
             attempt_id="held",
             job_id="job-held",
-            source_path=tmp_path / "fixture.wav",
+            source=FileAudioSource(tmp_path / "fixture.wav"),
             identity=identity,
             options={
                 "transcription_provider": "parakeet-onnx",
@@ -1320,7 +1520,7 @@ def test_worker_revalidates_unmanaged_local_snapshot_before_reuse(
         executor.submit(
             attempt_id="one",
             job_id="job-one",
-            source_path=tmp_path / "fixture.wav",
+            source=FileAudioSource(tmp_path / "fixture.wav"),
             identity=identity,
             options={"transcription_provider": "parakeet-onnx"},
             local_source=snapshot,
@@ -1332,7 +1532,7 @@ def test_worker_revalidates_unmanaged_local_snapshot_before_reuse(
         executor.submit(
             attempt_id="two",
             job_id="job-two",
-            source_path=tmp_path / "fixture.wav",
+            source=FileAudioSource(tmp_path / "fixture.wav"),
             identity=identity,
             options={"transcription_provider": "parakeet-onnx"},
             local_source=snapshot,

--- a/Tests/STT/test_local_stt_executor.py
+++ b/Tests/STT/test_local_stt_executor.py
@@ -708,7 +708,10 @@ def test_parakeet_buffer_runner_serializes_normalized_result_without_synthetic_j
             closure_fingerprint=None,
             local_snapshot_token=None,
         ),
-        options={"language": "en"},
+        options={
+            "language": "en",
+            "transcription_context": {"batch_id": "first-load-batch"},
+        },
         segment_end_frames=(2,),
     )
     provider = _parakeet_provider(request, tmp_path, None, lambda: False)
@@ -730,7 +733,7 @@ def test_parakeet_buffer_runner_serializes_normalized_result_without_synthetic_j
         "transcription_provenance": {
             "schema_version": 1,
             "attempt_id": "current-attempt",
-            "batch_id": None,
+            "batch_id": "current-batch",
             "job_id": None,
             "retry_of_attempt_id": None,
             "retry_of_job_id": None,

--- a/Tests/STT/test_parakeet_dispatch.py
+++ b/Tests/STT/test_parakeet_dispatch.py
@@ -1,0 +1,239 @@
+"""Focused tests for shared, download-free Parakeet dispatch resolution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Local_Ingestion.stt_batch_routing import PARAKEET_V2_MODEL
+from tldw_chatbook.Model_Artifacts import ArtifactRef
+from tldw_chatbook.STT.contracts import ExecutionDevice
+
+
+def _configured_files(root: Path, precision: str) -> None:
+    filenames = (
+        (
+            "config.json",
+            "vocab.txt",
+            "encoder-model.int8.onnx",
+            "decoder_joint-model.int8.onnx",
+        )
+        if precision == "int8"
+        else (
+            "config.json",
+            "vocab.txt",
+            "encoder-model.onnx",
+            "encoder-model.onnx.data",
+            "decoder_joint-model.onnx",
+        )
+    )
+    root.mkdir()
+    for index, filename in enumerate(filenames):
+        (root / filename).write_bytes(f"configured-{index}".encode())
+
+
+@pytest.mark.parametrize("precision", ("int8", "f32"))
+def test_configured_library_and_console_calls_share_exact_dispatch(
+    tmp_path: Path,
+    precision: str,
+) -> None:
+    from tldw_chatbook.STT.parakeet_dispatch import resolve_parakeet_dispatch
+
+    model_root = tmp_path / precision
+    _configured_files(model_root, precision)
+
+    library = resolve_parakeet_dispatch(
+        model_id=PARAKEET_V2_MODEL,
+        precision=precision,
+        model_dir=str(model_root),
+    )
+    console = resolve_parakeet_dispatch(
+        model_id=PARAKEET_V2_MODEL,
+        precision=precision,
+        model_dir=model_root,
+    )
+
+    assert library == console
+    assert library.identity.provider_id == "parakeet-onnx"
+    assert library.identity.model_id == PARAKEET_V2_MODEL
+    assert library.identity.precision == precision
+    assert library.identity.device is ExecutionDevice.CPU
+    assert library.identity.root_revision is None
+    assert library.identity.closure_fingerprint is None
+    assert library.identity.local_snapshot_token == library.local_source.token
+    assert library.managed_store_root is None
+    assert library.managed_artifact_ref is None
+    assert dict(library.option_updates) == {
+        "transcription_model_dir": str(model_root.absolute())
+    }
+
+
+@pytest.mark.parametrize("precision", ("int8", "f32"))
+def test_managed_library_and_console_calls_share_closure_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    precision: str,
+) -> None:
+    from tldw_chatbook.STT import parakeet_dispatch
+
+    root = ArtifactRef("parakeet-v2", "managed-revision", precision)
+    handle = SimpleNamespace(
+        root=root,
+        closure_fingerprint="managed-closure-fingerprint",
+    )
+
+    class _Lease:
+        def __init__(self) -> None:
+            self.handle = handle
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    leases: list[_Lease] = []
+
+    class _Service:
+        def acquire(self, reference: ArtifactRef) -> _Lease:
+            assert reference == root
+            lease = _Lease()
+            leases.append(lease)
+            return lease
+
+    managed_root = tmp_path / "managed-store"
+    monkeypatch.setattr(parakeet_dispatch, "parakeet_v2_managed_service", _Service)
+    monkeypatch.setattr(
+        parakeet_dispatch,
+        "active_managed_parakeet_dir",
+        lambda model, precision, *, service: tmp_path / "installed",
+    )
+    monkeypatch.setattr(
+        parakeet_dispatch,
+        "parakeet_reference",
+        lambda model, precision: root,
+    )
+    monkeypatch.setattr(
+        parakeet_dispatch,
+        "managed_model_artifact_root",
+        lambda: managed_root,
+    )
+    monkeypatch.setattr(
+        parakeet_dispatch,
+        "parakeet_v2_install_dir",
+        lambda: tmp_path / "missing-legacy",
+    )
+
+    library = parakeet_dispatch.resolve_parakeet_dispatch(
+        model_id=PARAKEET_V2_MODEL,
+        precision=precision,
+        model_dir=None,
+    )
+    console = parakeet_dispatch.resolve_parakeet_dispatch(
+        model_id=PARAKEET_V2_MODEL,
+        precision=precision,
+        model_dir=None,
+    )
+
+    assert library == console
+    assert library.identity.root_revision == "managed-revision"
+    assert library.identity.closure_fingerprint == "managed-closure-fingerprint"
+    assert library.identity.precision == precision
+    assert library.identity.local_snapshot_token is None
+    assert library.local_source is None
+    assert library.managed_store_root == managed_root
+    assert library.managed_artifact_ref == (
+        "parakeet-v2",
+        "managed-revision",
+        precision,
+    )
+    assert dict(library.option_updates) == {}
+    assert len(leases) == 2
+    assert all(lease.closed for lease in leases)
+
+
+def test_verified_legacy_library_and_console_calls_share_snapshot_and_options(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.STT import parakeet_dispatch
+
+    legacy_root = tmp_path / "legacy"
+    legacy_root.mkdir()
+    paths = (legacy_root / ".tldw-verified.json",) + tuple(
+        legacy_root / name
+        for name in (
+            "config.json",
+            "vocab.txt",
+            "encoder-model.int8.onnx",
+            "decoder_joint-model.int8.onnx",
+        )
+    )
+    for index, path in enumerate(paths):
+        path.write_bytes(f"legacy-{index}".encode())
+
+    monkeypatch.setattr(
+        parakeet_dispatch,
+        "active_managed_parakeet_dir",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(parakeet_dispatch, "parakeet_v2_install_dir", lambda: legacy_root)
+    monkeypatch.setattr(
+        parakeet_dispatch,
+        "verify_parakeet_v2_bundle",
+        lambda directory: Path(directory) == legacy_root,
+    )
+
+    library = parakeet_dispatch.resolve_parakeet_dispatch(
+        model_id=PARAKEET_V2_MODEL,
+        precision="int8",
+        model_dir=None,
+    )
+    console = parakeet_dispatch.resolve_parakeet_dispatch(
+        model_id=PARAKEET_V2_MODEL,
+        precision="int8",
+        model_dir=None,
+    )
+
+    assert library == console
+    assert library.identity.root_revision is None
+    assert library.identity.closure_fingerprint is None
+    assert library.identity.local_snapshot_token == library.local_source.token
+    assert dict(library.option_updates) == {
+        "transcription_model_dir": str(legacy_root.absolute()),
+        "_verify_legacy_parakeet_v2": True,
+    }
+
+
+def test_resolver_never_loads_download_layers_and_fails_without_installed_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.STT import parakeet_dispatch
+
+    monkeypatch.setattr(
+        parakeet_dispatch,
+        "active_managed_parakeet_dir",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        parakeet_dispatch,
+        "parakeet_v2_install_dir",
+        lambda: tmp_path / "missing",
+    )
+    monkeypatch.setattr(
+        parakeet_dispatch,
+        "verify_parakeet_v2_bundle",
+        lambda _directory: False,
+    )
+
+    with pytest.raises(FileNotFoundError, match="No installed Parakeet artifact"):
+        parakeet_dispatch.resolve_parakeet_dispatch(
+            model_id=PARAKEET_V2_MODEL,
+            precision="int8",
+            model_dir=None,
+        )
+
+    assert "tldw_chatbook.Model_Artifacts.acquisition" not in sys.modules
+    assert "tldw_chatbook.Model_Artifacts.fetch" not in sys.modules

--- a/Tests/STT/test_parakeet_onnx.py
+++ b/Tests/STT/test_parakeet_onnx.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
@@ -13,6 +14,7 @@ from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
 )
 from tldw_chatbook.Model_Artifacts.leases import ArtifactLeaseKey
 from tldw_chatbook.STT.contracts import (
+    BufferAudioSource,
     TimestampGranularity,
     TranscriptionWarningCode,
 )
@@ -32,15 +34,22 @@ class _FakeAsr:
 
 
 class _FakeModel:
-    def __init__(self, *, short_text: str = "short text", segments=()) -> None:
+    def __init__(
+        self,
+        *,
+        short_text: str = "short text",
+        recognize_texts: tuple[str, ...] = (),
+        segments=(),
+    ) -> None:
         self.short_text = short_text
+        self._recognize_texts = iter(recognize_texts)
         self.short_calls: list[tuple[object, dict[str, object]]] = []
         self.asr = _FakeAsr(list(segments))
         self.resampler = lambda waveforms, lengths, sample_rate: (waveforms, lengths)
 
     def recognize(self, audio_path, **kwargs):
         self.short_calls.append((audio_path, kwargs))
-        return self.short_text
+        return next(self._recognize_texts, self.short_text)
 
 
 class _FakeVad:
@@ -341,3 +350,202 @@ def test_long_direct_local_model_without_managed_vad_fails_with_retry_action(
         "task": "transcribe",
         "error_code": "artifact_incompatible",
     }
+
+
+@pytest.mark.parametrize(
+    ("channels", "pcm", "expected"),
+    [
+        (1, (-32768, 0, 16384, 32767), (-1.0, 0.0, 0.5, 32767 / 32768)),
+        (2, (-32768, 0, 16384, 32767), (-0.5, (16384 + 32767) / 2 / 32768)),
+    ],
+)
+def test_buffer_pcm_is_little_endian_mono_float32_with_exact_duration_and_no_staging(
+    monkeypatch: pytest.MonkeyPatch,
+    channels: int,
+    pcm: tuple[int, ...],
+    expected: tuple[float, ...],
+) -> None:
+    from tldw_chatbook.STT import parakeet_onnx
+
+    runtime, model, _vad, _root, _dependency = _runtime(short_text="ordinary text")
+    source = BufferAudioSource(
+        np.asarray(pcm, dtype="<i2").tobytes(),
+        sample_rate=8_000,
+        channels=channels,
+    )
+    monkeypatch.setattr(
+        parakeet_onnx,
+        "_prepared_wav",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("buffer PCM must not use file staging")
+        ),
+    )
+    monkeypatch.setattr(
+        parakeet_onnx.tempfile,
+        "NamedTemporaryFile",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("buffer PCM must not create a temporary file")
+        ),
+    )
+    monkeypatch.setattr(
+        parakeet_onnx.wave,
+        "open",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("buffer PCM must not stage a WAV")
+        ),
+    )
+
+    result = runtime.transcribe_buffer(
+        source=source,
+        segment_end_frames=(),
+        attempt_id="buffer-attempt",
+        language="en",
+        job_id=None,
+    )
+
+    waveform, kwargs = model.short_calls[0]
+    np.testing.assert_allclose(waveform, np.asarray(expected, dtype=np.float32))
+    assert waveform.dtype == np.float32
+    assert kwargs == {"sample_rate": 8_000}
+    assert result.normalized.text == "ordinary text"
+    assert result.logical_segments == ("ordinary text",)
+    assert result.normalized.duration_seconds == len(expected) / 8_000
+    assert result.normalized.provenance.attempt_id == "buffer-attempt"
+    assert result.normalized.provenance.job_id is None
+    assert result.normalized.provenance.requested_language == "en"
+    assert result.normalized.provenance.effective_language == "en"
+    assert result.normalized.warnings == ()
+    assert result.normalized.produced_capabilities.vad is False
+
+
+def test_v3_buffer_preserves_routing_warning_semantics() -> None:
+    runtime, _model, _vad, _root, _dependency = _runtime(
+        model_id=PARAKEET_V3_MODEL,
+        short_text="bonjour",
+    )
+
+    result = runtime.transcribe_buffer(
+        source=BufferAudioSource(b"\x00\x00\x01\x00", 16_000),
+        segment_end_frames=(),
+        attempt_id="buffer-v3",
+        language="fr",
+    )
+
+    assert result.normalized.provenance.requested_language == "fr"
+    assert result.normalized.provenance.effective_language == "auto"
+    assert result.normalized.provenance.detected_language is None
+    assert result.normalized.warnings == (
+        TranscriptionWarningCode.REQUESTED_LANGUAGE_NOT_ENFORCED,
+    )
+
+
+def test_buffer_preserves_two_ordered_logical_segment_texts() -> None:
+    runtime, model, _vad, _root, _dependency = _runtime()
+    model._recognize_texts = iter(("ordinary text", "console stop"))
+    source = BufferAudioSource(
+        np.asarray((100, 200, 300, 400), dtype="<i2").tobytes(),
+        sample_rate=16_000,
+    )
+
+    result = runtime.transcribe_buffer(
+        source=source,
+        segment_end_frames=(2, 4),
+        attempt_id="two-logical-segments",
+        language="en",
+    )
+
+    assert result.logical_segments == ("ordinary text", "console stop")
+    assert result.normalized.text == "ordinary text console stop"
+    assert len(model.short_calls) == 2
+    np.testing.assert_allclose(
+        model.short_calls[0][0],
+        np.asarray((100, 200), dtype=np.float32) / 32768.0,
+    )
+    np.testing.assert_allclose(
+        model.short_calls[1][0],
+        np.asarray((300, 400), dtype=np.float32) / 32768.0,
+    )
+
+
+def test_managed_long_buffer_uses_resident_vad_in_memory() -> None:
+    runtime, model, vad, _root, _dependency = _runtime(
+        segment_texts=("managed long text",),
+        segment_ranges=((0, 100),),
+    )
+    source = BufferAudioSource(
+        np.arange(310, dtype="<i2").tobytes(),
+        sample_rate=10,
+    )
+
+    result = runtime.transcribe_buffer(
+        source=source,
+        segment_end_frames=(),
+        attempt_id="managed-long",
+        language="en",
+    )
+
+    assert result.normalized.duration_seconds == 31.0
+    assert result.normalized.produced_capabilities.vad is True
+    assert result.logical_segments == ("managed long text",)
+    assert len(vad.calls) == 1
+    assert len(model.asr.calls) == 1
+    assert model.short_calls == []
+
+
+def test_verified_legacy_long_buffer_without_vad_recognizes_directly() -> None:
+    runtime, model, _vad, _root, _dependency = _runtime(short_text="legacy long text")
+    runtime._vad = None
+    source = BufferAudioSource(bytes(310 * 2), sample_rate=10)
+
+    result = runtime.transcribe_buffer(
+        source=source,
+        segment_end_frames=(),
+        attempt_id="legacy-long",
+        language="en",
+    )
+
+    assert result.normalized.duration_seconds == 31.0
+    assert result.normalized.produced_capabilities.vad is False
+    assert result.logical_segments == ("legacy long text",)
+    assert len(model.short_calls) == 1
+
+
+def test_buffer_cancellation_before_second_logical_segment_prevents_native_call() -> None:
+    from tldw_chatbook.STT.parakeet_onnx import ParakeetOnnxCancelled
+
+    runtime, model, _vad, _root, _dependency = _runtime()
+    model._recognize_texts = iter(("first", "must-not-run"))
+    source = BufferAudioSource(bytes(8), sample_rate=16_000)
+
+    with pytest.raises(ParakeetOnnxCancelled):
+        runtime.transcribe_buffer(
+            source=source,
+            segment_end_frames=(2, 4),
+            attempt_id="cancel-direct",
+            language="en",
+            is_cancelled=lambda: len(model.short_calls) == 1,
+        )
+
+    assert len(model.short_calls) == 1
+
+
+def test_buffer_cancellation_checks_before_each_logical_vad_inference() -> None:
+    from tldw_chatbook.STT.parakeet_onnx import ParakeetOnnxCancelled
+
+    runtime, model, vad, _root, _dependency = _runtime(
+        segment_texts=("first", "must-not-run"),
+        segment_ranges=((0, 100),),
+    )
+    source = BufferAudioSource(bytes(640), sample_rate=10)
+
+    with pytest.raises(ParakeetOnnxCancelled):
+        runtime.transcribe_buffer(
+            source=source,
+            segment_end_frames=(160, 320),
+            attempt_id="cancel-vad",
+            language="en",
+            is_cancelled=lambda: len(model.asr.calls) == 1,
+        )
+
+    assert len(vad.calls) == 1
+    assert len(model.asr.calls) == 1

--- a/Tests/STT/test_parakeet_onnx.py
+++ b/Tests/STT/test_parakeet_onnx.py
@@ -510,6 +510,38 @@ def test_verified_legacy_long_buffer_without_vad_recognizes_directly() -> None:
     assert len(model.short_calls) == 1
 
 
+def test_v3_long_buffer_without_managed_vad_fails_before_native_inference() -> None:
+    from tldw_chatbook.STT.parakeet_onnx import ParakeetOnnxFailure
+
+    runtime, model, _vad, _root, _dependency = _runtime(
+        model_id=PARAKEET_V3_MODEL,
+        short_text="must-not-run",
+    )
+    runtime._vad = None
+    source = BufferAudioSource(bytes(310 * 2), sample_rate=10)
+
+    with pytest.raises(ParakeetOnnxFailure) as raised:
+        runtime.transcribe_buffer(
+            source=source,
+            segment_end_frames=(),
+            attempt_id="v3-long-no-vad",
+            language="fr",
+        )
+
+    assert raised.value.error_detail == {
+        "category": "stt_failure",
+        "code": "artifact_incompatible",
+        "message": "Long-form Parakeet v3 requires the managed VAD dependency. "
+        "Retry with faster-whisper.",
+        "actions": ["retry_faster_whisper"],
+    }
+    assert raised.value.stt_failure_provenance["attempt_id"] == "v3-long-no-vad"
+    assert raised.value.stt_failure_provenance["job_id"] is None
+    assert raised.value.stt_failure_provenance["requested_language"] == "fr"
+    assert raised.value.stt_failure_provenance["effective_language"] == "auto"
+    assert model.short_calls == []
+
+
 def test_buffer_cancellation_before_second_logical_segment_prevents_native_call() -> None:
     from tldw_chatbook.STT.parakeet_onnx import ParakeetOnnxCancelled
 

--- a/Tests/STT/test_parakeet_onnx.py
+++ b/Tests/STT/test_parakeet_onnx.py
@@ -366,8 +366,16 @@ def test_buffer_pcm_is_little_endian_mono_float32_with_exact_duration_and_no_sta
     expected: tuple[float, ...],
 ) -> None:
     from tldw_chatbook.STT import parakeet_onnx
+    from tldw_chatbook.Utils import optional_deps
 
     runtime, model, _vad, _root, _dependency = _runtime(short_text="ordinary text")
+    dependency_requests: list[tuple[str, str]] = []
+
+    def require_dependency(module_name: str, feature_name: str):
+        dependency_requests.append((module_name, feature_name))
+        return np
+
+    monkeypatch.setattr(optional_deps, "require_dependency", require_dependency)
     source = BufferAudioSource(
         np.asarray(pcm, dtype="<i2").tobytes(),
         sample_rate=8_000,
@@ -416,6 +424,7 @@ def test_buffer_pcm_is_little_endian_mono_float32_with_exact_duration_and_no_sta
     assert result.normalized.provenance.effective_language == "en"
     assert result.normalized.warnings == ()
     assert result.normalized.produced_capabilities.vad is False
+    assert dependency_requests == [("numpy", "transcription_parakeet_onnx")]
 
 
 def test_v3_buffer_preserves_routing_warning_semantics() -> None:

--- a/Tests/STT/test_transcribe_cpp.py
+++ b/Tests/STT/test_transcribe_cpp.py
@@ -13,6 +13,7 @@ import pytest
 from tldw_chatbook.STT.contracts import (
     DeviceFailureOrigin,
     ExecutionDevice,
+    FileAudioSource,
     TranscriptionFailureCode,
     TranscriptionWarningCode,
 )
@@ -259,7 +260,7 @@ def test_native_backend_load_failure_is_typed_for_one_cpu_retry(
         generation=1,
         attempt_id="attempt-metal",
         job_id="job-metal",
-        source_path=tmp_path / "audio.wav",
+        source=FileAudioSource(tmp_path / "audio.wav"),
         identity=ModelIdentity(
             provider_id="transcribe-cpp",
             model_id="local-gguf:whisper",
@@ -326,7 +327,7 @@ def test_successful_cpu_retry_records_warning_and_original_requested_device(
         generation=2,
         attempt_id="attempt-cpu-retry",
         job_id="job-cpu-retry",
-        source_path=audio_path,
+        source=FileAudioSource(audio_path),
         identity=ModelIdentity(
             provider_id="transcribe-cpp",
             model_id="local-gguf:whisper",
@@ -338,7 +339,7 @@ def test_successful_cpu_retry_records_warning_and_original_requested_device(
         options={"_local_stt_cpu_fallback_requested_device": "auto"},
     )
 
-    provider = _transcribe_cpp_provider(request, model_path)
+    provider = _transcribe_cpp_provider(request, model_path, None, lambda: False)
     try:
         payload = provider.runner(str(audio_path), timestamps=True)
     finally:
@@ -371,7 +372,7 @@ def test_managed_gguf_rejects_windows_path_escape_syntax(
         generation=1,
         attempt_id="attempt-managed-path",
         job_id="job-managed-path",
-        source_path=tmp_path / "audio.wav",
+        source=FileAudioSource(tmp_path / "audio.wav"),
         identity=ModelIdentity(
             provider_id="transcribe-cpp",
             model_id="managed-gguf",
@@ -390,7 +391,7 @@ def test_managed_gguf_rejects_windows_path_escape_syntax(
     )
 
     with pytest.raises(_ProviderLoadFailure) as raised:
-        _transcribe_cpp_provider(request, model_root)
+        _transcribe_cpp_provider(request, model_root, None, lambda: False)
 
     assert raised.value.code is TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE
 
@@ -412,7 +413,7 @@ def test_managed_gguf_rejects_symlink_escape(
         generation=1,
         attempt_id="attempt-managed-link",
         job_id="job-managed-link",
-        source_path=tmp_path / "audio.wav",
+        source=FileAudioSource(tmp_path / "audio.wav"),
         identity=ModelIdentity(
             provider_id="transcribe-cpp",
             model_id="managed-gguf",
@@ -431,7 +432,7 @@ def test_managed_gguf_rejects_symlink_escape(
     )
 
     with pytest.raises(_ProviderLoadFailure) as raised:
-        _transcribe_cpp_provider(request, model_root)
+        _transcribe_cpp_provider(request, model_root, None, lambda: False)
 
     assert raised.value.code is TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE
 

--- a/Tests/STT/test_transcription_service_facade.py
+++ b/Tests/STT/test_transcription_service_facade.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import inspect
+import threading
 from pathlib import Path
+from types import SimpleNamespace
 from typing import get_type_hints
 from unittest.mock import patch
 
@@ -240,6 +242,48 @@ def test_facade_preserves_buffer_arguments_and_provider_specific_kwargs(
             {"model_dir": "/models/parakeet"},
         )
     ]
+
+
+@pytest.mark.parametrize(
+    ("provider_kwargs", "expected_local_only"),
+    [({}, False), ({"local_files_only": True}, True)],
+)
+def test_retained_faster_whisper_buffer_honors_explicit_local_only_without_changing_default(
+    monkeypatch: pytest.MonkeyPatch,
+    provider_kwargs: dict[str, object],
+    expected_local_only: bool,
+) -> None:
+    constructor_calls: list[dict[str, object]] = []
+
+    class _WhisperModel:
+        def __init__(self, _model: str, **kwargs: object) -> None:
+            constructor_calls.append(kwargs)
+
+        def transcribe(self, _audio: object, **_kwargs: object) -> object:
+            return iter(()), SimpleNamespace(language="en")
+
+    monkeypatch.setattr(service_module, "WhisperModel", _WhisperModel)
+    backend = object.__new__(_LegacyTranscriptionBackend)
+    backend.config = {
+        "default_model": "base",
+        "default_language": "en",
+        "device": "cpu",
+        "compute_type": "int8",
+    }
+    backend._model_cache = {}
+    backend._model_cache_lock = threading.Lock()
+
+    backend._transcribe_buffer_with_faster_whisper(
+        b"\x00\x00" * 16,
+        sample_rate=16_000,
+        channels=1,
+        sample_width=2,
+        model="base",
+        language="en",
+        **provider_kwargs,
+    )
+
+    assert constructor_calls[0]["local_files_only"] is expected_local_only
 
 
 class _Dispatcher:

--- a/Tests/STT/test_transcription_service_facade.py
+++ b/Tests/STT/test_transcription_service_facade.py
@@ -24,8 +24,12 @@ def _signature_shape(callable_object: object) -> tuple[tuple[str, object, object
     )
 
 
-def test_public_constructor_remains_zero_argument() -> None:
-    assert _signature_shape(TranscriptionService) == ()
+def test_public_constructor_adds_only_a_keyword_dispatcher() -> None:
+    keyword_only = inspect.Parameter.KEYWORD_ONLY
+
+    assert _signature_shape(TranscriptionService) == (
+        ("local_stt_dispatcher", keyword_only, None),
+    )
 
 
 def test_public_method_signatures_match_the_legacy_contract() -> None:
@@ -214,8 +218,8 @@ def test_facade_preserves_buffer_arguments_and_provider_specific_kwargs(
         16_000,
         2,
         1,
-        "parakeet-onnx",
-        "nemo-parakeet-tdt-0.6b-v2",
+        "faster-whisper",
+        "base.en",
         "en",
         model_dir="/models/parakeet",
     )
@@ -229,12 +233,270 @@ def test_facade_preserves_buffer_arguments_and_provider_specific_kwargs(
                 16_000,
                 2,
                 1,
-                "parakeet-onnx",
-                "nemo-parakeet-tdt-0.6b-v2",
+                "faster-whisper",
+                "base.en",
                 "en",
             ),
             {"model_dir": "/models/parakeet"},
         )
+    ]
+
+
+class _Dispatcher:
+    def __init__(self) -> None:
+        self.buffer_calls: list[dict[str, object]] = []
+        self.dictation_calls: list[dict[str, object]] = []
+        self.buffer_result = {
+            "text": "shared result",
+            "segments": [],
+            "language": "en",
+        }
+        self.handle = object()
+        self.closed = False
+
+    def transcribe_buffer(self, **kwargs: object) -> object:
+        self.buffer_calls.append(kwargs)
+        return self.buffer_result
+
+    def begin_dictation(self, **kwargs: object) -> object:
+        self.dictation_calls.append(kwargs)
+        return self.handle
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.parametrize(
+    ("provider", "configured"),
+    [
+        pytest.param("parakeet-onnx", "faster-whisper", id="explicit"),
+        pytest.param(None, "parakeet-onnx", id="configured-default"),
+    ],
+)
+def test_parakeet_buffer_uses_the_shared_dispatcher_and_compatibility_result(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str | None,
+    configured: str,
+) -> None:
+    dispatcher = _Dispatcher()
+    dispatch = object()
+    bridge = _Bridge()
+    bridge.config["default_provider"] = configured
+    monkeypatch.setattr(
+        service_module,
+        "LegacyTranscriptionBridge",
+        lambda _backend_factory: bridge,
+    )
+    monkeypatch.setattr(
+        service_module,
+        "resolve_parakeet_dispatch",
+        lambda **_kwargs: dispatch,
+        raising=False,
+    )
+
+    service = TranscriptionService(local_stt_dispatcher=dispatcher)
+    result = service.transcribe_buffer(
+        b"\x00\x01" * 4,
+        24_000,
+        2,
+        1,
+        provider,
+        None,
+        None,
+    )
+
+    assert result is dispatcher.buffer_result
+    assert bridge.calls == []
+    call = dispatcher.buffer_calls[0]
+    source = call["source"]
+    assert source.audio == b"\x00\x01" * 4
+    assert (source.sample_rate, source.channels, source.sample_width) == (24_000, 2, 1)
+    assert call == {"source": source, "dispatch": dispatch, "language": "en"}
+
+
+@pytest.mark.parametrize(
+    ("configured_precision", "expected"),
+    [(None, "int8"), (" F32 ", "f32")],
+)
+def test_parakeet_buffer_resolves_the_configured_precision_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    configured_precision: str | None,
+    expected: str,
+) -> None:
+    dispatcher = _Dispatcher()
+    captured: dict[str, object] = {}
+    bridge = _Bridge()
+    monkeypatch.setattr(
+        service_module,
+        "LegacyTranscriptionBridge",
+        lambda _backend_factory: bridge,
+    )
+    monkeypatch.setattr(
+        service_module,
+        "get_cli_setting",
+        lambda key, default=None: (
+            configured_precision
+            if key == "transcription.default_precision"
+            else default
+        ),
+    )
+
+    def _resolve(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        service_module,
+        "resolve_parakeet_dispatch",
+        _resolve,
+        raising=False,
+    )
+
+    TranscriptionService(local_stt_dispatcher=dispatcher).transcribe_buffer(
+        b"\x00\x00",
+        16_000,
+        provider="parakeet-onnx",
+    )
+
+    assert captured == {
+        "model_id": "nemo-parakeet-tdt-0.6b-v2",
+        "precision": expected,
+        "model_dir": None,
+    }
+
+
+def test_invalid_parakeet_precision_fails_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dispatcher = _Dispatcher()
+    bridge = _Bridge()
+    resolved: list[str] = []
+    monkeypatch.setattr(
+        service_module,
+        "LegacyTranscriptionBridge",
+        lambda _backend_factory: bridge,
+    )
+    monkeypatch.setattr(
+        service_module,
+        "get_cli_setting",
+        lambda key, default=None: (
+            "fp16" if key == "transcription.default_precision" else default
+        ),
+    )
+
+    def _reject(**kwargs: object) -> object:
+        resolved.append(str(kwargs["precision"]))
+        raise ValueError("unsupported Parakeet precision: fp16")
+
+    monkeypatch.setattr(
+        service_module,
+        "resolve_parakeet_dispatch",
+        _reject,
+        raising=False,
+    )
+
+    with pytest.raises(ValueError, match="unsupported Parakeet precision"):
+        TranscriptionService(local_stt_dispatcher=dispatcher).transcribe_buffer(
+            b"\x00\x00",
+            16_000,
+            provider="parakeet-onnx",
+        )
+
+    assert resolved == ["fp16"]
+    assert dispatcher.buffer_calls == []
+    assert bridge.calls == []
+
+
+def test_parakeet_buffer_requires_the_shared_dispatcher(
+    facade: tuple[TranscriptionService, _Bridge],
+) -> None:
+    service, bridge = facade
+
+    with pytest.raises(
+        TranscriptionError,
+        match="requires the shared local executor",
+    ):
+        service.transcribe_buffer(
+            b"\x00\x00",
+            16_000,
+            provider="parakeet-onnx",
+        )
+
+    assert bridge.calls == []
+
+
+def test_parakeet_streaming_reports_unsupported_without_consulting_the_bridge(
+    facade: tuple[TranscriptionService, _Bridge],
+) -> None:
+    service, bridge = facade
+
+    assert service.create_streaming_transcriber(provider="parakeet-onnx") is None
+    assert bridge.calls == []
+
+
+def test_facade_cleanup_does_not_close_the_app_owned_dispatcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dispatcher = _Dispatcher()
+    bridge = _Bridge()
+    monkeypatch.setattr(
+        service_module,
+        "LegacyTranscriptionBridge",
+        lambda _backend_factory: bridge,
+    )
+    service = TranscriptionService(local_stt_dispatcher=dispatcher)
+
+    service.cleanup()
+
+    assert bridge.calls == [("cleanup", (), {})]
+    assert dispatcher.closed is False
+
+
+def test_begin_dictation_capture_forwards_the_resolved_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dispatcher = _Dispatcher()
+    bridge = _Bridge()
+    dispatch = object()
+
+    def callback(_sequence: int, _text: str) -> None:
+        return None
+
+    monkeypatch.setattr(
+        service_module,
+        "LegacyTranscriptionBridge",
+        lambda _backend_factory: bridge,
+    )
+    monkeypatch.setattr(
+        service_module,
+        "resolve_parakeet_dispatch",
+        lambda **_kwargs: dispatch,
+        raising=False,
+    )
+
+    handle = TranscriptionService(
+        local_stt_dispatcher=dispatcher
+    ).begin_dictation_capture(
+        capture_generation=7,
+        model=None,
+        language="en",
+        sample_rate=16_000,
+        channels=1,
+        sample_width=2,
+        on_logical_segment=callback,
+    )
+
+    assert handle is dispatcher.handle
+    assert dispatcher.dictation_calls == [
+        {
+            "capture_generation": 7,
+            "dispatch": dispatch,
+            "sample_rate": 16_000,
+            "channels": 1,
+            "sample_width": 2,
+            "language": "en",
+            "on_logical_segment": callback,
+        }
     ]
 
 

--- a/Tests/STT/test_transcription_service_facade.py
+++ b/Tests/STT/test_transcription_service_facade.py
@@ -544,6 +544,49 @@ def test_begin_dictation_capture_forwards_the_resolved_dispatch(
     ]
 
 
+def test_begin_dictation_capture_resolves_the_configured_model_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dispatcher = _Dispatcher()
+    bridge = _Bridge()
+    bridge.config["parakeet_onnx_model_dir"] = str(tmp_path)
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        service_module,
+        "LegacyTranscriptionBridge",
+        lambda _backend_factory: bridge,
+    )
+
+    def _resolve(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        service_module,
+        "resolve_parakeet_dispatch",
+        _resolve,
+        raising=False,
+    )
+
+    TranscriptionService(local_stt_dispatcher=dispatcher).begin_dictation_capture(
+        capture_generation=7,
+        model=None,
+        language="en",
+        sample_rate=16_000,
+        channels=1,
+        sample_width=2,
+        on_logical_segment=lambda _sequence, _text: None,
+    )
+
+    assert captured == {
+        "model_id": "nemo-parakeet-tdt-0.6b-v2",
+        "precision": "int8",
+        "model_dir": str(tmp_path),
+    }
+
+
 @pytest.mark.parametrize(
     ("method_name", "arguments", "keywords", "bridge_method"),
     [

--- a/Tests/UI/test_console_controller_wiring.py
+++ b/Tests/UI/test_console_controller_wiring.py
@@ -196,6 +196,45 @@ def test_dictation_resolves_the_hands_free_sibling_at_call_time():
     assert screen._dictation._hands_free_session_accessor() is sentinel
 
 
+def test_dictation_session_late_binds_the_app_owned_service_factory():
+    """The session must follow app factory replacement after screen wiring."""
+    screen = _unmounted_console()
+    first = object()
+    second = object()
+    calls: list[tuple[object, dict]] = []
+
+    def first_factory(**kwargs):
+        calls.append((first, kwargs))
+        return first
+
+    def second_factory(**kwargs):
+        calls.append((second, kwargs))
+        return second
+
+    screen.app_instance._create_console_dictation_service = first_factory
+    session = screen._dictation._create_console_dictation_session()
+    assert session._build_service(language="en") is first
+
+    screen.app_instance._create_console_dictation_service = second_factory
+    assert session._build_service(language="fr") is second
+    assert calls == [
+        (
+            first,
+            {
+                "language": "en",
+                "max_buffer_bytes": 1_920_000,
+            },
+        ),
+        (
+            second,
+            {
+                "language": "fr",
+                "max_buffer_bytes": 1_920_000,
+            },
+        ),
+    ]
+
+
 def test_hands_free_reads_dictation_state_through_the_screen_at_call_time():
     screen = _unmounted_console()
     sentinel = object()

--- a/Tests/UI/test_console_dictation.py
+++ b/Tests/UI/test_console_dictation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import time
 from unittest.mock import Mock
@@ -16,6 +17,7 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
 )
 from tldw_chatbook.UI.Console_Modules import dictation as dictation_module
 from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
 
 
 class FakeDictationSession:
@@ -27,6 +29,11 @@ class FakeDictationSession:
         stop_error: str = "",
         stop_started: threading.Event | None = None,
         stop_release: threading.Event | None = None,
+        retry_available: bool = False,
+        retry_transcript: str = "retried words",
+        retry_error: str = "",
+        retry_started: threading.Event | None = None,
+        retry_release: threading.Event | None = None,
     ) -> None:
         self.transcript = transcript
         self.start_error = start_error
@@ -36,6 +43,32 @@ class FakeDictationSession:
         self.start_calls = 0
         self.stop_calls = 0
         self.discard_calls = 0
+        self._retry_available = retry_available
+        self.retry_transcript = retry_transcript
+        self.retry_error = retry_error
+        self.retry_started = retry_started
+        self.retry_release = retry_release
+        self.retry_calls = 0
+        self.clear_retry_calls = 0
+
+    @property
+    def retry_available(self) -> bool:
+        return self._retry_available
+
+    def clear_retry(self) -> None:
+        self.clear_retry_calls += 1
+        self._retry_available = False
+
+    def retry_with_faster_whisper(self) -> str:
+        self.retry_calls += 1
+        self._retry_available = False
+        if self.retry_started is not None:
+            self.retry_started.set()
+        if self.retry_release is not None:
+            self.retry_release.wait(timeout=2)
+        if self.retry_error:
+            raise RuntimeError(self.retry_error)
+        return self.retry_transcript
 
     def start(self, *, on_buffer_limit=None) -> None:
         self.start_calls += 1
@@ -55,6 +88,7 @@ class FakeDictationSession:
 
     def discard(self) -> None:
         self.discard_calls += 1
+        self._retry_available = False
 
 
 def _ready_host():
@@ -79,6 +113,30 @@ async def _wait_for_mic_label(composer, pilot, expected: str, timeout=4.0):
         await pilot.pause(0.01)
     assert str(button.label) == expected
     return button
+
+
+async def _wait_for_retry_dialog(
+    dialogs: list[ConfirmationDialog], pilot, timeout=4.0
+) -> ConfirmationDialog:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and not dialogs:
+        await pilot.pause(0.01)
+    assert dialogs
+    return dialogs[0]
+
+
+async def _wait_for_mounted_retry_dialog(
+    host, pilot, timeout=4.0
+) -> ConfirmationDialog:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        modal = host.screen_stack[-1]
+        if isinstance(modal, ConfirmationDialog):
+            return modal
+        await pilot.pause(0.01)
+    modal = host.screen_stack[-1]
+    assert isinstance(modal, ConfirmationDialog)
+    return modal
 
 
 @pytest.mark.asyncio
@@ -226,3 +284,364 @@ async def test_console_mic_failures_are_visible_preserve_draft_and_recover_idle(
             if stage == "stop":
                 assert fake.discard_calls == 1
             notify.reset_mock()
+
+
+@pytest.mark.asyncio
+async def test_retryable_parakeet_failure_confirms_one_replay_and_normal_insertion(
+    monkeypatch,
+):
+    fake = FakeDictationSession(
+        stop_error="Parakeet transcription failed.",
+        retry_available=True,
+        retry_transcript="recovered words",
+    )
+    monkeypatch.setattr(
+        dictation_module.ConsoleDictationController,
+        "_create_console_dictation_session",
+        lambda self: fake,
+    )
+    _, host = _ready_host()
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        # The harness mounts a ChatScreen built with a separate app_instance;
+        # production uses the running app for both identities.
+        console.app_instance.push_screen_wait = host.push_screen_wait
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("hello world")
+        for _ in range(5):
+            composer.move_cursor_left()
+
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictating")
+        await pilot.pause(0.6)
+        await pilot.click("#console-dictation")
+        dialog = await _wait_for_mounted_retry_dialog(host, pilot)
+
+        assert dialog.title == "Parakeet transcription failed"
+        assert dialog.message == (
+            "Parakeet failed. Retry this audio with faster-whisper?"
+        )
+        assert dialog.confirm_label == "Retry"
+        assert dialog.cancel_label == "Keep draft"
+
+        await pilot.click("#confirm-button")
+        await _wait_for_mic_label(composer, pilot, "Dictate")
+
+        assert composer.draft_text() == "hello recovered words world"
+        assert fake.retry_calls == 1
+        assert fake.retry_available is False
+
+
+@pytest.mark.asyncio
+async def test_declining_parakeet_retry_preserves_draft_and_clears_retained_audio(
+    monkeypatch,
+):
+    fake = FakeDictationSession(
+        stop_error="Parakeet transcription failed.",
+        retry_available=True,
+    )
+    monkeypatch.setattr(
+        dictation_module.ConsoleDictationController,
+        "_create_console_dictation_session",
+        lambda self: fake,
+    )
+    _, host = _ready_host()
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        console.app_instance.push_screen_wait = host.push_screen_wait
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("keep this draft")
+
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictating")
+        await pilot.pause(0.6)
+        await pilot.click("#console-dictation")
+        await _wait_for_mounted_retry_dialog(host, pilot)
+        await pilot.click("#cancel-button")
+        await _wait_for_mic_label(composer, pilot, "Dictate")
+
+        assert composer.draft_text() == "keep this draft"
+        assert fake.retry_calls == 0
+        assert fake.clear_retry_calls >= 1
+        assert fake.retry_available is False
+        assert console._console_dictation_session is None
+        assert console._console_dictation_timer is None
+        assert console._console_dictation_elapsed_timer is None
+
+
+@pytest.mark.asyncio
+async def test_retry_failure_is_sanitized_clears_audio_and_preserves_the_draft(
+    monkeypatch,
+):
+    fake = FakeDictationSession(
+        stop_error="Parakeet transcription failed.",
+        retry_available=True,
+        retry_error="Dictation retry failed.",
+    )
+    monkeypatch.setattr(
+        dictation_module.ConsoleDictationController,
+        "_create_console_dictation_session",
+        lambda self: fake,
+    )
+    app, host = _ready_host()
+    notify = Mock()
+    app.notify = notify
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        dialogs: list[ConfirmationDialog] = []
+
+        async def push_screen_wait(dialog):
+            dialogs.append(dialog)
+            return True
+
+        console.app_instance.push_screen_wait = push_screen_wait
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("keep this draft")
+
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictating")
+        await pilot.pause(0.6)
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictate")
+
+        assert len(dialogs) == 1
+        assert composer.draft_text() == "keep this draft"
+        assert fake.retry_calls == 1
+        assert fake.retry_available is False
+        errors = [
+            str(call.args[0])
+            for call in notify.call_args_list
+            if call.kwargs.get("severity") == "error"
+        ]
+        assert errors == ["Dictation failed: Dictation retry failed."]
+        assert all("Traceback" not in error for error in errors)
+
+
+@pytest.mark.asyncio
+async def test_nonretryable_or_missing_faster_whisper_never_opens_confirmation(
+    monkeypatch,
+):
+    """The session port withholds retry for both cases; Console stays generic."""
+    fake = FakeDictationSession(
+        stop_error="Parakeet transcription failed.",
+        retry_available=False,
+    )
+    monkeypatch.setattr(
+        dictation_module.ConsoleDictationController,
+        "_create_console_dictation_session",
+        lambda self: fake,
+    )
+    app, host = _ready_host()
+    notify = Mock()
+    app.notify = notify
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        dialogs: list[ConfirmationDialog] = []
+
+        async def push_screen_wait(dialog):
+            dialogs.append(dialog)
+            return True
+
+        console.app_instance.push_screen_wait = push_screen_wait
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("keep this draft")
+
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictating")
+        await pilot.pause(0.6)
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictate")
+
+        assert dialogs == []
+        assert fake.retry_calls == 0
+        assert fake.discard_calls == 1
+        assert composer.draft_text() == "keep this draft"
+        errors = [
+            str(call.args[0])
+            for call in notify.call_args_list
+            if call.kwargs.get("severity") == "error"
+        ]
+        assert errors == ["Dictation failed: Parakeet transcription failed."]
+        assert all("Traceback" not in error for error in errors)
+
+
+@pytest.mark.asyncio
+async def test_cancelling_retry_prompt_returns_idle_and_clears_retained_audio(
+    monkeypatch,
+):
+    fake = FakeDictationSession(
+        stop_error="Parakeet transcription failed.",
+        retry_available=True,
+    )
+    monkeypatch.setattr(
+        dictation_module.ConsoleDictationController,
+        "_create_console_dictation_session",
+        lambda self: fake,
+    )
+    _, host = _ready_host()
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        dialogs: list[ConfirmationDialog] = []
+        decision = asyncio.get_running_loop().create_future()
+
+        async def push_screen_wait(dialog):
+            dialogs.append(dialog)
+            return await decision
+
+        console.app_instance.push_screen_wait = push_screen_wait
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("keep this draft")
+
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictating")
+        await pilot.pause(0.6)
+        await pilot.click("#console-dictation")
+        await _wait_for_retry_dialog(dialogs, pilot)
+        decision.cancel()
+        await _wait_for_mic_label(composer, pilot, "Dictate")
+
+        assert composer.draft_text() == "keep this draft"
+        assert fake.retry_calls == 0
+        assert fake.retry_available is False
+        assert console._console_dictation_session is None
+
+
+@pytest.mark.asyncio
+async def test_retry_prompt_screen_unmount_discards_retained_audio(monkeypatch):
+    fake = FakeDictationSession(
+        stop_error="Parakeet transcription failed.",
+        retry_available=True,
+    )
+    monkeypatch.setattr(
+        dictation_module.ConsoleDictationController,
+        "_create_console_dictation_session",
+        lambda self: fake,
+    )
+    _, host = _ready_host()
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        dialogs: list[ConfirmationDialog] = []
+        decision = asyncio.get_running_loop().create_future()
+
+        async def push_screen_wait(dialog):
+            dialogs.append(dialog)
+            return await decision
+
+        console.app_instance.push_screen_wait = push_screen_wait
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("keep this draft")
+
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictating")
+        await pilot.pause(0.6)
+        await pilot.click("#console-dictation")
+        await _wait_for_retry_dialog(dialogs, pilot)
+        await host.pop_screen()
+        await pilot.pause()
+
+        assert fake.retry_available is False
+        assert fake.discard_calls == 1
+        assert console._console_dictation_session is None
+
+
+@pytest.mark.asyncio
+async def test_retry_prompt_app_shutdown_discards_retained_audio(monkeypatch):
+    fake = FakeDictationSession(
+        stop_error="Parakeet transcription failed.",
+        retry_available=True,
+    )
+    monkeypatch.setattr(
+        dictation_module.ConsoleDictationController,
+        "_create_console_dictation_session",
+        lambda self: fake,
+    )
+    _, host = _ready_host()
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        dialogs: list[ConfirmationDialog] = []
+        decision = asyncio.get_running_loop().create_future()
+
+        async def push_screen_wait(dialog):
+            dialogs.append(dialog)
+            return await decision
+
+        console.app_instance.push_screen_wait = push_screen_wait
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictating")
+        await pilot.pause(0.6)
+        await pilot.click("#console-dictation")
+        await _wait_for_retry_dialog(dialogs, pilot)
+
+    assert fake.retry_available is False
+    assert fake.discard_calls == 1
+    assert console._console_dictation_session is None
+
+
+@pytest.mark.asyncio
+async def test_retry_success_racing_teardown_cannot_insert_into_new_generation(
+    monkeypatch,
+):
+    retry_started = threading.Event()
+    retry_release = threading.Event()
+    failed = FakeDictationSession(
+        stop_error="Parakeet transcription failed.",
+        retry_available=True,
+        retry_transcript="stale recovered words",
+        retry_started=retry_started,
+        retry_release=retry_release,
+    )
+    current = FakeDictationSession(transcript="fresh capture")
+    sessions = iter((failed, current))
+    monkeypatch.setattr(
+        dictation_module.ConsoleDictationController,
+        "_create_console_dictation_session",
+        lambda self: next(sessions),
+    )
+    _, host = _ready_host()
+
+    try:
+        async with host.run_test(size=(140, 42)) as pilot:
+            console = await _mounted_console(host, pilot)
+
+            async def push_screen_wait(_dialog):
+                return True
+
+            console.app_instance.push_screen_wait = push_screen_wait
+            composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+
+            await pilot.click("#console-dictation")
+            await _wait_for_mic_label(composer, pilot, "Dictating")
+            await pilot.pause(0.6)
+            await pilot.click("#console-dictation")
+            while not retry_started.is_set():
+                await pilot.pause(0.01)
+
+            await console._dictation.teardown()
+            console._dictation._request_console_dictation_start()
+            await _wait_for_mic_label(composer, pilot, "Dictating")
+            assert console._console_dictation_session is current
+
+            retry_release.set()
+            await pilot.pause(0.1)
+            assert composer.draft_text() == ""
+            assert console._console_dictation_session is current
+
+            await pilot.pause(0.6)
+            await pilot.click("#console-dictation")
+            await _wait_for_mic_label(composer, pilot, "Dictate")
+
+            assert composer.draft_text() == "fresh capture"
+            assert failed.retry_calls == 1
+            assert failed.retry_available is False
+            assert failed.discard_calls == 1
+    finally:
+        retry_release.set()

--- a/Tests/UI/test_console_dictation_streaming.py
+++ b/Tests/UI/test_console_dictation_streaming.py
@@ -93,6 +93,13 @@ class FakeDictationService:
         # the (real) processing thread's loop; a test asserts it stays unset
         # to prove a stale error never bypassed the capture it was not for.
         self.stop_processing = threading.Event()
+        self.uses_deferred_dictation = False
+        self.waiting_for_executor = False
+        self.executor_results_emitted = 0
+
+    def reserve_deferred_dictation(self, capture_generation: int):
+        self.capture_generation = capture_generation
+        return SimpleNamespace(waiting_for_executor=self.waiting_for_executor)
 
     def _record_release(self) -> None:
         self.release_calls += 1
@@ -139,6 +146,13 @@ class FakeDictationService:
         assert self.on_final is not None, "start_dictation() has not run yet"
         self.on_final(text)
 
+    def emit_executor_result(self, *logical_segments: str) -> None:
+        """Deliver all logical boundaries returned by one executor request."""
+
+        self.executor_results_emitted += 1
+        for text in logical_segments:
+            self.emit_final(text)
+
     def emit_segment_transcribing(self, done: bool = False) -> None:
         assert self.on_segment_transcribing is not None, (
             "start_dictation() has not run yet"
@@ -175,6 +189,7 @@ def _patch_availability(
     monkeypatch,
     *,
     availability: voice_module.Availability | None = None,
+    provider: str = "faster-whisper",
 ) -> None:
     """Pretend a capture backend and a local provider are installed.
 
@@ -195,10 +210,10 @@ def _patch_availability(
         voice_module,
         "resolve",
         lambda: voice_module.EffectiveConfig(
-            provider="faster-whisper",
+            provider=provider,
             model=None,
             language="en",
-            configured_provider="faster-whisper",
+            configured_provider=provider,
             was_overridden=False,
         ),
     )
@@ -241,6 +256,62 @@ def _install_streaming_session(monkeypatch, service: FakeDictationService) -> li
         factory,
     )
     return sessions
+
+
+@pytest.mark.asyncio
+async def test_busy_parakeet_capture_stays_live_then_inserts_without_sending(
+    monkeypatch,
+):
+    """A reserved capture explains the wait and keeps the ordinary success tail."""
+    service = FakeDictationService()
+    service.uses_deferred_dictation = True
+    service.waiting_for_executor = True
+    service.start_gate = threading.Event()
+    _patch_availability(monkeypatch, provider="parakeet-onnx")
+    _install_streaming_session(monkeypatch, service)
+    _, host = _ready_host()
+
+    try:
+        async with host.run_test(size=(140, 42)) as pilot:
+            console = await _mounted_console(host, pilot)
+            composer = console.query_one(
+                "#console-native-composer", ConsoleComposerBar
+            )
+            store = console._ensure_console_chat_store()
+            message_count = len(
+                store.messages_for_session(store.active_session_id)
+            )
+
+            await pilot.click("#console-dictation")
+            deadline = time.monotonic() + 4
+            while (
+                time.monotonic() < deadline
+                and composer._voice_preparing_message
+                != "Local transcription busy — dictation will run next."
+            ):
+                await pilot.pause(0.01)
+
+            assert console._console_dictation_state == "starting"
+            assert (
+                composer._voice_preparing_message
+                == "Local transcription busy — dictation will run next."
+            )
+
+            service.start_gate.set()
+            await _wait_for_mic_label(composer, pilot, "Dictating")
+            service.emit_final("queued dictation")
+            await pilot.pause(0.1)
+            await pilot.click("#console-dictation")
+            await _wait_for_mic_label(composer, pilot, "Dictate")
+
+            assert composer.draft_text() == "queued dictation"
+            assert (
+                len(store.messages_for_session(store.active_session_id))
+                == message_count
+            )
+            assert service.start_calls == 1
+    finally:
+        service.start_gate.set()
 
 
 @pytest.mark.asyncio
@@ -758,6 +829,33 @@ def test_a_stale_speech_resumed_is_dropped_by_the_session_adapter():
     session._handle_event(voice_module.VoiceSpeechResumed(), 4)  # stale
 
     assert events == []
+
+
+def test_streaming_session_delegates_one_shot_retry_state():
+    calls: list[str] = []
+
+    class RetryController:
+        retry_available = True
+
+        def clear_retry(self) -> None:
+            calls.append("clear")
+            self.retry_available = False
+
+        def retry_with_faster_whisper(self) -> str:
+            calls.append("retry")
+            self.retry_available = False
+            return "recovered"
+
+    session = dictation_module.ConsoleStreamingDictationSession(
+        on_event=lambda _session, _event: None,
+    )
+    session._controller = RetryController()
+
+    assert session.retry_available is True
+    assert session.retry_with_faster_whisper() == "recovered"
+    assert session.retry_available is False
+    session.clear_retry()
+    assert calls == ["retry", "clear"]
 
 
 @pytest.mark.asyncio
@@ -1586,15 +1684,8 @@ async def test_the_console_capture_is_given_a_bounded_pcm_budget(monkeypatch):
         await _wait_for_mic_label(composer, pilot, "Dictating")
 
         bound = service.factory_kwargs.get("max_buffer_bytes")
-        assert bound == dictation_module.CONSOLE_DICTATION_MAX_BYTES
-        # Derived from the session cap, not a magic number: 60s of 16kHz mono
-        # 16-bit PCM plus headroom, so the wall timer always ends an ordinary
-        # capture first and this stays a memory backstop.
-        assert bound >= int(
-            dictation_module.CONSOLE_DICTATION_SAMPLE_RATE
-            * dictation_module.CONSOLE_DICTATION_SAMPLE_WIDTH
-            * dictation_module.CONSOLE_DICTATION_MAX_SECONDS
-        )
+        # Hand-derived: 60 s × 16,000 Hz × mono × 2-byte samples.
+        assert bound == 1_920_000
         assert service.factory_kwargs.get("on_buffer_limit") is not None
 
 
@@ -1619,10 +1710,14 @@ async def test_the_buffer_limit_callback_stops_the_capture_from_its_own_thread(
     async with host.run_test(size=(140, 42)) as pilot:
         console = await _mounted_console(host, pilot)
         composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("before after")
+        for _ in range(5):
+            composer.move_cursor_left()
 
         await pilot.click("#console-dictation")
         await _wait_for_mic_label(composer, pilot, "Dictating")
-
+        service.emit_final("all accepted pcm")
+        await pilot.pause()
         on_buffer_limit = service.factory_kwargs["on_buffer_limit"]
         returned = threading.Event()
 
@@ -1639,11 +1734,25 @@ async def test_the_buffer_limit_callback_stops_the_capture_from_its_own_thread(
 
         await _wait_for_mic_label(composer, pilot, "Dictate")
         assert service.stop_calls == 1
-        assert any(
-            "Dictation limit reached" in str(call.args[0])
-            and call.kwargs.get("severity") == "warning"
+        assert composer.draft_text() == "before all accepted pcm after"
+        assert console._console_dictation_timer is None
+        assert console._console_dictation_elapsed_timer is None
+        assert [
+            (str(call.args[0]), call.kwargs.get("severity"))
             for call in notify.call_args_list
-        )
+        ] == [("Limit reached — press Mic to continue.", "warning")]
+
+        # Limit recovery is an explicit physical Mic press, never a timer or
+        # hidden reopen. The old capture stays stopped until this click.
+        await pilot.pause(0.2)
+        assert service.start_calls == 1
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictating")
+        assert service.start_calls == 2
+        service.emit_final("second capture")
+        await pilot.pause()
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictate")
 
 
 @pytest.mark.asyncio
@@ -1892,10 +2001,10 @@ async def test_capture_ending_command_is_kept_out_of_segments_but_forwarded(
 
         monkeypatch.setattr(session, "_on_event", _spy)
 
-        service.emit_final("dictated words")
-        service.emit_final("Console, stop.")
+        service.emit_executor_result("dictated words", "Console, stop.")
         await pilot.pause()
 
+        assert service.executor_results_emitted == 1
         assert session.commands_consumed == 1
         forwarded_commands = [
             event for event in received if isinstance(event, VoiceCommand)

--- a/Tests/UI/test_console_dictation_streaming.py
+++ b/Tests/UI/test_console_dictation_streaming.py
@@ -24,6 +24,9 @@ from Tests.UI.test_console_dictation import (
     _ready_host,
     _wait_for_mic_label,
 )
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
 from tldw_chatbook.Chat import console_voice_input as voice_module
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.console_voice_input import VoiceCommand, VoiceFailed
@@ -319,6 +322,74 @@ async def test_busy_parakeet_capture_stays_live_then_inserts_without_sending(
                 == message_count
             )
             assert service.start_calls == 1
+    finally:
+        service.start_gate.set()
+
+
+@pytest.mark.asyncio
+async def test_busy_parakeet_mic_stays_reachable_and_cancels_at_80_columns(
+    monkeypatch,
+):
+    service = FakeDictationService()
+    service.uses_deferred_dictation = True
+    service.waiting_for_executor = True
+    service.start_gate = threading.Event()
+    _patch_availability(monkeypatch, provider="parakeet-onnx")
+    _install_streaming_session(monkeypatch, service)
+    monkeypatch.setattr(ConsoleHarness, "CSS_PATH", str(_BUNDLED_STYLESHEET))
+    _, host = _ready_host()
+
+    try:
+        async with host.run_test(size=(80, 42)) as pilot:
+            console = await _mounted_console(host, pilot)
+            composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+
+            await pilot.click("#console-dictation")
+            deadline = time.monotonic() + 4
+            while (
+                time.monotonic() < deadline
+                and composer._voice_preparing_message
+                != "Local transcription busy — dictation will run next."
+            ):
+                await pilot.pause(0.01)
+            await pilot.pause()
+
+            actions = composer.query_one("#console-composer-actions")
+            mic = composer.query_one("#console-dictation", Button)
+            assert "Local transcription busy — dictation will run next." in _painted(
+                composer.query_one("#console-voice-status", Static)
+            )
+            assert actions.region.width == 25
+            assert actions.region.right <= composer.region.right <= host.size.width
+            assert mic.region.right <= composer.region.right
+            assert mic.visible
+            assert not mic.disabled
+            click_offset = (
+                mic.region.x + mic.region.width // 2,
+                mic.region.y,
+            )
+            hit_widget, _ = host.screen.get_widget_at(*click_offset)
+            assert hit_widget is mic
+
+            # Textual deliberately ignores a second Click while the first
+            # press's short `-active` visual effect is still running. Wait
+            # for that stock button animation, not for layout: the capture
+            # must remain starting and the same Mic cell must stay targeted.
+            deadline = time.monotonic() + 1
+            while time.monotonic() < deadline and mic.has_class("-active"):
+                await pilot.pause(0.01)
+            assert console._console_dictation_state == "starting"
+            hit_widget, _ = host.screen.get_widget_at(*click_offset)
+            assert hit_widget is mic
+            assert await pilot.click(offset=click_offset) is True
+            await _wait_for_mic_label(composer, pilot, "Dictate")
+
+            assert console._console_dictation_state == "idle"
+            assert console._console_dictation_session is None
+            assert composer.query_one("#console-composer-collapse").display
+            assert composer.query_one("#console-composer-menu").display
+            assert composer.query_one("#console-command-visible-text").display
+            assert composer.query_one("#console-send-disabled-reason").display
     finally:
         service.start_gate.set()
 

--- a/Tests/UI/test_console_dictation_streaming.py
+++ b/Tests/UI/test_console_dictation_streaming.py
@@ -61,9 +61,16 @@ class FakeDictationService:
     -- at exactly the moment it wants them.
     """
 
-    def __init__(self, *, started: bool = True, start_error: str = "") -> None:
+    def __init__(
+        self,
+        *,
+        started: bool = True,
+        start_error: str = "",
+        stop_exception: Exception | None = None,
+    ) -> None:
         self.started = started
         self.start_error = start_error
+        self.stop_exception = stop_exception
         self.start_calls = 0
         self.stop_calls = 0
         self.release_calls = 0
@@ -137,6 +144,8 @@ class FakeDictationService:
         self.stop_entered.set()
         if self.stop_gate is not None:
             self.stop_gate.wait(timeout=4)
+        if self.stop_exception is not None:
+            raise self.stop_exception
 
     def emit_partial(self, text: str) -> None:
         assert self.on_partial is not None, "start_dictation() has not run yet"
@@ -841,10 +850,10 @@ def test_streaming_session_delegates_one_shot_retry_state():
             calls.append("clear")
             self.retry_available = False
 
-        def retry_with_faster_whisper(self) -> str:
+        def retry_segments_with_faster_whisper(self) -> tuple[str, ...]:
             calls.append("retry")
             self.retry_available = False
-            return "recovered"
+            return ("recovered",)
 
     session = dictation_module.ConsoleStreamingDictationSession(
         on_event=lambda _session, _event: None,
@@ -856,6 +865,161 @@ def test_streaming_session_delegates_one_shot_retry_state():
     assert session.retry_available is False
     session.clear_retry()
     assert calls == ["retry", "clear"]
+
+
+def test_streaming_retry_merges_prefix_and_classifies_each_logical_segment():
+    events: list = []
+
+    class RetryController:
+        retry_available = True
+
+        def retry_segments_with_faster_whisper(self) -> tuple[str, ...]:
+            self.retry_available = False
+            return ("recovered words", "Console, stop.")
+
+        def clear_retry(self) -> None:
+            self.retry_available = False
+
+    session = dictation_module.ConsoleStreamingDictationSession(
+        on_event=lambda _session, event: events.append(event),
+    )
+    session._controller = RetryController()
+    session._handle_event(voice_module.VoiceFinal("prefix already finalized"))
+    events.clear()
+
+    transcript = session.retry_with_faster_whisper()
+
+    assert transcript == "prefix already finalized recovered words"
+    assert events == [
+        voice_module.VoiceFinal("recovered words"),
+        VoiceCommand("stop"),
+    ]
+    assert session.commands_consumed == 1
+    assert session.retry_available is False
+
+
+def test_streaming_retry_events_keep_the_generation_that_started_the_replay():
+    retry_started = threading.Event()
+    retry_release = threading.Event()
+    events: list = []
+
+    class RetryController:
+        retry_available = True
+
+        def retry_segments_with_faster_whisper(self) -> tuple[str, ...]:
+            retry_started.set()
+            retry_release.wait(timeout=2)
+            self.retry_available = False
+            return ("stale recovered words",)
+
+    session = dictation_module.ConsoleStreamingDictationSession(
+        on_event=lambda _session, event: events.append(event),
+    )
+    session._controller = RetryController()
+    session._capture_generation = 1
+    result: list[str] = []
+    thread = threading.Thread(
+        target=lambda: result.append(session.retry_with_faster_whisper())
+    )
+
+    thread.start()
+    assert retry_started.wait(timeout=2)
+    with session._lock:
+        session._capture_generation = 2
+        session._segments[:] = ["new capture words"]
+    retry_release.set()
+    thread.join(timeout=2)
+
+    assert not thread.is_alive()
+    assert result == ["new capture words"]
+    assert events == []
+    assert session._segments == ["new capture words"]
+
+
+@pytest.mark.asyncio
+async def test_mounted_retry_keeps_prefix_and_routes_retried_stop_command(
+    monkeypatch,
+):
+    from tldw_chatbook.STT.contracts import BufferAudioSource
+    from tldw_chatbook.STT.dispatch_coordinator import (
+        RetryableDictationBuffer,
+        RetryableDictationFailure,
+    )
+
+    class RetryTranscriber:
+        def __init__(self) -> None:
+            self.texts = ["recovered suffix", "Console, stop."]
+            self.calls: list[dict] = []
+
+        def transcribe_buffer(self, **kwargs):
+            self.calls.append(kwargs)
+            return {"text": self.texts.pop(0)}
+
+    retry_buffer = RetryableDictationBuffer(
+        BufferAudioSource(b"\x01\x00\x02\x00\x03\x00\x04\x00", 16_000, 1, 2),
+        (2, 4),
+    )
+    service = FakeDictationService(
+        stop_exception=RetryableDictationFailure(retry_buffer)
+    )
+    service.uses_deferred_dictation = True
+    service.transcription_service = RetryTranscriber()
+    service.language = "en"
+    _patch_availability(monkeypatch, provider="parakeet-onnx")
+    monkeypatch.setattr(
+        voice_module,
+        "installed_local_providers",
+        lambda: ("parakeet-onnx", "faster-whisper"),
+    )
+    monkeypatch.setattr(
+        voice_module,
+        "_faster_whisper_model_is_local",
+        lambda _model: True,
+    )
+    _install_streaming_session(monkeypatch, service)
+    _, host = _ready_host()
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+
+        async def confirm_retry(_dialog):
+            return True
+
+        console.app_instance.push_screen_wait = confirm_retry
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        store = console._ensure_console_chat_store()
+        message_count = len(store.messages_for_session(store.active_session_id))
+        stop_requests = 0
+        original_stop_request = console._dictation._request_console_dictation_stop
+
+        def count_stop_request() -> None:
+            nonlocal stop_requests
+            stop_requests += 1
+            original_stop_request()
+
+        monkeypatch.setattr(
+            console._dictation,
+            "_request_console_dictation_stop",
+            count_stop_request,
+        )
+
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictating")
+        service.emit_final("prefix already finalized")
+        await pilot.pause()
+        await pilot.pause(0.6)
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictate")
+
+        assert composer.draft_text() == ("prefix already finalized recovered suffix")
+        assert "Console" not in composer.draft_text()
+        assert stop_requests == 2
+        assert len(store.messages_for_session(store.active_session_id)) == message_count
+        assert len(service.transcription_service.calls) == 2
+        assert all(
+            call["local_files_only"] is True
+            for call in service.transcription_service.calls
+        )
 
 
 @pytest.mark.asyncio
@@ -988,7 +1152,15 @@ async def test_the_transcribing_indication_reverts_on_a_mid_capture_stop(monkeyp
         assert "Transcribing" in _painted(chip)
 
         await pilot.click("#console-dictation")
-        await _wait_for_mic_label(composer, pilot, "Dictate")
+        button = await _wait_for_mic_label(composer, pilot, "Dictate")
+        assert console._console_dictation_state == "idle"
+        assert console._console_dictation_session is None
+        # This fake stop finishes inside Textual's 0.2 s pressed animation.
+        # Button deliberately ignores clicks while its ``-active`` class is
+        # present, so wait for that input animation rather than racing it.
+        assert button.has_class("-active")
+        while button.has_class("-active"):
+            await pilot.pause(0.01)
 
         # A fresh capture must start clean, with no leftover indication.
         await pilot.click("#console-dictation")

--- a/Tests/UI/test_console_dictation_streaming.py
+++ b/Tests/UI/test_console_dictation_streaming.py
@@ -28,6 +28,7 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
 from tldw_chatbook.Chat import console_voice_input as voice_module
+from tldw_chatbook.Chat.attachment_core import PendingAttachment
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.console_voice_input import VoiceCommand, VoiceFailed
 from tldw_chatbook.UI.Console_Modules import dictation as dictation_module
@@ -184,6 +185,20 @@ class FakeDictationService:
     def emit_error(self, message: str) -> None:
         assert self.on_error is not None, "start_dictation() has not run yet"
         self.on_error(RuntimeError(message))
+
+
+def _staged_image(name: str) -> PendingAttachment:
+    data = f"png-bytes-{name}".encode()
+    return PendingAttachment(
+        file_path=f"/tmp/{name}",
+        display_name=name,
+        file_type="image",
+        insert_mode="attachment",
+        data=data,
+        mime_type="image/png",
+        original_size=len(data),
+        processed_size=len(data),
+    )
 
 
 def _painted(widget) -> str:
@@ -390,6 +405,86 @@ async def test_busy_parakeet_mic_stays_reachable_and_cancels_at_80_columns(
             assert composer.query_one("#console-composer-menu").display
             assert composer.query_one("#console-command-visible-text").display
             assert composer.query_one("#console-send-disabled-reason").display
+    finally:
+        service.start_gate.set()
+
+
+@pytest.mark.asyncio
+async def test_busy_parakeet_mic_stays_reachable_with_staged_attachments(
+    monkeypatch,
+):
+    service = FakeDictationService()
+    service.uses_deferred_dictation = True
+    service.waiting_for_executor = True
+    service.start_gate = threading.Event()
+    _patch_availability(monkeypatch, provider="parakeet-onnx")
+    _install_streaming_session(monkeypatch, service)
+    monkeypatch.setattr(ConsoleHarness, "CSS_PATH", str(_BUNDLED_STYLESHEET))
+    _, host = _ready_host()
+
+    try:
+        async with host.run_test(size=(80, 42)) as pilot:
+            console = await _mounted_console(host, pilot)
+            composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+            store = console._ensure_console_chat_store()
+            session = store.ensure_session()
+            staged = [_staged_image("one.png"), _staged_image("two.png")]
+            for attachment in staged:
+                assert store.add_pending_attachment(session.id, attachment)
+            console._sync_console_composer_action_state(can_save_chatbook=False)
+            await pilot.pause()
+
+            indicator = composer.query_one("#console-attachment-indicator", Static)
+            clear_button = composer.query_one("#console-clear-attachment", Button)
+            actions = composer.query_one("#console-composer-actions")
+            assert "2 files" in _painted(indicator)
+            assert clear_button.display
+            assert str(clear_button.tooltip) == "Remove all 2 pending attachments."
+            assert actions.region.width == 29
+
+            mic = composer.query_one("#console-dictation", Button)
+            mic.press()
+            deadline = time.monotonic() + 4
+            while (
+                time.monotonic() < deadline
+                and composer._voice_preparing_message
+                != "Local transcription busy — dictation will run next."
+            ):
+                await pilot.pause(0.01)
+            # Exercise the production refresh that re-applies the staged label
+            # after sync_dictation_state has restored the busy copy.
+            console._sync_console_composer_action_state(can_save_chatbook=False)
+            await pilot.pause()
+
+            assert "Local transcription busy — dictation will run next." in _painted(
+                composer.query_one("#console-voice-status", Static)
+            )
+            assert not indicator.display
+            assert not clear_button.display
+            assert actions.region.width == 25
+            assert actions.region.right <= composer.region.right <= host.size.width
+            assert mic.region.right <= composer.region.right
+            click_offset = (
+                mic.region.x + mic.region.width // 2,
+                mic.region.y,
+            )
+            hit_widget, _ = host.screen.get_widget_at(*click_offset)
+            assert hit_widget is mic
+
+            deadline = time.monotonic() + 1
+            while time.monotonic() < deadline and mic.has_class("-active"):
+                await pilot.pause(0.01)
+            assert await pilot.click(offset=click_offset) is True
+            await _wait_for_mic_label(composer, pilot, "Dictate")
+            await pilot.pause()
+
+            assert console._console_dictation_state == "idle"
+            assert store.pending_attachments(session.id) == staged
+            assert "2 files" in _painted(indicator)
+            assert indicator.display
+            assert clear_button.display
+            assert str(clear_button.tooltip) == "Remove all 2 pending attachments."
+            assert actions.region.width == 29
     finally:
         service.start_gate.set()
 

--- a/Tests/UI/test_console_hands_free_wiring.py
+++ b/Tests/UI/test_console_hands_free_wiring.py
@@ -1636,16 +1636,10 @@ async def _wait_for(condition, pilot, *, timeout: float = _ASYNC_SETTLE_TIMEOUT)
 
 
 @pytest.mark.asyncio
-async def test_two_consecutive_empty_limits_really_reopen_then_really_exit(
+async def test_hands_free_limit_exits_without_reopen_until_a_physical_mic_press(
     monkeypatch,
 ):
-    """End-to-end pin for B2: a wall-clock/buffer-limit ending with NOTHING
-    dictated must reopen the REAL microphone (not just the FSM's belief) --
-    and a SECOND consecutive empty ending must actually exit the loop.
-    Asserts on the dictation SERVICE's own `start_calls`, never the FSM's
-    `capture_open` property, since that is exactly what B1's probe showed
-    can lie.
-    """
+    """A bounded ending inserts normally and requires an explicit resume."""
     service = FakeDictationService()
     _patch_availability(monkeypatch)
     _install_streaming_session(monkeypatch, service)
@@ -1664,31 +1658,30 @@ async def test_two_consecutive_empty_limits_really_reopen_then_really_exit(
         assert console._console_hands_free is not None
         assert service.start_calls == 1
 
-        # First empty-limit ending: nothing was dictated (no `emit_final`
-        # call). Must reopen for one more turn.
-        console._dictation._handle_console_dictation_limit()
-        await _wait_for(lambda: service.start_calls == 2, pilot)
-        await _wait_for_mic_label(composer, pilot, "Dictating")
-        assert console._console_hands_free is not None
-        assert console._console_hands_free.controller.state == "listening"
-
-        # Second CONSECUTIVE empty-limit ending: must exit the loop, not
-        # reopen a third time.
+        service.emit_final("retained bounded text")
+        await pilot.pause()
         console._dictation._handle_console_dictation_limit()
         await _wait_for(lambda: console._console_hands_free is None, pilot)
+        await _wait_for_mic_label(composer, pilot, "Dictate")
+
         await pilot.pause(0.2)
-        assert service.start_calls == 2  # no third reopen
+        assert composer.draft_text() == "retained bounded text"
+        assert service.start_calls == 1
+
+        await pilot.click("#console-dictation")
+        await _wait_for_mic_label(composer, pilot, "Dictating")
+        assert service.start_calls == 2
+        service.emit_final("resumed physically")
+        await pilot.pause()
+        await pilot.click("#console-dictation")
         await _wait_for_mic_label(composer, pilot, "Dictate")
 
 
 @pytest.mark.asyncio
-async def test_empty_limit_with_segments_reopen_pending_reply_still_speaks(
+async def test_hands_free_limit_never_auto_sends_the_retained_text(
     monkeypatch,
 ):
-    """A limit-triggered ending WITH segments pending must still drive a
-    real send (the `RequestStopAndSend`-equivalent path) once the capture
-    has actually finished stopping -- deferring `on_capture_ended` to
-    after `idle` must not break the had-segments branch."""
+    """Limit recovery follows ordinary insertion, never the send path."""
     service = FakeDictationService()
     _patch_availability(monkeypatch)
     _install_streaming_session(monkeypatch, service)
@@ -1712,23 +1705,16 @@ async def test_empty_limit_with_segments_reopen_pending_reply_still_speaks(
 
         service.emit_final("dictated before the limit hit")
         await pilot.pause()
-        # A real countdown may or may not have expired yet; force the
-        # limit path directly, matching what the 60s wall timer would do
-        # with a segment already finalized (state may be `listening` if
-        # the countdown drained, or `countdown` -- `_handle_console_
-        # dictation_limit` only cares that dictation is still `recording`).
         console._dictation._handle_console_dictation_limit()
 
-        await _wait_for(lambda: bool(gateway.sent_messages), pilot)
-        sent_user_turns = [
-            m["content"]
-            for turn in gateway.sent_messages
-            for m in turn
-            if m.get("role") == "user"
-        ]
-        assert any("dictated before the limit hit" in t for t in sent_user_turns)
-        await _wait_for(lambda: bool(tts.calls), pilot)
-        assert any("Limit triggered reply" in text for text, _q in tts.calls)
+        await _wait_for(lambda: console._console_hands_free is None, pilot)
+        await _wait_for_mic_label(composer, pilot, "Dictate")
+        await pilot.pause(0.3)
+
+        assert composer.draft_text() == "dictated before the limit hit"
+        assert gateway.sent_messages == []
+        assert not any("Limit triggered reply" in text for text, _q in tts.calls)
+        assert service.start_calls == 1
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_voice_chip.py
+++ b/Tests/UI/test_console_voice_chip.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from textual.app import App
 from textual.widgets import Static
@@ -18,6 +20,17 @@ from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBa
 class ComposerApp(App):
     def compose(self):
         yield ConsoleComposerBar(id="console-native-composer")
+
+
+class ProductionCssComposerApp(ComposerApp):
+    """Mount the composer with the generated production stylesheet."""
+
+    CSS_PATH = str(
+        Path(__file__).resolve().parents[2]
+        / "tldw_chatbook"
+        / "css"
+        / "tldw_cli_modular.tcss"
+    )
 
 
 def _visible(widget) -> bool:
@@ -194,7 +207,7 @@ async def test_preparing_and_error_states_render_their_message():
 
 @pytest.mark.asyncio
 async def test_busy_dictation_copy_uses_the_existing_chip_and_clears_at_idle():
-    app = ComposerApp()
+    app = ProductionCssComposerApp()
     async with app.run_test(size=(80, 12)) as pilot:
         composer = app.query_one(ConsoleComposerBar)
         message = "Local transcription busy — dictation will run next."
@@ -210,12 +223,67 @@ async def test_busy_dictation_copy_uses_the_existing_chip_and_clears_at_idle():
         # An ordinary control-bar refresh must not erase the busy status.
         composer.sync_dictation_state("starting")
         await pilot.pause()
-        assert str(chip.renderable) == message
+        assert message in _painted(chip)
 
         composer.sync_dictation_state("idle")
         await pilot.pause()
         assert chip.styles.width.value == 0
         assert _painted(chip) == ""
+
+
+@pytest.mark.asyncio
+async def test_production_css_busy_status_stays_meaningful_at_narrow_width():
+    app = ProductionCssComposerApp()
+    async with app.run_test(size=(48, 12)) as pilot:
+        composer = app.query_one(ConsoleComposerBar)
+
+        composer.sync_dictation_state("starting")
+        composer.set_voice_preparing_message(
+            "Local transcription busy — dictation will run next."
+        )
+        await pilot.pause()
+
+        chip = composer.query_one("#console-voice-status", Static)
+        painted = _painted(chip)
+        assert painted.startswith("Local trans")
+        assert painted.endswith("…")
+        assert _visible(chip)
+        assert chip.region.x + chip.region.width <= composer.region.right
+
+
+@pytest.mark.asyncio
+async def test_production_css_ordinary_voice_states_restore_normal_padding():
+    app = ProductionCssComposerApp()
+    async with app.run_test(size=(80, 12)) as pilot:
+        composer = app.query_one(ConsoleComposerBar)
+        chip = composer.query_one("#console-voice-status", Static)
+
+        composer.set_voice_status(
+            STATE_PREPARING,
+            message="Local transcription busy — dictation will run next.",
+        )
+        composer.set_voice_status(STATE_PREPARING, message="Loading model…")
+        await pilot.pause()
+        assert "Loading model…" in _painted(chip)
+        assert chip.styles.padding.left == 1
+        assert chip.styles.padding.right == 1
+
+        composer.set_voice_status(STATE_ERROR, message="No microphone access.")
+        await pilot.pause()
+        assert "No microphone access." in _painted(chip)
+        assert chip.styles.padding.left == 1
+        assert chip.styles.padding.right == 1
+
+        composer.set_voice_status(
+            STATE_LISTENING,
+            partial="ordinary listening partial",
+            elapsed_seconds=7,
+        )
+        await pilot.pause()
+        assert "0:07" in _painted(chip)
+        assert "ordinary listening partial" in _painted(chip)
+        assert chip.styles.padding.left == 1
+        assert chip.styles.padding.right == 1
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_voice_chip.py
+++ b/Tests/UI/test_console_voice_chip.py
@@ -294,6 +294,62 @@ async def test_busy_presentation_preserves_draft_and_caret_then_restores_recordi
 
 
 @pytest.mark.asyncio
+async def test_busy_presentation_suppresses_and_restores_staged_attachment():
+    app = ProductionCssComposerApp()
+    async with app.run_test(size=(80, 12)) as pilot:
+        composer = app.query_one(ConsoleComposerBar)
+        indicator = composer.query_one("#console-attachment-indicator", Static)
+        clear_button = composer.query_one("#console-clear-attachment")
+        actions = composer.query_one("#console-composer-actions")
+
+        composer.set_pending_attachment_label("2 files", count=2, total=5)
+        await pilot.pause()
+        assert "2 files" in _painted(indicator)
+        assert _visible(indicator)
+        assert _visible(clear_button)
+        assert str(clear_button.tooltip) == "Remove all 2 pending attachments."
+        assert actions.region.width == 29
+
+        composer.set_voice_status(
+            STATE_PREPARING,
+            message="Local transcription busy — dictation will run next.",
+        )
+        # A production control-bar refresh may reapply this setter while the
+        # deferred capture still owns the full-width preparing presentation.
+        composer.set_pending_attachment_label("2 files", count=2, total=5)
+        await pilot.pause()
+
+        assert not _visible(indicator)
+        assert not _visible(clear_button)
+        assert actions.region.width == 25
+        assert "2 files" in str(indicator.renderable)
+        assert str(clear_button.tooltip) == "Remove all 2 pending attachments."
+
+        expanded = composer.query_one("#console-composer-expanded")
+        collapsed = composer.query_one("#console-composer-collapsed")
+        composer.set_collapsed(True)
+        composer.set_pending_attachment_label("2 files", count=2, total=5)
+        assert not expanded.display
+        assert collapsed.display
+        composer.set_collapsed(False)
+
+        composer.set_voice_status(STATE_LISTENING, elapsed_seconds=0)
+        await pilot.pause()
+
+        assert "2 files" in _painted(indicator)
+        assert _visible(indicator)
+        assert _visible(clear_button)
+        assert str(clear_button.tooltip) == "Remove all 2 pending attachments."
+        assert actions.region.width == 29
+
+        composer.set_pending_attachment_label(None)
+        await pilot.pause()
+        assert not _visible(indicator)
+        assert not _visible(clear_button)
+        assert actions.region.width == 25
+
+
+@pytest.mark.asyncio
 async def test_production_css_busy_status_stays_meaningful_at_narrow_width():
     app = ProductionCssComposerApp()
     async with app.run_test(size=(48, 12)) as pilot:

--- a/Tests/UI/test_console_voice_chip.py
+++ b/Tests/UI/test_console_voice_chip.py
@@ -195,7 +195,7 @@ async def test_preparing_and_error_states_render_their_message():
 @pytest.mark.asyncio
 async def test_busy_dictation_copy_uses_the_existing_chip_and_clears_at_idle():
     app = ComposerApp()
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(80, 12)) as pilot:
         composer = app.query_one(ConsoleComposerBar)
         message = "Local transcription busy — dictation will run next."
 
@@ -204,7 +204,7 @@ async def test_busy_dictation_copy_uses_the_existing_chip_and_clears_at_idle():
         await pilot.pause()
         chip = composer.query_one("#console-voice-status", Static)
 
-        assert str(chip.renderable) == message
+        assert message in _painted(chip)
         assert _visible(chip)
 
         # An ordinary control-bar refresh must not erase the busy status.

--- a/Tests/UI/test_console_voice_chip.py
+++ b/Tests/UI/test_console_voice_chip.py
@@ -211,6 +211,20 @@ async def test_busy_dictation_copy_uses_the_existing_chip_and_clears_at_idle():
     async with app.run_test(size=(80, 12)) as pilot:
         composer = app.query_one(ConsoleComposerBar)
         message = "Local transcription busy — dictation will run next."
+        presentation = [
+            composer.query_one(selector)
+            for selector in (
+                "#console-composer-collapse",
+                "#console-composer-menu",
+                "#console-command-visible-text",
+                "#console-send-disabled-reason",
+            )
+        ]
+        actions = composer.query_one("#console-composer-actions")
+        mic = composer.query_one("#console-dictation")
+        idle_action_width = actions.region.width
+        idle_mic_width = mic.region.width
+        assert all(_visible(widget) for widget in presentation)
 
         composer.sync_dictation_state("starting")
         composer.set_voice_preparing_message(message)
@@ -219,6 +233,14 @@ async def test_busy_dictation_copy_uses_the_existing_chip_and_clears_at_idle():
 
         assert message in _painted(chip)
         assert _visible(chip)
+        assert all(not _visible(widget) for widget in presentation)
+        assert idle_action_width == 25
+        assert actions.region.width == idle_action_width
+        assert mic.region.width == idle_mic_width
+        assert actions.region.right <= composer.region.right <= app.size.width
+        assert mic.region.right <= composer.region.right
+        assert _visible(mic)
+        assert await pilot.click(mic) is True
 
         # An ordinary control-bar refresh must not erase the busy status.
         composer.sync_dictation_state("starting")
@@ -229,6 +251,46 @@ async def test_busy_dictation_copy_uses_the_existing_chip_and_clears_at_idle():
         await pilot.pause()
         assert chip.styles.width.value == 0
         assert _painted(chip) == ""
+        assert all(_visible(widget) for widget in presentation)
+
+
+@pytest.mark.asyncio
+async def test_busy_presentation_preserves_draft_and_caret_then_restores_recording():
+    app = ProductionCssComposerApp()
+    async with app.run_test(size=(80, 12)) as pilot:
+        composer = app.query_one(ConsoleComposerBar)
+        composer.load_draft("keep this draft")
+        for _ in range(5):
+            composer.move_cursor_left()
+        before_text = composer.draft_text()
+        before_caret = composer.cursor_index
+        controls = [
+            composer.query_one(selector)
+            for selector in (
+                "#console-composer-collapse",
+                "#console-composer-menu",
+                "#console-command-visible-text",
+            )
+        ]
+        reason = composer.query_one("#console-send-disabled-reason")
+
+        composer.sync_dictation_state("starting")
+        composer.set_voice_preparing_message(
+            "Local transcription busy — dictation will run next."
+        )
+        await pilot.pause()
+
+        assert all(not _visible(widget) for widget in (*controls, reason))
+        assert composer.draft_text() == before_text
+        assert composer.cursor_index == before_caret
+
+        composer.sync_dictation_state("recording")
+        await pilot.pause()
+
+        assert all(_visible(widget) for widget in controls)
+        assert not _visible(reason)
+        assert composer.draft_text() == before_text
+        assert composer.cursor_index == before_caret
 
 
 @pytest.mark.asyncio
@@ -267,12 +329,16 @@ async def test_production_css_ordinary_voice_states_restore_normal_padding():
         assert "Loading model…" in _painted(chip)
         assert chip.styles.padding.left == 1
         assert chip.styles.padding.right == 1
+        assert chip.styles.margin.left == 0
+        assert chip.styles.margin.right == 1
 
         composer.set_voice_status(STATE_ERROR, message="No microphone access.")
         await pilot.pause()
         assert "No microphone access." in _painted(chip)
         assert chip.styles.padding.left == 1
         assert chip.styles.padding.right == 1
+        assert chip.styles.margin.left == 0
+        assert chip.styles.margin.right == 1
 
         composer.set_voice_status(
             STATE_LISTENING,
@@ -284,6 +350,8 @@ async def test_production_css_ordinary_voice_states_restore_normal_padding():
         assert "ordinary listening partial" in _painted(chip)
         assert chip.styles.padding.left == 1
         assert chip.styles.padding.right == 1
+        assert chip.styles.margin.left == 0
+        assert chip.styles.margin.right == 1
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_voice_chip.py
+++ b/Tests/UI/test_console_voice_chip.py
@@ -193,6 +193,32 @@ async def test_preparing_and_error_states_render_their_message():
 
 
 @pytest.mark.asyncio
+async def test_busy_dictation_copy_uses_the_existing_chip_and_clears_at_idle():
+    app = ComposerApp()
+    async with app.run_test() as pilot:
+        composer = app.query_one(ConsoleComposerBar)
+        message = "Local transcription busy — dictation will run next."
+
+        composer.sync_dictation_state("starting")
+        composer.set_voice_preparing_message(message)
+        await pilot.pause()
+        chip = composer.query_one("#console-voice-status", Static)
+
+        assert str(chip.renderable) == message
+        assert _visible(chip)
+
+        # An ordinary control-bar refresh must not erase the busy status.
+        composer.sync_dictation_state("starting")
+        await pilot.pause()
+        assert str(chip.renderable) == message
+
+        composer.sync_dictation_state("idle")
+        await pilot.pause()
+        assert chip.styles.width.value == 0
+        assert _painted(chip) == ""
+
+
+@pytest.mark.asyncio
 async def test_the_mic_tooltips_claim_nothing_the_backend_no_longer_does():
     """The button's own copy outlived the backend it described.
 

--- a/backlog/tasks/task-603 - Restore-bounded-Parakeet-ONNX-dictation-buffers.md
+++ b/backlog/tasks/task-603 - Restore-bounded-Parakeet-ONNX-dictation-buffers.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-08 21:29'
+updated_date: '2026-08-09 04:22'
 labels:
   - stt
   - dictation
@@ -30,9 +30,9 @@ Preserve microphone and in-memory buffer transcription after legacy Parakeet rem
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The public bounded-buffer transcription path uses LocalSTTExecutor and returns normalized Parakeet ONNX results without creating another model process.
-- [ ] #2 The Parakeet ONNX streaming factory reports unsupported through the existing fallback contract rather than advertising true streaming.
-- [ ] #3 At most one dictation inference is pending; new audio coalesces within explicit duration and byte limits and never silently drops captured samples.
+- [x] #1 The public bounded-buffer transcription path uses LocalSTTExecutor and returns normalized Parakeet ONNX results without creating another model process.
+- [x] #2 The Parakeet ONNX streaming factory reports unsupported through the existing fallback contract rather than advertising true streaming.
+- [x] #3 At most one dictation inference is pending; new audio coalesces within explicit duration and byte limits and never silently drops captured samples.
 - [ ] #4 When limits would be exceeded, capture pauses visibly with a recoverable overrun state and resumes only through an explicit user action.
 - [ ] #5 Dictation is selected before the next batch item without preempting active native inference, and users can pause future batch dispatch while local transcription is busy.
 - [ ] #6 Latency, backpressure, cancellation, shutdown, and batch coexistence tests pass on representative supported platforms before legacy providers can be removed.
@@ -53,3 +53,15 @@ Plan: Docs/superpowers/plans/2026-08-08-task-603-bounded-parakeet-dictation.md
 6. Wire Console busy, limit, explicit resume, and faster-whisper retry through existing UI controllers.
 7. Run only focused verification, collect macOS evidence, and keep Windows/Linux/TASK-605 gates open.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the bounded Parakeet ONNX dictation path under [ADR-025](../decisions/025-shared-stt-artifacts-and-runtime-routing.md). One app-owned LocalSTTExecutor and LocalSTTDispatchCoordinator now serve both Library file work and bounded Console PCM buffers; frame-based logical boundaries, one pending inference, format-derived 60-second/byte limits, generation fencing, and one-shot retry ownership prevent a second model process or unbounded queue. The Parakeet ONNX streaming factory continues to report unsupported, so this remains bounded whole-segment recognition rather than true streaming.
+
+Console wiring uses the existing chip/controller for busy, limit, explicit physical resume, retained caret insertion without auto-send, and bounded faster-whisper retry. The retired production route is bypassed but its dead legacy implementation remains intentionally present for TASK-605. Evidence is recorded in [Docs/STT_Evaluation/task-603](../../Docs/STT_Evaluation/task-603/README.md).
+
+Fresh post-rebase focused evidence at f8827ddff24b7415acc1b7f40dc40564b55a014d: 148 coordinator/executor/runtime/facade tests passed in 7.31s; ten exact app/Chat/UI contract nodes passed in 13.18s; review-fix boundary nodes passed and the full coordinator file passed 38 tests; changed-package py_compile and git diff --check passed. Changed-file Ruff reports only two proven pre-existing findings in Tests/Library/test_library_ingest_runner.py. Whole-branch review fixed one Important one-shot over-limit defect and approved focused re-review with no remaining finding.
+
+The macOS runtime evidence is a non-UI fallback: the real app factory, app-owned coordinator/executor, and Parakeet v2 INT8 ONNX CPU transcribed 4.7025 seconds / 150480 PCM bytes to the exact expected English sentence in 4.407s without network or profile/store mutation. It does not prove a real Mic press or Console surface. The one required changed-test union aborted at 96% with exit 134 during a background retained Parakeet MLX native warm-up; its exact active node passed alone, but the union is not green. Real Mic/caret, visible busy ordering, live limit/explicit resume, safe real retry, Windows, Linux, and TASK-605 remain open. Mergeable implementation evidence is partial, not release-gate completion; status remains In Progress and AC4-AC6 remain unchecked.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-603 - Restore-bounded-Parakeet-ONNX-dictation-buffers.md
+++ b/backlog/tasks/task-603 - Restore-bounded-Parakeet-ONNX-dictation-buffers.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-603
 title: Restore bounded Parakeet ONNX dictation buffers
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-24 01:04'
+updated_date: '2026-08-08 21:29'
 labels:
   - stt
   - dictation
@@ -14,6 +16,9 @@ references:
   - backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
 documentation:
   - Docs/superpowers/specs/2026-07-23-stt-parakeet-onnx-transcribe-cpp-design.md
+  - >-
+    Docs/superpowers/specs/2026-08-08-task-603-bounded-parakeet-dictation-design.md
+  - Docs/superpowers/plans/2026-08-08-task-603-bounded-parakeet-dictation.md
 priority: high
 ---
 
@@ -32,3 +37,19 @@ Preserve microphone and in-memory buffer transcription after legacy Parakeet rem
 - [ ] #5 Dictation is selected before the next batch item without preempting active native inference, and users can pause future batch dispatch while local transcription is busy.
 - [ ] #6 Latency, backpressure, cancellation, shutdown, and batch coexistence tests pass on representative supported platforms before legacy providers can be removed.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no new ADR
+ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+Reason: ADR-025 already governs the shared executor, bounded in-memory dictation, dictation-next admission, fallback, and release gates.
+Plan: Docs/superpowers/plans/2026-08-08-task-603-bounded-parakeet-dictation.md
+1. Extend LocalSTTExecutor requests from file-only to file-or-buffer with validated logical frame boundaries.
+2. Share exact Parakeet artifact identity and add normalized in-memory recognition.
+3. Add one bounded dictation-next admission coordinator in front of the queue-less executor.
+4. Route Library and Console through the same app-owned coordinator and shutdown boundary.
+5. Adapt the public facade and live dictation service without blocking the audio processing thread.
+6. Wire Console busy, limit, explicit resume, and faster-whisper retry through existing UI controllers.
+7. Run only focused verification, collect macOS evidence, and keep Windows/Linux/TASK-605 gates open.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-603 - Restore-bounded-Parakeet-ONNX-dictation-buffers.md
+++ b/backlog/tasks/task-603 - Restore-bounded-Parakeet-ONNX-dictation-buffers.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-09 04:22'
+updated_date: '2026-08-09 05:31'
 labels:
   - stt
   - dictation
@@ -33,8 +33,8 @@ Preserve microphone and in-memory buffer transcription after legacy Parakeet rem
 - [x] #1 The public bounded-buffer transcription path uses LocalSTTExecutor and returns normalized Parakeet ONNX results without creating another model process.
 - [x] #2 The Parakeet ONNX streaming factory reports unsupported through the existing fallback contract rather than advertising true streaming.
 - [x] #3 At most one dictation inference is pending; new audio coalesces within explicit duration and byte limits and never silently drops captured samples.
-- [ ] #4 When limits would be exceeded, capture pauses visibly with a recoverable overrun state and resumes only through an explicit user action.
-- [ ] #5 Dictation is selected before the next batch item without preempting active native inference, and users can pause future batch dispatch while local transcription is busy.
+- [x] #4 When limits would be exceeded, capture pauses visibly with a recoverable overrun state and resumes only through an explicit user action.
+- [x] #5 Dictation is selected before the next batch item without preempting active native inference, and users can pause future batch dispatch while local transcription is busy.
 - [ ] #6 Latency, backpressure, cancellation, shutdown, and batch coexistence tests pass on representative supported platforms before legacy providers can be removed.
 <!-- AC:END -->
 
@@ -57,11 +57,5 @@ Plan: Docs/superpowers/plans/2026-08-08-task-603-bounded-parakeet-dictation.md
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented the bounded Parakeet ONNX dictation path under [ADR-025](../decisions/025-shared-stt-artifacts-and-runtime-routing.md). One app-owned LocalSTTExecutor and LocalSTTDispatchCoordinator now serve both Library file work and bounded Console PCM buffers; frame-based logical boundaries, one pending inference, format-derived 60-second/byte limits, generation fencing, and one-shot retry ownership prevent a second model process or unbounded queue. The Parakeet ONNX streaming factory continues to report unsupported, so this remains bounded whole-segment recognition rather than true streaming.
-
-Console wiring uses the existing chip/controller for busy, limit, explicit physical resume, retained caret insertion without auto-send, and bounded faster-whisper retry. The retired production route is bypassed but its dead legacy implementation remains intentionally present for TASK-605. Evidence is recorded in [Docs/STT_Evaluation/task-603](../../Docs/STT_Evaluation/task-603/README.md).
-
-Fresh post-rebase focused evidence at f8827ddff24b7415acc1b7f40dc40564b55a014d: 148 coordinator/executor/runtime/facade tests passed in 7.31s; ten exact app/Chat/UI contract nodes passed in 13.18s; review-fix boundary nodes passed and the full coordinator file passed 38 tests; changed-package py_compile and git diff --check passed. Changed-file Ruff reports only two proven pre-existing findings in Tests/Library/test_library_ingest_runner.py. Whole-branch review fixed one Important one-shot over-limit defect and approved focused re-review with no remaining finding.
-
-The macOS runtime evidence is a non-UI fallback: the real app factory, app-owned coordinator/executor, and Parakeet v2 INT8 ONNX CPU transcribed 4.7025 seconds / 150480 PCM bytes to the exact expected English sentence in 4.407s without network or profile/store mutation. It does not prove a real Mic press or Console surface. The one required changed-test union aborted at 96% with exit 134 during a background retained Parakeet MLX native warm-up; its exact active node passed alone, but the union is not green. Real Mic/caret, visible busy ordering, live limit/explicit resume, safe real retry, Windows, Linux, and TASK-605 remain open. Mergeable implementation evidence is partial, not release-gate completion; status remains In Progress and AC4-AC6 remain unchecked.
+Implemented bounded Parakeet ONNX dictation under ADR-025: one app-owned LocalSTTExecutor and LocalSTTDispatchCoordinator serve Library file work and Console PCM buffers with frame-aligned 60-second/byte limits, one pending inference, generation fencing, cancellation/shutdown ownership, dictation-next admission, visible limit recovery, explicit Mic resume, and bounded local-only faster-whisper retry. The Parakeet streaming factory remains unsupported rather than claiming true streaming; dead legacy code remains intentionally retained for TASK-605. Evidence is recorded in Docs/STT_Evaluation/task-603. At rebased commit 24a2ba3cf, a real macOS Console Mic smoke opened PyAudio, captured the verified speech fixture, routed 159360 PCM bytes through v2 INT8 ONNX CPU, inserted the exact transcript at the existing caret without sending, returned Mic to idle, and emitted no failure. The live run fixed configured local-model handoff and Textual fileno-less-stderr spawning. Fresh directly related gates passed: 94 executor/facade tests and 7 limit/resume/batch-ordering nodes; focused review found no issues. AC1-AC5 are complete. TASK-603 remains In Progress because AC6 still requires representative Windows/Linux and complete release-gate evidence; the aborted changed-test union and TASK-605 default/legacy work remain open.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Audio/dictation_service_lazy.py
+++ b/tldw_chatbook/Audio/dictation_service_lazy.py
@@ -632,11 +632,12 @@ class LazyLiveDictationService:
         ):
             return
         self._dictation_next_sequence += 1
-        self._notify_segment_transcribing(done=True)
         if not (text or "").strip():
+            self._notify_segment_transcribing(done=True)
             self._notify_segment_no_final()
             return
         self._handle_partial_text(text)
+        self._notify_segment_transcribing(done=True)
         self._finalize_current_segment()
 
     def start_dictation(
@@ -1582,6 +1583,16 @@ class LazyLiveDictationService:
                 return DictationResult(transcript="", segments=[], duration=0.0)
             self.state = DictationState.IDLE
 
+        # Quiesce the producer before asking the processing thread to drain.
+        # Otherwise a recorder callback can enqueue PCM after the processor's
+        # final drain and after the deferred handle has been sealed.
+        recorder = self._audio_service
+        if recorder is not None:
+            try:
+                recorder.stop_recording()
+            except Exception:  # noqa: BLE001 - teardown must never raise
+                logger.opt(exception=True).warning("Failed to release audio capture")
+
         # Stop processing
         if self.stop_processing:
             self.stop_processing.set()
@@ -1636,18 +1647,6 @@ class LazyLiveDictationService:
             captured_bytes=self.captured_bytes,
             transcription_complete=transcription_complete,
         )
-
-        # Release capture explicitly. The non-lazy service does this in its own
-        # stop_dictation; this one never did, so every successful stop left the
-        # microphone live. Use the private attribute, not the `audio_service`
-        # property -- reading the property lazily CONSTRUCTS a recorder, which
-        # would open an audio device during teardown.
-        recorder = self._audio_service
-        if recorder is not None:
-            try:
-                recorder.stop_recording()
-            except Exception:  # noqa: BLE001 - teardown must never raise
-                logger.opt(exception=True).warning("Failed to release audio capture")
 
         # Cleanup
         self._cleanup()

--- a/tldw_chatbook/Audio/dictation_service_lazy.py
+++ b/tldw_chatbook/Audio/dictation_service_lazy.py
@@ -180,6 +180,10 @@ class LazyLiveDictationService:
     #: built via `__new__` without going through `start_dictation()` needs
     #: this class-level default too.
     on_segment_transcribing: Optional[Callable[[bool], None]] = None
+    _dictation_handle: Optional[Any] = None
+    _dictation_capture_generation: Optional[int] = None
+    _dictation_next_sequence: int = 0
+    _deferred_limit_reported: bool = False
     #: Same `__new__`-safety reasoning again: `_audio_callback` reads both of
     #: these unconditionally on every frame, so a service built via `__new__`
     #: without going through `start_dictation()` needs class-level defaults
@@ -211,6 +215,7 @@ class LazyLiveDictationService:
         audio_backend: Optional[str] = None,
         max_buffer_bytes: Optional[int] = None,
         on_buffer_limit: Optional[Callable[[], None]] = None,
+        transcription_service_factory: Optional[Callable[[], Any]] = None,
     ):
         """Initialize dictation service with lazy loading.
 
@@ -233,6 +238,8 @@ class LazyLiveDictationService:
             on_buffer_limit: Invoked once when `max_buffer_bytes` is reached,
                 from a daemon notification thread the recorder spawns. Ignored
                 unless `max_buffer_bytes` is set.
+            transcription_service_factory: Optional app-owned facade factory,
+                invoked only when transcription is first needed.
         """
         self.transcription_provider = transcription_provider
         self.transcription_model = transcription_model
@@ -242,6 +249,7 @@ class LazyLiveDictationService:
         self.audio_backend_preference = audio_backend
         self.max_buffer_bytes = max_buffer_bytes
         self.on_buffer_limit = on_buffer_limit
+        self._transcription_service_factory = transcription_service_factory
 
         # Lazy-loaded services
         self._audio_service = None
@@ -267,6 +275,10 @@ class LazyLiveDictationService:
 
         # Streaming transcriber
         self.streaming_transcriber = None
+        self._dictation_handle = None
+        self._dictation_capture_generation = None
+        self._dictation_next_sequence = 0
+        self._deferred_limit_reported = False
 
         # Callbacks
         self.on_partial_transcript = None
@@ -388,9 +400,7 @@ class LazyLiveDictationService:
             what lets a pause finalize a segment instead of ambient noise
             holding `last_speech_time` fresh forever.
         """
-        raw = get_cli_setting(
-            "dictation.vad_aggressiveness", cls.VAD_AGGRESSIVENESS
-        )
+        raw = get_cli_setting("dictation.vad_aggressiveness", cls.VAD_AGGRESSIVENESS)
         try:
             aggressiveness = int(raw)
         except (TypeError, ValueError, OverflowError):
@@ -534,9 +544,14 @@ class LazyLiveDictationService:
             and self._transcription_init_error is None
         ):
             try:
-                from ..Local_Ingestion.transcription_service import TranscriptionService
+                factory = getattr(self, "_transcription_service_factory", None)
+                if factory is None:
+                    from ..Local_Ingestion.transcription_service import (
+                        TranscriptionService,
+                    )
 
-                self._transcription_service = TranscriptionService()
+                    factory = TranscriptionService
+                self._transcription_service = factory()
                 logger.info("Transcription service initialized successfully")
             except Exception as e:
                 self._transcription_init_error = str(e)
@@ -551,6 +566,78 @@ class LazyLiveDictationService:
             raise TranscriptionInitializationError(self._transcription_init_error)
 
         return self._transcription_service
+
+    @property
+    def uses_deferred_dictation(self) -> bool:
+        """Return whether this exact capture reserved shared Parakeet."""
+
+        return (
+            self.transcription_provider == "parakeet-onnx"
+            and self._dictation_handle is not None
+        )
+
+    def reserve_deferred_dictation(self, capture_generation: int) -> Any | None:
+        """Reserve shared Parakeet execution before model preparation."""
+
+        if self.transcription_provider != "parakeet-onnx":
+            return None
+        facade = self.transcription_service
+        if not bool(getattr(facade, "uses_deferred_local_stt_dispatch", False)):
+            return None
+        if (
+            self._dictation_handle is not None
+            and self._dictation_capture_generation == capture_generation
+        ):
+            return self._dictation_handle
+        if self._dictation_handle is not None:
+            self._dictation_handle.cancel()
+
+        recorder = self._audio_service
+        sample_rate = getattr(recorder, "sample_rate", None) or 16_000
+        channels = getattr(recorder, "channels", None) or 1
+        self._dictation_capture_generation = capture_generation
+        self._dictation_next_sequence = 0
+        self._deferred_limit_reported = False
+        self._dictation_handle = facade.begin_dictation_capture(
+            capture_generation=capture_generation,
+            model=self.transcription_model,
+            language=self.language,
+            sample_rate=sample_rate,
+            channels=channels,
+            sample_width=2,
+            on_logical_segment=(
+                lambda sequence, text, _generation=capture_generation: (
+                    self._handle_deferred_logical_segment(
+                        _generation,
+                        sequence,
+                        text,
+                    )
+                )
+            ),
+        )
+        return self._dictation_handle
+
+    def _handle_deferred_logical_segment(
+        self,
+        capture_generation: int,
+        sequence: int,
+        text: str,
+    ) -> None:
+        """Publish one ordered callback only for the owning capture."""
+
+        if (
+            capture_generation != self._dictation_capture_generation
+            or self._dictation_handle is None
+            or sequence != self._dictation_next_sequence
+        ):
+            return
+        self._dictation_next_sequence += 1
+        self._notify_segment_transcribing(done=True)
+        if not (text or "").strip():
+            self._notify_segment_no_final()
+            return
+        self._handle_partial_text(text)
+        self._finalize_current_segment()
 
     def start_dictation(
         self,
@@ -651,6 +738,7 @@ class LazyLiveDictationService:
             self.current_transcript = ""
             self.audio_buffer = []
             self.captured_bytes = 0
+            self._deferred_limit_reported = False
             # A repeat capture on a reused service instance must not inherit
             # the previous capture's "already saw a first frame" state -- its
             # own very first frame is capture start again, not a resume.
@@ -1180,6 +1268,20 @@ class LazyLiveDictationService:
         # a dead capture without it.
         self._notify_segment_transcribing(done=False)
         audio_data = b"".join(segment_audio)
+        handle = self._dictation_handle
+        if handle is not None:
+            status = handle.append_segment(audio_data)
+            if (
+                getattr(status, "value", status) == "limit_reached"
+                and not self._deferred_limit_reported
+            ):
+                self._deferred_limit_reported = True
+                if self.on_buffer_limit is not None:
+                    try:
+                        self.on_buffer_limit()
+                    except Exception as exc:
+                        logger.error("Buffer-limit callback error: {}", exc)
+            return
         # Snapshot before the call and compare after, rather than reading
         # `current_transcript` alone post-call: this call is the only writer
         # while it runs (this thread, sequential with `_finalize_current_
@@ -1483,6 +1585,11 @@ class LazyLiveDictationService:
         # Stop processing
         if self.stop_processing:
             self.stop_processing.set()
+            # Wake the loop immediately if it is inside its 100 ms queue
+            # poll. Deferred Parakeet keeps native inference off this thread,
+            # so stop should not spend its 50 ms regression budget waiting
+            # for an otherwise idle timeout to elapse.
+            self.processing_queue.put(("stop", b""))
 
         # Wait for the processing thread to drain and transcribe what is left.
         # The old hard-coded 2.0s was shorter than a single warm transcription,
@@ -1499,6 +1606,18 @@ class LazyLiveDictationService:
                     "audio still in flight was dropped",
                     self.stop_join_timeout_seconds,
                 )
+
+        # Deferred Parakeet inference is intentionally outside the processing
+        # thread's bounded join. The processing thread only appends/seals PCM;
+        # this blocking stop worker owns the native completion wait.
+        deferred_error: BaseException | None = None
+        handle = self._dictation_handle
+        if handle is not None and transcription_complete:
+            try:
+                handle.finish()
+                handle.wait()
+            except BaseException as exc:  # returned through the blocking API
+                deferred_error = exc
 
         # Finalize any remaining transcript
         self._finalize_current_segment()
@@ -1533,11 +1652,40 @@ class LazyLiveDictationService:
         # Cleanup
         self._cleanup()
 
+        if deferred_error is None and handle is not None and transcription_complete:
+            self._dictation_handle = None
+            self._dictation_capture_generation = None
+
         word_count = len(result.transcript.split()) if result.transcript else 0
         logger.info(
             f"Dictation stopped. Words: {word_count}, Duration: {result.duration:.1f}s"
         )
+        if deferred_error is not None:
+            raise deferred_error
         return result
+
+    def abandon(self) -> None:
+        """Cancel deferred work and release capture without joining threads."""
+
+        recorder = self._audio_service
+        if recorder is not None:
+            try:
+                recorder.stop_recording()
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Failed to release abandoned audio capture"
+                )
+        self.stop_processing.set()
+        handle, self._dictation_handle = self._dictation_handle, None
+        self._dictation_capture_generation = None
+        if handle is not None:
+            try:
+                handle.cancel()
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Failed to cancel abandoned deferred dictation"
+                )
+        self._cleanup()
 
     def pause_dictation(self):
         """Pause dictation (temporarily stop processing)."""

--- a/tldw_chatbook/Chat/console_voice_input.py
+++ b/tldw_chatbook/Chat/console_voice_input.py
@@ -1364,7 +1364,7 @@ class ConsoleVoiceInputController:
         # processing thread from THIS attempt finally calls one of them (see
         # `start()`'s `capture_generation` parameter).
         self._pending_capture_generation: int | None = None
-        self._retry_action: Callable[[], str] | None = None
+        self._retry_action: Callable[[], tuple[str, ...]] | None = None
 
     @property
     def state(self) -> str:
@@ -1397,6 +1397,11 @@ class ConsoleVoiceInputController:
 
     def retry_with_faster_whisper(self) -> str:
         """Consume the one retained faster-whisper retry and return its text."""
+
+        return " ".join(self.retry_segments_with_faster_whisper())
+
+    def retry_segments_with_faster_whisper(self) -> tuple[str, ...]:
+        """Consume the retry while preserving its logical segment texts."""
 
         with self._state_lock:
             action, self._retry_action = self._retry_action, None
@@ -2116,10 +2121,10 @@ class ConsoleVoiceInputController:
         transcriber: Any,
         language: str,
         retry_buffer: Any,
-    ) -> Callable[[], str]:
+    ) -> Callable[[], tuple[str, ...]]:
         """Build one replay over exactly the retained logical boundaries."""
 
-        def _retry() -> str:
+        def _retry() -> tuple[str, ...]:
             try:
                 source = retry_buffer.source
                 frame_bytes = source.channels * source.sample_width
@@ -2145,7 +2150,7 @@ class ConsoleVoiceInputController:
                     text = result.get("text", "") if isinstance(result, dict) else ""
                     if isinstance(text, str) and text.strip():
                         texts.append(text.strip())
-                return " ".join(texts)
+                return tuple(texts)
             except Exception:  # noqa: BLE001 - retry errors are sanitized
                 logger.opt(exception=True).warning(
                     "Console dictation faster-whisper retry failed"

--- a/tldw_chatbook/Chat/console_voice_input.py
+++ b/tldw_chatbook/Chat/console_voice_input.py
@@ -169,7 +169,12 @@ def _faster_whisper_model_is_local(model: str) -> bool:
     """Resolve a faster-whisper model from local cache without downloading."""
 
     try:
-        utilities = importlib.import_module("faster_whisper.utils")
+        from ..Utils.optional_deps import require_dependency
+
+        utilities = require_dependency(
+            "faster_whisper",
+            "transcription_faster_whisper",
+        )
         utilities.download_model(model, local_files_only=True)
     except Exception:  # noqa: BLE001 - cache misses vary by hub version
         logger.opt(exception=True).debug(

--- a/tldw_chatbook/Chat/console_voice_input.py
+++ b/tldw_chatbook/Chat/console_voice_input.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 # (`monkeypatch.setattr(cvi.importlib.util, "find_spec", ...)` and
 # `monkeypatch.setattr(cvi.sys, "platform", ...)` both mutate the real module
 # objects, which the detection helpers then read).
+import importlib
 import importlib.util  # noqa: F401 - patched seam; see comment above
 import string
 import sys  # noqa: F401 - patched seam; see comment above
@@ -164,6 +165,20 @@ def capture_available() -> bool:
     return any(_module_installed(name) for name in CAPTURE_MODULES)
 
 
+def _faster_whisper_model_is_local(model: str) -> bool:
+    """Resolve a faster-whisper model from local cache without downloading."""
+
+    try:
+        utilities = importlib.import_module("faster_whisper.utils")
+        utilities.download_model(model, local_files_only=True)
+    except Exception:  # noqa: BLE001 - cache misses vary by hub version
+        logger.opt(exception=True).debug(
+            "Faster-whisper retry model is not available in the local cache"
+        )
+        return False
+    return True
+
+
 def probe() -> Availability:
     """Report whether dictation is usable, distinguishing the two failures.
 
@@ -207,6 +222,7 @@ DICTATION_FAST_MODEL_PROVIDER = "faster-whisper"
 #: this; this is only the *unset* default for a dictation capture, and it
 #: never changes what the transcription stack itself uses elsewhere.
 DICTATION_FAST_MODEL_DEFAULT = "base"
+DICTATION_RETRY_FAILED_REASON = "Dictation retry failed."
 
 
 @dataclass(frozen=True)
@@ -2045,10 +2061,17 @@ class ConsoleVoiceInputController:
             from ..STT.dispatch_coordinator import RetryableDictationFailure
 
             if isinstance(exc, RetryableDictationFailure):
-                can_retry = "faster-whisper" in installed_local_providers()
-                if can_retry and service is not None:
+                retry_action = None
+                if (
+                    service is not None
+                    and "faster-whisper" in installed_local_providers()
+                    and _faster_whisper_model_is_local(DICTATION_FAST_MODEL_DEFAULT)
+                ):
+                    transcriber = service.transcription_service
+                    language = getattr(service, "language", DEFAULT_LANGUAGE)
                     retry_action = self._build_faster_whisper_retry(
-                        service,
+                        transcriber,
+                        language,
                         exc.retry_buffer,
                     )
                     with self._state_lock:
@@ -2059,7 +2082,7 @@ class ConsoleVoiceInputController:
                     self._release(service)
                 self._fail(
                     str(exc),
-                    retry_available=can_retry and service is not None,
+                    retry_available=retry_action is not None,
                 )
                 return
             logger.opt(exception=True).warning("Console dictation failed to stop")
@@ -2090,37 +2113,44 @@ class ConsoleVoiceInputController:
 
     @staticmethod
     def _build_faster_whisper_retry(
-        service: Any,
+        transcriber: Any,
+        language: str,
         retry_buffer: Any,
     ) -> Callable[[], str]:
         """Build one replay over exactly the retained logical boundaries."""
 
         def _retry() -> str:
-            source = retry_buffer.source
-            frame_bytes = source.channels * source.sample_width
-            start_frame = 0
-            texts: list[str] = []
-            transcriber = service.transcription_service
-            for end_frame in retry_buffer.segment_end_frames:
-                audio = source.audio[
-                    start_frame * frame_bytes : end_frame * frame_bytes
-                ]
-                start_frame = end_frame
-                if not audio:
-                    continue
-                result = transcriber.transcribe_buffer(
-                    audio_data=audio,
-                    sample_rate=source.sample_rate,
-                    channels=source.channels,
-                    sample_width=source.sample_width,
-                    provider=DICTATION_FAST_MODEL_PROVIDER,
-                    model=DICTATION_FAST_MODEL_DEFAULT,
-                    language=getattr(service, "language", DEFAULT_LANGUAGE),
+            try:
+                source = retry_buffer.source
+                frame_bytes = source.channels * source.sample_width
+                start_frame = 0
+                texts: list[str] = []
+                for end_frame in retry_buffer.segment_end_frames:
+                    audio = source.audio[
+                        start_frame * frame_bytes : end_frame * frame_bytes
+                    ]
+                    start_frame = end_frame
+                    if not audio:
+                        continue
+                    result = transcriber.transcribe_buffer(
+                        audio_data=audio,
+                        sample_rate=source.sample_rate,
+                        channels=source.channels,
+                        sample_width=source.sample_width,
+                        provider=DICTATION_FAST_MODEL_PROVIDER,
+                        model=DICTATION_FAST_MODEL_DEFAULT,
+                        language=language,
+                        local_files_only=True,
+                    )
+                    text = result.get("text", "") if isinstance(result, dict) else ""
+                    if isinstance(text, str) and text.strip():
+                        texts.append(text.strip())
+                return " ".join(texts)
+            except Exception:  # noqa: BLE001 - retry errors are sanitized
+                logger.opt(exception=True).warning(
+                    "Console dictation faster-whisper retry failed"
                 )
-                text = result.get("text", "") if isinstance(result, dict) else ""
-                if isinstance(text, str) and text.strip():
-                    texts.append(text.strip())
-            return " ".join(texts)
+                raise RuntimeError(DICTATION_RETRY_FAILED_REASON) from None
 
         return _retry
 

--- a/tldw_chatbook/Chat/console_voice_input.py
+++ b/tldw_chatbook/Chat/console_voice_input.py
@@ -81,7 +81,10 @@ WARMUP_DURATION_MS = 500
 #: Half a second of digital silence: long enough that every provider's own
 #: framing accepts it, short enough that a warm load stays imperceptible.
 WARMUP_PCM = b"\x00" * (
-    WARMUP_SAMPLE_RATE * WARMUP_CHANNELS * WARMUP_SAMPLE_WIDTH * WARMUP_DURATION_MS
+    WARMUP_SAMPLE_RATE
+    * WARMUP_CHANNELS
+    * WARMUP_SAMPLE_WIDTH
+    * WARMUP_DURATION_MS
     // 1000
 )
 # The chip these render into is `VOICE_CHIP_MAX_WIDTH = 42` cells and exactly
@@ -126,7 +129,9 @@ WARMUP_DEGRADED_REASON_TEMPLATE = (
 # so the transcript is not empty because the microphone was silent -- it is
 # empty because the work never finished. Saying "no audio was captured" here
 # blames the one component that was demonstrably working.
-TRANSCRIPTION_INCOMPLETE_REASON = "Transcription did not finish before dictation stopped."
+TRANSCRIPTION_INCOMPLETE_REASON = (
+    "Transcription did not finish before dictation stopped."
+)
 TRANSCRIPTION_INCOMPLETE_REMEDY = (
     "The speech model was still running. Try a shorter capture or a faster "
     "model, or raise dictation.stop_join_timeout_seconds."
@@ -539,6 +544,14 @@ class VoiceFailed:
 
     reason: str
     remedy: str = ""
+    retry_available: bool = False
+
+
+@dataclass(frozen=True)
+class VoiceLocalSTTBusy:
+    """Shared local transcription is active; this capture owns next admission."""
+
+    message: str = "Local transcription busy — dictation will run next."
 
 
 @dataclass(frozen=True)
@@ -781,14 +794,19 @@ def classify_segment(text: str) -> "VoiceCommand | VoiceFinal":
     """
     normalized = normalize_spoken(text)
     configured_prefix = command_prefix()
-    prefixes = (configured_prefix, *(
-        alias for alias in MISHEARD_PREFIXES if configured_prefix == DEFAULT_COMMAND_PREFIX
-    ))
+    prefixes = (
+        configured_prefix,
+        *(
+            alias
+            for alias in MISHEARD_PREFIXES
+            if configured_prefix == DEFAULT_COMMAND_PREFIX
+        ),
+    )
     for prefix in prefixes:
         marker = f"{prefix} "
         if not normalized.startswith(marker):
             continue
-        remainder = normalized[len(marker):]
+        remainder = normalized[len(marker) :]
         name = COMMAND_PHRASES.get(remainder)
         if name is None:
             corrected = MISHEARD_PHRASES.get(remainder)
@@ -890,7 +908,9 @@ def handsfree_send_delay_seconds() -> float:
         The countdown duration in seconds, always positive.
     """
     raw = get_cli_setting(
-        "dictation", "handsfree_send_delay_seconds", DEFAULT_HANDSFREE_SEND_DELAY_SECONDS
+        "dictation",
+        "handsfree_send_delay_seconds",
+        DEFAULT_HANDSFREE_SEND_DELAY_SECONDS,
     )
     try:
         value = float(raw)
@@ -1056,9 +1076,7 @@ def realtime_turn_detection() -> str:
     Returns:
         `"semantic_vad"` or `"server_vad"`.
     """
-    raw = get_cli_setting(
-        "realtime", "turn_detection", DEFAULT_REALTIME_TURN_DETECTION
-    )
+    raw = get_cli_setting("realtime", "turn_detection", DEFAULT_REALTIME_TURN_DETECTION)
     value = raw.strip().lower() if isinstance(raw, str) else raw
     if value not in _REALTIME_TURN_DETECTION_VALUES:
         logger.warning(
@@ -1157,9 +1175,7 @@ def handsfree_engine() -> str:
     raw = get_cli_setting("dictation", "handsfree_engine", "auto")
     value = raw.strip().lower() if isinstance(raw, str) else raw
     if value not in _HANDSFREE_ENGINE_VALUES:
-        logger.warning(
-            "dictation.handsfree_engine invalid ({!r}); using 'auto'", raw
-        )
+        logger.warning("dictation.handsfree_engine invalid ({!r}); using 'auto'", raw)
         return "auto"
     return value
 
@@ -1332,6 +1348,7 @@ class ConsoleVoiceInputController:
         # processing thread from THIS attempt finally calls one of them (see
         # `start()`'s `capture_generation` parameter).
         self._pending_capture_generation: int | None = None
+        self._retry_action: Callable[[], str] | None = None
 
     @property
     def state(self) -> str:
@@ -1348,6 +1365,28 @@ class ConsoleVoiceInputController:
     def last_capture_outcome(self) -> CaptureOutcome:
         """What the service reported about the most recently stopped capture."""
         return self._last_capture_outcome
+
+    @property
+    def retry_available(self) -> bool:
+        """Return whether this controller owns one explicit bounded retry."""
+
+        with self._state_lock:
+            return self._retry_action is not None
+
+    def clear_retry(self) -> None:
+        """Discard any retained retry PCM owned by this controller."""
+
+        with self._state_lock:
+            self._retry_action = None
+
+    def retry_with_faster_whisper(self) -> str:
+        """Consume the one retained faster-whisper retry and return its text."""
+
+        with self._state_lock:
+            action, self._retry_action = self._retry_action, None
+        if action is None:
+            raise RuntimeError("No dictation retry is available.")
+        return action()
 
     @property
     def is_active(self) -> bool:
@@ -1389,6 +1428,7 @@ class ConsoleVoiceInputController:
         remedy: str = "",
         *,
         generation: int | None = None,
+        retry_available: bool = False,
     ) -> None:
         # Mutate first so a throwing `emit` cannot leave the machine wedged,
         # but keep VoiceFailed ahead of VoiceStateChanged(idle): the UI clears
@@ -1405,7 +1445,14 @@ class ConsoleVoiceInputController:
         # screen-side session-identity/state guards already cover a stale
         # idle transition, and `_handle_event` does not gate that event type.
         self._state = STATE_IDLE
-        self._emit_capture_event(VoiceFailed(reason=reason, remedy=remedy), generation)
+        self._emit_capture_event(
+            VoiceFailed(
+                reason=reason,
+                remedy=remedy,
+                retry_available=retry_available,
+            ),
+            generation,
+        )
         self._emit(VoiceStateChanged(STATE_IDLE))
 
     def start(self, *, capture_generation: int | None = None) -> None:
@@ -1437,6 +1484,7 @@ class ConsoleVoiceInputController:
             self._last_capture_outcome = CaptureOutcome()
             self._state = STATE_PREPARING
             self._pending_capture_generation = capture_generation
+            self._retry_action = None
         self._emit(VoiceStateChanged(STATE_PREPARING))
 
         # Each `try` below covers only the call that can crash unexpectedly,
@@ -1448,7 +1496,9 @@ class ConsoleVoiceInputController:
         try:
             availability = probe()
         except Exception as exc:  # noqa: BLE001 - a probe crash must not wedge preparing
-            logger.opt(exception=True).warning("Console dictation availability probe crashed")
+            logger.opt(exception=True).warning(
+                "Console dictation availability probe crashed"
+            )
             self._fail(str(exc))
             return
 
@@ -1459,7 +1509,9 @@ class ConsoleVoiceInputController:
         try:
             effective = resolve()
         except Exception as exc:  # noqa: BLE001 - a resolve crash must not wedge preparing
-            logger.opt(exception=True).warning("Console dictation provider resolution crashed")
+            logger.opt(exception=True).warning(
+                "Console dictation provider resolution crashed"
+            )
             self._fail(str(exc))
             return
 
@@ -1513,7 +1565,9 @@ class ConsoleVoiceInputController:
         try:
             self._run_begin(effective)
         except Exception:  # noqa: BLE001 - nothing may escape _begin(); see docstring
-            logger.opt(exception=True).warning("Console dictation _begin() raised unexpectedly")
+            logger.opt(exception=True).warning(
+                "Console dictation _begin() raised unexpectedly"
+            )
 
     def _run_begin(self, effective: EffectiveConfig) -> None:
         """The actual work of `_begin()`, shielded from its caller by `_begin()`."""
@@ -1544,6 +1598,31 @@ class ConsoleVoiceInputController:
             self._fail(str(exc))
             return
 
+        if effective.provider == "parakeet-onnx":
+            reserve = getattr(service, "reserve_deferred_dictation", None)
+            if callable(reserve):
+                try:
+                    handle = reserve(
+                        capture_generation
+                        if isinstance(capture_generation, int)
+                        and capture_generation >= 0
+                        else 0
+                    )
+                except Exception as exc:  # noqa: BLE001 - reservation is required
+                    logger.opt(exception=True).warning(
+                        "Console dictation could not reserve shared local STT"
+                    )
+                    self._release(service)
+                    self._fail(str(exc))
+                    return
+                if handle is not None and bool(
+                    getattr(handle, "waiting_for_executor", False)
+                ):
+                    self._emit_quietly(
+                        VoiceLocalSTTBusy(),
+                        "local transcription busy notice",
+                    )
+
         # Before the microphone opens, never after: a model load that happens
         # on the first audio chunk runs while the user is already speaking and
         # behind the stop-side join, which is exactly how a good capture came
@@ -1568,9 +1647,11 @@ class ConsoleVoiceInputController:
                 on_segment_no_final=lambda _gen=capture_generation: (
                     self._emit_capture_event(VoiceSegmentNoFinal(), _gen)
                 ),
-                on_state_change=lambda _state: None,  # our state machine is authoritative
-                on_error=lambda error, _gen=capture_generation: self._report_service_error(
-                    error, generation=_gen
+                on_state_change=lambda _state: (
+                    None
+                ),  # our state machine is authoritative
+                on_error=lambda error, _gen=capture_generation: (
+                    self._report_service_error(error, generation=_gen)
                 ),
                 save_audio=self.save_audio_requested,
             )
@@ -1646,6 +1727,8 @@ class ConsoleVoiceInputController:
         if self._abandoned:
             self._release(service)
             return False
+        if bool(getattr(service, "uses_deferred_dictation", False)):
+            return True
         if not warm_before_capture_enabled():
             logger.debug(
                 "Console dictation model warm-up disabled by "
@@ -1681,7 +1764,9 @@ class ConsoleVoiceInputController:
             self._release(service)
             return False
         if error is not None:
-            logger.opt(exception=error).warning("Console dictation model warm-up failed")
+            logger.opt(exception=error).warning(
+                "Console dictation model warm-up failed"
+            )
             self._emit_quietly(
                 VoiceModelWarmupFailed(
                     reason=(
@@ -1765,7 +1850,9 @@ class ConsoleVoiceInputController:
         """Phrase a warm-up failure as a model problem, never a microphone one."""
         return f"{WARMUP_REASON_TEMPLATE.format(provider=effective.provider)} {exc}".strip()
 
-    def _report_service_error(self, error: Any, *, generation: int | None = None) -> None:
+    def _report_service_error(
+        self, error: Any, *, generation: int | None = None
+    ) -> None:
         """Turn a service-reported error into a failure, recording that we did.
 
         `LazyLiveDictationService` reports through this callback
@@ -1917,7 +2004,9 @@ class ConsoleVoiceInputController:
             self._emit(VoiceStateChanged(STATE_FINISHING))
             self._spawn(self._finish)
         except Exception as exc:  # noqa: BLE001 - finishing must never wedge
-            logger.opt(exception=True).warning("Console dictation could not be finished")
+            logger.opt(exception=True).warning(
+                "Console dictation could not be finished"
+            )
             # The microphone is live and no worker will ever run `_finish()`
             # now, so drop it here rather than leave it recording behind an
             # idle state machine.
@@ -1940,7 +2029,9 @@ class ConsoleVoiceInputController:
         try:
             self._run_finish()
         except Exception:  # noqa: BLE001 - nothing may escape _finish(); see docstring
-            logger.opt(exception=True).warning("Console dictation _finish() raised unexpectedly")
+            logger.opt(exception=True).warning(
+                "Console dictation _finish() raised unexpectedly"
+            )
 
     def _run_finish(self) -> None:
         """The actual work of `_finish()`, shielded from its caller by `_finish()`."""
@@ -1948,6 +2039,29 @@ class ConsoleVoiceInputController:
         try:
             result = service.stop_dictation() if service is not None else None
         except Exception as exc:  # noqa: BLE001
+            # Imported only on the stop-side failure path: keeping the STT
+            # package out of this module's import graph preserves cheap
+            # Console startup and the existing import-cost contract.
+            from ..STT.dispatch_coordinator import RetryableDictationFailure
+
+            if isinstance(exc, RetryableDictationFailure):
+                can_retry = "faster-whisper" in installed_local_providers()
+                if can_retry and service is not None:
+                    retry_action = self._build_faster_whisper_retry(
+                        service,
+                        exc.retry_buffer,
+                    )
+                    with self._state_lock:
+                        self._retry_action = retry_action
+                else:
+                    self.clear_retry()
+                if service is not None:
+                    self._release(service)
+                self._fail(
+                    str(exc),
+                    retry_available=can_retry and service is not None,
+                )
+                return
             logger.opt(exception=True).warning("Console dictation failed to stop")
             # The service was already claimed, so nothing else will ever
             # release it: without this, a `stop_dictation()` that raises
@@ -1959,6 +2073,7 @@ class ConsoleVoiceInputController:
                 self._release(service)
             self._fail(str(exc))
             return
+        self.clear_retry()
         # How many bytes the recorder delivered, and whether the transcription
         # thread actually finished. Without this the caller can only guess from
         # an empty transcript -- and it guessed "microphone", every time.
@@ -1972,6 +2087,42 @@ class ConsoleVoiceInputController:
         if service is not None:
             self._release(service)
         self._enter_idle()
+
+    @staticmethod
+    def _build_faster_whisper_retry(
+        service: Any,
+        retry_buffer: Any,
+    ) -> Callable[[], str]:
+        """Build one replay over exactly the retained logical boundaries."""
+
+        def _retry() -> str:
+            source = retry_buffer.source
+            frame_bytes = source.channels * source.sample_width
+            start_frame = 0
+            texts: list[str] = []
+            transcriber = service.transcription_service
+            for end_frame in retry_buffer.segment_end_frames:
+                audio = source.audio[
+                    start_frame * frame_bytes : end_frame * frame_bytes
+                ]
+                start_frame = end_frame
+                if not audio:
+                    continue
+                result = transcriber.transcribe_buffer(
+                    audio_data=audio,
+                    sample_rate=source.sample_rate,
+                    channels=source.channels,
+                    sample_width=source.sample_width,
+                    provider=DICTATION_FAST_MODEL_PROVIDER,
+                    model=DICTATION_FAST_MODEL_DEFAULT,
+                    language=getattr(service, "language", DEFAULT_LANGUAGE),
+                )
+                text = result.get("text", "") if isinstance(result, dict) else ""
+                if isinstance(text, str) and text.strip():
+                    texts.append(text.strip())
+            return " ".join(texts)
+
+        return _retry
 
     def _enter_idle(self) -> None:
         """Atomically return to `idle`, re-checking abandonment.
@@ -2021,6 +2172,7 @@ class ConsoleVoiceInputController:
             self._abandoned = True
             service, self._service = self._service, None
             self._state = STATE_IDLE
+            self._retry_action = None
         if service is not None:
             self._release(service)
 
@@ -2043,6 +2195,15 @@ class ConsoleVoiceInputController:
         Args:
             service: The dictation service instance to release.
         """
+        abandon = getattr(service, "abandon", None)
+        if callable(abandon):
+            try:
+                abandon()
+            except Exception:  # noqa: BLE001 - teardown must never raise
+                logger.opt(exception=True).debug(
+                    "Console dictation service abandon failed"
+                )
+            return
         try:
             audio = getattr(service, "_audio_service", None)
             if audio is not None and hasattr(audio, "stop_recording"):

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -3534,6 +3534,7 @@ class _LegacyTranscriptionBackend:
         # Get model configuration
         model = model or self.config.get("default_model", "base")
         language = language or self.config.get("default_language", "en")
+        local_files_only = kwargs.pop("local_files_only", False)
 
         # Load model - use the same logic as in _transcribe_with_faster_whisper
         cache_key = f"faster-whisper-{model}"
@@ -3550,7 +3551,7 @@ class _LegacyTranscriptionBackend:
                             device=self.config["device"],
                             compute_type=self.config["compute_type"],
                             download_root=None,
-                            local_files_only=False,
+                            local_files_only=local_files_only,
                         )
                     model_load_time = time.time() - model_load_start
                     logger.info(

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -4273,7 +4273,7 @@ class TranscriptionService:
             )
             .strip()
             .lower(),
-            model_dir=None,
+            model_dir=self.config.get("parakeet_onnx_model_dir") or None,
         )
         return self._local_stt_dispatcher.begin_dictation(
             capture_generation=capture_generation,

--- a/tldw_chatbook/Local_Ingestion/transcription_service.py
+++ b/tldw_chatbook/Local_Ingestion/transcription_service.py
@@ -39,6 +39,12 @@ except ImportError:
 # Local imports
 from ..config import get_cli_setting
 from ..STT.legacy_bridge import LegacyTranscriptionBridge
+from ..STT.contracts import BufferAudioSource
+from ..STT.dispatch_coordinator import (
+    DictationCaptureHandle,
+    LocalSTTDispatchCoordinator,
+)
+from ..STT.parakeet_dispatch import resolve_parakeet_dispatch
 from ..Utils.path_validation import validate_path_simple
 from .parakeet_v2_artifact import active_managed_parakeet_v2_dir
 from .parakeet_v2_installer import (
@@ -50,6 +56,7 @@ from .parakeet_v2_installer import (
 )
 from .stt_batch_routing import (
     BatchSTTRoutingError,
+    PARAKEET_V2_MODEL,
     PARAKEET_V3_MODEL,
     resolve_batch_stt_route,
 )
@@ -1022,6 +1029,7 @@ class _LegacyTranscriptionBackend:
                 language,
                 **kwargs,
             )
+        # Retained until TASK-605; unreachable from production Parakeet facade.
         if provider == "parakeet-onnx":
             return self._transcribe_buffer_with_parakeet_onnx(
                 audio_data,
@@ -3844,9 +3852,9 @@ class _LegacyTranscriptionBackend:
         # not lose precision for real int16 input).
         tmp_path: Optional[str] = None
         try:
-            pcm = np.clip(
-                np.round(audio_array * 32768.0), -32768, 32767
-            ).astype(np.int16)
+            pcm = np.clip(np.round(audio_array * 32768.0), -32768, 32767).astype(
+                np.int16
+            )
             # `prefix` identifies these files as ours in a temp-dir listing;
             # review Finding 3 (PR #1171): a crash between here and the
             # `finally` below leaves raw microphone audio on disk, so a
@@ -4096,12 +4104,23 @@ class _LegacyTranscriptionBackend:
 class TranscriptionService:
     """Explicit compatibility facade over the retained transcription backend."""
 
-    def __init__(self):
-        """Initialize the retained backend bridge without changing defaults."""
+    def __init__(
+        self,
+        *,
+        local_stt_dispatcher: LocalSTTDispatchCoordinator | None = None,
+    ) -> None:
+        """Initialize the facade over retained and shared local execution."""
 
         self._bridge = LegacyTranscriptionBridge(_LegacyTranscriptionBackend)
+        self._local_stt_dispatcher = local_stt_dispatcher
         # Preserve construction-time configuration and availability probing.
         _ = self._bridge.config
+
+    @property
+    def uses_deferred_local_stt_dispatch(self) -> bool:
+        """Return whether Parakeet calls use the app-owned coordinator."""
+
+        return self._local_stt_dispatcher is not None
 
     @property
     def config(self) -> Dict[str, Any]:
@@ -4184,7 +4203,41 @@ class TranscriptionService:
         language: Optional[str] = None,
         **kwargs,
     ) -> Dict[str, Any]:
-        """Forward the unchanged public buffer-transcription call."""
+        """Transcribe PCM through shared Parakeet or the retained providers."""
+
+        effective_provider = provider or self.config["default_provider"]
+        if effective_provider == "parakeet-onnx":
+            if self._local_stt_dispatcher is None:
+                raise TranscriptionError(
+                    "Parakeet ONNX buffer transcription requires the shared local executor."
+                )
+            source = BufferAudioSource(
+                audio_data,
+                sample_rate,
+                channels,
+                sample_width,
+            )
+            dispatch = resolve_parakeet_dispatch(
+                model_id=model or PARAKEET_V2_MODEL,
+                precision=str(
+                    kwargs.pop(
+                        "precision",
+                        get_cli_setting(
+                            "transcription.default_precision",
+                            "int8",
+                        ),
+                    )
+                    or "int8"
+                )
+                .strip()
+                .lower(),
+                model_dir=kwargs.pop("model_dir", None),
+            )
+            return self._local_stt_dispatcher.transcribe_buffer(
+                source=source,
+                dispatch=dispatch,
+                language=language or "en",
+            )
 
         return self._bridge.transcribe_buffer_legacy(
             audio_data,
@@ -4195,6 +4248,40 @@ class TranscriptionService:
             model,
             language,
             **kwargs,
+        )
+
+    def begin_dictation_capture(
+        self,
+        *,
+        capture_generation: int,
+        model: str | None,
+        language: str,
+        sample_rate: int,
+        channels: int,
+        sample_width: int,
+        on_logical_segment: Callable[[int, str], None],
+    ) -> DictationCaptureHandle:
+        """Reserve one asynchronous Parakeet dictation capture."""
+
+        if self._local_stt_dispatcher is None:
+            raise TranscriptionError("The shared local executor is unavailable.")
+        dispatch = resolve_parakeet_dispatch(
+            model_id=model or PARAKEET_V2_MODEL,
+            precision=str(
+                get_cli_setting("transcription.default_precision", "int8") or "int8"
+            )
+            .strip()
+            .lower(),
+            model_dir=None,
+        )
+        return self._local_stt_dispatcher.begin_dictation(
+            capture_generation=capture_generation,
+            dispatch=dispatch,
+            sample_rate=sample_rate,
+            channels=channels,
+            sample_width=sample_width,
+            language=language,
+            on_logical_segment=on_logical_segment,
         )
 
     def get_available_providers(self) -> List[str]:
@@ -4246,6 +4333,10 @@ class TranscriptionService:
         **kwargs,
     ):
         """Create a retained-provider streaming transcriber when supported."""
+
+        effective_provider = provider or self.config["default_provider"]
+        if effective_provider == "parakeet-onnx":
+            return None
 
         return self._bridge.create_streaming_transcriber_legacy(
             provider,

--- a/tldw_chatbook/STT/dispatch_coordinator.py
+++ b/tldw_chatbook/STT/dispatch_coordinator.py
@@ -13,10 +13,12 @@ from typing import Any, Literal
 from .contracts import BufferAudioSource, TranscriptionFailureCode
 from .executor import (
     ExecutorBusyError,
+    ExecutorEvent,
     ExecutorFailure,
     ExecutorResult,
     ExecutorUnavailableError,
     LocalSTTExecutor,
+    WorkerPhase,
 )
 from .parakeet_dispatch import ParakeetDispatch
 
@@ -110,6 +112,7 @@ class _Callbacks:
     attempt_id: str
     on_result: Callable[[ExecutorResult], None]
     on_failure: Callable[[ExecutorFailure], None]
+    on_event: Callable[[ExecutorEvent], None] = lambda _event: None
     request: _Request | None = None
     generation: int | None = None
     started: bool = False
@@ -214,6 +217,7 @@ class LocalSTTDispatchCoordinator:
             attempt_id,
             executor_kwargs.pop("on_result", lambda _result: None),
             executor_kwargs.pop("on_failure", lambda _failure: None),
+            on_event=executor_kwargs.pop("on_event", lambda _event: None),
         )
         with self._lock:
             if self._closed:
@@ -226,6 +230,7 @@ class LocalSTTDispatchCoordinator:
         try:
             generation = self._executor.submit(
                 **executor_kwargs,
+                on_event=lambda value: self._event(callbacks, value),
                 on_result=lambda value: self._terminal(callbacks, value),
                 on_failure=lambda value: self._terminal(callbacks, value),
             )
@@ -497,7 +502,7 @@ class LocalSTTDispatchCoordinator:
             request.attempt_id,
             lambda _result: None,
             lambda _failure: None,
-            request,
+            request=request,
             handoff=handoff or _Handoff(),
         )
         capture = request.capture
@@ -544,10 +549,34 @@ class LocalSTTDispatchCoordinator:
 
     def _publish_generation(self, callbacks: _Callbacks, generation: int) -> None:
         with self._lock:
-            callbacks.generation, early = generation, callbacks.early
+            if callbacks.generation is None:
+                callbacks.generation = generation
+            early = callbacks.early
             callbacks.early = None
         if early is not None:
             self._terminal(callbacks, early)
+
+    def _event(self, callbacks: _Callbacks, event: ExecutorEvent) -> None:
+        with self._lock:
+            if (
+                callbacks.started
+                or event.attempt_id != callbacks.attempt_id
+                or not self._matches_locked(callbacks.kind, callbacks.attempt_id)
+            ):
+                return
+            generation = callbacks.generation
+            if generation is None:
+                if event.phase is not WorkerPhase.PREPARING:
+                    return
+                callbacks.generation = event.generation
+            elif event.generation != generation:
+                if (
+                    event.phase is not WorkerPhase.PREPARING
+                    or event.generation < generation
+                ):
+                    return
+                callbacks.generation = event.generation
+        self._deliver(callbacks.on_event, event)
 
     def _terminal(
         self,

--- a/tldw_chatbook/STT/dispatch_coordinator.py
+++ b/tldw_chatbook/STT/dispatch_coordinator.py
@@ -27,7 +27,19 @@ _RETRY_ACTION = "retry_faster_whisper"
 
 
 def pcm_byte_limit(*, sample_rate: int, channels: int, sample_width: int) -> int:
-    """Return the canonical 60-second PCM byte ceiling."""
+    """Return the canonical 60-second PCM byte ceiling.
+
+    Args:
+        sample_rate: PCM sample rate in frames per second.
+        channels: Number of interleaved PCM channels.
+        sample_width: Bytes per PCM channel sample.
+
+    Returns:
+        Maximum frame-aligned bytes accepted for one dictation capture.
+
+    Raises:
+        ValueError: Any PCM format value is invalid.
+    """
 
     _validate_format(sample_rate, channels, sample_width)
     return int(sample_rate * channels * sample_width * DICTATION_MAX_SECONDS)
@@ -167,7 +179,7 @@ class DictationCaptureHandle:
         if retry is not None:
             raise RetryableDictationFailure(retry)
         if failure is not None:
-            raise RuntimeError(failure)
+            raise RuntimeError(failure.value)
 
     def cancel(self, *, force: bool = False) -> bool:
         """Cancel pending work or the exact active executor attempt."""
@@ -282,7 +294,7 @@ class LocalSTTDispatchCoordinator:
         with self._lock:
             payload = handle._capture.last_payload
         if payload is None:
-            raise RuntimeError(TranscriptionFailureCode.INFERENCE_FAILED)
+            raise RuntimeError(TranscriptionFailureCode.INFERENCE_FAILED.value)
         return payload
 
     def begin_dictation(

--- a/tldw_chatbook/STT/dispatch_coordinator.py
+++ b/tldw_chatbook/STT/dispatch_coordinator.py
@@ -1,0 +1,732 @@
+"""Bounded dictation-next admission for the queue-less local STT executor."""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Literal
+
+from .contracts import BufferAudioSource, TranscriptionFailureCode
+from .executor import (
+    ExecutorBusyError,
+    ExecutorFailure,
+    ExecutorResult,
+    ExecutorUnavailableError,
+    LocalSTTExecutor,
+)
+from .parakeet_dispatch import ParakeetDispatch
+
+DICTATION_MAX_SECONDS = 60.0
+_RETRY_ACTION = "retry_faster_whisper"
+
+
+def pcm_byte_limit(*, sample_rate: int, channels: int, sample_width: int) -> int:
+    """Return the canonical 60-second PCM byte ceiling."""
+
+    _validate_format(sample_rate, channels, sample_width)
+    return int(sample_rate * channels * sample_width * DICTATION_MAX_SECONDS)
+
+
+class DictationAppendStatus(str, Enum):
+    """Result of one bounded logical-segment append."""
+
+    ACCEPTED = "accepted"
+    LIMIT_REACHED = "limit_reached"
+
+
+@dataclass(frozen=True, slots=True)
+class RetryableDictationBuffer:
+    """PCM and logical boundaries retained for one explicit retry."""
+
+    source: BufferAudioSource
+    segment_end_frames: tuple[int, ...]
+
+
+class RetryableDictationFailure(RuntimeError):
+    """Sanitized failure carrying bounded explicit-retry PCM."""
+
+    def __init__(self, retry_buffer: RetryableDictationBuffer) -> None:
+        self.retry_buffer = retry_buffer
+        super().__init__("Parakeet transcription failed.")
+
+
+@dataclass(slots=True)
+class _Capture:
+    generation: int
+    dispatch: ParakeetDispatch
+    sample_rate: int
+    channels: int
+    sample_width: int
+    language: str
+    callback: Callable[[int, str], None]
+    done: threading.Event = field(default_factory=threading.Event)
+    total_bytes: int = 0
+    next_sequence: int = 0
+    finished: bool = False
+    cancelled: bool = False
+    retrying: bool = False
+    failure: TranscriptionFailureCode | None = None
+    retry_audio: bytearray = field(default_factory=bytearray, repr=False)
+    retry_ends: list[int] = field(default_factory=list, repr=False)
+    retry_buffer: RetryableDictationBuffer | None = field(default=None, repr=False)
+    last_payload: dict[str, Any] | None = field(default=None, repr=False)
+
+    @property
+    def frame_bytes(self) -> int:
+        return self.channels * self.sample_width
+
+
+@dataclass(slots=True)
+class _Pending:
+    capture: _Capture
+    sequence_start: int
+    audio: bytearray = field(default_factory=bytearray, repr=False)
+    ends: list[int] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class _Request:
+    capture: _Capture
+    attempt_id: str
+    source: BufferAudioSource = field(repr=False)
+    ends: tuple[int, ...]
+    sequence_start: int
+
+
+@dataclass(slots=True)
+class _Handoff:
+    running: bool = False
+    deferred: tuple[_Callbacks, ExecutorResult | ExecutorFailure] | None = None
+
+
+@dataclass(slots=True)
+class _Callbacks:
+    kind: Literal["library", "dictation"]
+    attempt_id: str
+    on_result: Callable[[ExecutorResult], None]
+    on_failure: Callable[[ExecutorFailure], None]
+    request: _Request | None = None
+    generation: int | None = None
+    started: bool = False
+    handoff: _Handoff = field(default_factory=_Handoff)
+    early: ExecutorResult | ExecutorFailure | None = None
+
+
+def _validate_format(sample_rate: int, channels: int, sample_width: int) -> None:
+    if type(sample_rate) is not int or sample_rate <= 0:
+        raise ValueError("sample_rate must be a positive integer")
+    if type(channels) is not int or channels <= 0:
+        raise ValueError("channels must be a positive integer")
+    if type(sample_width) is not int or sample_width not in {1, 2, 3, 4}:
+        raise ValueError("sample_width must be one of 1, 2, 3, or 4")
+
+
+class DictationCaptureHandle:
+    """One asynchronous bounded dictation capture."""
+
+    __slots__ = ("_capture", "_coordinator")
+
+    def __init__(
+        self,
+        coordinator: LocalSTTDispatchCoordinator,
+        capture: _Capture,
+    ) -> None:
+        self._coordinator = coordinator
+        self._capture = capture
+
+    @property
+    def waiting_for_executor(self) -> bool:
+        """Return whether this capture waits behind active Library work."""
+
+        return self._coordinator._waiting(self._capture)
+
+    def append_segment(self, audio: bytes) -> DictationAppendStatus:
+        """Append one logical PCM segment without waiting for inference."""
+
+        return self._coordinator._append(self._capture, audio)
+
+    def finish(self) -> None:
+        """Seal the capture after its last accepted segment."""
+
+        self._coordinator._finish(self._capture)
+
+    def wait(self) -> None:
+        """Wait for completion and raise only normalized failures."""
+
+        self._capture.done.wait()
+        with self._coordinator._lock:
+            retry, failure = self._capture.retry_buffer, self._capture.failure
+        if retry is not None:
+            raise RetryableDictationFailure(retry)
+        if failure is not None:
+            raise RuntimeError(failure)
+
+    def cancel(self, *, force: bool = False) -> bool:
+        """Cancel pending work or the exact active executor attempt."""
+
+        return self._coordinator._cancel(self._capture, force)
+
+    def take_retry_buffer(self) -> RetryableDictationBuffer | None:
+        """Transfer retained retry PCM at most once."""
+
+        with self._coordinator._lock:
+            value, self._capture.retry_buffer = self._capture.retry_buffer, None
+            return value
+
+
+class LocalSTTDispatchCoordinator:
+    """Admit Library work and one dictation reservation in strict order."""
+
+    def __init__(
+        self,
+        executor: LocalSTTExecutor,
+        *,
+        on_dictation_idle: Callable[[], None] | None = None,
+    ) -> None:
+        self._executor = executor
+        self._on_dictation_idle = on_dictation_idle or (lambda: None)
+        self._lock = threading.RLock()
+        self._active_kind: Literal["library", "dictation"] | None = None
+        self._active_attempt_id: str | None = None
+        self._reservation: _Capture | None = None
+        self._pending: _Pending | None = None
+        self._closed = False
+
+    @property
+    def dictation_reserved(self) -> bool:
+        """Return whether dictation gates future heavy Library work."""
+
+        with self._lock:
+            return self._reservation is not None
+
+    def submit_library(self, **executor_kwargs: Any) -> int:
+        """Submit one Library request immediately, without queueing it."""
+
+        attempt_id = executor_kwargs.get("attempt_id")
+        if type(attempt_id) is not str or not attempt_id.strip():
+            raise ValueError("attempt_id must be a non-empty string")
+        callbacks = _Callbacks(
+            "library",
+            attempt_id,
+            executor_kwargs.pop("on_result", lambda _result: None),
+            executor_kwargs.pop("on_failure", lambda _failure: None),
+        )
+        with self._lock:
+            if self._closed:
+                raise ExecutorUnavailableError("Local STT dispatch is closed")
+            if self._reservation is not None:
+                raise ExecutorBusyError("Local STT dictation has the next slot")
+            if self._active_kind is not None:
+                raise ExecutorBusyError("Local STT already has active work")
+            self._claim_locked("library", attempt_id)
+        try:
+            generation = self._executor.submit(
+                **executor_kwargs,
+                on_result=lambda value: self._terminal(callbacks, value),
+                on_failure=lambda value: self._terminal(callbacks, value),
+            )
+        except Exception:
+            with self._lock:
+                if self._matches_locked("library", attempt_id):
+                    self._clear_active_locked()
+            raise
+        self._publish_generation(callbacks, generation)
+        return generation
+
+    def transcribe_buffer(
+        self,
+        *,
+        source: BufferAudioSource,
+        dispatch: ParakeetDispatch,
+        language: str,
+    ) -> dict[str, Any]:
+        """Submit one buffer through shared admission and block for its payload."""
+
+        if type(source) is not BufferAudioSource:
+            raise TypeError("source must be a BufferAudioSource")
+        handle = self.begin_dictation(
+            capture_generation=uuid.uuid4().int,
+            dispatch=dispatch,
+            sample_rate=source.sample_rate,
+            channels=source.channels,
+            sample_width=source.sample_width,
+            language=language,
+            on_logical_segment=lambda _sequence, _text: None,
+        )
+        handle.append_segment(source.audio)
+        handle.finish()
+        handle.wait()
+        with self._lock:
+            payload = handle._capture.last_payload
+        if payload is None:
+            raise RuntimeError(TranscriptionFailureCode.INFERENCE_FAILED)
+        return payload
+
+    def begin_dictation(
+        self,
+        *,
+        capture_generation: int,
+        dispatch: ParakeetDispatch,
+        sample_rate: int,
+        channels: int,
+        sample_width: int,
+        language: str,
+        on_logical_segment: Callable[[int, str], None],
+    ) -> DictationCaptureHandle:
+        """Reserve the next local-STT slot for one capture."""
+
+        if type(capture_generation) is not int or capture_generation < 0:
+            raise ValueError("capture_generation must be a non-negative integer")
+        if type(dispatch) is not ParakeetDispatch:
+            raise TypeError("dispatch must be a ParakeetDispatch")
+        _validate_format(sample_rate, channels, sample_width)
+        if type(language) is not str or not language.strip():
+            raise ValueError("language must be a non-empty string")
+        if not callable(on_logical_segment):
+            raise TypeError("on_logical_segment must be callable")
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Local STT dispatch is closed")
+            existing = self._reservation
+            match = existing is not None and (
+                existing.generation,
+                existing.dispatch.identity,
+                existing.sample_rate,
+                existing.channels,
+                existing.sample_width,
+                existing.language,
+            ) == (
+                capture_generation,
+                dispatch.identity,
+                sample_rate,
+                channels,
+                sample_width,
+                language,
+            )
+            if existing is not None:
+                if match and not existing.cancelled:
+                    return DictationCaptureHandle(self, existing)
+                raise ExecutorBusyError("Another dictation capture is already reserved")
+            capture = _Capture(
+                capture_generation,
+                dispatch,
+                sample_rate,
+                channels,
+                sample_width,
+                language,
+                on_logical_segment,
+            )
+            self._reservation = capture
+            return DictationCaptureHandle(self, capture)
+
+    def close(self) -> None:
+        """Release coordinator-owned audio without closing or joining the executor."""
+
+        done = None
+        attempt_id = None
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            capture = self._reservation
+            if capture is None:
+                return
+            self._mark_cancelled_locked(capture)
+            if self._active_kind == "dictation":
+                attempt_id = self._active_attempt_id
+            else:
+                self._reservation, done = None, capture.done
+        if attempt_id is not None:
+            self._executor.cancel(attempt_id)
+        if done is not None:
+            done.set()
+
+    def _waiting(self, capture: _Capture) -> bool:
+        with self._lock:
+            return self._reservation is capture and self._active_kind == "library"
+
+    def _append(self, capture: _Capture, audio: bytes) -> DictationAppendStatus:
+        if type(audio) is not bytes:
+            raise TypeError("audio must be bytes")
+        if not audio:
+            raise ValueError("audio must not be empty")
+        if len(audio) % capture.frame_bytes:
+            raise ValueError("audio must contain complete interleaved PCM frames")
+        request = done = None
+        notify = False
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Local STT dispatch is closed")
+            if self._reservation is not capture or capture.cancelled:
+                raise RuntimeError("dictation capture is no longer active")
+            if capture.finished:
+                raise RuntimeError("dictation capture is already finished")
+            limit = pcm_byte_limit(
+                sample_rate=capture.sample_rate,
+                channels=capture.channels,
+                sample_width=capture.sample_width,
+            )
+            accepted = audio[: limit - capture.total_bytes]
+            capture.total_bytes += len(accepted)
+            if capture.retrying:
+                capture.retry_audio.extend(accepted)
+                capture.retry_ends.append(
+                    len(capture.retry_audio) // capture.frame_bytes
+                )
+                capture.next_sequence += 1
+            else:
+                self._append_pending_locked(capture, accepted)
+                if self._active_kind is None:
+                    request = self._snapshot_locked()
+            reached = len(accepted) < len(audio) or capture.total_bytes == limit
+            if reached:
+                capture.finished = True
+                if capture.retrying:
+                    self._finalize_retry_locked(capture)
+                    notify = self._clear_reservation_locked(capture)
+                    done = capture.done
+        if request is not None:
+            submit_done, submit_notify = self._submit_dictation(request)
+            done, notify = submit_done or done, submit_notify or notify
+        self._post(done, notify)
+        return (
+            DictationAppendStatus.LIMIT_REACHED
+            if reached
+            else DictationAppendStatus.ACCEPTED
+        )
+
+    def _finish(self, capture: _Capture) -> None:
+        done = None
+        notify = False
+        with self._lock:
+            if capture.done.is_set() or capture.cancelled:
+                return
+            if self._reservation is not capture:
+                return
+            capture.finished = True
+            if capture.retrying:
+                self._finalize_retry_locked(capture)
+            if self._active_kind != "dictation" and self._pending is None:
+                notify = self._clear_reservation_locked(capture)
+                done = capture.done
+        self._post(done, notify)
+
+    def _cancel(self, capture: _Capture, force: bool) -> bool:
+        done = None
+        notify = False
+        attempt_id = None
+        with self._lock:
+            if capture.cancelled:
+                return False
+            if capture.done.is_set():
+                if capture.retry_buffer is None:
+                    return False
+                self._mark_cancelled_locked(capture)
+                return True
+            if self._reservation is not capture:
+                return False
+            self._mark_cancelled_locked(capture)
+            if self._active_kind == "dictation":
+                attempt_id = self._active_attempt_id
+            else:
+                notify = self._clear_reservation_locked(capture)
+                done = capture.done
+        accepted = True
+        if attempt_id is not None:
+            method = self._executor.force_stop if force else self._executor.cancel
+            accepted = method(attempt_id)
+        self._post(done, notify)
+        return accepted
+
+    def _append_pending_locked(self, capture: _Capture, audio: bytes) -> None:
+        if self._pending is None:
+            self._pending = _Pending(capture, capture.next_sequence)
+        elif self._pending.capture is not capture:
+            raise ExecutorBusyError("Another dictation request is already pending")
+        self._pending.audio.extend(audio)
+        self._pending.ends.append(len(self._pending.audio) // capture.frame_bytes)
+        capture.next_sequence += 1
+
+    def _snapshot_locked(self) -> _Request:
+        pending = self._pending
+        if pending is None or not pending.audio:
+            raise RuntimeError("no pending dictation audio")
+        capture = pending.capture
+        request = _Request(
+            capture,
+            uuid.uuid4().hex,
+            BufferAudioSource(
+                bytes(pending.audio),
+                capture.sample_rate,
+                capture.channels,
+                capture.sample_width,
+            ),
+            tuple(pending.ends),
+            pending.sequence_start,
+        )
+        self._pending = None
+        self._claim_locked("dictation", request.attempt_id)
+        return request
+
+    def _submit_dictation(
+        self,
+        request: _Request,
+        handoff: _Handoff | None = None,
+    ) -> tuple[threading.Event | None, bool]:
+        callbacks = _Callbacks(
+            "dictation",
+            request.attempt_id,
+            lambda _result: None,
+            lambda _failure: None,
+            request,
+            handoff=handoff or _Handoff(),
+        )
+        capture = request.capture
+        options = dict(capture.dispatch.option_updates)
+        options["language"] = capture.language
+        try:
+            generation = self._executor.submit(
+                attempt_id=request.attempt_id,
+                job_id=None,
+                source=request.source,
+                identity=capture.dispatch.identity,
+                options=options,
+                segment_end_frames=request.ends,
+                local_source=capture.dispatch.local_source,
+                managed_store_root=capture.dispatch.managed_store_root,
+                managed_artifact_ref=capture.dispatch.managed_artifact_ref,
+                on_result=lambda value: self._terminal(callbacks, value),
+                on_failure=lambda value: self._terminal(callbacks, value),
+            )
+        except Exception:
+            with self._lock:
+                if not self._matches_locked("dictation", request.attempt_id):
+                    return None, False
+                self._clear_active_locked()
+                capture.failure = (
+                    TranscriptionFailureCode.CANCELLED
+                    if capture.cancelled or self._closed
+                    else TranscriptionFailureCode.PROVIDER_UNAVAILABLE
+                )
+                capture.finished = True
+                self._discard_pending_locked(capture)
+                return capture.done, self._clear_reservation_locked(capture)
+        self._publish_generation(callbacks, generation)
+        with self._lock:
+            cancelled = capture.cancelled or self._closed
+        if cancelled:
+            self._executor.cancel(request.attempt_id)
+        return None, False
+
+    def _publish_generation(self, callbacks: _Callbacks, generation: int) -> None:
+        with self._lock:
+            callbacks.generation, early = generation, callbacks.early
+            callbacks.early = None
+        if early is not None:
+            self._terminal(callbacks, early)
+
+    def _terminal(
+        self,
+        callbacks: _Callbacks,
+        envelope: ExecutorResult | ExecutorFailure,
+    ) -> None:
+        with self._lock:
+            if (
+                callbacks.started
+                or envelope.attempt_id != callbacks.attempt_id
+                or not self._matches_locked(callbacks.kind, callbacks.attempt_id)
+            ):
+                return
+            if callbacks.generation is None:
+                callbacks.early = callbacks.early or envelope
+                return
+            if envelope.generation != callbacks.generation:
+                return
+            callbacks.started = True
+            handoff = callbacks.handoff
+            if handoff.running:
+                handoff.deferred = handoff.deferred or (callbacks, envelope)
+                return
+            handoff.running = True
+        threading.Thread(
+            target=self._handoff,
+            args=(handoff, callbacks, envelope),
+            name=f"local-stt-dispatch-{callbacks.attempt_id[:12]}",
+            daemon=True,
+        ).start()
+
+    def _handoff(
+        self,
+        handoff: _Handoff,
+        callbacks: _Callbacks,
+        envelope: ExecutorResult | ExecutorFailure,
+    ) -> None:
+        current = (callbacks, envelope)
+        while True:
+            self._transition(*current)
+            with self._lock:
+                if handoff.deferred is None:
+                    handoff.running = False
+                    return
+                current, handoff.deferred = handoff.deferred, None
+
+    def _transition(
+        self,
+        callbacks: _Callbacks,
+        envelope: ExecutorResult | ExecutorFailure,
+    ) -> None:
+        next_request = done = None
+        notify = deliver_segments = False
+        with self._lock:
+            if not self._matches_locked(callbacks.kind, callbacks.attempt_id):
+                return
+            self._clear_active_locked()
+            if callbacks.kind == "dictation":
+                request = callbacks.request
+                assert request is not None
+                capture = request.capture
+                if capture.cancelled:
+                    self._mark_cancelled_locked(capture)
+                elif type(envelope) is ExecutorResult:
+                    capture.last_payload = envelope.payload
+                    deliver_segments = True
+                elif (
+                    envelope.code is not TranscriptionFailureCode.CANCELLED
+                    and _RETRY_ACTION in envelope.recovery_actions
+                ):
+                    capture.retrying, capture.failure = True, None
+                    self._merge_retry_locked(capture, request.source.audio, request.ends)
+                    if self._pending is not None and self._pending.capture is capture:
+                        self._merge_retry_locked(
+                            capture,
+                            bytes(self._pending.audio),
+                            tuple(self._pending.ends),
+                        )
+                        self._pending = None
+                else:
+                    capture.failure, capture.finished = envelope.code, True
+                    self._discard_pending_locked(capture)
+            capture = self._reservation
+            if (
+                capture is not None
+                and not capture.cancelled
+                and not capture.retrying
+                and self._pending is not None
+            ):
+                next_request = self._snapshot_locked()
+            elif capture is not None and capture.finished:
+                if capture.retrying:
+                    self._finalize_retry_locked(capture)
+                notify = self._clear_reservation_locked(capture)
+                done = capture.done
+        if next_request is not None:
+            submit_done, submit_notify = self._submit_dictation(
+                next_request,
+                callbacks.handoff,
+            )
+            done, notify = submit_done or done, submit_notify or notify
+        if callbacks.kind == "library":
+            callback = (
+                callbacks.on_result
+                if type(envelope) is ExecutorResult
+                else callbacks.on_failure
+            )
+            self._deliver(callback, envelope)
+        elif deliver_segments:
+            assert callbacks.request is not None and type(envelope) is ExecutorResult
+            segments = envelope.payload.get("logical_segments", ())
+            if isinstance(segments, (tuple, list)):
+                for offset, text in enumerate(segments):
+                    if type(text) is str:
+                        self._deliver(
+                            callbacks.request.capture.callback,
+                            callbacks.request.sequence_start + offset,
+                            text,
+                        )
+        self._post(done, notify)
+
+    def _merge_retry_locked(
+        self,
+        capture: _Capture,
+        audio: bytes,
+        ends: tuple[int, ...],
+    ) -> None:
+        base = len(capture.retry_audio) // capture.frame_bytes
+        capture.retry_audio.extend(audio)
+        capture.retry_ends.extend(base + end for end in ends)
+
+    def _finalize_retry_locked(self, capture: _Capture) -> None:
+        if capture.retry_buffer is None and capture.retry_audio:
+            capture.retry_buffer = RetryableDictationBuffer(
+                BufferAudioSource(
+                    bytes(capture.retry_audio),
+                    capture.sample_rate,
+                    capture.channels,
+                    capture.sample_width,
+                ),
+                tuple(capture.retry_ends),
+            )
+        capture.retry_audio.clear()
+        capture.retry_ends.clear()
+
+    def _mark_cancelled_locked(self, capture: _Capture) -> None:
+        capture.cancelled = capture.finished = True
+        capture.failure = TranscriptionFailureCode.CANCELLED
+        capture.retry_audio.clear()
+        capture.retry_ends.clear()
+        capture.retry_buffer = None
+        self._discard_pending_locked(capture)
+
+    def _discard_pending_locked(self, capture: _Capture) -> None:
+        if self._pending is not None and self._pending.capture is capture:
+            self._pending = None
+
+    def _clear_reservation_locked(self, capture: _Capture) -> bool:
+        if self._reservation is not capture:
+            return False
+        self._reservation = None
+        return True
+
+    def _claim_locked(
+        self,
+        kind: Literal["library", "dictation"],
+        attempt_id: str,
+    ) -> None:
+        self._active_kind, self._active_attempt_id = kind, attempt_id
+
+    def _matches_locked(
+        self,
+        kind: Literal["library", "dictation"],
+        attempt_id: str,
+    ) -> bool:
+        return self._active_kind == kind and self._active_attempt_id == attempt_id
+
+    def _clear_active_locked(self) -> None:
+        self._active_kind = self._active_attempt_id = None
+
+    def _post(self, done: threading.Event | None, notify: bool) -> None:
+        if done is not None:
+            done.set()
+        if notify and not self._closed:
+            self._deliver(self._on_dictation_idle)
+
+    @staticmethod
+    def _deliver(callback: Callable[..., Any], *args: Any) -> None:
+        try:
+            callback(*args)
+        except Exception:
+            return
+
+
+__all__ = [
+    "DICTATION_MAX_SECONDS",
+    "DictationAppendStatus",
+    "DictationCaptureHandle",
+    "LocalSTTDispatchCoordinator",
+    "RetryableDictationBuffer",
+    "RetryableDictationFailure",
+    "pcm_byte_limit",
+]

--- a/tldw_chatbook/STT/dispatch_coordinator.py
+++ b/tldw_chatbook/STT/dispatch_coordinator.py
@@ -67,6 +67,7 @@ class _Capture:
     next_sequence: int = 0
     finished: bool = False
     cancelled: bool = False
+    force_cancel: bool = False
     retrying: bool = False
     failure: TranscriptionFailureCode | None = None
     retry_audio: bytearray = field(default_factory=bytearray, repr=False)
@@ -172,9 +173,7 @@ class DictationCaptureHandle:
     def take_retry_buffer(self) -> RetryableDictationBuffer | None:
         """Transfer retained retry PCM at most once."""
 
-        with self._coordinator._lock:
-            value, self._capture.retry_buffer = self._capture.retry_buffer, None
-            return value
+        return self._coordinator._take_retry(self._capture)
 
 
 class LocalSTTDispatchCoordinator:
@@ -193,6 +192,7 @@ class LocalSTTDispatchCoordinator:
         self._active_attempt_id: str | None = None
         self._reservation: _Capture | None = None
         self._pending: _Pending | None = None
+        self._retry_owner: _Capture | None = None
         self._closed = False
 
     @property
@@ -229,9 +229,16 @@ class LocalSTTDispatchCoordinator:
                 on_failure=lambda value: self._terminal(callbacks, value),
             )
         except Exception:
+            next_request = done = None
+            notify = False
             with self._lock:
                 if self._matches_locked("library", attempt_id):
                     self._clear_active_locked()
+                    next_request, done, notify = self._advance_locked()
+            if next_request is not None:
+                submit_done, submit_notify = self._submit_dictation(next_request)
+                done, notify = submit_done or done, submit_notify or notify
+            self._post(done, notify)
             raise
         self._publish_generation(callbacks, generation)
         return generation
@@ -331,6 +338,8 @@ class LocalSTTDispatchCoordinator:
             if self._closed:
                 return
             self._closed = True
+            if self._retry_owner is not None:
+                self._release_retry_locked(self._retry_owner)
             capture = self._reservation
             if capture is None:
                 return
@@ -428,18 +437,25 @@ class LocalSTTDispatchCoordinator:
                 return True
             if self._reservation is not capture:
                 return False
+            capture.force_cancel = force
             self._mark_cancelled_locked(capture)
             if self._active_kind == "dictation":
                 attempt_id = self._active_attempt_id
             else:
                 notify = self._clear_reservation_locked(capture)
                 done = capture.done
-        accepted = True
         if attempt_id is not None:
             method = self._executor.force_stop if force else self._executor.cancel
-            accepted = method(attempt_id)
+            method(attempt_id)
         self._post(done, notify)
-        return accepted
+        return True
+
+    def _take_retry(self, capture: _Capture) -> RetryableDictationBuffer | None:
+        with self._lock:
+            value, capture.retry_buffer = capture.retry_buffer, None
+            if self._retry_owner is capture:
+                self._retry_owner = None
+            return value
 
     def _append_pending_locked(self, capture: _Capture, audio: bytes) -> None:
         if self._pending is None:
@@ -516,9 +532,14 @@ class LocalSTTDispatchCoordinator:
                 return capture.done, self._clear_reservation_locked(capture)
         self._publish_generation(callbacks, generation)
         with self._lock:
-            cancelled = capture.cancelled or self._closed
-        if cancelled:
-            self._executor.cancel(request.attempt_id)
+            cancel_method = (
+                self._executor.force_stop
+                if capture.cancelled and capture.force_cancel
+                else self._executor.cancel
+            )
+            cancel_after_submit = capture.cancelled or self._closed
+        if cancel_after_submit:
+            cancel_method(request.attempt_id)
         return None, False
 
     def _publish_generation(self, callbacks: _Callbacks, generation: int) -> None:
@@ -609,19 +630,7 @@ class LocalSTTDispatchCoordinator:
                 else:
                     capture.failure, capture.finished = envelope.code, True
                     self._discard_pending_locked(capture)
-            capture = self._reservation
-            if (
-                capture is not None
-                and not capture.cancelled
-                and not capture.retrying
-                and self._pending is not None
-            ):
-                next_request = self._snapshot_locked()
-            elif capture is not None and capture.finished:
-                if capture.retrying:
-                    self._finalize_retry_locked(capture)
-                notify = self._clear_reservation_locked(capture)
-                done = capture.done
+            next_request, done, notify = self._advance_locked()
         if next_request is not None:
             submit_done, submit_notify = self._submit_dictation(
                 next_request,
@@ -648,6 +657,23 @@ class LocalSTTDispatchCoordinator:
                         )
         self._post(done, notify)
 
+    def _advance_locked(
+        self,
+    ) -> tuple[_Request | None, threading.Event | None, bool]:
+        capture = self._reservation
+        if (
+            capture is not None
+            and not capture.cancelled
+            and not capture.retrying
+            and self._pending is not None
+        ):
+            return self._snapshot_locked(), None, False
+        if capture is not None and capture.finished:
+            if capture.retrying:
+                self._finalize_retry_locked(capture)
+            return None, capture.done, self._clear_reservation_locked(capture)
+        return None, None, False
+
     def _merge_retry_locked(
         self,
         capture: _Capture,
@@ -660,6 +686,8 @@ class LocalSTTDispatchCoordinator:
 
     def _finalize_retry_locked(self, capture: _Capture) -> None:
         if capture.retry_buffer is None and capture.retry_audio:
+            if self._retry_owner is not None and self._retry_owner is not capture:
+                self._release_retry_locked(self._retry_owner)
             capture.retry_buffer = RetryableDictationBuffer(
                 BufferAudioSource(
                     bytes(capture.retry_audio),
@@ -669,16 +697,22 @@ class LocalSTTDispatchCoordinator:
                 ),
                 tuple(capture.retry_ends),
             )
+            self._retry_owner = capture
         capture.retry_audio.clear()
         capture.retry_ends.clear()
 
     def _mark_cancelled_locked(self, capture: _Capture) -> None:
         capture.cancelled = capture.finished = True
         capture.failure = TranscriptionFailureCode.CANCELLED
+        self._release_retry_locked(capture)
+        self._discard_pending_locked(capture)
+
+    def _release_retry_locked(self, capture: _Capture) -> None:
         capture.retry_audio.clear()
         capture.retry_ends.clear()
         capture.retry_buffer = None
-        self._discard_pending_locked(capture)
+        if self._retry_owner is capture:
+            self._retry_owner = None
 
     def _discard_pending_locked(self, capture: _Capture) -> None:
         if self._pending is not None and self._pending.capture is capture:

--- a/tldw_chatbook/STT/dispatch_coordinator.py
+++ b/tldw_chatbook/STT/dispatch_coordinator.py
@@ -260,6 +260,13 @@ class LocalSTTDispatchCoordinator:
 
         if type(source) is not BufferAudioSource:
             raise TypeError("source must be a BufferAudioSource")
+        limit = pcm_byte_limit(
+            sample_rate=source.sample_rate,
+            channels=source.channels,
+            sample_width=source.sample_width,
+        )
+        if len(source.audio) > limit:
+            raise ValueError("source audio exceeds the 60-second PCM limit")
         handle = self.begin_dictation(
             capture_generation=uuid.uuid4().int,
             dispatch=dispatch,

--- a/tldw_chatbook/STT/dispatch_coordinator.py
+++ b/tldw_chatbook/STT/dispatch_coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 import uuid
+import weakref
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -53,7 +54,7 @@ class RetryableDictationFailure(RuntimeError):
         super().__init__("Parakeet transcription failed.")
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, eq=False, weakref_slot=True)
 class _Capture:
     generation: int
     dispatch: ParakeetDispatch
@@ -192,7 +193,7 @@ class LocalSTTDispatchCoordinator:
         self._active_attempt_id: str | None = None
         self._reservation: _Capture | None = None
         self._pending: _Pending | None = None
-        self._retry_owner: _Capture | None = None
+        self._retry_owners: weakref.WeakSet[_Capture] = weakref.WeakSet()
         self._closed = False
 
     @property
@@ -338,8 +339,8 @@ class LocalSTTDispatchCoordinator:
             if self._closed:
                 return
             self._closed = True
-            if self._retry_owner is not None:
-                self._release_retry_locked(self._retry_owner)
+            for owner in tuple(self._retry_owners):
+                self._release_retry_locked(owner)
             capture = self._reservation
             if capture is None:
                 return
@@ -453,8 +454,7 @@ class LocalSTTDispatchCoordinator:
     def _take_retry(self, capture: _Capture) -> RetryableDictationBuffer | None:
         with self._lock:
             value, capture.retry_buffer = capture.retry_buffer, None
-            if self._retry_owner is capture:
-                self._retry_owner = None
+            self._retry_owners.discard(capture)
             return value
 
     def _append_pending_locked(self, capture: _Capture, audio: bytes) -> None:
@@ -686,8 +686,6 @@ class LocalSTTDispatchCoordinator:
 
     def _finalize_retry_locked(self, capture: _Capture) -> None:
         if capture.retry_buffer is None and capture.retry_audio:
-            if self._retry_owner is not None and self._retry_owner is not capture:
-                self._release_retry_locked(self._retry_owner)
             capture.retry_buffer = RetryableDictationBuffer(
                 BufferAudioSource(
                     bytes(capture.retry_audio),
@@ -697,7 +695,7 @@ class LocalSTTDispatchCoordinator:
                 ),
                 tuple(capture.retry_ends),
             )
-            self._retry_owner = capture
+            self._retry_owners.add(capture)
         capture.retry_audio.clear()
         capture.retry_ends.clear()
 
@@ -711,8 +709,7 @@ class LocalSTTDispatchCoordinator:
         capture.retry_audio.clear()
         capture.retry_ends.clear()
         capture.retry_buffer = None
-        if self._retry_owner is capture:
-            self._retry_owner = None
+        self._retry_owners.discard(capture)
 
     def _discard_pending_locked(self, capture: _Capture) -> None:
         if self._pending is not None and self._pending.capture is capture:

--- a/tldw_chatbook/STT/executor.py
+++ b/tldw_chatbook/STT/executor.py
@@ -20,6 +20,8 @@ from multiprocessing.connection import Connection
 from pathlib import Path
 from typing import Any
 
+from tldw_chatbook.Utils.fd_protection import protect_file_descriptors
+
 from .contracts import (
     BufferAudioSource,
     DeviceFailureOrigin,
@@ -674,23 +676,25 @@ class LocalSTTExecutor:
         generation = self._generation_counter
         scratch_path = Path(tempfile.mkdtemp(prefix=f"tldw_stt_g{generation}_"))
         scratch_path.chmod(0o700)
-        parent_connection, child_connection = self._context.Pipe(duplex=True)
-        admission_event = self._context.Event()
-        cancellation_event = self._context.Event()
-        process = self._context.Process(
-            target=target,
-            args=(
-                child_connection,
-                admission_event,
-                cancellation_event,
-                generation,
-                str(scratch_path),
-            ),
-            name=f"local-stt-worker-{generation}",
-        )
+        with protect_file_descriptors():
+            parent_connection, child_connection = self._context.Pipe(duplex=True)
+            admission_event = self._context.Event()
+            cancellation_event = self._context.Event()
+            process = self._context.Process(
+                target=target,
+                args=(
+                    child_connection,
+                    admission_event,
+                    cancellation_event,
+                    generation,
+                    str(scratch_path),
+                ),
+                name=f"local-stt-worker-{generation}",
+            )
         tree: ExecutorProcessTree | None = None
         try:
-            process.start()
+            with protect_file_descriptors():
+                process.start()
             child_connection.close()
             if not parent_connection.poll(self._startup_timeout):
                 raise ProcessContainmentError("worker bootstrap timed out")

--- a/tldw_chatbook/STT/executor.py
+++ b/tldw_chatbook/STT/executor.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import Any
 
 from tldw_chatbook.Utils.fd_protection import protect_file_descriptors
-
 from .contracts import (
     BufferAudioSource,
     DeviceFailureOrigin,

--- a/tldw_chatbook/STT/executor.py
+++ b/tldw_chatbook/STT/executor.py
@@ -21,8 +21,10 @@ from pathlib import Path
 from typing import Any
 
 from .contracts import (
+    BufferAudioSource,
     DeviceFailureOrigin,
     ExecutionDevice,
+    FileAudioSource,
     TranscriptionFailureCode,
 )
 from .executor_process_tree import (
@@ -192,19 +194,40 @@ class ExecutorRequest:
 
     generation: int
     attempt_id: str
-    job_id: str
-    source_path: Path = field(repr=False)
+    job_id: str | None
+    source: FileAudioSource | BufferAudioSource = field(repr=False)
     identity: ModelIdentity
     options: dict[str, Any] = field(repr=False)
+    segment_end_frames: tuple[int, ...] = ()
     local_source: LocalSourceSnapshot | None = field(default=None, repr=False)
     managed_store_root: Path | None = field(default=None, repr=False)
     managed_artifact_ref: tuple[str, str, str] | None = None
 
     def __post_init__(self) -> None:
         _require_generation_and_attempt(self.generation, self.attempt_id)
-        _require_nonempty_text("job_id", self.job_id)
-        if not isinstance(self.source_path, Path):
-            raise TypeError("source_path must be a Path")
+        if self.job_id is not None:
+            _require_nonempty_text("job_id", self.job_id)
+        if type(self.source) not in (FileAudioSource, BufferAudioSource):
+            raise TypeError("source must be a FileAudioSource or BufferAudioSource")
+        if self.segment_end_frames:
+            if type(self.source) is not BufferAudioSource:
+                raise ValueError("segment_end_frames require a buffer source")
+            frame_bytes = self.source.channels * self.source.sample_width
+            total_frames = len(self.source.audio) // frame_bytes
+            if (
+                any(type(end) is not int or end <= 0 for end in self.segment_end_frames)
+                or any(
+                    a >= b
+                    for a, b in zip(
+                        self.segment_end_frames,
+                        self.segment_end_frames[1:],
+                    )
+                )
+                or self.segment_end_frames[-1] != total_frames
+            ):
+                raise ValueError(
+                    "segment_end_frames must increase to the final PCM frame"
+                )
         if type(self.identity) is not ModelIdentity:
             raise TypeError("identity must be a ModelIdentity")
         if type(self.options) is not dict:
@@ -467,10 +490,11 @@ class LocalSTTExecutor:
         self,
         *,
         attempt_id: str,
-        job_id: str,
-        source_path: Path,
+        job_id: str | None,
+        source: FileAudioSource | BufferAudioSource,
         identity: ModelIdentity,
         options: dict[str, Any],
+        segment_end_frames: tuple[int, ...] = (),
         local_source: LocalSourceSnapshot | None = None,
         managed_store_root: Path | None = None,
         managed_artifact_ref: tuple[str, str, str] | None = None,
@@ -509,9 +533,10 @@ class LocalSTTExecutor:
                 generation=self._worker_generation,
                 attempt_id=attempt_id,
                 job_id=job_id,
-                source_path=source_path,
+                source=source,
                 identity=identity,
                 options=request_options,
+                segment_end_frames=segment_end_frames,
                 local_source=local_source,
                 managed_store_root=managed_store_root,
                 managed_artifact_ref=managed_artifact_ref,

--- a/tldw_chatbook/STT/executor_worker.py
+++ b/tldw_chatbook/STT/executor_worker.py
@@ -641,17 +641,24 @@ def _parakeet_provider(
             raise
         except Exception:
             raise buffer_failure() from None
-        provenance = build_transcription_provenance_document(
+        normalized = replace(
             result.normalized,
+            provenance=replace(
+                result.normalized.provenance,
+                batch_id=current_context.get("batch_id"),
+            ),
+        )
+        provenance = build_transcription_provenance_document(
+            normalized,
             failed_attempt=current_context.get(
                 "retry_source_failure_provenance"
             ),
         )
         return {
-            "text": result.normalized.text,
+            "text": normalized.text,
             "logical_segments": result.logical_segments,
-            "duration": result.normalized.duration_seconds,
-            "transcription_model": result.normalized.provenance.model_id,
+            "duration": normalized.duration_seconds,
+            "transcription_model": normalized.provenance.model_id,
             "transcription_provenance": provenance,
         }
 

--- a/tldw_chatbook/STT/executor_worker.py
+++ b/tldw_chatbook/STT/executor_worker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, replace
@@ -428,14 +429,18 @@ def _parakeet_provider(
     context = request.options.get("transcription_context") or {}
     if not isinstance(context, dict):
         context = {}
+    model_id = request.identity.model_id
+    precision = request.identity.precision
     requested_language = request.options.get("language") or "en"
     effective_language = (
         "auto"
-        if request.identity.model_id == "nemo-parakeet-tdt-0.6b-v3"
+        if model_id == "nemo-parakeet-tdt-0.6b-v3"
         else "en"
     )
     artifact_root = None
     artifact_dependencies: tuple[Any, ...] = ()
+
+    missing = object()
 
     def failure(
         code: TranscriptionFailureCode,
@@ -444,7 +449,7 @@ def _parakeet_provider(
         effective_device: ExecutionDevice | None = None,
         attempt_id: str | None = None,
         batch_id: str | None = None,
-        job_id: str | None = None,
+        job_id: str | None | object = missing,
         language: str | None = None,
     ) -> ParakeetOnnxFailure:
         return ParakeetOnnxFailure(
@@ -452,11 +457,11 @@ def _parakeet_provider(
             message,
             attempt_id=attempt_id or request.attempt_id,
             batch_id=batch_id if batch_id is not None else context.get("batch_id"),
-            job_id=job_id or request.job_id,
-            model_id=request.identity.model_id,
+            job_id=request.job_id if job_id is missing else job_id,
+            model_id=model_id,
             artifact_root=artifact_root,
             artifact_dependencies=artifact_dependencies,
-            precision=request.identity.precision,
+            precision=precision,
             requested_language=language or requested_language,
             effective_language=effective_language,
             effective_device=effective_device,
@@ -512,8 +517,8 @@ def _parakeet_provider(
         runtime = ParakeetOnnxRuntime.load(
             model_root=model_root,
             vad_root=vad_root,
-            model_id=request.identity.model_id,
-            precision=request.identity.precision,
+            model_id=model_id,
+            precision=precision,
             artifact_root=artifact_root,
             artifact_dependencies=artifact_dependencies,
         )
@@ -588,7 +593,102 @@ def _parakeet_provider(
             "transcription_provenance": provenance,
         }
 
-    return ProviderRuntime(runner=runner, close=runtime.close)
+    def buffer_runner(
+        source: BufferAudioSource,
+        *,
+        segment_end_frames: tuple[int, ...],
+        attempt_id: str,
+        job_id: str | None,
+        language: str,
+        transcription_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        if source.sample_width != 2:
+            raise _ProviderLoadFailure(
+                TranscriptionFailureCode.UNSUPPORTED_CAPABILITY
+            )
+        current_context = (
+            transcription_context
+            if isinstance(transcription_context, dict)
+            else {}
+        )
+
+        def buffer_failure() -> ParakeetOnnxFailure:
+            return ParakeetOnnxFailure(
+                TranscriptionFailureCode.INFERENCE_FAILED,
+                "Parakeet ONNX could not complete this transcription.",
+                attempt_id=attempt_id,
+                batch_id=current_context.get("batch_id"),
+                job_id=job_id,
+                model_id=model_id,
+                artifact_root=artifact_root,
+                artifact_dependencies=artifact_dependencies,
+                precision=precision,
+                requested_language=language,
+                effective_language=effective_language,
+                effective_device=ExecutionDevice.CPU,
+            )
+
+        try:
+            result = runtime.transcribe_buffer(
+                source=source,
+                segment_end_frames=segment_end_frames,
+                attempt_id=attempt_id,
+                language=language,
+                job_id=job_id,
+                is_cancelled=is_cancelled,
+            )
+        except (ParakeetOnnxCancelled, ParakeetOnnxFailure):
+            raise
+        except Exception:
+            raise buffer_failure() from None
+        provenance = build_transcription_provenance_document(
+            result.normalized,
+            failed_attempt=current_context.get(
+                "retry_source_failure_provenance"
+            ),
+        )
+        return {
+            "text": result.normalized.text,
+            "logical_segments": result.logical_segments,
+            "duration": result.normalized.duration_seconds,
+            "transcription_model": result.normalized.provenance.model_id,
+            "transcription_provenance": provenance,
+        }
+
+    return ProviderRuntime(
+        runner=runner,
+        close=runtime.close,
+        buffer_runner=buffer_runner,
+    )
+
+
+def _buffer_runner_kwargs(
+    runner: Callable[..., dict[str, Any]],
+    request: ExecutorRequest,
+) -> dict[str, Any]:
+    """Build current-request metadata accepted by one buffer runner."""
+
+    context = request.options.get("transcription_context") or {}
+    if not isinstance(context, dict):
+        context = {}
+    values = {
+        "segment_end_frames": request.segment_end_frames,
+        "attempt_id": request.attempt_id,
+        "job_id": request.job_id,
+        "language": request.options.get("language") or "en",
+        "transcription_context": dict(context),
+    }
+    try:
+        parameters = inspect.signature(runner).parameters.values()
+    except (TypeError, ValueError):
+        return values
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    ):
+        return values
+    accepted = {parameter.name for parameter in parameters}
+    return {name: value for name, value in values.items() if name in accepted}
 
 
 def _default_provider_builder(
@@ -717,7 +817,10 @@ def _run_executor_worker(
                 ):
                     payload = resident.provider.buffer_runner(
                         request.source,
-                        segment_end_frames=request.segment_end_frames,
+                        **_buffer_runner_kwargs(
+                            resident.provider.buffer_runner,
+                            request,
+                        ),
                     )
                 else:
                     raise _ProviderLoadFailure(

--- a/tldw_chatbook/STT/executor_worker.py
+++ b/tldw_chatbook/STT/executor_worker.py
@@ -10,8 +10,10 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
 from .contracts import (
+    BufferAudioSource,
     DeviceFailureOrigin,
     ExecutionDevice,
+    FileAudioSource,
     TranscriptionFailureCode,
     TranscriptionWarningCode,
 )
@@ -42,6 +44,7 @@ class ProviderRuntime:
 
     runner: TranscriptionRunner
     close: Callable[[], None]
+    buffer_runner: Callable[..., dict[str, Any]] | None = None
 
 
 @dataclass(slots=True)
@@ -702,11 +705,24 @@ def _run_executor_worker(
                         WorkerPhase.TRANSCRIBING,
                     )
                 )
-                payload = parse_job(
-                    request.source_path,
-                    dict(request.options),
-                    transcription_runner=resident.provider.runner,
-                )
+                if type(request.source) is FileAudioSource:
+                    payload = parse_job(
+                        request.source.path,
+                        dict(request.options),
+                        transcription_runner=resident.provider.runner,
+                    )
+                elif (
+                    request.identity.provider_id == "parakeet-onnx"
+                    and resident.provider.buffer_runner is not None
+                ):
+                    payload = resident.provider.buffer_runner(
+                        request.source,
+                        segment_end_frames=request.segment_end_frames,
+                    )
+                else:
+                    raise _ProviderLoadFailure(
+                        TranscriptionFailureCode.UNSUPPORTED_CAPABILITY
+                    )
                 if cancellation_event.is_set():
                     connection.send(_cancelled_failure(request))
                     continue

--- a/tldw_chatbook/STT/parakeet_dispatch.py
+++ b/tldw_chatbook/STT/parakeet_dispatch.py
@@ -1,0 +1,172 @@
+"""Download-free resolution of exact installed Parakeet worker identity."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+from tldw_chatbook.Local_Ingestion.parakeet_v2_artifact import (
+    active_managed_parakeet_dir,
+    parakeet_reference,
+    parakeet_v2_managed_service,
+)
+from tldw_chatbook.Local_Ingestion.parakeet_v2_installer import (
+    PARAKEET_V2_FILES,
+    VERIFICATION_RECEIPT,
+    parakeet_v2_install_dir,
+    verify_parakeet_v2_bundle,
+)
+from tldw_chatbook.Local_Ingestion.stt_batch_routing import PARAKEET_V2_MODEL
+from tldw_chatbook.Model_Artifacts.store import managed_model_artifact_root
+from tldw_chatbook.Utils.path_validation import validate_path_simple
+
+from .contracts import ExecutionDevice
+from .executor import LocalSourceSnapshot, ModelIdentity, snapshot_local_source
+
+
+@dataclass(frozen=True, slots=True)
+class ParakeetDispatch:
+    """Exact installed artifact identity and caller-local worker option updates."""
+
+    identity: ModelIdentity
+    local_source: LocalSourceSnapshot | None
+    managed_store_root: Path | None
+    managed_artifact_ref: tuple[str, str, str] | None
+    option_updates: Mapping[str, Any]
+
+
+def _configured_paths(model_root: Path, precision: str) -> tuple[Path, ...]:
+    filenames = (
+        (
+            "config.json",
+            "vocab.txt",
+            "encoder-model.int8.onnx",
+            "decoder_joint-model.int8.onnx",
+        )
+        if precision == "int8"
+        else (
+            "config.json",
+            "vocab.txt",
+            "encoder-model.onnx",
+            "encoder-model.onnx.data",
+            "decoder_joint-model.onnx",
+        )
+    )
+    return tuple(model_root / filename for filename in filenames)
+
+
+def _dispatch(
+    *,
+    model_id: str,
+    precision: str,
+    local_source: LocalSourceSnapshot | None = None,
+    root_revision: str | None = None,
+    closure_fingerprint: str | None = None,
+    managed_store_root: Path | None = None,
+    managed_artifact_ref: tuple[str, str, str] | None = None,
+    option_updates: Mapping[str, Any] | None = None,
+) -> ParakeetDispatch:
+    return ParakeetDispatch(
+        identity=ModelIdentity(
+            provider_id="parakeet-onnx",
+            model_id=model_id,
+            root_revision=root_revision,
+            closure_fingerprint=closure_fingerprint,
+            precision=precision,
+            device=ExecutionDevice.CPU,
+            local_snapshot_token=(
+                local_source.token if local_source is not None else None
+            ),
+        ),
+        local_source=local_source,
+        managed_store_root=managed_store_root,
+        managed_artifact_ref=managed_artifact_ref,
+        option_updates=MappingProxyType(dict(option_updates or {})),
+    )
+
+
+def resolve_parakeet_dispatch(
+    *,
+    model_id: str,
+    precision: str,
+    model_dir: str | Path | None,
+) -> ParakeetDispatch:
+    """Resolve an installed configured, managed, or verified legacy artifact.
+
+    Resolution is synchronous and local-only. It never invokes artifact
+    acquisition, provisioning, or download code.
+    """
+
+    reference = parakeet_reference(model_id, precision)
+    if model_dir is not None and str(model_dir).strip():
+        model_root = validate_path_simple(model_dir, require_exists=True).absolute()
+        local_source = snapshot_local_source(
+            _configured_paths(model_root, precision)
+        )
+        return _dispatch(
+            model_id=model_id,
+            precision=precision,
+            local_source=local_source,
+            option_updates={"transcription_model_dir": str(model_root)},
+        )
+
+    service = parakeet_v2_managed_service()
+    if (
+        active_managed_parakeet_dir(
+            model_id,
+            precision,
+            service=service,
+        )
+        is not None
+    ):
+        leased = service.acquire(reference)
+        try:
+            handle = leased.handle
+            if handle.root != reference:
+                raise FileNotFoundError(
+                    "No installed Parakeet artifact matches the requested identity."
+                )
+            root_revision = handle.root.revision
+            closure_fingerprint = handle.closure_fingerprint
+        finally:
+            leased.close()
+        return _dispatch(
+            model_id=model_id,
+            precision=precision,
+            root_revision=root_revision,
+            closure_fingerprint=closure_fingerprint,
+            managed_store_root=managed_model_artifact_root().absolute(),
+            managed_artifact_ref=(
+                reference.artifact_id,
+                reference.revision,
+                reference.variant,
+            ),
+        )
+
+    if model_id == PARAKEET_V2_MODEL and precision == "int8":
+        legacy_root = parakeet_v2_install_dir().absolute()
+        if verify_parakeet_v2_bundle(legacy_root):
+            legacy_paths = (
+                legacy_root / VERIFICATION_RECEIPT,
+                *(legacy_root / item.filename for item in PARAKEET_V2_FILES),
+            )
+            local_source = snapshot_local_source(legacy_paths)
+            return _dispatch(
+                model_id=model_id,
+                precision=precision,
+                local_source=local_source,
+                option_updates={
+                    "transcription_model_dir": str(legacy_root),
+                    "_verify_legacy_parakeet_v2": True,
+                },
+            )
+
+    raise FileNotFoundError(
+        "No installed Parakeet artifact matches the requested model and precision."
+    )
+
+
+__all__ = ["ParakeetDispatch", "resolve_parakeet_dispatch"]

--- a/tldw_chatbook/STT/parakeet_onnx.py
+++ b/tldw_chatbook/STT/parakeet_onnx.py
@@ -347,7 +347,25 @@ class ParakeetOnnxRuntime:
         job_id: str | None = None,
         is_cancelled: Callable[[], bool] | None = None,
     ) -> ParakeetBufferResult:
-        """Transcribe validated interleaved 16-bit PCM entirely in memory."""
+        """Transcribe validated interleaved 16-bit PCM entirely in memory.
+
+        Args:
+            source: Bounded PCM bytes and their audio format.
+            segment_end_frames: Increasing logical segment boundaries ending at
+                the final PCM frame, or an empty tuple for one segment.
+            attempt_id: Stable identifier for this inference attempt.
+            language: Requested language code.
+            job_id: Optional Library job identifier.
+            is_cancelled: Optional cancellation probe called before inference.
+
+        Returns:
+            Normalized transcription plus text for each logical segment.
+
+        Raises:
+            ImportError: NumPy is unavailable for the Parakeet ONNX feature.
+            ParakeetOnnxFailure: PCM or artifact capabilities are unsupported.
+            ValueError: Logical segment boundaries are invalid.
+        """
 
         if source.sample_width != 2:
             normalized_language = (language or "en").strip().lower()
@@ -367,7 +385,9 @@ class ParakeetOnnxRuntime:
                 ),
             )
 
-        import numpy as np
+        from tldw_chatbook.Utils.optional_deps import require_dependency
+
+        np = require_dependency("numpy", "transcription_parakeet_onnx")
 
         started = time.monotonic()
         model_load_seconds = self._take_model_load_seconds()

--- a/tldw_chatbook/STT/parakeet_onnx.py
+++ b/tldw_chatbook/STT/parakeet_onnx.py
@@ -7,10 +7,12 @@ import subprocess
 import tempfile
 import time
 import wave
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
+from itertools import pairwise
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
     PARAKEET_V2_MODEL,
@@ -18,6 +20,7 @@ from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
 )
 
 from .contracts import (
+    BufferAudioSource,
     ExecutionDevice,
     ProducedCapabilities,
     TimestampGranularity,
@@ -35,8 +38,15 @@ from .persistence import (
     load_failed_transcription_attempt,
 )
 
-
 LONG_FORM_SECONDS = 30.0
+
+
+@dataclass(frozen=True, slots=True)
+class ParakeetBufferResult:
+    """Normalized buffer result plus text for each caller-logical segment."""
+
+    normalized: TranscriptionResult
+    logical_segments: tuple[str, ...]
 
 
 class ParakeetOnnxCancelled(RuntimeError):
@@ -190,7 +200,7 @@ class ParakeetOnnxRuntime:
         precision: str,
         artifact_root: Any | None,
         artifact_dependencies: tuple[Any, ...],
-    ) -> "ParakeetOnnxRuntime":
+    ) -> ParakeetOnnxRuntime:
         """Load only explicit local paths with ONNX Runtime's CPU provider.
 
         Args:
@@ -279,8 +289,7 @@ class ParakeetOnnxRuntime:
             ParakeetOnnxFailure: If long-form input lacks the managed VAD.
         """
         started = time.monotonic()
-        model_load_seconds = self.model_load_seconds
-        self.model_load_seconds = 0.0
+        model_load_seconds = self._take_model_load_seconds()
         normalized_language = (language or "en").strip().lower()
         effective_language = (
             "auto" if self.model_id == PARAKEET_V3_MODEL else "en"
@@ -312,7 +321,133 @@ class ParakeetOnnxRuntime:
                 self._check_cancelled(is_cancelled)
                 text = str(self._model.recognize(wav_path)).strip()
                 raw_segments = ((0.0, duration, text),) if text else ()
-        inference_seconds = time.monotonic() - started
+        return self._build_result(
+            text=text,
+            raw_segments=raw_segments,
+            duration=duration,
+            attempt_id=attempt_id,
+            batch_id=batch_id,
+            job_id=job_id,
+            retry_of_attempt_id=retry_of_attempt_id,
+            retry_of_job_id=retry_of_job_id,
+            language=normalized_language,
+            timestamps=timestamps,
+            used_vad=use_vad,
+            model_load_seconds=model_load_seconds,
+            inference_seconds=time.monotonic() - started,
+        )
+
+    def transcribe_buffer(
+        self,
+        *,
+        source: BufferAudioSource,
+        segment_end_frames: tuple[int, ...],
+        attempt_id: str,
+        language: str,
+        job_id: str | None = None,
+        is_cancelled: Callable[[], bool] | None = None,
+    ) -> ParakeetBufferResult:
+        """Transcribe validated interleaved 16-bit PCM entirely in memory."""
+
+        if source.sample_width != 2:
+            normalized_language = (language or "en").strip().lower()
+            raise ParakeetOnnxFailure(
+                TranscriptionFailureCode.UNSUPPORTED_CAPABILITY,
+                "Parakeet ONNX buffer transcription requires 16-bit PCM audio.",
+                attempt_id=attempt_id,
+                batch_id=None,
+                job_id=job_id,
+                model_id=self.model_id,
+                artifact_root=self.artifact_root,
+                artifact_dependencies=self.artifact_dependencies,
+                precision=self.precision,
+                requested_language=normalized_language,
+                effective_language=(
+                    "auto" if self.model_id == PARAKEET_V3_MODEL else "en"
+                ),
+            )
+
+        import numpy as np
+
+        started = time.monotonic()
+        model_load_seconds = self._take_model_load_seconds()
+        samples = np.frombuffer(source.audio, dtype="<i2").reshape(
+            -1, source.channels
+        )
+        mono = samples.astype(np.float32).mean(axis=1) / 32768.0
+        ends = segment_end_frames or (len(mono),)
+        if (
+            any(type(end) is not int or end <= 0 for end in ends)
+            or any(a >= b for a, b in pairwise(ends))
+            or ends[-1] != len(mono)
+        ):
+            raise ValueError(
+                "segment_end_frames must increase to the final PCM frame"
+            )
+        starts = (0, *ends[:-1])
+        logical_waveforms = tuple(
+            mono[start:end] for start, end in zip(starts, ends)
+        )
+        duration = len(mono) / source.sample_rate
+        use_vad = duration > LONG_FORM_SECONDS and self._vad is not None
+        if use_vad:
+            logical_segments = self._transcribe_buffer_segments(
+                logical_waveforms,
+                sample_rate=source.sample_rate,
+                is_cancelled=is_cancelled,
+            )
+        else:
+            logical_segments_list: list[str] = []
+            for waveform in logical_waveforms:
+                self._check_cancelled(is_cancelled)
+                text = str(
+                    self._model.recognize(
+                        waveform,
+                        sample_rate=source.sample_rate,
+                    )
+                ).strip()
+                logical_segments_list.append(text)
+            logical_segments = tuple(logical_segments_list)
+        text = " ".join(item for item in logical_segments if item)
+        normalized = self._build_result(
+            text=text,
+            raw_segments=(),
+            duration=duration,
+            attempt_id=attempt_id,
+            batch_id=None,
+            job_id=job_id,
+            retry_of_attempt_id=None,
+            retry_of_job_id=None,
+            language=(language or "en").strip().lower(),
+            timestamps=False,
+            used_vad=use_vad,
+            model_load_seconds=model_load_seconds,
+            inference_seconds=time.monotonic() - started,
+        )
+        return ParakeetBufferResult(
+            normalized=normalized,
+            logical_segments=logical_segments,
+        )
+
+    def _build_result(
+        self,
+        *,
+        text: str,
+        raw_segments: tuple[tuple[float, float, str], ...],
+        duration: float,
+        attempt_id: str,
+        batch_id: str | None,
+        job_id: str | None,
+        retry_of_attempt_id: str | None,
+        retry_of_job_id: str | None,
+        language: str,
+        timestamps: bool,
+        used_vad: bool,
+        model_load_seconds: float,
+        inference_seconds: float,
+    ) -> TranscriptionResult:
+        """Assemble the shared normalized file-or-buffer result contract."""
+
         granularity = (
             TimestampGranularity.SEGMENT
             if timestamps
@@ -327,6 +462,7 @@ class ParakeetOnnxRuntime:
             else ()
         )
         is_v3 = self.model_id == PARAKEET_V3_MODEL
+        effective_language = "auto" if is_v3 else "en"
         warnings = (
             (TranscriptionWarningCode.REQUESTED_LANGUAGE_NOT_ENFORCED,)
             if is_v3
@@ -346,7 +482,7 @@ class ParakeetOnnxRuntime:
             precision=self.precision,
             requested_device=ExecutionDevice.CPU,
             effective_device=ExecutionDevice.CPU,
-            requested_language=normalized_language,
+            requested_language=language,
             effective_language=effective_language,
             detected_language=None,
             task=TranscriptionTask.TRANSCRIBE,
@@ -359,7 +495,7 @@ class ParakeetOnnxRuntime:
                 timestamps=granularity,
                 punctuation=True,
                 capitalization=True,
-                vad=use_vad,
+                vad=used_vad,
                 diarization=False,
             ),
             duration_seconds=duration,
@@ -372,6 +508,55 @@ class ParakeetOnnxRuntime:
             ),
             warnings=warnings,
         )
+
+    def _transcribe_buffer_segments(
+        self,
+        logical_waveforms: tuple[Any, ...],
+        *,
+        sample_rate: int,
+        is_cancelled: Callable[[], bool] | None,
+    ) -> tuple[str, ...]:
+        """Run resident VAD and ASR for each logical in-memory waveform."""
+
+        logical_texts: list[str] = []
+        for logical_waveform in logical_waveforms:
+            self._check_cancelled(is_cancelled)
+            waveforms, lengths = self._model.resampler(
+                [logical_waveform],
+                [len(logical_waveform)],
+                sample_rate,
+            )
+            target_rate = self._model.asr._get_sample_rate()
+            self._check_cancelled(is_cancelled)
+            segment_groups = self._vad.segment_batch(
+                waveforms,
+                lengths,
+                target_rate,
+            )
+            recognized_segments: list[str] = []
+            for waveform, ranges in zip(
+                waveforms,
+                segment_groups,
+                strict=True,
+            ):
+                for start, end in ranges:
+                    self._check_cancelled(is_cancelled)
+                    batch, batch_lengths = self._pad_list([waveform[start:end]])
+                    recognized = self._model.asr.recognize_batch(
+                        batch,
+                        batch_lengths,
+                    )
+                    result = next(iter(recognized))
+                    text = str(result.text).strip()
+                    if text:
+                        recognized_segments.append(text)
+            logical_texts.append(" ".join(recognized_segments))
+        return tuple(logical_texts)
+
+    def _take_model_load_seconds(self) -> float:
+        model_load_seconds = self.model_load_seconds
+        self.model_load_seconds = 0.0
+        return model_load_seconds
 
     def _transcribe_segments(
         self,
@@ -414,6 +599,7 @@ class ParakeetOnnxRuntime:
 
 
 __all__ = [
+    "ParakeetBufferResult",
     "ParakeetOnnxCancelled",
     "ParakeetOnnxFailure",
     "ParakeetOnnxRuntime",

--- a/tldw_chatbook/STT/parakeet_onnx.py
+++ b/tldw_chatbook/STT/parakeet_onnx.py
@@ -389,6 +389,26 @@ class ParakeetOnnxRuntime:
             mono[start:end] for start, end in zip(starts, ends)
         )
         duration = len(mono) / source.sample_rate
+        if (
+            duration > LONG_FORM_SECONDS
+            and self._vad is None
+            and self.model_id != PARAKEET_V2_MODEL
+        ):
+            normalized_language = (language or "en").strip().lower()
+            raise ParakeetOnnxFailure(
+                TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
+                "Long-form Parakeet v3 requires the managed VAD dependency. "
+                "Retry with faster-whisper.",
+                attempt_id=attempt_id,
+                batch_id=None,
+                job_id=job_id,
+                model_id=self.model_id,
+                artifact_root=self.artifact_root,
+                artifact_dependencies=self.artifact_dependencies,
+                precision=self.precision,
+                requested_language=normalized_language,
+                effective_language="auto",
+            )
         use_vad = duration > LONG_FORM_SECONDS and self._vad is not None
         if use_vad:
             logical_segments = self._transcribe_buffer_segments(

--- a/tldw_chatbook/UI/Console_Modules/dictation.py
+++ b/tldw_chatbook/UI/Console_Modules/dictation.py
@@ -616,9 +616,18 @@ class ConsoleStreamingDictationSession:
         self._controller.clear_retry()
 
     def retry_with_faster_whisper(self) -> str:
-        """Consume the retained replay once and return its transcript."""
+        """Replay logical segments, classify them, and return the full capture."""
 
-        return self._controller.retry_with_faster_whisper()
+        with self._lock:
+            generation = self._capture_generation
+        logical_texts = self._controller.retry_segments_with_faster_whisper()
+        for text in logical_texts:
+            self._handle_event(
+                console_voice_input.classify_segment(text),
+                generation,
+            )
+        with self._lock:
+            return _join_segments(self._segments)
 
     def discard(self) -> None:
         """Release the microphone without the blocking join.

--- a/tldw_chatbook/UI/Console_Modules/dictation.py
+++ b/tldw_chatbook/UI/Console_Modules/dictation.py
@@ -130,6 +130,7 @@ from ...Chat.console_voice_input import (
     VoiceDictationModelDefaulted,
     VoiceFailed,
     VoiceFinal,
+    VoiceLocalSTTBusy,
     VoiceModelPreparing,
     VoiceModelWarmupFailed,
     VoicePartial,
@@ -141,7 +142,9 @@ from ...Chat.console_voice_input import (
     default_service_factory,
 )
 from ...Chat.console_glyphs import GLYPH_VOICE_WORKING
+from ...STT.dispatch_coordinator import DICTATION_MAX_SECONDS, pcm_byte_limit
 from ...Utils.persistent_diagnostics import persist_event
+from ...Widgets.confirmation_dialog import ConfirmationDialog
 from ...Widgets.Console import ConsoleComposerBar
 from ...Widgets.glyph_fallback import resolve_glyph
 
@@ -150,7 +153,7 @@ if TYPE_CHECKING:
 
 logger = logger.bind(module="ChatScreen")
 
-CONSOLE_DICTATION_MAX_SECONDS = 60.0
+CONSOLE_DICTATION_MAX_SECONDS = DICTATION_MAX_SECONDS
 #: `AudioRecordingService`'s own capture defaults, restated rather than
 #: imported: `tldw_chatbook.Audio` pulls in the transcription stack at module
 #: scope, and this module must stay importable without it (see
@@ -158,20 +161,13 @@ CONSOLE_DICTATION_MAX_SECONDS = 60.0
 CONSOLE_DICTATION_SAMPLE_RATE = 16_000
 CONSOLE_DICTATION_CHANNELS = 1
 CONSOLE_DICTATION_SAMPLE_WIDTH = 2
-#: Slack over the wall-clock cap so the bound is a *memory* backstop and never
-#: the thing that ends an ordinary capture: the 60 s timer below should always
-#: win first, and only a recorder that outruns its own clock (a wedged timer, a
-#: device delivering faster than real time) should ever reach this.
-CONSOLE_DICTATION_BUFFER_HEADROOM = 1.5
 #: The PCM bound handed to the recorder. Without it `AudioRecordingService`
 #: retains every chunk for the whole capture -- and so do its undrained
 #: `audio_queue` and `LazyLiveDictationService.audio_buffer`, at ~32 KB/s each.
-CONSOLE_DICTATION_MAX_BYTES = int(
-    CONSOLE_DICTATION_SAMPLE_RATE
-    * CONSOLE_DICTATION_CHANNELS
-    * CONSOLE_DICTATION_SAMPLE_WIDTH
-    * CONSOLE_DICTATION_MAX_SECONDS
-    * CONSOLE_DICTATION_BUFFER_HEADROOM
+CONSOLE_DICTATION_MAX_BYTES = pcm_byte_limit(
+    sample_rate=CONSOLE_DICTATION_SAMPLE_RATE,
+    channels=CONSOLE_DICTATION_CHANNELS,
+    sample_width=CONSOLE_DICTATION_SAMPLE_WIDTH,
 )
 
 
@@ -608,6 +604,22 @@ class ConsoleStreamingDictationSession:
         heard = heard or bool(outcome.captured_bytes)
         raise RuntimeError(NO_SPEECH_MESSAGE if heard else NO_CAPTURE_MESSAGE)
 
+    @property
+    def retry_available(self) -> bool:
+        """Whether one bounded faster-whisper replay is retained."""
+
+        return self._controller.retry_available
+
+    def clear_retry(self) -> None:
+        """Release any retained retry PCM without replaying it."""
+
+        self._controller.clear_retry()
+
+    def retry_with_faster_whisper(self) -> str:
+        """Consume the retained replay once and return its transcript."""
+
+        return self._controller.retry_with_faster_whisper()
+
     def discard(self) -> None:
         """Release the microphone without the blocking join.
 
@@ -653,6 +665,7 @@ class ConsoleDictationController:
         run_pending_voice_action: Callable[[str | None], Any],
         undo_histories_accessor: Callable[[], dict[str, Any]],
         visible_draft_session_id_accessor: Callable[[], str | None],
+        dictation_service_factory: Callable[..., Any] = default_service_factory,
     ) -> None:
         """Build the controller and bind everything its moved bodies need.
 
@@ -800,6 +813,7 @@ class ConsoleDictationController:
         self._run_pending_voice_action_fn = run_pending_voice_action
         self._undo_histories_accessor = undo_histories_accessor
         self._visible_draft_session_id_accessor = visible_draft_session_id_accessor
+        self._dictation_service_factory = dictation_service_factory
 
         # Dictation's own state, moved verbatim from `ChatScreen.__init__`.
         self._console_dictation_session: Any | None = None
@@ -1335,6 +1349,13 @@ class ConsoleDictationController:
             if event.detail:
                 self.app_instance.notify(event.detail, severity="information")
             return
+        if isinstance(event, VoiceLocalSTTBusy):
+            if self._console_dictation_state != "starting":
+                return
+            composer = self._console_composer_or_none()
+            if composer is not None:
+                composer.set_voice_preparing_message(event.message)
+            return
         if isinstance(event, VoiceModelWarmupFailed):
             # Advisory, not fatal: the capture is going ahead. Making this
             # fatal would mean one transient error permanently disables
@@ -1475,61 +1496,17 @@ class ConsoleDictationController:
         if self._console_dictation_state != "recording":
             return
         self.app_instance.notify(
-            "Dictation limit reached; transcribing the captured audio.",
+            "Limit reached — press Mic to continue.",
             severity="warning",
         )
         if self._console_hands_free is not None:
-            # `had_segments` must be read NOW, while the capture is still
-            # `recording` (the segments live on the session object that is
-            # about to be released).
-            had_segments = False
-            session = self._console_dictation_session
-            if session is not None:
-                with session._lock:
-                    had_segments = bool(session._segments)
-            if had_segments:
-                # WITH segments pending, `on_capture_ended` must fire
-                # synchronously, HERE, while still `recording` -- exactly
-                # like the original (pre-review) design: it emits
-                # `RequestStopAndSend`, which (via `_console_hands_free_
-                # request_stop_and_send`'s "recording" branch) drives the
-                # REAL stop-and-send itself, making the trailing, always-run
-                # `_request_console_dictation_stop()` call below a harmless
-                # no-op (state has already moved on to `transcribing`).
-                # Deferring this case the same way the empty case needs
-                # (see below) would let the trailing unconditional stop run
-                # FIRST and finish the capture on its own, ordinary
-                # (non-send) path -- by the time a deferred `on_capture_
-                # ended` then tried to retroactively queue a send,
-                # `_console_dictation_origin_session_id` would already be
-                # cleared to `None` and the draft could have moved on.
-                self._console_hands_free.controller.on_capture_ended(
-                    had_segments=True, limit_hit=True
-                )
-            else:
-                # Task-5 review B2: with NOTHING captured, `on_capture_
-                # ended` must NOT be delivered until the capture has
-                # actually reached `idle` (mic released). Delivering it
-                # synchronously here made an empty-capture `OpenCapture`
-                # reopen a same-tick no-op (`_console_hands_free_open_
-                # capture`'s own `state == "idle"` guard correctly refuses
-                # -- the mic is not free yet) while the FSM still recorded
-                # `capture_open = True` and burned the reopen-once ceiling
-                # regardless: permanently mic-dead, with no second
-                # `on_capture_ended` ever able to arrive to trigger the
-                # ceiling's own exit. See `_deliver_console_hands_free_
-                # capture_ended`, scheduled below instead of called
-                # directly -- unlike the had-segments branch above, there
-                # is no pending send whose session/draft state could go
-                # stale in the meantime, so deferring is safe here.
-                self.run_worker(
-                    self._deliver_console_hands_free_capture_ended(
-                        self._console_hands_free, False
-                    ),
-                    exclusive=False,
-                    group="console-hands-free-capture-ended",
-                    exit_on_error=False,
-                )
+            # A bounded ending is never a conversational turn boundary. Exit
+            # the loop through its existing close-capture path so retained
+            # text follows ordinary caret insertion without auto-send or the
+            # loop's historical one-time reopen. A later physical Mic press
+            # starts a fresh capture explicitly.
+            self._console_hands_free.controller.on_exit_request()
+            return
         self._request_console_dictation_stop()
 
     def _create_console_dictation_session(self) -> Any:
@@ -1540,6 +1517,12 @@ class ConsoleDictationController:
         """
         return ConsoleStreamingDictationSession(
             on_event=self._emit_console_dictation_event,
+            service_factory=self._dictation_service_factory,
+            max_buffer_bytes=pcm_byte_limit(
+                sample_rate=CONSOLE_DICTATION_SAMPLE_RATE,
+                channels=CONSOLE_DICTATION_CHANNELS,
+                sample_width=CONSOLE_DICTATION_SAMPLE_WIDTH,
+            ),
         )
 
 
@@ -1585,7 +1568,7 @@ class ConsoleDictationController:
             return
         self._set_console_dictation_state("recording")
         self._console_dictation_timer = self.set_timer(
-            CONSOLE_DICTATION_MAX_SECONDS,
+            DICTATION_MAX_SECONDS,
             self._handle_console_dictation_limit,
         )
         self._console_dictation_elapsed_timer = self.set_interval(
@@ -1713,10 +1696,85 @@ class ConsoleDictationController:
         try:
             transcript = await asyncio.to_thread(session.stop_and_transcribe)
         except Exception as exc:
-            await asyncio.to_thread(session.discard)
-            if self._console_dictation_session is session:
-                self._notify_console_dictation_error(exc)
+            if not session.retry_available:
+                await asyncio.to_thread(session.discard)
+                if self._console_dictation_session is session:
+                    self._notify_console_dictation_error(exc)
+                return
+            try:
+                confirmed = await self.run_worker(
+                    self.app_instance.push_screen_wait(
+                        ConfirmationDialog(
+                            title="Parakeet transcription failed",
+                            message=(
+                                "Parakeet failed. Retry this audio with "
+                                "faster-whisper?"
+                            ),
+                            confirm_label="Retry",
+                            cancel_label="Keep draft",
+                        )
+                    ),
+                    exclusive=False,
+                    exit_on_error=False,
+                ).wait()
+            except asyncio.CancelledError:
+                self._finish_failed_console_dictation(session)
+                raise
+            except Exception:  # noqa: BLE001 - modal teardown is best effort
+                logger.opt(exception=True).debug(
+                    "Console dictation retry prompt did not complete"
+                )
+                self._finish_failed_console_dictation(session)
+                return
+            if not confirmed:
+                self._finish_failed_console_dictation(session)
+                return
+            try:
+                transcript = await asyncio.to_thread(
+                    session.retry_with_faster_whisper
+                )
+            except Exception as retry_exc:
+                owns_session = self._console_dictation_session is session
+                self._finish_failed_console_dictation(session)
+                if owns_session and self.is_mounted:
+                    self._notify_console_dictation_error(retry_exc)
+                return
+        await self._finish_successful_console_dictation(
+            session,
+            origin_session_id=origin_session_id,
+            transcript=transcript,
+        )
+
+    def _finish_failed_console_dictation(self, session: Any) -> None:
+        """Clear one failed/rejected retry without mutating the draft."""
+
+        try:
+            session.clear_retry()
+        except Exception:  # noqa: BLE001 - cleanup must always reach idle
+            logger.opt(exception=True).debug(
+                "Console dictation retry state could not be cleared"
+            )
+        if self._console_dictation_session is not session:
             return
+        self._cancel_console_dictation_timer()
+        self._cancel_console_dictation_elapsed_timer()
+        self._console_dictation_session = None
+        self._console_dictation_origin_session_id = None
+        self._console_dictation_partial = ""
+        self._console_pending_voice_action = None
+        self._console_dictation_late_discard_ack = False
+        self._set_console_dictation_state("idle")
+
+    async def _finish_successful_console_dictation(
+        self,
+        session: Any,
+        *,
+        origin_session_id: str | None,
+        transcript: str,
+    ) -> None:
+        """Apply the single insertion/idle/action tail for success or retry."""
+
+        session.clear_retry()
         if not self.is_mounted:
             return
         if self._console_dictation_session is not session:

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -378,6 +378,9 @@ def build_console_controllers(screen: "ChatScreen") -> None:
         visible_draft_session_id_accessor=(
             lambda: screen._console_visible_draft_session_id
         ),
+        dictation_service_factory=lambda **kwargs: (
+            screen.app_instance._create_console_dictation_service(**kwargs)
+        ),
     )
     #: The V3 pipeline hands-free loop's state and lifecycle, plus the
     #: two-engine fork/action coordination it shares with the V4

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -4265,6 +4265,8 @@ class ConsoleComposerBar(Horizontal):
             indicator.styles.width = 0
             clear_button.styles.display = "none"
             self._set_actions_row_width(actions, BASE_ACTIONS_WIDTH)
+        if self._voice_full_width_preparing:
+            self._sync_full_width_voice_presentation(True)
 
     def set_voice_status(
         self,
@@ -4390,11 +4392,23 @@ class ConsoleComposerBar(Horizontal):
                 self.query_one("#console-composer-menu", Button),
                 self.query_one("#console-command-visible-text", Static),
             )
+            attachment_indicator = self.query_one(
+                "#console-attachment-indicator", Static
+            )
+            clear_attachment = self.query_one("#console-clear-attachment", Button)
+            actions = self.query_one("#console-composer-actions", Horizontal)
         except NoMatches:
             return
 
         for control in controls:
             control.styles.display = "none" if active else "block"
+        attachment_visible = not active and self._pending_attachment_label is not None
+        attachment_indicator.styles.display = "block" if attachment_visible else "none"
+        clear_attachment.styles.display = "block" if attachment_visible else "none"
+        self._set_actions_row_width(
+            actions,
+            ATTACHMENT_ACTIONS_WIDTH if attachment_visible else BASE_ACTIONS_WIDTH,
+        )
         self._sync_collapsed_presentation()
         self._sync_send_disabled_reason(
             self._send_disabled_reason,

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -4354,6 +4354,14 @@ class ConsoleComposerBar(Horizontal):
         chip.styles.min_width = 0
         chip.styles.height = 1
         chip.styles.min_height = 1
+        # Production CSS resolves the 53-cell ceiling to 52 cells here. A
+        # full-width preparing message therefore needs one of the two padding
+        # cells back; keep the leading pad and restore both for every ordinary
+        # state on its next write.
+        if state == STATE_PREPARING and cell_len(body) + 2 >= self.VOICE_CHIP_MAX_WIDTH:
+            chip.styles.padding = (0, 0, 0, 1)
+        else:
+            chip.styles.padding = None
         chip.set_class(state == "error", "console-voice-status-error")
         chip.update(Content(body))
 

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -374,7 +374,9 @@ class ConsoleComposerBar(Horizontal):
     MAX_DRAFT_ROWS = 4
     COMPOSER_CHROME_ROWS = 4
     VOICE_CHIP_MIN_WIDTH = 24
-    VOICE_CHIP_MAX_WIDTH = 42
+    # Fits the 51-cell shared-executor busy copy plus the chip's cell of
+    # horizontal padding on each side at ordinary Console widths.
+    VOICE_CHIP_MAX_WIDTH = 53
     #: Cell cap for the inline `#console-send-disabled-reason` strip. The
     #: longest copy `build_console_disabled_reason` emits is 49 cells, so 52
     #: renders every reason whole at common widths while the `1fr` draft

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -534,6 +534,10 @@ class ConsoleComposerBar(Horizontal):
         #: cannot stomp the chip back to "0:00" mid-capture.
         self._voice_partial: str = ""
         self._voice_elapsed_seconds: int = 0
+        #: Derived presentation latch for the one overlength preparing copy.
+        #: It hides only redundant row chrome; canonical draft/editor state
+        #: remains untouched and is revealed by every later ordinary repaint.
+        self._voice_full_width_preparing = False
         #: Latest model-preparation status for the chip, held for the same
         #: reason `_voice_partial` is: `sync_dictation_state` is called
         #: unconditionally by every control-bar refresh (changing a provider,
@@ -1301,6 +1305,11 @@ class ConsoleComposerBar(Horizontal):
             strip.styles.max_width = 0
             strip.styles.height = 0
             strip.styles.min_height = 0
+        if self._voice_full_width_preparing:
+            # The exact executor-wait copy and unchanged Mic/Send budget fill
+            # the row. Keep this redundant guidance cached but out of layout
+            # until the next ordinary voice-status repaint restores it.
+            strip.styles.display = "none"
 
     def sync_action_state(
         self,
@@ -4305,6 +4314,7 @@ class ConsoleComposerBar(Horizontal):
             return
 
         if state in ("idle", "unavailable"):
+            self._sync_full_width_voice_presentation(False)
             chip.styles.display = "none"
             chip.styles.width = 0
             chip.styles.min_width = 0
@@ -4354,16 +4364,42 @@ class ConsoleComposerBar(Horizontal):
         chip.styles.min_width = 0
         chip.styles.height = 1
         chip.styles.min_height = 1
-        # Production CSS resolves the 53-cell ceiling to 52 cells here. A
-        # full-width preparing message therefore needs one of the two padding
-        # cells back; keep the leading pad and restore both for every ordinary
-        # state on its next write.
-        if state == STATE_PREPARING and cell_len(body) + 2 >= self.VOICE_CHIP_MAX_WIDTH:
+        # Production CSS resolves the 53-cell ceiling to 52 cells here. The
+        # 51-cell executor-wait copy therefore gives back its trailing padding,
+        # keeps the normal one-cell right margin, and temporarily hides only
+        # presentation chrome; every ordinary repaint restores both padding
+        # and chrome without touching draft/editor state.
+        full_width_preparing = (
+            state == STATE_PREPARING and cell_len(body) + 2 >= self.VOICE_CHIP_MAX_WIDTH
+        )
+        self._sync_full_width_voice_presentation(full_width_preparing)
+        if full_width_preparing:
             chip.styles.padding = (0, 0, 0, 1)
         else:
             chip.styles.padding = None
+        chip.styles.margin = None
         chip.set_class(state == "error", "console-voice-status-error")
         chip.update(Content(body))
+
+    def _sync_full_width_voice_presentation(self, active: bool) -> None:
+        """Make room for the persistent executor-wait copy without data loss."""
+        self._voice_full_width_preparing = active
+        try:
+            controls = (
+                self.query_one("#console-composer-collapse", Button),
+                self.query_one("#console-composer-menu", Button),
+                self.query_one("#console-command-visible-text", Static),
+            )
+        except NoMatches:
+            return
+
+        for control in controls:
+            control.styles.display = "none" if active else "block"
+        self._sync_collapsed_presentation()
+        self._sync_send_disabled_reason(
+            self._send_disabled_reason,
+            muted=not self._send_blocked,
+        )
 
     def compose(self) -> ComposeResult:
         """Build the expanded and collapsed composer presentations.

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -3357,6 +3357,21 @@ class LibraryIngestQueueMixin:
                 self._handle_broken_ingest_parse_pool(generation, job_id, exc)
                 return
 
+    def _marshal_ingest_pool_call(
+        self,
+        callback: Callable[..., Any],
+        *args: Any,
+    ) -> None:
+        """Marshal a pool callback, tolerating only shutdown cancellation."""
+
+        if self._ingest_shutdown:
+            return
+        try:
+            self.call_from_thread(callback, *args)
+        except concurrent.futures.CancelledError:
+            if not self._ingest_shutdown:
+                raise
+
     def _ingest_pool_callback(
         self, generation: int, job_id: str, result: Dict[str, Any]
     ) -> None:
@@ -3385,9 +3400,7 @@ class LibraryIngestQueueMixin:
                 ``_top_up_ingest_parse_pool``.
             result: ``run_parse_job``'s structured return value.
         """
-        if self._ingest_shutdown:
-            return
-        self.call_from_thread(
+        self._marshal_ingest_pool_call(
             self._on_ingest_parse_complete, generation, job_id, result
         )
 
@@ -3396,9 +3409,7 @@ class LibraryIngestQueueMixin:
     ) -> None:
         """``apply_async`` ``error_callback``: same thread + shutdown
         contract as ``_ingest_pool_callback`` (see its docstring)."""
-        if self._ingest_shutdown:
-            return
-        self.call_from_thread(
+        self._marshal_ingest_pool_call(
             self._handle_broken_ingest_parse_pool, generation, job_id, exc
         )
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2826,6 +2826,13 @@ class LibraryIngestQueueMixin:
                 ),
                 explicit_retry=job.retry_count > 0,
             )
+        except ExecutorBusyError:
+            self._marshal_local_stt_call(
+                self._on_ingest_local_stt_deferred,
+                job.job_id,
+                attempt_id,
+            )
+            return
         except Exception as exc:
             provider = str(options.get("transcription_provider") or "")
             code, actions = self._classify_local_stt_dispatch_error(provider, exc)
@@ -2896,6 +2903,9 @@ class LibraryIngestQueueMixin:
             or generation <= binding[0]
         ):
             return
+        if self._claim_ingest_local_stt_job(job_id) is None:
+            self._ingest_local_stt_jobs.pop(job_id, None)
+            return
         self._ingest_local_stt_jobs[job_id] = (generation, attempt_id)
 
     def cancel_local_ingest_job(self, job_id: str) -> bool:
@@ -2955,6 +2965,39 @@ class LibraryIngestQueueMixin:
             return
         if executor.wait_for_retirement(10.0):
             self._marshal_local_stt_call(self._top_up_ingest_parse_pool)
+
+    def _on_ingest_local_stt_deferred(
+        self,
+        job_id: str,
+        attempt_id: str,
+    ) -> None:
+        """Release a provisional Library claim blocked by dictation admission."""
+
+        if self._ingest_shutdown or self._ingest_local_stt_jobs.get(job_id) != (
+            0,
+            attempt_id,
+        ):
+            return
+        self._ingest_local_stt_jobs.pop(job_id, None)
+        self._top_up_ingest_parse_pool()
+
+    def _claim_ingest_local_stt_job(
+        self,
+        job_id: str,
+    ) -> LibraryIngestJob | None:
+        """Publish a provisionally dispatched local-STT job as parsing."""
+
+        current = self.library_ingest_jobs.get_job(job_id)
+        if current is None:
+            return None
+        if current.state is IngestJobState.PARSING:
+            return current
+        if current.state is not IngestJobState.QUEUED:
+            return None
+        return self.library_ingest_jobs.mark_parsing(
+            job_id,
+            detected_type=current.detected_type,
+        )
 
     def _on_ingest_local_stt_dispatch_failure(
         self,
@@ -3061,6 +3104,8 @@ class LibraryIngestQueueMixin:
                 event.generation,
                 event.attempt_id,
             )
+        if self._claim_ingest_local_stt_job(job_id) is None:
+            return
         existing = self.library_ingest_jobs.get_job(job_id)
         progress = dict(existing.progress or {}) if existing is not None else {}
         progress["phase"] = event.phase.value
@@ -3075,6 +3120,9 @@ class LibraryIngestQueueMixin:
             job_id, result
         ):
             return
+        if self._claim_ingest_local_stt_job(job_id) is None:
+            self._ingest_local_stt_jobs.pop(job_id, None)
+            return
         self._ingest_local_stt_jobs.pop(job_id, None)
         self._ingest_parsed_payloads[job_id] = result.payload
         self._start_library_ingest_queue_if_idle()
@@ -3088,6 +3136,9 @@ class LibraryIngestQueueMixin:
         if self._ingest_shutdown or not self._local_stt_terminal_matches(
             job_id, failure
         ):
+            return
+        if self._claim_ingest_local_stt_job(job_id) is None:
+            self._ingest_local_stt_jobs.pop(job_id, None)
             return
         self._ingest_local_stt_jobs.pop(job_id, None)
         message = TRANSCRIPTION_FAILURE_CONTRACT[failure.code][0]
@@ -3147,14 +3198,27 @@ class LibraryIngestQueueMixin:
             return
         worker_count = self._ingest_parse_worker_count()
         heavy_cap = self._ingest_heavy_lane_max_workers()
-        # Read the total + heavy in-flight counts ONCE, then track them locally
-        # as we dispatch. This whole method is UI-thread-only and synchronous,
-        # so nothing but our own mark_parsing() calls can change these counts
-        # mid-loop -- re-scanning the registry (O(N)) every iteration would make
-        # the loop O(worker_count * N) on the UI thread for no benefit.
+        # Read the total + heavy in-flight counts ONCE, then include local-STT
+        # jobs provisionally owned by an off-loop dispatch thread. Those rows
+        # remain QUEUED until coordinator admission succeeds, but still consume
+        # capacity; otherwise a later top-up could overfill the pool with light
+        # work while identity resolution is in flight.
         parsing_count = self.library_ingest_jobs.counts().get("parsing", 0)
         heavy_parsing_count = self.library_ingest_jobs.parsing_count_for_types(
             _INGEST_HEAVY_TYPES
+        )
+        provisional_local_jobs = []
+        for provisional_job_id in self._ingest_local_stt_jobs:
+            provisional = self.library_ingest_jobs.get_job(provisional_job_id)
+            if (
+                provisional is not None
+                and provisional.state is IngestJobState.QUEUED
+            ):
+                provisional_local_jobs.append(provisional)
+        parsing_count += len(provisional_local_jobs)
+        heavy_parsing_count += sum(
+            job.detected_type in _INGEST_HEAVY_TYPES
+            for job in provisional_local_jobs
         )
         while parsing_count < worker_count:
             # LocalSTTExecutor intentionally accepts one request at a time.
@@ -3175,63 +3239,31 @@ class LibraryIngestQueueMixin:
             )
             if job is None:
                 return
-            claimed = self.library_ingest_jobs.mark_parsing(
-                job.job_id, detected_type=job.detected_type
-            )
-            if claimed is None:
-                # Invariant violation (Task-3 reviewer's guard note): the
-                # job we just pulled off `next_queued()` was no longer
-                # QUEUED by the time we tried to claim it -- should be
-                # impossible on the UI thread (this whole method is
-                # UI-thread-only, so nothing else can race the queue
-                # between the two calls), but a coordinator bug here must
-                # never crash the submission path. `break`, not `continue`
-                # (whole-branch review, Minor 2): `next_queued()` always
-                # returns the OLDEST queued job, so a `continue` would get
-                # the exact same unclaimable job handed straight back --
-                # an infinite loop on the UI thread. Breaking abandons
-                # only this top-up pass (logged); the next submission/
-                # retry/parse-completion re-attempts from scratch.
-                logger.error(
-                    f"Library ingest coordinator: mark_parsing rejected "
-                    f"job {job.job_id} (expected QUEUED) -- abandoning "
-                    f"this top-up pass."
-                )
-                break
-            # Track the just-claimed job locally (mirrors what a fresh
-            # counts()/parsing_count_for_types() scan would report next
-            # iteration) so the loop stays O(N), not O(worker_count * N).
-            parsing_count += 1
-            if job.detected_type in _INGEST_HEAVY_TYPES:
-                heavy_parsing_count += 1
             try:
-                options = self._ingest_job_options(claimed)
+                options = self._ingest_job_options(job)
             except BatchSTTRoutingError as exc:
                 error_text = _sanitize_library_ingest_error_text(str(exc))
                 failure_text = error_text or "Batch transcription routing failed."
                 logger.warning(
                     "Library ingest batch STT routing failed "
-                    f"(job_id={claimed.job_id}, "
-                    f"detected_type={claimed.detected_type}, "
+                    f"(job_id={job.job_id}, "
+                    f"detected_type={job.detected_type}, "
                     f"error={failure_text})."
                 )
                 self.library_ingest_jobs.mark_failed(
-                    claimed.job_id,
+                    job.job_id,
                     error=failure_text,
                     permanent=False,
                 )
-                parsing_count -= 1
-                if claimed.detected_type in _INGEST_HEAVY_TYPES:
-                    heavy_parsing_count -= 1
                 continue
-            job_id = claimed.job_id
-            source_path = claimed.source_path
+            job_id = job.job_id
+            source_path = job.source_path
             if options.get("transcription_provider") in {
                 "parakeet-onnx",
                 "transcribe-cpp",
             }:
                 try:
-                    self._submit_local_stt_job(claimed, options)
+                    self._submit_local_stt_job(job, options)
                 except Exception as exc:
                     code, recovery_actions = self._classify_local_stt_dispatch_error(
                         str(options.get("transcription_provider") or ""), exc
@@ -3254,11 +3286,24 @@ class LibraryIngestQueueMixin:
                             "actions": list(recovery_actions),
                         },
                     )
-                    parsing_count -= 1
-                    if claimed.detected_type in _INGEST_HEAVY_TYPES:
-                        heavy_parsing_count -= 1
                     continue
+                parsing_count += 1
+                if job.detected_type in _INGEST_HEAVY_TYPES:
+                    heavy_parsing_count += 1
                 continue
+            claimed = self.library_ingest_jobs.mark_parsing(
+                job.job_id, detected_type=job.detected_type
+            )
+            if claimed is None:
+                logger.error(
+                    f"Library ingest coordinator: mark_parsing rejected "
+                    f"job {job.job_id} (expected QUEUED) -- abandoning "
+                    f"this top-up pass."
+                )
+                break
+            parsing_count += 1
+            if job.detected_type in _INGEST_HEAVY_TYPES:
+                heavy_parsing_count += 1
             try:
                 pool = self._ensure_ingest_parse_pool()
             except Exception as exc:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -237,6 +237,7 @@ from tldw_chatbook.Local_Ingestion.stt_batch_routing import (
 from tldw_chatbook.STT.contracts import (
     TRANSCRIPTION_FAILURE_CONTRACT,
     ExecutionDevice,
+    FileAudioSource,
     TranscriptionFailureCode,
 )
 from tldw_chatbook.STT.executor import (
@@ -2835,7 +2836,7 @@ class LibraryIngestQueueMixin:
             generation = executor.submit(
                 attempt_id=attempt_id,
                 job_id=job.job_id,
-                source_path=Path(job.source_path),
+                source=FileAudioSource(Path(job.source_path)),
                 identity=dispatch["identity"],
                 options=options,
                 local_source=dispatch["local_source"],

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -251,6 +251,7 @@ from tldw_chatbook.STT.executor import (
     WorkerPhase,
     snapshot_local_source,
 )
+from tldw_chatbook.STT.dispatch_coordinator import LocalSTTDispatchCoordinator
 from tldw_chatbook.Home.active_work_adapter import (
     HomeControlAction,
     HomeControlResult,
@@ -2654,6 +2655,43 @@ class LibraryIngestQueueMixin:
                 self._local_stt_executor = executor
             return executor
 
+    def _ensure_local_stt_dispatch_coordinator(
+        self,
+    ) -> LocalSTTDispatchCoordinator:
+        """Return the one app-owned admission coordinator lazily."""
+
+        with self._local_stt_executor_lock:
+            if self._ingest_shutdown:
+                raise ExecutorUnavailableError("Local STT is shutting down")
+            executor = self._ensure_local_stt_executor()
+            coordinator = getattr(self, "_local_stt_dispatch_coordinator", None)
+            if coordinator is None:
+                coordinator = LocalSTTDispatchCoordinator(
+                    executor,
+                    on_dictation_idle=lambda: self._marshal_local_stt_call(
+                        self._top_up_ingest_parse_pool
+                    ),
+                )
+                self._local_stt_dispatch_coordinator = coordinator
+            return coordinator
+
+    def _create_console_dictation_service(self, **kwargs: Any) -> Any:
+        """Build Console dictation without importing its native stack eagerly."""
+
+        from tldw_chatbook.Audio.dictation_service_lazy import (
+            LazyLiveDictationService,
+        )
+        from tldw_chatbook.Local_Ingestion.transcription_service import (
+            TranscriptionService,
+        )
+
+        return LazyLiveDictationService(
+            **kwargs,
+            transcription_service_factory=lambda: TranscriptionService(
+                local_stt_dispatcher=self._ensure_local_stt_dispatch_coordinator()
+            ),
+        )
+
     def _build_local_stt_dispatch(
         self,
         job: LibraryIngestJob,
@@ -2703,84 +2741,23 @@ class LibraryIngestQueueMixin:
                     else None
                 )
 
-            if selected_dir:
-                from tldw_chatbook.Utils.path_validation import (
-                    validate_path_simple,
-                )
+            from tldw_chatbook.STT.parakeet_dispatch import (
+                resolve_parakeet_dispatch,
+            )
 
-                model_root = validate_path_simple(
-                    selected_dir,
-                    require_exists=True,
-                )
-                filenames = (
-                    (
-                        "config.json",
-                        "vocab.txt",
-                        "encoder-model.int8.onnx",
-                        "decoder_joint-model.int8.onnx",
-                    )
-                    if precision == "int8"
-                    else (
-                        "config.json",
-                        "vocab.txt",
-                        "encoder-model.onnx",
-                        "encoder-model.onnx.data",
-                        "decoder_joint-model.onnx",
-                    )
-                )
-                required = tuple(model_root / filename for filename in filenames)
-                local_source = snapshot_local_source(required)
-                options["transcription_model_dir"] = str(model_root)
-            else:
-                from tldw_chatbook.Local_Ingestion.parakeet_v2_artifact import (
-                    active_managed_parakeet_dir,
-                    parakeet_reference,
-                    parakeet_v2_managed_service,
-                )
-                from tldw_chatbook.Local_Ingestion.parakeet_v2_installer import (
-                    PARAKEET_V2_FILES,
-                    VERIFICATION_RECEIPT,
-                    parakeet_v2_install_dir,
-                )
-                from tldw_chatbook.Model_Artifacts.store import (
-                    managed_model_artifact_root,
-                )
-
-                service = parakeet_v2_managed_service()
-                reference = parakeet_reference(model_id, precision)
-                if (
-                    active_managed_parakeet_dir(
-                        model_id,
-                        precision,
-                        service=service,
-                    )
-                    is not None
-                ):
-                    leased = service.acquire(reference)
-                    try:
-                        root_revision = leased.handle.root.revision
-                        closure_fingerprint = leased.handle.closure_fingerprint
-                    finally:
-                        leased.close()
-                    managed_store_root = managed_model_artifact_root()
-                    managed_artifact_ref = (
-                        reference.artifact_id,
-                        reference.revision,
-                        reference.variant,
-                    )
-                elif model_id == PARAKEET_V2_MODEL and precision == "int8":
-                    legacy_root = parakeet_v2_install_dir()
-                    legacy_paths = (
-                        legacy_root / VERIFICATION_RECEIPT,
-                        *(
-                            legacy_root / descriptor.filename
-                            for descriptor in PARAKEET_V2_FILES
-                        ),
-                    )
-                    if all(path.is_file() for path in legacy_paths):
-                        local_source = snapshot_local_source(legacy_paths)
-                        options["transcription_model_dir"] = str(legacy_root)
-                        options["_verify_legacy_parakeet_v2"] = True
+            resolved = resolve_parakeet_dispatch(
+                model_id=model_id,
+                precision=precision,
+                model_dir=selected_dir,
+            )
+            options.update(resolved.option_updates)
+            return {
+                "attempt_id": attempt_id,
+                "identity": resolved.identity,
+                "local_source": resolved.local_source,
+                "managed_store_root": resolved.managed_store_root,
+                "managed_artifact_ref": resolved.managed_artifact_ref,
+            }
 
         identity = ModelIdentity(
             provider_id=provider,
@@ -2832,8 +2809,8 @@ class LibraryIngestQueueMixin:
             dispatch = self._build_local_stt_dispatch(job, options)
             if dispatch["attempt_id"] != attempt_id:
                 raise RuntimeError("Local STT attempt identity changed")
-            executor = self._ensure_local_stt_executor()
-            generation = executor.submit(
+            coordinator = self._ensure_local_stt_dispatch_coordinator()
+            generation = coordinator.submit_library(
                 attempt_id=attempt_id,
                 job_id=job.job_id,
                 source=FileAudioSource(Path(job.source_path)),
@@ -3184,7 +3161,15 @@ class LibraryIngestQueueMixin:
             # A legacy heavy-lane override above one must not turn the next
             # queued audio/video job into a spurious ExecutorBusyError.
             local_stt_busy = bool(self._ingest_local_stt_jobs)
-            heavy_full = heavy_parsing_count >= heavy_cap or local_stt_busy
+            coordinator = getattr(self, "_local_stt_dispatch_coordinator", None)
+            dictation_reserved = bool(
+                coordinator is not None and coordinator.dictation_reserved
+            )
+            heavy_full = (
+                heavy_parsing_count >= heavy_cap
+                or local_stt_busy
+                or dictation_reserved
+            )
             job = self.library_ingest_jobs.next_queued(
                 skip_types=_INGEST_HEAVY_TYPES if heavy_full else frozenset()
             )
@@ -3551,7 +3536,11 @@ class LibraryIngestQueueMixin:
         """
         self._ingest_shutdown = True
         with self._local_stt_executor_lock:
+            coordinator = getattr(self, "_local_stt_dispatch_coordinator", None)
             executor = getattr(self, "_local_stt_executor", None)
+            if coordinator is not None:
+                coordinator.close()
+            self._local_stt_dispatch_coordinator = None
             self._local_stt_executor = None
         local_jobs = getattr(self, "_ingest_local_stt_jobs", None)
         if local_jobs is None:
@@ -5656,8 +5645,11 @@ class TldwCli(
         self._ingest_parse_jobs_by_generation: dict[int, set[str]] = {}
         self._ingest_parse_pool_stop_event: Optional[threading.Event] = None
         self._ingest_parsed_payloads: dict[str, dict] = {}
-        self._local_stt_executor_lock = threading.Lock()
+        self._local_stt_executor_lock = threading.RLock()
         self._local_stt_executor: Optional[LocalSTTExecutor] = None
+        self._local_stt_dispatch_coordinator: Optional[
+            LocalSTTDispatchCoordinator
+        ] = None
         self._ingest_local_stt_jobs: dict[str, tuple[int, str]] = {}
         self._ingest_shutdown: bool = False
 


### PR DESCRIPTION
## Summary

- Route bounded Console microphone PCM through the one app-owned `LocalSTTExecutor` and `LocalSTTDispatchCoordinator` shared with Library ingestion.
- Add frame-aligned 60-second/byte limits, dictation-next admission, cancellation/shutdown fencing, visible limit recovery, explicit Mic resume, and bounded local-only faster-whisper retry.
- Keep Parakeet ONNX streaming explicitly unsupported rather than claiming true streaming, and retain the dead legacy implementation for TASK-605.
- Fix live Console blockers by honoring the configured local Parakeet model directory and protecting the first Python 3.12 STT worker spawn from Textual's fileno-less stderr.

## User-visible behavior

- The Console Mic records and transcribes through Parakeet v2 INT8 ONNX for explicit English dictation.
- Transcribed text is inserted at the existing caret without automatically sending the draft.
- Reaching the bounded capture limit retains accepted text, displays `Limit reached — press Mic to continue.`, returns to idle, and requires another physical Mic press to resume.
- Active native inference is not preempted; dictation runs before the next eligible heavy Library item.

## Verification

- `101 passed, 2 warnings in 12.63s` across the directly related executor, facade, limit/resume, and batch-ordering tests.
- Scoped Ruff check passed; `git diff --check origin/dev..HEAD` passed.
- Real macOS Console smoke: physical Mic start/stop opened PyAudio, captured a verified 4.7025-second fixture, routed 159,360 PCM bytes through Parakeet v2 INT8 ONNX CPU, inserted the exact expected transcript at the caret, sent no message, returned Mic to idle, and emitted no user-visible failure.
- Focused review found no Critical, Important, or Minor issues.

## Scope and remaining release gates

- TASK-603 remains **In Progress** with AC1-AC5 complete.
- AC6 remains open for representative Windows/Linux evidence and the complete release gate; this PR does not claim those platforms were exercised locally.
- The retained Parakeet MLX/native legacy-default removal and semantic default promotion remain TASK-605 work.
- No model download or artifact promotion was performed by the runtime verification.

Evidence: `Docs/STT_Evaluation/task-603/`  
Architecture: `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded Console dictation using Parakeet v2 INT8 ONNX through the app-owned local STT executor with a small coordinator that runs dictation before the next batch item. Enforces 60-second, frame-aligned limits with explicit resume and clear busy/limit UI; delivers TASK-603 AC1–AC5 (AC6 pending Windows/Linux evidence).

- New Features
  - Route Console mic PCM and public buffers through `LocalSTTExecutor` via a shared `LocalSTTDispatchCoordinator`; defer batch top-up behind a reserved dictation and resume Library after.
  - Executor/worker now accept `BufferAudioSource` with `segment_end_frames` to keep limits frame-accurate and admit dictation-next without preempting an active job.
  - Insert transcript at the caret without auto-send; render busy copy on the existing voice chip; keep the Mic visible, including with staged attachments.
  - Add `ParakeetDispatch` to resolve installed model identity and precision; keep Parakeet CPU-only English dictation; bounded `faster-whisper` retry preserves buffer ownership and transcript.

- Bug Fixes
  - Honor the configured Parakeet model directory and verification; preserve long-form context; reject oversized one-shot buffers.
  - Close coordinator admission races; follow executor retry generation; settle ingest callbacks during shutdown; enable mounted Console dictation.
  - Paint the full busy status and clear it at idle; require a physical Mic press after hitting the limit.
  - Protect the first Python 3.12 STT worker spawn from Textual’s fileno-less stderr.

<sup>Written for commit efcf14660b5833463d41dc0b15808ff4f3c71d2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



