### PR TITLE
fix(library): restore file-backed Notes access

### DIFF
--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -2061,6 +2061,17 @@ async def test_library_notes_source_choices_render_and_switch_by_keyboard(
             "Files source did not open from the keyboard",
         )
 
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: (
+                screen._library_notes_source == "files"
+                and bool(screen.query("#library-file-notes-workspace"))
+                and bool(screen.query("#library-notes-source-strip"))
+            ),
+            "Reselecting Notes did not retain the file-notes workspace",
+        )
+
         strip = screen.query_one("#library-notes-source-strip")
         database = screen.query_one("#library-notes-source-database", Button)
         files = screen.query_one("#library-notes-source-files", Button)

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -22030,8 +22030,8 @@ async def test_library_note_stage_visibility_skips_redundant_class_work() -> Non
 
 
 @pytest.mark.asyncio
-async def test_library_note_media_route_switch_preserves_shell_surfaces() -> None:
-    """Notes/Media route changes replace only the active canvas subtree."""
+async def test_library_note_media_route_switch_updates_contextual_chrome() -> None:
+    """Notes-only chrome follows the route while compatible swaps stay targeted."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
     host = LibraryHarness(app)
@@ -22041,27 +22041,30 @@ async def test_library_note_media_route_switch_preserves_shell_surfaces() -> Non
         await _wait_for_library_shell(screen, pilot)
         await _wait_for_library_notes_compact(screen, pilot, False)
         await _task10_open_notes_navigator(screen, pilot)
+        assert bool(screen.query("#library-notes-source-strip"))
         await _task10_activate_with_keyboard(screen, pilot, "#library-notes-row-0")
         await _wait_for_selector(screen, pilot, "#library-note-body")
 
-        header = screen.query_one("#library-header-line")
-        shell = screen.query_one("#library-shell-grid")
-        rail = screen.query_one("#library-rail")
-        canvas_host = screen.query_one("#library-canvas")
-
-        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
-        await _wait_for_selector(screen, pilot, "#library-media-list")
-        assert screen.query_one("#library-header-line") is header
-        assert screen.query_one("#library-shell-grid") is shell
-        assert screen.query_one("#library-rail") is rail
-        assert screen.query_one("#library-canvas") is canvas_host
+        notes_header = screen.query_one("#library-header-line")
+        notes_shell = screen.query_one("#library-shell-grid")
+        notes_rail = screen.query_one("#library-rail")
+        notes_canvas_host = screen.query_one("#library-canvas")
 
         await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
         await _wait_for_selector(screen, pilot, "#library-notes-filter")
-        assert screen.query_one("#library-header-line") is header
-        assert screen.query_one("#library-shell-grid") is shell
-        assert screen.query_one("#library-rail") is rail
-        assert screen.query_one("#library-canvas") is canvas_host
+        assert screen.query_one("#library-header-line") is notes_header
+        assert screen.query_one("#library-shell-grid") is notes_shell
+        assert screen.query_one("#library-rail") is notes_rail
+        assert screen.query_one("#library-canvas") is notes_canvas_host
+        assert bool(screen.query("#library-notes-source-strip"))
+
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+        await _wait_for_selector(screen, pilot, "#library-media-list")
+        assert not screen.query("#library-notes-source-strip")
+
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        assert bool(screen.query("#library-notes-source-strip"))
         assert screen.query_one("#library-row-browse-notes").has_class(
             "library-rail-row-selected"
         )

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -1494,6 +1494,48 @@ async def test_file_notes_source_transition_blocks_mutation_through_recompose(
 
 
 @pytest.mark.asyncio
+async def test_file_notes_create_route_returns_to_database_notes(monkeypatch):
+    """Create Note leaves Files only after its source transition is admitted."""
+    from tldw_chatbook.Library.library_shell_state import (
+        LIBRARY_ROW_BROWSE_NOTES,
+        LIBRARY_ROW_CREATE_NOTE,
+    )
+    from tldw_chatbook.UI.Screens.library_screen import (
+        LIBRARY_NOTES_SOURCE_DATABASE,
+        LIBRARY_NOTES_SOURCE_FILES,
+        LibraryScreen,
+    )
+
+    app = _build_test_app()
+    transition_events = []
+
+    class WorkspaceProbe:
+        async def flush_pending_work(self):
+            transition_events.append("flushed")
+            return True
+
+        def acquire_transition(self, kind):
+            transition_events.append(f"admitted:{kind}")
+            return lambda: transition_events.append("released")
+
+    workspace = WorkspaceProbe()
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+    screen._library_file_notes_workspace = workspace
+    screen._library_notes_source = LIBRARY_NOTES_SOURCE_FILES
+    screen._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
+    recompose = AsyncMock()
+    monkeypatch.setattr(screen, "recompose", recompose)
+
+    await screen._select_library_rail_row(LIBRARY_ROW_CREATE_NOTE)
+
+    assert transition_events == ["flushed", "admitted:source", "released"]
+    assert screen._library_selected_row_id == LIBRARY_ROW_CREATE_NOTE
+    assert screen._library_notes_source == LIBRARY_NOTES_SOURCE_DATABASE
+    assert screen.check_action("library_notes_escape", ()) is True
+    recompose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_file_notes_collections_source_transition_blocks_mutation_through_recompose(
     monkeypatch,
     tmp_path,

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -1649,6 +1649,7 @@ def test_check_action_gates_notes_files_back_to_active_files_mode():
     # Files mode genuinely owns the Notes canvas -- active.
     screen._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
     assert screen.check_action("library_notes_files_back", ()) is True
+    assert screen.check_action("library_notes_escape", ()) is False
 
     # Back to Database Notes -- inactive again.
     screen._library_notes_source = "database"

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1737,3 +1737,23 @@ PR #1463 review exposed a second portability trap: treating a missing
 while leaving the post-open identity check looking reassuring. Add an explicit
 missing-capability mutation test. If the platform cannot guarantee no-follow,
 fail closed before `open()` instead of opening first and rejecting afterward.
+## A targeted subtree swap must account for route-owned siblings outside that subtree (2026-08-09)
+
+**Incident (task-13213).** The Library optimized Notes/Media navigation by
+replacing only `#library-canvas`. The Notes `Database | Files` source strip is
+not a canvas child; it is a route-owned sibling composed above the shell grid.
+The optimization therefore made Notes look selected while omitting the only
+entry into file-backed notes, and it could leave the same strip stale after
+leaving Notes. A shell-identity regression stayed green because it asserted
+only the widgets the optimization deliberately preserved, never the contextual
+sibling it had skipped. Once the route boundary was tested, the original code
+failed at both 120x40 and 160x45.
+
+**The rule.** Before introducing a targeted recompose, inventory every
+route-owned surface, including siblings and wrappers outside the replacement
+host. Encode that inventory as a structural signature and use the targeted path
+only when the mounted signature matches the destination; otherwise await the
+canonical full composition seam. Tests must assert both halves of the boundary:
+contextual chrome appears on entry and disappears on exit. If stable child IDs
+are reused, hide and detach the outgoing subtree before mounting its replacement
+or Textual will reject the duplicate even when the route signature matches.

--- a/backlog/tasks/task-13213 - Restore-Library-Notes-source-strip-across-targeted-route-swaps.md
+++ b/backlog/tasks/task-13213 - Restore-Library-Notes-source-strip-across-targeted-route-swaps.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-09 19:57'
-updated_date: '2026-08-09 20:09'
+updated_date: '2026-08-09 13:43'
 labels:
   - library
   - notes
@@ -34,6 +34,8 @@ Restore reliable access to the Library Notes source selector so users can reach 
 - [x] #4 Reselecting Notes while Files owns the canvas retains the file-notes workspace, and Escape returns from Files to Database Notes.
 - [x] #5 Switching from a loading Database Note to Files invalidates the pending database session so its late completion cannot repopulate hidden editor state.
 - [x] #6 Focused mounted UI regressions, linting, changed-hunk formatting review, and diff checks pass.
+- [x] #7 Selecting Create Note from Files mode returns Notes to the Database source and restores the Database Notes Escape action.
+- [x] #8 Notes-source and Notes-canvas control flow uses named constants instead of repeated behavior-defining string literals.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -50,6 +52,7 @@ Reason: This is a contained UI composition-lifecycle regression and does not cha
 3. Preserve the existing File Notes exit and database-session invalidation contracts once the source selector is reachable again.
 4. Run focused Library Notes and shell tests at the supported compact terminal sizes.
 5. Run lint, changed-hunk formatting review, diff, and self-review checks, then document the implementation outcome.
+6. Address Qodo's source-state and maintainability findings with a Files-to-Create regression and named behavior constants.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -62,5 +65,6 @@ Reason: This is a contained UI composition-lifecycle regression and does not cha
 - Targeted Ruff (with seven unrelated pre-existing E721 findings excluded) and `git diff --check` passed. Changed hunks were reviewed against Ruff's formatter output; the three large pre-existing UI files still report whole-file formatting drift, so they were not mechanically reformatted into an unrelated large diff.
 - The existing Library user guide already accurately documents `Database | Files`; no user-facing documentation change was required. Added the route-owned-sibling incident to `backlog/docs/lessons-testing-evidence.md`.
 - ADR required: no. The change conforms to ADR-027 and ADR-029 and does not alter storage, synchronization, or ownership boundaries.
-- Backlog.md's CLI was blocked by the repository's pre-existing duplicate TASK-3401 collision and has no explicit-ID create option, so this collision-free task was recorded and completed directly in its canonical task file without altering the unrelated duplicate tasks.
+- Addressed both actionable Qodo findings: Create Note now normalizes Files to the Database source only after File Notes flush and transition admission succeed, and routing/source checks now share named source and canvas-kind constants. The new transition regression asserts the selected route, source, Escape action, and lease ordering.
+- Focused Qodo follow-up verification passed: eight route/source/session tests, targeted Ruff with the file's pre-existing E721 findings excluded, and `git diff --check`. The owner directed this PR to ignore the unrelated duplicate TASK-3401 CI failure, so no unrelated backlog task was renumbered.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-13213 - Restore-Library-Notes-source-strip-across-targeted-route-swaps.md
+++ b/backlog/tasks/task-13213 - Restore-Library-Notes-source-strip-across-targeted-route-swaps.md
@@ -1,0 +1,66 @@
+---
+id: TASK-13213
+title: Restore Library Notes source strip across targeted route swaps
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-09 19:57'
+updated_date: '2026-08-09 20:09'
+labels:
+  - library
+  - notes
+  - ux
+dependencies:
+  - TASK-1411
+  - TASK-2850
+documentation:
+  - backlog/decisions/027-portable-database-note-session-coordinator.md
+  - backlog/decisions/029-file-notes-disk-authority.md
+priority: high
+type: bug
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Restore reliable access to the Library Notes source selector so users can reach and safely leave file-backed notes after navigating into Notes from another Library route, without discarding the safe targeted-refresh optimization for structurally compatible routes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Entering Library Notes from a route without Notes-specific chrome visibly mounts the Database and Files choices at both 120x40 and 160x45, and choosing Files opens the retained file-notes workspace.
+- [x] #2 Leaving Library Notes removes the Notes-only source strip instead of leaving stale controls on other Library routes.
+- [x] #3 Targeted canvas replacement remains available when the mounted contextual chrome matches the destination route.
+- [x] #4 Reselecting Notes while Files owns the canvas retains the file-notes workspace, and Escape returns from Files to Database Notes.
+- [x] #5 Switching from a loading Database Note to Files invalidates the pending database session so its late completion cannot repopulate hidden editor state.
+- [x] #6 Focused mounted UI regressions, linting, changed-hunk formatting review, and diff checks pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+
+ADR path: N/A; this fix conforms to `backlog/decisions/027-portable-database-note-session-coordinator.md` and `backlog/decisions/029-file-notes-disk-authority.md`.
+
+Reason: This is a contained UI composition-lifecycle regression and does not change storage ownership, sync policy, schemas, security boundaries, or cross-module interfaces.
+
+1. Add mounted regression coverage for entering and leaving Notes across the contextual source-strip boundary.
+2. Gate targeted Library canvas replacement on whether the mounted Notes-specific chrome matches the destination route.
+3. Preserve the existing File Notes exit and database-session invalidation contracts once the source selector is reachable again.
+4. Run focused Library Notes and shell tests at the supported compact terminal sizes.
+5. Run lint, changed-hunk formatting review, diff, and self-review checks, then document the implementation outcome.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added a contextual-chrome guard to the targeted Library canvas replacement. Crossing the Notes boundary now awaits the canonical full recompose so the Database/Files source strip is added or removed with its route.
+- Preserved targeted replacement for compatible Database Notes routes, detaching the hidden outgoing canvas before mounting a stable-ID replacement to avoid Textual duplicate-ID rejection. File Notes remains on the full-composition path so its retained workspace is never replaced by a database canvas.
+- Restored File Notes lifecycle contracts exposed once the selector became reachable: Database Notes shortcuts no longer claim Escape in Files mode, and switching to Files invalidates/closes any pending database-note session before a late load can commit.
+- Updated mounted regressions for Notes/Media contextual chrome, file-workspace retention, keyboard source selection at 120x40 and 160x45, Escape, shell framing, and late-load invalidation. Seven consolidated mounted cases, two focused binding/action cases, and the 50-route-cycle ownership stress case passed.
+- Targeted Ruff (with seven unrelated pre-existing E721 findings excluded) and `git diff --check` passed. Changed hunks were reviewed against Ruff's formatter output; the three large pre-existing UI files still report whole-file formatting drift, so they were not mechanically reformatted into an unrelated large diff.
+- The existing Library user guide already accurately documents `Database | Files`; no user-facing documentation change was required. Added the route-owned-sibling incident to `backlog/docs/lessons-testing-evidence.md`.
+- ADR required: no. The change conforms to ADR-027 and ADR-029 and does not alter storage, synchronization, or ownership boundaries.
+- Backlog.md's CLI was blocked by the repository's pre-existing duplicate TASK-3401 collision and has no explicit-ID create option, so this collision-free task was recorded and completed directly in its canonical task file without altering the unrelated duplicate tasks.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -506,6 +506,9 @@ LIBRARY_MEDIA_HANDOFF_EXCERPT_CHARS = 500
 # removed and remounted here -- only the always-kept heading is listed.
 LIBRARY_RAG_RESULTS_STATIC_WIDGET_IDS = frozenset({"library-rag-results-heading"})
 LIBRARY_NOTES_COMPACT_BREAKPOINT = 120
+LIBRARY_NOTES_SOURCE_DATABASE = "database"
+LIBRARY_NOTES_SOURCE_FILES = "files"
+LIBRARY_CANVAS_KIND_NOTES = "notes"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -2285,7 +2288,9 @@ class LibraryScreen(BaseAppScreen):
         **kwargs: Any,
     ) -> None:
         super().__init__(app_instance, "library", **kwargs)
-        self._library_notes_source: Literal["database", "files"] = "database"
+        self._library_notes_source: Literal["database", "files"] = (
+            LIBRARY_NOTES_SOURCE_DATABASE
+        )
         self._library_file_notes_workspace: LibraryFileNotesWorkspace | None = None
         if file_notes_workspace_factory is None:
             self._library_file_notes_workspace_factory = lambda: (
@@ -3254,7 +3259,7 @@ class LibraryScreen(BaseAppScreen):
     def _library_notes_workflow_active(self) -> bool:
         """Return whether the current Library route is owned by Database Notes."""
         return (
-            self._library_notes_source == "database"
+            self._library_notes_source == LIBRARY_NOTES_SOURCE_DATABASE
             and self._library_selected_row_id
             in {
                 LIBRARY_ROW_BROWSE_NOTES,
@@ -4945,7 +4950,12 @@ class LibraryScreen(BaseAppScreen):
     def _file_notes_active(self) -> bool:
         """Return whether the retained File Notes workspace owns the canvas."""
         return (
-            getattr(self, "_library_notes_source", "database") == "files"
+            getattr(
+                self,
+                "_library_notes_source",
+                LIBRARY_NOTES_SOURCE_DATABASE,
+            )
+            == LIBRARY_NOTES_SOURCE_FILES
             and getattr(self, "_library_selected_row_id", "")
             == LIBRARY_ROW_BROWSE_NOTES
             and getattr(self, "_library_file_notes_workspace", None) is not None
@@ -4976,13 +4986,18 @@ class LibraryScreen(BaseAppScreen):
     def _library_note_editor_active(self) -> bool:
         """True while the in-canvas DATABASE note editor is the live view (task-2856).
 
-        Scoped to ``_library_notes_source == "database"`` so this never
+        Scoped to Database Notes so this never
         overlaps ``_file_notes_active()`` -- Files mode has its own
         dedicated Escape gate and never sets ``_library_notes_view``.
         """
         return (
             self._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
-            and getattr(self, "_library_notes_source", "database") == "database"
+            and getattr(
+                self,
+                "_library_notes_source",
+                LIBRARY_NOTES_SOURCE_DATABASE,
+            )
+            == LIBRARY_NOTES_SOURCE_DATABASE
             and getattr(self, "_library_notes_view", "list") == "editor"
         )
 
@@ -5020,7 +5035,12 @@ class LibraryScreen(BaseAppScreen):
             return getattr(self, "_library_media_view", "list") == "list"
         if row_id == LIBRARY_ROW_BROWSE_NOTES:
             return (
-                getattr(self, "_library_notes_source", "database") == "database"
+                getattr(
+                    self,
+                    "_library_notes_source",
+                    LIBRARY_NOTES_SOURCE_DATABASE,
+                )
+                == LIBRARY_NOTES_SOURCE_DATABASE
                 and getattr(self, "_library_notes_view", "list") == "list"
             )
         if row_id in (LIBRARY_ROW_BROWSE_PROMPTS, LIBRARY_ROW_CREATE_PROMPT):
@@ -7333,9 +7353,11 @@ class LibraryScreen(BaseAppScreen):
         )
         install_progress.display = self._parakeet_v2_install_progress is not None
         yield install_progress
-        if shell.canvas_kind == "notes":
+        if shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES:
             with Horizontal(id="library-notes-source-strip"):
-                database_selected = self._library_notes_source == "database"
+                database_selected = (
+                    self._library_notes_source == LIBRARY_NOTES_SOURCE_DATABASE
+                )
                 database_source = Button(
                     ("Database (selected)" if database_selected else "Database"),
                     id="library-notes-source-database",
@@ -7348,7 +7370,7 @@ class LibraryScreen(BaseAppScreen):
                     id="library-notes-source-separator",
                     markup=False,
                 )
-                files_selected = self._library_notes_source == "files"
+                files_selected = self._library_notes_source == LIBRARY_NOTES_SOURCE_FILES
                 files_source = Button(
                     "Files (selected)" if files_selected else "Files",
                     id="library-notes-source-files",
@@ -7405,8 +7427,8 @@ class LibraryScreen(BaseAppScreen):
                     "conversations",
                     "media",
                 ) or (
-                    shell.canvas_kind == "notes"
-                    and self._library_notes_source != "files"
+                    shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES
+                    and self._library_notes_source != LIBRARY_NOTES_SOURCE_FILES
                 )
                 if (
                     is_local_snapshot_canvas
@@ -7469,8 +7491,8 @@ class LibraryScreen(BaseAppScreen):
                         id="library-media-canvas",
                     )
                 elif (
-                    shell.canvas_kind == "notes"
-                    and self._library_notes_source == "files"
+                    shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES
+                    and self._library_notes_source == LIBRARY_NOTES_SOURCE_FILES
                 ):
                     # task-2850: File Notes owns the canvas PANE now, not
                     # the whole screen -- the rail and shell_grid frame
@@ -7488,7 +7510,7 @@ class LibraryScreen(BaseAppScreen):
                             markup=False,
                         )
                 elif (
-                    shell.canvas_kind == "notes"
+                    shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES
                     and self._library_notes_view == "editor"
                 ):
                     editor_state = self._library_note_editor_state()
@@ -7538,7 +7560,8 @@ class LibraryScreen(BaseAppScreen):
                             id="library-notes-canvas",
                         )
                 elif (
-                    shell.canvas_kind == "notes" and self._library_notes_view == "sync"
+                    shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES
+                    and self._library_notes_view == "sync"
                 ):
                     yield LibraryNotesCanvas(
                         mode="sync",
@@ -7546,7 +7569,7 @@ class LibraryScreen(BaseAppScreen):
                         compact=self._library_notes_compact,
                         id="library-notes-canvas",
                     )
-                elif shell.canvas_kind == "notes":
+                elif shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES:
                     yield LibraryNotesCanvas(
                         self._build_library_notes_state(),
                         sort_mode=self._library_notes_sort,
@@ -8254,7 +8277,7 @@ class LibraryScreen(BaseAppScreen):
         if (
             note_id != self._selected_note_id
             or self._library_notes_view != "editor"
-            or self._library_notes_source != "database"
+            or self._library_notes_source != LIBRARY_NOTES_SOURCE_DATABASE
         ):
             return
         outcome = await self._library_note_session.open_session(note_id)
@@ -8263,7 +8286,7 @@ class LibraryScreen(BaseAppScreen):
         if (
             note_id != self._selected_note_id
             or self._library_notes_view != "editor"
-            or self._library_notes_source != "database"
+            or self._library_notes_source != LIBRARY_NOTES_SOURCE_DATABASE
         ):
             return
         if outcome.kind is NoteLoadOutcomeKind.MISSING:
@@ -11098,7 +11121,7 @@ class LibraryScreen(BaseAppScreen):
     async def _show_library_file_notes(self, event: Button.Pressed) -> None:
         """Leave Database Notes safely and lazily mount File Notes."""
         event.stop()
-        if self._library_notes_source == "files":
+        if self._library_notes_source == LIBRARY_NOTES_SOURCE_FILES:
             return
         await self._flush_library_note_save()
         if self._library_note_dirty:
@@ -11109,7 +11132,7 @@ class LibraryScreen(BaseAppScreen):
             self._library_file_notes_workspace = (
                 self._library_file_notes_workspace_factory()
             )
-        self._library_notes_source = "files"
+        self._library_notes_source = LIBRARY_NOTES_SOURCE_FILES
         # task-2850: the Files-mode Escape binding only fires while
         # ``_file_notes_active()`` is true, so the footer's advertised keys
         # must follow this same transition or Escape works unadvertised.
@@ -11130,7 +11153,7 @@ class LibraryScreen(BaseAppScreen):
         sequence -- one seam, not a parallel key-driven path that could
         drift from the button's.
         """
-        if self._library_notes_source == "database":
+        if self._library_notes_source == LIBRARY_NOTES_SOURCE_DATABASE:
             return
         if not await self._flush_active_file_notes():
             return
@@ -11138,7 +11161,7 @@ class LibraryScreen(BaseAppScreen):
         if release_source is False:
             return
         try:
-            self._library_notes_source = "database"
+            self._library_notes_source = LIBRARY_NOTES_SOURCE_DATABASE
             self._register_footer_shortcuts()
             await self.recompose()
             # task-2856 AC1: this lands on the Notes LIST (never Files'
@@ -11209,14 +11232,16 @@ class LibraryScreen(BaseAppScreen):
         """
         try:
             notes_source_strip_mounted = bool(self.query("#library-notes-source-strip"))
-            destination_uses_notes_source_strip = shell.canvas_kind == "notes"
+            destination_uses_notes_source_strip = (
+                shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES
+            )
             if notes_source_strip_mounted != destination_uses_notes_source_strip:
                 return False
 
-            if shell.canvas_kind == "notes":
+            if shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES:
                 if (
                     self._library_notes_view != "list"
-                    or self._library_notes_source != "database"
+                    or self._library_notes_source != LIBRARY_NOTES_SOURCE_DATABASE
                 ):
                     return False
                 canvas: Widget = LibraryNotesCanvas(
@@ -11314,6 +11339,11 @@ class LibraryScreen(BaseAppScreen):
         if not await self._flush_library_skill_save():
             self._notify_skill_dirty_veto()
             return
+        if row_id == LIBRARY_ROW_CREATE_NOTE:
+            # Create Note is a database-only Notes route. File Notes owns a
+            # retained workspace, so normalize the source only after its
+            # flush and transition admission have succeeded.
+            self._library_notes_source = LIBRARY_NOTES_SOURCE_DATABASE
         # A rail selection is an explicit route boundary, even when the user
         # later returns to the same visual Notes region. Invalidate the token
         # now so leave→return cannot recreate authority by region equality.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -3253,10 +3253,14 @@ class LibraryScreen(BaseAppScreen):
 
     def _library_notes_workflow_active(self) -> bool:
         """Return whether the current Library route is owned by Database Notes."""
-        return self._library_selected_row_id in {
-            LIBRARY_ROW_BROWSE_NOTES,
-            LIBRARY_ROW_CREATE_NOTE,
-        }
+        return (
+            self._library_notes_source == "database"
+            and self._library_selected_row_id
+            in {
+                LIBRARY_ROW_BROWSE_NOTES,
+                LIBRARY_ROW_CREATE_NOTE,
+            }
+        )
 
     def _library_notes_focus_region(
         self,
@@ -11099,6 +11103,8 @@ class LibraryScreen(BaseAppScreen):
         await self._flush_library_note_save()
         if self._library_note_dirty:
             return
+        self._supersede_library_notes_navigation()
+        self._reset_library_note_editor_state()
         if self._library_file_notes_workspace is None:
             self._library_file_notes_workspace = (
                 self._library_file_notes_workspace_factory()
@@ -11189,7 +11195,10 @@ class LibraryScreen(BaseAppScreen):
         Notes and Media are the high-frequency browse routes exercised by the
         adaptive Notes workflow. Their list canvases can be rebuilt in the
         existing canvas host while the header, rail, and workbench grid retain
-        identity. Other routes keep the central whole-screen recompose seam.
+        identity when the destination uses the same contextual chrome already
+        mounted around that host. Crossing the Notes boundary must use the
+        central whole-screen recompose seam so its Database/Files source strip
+        is added or removed with the rest of the route-owned structure.
 
         Args:
             shell: Latest normalized Library shell state.
@@ -11199,8 +11208,16 @@ class LibraryScreen(BaseAppScreen):
             should use the whole-screen fallback.
         """
         try:
+            notes_source_strip_mounted = bool(self.query("#library-notes-source-strip"))
+            destination_uses_notes_source_strip = shell.canvas_kind == "notes"
+            if notes_source_strip_mounted != destination_uses_notes_source_strip:
+                return False
+
             if shell.canvas_kind == "notes":
-                if self._library_notes_view != "list":
+                if (
+                    self._library_notes_view != "list"
+                    or self._library_notes_source != "database"
+                ):
                     return False
                 canvas: Widget = LibraryNotesCanvas(
                     self._build_library_notes_state(),
@@ -11238,12 +11255,14 @@ class LibraryScreen(BaseAppScreen):
             # compositor may still hold the previous geometry for one frame;
             # without this guard a removed TextArea can be asked to render
             # after its component-style context has already been released.
+            # Detach before mounting because same-route replacements reuse
+            # their stable canvas ID and Textual rejects duplicate siblings.
             outgoing = tuple(canvas_host.children)
             for child in outgoing:
                 child.display = False
-            await canvas_host.mount(canvas)
             if outgoing:
                 await canvas_host.remove_children(outgoing)
+            await canvas_host.mount(canvas)
             self._apply_library_notes_stage_visibility()
             self._apply_library_notes_footer_context()
             return True
@@ -11395,7 +11414,7 @@ class LibraryScreen(BaseAppScreen):
         )
         self._library_selected_row_id = shell.selected_row_id
         if not await self._replace_library_browse_canvas(shell):
-            self.refresh(recompose=True)
+            await self.recompose()
         # task-2856 AC1: a rail-row press landing on one of the four list
         # canvases focuses its primary list's first row -- the entry-point
         # half of the same seam ``_exit_library_skill_editor_guarded`` /


### PR DESCRIPTION
## Summary

- restore the Library Notes `Database | Files` source strip when crossing into Notes and remove it when leaving
- preserve targeted canvas replacement only when the mounted contextual chrome matches, including stable-ID replacement safety
- retain the File Notes workspace on Notes reselection, restore Escape-to-Database behavior, and invalidate late Database Note loads when switching sources
- add mounted regressions, Backlog task notes, and the generalized route-owned-sibling testing lesson

## Test plan

- Focused mounted and binding suite: 9 passed
- 50-route-cycle ownership stress regression: passed
- `ruff check --ignore E721` on the four changed Python files: passed (unfiltered run has seven pre-existing E721 findings outside this patch)
- `git diff --check origin/dev`: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Library Notes Database | Files source strip across route changes so users can reliably enter and leave file-backed Notes. Hardens targeted canvas swaps with contextual-chrome checks and fixes the Create Note flow from Files (addresses TASK-13213).

- **Bug Fixes**
  - Mount the Notes source strip on entry to Notes; remove it when leaving.
  - Gate targeted canvas swaps on matching contextual chrome and Database Notes list state; otherwise use a full recompose.
  - Retain the File Notes workspace on reselection; Create Note from Files returns to Database after source transition admission; Escape is only active in Database Notes.
  - Invalidate pending Database Note loads when switching to Files to prevent late state repopulation.
  - Detach and remove the outgoing canvas before mounting replacements to avoid duplicate-ID errors.

- **Refactors**
  - Replace behavior-defining string literals with named constants for notes sources and canvas kind.

<sup>Written for commit 2d84b2fc6d8ab2da8d668439581a7c19bd3f5640. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

