### PR TITLE
feat(tts): add guided audio.cpp package foundation

### DIFF
--- a/Docs/superpowers/plans/2026-08-09-task-13200-audio-cpp-guided-foundation.md
+++ b/Docs/superpowers/plans/2026-08-09-task-13200-audio-cpp-guided-foundation.md
@@ -1,0 +1,98 @@
+# TASK-13200 Guided audio.cpp Foundation Implementation Plan
+
+> **For Codex:** Execute this plan test-first, one numbered task at a time. Do not
+> pull generated `server.json`, process lifecycle, Settings widgets, Speech Lab,
+> downloads, or later-family recipe work into this PR.
+
+**Goal:** Add the typed guided-setup state, sealed release-0.5.1 recipes for all
+Supertonic and PocketTTS packages, complete 21-family/67-package accounting, and
+a bounded read-only local package scanner.
+
+**Architecture:** Keep the existing `AudioCppConfig` runtime projection unchanged.
+A new full-settings model owns Guided and dormant manual/External values. A frozen
+recipe registry validates accepted package snapshots and exposes only allowlisted
+model projections. A separate scanner receives that registry, inspects one explicit
+root off-loop, and returns bounded evidence without launching or contacting anything.
+
+**Tech Stack:** Python 3.11, Pydantic 2, stdlib `asyncio`, `dataclasses`, `enum`,
+`hashlib`, `os`, `pathlib`, `stat`, `threading`, and pytest.
+
+**ADR required:** no new ADR
+
+**ADR path:** `backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md`
+
+**Reason:** This is a direct implementation of ADR-050's already-approved
+structured-settings, sealed-recipe, and explicit-root scanner boundaries.
+
+---
+
+### Task 1: Typed full-settings and accepted-package snapshots
+
+**Files:**
+- Create: `tldw_chatbook/TTS/audio_cpp_guided_config.py`
+- Create: `Tests/TTS/test_audio_cpp_guided_config.py`
+
+- [x] Write failing tests for legacy External/manual defaults, full dormant-value
+      round trips, bounded backend/device/thread/body/busy settings, immutable
+      accepted projections, unique public model IDs, and rejected extra fields.
+- [x] Run only the new test file and confirm the failures are missing APIs rather
+      than broken fixtures.
+- [x] Implement the smallest frozen Pydantic models and safe mapping projection
+      that satisfy those tests while leaving `AudioCppConfig` untouched.
+- [x] Re-run the new tests and existing `test_audio_cpp_config.py` plus
+      `test_audio_cpp_managed_config.py`.
+
+### Task 2: Sealed recipes, exact matching, and release accounting
+
+**Files:**
+- Create: `tldw_chatbook/TTS/audio_cpp_recipes.py`
+- Create: `Tests/TTS/test_audio_cpp_recipes.py`
+
+- [x] Write failing tests for all 4 Supertonic and 11 PocketTTS package IDs,
+      immutable recipe records, exact required layouts and model projections,
+      reviewed task/options/backend posture, traversal/absolute-path rejection,
+      exact/ambiguous/unknown/incomplete/permission matching, accepted-snapshot
+      validation, and the 21-family/67-package accounting totals.
+- [x] Run the new recipe tests and confirm the expected missing-API failures.
+- [x] Implement frozen recipe/evidence/accounting records, the production registry,
+      pure matcher/validator, and explicit Open-gap entries for the remaining 52
+      packages. Expose Verified claims only from exact evidenced tuples.
+- [x] Re-run recipe and guided-config tests.
+
+### Task 3: Bounded explicit-root package scanner
+
+**Files:**
+- Create: `tldw_chatbook/TTS/audio_cpp_package_scanner.py`
+- Create: `Tests/TTS/test_audio_cpp_package_scanner.py`
+
+- [x] Write failing tests for explicit-root recognition, canonical deduplication,
+      multiple variants in one root, missing/bad GGUF evidence, entry/depth/time/
+      candidate/result/metadata limits, cancellation, off-event-loop execution,
+      permission isolation, nested symlink escape attempts, top-level symlink
+      disclosure, and sanitized capped evidence.
+- [x] Run the scanner tests and confirm the expected missing-API failures.
+- [x] Implement one iterative no-follow scan, bounded header inspection, recipe-root
+      derivation, candidate identity construction, cooperative cancellation, and an
+      `asyncio.to_thread` wrapper. Never read tensor payloads or arbitrary file
+      contents.
+- [x] Re-run scanner and recipe tests.
+
+### Task 4: Side-effect proof, documentation truth, and task closeout
+
+**Files:**
+- Modify: `Tests/TTS/test_audio_cpp_guided_config.py`
+- Modify: `Tests/TTS/test_audio_cpp_recipes.py`
+- Modify: `Tests/TTS/test_audio_cpp_package_scanner.py`
+- Modify: `backlog/tasks/task-13200 - Build-guided-audio.cpp-package-recipes-and-bounded-scanner.md`
+
+- [x] Add a joined pure-foundation regression proving configuration, matching, and
+      scanning use no subprocess, socket, HTTP, download, or model-file write seam.
+- [x] Run mutation-style negative fixtures to prove near-match and bound assertions
+      fail when the safety condition is deliberately removed.
+- [x] Run focused tests, Ruff on changed Python files, bundle-independent full TTS
+      tests as proportionate verification, and `git diff --check`.
+- [x] Self-review against every acceptance criterion and ADR-050; record only actual
+      deviations or remaining evidence gaps.
+- [x] Check all acceptance criteria, add concise Implementation Notes including the
+      ADR decision and verification evidence, and mark TASK-13200 Done only after all
+      checks succeed.

--- a/Docs/superpowers/specs/2026-08-02-audio-cpp-managed-lifecycle-design.md
+++ b/Docs/superpowers/specs/2026-08-02-audio-cpp-managed-lifecycle-design.md
@@ -2,6 +2,12 @@
 
 Status: Approved by the user on 2026-08-02 after independent specification review
 
+Partially superseded: 2026-08-09 by the
+[guided model setup design](2026-08-09-audio-cpp-guided-model-setup-design.md),
+only for the additional generated-configuration source, auto-selected loopback
+port, recipe-driven model setup, and Windows target. Its user-provided
+`server.json` lifecycle remains normative.
+
 Date: 2026-08-02
 
 Target branch: `dev`

--- a/Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+++ b/Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
@@ -1,0 +1,1663 @@
+# audio.cpp Guided Model Setup and Clone Profiles — Product Requirements and Design
+
+Status: Approved by the user on 2026-08-09 after iterative design review
+
+Date: 2026-08-09
+
+Target branch: `dev`
+
+Supersedes: only the generated-configuration, fixed-port-for-all-Managed, and
+POSIX-only deferrals in the 2026-08-02 managed-lifecycle design. Its existing
+user-provided `server.json`, ownership, state, admission, diagnostics, and
+shutdown contracts remain normative.
+
+Extends:
+
+- the native adapter and complete-WAV contract in
+  [ADR-023](../../../backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md);
+- the managed child contract in the
+  [audio.cpp managed-lifecycle design](2026-08-02-audio-cpp-managed-lifecycle-design.md);
+- global/Studio ownership in
+  [ADR-039](../../../backlog/decisions/039-global-and-studio-tts-settings-ownership.md);
+  and
+- character TTS profile ownership in
+  [ADR-028](../../../backlog/decisions/028-character-tts-generation-profile-ownership.md).
+
+Normative decisions:
+
+- [ADR-050: Generated audio.cpp model setup](../../../backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md)
+- [ADR-051: Private TTS clone reference assets](../../../backlog/decisions/051-private-tts-clone-reference-assets.md)
+
+## Document purpose
+
+This document defines the next audio.cpp workstream after external-server and
+user-provided-binary/`server.json` support. It answers one concrete product
+question:
+
+> Can a new user install Chatbook, install `audiocpp_server` separately,
+> download or select a supported model package, configure it without writing
+> JSON, and hear a valid sample?
+
+The required answer after this workstream is **yes for every exact
+model/package/platform/backend tuple Chatbook labels as supported**. The final
+program goal is every audio.cpp `release-0.5.1` family tagged `TTS` or `Clone`,
+including the release's community table. Interim releases must state their
+exact coverage and cannot imply that every audio.cpp model works.
+
+This is a requirements and architecture document. It deliberately does not
+create Backlog tasks or an implementation plan.
+
+## Current-state baseline
+
+At the approved `dev` baseline, Chatbook already has:
+
+- an application-scoped TTS adapter registry with audio.cpp as the first native
+  adapter;
+- an External source for an independently managed audio.cpp server;
+- a Managed source using a user-provided executable and user-provided
+  `server.json`;
+- lazy launch, one owned child, health checks, exit supervision, explicit
+  restart/shutdown, saved/applied/process generations, bounded memory-only
+  diagnostics, and definitive application shutdown;
+- complete PCM16 WAV responses presented through an asynchronous response
+  interface;
+- global Speech & TTS Settings separated from Studio preferences;
+- Speech Lab catalog, generation, playback, export, and managed-runtime UX;
+- reusable provider/model/voice profiles and character assignments; and
+- an existing shared Model Library store for explicitly downloaded artifacts.
+
+The remaining first-time gap is setup knowledge. A user must already know how
+to translate a model package into audio.cpp's model entry, choose compatible
+assets and backend, and write `server.json`. Clone-capable families also need a
+private, typed owner for reference audio and transcript; the current profile
+schema intentionally has neither.
+
+## Upstream compatibility snapshot
+
+The initial recipe registry is pinned to the official audio.cpp
+[`release-0.5.1`](https://github.com/0xShug0/audio.cpp/releases/tag/release-0.5.1)
+tag:
+
+| Field | Pinned value |
+| --- | --- |
+| Tag | `release-0.5.1` |
+| Commit | `238ab6a9e321c17de8e120559f57efeedaeb1345` |
+| Release publication | 2026-08-04 |
+| Server entry point | `audiocpp_server --config <server.json>` |
+| Client contract | `/health`, `/v1/models`, `/v1/audio/speech` |
+| Initial response contract | complete structurally validated WAV |
+
+The release README and `model_specs/*.json` expose 21 unique families tagged
+`TTS` or `Clone`, with 67 declared package entries in the pinned snapshot. The
+family inventory is normative; package counts are an audit aid and may include
+multiple precision, language, or checkpoint variants that require distinct
+recipes.
+
+### Core release families
+
+| Family | Release tasks | Declared packages |
+| --- | --- | ---: |
+| `chatterbox` | TTS, Clone, VC | 3 |
+| `confucius4_tts` | Clone | 1 |
+| `dramabox` | TTS, Clone | 1 |
+| `fish_audio` | TTS, Clone, control | 2 |
+| `higgs_audio_tts` | TTS, Clone, control | 2 |
+| `miotts` | TTS, Clone | 3 |
+| `omnivoice` | TTS, Clone, design, control | 4 |
+| `pocket_tts` | TTS, Clone | 11 |
+| `qwen3_tts` | TTS, Clone, design, control | 9 |
+| `vevo2` | TTS plus non-TTS tasks | 3 |
+| `vibevoice` | TTS, dialogue | 2 |
+| `voxcpm2` | TTS, Clone, design, control | 4 |
+| `index_tts2` | TTS, Clone, control | 4 |
+| `irodori_tts` | TTS, Clone, design, control | 6 |
+| `moss_tts_nano` | TTS, Clone | 2 |
+| `moss_tts_local` | TTS, Clone, control | 2 |
+| `supertonic` | TTS | 4 |
+
+### Community release families
+
+| Family | Release tasks | Declared packages |
+| --- | --- | ---: |
+| `glm_tts` | TTS, Clone | 1 |
+| `inflect_v2` | TTS | 1 |
+| `outetts` | TTS, Clone | 1 |
+| `vietneu_tts` | TTS, Clone | 1 |
+
+`moss_tts_local` also appears in the release's community attribution table but
+is counted once because it is already in the core supported-model table and
+has one canonical model spec in this snapshot.
+
+Inclusion in this inventory means “must be evaluated and either receive exact
+approved recipes or remain an explicit release blocker.” It does not itself
+assert that every family, package, operating system, or backend already works
+through Chatbook.
+
+## Goals
+
+- Let a first-time user configure supported local audio.cpp packages without
+  editing JSON.
+- Preserve External mode and the existing user-provided `server.json` Managed
+  source for expert or unsupported configurations.
+- Support multiple configured TTS/Clone models in one lazy-loaded audio.cpp
+  child.
+- Auto-detect an already installed `audiocpp_server` and support manual browse,
+  without installing or downloading it.
+- Give exact, truthful compatibility and runtime evidence rather than a single
+  overloaded “supported” state.
+- Reuse the existing Model Library store for explicit curated downloads and
+  return an installed package directly to the Settings draft.
+- Support macOS, Linux, and Windows with exact platform/backend verification.
+- Add typed, private, reusable clone references to TTS profiles.
+- Preserve global Settings, Studio preferences, character profiles, and runtime
+  operations as separate owners.
+- Produce and audibly play a complete WAV in Speech Lab, including the
+  reference-required path where applicable.
+
+## Non-goals
+
+- Downloading, bundling, building, signing, installing, or updating the
+  audio.cpp server binary.
+- A remote recipe registry or any recipe-supplied executable code.
+- Guessing arbitrary GGUF compatibility from a filename or weak similarity.
+- Editing generated JSON or making it a second persistent configuration owner.
+- Multiple managed audio.cpp children, load balancing, failover, or process
+  adoption.
+- A general audio.cpp configuration editor exposing every upstream field.
+- Copying a user-selected local model package into application data.
+- Automatic model unloading, a VRAM scheduler, or a second resource manager.
+- Changing Studio preference ownership or silently adopting setup into Studio.
+- Native incremental playback/streaming in this workstream.
+- Non-loopback managed binding or Managed CORS.
+- Embedding clone audio in ordinary character cards or ordinary profile export.
+- Sending a client-local clone path to an independently owned External server;
+  that requires a future upload or remote-asset contract.
+- A generic redesign of every provider's voice profile options.
+- Claiming consent, speaker identity, provenance, authenticity, or forensic
+  erasure.
+
+## Product decisions
+
+### GM-DEC-001 — Two Managed setup sources
+
+Managed audio.cpp exposes exactly two setup sources:
+
+1. **Chatbook-guided setup** — structured global Settings generate the launch
+   artifact.
+2. **Existing server.json** — the user supplies the executable and JSON exactly
+   as in the current managed lifecycle.
+
+Existing users remain on their current source after upgrade. Switching sources
+preserves the dormant source's values so a user can switch back without
+re-entering paths. Save never rewrites a user-provided JSON file.
+
+### GM-DEC-002 — Server remains separately installed
+
+Chatbook detects `audiocpp_server` on `PATH` and reviewed platform install
+locations, and provides a file picker. It may show platform-specific
+installation guidance and official links. It does not invoke Homebrew, a
+system package manager, an installer, a compiler, or a download for the server.
+
+The executable is validated on Save without running it. Version and capability
+probing occur only during a deliberate Test/Start/replacement path.
+
+### GM-DEC-003 — Built-in exact recipes
+
+Guided setup recognizes packages through built-in declarative recipes. A recipe
+is immutable within a Chatbook release, cannot execute code, and is reviewed
+against an exact upstream release and package variant. Remote recipes and
+silent runtime updates are prohibited.
+
+Unknown packages are not rejected from audio.cpp generally. They remain usable
+through the existing user-provided JSON source.
+
+### GM-DEC-004 — One multi-model child
+
+All accepted guided models are projected into one generated `server.json` and
+one managed child. Top-level `lazy_load` is always true. audio.cpp registers all
+model IDs at startup, loads the selected model on first use, and retains loaded
+models until shutdown. Chatbook discloses that lazy loading is not unloading.
+
+### GM-DEC-005 — Generated configuration is ephemeral authority evidence
+
+Structured Settings are durable authority. A generated JSON file is an
+immutable, generation-scoped launch artifact. It is materialized only when a
+deliberate operation may launch or replace a child and is retained until that
+exact child and generation-local clients/tasks are definitively reaped.
+
+Chatbook never treats edits to that artifact as new settings and never
+revalidates its source files on every synthesis while the matching child is
+running.
+
+### GM-DEC-006 — Complete WAV first
+
+The native adapter keeps its asynchronous response interface but initially
+emits one complete bounded, structurally validated WAV. Upstream streaming
+support does not imply Chatbook streaming playback.
+
+### GM-DEC-007 — Cross-platform, tuple-scoped verification
+
+Generated setup targets macOS, Linux, and Windows. CPU is the baseline on each.
+CUDA, Metal, Vulkan, and HIP/ROCm are labeled Verified only for exact tuples
+covered by evidence. “Expected” and “Untested” are distinct from “Verified.”
+
+### GM-DEC-008 — Typed clone references
+
+Clone reference audio and transcript are typed profile data. They do not enter
+generic provider options, connection settings, generated JSON, or character
+cards. A transient first sample does not require profile creation; a successful
+result may be saved later using the exact canonical reference bytes that
+produced it.
+
+### GM-DEC-009 — Onboarding ends at audible value
+
+The primary onboarding user is new to audio.cpp package/configuration details,
+not necessarily new to local software. The “aha” moment is hearing their own
+valid sample, not completing a tour or reading every advanced setting.
+
+Guided setup therefore uses the real Settings → Speech Lab workflow with
+progressive disclosure and one next action. There is no separate tutorial mode,
+forced walkthrough, or package-install ceremony. Experienced users skip the
+guided path by retaining External or user-provided `server.json` setup.
+
+## Ownership and component architecture
+
+### GM-ARCH-001 — Owner matrix
+
+| Concern | Durable owner | Runtime owner |
+| --- | --- | --- |
+| Setup source, binary selection, models, backend preference, global defaults | Settings/config owner | TTS service projection |
+| Generated `server.json` | None; derived from structured settings | Managed generation/supervisor |
+| User-provided `server.json` | User-selected file | Existing managed generation/supervisor |
+| Recipe definitions | Installed Chatbook distribution | Recipe registry |
+| Local selected model bytes | User-selected/shared path | audio.cpp child |
+| Model Library downloads | Existing shared artifact store | Existing Model Library owner |
+| Applied child, endpoint, process health, diagnostics | None | App-owned supervisor/TTS service |
+| Studio provider/model/voice preferences | `speech_studio` namespace | Speech Lab |
+| Reusable voice selection/reference | TTS profile repository | Profile admission/materialization |
+| Current WAV and transient clone reference | None | Speech Lab current-result owner |
+| Character assignment | TTS profile repository | Character-aware request admission |
+
+No UI surface writes another owner's durable state. Settings says that edits
+are global and links to Speech Lab. Speech Lab may display effective global
+setup but cannot persist a second copy. A one-time setup preview intent never
+overwrites Studio preferences.
+
+### GM-ARCH-002 — Structured setup projection
+
+The durable guided setup is a bounded structured model, not arbitrary JSON. It
+contains:
+
+- setup source;
+- selected executable path or detected executable identity;
+- accepted recipe projections and their stable public model IDs;
+- default model ID;
+- backend preference (`auto` or one supported explicit backend);
+- optional device and thread controls admitted by the selected backend policy;
+- bounded request/body/busy limits owned by Chatbook; and
+- the existing lifecycle/synthesis safety limits.
+
+It does not persist a runtime port, live endpoint, process ID, loaded-model set,
+health, launch attempt, or Verified status. Those are observations or caches.
+
+### GM-ARCH-003 — App-owned generation artifact
+
+For each eligible launch, Chatbook writes one owner-private, immutable
+`server.json` under the active user-data area. Its identity includes the applied
+provider generation and launch attempt. The file uses atomic private creation,
+is opened without following a symlink, and is not placed in the installed
+package or current working directory.
+
+The child receives exactly:
+
+```text
+[resolved_audiocpp_server, "--config", generated_server_json]
+```
+
+There is no shell and no arbitrary argument field. The existing allowlisted
+non-credential environment boundary remains. The artifact and any attempt-
+local directory are removed only after the exact child, pipe drains, exit
+monitor, probes, HTTP clients, and generation cleanup are joined. Startup may
+clean a recognized leftover only after proving no live ownership lock exists;
+unknown files are left untouched.
+
+### GM-ARCH-004 — Recipe registry boundary
+
+The registry is a small, sealed collection of data records. It owns package
+recognition and safe projection, but not process launch, HTTP, downloads,
+profile storage, or UI state. A recipe cannot import Python, name a callback,
+invoke a converter, execute a hook, interpolate an environment variable, or
+add an unreviewed JSON/argv field.
+
+The registry provides pure operations for:
+
+- listing compatible recipe/package variants;
+- bounded matching of a pre-scanned package description;
+- validating one accepted normalized projection;
+- projecting allowlisted server model fields; and
+- mapping a recipe to reviewed Model Library artifact identifiers and source
+  links.
+
+### GM-ARCH-005 — Existing lifecycle authority remains
+
+The app owns one `AudioCppSupervisor`; the registry remains lease and transition
+authority; the native adapter remains HTTP/contract authority. Guided setup
+does not add a second process manager, synthesis quota, catalog store, or
+shutdown coordinator.
+
+The saved configuration generation, applied provider generation, process
+generation, and generated artifact identity remain distinct. Every client and
+result is fenced to the exact applied/process generation as already required by
+the managed-lifecycle design.
+
+The native catalog contract expands narrowly from upstream `task = "tts"` to
+the exact speech-task set `{"tts", "clone"}`. This is required for clone-only
+families such as `confucius4_tts`. ASR, VC, Music, and every other audio.cpp
+task remain excluded from the TTS adapter. The adapter cross-checks the
+server-reported task/model ID against the applied recipe projection and
+preserves typed text/clone capabilities in catalog evidence; the UI does not
+infer clone support from a family name.
+
+The provider-neutral request contract gains optional typed clone-reference
+input for native audio.cpp admission. The existing generic `options` mapping
+remains empty for audio.cpp profiles and is not used to smuggle `voice_ref` or
+`reference_text`.
+
+### GM-ARCH-006 — Windows ownership
+
+On Windows, Chatbook owns only the exact process handle it creates and the
+tasks/clients associated with that launch. It must use Windows-native
+creation, wait, terminate, and definitive handle-close behavior. It cannot
+claim ownership of arbitrary descendants or support builds that daemonize away
+from the owned handle.
+
+POSIX process-group behavior cannot be assumed to establish Windows safety.
+Cross-platform release evidence must prove the matching child cannot survive
+Chatbook's definitive shutdown path.
+
+## Persistent configuration and launch projection
+
+### GM-CFG-001 — Source selection and dormant values
+
+The active audio.cpp Managed source is explicit. Guided and user-JSON fields
+persist separately. Switching the selector changes only the active projection;
+it does not erase the inactive draft or copy fields between them.
+
+Existing configurations with a managed executable and JSON path continue to
+read as the user-JSON source without a migration write. The default for a new
+Managed setup is guided setup only after the user explicitly selects Managed.
+External remains a separate source and retains existing behavior.
+
+### GM-CFG-002 — Save remains side-effect free
+
+Save performs bounded local validation, persists atomically, and publishes the
+new saved generation. It does not:
+
+- run the executable or query its version;
+- choose or bind a runtime port;
+- materialize the launch artifact;
+- contact loopback or any remote origin;
+- launch, restart, stop, or adopt a process;
+- refresh catalog/voice data; or
+- synthesize hidden audio.
+
+A successful guided Save reports `Configuration saved — ready to test`. It
+does not report Running, Connected, Ready, or Verified.
+
+### GM-CFG-003 — Safe generated top-level fields
+
+Generated JSON always writes:
+
+- `host: "127.0.0.1"`;
+- one launch-selected bounded loopback `port`;
+- the resolved backend and validated device/thread projection;
+- `lazy_load: true`;
+- `log_request_body: false`;
+- bounded request-body and busy-timeout policy; and
+- the exact accepted `models` list.
+
+Generated setup never writes `cors_origins`, never enables request-body logs,
+and never accepts an arbitrary top-level extension. New upstream fields require
+a recipe/schema review and a design amendment if they widen trust or privacy.
+
+### GM-CFG-004 — Safe model fields
+
+Each generated model entry has a stable public ID and an allowlisted projection
+from its accepted recipe. The maximum initial field set is:
+
+- `id`;
+- `family`;
+- absolute `path`;
+- recipe-declared speech `task` (`tts` or `clone` as required by the exact
+  upstream family/session contract);
+- supported `mode` (`offline` initially unless a future Chatbook streaming
+  design explicitly admits another mode);
+- optional reviewed absolute `model_spec_override`;
+- optional bounded model `busy_timeout_ms`;
+- optional recipe-declared `load_options`; and
+- optional recipe-declared `session_options`.
+
+Recipe projections cannot place a clone reference or transcript in
+`default_voice_preset`/`voice_presets`. Clone material remains request-scoped.
+Arbitrary user JSON belongs in the existing user-provided source.
+
+### GM-CFG-005 — Absolute paths and model specs
+
+Generated model paths are absolute. The registry uses embedded package specs
+when the exact package supports them. Otherwise it supplies a reviewed,
+installed-distribution model-spec path or a validated user-selected override.
+It never depends accidentally on the app's current working directory.
+
+The generated child uses a deterministic working directory appropriate to the
+installed distribution and selected binary. The existing user-JSON source
+keeps its JSON-parent working-directory semantics because relative paths there
+belong to the user's file.
+
+### GM-CFG-006 — Port and endpoint
+
+Guided setup persists no fixed port. At each new launch Chatbook selects an
+available port from a finite loopback-only range, records it in the immutable
+artifact, and treats the child bind/result as authoritative. Port preflight is
+advisory because another process may race it.
+
+The runtime endpoint is a generation-bound observation and may be cached by
+executable identity for diagnostics, but it is never a global default. The
+user-JSON source retains its existing explicit-port, occupied-port-fails-closed
+behavior.
+
+### GM-CFG-007 — Accepted projection snapshot
+
+When the user accepts a matched package, Chatbook persists the normalized
+recipe ID/version, public model ID, canonical package root identity, selected
+variant, and safe projected values needed to reproduce the setup. A later
+Chatbook recipe update cannot silently reinterpret that record.
+
+If the installed recipe changes meaning, is withdrawn, or no longer accepts
+the saved projection, Settings shows `Review required`. The user reviews an
+explicit diff before a new projection becomes saved authority. An actively
+running child keeps its immutable applied projection until explicit
+replacement.
+
+## Binary, version, and compute selection
+
+### GM-BIN-001 — Detection
+
+Detection checks only reviewed candidates:
+
+- the executable already configured by the user;
+- `audiocpp_server` resolved through the application's sanitized `PATH` view;
+- known Homebrew locations on macOS; and
+- reviewed conventional install locations for supported Windows/Linux
+  distributions.
+
+Detection reports candidates; it does not execute them, recursively search the
+machine, rewrite `PATH`, or select an ambiguous candidate silently. Manual
+browse always remains available.
+
+### GM-BIN-002 — Version evidence
+
+A deliberate Test/Start may obtain a bounded version/build observation through
+an exact reviewed mechanism. `release-0.5.1` at the pinned commit is the first
+Verified baseline. A recognized incompatible version fails with a stable
+message. An unknown version may continue to Test after a warning, but its
+recipes display `Untested` and cannot inherit Verified platform/backend labels.
+
+Version output, executable paths, environment, and raw child errors remain out
+of general logs and public exception messages.
+
+### GM-BACKEND-001 — Auto and Advanced override
+
+The default is `Auto`. Candidate order derives from operating system,
+architecture, detected build/backend capabilities, and exact recipe evidence.
+The UI summarizes the resolved choice before launch. Advanced settings permit
+an explicit supported backend and validated device/thread values.
+
+The selection result is launch evidence, not durable host truth. A binary
+replacement or materially different build invalidates its cached observation.
+
+### GM-BACKEND-002 — Bounded fallback
+
+Automatic fallback is allowed only when:
+
+1. backend is `Auto`;
+2. the failure maps to a stable allowlisted backend-unavailable code;
+3. the exact failed child, clients, tasks, and generated artifact are reaped;
+4. the next candidate has recipe/platform evidence; and
+5. the UI records the attempted and selected backends without raw private
+   diagnostics.
+
+All other failures stop. The user receives explicit recovery, including
+`Try CPU`, rather than an unbounded backend cascade.
+
+## Recipe registry
+
+### GM-RECIPE-001 — Recipe identity
+
+A recipe identifies one exact package variant/revision, not merely a model
+family. Its stable identity includes:
+
+- recipe schema version and immutable recipe ID;
+- audio.cpp release/commit range;
+- family and package variant;
+- declared capabilities (`tts`, `clone`, design/control where relevant);
+- exact bounded metadata and layout signals;
+- required and optional relative assets;
+- allowed server projection and option domains;
+- voice/reference requirements;
+- compatible platform/backend evidence;
+- reviewed Model Library artifact IDs and static source links; and
+- recipe verification status and evidence reference.
+
+Recipe declarations cannot contain an absolute path, `..` traversal, a symlink
+requirement, executable path, shell text, environment expansion, credential, or
+arbitrary JSON fragment.
+
+### GM-RECIPE-002 — Exact match classes
+
+Matching produces one of:
+
+- **Exact** — one recipe variant satisfies every required signal.
+- **Ambiguous** — multiple variants remain possible; no variant is selected.
+- **Unknown** — no recipe matches; guided setup cannot add it.
+- **Incomplete** — a candidate variant is recognizable but required assets are
+  missing or the scan was bounded/cancelled before proof.
+- **Permission limited** — exact required evidence could not be inspected.
+
+There is no fuzzy “closest” selection. Ambiguous and unknown packages can use
+the manual `server.json` source.
+
+### GM-RECIPE-003 — Compatibility states
+
+The UI keeps three dimensions separate:
+
+1. **File readiness** — required package files are present and currently
+   readable within scan bounds.
+2. **Recipe evidence** — exact recipe/version/platform/backend classification.
+3. **Runtime evidence** — this applied child successfully exposed the model and
+   completed the relevant contract/sample.
+
+Valid labels include `Verified`, `Expected`, `Untested`, `Review required`,
+`Backend unsupported`, `Files missing`, and `Runtime failed`. A green runtime
+result cannot rewrite the persisted recipe identity; a recipe match cannot
+claim the model actually loaded.
+
+### GM-RECIPE-004 — Complete release accounting
+
+The registry carries an auditable matrix for all 21 pinned families and every
+declared package variant. Each entry is Approved, Explicitly unsupported with a
+reviewed reason, or an Open gap. The program is not complete while an Open gap
+exists or while an Explicitly unsupported entry contradicts the accepted goal
+without renewed user approval.
+
+Incremental releases publish the precise Approved subset in user-facing docs
+and tests. “Supports audio.cpp models” is prohibited as a blanket claim before
+the matrix is complete.
+
+### GM-RECIPE-005 — Withdrawal and upgrades
+
+A later Chatbook release may withdraw an unsafe recipe. A withdrawn saved model
+is visible but cannot start a new child until reviewed or moved to manual JSON.
+An already running child is not killed by passive recipe loading; the next
+explicit lifecycle action applies the safe policy.
+
+Recipe upgrades show a field-level safe projection diff. Accepting the update
+preserves the stable public model ID when the exact package identity is the
+same. It never changes the global default model, profile assignments, or Studio
+preferences silently.
+
+## Local package scanner and Model Library
+
+### GM-SCAN-001 — Explicit roots only
+
+The scanner examines only a root selected by the user for the current action or
+an exact package root returned by Model Library. It does not crawl a home
+directory, mounted volume, model cache, or arbitrary parent automatically.
+
+A top-level selected symlink may be resolved after clear disclosure. Its
+canonical target becomes the accepted root identity. Nested symlinks,
+junctions, reparse points, devices, sockets, and aliases are not traversed. A
+later top-level symlink retarget is a `Review required` change, not the same
+package.
+
+### GM-SCAN-002 — Bounded and responsive work
+
+Scanning runs in a cancellable worker outside the Textual event loop. The
+implementation defines finite, tested limits for:
+
+- directory depth;
+- visited entries;
+- candidate package roots;
+- bytes of metadata read per file and in aggregate;
+- individual and total scan time; and
+- retained unknown/error detail.
+
+Reaching any limit returns an explicit partial/incomplete result. It never
+silently treats an unvisited tree as absent. Cancellation stops publication and
+late results are fenced by root/draft revision.
+
+### GM-SCAN-003 — Recognition and deduplication
+
+The scanner reads only allowlisted relative files and bounded metadata needed by
+candidate recipes. It does not load model weights into a native runtime or hash
+multi-gigabyte packages during ordinary discovery.
+
+Candidate identity is at least:
+
+```text
+(canonical_root, recipe_variant, configuration_identity, weight_identity)
+```
+
+It is not root alone. Multi-file shards and required companion assets must be
+complete. Two valid variants in one root remain distinct; repeated discovery of
+the same exact identity is deduplicated.
+
+A durable internal UUID is allocated only after the user accepts a candidate.
+The public model ID is stable and separately validated for audio.cpp. Moving an
+accepted package through the explicit relocation flow preserves both IDs after
+the new exact identity is reviewed.
+
+### GM-SCAN-004 — Validation points
+
+Package evidence is checked:
+
+1. during scan;
+2. again at Add/Save against the accepted draft; and
+3. immediately before a deliberate new launch or replacement artifact is
+   published.
+
+A running child retains its immutable launch snapshot even if source files are
+later moved, deleted, or edited. The next replacement fails safely and explains
+which model needs attention. Ordinary synthesis against the running child does
+not repeatedly reopen every source file.
+
+### GM-SCAN-005 — Error and privacy presentation
+
+Permission failures and incomplete candidates are isolated per root/candidate.
+The primary result is a bounded summary. Unknown entries are collapsed behind
+an expandable, capped list. General logs and stable errors use recipe IDs,
+counts, and safe basenames where needed; they do not emit complete model paths,
+file contents, metadata payloads, or raw OS exceptions.
+
+### GM-LIB-001 — Curated installs
+
+Model Library shows only artifacts whose IDs are reviewed in a compatible
+recipe. An install is an explicit user action through the existing shared
+artifact owner. The setup screen never starts a download on mount, scan, save,
+or Test.
+
+On success, Model Library returns the exact installed package root and artifact
+identity to the preserved Settings draft. The draft remains unsaved until the
+user reviews it. Install does not select a default, start audio.cpp, create a
+profile, or change Studio preferences.
+
+### GM-LIB-002 — Removal dependencies
+
+Before removal, Chatbook shows dependencies from:
+
+- guided global audio.cpp setup;
+- the global default model/profile;
+- reusable TTS profiles, including references whose recipes require that
+  package;
+- character assignments reachable through those profiles; and
+- any other existing Model Library lease/owner.
+
+Removal requires explicit resolution. Chatbook does not silently retarget
+profiles, switch the global default, or delete clone references. A running child
+may retain already-open model state until shutdown, but later use/restart must
+report the missing package truthfully.
+
+## Lifecycle and generation semantics
+
+### GM-LIFE-001 — Deliberate apply boundaries
+
+When there is no live child, the latest valid guided settings may become
+applied on:
+
+- explicit Start/Test;
+- explicit catalog Refresh that requires a server;
+- first user-requested Speech Lab synthesis; or
+- lazy Console/Roleplay synthesis.
+
+Passive Settings mount, Speech Lab mount, status rendering, profile browsing,
+recipe loading, package scan, Save, and Model Library listing never launch or
+contact audio.cpp.
+
+### GM-LIFE-002 — Running child and staged settings
+
+When a child is Running and saved settings advance:
+
+- the active child, endpoint, adapter clients, catalog, and loaded models stay
+  bound to the applied generation;
+- ordinary Test, Refresh, and synthesis remain on that applied generation;
+- the UI shows the saved/applied diff and `Restart & Apply Settings`;
+- only the explicit replacement transition drains leases, stops/reaps the
+  exact child, generates the new artifact, and promotes the newest eligible
+  saved generation; and
+- a failed replacement does not relaunch an older staged projection silently.
+
+This preserves the current managed-lifecycle contract. “Test” cannot become a
+hidden restart merely because a newer configuration is saved.
+
+### GM-LIFE-003 — Launch transaction
+
+One launch attempt performs, in order:
+
+1. capture the eligible saved projection under the existing publication/
+   transition fence;
+2. revalidate the executable and accepted package projections;
+3. resolve backend and select a bounded loopback port;
+4. atomically materialize the immutable private artifact;
+5. launch one direct child with the existing sanitized environment;
+6. publish Starting without exposing an unverified endpoint;
+7. require process liveness, `/health`, `/v1/models`, expected model IDs, and
+   adapter contract evidence;
+8. publish Running/capability/catalog only for the exact process generation;
+   and
+9. retain all generation resources until exit/replacement/shutdown cleanup is
+   definitive.
+
+Any failure before Running invalidates the endpoint/evidence immediately,
+terminates only the exact child, joins all owned resources, removes only its
+exact artifact, and returns a stable safe failure. An eligible backend fallback
+starts a new launch attempt only after that rollback completes.
+
+### GM-LIFE-004 — Runtime revalidation
+
+A health failure invalidates catalog/voice/runtime evidence for the process
+generation. A later Test, Refresh, or synthesis revalidates the adapter contract
+before relying on it. A temporary recovery of the health probe alone does not
+make old catalog evidence fresh.
+
+Unexpected exit invalidates the endpoint and generation-bound evidence before
+potentially slow output/client cleanup. The first later deliberate operation
+uses the newest eligible saved settings. It cannot resurrect an older applied
+artifact merely because cleanup was still finishing.
+
+### GM-LIFE-005 — Definitive shutdown
+
+Restart, source switch, and shutdown reuse the registry's exclusive transition
+and drain admitted leases. Already admitted work may complete against its exact
+generation; new work is rejected. Application close seals new service and
+lifecycle admission, applies one outer shutdown deadline to any already-running
+startup/stop transition, and retains definitive joining until every owned child,
+handle, client, monitor, probe, drain, artifact lease, and lifecycle task
+reaches zero ownership.
+
+The foreground close budget may expire, but `wait_closed()` cannot claim
+terminal ownership completion while retained work remains.
+
+## Clone-reference profile model
+
+### GM-VOICE-001 — Profile schema v3
+
+The TTS profile repository advances from schema v2 to v3. The existing profile
+row remains the reusable provider/model/voice selection owner. A new
+one-to-one reference row, keyed by profile UUID with cascade delete, contains:
+
+| Field | Contract |
+| --- | --- |
+| `reference_id` | Immutable UUID, distinct from profile UUID |
+| `profile_id` | Unique foreign key to the profile |
+| `wav_bytes` | Canonical bounded WAV BLOB |
+| `reference_text` | Bounded non-empty transcript when required |
+| `sha256` | Digest of canonical WAV bytes |
+| `byte_length` | Canonical byte length |
+| `duration_ms` | Validated duration |
+| `sample_rate_hz` | Validated canonical rate |
+| `channels` | Validated canonical channel count |
+| `sample_encoding` | Canonical encoding identifier |
+| timestamps | Created/updated UTC metadata |
+
+The repository enforces one reference per profile, hard per-reference size and
+duration limits, hard total stored-byte/reference-count quotas, bounded
+transcript length, and recipe-specific narrower limits. Quotas are checked
+inside the mutation transaction.
+
+### GM-VOICE-002 — Canonical ingest
+
+Reference ingest accepts a regular user-selected WAV only. It uses no persisted
+source path. A bounded decoder validates supported RIFF/WAVE chunks, sample
+format, channels, rate, duration, and size; rejects malformed, compressed, or
+unsupported input; strips arbitrary metadata and unknown chunks; and writes one
+canonical WAV representation.
+
+Digest and metadata are computed from the canonical bytes. The source is
+rechecked before commit so a changed file cannot be represented by earlier
+validation. BLOB reads/writes are streamed or incrementally copied; list and
+normal profile-open paths load summaries only.
+
+### GM-VOICE-003 — Typed capability combinations
+
+An audio.cpp profile may hold:
+
+- an exact native `voice_id` only;
+- one clone reference only; or
+- both only if the exact recipe explicitly supports and defines their
+  precedence/combination.
+
+A recipe that requires a reference cannot be used without one. A text-only
+recipe cannot acquire a reference merely because the server accepts generic
+fields. Clone support never reopens arbitrary `options` on audio.cpp profiles.
+
+Reference-bearing execution initially requires the exact accepted guided
+Managed recipe and the app-owned local child. An External server or an
+unclassified user-provided JSON model may still use text and exact native voice
+IDs, but Chatbook does not send it a client-local materialization path. A stored
+reference remains visible and inactive with a recovery explanation when the
+applied source cannot safely consume it.
+
+### GM-VOICE-004 — Immutable admission
+
+Admission freezes:
+
+- profile UUID and revision;
+- provider/model/voice selection;
+- accepted recipe projection/version;
+- reference UUID and digest;
+- bounded transcript; and
+- applied provider/process generation.
+
+The materializer reads and fully validates the exact reference under the
+repository generation/revision fence, creates an opaque private per-session
+WAV path, and passes typed `voice_ref` and `reference_text` to the native
+request. It never puts them in `server.json`, voice presets, generic options,
+catalog state, or public artifact provenance.
+
+An edit/delete admitted after this capture affects future work. Already
+admitted speech may consume the exact captured reference until response close,
+after which the session materialization is removed.
+
+### GM-VOICE-005 — Session materialization
+
+Each materialization lives in an owner-private directory under the active
+user-data/runtime area and has an ownership lock tied to application session
+and operation identity. Files use opaque names and owner-only access. Normal
+completion, cancellation, provider failure, replacement, and app shutdown
+remove the exact directory after the adapter can no longer read it.
+
+Startup cleanup handles only directories with a recognized format and removes
+one only after it proves no live owner holds the lock. It does not delete an
+unknown directory, use age alone as proof, or follow a symlink/reparse point.
+
+### GM-VOICE-006 — Transient audition
+
+Speech Lab may stage one canonical reference for the current clone draft
+without creating a profile. The staged artifact is bounded, private, and owned
+by the current result workflow. It is deleted when replaced, discarded, or the
+app closes.
+
+After a successful result, `Save as Voice Profile` persists the exact canonical
+bytes and transcript used by that successful request. It does not reopen the
+original file. A failed generation does not offer to save an unproven reference
+as though it generated successfully, although the user may return to setup and
+correct it.
+
+### GM-VOICE-007 — Privacy statement
+
+The profile database, BLOB, pre-migration backup, backup/restore output, and
+temporary materializations are local private data. On POSIX they use ADR-029's
+owner-only boundary. Windows displays its actual separately implemented ACL
+posture and never translates POSIX-mode assumptions into a privacy claim.
+
+The product says plainly:
+
+- reference audio and transcript are stored locally in plaintext;
+- local filesystem controls are not encryption;
+- exports/backups contain sensitive audio when explicitly requested; and
+- deletion is best effort, not guaranteed forensic erasure across SQLite
+  journals, copy-on-write storage, backups, or physical media.
+
+### GM-VOICE-008 — Migration and downgrade
+
+Migration is eager on the schema-owning repository path:
+
+1. acquire the existing exclusive repository lifecycle boundary;
+2. validate the v2 source;
+3. create and retain an owner-private SQLite online backup of v2;
+4. migrate transactionally to v3;
+5. validate schema, foreign keys, integrity, and domain equivalence; and
+6. publish v3 only after success.
+
+Every existing v2 profile remains logically equivalent and has no reference
+row. A failure leaves v2 usable or the repository explicitly unavailable; no
+partial v3 store is published or silently recreated.
+
+An older build must refuse v3. Downgrade requires closing the new build,
+restoring the dedicated v2 backup, and then launching the old build. Changes
+made after migration are lost. Switching to manual `server.json` or disabling
+clone UI in the current build is a feature rollback, not a database downgrade.
+
+### GM-VOICE-009 — Backup, restore, and damage isolation
+
+Existing repository-owned SQLite online backup includes reference BLOBs and
+reports bounded progress/deadline/quota outcomes. Restore validates the full
+candidate, including reference digests/WAV structure and aggregate quotas,
+before replacement.
+
+Normal open remains metadata-oriented and does not read every BLOB. Full
+reference verification occurs on import, restore, backup qualification,
+reference edit, and exact admission. If a damaged reference row/BLOB can be
+isolated safely, that profile becomes unavailable while unrelated profiles
+remain usable. Structural database corruption or ambiguous integrity failure
+keeps the repository unavailable.
+
+## Portability
+
+### GM-PORT-001 — Ordinary sanitized portability
+
+Profiles without a reference retain the existing wire version 1. An ordinary
+export of a reference-bearing profile uses wire version 2 and contains only the
+sanitized profile selection plus an explicit `reference omitted` marker. It
+contains no WAV bytes, transcript, digest usable as a local path oracle,
+temporary path, assignment, endpoint, or generated configuration.
+
+An older reader skips the unsupported version. Importing wire v2 never creates
+or assigns a broken profile silently. The user chooses to attach a local WAV,
+import a separate bundle, or skip the attachment.
+
+### GM-PORT-002 — Explicit voice bundle
+
+The explicit portable container is a versioned ZIP, separate from character
+cards and ordinary profile export. Its allowlisted entries are exactly:
+
+```text
+manifest.json
+profile.json
+reference.wav
+reference.txt
+```
+
+The manifest carries the bundle schema, bounded metadata, entry sizes,
+canonical SHA-256 checksums, and generic user-declared provenance/consent note.
+The profile is the sanitized selection, not a database row. The archive has no
+model weights, character/persona data, assignments, app default, credentials,
+origins, paths, recipe code, process state, or timestamps not needed by the
+format.
+
+### GM-PORT-003 — Hostile archive admission
+
+Before extracting or storing, import rejects:
+
+- encrypted entries;
+- duplicate names and case/Unicode-normalization collisions;
+- absolute paths, traversal, separators outside the exact names, symlinks,
+  devices, or other special entries;
+- unknown/missing entries;
+- unsupported compression methods;
+- per-entry, aggregate compressed/uncompressed, ratio, count, transcript, and
+  manifest limits;
+- malformed JSON/text/WAV;
+- source archive changes during admission; and
+- checksum mismatch.
+
+Extraction uses an owner-private staging directory and never trusts archive
+paths. Checksums prove byte integrity only; the UI never labels them signature,
+authenticity, speaker identity, or consent proof.
+
+### GM-PORT-004 — Explicit import result
+
+Import shows exact profile UUID/name/model collisions and requires a user
+choice. It never overwrites, assigns to a character, changes app default, or
+retargets to another model automatically.
+
+If the bundle is structurally valid but its exact compatible recipe/model is
+absent, Chatbook may store it as inactive `Needs compatible model`. Runtime
+admission stays blocked until that exact dependency is installed and reviewed.
+
+## Global Settings UX
+
+### GM-UX-001 — Scope and information architecture
+
+Settings → Speech & TTS clearly states:
+
+> You are editing global TTS setup and defaults. Speech Lab has testing,
+> generation, playback, and Studio-only preferences.
+
+It links directly to Speech Lab. Guided setup does not mount inside Studio and
+never writes `speech_studio` preferences.
+
+The audio.cpp provider detail uses this order:
+
+1. setup source and External/Managed ownership;
+2. server executable detection/browse and version posture;
+3. configured model packages and default model;
+4. compute summary with Advanced override;
+5. validation/save summary; and
+6. one state-specific handoff to Speech Lab.
+
+Advanced lifecycle/safety fields remain discoverable without dominating the
+first-time path. Validation expands the containing disclosure and focuses the
+first invalid field.
+
+### GM-UX-002 — Model package list
+
+Each model row shows:
+
+- display name and stable public model ID;
+- family/package variant and capabilities;
+- local or Model Library ownership;
+- file readiness;
+- recipe evidence, including exact release/backend posture;
+- reference/voice requirement;
+- dependency count when relevant; and
+- runtime evidence for the matching applied generation, if any.
+
+The row does not collapse these into one colored dot. Text labels, symbols, and
+accessible descriptions communicate status without color alone. Unknown items
+appear in a bounded collapsed summary rather than flooding the screen.
+
+### GM-UX-003 — Add, scan, install, and review
+
+`Add local package` opens a picker, scans only the selected root, and returns
+exact/ambiguous/unknown/incomplete results. `Browse Model Library` opens the
+curated compatible subset; a completed install returns to the preserved draft
+with the package ready for review.
+
+Adding a matched package does not Save automatically. The user reviews the
+model ID, capabilities, backend posture, and any voice/reference requirements.
+Default-model selection is part of the same review.
+
+A non-destructive global provider/model change uses an inline before/after
+summary; Save itself is the confirmation. A modal is reserved for destructive
+dependency resolution, such as removing a package used by profiles.
+
+### GM-UX-004 — Saved, applied, and active truth
+
+Settings and Speech Lab distinguish:
+
+- current draft;
+- latest durably saved configuration generation;
+- applied provider generation;
+- active process generation and endpoint;
+- recipe/file evidence;
+- catalog/model evidence; and
+- most recent sample result.
+
+`Saved` never means `Applied`; `Applied` never means `Running`; `Running` never
+means a specific model loaded; a recipe match never means runtime success.
+
+### GM-UX-005 — Save outcome and handoff
+
+A successful Save says `Configuration saved — ready to test`. The guided CTA is
+`Open Speech Lab & Hear a Sample`. It carries a one-time setup-preview intent
+containing the saved provider/default-model identity and expected action. It
+does not persist Studio preferences or overwrite an existing Studio draft.
+
+If a live child uses older settings, the handoff says that the active
+configuration remains unchanged and focuses Speech Lab's dynamic primary
+action, not a generic Refresh control.
+
+## Speech Lab UX
+
+### GM-UX-010 — One immutable action projection
+
+One pure projection derives the visible label, operation, enabled state,
+disabled reason, tooltip, progress label, and post-operation focus target from
+the same immutable observation. The click handler executes that projected
+operation rather than recomputing from stale hidden state.
+
+Representative primary actions are:
+
+| State | Primary action |
+| --- | --- |
+| Guided setup saved, stopped, text-ready | `Start & Generate Sample` |
+| Guided setup saved, stopped, reference required | `Start & Set Up Voice` |
+| Live child, newer saved generation | `Restart & Apply Settings` |
+| Compatible server, missing clone reference | `Create Voice & Generate` |
+| Prior sample failed, server still healthy | `Retry Sample` |
+| Runtime observation unknown | `Test Connection` |
+
+Shutdown remains secondary. A state whose primary is Restart does not also show
+an enabled duplicate Restart in the runtime card.
+
+### GM-UX-011 — Provider switching and stale results
+
+The user may switch providers while lifecycle, catalog, voice, or generation
+work runs. Late results carry provider, saved/applied/process, draft, and
+operation revisions. They may update their retained owner but cannot disable,
+relabel, or execute an action for the newly selected provider.
+
+When audio.cpp is hidden and shown again, the pane clears or atomically renders
+its cached observation before accepting a click. A visible `Test Connection`
+can never execute a hidden stale Restart/Shutdown projection.
+
+### GM-UX-012 — Clone setup flow
+
+For a reference-required recipe, deliberate Start/Test first establishes the
+server and matching catalog. Speech Lab then pauses at a voice setup step with:
+
+- choose reference WAV;
+- enter/confirm bounded transcript;
+- local plaintext/privacy notice;
+- exact recipe guidance and validation;
+- `Create Voice & Generate`; and
+- an option to use an existing compatible Voice Profile.
+
+The user can audition without naming or saving a profile. After successful
+playback, the result offers `Save as Voice Profile`. Saving opens a concise
+profile name/assignment review and uses the exact successful reference
+artifact.
+
+### GM-UX-013 — Current result
+
+The current complete-WAV result is visually primary and includes:
+
+- Play/Pause;
+- duration and playback/generation status;
+- exact captured provider/model/voice-or-reference-safe provenance;
+- applied/process generation identity expressed without private paths;
+- `Generate again`;
+- `Save WAV as…`; and
+- `Save as Voice Profile` when the captured typed selection is eligible.
+
+Autoplay follows only the existing optional Studio autoplay preference. Setup
+does not silently enable it. A new result replaces the old current result only
+after successful validation; a failed retry does not erase the last playable
+WAV.
+
+### GM-UX-014 — Diagnostics and accessibility
+
+Diagnostics remain bounded, memory-only, sanitized, expandable, focusable, and
+keyboard-scrollable. The diagnostics viewport has a visible focus state and no
+nested scroll trap. Copy copies only the bounded sanitized projection.
+
+Every disabled action has a current reason. In-progress Test/Start/Restart/
+Generate states update labels and tooltips together. On a passive observation
+failure, controls leave their busy state and expose a safe Test/Retry path whose
+visible label matches its actual operation.
+
+The complete guided flow is keyboard-operable at supported narrow terminal
+sizes. Live regions announce scan, validation, lifecycle, generation, playback,
+and save outcomes without announcing every progress tick. Focus returns to a
+stable relevant control after dialogs and cancellation.
+
+## User journeys
+
+### Journey 1 — First-time text-ready package
+
+1. User installs Chatbook and installs `audiocpp_server` separately.
+2. In Settings → Speech & TTS, they select audio.cpp → Managed → Guided setup.
+3. Chatbook detects the executable or the user browses to it.
+4. User selects a supported local package or explicitly installs one from
+   Model Library.
+5. The bounded scanner finds one exact recipe; the user reviews the package,
+   model ID, backend summary, and default model.
+6. Save validates and persists without launching or contacting audio.cpp.
+7. Settings says `Configuration saved — ready to test` and opens Speech Lab.
+8. Speech Lab projects `Start & Generate Sample`.
+9. The deliberate action generates the immutable launch artifact, starts one
+   child, verifies catalog/model evidence, requests one sample, validates a WAV,
+   and presents Play.
+10. User hears the sample. The child remains available and the loaded model may
+    remain resident until Shutdown/app exit.
+
+### Journey 2 — First-time clone-required package
+
+1. Steps 1–7 above apply.
+2. Speech Lab projects `Start & Set Up Voice`.
+3. Start verifies the server and catalog without generating hidden audio.
+4. User chooses a bounded WAV and transcript; Chatbook canonicalizes a transient
+   private reference.
+5. `Create Voice & Generate` materializes the exact typed request reference,
+   generates and validates a WAV, cleans the session path, and presents Play.
+6. User hears the result and optionally saves the exact successful reference as
+   a reusable Voice Profile and assigns it to a character.
+
+### Journey 3 — Multiple models and lazy use
+
+1. User accepts several compatible packages in guided Settings and chooses one
+   global default.
+2. One generated config registers them all with `lazy_load: true`.
+3. Startup does not load every model.
+4. First synthesis for a selected model loads it; later requests reuse its
+   session.
+5. Selecting another configured model loads it in the same child.
+6. UI explains that both may remain in memory until shutdown; Chatbook does not
+   claim to unload them.
+
+### Journey 4 — Save while running
+
+1. Applied generation A is Running.
+2. User changes model/backend setup and saves generation B.
+3. A continues serving ordinary Test/Refresh/synthesis; no files are re-read for
+   each request.
+4. Settings and Speech Lab show saved B versus applied A.
+5. `Restart & Apply Settings` drains A, definitively reaps it and its artifact,
+   validates B, generates B's artifact, and launches B.
+6. Failure leaves runtime truthfully unavailable or on the still-valid outcome
+   defined before mutation; it never silently relaunches A or claims B applied.
+
+### Journey 5 — Unknown package or version
+
+1. Scanner cannot identify a package exactly, or the server build is unknown.
+2. Guided setup shows `Unknown`/`Untested` with the missing evidence and does
+   not guess.
+3. User may choose another reviewed package, follow a static official link, or
+   switch to the existing user-provided `server.json` source.
+4. An unknown server version may Test after warning, but the result cannot
+   inherit Verified recipe/platform/backend status.
+
+### Journey 6 — Model Library round trip
+
+1. User opens Model Library from the preserved guided Settings draft.
+2. Library shows only reviewed recipe artifacts compatible with the pinned
+   support surface.
+3. User explicitly installs one package into the shared store.
+4. Library returns the exact installed root/identity to the draft.
+5. User reviews and Saves; neither install nor return launches audio.cpp or
+   changes Studio/global default implicitly.
+
+### Journey 7 — Export and import a clone voice
+
+1. User explicitly exports a Voice Profile as a voice bundle.
+2. Chatbook warns that the archive contains plaintext reference audio and
+   transcript and records only a generic user declaration, not proof of consent.
+3. On another installation, import validates the hostile archive and exact
+   checksums before displaying the sanitized profile.
+4. A UUID/name collision and model dependency are reviewed explicitly.
+5. Import creates an unassigned profile or inactive `Needs compatible model`;
+   it never changes a character assignment or app default.
+
+### Journey 8 — Console/Roleplay lazy first use
+
+1. Valid guided setup is saved, but no child has run this session.
+2. A user explicitly invokes Speak in Console/Roleplay.
+3. Admission captures exact global or character profile selection.
+4. The one shared startup applies the latest eligible saved setup, and speech
+   waits on that retained startup.
+5. Complete WAV generation succeeds or returns a stable recovery action. No
+   passive character/profile browsing launches a child.
+
+## Error, privacy, and recovery contract
+
+### GM-ERR-001 — Stable phases
+
+Public failures identify a stable phase and safe recovery:
+
+- executable missing/not executable/unsupported build;
+- package missing/changed/incomplete/ambiguous/unknown;
+- recipe withdrawn/review required/backend unsupported;
+- generated configuration invalid;
+- loopback port/bind/startup/contract failure;
+- process exited/unhealthy/stopping/reconfiguring;
+- model absent/load failed/server busy;
+- reference invalid/quota exceeded/transcript required;
+- clone request unsupported/generation failed;
+- WAV invalid/too large;
+- profile store/migration/reference unavailable; and
+- bundle malformed/unsafe/integrity failed/dependency missing.
+
+Raw child, HTTP, OS, archive, SQLite, native decoder, or hook exception strings
+never cross the public boundary or remain reachable through chained exception
+context. Safe errors contain no full executable/model/reference/config/temp
+path, transcript, prompt, audio bytes, credential, or environment value.
+
+### GM-ERR-002 — Phase-local recovery
+
+Recovery preserves work that is still valid:
+
+- scan failure keeps the Settings draft;
+- Save validation failure expands/focuses the exact field or model row;
+- server startup failure leaves no child or artifact;
+- voice setup failure keeps a healthy server running;
+- generation/reference failure keeps the last valid playable WAV;
+- playback failure does not restart the server or regenerate;
+- profile save failure keeps the transient successful result/reference until
+  the user retries or discards it; and
+- bundle import failure commits no profile/reference/assignment.
+
+No failure silently falls back to another provider, model, voice, package,
+reference, or backend except the narrowly admitted Auto backend fallback.
+
+### GM-ERR-003 — Diagnostic containment
+
+General/persistent logs remain metadata-only. Managed child stdout/stderr stay
+in the existing bounded in-memory sanitized ring. For clone operations,
+diagnostic suppression/redaction covers:
+
+- reference/transcript request fields;
+- temporary materialization paths;
+- original source paths;
+- HTTP debug request bodies;
+- subprocess/debug-loop command lines containing private configured paths; and
+- nested exception graphs.
+
+The UI warns that native child output is only best-effort sanitized and should
+be reviewed before copying. Generated setup forcibly disables audio.cpp
+request-body logging.
+
+## Testing strategy
+
+### GM-TEST-001 — Pure configuration and recipe tests
+
+- Guided/manual source round trips and dormant-value preservation.
+- Side-effect-free Save guards: no subprocess, socket, HTTP, artifact, restart,
+  stop, or catalog call.
+- Strict generated JSON golden/projection tests with forbidden-field mutation
+  guards.
+- Every recipe declaration validates traversal, field allowlists, assets,
+  option domains, evidence, and package identity.
+- Exact/ambiguous/unknown/incomplete matching matrices for all declared package
+  variants.
+- A generated compatibility-accounting test fails on an unclassified pinned
+  family/package gap.
+
+### GM-TEST-002 — Scanner and Model Library tests
+
+- Depth/entry/candidate/metadata/time limits and explicit partial results.
+- Cancellation and stale draft/root result rejection.
+- Top-level symlink disclosure/retarget review; nested symlink, junction,
+  reparse, device, and traversal rejection on each OS.
+- Shard completeness, variant dedupe, relocation identity, permission isolation,
+  and unknown-result caps.
+- Model Library artifact filtering, explicit install, exact-root return, draft
+  preservation, and no server-binary/package-manager side effects.
+- Dependency-aware removal with global/profile/assignment truth and no silent
+  retargeting.
+
+### GM-TEST-003 — Generated lifecycle tests
+
+- Concurrent first use creates one artifact and one child.
+- Auto port selection, bind race, no CORS, no body logging, sanitized
+  environment, no shell, exact argv, absolute paths, deterministic workdir.
+- Multi-model lazy registration and first-use loading without an unload claim.
+- Save while running remains staged; ordinary operations stay on the applied
+  generation; only explicit Restart & Apply replaces.
+- Source deletion/change while Running does not break admitted use; next
+  deliberate replacement revalidates and fails safely.
+- Failed launch/fallback/restart/exit reaps exact process, Windows/POSIX handle,
+  tasks, clients, artifact, and locks before another attempt.
+- Health/exit evidence invalidation and generation fences cover every
+  interleaving already required by the managed-lifecycle design.
+- Application shutdown during scan/startup/restart/synthesis/reference
+  materialization stays within the shared foreground budget and retains
+  definitive ownership joining.
+
+### GM-TEST-004 — Profile/reference tests
+
+- v2→v3 migration, domain equivalence, retained v2 backup, atomic failure,
+  unsupported newer schema, explicit downgrade procedure.
+- Reference/profile one-to-one/cascade, optimistic revision, repository
+  generation, quota, aggregate quota, and concurrent admission/edit/delete.
+- WAV parser/canonicalizer matrices for chunk order, padding, metadata stripping,
+  unsupported encoding, truncation, overflow, duration/rate/channels, and
+  changed source.
+- Streaming BLOB I/O and metadata-only list/open assertions.
+- Typed voice/reference combination matrices per recipe.
+- Session private modes/ACL posture, ownership locks, crash leftovers, no
+  unsafe sweep, cleanup on success/failure/cancel/restart/shutdown.
+- Exact admitted revision/reference digest and raw-error/privacy exception-graph
+  guards.
+- Isolated damaged-reference behavior versus structural database corruption.
+
+Schema tests use isolated temporary profile databases. Development/UAT must
+never point a schema-bumping build at the user's live profile store.
+
+### GM-TEST-005 — Portability tests
+
+- Wire v1 remains byte/behavior compatible for non-reference profiles.
+- Wire v2 omits WAV/transcript and older readers skip it safely.
+- Ordinary import requires attach/bundle/skip and never creates a broken
+  assigned profile silently.
+- Bundle round trip and deterministic manifest/checksum behavior.
+- Archive rejection: encryption, duplicates, case/Unicode collision, traversal,
+  special entries, unknown entries, compression, bombs, limits, malformed
+  content, changed source, and mismatch.
+- Collision/model-missing import remains explicit, inactive when needed, and
+  never overwrites/assigns/defaults/retargets.
+- Backup/restore includes full references and respects progress/deadline/quota
+  validation.
+
+### GM-TEST-006 — Textual UX tests
+
+- Scope copy/global link and no Studio write.
+- Detection, package rows, status-dimension truth, scan/install return, review
+  diff, Save outcome, and Speech Lab handoff focus.
+- One immutable action projection: visible label and executed operation cannot
+  diverge under provider switches, observation failures, staged settings, or
+  late results.
+- Busy/disabled reasons and tooltips for every lifecycle/generation phase.
+- Clone setup, transient audition, current result, save-as-profile, and last
+  good WAV retention.
+- First invalid hidden field expands and receives focus.
+- Keyboard-only flow, focus restoration, live announcements, no color-only
+  status, narrow terminal geometry, and focusable/scrollable diagnostics.
+
+Reduced apps that imitate only part of the production application are not
+acceptable evidence for cross-owner flows. Tests compose the real production
+screen/service boundary or the smallest real owner below it.
+
+### GM-TEST-007 — Real process and compatibility gates
+
+For every recipe tuple labeled Verified:
+
+- run the exact supported `audiocpp_server` binary and exact package;
+- prove generated JSON is accepted;
+- verify health/catalog/default-model identity;
+- synthesize a structurally valid WAV using text or reference flow as declared;
+- verify lazy Console/Roleplay first use where applicable; and
+- prove shutdown leaves no owned child, handle, task, client, artifact, or
+  private materialization.
+
+At minimum, CPU real-process gates cover macOS, Linux, and Windows. Accelerated
+labels require their own real tuple gate. Unknown-version behavior and the
+manual user-JSON regression are separate gates.
+
+Normal CI remains hermetic and does not download audio.cpp, models, or network
+content. Large/accelerated compatibility suites use explicitly provisioned
+artifacts with checksums and opt-in runners.
+
+## Manual UAT and release evidence
+
+The release gate uses a clean temporary Chatbook config/data/profile database,
+never the developer's live files. Evidence records:
+
+- exact Chatbook commit;
+- audio.cpp tag, commit, binary origin, and executable identity;
+- OS version, architecture, compute backend/device;
+- recipe ID/version, family, package variant, model artifact identity;
+- whether the package was local or installed through Model Library;
+- generated configuration digest with private paths removed;
+- lifecycle state and model/catalog identity;
+- sample text class or sanitized digest, not private content;
+- reference metadata/digest without path/audio/transcript where applicable;
+- WAV format, rate, channels, duration, byte length, and structural validator;
+- shutdown/cleanup evidence; and
+- human audible-playback confirmation.
+
+Required journeys:
+
+1. clean first-time guided local-package setup, Save without launch, handoff,
+   Start & Generate, Play;
+2. Model Library install → exact root return → guided Save → sample;
+3. clone-required transient reference → Generate → Play → Save as Profile →
+   character roleplay response → Play;
+4. multiple configured models and lazy first use;
+5. save while running → staged truth → explicit Restart & Apply;
+6. unknown version warning and unknown/ambiguous package manual-source recovery;
+7. crash/health failure → evidence stale → later deliberate recovery;
+8. explicit External and user-JSON regressions, proving configured origin/file
+   ownership remains exact;
+9. ordinary sanitized export versus explicit voice-bundle warning/import; and
+10. keyboard-only/narrow-terminal setup and diagnostics.
+
+Audible confirmation is a required human datum; structural WAV validation alone
+does not prove a useful sample. Conversely, “I heard it” without pinned binary,
+model, app commit, and teardown evidence is not sufficient release evidence.
+
+## Delivery boundaries
+
+These are product release boundaries, not implementation tasks or a plan. Task
+decomposition occurs only after this design receives final approval.
+
+1. **Generated text-ready vertical** — guided setup, exact recipes for the
+   approved initial text-ready subset (starting with Supertonic and PocketTTS),
+   POSIX real-process evidence, and first-time sample UAT.
+2. **Clone-reference foundation** — profile v3, canonical private reference,
+   transient audition, typed admission, and explicit voice bundle.
+3. **Model Library and dependency UX** — reviewed artifact mapping, install
+   return, dependency-aware removal, and complete Settings review flow.
+4. **Windows lifecycle parity** — owned-handle launch/reap/shutdown,
+   path/ACL/scanner behavior, and Windows CPU UAT.
+5. **Complete release-0.5.1 recipe coverage** — every pinned TTS/Clone package
+   variant classified and all supported tuples evidenced.
+
+Each releasable increment states the exact family/package/platform/backend
+subset it supports. The program cannot call itself complete before boundary 5
+has zero unapproved gaps.
+
+## Rollout and rollback
+
+- External and existing user-JSON sources remain available throughout rollout.
+- Existing configs require no write and retain their source.
+- Guided fields may remain inert in builds where the feature is disabled.
+- A failed guided launch affects no legacy provider and leaves no owned child or
+  generated artifact.
+- A withdrawn recipe blocks only a new guided launch/replacement; it does not
+  passively kill a valid running generation.
+- Clone feature rollback disables new reference admission without deleting v3
+  data.
+- Application downgrade uses the dedicated v2 pre-migration backup and is
+  explicitly lossy for post-migration profile changes.
+- No rollback deletes user-selected packages, Model Library artifacts, user
+  JSON, exported WAVs/bundles, or unknown files.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Upstream package/schema churn | Pinned immutable recipes, accepted projection snapshots, explicit review, manual JSON escape hatch |
+| “All models” becomes an untestable promise | Exact 21-family/package accounting matrix and tuple-scoped labels |
+| Scanner freezes the TUI or walks too much | Explicit roots, finite limits, cancellable worker, partial result truth |
+| Package heuristics select the wrong family | Exact signals only; ambiguity blocks guided selection |
+| Generated JSON becomes a second owner | Structured settings authoritative; generation artifact immutable and never imported |
+| Auto backend hides real faults | Fallback only for stable allowlisted backend-unavailable codes after definitive cleanup |
+| Multiple model loads exhaust memory | Lazy-load disclosure; one child; no false unload promise; explicit shutdown |
+| Saved settings disrupt running speech | Existing saved/applied/process generations and explicit Restart & Apply |
+| Source files change while a child is live | Immutable applied snapshot; revalidate on next launch, not every synthesis |
+| Windows child survives app exit | Exact process-handle ownership, early close sealing, shared deadline, definitive joining, real UAT |
+| Clone reference leaks through paths/logs | Canonical BLOB owner, opaque session path, request-body logging off, safe errors/context severing |
+| SQLite BLOBs grow without bound | Per-reference and aggregate quotas, streamed I/O, summary reads |
+| Users assume local means encrypted | Explicit plaintext disclosure and no forensic-erasure claim |
+| Voice bundle is an archive attack | Exact entries, no traversal/special/encrypted files, strict size/ratio/checksum validation |
+| Imported voice is assigned silently | Explicit collision/dependency review; never overwrite/assign/default/retarget |
+| Migration makes downgrade unsafe | Retained v2 online backup and explicit closed-store downgrade procedure |
+| Tests pass but real audio is unusable | Pinned real-process gates plus human audible UAT |
+
+## Functional acceptance criteria
+
+- [ ] GM-AC-001: Existing External and user-provided `server.json` users retain
+  their source and behavior without a migration write or guided side effect.
+- [ ] GM-AC-002: A user can select Guided Managed setup, detect/browse a
+  separately installed server, add a supported package, choose a default, and
+  Save without any process, socket, HTTP, artifact, or model side effect.
+- [ ] GM-AC-003: A deliberate first use materializes one private immutable
+  loopback/no-CORS/no-body-log generated config and launches exactly one owned
+  no-shell child.
+- [ ] GM-AC-004: One generated server registers multiple accepted models with
+  lazy loading; first use loads the selected model and the UI does not claim
+  later unloading.
+- [ ] GM-AC-005: Saved, applied, process, file/recipe, catalog, and sample state
+  remain distinct across save, restart, failure, exit, and provider switching.
+- [ ] GM-AC-006: A running child keeps its immutable applied artifact and model
+  snapshot; source changes are revalidated only for the next deliberate launch
+  or replacement.
+- [ ] GM-AC-007: Backend Auto and explicit override work across the supported
+  platforms; fallback happens only for recognized failures after exact cleanup.
+- [ ] GM-AC-008: Scanning is explicit-root, bounded, cancellable, off-loop,
+  symlink-safe, exact-match-only, and reports partial/permission outcomes.
+- [ ] GM-AC-009: Recipe accounting covers every package variant in all 21
+  pinned TTS/Clone families, and user-facing support claims name the exact
+  evidenced subset until no unapproved gap remains.
+- [ ] GM-AC-010: Model Library shows reviewed compatible artifacts, installs
+  only on explicit action, returns the exact package root to the preserved
+  draft, and does not install the server binary.
+- [ ] GM-AC-011: Package removal discloses and explicitly resolves global,
+  profile, character-assignment, and artifact-owner dependencies without
+  silent retargeting or reference deletion.
+- [ ] GM-AC-012: Guided setup works on macOS, Linux, and Windows CPU with
+  exact-child definitive shutdown; accelerated status is Verified only with
+  tuple-specific evidence.
+- [ ] GM-AC-013: Reference ingest creates canonical bounded WAV bytes and a
+  bounded transcript in one profile-owned v3 reference row without persisting
+  the source path or arbitrary RIFF metadata.
+- [ ] GM-AC-014: Clone request admission freezes exact profile revision,
+  recipe, reference UUID/digest, transcript, and runtime generation, uses an
+  opaque private session path only with the compatible guided app-owned child,
+  and cleans it definitively; External/unclassified sources never receive it.
+- [ ] GM-AC-015: A transient reference can generate a sample without creating a
+  profile; Save as Voice Profile uses the exact successful canonical artifact.
+- [ ] GM-AC-016: v2→v3 migration is guarded by a retained private v2 backup,
+  transactional validation, domain-equivalent existing profiles, and explicit
+  lossy downgrade instructions.
+- [ ] GM-AC-017: Profile listing/open remains metadata-focused, BLOB operations
+  are streamed and quota-bound, backup/restore includes full references, and
+  an isolatable bad reference blocks only its profile.
+- [ ] GM-AC-018: Ordinary portability omits reference audio/transcript; explicit
+  voice bundles are strictly validated, plaintext-disclosed, unassigned on
+  import, and never auto-overwrite/default/retarget.
+- [ ] GM-AC-019: Settings states global ownership, preserves Studio
+  preferences, reports `saved — ready to test`, and hands off to the correct
+  dynamic Speech Lab primary action.
+- [ ] GM-AC-020: Speech Lab provides coherent state-specific actions, clone
+  setup, prominent Play/Pause/current-result controls, optional existing
+  autoplay preference, retry, WAV export, and profile save.
+- [ ] GM-AC-021: Provider switches, late results, observation failures, and
+  busy states cannot make a visible action execute a different stale operation
+  or leave recovery controls falsely disabled.
+- [ ] GM-AC-022: The guided and clone flows meet keyboard, focus, announcement,
+  non-color, narrow-layout, and scrollable-diagnostics accessibility gates.
+- [ ] GM-AC-023: Stable errors and exception graphs contain no full executable,
+  config, model, reference, temporary path, transcript, prompt, audio,
+  credential, environment, or raw upstream exception detail.
+- [ ] GM-AC-024: Normal CI is hermetic; provisioned real-process gates validate
+  each Verified tuple; manual UAT records exact evidence and human audible
+  playback.
+- [ ] GM-AC-025: A clean first-time user can complete local package selection or
+  Model Library install, Save, Speech Lab generation, Play, and definitive
+  shutdown without editing JSON.
+- [ ] GM-AC-026: A clean clone-required flow can create a transient voice,
+  generate/play audio, save a reusable profile, assign it to a character, and
+  audibly play a roleplay response without leaking reference data.
+- [ ] GM-AC-027: The native catalog admits only upstream `tts` and `clone`
+  speech tasks, preserves their typed capabilities, supports clone-only
+  families, and continues excluding ASR/VC/Music/other tasks.
+
+## ADR check
+
+ADR required: yes
+
+ADR paths:
+
+- `backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md`
+- `backlog/decisions/051-private-tts-clone-reference-assets.md`
+
+Reason: generated setup changes durable configuration authority, runtime launch
+artifacts, recipe/model discovery, cross-platform process ownership, and the
+Settings/Lab contract. Clone support independently changes the profile schema,
+private-data storage, admission snapshot, backup/downgrade, and portability
+boundary. Keeping these as two decisions prevents process configuration from
+becoming coupled to sensitive voice-reference storage.
+
+Existing ADRs followed rather than replaced wholesale:
+
+- ADR-023 — registry/native adapter/complete-WAV/one-child authority;
+- ADR-028 — profile and character-assignment ownership;
+- ADR-029 — local private data and metadata-only logs;
+- ADR-039 — global Settings versus Studio/runtime ownership; and
+- ADR-040 — shared model assets and active-user private paths.
+
+## References
+
+- [audio.cpp repository](https://github.com/0xShug0/audio.cpp)
+- [audio.cpp release-0.5.1](https://github.com/0xShug0/audio.cpp/releases/tag/release-0.5.1)
+- [Pinned audio.cpp README](https://github.com/0xShug0/audio.cpp/blob/238ab6a9e321c17de8e120559f57efeedaeb1345/README.md)
+- [Pinned audio.cpp server guide](https://github.com/0xShug0/audio.cpp/blob/238ab6a9e321c17de8e120559f57efeedaeb1345/app/server/README.md)
+- [Pinned audio.cpp model specs](https://github.com/0xShug0/audio.cpp/tree/238ab6a9e321c17de8e120559f57efeedaeb1345/model_specs)
+- [Existing adapter-registry design](2026-07-23-audio-cpp-tts-adapter-registry-design.md)
+- [Managed lifecycle design](2026-08-02-audio-cpp-managed-lifecycle-design.md)
+- [Speech & TTS ownership design](2026-07-31-speech-tts-settings-ownership-design.md)
+- [Character TTS profile design](2026-07-25-character-tts-generation-profiles-design.md)
+- [Voice-profile expansion design](2026-08-04-voice-profiles-expansion-design.md)
+- [ADR-050](../../../backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md)
+- [ADR-051](../../../backlog/decisions/051-private-tts-clone-reference-assets.md)

--- a/Tests/TTS/test_audio_cpp_guided_config.py
+++ b/Tests/TTS/test_audio_cpp_guided_config.py
@@ -1,0 +1,306 @@
+"""Typed durable settings for guided audio.cpp setup."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
+
+from tldw_chatbook.TTS.audio_cpp_config import AudioCppConfig
+
+
+def _api():
+    from tldw_chatbook.TTS.audio_cpp_guided_config import (
+        AudioCppAcceptedPackage,
+        AudioCppBackendPreference,
+        AudioCppBinarySelectionSource,
+        AudioCppManagedSetupSource,
+        AudioCppRecipeOption,
+        AudioCppSafeModelProjection,
+        AudioCppSettingsConfig,
+    )
+
+    return (
+        AudioCppAcceptedPackage,
+        AudioCppBackendPreference,
+        AudioCppBinarySelectionSource,
+        AudioCppManagedSetupSource,
+        AudioCppRecipeOption,
+        AudioCppSafeModelProjection,
+        AudioCppSettingsConfig,
+    )
+
+
+def _accepted_package(*, public_model_id: str = "supertonic-3-orig"):
+    (
+        AudioCppAcceptedPackage,
+        _,
+        _,
+        _,
+        _,
+        AudioCppSafeModelProjection,
+        _,
+    ) = _api()
+    return AudioCppAcceptedPackage(
+        package_uuid="d3f6d610-6fd9-4cde-9ea7-cc5175ca445b",
+        recipe_id="audio-cpp-0.5.1.supertonic.supertonic_3_orig",
+        recipe_revision=1,
+        package_variant="supertonic_3_orig",
+        public_model_id=public_model_id,
+        canonical_root="/models/Supertonic-3-GGUF",
+        canonical_root_identity="1" * 64,
+        configuration_identity="2" * 64,
+        weight_identity="3" * 64,
+        projection=AudioCppSafeModelProjection(
+            family="supertonic",
+            task="tts",
+            mode="offline",
+            model_relative_path="supertonic-3-orig.gguf",
+        ),
+    )
+
+
+def test_existing_external_and_managed_json_mappings_keep_legacy_runtime_meaning() -> (
+    None
+):
+    *_, AudioCppManagedSetupSource, _, _, AudioCppSettingsConfig = _api()
+    external = {
+        "mode": "external",
+        "base_url": "http://127.0.0.1:9000",
+        "connect_timeout_seconds": 7.0,
+    }
+    manual = {
+        "mode": "managed",
+        "managed_binary_path": "/opt/audio.cpp/audiocpp_server",
+        "managed_server_json_path": "/opt/audio.cpp/server.json",
+        "managed_startup_timeout_seconds": 12.0,
+    }
+
+    external_settings = AudioCppSettingsConfig.from_mapping(external)
+    manual_settings = AudioCppSettingsConfig.from_mapping(manual)
+
+    assert (
+        external_settings.managed_setup_source is AudioCppManagedSetupSource.USER_JSON
+    )
+    assert manual_settings.managed_setup_source is AudioCppManagedSetupSource.USER_JSON
+    assert AudioCppConfig.from_mapping(external).to_mapping() == {
+        "mode": "external",
+        "base_url": "http://127.0.0.1:9000",
+        "connect_timeout_seconds": 7.0,
+        "synthesis_timeout_seconds": 600.0,
+        "max_input_characters": 10_000,
+        "max_response_bytes": 128 * 1024 * 1024,
+        "max_metadata_bytes": 1024 * 1024,
+        "max_catalog_models": 1000,
+        "max_voices_per_model": 1000,
+        "max_identifier_characters": 256,
+    }
+    assert (
+        AudioCppConfig.from_mapping(manual).managed_server_json_path
+        == manual["managed_server_json_path"]
+    )
+
+
+def test_full_guided_and_dormant_values_round_trip_defensively() -> None:
+    (
+        _,
+        AudioCppBackendPreference,
+        AudioCppBinarySelectionSource,
+        AudioCppManagedSetupSource,
+        _,
+        _,
+        AudioCppSettingsConfig,
+    ) = _api()
+    package = _accepted_package()
+    raw = {
+        "mode": "external",
+        "base_url": "https://external.example.test",
+        "managed_setup_source": "guided",
+        "managed_binary_path": "/manual/audiocpp_server",
+        "managed_server_json_path": "/manual/server.json",
+        "guided_binary_path": "/guided/audiocpp_server",
+        "guided_binary_source": "homebrew",
+        "guided_packages": [package.model_dump(mode="json")],
+        "guided_default_model_id": package.public_model_id,
+        "guided_backend_preference": "metal",
+        "guided_device": 1,
+        "guided_threads": 6,
+        "guided_max_request_body_bytes": 64 * 1024 * 1024,
+        "guided_busy_timeout_ms": 90_000,
+        "managed_startup_timeout_seconds": 45.0,
+        "managed_health_check_interval_seconds": 15.0,
+        "managed_termination_grace_seconds": 8.0,
+        "connect_timeout_seconds": 4.0,
+        "synthesis_timeout_seconds": 120.0,
+        "max_input_characters": 2_000,
+        "max_response_bytes": 32 * 1024 * 1024,
+        "max_metadata_bytes": 512 * 1024,
+        "max_catalog_models": 12,
+        "max_voices_per_model": 24,
+        "max_identifier_characters": 128,
+    }
+
+    settings = AudioCppSettingsConfig.from_mapping(raw)
+    dumped = settings.to_mapping()
+    reparsed = AudioCppSettingsConfig.from_mapping(dumped)
+
+    assert settings == reparsed
+    assert settings.managed_setup_source is AudioCppManagedSetupSource.GUIDED
+    assert settings.guided_binary_source is AudioCppBinarySelectionSource.HOMEBREW
+    assert settings.guided_backend_preference is AudioCppBackendPreference.METAL
+    assert settings.managed_binary_path == "/manual/audiocpp_server"
+    assert settings.base_url == "https://external.example.test"
+    dumped["guided_packages"][0]["public_model_id"] = "mutated"  # type: ignore[index]
+    assert settings.guided_packages[0].public_model_id == "supertonic-3-orig"
+
+
+def test_unknown_runtime_and_extension_fields_are_not_retained() -> None:
+    *_, AudioCppSettingsConfig = _api()
+    settings = AudioCppSettingsConfig.from_mapping(
+        {
+            "mode": "external",
+            "base_url": "http://127.0.0.1:8080",
+            "runtime_port": 5555,
+            "pid": 123,
+            "health": "running",
+            "headers": {"Authorization": "secret"},
+        }
+    )
+
+    dumped = settings.to_mapping()
+
+    assert not {"runtime_port", "pid", "health", "headers"} & dumped.keys()
+    with pytest.raises(ValidationError):
+        AudioCppSettingsConfig(runtime_port=5555)  # type: ignore[call-arg]
+
+
+def test_safe_projection_is_frozen_bounded_and_has_no_arbitrary_json() -> None:
+    (
+        _,
+        _,
+        _,
+        _,
+        AudioCppRecipeOption,
+        AudioCppSafeModelProjection,
+        _,
+    ) = _api()
+    projection = AudioCppSafeModelProjection(
+        family="pocket_tts",
+        task="tts",
+        mode="offline",
+        model_relative_path=None,
+        load_options=(AudioCppRecipeOption(name="language", value="english"),),
+        session_options=(AudioCppRecipeOption(name="language", value="english"),),
+        busy_timeout_ms=60_000,
+    )
+
+    assert projection.load_options[0].value == "english"
+    with pytest.raises(ValidationError):
+        projection.family = "changed"  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        AudioCppSafeModelProjection(
+            family="pocket_tts",
+            task="tts",
+            mode="offline",
+            model_relative_path="../escape.gguf",
+        )
+    with pytest.raises(ValidationError):
+        AudioCppSafeModelProjection(
+            family="pocket_tts",
+            task="tts",
+            mode="offline",
+            shell="curl example.test",  # type: ignore[call-arg]
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("guided_backend_preference", "best"),
+        ("guided_device", -1),
+        ("guided_device", True),
+        ("guided_threads", 0),
+        ("guided_threads", True),
+        ("guided_max_request_body_bytes", 0),
+        ("guided_max_request_body_bytes", 2**53),
+        ("guided_busy_timeout_ms", -1),
+        ("guided_busy_timeout_ms", 2**31),
+    ),
+)
+def test_guided_compute_and_server_limits_are_bounded(
+    field: str, value: object
+) -> None:
+    *_, AudioCppSettingsConfig = _api()
+    values = AudioCppSettingsConfig().to_mapping()
+    values[field] = value
+
+    with pytest.raises(ValueError):
+        AudioCppSettingsConfig.from_mapping(values)
+
+
+def test_guided_default_must_name_one_unique_accepted_package() -> None:
+    *_, AudioCppSettingsConfig = _api()
+    first = _accepted_package(public_model_id="voice")
+    duplicate = _accepted_package(public_model_id="voice")
+    base = AudioCppSettingsConfig().to_mapping()
+
+    duplicate_values = deepcopy(base)
+    duplicate_values["guided_packages"] = [
+        first.model_dump(mode="json"),
+        duplicate.model_dump(mode="json"),
+    ]
+    duplicate_values["guided_default_model_id"] = "voice"
+    with pytest.raises(ValueError, match="unique"):
+        AudioCppSettingsConfig.from_mapping(duplicate_values)
+
+    missing_default = deepcopy(base)
+    missing_default["guided_packages"] = [first.model_dump(mode="json")]
+    missing_default["guided_default_model_id"] = "other"
+    with pytest.raises(ValueError, match="default"):
+        AudioCppSettingsConfig.from_mapping(missing_default)
+
+
+def test_guided_packages_require_unique_internal_uuids() -> None:
+    *_, AudioCppSettingsConfig = _api()
+    first = _accepted_package(public_model_id="first")
+    second = first.model_copy(
+        update={
+            "public_model_id": "second",
+            "canonical_root": "/models/other",
+            "canonical_root_identity": "4" * 64,
+            "configuration_identity": "5" * 64,
+            "weight_identity": "6" * 64,
+        }
+    )
+    values = AudioCppSettingsConfig().to_mapping()
+    values["guided_packages"] = [
+        first.model_dump(mode="json"),
+        second.model_dump(mode="json"),
+    ]
+
+    with pytest.raises(ValueError, match="internal UUIDs"):
+        AudioCppSettingsConfig.from_mapping(values)
+
+
+def test_accepted_package_requires_absolute_root_safe_ids_and_digest_identities() -> (
+    None
+):
+    AudioCppAcceptedPackage, *_ = _api()
+    accepted = _accepted_package()
+
+    with pytest.raises(ValidationError):
+        accepted.public_model_id = "changed"  # type: ignore[misc]
+    for changes in (
+        {"package_uuid": "not-a-uuid"},
+        {"package_uuid": "D3F6D610-6FD9-4CDE-9EA7-CC5175CA445B"},
+        {"canonical_root": "relative/model"},
+        {"canonical_root": "/models/with\ncontrol"},
+        {"public_model_id": "bad model id"},
+        {"weight_identity": "not-a-digest"},
+        {"recipe_revision": 0},
+    ):
+        values = accepted.model_dump(mode="python")
+        values.update(changes)
+        with pytest.raises(ValidationError):
+            AudioCppAcceptedPackage(**values)

--- a/Tests/TTS/test_audio_cpp_package_scanner.py
+++ b/Tests/TTS/test_audio_cpp_package_scanner.py
@@ -1,0 +1,843 @@
+"""Bounded read-only discovery for guided audio.cpp packages."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+import struct
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _api():
+    from tldw_chatbook.TTS.audio_cpp_package_scanner import (  # noqa: F401
+        AudioCppPackageScanError,
+        AudioCppScanIssueCode,
+        AudioCppScanLimit,
+        AudioCppScanLimits,
+        AudioCppScanOutcome,
+        _is_reparse_or_symlink,
+        scan_audio_cpp_package_root,
+        scan_audio_cpp_package_root_async,
+    )
+    from tldw_chatbook.TTS.audio_cpp_recipes import AudioCppMatchState  # noqa: F401
+
+    return locals()
+
+
+def _write_gguf(path: Path, *, version: int = 3) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"GGUF" + struct.pack("<I", version))
+
+
+def _write_safetensors(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(struct.pack("<Q", 2) + b"{}")
+
+
+def test_exact_gguf_package_is_discovered_from_only_the_selected_root(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    root = tmp_path / "selected"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf")
+
+    result = api["scan_audio_cpp_package_root"](root, request_revision=7)
+
+    assert result.outcome is api["AudioCppScanOutcome"].COMPLETE
+    assert result.request_revision == 7
+    assert result.visited_entries == 1
+    assert len(result.discoveries) == 1
+    discovery = result.discoveries[0]
+    assert discovery.match.state is api["AudioCppMatchState"].EXACT
+    assert discovery.match.candidates[0].recipe.package_variant == ("supertonic_3_orig")
+    assert discovery.description.safe_name == "selected"
+
+
+def test_nested_package_root_is_derived_without_scanning_its_parent_siblings(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    selected = tmp_path / "selected"
+    selected.mkdir()
+    _write_gguf(
+        selected / "PocketTTS-GGUF" / "spanish" / "pocket-tts-spanish-q8_0.gguf"
+    )
+    unrelated = tmp_path / "outside"
+    unrelated.mkdir()
+    _write_gguf(unrelated / "supertonic-3-orig.gguf")
+
+    result = api["scan_audio_cpp_package_root"](selected)
+
+    assert len(result.discoveries) == 1
+    candidate = result.discoveries[0].match.candidates[0]
+    assert candidate.recipe.package_variant == "pocket_tts_spanish_q8_0"
+    assert candidate.safe_name == "spanish"
+    assert "outside" not in repr(result)
+
+
+def test_multiple_exact_variants_in_one_root_are_preserved_as_ambiguous(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    root = tmp_path / "variants"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf")
+    _write_gguf(root / "supertonic-3-q8_0.gguf")
+
+    result = api["scan_audio_cpp_package_root"](root)
+
+    assert len(result.discoveries) == 1
+    match = result.discoveries[0].match
+    assert match.state is api["AudioCppMatchState"].AMBIGUOUS
+    assert {item.recipe.package_variant for item in match.candidates} == {
+        "supertonic_3_orig",
+        "supertonic_3_q8_0",
+    }
+
+
+def test_bad_gguf_version_is_recognizable_but_never_selected(tmp_path: Path) -> None:
+    api = _api()
+    root = tmp_path / "bad-version"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf", version=2)
+
+    result = api["scan_audio_cpp_package_root"](root)
+
+    assert len(result.discoveries) == 1
+    assert result.discoveries[0].match.state is api["AudioCppMatchState"].INCOMPLETE
+    assert result.discoveries[0].match.candidates == ()
+
+
+def test_multifile_safetensors_layout_requires_every_companion(tmp_path: Path) -> None:
+    api = _api()
+    root = tmp_path / "supertonic-3"
+    (root / "config").mkdir(parents=True)
+    (root / "config" / "tts.json").write_text("{}", encoding="utf-8")
+    (root / "config" / "unicode_indexer.json").write_text("{}", encoding="utf-8")
+    _write_safetensors(root / "ggml" / "supertonic.safetensors")
+
+    complete = api["scan_audio_cpp_package_root"](root)
+    (root / "config" / "unicode_indexer.json").unlink()
+    incomplete = api["scan_audio_cpp_package_root"](root)
+
+    assert complete.discoveries[0].match.state is api["AudioCppMatchState"].EXACT
+    assert incomplete.discoveries[0].match.state is (
+        api["AudioCppMatchState"].INCOMPLETE
+    )
+
+
+def test_entry_and_depth_limits_return_partial_instead_of_absent(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    limits_type = api["AudioCppScanLimits"]
+    limit = api["AudioCppScanLimit"]
+    outcome = api["AudioCppScanOutcome"]
+    root = tmp_path / "limited"
+    root.mkdir()
+    _write_gguf(root / "a" / "supertonic-3-orig.gguf")
+    _write_gguf(root / "b" / "supertonic-3-q8_0.gguf")
+
+    entry_limited = api["scan_audio_cpp_package_root"](
+        root,
+        limits=limits_type(max_entries=1),
+    )
+    depth_limited = api["scan_audio_cpp_package_root"](
+        root,
+        limits=limits_type(max_depth=0),
+    )
+
+    assert entry_limited.outcome is outcome.PARTIAL
+    assert limit.ENTRIES in entry_limited.limits_reached
+    assert depth_limited.outcome is outcome.PARTIAL
+    assert limit.DEPTH in depth_limited.limits_reached
+
+
+def test_candidate_and_result_limits_are_finite_and_truthful(tmp_path: Path) -> None:
+    api = _api()
+    limits_type = api["AudioCppScanLimits"]
+    limit = api["AudioCppScanLimit"]
+    root = tmp_path / "many"
+    root.mkdir()
+    for index, filename in enumerate(
+        ("supertonic-3-orig.gguf", "supertonic-3-q8_0.gguf")
+    ):
+        _write_gguf(root / str(index) / filename)
+
+    candidate_limited = api["scan_audio_cpp_package_root"](
+        root,
+        limits=limits_type(max_candidate_roots=1),
+    )
+    result_limited = api["scan_audio_cpp_package_root"](
+        root,
+        limits=limits_type(max_results=1),
+    )
+
+    assert limit.CANDIDATE_ROOTS in candidate_limited.limits_reached
+    assert len(candidate_limited.discoveries) <= 1
+    assert limit.RESULTS in result_limited.limits_reached
+    assert len(result_limited.discoveries) == 1
+
+
+def test_metadata_byte_limits_block_selection_without_reading_weights(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    limits_type = api["AudioCppScanLimits"]
+    limit = api["AudioCppScanLimit"]
+    root = tmp_path / "metadata-limited"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf")
+
+    result = api["scan_audio_cpp_package_root"](
+        root,
+        limits=limits_type(
+            max_metadata_bytes_per_file=4,
+            max_metadata_bytes_total=4,
+        ),
+    )
+
+    assert result.metadata_bytes_read <= 4
+    assert limit.METADATA_PER_FILE in result.limits_reached
+    assert result.discoveries[0].match.state is api["AudioCppMatchState"].INCOMPLETE
+
+
+def test_total_and_individual_time_limits_use_deterministic_work_fences(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    api = _api()
+    limits_type = api["AudioCppScanLimits"]
+    limit = api["AudioCppScanLimit"]
+    root = tmp_path / "timed"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf")
+    moments = iter((0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0))
+    monkeypatch.setattr(scanner, "_monotonic", lambda: next(moments, 1.0))
+
+    result = scanner.scan_audio_cpp_package_root(
+        root,
+        limits=limits_type(max_entry_seconds=0.5, max_total_seconds=100.0),
+    )
+
+    assert limit.ENTRY_TIME in result.limits_reached
+    assert result.outcome is api["AudioCppScanOutcome"].PARTIAL
+
+
+def test_total_time_limit_stops_before_scanning_more_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    api = _api()
+    root = tmp_path / "total-time-limited"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf")
+    moments = iter((0.0, 1.0))
+    monkeypatch.setattr(scanner, "_monotonic", lambda: next(moments, 1.0))
+
+    result = scanner.scan_audio_cpp_package_root(
+        root,
+        limits=api["AudioCppScanLimits"](max_total_seconds=0.5),
+    )
+
+    assert result.outcome is api["AudioCppScanOutcome"].PARTIAL
+    assert result.limits_reached == (api["AudioCppScanLimit"].TOTAL_TIME,)
+    assert result.visited_entries == 0
+
+
+def test_total_time_limit_downgrades_a_candidate_after_one_slow_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    api = _api()
+    root = tmp_path / "slow-final-entry"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf")
+    moments = iter((0.0, 0.0, 0.0, 0.0, 1.0, 1.0))
+    monkeypatch.setattr(scanner, "_monotonic", lambda: next(moments, 1.0))
+
+    result = scanner.scan_audio_cpp_package_root(
+        root,
+        limits=api["AudioCppScanLimits"](
+            max_entry_seconds=100.0,
+            max_total_seconds=0.5,
+        ),
+    )
+
+    assert result.outcome is api["AudioCppScanOutcome"].PARTIAL
+    assert result.limits_reached == (api["AudioCppScanLimit"].TOTAL_TIME,)
+    assert result.discoveries[0].match.state is api["AudioCppMatchState"].INCOMPLETE
+
+
+def test_pre_cancelled_scan_publishes_no_candidate(tmp_path: Path) -> None:
+    api = _api()
+    root = tmp_path / "cancelled"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf")
+    cancellation = threading.Event()
+    cancellation.set()
+
+    result = api["scan_audio_cpp_package_root"](
+        root,
+        cancellation_event=cancellation,
+    )
+
+    assert result.outcome is api["AudioCppScanOutcome"].CANCELLED
+    assert result.discoveries == ()
+    assert result.visited_entries == 0
+
+
+@pytest.mark.asyncio
+async def test_async_scan_runs_the_sync_scanner_off_the_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    root = tmp_path / "off-loop"
+    root.mkdir()
+    expected = scanner.scan_audio_cpp_package_root(root)
+    loop_thread = threading.get_ident()
+    observed: list[int] = []
+
+    def fake_scan(*_args, **_kwargs):
+        observed.append(threading.get_ident())
+        return expected
+
+    monkeypatch.setattr(scanner, "scan_audio_cpp_package_root", fake_scan)
+
+    result = await scanner.scan_audio_cpp_package_root_async(root)
+
+    assert result is expected
+    assert observed and observed[0] != loop_thread
+
+
+@pytest.mark.asyncio
+async def test_cancelling_async_scan_signals_the_worker_and_drops_late_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    root = tmp_path / "async-cancel"
+    root.mkdir()
+    started = threading.Event()
+    stopped = threading.Event()
+    real_scan = scanner.scan_audio_cpp_package_root
+
+    def slow_scan(*_args, cancellation_event=None, **_kwargs):
+        assert cancellation_event is not None
+        started.set()
+        while not cancellation_event.is_set():
+            time.sleep(0.001)
+        stopped.set()
+        return real_scan(root)
+
+    monkeypatch.setattr(scanner, "scan_audio_cpp_package_root", slow_scan)
+    task = asyncio.create_task(scanner.scan_audio_cpp_package_root_async(root))
+    await asyncio.to_thread(started.wait, 1.0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert await asyncio.to_thread(stopped.wait, 1.0)
+
+
+def test_nested_symlink_and_windows_reparse_points_are_never_traversed(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    issue = api["AudioCppScanIssueCode"]
+    root = tmp_path / "selected"
+    outside = tmp_path / "private-outside"
+    root.mkdir()
+    outside.mkdir()
+    _write_gguf(outside / "supertonic-3-orig.gguf")
+    (root / "escape").symlink_to(outside, target_is_directory=True)
+
+    result = api["scan_audio_cpp_package_root"](root)
+
+    assert result.discoveries == ()
+    assert issue.SYMLINK_SKIPPED in {item.code for item in result.issues}
+    reparse = SimpleNamespace(
+        st_mode=stat.S_IFDIR,
+        st_file_attributes=getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400),
+    )
+    assert api["_is_reparse_or_symlink"](reparse)
+
+
+def test_queued_directory_replaced_by_symlink_is_not_traversed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    api = _api()
+    root = tmp_path / "selected"
+    queued = root / "queued"
+    outside = tmp_path / "private-outside"
+    queued.mkdir(parents=True)
+    outside.mkdir()
+    _write_gguf(outside / "supertonic-3-orig.gguf")
+    real_scandir = scanner._scandir
+
+    class ReplacingIterator:
+        def __init__(self) -> None:
+            self._iterator = real_scandir(root)
+            self._replaced = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            try:
+                return next(self._iterator)
+            except StopIteration:
+                if not self._replaced:
+                    self._iterator.close()
+                    queued.rmdir()
+                    queued.symlink_to(outside, target_is_directory=True)
+                    self._replaced = True
+                raise
+
+        def close(self) -> None:
+            self._iterator.close()
+
+    def replacing_scandir(path):
+        return ReplacingIterator() if Path(path) == root else real_scandir(path)
+
+    monkeypatch.setattr(scanner, "_scandir", replacing_scandir)
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.discoveries == ()
+    assert api["AudioCppScanIssueCode"].SOURCE_CHANGED in {
+        item.code for item in result.issues
+    }
+    assert str(outside) not in repr(result)
+
+
+def test_directory_replaced_during_scandir_open_is_not_traversed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    api = _api()
+    root = tmp_path / "selected"
+    queued = root / "queued"
+    outside = tmp_path / "private-outside"
+    queued.mkdir(parents=True)
+    outside.mkdir()
+    _write_gguf(outside / "supertonic-3-orig.gguf")
+    real_scandir = scanner._scandir
+    replaced = False
+
+    def replacing_scandir(path):
+        nonlocal replaced
+        if Path(path) == queued and not replaced:
+            queued.rmdir()
+            queued.symlink_to(outside, target_is_directory=True)
+            replaced = True
+        return real_scandir(path)
+
+    monkeypatch.setattr(scanner, "_scandir", replacing_scandir)
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.discoveries == ()
+    assert api["AudioCppScanIssueCode"].SOURCE_CHANGED in {
+        item.code for item in result.issues
+    }
+    assert str(outside) not in repr(result)
+
+
+def test_top_level_symlink_requires_explicit_disclosure(tmp_path: Path) -> None:
+    api = _api()
+    target = tmp_path / "target"
+    target.mkdir()
+    _write_gguf(target / "supertonic-3-orig.gguf")
+    selected = tmp_path / "selected-link"
+    selected.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(api["AudioCppPackageScanError"], match="symlink"):
+        api["scan_audio_cpp_package_root"](selected)
+    result = api["scan_audio_cpp_package_root"](
+        selected,
+        allow_root_symlink=True,
+    )
+
+    assert result.root_was_symlink
+    assert result.discoveries[0].match.state is api["AudioCppMatchState"].EXACT
+
+
+def test_selected_root_with_symlinked_ancestor_requires_disclosure(
+    tmp_path: Path,
+) -> None:
+    api = _api()
+    target_parent = tmp_path / "target-parent"
+    package = target_parent / "package"
+    package.mkdir(parents=True)
+    _write_gguf(package / "supertonic-3-orig.gguf")
+    linked_parent = tmp_path / "linked-parent"
+    linked_parent.symlink_to(target_parent, target_is_directory=True)
+    selected = linked_parent / "package"
+
+    with pytest.raises(api["AudioCppPackageScanError"], match="symlink"):
+        api["scan_audio_cpp_package_root"](selected)
+
+    result = api["scan_audio_cpp_package_root"](
+        selected,
+        allow_root_symlink=True,
+    )
+
+    assert result.root_was_symlink
+    assert result.discoveries[0].match.state is api["AudioCppMatchState"].EXACT
+
+
+def test_permission_failure_is_isolated_and_uses_only_safe_bounded_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    api = _api()
+    root = tmp_path / "selected-private-root"
+    blocked = root / "blocked-private-child"
+    root.mkdir()
+    blocked.mkdir()
+    real_scandir = scanner._scandir
+
+    def permission_scandir(path):
+        if Path(path).name == blocked.name:
+            raise PermissionError("PRIVATE FULL PATH SHOULD NOT ESCAPE")
+        return real_scandir(path)
+
+    monkeypatch.setattr(scanner, "_scandir", permission_scandir)
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.outcome is api["AudioCppScanOutcome"].PERMISSION_LIMITED
+    assert len(result.issues) == 1
+    assert result.issues[0].safe_name == blocked.name
+    assert str(tmp_path) not in repr(result)
+    assert "PRIVATE FULL PATH" not in repr(result)
+
+
+def test_unrelated_permission_failure_does_not_poison_complete_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    api = _api()
+    root = tmp_path / "selected"
+    blocked = root / "blocked-sibling"
+    blocked.mkdir(parents=True)
+    _write_gguf(root / "supertonic-3-orig.gguf")
+    real_scandir = scanner._scandir
+
+    def permission_scandir(path):
+        if Path(path).name == blocked.name:
+            raise PermissionError("PRIVATE SIBLING PATH SHOULD NOT ESCAPE")
+        return real_scandir(path)
+
+    monkeypatch.setattr(scanner, "_scandir", permission_scandir)
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.outcome is api["AudioCppScanOutcome"].PERMISSION_LIMITED
+    assert result.discoveries[0].match.state is api["AudioCppMatchState"].EXACT
+    assert "PRIVATE SIBLING PATH" not in repr(result)
+
+
+def test_unreadable_sibling_reports_partial_without_poisoning_complete_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    api = _api()
+    root = tmp_path / "selected"
+    blocked = root / "unreadable-sibling"
+    blocked.mkdir(parents=True)
+    _write_gguf(root / "supertonic-3-orig.gguf")
+    real_scandir = scanner._scandir
+
+    def unreadable_scandir(path):
+        if Path(path).name == blocked.name:
+            raise OSError("PRIVATE SIBLING PATH SHOULD NOT ESCAPE")
+        return real_scandir(path)
+
+    monkeypatch.setattr(scanner, "_scandir", unreadable_scandir)
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.outcome is api["AudioCppScanOutcome"].PARTIAL
+    assert result.discoveries[0].match.state is api["AudioCppMatchState"].EXACT
+    assert "PRIVATE SIBLING PATH" not in repr(result)
+
+
+def test_zero_metadata_companion_is_opened_to_prove_readability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+    from tldw_chatbook.TTS.audio_cpp_recipes import AUDIO_CPP_RECIPE_REGISTRY
+
+    api = _api()
+    root = tmp_path / "pocket-tts"
+    recipe = AUDIO_CPP_RECIPE_REGISTRY.for_package("pocket_tts_english_safetensors")
+    for signal in recipe.required_files:
+        path = root / signal.relative_path
+        if signal.kind.value == "safetensors":
+            _write_safetensors(path)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"tokenizer")
+    real_open = scanner.os.open
+
+    def deny_tokenizer(path, flags, mode=0o777, *, dir_fd=None):
+        if Path(path).name == "tokenizer.model":
+            raise PermissionError("PRIVATE TOKENIZER PATH SHOULD NOT ESCAPE")
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(scanner.os, "open", deny_tokenizer)
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    discovery = result.discoveries[0]
+    tokenizer = next(
+        item
+        for item in discovery.description.files
+        if item.relative_path.endswith("tokenizer.model")
+    )
+    assert not tokenizer.readable
+    assert discovery.match.state is api["AudioCppMatchState"].PERMISSION_LIMITED
+    assert "PRIVATE TOKENIZER PATH" not in repr(result)
+
+
+def test_permission_failure_during_directory_iteration_is_isolated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    api = _api()
+    root = tmp_path / "selected-private-root"
+    root.mkdir()
+
+    class FailingIterator:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise PermissionError("PRIVATE ITERATOR PATH SHOULD NOT ESCAPE")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(scanner, "_scandir", lambda _path: FailingIterator())
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.outcome is api["AudioCppScanOutcome"].PERMISSION_LIMITED
+    assert result.issues == (
+        scanner.AudioCppScanIssue(
+            api["AudioCppScanIssueCode"].PERMISSION_DENIED,
+            root.name,
+        ),
+    )
+    assert str(tmp_path) not in repr(result)
+    assert "PRIVATE ITERATOR PATH" not in repr(result)
+
+
+def test_directory_iterator_close_failure_is_sanitized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    api = _api()
+    root = tmp_path / "selected-private-root"
+    root.mkdir()
+
+    class CloseFailingIterator:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise StopIteration
+
+        def close(self) -> None:
+            raise OSError("PRIVATE CLOSE PATH SHOULD NOT ESCAPE")
+
+    monkeypatch.setattr(scanner, "_scandir", lambda _path: CloseFailingIterator())
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.outcome is api["AudioCppScanOutcome"].COMPLETE
+    assert result.issues == (
+        scanner.AudioCppScanIssue(
+            api["AudioCppScanIssueCode"].UNREADABLE,
+            root.name,
+        ),
+    )
+    assert str(tmp_path) not in repr(result)
+    assert "PRIVATE CLOSE PATH" not in repr(result)
+
+
+def test_descriptor_close_failure_invalidates_file_evidence_without_escaping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    api = _api()
+    root = tmp_path / "selected-private-root"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf")
+    real_close = scanner.os.close
+
+    def close_then_fail(descriptor: int) -> None:
+        real_close(descriptor)
+        raise OSError("PRIVATE DESCRIPTOR PATH SHOULD NOT ESCAPE")
+
+    monkeypatch.setattr(scanner.os, "close", close_then_fail)
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.outcome is api["AudioCppScanOutcome"].PARTIAL
+    assert result.discoveries[0].match.state is api["AudioCppMatchState"].INCOMPLETE
+    assert result.issues == (
+        scanner.AudioCppScanIssue(
+            api["AudioCppScanIssueCode"].UNREADABLE,
+            "supertonic-3-orig.gguf",
+        ),
+    )
+    assert str(tmp_path) not in repr(result)
+    assert "PRIVATE DESCRIPTOR PATH" not in repr(result)
+
+
+def test_unknown_and_issue_detail_is_sanitized_and_capped(tmp_path: Path) -> None:
+    api = _api()
+    limits_type = api["AudioCppScanLimits"]
+    root = tmp_path / "unknowns"
+    root.mkdir()
+    for index in range(5):
+        (root / f"unknown-{index}\nprivate.gguf").write_bytes(b"not gguf")
+
+    result = api["scan_audio_cpp_package_root"](
+        root,
+        limits=limits_type(max_unknown_names=2, max_issues=2),
+    )
+
+    assert len(result.unknown_names) == 2
+    assert result.unknown_names_truncated
+    assert all("\n" not in name and len(name) <= 128 for name in result.unknown_names)
+    assert str(tmp_path) not in repr(result)
+
+
+@pytest.mark.parametrize(
+    "changes",
+    (
+        {"max_depth": -1},
+        {"max_entries": 0},
+        {"max_candidate_roots": 0},
+        {"max_results": 0},
+        {"max_metadata_bytes_per_file": 0},
+        {"max_metadata_bytes_total": 0},
+        {"max_entry_seconds": 0},
+        {"max_total_seconds": 0},
+        {"max_issues": 0},
+        {"max_unknown_names": 0},
+    ),
+)
+def test_all_scanner_limits_are_finite_positive_bounds(
+    changes: dict[str, object],
+) -> None:
+    limits_type = _api()["AudioCppScanLimits"]
+
+    with pytest.raises(ValueError):
+        limits_type(**changes)
+
+
+def test_guided_foundation_has_no_process_network_or_model_write_side_effects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import socket
+    import subprocess
+    import urllib.request
+
+    import httpx
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+    from tldw_chatbook.TTS.audio_cpp_guided_config import AudioCppSettingsConfig
+    from tldw_chatbook.TTS.audio_cpp_recipes import AUDIO_CPP_RECIPE_REGISTRY
+
+    root = tmp_path / "selected-model"
+    root.mkdir()
+    model_file = root / "supertonic-3-orig.gguf"
+    _write_gguf(model_file)
+
+    def snapshot() -> tuple[bytes, tuple[int, int, int, int, int]]:
+        info = model_file.stat()
+        return model_file.read_bytes(), (
+            info.st_dev,
+            info.st_ino,
+            info.st_mode,
+            info.st_size,
+            info.st_mtime_ns,
+        )
+
+    before = snapshot()
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("guided foundation attempted a forbidden side effect")
+
+    monkeypatch.setattr(subprocess, "Popen", forbidden)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", forbidden)
+    monkeypatch.setattr(socket, "socket", forbidden)
+    monkeypatch.setattr(httpx, "Client", forbidden)
+    monkeypatch.setattr(httpx, "AsyncClient", forbidden)
+    monkeypatch.setattr(urllib.request, "urlopen", forbidden)
+
+    real_open = scanner.os.open
+    write_flags = os.O_WRONLY | os.O_RDWR | os.O_CREAT | os.O_TRUNC | os.O_APPEND
+
+    def read_only_open(path, flags, mode=0o777, *, dir_fd=None):
+        assert flags & write_flags == 0
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(scanner.os, "open", read_only_open)
+
+    scan = scanner.scan_audio_cpp_package_root(root)
+    candidate = scan.discoveries[0].match.candidates[0]
+    accepted = candidate.accept()
+    settings = AudioCppSettingsConfig.from_mapping(
+        {
+            "mode": "managed",
+            "managed_setup_source": "guided",
+            "guided_binary_path": "/opt/homebrew/bin/audiocpp_server",
+            "guided_packages": [accepted.model_dump(mode="json")],
+            "guided_default_model_id": accepted.public_model_id,
+        }
+    )
+
+    recipe = AUDIO_CPP_RECIPE_REGISTRY.validate_accepted(settings.guided_packages[0])
+
+    assert recipe.recipe_id == accepted.recipe_id
+    assert before == snapshot()

--- a/Tests/TTS/test_audio_cpp_package_scanner.py
+++ b/Tests/TTS/test_audio_cpp_package_scanner.py
@@ -115,6 +115,67 @@ def test_bad_gguf_version_is_recognizable_but_never_selected(tmp_path: Path) -> 
     assert result.discoveries[0].match.candidates == ()
 
 
+def test_selected_root_is_validated_before_any_filesystem_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    calls: list[str] = []
+
+    def reject_path(*_args, **_kwargs) -> Path:
+        calls.append("validate")
+        raise ValueError("private validator detail")
+
+    def reject_probe(*_args, **_kwargs):
+        calls.append("lstat")
+        raise OSError("private filesystem detail")
+
+    monkeypatch.setattr(scanner, "validate_path_simple", reject_path, raising=False)
+    monkeypatch.setattr(scanner.os, "lstat", reject_probe)
+
+    with pytest.raises(
+        scanner.AudioCppPackageScanError,
+        match="Selected audio.cpp package root is unavailable",
+    ):
+        scanner.scan_audio_cpp_package_root(tmp_path / "selected")
+
+    assert calls == ["validate"]
+
+
+def test_missing_no_follow_open_support_fails_closed_without_opening_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+    from tldw_chatbook.TTS.audio_cpp_recipes import AudioCppMatchState
+
+    root = tmp_path / "selected"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf")
+    real_open = scanner.os.open
+    opened: list[Path] = []
+
+    def recording_open(path, flags, mode=0o777, *, dir_fd=None):
+        opened.append(Path(path))
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.delattr(scanner.os, "O_NOFOLLOW", raising=False)
+    monkeypatch.setattr(scanner.os, "open", recording_open)
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert opened == []
+    assert result.outcome is scanner.AudioCppScanOutcome.PARTIAL
+    assert result.discoveries[0].match.state is AudioCppMatchState.INCOMPLETE
+    assert result.issues == (
+        scanner.AudioCppScanIssue(
+            scanner.AudioCppScanIssueCode.NO_FOLLOW_UNAVAILABLE,
+            "supertonic-3-orig.gguf",
+        ),
+    )
+
+
 def test_multifile_safetensors_layout_requires_every_companion(tmp_path: Path) -> None:
     api = _api()
     root = tmp_path / "supertonic-3"

--- a/Tests/TTS/test_audio_cpp_recipes.py
+++ b/Tests/TTS/test_audio_cpp_recipes.py
@@ -1,0 +1,426 @@
+"""Sealed audio.cpp package recipes and release accounting."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+from hashlib import sha256
+from uuid import UUID
+
+import pytest
+
+
+SUPERONIC_PACKAGES = {
+    "supertonic_3_q8_0": ("supertonic-3-q8_0.gguf",),
+    "supertonic_3_f16": ("supertonic-3-f16.gguf",),
+    "supertonic_3_orig": ("supertonic-3-orig.gguf",),
+    "supertonic_3_safetensors": (
+        "config/tts.json",
+        "config/unicode_indexer.json",
+        "ggml/supertonic.safetensors",
+    ),
+}
+POCKET_GGUF_PACKAGES = {
+    f"pocket_tts_{language}_{precision}": (f"pocket-tts-{language}-{precision}.gguf",)
+    for language in ("english", "german", "italian", "portuguese", "spanish")
+    for precision in ("q8_0", "bf16")
+}
+POCKET_SAFETENSORS_FILES = (
+    *(
+        f"languages/english/embeddings/{voice}.safetensors"
+        for voice in (
+            "alba",
+            "anna",
+            "azelma",
+            "bill_boerst",
+            "caro_davy",
+            "charles",
+            "cosette",
+            "eponine",
+            "estelle",
+            "eve",
+            "fantine",
+            "george",
+            "giovanni",
+            "jane",
+            "javert",
+            "jean",
+            "juergen",
+            "lola",
+            "marius",
+            "mary",
+            "michael",
+            "paul",
+            "peter_yearsley",
+            "rafael",
+            "stuart_bell",
+            "vera",
+        )
+    ),
+    "languages/english/model.safetensors",
+    "languages/english/tokenizer.model",
+)
+EXPECTED_INITIAL_PACKAGES = {
+    **SUPERONIC_PACKAGES,
+    **POCKET_GGUF_PACKAGES,
+    "pocket_tts_english_safetensors": POCKET_SAFETENSORS_FILES,
+}
+EXPECTED_RELEASE_FAMILY_COUNTS = {
+    "supertonic": 4,
+    "pocket_tts": 11,
+    "chatterbox": 3,
+    "dramabox": 1,
+    "miotts": 3,
+    "vibevoice": 2,
+    "moss_tts_nano": 2,
+    "fish_audio": 2,
+    "higgs_audio_tts": 2,
+    "omnivoice": 4,
+    "qwen3_tts": 9,
+    "voxcpm2": 4,
+    "confucius4_tts": 1,
+    "vevo2": 3,
+    "index_tts2": 4,
+    "irodori_tts": 6,
+    "moss_tts_local": 2,
+    "glm_tts": 1,
+    "inflect_v2": 1,
+    "outetts": 1,
+    "vietneu_tts": 1,
+}
+
+
+def _api():
+    from tldw_chatbook.TTS.audio_cpp_recipes import (  # noqa: F401
+        AUDIO_CPP_PINNED_COMMIT,
+        AUDIO_CPP_PINNED_RELEASE,
+        AUDIO_CPP_RECIPE_REGISTRY,
+        AUDIO_CPP_RELEASE_ACCOUNTING,
+        AudioCppBackendEvidenceState,
+        AudioCppFileKind,
+        AudioCppFileRole,
+        AudioCppFileSignal,
+        AudioCppMatchState,
+        AudioCppPackageDescription,
+        AudioCppPackageFileEvidence,
+        AudioCppRecipeRegistry,
+        AudioCppRecipeSupportState,
+    )
+
+    return locals()
+
+
+def _identity(label: str) -> str:
+    return sha256(label.encode("utf-8")).hexdigest()
+
+
+def _description(recipe, *, missing=(), invalid=(), partial=False, permission=False):
+    api = _api()
+    evidence_type = api["AudioCppPackageFileEvidence"]
+    description_type = api["AudioCppPackageDescription"]
+    files = tuple(
+        evidence_type(
+            relative_path=signal.relative_path,
+            size_bytes=128,
+            identity=_identity(signal.relative_path),
+            readable=True,
+            metadata_valid=signal.relative_path not in invalid,
+        )
+        for signal in recipe.required_files
+        if signal.relative_path not in missing
+    )
+    return description_type(
+        canonical_root="/models/package",
+        canonical_root_identity=_identity("root"),
+        safe_name="package",
+        files=files,
+        partial=partial,
+        permission_limited=permission,
+    )
+
+
+def test_registry_is_pinned_and_contains_every_initial_package_exactly_once() -> None:
+    api = _api()
+    registry = api["AUDIO_CPP_RECIPE_REGISTRY"]
+
+    assert api["AUDIO_CPP_PINNED_RELEASE"] == "release-0.5.1"
+    assert api["AUDIO_CPP_PINNED_COMMIT"] == (
+        "238ab6a9e321c17de8e120559f57efeedaeb1345"
+    )
+    assert len(registry.recipes) == 15
+    assert {recipe.package_variant for recipe in registry.recipes} == set(
+        EXPECTED_INITIAL_PACKAGES
+    )
+    assert len({recipe.recipe_id for recipe in registry.recipes}) == 15
+
+
+def test_registry_collection_cannot_be_replaced_after_construction() -> None:
+    registry = _api()["AUDIO_CPP_RECIPE_REGISTRY"]
+
+    with pytest.raises(AttributeError):
+        registry.recipes = ()
+
+
+@pytest.mark.parametrize("package_variant", sorted(EXPECTED_INITIAL_PACKAGES))
+def test_recipe_has_exact_reviewed_layout_and_safe_projection(
+    package_variant: str,
+) -> None:
+    api = _api()
+    registry = api["AUDIO_CPP_RECIPE_REGISTRY"]
+    support_state = api["AudioCppRecipeSupportState"]
+    backend_state = api["AudioCppBackendEvidenceState"]
+    recipe = registry.for_package(package_variant)
+
+    assert (
+        tuple(signal.relative_path for signal in recipe.required_files)
+        == (EXPECTED_INITIAL_PACKAGES[package_variant])
+    )
+    assert recipe.audio_cpp_release == "release-0.5.1"
+    assert recipe.audio_cpp_commit == api["AUDIO_CPP_PINNED_COMMIT"]
+    assert recipe.schema_version == 1
+    assert recipe.recipe_revision == 1
+    assert recipe.support_state is support_state.APPROVED
+    assert recipe.projection.family == recipe.family
+    assert recipe.projection.task == "tts"
+    assert recipe.projection.mode == "offline"
+    assert recipe.source_links and all(
+        api["AUDIO_CPP_PINNED_COMMIT"] in link for link in recipe.source_links
+    )
+    assert recipe.evidence_reference
+    assert recipe.backend_evidence
+    assert all(item.state is backend_state.EXPECTED for item in recipe.backend_evidence)
+    if package_variant.endswith(("q8_0", "bf16", "f16", "orig")):
+        assert (
+            recipe.projection.model_relative_path
+            == EXPECTED_INITIAL_PACKAGES[package_variant][0]
+        )
+    else:
+        assert recipe.projection.model_relative_path is None
+
+
+def test_tasks_and_pocket_language_options_follow_the_pinned_specs() -> None:
+    registry = _api()["AUDIO_CPP_RECIPE_REGISTRY"]
+
+    for recipe in registry.recipes:
+        if recipe.family == "supertonic":
+            assert recipe.capabilities == ("tts",)
+            assert recipe.projection.load_options == ()
+            assert recipe.projection.session_options == ()
+            continue
+        assert recipe.family == "pocket_tts"
+        assert recipe.capabilities == ("tts", "clone")
+        language = recipe.package_variant.split("_")[2]
+        assert {(item.name, item.value) for item in recipe.projection.load_options} == {
+            ("language", language)
+        }
+        assert {
+            (item.name, item.value) for item in recipe.projection.session_options
+        } == {("language", language)}
+
+
+def test_recipe_records_are_frozen_and_reject_path_or_extension_attacks() -> None:
+    api = _api()
+    registry = api["AUDIO_CPP_RECIPE_REGISTRY"]
+    file_signal = api["AudioCppFileSignal"]
+    file_kind = api["AudioCppFileKind"]
+    file_role = api["AudioCppFileRole"]
+    recipe = registry.recipes[0]
+
+    with pytest.raises(FrozenInstanceError):
+        recipe.family = "changed"
+    for path in (
+        "/private/model.gguf",
+        "../model.gguf",
+        "models/../../model.gguf",
+        "C:\\private\\model.gguf",
+        "$HOME/model.gguf",
+        "models\n/model.gguf",
+    ):
+        with pytest.raises(ValueError):
+            file_signal(
+                relative_path=path,
+                kind=file_kind.GGUF,
+                role=file_role.WEIGHT,
+            )
+    with pytest.raises(TypeError):
+        replace(recipe, shell="curl example.test")
+    with pytest.raises(ValueError):
+        replace(recipe, required_files=list(recipe.required_files))
+    with pytest.raises(ValueError):
+        replace(recipe, backend_evidence=list(recipe.backend_evidence))
+    with pytest.raises(ValueError):
+        file_signal(
+            relative_path="model.gguf",
+            kind="gguf",  # type: ignore[arg-type]
+            role=file_role.WEIGHT,
+        )
+
+
+@pytest.mark.parametrize("package_variant", sorted(EXPECTED_INITIAL_PACKAGES))
+def test_every_reviewed_recipe_matches_only_complete_valid_evidence(
+    package_variant: str,
+) -> None:
+    api = _api()
+    registry = api["AUDIO_CPP_RECIPE_REGISTRY"]
+    match_state = api["AudioCppMatchState"]
+    recipe = registry.for_package(package_variant)
+
+    exact = registry.match(_description(recipe))
+    missing = registry.match(
+        _description(recipe, missing=(recipe.required_files[-1].relative_path,))
+    )
+    invalid = registry.match(
+        _description(recipe, invalid=(recipe.required_files[0].relative_path,))
+    )
+
+    assert exact.state is match_state.EXACT
+    assert len(exact.candidates) == 1
+    assert exact.candidates[0].recipe.recipe_id == recipe.recipe_id
+    # A multi-file layout remains recognizable when one companion disappears.
+    # Removing the sole signal from a single-file package leaves no evidence from
+    # which to infer a variant, so the truthful fail-closed state is Unknown.
+    expected_missing_state = (
+        match_state.INCOMPLETE
+        if len(recipe.required_files) > 1
+        else match_state.UNKNOWN
+    )
+    assert missing.state is expected_missing_state
+    if expected_missing_state is match_state.INCOMPLETE:
+        assert recipe.recipe_id in missing.recipe_ids
+    assert invalid.state is match_state.INCOMPLETE
+    assert recipe.recipe_id in invalid.recipe_ids
+
+
+def test_near_match_partial_and_permission_evidence_fail_closed() -> None:
+    api = _api()
+    registry = api["AUDIO_CPP_RECIPE_REGISTRY"]
+    description_type = api["AudioCppPackageDescription"]
+    evidence_type = api["AudioCppPackageFileEvidence"]
+    match_state = api["AudioCppMatchState"]
+    recipe = registry.for_package("supertonic_3_orig")
+    near = description_type(
+        canonical_root="/models/package",
+        canonical_root_identity=_identity("root"),
+        safe_name="package",
+        files=(
+            evidence_type(
+                relative_path="supertonic-4-orig.gguf",
+                size_bytes=128,
+                identity=_identity("near"),
+                readable=True,
+                metadata_valid=True,
+            ),
+        ),
+    )
+
+    assert registry.match(near).state is match_state.UNKNOWN
+    assert registry.match(_description(recipe, partial=True)).state is (
+        match_state.INCOMPLETE
+    )
+    assert registry.match(_description(recipe, permission=True)).state is (
+        match_state.PERMISSION_LIMITED
+    )
+
+
+def test_conflicting_exact_recipes_remain_ambiguous_for_review() -> None:
+    api = _api()
+    production = api["AUDIO_CPP_RECIPE_REGISTRY"]
+    registry_type = api["AudioCppRecipeRegistry"]
+    match_state = api["AudioCppMatchState"]
+    recipe = production.for_package("supertonic_3_orig")
+    conflict = replace(
+        recipe,
+        recipe_id="audio-cpp-0.5.1.supertonic.supertonic_3_orig_alt",
+        package_variant="supertonic_3_orig_alt",
+        default_public_model_id="supertonic-3-orig-alt",
+    )
+    registry = registry_type((recipe, conflict))
+
+    result = registry.match(_description(recipe))
+
+    assert result.state is match_state.AMBIGUOUS
+    assert result.recipe_ids == tuple(sorted((recipe.recipe_id, conflict.recipe_id)))
+    assert len(result.candidates) == 2
+
+
+def test_accepted_snapshot_must_equal_the_exact_recipe_revision_and_projection() -> (
+    None
+):
+    registry = _api()["AUDIO_CPP_RECIPE_REGISTRY"]
+    recipe = registry.for_package("supertonic_3_orig")
+    candidate = registry.match(_description(recipe)).candidates[0]
+    accepted = candidate.accept(public_model_id="narrator")
+    second = candidate.accept(public_model_id="narrator")
+
+    assert registry.validate_accepted(accepted) is recipe
+    assert str(UUID(accepted.package_uuid)) == accepted.package_uuid
+    assert accepted.package_uuid != second.package_uuid
+    assert accepted.public_model_id == second.public_model_id
+    with pytest.raises(ValueError, match="review"):
+        registry.validate_accepted(accepted.model_copy(update={"recipe_revision": 2}))
+    with pytest.raises(ValueError, match="review"):
+        registry.validate_accepted(
+            accepted.model_copy(
+                update={
+                    "projection": accepted.projection.model_copy(
+                        update={"family": "pocket_tts"}
+                    )
+                }
+            )
+        )
+
+
+def test_release_accounting_is_complete_and_truthful_for_all_21_families() -> None:
+    api = _api()
+    accounting = api["AUDIO_CPP_RELEASE_ACCOUNTING"]
+    support_state = api["AudioCppRecipeSupportState"]
+    registry = api["AUDIO_CPP_RECIPE_REGISTRY"]
+    counts: dict[str, int] = {}
+    for entry in accounting:
+        counts[entry.family] = counts.get(entry.family, 0) + 1
+
+    assert len(accounting) == 67
+    assert counts == EXPECTED_RELEASE_FAMILY_COUNTS
+    assert sum(entry.state is support_state.APPROVED for entry in accounting) == 15
+    assert sum(entry.state is support_state.OPEN_GAP for entry in accounting) == 52
+    assert not any(
+        entry.state is support_state.EXPLICITLY_UNSUPPORTED for entry in accounting
+    )
+    assert {
+        entry.package_variant
+        for entry in accounting
+        if entry.state is support_state.APPROVED
+    } == {recipe.package_variant for recipe in registry.recipes}
+    assert all(
+        entry.recipe_id is not None
+        if entry.state is support_state.APPROVED
+        else entry.reason == "Recipe review is not complete."
+        for entry in accounting
+    )
+    pinned_rows = "\n".join(
+        sorted(f"{entry.family}:{entry.package_variant}" for entry in accounting)
+    )
+    assert sha256(pinned_rows.encode("utf-8")).hexdigest() == (
+        "10d75a8ab499d15cbb49c73dc8a070d994c788dda66f5d82315747146c9d8480"
+    )
+
+
+def test_user_facing_verified_claims_exclude_expected_or_untested_tuples() -> None:
+    api = _api()
+    registry = api["AUDIO_CPP_RECIPE_REGISTRY"]
+    registry_type = api["AudioCppRecipeRegistry"]
+    backend_state = api["AudioCppBackendEvidenceState"]
+    recipe = registry.recipes[0]
+
+    assert registry.verified_support_claims() == ()
+    verified_tuple = replace(
+        recipe.backend_evidence[0],
+        state=backend_state.VERIFIED,
+        evidence_reference="qa/audio-cpp/release-0.5.1/darwin-arm64-cpu",
+    )
+    verified_recipe = replace(recipe, backend_evidence=(verified_tuple,))
+    claims = registry_type((verified_recipe,)).verified_support_claims()
+
+    assert len(claims) == 1
+    assert claims[0].recipe_id == recipe.recipe_id
+    assert claims[0].backend == verified_tuple.backend
+    assert claims[0].evidence_reference == verified_tuple.evidence_reference

--- a/Tests/TTS/test_audio_cpp_recipes.py
+++ b/Tests/TTS/test_audio_cpp_recipes.py
@@ -160,6 +160,26 @@ def test_registry_collection_cannot_be_replaced_after_construction() -> None:
         registry.recipes = ()
 
 
+def test_registry_rejects_conflicting_validation_contracts_for_one_path() -> None:
+    api = _api()
+    registry = api["AUDIO_CPP_RECIPE_REGISTRY"]
+    recipe = registry.for_package("supertonic_3_orig")
+    conflicting_signal = replace(
+        recipe.required_files[0],
+        kind=api["AudioCppFileKind"].JSON,
+    )
+    conflicting_recipe = replace(
+        recipe,
+        recipe_id="audio-cpp-0.5.1.supertonic.conflicting-path-contract",
+        package_variant="conflicting_path_contract",
+        default_public_model_id="conflicting-path-contract",
+        required_files=(conflicting_signal,),
+    )
+
+    with pytest.raises(ValueError, match="conflicting file validation contracts"):
+        api["AudioCppRecipeRegistry"]((recipe, conflicting_recipe))
+
+
 @pytest.mark.parametrize("package_variant", sorted(EXPECTED_INITIAL_PACKAGES))
 def test_recipe_has_exact_reviewed_layout_and_safe_projection(
     package_variant: str,

--- a/backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
+++ b/backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
@@ -3,6 +3,10 @@
 Status: Accepted
 Date: 2026-07-23
 Amended: 2026-08-02
+Partially superseded: 2026-08-09 by
+[ADR-050](050-audio-cpp-generated-model-setup-ownership.md), only for the new
+guided generated-configuration source and Windows target; the External and
+user-provided-`server.json` contracts remain in force
 Related Tasks: TASK-561, TASK-560, TASK-569, TASK-710, TASK-763
 Supersedes: N/A
 

--- a/backlog/decisions/028-character-tts-generation-profile-ownership.md
+++ b/backlog/decisions/028-character-tts-generation-profile-ownership.md
@@ -4,6 +4,10 @@ Status: Accepted
 Date: 2026-07-26
 Amended: 2026-07-31 (TASK-1626, explicit sanitized portability); 2026-08-04
 (TASK-2450, seven-provider expansion — see amendment block below)
+Partially superseded: 2026-08-09 by
+[ADR-051](051-private-tts-clone-reference-assets.md), only for the new typed
+audio.cpp clone-reference/profile-v3 contract; all other profile ownership,
+assignment, and sanitized portability boundaries remain in force
 Related Tasks: TASK-710, TASK-763, TASK-1626, TASK-2450
 Extends: ADR-023
 Supersedes: N/A

--- a/backlog/decisions/039-global-and-studio-tts-settings-ownership.md
+++ b/backlog/decisions/039-global-and-studio-tts-settings-ownership.md
@@ -3,6 +3,10 @@
 Status: Accepted
 Date: 2026-07-31
 Amended: 2026-08-02
+Partially superseded: 2026-08-09 by
+[ADR-050](050-audio-cpp-generated-model-setup-ownership.md), only for the new
+globally owned guided generated-configuration source; the four-owner model and
+existing External/user-JSON sources remain in force
 Related Task: N/A — program task decomposition follows the approved PRD
 Extends:
 [ADR-012 Provider Credential Settings Boundary](012-provider-credential-settings-boundary.md),

--- a/backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md
+++ b/backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md
@@ -1,0 +1,178 @@
+# ADR-050: Generate audio.cpp model setup from structured global settings
+
+Status: Accepted
+Date: 2026-08-09
+Related Task: N/A — task decomposition follows the approved design
+Extends: ADR-023, ADR-039, ADR-040
+Supersedes: Only the conflicting generated-configuration and Windows deferrals
+in ADR-023 and ADR-039; all other boundaries remain in force
+
+## Decision
+
+Chatbook will add a second Managed audio.cpp setup source: structured global
+Settings that materialize an application-owned, generation-specific
+`server.json` only when a deliberate operation is eligible to launch or replace
+the managed child. The existing user-provided `server.json` source remains
+supported and unchanged.
+
+Structured global Settings are the sole durable authority for generated setup.
+The materialized JSON is an immutable launch artifact, not a second editable
+configuration store. Chatbook never imports edits from it and never presents it
+as user-editable. A saved configuration can remain staged while the active
+child continues using its exact applied artifact. Save validates and persists;
+it does not create the artifact, bind a port, probe, launch, restart, or stop a
+process.
+
+Generated setup uses a built-in, immutable recipe registry. Recipes are
+declarative, versioned with Chatbook, and pinned to reviewed audio.cpp release
+evidence. They recognize exact model-package layouts and project only
+allowlisted server fields. They cannot execute code, download content, add
+arbitrary launch arguments, enable CORS, enable request-body logging, or accept
+non-loopback managed binding. Runtime remote recipe updates are prohibited.
+
+The initial compatibility baseline is audio.cpp `release-0.5.1`, commit
+`238ab6a9e321c17de8e120559f57efeedaeb1345`. The compatibility goal is every
+released core or community family tagged `TTS` or `Clone` in that snapshot and
+every approved package variant for those families. A release may claim only
+the exact recipe/package/platform/backend tuples for which evidence exists;
+Chatbook cannot claim general release coverage while an unapproved gap remains.
+
+Models selected from disk are referenced in place with absolute paths. Chatbook
+does not copy them into application data. Model Library installations remain
+explicit user actions and use the existing shared managed-model store. A
+recipe's reviewed artifact identifiers may connect the two flows, but setup
+never invokes a package manager or downloads the audio.cpp server binary.
+
+The generated launch contract is:
+
+- exact `127.0.0.1` binding, CORS disabled, and request-body logging disabled;
+- a port selected at launch from a bounded application-owned loopback range;
+- `lazy_load: true`, with all accepted configured models registered in one
+  server and loaded by audio.cpp on first model use;
+- absolute model and model-spec paths;
+- one direct, no-shell `audiocpp_server --config <artifact>` child;
+- one application-owned managed child per Chatbook process; and
+- the existing saved/applied/process-generation, lease-drain, supervision,
+  diagnostics, and bounded-shutdown rules from ADR-023.
+
+The native TTS catalog admits only audio.cpp's exact speech tasks `tts` and
+`clone`. It preserves those typed capabilities and cross-checks them against
+the applied recipe; it does not broaden into ASR, voice conversion, music, or
+other audio.cpp task routing. Native clone requests extend the provider-neutral
+request with typed reference input rather than reopening generic options.
+
+Chatbook may detect an existing `audiocpp_server` on `PATH` or in a reviewed
+platform install location and may let the user browse to one. It does not
+install, update, bundle, or adopt the server. Unknown server versions are
+allowed to Test with an explicit warning but never inherit Verified status.
+
+Generated setup targets macOS, Linux, and Windows. Verification is an exact
+tuple of Chatbook version, audio.cpp release and commit, operating system,
+architecture, binary identity, model recipe and package, and compute backend.
+CPU is the cross-platform baseline; accelerated backends are Verified only on
+the tuples actually exercised. Backend `Auto` selects from observed host and
+binary evidence. Automatic fallback is permitted only for a stable,
+recognized backend-unavailable failure and only after the failed child and
+artifact are definitively reaped. Otherwise recovery is explicit, including a
+`Try CPU` action.
+
+The local package scanner examines only roots explicitly chosen by the user. It
+is bounded, cancellable, runs off the Textual event loop, does not recursively
+follow nested symlinks, and reports exact, ambiguous, unknown, incomplete, and
+permission-limited outcomes separately. A recipe match is configuration
+assistance, not proof that arbitrary bytes are safe or loadable; audio.cpp
+remains the runtime contract authority. Chatbook persists the normalized recipe
+projection accepted by the user so a later recipe update cannot silently
+reinterpret an installed model.
+
+The Settings surface owns setup and global defaults. Speech Lab owns deliberate
+Test/Start/Restart/Shutdown, synthesis, playback, and diagnostics. Studio
+preferences remain separate and are never overwritten by global setup. The
+first generation result remains one complete validated WAV delivered through
+the existing asynchronous response interface.
+
+## Context
+
+ADR-023 deliberately began with an external server, then added a managed child
+whose binary and `server.json` are both user-provided. That boundary is usable
+for experienced audio.cpp users but does not meet the first-time path now being
+designed: install Chatbook, install audio.cpp separately, download or select a
+supported model package, configure it without hand-authoring JSON, and hear a
+sample.
+
+audio.cpp `release-0.5.1` exposes multiple TTS and voice-cloning families through
+one server, package model specs, lazy model loading, and OpenAI-shaped speech
+requests. Its configuration remains sufficiently model-specific that accepting
+an arbitrary GGUF and guessing fields would be unreliable. A bounded recipe
+registry gives Chatbook an auditable compatibility promise without embedding
+upstream executable logic or becoming a general audio.cpp configuration editor.
+
+This is an architecture decision because it changes configuration authority,
+managed-runtime launch inputs, artifact lifecycle, cross-platform process
+ownership, model-discovery contracts, and the long-lived division between
+Settings and Speech Lab.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Keep user-authored `server.json` as the only Managed path | Preserves expert control but leaves the stated first-time flow dependent on manual JSON and upstream schema knowledge. |
+| Treat generated JSON as another editable durable file | Creates two authorities, makes staged/applied truth ambiguous, and allows edits that bypass Settings validation. |
+| Copy every selected model into application data | Duplicates very large assets, breaks user-managed layouts, and conflicts with the existing shared-artifact boundary. |
+| Accept any GGUF and infer its family heuristically | A GGUF filename or weak metadata match cannot safely determine required companion assets, task, mode, voice contract, or model-spec projection. |
+| Download or install audio.cpp from Chatbook | Adds binary distribution, signing, update, platform-toolchain, licensing, and trust responsibilities outside this workstream. |
+| Fetch recipes from a remote service | Makes compatibility and launch behavior change outside the installed application version and expands the supply-chain boundary. |
+| Start one child per model | Multiplies lifecycle, memory, port, diagnostics, and shutdown ownership despite audio.cpp already supporting multiple registered models. |
+| Add automatic model unloading or a VRAM scheduler | audio.cpp intentionally retains loaded sessions; a second resource manager is not required for the first usable setup flow. |
+| Silently fall back through every backend | Can hide broken builds and leave multiple failed children or inconsistent evidence; fallback is safe only for stable recognized failures. |
+
+## Consequences
+
+### Benefits
+
+- A new user can configure supported audio.cpp model packages without writing
+  JSON while expert users retain the existing manual source.
+- Durable settings, generated launch artifacts, applied process state, and
+  runtime evidence have explicit non-overlapping owners.
+- Compatibility claims are reviewable at family, package, platform, and
+  backend granularity.
+- Multiple configured models share the already accepted one-child lifecycle.
+- The design stays offline-capable and does not introduce remote code or a new
+  runtime dependency.
+
+### Accepted trade-offs
+
+- Recipe work must track upstream package variants; an unknown or ambiguous
+  package remains manual-only until explicitly reviewed.
+- Referencing user-selected packages in place means moves, deletion, symlink
+  retargeting, or byte replacement can require review or fail the next
+  deliberate launch.
+- Generated setup cannot expose every upstream option. Unsupported expert
+  fields require the user-provided JSON source.
+- A Verified label is narrower than “audio.cpp supports it”; it requires exact
+  Chatbook evidence for the displayed tuple.
+- Windows lifecycle and privacy guarantees must be implemented and verified
+  explicitly rather than inferred from POSIX behavior.
+- Lazy loading reduces startup cost but does not unload a model after first use;
+  the UI must disclose that memory remains resident until shutdown.
+
+## Rollback
+
+- Disable the generated setup source while retaining its structured settings
+  as inert data.
+- Preserve the user-provided JSON and External sources as recovery paths.
+- Stop any owned child through the existing definitive lifecycle before
+  disabling generated launch.
+- Do not delete selected model packages, Model Library artifacts, user JSON, or
+  unknown generation artifacts during rollback.
+- A build that no longer understands a stored recipe projection must present it
+  as needing review; it must not reinterpret or silently launch it.
+
+## Links
+
+- [Guided model setup design](../../Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md)
+- [ADR-023: TTS adapter registry and audio.cpp runtime](023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md)
+- [ADR-039: Global and Studio TTS settings ownership](039-global-and-studio-tts-settings-ownership.md)
+- [ADR-040: Profile-owned state and shared asset paths](040-profile-owned-state-and-shared-asset-paths.md)
+- [Managed lifecycle design](../../Docs/superpowers/specs/2026-08-02-audio-cpp-managed-lifecycle-design.md)
+- [audio.cpp release-0.5.1](https://github.com/0xShug0/audio.cpp/releases/tag/release-0.5.1)

--- a/backlog/decisions/051-private-tts-clone-reference-assets.md
+++ b/backlog/decisions/051-private-tts-clone-reference-assets.md
@@ -1,0 +1,193 @@
+# ADR-051: Store TTS clone references as private profile-owned assets
+
+Status: Accepted
+Date: 2026-08-09
+Related Task: N/A — task decomposition follows the approved design
+Extends: ADR-028, ADR-029, ADR-040, ADR-050
+Supersedes: The audio.cpp empty-options/no-reference limitation in ADR-028 only;
+all other profile ownership and portability rules remain in force
+
+## Decision
+
+Chatbook will extend its local TTS generation profiles with one typed optional
+voice-clone reference. The reference is profile-owned private data, not an
+audio.cpp connection setting, generic provider option, character-card field,
+server configuration field, or durable source-file path.
+
+The profile database will advance from schema v2 to schema v3. A one-to-one
+reference table keyed by profile UUID stores:
+
+- an immutable reference UUID;
+- canonical, bounded WAV bytes as a SQLite BLOB;
+- the bounded reference transcript;
+- SHA-256, byte length, duration, sample rate, channel count, sample encoding;
+  and
+- creation and update timestamps.
+
+The original selected path is never persisted. Ingest accepts only a bounded
+supported WAV shape, decodes and canonicalizes it, removes arbitrary RIFF
+metadata, computes the digest from the canonical bytes, and commits the profile
+change and reference atomically. Global per-reference and aggregate quotas
+apply independently of narrower recipe guidance. Listing profiles reads
+metadata summaries rather than loading BLOBs, and BLOB import/export uses
+streaming I/O.
+
+The SQLite file remains local plaintext private storage under ADR-029. Chatbook
+must say that this protects access through filesystem ownership controls but is
+not encryption. Best-effort deletion, WAL checkpointing, and private temporary
+cleanup are required, but the product must not claim forensic erasure.
+
+An admitted clone request captures an immutable profile revision, reference
+UUID, and canonical digest. The exact reference is materialized into an opaque,
+owner-private per-session path and sent to the native audio.cpp adapter through
+typed `voice_ref` and `reference_text` request fields. It never enters generated
+`server.json`, generic options, general logs, child diagnostic output, HTTP
+debug logging, or public exception graphs.
+
+Reference-bearing profile execution initially requires an exact compatible
+guided-Managed recipe and the application-owned local child. Chatbook does not
+send a client-local materialized path to an independently owned External server
+or to an unclassified user-JSON model. Those sources retain text and exact
+voice-ID behavior. A future External clone path requires a separately designed
+upload or remote-asset contract; filesystem coincidence is not authority.
+
+Materialization directories use ownership locks. Normal completion removes the
+exact session directory. Startup cleanup may remove a leftover only after it
+proves that no live owner holds the corresponding lock; it cannot sweep
+unrecognized paths speculatively.
+
+The first clone audition may use a transient canonical reference without
+forcing profile creation. After successful synthesis, Chatbook may offer
+`Save as Voice Profile`. That save uses the exact canonical bytes that produced
+the current successful result; it does not reopen the original path. The
+transient artifact is bounded and retained only with the current result until
+save, replacement, discard, or application close.
+
+An audio.cpp profile may contain an exact `voice_id`, a clone reference, or
+both only when the exact accepted recipe declares that combination. Clone
+fields are typed provider capability, not arbitrary profile options. An edit
+increments the profile revision. Speech admitted against an older immutable
+revision may finish; later requests observe the new revision.
+
+Ordinary profile and character-card portability remains sanitized:
+
+- profiles without references keep the existing wire version 1;
+- a reference-bearing ordinary export uses wire version 2 and states that the
+  local reference was omitted;
+- it contains neither reference bytes nor transcript; and
+- import never silently creates, assigns, or repairs a reference-bearing
+  profile. The user must attach a local WAV, import an explicit bundle, or skip
+  the attachment.
+
+Reference transfer is a separate explicit voice bundle, not a character-card
+extension. The bundle is a strict versioned ZIP containing only a manifest,
+sanitized profile projection, canonical `reference.wav`, UTF-8 transcript, and
+bounded metadata/checksums. It excludes model files, character data,
+assignments, credentials, endpoints, source paths, and runtime state. Export and
+import display a plaintext-sensitive-data warning and a generic
+consent/provenance notice. Chatbook records no claim that legal consent was
+proved.
+
+Bundle import treats the archive as hostile. It rejects encrypted entries,
+duplicates, case or Unicode-normalization collisions, traversal, symlinks,
+devices, unknown entries, unsupported compression, excessive counts or sizes,
+decompression bombs, changed source bytes, and checksum mismatch. Checksums
+prove integrity only, not authenticity. UUID/name collisions require explicit
+review; import never overwrites, assigns, or changes a default automatically.
+A structurally valid bundle whose exact compatible model is absent may be
+stored visibly as `Needs compatible model`, but is never auto-retargeted.
+
+The existing profile repository remains the sole lifecycle owner. SQLite online
+backup and restore include the reference BLOB and validate schema, quotas, and
+integrity. Normal repository open remains metadata-focused; full WAV/digest
+validation occurs on import, restore, backup qualification, reference edit, and
+exact request admission rather than reading every BLOB at startup. A safely
+isolatable bad reference makes only its profile unavailable; structural store
+corruption still fails the repository closed.
+
+Migration is eager and guarded: validate v2, create a separately retained
+owner-private v2 pre-migration backup, migrate transactionally, validate v3,
+then publish the new store. Existing profiles remain domain-equivalent and have
+no reference row. Failure leaves v2 usable or the repository unavailable; it
+never publishes a partial migration. Downgrade is explicit: close the new app,
+restore the dedicated v2 backup, then use the old build, accepting loss of
+post-migration profile changes. Switching to manual audio.cpp setup inside the
+new build is feature rollback, not a database downgrade.
+
+## Context
+
+Several audio.cpp families in the approved `release-0.5.1` compatibility scope
+require or benefit from a reference recording and transcript. Chatbook's current
+profile schema stores exact model/voice selections but intentionally rejects
+audio.cpp options and has no owner for reference audio. Persisting a source path
+would break portability and could silently change the voice when that file is
+replaced. Putting raw audio in character cards would leak a private biometric-
+adjacent artifact through ordinary sharing.
+
+The feature therefore needs an explicit data owner, migration, request-admission
+snapshot, temporary-materialization lifecycle, backup behavior, and separate
+portable container. These are privacy, storage, schema, service-contract, and
+portability decisions, so they require a canonical ADR independent of the
+generated server-configuration decision.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Persist the user's source path | The bytes can move or change silently, paths leak local identity, and ordinary backup/export cannot reproduce the admitted voice. |
+| Put `voice_ref` and transcript in generic profile options | Evades typed validation, makes privacy review difficult, and risks sending paths or text to providers that do not support cloning. |
+| Store references in generated `server.json` voice presets | Makes a private profile asset a process-wide setting, leaks paths into child diagnostics, and prevents exact per-request/profile revision admission. |
+| Send the temporary local path to any External server | A remote or independently owned server may not share the filesystem and may persist/log the path or read it outside Chatbook's cleanup contract. |
+| Embed reference audio in character cards | Couples reusable profiles to characters and silently exports sensitive bytes through a common interchange format. |
+| Copy the original file byte-for-byte | Retains arbitrary RIFF metadata, unsupported encodings, and mutable or excessive content that Chatbook did not validate. |
+| Store one reference file beside the database | Adds cross-file transactions, orphan and replacement races, and backup/restore inconsistency without a demonstrated size need. |
+| Encrypt only this BLOB with a new app key | Introduces key creation, recovery, backup, rotation, and unlock UX beyond the established local-private boundary; the product must state plaintext honestly. |
+| Include reference bytes in ordinary portable profile v1 | Breaks existing sanitized portability assumptions and surprises card/profile sharing with a large sensitive payload. |
+| Auto-match a missing model on bundle import | A different family or variant can change voice semantics and request requirements; compatibility must remain exact and user-reviewed. |
+
+## Consequences
+
+### Benefits
+
+- Clone-capable audio.cpp families can participate in reusable per-character
+  voices without persisting mutable source paths.
+- Exact admitted bytes, transcript, profile revision, and runtime request remain
+  auditable and generation-safe.
+- Ordinary character/profile sharing remains sanitized by default.
+- Explicit bundles support intentional transfer with strict archive and privacy
+  boundaries.
+- Backup and restore stay repository-owned and transactionally consistent.
+
+### Accepted trade-offs
+
+- The profile database may become materially larger and needs explicit quotas
+  and streaming BLOB operations.
+- Reference audio is plaintext at rest; filesystem privacy is not encryption.
+- Secure deletion is best effort on SQLite, journaling files, copy-on-write
+  filesystems, backups, and storage media.
+- Users must keep the transcript with the reference and may need to attach or
+  import the reference again on another device.
+- A pre-v3 build cannot consume post-migration profile changes. Downgrade uses
+  the retained v2 backup and loses newer edits.
+- Bundle integrity does not establish speaker identity, provenance, consent, or
+  authenticity.
+
+## Rollback
+
+- Disable creation and admission of reference-bearing profiles without deleting
+  v3 data.
+- Keep non-reference v3 profiles usable in the current build where safe; do not
+  ask an older build to open v3.
+- Remove transient session material through the normal locked cleanup path.
+- For application downgrade, restore the dedicated pre-migration v2 backup only
+  while the v3 repository is closed.
+- Never synthesize from a missing, damaged, quota-violating, or unsupported
+  reference and never silently fall back to an unrelated voice.
+
+## Links
+
+- [Guided model setup design](../../Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md)
+- [ADR-028: Character TTS generation profile ownership](028-character-tts-generation-profile-ownership.md)
+- [ADR-029: Local private data boundary](029-local-private-data-boundary.md)
+- [ADR-040: Profile-owned state and shared asset paths](040-profile-owned-state-and-shared-asset-paths.md)
+- [ADR-050: Generated audio.cpp model setup](050-audio-cpp-generated-model-setup-ownership.md)

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -45,6 +45,8 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-043](043-console-rail-compact-collapse-yields-to-explicit-toggle.md) | Accepted | Console rail compact-collapse rules are the responsive default rendering, not a hard block: explicit rail toggles are honored at any width with the main-column min-width waived, so manual toggles never silently no-op. |
 | [ADR-045](045-qwencloud-dual-api-provider-boundary.md) | Accepted | Treat QwenCloud Responses and Chat Completions as two wire modes of one first-class provider while reusing the shared Console, native-tool, readiness, and model-catalog boundaries. |
 | [ADR-049](049-local-prompt-retained-version-history.md) | Accepted | Expose local Prompt and Recipe sync snapshots as bounded retained history with indexed paging, atomic keyword capture, and conditional restore as a new current version. |
+| [ADR-050](050-audio-cpp-generated-model-setup-ownership.md) | Accepted | Generate immutable audio.cpp launch artifacts from structured global settings and a built-in exact-package recipe registry while retaining the manual server.json path. |
+| [ADR-051](051-private-tts-clone-reference-assets.md) | Accepted | Store canonical TTS clone references as private profile-owned assets with typed admission and separate explicit portability. |
 
 ## Historical Decision Material
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1731,3 +1731,9 @@ and immediately after opening the iterator; close without iterating if either
 observation differs or becomes a symlink/reparse point. For files, combine a
 no-follow open with `fstat` identity/type comparison before reading metadata.
 Static fixtures prove policy for stable trees, not race safety.
+
+PR #1463 review exposed a second portability trap: treating a missing
+`O_NOFOLLOW` as flag value zero silently removed the primary file-open fence
+while leaving the post-open identity check looking reassuring. Add an explicit
+missing-capability mutation test. If the platform cannot guarantee no-follow,
+fail closed before `open()` instead of opening first and rejecting afterward.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1714,3 +1714,20 @@ drift-back": a settle pass's own trailing invisibility pass undoing the settle.
    `test_mcp_inspector.py`'s `InspectorAppWithBundledCSS` does) before deciding
    what it means -- in both directions: a bug the harness shows may not exist
    live, and a bug live may not show in the harness.
+
+## A static symlink fixture does not prove a scanner is no-follow (TASK-13200, 2026-08-09)
+
+**What happened.** The guided audio.cpp package scanner correctly skipped a
+nested symlink that existed before scanning, so its original path-escape test
+passed. A mutation fixture then replaced an already-queued directory with a
+symlink. The next `scandir(path)` followed the new target and produced an exact
+candidate outside the selected tree. A pre-open `lstat` alone still left a
+smaller replacement window while the iterator was being opened.
+
+**What to do.** Test no-follow traversal at three boundaries: a link present at
+discovery, a queued directory replaced before traversal, and replacement while
+the directory iterator opens. Fence the queued identity both immediately before
+and immediately after opening the iterator; close without iterating if either
+observation differs or becomes a symlink/reparse point. For files, combine a
+no-follow open with `fstat` identity/type comparison before reading metadata.
+Static fixtures prove policy for stable trees, not race safety.

--- a/backlog/tasks/task-13200 - Build-guided-audio.cpp-package-recipes-and-bounded-scanner.md
+++ b/backlog/tasks/task-13200 - Build-guided-audio.cpp-package-recipes-and-bounded-scanner.md
@@ -68,7 +68,7 @@ ADR required: no new ADR. This task directly implements the structured-settings,
 Verification:
 
 - `pytest` foundation set: 96 passed.
-- `pytest Tests/TTS` excluding six sandbox-blocked loopback cases: 2,597 passed, 16 skipped, 6 deselected.
+- `pytest Tests/TTS` excluding six sandbox-blocked loopback cases: 2,600 passed, 16 skipped, 6 deselected.
 - The six deselected real-socket/process cases rerun outside the sandbox: 6 passed.
 - Ruff check and format check passed for every changed Python file; compileall and `git diff --cached --check` passed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-13200 - Build-guided-audio.cpp-package-recipes-and-bounded-scanner.md
+++ b/backlog/tasks/task-13200 - Build-guided-audio.cpp-package-recipes-and-bounded-scanner.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-13200
 title: Build guided audio.cpp package recipes and bounded scanner
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-09 17:38'
+updated_date: '2026-08-09 19:01'
 labels:
   - tts
   - audio-cpp
@@ -26,11 +28,46 @@ Create the typed guided-setup configuration, exact recipe registry, and bounded 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Guided Managed setup has a typed structured configuration whose source, binary, accepted packages, default model, backend preference, safety limits, and dormant values round-trip without changing existing External or user-provided server.json configurations.
-- [ ] #2 An immutable recipe registry identifies the pinned audio.cpp release, exact family/package variant, supported speech tasks, required files, safe model projection, backend tuples, compatibility state, and recipe revision without admitting arbitrary JSON fields.
-- [ ] #3 Every pinned Supertonic and PocketTTS package variant is classified by an exact reviewed recipe or an explicit unsupported/blocking result; ambiguous, heuristic-only, unknown-version, and incomplete packages are never silently selected.
-- [ ] #4 Local discovery scans only user-approved roots off the event loop, obeys finite file/depth/time/result limits, supports cancellation, does not follow symlinks or reparse points, and reports partial and permission outcomes truthfully.
-- [ ] #5 Discovery deduplicates canonical package identities, preserves all ambiguous candidates for review, and exposes only sanitized names and bounded relative evidence in normal UI/error surfaces.
-- [ ] #6 The accounting surface lists all 21 pinned families and 67 declared packages with exact support states, while user-facing support claims include only evidenced recipe/platform/backend tuples.
-- [ ] #7 Pure tests cover configuration round trips, exact positive and negative recipe fixtures, ambiguity, scanner bounds/cancellation/path attacks, and prove this foundation performs no process launch, socket bind, HTTP request, model download, or model-file write.
+- [x] #1 Guided Managed setup has a typed structured configuration whose source, binary, accepted packages, default model, backend preference, safety limits, and dormant values round-trip without changing existing External or user-provided server.json configurations.
+- [x] #2 An immutable recipe registry identifies the pinned audio.cpp release, exact family/package variant, supported speech tasks, required files, safe model projection, backend tuples, compatibility state, and recipe revision without admitting arbitrary JSON fields.
+- [x] #3 Every pinned Supertonic and PocketTTS package variant is classified by an exact reviewed recipe or an explicit unsupported/blocking result; ambiguous, heuristic-only, unknown-version, and incomplete packages are never silently selected.
+- [x] #4 Local discovery scans only user-approved roots off the event loop, obeys finite file/depth/time/result limits, supports cancellation, does not follow symlinks or reparse points, and reports partial and permission outcomes truthfully.
+- [x] #5 Discovery deduplicates canonical package identities, preserves all ambiguous candidates for review, and exposes only sanitized names and bounded relative evidence in normal UI/error surfaces.
+- [x] #6 The accounting surface lists all 21 pinned families and 67 declared packages with exact support states, while user-facing support claims include only evidenced recipe/platform/backend tuples.
+- [x] #7 Pure tests cover configuration round trips, exact positive and negative recipe fixtures, ambiguity, scanner bounds/cancellation/path attacks, and prove this foundation performs no process launch, socket bind, HTTP request, model download, or model-file write.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a frozen full-settings model for Guided, External, and dormant user-JSON values without changing `AudioCppConfig`.
+2. Add the sealed release-0.5.1 Supertonic/PocketTTS recipe registry, exact matcher, accepted-projection validator, and 21-family/67-package accounting.
+3. Add an explicit-root, no-follow, bounded, cancellable off-loop scanner with sanitized evidence and canonical deduplication.
+4. Prove the joined foundation is side-effect free, run focused/static verification, self-review, document results, and close the task.
+
+ADR required: no new ADR.
+
+ADR path: `backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md`
+
+Reason: Direct implementation of ADR-050's approved structured-settings, sealed-recipe, and explicit-root scanner boundaries.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the guided audio.cpp foundation without changing the existing runtime `AudioCppConfig` or adding launch, generated-JSON, UI, download, or Model Library behavior.
+
+- Added frozen full-settings and accepted-package models, including dormant External/manual values, bounded compute/safety fields, durable package UUIDs, immutable recipe projections, and defensive JSON round trips.
+- Added a sealed release-0.5.1 registry for all 4 Supertonic and 11 PocketTTS packages, exact fail-closed matching, accepted-snapshot validation, tuple-scoped evidence, and complete 21-family/67-package accounting (15 Approved, 52 explicit Open gaps, no unsupported claims).
+- Added an explicit-root scanner with finite depth/entry/candidate/result/metadata/time/detail budgets, cancellation/off-loop execution, canonical identities, path-safe evidence, per-candidate permission/partial truth, and symlink/reparse race fencing.
+- Added pure positive, negative, mutation-style, privacy, and joined side-effect regressions. Recorded the queued-directory symlink-race lesson in `backlog/docs/lessons-testing-evidence.md`.
+
+ADR required: no new ADR. This task directly implements the structured-settings, sealed-recipe, accepted-snapshot, and explicit-root scanner boundaries in `backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md`.
+
+Verification:
+
+- `pytest` foundation set: 93 passed.
+- `pytest Tests/TTS` excluding six sandbox-blocked loopback cases: 2,597 passed, 16 skipped, 6 deselected.
+- The six deselected real-socket/process cases rerun outside the sandbox: 6 passed.
+- Ruff check and format check passed for every changed Python file; compileall and `git diff --cached --check` passed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-13200 - Build-guided-audio.cpp-package-recipes-and-bounded-scanner.md
+++ b/backlog/tasks/task-13200 - Build-guided-audio.cpp-package-recipes-and-bounded-scanner.md
@@ -61,12 +61,13 @@ Implemented the guided audio.cpp foundation without changing the existing runtim
 - Added a sealed release-0.5.1 registry for all 4 Supertonic and 11 PocketTTS packages, exact fail-closed matching, accepted-snapshot validation, tuple-scoped evidence, and complete 21-family/67-package accounting (15 Approved, 52 explicit Open gaps, no unsupported claims).
 - Added an explicit-root scanner with finite depth/entry/candidate/result/metadata/time/detail budgets, cancellation/off-loop execution, canonical identities, path-safe evidence, per-candidate permission/partial truth, and symlink/reparse race fencing.
 - Added pure positive, negative, mutation-style, privacy, and joined side-effect regressions. Recorded the queued-directory symlink-race lesson in `backlog/docs/lessons-testing-evidence.md`.
+- PR review hardened the scanner to validate selected-root syntax before filesystem access, fail closed before file open when no-follow support is unavailable, and reject conflicting same-path recipe validation contracts. Public APIs now carry complete Google-style parameter/result/error documentation.
 
 ADR required: no new ADR. This task directly implements the structured-settings, sealed-recipe, accepted-snapshot, and explicit-root scanner boundaries in `backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md`.
 
 Verification:
 
-- `pytest` foundation set: 93 passed.
+- `pytest` foundation set: 96 passed.
 - `pytest Tests/TTS` excluding six sandbox-blocked loopback cases: 2,597 passed, 16 skipped, 6 deselected.
 - The six deselected real-socket/process cases rerun outside the sandbox: 6 passed.
 - Ruff check and format check passed for every changed Python file; compileall and `git diff --cached --check` passed.

--- a/backlog/tasks/task-13200 - Build-guided-audio.cpp-package-recipes-and-bounded-scanner.md
+++ b/backlog/tasks/task-13200 - Build-guided-audio.cpp-package-recipes-and-bounded-scanner.md
@@ -1,0 +1,36 @@
+---
+id: TASK-13200
+title: Build guided audio.cpp package recipes and bounded scanner
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:38'
+labels:
+  - tts
+  - audio-cpp
+  - backend
+  - scanner
+dependencies:
+  - TASK-3795
+references:
+  - backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the typed guided-setup configuration, exact recipe registry, and bounded local package discovery foundation for the initial Supertonic and PocketTTS packages.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Guided Managed setup has a typed structured configuration whose source, binary, accepted packages, default model, backend preference, safety limits, and dormant values round-trip without changing existing External or user-provided server.json configurations.
+- [ ] #2 An immutable recipe registry identifies the pinned audio.cpp release, exact family/package variant, supported speech tasks, required files, safe model projection, backend tuples, compatibility state, and recipe revision without admitting arbitrary JSON fields.
+- [ ] #3 Every pinned Supertonic and PocketTTS package variant is classified by an exact reviewed recipe or an explicit unsupported/blocking result; ambiguous, heuristic-only, unknown-version, and incomplete packages are never silently selected.
+- [ ] #4 Local discovery scans only user-approved roots off the event loop, obeys finite file/depth/time/result limits, supports cancellation, does not follow symlinks or reparse points, and reports partial and permission outcomes truthfully.
+- [ ] #5 Discovery deduplicates canonical package identities, preserves all ambiguous candidates for review, and exposes only sanitized names and bounded relative evidence in normal UI/error surfaces.
+- [ ] #6 The accounting surface lists all 21 pinned families and 67 declared packages with exact support states, while user-facing support claims include only evidenced recipe/platform/backend tuples.
+- [ ] #7 Pure tests cover configuration round trips, exact positive and negative recipe fixtures, ambiguity, scanner bounds/cancellation/path attacks, and prove this foundation performs no process launch, socket bind, HTTP request, model download, or model-file write.
+<!-- AC:END -->

--- a/backlog/tasks/task-13201 - Generate-and-supervise-guided-audio.cpp-configurations-on-POSIX.md
+++ b/backlog/tasks/task-13201 - Generate-and-supervise-guided-audio.cpp-configurations-on-POSIX.md
@@ -1,0 +1,38 @@
+---
+id: TASK-13201
+title: Generate and supervise guided audio.cpp configurations on POSIX
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:38'
+labels:
+  - tts
+  - audio-cpp
+  - backend
+  - lifecycle
+dependencies:
+  - TASK-13200
+references:
+  - backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
+  - backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Project accepted guided settings into immutable generation-local server configuration and run them through the existing managed audio.cpp lifecycle on macOS and Linux.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Saving guided settings remains side-effect free; only a deliberate Test, Start, Restart & Apply, or synthesis may validate launch inputs, allocate a loopback port, create an artifact, contact audio.cpp, or launch a child.
+- [ ] #2 A deliberate launch projects the exact accepted settings and recipes into one private immutable generation-local server.json using safe top-level fields, absolute accepted model paths, loopback-only/no-CORS/no-body-log defaults, lazy loading, and one generated endpoint.
+- [ ] #3 The existing app-scoped supervisor launches exactly one no-shell audiocpp_server child for all accepted models, publishes only the generated loopback endpoint, and definitively reaps the exact child and removes the exact artifact on failure, replacement, shutdown, and app exit.
+- [ ] #4 Saved, applied, process, recipe/file, catalog, and capability generations remain distinct; a live child keeps its accepted snapshot despite source-file changes, and the next deliberate replacement revalidates before mutation.
+- [ ] #5 Backend Auto and explicit overrides select only recipe-supported tuples, and fallback occurs only for allowlisted backend-unavailable failures after the failed child and artifact are definitively cleaned up.
+- [ ] #6 The native catalog admits only upstream tts and clone speech tasks, preserves typed capabilities including clone-only packages, and rejects ASR, VC, Music, and other task types from the TTS adapter.
+- [ ] #7 Launch, validation, probe, catalog, backend, and cleanup failures use stable recovery phases and context-free sanitized errors that expose no executable, config, model, temporary, environment, prompt, credential, or raw upstream detail.
+- [ ] #8 Hermetic lifecycle tests and pinned macOS/Linux real-process evidence cover multi-model lazy registration, first synthesis, saved-while-running replacement, crash recovery, exact shutdown, and zero orphan/artifact leakage.
+<!-- AC:END -->

--- a/backlog/tasks/task-13202 - Deliver-the-first-time-guided-audio.cpp-setup-and-sample-flow.md
+++ b/backlog/tasks/task-13202 - Deliver-the-first-time-guided-audio.cpp-setup-and-sample-flow.md
@@ -1,0 +1,41 @@
+---
+id: TASK-13202
+title: Deliver the first-time guided audio.cpp setup and sample flow
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:39'
+labels:
+  - tts
+  - audio-cpp
+  - settings
+  - speech-lab
+  - uat
+dependencies:
+  - TASK-13201
+references:
+  - backlog/decisions/039-global-and-studio-tts-settings-ownership.md
+  - backlog/decisions/040-speech-lab-current-result-and-auto-play.md
+  - backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let a first-time user configure a supported local package in Global Settings and generate, play, and reuse a complete WAV from Speech Lab without editing JSON.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Global Settings clearly separates External, user-provided server.json, and Guided Managed sources; Guided setup can detect or browse to the separately installed server, add/scan reviewed packages, select a default model and backend, and preserves dormant source values.
+- [ ] #2 The package review shows exact family/variant, task capability, compatibility/evidence state, model ID, path-safe summary, lazy-load/memory behavior, and recovery guidance without claiming Chatbook downloads the server or supports an unevidenced tuple.
+- [ ] #3 Save performs no launch, socket, HTTP, catalog, synthesis, generated-artifact, or model-file side effect; it reports Configuration saved — ready to test and hands focus to the single current Speech Lab primary action while leaving Studio preferences separate.
+- [ ] #4 Speech Lab derives label, operation, enabled state, reason, tooltip, progress copy, and post-action focus from one immutable observation, including Start & Generate Sample, Restart & Apply Settings, Retry Sample, Test Connection, and Shutdown without duplicate restart actions.
+- [ ] #5 A deliberate first sample starts one shared child, verifies the selected catalog entry, generates a structurally valid complete WAV, and presents prominent Play/Pause, duration/status, safe provenance, Generate again, and Save WAV controls; autoplay changes only through the existing optional Studio preference.
+- [ ] #6 Multiple accepted models remain registered in the one lazy child, changing the selected model reuses that child, and the UI truthfully warns that loaded models may remain resident until shutdown rather than promising unload.
+- [ ] #7 Console and Roleplay Speak actions lazily use the exact captured global or character selection without passive browsing launches, and provider switches or late lifecycle/catalog/generation results cannot relabel, disable, or execute a stale visible action.
+- [ ] #8 The full guided flow is keyboard-operable and screen-reader/non-color legible at supported narrow widths, with current disabled reasons, focus restoration, bounded scrollable diagnostics, and live announcements that do not spam progress ticks.
+- [ ] #9 User documentation and pinned first-time macOS/Linux UAT demonstrate install-server-separately, package selection, side-effect-free Save, sample generation, audible playback, multi-model reuse, restart/apply, crash recovery, explicit shutdown, and unchanged External/manual-json behavior without editing JSON.
+<!-- AC:END -->

--- a/backlog/tasks/task-13203 - Add-private-clone-reference-profile-storage-and-migration.md
+++ b/backlog/tasks/task-13203 - Add-private-clone-reference-profile-storage-and-migration.md
@@ -1,0 +1,39 @@
+---
+id: TASK-13203
+title: Add private clone-reference profile storage and migration
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:39'
+labels:
+  - tts
+  - audio-cpp
+  - profiles
+  - privacy
+dependencies:
+  - TASK-13200
+references:
+  - backlog/decisions/028-character-tts-generation-profile-ownership.md
+  - backlog/decisions/029-local-private-data-boundary.md
+  - backlog/decisions/051-private-tts-clone-reference-assets.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Extend TTS profiles with canonical private clone-reference assets, safe migration, quotas, backup, restore, and damage isolation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The profile repository advances from v2 to v3 with one optional reference row per profile containing immutable reference UUID, canonical bounded WAV BLOB, bounded transcript, digest, validated audio metadata, and timestamps, while existing profile and character-assignment semantics remain unchanged.
+- [ ] #2 Reference ingest accepts only a regular bounded WAV, validates and canonicalizes supported audio, strips arbitrary RIFF metadata, rechecks the source before commit, persists no source path, and commits reference plus profile revision atomically.
+- [ ] #3 Per-reference size/duration/transcript limits and aggregate byte/count quotas are enforced transactionally, BLOB reads and writes are bounded/streamed, and list/open paths load metadata summaries rather than reference bytes.
+- [ ] #4 Migration takes and retains an owner-private v2 online backup, validates the source and migrated schema/integrity/domain equivalence transactionally, publishes no partial v3 store on failure, and older builds refuse v3 with documented lossy v2-restore downgrade steps.
+- [ ] #5 Repository backup and restore include full reference data, validate digests/WAV structure/quotas before replacement, and isolate a safely attributable damaged reference to its profile while structural or ambiguous corruption keeps the repository unavailable.
+- [ ] #6 Editing, replacing, and deleting a reference follow profile revision and cascade ownership rules without silently retargeting a profile or character, and existing v2 profiles migrate with no reference and identical effective selection.
+- [ ] #7 Storage, errors, diagnostics, logs, and tests expose no source path, transcript, audio bytes, digest-derived identity, or raw database detail; user-facing copy truthfully states local plaintext, filesystem-not-encryption, backup/export sensitivity, and best-effort deletion.
+- [ ] #8 Migration, quota, canonicalization, concurrency, backup/restore, damage-isolation, downgrade-refusal, privacy, and unchanged v2-profile behavior are covered using isolated temporary repositories only.
+<!-- AC:END -->

--- a/backlog/tasks/task-13204 - Admit-and-materialize-guided-audio.cpp-clone-references-safely.md
+++ b/backlog/tasks/task-13204 - Admit-and-materialize-guided-audio.cpp-clone-references-safely.md
@@ -1,0 +1,40 @@
+---
+id: TASK-13204
+title: Admit and materialize guided audio.cpp clone references safely
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:39'
+labels:
+  - tts
+  - audio-cpp
+  - backend
+  - privacy
+dependencies:
+  - TASK-13201
+  - TASK-13203
+references:
+  - backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
+  - backlog/decisions/028-character-tts-generation-profile-ownership.md
+  - backlog/decisions/051-private-tts-clone-reference-assets.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add typed clone capability admission and generation-scoped private reference materialization for compatible guided managed audio.cpp children.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Audio.cpp profile admission supports exact native voice only, clone reference only, or both solely when the accepted recipe defines the combination and precedence; required references and clone-only families are handled without reopening generic options.
+- [ ] #2 Admission freezes the exact profile UUID/revision, provider/model/voice selection, recipe identity/revision, reference UUID/digest/transcript, and applied provider/process generation before any asynchronous work begins.
+- [ ] #3 Reference-bearing requests are allowed only for a compatible accepted guided recipe and the app-owned managed child; External servers and unclassified user-provided server.json models never receive a client-local reference path.
+- [ ] #4 The exact admitted reference is revalidated under repository revision/generation fences and materialized to an opaque owner-private operation directory with typed voice_ref and reference_text request fields, never to server.json, catalog state, profile options, or public provenance.
+- [ ] #5 Normal completion, response close, cancellation, timeout, generation replacement, child exit, and app shutdown retain ownership until the adapter can no longer read the file and then definitively remove the exact materialization.
+- [ ] #6 Startup cleanup touches only recognized owned directories after proving no live owner holds the lock, follows no symlink/reparse point, and never deletes unknown or merely old paths.
+- [ ] #7 Raw request bodies and reference paths remain absent from diagnostics/logs; all validation, capability, generation-loss, transport, and cleanup failures are normalized outside the exception graph with stable safe recovery guidance.
+- [ ] #8 Tests cover admission/edit/delete races, incompatible sources/recipes, exact payload shape, lease retention, every terminal cleanup path, stale-directory attacks, and privacy mutation guards.
+<!-- AC:END -->

--- a/backlog/tasks/task-13205 - Add-clone-setup-and-character-voice-workflows.md
+++ b/backlog/tasks/task-13205 - Add-clone-setup-and-character-voice-workflows.md
@@ -1,0 +1,42 @@
+---
+id: TASK-13205
+title: Add clone setup and character voice workflows
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:39'
+labels:
+  - tts
+  - audio-cpp
+  - speech-lab
+  - roleplay
+  - profiles
+dependencies:
+  - TASK-13202
+  - TASK-13204
+references:
+  - backlog/decisions/028-character-tts-generation-profile-ownership.md
+  - backlog/decisions/040-speech-lab-current-result-and-auto-play.md
+  - backlog/decisions/051-private-tts-clone-reference-assets.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Provide transient clone audition, reusable voice-profile save, character assignment, and character-roleplay generation in Speech Lab.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A reference-required guided recipe projects Start & Set Up Voice or Create Voice & Generate only after the matching server/catalog is ready, while an existing compatible Voice Profile remains selectable without confusing User Profiles with character/persona data.
+- [ ] #2 Speech Lab lets the user choose a bounded WAV, enter or confirm the required bounded transcript, review exact recipe guidance and local-plaintext privacy copy, and correct field-specific validation without losing the rest of the draft.
+- [ ] #3 Clone audition canonicalizes one private transient reference owned by the current-result workflow, creates no profile before explicit save, and removes the staged artifact when replaced, discarded, or the app closes.
+- [ ] #4 Create Voice & Generate uses the exact staged artifact and typed clone admission, produces a structurally valid complete WAV, cleans the request materialization, and presents the normal prominent playback/current-result controls with safe reference provenance.
+- [ ] #5 Save as Voice Profile is offered only after successful generation and persists the exact canonical bytes and transcript captured by that successful result without reopening the source; failed generation preserves recovery but does not present the reference as proven.
+- [ ] #6 Profile naming and assignment review never silently changes an app default or character assignment; an explicitly assigned character later captures that exact profile revision for Console/Roleplay speech.
+- [ ] #7 A first lazy character-roleplay Speak request starts or joins the one compatible managed child, generates the response with the assigned clone profile, produces audible playback, and browsing characters/profiles remains passive.
+- [ ] #8 Provider switching, reference/profile edits, late generation, failed passive observation, retry, and busy states cannot replace a successful playable result, execute a stale operation, or strand controls/focus; the full flow meets keyboard/narrow-layout/live-announcement requirements.
+- [ ] #9 Hermetic UI/runtime tests plus clean-profile real-process UAT cover transient audition, save, assignment, character roleplay, audible playback, cancellation, cleanup, and privacy without exposing reference audio, transcript, or paths in evidence.
+<!-- AC:END -->

--- a/backlog/tasks/task-13206 - Add-explicit-clone-voice-bundle-portability.md
+++ b/backlog/tasks/task-13206 - Add-explicit-clone-voice-bundle-portability.md
@@ -1,0 +1,39 @@
+---
+id: TASK-13206
+title: Add explicit clone voice bundle portability
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:39'
+labels:
+  - tts
+  - audio-cpp
+  - profiles
+  - security
+  - portability
+dependencies:
+  - TASK-13205
+references:
+  - backlog/decisions/028-character-tts-generation-profile-ownership.md
+  - backlog/decisions/029-local-private-data-boundary.md
+  - backlog/decisions/051-private-tts-clone-reference-assets.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add explicit warning-gated export and hostile-input-safe import for portable clone voice bundles while ordinary exports remain sanitized.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Ordinary profile export keeps reference-free profiles on wire v1 and exports reference-bearing profiles as sanitized wire v2 with an explicit reference-omitted marker and no audio, transcript, local-oracle digest, path, assignment, endpoint, generated config, or private runtime state.
+- [ ] #2 Explicit voice-bundle export requires a plaintext/sensitive-data warning and creates only the versioned allowlisted ZIP entries manifest.json, profile.json, reference.wav, and reference.txt with bounded metadata, exact sizes, and canonical SHA-256 checksums.
+- [ ] #3 Bundle data contains the sanitized profile selection and generic user declaration only—never model weights, character/persona data, assignments, defaults, credentials, origins, recipe code, process state, or unnecessary timestamps.
+- [ ] #4 Import validates the unchanged source archive before storage and rejects encryption, duplicate or normalized-name collisions, absolute/traversal/separator paths, symlinks/special files, unknown or missing entries, unsupported compression, size/count/ratio limit breaches, malformed content, and checksum mismatch.
+- [ ] #5 Validation and extraction use a bounded owner-private staging directory without trusting archive paths, clean up on every terminal path, and describe checksums only as byte integrity rather than authenticity, speaker identity, signature, or consent proof.
+- [ ] #6 Import displays exact UUID, name, recipe, and model dependency conflicts for explicit user resolution; it never overwrites, assigns, changes a default, or retargets automatically, and may store a valid unresolved bundle only as inactive Needs compatible model.
+- [ ] #7 Hostile-archive, source-mutation, quota, collision, old-reader, missing-model, cleanup, privacy, and deterministic round-trip tests pass, and manual UAT proves ordinary sanitized export versus explicit warned bundle transfer.
+<!-- AC:END -->

--- a/backlog/tasks/task-13207 - Integrate-guided-audio.cpp-packages-with-Model-Library.md
+++ b/backlog/tasks/task-13207 - Integrate-guided-audio.cpp-packages-with-Model-Library.md
@@ -1,0 +1,38 @@
+---
+id: TASK-13207
+title: Integrate guided audio.cpp packages with Model Library
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:39'
+labels:
+  - tts
+  - audio-cpp
+  - model-library
+  - settings
+dependencies:
+  - TASK-13202
+  - TASK-13203
+references:
+  - backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md
+  - backlog/decisions/051-private-tts-clone-reference-assets.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Connect reviewed audio.cpp model artifacts to the existing Model Library and provide dependency-aware removal without installing the server binary.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Model Library exposes only reviewed audio.cpp artifacts mapped to an exact recipe/package identity and displays family, variant, speech tasks, size/checksum/license/source, required companion files, and exact evidenced compatibility without implying it installs audiocpp_server.
+- [ ] #2 Installation occurs only after explicit user action through the existing shared artifact-store owner, verifies the declared artifact, and returns the exact installed package root/identity to the preserved Guided Settings draft without launching audio.cpp or changing global/Studio defaults.
+- [ ] #3 Returning from Model Library preserves all unrelated Settings draft fields and shows the installed package in the same exact review/validation flow as a scanned local package before Save.
+- [ ] #4 A removal preview accounts for global guided configurations, TTS profiles and clone references, character assignments, active/staged runtime generations, and shared artifact owners before any bytes are removed.
+- [ ] #5 Removal requires an explicit resolution for every blocking dependency, never silently retargets a configuration/profile/character, never deletes a reference asset as a side effect, and does not disrupt an immutable live child snapshot.
+- [ ] #6 Interrupted install/remove, checksum failure, missing files, shared ownership, and source disappearance produce truthful recoverable state with no partial authority transfer or orphaned registry entry.
+- [ ] #7 Hermetic store/UI/dependency tests and a clean-profile UAT cover install → exact-root return → guided Save → sample generation plus blocked and approved removal, with no network or large artifact requirement in normal CI.
+<!-- AC:END -->

--- a/backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md
+++ b/backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md
@@ -1,0 +1,41 @@
+---
+id: TASK-13208
+title: Add Windows parity for guided audio.cpp lifecycle and cloning
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:39'
+labels:
+  - tts
+  - audio-cpp
+  - windows
+  - lifecycle
+  - privacy
+dependencies:
+  - TASK-13204
+  - TASK-13207
+references:
+  - backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
+  - backlog/decisions/029-local-private-data-boundary.md
+  - backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md
+  - backlog/decisions/051-private-tts-clone-reference-assets.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Provide Windows process, path, ACL, scanner, backend-selection, clone-materialization, and definitive-shutdown parity for guided setup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Guided binary detection, file/folder selection, canonical package identity, auto-port allocation, generated configuration, and bounded scanning work with Windows path, drive, Unicode, long-path, symlink, and reparse-point semantics without applying POSIX assumptions.
+- [ ] #2 Chatbook uses Windows-native no-shell process creation, waits on and terminates only the exact handle it owns, closes that handle definitively, and makes no ownership claim for arbitrary descendants or daemonizing server builds.
+- [ ] #3 Restart, crash, cancellation, app close, and close-during-start/stop races honor one bounded shutdown budget while retained joining proves no owned process handle, task, client, generated artifact, or endpoint remains.
+- [ ] #4 Generated artifacts and clone-reference materializations use an explicitly implemented owner-private Windows ACL posture, surface that actual posture truthfully, and clean recognized exact-owned paths without following reparse points or deleting unknown directories.
+- [ ] #5 Backend Auto and explicit CPU/accelerated choices are recipe- and device-aware on Windows, use the same allowlisted definitive-cleanup fallback rule, and label only provisioned tuple evidence as Verified.
+- [ ] #6 Settings and Speech Lab preserve the same saved/applied/process truth, keyboard/focus behavior, sample/clone flows, stable errors, and privacy guarantees on Windows as on POSIX.
+- [ ] #7 Windows-specific unit/integration tests plus pinned Windows CPU real-process UAT prove generated JSON acceptance, health/catalog, text and clone WAV synthesis, Model Library/local package paths, exact shutdown, no orphaned child/handle, and audible playback in a disposable profile.
+<!-- AC:END -->

--- a/backlog/tasks/task-13209 - Add-audio.cpp-recipes-for-base-core-model-families.md
+++ b/backlog/tasks/task-13209 - Add-audio.cpp-recipes-for-base-core-model-families.md
@@ -1,0 +1,36 @@
+---
+id: TASK-13209
+title: Add audio.cpp recipes for base core model families
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:39'
+labels:
+  - tts
+  - audio-cpp
+  - recipes
+  - compatibility
+dependencies:
+  - TASK-13208
+references:
+  - backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md
+  - backlog/decisions/051-private-tts-clone-reference-assets.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add exact release-0.5.1 recipes and evidence for chatterbox, dramabox, miotts, vibevoice, and moss_tts_nano.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 11 declared release-0.5.1 package entries across chatterbox (3), dramabox (1), miotts (3), vibevoice (2), and moss_tts_nano (2) have exact immutable recipe identities and no unreviewed package gap.
+- [ ] #2 Each recipe declares only its upstream-supported tts/clone capabilities, exact required and optional files, safe model fields, model/voice/reference rules, lazy-load behavior, backend/platform tuples, compatibility state, and pinned recipe revision.
+- [ ] #3 Exact positive package fixtures are recognized deterministically, while missing, extra-conflicting, ambiguous, renamed, mismatched-version, symlink/reparse, and near-match fixtures are rejected or left explicitly unclassified.
+- [ ] #4 Generated server.json and catalog cross-check tests prove the exact model IDs/tasks for every recipe and continue excluding VC, dialogue-only, ASR, Music, and other non-TTS task entries from native TTS admission.
+- [ ] #5 Every tuple labeled Verified has provisioned real-process evidence for configuration acceptance, health/catalog identity, structurally valid text or clone WAV output as declared, and definitive zero-leak shutdown; all other tuples remain visibly Untested, Unsupported, or Blocked.
+- [ ] #6 The support/accounting UI and documentation name this exact family/package/platform/backend subset without changing existing Supertonic, PocketTTS, External, or user-provided server.json behavior.
+<!-- AC:END -->

--- a/backlog/tasks/task-13210 - Add-audio.cpp-recipes-for-control-and-design-core-families.md
+++ b/backlog/tasks/task-13210 - Add-audio.cpp-recipes-for-control-and-design-core-families.md
@@ -1,0 +1,36 @@
+---
+id: TASK-13210
+title: Add audio.cpp recipes for control and design core families
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:39'
+labels:
+  - tts
+  - audio-cpp
+  - recipes
+  - compatibility
+dependencies:
+  - TASK-13209
+references:
+  - backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md
+  - backlog/decisions/051-private-tts-clone-reference-assets.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add exact release-0.5.1 recipes and evidence for fish_audio, higgs_audio_tts, omnivoice, qwen3_tts, and voxcpm2.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 21 declared release-0.5.1 package entries across fish_audio (2), higgs_audio_tts (2), omnivoice (4), qwen3_tts (9), and voxcpm2 (4) have exact immutable recipe identities and no unreviewed package gap.
+- [ ] #2 Each recipe declares its exact tts/clone capabilities, required and optional files, safe model fields, voice/reference combination and precedence, design/control defaults permitted by the typed contract, backend/platform tuples, compatibility state, and pinned recipe revision.
+- [ ] #3 Design and control support remains a recipe-bounded typed surface rather than arbitrary options; unsupported upstream controls are omitted truthfully and cannot be smuggled through profile or request mappings.
+- [ ] #4 Exact positive fixtures and adversarial missing/conflicting/ambiguous/version/path fixtures prove deterministic recognition, and generated-config/catalog tests cross-check every recipe's exact task and model identity.
+- [ ] #5 Every tuple labeled Verified has provisioned real-process text/clone/control evidence as declared plus definitive cleanup; accelerated labels require device-specific evidence and no fallback failure may inherit a Verified label from another backend.
+- [ ] #6 The support/accounting UI and documentation name this exact family/package/platform/backend subset without regressing earlier recipe batches, clone privacy, or manual audio.cpp sources.
+<!-- AC:END -->

--- a/backlog/tasks/task-13211 - Add-audio.cpp-recipes-for-specialized-core-model-families.md
+++ b/backlog/tasks/task-13211 - Add-audio.cpp-recipes-for-specialized-core-model-families.md
@@ -1,0 +1,36 @@
+---
+id: TASK-13211
+title: Add audio.cpp recipes for specialized core model families
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:39'
+labels:
+  - tts
+  - audio-cpp
+  - recipes
+  - compatibility
+dependencies:
+  - TASK-13210
+references:
+  - backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md
+  - backlog/decisions/051-private-tts-clone-reference-assets.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add exact release-0.5.1 recipes and evidence for confucius4_tts, vevo2, index_tts2, irodori_tts, and moss_tts_local.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 16 declared release-0.5.1 package entries across confucius4_tts (1), vevo2 (3), index_tts2 (4), irodori_tts (6), and moss_tts_local (2) have exact immutable recipe identities and no unreviewed package gap.
+- [ ] #2 Clone-only confucius4_tts is discoverable and usable through typed clone capability without a fabricated tts entry, while vevo2 non-TTS tasks and every unrelated upstream task remain excluded from native TTS admission.
+- [ ] #3 Each recipe declares exact required/optional files, safe model fields, voice/reference/design/control semantics, backend/platform tuples, compatibility state, lazy-load behavior, and pinned recipe revision without family-name inference.
+- [ ] #4 Exact positive fixtures and adversarial missing/conflicting/ambiguous/version/path fixtures prove deterministic recognition, and generated-config/catalog tests cross-check every accepted model/task identity.
+- [ ] #5 Every tuple labeled Verified has provisioned real-process text or clone evidence as declared plus definitive cleanup; unsupported or unevidenced specialized combinations remain explicit blockers rather than silent fallbacks.
+- [ ] #6 The support/accounting UI and documentation name this exact subset, count moss_tts_local once despite community attribution, and preserve all earlier recipe/manual-source behavior.
+<!-- AC:END -->

--- a/backlog/tasks/task-13212 - Complete-audio.cpp-community-recipes-and-release-accounting.md
+++ b/backlog/tasks/task-13212 - Complete-audio.cpp-community-recipes-and-release-accounting.md
@@ -1,0 +1,43 @@
+---
+id: TASK-13212
+title: Complete audio.cpp community recipes and release accounting
+status: To Do
+assignee: []
+created_date: '2026-08-09 17:39'
+labels:
+  - tts
+  - audio-cpp
+  - recipes
+  - compatibility
+  - release
+dependencies:
+  - TASK-13206
+  - TASK-13207
+  - TASK-13208
+  - TASK-13211
+references:
+  - backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md
+  - backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md
+  - backlog/decisions/051-private-tts-clone-reference-assets.md
+documentation:
+  - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add exact release-0.5.1 recipes for glm_tts, inflect_v2, outetts, and vietneu_tts and close the 21-family 67-package accounting matrix.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The four declared release-0.5.1 community package entries—glm_tts, inflect_v2, outetts, and vietneu_tts—have exact immutable recipes, typed tts/clone capability where upstream declares it, adversarial recognition tests, and tuple-scoped real-process evidence.
+- [ ] #2 The canonical inventory accounts exactly once for all 21 pinned families and all 67 declared package entries, with every entry Supported, Unsupported with reviewed reason, or an explicit release blocker and no unknown, duplicated, or unapproved gap.
+- [ ] #3 Every Supported entry has exact package signals, safe generated model projection, catalog/task cross-check, voice/reference rules, backend/platform compatibility state, recipe revision, and withdrawal/upgrade behavior tied to the pinned audio.cpp release.
+- [ ] #4 Public Settings, Model Library, Speech Lab, documentation, and diagnostics derive support claims from the same accounting data and name the exact evidenced family/package/OS/backend subset rather than claiming blanket support.
+- [ ] #5 Provisioned compatibility gates cover every Verified tuple, at minimum CPU on macOS, Linux, and Windows, while accelerated tuples require their own evidence and normal CI remains hermetic with no binary/model/network/audio-hardware dependency.
+- [ ] #6 Clean-profile release UAT records exact sanitized app/server/recipe/artifact/runtime/WAV/shutdown evidence and human audible confirmation for local selection, Model Library, text, clone/profile/roleplay, multi-model lazy use, staged restart, failure recovery, source regressions, portability, and keyboard/narrow-layout journeys.
+- [ ] #7 Existing External and user-provided server.json users retain exact behavior and ownership, generated/clone failures leave no child, handle, client, task, artifact, or materialization, and complete-WAV async adapter behavior remains unchanged.
+- [ ] #8 Release documentation declares the guided-model workstream complete only after all blockers are resolved and the 21-family/67-package matrix, platform evidence, recipe revisions, rollback behavior, and sanitized UAT are traceable to the exact commit.
+<!-- AC:END -->

--- a/tldw_chatbook/TTS/audio_cpp_guided_config.py
+++ b/tldw_chatbook/TTS/audio_cpp_guided_config.py
@@ -548,7 +548,18 @@ class AudioCppSettingsConfig(_FrozenModel):
 
     @classmethod
     def from_mapping(cls, values: Mapping[str, Any]) -> AudioCppSettingsConfig:
-        """Copy approved full-settings fields from one configuration mapping."""
+        """Copy approved full-settings fields from one configuration mapping.
+
+        Args:
+            values: Mapping containing current, dormant, or unrelated settings.
+
+        Returns:
+            A validated immutable copy of approved audio.cpp settings fields.
+
+        Raises:
+            ValueError: If the input is not a mapping or an approved value is
+                invalid.
+        """
         if not isinstance(values, Mapping):
             raise ValueError("audio.cpp settings configuration must be a mapping")
         projected = {
@@ -557,7 +568,11 @@ class AudioCppSettingsConfig(_FrozenModel):
         return cls(**projected)
 
     def to_mapping(self) -> dict[str, object]:
-        """Return one defensive JSON-compatible mapping of approved fields."""
+        """Return one defensive JSON-compatible mapping of approved fields.
+
+        Returns:
+            A deep-copied mapping suitable for durable JSON/TOML projection.
+        """
         return deepcopy(self.model_dump(mode="json"))
 
 

--- a/tldw_chatbook/TTS/audio_cpp_guided_config.py
+++ b/tldw_chatbook/TTS/audio_cpp_guided_config.py
@@ -1,0 +1,572 @@
+"""Typed durable configuration for guided audio.cpp setup.
+
+This module models saved Settings state only. It deliberately does not project a
+server configuration, inspect files, contact audio.cpp, or own process lifecycle.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import unicodedata
+from collections.abc import Mapping
+from copy import deepcopy
+from enum import StrEnum
+from numbers import Real
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
+
+from .audio_cpp_config import AudioCppConfig
+
+
+_IDENTIFIER = re.compile(r"[a-z0-9][a-z0-9._-]{0,127}\Z", re.ASCII)
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+_MAX_JSON_INTEGER = 2**53 - 1
+_MAX_INT32 = 2**31 - 1
+_COMMON_TIMEOUT_FIELDS = (
+    "connect_timeout_seconds",
+    "synthesis_timeout_seconds",
+)
+_COMMON_LIMIT_FIELDS = (
+    "max_input_characters",
+    "max_response_bytes",
+    "max_metadata_bytes",
+    "max_catalog_models",
+    "max_voices_per_model",
+    "max_identifier_characters",
+)
+_MANAGED_TIMING_BOUNDS = {
+    "managed_startup_timeout_seconds": (1.0, 300.0),
+    "managed_health_check_interval_seconds": (2.0, 300.0),
+    "managed_termination_grace_seconds": (0.1, 60.0),
+}
+
+
+class AudioCppManagedSetupSource(StrEnum):
+    """Durable source for the active Managed configuration."""
+
+    USER_JSON = "user_json"
+    GUIDED = "guided"
+
+
+class AudioCppBinarySelectionSource(StrEnum):
+    """Reviewed provenance for a guided executable selection."""
+
+    MANUAL = "manual"
+    CONFIGURED = "configured"
+    PATH = "path"
+    HOMEBREW = "homebrew"
+    CONVENTIONAL = "conventional"
+
+
+class AudioCppBackendPreference(StrEnum):
+    """Bounded persisted backend preference; Auto is resolved at launch."""
+
+    AUTO = "auto"
+    CPU = "cpu"
+    CUDA = "cuda"
+    METAL = "metal"
+    VULKAN = "vulkan"
+    HIP = "hip"
+
+
+def _contains_unsafe_text(value: str) -> bool:
+    return any(
+        character in {"\x00", "\r", "\n"}
+        or unicodedata.category(character) in {"Cc", "Cf", "Cs"}
+        for character in value
+    )
+
+
+def _safe_token(value: object, *, label: str) -> str:
+    if (
+        type(value) is not str
+        or not _IDENTIFIER.fullmatch(value)
+        or _contains_unsafe_text(value)
+    ):
+        raise ValueError(f"audio.cpp {label} is invalid")
+    return value
+
+
+def _safe_digest(value: object, *, label: str) -> str:
+    if type(value) is not str or not _DIGEST.fullmatch(value):
+        raise ValueError(f"audio.cpp {label} must be a lowercase SHA-256 identity")
+    return value
+
+
+def _safe_relative_path(value: object, *, label: str) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or value != value.strip()
+        or len(value) > 1024
+        or "\\" in value
+        or _contains_unsafe_text(value)
+    ):
+        raise ValueError(f"audio.cpp {label} must be a safe relative path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or value in {".", ".."} or ".." in path.parts:
+        raise ValueError(f"audio.cpp {label} must be a safe relative path")
+    if path.as_posix() != value:
+        raise ValueError(f"audio.cpp {label} must be a safe relative path")
+    return value
+
+
+def _safe_absolute_path(value: object, *, label: str, allow_empty: bool) -> str:
+    if type(value) is not str:
+        raise ValueError(f"audio.cpp {label} must be a path string")
+    if allow_empty and not value:
+        return value
+    if (
+        not value
+        or value != value.strip()
+        or len(value) > 4096
+        or _contains_unsafe_text(value)
+        or not (
+            PurePosixPath(value).is_absolute() or PureWindowsPath(value).is_absolute()
+        )
+    ):
+        raise ValueError(f"audio.cpp {label} must be an absolute path")
+    return value
+
+
+def _strict_integer(
+    value: object,
+    *,
+    label: str,
+    minimum: int,
+    maximum: int,
+) -> int:
+    if type(value) is not int or value < minimum or value > maximum:
+        raise ValueError(
+            f"audio.cpp {label} must be an integer from {minimum} through {maximum}"
+        )
+    return value
+
+
+def _bounded_number(
+    value: object,
+    *,
+    label: str,
+    minimum: float,
+    maximum: float,
+) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, Real)
+        or not math.isfinite(float(value))
+        or float(value) < minimum
+        or float(value) > maximum
+    ):
+        raise ValueError(
+            f"audio.cpp {label} must be a finite number from {minimum:g} "
+            f"through {maximum:g}"
+        )
+    return float(value)
+
+
+class _FrozenModel(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        hide_input_in_errors=True,
+        strict=True,
+    )
+
+
+class AudioCppRecipeOption(_FrozenModel):
+    """One immutable string option admitted by an exact recipe."""
+
+    name: str
+    value: str
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _validate_name(cls, value: object) -> str:
+        return _safe_token(value, label="recipe option name")
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _validate_value(cls, value: object) -> str:
+        if (
+            type(value) is not str
+            or not value
+            or value != value.strip()
+            or len(value) > 256
+            or _contains_unsafe_text(value)
+        ):
+            raise ValueError("audio.cpp recipe option value is invalid")
+        return value
+
+
+class AudioCppSafeModelProjection(_FrozenModel):
+    """Allowlisted model-entry fields frozen into an accepted package."""
+
+    family: str
+    task: Literal["tts", "clone"]
+    mode: Literal["offline"] = "offline"
+    model_relative_path: str | None = None
+    model_spec_override_relative_path: str | None = None
+    busy_timeout_ms: int | None = None
+    load_options: tuple[AudioCppRecipeOption, ...] = ()
+    session_options: tuple[AudioCppRecipeOption, ...] = ()
+
+    @field_validator("family", mode="before")
+    @classmethod
+    def _validate_family(cls, value: object) -> str:
+        return _safe_token(value, label="recipe family")
+
+    @field_validator("task", mode="before")
+    @classmethod
+    def _validate_task(cls, value: object) -> str:
+        if value not in {"tts", "clone"}:
+            raise ValueError("audio.cpp recipe task must be tts or clone")
+        return str(value)
+
+    @field_validator("mode", mode="before")
+    @classmethod
+    def _validate_mode(cls, value: object) -> str:
+        if value != "offline":
+            raise ValueError("audio.cpp recipe mode must be offline")
+        return "offline"
+
+    @field_validator(
+        "model_relative_path",
+        "model_spec_override_relative_path",
+        mode="before",
+    )
+    @classmethod
+    def _validate_relative_path(
+        cls,
+        value: object,
+        info: ValidationInfo,
+    ) -> str | None:
+        if value is None:
+            return None
+        return _safe_relative_path(value, label=info.field_name)
+
+    @field_validator("busy_timeout_ms", mode="before")
+    @classmethod
+    def _validate_busy_timeout(cls, value: object) -> int | None:
+        if value is None:
+            return None
+        return _strict_integer(
+            value,
+            label="model busy_timeout_ms",
+            minimum=1,
+            maximum=_MAX_INT32,
+        )
+
+    @field_validator("load_options", "session_options", mode="before")
+    @classmethod
+    def _normalize_options(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @model_validator(mode="after")
+    def _unique_options(self) -> AudioCppSafeModelProjection:
+        for options in (self.load_options, self.session_options):
+            names = tuple(option.name for option in options)
+            if len(names) != len(set(names)):
+                raise ValueError("audio.cpp recipe option names must be unique")
+        return self
+
+
+class AudioCppAcceptedPackage(_FrozenModel):
+    """Immutable accepted recipe snapshot stored by Guided Settings."""
+
+    package_uuid: str
+    recipe_id: str
+    recipe_revision: int
+    package_variant: str
+    public_model_id: str
+    canonical_root: str
+    canonical_root_identity: str
+    configuration_identity: str
+    weight_identity: str
+    projection: AudioCppSafeModelProjection
+
+    @field_validator("package_uuid", mode="before")
+    @classmethod
+    def _validate_package_uuid(cls, value: object) -> str:
+        if type(value) is not str:
+            raise ValueError("audio.cpp accepted package UUID is invalid")
+        try:
+            parsed = UUID(value)
+        except ValueError:
+            raise ValueError("audio.cpp accepted package UUID is invalid") from None
+        if str(parsed) != value:
+            raise ValueError("audio.cpp accepted package UUID is invalid")
+        return value
+
+    @field_validator("recipe_id", "package_variant", "public_model_id", mode="before")
+    @classmethod
+    def _validate_identifier(cls, value: object, info: ValidationInfo) -> str:
+        return _safe_token(value, label=info.field_name)
+
+    @field_validator("recipe_revision", mode="before")
+    @classmethod
+    def _validate_revision(cls, value: object) -> int:
+        return _strict_integer(
+            value,
+            label="recipe revision",
+            minimum=1,
+            maximum=_MAX_INT32,
+        )
+
+    @field_validator("canonical_root", mode="before")
+    @classmethod
+    def _validate_root(cls, value: object) -> str:
+        return _safe_absolute_path(
+            value, label="canonical package root", allow_empty=False
+        )
+
+    @field_validator(
+        "canonical_root_identity",
+        "configuration_identity",
+        "weight_identity",
+        mode="before",
+    )
+    @classmethod
+    def _validate_digest(cls, value: object, info: ValidationInfo) -> str:
+        return _safe_digest(value, label=info.field_name)
+
+
+class AudioCppSettingsConfig(_FrozenModel):
+    """Full durable audio.cpp Settings state, including dormant source values."""
+
+    mode: Literal["external", "managed"] = "external"
+    base_url: str = "http://127.0.0.1:8080"
+
+    managed_setup_source: AudioCppManagedSetupSource = (
+        AudioCppManagedSetupSource.USER_JSON
+    )
+    managed_binary_path: str = ""
+    managed_server_json_path: str = ""
+
+    guided_binary_path: str = ""
+    guided_binary_source: AudioCppBinarySelectionSource = (
+        AudioCppBinarySelectionSource.MANUAL
+    )
+    guided_packages: tuple[AudioCppAcceptedPackage, ...] = ()
+    guided_default_model_id: str | None = None
+    guided_backend_preference: AudioCppBackendPreference = (
+        AudioCppBackendPreference.AUTO
+    )
+    guided_device: int | None = None
+    guided_threads: int | None = None
+    guided_max_request_body_bytes: int = 256 * 1024 * 1024
+    guided_busy_timeout_ms: int = 300_000
+
+    managed_startup_timeout_seconds: float = 30.0
+    managed_health_check_interval_seconds: float = 10.0
+    managed_termination_grace_seconds: float = 5.0
+    connect_timeout_seconds: float = 5.0
+    synthesis_timeout_seconds: float = 600.0
+    max_input_characters: int = 10_000
+    max_response_bytes: int = 128 * 1024 * 1024
+    max_metadata_bytes: int = 1024 * 1024
+    max_catalog_models: int = 1000
+    max_voices_per_model: int = 1000
+    max_identifier_characters: int = 256
+
+    @field_validator("mode", mode="before")
+    @classmethod
+    def _validate_outer_mode(cls, value: object) -> str:
+        if value not in {"external", "managed"}:
+            raise ValueError("audio.cpp mode must be external or managed")
+        return str(value)
+
+    @field_validator("base_url", mode="before")
+    @classmethod
+    def _validate_base_url(cls, value: object) -> str:
+        return AudioCppConfig.from_mapping(
+            {"mode": "external", "base_url": value}
+        ).base_url
+
+    @field_validator("managed_setup_source", mode="before")
+    @classmethod
+    def _validate_setup_source(cls, value: object) -> AudioCppManagedSetupSource:
+        try:
+            return AudioCppManagedSetupSource(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise ValueError(
+                "audio.cpp managed_setup_source must be user_json or guided"
+            ) from None
+
+    @field_validator("guided_binary_source", mode="before")
+    @classmethod
+    def _validate_binary_source(cls, value: object) -> AudioCppBinarySelectionSource:
+        try:
+            return AudioCppBinarySelectionSource(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise ValueError("audio.cpp guided binary source is invalid") from None
+
+    @field_validator("guided_backend_preference", mode="before")
+    @classmethod
+    def _validate_backend(cls, value: object) -> AudioCppBackendPreference:
+        try:
+            return AudioCppBackendPreference(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise ValueError("audio.cpp guided backend preference is invalid") from None
+
+    @field_validator(
+        "managed_binary_path",
+        "managed_server_json_path",
+        "guided_binary_path",
+        mode="before",
+    )
+    @classmethod
+    def _validate_selected_path(cls, value: object, info: ValidationInfo) -> str:
+        return _safe_absolute_path(value, label=info.field_name, allow_empty=True)
+
+    @field_validator("guided_packages", mode="before")
+    @classmethod
+    def _normalize_packages(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator("guided_default_model_id", mode="before")
+    @classmethod
+    def _validate_default_model(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        return _safe_token(value, label="guided default model id")
+
+    @field_validator("guided_device", mode="before")
+    @classmethod
+    def _validate_device(cls, value: object) -> int | None:
+        if value is None:
+            return None
+        return _strict_integer(
+            value,
+            label="guided device",
+            minimum=0,
+            maximum=1024,
+        )
+
+    @field_validator("guided_threads", mode="before")
+    @classmethod
+    def _validate_threads(cls, value: object) -> int | None:
+        if value is None:
+            return None
+        return _strict_integer(
+            value,
+            label="guided threads",
+            minimum=1,
+            maximum=1024,
+        )
+
+    @field_validator("guided_max_request_body_bytes", mode="before")
+    @classmethod
+    def _validate_body_limit(cls, value: object) -> int:
+        return _strict_integer(
+            value,
+            label="guided max request body bytes",
+            minimum=1,
+            maximum=_MAX_JSON_INTEGER,
+        )
+
+    @field_validator("guided_busy_timeout_ms", mode="before")
+    @classmethod
+    def _validate_server_busy_timeout(cls, value: object) -> int:
+        return _strict_integer(
+            value,
+            label="guided busy timeout",
+            minimum=1,
+            maximum=_MAX_INT32,
+        )
+
+    @field_validator(*_COMMON_TIMEOUT_FIELDS, mode="before")
+    @classmethod
+    def _validate_common_timeout(cls, value: object, info: ValidationInfo) -> float:
+        return _bounded_number(
+            value,
+            label=info.field_name,
+            minimum=0.001,
+            maximum=86_400,
+        )
+
+    @field_validator(*_MANAGED_TIMING_BOUNDS, mode="before")
+    @classmethod
+    def _validate_managed_timing(cls, value: object, info: ValidationInfo) -> float:
+        minimum, maximum = _MANAGED_TIMING_BOUNDS[info.field_name]
+        return _bounded_number(
+            value,
+            label=info.field_name,
+            minimum=minimum,
+            maximum=maximum,
+        )
+
+    @field_validator(*_COMMON_LIMIT_FIELDS, mode="before")
+    @classmethod
+    def _validate_common_limit(cls, value: object, info: ValidationInfo) -> int:
+        return _strict_integer(
+            value,
+            label=info.field_name,
+            minimum=1,
+            maximum=_MAX_JSON_INTEGER,
+        )
+
+    @model_validator(mode="after")
+    def _validate_guided_package_set(self) -> AudioCppSettingsConfig:
+        package_uuids = tuple(package.package_uuid for package in self.guided_packages)
+        if len(package_uuids) != len(set(package_uuids)):
+            raise ValueError("audio.cpp guided package internal UUIDs must be unique")
+        model_ids = tuple(package.public_model_id for package in self.guided_packages)
+        if len(model_ids) != len(set(model_ids)):
+            raise ValueError("audio.cpp guided public model IDs must be unique")
+        candidate_ids = tuple(
+            (
+                package.canonical_root,
+                package.package_variant,
+                package.configuration_identity,
+                package.weight_identity,
+            )
+            for package in self.guided_packages
+        )
+        if len(candidate_ids) != len(set(candidate_ids)):
+            raise ValueError("audio.cpp guided package identities must be unique")
+        if self.guided_default_model_id is not None and (
+            self.guided_default_model_id not in model_ids
+        ):
+            raise ValueError(
+                "audio.cpp guided default model must name an accepted package"
+            )
+        return self
+
+    @classmethod
+    def from_mapping(cls, values: Mapping[str, Any]) -> AudioCppSettingsConfig:
+        """Copy approved full-settings fields from one configuration mapping."""
+        if not isinstance(values, Mapping):
+            raise ValueError("audio.cpp settings configuration must be a mapping")
+        projected = {
+            name: deepcopy(values[name]) for name in cls.model_fields if name in values
+        }
+        return cls(**projected)
+
+    def to_mapping(self) -> dict[str, object]:
+        """Return one defensive JSON-compatible mapping of approved fields."""
+        return deepcopy(self.model_dump(mode="json"))
+
+
+__all__ = (
+    "AudioCppAcceptedPackage",
+    "AudioCppBackendPreference",
+    "AudioCppBinarySelectionSource",
+    "AudioCppManagedSetupSource",
+    "AudioCppRecipeOption",
+    "AudioCppSafeModelProjection",
+    "AudioCppSettingsConfig",
+)

--- a/tldw_chatbook/TTS/audio_cpp_package_scanner.py
+++ b/tldw_chatbook/TTS/audio_cpp_package_scanner.py
@@ -16,6 +16,8 @@ from pathlib import Path, PurePosixPath
 from time import monotonic as _monotonic
 from typing import Any
 
+from tldw_chatbook.Utils.path_validation import validate_path_simple
+
 from .audio_cpp_recipes import (
     AUDIO_CPP_RECIPE_REGISTRY,
     AudioCppFileKind,
@@ -67,6 +69,7 @@ class AudioCppScanIssueCode(StrEnum):
     SYMLINK_SKIPPED = "symlink_skipped"
     REPARSE_SKIPPED = "reparse_skipped"
     SPECIAL_FILE_SKIPPED = "special_file_skipped"
+    NO_FOLLOW_UNAVAILABLE = "no_follow_unavailable"
 
 
 def _positive_integer(value: object, label: str, *, allow_zero: bool = False) -> int:
@@ -207,13 +210,16 @@ def _same_source(first: os.stat_result, second: os.stat_result) -> bool:
     )
 
 
-def _read_only_no_follow_flags() -> int:
+def _read_only_no_follow_flags() -> int | None:
+    no_follow = getattr(os, "O_NOFOLLOW", 0)
+    if not no_follow:
+        return None
     return (
         os.O_RDONLY
         | getattr(os, "O_CLOEXEC", 0)
         | getattr(os, "O_BINARY", 0)
         | getattr(os, "O_NONBLOCK", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
+        | no_follow
     )
 
 
@@ -312,6 +318,20 @@ def _inspect_file(
     readable = True
     valid = info.st_size >= signal.minimum_size_bytes
     identity = _filesystem_identity(info)
+    open_flags = _read_only_no_follow_flags()
+    if open_flags is None:
+        state.add_incomplete(
+            AudioCppScanIssueCode.NO_FOLLOW_UNAVAILABLE,
+            relative_parts,
+            path.name,
+        )
+        return AudioCppPackageFileEvidence(
+            relative_path=signal.relative_path,
+            size_bytes=info.st_size,
+            identity=identity,
+            readable=False,
+            metadata_valid=False,
+        )
     if required_bytes > state.limits.max_metadata_bytes_per_file:
         state.add_limit(AudioCppScanLimit.METADATA_PER_FILE)
         valid = False
@@ -326,7 +346,7 @@ def _inspect_file(
 
     descriptor: int | None = None
     try:
-        descriptor = os.open(path, _read_only_no_follow_flags())
+        descriptor = os.open(path, open_flags)
         opened_info = os.fstat(descriptor)
         if not stat.S_ISREG(opened_info.st_mode) or not _same_source(info, opened_info):
             readable = False
@@ -383,20 +403,10 @@ def _inspect_file(
 def _signal_index(
     registry: AudioCppRecipeRegistry,
 ) -> tuple[tuple[tuple[str, ...], AudioCppFileSignal], ...]:
-    unique: dict[
-        tuple[str, AudioCppFileKind, str, int],
-        AudioCppFileSignal,
-    ] = {}
+    unique: dict[str, AudioCppFileSignal] = {}
     for recipe in registry.recipes:
         for signal in recipe.required_files:
-            unique[
-                (
-                    signal.relative_path,
-                    signal.kind,
-                    signal.role.value,
-                    signal.minimum_size_bytes,
-                )
-            ] = signal
+            unique.setdefault(signal.relative_path, signal)
     return tuple(
         sorted(
             (
@@ -445,7 +455,11 @@ def _resolve_selected_root(
     allow_root_symlink: bool,
 ) -> tuple[Path, os.stat_result, bool]:
     try:
-        selected = Path(root)
+        selected = validate_path_simple(
+            root,
+            require_exists=False,
+            probe_existing=False,
+        )
         selected_info = os.lstat(selected)
     except (OSError, TypeError, ValueError):
         raise AudioCppPackageScanError(
@@ -514,7 +528,26 @@ def scan_audio_cpp_package_root(
     allow_root_symlink: bool = False,
     request_revision: int = 0,
 ) -> AudioCppPackageScanResult:
-    """Inspect exactly one user-selected root with finite no-follow budgets."""
+    """Inspect exactly one user-selected root with finite no-follow budgets.
+
+    Args:
+        root: User-selected package directory. The scanner never searches a
+            parent or sibling automatically.
+        registry: Sealed recipe registry used for exact matching.
+        limits: Optional finite scanner budgets; defaults are used when absent.
+        cancellation_event: Optional cross-thread cancellation signal.
+        allow_root_symlink: Whether to resolve a disclosed top-level symlink.
+            Nested links and reparse points are always skipped.
+        request_revision: Non-negative caller revision copied into the result.
+
+    Returns:
+        One immutable, bounded scan result with sanitized retained evidence.
+
+    Raises:
+        AudioCppPackageScanError: If the selected root is invalid or unusable.
+        TypeError: If the registry, limits, or cancellation signal is invalid.
+        ValueError: If the request revision is invalid.
+    """
     if not isinstance(registry, AudioCppRecipeRegistry):
         raise TypeError("audio.cpp recipe registry is required")
     if type(request_revision) is not int or request_revision < 0:
@@ -813,7 +846,25 @@ async def scan_audio_cpp_package_root_async(
     allow_root_symlink: bool = False,
     request_revision: int = 0,
 ) -> AudioCppPackageScanResult:
-    """Run one scan in a worker thread and signal it if the caller cancels."""
+    """Run one package scan off-loop and propagate caller cancellation.
+
+    Args:
+        root: User-selected package directory.
+        registry: Sealed recipe registry used for exact matching.
+        limits: Optional finite scanner budgets; defaults are used when absent.
+        cancellation_event: Optional cross-thread cancellation signal.
+        allow_root_symlink: Whether to resolve a disclosed top-level symlink.
+        request_revision: Non-negative caller revision copied into the result.
+
+    Returns:
+        The immutable result produced by :func:`scan_audio_cpp_package_root`.
+
+    Raises:
+        asyncio.CancelledError: If the awaiting caller cancels the scan.
+        AudioCppPackageScanError: If the selected root is invalid or unusable.
+        TypeError: If the registry, limits, or cancellation signal is invalid.
+        ValueError: If the request revision is invalid.
+    """
     cancellation = cancellation_event or threading.Event()
     work = asyncio.create_task(
         asyncio.to_thread(

--- a/tldw_chatbook/TTS/audio_cpp_package_scanner.py
+++ b/tldw_chatbook/TTS/audio_cpp_package_scanner.py
@@ -1,0 +1,847 @@
+"""Bounded read-only local package discovery for guided audio.cpp setup."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+import stat
+import threading
+import unicodedata
+from collections import deque
+from dataclasses import dataclass, field
+from enum import StrEnum
+from hashlib import sha256
+from pathlib import Path, PurePosixPath
+from time import monotonic as _monotonic
+from typing import Any
+
+from .audio_cpp_recipes import (
+    AUDIO_CPP_RECIPE_REGISTRY,
+    AudioCppFileKind,
+    AudioCppFileSignal,
+    AudioCppMatchResult,
+    AudioCppMatchState,
+    AudioCppPackageDescription,
+    AudioCppPackageFileEvidence,
+    AudioCppRecipeRegistry,
+)
+
+
+_scandir = os.scandir
+_REPARSE_ATTRIBUTE = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+
+
+class AudioCppPackageScanError(ValueError):
+    """Stable path-independent error for an unusable selected root."""
+
+
+class AudioCppScanOutcome(StrEnum):
+    """Overall scan completeness independent of individual recipe matches."""
+
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    PERMISSION_LIMITED = "permission_limited"
+    CANCELLED = "cancelled"
+
+
+class AudioCppScanLimit(StrEnum):
+    """Finite scanner budget that stopped or downgraded discovery."""
+
+    DEPTH = "depth"
+    ENTRIES = "entries"
+    CANDIDATE_ROOTS = "candidate_roots"
+    RESULTS = "results"
+    METADATA_PER_FILE = "metadata_per_file"
+    METADATA_TOTAL = "metadata_total"
+    ENTRY_TIME = "entry_time"
+    TOTAL_TIME = "total_time"
+
+
+class AudioCppScanIssueCode(StrEnum):
+    """Sanitized per-entry issue code."""
+
+    PERMISSION_DENIED = "permission_denied"
+    UNREADABLE = "unreadable"
+    SOURCE_CHANGED = "source_changed"
+    SYMLINK_SKIPPED = "symlink_skipped"
+    REPARSE_SKIPPED = "reparse_skipped"
+    SPECIAL_FILE_SKIPPED = "special_file_skipped"
+
+
+def _positive_integer(value: object, label: str, *, allow_zero: bool = False) -> int:
+    minimum = 0 if allow_zero else 1
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"audio.cpp scanner {label} is invalid")
+    return value
+
+
+def _positive_seconds(value: object, label: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or float(value) <= 0
+    ):
+        raise ValueError(f"audio.cpp scanner {label} is invalid")
+    return float(value)
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppScanLimits:
+    """All finite work and retained-detail budgets for one explicit root."""
+
+    max_depth: int = 8
+    max_entries: int = 4096
+    max_candidate_roots: int = 128
+    max_results: int = 64
+    max_metadata_bytes_per_file: int = 64 * 1024
+    max_metadata_bytes_total: int = 1024 * 1024
+    max_entry_seconds: float = 0.25
+    max_total_seconds: float = 5.0
+    max_issues: int = 16
+    max_unknown_names: int = 16
+
+    def __post_init__(self) -> None:
+        _positive_integer(self.max_depth, "max_depth", allow_zero=True)
+        for name in (
+            "max_entries",
+            "max_candidate_roots",
+            "max_results",
+            "max_metadata_bytes_per_file",
+            "max_metadata_bytes_total",
+            "max_issues",
+            "max_unknown_names",
+        ):
+            _positive_integer(getattr(self, name), name)
+        _positive_seconds(self.max_entry_seconds, "max_entry_seconds")
+        _positive_seconds(self.max_total_seconds, "max_total_seconds")
+        if self.max_metadata_bytes_per_file > self.max_metadata_bytes_total:
+            raise ValueError(
+                "audio.cpp scanner per-file metadata limit exceeds total limit"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppScanIssue:
+    """One path-sanitized retained scanner issue."""
+
+    code: AudioCppScanIssueCode
+    safe_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppPackageDiscovery:
+    """One deduplicated candidate root and its pure recipe match."""
+
+    description: AudioCppPackageDescription
+    match: AudioCppMatchResult
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppPackageScanResult:
+    """Bounded immutable result for one explicit scan request."""
+
+    outcome: AudioCppScanOutcome
+    request_revision: int
+    selected_root_name: str
+    canonical_root: str = field(repr=False)
+    canonical_root_identity: str
+    root_was_symlink: bool
+    discoveries: tuple[AudioCppPackageDiscovery, ...]
+    limits_reached: tuple[AudioCppScanLimit, ...]
+    issues: tuple[AudioCppScanIssue, ...]
+    issues_truncated: bool
+    unknown_names: tuple[str, ...]
+    unknown_names_truncated: bool
+    visited_entries: int
+    metadata_bytes_read: int
+
+
+def _safe_name(value: str) -> str:
+    cleaned = "".join(
+        character
+        for character in value
+        if not unicodedata.category(character).startswith("C")
+    ).strip()
+    return (cleaned or "Selected package")[:128]
+
+
+def _filesystem_identity(info: os.stat_result) -> str:
+    encoded = ":".join(
+        str(value)
+        for value in (
+            info.st_dev,
+            info.st_ino,
+            info.st_mode,
+            info.st_size,
+            info.st_mtime_ns,
+            info.st_ctime_ns,
+        )
+    )
+    return sha256(encoded.encode("ascii")).hexdigest()
+
+
+def _is_reparse_or_symlink(info: Any) -> bool:
+    """Return whether a no-follow stat identifies a link/reparse object."""
+    return stat.S_ISLNK(info.st_mode) or bool(
+        getattr(info, "st_file_attributes", 0) & _REPARSE_ATTRIBUTE
+    )
+
+
+def _same_source(first: os.stat_result, second: os.stat_result) -> bool:
+    return (
+        first.st_dev,
+        first.st_ino,
+        first.st_mode,
+        first.st_size,
+        first.st_mtime_ns,
+        first.st_ctime_ns,
+    ) == (
+        second.st_dev,
+        second.st_ino,
+        second.st_mode,
+        second.st_size,
+        second.st_mtime_ns,
+        second.st_ctime_ns,
+    )
+
+
+def _read_only_no_follow_flags() -> int:
+    return (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+
+
+def _required_metadata_bytes(kind: AudioCppFileKind) -> int:
+    if kind is AudioCppFileKind.GGUF:
+        return 8
+    if kind is AudioCppFileKind.SAFETENSORS:
+        return 9
+    if kind is AudioCppFileKind.JSON:
+        return 1
+    return 0
+
+
+def _metadata_is_valid(kind: AudioCppFileKind, data: bytes, size_bytes: int) -> bool:
+    if kind is AudioCppFileKind.GGUF:
+        return (
+            len(data) == 8
+            and data[:4] == b"GGUF"
+            and int.from_bytes(data[4:8], "little") == 3
+        )
+    if kind is AudioCppFileKind.SAFETENSORS:
+        if len(data) != 9:
+            return False
+        header_size = int.from_bytes(data[:8], "little")
+        return 2 <= header_size <= size_bytes - 8 and data[8:9] == b"{"
+    if kind is AudioCppFileKind.JSON:
+        return data in {b"{", b"["}
+    return True
+
+
+@dataclass(slots=True)
+class _ScanState:
+    limits: AudioCppScanLimits
+    started_at: float
+    cancellation_event: threading.Event
+    visited_entries: int = 0
+    metadata_bytes_read: int = 0
+    limits_reached: set[AudioCppScanLimit] = field(default_factory=set)
+    issues: list[AudioCppScanIssue] = field(default_factory=list)
+    issues_truncated: bool = False
+    unknown_names: list[str] = field(default_factory=list)
+    unknown_names_truncated: bool = False
+    permission_limited: bool = False
+    permission_paths: set[tuple[str, ...]] = field(default_factory=set)
+    incomplete_paths: set[tuple[str, ...]] = field(default_factory=set)
+    stopped: bool = False
+
+    def add_limit(self, limit: AudioCppScanLimit) -> None:
+        self.limits_reached.add(limit)
+
+    def add_issue(self, code: AudioCppScanIssueCode, name: str) -> None:
+        if len(self.issues) >= self.limits.max_issues:
+            self.issues_truncated = True
+            return
+        self.issues.append(AudioCppScanIssue(code, _safe_name(name)))
+
+    def add_permission(self, path: tuple[str, ...], name: str) -> None:
+        self.permission_limited = True
+        self.permission_paths.add(path)
+        self.add_issue(AudioCppScanIssueCode.PERMISSION_DENIED, name)
+
+    def add_incomplete(
+        self,
+        code: AudioCppScanIssueCode,
+        path: tuple[str, ...],
+        name: str,
+    ) -> None:
+        self.incomplete_paths.add(path)
+        self.add_issue(code, name)
+
+    def add_unknown(self, name: str) -> None:
+        if len(self.unknown_names) >= self.limits.max_unknown_names:
+            self.unknown_names_truncated = True
+            return
+        self.unknown_names.append(_safe_name(name))
+
+    def cancellation_or_total_limit(self) -> bool:
+        if self.cancellation_event.is_set():
+            self.stopped = True
+            return True
+        if _monotonic() - self.started_at > self.limits.max_total_seconds:
+            self.add_limit(AudioCppScanLimit.TOTAL_TIME)
+            self.stopped = True
+            return True
+        return False
+
+
+def _inspect_file(
+    path: Path,
+    relative_parts: tuple[str, ...],
+    info: os.stat_result,
+    signal: AudioCppFileSignal,
+    state: _ScanState,
+) -> AudioCppPackageFileEvidence:
+    required_bytes = _required_metadata_bytes(signal.kind)
+    readable = True
+    valid = info.st_size >= signal.minimum_size_bytes
+    identity = _filesystem_identity(info)
+    if required_bytes > state.limits.max_metadata_bytes_per_file:
+        state.add_limit(AudioCppScanLimit.METADATA_PER_FILE)
+        valid = False
+        required_bytes = 0
+    elif (
+        state.metadata_bytes_read + required_bytes
+        > state.limits.max_metadata_bytes_total
+    ):
+        state.add_limit(AudioCppScanLimit.METADATA_TOTAL)
+        valid = False
+        required_bytes = 0
+
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, _read_only_no_follow_flags())
+        opened_info = os.fstat(descriptor)
+        if not stat.S_ISREG(opened_info.st_mode) or not _same_source(info, opened_info):
+            readable = False
+            valid = False
+            state.add_incomplete(
+                AudioCppScanIssueCode.SOURCE_CHANGED,
+                relative_parts,
+                path.name,
+            )
+        else:
+            if required_bytes:
+                data = os.read(descriptor, required_bytes)
+                state.metadata_bytes_read += len(data)
+                valid = valid and _metadata_is_valid(
+                    signal.kind,
+                    data,
+                    opened_info.st_size,
+                )
+            identity = _filesystem_identity(opened_info)
+    except PermissionError:
+        readable = False
+        valid = False
+        state.add_permission(relative_parts, path.name)
+    except OSError:
+        readable = False
+        valid = False
+        state.add_incomplete(
+            AudioCppScanIssueCode.UNREADABLE,
+            relative_parts,
+            path.name,
+        )
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                readable = False
+                valid = False
+                state.add_incomplete(
+                    AudioCppScanIssueCode.UNREADABLE,
+                    relative_parts,
+                    path.name,
+                )
+
+    return AudioCppPackageFileEvidence(
+        relative_path=signal.relative_path,
+        size_bytes=info.st_size,
+        identity=identity,
+        readable=readable,
+        metadata_valid=valid,
+    )
+
+
+def _signal_index(
+    registry: AudioCppRecipeRegistry,
+) -> tuple[tuple[tuple[str, ...], AudioCppFileSignal], ...]:
+    unique: dict[
+        tuple[str, AudioCppFileKind, str, int],
+        AudioCppFileSignal,
+    ] = {}
+    for recipe in registry.recipes:
+        for signal in recipe.required_files:
+            unique[
+                (
+                    signal.relative_path,
+                    signal.kind,
+                    signal.role.value,
+                    signal.minimum_size_bytes,
+                )
+            ] = signal
+    return tuple(
+        sorted(
+            (
+                (PurePosixPath(signal.relative_path).parts, signal)
+                for signal in unique.values()
+            ),
+            key=lambda item: (item[1].relative_path, item[1].kind.value),
+        )
+    )
+
+
+def _path_failure_affects_candidate(
+    affected_paths: set[tuple[str, ...]],
+    candidate_root: tuple[str, ...],
+    signals: tuple[tuple[tuple[str, ...], AudioCppFileSignal], ...],
+) -> bool:
+    for affected_path in affected_paths:
+        if affected_path[: len(candidate_root)] != candidate_root:
+            continue
+        relative_failure = affected_path[len(candidate_root) :]
+        if not relative_failure or any(
+            signal_parts[: len(relative_failure)] == relative_failure
+            for signal_parts, _signal in signals
+        ):
+            return True
+    return False
+
+
+def _close_directory_iterator(
+    iterator: object,
+    state: _ScanState,
+    directory_name: str,
+) -> None:
+    close = getattr(iterator, "close", None)
+    if close is None:
+        return
+    try:
+        close()
+    except OSError:
+        state.add_issue(AudioCppScanIssueCode.UNREADABLE, directory_name)
+
+
+def _resolve_selected_root(
+    root: str | os.PathLike[str],
+    *,
+    allow_root_symlink: bool,
+) -> tuple[Path, os.stat_result, bool]:
+    try:
+        selected = Path(root)
+        selected_info = os.lstat(selected)
+    except (OSError, TypeError, ValueError):
+        raise AudioCppPackageScanError(
+            "Selected audio.cpp package root is unavailable."
+        ) from None
+    root_is_link = _is_reparse_or_symlink(selected_info)
+    if root_is_link and not allow_root_symlink:
+        raise AudioCppPackageScanError(
+            "Selected audio.cpp package root is a symlink; review its target first."
+        )
+    try:
+        canonical = selected.resolve(strict=True)
+        canonical_info = os.stat(canonical, follow_symlinks=False)
+    except OSError:
+        raise AudioCppPackageScanError(
+            "Selected audio.cpp package root is unavailable."
+        ) from None
+    root_is_link = root_is_link or (
+        os.path.normcase(os.path.abspath(os.fspath(selected)))
+        != os.path.normcase(os.path.abspath(os.fspath(canonical)))
+    )
+    if root_is_link and not allow_root_symlink:
+        raise AudioCppPackageScanError(
+            "Selected audio.cpp package root is a symlink; review its target first."
+        )
+    if _is_reparse_or_symlink(canonical_info) or not stat.S_ISDIR(
+        canonical_info.st_mode
+    ):
+        raise AudioCppPackageScanError(
+            "Selected audio.cpp package root must be a readable directory."
+        )
+    return canonical, canonical_info, root_is_link
+
+
+def _cancelled_result(
+    *,
+    request_revision: int,
+    canonical_root: Path,
+    root_info: os.stat_result,
+    root_was_symlink: bool,
+) -> AudioCppPackageScanResult:
+    return AudioCppPackageScanResult(
+        outcome=AudioCppScanOutcome.CANCELLED,
+        request_revision=request_revision,
+        selected_root_name=_safe_name(canonical_root.name),
+        canonical_root=str(canonical_root),
+        canonical_root_identity=_filesystem_identity(root_info),
+        root_was_symlink=root_was_symlink,
+        discoveries=(),
+        limits_reached=(),
+        issues=(),
+        issues_truncated=False,
+        unknown_names=(),
+        unknown_names_truncated=False,
+        visited_entries=0,
+        metadata_bytes_read=0,
+    )
+
+
+def scan_audio_cpp_package_root(
+    root: str | os.PathLike[str],
+    *,
+    registry: AudioCppRecipeRegistry = AUDIO_CPP_RECIPE_REGISTRY,
+    limits: AudioCppScanLimits | None = None,
+    cancellation_event: threading.Event | None = None,
+    allow_root_symlink: bool = False,
+    request_revision: int = 0,
+) -> AudioCppPackageScanResult:
+    """Inspect exactly one user-selected root with finite no-follow budgets."""
+    if not isinstance(registry, AudioCppRecipeRegistry):
+        raise TypeError("audio.cpp recipe registry is required")
+    if type(request_revision) is not int or request_revision < 0:
+        raise ValueError("audio.cpp scan request revision is invalid")
+    active_limits = AudioCppScanLimits() if limits is None else limits
+    if not isinstance(active_limits, AudioCppScanLimits):
+        raise TypeError("audio.cpp scan limits are required")
+    cancellation = cancellation_event or threading.Event()
+    if not isinstance(cancellation, threading.Event):
+        raise TypeError("audio.cpp scan cancellation event is invalid")
+    canonical_root, root_info, root_was_symlink = _resolve_selected_root(
+        root,
+        allow_root_symlink=allow_root_symlink,
+    )
+    if cancellation.is_set():
+        return _cancelled_result(
+            request_revision=request_revision,
+            canonical_root=canonical_root,
+            root_info=root_info,
+            root_was_symlink=root_was_symlink,
+        )
+
+    state = _ScanState(active_limits, _monotonic(), cancellation)
+    signals = _signal_index(registry)
+    queue: deque[tuple[Path, tuple[str, ...], int]] = deque(((canonical_root, (), 0),))
+    directory_identities: dict[tuple[str, ...], str] = {
+        (): _filesystem_identity(root_info)
+    }
+    candidate_evidence: dict[
+        tuple[str, ...],
+        dict[str, AudioCppPackageFileEvidence],
+    ] = {}
+    inspection_cache: dict[
+        tuple[str, AudioCppFileKind, int],
+        AudioCppPackageFileEvidence,
+    ] = {}
+
+    while queue and not state.stopped:
+        directory, relative_directory, depth = queue.popleft()
+        if state.cancellation_or_total_limit():
+            break
+        iterator: object | None = None
+        try:
+            current_info = os.stat(directory, follow_symlinks=False)
+            if (
+                _is_reparse_or_symlink(current_info)
+                or not stat.S_ISDIR(current_info.st_mode)
+                or _filesystem_identity(current_info)
+                != directory_identities[relative_directory]
+            ):
+                state.add_incomplete(
+                    AudioCppScanIssueCode.SOURCE_CHANGED,
+                    relative_directory,
+                    directory.name,
+                )
+                continue
+            iterator = _scandir(directory)
+            opened_info = os.stat(directory, follow_symlinks=False)
+            if (
+                _is_reparse_or_symlink(opened_info)
+                or not stat.S_ISDIR(opened_info.st_mode)
+                or _filesystem_identity(opened_info)
+                != directory_identities[relative_directory]
+            ):
+                state.add_incomplete(
+                    AudioCppScanIssueCode.SOURCE_CHANGED,
+                    relative_directory,
+                    directory.name,
+                )
+                _close_directory_iterator(iterator, state, directory.name)
+                continue
+        except PermissionError:
+            if iterator is not None:
+                _close_directory_iterator(iterator, state, directory.name)
+            state.add_permission(relative_directory, directory.name)
+            continue
+        except OSError:
+            if iterator is not None:
+                _close_directory_iterator(iterator, state, directory.name)
+            state.add_incomplete(
+                AudioCppScanIssueCode.UNREADABLE,
+                relative_directory,
+                directory.name,
+            )
+            continue
+        try:
+            for entry in iterator:
+                if state.cancellation_or_total_limit():
+                    break
+                if state.visited_entries >= active_limits.max_entries:
+                    state.add_limit(AudioCppScanLimit.ENTRIES)
+                    state.stopped = True
+                    break
+                state.visited_entries += 1
+                entry_started = _monotonic()
+                relative_parts = (*relative_directory, entry.name)
+                try:
+                    info = entry.stat(follow_symlinks=False)
+                except PermissionError:
+                    state.add_permission(relative_parts, entry.name)
+                    continue
+                except OSError:
+                    state.add_incomplete(
+                        AudioCppScanIssueCode.UNREADABLE,
+                        relative_parts,
+                        entry.name,
+                    )
+                    continue
+
+                entry_path = directory / entry.name
+                is_reparse = bool(
+                    getattr(info, "st_file_attributes", 0) & _REPARSE_ATTRIBUTE
+                )
+                if _is_reparse_or_symlink(info):
+                    state.add_issue(
+                        AudioCppScanIssueCode.REPARSE_SKIPPED
+                        if is_reparse and not stat.S_ISLNK(info.st_mode)
+                        else AudioCppScanIssueCode.SYMLINK_SKIPPED,
+                        entry.name,
+                    )
+                elif stat.S_ISDIR(info.st_mode):
+                    if depth >= active_limits.max_depth:
+                        state.add_limit(AudioCppScanLimit.DEPTH)
+                    else:
+                        directory_identities[relative_parts] = _filesystem_identity(
+                            info
+                        )
+                        queue.append((entry_path, relative_parts, depth + 1))
+                elif stat.S_ISREG(info.st_mode):
+                    matched = False
+                    for signal_parts, signal in signals:
+                        if (
+                            len(relative_parts) < len(signal_parts)
+                            or relative_parts[-len(signal_parts) :] != signal_parts
+                        ):
+                            continue
+                        matched = True
+                        candidate_root = relative_parts[: -len(signal_parts)]
+                        if candidate_root not in candidate_evidence:
+                            if (
+                                len(candidate_evidence)
+                                >= active_limits.max_candidate_roots
+                            ):
+                                state.add_limit(AudioCppScanLimit.CANDIDATE_ROOTS)
+                                continue
+                            candidate_evidence[candidate_root] = {}
+                        cache_key = (
+                            str(entry_path),
+                            signal.kind,
+                            signal.minimum_size_bytes,
+                        )
+                        cached = inspection_cache.get(cache_key)
+                        if cached is None:
+                            cached = _inspect_file(
+                                entry_path,
+                                relative_parts,
+                                info,
+                                signal,
+                                state,
+                            )
+                            inspection_cache[cache_key] = cached
+                        evidence = AudioCppPackageFileEvidence(
+                            relative_path=signal.relative_path,
+                            size_bytes=cached.size_bytes,
+                            identity=cached.identity,
+                            readable=cached.readable,
+                            metadata_valid=cached.metadata_valid,
+                        )
+                        candidate_evidence[candidate_root][signal.relative_path] = (
+                            evidence
+                        )
+                    if not matched and entry.name.casefold().endswith(
+                        (".gguf", ".safetensors")
+                    ):
+                        state.add_unknown(entry.name)
+                else:
+                    state.add_issue(
+                        AudioCppScanIssueCode.SPECIAL_FILE_SKIPPED, entry.name
+                    )
+
+                if _monotonic() - entry_started > active_limits.max_entry_seconds:
+                    state.add_limit(AudioCppScanLimit.ENTRY_TIME)
+        except PermissionError:
+            state.add_permission(relative_directory, directory.name)
+        except OSError:
+            state.add_incomplete(
+                AudioCppScanIssueCode.UNREADABLE,
+                relative_directory,
+                directory.name,
+            )
+        finally:
+            _close_directory_iterator(iterator, state, directory.name)
+
+    state.cancellation_or_total_limit()
+    if cancellation.is_set():
+        return _cancelled_result(
+            request_revision=request_revision,
+            canonical_root=canonical_root,
+            root_info=root_info,
+            root_was_symlink=root_was_symlink,
+        )
+
+    global_partial = bool(state.limits_reached)
+    discoveries: list[AudioCppPackageDiscovery] = []
+    seen_discoveries: set[tuple[str, tuple[str, ...], tuple[tuple[str, str], ...]]] = (
+        set()
+    )
+    candidate_items = sorted(candidate_evidence.items(), key=lambda item: item[0])
+    for relative_root, evidence in candidate_items:
+        candidate_path = canonical_root.joinpath(*relative_root)
+        root_identity = directory_identities.get(relative_root)
+        if root_identity is None:
+            try:
+                candidate_info = os.stat(candidate_path, follow_symlinks=False)
+            except OSError:
+                state.add_issue(
+                    AudioCppScanIssueCode.SOURCE_CHANGED, candidate_path.name
+                )
+                continue
+            if _is_reparse_or_symlink(candidate_info) or not stat.S_ISDIR(
+                candidate_info.st_mode
+            ):
+                state.add_issue(
+                    AudioCppScanIssueCode.SOURCE_CHANGED, candidate_path.name
+                )
+                continue
+            root_identity = _filesystem_identity(candidate_info)
+        description = AudioCppPackageDescription(
+            canonical_root=str(candidate_path),
+            canonical_root_identity=root_identity,
+            safe_name=_safe_name(candidate_path.name),
+            files=tuple(sorted(evidence.values(), key=lambda item: item.relative_path)),
+            partial=global_partial
+            or _path_failure_affects_candidate(
+                state.incomplete_paths,
+                relative_root,
+                signals,
+            ),
+            permission_limited=_path_failure_affects_candidate(
+                state.permission_paths,
+                relative_root,
+                signals,
+            ),
+        )
+        match = registry.match(description)
+        if match.state is AudioCppMatchState.UNKNOWN:
+            continue
+        identity = (
+            str(candidate_path),
+            match.recipe_ids,
+            tuple(
+                sorted(
+                    (item.relative_path, item.identity) for item in description.files
+                )
+            ),
+        )
+        if identity in seen_discoveries:
+            continue
+        if len(discoveries) >= active_limits.max_results:
+            state.add_limit(AudioCppScanLimit.RESULTS)
+            break
+        seen_discoveries.add(identity)
+        discoveries.append(AudioCppPackageDiscovery(description, match))
+
+    limits_reached = tuple(sorted(state.limits_reached, key=lambda item: item.value))
+    if state.permission_limited:
+        outcome = AudioCppScanOutcome.PERMISSION_LIMITED
+    elif limits_reached or state.incomplete_paths:
+        outcome = AudioCppScanOutcome.PARTIAL
+    else:
+        outcome = AudioCppScanOutcome.COMPLETE
+    return AudioCppPackageScanResult(
+        outcome=outcome,
+        request_revision=request_revision,
+        selected_root_name=_safe_name(canonical_root.name),
+        canonical_root=str(canonical_root),
+        canonical_root_identity=_filesystem_identity(root_info),
+        root_was_symlink=root_was_symlink,
+        discoveries=tuple(discoveries),
+        limits_reached=limits_reached,
+        issues=tuple(state.issues),
+        issues_truncated=state.issues_truncated,
+        unknown_names=tuple(state.unknown_names),
+        unknown_names_truncated=state.unknown_names_truncated,
+        visited_entries=state.visited_entries,
+        metadata_bytes_read=state.metadata_bytes_read,
+    )
+
+
+async def scan_audio_cpp_package_root_async(
+    root: str | os.PathLike[str],
+    *,
+    registry: AudioCppRecipeRegistry = AUDIO_CPP_RECIPE_REGISTRY,
+    limits: AudioCppScanLimits | None = None,
+    cancellation_event: threading.Event | None = None,
+    allow_root_symlink: bool = False,
+    request_revision: int = 0,
+) -> AudioCppPackageScanResult:
+    """Run one scan in a worker thread and signal it if the caller cancels."""
+    cancellation = cancellation_event or threading.Event()
+    work = asyncio.create_task(
+        asyncio.to_thread(
+            scan_audio_cpp_package_root,
+            root,
+            registry=registry,
+            limits=limits,
+            cancellation_event=cancellation,
+            allow_root_symlink=allow_root_symlink,
+            request_revision=request_revision,
+        )
+    )
+    try:
+        return await work
+    except asyncio.CancelledError:
+        cancellation.set()
+        raise
+
+
+__all__ = (
+    "AudioCppPackageDiscovery",
+    "AudioCppPackageScanError",
+    "AudioCppPackageScanResult",
+    "AudioCppScanIssue",
+    "AudioCppScanIssueCode",
+    "AudioCppScanLimit",
+    "AudioCppScanLimits",
+    "AudioCppScanOutcome",
+    "scan_audio_cpp_package_root",
+    "scan_audio_cpp_package_root_async",
+)

--- a/tldw_chatbook/TTS/audio_cpp_recipes.py
+++ b/tldw_chatbook/TTS/audio_cpp_recipes.py
@@ -1,0 +1,927 @@
+"""Sealed package recipes for guided audio.cpp setup.
+
+Recipes are inert data. Matching consumes a bounded pre-scanned description;
+this module performs no filesystem, network, process, download, or UI work.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from enum import StrEnum
+from hashlib import sha256
+from pathlib import PurePosixPath, PureWindowsPath
+from types import MappingProxyType
+from uuid import uuid4
+
+from .audio_cpp_guided_config import (
+    AudioCppAcceptedPackage,
+    AudioCppBackendPreference,
+    AudioCppRecipeOption,
+    AudioCppSafeModelProjection,
+)
+
+
+AUDIO_CPP_PINNED_RELEASE = "release-0.5.1"
+AUDIO_CPP_PINNED_COMMIT = "238ab6a9e321c17de8e120559f57efeedaeb1345"
+AUDIO_CPP_RECIPE_SCHEMA_VERSION = 1
+
+_TOKEN = re.compile(r"[a-z0-9][a-z0-9._-]{0,127}\Z", re.ASCII)
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+_PINNED_MODEL_SPEC_BASE = (
+    f"https://github.com/0xShug0/audio.cpp/blob/{AUDIO_CPP_PINNED_COMMIT}/model_specs"
+)
+_RECIPE_EVIDENCE_REFERENCE = (
+    "Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md"
+)
+
+
+class AudioCppFileKind(StrEnum):
+    """Bounded metadata inspection rule for a required package file."""
+
+    GGUF = "gguf"
+    SAFETENSORS = "safetensors"
+    JSON = "json"
+    TOKENIZER = "tokenizer"
+    OTHER = "other"
+
+
+class AudioCppFileRole(StrEnum):
+    """Identity role used when fencing an accepted package."""
+
+    CONFIGURATION = "configuration"
+    WEIGHT = "weight"
+    VOICE = "voice"
+    OTHER = "other"
+
+
+class AudioCppBackendEvidenceState(StrEnum):
+    """Truthful posture for one exact recipe/platform/backend tuple."""
+
+    VERIFIED = "verified"
+    EXPECTED = "expected"
+    UNTESTED = "untested"
+    UNSUPPORTED = "unsupported"
+    BLOCKED = "blocked"
+
+
+class AudioCppRecipeSupportState(StrEnum):
+    """Auditable release-accounting state for one package variant."""
+
+    APPROVED = "approved"
+    EXPLICITLY_UNSUPPORTED = "explicitly_unsupported"
+    OPEN_GAP = "open_gap"
+
+
+class AudioCppMatchState(StrEnum):
+    """Fail-closed result of matching one pre-scanned package description."""
+
+    EXACT = "exact"
+    AMBIGUOUS = "ambiguous"
+    UNKNOWN = "unknown"
+    INCOMPLETE = "incomplete"
+    PERMISSION_LIMITED = "permission_limited"
+
+
+class AudioCppReferenceRequirement(StrEnum):
+    """Recipe-declared voice-reference posture."""
+
+    NONE = "none"
+    OPTIONAL = "optional"
+    REQUIRED = "required"
+
+
+def _unsafe_text(value: str) -> bool:
+    return any(
+        character in {"\x00", "\r", "\n"}
+        or unicodedata.category(character) in {"Cc", "Cf", "Cs"}
+        for character in value
+    )
+
+
+def _require_token(value: str, label: str) -> None:
+    if type(value) is not str or not _TOKEN.fullmatch(value) or _unsafe_text(value):
+        raise ValueError(f"audio.cpp {label} is invalid")
+
+
+def _require_digest(value: str, label: str) -> None:
+    if type(value) is not str or not _DIGEST.fullmatch(value):
+        raise ValueError(f"audio.cpp {label} must be a lowercase SHA-256 identity")
+
+
+def _require_relative_path(value: str, label: str) -> None:
+    if (
+        type(value) is not str
+        or not value
+        or value != value.strip()
+        or len(value) > 1024
+        or "\\" in value
+        or "$" in value
+        or "%" in value
+        or _unsafe_text(value)
+    ):
+        raise ValueError(f"audio.cpp {label} must be a safe relative path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or value in {".", ".."} or ".." in path.parts:
+        raise ValueError(f"audio.cpp {label} must be a safe relative path")
+    if path.as_posix() != value:
+        raise ValueError(f"audio.cpp {label} must be a safe relative path")
+
+
+def _require_absolute_path(value: str, label: str) -> None:
+    if (
+        type(value) is not str
+        or not value
+        or value != value.strip()
+        or len(value) > 4096
+        or _unsafe_text(value)
+        or not (
+            PurePosixPath(value).is_absolute() or PureWindowsPath(value).is_absolute()
+        )
+    ):
+        raise ValueError(f"audio.cpp {label} must be an absolute path")
+
+
+def _safe_name(value: str) -> str:
+    if type(value) is not str:
+        raise ValueError("audio.cpp package display name is invalid")
+    cleaned = "".join(
+        character
+        for character in value
+        if not unicodedata.category(character).startswith("C")
+    ).strip()
+    if not cleaned:
+        return "Selected package"
+    return cleaned[:128]
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppFileSignal:
+    """Exact allowlisted relative-file signal for one package recipe."""
+
+    relative_path: str
+    kind: AudioCppFileKind
+    role: AudioCppFileRole
+    minimum_size_bytes: int = 1
+
+    def __post_init__(self) -> None:
+        _require_relative_path(self.relative_path, "recipe file path")
+        if not isinstance(self.kind, AudioCppFileKind) or not isinstance(
+            self.role, AudioCppFileRole
+        ):
+            raise ValueError("audio.cpp recipe file signal type is invalid")
+        if type(self.minimum_size_bytes) is not int or self.minimum_size_bytes < 1:
+            raise ValueError("audio.cpp recipe file minimum size must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppBackendEvidence:
+    """One exact platform/backend compatibility posture."""
+
+    system: str
+    architecture: str
+    backend: AudioCppBackendPreference
+    state: AudioCppBackendEvidenceState
+    evidence_reference: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.backend, AudioCppBackendPreference) or not isinstance(
+            self.state, AudioCppBackendEvidenceState
+        ):
+            raise ValueError("audio.cpp backend evidence type is invalid")
+        _require_token(self.system, "backend system")
+        _require_token(self.architecture, "backend architecture")
+        if self.backend is AudioCppBackendPreference.AUTO:
+            raise ValueError("audio.cpp recipe backend evidence cannot use auto")
+        if (
+            type(self.evidence_reference) is not str
+            or not self.evidence_reference
+            or len(self.evidence_reference) > 512
+            or _unsafe_text(self.evidence_reference)
+        ):
+            raise ValueError("audio.cpp backend evidence reference is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppPackageRecipe:
+    """Immutable reviewed projection for one exact upstream package variant."""
+
+    schema_version: int
+    recipe_id: str
+    recipe_revision: int
+    audio_cpp_release: str
+    audio_cpp_commit: str
+    family: str
+    package_variant: str
+    display_name: str
+    package_format: AudioCppFileKind
+    precision: str
+    capabilities: tuple[str, ...]
+    required_files: tuple[AudioCppFileSignal, ...]
+    optional_files: tuple[AudioCppFileSignal, ...]
+    projection: AudioCppSafeModelProjection
+    default_public_model_id: str
+    reference_requirement: AudioCppReferenceRequirement
+    backend_evidence: tuple[AudioCppBackendEvidence, ...]
+    support_state: AudioCppRecipeSupportState
+    evidence_reference: str
+    source_links: tuple[str, ...]
+    model_library_artifact_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        tuple_fields = (
+            self.capabilities,
+            self.required_files,
+            self.optional_files,
+            self.backend_evidence,
+            self.source_links,
+            self.model_library_artifact_ids,
+        )
+        if any(type(value) is not tuple for value in tuple_fields):
+            raise ValueError("audio.cpp recipe collections must be immutable tuples")
+        if not isinstance(self.package_format, AudioCppFileKind) or not isinstance(
+            self.reference_requirement, AudioCppReferenceRequirement
+        ):
+            raise ValueError("audio.cpp recipe classification is invalid")
+        if not all(
+            isinstance(item, AudioCppFileSignal)
+            for item in (*self.required_files, *self.optional_files)
+        ) or not all(
+            isinstance(item, AudioCppBackendEvidence) for item in self.backend_evidence
+        ):
+            raise ValueError("audio.cpp recipe record type is invalid")
+        if self.schema_version != AUDIO_CPP_RECIPE_SCHEMA_VERSION:
+            raise ValueError("audio.cpp recipe schema version is unsupported")
+        if type(self.recipe_revision) is not int or self.recipe_revision < 1:
+            raise ValueError("audio.cpp recipe revision must be positive")
+        for value, label in (
+            (self.recipe_id, "recipe id"),
+            (self.family, "recipe family"),
+            (self.package_variant, "package variant"),
+            (self.precision, "package precision"),
+            (self.default_public_model_id, "default public model id"),
+        ):
+            _require_token(value, label)
+        if (
+            type(self.display_name) is not str
+            or not self.display_name.strip()
+            or len(self.display_name) > 256
+            or _unsafe_text(self.display_name)
+        ):
+            raise ValueError("audio.cpp recipe display name is invalid")
+        if self.audio_cpp_release != AUDIO_CPP_PINNED_RELEASE:
+            raise ValueError("audio.cpp recipe release is not pinned")
+        if self.audio_cpp_commit != AUDIO_CPP_PINNED_COMMIT:
+            raise ValueError("audio.cpp recipe commit is not pinned")
+        if self.support_state is not AudioCppRecipeSupportState.APPROVED:
+            raise ValueError("only approved entries may enter the recipe registry")
+        if self.projection.family != self.family:
+            raise ValueError("audio.cpp recipe projection family does not match")
+        if not self.required_files:
+            raise ValueError("audio.cpp recipe requires at least one file")
+        all_paths = tuple(
+            signal.relative_path
+            for signal in (*self.required_files, *self.optional_files)
+        )
+        if len(all_paths) != len(set(all_paths)):
+            raise ValueError("audio.cpp recipe file signals must be unique")
+        if (
+            self.projection.model_relative_path is not None
+            and self.projection.model_relative_path
+            not in {signal.relative_path for signal in self.required_files}
+        ):
+            raise ValueError("audio.cpp recipe model path must be a required file")
+        if not self.capabilities or not set(self.capabilities) <= {
+            "tts",
+            "clone",
+            "design",
+        }:
+            raise ValueError("audio.cpp recipe capabilities are invalid")
+        if len(self.capabilities) != len(set(self.capabilities)):
+            raise ValueError("audio.cpp recipe capabilities must be unique")
+        if not self.backend_evidence:
+            raise ValueError("audio.cpp recipe requires backend posture")
+        if (
+            type(self.evidence_reference) is not str
+            or not self.evidence_reference
+            or len(self.evidence_reference) > 512
+            or _unsafe_text(self.evidence_reference)
+        ):
+            raise ValueError("audio.cpp recipe evidence reference is invalid")
+        if not self.source_links or any(
+            not link.startswith("https://")
+            or AUDIO_CPP_PINNED_COMMIT not in link
+            or len(link) > 1024
+            for link in self.source_links
+        ):
+            raise ValueError("audio.cpp recipe source links must be pinned HTTPS links")
+        for artifact_id in self.model_library_artifact_ids:
+            _require_token(artifact_id, "model library artifact id")
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppPackageFileEvidence:
+    """Bounded identity and readiness evidence for one allowlisted file."""
+
+    relative_path: str
+    size_bytes: int
+    identity: str
+    readable: bool
+    metadata_valid: bool
+
+    def __post_init__(self) -> None:
+        _require_relative_path(self.relative_path, "scanned evidence path")
+        if type(self.size_bytes) is not int or self.size_bytes < 0:
+            raise ValueError("audio.cpp scanned file size is invalid")
+        _require_digest(self.identity, "scanned file identity")
+        if type(self.readable) is not bool or type(self.metadata_valid) is not bool:
+            raise ValueError("audio.cpp scanned file readiness is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppPackageDescription:
+    """Pre-scanned exact-root description consumed by the pure matcher."""
+
+    canonical_root: str = field(repr=False)
+    canonical_root_identity: str
+    safe_name: str
+    files: tuple[AudioCppPackageFileEvidence, ...]
+    partial: bool = False
+    permission_limited: bool = False
+
+    def __post_init__(self) -> None:
+        if type(self.files) is not tuple or not all(
+            isinstance(item, AudioCppPackageFileEvidence) for item in self.files
+        ):
+            raise ValueError("audio.cpp scanned evidence must be an immutable tuple")
+        _require_absolute_path(self.canonical_root, "canonical package root")
+        _require_digest(self.canonical_root_identity, "canonical root identity")
+        object.__setattr__(self, "safe_name", _safe_name(self.safe_name))
+        paths = tuple(item.relative_path for item in self.files)
+        if len(paths) != len(set(paths)):
+            raise ValueError("audio.cpp scanned evidence paths must be unique")
+        if type(self.partial) is not bool or type(self.permission_limited) is not bool:
+            raise ValueError("audio.cpp scan state is invalid")
+
+
+def _identity(parts: tuple[str, ...]) -> str:
+    return sha256("\x00".join(parts).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppPackageCandidate:
+    """One exact candidate suitable for explicit user acceptance."""
+
+    recipe: AudioCppPackageRecipe
+    canonical_root: str = field(repr=False)
+    canonical_root_identity: str
+    configuration_identity: str
+    weight_identity: str
+    safe_name: str
+    evidence_relative_paths: tuple[str, ...]
+
+    def accept(self, *, public_model_id: str | None = None) -> AudioCppAcceptedPackage:
+        """Freeze this exact match into a durable accepted snapshot."""
+        return AudioCppAcceptedPackage(
+            package_uuid=str(uuid4()),
+            recipe_id=self.recipe.recipe_id,
+            recipe_revision=self.recipe.recipe_revision,
+            package_variant=self.recipe.package_variant,
+            public_model_id=(
+                self.recipe.default_public_model_id
+                if public_model_id is None
+                else public_model_id
+            ),
+            canonical_root=self.canonical_root,
+            canonical_root_identity=self.canonical_root_identity,
+            configuration_identity=self.configuration_identity,
+            weight_identity=self.weight_identity,
+            projection=self.recipe.projection,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppMatchResult:
+    """Pure fail-closed recipe matching result."""
+
+    state: AudioCppMatchState
+    recipe_ids: tuple[str, ...] = ()
+    candidates: tuple[AudioCppPackageCandidate, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppVerifiedSupportClaim:
+    """One user-facing support claim backed by an exact evidence tuple."""
+
+    recipe_id: str
+    family: str
+    package_variant: str
+    system: str
+    architecture: str
+    backend: AudioCppBackendPreference
+    evidence_reference: str
+
+
+class AudioCppRecipeRegistry:
+    """Small immutable registry with pure matching and snapshot validation."""
+
+    __slots__ = ("_by_id", "_by_package", "_recipes")
+
+    def __init__(self, recipes: tuple[AudioCppPackageRecipe, ...]) -> None:
+        ordered = tuple(sorted(recipes, key=lambda item: item.recipe_id))
+        if len({recipe.recipe_id for recipe in ordered}) != len(ordered):
+            raise ValueError("audio.cpp recipe IDs must be unique")
+        if len({recipe.package_variant for recipe in ordered}) != len(ordered):
+            raise ValueError("audio.cpp package variants must be unique")
+        object.__setattr__(self, "_recipes", ordered)
+        object.__setattr__(
+            self,
+            "_by_id",
+            MappingProxyType({recipe.recipe_id: recipe for recipe in ordered}),
+        )
+        object.__setattr__(
+            self,
+            "_by_package",
+            MappingProxyType({recipe.package_variant: recipe for recipe in ordered}),
+        )
+
+    def __setattr__(self, _name: str, _value: object) -> None:
+        raise AttributeError("audio.cpp recipe registry is immutable")
+
+    @property
+    def recipes(self) -> tuple[AudioCppPackageRecipe, ...]:
+        """Return the immutable ordered recipe collection."""
+        return self._recipes
+
+    def for_package(self, package_variant: str) -> AudioCppPackageRecipe:
+        """Return one exact package recipe or raise a stable lookup error."""
+        try:
+            return self._by_package[package_variant]
+        except (KeyError, TypeError):
+            raise ValueError("audio.cpp package recipe is unavailable") from None
+
+    @staticmethod
+    def _candidate(
+        recipe: AudioCppPackageRecipe,
+        description: AudioCppPackageDescription,
+        evidence: dict[str, AudioCppPackageFileEvidence],
+    ) -> AudioCppPackageCandidate:
+        configuration_parts = tuple(
+            f"{signal.relative_path}:{evidence[signal.relative_path].identity}"
+            for signal in recipe.required_files
+            if signal.role in {AudioCppFileRole.CONFIGURATION, AudioCppFileRole.OTHER}
+        ) or (f"{recipe.recipe_id}:{recipe.recipe_revision}",)
+        weight_parts = tuple(
+            f"{signal.relative_path}:{evidence[signal.relative_path].identity}"
+            for signal in recipe.required_files
+            if signal.role in {AudioCppFileRole.WEIGHT, AudioCppFileRole.VOICE}
+        ) or (f"{recipe.recipe_id}:{recipe.recipe_revision}:no-weight",)
+        return AudioCppPackageCandidate(
+            recipe=recipe,
+            canonical_root=description.canonical_root,
+            canonical_root_identity=description.canonical_root_identity,
+            configuration_identity=_identity(configuration_parts),
+            weight_identity=_identity(weight_parts),
+            safe_name=description.safe_name,
+            evidence_relative_paths=tuple(
+                signal.relative_path for signal in recipe.required_files
+            ),
+        )
+
+    def match(self, description: AudioCppPackageDescription) -> AudioCppMatchResult:
+        """Match one bounded description without fuzzy or closest selection."""
+        if not isinstance(description, AudioCppPackageDescription):
+            raise TypeError("audio.cpp package description is required")
+        evidence = {item.relative_path: item for item in description.files}
+        recognizable: list[AudioCppPackageRecipe] = []
+        exact: list[AudioCppPackageRecipe] = []
+        for recipe in self.recipes:
+            required_paths = {signal.relative_path for signal in recipe.required_files}
+            if required_paths & evidence.keys():
+                recognizable.append(recipe)
+            if all(
+                signal.relative_path in evidence
+                and evidence[signal.relative_path].readable
+                and evidence[signal.relative_path].metadata_valid
+                and evidence[signal.relative_path].size_bytes
+                >= signal.minimum_size_bytes
+                for signal in recipe.required_files
+            ):
+                exact.append(recipe)
+
+        candidate_recipes = exact or recognizable
+        recipe_ids = tuple(sorted(recipe.recipe_id for recipe in candidate_recipes))
+        if description.permission_limited:
+            return AudioCppMatchResult(
+                AudioCppMatchState.PERMISSION_LIMITED,
+                recipe_ids=recipe_ids,
+            )
+        if description.partial:
+            return AudioCppMatchResult(
+                AudioCppMatchState.INCOMPLETE,
+                recipe_ids=recipe_ids,
+            )
+        candidates = tuple(
+            self._candidate(recipe, description, evidence)
+            for recipe in sorted(exact, key=lambda item: item.recipe_id)
+        )
+        if len(candidates) == 1:
+            return AudioCppMatchResult(
+                AudioCppMatchState.EXACT,
+                recipe_ids=(candidates[0].recipe.recipe_id,),
+                candidates=candidates,
+            )
+        if len(candidates) > 1:
+            return AudioCppMatchResult(
+                AudioCppMatchState.AMBIGUOUS,
+                recipe_ids=tuple(
+                    candidate.recipe.recipe_id for candidate in candidates
+                ),
+                candidates=candidates,
+            )
+        if recognizable:
+            return AudioCppMatchResult(
+                AudioCppMatchState.INCOMPLETE,
+                recipe_ids=recipe_ids,
+            )
+        return AudioCppMatchResult(AudioCppMatchState.UNKNOWN)
+
+    def validate_accepted(
+        self,
+        accepted: AudioCppAcceptedPackage,
+    ) -> AudioCppPackageRecipe:
+        """Require an accepted snapshot to equal the installed recipe exactly."""
+        try:
+            recipe = self._by_id[accepted.recipe_id]
+        except (AttributeError, KeyError, TypeError):
+            raise ValueError(
+                "audio.cpp accepted package requires recipe review"
+            ) from None
+        if (
+            accepted.recipe_revision != recipe.recipe_revision
+            or accepted.package_variant != recipe.package_variant
+            or accepted.projection != recipe.projection
+        ):
+            raise ValueError("audio.cpp accepted package requires recipe review")
+        return recipe
+
+    def verified_support_claims(self) -> tuple[AudioCppVerifiedSupportClaim, ...]:
+        """Return only exact tuples carrying retained Verified evidence."""
+        claims = [
+            AudioCppVerifiedSupportClaim(
+                recipe_id=recipe.recipe_id,
+                family=recipe.family,
+                package_variant=recipe.package_variant,
+                system=evidence.system,
+                architecture=evidence.architecture,
+                backend=evidence.backend,
+                evidence_reference=evidence.evidence_reference,
+            )
+            for recipe in self.recipes
+            for evidence in recipe.backend_evidence
+            if evidence.state is AudioCppBackendEvidenceState.VERIFIED
+        ]
+        return tuple(
+            sorted(
+                claims,
+                key=lambda item: (
+                    item.recipe_id,
+                    item.system,
+                    item.architecture,
+                    item.backend.value,
+                ),
+            )
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AudioCppReleaseAccountingEntry:
+    """One package row in the complete pinned-release accounting matrix."""
+
+    family: str
+    package_variant: str
+    state: AudioCppRecipeSupportState
+    recipe_id: str | None = None
+    reason: str | None = None
+
+
+_EXPECTED_CPU_BACKENDS = tuple(
+    AudioCppBackendEvidence(
+        system=system,
+        architecture=architecture,
+        backend=AudioCppBackendPreference.CPU,
+        state=AudioCppBackendEvidenceState.EXPECTED,
+        evidence_reference=(
+            "backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md"
+            "#decision"
+        ),
+    )
+    for system, architecture in (
+        ("darwin", "arm64"),
+        ("darwin", "x86_64"),
+        ("linux", "aarch64"),
+        ("linux", "x86_64"),
+        ("windows", "x86_64"),
+    )
+)
+
+
+def _gguf_file(path: str) -> AudioCppFileSignal:
+    return AudioCppFileSignal(path, AudioCppFileKind.GGUF, AudioCppFileRole.WEIGHT, 8)
+
+
+def _safetensors_file(path: str, role: AudioCppFileRole) -> AudioCppFileSignal:
+    return AudioCppFileSignal(path, AudioCppFileKind.SAFETENSORS, role, 10)
+
+
+def _config_file(path: str) -> AudioCppFileSignal:
+    kind = (
+        AudioCppFileKind.JSON if path.endswith(".json") else AudioCppFileKind.TOKENIZER
+    )
+    return AudioCppFileSignal(path, kind, AudioCppFileRole.CONFIGURATION, 1)
+
+
+def _recipe(
+    *,
+    family: str,
+    package_variant: str,
+    display_name: str,
+    package_format: AudioCppFileKind,
+    precision: str,
+    capabilities: tuple[str, ...],
+    required_files: tuple[AudioCppFileSignal, ...],
+    model_relative_path: str | None,
+    language: str | None = None,
+) -> AudioCppPackageRecipe:
+    options = (
+        ()
+        if language is None
+        else (AudioCppRecipeOption(name="language", value=language),)
+    )
+    projection = AudioCppSafeModelProjection(
+        family=family,
+        task="tts",
+        mode="offline",
+        model_relative_path=model_relative_path,
+        load_options=options,
+        session_options=options,
+    )
+    return AudioCppPackageRecipe(
+        schema_version=AUDIO_CPP_RECIPE_SCHEMA_VERSION,
+        recipe_id=f"audio-cpp-0.5.1.{family}.{package_variant}",
+        recipe_revision=1,
+        audio_cpp_release=AUDIO_CPP_PINNED_RELEASE,
+        audio_cpp_commit=AUDIO_CPP_PINNED_COMMIT,
+        family=family,
+        package_variant=package_variant,
+        display_name=display_name,
+        package_format=package_format,
+        precision=precision,
+        capabilities=capabilities,
+        required_files=required_files,
+        optional_files=(),
+        projection=projection,
+        default_public_model_id=package_variant.replace("_", "-"),
+        reference_requirement=(
+            AudioCppReferenceRequirement.OPTIONAL
+            if "clone" in capabilities
+            else AudioCppReferenceRequirement.NONE
+        ),
+        backend_evidence=_EXPECTED_CPU_BACKENDS,
+        support_state=AudioCppRecipeSupportState.APPROVED,
+        evidence_reference=_RECIPE_EVIDENCE_REFERENCE,
+        source_links=(f"{_PINNED_MODEL_SPEC_BASE}/{family}.json",),
+    )
+
+
+_SUPERTONIC_VARIANTS = (
+    ("supertonic_3_q8_0", "Supertonic 3 Q8_0 GGUF", "q8_0", "supertonic-3-q8_0.gguf"),
+    ("supertonic_3_f16", "Supertonic 3 F16 GGUF", "f16", "supertonic-3-f16.gguf"),
+    (
+        "supertonic_3_orig",
+        "Supertonic 3 Original-Dtype GGUF",
+        "orig",
+        "supertonic-3-orig.gguf",
+    ),
+)
+_POCKET_GGUF_VARIANTS = tuple(
+    (
+        f"pocket_tts_{language}_{precision}",
+        f"PocketTTS {language.title()} {precision.upper()} GGUF",
+        precision,
+        language,
+        f"pocket-tts-{language}-{precision}.gguf",
+    )
+    for language in ("english", "german", "italian", "portuguese", "spanish")
+    for precision in ("q8_0", "bf16")
+)
+_POCKET_VOICES = (
+    "alba",
+    "anna",
+    "azelma",
+    "bill_boerst",
+    "caro_davy",
+    "charles",
+    "cosette",
+    "eponine",
+    "estelle",
+    "eve",
+    "fantine",
+    "george",
+    "giovanni",
+    "jane",
+    "javert",
+    "jean",
+    "juergen",
+    "lola",
+    "marius",
+    "mary",
+    "michael",
+    "paul",
+    "peter_yearsley",
+    "rafael",
+    "stuart_bell",
+    "vera",
+)
+
+_INITIAL_RECIPES = (
+    *(
+        _recipe(
+            family="supertonic",
+            package_variant=variant,
+            display_name=display,
+            package_format=AudioCppFileKind.GGUF,
+            precision=precision,
+            capabilities=("tts",),
+            required_files=(_gguf_file(filename),),
+            model_relative_path=filename,
+        )
+        for variant, display, precision, filename in _SUPERTONIC_VARIANTS
+    ),
+    _recipe(
+        family="supertonic",
+        package_variant="supertonic_3_safetensors",
+        display_name="Supertonic 3 Safetensors",
+        package_format=AudioCppFileKind.SAFETENSORS,
+        precision="native",
+        capabilities=("tts",),
+        required_files=(
+            _config_file("config/tts.json"),
+            _config_file("config/unicode_indexer.json"),
+            _safetensors_file("ggml/supertonic.safetensors", AudioCppFileRole.WEIGHT),
+        ),
+        model_relative_path=None,
+    ),
+    *(
+        _recipe(
+            family="pocket_tts",
+            package_variant=variant,
+            display_name=display,
+            package_format=AudioCppFileKind.GGUF,
+            precision=precision,
+            capabilities=("tts", "clone"),
+            required_files=(_gguf_file(filename),),
+            model_relative_path=filename,
+            language=language,
+        )
+        for variant, display, precision, language, filename in _POCKET_GGUF_VARIANTS
+    ),
+    _recipe(
+        family="pocket_tts",
+        package_variant="pocket_tts_english_safetensors",
+        display_name="PocketTTS English Safetensors",
+        package_format=AudioCppFileKind.SAFETENSORS,
+        precision="native",
+        capabilities=("tts", "clone"),
+        required_files=(
+            *(
+                _safetensors_file(
+                    f"languages/english/embeddings/{voice}.safetensors",
+                    AudioCppFileRole.VOICE,
+                )
+                for voice in _POCKET_VOICES
+            ),
+            _safetensors_file(
+                "languages/english/model.safetensors",
+                AudioCppFileRole.WEIGHT,
+            ),
+            _config_file("languages/english/tokenizer.model"),
+        ),
+        model_relative_path=None,
+        language="english",
+    ),
+)
+
+AUDIO_CPP_RECIPE_REGISTRY = AudioCppRecipeRegistry(_INITIAL_RECIPES)
+
+
+_RELEASE_PACKAGES: dict[str, tuple[str, ...]] = {
+    "supertonic": tuple(item[0] for item in _SUPERTONIC_VARIANTS)
+    + ("supertonic_3_safetensors",),
+    "pocket_tts": tuple(item[0] for item in _POCKET_GGUF_VARIANTS)
+    + ("pocket_tts_english_safetensors",),
+    "chatterbox": ("chatterbox_q8_0", "chatterbox_f16", "chatterbox_safetensors"),
+    "dramabox": ("dramabox_q8_0",),
+    "miotts": ("miotts_1_7b_q8_0", "miotts_1_7b_bf16", "miotts_1_7b_orig"),
+    "vibevoice": ("vibevoice_1_5b_q8_0", "vibevoice_1_5b_bf16"),
+    "moss_tts_nano": ("moss_tts_nano_100m_q8_0", "moss_tts_nano_100m_bf16"),
+    "fish_audio": ("fish_audio_s2_pro_q8_0", "fish_audio_s2_pro_bf16"),
+    "higgs_audio_tts": ("higgs_audio_tts_4b_q8_0", "higgs_audio_tts_4b_bf16"),
+    "omnivoice": (
+        "omnivoice_q8_0",
+        "omnivoice_bf16",
+        "omnivoice_f16",
+        "omnivoice_safetensors",
+    ),
+    "qwen3_tts": (
+        "qwen3_tts_1_7b_base_q8_0",
+        "qwen3_tts_1_7b_base_bf16",
+        "qwen3_tts_1_7b_base_orig",
+        "qwen3_tts_1_7b_customvoice_q8_0",
+        "qwen3_tts_1_7b_customvoice_bf16",
+        "qwen3_tts_1_7b_voicedesign_q8_0",
+        "qwen3_tts_1_7b_voicedesign_bf16",
+        "qwen3_tts_1_7b_base_safetensors",
+        "qwen3_tts_0_6b_base_safetensors",
+    ),
+    "voxcpm2": ("voxcpm2_q8_0", "voxcpm2_bf16", "voxcpm2_orig", "voxcpm2_safetensors"),
+    "confucius4_tts": ("confucius4_tts_orig",),
+    "vevo2": ("vevo2_q8_0", "vevo2_f16", "vevo2_orig"),
+    "index_tts2": (
+        "index_tts2_q8_0",
+        "index_tts2_f16",
+        "index_tts2_orig",
+        "index_tts2_safetensors",
+    ),
+    "irodori_tts": (
+        "irodori_tts_v4_small_q8_0",
+        "irodori_tts_v4_small_f16",
+        "irodori_tts_600m_v3_voicedesign_q8_0",
+        "irodori_tts_600m_v3_voicedesign_f16",
+        "irodori_tts_500m_v3_q8_0",
+        "irodori_tts_500m_v3_f16",
+    ),
+    "moss_tts_local": ("moss_tts_local_v1_5_q8_0", "moss_tts_local_v1_5_bf16"),
+    "glm_tts": ("glm_tts_q8_0",),
+    "inflect_v2": ("inflect_micro_v2_orig",),
+    "outetts": ("outetts_1_0_1b_q8_0",),
+    "vietneu_tts": ("vietneu_tts_v3_turbo_q8_0",),
+}
+
+
+def _release_accounting() -> tuple[AudioCppReleaseAccountingEntry, ...]:
+    approved = {
+        recipe.package_variant: recipe.recipe_id
+        for recipe in AUDIO_CPP_RECIPE_REGISTRY.recipes
+    }
+    rows = tuple(
+        AudioCppReleaseAccountingEntry(
+            family=family,
+            package_variant=package_variant,
+            state=(
+                AudioCppRecipeSupportState.APPROVED
+                if package_variant in approved
+                else AudioCppRecipeSupportState.OPEN_GAP
+            ),
+            recipe_id=approved.get(package_variant),
+            reason=(
+                None
+                if package_variant in approved
+                else "Recipe review is not complete."
+            ),
+        )
+        for family, packages in _RELEASE_PACKAGES.items()
+        for package_variant in packages
+    )
+    if len(_RELEASE_PACKAGES) != 21 or len(rows) != 67:
+        raise RuntimeError("audio.cpp pinned release accounting is incomplete")
+    return rows
+
+
+AUDIO_CPP_RELEASE_ACCOUNTING = _release_accounting()
+
+
+__all__ = (
+    "AUDIO_CPP_PINNED_COMMIT",
+    "AUDIO_CPP_PINNED_RELEASE",
+    "AUDIO_CPP_RECIPE_REGISTRY",
+    "AUDIO_CPP_RECIPE_SCHEMA_VERSION",
+    "AUDIO_CPP_RELEASE_ACCOUNTING",
+    "AudioCppBackendEvidence",
+    "AudioCppBackendEvidenceState",
+    "AudioCppFileKind",
+    "AudioCppFileRole",
+    "AudioCppFileSignal",
+    "AudioCppMatchResult",
+    "AudioCppMatchState",
+    "AudioCppPackageCandidate",
+    "AudioCppPackageDescription",
+    "AudioCppPackageFileEvidence",
+    "AudioCppPackageRecipe",
+    "AudioCppRecipeRegistry",
+    "AudioCppRecipeSupportState",
+    "AudioCppReferenceRequirement",
+    "AudioCppReleaseAccountingEntry",
+    "AudioCppVerifiedSupportClaim",
+)

--- a/tldw_chatbook/TTS/audio_cpp_recipes.py
+++ b/tldw_chatbook/TTS/audio_cpp_recipes.py
@@ -382,7 +382,17 @@ class AudioCppPackageCandidate:
     evidence_relative_paths: tuple[str, ...]
 
     def accept(self, *, public_model_id: str | None = None) -> AudioCppAcceptedPackage:
-        """Freeze this exact match into a durable accepted snapshot."""
+        """Freeze this exact match into a durable accepted snapshot.
+
+        Args:
+            public_model_id: Optional user-facing model ID override.
+
+        Returns:
+            A new immutable accepted-package snapshot with a durable UUID.
+
+        Raises:
+            ValueError: If the requested public model ID is invalid.
+        """
         return AudioCppAcceptedPackage(
             package_uuid=str(uuid4()),
             recipe_id=self.recipe.recipe_id,
@@ -434,6 +444,15 @@ class AudioCppRecipeRegistry:
             raise ValueError("audio.cpp recipe IDs must be unique")
         if len({recipe.package_variant for recipe in ordered}) != len(ordered):
             raise ValueError("audio.cpp package variants must be unique")
+        path_contracts: dict[str, tuple[AudioCppFileKind, int]] = {}
+        for recipe in ordered:
+            for signal in recipe.required_files:
+                contract = (signal.kind, signal.minimum_size_bytes)
+                previous = path_contracts.setdefault(signal.relative_path, contract)
+                if previous != contract:
+                    raise ValueError(
+                        "audio.cpp recipes have conflicting file validation contracts"
+                    )
         object.__setattr__(self, "_recipes", ordered)
         object.__setattr__(
             self,
@@ -451,11 +470,25 @@ class AudioCppRecipeRegistry:
 
     @property
     def recipes(self) -> tuple[AudioCppPackageRecipe, ...]:
-        """Return the immutable ordered recipe collection."""
+        """Return the immutable ordered recipe collection.
+
+        Returns:
+            Every installed recipe ordered by recipe ID.
+        """
         return self._recipes
 
     def for_package(self, package_variant: str) -> AudioCppPackageRecipe:
-        """Return one exact package recipe or raise a stable lookup error."""
+        """Return one exact package recipe or raise a stable lookup error.
+
+        Args:
+            package_variant: Exact pinned package variant identifier.
+
+        Returns:
+            The reviewed recipe for the requested package variant.
+
+        Raises:
+            ValueError: If the package variant has no installed recipe.
+        """
         try:
             return self._by_package[package_variant]
         except (KeyError, TypeError):
@@ -490,7 +523,18 @@ class AudioCppRecipeRegistry:
         )
 
     def match(self, description: AudioCppPackageDescription) -> AudioCppMatchResult:
-        """Match one bounded description without fuzzy or closest selection."""
+        """Match one bounded description without fuzzy or closest selection.
+
+        Args:
+            description: Pre-scanned, bounded evidence for one candidate root.
+
+        Returns:
+            An exact, ambiguous, incomplete, permission-limited, or unknown
+            match result.
+
+        Raises:
+            TypeError: If ``description`` is not package evidence.
+        """
         if not isinstance(description, AudioCppPackageDescription):
             raise TypeError("audio.cpp package description is required")
         evidence = {item.relative_path: item for item in description.files}
@@ -551,7 +595,17 @@ class AudioCppRecipeRegistry:
         self,
         accepted: AudioCppAcceptedPackage,
     ) -> AudioCppPackageRecipe:
-        """Require an accepted snapshot to equal the installed recipe exactly."""
+        """Require an accepted snapshot to equal the installed recipe exactly.
+
+        Args:
+            accepted: Durable package snapshot to validate.
+
+        Returns:
+            The exact currently installed recipe.
+
+        Raises:
+            ValueError: If the recipe is absent or its frozen projection changed.
+        """
         try:
             recipe = self._by_id[accepted.recipe_id]
         except (AttributeError, KeyError, TypeError):
@@ -567,7 +621,11 @@ class AudioCppRecipeRegistry:
         return recipe
 
     def verified_support_claims(self) -> tuple[AudioCppVerifiedSupportClaim, ...]:
-        """Return only exact tuples carrying retained Verified evidence."""
+        """Return only exact tuples carrying retained Verified evidence.
+
+        Returns:
+            Sorted support claims whose backend evidence is explicitly verified.
+        """
         claims = [
             AudioCppVerifiedSupportClaim(
                 recipe_id=recipe.recipe_id,


### PR DESCRIPTION
## Summary

- add frozen guided audio.cpp settings and durable accepted-package snapshots without changing the existing runtime AudioCppConfig
- add sealed release-0.5.1 recipes for all Supertonic and PocketTTS packages plus complete 21-family/67-package accounting
- add a bounded, cancellable, explicit-root read-only scanner with sanitized evidence and symlink/reparse race fencing
- harden selected-root validation, fail-closed no-follow behavior, and recipe signal-contract invariants from PR review

## Scope

This is TASK-13200 only. It deliberately excludes generated server.json materialization, lifecycle integration, Settings/Speech Lab UI, Model Library downloads, and clone-reference storage.

## Verification

- 96 focused guided-config, recipe, and scanner tests passed
- 2,600 broader TTS tests passed with 16 expected skips and 6 sandbox-only socket tests deselected
- the 6 socket/process cases passed when rerun outside the sandbox
- Ruff check, Ruff format check, compileall, and git diff check passed
- Qodo re-review reports 0 bugs and 0 rule violations; all review threads are resolved

## Known base check

- No duplicate backlog task IDs fails on the pre-existing duplicate TASK-3401 files already present on dev; this PR adds only unique TASK-13200 through TASK-13212 files

## Task

- TASK-13200