### PR TITLE
Fix Console web-tool discoverability and fake MCP ingest

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -143,6 +143,20 @@ shows their state: "N tools ready", or "N servers enabled, not connected" when
 servers are configured but unreachable. MCP tool calls go through the same
 "Approval required" card as everything else.
 
+### Web research tools
+
+Console's standard web tools are `web_search` (find links), `web_fetch`
+(extract one URL), and `web_crawl` (bounded same-host crawl). They are local
+agent tools, not tools supplied by an external MCP server. Enable them in
+**MCP → Servers → built-in server → Tool gates → Local workspace + web
+tools**, restart the app, then choose Allow, Ask, or Off for each one in MCP
+Permissions. `[mcp] expose_local_tools` is only for external MCP clients and
+does not enable these tools in Console.
+
+Web-tool results are ephemeral. To persist a page in Library, use **Library →
+Import…** and submit its URL; Console does not advertise the retired
+`ingest_media` placeholder.
+
 ### Stopping & leaving
 
 - **Stop** (appears next to Send while a run is active) stops **this tab's

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -32,15 +32,15 @@ into two subheadings:
 
 - **Agent built-ins** — the app's own file/note tools (read/list/write a
   file, glob/grep the workspace, create/update a note).
-- **Local workspace tools** — a master switch, labeled **Local workspace
-  tools (master switch)**, that turns the whole local-tool group on or off
-  for the Console/agent path, plus **web_deep_search** (multi-query web
-  research; costs real money on paid providers), gated individually
-  underneath it. While the master is off, every OTHER checkbox in this
-  group renders disabled — with its own gate still shown truthfully, but
-  greyed out — and a note explains why: "Master switch is off — these
-  tools stay unavailable regardless of their own gates." Turning the
-  master back on re-enables its dependents on the next resync.
+- **Local workspace + web tools** — a master switch, labeled **Local
+  workspace + web tools (master switch)**, that registers `web_search`,
+  `web_fetch`, and `web_crawl` alongside the workspace file, Git, and
+  session-todo tools for Console agents. `web_deep_search` (multi-query web
+  research that may cost real money on paid providers) has an additional
+  individual gate underneath it. While the master is off, the standard web
+  tools do not exist in Tools, Permissions, or the Console agent catalog.
+  Turning the master on and restarting the app registers them; use
+  Permissions afterward to choose Allow, Ask, or Off per tool.
 
 The master switch governs the **Console/agent path only**. It does *not*
 control whether an enabled tool (e.g. `web_deep_search`) is exposed to
@@ -57,10 +57,23 @@ clients launch) even though these particular checkboxes control the
 in-process *agent* tool catalog — a different subsystem sharing the same
 detail pane for discoverability.
 
-If any gate is off, both the Permissions matrix's legend (always visible,
-under the marker key) and the Tools-mode empty state (when nothing else is
-showing) name how many: "N tool gate(s) are off — enable them in the
-built-in server's detail (Servers mode)."
+If the local master is off, both the Permissions matrix's legend (always
+visible, under the marker key) and the Tools-mode empty state explicitly name
+`web_search`, `web_fetch`, and `web_crawl`, point back to the built-in server
+detail, and say to restart. Other disabled gates still report the total number
+of gates that are off.
+
+### Web research is not persistent ingestion
+
+`web_search` finds result links, `web_fetch` extracts one URL, and `web_crawl`
+walks a bounded same-host site. Their results are ephemeral tool output; they
+do not add media to Library. There is no interactive-browser tool named
+`web_browse`.
+
+For persistent URL ingestion, use **Library → Import…**, paste the URL, review
+the web-page options, and press **Start import**. The old MCP `ingest_media`
+entry was an unimplemented placeholder that returned a fabricated `queued`
+response without submitting any work; it is no longer advertised.
 
 ## Testing a tool (Tools mode)
 

--- a/Docs/superpowers/plans/2026-08-08-console-rail-label-setting.md
+++ b/Docs/superpowers/plans/2026-08-08-console-rail-label-setting.md
@@ -321,7 +321,7 @@ git commit -m "feat(settings): add Console rail label preference"
 - Modify: `Tests/UI/test_settings_configuration_hub.py` or create `Tests/UI/test_console_rail_label_setting.py`
 - Modify: `Docs/User_Guide/settings.md`
 - Modify: `Docs/User_Guide/console/chat-basics.md`
-- Modify: `backlog/tasks/task-3401 - Make-Console-rail-label-style-configurable.md`
+- Modify: `backlog/tasks/task-14650 - Make-Console-rail-label-style-configurable.md`
 
 **Interfaces:**
 - Consumes: successful Settings save updates `app.app_config`; each new `ChatScreen(app)` reads that object during composition.
@@ -376,11 +376,11 @@ If failures occur, compare the identical command and failure set against a clean
 
 - [x] **Step 9: Complete Backlog and commit**
 
-Check all acceptance criteria only after evidence is green. Add concise Implementation Notes covering approach, files, tests, visual verification, ADR decision, and deviations. Set TASK-3401 to Done through the Backlog CLI.
+Check all acceptance criteria only after evidence is green. Add concise Implementation Notes covering approach, files, tests, visual verification, ADR decision, and deviations. Set TASK-14650 to Done through the Backlog CLI.
 
 ```bash
 git add Docs/User_Guide/settings.md Docs/User_Guide/console/chat-basics.md \
-  "backlog/tasks/task-3401 - Make-Console-rail-label-style-configurable.md" \
+  "backlog/tasks/task-14650 - Make-Console-rail-label-style-configurable.md" \
   Tests/UI/test_console_rail_label_setting.py
 git commit -m "docs(console): document configurable rail labels"
 ```

--- a/Tests/Agents/test_builtin_tool_gate.py
+++ b/Tests/Agents/test_builtin_tool_gate.py
@@ -531,6 +531,8 @@ def test_tool_gate_breadcrumb_names_the_off_count(monkeypatch):
     assert text is not None
     assert "9" in text
     assert "Servers mode" in text
+    assert "web_search, web_fetch, web_crawl" in text
+    assert "restart the app" in text
 
 
 def test_gate_key_pairs_and_all_tool_gates_can_never_drift(monkeypatch):
@@ -556,5 +558,26 @@ def test_count_off_tool_gates_constructs_no_tools(monkeypatch):
         "tldw_chatbook.config.get_cli_setting", lambda s, k, d=None: d
     )
     assert builtin_tool_gate.count_off_tool_gates() == 9
-    assert builtin_tool_gate.tool_gate_breadcrumb() is not None
-    assert "9 tool gate(s)" in builtin_tool_gate.tool_gate_breadcrumb()
+    breadcrumb = builtin_tool_gate.tool_gate_breadcrumb()
+    assert breadcrumb is not None
+    assert "9 tool gate(s)" in breadcrumb
+    assert "web_search, web_fetch, web_crawl" in breadcrumb
+    assert "restart the app" in breadcrumb
+
+
+def test_tool_gate_breadcrumb_reads_each_config_gate_once(monkeypatch):
+    """Count and master-state messaging share one coherent config snapshot."""
+    from tldw_chatbook.Agents import builtin_tool_gate
+
+    reads: list[tuple[str, str]] = []
+
+    def read_gate(section, key, default=None):
+        reads.append((section, key))
+        return default
+
+    monkeypatch.setattr("tldw_chatbook.config.get_cli_setting", read_gate)
+
+    breadcrumb = builtin_tool_gate.tool_gate_breadcrumb()
+
+    assert breadcrumb is not None
+    assert reads == builtin_tool_gate._gate_key_pairs()

--- a/Tests/Chat/test_console_local_review_hook.py
+++ b/Tests/Chat/test_console_local_review_hook.py
@@ -243,6 +243,12 @@ def test_compose_local_provider_eligible(monkeypatch, tmp_path):
     assert isinstance(local_provider, LocalToolProvider)
     assert local_provider._root == tmp_path.resolve()
     assert callable(hook)
+    catalog_ids = {entry.id for entry in local_provider.list_catalog()}
+    assert {
+        "local:web_search",
+        "local:web_fetch",
+        "local:web_crawl",
+    } <= catalog_ids
     # resolve_state is the same payload source the MCP gate uses.
     gate = local_provider.pending_gate_for("fs_list", {"path": "."})
     assert gate is not None and gate.server_key == "local:__local__"

--- a/Tests/MCP/test_builtin_tool_imports.py
+++ b/Tests/MCP/test_builtin_tool_imports.py
@@ -171,13 +171,12 @@ _LEGACY_TOOL_NAMES_IN_ORDER = [
     "list_characters",
     "get_conversation_history",
     "export_conversation",
-    "ingest_media",
 ]
 
 
-def test_legacy_manifest_tool_names_and_order_are_unchanged():
+def test_implemented_legacy_manifest_tool_names_and_order_are_stable():
     """The 18 appended Library tools must not rename, reorder, or reshape the
-    10 legacy AST-derived manifest entries (plan Task 9 Step 8): existing
+    9 implemented legacy AST-derived manifest entries (TASK-4000): existing
     clients key off these names and payload schemas."""
     from tldw_chatbook.MCP.server import describe_local_mcp_capabilities
 

--- a/Tests/MCP/test_library_tools.py
+++ b/Tests/MCP/test_library_tools.py
@@ -5,7 +5,7 @@ file pins their local MCP exposure, which is deliberately FastMCP-free (owner
 directive, 2026-08-07) -- the in-app surface is the manifest plus the direct
 runtime delegate:
 
-- manifest: ``describe_local_mcp_capabilities()`` keeps the 10 AST-derived
+- manifest: ``describe_local_mcp_capabilities()`` keeps the 9 implemented AST-derived
   legacy tools unchanged and appends exactly the 18 descriptor tools, with
   names/descriptions/``inputSchema`` taken from ``LIBRARY_TOOL_DESCRIPTORS``
   (never hand-duplicated literals);
@@ -45,7 +45,6 @@ LEGACY_TOOL_NAMES = [
     "list_characters",
     "get_conversation_history",
     "export_conversation",
-    "ingest_media",
 ]
 
 LIBRARY_TOOL_NAMES = list(LIBRARY_TOOL_DESCRIPTORS)
@@ -76,6 +75,15 @@ def test_manifest_keeps_legacy_tools_then_appends_the_18_descriptor_tools():
     library_entries = tools[len(LEGACY_TOOL_NAMES) :]
     assert [entry["name"] for entry in library_entries] == LIBRARY_TOOL_NAMES
     assert len(tools) == len(LEGACY_TOOL_NAMES) + 18
+
+
+def test_manifest_does_not_advertise_unimplemented_ingest_media():
+    """The local MCP manifest omits the retired placeholder ingest tool."""
+    names = {
+        entry["name"] for entry in describe_local_mcp_capabilities()["tools"]
+    }
+
+    assert "ingest_media" not in names
 
 
 def test_manifest_library_entries_match_descriptors_exactly():
@@ -112,6 +120,15 @@ async def test_tools_list_request_exposes_library_schemas():
 
 
 # -- Direct-runtime dispatch ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delegate_refuses_retired_placeholder_ingest_media():
+    """Direct runtime dispatch rejects the retired placeholder ingest tool."""
+    delegate = LocalMCPRuntimeDelegate(library_service=FakeLibraryToolService())
+
+    with pytest.raises(KeyError, match="Unsupported local MCP tool: ingest_media"):
+        await delegate.execute_tool("ingest_media", {"url": "https://example.com"})
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_mcp_servers_mode.py
+++ b/Tests/UI/test_mcp_servers_mode.py
@@ -770,7 +770,7 @@ async def test_tool_gate_checkboxes_render_under_builtin_detail_with_subheadings
 ):
     """The builtin detail pane also renders a "Tool gates" group -- one
     Checkbox per `all_tool_gates()` entry, under two subheadings ("Agent
-    built-ins" / "Local workspace tools"), plus the ADAPTED restart note
+    built-ins" / "Local workspace + web tools"), plus the ADAPTED restart note
     (NOT the `[mcp]` toggles' "next client launch" wording -- these gates
     affect the in-process agent runtime, no MCP client involved).
     """
@@ -798,7 +798,12 @@ async def test_tool_gate_checkboxes_render_under_builtin_detail_with_subheadings
         heading_builtin = app.query_one("#mcp-gate-heading-builtin", Static)
         heading_local = app.query_one("#mcp-gate-heading-local", Static)
         assert "Agent built-ins" in str(heading_builtin.renderable)
-        assert "Local workspace tools" in str(heading_local.renderable)
+        assert "Local workspace + web tools" in str(heading_local.renderable)
+
+        includes = app.query_one("#mcp-gate-local-includes", Static)
+        includes_text = str(includes.renderable)
+        assert "web_search, web_fetch, and web_crawl" in includes_text
+        assert "web_deep_search is separately gated" in includes_text
 
         first_cb = app.query_one(f"#mcp-gate-{first_builtin_key}", Checkbox)
         assert first_cb.value is True
@@ -847,13 +852,13 @@ async def test_local_group_dependents_are_disabled_while_master_is_off(monkeypat
         note = app.query_one("#mcp-gate-local-master-off-note", Static)
         assert (
             "Master switch is off" in str(note.renderable)
-            and "unavailable" in str(note.renderable)
+            and "web_search, web_fetch, web_crawl" in str(note.renderable)
         )
 
         master_cb = app.query_one(f"#mcp-gate-{LOCAL_TOOLS_MASTER_KEY}", Checkbox)
         assert master_cb.value is False
         assert master_cb.disabled is False  # the master itself stays clickable
-        assert "Local workspace tools (master switch)" in str(master_cb.label)
+        assert "Local workspace + web tools (master switch)" in str(master_cb.label)
 
         dependent_cb = app.query_one(f"#mcp-gate-{WEB_DEEP_SEARCH_GATE_KEY}", Checkbox)
         assert dependent_cb.value is True  # its own gate really is on...

--- a/Tests/UI/test_mcp_tools_mode.py
+++ b/Tests/UI/test_mcp_tools_mode.py
@@ -140,7 +140,6 @@ def test_all_builtin_tools_render_form_column():
         "list_characters",
         "get_conversation_history",
         "export_conversation",
-        "ingest_media",
     }
     assert {tool["name"] for tool in tools} == (
         legacy_tool_names | set(LIBRARY_TOOL_DESCRIPTORS)

--- a/backlog/tasks/task-14650 - Make-Console-rail-label-style-configurable.md
+++ b/backlog/tasks/task-14650 - Make-Console-rail-label-style-configurable.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-3401
+id: TASK-14650
 title: Make Console rail label style configurable
 status: In Progress
 assignee: []
@@ -61,6 +61,7 @@ Implemented an opt-in stacked presentation for collapsed Console rail labels whi
 - Broader targeted run before the final ownership expectation correction recorded 384 passes and 9 failures; the feature-caused ownership failure was corrected and reverified. The remaining eight are existing dev baselines: four 120x30 Console geometry tests and four Appearance tests caused by the missing _appearance_bool_label helper.
 - Repository-wide pytest was attempted and stopped during collection with 28 missing optional-dependency errors, including NumPy, Playwright, and audio/TTS extras. Ruff and MyPy are not installed in this worktree, so strict Definition of Done remains blocked and the task stays In Progress.
 - ADR required: no. This is an additive presentation preference using existing config, Settings, and Console boundaries; no schema, dependency, security, or cross-module contract decision was introduced.
+- Backlog hygiene: renumbered from TASK-3401 to TASK-14650 in PR #1465 because dev also contained the established TASK-3401 video-generation epic and the duplicate-ID guard correctly rejected the collision.
 
 Modified production areas: tldw_chatbook/config.py, tldw_chatbook/UI/Screens/chat_screen.py, tldw_chatbook/UI/Screens/settings_screen.py. Added or updated focused tests, user guides, design/plan artifacts, and this Backlog task.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3793 - Fix-character-avatar-rendering-Console-rail-0x0-collapse-Roleplay-thumb-fold-stripes.md
+++ b/backlog/tasks/task-3793 - Fix-character-avatar-rendering-Console-rail-0x0-collapse-Roleplay-thumb-fold-stripes.md
@@ -58,7 +58,8 @@ Rebase integration (2026-08-08): PR #1434 was rebased onto `origin/dev` at
 `3023578c0`. The documentation conflict retained both dev's newer testing
 lessons and this task's painted-region lesson. The task was renumbered from
 3401 to 3793, and its follow-up from 3402 to 3794, because current dev already
-owns TASK-3401 for the Console rail-label preference and claimed TASK-3771
+owns the Console rail-label preference (renumbered from TASK-3401 to
+TASK-14650 in PR #1465) and claimed TASK-3771
 during the final pre-merge refresh. ADR check remains no/N/A:
 this integration preserves the existing rendering fix and architecture.
 

--- a/backlog/tasks/task-4000 - Make-Console-web-access-and-MCP-ingest-outcomes-honest.md
+++ b/backlog/tasks/task-4000 - Make-Console-web-access-and-MCP-ingest-outcomes-honest.md
@@ -1,0 +1,58 @@
+---
+id: TASK-4000
+title: Make Console web access and MCP ingest outcomes honest
+status: Done
+assignee: []
+created_date: '2026-08-09 19:25'
+updated_date: '2026-08-09 19:43'
+labels: []
+dependencies: []
+priority: high
+type: bug
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure Console agents can discover and use the intended web research tools through an understandable registration path, and prevent the advertised MCP media-ingest tool from reporting a queued success when no ingestion work is performed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Console users can enable the standard web_search, web_fetch, and web_crawl tools from the MCP management surface with clear restart and scope guidance.
+- [x] #2 A Console agent is not offered an ingest_media tool that returns a fabricated queued success without submitting real work.
+- [x] #3 The standalone and in-process MCP capability surfaces agree about whether ingest_media is available and never claim success for an unimplemented operation.
+- [x] #4 Focused automated tests cover Console catalog composition, MCP capability inventory, and direct runtime behavior.
+- [x] #5 User documentation explains the web-tool gate, permissions, restart boundary, and the supported route for persistent web ingestion.
+- [x] #6 The PR leaves the Backlog duplicate-ID guard green by reconciling the pre-existing TASK-3401 collision exposed by the latest dev base.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Characterize the Console catalog path and the two MCP ingest handlers with focused regression tests.
+2. Make the existing local-tools master gate explicitly disclose the standard web tools, scope, and restart requirement.
+3. Remove the unimplemented ingest_media advertisement and dispatch path from both local MCP runtimes.
+4. Document the distinction between ephemeral web research and persistent Library URL ingestion.
+5. Run focused tests, lint the changed Python files, and review the final diff.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a routine truthfulness and discoverability bug fix that preserves the existing tool-provider and ingestion boundaries.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Renamed and expanded the built-in local-tools gate copy so the MCP Servers surface, Permissions breadcrumb, and documentation explicitly identify web_search, web_fetch, and web_crawl, their Console-only scope, and the restart boundary. Removed the unimplemented ingest_media registration, runtime handler, and action mapping so neither local MCP surface can fabricate a queued result; persistent URL ingestion remains the Library Import workflow.
+
+Added regression coverage for Console catalog composition, mounted Textual gate guidance, the AST-derived MCP manifest, and direct-runtime rejection. Focused changed-case tests passed (5), mounted UI tests passed (4), the complete gate suite passed (33), and Ruff passed all changed Python files. A broader related run passed 216 tests and exposed one pre-existing Windows HOME/expanduser test isolation failure unrelated to these changes.
+
+ADR required: no. No provider, persistence, or service boundary changed. No new lessons entry was needed; the repository's existing testing-evidence guidance already covers fabricated success responses.
+
+Post-review follow-up: rebased onto the latest dev, added the requested test docstrings, made breadcrumb gate reads single-pass and snapshot-consistent, and renumbered the smaller pre-existing Console rail task from TASK-3401 to TASK-14650 so the Backlog guard no longer collides with the established TASK-3401 video epic.
+
+Post-review verification: 34 built-in gate tests, 108 MCP tests, 75 Console/provider tests (with the known Windows HOME isolation case deselected), and 4 mounted MCP UI tests passed. Ruff passed every changed Python file, and the CI-equivalent scan found no duplicate filename or frontmatter IDs across 1,658 Backlog task files.
+
+The first post-rebase minimum-Textual CI run then exposed one additional stale Tools-mode inventory expectation for the retired ingest_media entry: 264 tests passed and that single assertion failed. The expectation was corrected and added to the focused verification set before the next push.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Agents/builtin_tool_gate.py
+++ b/tldw_chatbook/Agents/builtin_tool_gate.py
@@ -455,11 +455,11 @@ LOCAL_TOOLS_MASTER_KEY = "local_tools_enabled"
 #: making this switch also govern MCP exposure is a separate, out-of-scope
 #: behavior change.
 _LOCAL_TOOLS_MASTER_DESCRIPTION = (
-    "Master switch for the local workspace tool group in the Console/agent "
-    "path (fs_*/web_*/todo_* tools plus web_deep_search). Off by default; "
-    "the group's individual gates still apply once this is on. Does NOT "
-    "govern exposure to external MCP clients -- that's the separate "
-    "[mcp] expose_local_tools switch."
+    "Master switch for standard web research (web_search, web_fetch, "
+    "web_crawl) and local workspace tools (fs_*/git_*/todo_*) in the "
+    "Console/agent path. Off by default; web_deep_search also needs its "
+    "individual gate. Does NOT govern exposure to external MCP clients -- "
+    "that's the separate [mcp] expose_local_tools switch."
 )
 
 #: Hand-written description for web_deep_search -- also has no Tool
@@ -562,19 +562,32 @@ def _gate_key_pairs() -> list[tuple[str, str]]:
     return pairs
 
 
-def count_off_tool_gates() -> int:
-    """How many registration gates are currently OFF — coerced config reads
-    only, NO Tool construction (Qodo PR #1453: the breadcrumb runs on every
-    Permissions-mode resync, and `all_tool_gates()` builds every gateable
-    Tool just to read descriptions — needless work plus repeated warning
-    logs for optional tools that cannot construct on this system)."""
+def _off_tool_gate_status() -> tuple[int, bool]:
+    """Read gate state once and summarize disabled registration gates.
+
+    Returns:
+        A pair of the disabled-gate count and whether the local-tools master
+        gate is disabled.
+    """
     from ..config import coerce_bool_setting, get_cli_setting
 
-    return sum(
-        1
-        for section, key in _gate_key_pairs()
-        if not coerce_bool_setting(get_cli_setting(section, key, False), False)
-    )
+    off = 0
+    local_master_off = False
+    for section, key in _gate_key_pairs():
+        enabled = coerce_bool_setting(
+            get_cli_setting(section, key, False), False
+        )
+        if enabled:
+            continue
+        off += 1
+        if section == "console" and key == LOCAL_TOOLS_MASTER_KEY:
+            local_master_off = True
+    return off, local_master_off
+
+
+def count_off_tool_gates() -> int:
+    """Count disabled registration gates without constructing Tool objects."""
+    return _off_tool_gate_status()[0]
 
 
 def tool_gate_breadcrumb(gates: list[ToolGate] | None = None) -> str | None:
@@ -596,11 +609,22 @@ def tool_gate_breadcrumb(gates: list[ToolGate] | None = None) -> str | None:
     """
     if gates is None:
         # Count-only path: no Tool construction (see count_off_tool_gates).
-        off = count_off_tool_gates()
+        off, local_master_off = _off_tool_gate_status()
     else:
         off = sum(1 for gate in gates if not gate.enabled)
+        local_master_off = any(
+            gate.key == LOCAL_TOOLS_MASTER_KEY and not gate.enabled
+            for gate in gates
+        )
     if off == 0:
         return None
+    if local_master_off:
+        return (
+            "Standard web tools (web_search, web_fetch, web_crawl) and local "
+            "workspace tools are off — enable 'Local workspace + web tools' "
+            "in the built-in server's detail (Servers mode), then restart "
+            f"the app. {off} tool gate(s) are off in total."
+        )
     return (
         f"{off} tool gate(s) are off — enable them in the built-in "
         "server's detail (Servers mode)."

--- a/tldw_chatbook/MCP/local_control_service.py
+++ b/tldw_chatbook/MCP/local_control_service.py
@@ -78,7 +78,6 @@ _TOOL_ACTION_IDS = {
     "list_characters": "character.persona.list.local",
     "get_conversation_history": "chat.detail.local",
     "export_conversation": "chat.detail.local",
-    "ingest_media": "media.ingestion_jobs.launch.local",
     **{
         name: _library_tool_action_id(descriptor)
         for name, descriptor in LIBRARY_TOOL_DESCRIPTORS.items()

--- a/tldw_chatbook/MCP/local_runtime_delegate.py
+++ b/tldw_chatbook/MCP/local_runtime_delegate.py
@@ -640,15 +640,6 @@ class LocalMCPRuntimeDelegate:
             format=str(arguments.get("format") or "markdown"),
         )
 
-    async def _tool_ingest_media(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        if not arguments.get("url") and not arguments.get("file_path"):
-            return {"error": "Either url or file_path must be provided"}
-        return {
-            "status": "queued",
-            "media_id": "placeholder_id",
-            "message": "Media ingestion queued",
-        }
-
     def _require_chachanotes_db(self):
         db = get_chachanotes_db_lazy()
         if db is None:

--- a/tldw_chatbook/MCP/server.py
+++ b/tldw_chatbook/MCP/server.py
@@ -142,7 +142,7 @@ def _signature_to_input_schema(fn: ast.AsyncFunctionDef | ast.FunctionDef) -> di
     """Synthesize a JSON-schema ``inputSchema`` fragment from a tool function's AST signature.
 
     Keyword-only args (``fn.args.kwonlyargs``/``kw_defaults``) are
-    intentionally unhandled: none of the ten built-in ``@self.mcp.tool()``
+    intentionally unhandled: none of the nine built-in ``@self.mcp.tool()``
     registrations in this module use them (verified by reading
     ``server.py``'s ``_register_tools`` body), so there is nothing to map
     yet -- add support here if a future tool introduces one.
@@ -678,30 +678,6 @@ class TldwMCPServer:
             return await self.tools.export_conversation(
                 conversation_id=conversation_id, format=format
             )
-
-        # Media ingestion tool (placeholder)
-        @self.mcp.tool()
-        async def ingest_media(
-            url: Optional[str] = None,
-            file_path: Optional[str] = None,
-            media_type: str = "auto",
-            title: Optional[str] = None,
-            tags: Optional[List[str]] = None,
-        ) -> Dict[str, Any]:
-            """Ingest media from URL or file path."""
-            try:
-                if not url and not file_path:
-                    return {"error": "Either url or file_path must be provided"}
-
-                # TODO: Implement actual media ingestion
-                return {
-                    "status": "queued",
-                    "media_id": "placeholder_id",
-                    "message": "Media ingestion queued",
-                }
-            except Exception as e:
-                logger.error(f"Error in ingest_media: {e}")
-                return {"error": str(e)}
 
     def _register_resources(self):
         """Register MCP resources."""

--- a/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
@@ -214,7 +214,12 @@ _TOOL_GATE_NOTE_TEXT = (
 # here, display-only. The Checkbox's `id` is still built from `gate.key`
 # (LOCAL_TOOLS_MASTER_KEY), never from this label, so the save/reload path
 # is untouched.
-_LOCAL_TOOLS_MASTER_LABEL = "Local workspace tools (master switch)"
+_LOCAL_TOOLS_MASTER_LABEL = "Local workspace + web tools (master switch)"
+
+_LOCAL_TOOLS_INCLUDED_TEXT = (
+    "Includes web_search, web_fetch, and web_crawl, plus workspace file, "
+    "Git, and session todo tools. web_deep_search is separately gated."
+)
 
 # task-3240 fix round 1 (Important 1a): shown under the "Local workspace
 # tools" subheading whenever the master switch is off -- without it, an
@@ -222,8 +227,8 @@ _LOCAL_TOOLS_MASTER_LABEL = "Local workspace tools (master switch)"
 # read as independent toggles) but stays unreachable until the master is
 # also turned on.
 _LOCAL_TOOLS_MASTER_OFF_NOTE_TEXT = (
-    "Master switch is off — these tools stay unavailable regardless of "
-    "their own gates."
+    "Master switch is off — web_search, web_fetch, web_crawl, and the local "
+    "workspace tools are unavailable to Console agents."
 )
 
 
@@ -1207,7 +1212,7 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
         widgets()` -- spec review finding 5 (branch (b)): `_collect_
         snapshots()` never produces a `local:__local__` row, so this is the
         only reachable place for ALL nine gates. Rendered under two
-        subheadings ("Agent built-ins" / "Local workspace tools") so the
+        subheadings ("Agent built-ins" / "Local workspace + web tools") so the
         accepted UX trade-off stays visible rather than papered over: this
         pane is badged as the built-in MCP SERVER, but these checkboxes
         control the in-process AGENT tool catalog -- a different subsystem.
@@ -1250,8 +1255,16 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
         if local_gates:
             widgets.append(
                 Static(
-                    "Local workspace tools",
+                    "Local workspace + web tools",
                     id="mcp-gate-heading-local",
+                    classes="ds-field-row",
+                    markup=False,
+                )
+            )
+            widgets.append(
+                Static(
+                    _LOCAL_TOOLS_INCLUDED_TEXT,
+                    id="mcp-gate-local-includes",
                     classes="ds-field-row",
                     markup=False,
                 )


### PR DESCRIPTION
## Summary

- make the built-in MCP server detail explicitly disclose and enable `web_search`, `web_fetch`, and `web_crawl` through the existing local-tools master gate
- add restart, scope, permissions, and persistent Library-ingestion guidance to the UI breadcrumbs and user docs
- retire the unimplemented `ingest_media` MCP tool so standalone and in-process runtimes cannot return a fabricated queued success

## Verification

- 5 focused changed-case tests passed
- 4 mounted Textual UI tests passed
- 33 built-in tool-gate tests passed
- 216/217 tests passed in the broader related suite; the remaining failure is the pre-existing Windows `HOME`/`expanduser()` isolation case
- Ruff passed all changed Python files

Backlog: TASK-4000

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Console web-tool discoverability and honesty: exposes `web_search`, `web_fetch`, and `web_crawl` behind the renamed “Local workspace + web tools (master switch)” with restart guidance, and removes the fake `ingest_media` MCP tool so no fabricated “queued” results are returned. Addresses TASK-4000 by aligning UI, docs, agent catalog, and MCP surfaces.

- **Bug Fixes**
  - Exposes `web_search`, `web_fetch`, and `web_crawl` under the built-in MCP server’s “Local workspace + web tools (master switch)”; after restart, they appear to agents and can be Allowed/Asked/Off via Permissions. UI adds an included-tools note; `web_deep_search` stays separately gated.
  - Breadcrumbs, Permissions legend, and empty states now name the web tools and tell users to restart when the master is off.
  - Removes unimplemented `ingest_media` from manifest and runtime; both in-process and standalone paths now reject it. Docs clarify web research is ephemeral and point to Library → Import… for persistent URL ingestion.
  - Breadcrumb/count reads use a single config snapshot (no Tool construction). Adds focused tests for catalog composition, manifest stability (9 implemented legacy tools), UI copy, and delegate rejection.

- **Migration**
  - To enable web research: MCP → Servers → built-in server → Tool gates → “Local workspace + web tools” → restart → set Permissions per tool.
  - For persistent URL ingestion, use Library → Import…; `ingest_media` is removed.

<sup>Written for commit 70374be5b018cf045cdb9f1789b1ab3e1260f39c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

