### PR TITLE
chore: renumber duplicate task-3401 (unblocks duplicate-ID CI gate)

### DIFF
--- a/backlog/tasks/task-13262 - Make-Console-rail-label-style-configurable.md
+++ b/backlog/tasks/task-13262 - Make-Console-rail-label-style-configurable.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-3401
+id: TASK-13262
 title: Make Console rail label style configurable
 status: In Progress
 assignee: []


### PR DESCRIPTION
`task-3401` was claimed by two unrelated task files on dev:

- `task-3401 - Make-Console-rail-label-style-configurable.md` (In Progress)
- `task-3401 - Video-generation-ephemeral-storage-playback-and-streaming.md` (To Do, 12 subtasks)

so the **No duplicate backlog task IDs** workflow failed on every PR branched from dev — including PRs that never touch `backlog/tasks/` (observed on #1461).

**Which one moved and why:** the Console rail-label task. The video-generation id is load-bearing for the active `feat/task-3401-video-generation-foundation` branch and its subtasks `task-3401.1`–`.12`; moving it would have rippled through all of them plus the branch name.

New id `13262` leapfrogs the max id across origin/dev and every local worktree (13212) with headroom, and was ghost-checked against dev history (`git log --diff-filter=A`) so it was never previously used and removed. Filename and frontmatter `id:` both updated. The gate's own check now passes locally: zero duplicate filenames, zero duplicate frontmatter ids.

Closes task-13158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbered the Console rail-label backlog task from `task-3401` to `task-13262` to resolve a duplicate ID and unblock the "No duplicate backlog task IDs" CI gate. The video-generation `task-3401` and its `.1–.12` subtasks remain unchanged; closes task-13158.

- **Bug Fixes**
  - Renamed file to `backlog/tasks/task-13262 - Make-Console-rail-label-style-configurable.md` and updated frontmatter `id` to `TASK-13262`.
  - Chose an unused ID above current max to prevent future collisions.

<sup>Written for commit 82d9d0ae25c770fc149df4664e09e39da4832202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

