### PR TITLE
chore(backlog): 2026-08-09 Library re-critique findings (tasks 4020-4023)

### DIFF
--- a/.impeccable/critique/2026-08-09T20-15-07Z__tldw-chatbook-ui-screens-library-screen-py.md
+++ b/.impeccable/critique/2026-08-09T20-15-07Z__tldw-chatbook-ui-screens-library-screen-py.md
@@ -1,0 +1,93 @@
+---
+target: Library screen and subscreens (re-critique after 3 fix arcs)
+total_score: 22
+max_score: 40
+na_heuristics: 
+p0_count: 1
+p1_count: 9
+timestamp: 2026-08-09T20-15-07Z
+slug: tldw-chatbook-ui-screens-library-screen-py
+---
+Method: dual-agent (A: design-director live walkthrough · B: mechanical probes/detector) — isolated tmux instances (`rcritA6729`/`rcritB6729`), scratch profiles, identity-verified on every launch; dev `4d0232358` (all three fix arcs merged), read-only worktree.
+
+# Re-critique — Library screen + all subscreens (2026-08-09)
+
+Baseline: **22/40** on 2026-08-06 (0 P0 / 8 P1). Three fix arcs merged since: PR #1410 (P1s), PR #1420 (P2 batch), PR #1459 (polish batch).
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Import preflight/queue/receipts exemplary; bulk delete completes in total silence |
+| 2 | Match System / Real World | 2 | "opens staging canvas" ×3 in primary nav; "Collection record", "delete records", "0 blocks" |
+| 3 | User Control and Freedom | 1 | **Escape from the Notes editor terminates the application**; no undo/trash for bulk delete |
+| 4 | Consistency and Standards | 1 | Four footer dialects, three active-state markers, three toolbar layouts, `▸` means two things; empty prompt/skill drafts discard but empty notes persist |
+| 5 | Error Prevention | 3 | Disabled-with-reason gating real; accepts `libexport.ziprary export 2026-08-09.zip` without a murmur |
+| 6 | Recognition Rather Than Recall | 2 | Cycle-buttons hide their option space; copy names a control that never renders |
+| 7 | Flexibility and Efficiency | 3 | Bulk actions real and working; 38 Tab presses to the first canvas control; Enter in rail search doesn't search |
+| 8 | Aesthetic and Minimalist Design | 2 | 30-char list column on a 170-col terminal; 7-row viewport for a 33-line document |
+| 9 | Error Recovery | 3 | Miss/blocked copy is model-quality; the app's worst error has no message and takes the session |
+| 10 | Help and Documentation | 2 | F1 lists Escape 2–3× with contradictory labels; doesn't close on second F1; per-canvas footers carry the real help |
+| **Total** | | **22/40** | **Unchanged number, materially changed composition** |
+
+Trend for this slug: 23 → 21 → 27 → 22 → **22** (out of 40).
+
+## The headline: we shipped a P0 fixing the last critique's headline
+
+The 2026-08-06 critique's lead finding was *"Escape is a no-op on every canvas tested."* The remediation wired Escape into `action_library_notes_escape` → `self._back_from_library_note_editor()` — **a method that exists nowhere in the codebase**. `grep -rn "_back_from_library_note_editor" tldw_chatbook/` returns exactly one hit: the call site (`library_screen.py:4371`). Library ▸ Notes ▸ New ▸ Blank note ▸ Escape raises `AttributeError`, the exception is unhandled, and the app terminates (`event=unhandled_exception` → `event=app_stopping`). Reproduced 3/3 by A and 2/2 by B independently; confirmed statically by the controller.
+
+Two aggravators: the footer on that canvas advertises `Esc Notes` as the way out, and the sibling Prompt editor's Escape works correctly — so users learn the gesture is safe, then get punished. B's AST sweep of `LibraryScreen` for undefined `self.X()` calls found **exactly this one** — no sibling landmines. The branch is guarded by `if self._library_notes_view == "editor":`, which is why no mount-time smoke test reached it.
+
+**Fix already in flight** on the residue branch with a state-setting regression test.
+
+## Verified fixed since 2026-08-06 (both arms agreeing)
+
+- **Select mode bulk actions (LIB-05)** — real and working. B's zip listing proves selection-scoped export contains *exactly* the 2 selected items (`total_media_items: 2`); delete drops the rail 3→1; the double-press guard holds (V2: one decrement). The confirm — `Delete 2 selected items? This moves them to trash.` with the footer rewriting to `esc cancel delete` — is now the best destructive-action pattern in the product.
+- **Media viewer markdown (LIB-13)** — rendered with a real box-drawn table; `Rendered (selected) | Raw` toggle works both ways and marks state in **text**, not colour.
+- **Export receipt + gating (LIB-11/12)** — durable across canvas exit and re-entry; the disabled button carries a visible reason.
+- **Study handoff (LIB-06)** — breadcrumb, Escape-back, and an honest tab bar at the destination; provenance carried across.
+- **Files mode (LIB-01)** — rebuilt exactly as prescribed, inside the Library frame, with adjacent prompt and button.
+- **Folder-notes cross-references (LIB-19)** — all three surfaces now explain their relationship to each other. Genuinely good writing.
+- **Import/Export vocabulary (LIB-10)** — "ingest" and "chatbook" gone end to end.
+- **Rail truncation (LIB-18)** — B confirms **no mid-word truncation at 120/100/80**; degradation is whole-gloss-drop plus short-title swap, exactly as designed.
+- **Focus visibility** — B: 12/12 Tab stops visibly distinct, none byte-identical to unfocused.
+- **Search headlines, Conversations title, export quality caption** — all fixed.
+
+## Priority issues
+
+### P0
+- **RC-01 — Escape from the Notes editor kills the app.** See headline. Fix in flight.
+
+### P1
+- **RC-02 — Our own nav ghosting is not producing its intended outcome at dev tip.** B measured tab labels cut **mid-word at 80 AND 120** (`⌃6 Watc`, `⌃9 M`, scroll fragments `‹ oleplay…`, `‹ edules…`) and found **no ghosted tabs** — the bar scrolls instead. The ghost machinery IS present (10 references in `main_navigation.py`, 2 in `_navigation.tcss`), so this is a failure of effect, not missing code. Leading hypothesis: dev replaced the in-strip pager with `NavOverflowMenu` during our arc, and the polish batch's rebase reconciliation kept the ghosting while the scroll/paging model beneath it changed. Task-3200's entire four-round arc was about this exact defect. **Re-verify and re-root-cause against the new overflow model.** (Mitigating: no ghost was clickable-while-invisible — B's blank-cell click did not navigate.)
+- **RC-03 — Blank notes still persist; the GC exists but its predicate never fires.** B: opening the blank editor bumps `Notes (2)→(3)` and shows `Saved` before any keystroke; exiting via `‹ Notes` retains it; typing then deleting everything also retains it (`Notes (4)`, four indistinguishable `Untitled` rows). The session-blank GC from the P2 batch IS present and IS wired to ~7 exit paths including this one. Leading hypothesis, worth checking first: the title field carries the **literal string "Untitled"** rather than a placeholder, so `_flush_library_note_save`'s emptiness test (`any(value.strip() for value in (title, content, keywords))`) sees a truthy title and takes the save branch. Contrast: empty **prompt** and **skill** drafts discard correctly — the right behavior exists twice in the same screen.
+- **RC-04 — Soft-deleted media becomes permanently un-importable.** B: bulk-delete 2 items → re-import the same files → `≡ matched · Already in Library — matched an existing item; nothing new was imported.` while the items are absent from the list and the count stays down. Dedup matches soft-deleted rows, so the file can never be re-added and the "trash" is unreachable. **Data-loss-shaped**: the user's content is neither present nor restorable through the UI.
+- **RC-05 — Bulk delete has no receipt, no undo, and the promised trash does not exist.** The confirm earns consent by promising reversibility; nothing in the rail, the `type:` filter, or any canvas reaches a trash. Creation gets `✓ done · file · 1s` + a jump link; destruction gets silence. (Compounds RC-04.)
+- **RC-06 — The Notes canvas advertises a control that never renders.** Copy: *"…for notes that live in a folder on disk, switch to Files, or use Sync to mirror one in."* The `Database | Files` strip (`library_screen.py:7333`) is absent on first paint; A found it appears only after a Sync round-trip, B confirms it is absent in both plain and ANSI captures and unreachable by 18 Tab presses. **LIB-01's fix landed the destination and lost the door** — arguably worse than the old dead end, because the old failure was discoverable.
+- **RC-07 — Disabled state is colour-only at 1.08:1–2.30:1, with no reason at the control.** Measured: Select-mode bulk buttons **1.08:1** when 0 selected (the very buttons LIB-05 added — present, focusable, meaningful, unreadable); Media `Select` when empty 1.45:1 (click does nothing, says nothing); Export button ~1.4–1.51:1; Collections' three buttons 2.30:1 *even when enabled*. Violates two stated principles at once. The product's non-colour vocabulary already exists (`☐/☑`, `▸`, `┃…┃`, `(selected)`, `✓/○`) — it simply was never applied to disabled state.
+- **RC-08 — Search/RAG buries its own output.** Results land ~30 rows below the fold behind a configuration panel; clicking `Run` leaves the visible half of the canvas pixel-identical. Enter in the rail search navigates and pre-fills but does not run. Two search inputs are live with different values, and navigation silently overwrites one with the other; the never-executed string still enters `Recent searches`.
+- **RC-09 — DB sizes are computed once and never refreshed.** B: UI showed `Prompts 148.0KB / Media 476.0KB` while disk (incl. `-shm`) was 180.0KB/508.0KB; a forced recompose with **no disk change** corrected both. `get_formatted_db_size_with_wal` does sum the sidecars — task-2859's fix is correct, and stale. It understates by exactly the sidecar size.
+- **RC-10 — F1 contradicts itself and won't close.** Notes list lists Escape three times with two conflicting labels (`- esc: focus rail` / `- escape: Back` / `- escape: Focus rail`); Media lists it twice; Search/RAG omits F6 though the footer advertises it; Collections' panel says nothing about Collections. Second F1 does not dismiss the panel.
+
+### P2 (selected from ~20)
+Escape still inert on Export, Collections, and the Study staging canvas; the staging canvas has no back path at all. `Export…` from within Media navigates away with no return. Collections stacks four "nothing here" sentences, still has no "Add to collection" anywhere, and its only enabled control with a collection selected is `Delete Collection` — styled identically to the benign buttons, with a confirm that names nothing and offers no Cancel. "opens staging canvas" printed three times in the primary nav. Four footer dialects; the hub's `i`/`n` shortcuts vanish elsewhere with no statement of whether they still work. `▸` overloaded (disclosure vs silent cycler). Import and Export receipts have entirely different grammars. Export scope "Everything" excludes Prompts, Skills, Collections. Expanding Details silently strips glosses from three unrelated rail rows (scrollbar steals a column). At ≤100 cols the landing canvas vanishes entirely while the rail still says "pick a section on the left". `Type: plaintext` for a `.md` the viewer renders as markdown; extensions stripped from every list title. Media list truncates at 17 chars with ~115 columns blank. Toast overlaps the queue's Clear button.
+
+## Strengths
+1. **The Import pipeline** — preflight facts accumulate as you type, the collapsed settings header states its own contents, per-file queue rows carry duration and a jump link, Unicode round-trips perfectly. The best-designed flow in the product.
+2. **Bulk delete's confirmation copy** — count, action, and reversibility in nine words, with a context-aware footer. (The follow-through is the problem, not the dialog.)
+3. **Cross-boundary honesty** — the Study staging canvas prints `Carries forward: …` before you commit, and the destination re-states its provenance. Nothing is smuggled across.
+
+## Persona red flags
+- **Alex (power user):** his reflex Escape kills the app; Enter doesn't search; the bulk buttons he came for are invisible until after he selects; cycle-buttons can't be jumped; 38 Tabs to the first canvas control.
+- **Jordan (first-timer):** told to "switch to Files" with no Files control on screen; reads "opens staging canvas" three times; four "nothing here" sentences on Collections; ends up with four indistinguishable `Untitled` notes.
+- **Sam (keyboard/a11y):** disabled state is colour-only at 1.08:1; the only enabled control on a populated Collections canvas is the destructive one; the `Database | Files` toggle is not in the focus chain at all; Escape terminates the app. Positives: focus is shape-marked (`┃…┃`), selection is text-marked, 12/12 stops visibly distinct.
+
+## What the arcs actually bought
+Eight of ten prior findings are genuinely fixed with evidence, and heuristics 1, 5, 7, 9 improved on real machinery. The score didn't move because **the fixes cast three shadows** (Files mode's lost door, the invisible bulk buttons, jargon replacing a lie) and because the *source* of inconsistency migrated rather than reduced: the old fracture was vocabulary, and we fixed it; the new fracture is grammar — four footer dialects, three active-state markers, three toolbar layouts, one glyph with two meanings. **Fixing the words did not fix the system.**
+
+Two of our own shipped fixes (nav ghosting, blank-note GC) are present in code but not producing their intended effect at dev tip — both worth re-rooting before anything new is built on them.
+
+## Questions
+1. The last critique's headline demanded Escape work; the remediation wired it to a method that doesn't exist, behind a state branch no mount-time test enters. What test shape would have caught it — and why does a codebase with mutation-tested guards elsewhere have none on the exit path of its most-used editor?
+2. Every non-colour vocabulary this product needs already exists and is used well. What is preventing "unavailable, because —" from joining it, and is the honest answer that disabled state has no owner?
+3. Import tells you type, size and count before you commit, then hands you a receipt with a jump link. Bulk delete tells you nothing, promises a trash that doesn't exist, and makes the deleted file permanently un-importable. Is the operative principle "show status before action" — or "creation deserves ceremony and destruction is plumbing"?

--- a/backlog/tasks/task-4020 - Nav-ghosting-does-not-prevent-mid-word-tab-cuts-after-the-overflow-menu-change.md
+++ b/backlog/tasks/task-4020 - Nav-ghosting-does-not-prevent-mid-word-tab-cuts-after-the-overflow-menu-change.md
@@ -1,0 +1,46 @@
+---
+id: TASK-4020
+title: Nav ghosting does not prevent mid-word tab cuts after the overflow-menu change
+status: To Do
+assignee: []
+created_date: '2026-08-09 20:30'
+labels:
+  - navigation
+  - regression
+  - recritique-2026-08-09
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Library re-critique 2026-08-09 (RC-02), measured at dev `4d0232358` by the mechanical arm.
+
+task-3200's four-round arc existed to guarantee that a destination tab label is never rendered
+mid-word-clipped. At dev tip that guarantee does not hold:
+
+- 80 cols: `⌃6 Watc  More ▾`
+- 120 cols: `⌃9 M  More ▾`
+- scroll fragments observed: `‹ ts  ⌃5 Roleplay…`, `‹ oleplay…`, `‹ lists…`, `‹ edules…`
+
+No ghosted tabs were observed at all — the bar scrolls with a `‹` indicator instead.
+
+**The ghosting machinery is present** (10 references in `UI/Navigation/main_navigation.py`, 2 in
+`css/components/_navigation.tcss`), so this is a failure of effect, not lost code. Leading
+hypothesis: dev replaced the in-strip pager with `NavOverflowMenu` while task-3200 was in flight;
+the polish batch's rebase (PR #1459) kept the ghosting mechanism and dropped the pager-specific
+pieces, but the scroll/paging model the straddle detection was written against changed underneath
+it. Re-root-cause against the current overflow model rather than re-patching the old assumptions.
+
+Mitigating: no ghosted tab was clickable-while-invisible (a blank-cell click did not navigate), so
+the round-1 interactivity hole stays closed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 No destination tab label renders mid-word-clipped at 80, 100 or 120 columns, verified by rendered-geometry assertions and live capture
+- [ ] #2 The root cause is stated: why the existing ghost/straddle detection stopped producing its effect under the overflow-menu model
+- [ ] #3 The scroll-fragment renders (`‹ oleplay…`) are gone or are a deliberate, documented affordance
+- [ ] #4 Regression coverage runs against the CURRENT overflow model, and the now-obsolete assumptions in task-3200's tests are corrected rather than left passing vacuously
+<!-- AC:END -->

--- a/backlog/tasks/task-4021 - Blank-note-GC-never-fires-because-the-title-is-seeded-Untitled.md
+++ b/backlog/tasks/task-4021 - Blank-note-GC-never-fires-because-the-title-is-seeded-Untitled.md
@@ -1,0 +1,51 @@
+---
+id: TASK-4021
+title: Blank-note GC never fires because the title is seeded "Untitled"
+status: To Do
+assignee: []
+created_date: '2026-08-09 20:30'
+labels:
+  - library
+  - notes
+  - recritique-2026-08-09
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Library re-critique 2026-08-09 (RC-03), confirmed by both critique arms AND by the P0 fix agent
+reading the code path.
+
+Opening Library ▸ Notes ▸ New ▸ Blank note bumps the rail count (`Notes (2)` → `(3)`) and shows
+`Saved` before any keystroke; exiting by ANY path retains the row. Typing text and then deleting
+all of it also retains it. Four indistinguishable `Untitled` rows accumulate from merely opening
+the editor, and they propagate outward — the Study staging canvas reads
+`Carries forward: Untitled, Untitled, Untitled and 1 more.`
+
+**Root cause (confirmed, not hypothesised):** the session-blank GC added by the P2 batch is present
+and `_flush_library_note_save` is wired to ~7 exit paths, but its emptiness test reads the
+coordinator snapshot's `title`, which `handle_library_notes_create_blank` seeds with the **literal
+string `"Untitled"`** rather than leaving it blank with a placeholder. So
+`any(value.strip() for value in (title, content, keywords))` is always truthy and the GC branch is
+unreachable.
+
+Pre-existing on `origin/dev` (byte-identical source; the three GC tests fail identically there).
+Not Escape-specific — reproduces via the Back button too.
+
+**Prior art:** an unmerged sibling branch carries commit `f8bd6e8ac` (task-3315) fixing this in
+tandem with a coupled save-seam change. Read it before implementing; the coupling is the reason it
+was not a one-liner.
+
+Contrast worth preserving: empty **prompt** and **skill** drafts discard correctly on exit — the
+right behaviour already exists twice in the same screen.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Opening the blank-note editor and leaving without typing persists no row, by every exit path (Escape, Back, rail switch, screen leave)
+- [ ] #2 Typing into a session blank and then deleting everything also persists no row; a pre-existing note emptied out still saves
+- [ ] #3 The title is a placeholder rather than a literal seeded value, or the emptiness predicate reads a field that is genuinely empty
+- [ ] #4 The three currently-failing GC tests pass, and the fix is reconciled with task-3315's prior art rather than duplicating it
+<!-- AC:END -->

--- a/backlog/tasks/task-4022 - Soft-deleted-media-is-permanently-un-importable-and-the-trash-is-unreachable.md
+++ b/backlog/tasks/task-4022 - Soft-deleted-media-is-permanently-un-importable-and-the-trash-is-unreachable.md
@@ -1,0 +1,52 @@
+---
+id: TASK-4022
+title: Soft-deleted media is permanently un-importable and the trash is unreachable
+status: To Do
+assignee: []
+created_date: '2026-08-09 20:30'
+labels:
+  - library
+  - media
+  - data-loss
+  - recritique-2026-08-09
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Library re-critique 2026-08-09 (RC-04/RC-05), reproduced by the mechanical arm at dev `4d0232358`.
+
+Repro: import a file → Media ▸ Select → check it → Delete selected → confirm. Then re-import the
+same file. Result:
+
+    ≡ matched · short.txt
+    Already in Library — matched an existing item; nothing new was imported.
+
+…while `Media (1)` and the item is absent from every list. The import dedup matches
+**soft-deleted** rows, so a deleted file can never be re-added. Meanwhile the confirmation dialog
+promises `This moves them to trash.` and there is no trash anywhere in the product — not in the
+rail, not in the `type:` filter (which offers only `All` and the ingested types), not on any canvas.
+
+Net effect: the user's content is neither present nor restorable through the UI, and the one action
+that promised reversibility is the one that makes it unreachable.
+
+Two coupled defects, both in scope here:
+1. Dedup must not match soft-deleted rows (or must offer to restore the existing row instead of
+   silently refusing the import).
+2. Bulk delete completes with no receipt and no undo. Compare the asymmetry: creating one item
+   yields `✓ done · file · 1s` plus an `Open in Library` jump; destroying two yields silence.
+
+Either ship the trash the copy promises (a `type: Trash` value or a rail row, with restore), or
+change the copy to state what actually happens — but the current combination of a reversibility
+promise, no destination, and a permanent import block is the worst of the three options.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A file deleted from Media can be re-imported, or the duplicate-match path offers restore instead of silently refusing
+- [ ] #2 Bulk delete emits a receipt naming the count, with an undo affordance at the point of action
+- [ ] #3 The confirmation copy and the product agree: either the trash is reachable and restores, or the copy stops promising it
+- [ ] #4 Live verification of the full cycle: import → delete → re-import → the item is present exactly once
+<!-- AC:END -->

--- a/backlog/tasks/task-4023 - Library-P1-P2-batch-from-the-2026-08-09-re-critique.md
+++ b/backlog/tasks/task-4023 - Library-P1-P2-batch-from-the-2026-08-09-re-critique.md
@@ -1,0 +1,84 @@
+---
+id: TASK-4023
+title: Library P1/P2 batch from the 2026-08-09 re-critique
+status: To Do
+assignee: []
+created_date: '2026-08-09 20:30'
+labels:
+  - library
+  - ux
+  - recritique-2026-08-09
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Library re-critique 2026-08-09, snapshot
+`.impeccable/critique/2026-08-09T20-15-07Z__tldw-chatbook-ui-screens-library-screen-py.md`
+(22/40; trend 23 → 21 → 27 → 22 → 22). The P0 (Escape crash) shipped in PR #1464; the three
+highest-value findings are tasks 4020/4021/4022. This is the remainder — grouped for one pass,
+split if any item grows.
+
+**Accessibility / honesty (highest value in this batch)**
+1. RC-07 — disabled state is colour-only, measured: Select-mode bulk buttons **1.08:1** when 0
+   selected (the very buttons task-2853 added — present, focusable, meaningful, unreadable);
+   Media `Select` when empty 1.45:1 and silent on click; Export ~1.4–1.51:1; Collections' three
+   buttons **2.30:1 even when enabled**. Floor disabled contrast at 3:1, add a non-colour marker,
+   and attach the reason to the control. The product's non-colour vocabulary already exists
+   (`☐/☑`, `▸`, `┃…┃`, `(selected)`, `✓/○`) — disabled state simply never joined it.
+2. RC-06 — the Notes canvas copy says "switch to Files" but the `Database | Files` strip
+   (`library_screen.py:7333`) does not render on first paint: the fast rail-click path
+   (`_replace_library_browse_canvas`) swaps only the inner canvas and never composes the strip;
+   only a full recompose renders it. Named `task-3317` in an unmerged sibling branch's test
+   docstrings — reconcile rather than duplicate.
+3. RC-09 — DB sizes in the Details disclosure are computed once and never refreshed: UI showed
+   `Prompts 148.0KB / Media 476.0KB` while disk incl. sidecars was 180.0KB/508.0KB; a recompose
+   with no disk change corrected both. task-2859's WAL-inclusive helper is correct and stale.
+4. RC-10 — F1 lists Escape 2–3× with contradictory labels (`- esc: focus rail` / `- escape: Back`
+   / `- escape: Focus rail`), omits F6 on Search/RAG though the footer advertises it, says nothing
+   about Collections on the Collections panel, and does not close on a second F1.
+
+**Interaction grammar (the score's current ceiling)**
+5. Four footer dialects across seven canvases (different separators, different key names:
+   `F6 panes` vs `F6 next pane`, `/ Find` vs `/ focus search`); the hub's `i`/`n` shortcuts vanish
+   elsewhere with no statement of whether they still work.
+6. Three active-state markers (`▸` prefix, `┃…┃` bars, `(selected)` text) and three toolbar
+   layouts (Media vertical, Notes 3×2 grid, Prompts/Skills single row).
+7. `▸` carries two incompatible meanings: disclosure (`Details ▸`) vs silent cycler
+   (`type: All ▸`, `mode: Search ▸`) that advances with no menu — the option set is undiscoverable.
+8. Escape still inert on Export, Collections, and the Study staging canvas; the staging canvas has
+   no back path at all; `Export…` from within Media navigates away with no return.
+
+**Search**
+9. RC-08 — results land ~30 rows below the fold behind the configuration panel; clicking `Run`
+   leaves the visible half of the canvas pixel-identical. Enter in the rail search navigates and
+   pre-fills but does not run. Two search inputs are live with different values and navigation
+   silently overwrites one with the other; never-executed strings still enter `Recent searches`.
+
+**Layout**
+10. Media list renders in a ~30-char column on a 170-col terminal with the detail below it, and
+    truncates titles at 17 chars while ~115 columns sit blank; the media viewer gives a 33-line
+    document a 7-row viewport while spending 2 lines on a `file://` temp path.
+11. At ≤100 cols the landing canvas vanishes entirely while the rail still reads "pick a section
+    on the left".
+
+**Copy**
+12. "opens staging canvas" printed three times in the primary nav (a truthfulness fix that traded
+    a lie for internal jargon); Collections stacks four "nothing here" sentences and still offers
+    no "Add to collection" anywhere; export scope "Everything" excludes Prompts/Skills/Collections;
+    `Type: plaintext` for a `.md` the viewer renders as markdown, with extensions stripped from
+    every list title.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Disabled controls meet a 3:1 floor, carry a non-colour marker, and state their reason at the control
+- [ ] #2 The Files strip renders on first paint; the Notes copy and the rendered controls agree
+- [ ] #3 Details DB sizes refresh rather than reporting a stale first reading
+- [ ] #4 F1 lists each binding once with one label per key, includes the keys its own footer advertises, and closes on a second press
+- [ ] #5 One footer grammar, one active-state marker vocabulary, and one meaning per glyph across the Library's canvases
+- [ ] #6 Search results are visible at the point of action, Enter runs the search, and one query model backs both inputs
+- [ ] #7 Each remaining copy/layout item is fixed or declined with a one-line reason in the notes
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Backlog + critique snapshot only — no product code.

Dual-agent re-critique of the Library screen and all subscreens after three fix arcs (PRs #1410, #1420, #1459). **22/40**; trend for this surface 23 → 21 → 27 → 22 → 22. Snapshot: `.impeccable/critique/2026-08-09T20-15-07Z__tldw-chatbook-ui-screens-library-screen-py.md`.

The **P0 already shipped** in PR #1464: `action_library_notes_escape` called `_back_from_library_note_editor()`, a method that never existed in any commit — Escape from the Notes editor terminated the app, on a canvas whose footer advertises `Esc Notes` as the way out.

Filed here:

- **task-4020 (high)** — nav ghosting no longer prevents mid-word tab cuts (`⌃6 Watc` at 80, `⌃9 M` at 120). The machinery is present; dev's overflow-menu replacement changed the scroll model task-3200's straddle detection was written against.
- **task-4021 (high)** — the blank-note GC is unreachable: the title is seeded with the literal string `"Untitled"`, so the emptiness predicate is always truthy. Confirmed by reading the path, not inferred. Prior art in an unmerged sibling branch (task-3315).
- **task-4022 (high)** — soft-deleted media is permanently un-importable (dedup matches deleted rows) while the confirm promises a trash that exists nowhere. Content ends up neither present nor restorable.
- **task-4023 (medium)** — the P1/P2 remainder: disabled-state contrast measured at 1.08:1–2.30:1, the Files strip missing on first paint, stale DB sizes, F1 contradicting itself, the interaction-grammar fracture, search burial, layout, copy.

## What the arcs bought

Eight of ten prior findings verified fixed with evidence — selection-scoped export proven by unzipping the bundle, the double-press guard holding, markdown rendering with a text-marked toggle, durable export receipts, no mid-word *rail* truncation at any width, 12/12 Tab stops visibly distinct.

The score held flat because three fixes cast shadows (Files mode's door lost, the new bulk buttons at 1.08:1, jargon replacing a lie) and because the inconsistency migrated rather than reduced: the old fracture was vocabulary and we fixed it; the new one is grammar — four footer dialects, three active-state markers, three toolbar layouts, one glyph with two meanings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filed the 2026-08-09 Library re-critique snapshot and added backlog tasks 4020–4023 to track high-priority Library issues. No product code changes; this documents a 22/40 score and queues follow-ups for nav ghosting, blank-note GC, soft-deleted media/trash, and a P1/P2 cleanup batch.

<sup>Written for commit b426d7d7a6653b8e41f7c08fcce2306d5ffe1b52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

