### PR TITLE
feat: concurrent sub-agents (supervisor fleet PR 2a)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -44,9 +44,12 @@ reply:
 - Status line: `Agent: idle`, or `Agent: running · step N` while working.
 - One `·`-prefixed line per step.
 - One line per sub-agent, prefixed `✓` (done), `●` (running), `⚠` (stuck), or
-  `✗` (error/cancelled). **Click a sub-agent line to drill in** — the status
-  line becomes `Sub-agent · <status> (Back)` with that run's own step lines;
-  the **Back** button returns to the main run.
+  `✗` (error/cancelled). Several of these can read `●` at once — sub-agents
+  the supervisor spawned in the same reply run in parallel, not one at a
+  time; see [Parallel sub-agents](#parallel-sub-agents-the-fleet). **Click a
+  sub-agent line to drill in** — the status line becomes `Sub-agent ·
+  <status> (Back)` with that run's own step lines; the **Back** button
+  returns to the main run.
 - **View full log** opens the "Full run log — <run id>" window: the complete,
   untruncated record ("what the model actually saw, before the Console's
   display cap trimmed it"). **Close** or **Esc** dismisses it.
@@ -93,6 +96,14 @@ current definition — if the server later changes the tool, the approval card
 comes back with a "(definition changed)" badge. Review or change a remembered
 allow from the tool's row on the [MCP screen](../mcp.md) 🚧.
 
+With sub-agents running in parallel (see below), more than one approval card
+can be pending at once — cards aren't merged across sub-agents: each is
+scoped to the one run that raised it, so deciding one card never resolves or
+touches another's. Cancelling that sub-agent (see
+[Stopping & leaving](#stopping--leaving)) withdraws only its own still-pending
+cards; a sibling sub-agent's card, or the parent's, is left exactly as it
+was.
+
 ### Background & parked runs
 
 Tabs with unwatched activity carry a status marker, listed in F1 help:
@@ -135,6 +146,40 @@ already streaming.
   `definition_fingerprint` (a content hash of its instructions, tools, and
   model at spawn time) are written on every named-agent spawn. Neither is
   currently surfaced in **View full log** or anywhere else in the UI.
+
+### Parallel sub-agents (the fleet)
+
+Sub-agents the supervisor spawns within a **single reply** no longer run one
+at a time — up to a configured number can be live together, each working its
+own task concurrently. The Agent rail shows this directly: several
+`●`-prefixed sub-agent lines can be running at once (see
+[Layout tour](#layout-tour--what-you-see-during-a-run) above).
+
+- **How results come back.** The supervisor has to explicitly collect a
+  sub-agent's result before it can use it — spawning one hands back a
+  handle, not an answer. It gathers results with its own internal
+  `wait_agents` step (optionally for just one sub-agent, to get that one's
+  answer back in full rather than sharing a combined budget with its
+  siblings) and can check progress without blocking via `check_agents`. This
+  is internal turn mechanics, not something you drive — the reply you see
+  simply arrives once every sub-agent it waited on has finished, and by then
+  it has already folded each result into its answer.
+- **Skills still run one at a time.** Running a skill (`$name`) always
+  returns that skill's own output directly into the same turn, never a
+  fleet handle — skills are not part of the parallel fleet.
+- **How many can run at once.** Capped at `[agents] max_live_subagents` in
+  `config.toml` (default **3**; no Settings UI switch — hand-edit the file).
+  Setting it to `1` turns the fleet off entirely: sub-agents go back to
+  running one at a time, synchronously, exactly as before. Trying to spawn
+  a sub-agent past the live cap is refused ("live sub-agent limit reached
+  (N already running); call wait_agents to collect a finished sub-agent
+  before starting another") rather than queued — the supervisor collects
+  a finished sub-agent to free a slot, then retries, and the refusal itself
+  doesn't count against its per-turn spawn budget. A bad value in the
+  config file never stops a run: zero or a negative number floors to `1`
+  (fleet off), and anything that isn't a number at all (letters, a blank)
+  falls back to the default of `3` (fleet on) — either way the run
+  proceeds instead of erroring.
 
 ### Skills
 
@@ -188,8 +233,11 @@ Import…** and submit its URL; Console does not advertise the retired
 ### Stopping & leaving
 
 - **Stop** (appears next to Send while a run is active) stops **this tab's
-  run only** — other tabs keep going. The partial reply is tagged
-  `[stopped]` and a System row records "Response stopped by user."
+  run only** — other tabs keep going. Any sub-agents still working for that
+  run are cancelled with it, and any of their approval cards still pending
+  are withdrawn (denied) at the same time — a sibling sub-agent's card
+  belonging to a *different* tab's run is untouched. The partial reply is
+  tagged `[stopped]` and a System row records "Response stopped by user."
 - Leaving the Console screen is different: after the "Leave Console?" confirm,
   **every** in-flight run is cancelled and every pending or parked approval is
   denied — never approved. Details in
@@ -233,7 +281,13 @@ Enter). Tab-fleet keys (Ctrl+T, Alt+1…9, Ctrl+K) are covered in
 - **Settings > Console Behavior** — "Max parallel agent runs" (saved as
   `console.max_parallel_runs`; raising it is allowed without limit) and
   "Tool result display cap" (how much of a tool result the transcript
-  preview shows).
+  preview shows). This caps parallel **tabs**, a different knob from
+  `[agents] max_live_subagents` below, which caps parallel **sub-agents
+  within one reply**.
+- **`[agents] max_live_subagents`** in `config.toml` — how many sub-agents
+  of one reply may run at once (default 3; `1` disables the fleet). No
+  Settings UI switch; see [Parallel sub-agents](#parallel-sub-agents-the-fleet)
+  above.
 - **Settings > Agents** — create and manage the named agent definitions the
   supervisor can delegate to; see [Named agents](#named-agents) above.
 - [Library ▸ Skills](../library/skills.md) — create, import, review, and

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -317,4 +317,11 @@ against dev @ 3dd3e7431 — 2026-08-09 (fleet PR-1: driven live — Console
 delegated to a real named definition, the transcript showed the
 `[researcher]` sub-agent marker, and the reply visibly honored the
 definition's instructions; the rest of this page's content unchanged from
-the prior stamp).*
+the prior stamp). Parallel sub-agents section, concurrent-approval-card
+scoping, and the `max_live_subagents` knob added @ d21a91649 — 2026-08-10
+(fleet PR2a Task 8: driven live — a single reply spawned two sub-agents at
+once, both appeared in the Agent rail with their own handle ids and
+results, the reply incorporated both, `sqlite3` showed two terminal child
+run rows, and Stop mid-fleet cancelled two live children with zero rows
+left `running`; the rest of this page's content unchanged from the prior
+stamp).*

--- a/Docs/superpowers/plans/2026-08-09-supervisor-fleet-pr2a-concurrency-runtime.md
+++ b/Docs/superpowers/plans/2026-08-09-supervisor-fleet-pr2a-concurrency-runtime.md
@@ -1,0 +1,751 @@
+# Supervisor Fleet PR 2a — Concurrency Runtime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sub-agents run concurrently on their own threads under a `FleetCoordinator`, with `wait_agents`/`check_agents` runtime tools, while every shared seam the old one-child-at-a-time design relied on (both permission gates, the tool registry cache, run-status writes, step attribution) is made concurrency-safe.
+
+**Architecture:** A new pure-ish `FleetCoordinator` (`Agents/fleet_coordinator.py`) owns child handles, the live-children cap, and the outbound event queue; `agent_service`'s spawn closure registers + launches instead of running inline. Phase 2 keeps children **turn-scoped** (the turn does not end until every child is finished or cancelled), but the coordinator is built for the cross-turn lifetime PR 3a will enable — no throwaway model.
+
+**Tech Stack:** Python ≥3.11 (`threading`, `concurrent.futures` not required), Textual 8.x, SQLite WAL with per-thread held connections, pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-08-08-supervisor-agent-fleet-design.md` §5 (phase 2 rows of the corrections table are mandatory, not optional) + §3 invariants. Read both before Task 1.
+
+## Global Constraints
+
+- Worktree `.worktrees/fleet-pr2a`, branch `feat/fleet-concurrency-runtime` (already cut from merged dev). NEVER run git outside it. NEVER use `git stash` (shared across 100+ worktrees). Push after every task.
+- pytest is the ONLY python entry point. A bare `python -c` importing `tldw_chatbook.config` triggers the app's config-rewrite and has touched the user's LIVE config — never do it. Never read/write `~/.config/tldw_cli` or `~/.local/share/tldw_cli`.
+- `agent_models.py` and `agent_runtime.py` stay pure (stdlib only; no Textual/app/DB/I/O). `fleet_coordinator.py` may import `threading` and stdlib only — no DB, no Textual. The impure wiring lives in `agent_service.py`.
+- **Byte-identical single-child behavior is an acceptance criterion.** With `max_live_subagents=1` (or one spawn), observable behavior — ordering of steps, run rows, results, budget accounting — must match pre-PR. The existing spawn suite is the guard; it must pass unmodified.
+- Depth-1 stays structural: children never spawn (`clamp_child_budget` zeroes `max_subagents`); fleet tools are primary-only, pinned like `install_skill`.
+- Intersection-never-union and the identity-contract prompt append (PR 1) are untouched.
+- `clamp_child_budget` stays byte-identical in this PR (turn-scoped children must still die with the parent). Containment changes land in PR 3a.
+- Commit trailer: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+### Verified seam map (current dev, `f24f8c692`) — cite these, do not re-derive
+
+| Seam | Location |
+|---|---|
+| spawn closure signature | `agent_service.py:691-696` (`spawn_task`, kw-only `allowed_tools`, `agent`) |
+| `sub_agent_spawns` counter | `agent_service.py:689` — a local of `_run_one` |
+| budget gate + increment | `agent_service.py:737-739` |
+| inline child call | `agent_service.py:814-830`, inside `with scope:` |
+| child result handling | `agent_service.py:831-841` |
+| `_run_one` signature | `agent_service.py:526-539` |
+| `on_step` invocation | `agent_service.py:1379-1383` — `lambda s: self._on_step(s, agent_kind)`, **no run_id** |
+| `set_status` UPDATE | `AgentRuns_DB.py:659-664` — unconditional |
+| registry caches + race comment | `tool_catalog.py:893-907`, `_ensure_catalog_cache:976-1006`, `invoke_by_name:1032-1063` |
+| MCP gate state | `mcp_tool_provider.py:214` `_stamped_decisions` (keyed by llm_name), `stamp_scope:406-434`, `apply_batch_decisions:367-386` |
+| builtin gate state | `builtin_tool_gate.py:65-67` `_stamps` (keyed by tool_name), `begin_turn:68-79`, `stamp_scope:79-117` |
+| `begin_turn` call site | `console_chat_controller.py:518` (only production caller) |
+| `stamp_scope` composition | `console_agent_bridge.py:2021-2036` via `_combine_state_scopes:188` |
+| approval round key | `console_chat_controller.py:2752` — `round_id = str(uuid4())` — **already globally unique; no re-keying needed** |
+| approval round registry | `console_chat_controller.py:2763-2768`, `add_pending_round:1498`, `discard_pending_round:1537` |
+| approval timeout enforcement | `console_chat_controller.py:2770-2771`, `2840`, `2867-2870` |
+| `AgentService` lifetime | constructed **per turn** at `console_agent_bridge.py:2063`; the `ToolCatalogRegistry` is **long-lived on the bridge** |
+
+---
+
+### Task 1: `FleetCoordinator` + `FleetHandle` (pure, no I/O)
+
+**Files:**
+- Create: `tldw_chatbook/Agents/fleet_coordinator.py`
+- Test: Create `Tests/Agents/test_fleet_coordinator.py`
+
+**Interfaces:**
+- Consumes: `AgentStep`, run-status constants from `agent_models`.
+- Produces (imported by Tasks 2-5):
+  - `FleetHandle` dataclass: `handle_id: str`, `run_id: str | None`, `agent: str | None`, `task: str`, `status: str`, `result: str = ""`, `error: str = ""`, `started_at: float`, `finished_at: float | None`
+  - `FleetEvent` frozen dataclass: `kind: str` (`FLEET_STARTED`/`FLEET_FINISHED`), `handle_id: str`, `run_id: str | None`, `agent: str | None`, `status: str`
+  - `FleetCoordinator(max_live: int, clock: Callable[[], float])` with methods: `reserve(task, agent) -> FleetHandle | None` (None when at cap), `attach_run(handle_id, run_id)`, `finish(handle_id, status, result="", error="")`, `get(handle_id) -> FleetHandle | None`, `snapshot() -> list[FleetHandle]`, `live_count() -> int`, `drain_events() -> list[FleetEvent]`, `all_finished() -> bool`
+  - Constants `FLEET_STARTED`, `FLEET_FINISHED`
+- Thread-safety: every public method takes one `threading.RLock`. `snapshot()` returns copies, never internal objects.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""FleetCoordinator: pure handle/state machine for concurrent children."""
+
+import threading
+
+import pytest
+
+from tldw_chatbook.Agents.agent_models import RUN_DONE, RUN_ERROR
+from tldw_chatbook.Agents.fleet_coordinator import (
+    FLEET_FINISHED,
+    FLEET_STARTED,
+    FleetCoordinator,
+)
+
+
+def _coord(max_live=3):
+    ticks = iter(range(1000))
+    return FleetCoordinator(max_live=max_live, clock=lambda: float(next(ticks)))
+
+
+def test_reserve_returns_handle_and_emits_started():
+    c = _coord()
+    h = c.reserve(task="do x", agent="researcher")
+    assert h is not None and h.task == "do x" and h.agent == "researcher"
+    assert h.status == "running" and h.finished_at is None
+    events = c.drain_events()
+    assert [e.kind for e in events] == [FLEET_STARTED]
+    assert events[0].handle_id == h.handle_id
+    assert c.drain_events() == []  # drain is destructive
+
+
+def test_reserve_refuses_past_live_cap():
+    c = _coord(max_live=2)
+    assert c.reserve(task="a", agent=None) is not None
+    assert c.reserve(task="b", agent=None) is not None
+    assert c.reserve(task="c", agent=None) is None
+    assert c.live_count() == 2
+
+
+def test_finish_frees_a_slot_and_emits_finished():
+    c = _coord(max_live=1)
+    h = c.reserve(task="a", agent=None)
+    assert c.reserve(task="b", agent=None) is None
+    c.finish(h.handle_id, RUN_DONE, result="answer")
+    assert c.live_count() == 0
+    assert c.reserve(task="b", agent=None) is not None
+    kinds = [e.kind for e in c.drain_events()]
+    assert kinds == [FLEET_STARTED, FLEET_FINISHED, FLEET_STARTED]
+    done = c.get(h.handle_id)
+    assert done.status == RUN_DONE and done.result == "answer"
+    assert done.finished_at is not None
+
+
+def test_finish_is_idempotent_first_writer_wins():
+    # A child abandoned after a join timeout can finish LATE; the
+    # coordinator must not let it overwrite a terminal status.
+    c = _coord()
+    h = c.reserve(task="a", agent=None)
+    c.finish(h.handle_id, "cancelled")
+    c.finish(h.handle_id, RUN_DONE, result="late answer")
+    assert c.get(h.handle_id).status == "cancelled"
+    assert c.get(h.handle_id).result == ""
+
+
+def test_attach_run_records_run_id():
+    c = _coord()
+    h = c.reserve(task="a", agent=None)
+    c.attach_run(h.handle_id, "run-123")
+    assert c.get(h.handle_id).run_id == "run-123"
+    c.finish(h.handle_id, RUN_ERROR, error="boom")
+    assert c.drain_events()[-1].run_id == "run-123"
+
+
+def test_snapshot_returns_copies_not_internals():
+    c = _coord()
+    h = c.reserve(task="a", agent=None)
+    snap = c.snapshot()
+    snap[0].status = "tampered"
+    assert c.get(h.handle_id).status == "running"
+
+
+def test_all_finished_reflects_live_state():
+    c = _coord()
+    assert c.all_finished() is True
+    h = c.reserve(task="a", agent=None)
+    assert c.all_finished() is False
+    c.finish(h.handle_id, RUN_DONE)
+    assert c.all_finished() is True
+
+
+def test_concurrent_reserve_never_exceeds_cap():
+    c = _coord(max_live=5)
+    got = []
+    lock = threading.Lock()
+
+    def worker():
+        h = c.reserve(task="t", agent=None)
+        with lock:
+            got.append(h)
+
+    threads = [threading.Thread(target=worker) for _ in range(40)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert sum(1 for h in got if h is not None) == 5
+    assert c.live_count() == 5
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Agents/test_fleet_coordinator.py -v`
+Expected: FAIL / ImportError (no `fleet_coordinator` module).
+
+- [ ] **Step 3: Implement**
+
+Write `tldw_chatbook/Agents/fleet_coordinator.py`. Requirements the tests pin:
+- Module docstring stating: pure state machine, stdlib only (`threading`, `dataclasses`, `uuid`, `typing`), no DB/Textual/I/O — mirrors `agent_runtime`'s purity rule; the impure thread launching lives in `agent_service`.
+- One `threading.RLock` guarding all state. `reserve` checks the cap and inserts atomically under the lock (the concurrency test proves it).
+- `finish` ignores a second call on an already-terminal handle (**first-writer-wins**) and only then appends `FLEET_FINISHED`; document that this exists because an abandoned thread can finish after the coordinator already cancelled it.
+- `drain_events` returns and clears the queue under the lock.
+- `handle_id` from `uuid.uuid4().hex`.
+- `snapshot`/`get` return `dataclasses.replace(...)` copies.
+- Type hints on every public method; Google-style docstrings (repo style).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Agents/test_fleet_coordinator.py -v`
+Expected: 8 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/fleet_coordinator.py Tests/Agents/test_fleet_coordinator.py
+git commit -m "feat: FleetCoordinator handle/state machine" && git push
+```
+
+---
+
+### Task 2: Terminal-status guard on `set_status`
+
+**Files:**
+- Modify: `tldw_chatbook/DB/AgentRuns_DB.py` (`set_status`, `:647-664`)
+- Test: `Tests/DB/test_agent_runs_db.py` (append)
+
+**Interfaces:**
+- Produces: `set_status` becomes a no-op when the run is already terminal; adds `-> bool` (True when a row changed). Existing callers ignore the return value — verify `agent_service.py:524` still compiles unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_set_status_first_terminal_write_wins(db):
+    # A child abandoned after a join timeout can persist LATE; it must not
+    # overwrite the terminal status the coordinator already recorded.
+    run_id = db.create_run(conversation_id="c", agent_kind="subagent", task="t")
+    assert db.set_status(run_id, "cancelled") is True
+    assert db.set_status(run_id, "done", result="late answer") is False
+    run = db.get_run(run_id)
+    assert run["status"] == "cancelled"
+    assert run["result"] is None
+
+
+def test_set_status_still_updates_a_running_run(db):
+    run_id = db.create_run(conversation_id="c", agent_kind="primary")
+    assert db.set_status(run_id, "done", result="ok") is True
+    assert db.get_run(run_id)["status"] == "done"
+    assert db.get_run(run_id)["result"] == "ok"
+
+
+def test_set_status_missing_run_returns_false(db):
+    assert db.set_status("nope", "done") is False
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/DB/test_agent_runs_db.py -v -k set_status`
+Expected: FAIL (the late write currently wins; return is `None`).
+
+- [ ] **Step 3: Implement**
+
+In `set_status`, import `TERMINAL_RUN_STATUSES` from `..Agents.agent_models` (the module already imports from there for `AgentDefinition`) and add the guard to the UPDATE:
+
+```python
+        placeholders = ",".join("?" for _ in TERMINAL_RUN_STATUSES)
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                "UPDATE agent_runs SET status = ?, "
+                "result = COALESCE(?, result), updated_at = ? "
+                f"WHERE id = ? AND status NOT IN ({placeholders})",
+                (status, result, _now_iso(), run_id, *sorted(TERMINAL_RUN_STATUSES)),
+            )
+        return cursor.rowcount > 0
+```
+
+Update the docstring: state that a run already in a terminal status is never rewritten (first-writer-wins), because an abandoned child thread can persist after the coordinator recorded `cancelled`, and add a `Returns:` section.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/DB/test_agent_runs_db.py Tests/Agents/test_agent_runs_db_connection_reuse.py -v`
+Expected: ALL PASS (0 failures — the 3 trace-spy tests were repaired on dev; a failure here is yours).
+
+- [ ] **Step 5: Check `reconcile_orphaned_runs` still behaves**
+
+Run: `pytest Tests/DB/test_agent_runs_db.py -v -k reconcile`
+Expected: PASS. (It updates `WHERE status = 'running'`, so the new guard cannot affect it — confirm, don't assume.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/DB/AgentRuns_DB.py Tests/DB/test_agent_runs_db.py
+git commit -m "fix: first-writer-wins guard on terminal run status" && git push
+```
+
+---
+
+### Task 3: `run_id` on `on_step`
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_service.py` (`__init__:288`, the `LoopDeps` `on_step` at `:1379-1383`)
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py` (the `on_step` closure passed at `:2063`)
+- Test: `Tests/Agents/test_agent_service_on_step.py` (append), `Tests/Chat/test_console_agent_bridge.py` (verify unchanged)
+
+**Interfaces:**
+- Produces: `on_step` callback signature becomes `(step: AgentStep, agent_kind: str, run_id: str) -> None`. Every caller must be updated in the same task — an un-updated caller raises `TypeError` at runtime, not import time.
+
+- [ ] **Step 1: Write the failing test** (append to `Tests/Agents/test_agent_service_on_step.py`; read the file's existing helpers first and reuse them)
+
+```python
+def test_on_step_receives_run_id_for_primary_and_child(db):
+    seen = []
+    service, _chat = make_service_with_on_step(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "child work"}),
+            "child answer",
+            "parent answer",
+        ],
+        on_step=lambda step, kind, run_id: seen.append((kind, run_id, step.kind)),
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    primary_ids = {r for k, r, _ in seen if k == "primary"}
+    child_ids = {r for k, r, _ in seen if k == "subagent"}
+    assert primary_ids == {run_id}
+    assert len(child_ids) == 1 and child_ids.isdisjoint(primary_ids)
+    # Every step carries a non-empty run id.
+    assert all(r for _k, r, _s in seen)
+```
+
+(`make_service_with_on_step` may not exist — if the file builds the service inline, follow that shape instead and keep the assertions identical.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Agents/test_agent_service_on_step.py -v`
+Expected: FAIL — `TypeError: <lambda>() takes 2 positional arguments but 3 were given`.
+
+- [ ] **Step 3: Implement**
+
+- `agent_service.py:288`: `on_step: Callable[[AgentStep, str, str], None] | None = None,`
+- `agent_service.py:1379-1383`: `(lambda s: self._on_step(s, agent_kind, run_id))` — `run_id` is already in scope in `_run_one` (assigned at `:541`). Verify that by reading, not assuming.
+- `console_agent_bridge.py`: find the `on_step` closure passed at `:2063` and widen its signature to accept `run_id`. **Do not** change what it does with it in this task (PR 2b consumes it); just accept and ignore, with a comment saying PR 2b routes fleet rows by it.
+- Grep the whole repo for other `on_step=` call sites (tests included) and update every one: `grep -rn "on_step" --include=*.py`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Agents/ Tests/Chat/test_console_agent_bridge.py -q`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u && git commit -m "feat: attribute steps to their run id" && git push
+```
+
+---
+
+### Task 4: Registry cache lock
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/tool_catalog.py` (`ToolCatalogRegistry.__init__`, `_ensure_catalog_cache`, `reset_catalog_cache`, `register_provider`, `resolve_name`, `_owner_and_id`, `_source_for`)
+- Test: Create `Tests/Agents/test_tool_catalog_concurrency.py`
+
+**Interfaces:**
+- Produces: no signature changes — internal `threading.RLock` only. `invoke_by_name`'s two reads become one locked snapshot read.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Registry cache under concurrent lookups (fleet PR 2a).
+
+The registry's own comment (tool_catalog.py:893-907) documents that
+`_owner_cache` and `_name_to_id_cache` are rebuilt without a lock, so two
+concurrent lookups can observe different generations. With N children on
+their own threads sharing the bridge's long-lived registry, that stops
+being exotic.
+"""
+
+import threading
+
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
+
+
+def test_concurrent_resolution_never_sees_a_torn_cache():
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    known = [e.name for e in registry.list_catalog()]
+    assert known, "catalog must be non-empty for this test to mean anything"
+
+    errors = []
+    barrier = threading.Barrier(8)
+
+    def hammer():
+        barrier.wait()
+        for _ in range(200):
+            registry.reset_catalog_cache()
+            for name in known:
+                tool_id = registry.resolve_name(name)
+                if tool_id is None:
+                    errors.append(f"resolve_name({name}) -> None")
+                    return
+
+    threads = [threading.Thread(target=hammer) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []
+```
+
+- [ ] **Step 2: Run to verify it fails (or is flaky) before the fix**
+
+Run: `pytest Tests/Agents/test_tool_catalog_concurrency.py -v` — repeat up to 5 times.
+Expected: at least one run FAILS (a `resolve_name -> None` while another thread reset the cache). Record what you observed. **If it never fails in 5 runs, say so in your report** — implement the lock anyway (the race is documented in the code and the fleet makes it routine), but do not claim you reproduced it.
+
+- [ ] **Step 3: Implement**
+
+- `__init__`: add `self._cache_lock = threading.RLock()` (import `threading` at module top).
+- `_ensure_catalog_cache`: take the lock around the check-and-rebuild. Return the three maps as a tuple so callers get one coherent generation instead of re-reading fields.
+- `reset_catalog_cache` and `register_provider`: take the lock around the `= None` invalidations.
+- `resolve_name`, `_owner_and_id`, `_source_for`: read via the locked snapshot.
+- `invoke_by_name`: get name→id and owner from **one** locked call so a reset between the two reads can no longer produce the "provider is None" fallback. Keep that fallback branch (defense in depth) and update its comment to say the lock now makes it unreachable in-process.
+- Update the `__init__` warning comment (`:893-907`) to record that the lock closed this, keeping the historical explanation.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Agents/test_tool_catalog_concurrency.py -v` — run it 5 times; all must pass.
+Then: `pytest Tests/Agents/ -q` — ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/tool_catalog.py Tests/Agents/test_tool_catalog_concurrency.py
+git commit -m "fix: lock the tool-catalog cache for concurrent children" && git push
+```
+
+---
+
+### Task 5: Per-run scoping for BOTH permission gates
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/builtin_tool_gate.py` (`_stamps`, `begin_turn`, `stamp`, `stamped/resolve` readers, `stamp_scope`)
+- Modify: `tldw_chatbook/Agents/mcp_tool_provider.py` (`_stamped_decisions`, `apply_batch_decisions`, `stamped_decision`, `stamp_scope`)
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (`begin_turn` call at `:518`; the `apply_batch_decisions` calls at `:360,365,535,543,681,744,753`)
+- Test: `Tests/Agents/test_gate_run_scoping.py` (create); `Tests/Agents/test_agent_service_review_state_scope.py` (must still pass)
+
+**Interfaces:**
+- Produces: both gates key their per-turn verdict state by `(run_id, name)` instead of `name`. Public methods gain a `run_id: str` parameter. `stamp_scope` remains for backward compatibility but becomes a no-op-shaped context manager scoped to one run id.
+- The **current** design is snapshot/restore (LIFO), which is only sound for a nested inline child. With N children on their own threads there is no LIFO: a child's `begin_turn` clears stamps its siblings and parent are still consuming.
+
+- [ ] **Step 1: Write the failing tests** (`Tests/Agents/test_gate_run_scoping.py`)
+
+```python
+"""Both permission gates must key verdicts per RUN, not per tool name.
+
+Pre-fix, `BuiltinToolGate.begin_turn()` cleared a dict keyed by tool name
+on a SHARED gate instance, and `MCPToolProvider.apply_batch_decisions`
+REPLACED its dict wholesale — so with concurrent children, one child's
+turn wipes or overwrites a verdict a sibling (or the parent) already
+decided and has not yet consumed.
+"""
+
+import threading
+
+from tldw_chatbook.Agents.builtin_tool_gate import BuiltinToolGate
+from tldw_chatbook.Agents.mcp_tool_provider import MCPToolProvider
+
+
+def test_builtin_gate_stamps_do_not_leak_across_runs():
+    gate = BuiltinToolGate(service=None)
+    gate.begin_turn("run-parent")
+    gate.stamp("run-parent", "calculator", "proceed")
+    # A concurrent child starts its own turn on the SAME gate instance.
+    gate.begin_turn("run-child")
+    gate.stamp("run-child", "calculator", "deny")
+    # The parent's verdict must survive the child's turn untouched.
+    assert gate.stamped("run-parent", "calculator") == "proceed"
+    assert gate.stamped("run-child", "calculator") == "deny"
+
+
+def test_builtin_gate_begin_turn_clears_only_its_own_run():
+    gate = BuiltinToolGate(service=None)
+    gate.begin_turn("run-a")
+    gate.stamp("run-a", "calculator", "proceed")
+    gate.begin_turn("run-b")
+    assert gate.stamped("run-a", "calculator") == "proceed"
+    gate.begin_turn("run-a")  # a's NEXT turn clears a's stamps
+    assert gate.stamped("run-a", "calculator") is None
+
+
+def test_mcp_decisions_do_not_clobber_across_runs():
+    provider = MCPToolProvider.__new__(MCPToolProvider)
+    provider._init_decision_state()  # helper added by this task
+    provider.apply_batch_decisions("run-parent", {"srv__tool": "proceed"})
+    provider.apply_batch_decisions("run-child", {"srv__tool": "deny"})
+    assert provider.stamped_decision("run-parent", "srv__tool") == "proceed"
+    assert provider.stamped_decision("run-child", "srv__tool") == "deny"
+
+
+def test_concurrent_runs_keep_their_own_verdicts():
+    gate = BuiltinToolGate(service=None)
+    errors = []
+
+    def worker(i):
+        run = f"run-{i}"
+        gate.begin_turn(run)
+        gate.stamp(run, "calculator", f"verdict-{i}")
+        for _ in range(200):
+            if gate.stamped(run, "calculator") != f"verdict-{i}":
+                errors.append(run)
+                return
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Agents/test_gate_run_scoping.py -v`
+Expected: FAIL — `begin_turn()` takes no run_id (TypeError), which is the point.
+
+- [ ] **Step 3: Implement**
+
+Builtin gate:
+- `self._stamps: dict[tuple[str, str], str]` keyed `(run_id, tool_name)`; `self._payload` may stay global (it is config, not per-run) — verify by reading `_load_payload` before deciding, and say which you chose in your report.
+- `begin_turn(run_id)`: drop only that run's keys.
+- `stamp(run_id, tool_name, decision)`, `stamped(run_id, tool_name)`, and any resolver that reads a stamp: thread `run_id` through.
+- Guard all mutation with a `threading.RLock` (concurrent children mutate one instance).
+- `stamp_scope(run_id)`: keep as a compatibility context manager that snapshots/restores only that run's keys; document that per-run keying is now the real mechanism and this exists for the nested/inline path.
+
+MCP provider: same treatment for `_stamped_decisions` → `(run_id, llm_name)`; `apply_batch_decisions(run_id, decisions)` merges into that run's slice instead of replacing the whole dict; `stamped_decision(run_id, llm_name)`. Add `_init_decision_state()` (used by the test to build a bare instance) that initializes the dict + lock; call it from `__init__`.
+
+Callers: `console_chat_controller.py:518` `begin_turn` and the seven `apply_batch_decisions` call sites must pass the run id. **The controller does not currently know the run id** — thread it from the review hook. Read `build_tool_review_hook`/`build_mcp_review_hook` and `agent_service`'s `review_tool_calls` invocation first: the cleanest seam is for `AgentService` to pass its `run_id` into `review_tool_calls`. If that requires widening `LoopDeps.review_tool_calls`, do it and update every call site; state the chosen seam in your report.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Agents/test_gate_run_scoping.py Tests/Agents/test_builtin_tool_gate.py Tests/Agents/test_agent_service_review_state_scope.py Tests/Chat/test_console_chat_controller.py Tests/UI/test_console_mcp_approval.py -q`
+Expected: ALL PASS. `test_agent_service_review_state_scope.py` is the C1 regression suite — it MUST stay green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u && git commit -m "fix: key permission-gate verdicts per run" && git push
+```
+
+---
+
+### Task 6: Threaded spawn + `wait_agents`/`check_agents`
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_models.py` (two tool-name constants + `RUNTIME_TOOL_NAMES`)
+- Modify: `tldw_chatbook/Agents/tool_catalog.py` (two `ToolSchema`s)
+- Modify: `tldw_chatbook/Agents/agent_runtime.py` (`LoopDeps` fields + dispatch branches)
+- Modify: `tldw_chatbook/Agents/agent_service.py` (coordinator wiring, threaded spawn, tool implementations, end-of-turn join)
+- Test: `Tests/Agents/test_fleet_runtime.py` (create); existing spawn suites must pass unmodified
+
+**Interfaces:**
+- Consumes: Task 1's coordinator, Task 2's guard, Task 3's run_id.
+- Produces: `WAIT_AGENTS_TOOL_NAME = "wait_agents"`, `CHECK_AGENTS_TOOL_NAME = "check_agents"`; `spawn(...)` returns immediately with a handle id in its `ToolResult.content`.
+
+- [ ] **Step 1: Write the failing tests** (`Tests/Agents/test_fleet_runtime.py`; reuse `Tests/Agents/test_agent_service.py`'s `ScriptedChat`/`make_service`/`fence`/`CFG` helpers — import or copy their shape)
+
+```python
+def test_two_children_run_concurrently_and_wait_collects_both(db):
+    # Parent spawns two, then waits; both results come back.
+    service, chat = make_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one"}),
+            fence(SPAWN_TOOL_NAME, {"task": "task two"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "combined answer",
+            # child scripts are consumed by the child threads:
+            "answer one",
+            "answer two",
+        ],
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert db.count_subagent_runs("c") == 2
+    # Both children's results reached the parent's wait result.
+    wait_results = [
+        m for m in chat.calls[-1]["messages_payload"]
+        if "answer one" in str(m.get("content", ""))
+    ]
+    assert wait_results
+
+
+def test_spawn_returns_handle_without_blocking(db):
+    # The spawn tool result must name a handle, not the child's answer.
+    ...
+
+
+def test_check_agents_reports_status_without_blocking(db):
+    ...
+
+
+def test_live_cap_refuses_beyond_max_live_subagents(db):
+    ...
+
+
+def test_end_of_turn_waits_for_stragglers(db):
+    # Parent finishes its text without calling wait_agents; the service
+    # must not return until children are finished or cancelled, and no
+    # run row may be left 'running'.
+    ...
+
+
+def test_single_child_path_is_unchanged(db):
+    # Byte-identical AC: one spawn + wait behaves exactly like the old
+    # inline path — same run rows, same result text.
+    ...
+```
+
+Fill in every `...` with real code before running — a plan-shaped stub is not a test. Model each on the existing `test_spawn_creates_linked_child_with_clean_context` arrangement.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Agents/test_fleet_runtime.py -v`
+Expected: FAIL (no `wait_agents`).
+
+- [ ] **Step 3: Implement**
+
+1. `agent_models.py`: add both name constants and include them in `RUNTIME_TOOL_NAMES`.
+2. `tool_catalog.py`: `WAIT_AGENTS_SCHEMA` (optional `ids: array of string`; omitted = all) and `CHECK_AGENTS_SCHEMA` (no params).
+3. `agent_service.__init__`: accept `fleet_coordinator: FleetCoordinator | None = None`; when None, build one per `run_turn` sized from config (`[agents] max_live_subagents`, default 3) — read the config the way the service already reads settings, or take it as a constructor arg from the bridge if the service has no config access (check first; state which you chose).
+4. Spawn closure: replace the inline `with scope: self._run_one(...)` block (`:814-830`) with: `reserve` on the coordinator (refuse with a clear `ToolResult` when at cap), start a daemon `threading.Thread` running the child's `_run_one` with the SAME arguments, `attach_run` when the child's run id is known, `finish` in a `finally`. Return `ToolResult(ok=True, content=f"started {handle_id}: <task snippet>")`. **Keep `sub_agent_spawns` and the budget check exactly where they are** — spawns-per-turn is unchanged; the coordinator cap is a separate, additional bound.
+   - The child thread must catch every exception and `finish(handle_id, RUN_ERROR, error=...)` — an uncaught exception on a daemon thread would otherwise strand the parent's join.
+   - `scope` (`review_state_scope`) is **no longer** the mechanism protecting gate state (Task 5 replaced it); keep acquiring it around the child for the non-fleet/local-provider scopes, but note in a comment that per-run keying is the load-bearing protection now.
+5. `wait_agents(ids=None)`: poll the coordinator until the named (or all) handles are terminal, `should_cancel` each poll, bounded by the parent's remaining wall-clock; on cancel/timeout, cooperatively cancel outstanding children. Compose the result: one entry per child, each truncated to `max_subagent_result_chars`, and the WHOLE result additionally budgeted to `max_tool_result_chars` split evenly across children (spec §5 — otherwise 5 children × 4000 chars silently truncates mid-result). Tell the model it can re-fetch one child in full via `wait_agents([id])`.
+6. `check_agents()`: format `coordinator.snapshot()` as compact lines (handle, agent, status, elapsed).
+7. `_run_one` schema pinning: add both schemas next to `build_spawn_schema(...)` (`:543` area) gated on `agent_kind == AGENT_KIND_PRIMARY` **and** `max_subagents > 0`, mirroring `install_skill`'s primary-only gate.
+8. `agent_runtime.py`: add `wait_agents`/`check_agents` to `LoopDeps` and dispatch branches beside `SPAWN_TOOL_NAME`. Both must be dispatched **in-loop** (like spawn), not through `invoke_tool`'s per-call timeout wrapper.
+9. End of `run_turn`: after `_run_one` returns, if any child is still live, wait (bounded by remaining wall-clock), then cooperative-cancel, then abandon after a **5s join timeout**, marking abandoned handles `cancelled` (Task 2's DB guard makes a late child write a no-op).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Agents/test_fleet_runtime.py -v`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Prove the no-fleet path is untouched**
+
+Run: `pytest Tests/Agents/ Tests/Chat/test_console_agent_bridge.py Tests/Agents/test_skill_tool_spawn.py -q`
+Expected: ALL PASS — the pre-existing spawn/skill suites are the byte-identical guard and must be unmodified. If you had to change ANY existing test, stop and report it as a deviation with the reason.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u && git commit -m "feat: concurrent sub-agents with wait_agents/check_agents" && git push
+```
+
+---
+
+### Task 7: Cancellation revokes pending approval cards
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (round registry; add a revoke entry point)
+- Modify: `tldw_chatbook/Agents/agent_service.py` (call revoke when a child is cancelled/abandoned)
+- Test: `Tests/UI/test_console_mcp_approval.py` or `Tests/Chat/test_console_chat_controller.py` (append — put it where the round-accounting tests already live)
+
+**Interfaces:**
+- Consumes: Task 6's cancellation path; Task 3's run_id.
+- Produces: `ConsoleChatController.revoke_approval_rounds_for_run(run_id) -> int` — resolves every outstanding round belonging to that run as `"deny"`, sets its event, and removes the card.
+
+**Why (spec §6, safety item):** the approval wait happens inside `_call_with_timeout`'s per-call daemon thread. If a child is cancelled or abandoned while a card is on screen, the user can still approve it and the tool executes for real (file written, message sent) while the run reads `cancelled`. The documented invariant `approval_timeout < max_tool_call_seconds` exists for exactly this class of hazard.
+
+- [ ] **Step 1: Write the failing test**
+
+Model it on the existing approval-round tests. Shape:
+```python
+def test_revoking_a_run_denies_its_outstanding_rounds(controller_fixture):
+    # Arm a round for run-A and one for run-B, revoke run-A, assert:
+    #  - run-A's decisions are all "deny" and its event is set
+    #  - run-A's round is gone from _pending_approval_rounds / _pending_approvals
+    #  - run-B's round is untouched and still pending
+```
+Write it fully against the real controller fixtures in that file — read two neighboring round tests first and match their construction exactly.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/UI/test_console_mcp_approval.py -v -k revok`
+Expected: FAIL (no such method).
+
+- [ ] **Step 3: Implement**
+
+- Record the owning `run_id` alongside each round when it is armed (`:2763-2768` stores a dict already — add the key; the run id arrives via Task 5's threading of run_id into the review hook).
+- `revoke_approval_rounds_for_run(run_id)`: under `_approval_state_lock`, find matching rounds, fill every undecided name with `"deny"`, set the event (so the waiting thread returns immediately), discard from `_pending_approvals`, and remove the card from the UI the same way a resolved card is removed (find that path; do not invent a second removal mechanism).
+- Wire it: when the fleet cancels or abandons a child, call it for that child's run id. If `AgentService` has no controller reference, add an optional `revoke_approvals: Callable[[str], None] | None = None` constructor seam wired by the bridge — same pattern as the other injected seams.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/UI/test_console_mcp_approval.py Tests/Chat/test_console_chat_controller.py -q`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u && git commit -m "fix: revoke pending approval cards when a child is cancelled" && git push
+```
+
+---
+
+### Task 8: Provider thread-safety audit + config + docs
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/mcp_tool_provider.py` (execution lock, pending audit outcome)
+- Modify: config defaults (`[agents] max_live_subagents`) wherever provider defaults live — find it, do not guess
+- Modify: `Docs/User_Guide/console/agent-runs-and-tools.md`
+- Test: whatever the audit requires; `Tests/Agents/test_fleet_runtime.py` (append a cap-from-config test)
+
+- [ ] **Step 1: Audit each provider's `invoke` for shared mutable state**
+
+For each of `MCPToolProvider`, `BuiltinToolProvider`, `LocalToolProvider` (and any other registered provider): read `invoke` and every attribute it touches; list what is shared mutable state across concurrent calls. Write the findings into your report as a table (provider → shared state → safe/unsafe → decision).
+
+- [ ] **Step 2: Lock what is not proven safe**
+
+Per spec §5: an unaudited or unsafe provider gets a per-provider `threading.Lock` around `invoke` (serializes that provider's calls across the fleet — a throttle, not a break). **MCP starts locked until proven otherwise.** Add the lock with a comment naming what it protects and what would let a future task remove it.
+
+- [ ] **Step 3: Config knob**
+
+Add `[agents] max_live_subagents` (default 3) to the config defaults and make the coordinator read it. Add a test that a config value of 1 makes a second concurrent spawn refuse with the cap message.
+
+- [ ] **Step 4: Docs**
+
+Update `Docs/User_Guide/console/agent-runs-and-tools.md`: sub-agents can now run in parallel within a reply; the supervisor collects results with `wait_agents`; approval cards name the agent; cancelling cancels its pending cards; the new config knob. Update the "Verified against" stamp (`*Verified against dev @ <short-sha> — <YYYY-MM-DD>*`) using the sha of your final content commit.
+
+- [ ] **Step 5: Full targeted battery**
+
+```bash
+pytest Tests/Agents/ Tests/DB/test_agent_runs_db.py Tests/Chat/test_console_agent_bridge.py \
+  Tests/Chat/test_console_chat_controller.py Tests/UI/test_console_mcp_approval.py -q
+pytest --collect-only -q | tail -2
+```
+Expected: 0 failures; collect-only clean. READ and report the counts.
+
+- [ ] **Step 6: Live verification** (per `backlog/docs/lessons-live-verification.md`)
+
+tmux, scratch `TLDW_CONFIG_PATH` (never the live config), real provider key from a repo-root `*-api-key.txt` (note: `openrouter-api-key.txt` returns 401 on chat completions — use another). Verify and capture panes: (1) a prompt that makes the supervisor spawn two agents in one reply, (2) both appear in the rail's sub-agent section, (3) the reply incorporates both results, (4) `sqlite3` shows two child run rows, both terminal, (5) Stop mid-fleet leaves no run row in `running`. If a check cannot be completed after 2-3 genuine attempts, STOP and report exactly what you saw — never fabricate evidence.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -u && git commit -m "feat: provider locks, fleet config knob, docs" && git push
+```
+
+---
+
+## Self-review notes (already applied)
+
+- Spec §5 phase-2 rows all covered: coordinator+threads (T6), wait/check (T6), both gates per-run (T5), registry lock (T4), on_step run_id (T3), set_status guard (T2), card revocation (T7), provider audit/locks (T8).
+- **Approval-round keying is already correct on dev** — rounds use `uuid4()`, so the spec's "audit that round keys are globally unique" item is resolved with no code change; T7 only adds run ownership so revocation can target them.
+- `clamp_child_budget` deliberately untouched (spec §5: the swap belongs to PR 3a).
+- Deferred-to-PR-2a items from task-13154 that are IN scope here: convert the spawn-closure `assert` to a raise (do it in T6 while rewriting that closure); add a load-once-per-turn call-count guard (add it in T6's test file).
+- Known live-surface weakness for PR 2b (not this PR): live `SubAgentSummary` rows are appended once at `STEP_SPAWN` and never updated, so they always read "running" until the historical path re-derives them.

--- a/Docs/superpowers/plans/2026-08-09-supervisor-fleet-pr2a-concurrency-runtime.md
+++ b/Docs/superpowers/plans/2026-08-09-supervisor-fleet-pr2a-concurrency-runtime.md
@@ -15,7 +15,21 @@
 - Worktree `.worktrees/fleet-pr2a`, branch `feat/fleet-concurrency-runtime` (already cut from merged dev). NEVER run git outside it. NEVER use `git stash` (shared across 100+ worktrees). Push after every task.
 - pytest is the ONLY python entry point. A bare `python -c` importing `tldw_chatbook.config` triggers the app's config-rewrite and has touched the user's LIVE config — never do it. Never read/write `~/.config/tldw_cli` or `~/.local/share/tldw_cli`.
 - `agent_models.py` and `agent_runtime.py` stay pure (stdlib only; no Textual/app/DB/I/O). `fleet_coordinator.py` may import `threading` and stdlib only — no DB, no Textual. The impure wiring lives in `agent_service.py`.
-- **Byte-identical single-child behavior is an acceptance criterion.** With `max_live_subagents=1` (or one spawn), observable behavior — ordering of steps, run rows, results, budget accounting — must match pre-PR. The existing spawn suite is the guard; it must pass unmodified.
+- **Byte-identical behavior AC — amended 2026-08-09 after Task 6 (the original was unsatisfiable).**
+  The original constraint required all three of: (i) byte-identical at `max_live_subagents=1`
+  *or one spawn*, (ii) the existing spawn suites pass unmodified, (iii) default 3 (Task 8).
+  These cannot all hold: those suites drive one ordered reply queue and index
+  `chat.calls[1]`, and they assert the *spawn* tool_result carries the child's capped text —
+  all three encode inline **semantics**, not just inline ordering. Under a live fleet the
+  result arrives via `wait_agents` and the parent emits an extra tool call, so "one spawn"
+  is not byte-identical either. Flipping the default measures at **23 failures across 11
+  files**. The AC is therefore re-pinned as:
+  - **`max_live_subagents=1` means no coordinator is built and the spawn closure takes the
+    verbatim pre-PR inline branch** — byte-identical, guarded by the three suites passing
+    unmodified. This is the *only* byte-identical claim.
+  - **At `max_live_subagents>1` behavior deliberately changes** (results via `wait_agents`);
+    the affected suites are converted to addressed replies in **Task 6.5**, which also flips
+    the default. No task may claim the byte-identical AC while the fleet is on.
 - Depth-1 stays structural: children never spawn (`clamp_child_budget` zeroes `max_subagents`); fleet tools are primary-only, pinned like `install_skill`.
 - Intersection-never-union and the identity-contract prompt append (PR 1) are untouched.
 - `clamp_child_budget` stays byte-identical in this PR (turn-scoped children must still die with the parent). Containment changes land in PR 3a.
@@ -697,6 +711,77 @@ git add -u && git commit -m "fix: revoke pending approval cards when a child is 
 
 ---
 
+### Task 6.5: Turn the fleet ON (default flip + convert ordered spawn scripts)
+
+**Added 2026-08-09.** Task 6 shipped the runtime behind `max_live_subagents=1`, i.e. dark:
+at the default no coordinator is built, spawn stays inline, and neither fleet tool is
+offered. Without this task the PR merges with its central feature unreachable and Task 8's
+live verification ("spawn two agents in one reply") permanently unperformable. Do not fold
+this into Task 8 — it is a suite conversion, not a config tweak.
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_service.py` (`DEFAULT_MAX_LIVE_SUBAGENTS` 1 → 3)
+- Modify: the 11 test files below
+- Test: `Tests/Agents/test_fleet_runtime.py` (re-pin the two default-dependent tests)
+
+**Interfaces:** no API change — this flips a default and converts test harnesses.
+
+- [ ] **Step 1: Measure the true baseline before changing anything**
+
+Flip `DEFAULT_MAX_LIVE_SUBAGENTS` to 3, run the full battery, and record the exact failing
+test list. The review measured **23 failures / 11 files**: `test_agent_service.py` (8),
+`test_skill_tool_spawn.py` (3), `test_console_agent_bridge.py` (2),
+`test_search_run_log_runtime_tool.py` (2), `test_fleet_runtime.py` (2, self-inflicted),
+and 1 each in `test_install_skill_runtime_tool.py`, `test_run_log_cross_run_search.py`,
+`test_run_log_sandbox_isolation.py`, `test_run_log_stats_slice_runtime_tools.py`,
+`test_run_log_workspace_isolation.py`, `test_run_skill_script_runtime_tool.py`.
+If your list differs, reconcile it before proceeding — a new failure is a real regression.
+
+- [ ] **Step 2: Convert ordered reply queues to addressed ones**
+
+`ScriptedChat` pops off one shared list (`self.replies.pop(0)`) and tests index
+`chat.calls[1]` positionally; with concurrent children neither is deterministic. Use the
+`FleetChat` pattern already in `Tests/Agents/test_fleet_runtime.py` (address replies by
+which agent/turn asked for them, not by arrival order). Convert each failing test.
+**Preserve every assertion's meaning.** Where a test asserted the *spawn* tool_result
+carries the child's capped text, that assertion moves to the `wait_agents` result — same
+guarantee, new carrier; say so in a comment so a future reader doesn't read it as a
+weakening.
+
+- [ ] **Step 3: Re-pin the two default-dependent fleet tests**
+
+`test_without_a_coordinator_spawn_stays_inline` and
+`test_fleet_tools_are_not_offered_without_a_coordinator` currently rely on default==1.
+Re-pin them on an explicit `max_live_subagents=1` (monkeypatched config or injected
+`None`), so they keep guarding the inline branch after the default moves.
+
+- [ ] **Step 4: Retire the contradicted bridge test**
+
+`Tests/Chat/test_console_agent_bridge.py::test_run_reply_wires_mcp_provider_stamp_scope_around_a_spawned_child`
+pins the behavior Task 6 deliberately removed on the threaded path (holding
+`review_state_scope` around a child). Task 5's per-run keying is the replacement
+protection, and `LocalToolProvider.stamp_scope` *clears* the parent's slice on entry, so
+holding it across siblings would wipe the parent's live verdicts. Replace it with a test
+asserting the parent's verdicts SURVIVE a concurrent child (the protection that actually
+holds now) rather than deleting the coverage.
+
+- [ ] **Step 5: Gate**
+
+```bash
+pytest Tests/Agents/ Tests/Chat/ Tests/MCP/ -q
+pytest --collect-only -q | tail -2
+```
+Expected: 0 failures. READ and report the counts. Any test you touched: state in the report
+what its assertion guaranteed before and after.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u && git commit -m "feat: enable the agent fleet by default (max_live_subagents=3)" && git push
+```
+
+---
+
 ### Task 8: Provider thread-safety audit + config + docs
 
 **Files:**
@@ -715,7 +800,14 @@ Per spec §5: an unaudited or unsafe provider gets a per-provider `threading.Loc
 
 - [ ] **Step 3: Config knob**
 
-Add `[agents] max_live_subagents` (default 3) to the config defaults and make the coordinator read it. Add a test that a config value of 1 makes a second concurrent spawn refuse with the cap message.
+`[agents] max_live_subagents` already exists (Task 6) and is already 3 (Task 6.5) — this
+step is now only: make sure it is documented wherever the repo lists config defaults, and
+that an out-of-range/garbage value degrades safely.
+**The original step's test ("a config value of 1 makes a second concurrent spawn refuse")
+is unwritable and must not be attempted**: 1 means no coordinator is built at all, so the
+second spawn runs inline rather than refusing. The equivalent coverage — a cap refusal —
+already exists in `Tests/Agents/test_fleet_runtime.py` via an injected `max_live=1`
+coordinator.
 
 - [ ] **Step 4: Docs**
 

--- a/Docs/superpowers/plans/2026-08-09-supervisor-fleet-pr2a-concurrency-runtime.md
+++ b/Docs/superpowers/plans/2026-08-09-supervisor-fleet-pr2a-concurrency-runtime.md
@@ -750,10 +750,14 @@ weakening.
 
 - [ ] **Step 3: Re-pin the two default-dependent fleet tests**
 
-`test_without_a_coordinator_spawn_stays_inline` and
-`test_fleet_tools_are_not_offered_without_a_coordinator` currently rely on default==1.
-Re-pin them on an explicit `max_live_subagents=1` (monkeypatched config or injected
-`None`), so they keep guarding the inline branch after the default moves.
+`test_without_a_coordinator_spawn_stays_inline`,
+`test_fleet_tools_are_not_offered_without_a_coordinator`, and
+`test_config_of_one_or_junk_keeps_the_inline_path` (its `"nonsense"`/`None` cases resolve
+through `DEFAULT_MAX_LIVE_SUBAGENTS`, so they flip meaning when the default does) all rely
+on default==1. Re-pin each on an explicit `max_live_subagents=1` (monkeypatched config or
+injected `None`), so they keep guarding the inline branch after the default moves. Sweep
+for any other test whose expectation is "no coordinator" without saying so explicitly —
+grep `_coerce_max_live_subagents` and `DEFAULT_MAX_LIVE_SUBAGENTS` in Tests/.
 
 - [ ] **Step 4: Retire the contradicted bridge test**
 

--- a/Tests/Agents/conftest.py
+++ b/Tests/Agents/conftest.py
@@ -1,3 +1,58 @@
-"""Re-export scratch_config for Tests/Agents/ (see Tests/Internal_Prompts/conftest.py)."""
+"""Shared Agents-suite fixtures.
+
+`scratch_config` is re-exported from Tests/Internal_Prompts/conftest.py.
+
+`inline_spawns` (PR2a Task 6.5) pins the fleet OFF. Read its docstring
+before writing any test that spawns a sub-agent: since Task 6.5 the
+shipped default is `max_live_subagents = 3`, so **a test that builds an
+`AgentService` without saying which path it wants silently gets the
+THREADED one**. That is not a hypothetical -- it is exactly how
+`test_agent_service_review_state_scope.py` lost its coverage while staying
+green (its six tests describe an INLINE, mid-parent-dispatch interleave in
+their docstrings and were running threaded; deleting the whole C1
+protection left the file passing).
+"""
+
+import pytest
+
+from tldw_chatbook.Agents import agent_service
 
 from Tests.Internal_Prompts.conftest import scratch_config  # noqa: F401
+
+
+def pin_max_live_subagents(monkeypatch, value):
+    """Make `[agents] max_live_subagents` read as `value` for this test.
+
+    Every OTHER `_setting` key (the run-log eviction knobs read by
+    `_make_call_model`) keeps returning its own default, so this never
+    silently reconfigures unrelated behaviour.
+
+    Args:
+        monkeypatch: pytest's monkeypatch fixture.
+        value: the raw config value to serve. `1` (or anything coercing to
+            <= 1) selects the inline path; `> 1` builds a fleet.
+    """
+    real_key = agent_service.MAX_LIVE_SUBAGENTS_KEY
+
+    def fake_setting(key, default):
+        return value if key == real_key else default
+
+    monkeypatch.setattr(agent_service, "_setting", fake_setting)
+
+
+@pytest.fixture()
+def inline_spawns(monkeypatch):
+    """Pin the INLINE spawn path: `[agents] max_live_subagents = 1`.
+
+    Use this in any test whose subject is what happens *while a child
+    runs* -- nested-run state scoping, record ordering, step ordering --
+    because that subject only exists on the inline path, where `spawn`
+    runs the child's whole loop synchronously before returning. On the
+    threaded default the child is off on its own thread and such a test
+    usually still passes while proving nothing.
+
+    A test that wants the fleet should say so just as explicitly (inject a
+    `FleetCoordinator`, or `pin_max_live_subagents(monkeypatch, 3)`).
+    """
+    pin_max_live_subagents(monkeypatch, 1)
+    return 1

--- a/Tests/Agents/test_agent_models.py
+++ b/Tests/Agents/test_agent_models.py
@@ -3,6 +3,7 @@
 import dataclasses
 
 from tldw_chatbook.Agents.agent_models import (
+    CHECK_AGENTS_TOOL_NAME,
     DIRECT_DISCLOSE_THRESHOLD,
     INSTALL_SKILL_TOOL_NAME,
     LOOP_DETECTION_N,
@@ -28,6 +29,7 @@ from tldw_chatbook.Agents.agent_models import (
     ToolCatalogEntry,
     ToolResult,
     ToolSchema,
+    WAIT_AGENTS_TOOL_NAME,
     clamp_child_budget,
 )
 
@@ -63,6 +65,8 @@ def test_runtime_tool_names():
         SEARCH_RUN_LOG_TOOL_NAME,
         RUN_LOG_STATS_TOOL_NAME,
         RUN_LOG_SLICE_TOOL_NAME,
+        WAIT_AGENTS_TOOL_NAME,
+        CHECK_AGENTS_TOOL_NAME,
     }
     assert DIRECT_DISCLOSE_THRESHOLD == 16 and LOOP_DETECTION_N == 3
 

--- a/Tests/Agents/test_agent_runtime_review_hook.py
+++ b/Tests/Agents/test_agent_runtime_review_hook.py
@@ -437,8 +437,14 @@ def _registry():
 def test_agent_service_threads_review_tool_calls_into_loop_deps(db):
     seen_batches = []
 
-    def review(batch):
+    # PR2a Task 5: an `AgentService`-wired hook takes `(batch, run_id)` --
+    # the service binds ITS run id in, which is how the review hook knows
+    # which run's gate slice to stamp. (`LoopDeps.review_tool_calls` itself
+    # is unchanged and still 1-arg; the tests above drive that shape
+    # directly.)
+    def review(batch, run_id):
         seen_batches.append([c.name for c in batch])
+        assert run_id, "the service must bind a real run id into the hook"
         return {"calculator": "Blocked by policy"}
 
     chat = ScriptedChat(

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -136,9 +136,55 @@ class FleetChat:
     instead); ``parent_calls`` records the primary agent's own calls and
     ``child_calls`` each child's, each in that agent's own order, which IS
     stable because one agent's turns are strictly sequential.
+
+    FAILING LOUDLY (PR2a Task 6.5 review). A scripting mistake here used to
+    vanish: a bare ``assert`` raised on a CHILD's thread is swallowed by
+    ``AgentService``'s ``run_child`` (which catches BaseException by design,
+    so a buggy child cannot strand the parent's join) and becomes
+    ``status=error``, so any test not asserting the child's RESULT still
+    passed -- vacuously. Demonstrated: mis-keying ``test_child_cannot_spawn``'s
+    child script to a task text no child ever asks for left it green. Since
+    this harness is now load-bearing for nine suites, and a future task-text
+    rename is exactly the kind of change that would re-introduce it, every
+    scripting fault is recorded in ``harness_errors``, re-raised on the
+    parent's next call, and swept at teardown by the autouse
+    ``_fleet_chat_scripts_fully_consumed`` fixture in ``Tests/conftest.py``
+    -- which also fails a test that left any scripted turn UNUSED.
     """
 
-    def __init__(self, parent_replies, child_replies=None, *, reply=provider_reply):
+    #: Every instance built during the current test, for the autouse sweep.
+    _live_instances: list["FleetChat"] = []
+
+    def __init__(
+        self,
+        parent_replies,
+        child_replies=None,
+        *,
+        reply=provider_reply,
+        allow_unconsumed=False,
+    ):
+        """
+        Args:
+            parent_replies: ordered script for the primary agent.
+            child_replies: {task_text: ordered script} per child.
+            reply: item -> provider response. `verbatim` for suites whose
+                scripts already hold full response envelopes.
+            allow_unconsumed: opt OUT of the "every scripted turn was
+                used" teardown check -- and ONLY that check. Set it when a
+                test deliberately strands turns: a child cancelled
+                mid-flight, one wedged past the wall clock, one that
+                raises instead of answering.
+
+                KNOWN RESIDUAL, measured: for such a test a mis-keyed
+                child script can still pass silently, because the child
+                may be cancelled (or may explode) before it ever asks for
+                a reply -- so neither signal exists to fire. There is no
+                signal to recover here; the mitigation is that this flag
+                is rare and deliberate (three tests in the fleet suite,
+                each commented). A child that DOES get to ask still
+                records a `harness_errors` entry, which is fatal
+                regardless of this flag.
+        """
         self.parent_replies = list(parent_replies)
         self.child_replies = {
             task: list(script) for task, script in (child_replies or {}).items()
@@ -146,28 +192,63 @@ class FleetChat:
         self.calls: list[dict] = []
         self.parent_calls: list[dict] = []
         self.child_calls: dict[str, list[dict]] = {}
+        self.harness_errors: list[str] = []
+        self.allow_unconsumed = allow_unconsumed
         self._reply = reply
         self._lock = threading.Lock()
+        FleetChat._live_instances.append(self)
+
+    def _fault(self, message):
+        """Record a scripting fault and raise it on the calling thread."""
+        self.harness_errors.append(message)
+        raise AssertionError(f"FleetChat scripting fault: {message}")
 
     def __call__(self, **kwargs):
         payload = kwargs["messages_payload"]
         task = child_task_of(payload)
         with self._lock:
             self.calls.append(kwargs)
+            # Surface a fault raised earlier on a CHILD's thread, where the
+            # runtime swallowed it, the first time the parent calls again.
+            if self.harness_errors:
+                raise AssertionError(
+                    "FleetChat scripting fault on another agent's thread: "
+                    + "; ".join(self.harness_errors)
+                )
             if task is None:
                 self.parent_calls.append(kwargs)
-                assert self.parent_replies, "parent script exhausted"
+                if not self.parent_replies:
+                    self._fault("parent script exhausted")
                 item = self.parent_replies.pop(0)
             else:
                 self.child_calls.setdefault(task, []).append(kwargs)
                 script = self.child_replies.get(task)
-                assert script, f"no scripted reply left for child task {task!r}"
+                if not script:
+                    self._fault(
+                        f"no scripted reply left for child task {task!r}; "
+                        f"scripted tasks are {sorted(self.child_replies)}"
+                    )
                 item = script.pop(0)
         # Called OUTSIDE the lock: a gated reply blocks here, and holding
         # the lock would serialize the very concurrency under test.
         if callable(item):
             item = item()
         return self._reply(item)
+
+    def unconsumed(self):
+        """Scripted turns nobody ever asked for, as readable strings."""
+        if self.allow_unconsumed:
+            return []
+        leftovers = []
+        if self.parent_replies:
+            leftovers.append(f"parent has {len(self.parent_replies)} unused turn(s)")
+        for task, script in self.child_replies.items():
+            if script:
+                leftovers.append(
+                    f"child {task!r} has {len(script)} unused turn(s) "
+                    f"(asked for {len(self.child_calls.get(task, []))})"
+                )
+        return leftovers
 
 
 @pytest.fixture()
@@ -473,16 +554,55 @@ def test_run_turn_records_assistant_message_id_on_primary_only(db):
     assert child["assistant_message_id"] is None
 
 
-def test_subagent_result_is_capped(db):
+def test_subagent_result_is_capped(db, inline_spawns):
     """A child's oversized answer reaches the parent capped, not whole.
 
-    PR2a Task 6.5 -- SAME GUARANTEE, NEW CARRIER, NOT A WEAKENING. This
-    used to read the SPAWN call's own tool_result, because an inline spawn
-    returned the child's text itself. Under the fleet spawn returns a
-    handle and the child's text arrives through `wait_agents`, so the cap
-    is asserted on the `wait_agents` result instead. The property is
-    unchanged and still the one that matters: a 10,000-char child answer
-    must not enter the supervisor's context at full length.
+    THE INLINE CARRIER, verbatim. This is the original test, re-pinned on
+    `max_live_subagents = 1` -- the shipped kill switch, and the path whose
+    own cap (`agent_service`'s `spawn`, inline branch) is the code under
+    test here.
+
+    PR2a Task 6.5 review caught me moving this assertion to `wait_agents`
+    and calling it "the same guarantee, new carrier". It was not: the
+    fleet's own cap was ALREADY covered by
+    `test_fleet_runtime.test_wait_agents_splits_the_history_budget_across_children`,
+    so the move landed on held ground and left the inline cap with no
+    coverage at all -- deleting those three lines kept Tests/Agents and
+    Tests/Chat fully green. Both carriers are now pinned: this test for the
+    inline branch, `test_subagent_result_is_capped_under_the_fleet` below
+    for the threaded one.
+    """
+    long_answer = "x" * 10000
+    service, _ = make_service(
+        db, [fence(SPAWN_TOOL_NAME, {"task": "t"}), long_answer, "done"]
+    )
+    tight = AgentConfig(
+        model="m",
+        system_prompt="s",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(max_subagent_result_chars=100),
+    )
+    _, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "q"}],
+        config=tight,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    run = db.list_runs("c", include_superseded=False)
+    parent = next(r for r in run if r["agent_kind"] == "primary")
+    capped = [s for s in parent["steps"] if s["kind"] == "tool_result"][0]
+    assert "[truncated]" in capped["result"]
+    assert len(capped["result"]) < 300
+
+
+def test_subagent_result_is_capped_under_the_fleet(db):
+    """The same cap, on the threaded carrier: `wait_agents`.
+
+    Companion to the inline test above (PR2a Task 6.5). With the fleet on,
+    `spawn` returns a handle and the child's text reaches the supervisor
+    through `wait_agents`, so that is where the cap must be observable.
+    Both branches cap, and both are now pinned.
     """
     long_answer = "x" * 10000
     chat = FleetChat(

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -1234,8 +1234,14 @@ def test_make_invoke_tool_wraps_slow_custom_tool_cancellable(db, monkeypatch):
         allowed_tools=("calculator",),
         budget=RunBudget(max_tool_call_seconds=5.0),
     )
+    # PR2a Task 5: `run_id` is keyword-REQUIRED -- it binds the dispatching
+    # run for the permission gates (run_context), and a default would let a
+    # caller silently lose every approval stamp instead of failing loudly.
     invoke_tool = service._make_invoke_tool(
-        cfg, disclosed_names={"calculator"}, should_cancel=lambda: True
+        cfg,
+        disclosed_names={"calculator"},
+        should_cancel=lambda: True,
+        run_id="run-1",
     )
     from tldw_chatbook.Agents.agent_models import ToolCall
     t0 = time.monotonic()
@@ -1268,7 +1274,9 @@ def test_make_invoke_tool_bypasses_wrapper_when_unlimited(db, monkeypatch):
         allowed_tools=("calculator",),
         budget=RunBudget(max_tool_call_seconds=0),
     )
-    invoke_tool = service._make_invoke_tool(cfg, disclosed_names={"calculator"})
+    invoke_tool = service._make_invoke_tool(
+        cfg, disclosed_names={"calculator"}, run_id="run-1"
+    )
     from tldw_chatbook.Agents.agent_models import ToolCall
     result = invoke_tool(ToolCall(name="calculator", args={"expression": "2+2"}))
     assert result.ok is True
@@ -1294,7 +1302,9 @@ def test_make_invoke_tool_wraps_slow_custom_tool_in_timeout(db, monkeypatch):
         allowed_tools=("calculator",),
         budget=RunBudget(max_tool_call_seconds=0.2),
     )
-    invoke_tool = service._make_invoke_tool(cfg, disclosed_names={"calculator"})
+    invoke_tool = service._make_invoke_tool(
+        cfg, disclosed_names={"calculator"}, run_id="run-1"
+    )
     from tldw_chatbook.Agents.agent_models import ToolCall
     result = invoke_tool(ToolCall(name="calculator", args={"expression": "2+2"}))
     assert result.ok is False

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -3,6 +3,7 @@
 
 import dataclasses
 import json
+import threading
 import time
 
 import pytest
@@ -14,6 +15,7 @@ from tldw_chatbook.Agents.agent_models import (
     RUN_DONE,
     RUN_STUCK,
     SPAWN_TOOL_NAME,
+    WAIT_AGENTS_TOOL_NAME,
     AgentConfig,
     AgentDefinition,
     RunBudget,
@@ -56,7 +58,12 @@ def native_call(name, args, call_id="c1"):
 
 
 class ScriptedChat:
-    """Returns scripted replies; records every call's kwargs."""
+    """Returns scripted replies; records every call's kwargs.
+
+    ONE ordered queue shared by every agent in the run tree, which is
+    deterministic only while children run INLINE (see `FleetChat` below
+    for the addressed variant the fleet needs).
+    """
 
     def __init__(self, replies):
         self.replies = list(replies)
@@ -65,6 +72,102 @@ class ScriptedChat:
     def __call__(self, **kwargs):
         self.calls.append(kwargs)
         return provider_reply(self.replies.pop(0))
+
+
+#: The child's system prompt is the sub-agent prompt (plus, for a named
+#: agent, its appended instructions) followed by the rendered fence
+#: protocol -- so a prefix match on its first sentence is what identifies a
+#: child's provider call, the same identity contract
+#: `console_agent_bridge._is_subagent` relies on.
+SUBAGENT_PROMPT_PREFIX = SUBAGENT_SYSTEM_PROMPT.split(".")[0]
+
+
+def child_task_of(payload):
+    """The task text of the child whose provider call this payload is.
+
+    Args:
+        payload: The ``messages_payload`` handed to ``chat_api_call``.
+
+    Returns:
+        The child's task text (its first user message), or ``None`` when
+        this payload belongs to the primary agent.
+    """
+    if not payload:
+        return None
+    system = payload[0]
+    if system.get("role") != "system":
+        return None
+    if not str(system.get("content", "")).startswith(SUBAGENT_PROMPT_PREFIX):
+        return None
+    for message in payload[1:]:
+        if message.get("role") == "user":
+            return str(message.get("content", ""))
+    return None
+
+
+def verbatim(item):
+    """``reply`` hook for scripts already holding full provider responses.
+
+    ``provider_reply`` wraps a str/message-dict into the ``{"choices":
+    [{"message": ...}]}`` envelope; several suites script that envelope
+    directly, and hand this in so ``FleetChat`` passes their entries
+    through untouched.
+    """
+    return item
+
+
+class FleetChat:
+    """Addressed scripted provider: one script per agent, not one queue.
+
+    PR2a Task 6.5. `ScriptedChat` pops one shared ordered list, which stops
+    being deterministic the moment children run on their own threads
+    (whichever thread wins the race takes the next reply) -- and the fleet
+    is ON by default from Task 6.5 on. This keeps the same shape but
+    ADDRESSES replies: an ordered script for the primary agent, and a
+    separate ordered script per child TASK TEXT. Every reply therefore
+    goes to the agent it was written for, no matter who calls first.
+
+    Replies may be plain strings/dicts (as ``ScriptedChat``) or zero-arg
+    callables, which are invoked at call time -- that is how a test gates a
+    child on an ``Event`` or a ``Barrier`` while the parent keeps running.
+
+    ``calls`` records every call in arrival order (so it is NOT a stable
+    index under concurrency -- address ``parent_calls``/``child_calls``
+    instead); ``parent_calls`` records the primary agent's own calls and
+    ``child_calls`` each child's, each in that agent's own order, which IS
+    stable because one agent's turns are strictly sequential.
+    """
+
+    def __init__(self, parent_replies, child_replies=None, *, reply=provider_reply):
+        self.parent_replies = list(parent_replies)
+        self.child_replies = {
+            task: list(script) for task, script in (child_replies or {}).items()
+        }
+        self.calls: list[dict] = []
+        self.parent_calls: list[dict] = []
+        self.child_calls: dict[str, list[dict]] = {}
+        self._reply = reply
+        self._lock = threading.Lock()
+
+    def __call__(self, **kwargs):
+        payload = kwargs["messages_payload"]
+        task = child_task_of(payload)
+        with self._lock:
+            self.calls.append(kwargs)
+            if task is None:
+                self.parent_calls.append(kwargs)
+                assert self.parent_replies, "parent script exhausted"
+                item = self.parent_replies.pop(0)
+            else:
+                self.child_calls.setdefault(task, []).append(kwargs)
+                script = self.child_replies.get(task)
+                assert script, f"no scripted reply left for child task {task!r}"
+                item = script.pop(0)
+        # Called OUTSIDE the lock: a gated reply blocks here, and holding
+        # the lock would serialize the very concurrency under test.
+        if callable(item):
+            item = item()
+        return self._reply(item)
 
 
 @pytest.fixture()
@@ -77,6 +180,13 @@ def make_service(db, replies):
     registry.register_provider(BuiltinToolProvider())
     chat = ScriptedChat(replies)
     return AgentService(db=db, registry=registry, chat_call=chat), chat
+
+
+def _service_with(db, chat):
+    """`make_service` for a chat double built by the caller (a `FleetChat`)."""
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    return AgentService(db=db, registry=registry, chat_call=chat)
 
 
 CFG = AgentConfig(
@@ -174,17 +284,20 @@ def test_native_kill_switch_forces_fence(db):
 
 
 def test_native_subagent_turns_also_carry_tools(db):
-    service, chat = make_service(
-        db,
+    # PR2a Task 6.5: the fleet is ON by default, so the child runs on its
+    # own thread -- addressed script, and `chat.child_calls[task]` instead
+    # of `chat.calls[1]`. Same call, named rather than counted.
+    chat = FleetChat(
         [
             {
                 "content": None,
                 "tool_calls": [native_call("spawn_subagent", {"task": "say hi"}, "s1")],
             },
-            "hi from child",  # child's (native-mode) only turn
             "done",
         ],
+        {"say hi": ["hi from child"]},  # child's (native-mode) only turn
     )
+    service = _service_with(db, chat)
     _run_id, outcome = service.run_turn(
         conversation_id="c",
         messages=[{"role": "user", "content": "go"}],
@@ -193,7 +306,7 @@ def test_native_subagent_turns_also_carry_tools(db):
         should_cancel=lambda: False,
     )
     assert outcome.status == RUN_DONE
-    child_call = chat.calls[1]
+    child_call = chat.child_calls["say hi"][0]
     assert child_call["messages_payload"][0]["content"].startswith(
         SUBAGENT_SYSTEM_PROMPT
     )
@@ -304,14 +417,15 @@ def test_permission_gate_blocks_disallowed_tool(db):
 
 
 def test_spawn_creates_linked_child_with_clean_context(db):
-    service, chat = make_service(
-        db,
+    # PR2a Task 6.5: addressed script (the child is on its own thread).
+    chat = FleetChat(
         [
             fence(SPAWN_TOOL_NAME, {"task": "compute 6*7"}),  # parent turn 1
-            "sub answer: 42",  # CHILD turn 1
             "The sub-agent says 42.",  # parent turn 2
         ],
+        {"compute 6*7": ["sub answer: 42"]},  # CHILD turn 1
     )
+    service = _service_with(db, chat)
     run_id, outcome = service.run_turn(
         conversation_id="c",
         messages=[{"role": "user", "content": "delegate this"}],
@@ -325,8 +439,9 @@ def test_spawn_creates_linked_child_with_clean_context(db):
     assert child["task"] == "compute 6*7"
     assert child["status"] == "done" and child["result"] == "sub answer: 42"
     # Clean context: the child's provider call saw ONLY its task + its own
-    # system prompt — never the parent's transcript.
-    child_call = chat.calls[1]["messages_payload"]
+    # system prompt — never the parent's transcript. Addressed by task text
+    # rather than by `calls[1]`: same call, named rather than counted.
+    child_call = chat.child_calls["compute 6*7"][0]["messages_payload"]
     assert child_call[0]["role"] == "system"
     assert SUBAGENT_SYSTEM_PROMPT.split(".")[0] in child_call[0]["content"]
     assert child_call[1] == {"role": "user", "content": "compute 6*7"}
@@ -359,15 +474,33 @@ def test_run_turn_records_assistant_message_id_on_primary_only(db):
 
 
 def test_subagent_result_is_capped(db):
+    """A child's oversized answer reaches the parent capped, not whole.
+
+    PR2a Task 6.5 -- SAME GUARANTEE, NEW CARRIER, NOT A WEAKENING. This
+    used to read the SPAWN call's own tool_result, because an inline spawn
+    returned the child's text itself. Under the fleet spawn returns a
+    handle and the child's text arrives through `wait_agents`, so the cap
+    is asserted on the `wait_agents` result instead. The property is
+    unchanged and still the one that matters: a 10,000-char child answer
+    must not enter the supervisor's context at full length.
+    """
     long_answer = "x" * 10000
-    service, _ = make_service(
-        db, [fence(SPAWN_TOOL_NAME, {"task": "t"}), long_answer, "done"]
+    chat = FleetChat(
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "t"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {"t": [long_answer]},
     )
+    service = _service_with(db, chat)
     tight = AgentConfig(
         model="m",
         system_prompt="s",
         allowed_tools=(SPAWN_TOOL_NAME,),
-        budget=RunBudget(max_subagent_result_chars=100),
+        # max_steps raised only to fit the extra collection round the fleet
+        # adds; nothing here ever asserted on the step budget.
+        budget=RunBudget(max_subagent_result_chars=100, max_steps=16),
     )
     _, outcome = service.run_turn(
         conversation_id="c",
@@ -378,21 +511,30 @@ def test_subagent_result_is_capped(db):
     assert outcome.status == RUN_DONE
     run = db.list_runs("c", include_superseded=False)
     parent = next(r for r in run if r["agent_kind"] == "primary")
-    capped = [s for s in parent["steps"] if s["kind"] == "tool_result"][0]
+    capped = [
+        s
+        for s in parent["steps"]
+        if s["kind"] == "tool_result" and s["tool_name"] == WAIT_AGENTS_TOOL_NAME
+    ][0]
     assert "[truncated]" in capped["result"]
     assert len(capped["result"]) < 300
 
 
 def test_child_cannot_spawn(db):
-    service, _ = make_service(
-        db,
+    # PR2a Task 6.5: addressed script (the child is on its own thread).
+    chat = FleetChat(
         [
             fence(SPAWN_TOOL_NAME, {"task": "t"}),  # parent spawns
-            fence(SPAWN_TOOL_NAME, {"task": "nested"}),  # CHILD tries to spawn
-            "child recovered",  # child answers
             "parent done",
         ],
+        {
+            "t": [
+                fence(SPAWN_TOOL_NAME, {"task": "nested"}),  # CHILD tries to spawn
+                "child recovered",  # child answers
+            ]
+        },
     )
+    service = _service_with(db, chat)
     _, outcome = service.run_turn(
         conversation_id="c",
         messages=[{"role": "user", "content": "q"}],
@@ -1358,14 +1500,15 @@ def _seed_definition(db, defn=RESEARCHER_DEFN):
 
 def test_named_spawn_appends_instructions_and_keeps_identity_prefix(db):
     _seed_definition(db)
-    service, chat = make_service(
-        db,
+    # PR2a Task 6.5: addressed script (the child is on its own thread).
+    chat = FleetChat(
         [
             fence(SPAWN_TOOL_NAME, {"task": "compute 6*7", "agent": "researcher"}),
-            "sub answer: 42",
             "done",
         ],
+        {"compute 6*7": ["sub answer: 42"]},
     )
+    service = _service_with(db, chat)
     run_id, outcome = service.run_turn(
         conversation_id="c",
         messages=[{"role": "user", "content": "delegate"}],
@@ -1373,7 +1516,7 @@ def test_named_spawn_appends_instructions_and_keeps_identity_prefix(db):
         api_endpoint="llama_cpp",
     )
     assert outcome.status == RUN_DONE
-    child_system = chat.calls[1]["messages_payload"][0]
+    child_system = chat.child_calls["compute 6*7"][0]["messages_payload"][0]
     assert child_system["role"] == "system"
     # IDENTITY CONTRACT: base subagent prompt stays the PREFIX
     # (console_agent_bridge._is_subagent prefix-matches it) ...
@@ -1393,14 +1536,15 @@ def test_named_spawn_intersects_allowlist_never_grants(db):
             tool_allowlist=("calculator", "forbidden_tool"),
         ),
     )
-    service, chat = make_service(
-        db,
+    # PR2a Task 6.5: addressed script (the child is on its own thread).
+    chat = FleetChat(
         [
             fence(SPAWN_TOOL_NAME, {"task": "t", "agent": "narrow"}),
-            "child done",
             "done",
         ],
+        {"t": ["child done"]},
     )
+    service = _service_with(db, chat)
     service.run_turn(
         conversation_id="c",
         messages=[{"role": "user", "content": "go"}],
@@ -1410,7 +1554,7 @@ def test_named_spawn_intersects_allowlist_never_grants(db):
     # Channel-agnostic: disclosed schemas may ride the system prompt
     # (fence protocol) OR the tools= kwarg (native) — inspect the whole
     # provider call.
-    child_call = json.dumps(chat.calls[1], default=str)
+    child_call = json.dumps(chat.child_calls["t"][0], default=str)
     assert "calculator" in child_call
     assert "get_current_datetime" not in child_call  # narrowed away
     assert "forbidden_tool" not in child_call  # never granted
@@ -1423,34 +1567,39 @@ def test_named_spawn_model_override_same_endpoint(db):
             name="cheap", instructions="Do it.", model="tiny-model"
         ),
     )
-    service, chat = make_service(
-        db,
-        [fence(SPAWN_TOOL_NAME, {"task": "t", "agent": "cheap"}), "ok", "done"],
+    # PR2a Task 6.5: addressed script (the child is on its own thread).
+    chat = FleetChat(
+        [fence(SPAWN_TOOL_NAME, {"task": "t", "agent": "cheap"}), "done"],
+        {"t": ["ok"]},
     )
+    service = _service_with(db, chat)
     service.run_turn(
         conversation_id="c",
         messages=[{"role": "user", "content": "go"}],
         config=CFG,
         api_endpoint="llama_cpp",
     )
-    assert chat.calls[1]["model"] == "tiny-model"
-    assert chat.calls[0]["model"] == "test-model"
-    assert chat.calls[1]["api_endpoint"] == "llama_cpp"
+    child_call = chat.child_calls["t"][0]
+    assert child_call["model"] == "tiny-model"
+    assert chat.parent_calls[0]["model"] == "test-model"
+    assert child_call["api_endpoint"] == "llama_cpp"
 
 
 def test_unknown_agent_refused_without_burning_budget(db):
     _seed_definition(db)
-    service, chat = make_service(
-        db,
+    # PR2a Task 6.5: addressed script -- both children are on their own
+    # threads, so their two answers are no longer interleaved into the
+    # parent's queue at fixed positions.
+    chat = FleetChat(
         [
             fence(SPAWN_TOOL_NAME, {"task": "t", "agent": "nope"}),
             fence(SPAWN_TOOL_NAME, {"task": "t2", "agent": "researcher"}),
-            "child ok",
             fence(SPAWN_TOOL_NAME, {"task": "t3", "agent": "researcher"}),
-            "child ok 2",
             "done",
         ],
+        {"t2": ["child ok"], "t3": ["child ok 2"]},
     )
+    service = _service_with(db, chat)
     # 3 parent-level spawn rounds (1 refused + 2 real) + the final answer =
     # 10 parent steps; CFG's default max_steps=8 would trip stuck before
     # the model ever gets to answer -- raise it, mirroring
@@ -1468,8 +1617,10 @@ def test_unknown_agent_refused_without_burning_budget(db):
     # slot, so BOTH later spawns succeed.
     assert outcome.status == RUN_DONE
     assert db.count_subagent_runs("c") == 2
-    # The refusal itself surfaced the roster to the model.
-    refusal = chat.calls[1]["messages_payload"]
+    # The refusal itself surfaced the roster to the model -- the PARENT's
+    # own second turn, addressed rather than counted (`calls[1]` may now be
+    # a child's).
+    refusal = chat.parent_calls[1]["messages_payload"]
     assert any(
         "unknown agent 'nope'" in str(m.get("content", "")) for m in refusal
     )

--- a/Tests/Agents/test_agent_service_on_step.py
+++ b/Tests/Agents/test_agent_service_on_step.py
@@ -46,7 +46,7 @@ def test_on_step_receives_primary_steps_in_order(tmp_path):
         db,
         reg,
         chat_call=chat_call,
-        on_step=lambda step, kind: seen.append((kind, step.kind)),
+        on_step=lambda step, kind, run_id: seen.append((kind, step.kind)),
     )
     _run_id, outcome = service.run_turn(
         conversation_id="c1",
@@ -84,7 +84,7 @@ def test_on_step_distinguishes_subagent_steps(tmp_path):
         db,
         reg,
         chat_call=chat_call,
-        on_step=lambda step, kind: seen.append((kind, step.kind)),
+        on_step=lambda step, kind, run_id: seen.append((kind, step.kind)),
     )
     _run_id, outcome = service.run_turn(
         conversation_id="c1",
@@ -107,7 +107,7 @@ def test_on_step_exception_does_not_crash_run(tmp_path):
     def chat_call(**kwargs):
         return {"choices": [{"message": {"content": "hello"}}]}
 
-    def bad_on_step(step, kind):
+    def bad_on_step(step, kind, run_id):
         raise RuntimeError("boom")
 
     service = AgentService(db, reg, chat_call=chat_call, on_step=bad_on_step)
@@ -134,3 +134,52 @@ def test_on_step_default_is_noop(tmp_path):
         api_endpoint="llama_cpp",
     )
     assert outcome.status == "done"  # no on_step wired → no crash
+
+
+def test_on_step_receives_run_id_for_primary_and_child(tmp_path):
+    """Task 3 (fleet PR 2a): on_step's third argument is the run_id of the
+    run that produced the step -- the PRIMARY run's own id for primary
+    steps, and the CHILD run's own (distinct) id for a spawned sub-agent's
+    steps. This is what lets a fleet of concurrent children be told apart
+    downstream (PR 2b)."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = _registry()
+    script = [
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": _fence(SPAWN_TOOL_NAME, {"task": "child work"})
+                    }
+                }
+            ]
+        },
+        {"choices": [{"message": {"content": "child answer"}}]},
+        {"choices": [{"message": {"content": "parent answer"}}]},
+    ]
+
+    def chat_call(**kwargs):
+        return script.pop(0)
+
+    seen = []
+    service = AgentService(
+        db,
+        reg,
+        chat_call=chat_call,
+        on_step=lambda step, kind, run_id: seen.append((kind, run_id, step.kind)),
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "go"}],
+        config=AgentConfig(
+            model="m", system_prompt="s", allowed_tools=("calculator", SPAWN_TOOL_NAME)
+        ),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == "done"
+    primary_ids = {r for k, r, _ in seen if k == AGENT_KIND_PRIMARY}
+    child_ids = {r for k, r, _ in seen if k == AGENT_KIND_SUBAGENT}
+    assert primary_ids == {run_id}
+    assert len(child_ids) == 1 and child_ids.isdisjoint(primary_ids)
+    # Every step carries a non-empty run id.
+    assert all(r for _k, r, _s in seen)

--- a/Tests/Agents/test_agent_service_on_step.py
+++ b/Tests/Agents/test_agent_service_on_step.py
@@ -62,7 +62,7 @@ def test_on_step_receives_primary_steps_in_order(tmp_path):
     assert all(who == AGENT_KIND_PRIMARY for (who, _k) in seen)
 
 
-def test_on_step_distinguishes_subagent_steps(tmp_path):
+def test_on_step_distinguishes_subagent_steps(tmp_path, inline_spawns):
     db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
     reg = _registry()
     # Primary spawns a sub-agent; sub-agent answers directly.
@@ -136,7 +136,7 @@ def test_on_step_default_is_noop(tmp_path):
     assert outcome.status == "done"  # no on_step wired → no crash
 
 
-def test_on_step_receives_run_id_for_primary_and_child(tmp_path):
+def test_on_step_receives_run_id_for_primary_and_child(tmp_path, inline_spawns):
     """Task 3 (fleet PR 2a): on_step's third argument is the run_id of the
     run that produced the step -- the PRIMARY run's own id for primary
     steps, and the CHILD run's own (distinct) id for a spawned sub-agent's

--- a/Tests/Agents/test_agent_service_review_state_scope.py
+++ b/Tests/Agents/test_agent_service_review_state_scope.py
@@ -21,6 +21,17 @@ wraps every nested `_run_one` call in a caller-supplied context manager.
 snapshot `_stamped_decisions` on enter, restore (not merge) it on exit, so
 the child's mutations to the shared dict are fully undone the instant it
 returns control to the parent.
+
+PR2a Task 5 SUPERSEDED that mechanism without removing it. Snapshot/restore
+is sound only while the child is strictly nested and inline (LIFO); with N
+children on their own threads there is no LIFO, and one child's turn would
+still wipe a sibling's live verdict. Both gates now key their per-turn
+verdicts by `(run_id, name)`, so a run can only ever clear or overwrite its
+OWN slice. Every security assertion in this file is unchanged and still
+passes; the ONE test whose shape changed is the negative control at the
+bottom, which used to assert the clobber happens when the scope is unwired
+and now asserts the parent's approval survives anyway -- see its own
+docstring.
 """
 
 from __future__ import annotations
@@ -609,16 +620,30 @@ def test_child_spawned_mid_turn_resolves_a_mutating_builtin_tool_and_the_parents
     assert not results["write_thing"].result.startswith("ERROR")
 
 
-def test_child_spawned_mid_turn_without_stamp_scope_clobbers_the_parents_approval(
+def test_child_spawned_mid_turn_without_stamp_scope_keeps_the_parents_approval(
     db,
 ):
     """Same interleave as the test above, with ``review_state_scope`` left
-    unwired -- proving the previous test is not passing trivially. Without
-    the scope the child's ``begin_turn()`` clears the WHOLE ``_stamps``
-    dict and is never restored, so the parent's own pre-child
-    ``write_thing`` approval is gone by the time the parent's own dispatch
-    loop reaches it -- it fails closed, even though a human already
-    approved it this very turn."""
+    unwired -- now proving PER-RUN KEYING, not the scope, is what protects
+    the parent.
+
+    **This test's assertion was inverted by PR2a Task 5, deliberately.**
+    It used to assert the clobber: without the scope, the child's
+    ``begin_turn()`` cleared the WHOLE name-keyed ``_stamps`` dict and
+    never restored it, so the parent's own pre-child ``write_thing``
+    approval was gone by the time the parent's dispatch loop reached it
+    and the approved call failed closed. That was a negative control for a
+    mechanism (snapshot/restore) that is sound ONLY for a strictly nested,
+    LIFO, inline child -- which is exactly what PR2a Task 6 stops being
+    true when N children run on their own threads.
+
+    Both gates now key every per-turn verdict by ``(run_id, tool_name)``,
+    so the child's ``begin_turn(child_run_id)`` cannot touch the parent's
+    slice whether or not a scope wraps it. The parent's approved call must
+    therefore still succeed here. Break per-run keying (make
+    ``begin_turn`` clear the whole dict again) and this test fails -- it
+    is the same defect it always detected, asserted from the other side.
+    """
     gate = BuiltinToolGate(service=None)
     registry, builtin_provider = _registry_with_mutating_builtins(
         gate, "write_thing", "write_other_thing"
@@ -669,11 +694,10 @@ def test_child_spawned_mid_turn_without_stamp_scope_clobbers_the_parents_approva
     assert outcome.status == RUN_DONE
     # The child's own call is unaffected either way.
     assert not results["write_other_thing"].result.startswith("ERROR")
-    # This is the clobber: the parent's own pre-child approval was wiped by
-    # the child's begin_turn() and never restored, so its remaining call
-    # fails closed despite having been approved this turn.
-    assert results["write_thing"].result.startswith("ERROR")
-    assert "approval" in results["write_thing"].result.lower()
+    # No clobber any more: the child's begin_turn() only cleared its OWN
+    # run's slice, so the parent's pre-child approval is still there for
+    # its own remaining call -- with no review_state_scope wired at all.
+    assert not results["write_thing"].result.startswith("ERROR")
 
 
 def test_child_run_with_no_approval_route_still_fails_closed_for_a_mutating_builtin_tool(

--- a/Tests/Agents/test_agent_service_review_state_scope.py
+++ b/Tests/Agents/test_agent_service_review_state_scope.py
@@ -218,7 +218,7 @@ def _registry_with_mcp(provider: MCPToolProvider) -> ToolCatalogRegistry:
 
 
 def test_parent_deny_is_not_overridden_by_a_same_turn_spawned_childs_approval(
-    db, running_loop
+    db, running_loop, inline_spawns
 ):
     """Parent batch = [spawn_subagent, mcp_X]. Parent denies mcp_X. The
     spawned child (dispatched INLINE, mid-parent-dispatch) approves its OWN
@@ -309,7 +309,7 @@ def test_parent_deny_is_not_overridden_by_a_same_turn_spawned_childs_approval(
 
 
 def test_child_run_does_not_wipe_a_parent_approval_via_its_own_empty_apply(
-    db, running_loop
+    db, running_loop, inline_spawns
 ):
     """The child spawned this turn calls a NON-MCP tool (calculator) -- its
     OWN review-hook invocation resolves `pending=[]` and (routinely, every
@@ -389,7 +389,7 @@ def test_child_run_does_not_wipe_a_parent_approval_via_its_own_empty_apply(
 # ---------------------------------------------------------------------------
 
 
-def test_review_state_scope_defaults_to_none_and_spawn_still_works(db):
+def test_review_state_scope_defaults_to_none_and_spawn_still_works(db, inline_spawns):
     """Omitting `review_state_scope` (every caller before this task, and
     every non-MCP run today) must not change existing spawn behavior --
     `spawn` falls back to a no-op `contextlib.nullcontext()`."""
@@ -518,7 +518,7 @@ def _registry_with_mutating_builtins(
 
 
 def test_child_spawned_mid_turn_resolves_a_mutating_builtin_tool_and_the_parents_own_stamp_survives(
-    db,
+    db, inline_spawns
 ):
     """AC#2 (task-628): a parent batch = [spawn_subagent, write_thing]. The
     parent's own review round trip approves ``write_thing`` for this turn.
@@ -621,7 +621,7 @@ def test_child_spawned_mid_turn_resolves_a_mutating_builtin_tool_and_the_parents
 
 
 def test_child_spawned_mid_turn_without_stamp_scope_keeps_the_parents_approval(
-    db,
+    db, inline_spawns
 ):
     """Same interleave as the test above, with ``review_state_scope`` left
     unwired -- now proving PER-RUN KEYING, not the scope, is what protects
@@ -701,7 +701,7 @@ def test_child_spawned_mid_turn_without_stamp_scope_keeps_the_parents_approval(
 
 
 def test_child_run_with_no_approval_route_still_fails_closed_for_a_mutating_builtin_tool(
-    db,
+    db, inline_spawns
 ):
     """AC#4 (task-628): this task fixes ROUTING for a run that has an
     approval path; it must not weaken ``BuiltinToolGate``'s own fail-closed
@@ -756,3 +756,61 @@ def test_child_run_with_no_approval_route_still_fails_closed_for_a_mutating_buil
     assert "write_thing" in results
     assert results["write_thing"].result.startswith("ERROR")
     assert "approval" in results["write_thing"].result.lower()
+
+
+# ---------------------------------------------------------------------------
+# PR2a Task 6.5: the inline scope's own contract, now that an inline child
+# can run WHILE fleet siblings do
+# ---------------------------------------------------------------------------
+
+
+def test_stamp_scope_restore_touches_only_its_own_runs_slice(running_loop):
+    """`stamp_scope(parent)` must not disturb any OTHER run's verdicts.
+
+    Why this test exists, and why it is a direct one rather than an
+    end-to-end one: the six tests above are pinned INLINE so they exercise
+    the interleave their docstrings describe, but none of them can kill the
+    scope -- delete `review_state_scope` from the inline branch entirely
+    and they all still pass, because PR2a Task 5's per-run keying is what
+    actually protects the parent there (`MCPToolProvider.stamp_scope`'s own
+    docstring says as much: "belt-and-braces for that inline path").
+    Asserting the scope end-to-end would therefore be vacuous.
+
+    What is NOT vacuous, and is newly load-bearing since Task 6.5 made
+    SKILL calls run inline while the fleet is live, is the scope's
+    isolation: an inline child now enters `stamp_scope(parent_run_id)` at a
+    moment when threaded siblings are running and stamping. If the restore
+    rewrote anything outside the parent's own slice, it would silently wipe
+    a live sibling's verdict -- the exact failure Task 6 removed the scope
+    from the threaded path to avoid. This pins the property the inline
+    branch's comment relies on: the restore rewrites ONLY `key[0] ==
+    run_id`.
+    """
+    service = FakeMCPService()
+    provider = MCPToolProvider(service=service, main_loop=running_loop)
+    asyncio.run(provider.compose_catalog())
+    tool_id = provider.list_catalog()[0].id
+
+    provider.apply_batch_decisions("parent-run", {tool_id: "approve_once"})
+    provider.apply_batch_decisions("sibling-run", {tool_id: "deny"})
+
+    with provider.stamp_scope("parent-run"):
+        # This provider SNAPSHOTS on entry without clearing (unlike
+        # `LocalToolProvider.stamp_scope`, which clears its own slice
+        # deliberately -- see its docstring). Either way the entry touches
+        # nobody else's slice.
+        assert provider.stamped_decision("parent-run", tool_id) == "approve_once"
+        assert provider.stamped_decision("sibling-run", tool_id) == "deny"
+        # A sibling stamping DURING the window is what a live fleet child
+        # does; it must survive the restore below.
+        provider.apply_batch_decisions("late-sibling-run", {tool_id: "approve_once"})
+        # The parent's own slice IS rolled back to the snapshot on exit,
+        # which is why holding this scope around CONCURRENT children (where
+        # the parent keeps stamping) would lose verdicts -- Task 6 removed
+        # it from the threaded path for exactly that reason.
+        provider.apply_batch_decisions("parent-run", {tool_id: "deny"})
+
+    # Restored for the parent, and neither sibling was rolled back.
+    assert provider.stamped_decision("parent-run", tool_id) == "approve_once"
+    assert provider.stamped_decision("sibling-run", tool_id) == "deny"
+    assert provider.stamped_decision("late-sibling-run", tool_id) == "approve_once"

--- a/Tests/Agents/test_agent_service_review_state_scope.py
+++ b/Tests/Agents/test_agent_service_review_state_scope.py
@@ -477,7 +477,7 @@ def _tool_result_collector():
     """
     results: dict = {}
 
-    def on_step(step, _agent_kind: str) -> None:
+    def on_step(step, _agent_kind: str, _run_id: str) -> None:
         if step.kind == "tool_result" and step.tool_name:
             results[step.tool_name] = step
 

--- a/Tests/Agents/test_builtin_gate_live_tools.py
+++ b/Tests/Agents/test_builtin_gate_live_tools.py
@@ -11,10 +11,11 @@ import threading
 import pytest
 
 from tldw_chatbook.Agents.builtin_tool_gate import BuiltinToolGate
+from tldw_chatbook.Agents.run_context import use_run_id
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
 from tldw_chatbook.MCP.permission_store import BUILTIN_TOOL_SERVER_KEY
 
-from Tests.Agents.test_builtin_tool_gate import _FakeService
+from Tests.Agents.test_builtin_tool_gate import RUN, _FakeService
 
 
 @pytest.fixture
@@ -70,17 +71,23 @@ def test_a_stamped_permit_lets_a_mutating_tool_run(all_gates_on, tmp_path, monke
     """The approval round trip: a per-turn permit reaches execution."""
     service = _FakeService()
     gate = BuiltinToolGate(service=service)
-    gate.begin_turn()
-    gate.stamp("write_file", "approve_once")
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, "write_file", "approve_once")
     provider = BuiltinToolProvider(gate=gate)
 
     target = tmp_path / "out.txt"
     import tldw_chatbook.Tools.file_operation_tools as fot
 
     monkeypatch.setattr(fot, "_resolve_sandbox_config", lambda: str(tmp_path))
-    result = provider.invoke(
-        "builtin:write_file", {"file_path": "out.txt", "content": "hello"}
-    )
+    # PR2a Task 5: a stamp belongs to a RUN, and `invoke()` reads the
+    # dispatching run from `run_context` (bound in production by
+    # `AgentService` around each invocation). Same assertion as before --
+    # the permit granted for this turn reaches execution -- now stated
+    # against the run that was granted it.
+    with use_run_id(RUN):
+        result = provider.invoke(
+            "builtin:write_file", {"file_path": "out.txt", "content": "hello"}
+        )
 
     assert result.ok is True, result.error
     assert target.read_text(encoding="utf-8") == "hello"
@@ -102,11 +109,14 @@ def test_a_resolved_deny_beats_a_permitting_stamp(all_gates_on):
         }
     }
     gate = BuiltinToolGate(service=_FakeService(payload=payload))
-    gate.begin_turn()
-    gate.stamp("write_file", "approve_once")
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, "write_file", "approve_once")
     provider = BuiltinToolProvider(gate=gate)
 
-    result = provider.invoke("builtin:write_file", {"file_path": "x", "content": "y"})
+    with use_run_id(RUN):
+        result = provider.invoke(
+            "builtin:write_file", {"file_path": "x", "content": "y"}
+        )
     assert result.ok is False
     assert "Off" in result.error
 
@@ -166,14 +176,19 @@ def test_note_tool_executes_on_a_worker_thread(
     monkeypatch.setattr(nmt, "_resolve_user_id", lambda: "alice")
 
     gate = BuiltinToolGate(service=_FakeService())
-    gate.begin_turn()
-    gate.stamp(tool_name, "approve_once")
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, tool_name, "approve_once")
     provider = BuiltinToolProvider(gate=gate)
 
     box = {}
 
     def run():
-        box["result"] = provider.invoke(f"builtin:{tool_name}", args)
+        # The run-id binding is established ON the worker thread, exactly
+        # as `AgentService._make_invoke_tool` does it for the per-call
+        # daemon thread `_call_with_timeout` spawns (a ContextVar set on
+        # the parent thread is not visible in a new one).
+        with use_run_id(RUN):
+            box["result"] = provider.invoke(f"builtin:{tool_name}", args)
 
     worker = threading.Thread(target=run, name="tool-worker")
     worker.start()
@@ -194,23 +209,31 @@ def test_a_parents_approval_survives_a_nested_sub_agent_run(all_gates_on):
     unusable the moment a sub-agent runs. P1/task-628 proved this with a
     synthetic tool; this is the first coverage with a tool a user can
     actually reach.
+
+    PR2a Task 5: the nested turn below deliberately reuses the PARENT's
+    run id, which is what still exercises the scope's own guarantee -- a
+    real child now has its own run id and cannot reach this slice at all
+    (per-run keying, pinned by `test_gate_run_scoping.py`). Same
+    assertions, same failure they detect.
     """
     gate = BuiltinToolGate(service=_FakeService())
-    gate.begin_turn()
-    gate.stamp("write_file", "approve_once")
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, "write_file", "approve_once")
     provider = BuiltinToolProvider(gate=gate)
 
-    with gate.stamp_scope():
+    with gate.stamp_scope(RUN):
         # Stand in for the child run: it clears the turn and records its own
         # verdicts on the SAME gate.
-        gate.begin_turn()
-        gate.stamp("read_file", "deny")
+        gate.begin_turn(RUN)
+        gate.stamp(RUN, "read_file", "deny")
 
     # The parent's approval must be back: the resolved verdict for write_file
     # is checked directly (not inferred from invoke()'s outcome, which can
     # also fail closed on sandbox containment for unrelated reasons).
-    assert gate.check(provider.tool_for("write_file")) is None, (
+    assert gate.check(provider.tool_for("write_file"), RUN) is None, (
         "parent's stamp was clobbered by the nested run"
     )
     # The child's verdict must not leak to the parent's stamp table.
-    assert "read_file" not in gate._stamps, "child's verdict leaked to the parent"
+    assert (RUN, "read_file") not in gate._stamps, (
+        "child's verdict leaked to the parent"
+    )

--- a/Tests/Agents/test_builtin_gate_real_tool_coverage.py
+++ b/Tests/Agents/test_builtin_gate_real_tool_coverage.py
@@ -90,7 +90,8 @@ def test_a_real_reads_tagged_tool_reaches_the_approval_card_not_silence(
         gate, _RealToolProvider(tool), None, request_approvals
     )
     verdicts = hook(
-        [ToolCall(name="read_file", args={"file_path": "notes.md"}, call_id="c1")]
+        [ToolCall(name="read_file", args={"file_path": "notes.md"}, call_id="c1")],
+        "run-1",
     )
 
     assert [row.llm_name for row in rows] == ["read_file"], (

--- a/Tests/Agents/test_builtin_provider_workspace_binding.py
+++ b/Tests/Agents/test_builtin_provider_workspace_binding.py
@@ -16,7 +16,7 @@ class _ProbeTool:
 
 
 class _OpenGate:
-    def check(self, tool, run_id=""):
+    def check(self, tool, run_id):
         return None
 
 

--- a/Tests/Agents/test_builtin_provider_workspace_binding.py
+++ b/Tests/Agents/test_builtin_provider_workspace_binding.py
@@ -16,7 +16,7 @@ class _ProbeTool:
 
 
 class _OpenGate:
-    def check(self, tool):
+    def check(self, tool, run_id=""):
         return None
 
 

--- a/Tests/Agents/test_builtin_tool_gate.py
+++ b/Tests/Agents/test_builtin_tool_gate.py
@@ -3,6 +3,13 @@ import pytest
 from tldw_chatbook.Agents.builtin_tool_gate import BuiltinToolGate, build_builtin_gate
 from tldw_chatbook.Tools.tool_executor import CalculatorTool, Tool
 
+#: PR2a Task 5: the gate keys every per-turn verdict by ``(run_id,
+#: tool_name)``, so each of these single-run tests names the one run whose
+#: turn it is exercising. The assertions are unchanged -- what a run stamps
+#: is what that same run's ``check()`` sees; cross-run isolation is what
+#: ``Tests/Agents/test_gate_run_scoping.py`` pins.
+RUN = "run-1"
+
 
 class _Mutating(Tool):
     @property
@@ -113,64 +120,64 @@ class _ServiceWithoutStore:
 
 def test_untagged_tool_is_permitted():
     gate = BuiltinToolGate(_FakeService())
-    assert gate.check(CalculatorTool()) is None
+    assert gate.check(CalculatorTool(), RUN) is None
 
 
 def test_mutating_tool_without_approval_fails_closed():
     gate = BuiltinToolGate(_FakeService())
-    reason = gate.check(_Mutating())
+    reason = gate.check(_Mutating(), RUN)
     assert reason is not None and "approval" in reason.lower()
 
 
 def test_kill_switch_blocks_even_untagged_tools():
     gate = BuiltinToolGate(_FakeService(kill=True))
-    reason = gate.check(CalculatorTool())
+    reason = gate.check(CalculatorTool(), RUN)
     assert reason is not None and "kill switch" in reason.lower()
 
 
 def test_stamped_approval_permits_a_mutating_tool():
     gate = BuiltinToolGate(_FakeService())
-    gate.begin_turn()
-    gate.stamp("write_thing", "approve_once")
-    assert gate.check(_Mutating()) is None
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, "write_thing", "approve_once")
+    assert gate.check(_Mutating(), RUN) is None
 
 
 def test_begin_turn_clears_prior_stamps():
     gate = BuiltinToolGate(_FakeService())
-    gate.begin_turn()
-    gate.stamp("write_thing", "approve_once")
-    gate.begin_turn()
-    assert gate.check(_Mutating()) is not None
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, "write_thing", "approve_once")
+    gate.begin_turn(RUN)
+    assert gate.check(_Mutating(), RUN) is not None
 
 
 def test_session_approval_permits_without_a_stamp():
     gate = BuiltinToolGate(_FakeService(session={"write_thing"}))
-    assert gate.check(_Mutating()) is None
+    assert gate.check(_Mutating(), RUN) is None
 
 
 def test_approve_session_records_a_session_approval():
     svc = _FakeService()
     gate = BuiltinToolGate(svc)
-    gate.begin_turn()
-    gate.stamp("write_thing", "approve_session")
-    assert gate.check(_Mutating()) is None
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, "write_thing", "approve_session")
+    assert gate.check(_Mutating(), RUN) is None
     assert svc.session_approved == ["write_thing"]
 
 
 def test_no_service_still_gates_mutating_tools():
     # Constraint 7: a missing service is never allow-everything.
     gate = BuiltinToolGate(None)
-    assert gate.check(CalculatorTool()) is None
-    assert gate.check(_Mutating()) is not None
+    assert gate.check(CalculatorTool(), RUN) is None
+    assert gate.check(_Mutating(), RUN) is not None
 
 
 def test_payload_is_loaded_once_per_turn():
     # Constraint 8: one store load per turn, not per call.
     svc = _FakeService()
     gate = BuiltinToolGate(svc)
-    gate.begin_turn()
+    gate.begin_turn(RUN)
     for _ in range(5):
-        gate.check(CalculatorTool())
+        gate.check(CalculatorTool(), RUN)
     assert svc.loads == 1
 
 
@@ -181,9 +188,9 @@ def test_no_persistent_state_is_ever_written_for_builtins():
     svc = _FakeService()
     svc.set_tool_state = lambda *a, **k: pytest.fail("persistent write")
     gate = BuiltinToolGate(svc)
-    gate.begin_turn()
-    gate.stamp("write_thing", "always_allow")
-    gate.check(_Mutating())          # must not raise via set_tool_state
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, "write_thing", "always_allow")
+    gate.check(_Mutating(), RUN)          # must not raise via set_tool_state
 
 
 def test_deny_state_blocks():
@@ -195,7 +202,7 @@ def test_deny_state_blocks():
         }
     }
     gate = BuiltinToolGate(_FakeService(payload=payload))
-    assert gate.check(CalculatorTool()) is not None
+    assert gate.check(CalculatorTool(), RUN) is not None
 
 
 def test_service_present_but_permission_store_is_none_still_gates():
@@ -205,8 +212,8 @@ def test_service_present_but_permission_store_is_none_still_gates():
     same allow-floor behavior as no service at all, never crash and never
     become allow-everything for tagged tools."""
     gate = BuiltinToolGate(_ServiceWithoutStore())
-    assert gate.check(CalculatorTool()) is None
-    assert gate.check(_Mutating()) is not None
+    assert gate.check(CalculatorTool(), RUN) is None
+    assert gate.check(_Mutating(), RUN) is not None
 
 
 def test_build_builtin_gate_with_no_service_still_gates():
@@ -214,8 +221,8 @@ def test_build_builtin_gate_with_no_service_still_gates():
     gate that still gates -- ``None`` is never "ungated" (Constraint 7)."""
     gate = build_builtin_gate()
     assert isinstance(gate, BuiltinToolGate)
-    assert gate.check(CalculatorTool()) is None
-    assert gate.check(_Mutating()) is not None
+    assert gate.check(CalculatorTool(), RUN) is None
+    assert gate.check(_Mutating(), RUN) is not None
 
 
 def test_build_builtin_gate_uses_the_passed_service():
@@ -223,7 +230,7 @@ def test_build_builtin_gate_uses_the_passed_service():
     given service in -- proven by its kill switch taking effect."""
     svc = _FakeService(kill=True)
     gate = build_builtin_gate(svc)
-    reason = gate.check(CalculatorTool())
+    reason = gate.check(CalculatorTool(), RUN)
     assert reason is not None and "kill switch" in reason.lower()
 
 
@@ -241,9 +248,9 @@ def test_effective_deny_wins_over_stamped_approve_once():
         }
     }
     gate = BuiltinToolGate(_FakeService(payload=payload))
-    gate.begin_turn()
-    gate.stamp("calculator", "approve_once")
-    reason = gate.check(CalculatorTool())
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, "calculator", "approve_once")
+    reason = gate.check(CalculatorTool(), RUN)
     assert reason is not None and "off" in reason.lower()
 
 
@@ -260,7 +267,7 @@ def test_effective_deny_wins_over_live_session_approval():
         }
     }
     gate = BuiltinToolGate(_FakeService(payload=payload, session={"calculator"}))
-    reason = gate.check(CalculatorTool())
+    reason = gate.check(CalculatorTool(), RUN)
     assert reason is not None and "off" in reason.lower()
 
 
@@ -275,48 +282,55 @@ def test_stamp_scope_restores_stamps_after_a_nested_run():
     first act is `begin_turn()`. Without a scope the parent's verdicts for
     this turn are wiped before its own remaining same-batch tool calls are
     dispatched. Mirrors `MCPToolProvider.stamp_scope`.
+
+    PR2a Task 5: the nested `begin_turn` here deliberately uses the SAME
+    run id as the parent. A real child now has its OWN run id and cannot
+    reach this slice at all (that is the new, load-bearing protection --
+    see `test_gate_run_scoping.py`); reusing the id is what still
+    exercises the scope's own guarantee, which is unchanged: whatever
+    happens to this run's slice inside the scope is undone on exit.
     """
     gate = BuiltinToolGate(_FakeService())
-    gate.begin_turn()
-    gate.stamp("write_thing", "approve_once")
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, "write_thing", "approve_once")
 
-    with gate.stamp_scope():
+    with gate.stamp_scope(RUN):
         # Stand in for the child's own turn against the shared gate.
-        gate.begin_turn()
-        gate.stamp("other_tool", "deny")
-        assert gate.check(_Mutating()) is not None  # child wiped it in-scope
+        gate.begin_turn(RUN)
+        gate.stamp(RUN, "other_tool", "deny")
+        assert gate.check(_Mutating(), RUN) is not None  # child wiped it in-scope
 
     # Parent's verdict is back, and the child's is gone (restore, not merge).
-    assert gate.check(_Mutating()) is None
-    assert gate._stamps == {"write_thing": "approve_once"}
+    assert gate.check(_Mutating(), RUN) is None
+    assert gate._stamps == {(RUN, "write_thing"): "approve_once"}
 
 
 def test_stamp_scope_restores_even_when_the_nested_run_raises():
     gate = BuiltinToolGate(_FakeService())
-    gate.begin_turn()
-    gate.stamp("write_thing", "approve_once")
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, "write_thing", "approve_once")
 
     try:
-        with gate.stamp_scope():
-            gate.begin_turn()
+        with gate.stamp_scope(RUN):
+            gate.begin_turn(RUN)
             raise RuntimeError("child blew up")
     except RuntimeError:
         pass
 
-    assert gate.check(_Mutating()) is None
+    assert gate.check(_Mutating(), RUN) is None
 
 
 def test_stamp_scope_is_reentrant_for_nested_scopes():
     gate = BuiltinToolGate(_FakeService())
-    gate.begin_turn()
-    gate.stamp("write_thing", "approve_once")
-    with gate.stamp_scope():
-        gate.begin_turn()
-        gate.stamp("write_thing", "deny")
-        with gate.stamp_scope():
-            gate.begin_turn()
-        assert gate._stamps == {"write_thing": "deny"}
-    assert gate._stamps == {"write_thing": "approve_once"}
+    gate.begin_turn(RUN)
+    gate.stamp(RUN, "write_thing", "approve_once")
+    with gate.stamp_scope(RUN):
+        gate.begin_turn(RUN)
+        gate.stamp(RUN, "write_thing", "deny")
+        with gate.stamp_scope(RUN):
+            gate.begin_turn(RUN)
+        assert gate._stamps == {(RUN, "write_thing"): "deny"}
+    assert gate._stamps == {(RUN, "write_thing"): "approve_once"}
 
 
 # --- task-627 (P2 Task 2): settings-time enumeration -------------------------

--- a/Tests/Agents/test_fleet_coordinator.py
+++ b/Tests/Agents/test_fleet_coordinator.py
@@ -104,3 +104,17 @@ def test_concurrent_reserve_never_exceeds_cap():
         t.join()
     assert sum(1 for h in got if h is not None) == 5
     assert c.live_count() == 5
+
+
+def test_finish_guard_survives_a_status_outside_the_terminal_vocabulary():
+    # The guard must not rely on status vocabulary membership. A handle that
+    # finishes with "timeout" (not in TERMINAL_RUN_STATUSES) should reject a
+    # later finish with RUN_DONE. This tests the idempotency guard's use of
+    # liveness, not status membership.
+    c = _coord()
+    h = c.reserve(task="a", agent=None)
+    c.finish(h.handle_id, "timeout")
+    c.finish(h.handle_id, RUN_DONE, result="late answer")
+    assert c.get(h.handle_id).status == "timeout"
+    assert c.get(h.handle_id).result == ""
+    assert c.live_count() == 0

--- a/Tests/Agents/test_fleet_coordinator.py
+++ b/Tests/Agents/test_fleet_coordinator.py
@@ -1,0 +1,106 @@
+"""FleetCoordinator: pure handle/state machine for concurrent children."""
+
+import threading
+
+import pytest
+
+from tldw_chatbook.Agents.agent_models import RUN_DONE, RUN_ERROR
+from tldw_chatbook.Agents.fleet_coordinator import (
+    FLEET_FINISHED,
+    FLEET_STARTED,
+    FleetCoordinator,
+)
+
+
+def _coord(max_live=3):
+    ticks = iter(range(1000))
+    return FleetCoordinator(max_live=max_live, clock=lambda: float(next(ticks)))
+
+
+def test_reserve_returns_handle_and_emits_started():
+    c = _coord()
+    h = c.reserve(task="do x", agent="researcher")
+    assert h is not None and h.task == "do x" and h.agent == "researcher"
+    assert h.status == "running" and h.finished_at is None
+    events = c.drain_events()
+    assert [e.kind for e in events] == [FLEET_STARTED]
+    assert events[0].handle_id == h.handle_id
+    assert c.drain_events() == []  # drain is destructive
+
+
+def test_reserve_refuses_past_live_cap():
+    c = _coord(max_live=2)
+    assert c.reserve(task="a", agent=None) is not None
+    assert c.reserve(task="b", agent=None) is not None
+    assert c.reserve(task="c", agent=None) is None
+    assert c.live_count() == 2
+
+
+def test_finish_frees_a_slot_and_emits_finished():
+    c = _coord(max_live=1)
+    h = c.reserve(task="a", agent=None)
+    assert c.reserve(task="b", agent=None) is None
+    c.finish(h.handle_id, RUN_DONE, result="answer")
+    assert c.live_count() == 0
+    assert c.reserve(task="b", agent=None) is not None
+    kinds = [e.kind for e in c.drain_events()]
+    assert kinds == [FLEET_STARTED, FLEET_FINISHED, FLEET_STARTED]
+    done = c.get(h.handle_id)
+    assert done.status == RUN_DONE and done.result == "answer"
+    assert done.finished_at is not None
+
+
+def test_finish_is_idempotent_first_writer_wins():
+    # A child abandoned after a join timeout can finish LATE; the
+    # coordinator must not let it overwrite a terminal status.
+    c = _coord()
+    h = c.reserve(task="a", agent=None)
+    c.finish(h.handle_id, "cancelled")
+    c.finish(h.handle_id, RUN_DONE, result="late answer")
+    assert c.get(h.handle_id).status == "cancelled"
+    assert c.get(h.handle_id).result == ""
+
+
+def test_attach_run_records_run_id():
+    c = _coord()
+    h = c.reserve(task="a", agent=None)
+    c.attach_run(h.handle_id, "run-123")
+    assert c.get(h.handle_id).run_id == "run-123"
+    c.finish(h.handle_id, RUN_ERROR, error="boom")
+    assert c.drain_events()[-1].run_id == "run-123"
+
+
+def test_snapshot_returns_copies_not_internals():
+    c = _coord()
+    h = c.reserve(task="a", agent=None)
+    snap = c.snapshot()
+    snap[0].status = "tampered"
+    assert c.get(h.handle_id).status == "running"
+
+
+def test_all_finished_reflects_live_state():
+    c = _coord()
+    assert c.all_finished() is True
+    h = c.reserve(task="a", agent=None)
+    assert c.all_finished() is False
+    c.finish(h.handle_id, RUN_DONE)
+    assert c.all_finished() is True
+
+
+def test_concurrent_reserve_never_exceeds_cap():
+    c = _coord(max_live=5)
+    got = []
+    lock = threading.Lock()
+
+    def worker():
+        h = c.reserve(task="t", agent=None)
+        with lock:
+            got.append(h)
+
+    threads = [threading.Thread(target=worker) for _ in range(40)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert sum(1 for h in got if h is not None) == 5
+    assert c.live_count() == 5

--- a/Tests/Agents/test_fleet_runtime.py
+++ b/Tests/Agents/test_fleet_runtime.py
@@ -175,7 +175,13 @@ def db(tmp_path):
 
 
 def make_fleet_service(
-    db, parent_replies, child_replies=None, max_live=3, providers=()
+    db,
+    parent_replies,
+    child_replies=None,
+    max_live=3,
+    providers=(),
+    revoke_approvals=None,
+    review_tool_calls=None,
 ):
     """An AgentService wired for the fleet (explicit coordinator = opt in)."""
     registry = ToolCatalogRegistry()
@@ -189,6 +195,8 @@ def make_fleet_service(
         registry=registry,
         chat_call=chat,
         fleet_coordinator=coordinator,
+        revoke_approvals=revoke_approvals,
+        review_tool_calls=review_tool_calls,
     )
     return service, chat, coordinator
 
@@ -1044,6 +1052,68 @@ def test_wait_agents_cancellation_stops_children_and_ends_the_run(db):
     assert child["status"] == RUN_CANCELLED
 
 
+def test_cancelling_and_abandoning_a_child_revokes_its_approval_cards(db):
+    """PR2a Task 7: a stopped child's pending approval card is revoked.
+
+    The approval wait lives on the child's own per-call daemon thread, so
+    a card left on screen after the child is cancelled is a card the user
+    can still press Approve on -- and the tool would run for real for a
+    run that already reads ``cancelled``. The service does not know what a
+    card is; it only knows which run it just stopped, and hands that id to
+    the injected ``revoke_approvals`` seam (wired by the Console bridge to
+    ``ConsoleChatController.revoke_approval_rounds_for_run``).
+
+    The child here is wedged inside its provider call, so it is both
+    cooperatively cancelled AND abandoned -- the two moments that must
+    revoke.
+    """
+    never = threading.Event()
+    entered = threading.Event()
+
+    def wedged_child():
+        entered.set()
+        never.wait(30.0)  # released in the finally below, not by the run
+        return "unreachable"
+
+    revoked: list[str] = []
+    short = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(
+            max_steps=40,
+            max_model_turns=40,
+            max_subagents=2,
+            max_wall_seconds=1.0,
+        ),
+    )
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [fence(SPAWN_TOOL_NAME, {"task": "wedged"}), "parent done"],
+        {"wedged": [wedged_child]},
+        revoke_approvals=revoked.append,
+    )
+    try:
+        _run_id, outcome = service.run_turn(
+            conversation_id="c",
+            messages=[{"role": "user", "content": "go"}],
+            config=short,
+            api_endpoint="llama_cpp",
+        )
+        assert entered.is_set()
+        assert outcome.status == RUN_DONE
+        child_run_ids = [handle.run_id for handle in coordinator.snapshot()]
+        assert child_run_ids and all(child_run_ids), (
+            "precondition: the child's run id reached its handle"
+        )
+        # Revoked for exactly the children this turn stopped -- never for
+        # the parent, whose own card (if any) belongs to a live run.
+        assert set(revoked) == set(child_run_ids)
+        assert _run_id not in revoked
+    finally:
+        never.set()
+
+
 def test_wait_agents_is_bounded_by_the_runs_remaining_wall_clock(
     db, monkeypatch
 ):
@@ -1340,6 +1410,60 @@ def test_child_tool_call_binds_the_childs_own_run_id(db):
     child = next(r for r in db.list_runs("c") if r["agent_kind"] == "subagent")
     assert probe.seen == [child["id"]]
     assert probe.seen[0] != ""
+
+
+def test_the_review_hook_runs_with_its_own_runs_id_bound(db):
+    """The approval bridge the review hook calls must see the run id.
+
+    PR2a Task 7: an approval card is armed from inside
+    ``review_tool_calls`` (and from ``MCPToolProvider.invoke``'s
+    single-call fallback), and each armed round records WHICH RUN armed
+    it so a cancelled child's card can be revoked without touching a live
+    sibling's. The hook's own ``run_id`` parameter cannot reach that
+    bridge -- it is a pre-bound callable whose signature the hook builders
+    do not own -- so the service binds the same ``run_context``
+    ContextVar around the hook that it already binds around tool
+    execution. Unbound, ownership would silently read ``""`` and every
+    revoke would be a no-op: fail-OPEN, which is the direction that
+    leaves a cancelled child's card pressable.
+    """
+    seen: list[tuple[str, str]] = []
+
+    def review(calls, run_id):
+        seen.append((run_id, current_run_id()))
+        return {}
+
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=("calculator", SPAWN_TOOL_NAME),
+        budget=RunBudget(max_steps=40, max_model_turns=40, max_subagents=2),
+    )
+    service, _chat, _coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "probe task"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {"probe task": [fence("calculator", {"expression": "1+1"}), "child done"]},
+        review_tool_calls=review,
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=cfg,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert seen, "the review hook never ran"
+    # Every batch: the id bound for the hook IS the run the hook was told
+    # it was reviewing -- never "" and never a sibling's.
+    assert all(bound == hook_run_id for hook_run_id, bound in seen), seen
+    child = next(r for r in db.list_runs("c") if r["agent_kind"] == "subagent")
+    bound_ids = {bound for _hook_run_id, bound in seen}
+    assert child["id"] in bound_ids, "the child's own batch was reviewed unbound"
+    assert run_id in bound_ids
 
 
 # -- deferred self-review items -------------------------------------------

--- a/Tests/Agents/test_fleet_runtime.py
+++ b/Tests/Agents/test_fleet_runtime.py
@@ -14,9 +14,11 @@ the older one.
 Scripting note: ``test_agent_service.ScriptedChat`` pops one shared
 ordered list, which stops being deterministic the moment children run on
 their own threads (whichever thread wins the race takes the next reply).
-``FleetChat`` below keeps the same shape but ADDRESSES replies -- an
-ordered script for the parent, a per-task script for each child -- so
-every assertion here is deterministic under real threads.
+``test_agent_service.FleetChat`` keeps the same shape but ADDRESSES
+replies -- an ordered script for the parent, a per-task script for each
+child -- so every assertion here is deterministic under real threads. It
+was written here and moved next to ``ScriptedChat`` in Task 6.5, when
+flipping the default made nine other suites need it too.
 """
 
 import threading
@@ -46,10 +48,7 @@ from tldw_chatbook.Agents.agent_models import (
     WAIT_AGENTS_TOOL_NAME,
 )
 from tldw_chatbook.Agents import agent_service
-from tldw_chatbook.Agents.agent_service import (
-    SUBAGENT_SYSTEM_PROMPT,
-    AgentService,
-)
+from tldw_chatbook.Agents.agent_service import AgentService
 from tldw_chatbook.Agents.fleet_coordinator import FleetCoordinator
 from tldw_chatbook.Agents.run_context import current_run_id
 from tldw_chatbook.Agents.tool_catalog import (
@@ -61,76 +60,14 @@ from tldw_chatbook.Agents.tool_catalog import (
 )
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
-from Tests.Agents.test_agent_service import ScriptedChat, fence, provider_reply
-
-# The child's system prompt is the sub-agent prompt (plus, for a named
-# agent, its instructions) followed by the rendered fence protocol -- so a
-# prefix match on its first sentence is what identifies a child's provider
-# call, the same identity contract `console_agent_bridge._is_subagent`
-# relies on.
-_SUBAGENT_PREFIX = SUBAGENT_SYSTEM_PROMPT.split(".")[0]
+from Tests.Agents.test_agent_service import (
+    SUBAGENT_PROMPT_PREFIX,
+    FleetChat,
+    ScriptedChat,
+    fence,
+)
 
 _JOIN_TIMEOUT = 5.0
-
-
-def _child_task(payload: list[dict]) -> str | None:
-    """The task text of the child whose provider call this payload is.
-
-    Args:
-        payload: The ``messages_payload`` handed to ``chat_api_call``.
-
-    Returns:
-        The child's task text (its first user message), or ``None`` when
-        this payload belongs to the primary agent.
-    """
-    if not payload:
-        return None
-    system = payload[0]
-    if system.get("role") != "system":
-        return None
-    if not str(system.get("content", "")).startswith(_SUBAGENT_PREFIX):
-        return None
-    for message in payload[1:]:
-        if message.get("role") == "user":
-            return str(message.get("content", ""))
-    return None
-
-
-class FleetChat:
-    """Addressed scripted provider: one script per agent, not one queue.
-
-    Replies may be plain strings/dicts (as ``ScriptedChat``) or zero-arg
-    callables, which are invoked at call time -- that is how a test gates a
-    child on an ``Event`` or a ``Barrier`` while the parent keeps running.
-    """
-
-    def __init__(self, parent_replies, child_replies=None):
-        self.parent_replies = list(parent_replies)
-        self.child_replies = {
-            task: list(script) for task, script in (child_replies or {}).items()
-        }
-        self.calls: list[dict] = []
-        self.child_calls: dict[str, list[dict]] = {}
-        self._lock = threading.Lock()
-
-    def __call__(self, **kwargs):
-        payload = kwargs["messages_payload"]
-        task = _child_task(payload)
-        with self._lock:
-            self.calls.append(kwargs)
-            if task is None:
-                assert self.parent_replies, "parent script exhausted"
-                item = self.parent_replies.pop(0)
-            else:
-                self.child_calls.setdefault(task, []).append(kwargs)
-                script = self.child_replies.get(task)
-                assert script, f"no scripted reply left for child task {task!r}"
-                item = script.pop(0)
-        # Called OUTSIDE the lock: a gated reply blocks here, and holding
-        # the lock would serialize the very concurrency under test.
-        if callable(item):
-            item = item()
-        return provider_reply(item)
 
 
 class RunIdProbeProvider:
@@ -205,13 +142,40 @@ def make_fleet_service(
     return service, chat, coordinator
 
 
-def make_inline_service(db, replies):
-    """An AgentService with NO coordinator -- the pre-PR inline path.
+def _patch_max_live(monkeypatch, value):
+    """Make `[agents] max_live_subagents` read as `value`.
+
+    Every OTHER `_setting` key (the run-log eviction knobs read by
+    `_make_call_model`) must keep returning its own default, or this
+    fixture would silently reconfigure unrelated behaviour.
+    """
+    real_key = agent_service.MAX_LIVE_SUBAGENTS_KEY
+
+    def fake_setting(key, default):
+        return value if key == real_key else default
+
+    monkeypatch.setattr(agent_service, "_setting", fake_setting)
+
+
+def make_inline_service(db, replies, monkeypatch, *, max_live=1):
+    """An AgentService on the pre-PR inline path: no coordinator, cap 1.
+
+    `monkeypatch` is REQUIRED, not optional: since Task 6.5 the shipped
+    default is 3, so merely omitting the injected coordinator no longer
+    buys the inline path -- `run_turn` would size a fleet from config.
+    Every inline-path test therefore has to say `max_live_subagents = 1`
+    out loud, which is also what a user opting out actually writes.
 
     Uses the ORDINARY single-queue ``ScriptedChat``: with no fleet there
     are no threads, so strict reply ordering is exactly what should still
     hold -- and asserting against it is the point.
+
+    Args:
+        max_live: the raw `[agents] max_live_subagents` value to pin.
+            Defaults to the opt-out, `1`; the config-coercion test passes
+            other values that must ALSO resolve to the inline path.
     """
+    _patch_max_live(monkeypatch, max_live)
     registry = ToolCatalogRegistry()
     registry.register_provider(BuiltinToolProvider())
     chat = ScriptedChat(replies)
@@ -642,7 +606,7 @@ def test_single_child_under_a_live_fleet_routes_through_wait_agents(db):
     # Same clean context: the child saw only its task + its own prompt.
     child_call = chat.child_calls["compute 6*7"][0]["messages_payload"]
     assert child_call[0]["role"] == "system"
-    assert child_call[0]["content"].startswith(_SUBAGENT_PREFIX)
+    assert child_call[0]["content"].startswith(SUBAGENT_PROMPT_PREFIX)
     assert child_call[1] == {"role": "user", "content": "compute 6*7"}
     assert not any("delegate this" in m["content"] for m in child_call)
     # Same result text reaches the parent -- via wait_agents rather than
@@ -651,11 +615,16 @@ def test_single_child_under_a_live_fleet_routes_through_wait_agents(db):
     assert wait_results and "sub answer: 42" in wait_results[0]
 
 
-def test_without_a_coordinator_spawn_stays_inline(db):
-    """No coordinator => the pre-PR inline path, result returned by spawn.
+def test_max_live_of_one_keeps_spawn_inline(db, monkeypatch):
+    """`max_live_subagents = 1` => the pre-PR inline path, result from spawn.
 
-    This is the gate that keeps the existing spawn suites byte-identical:
-    the fleet is opt-in, and an un-opted-in service must not thread.
+    This is the KILL SWITCH gate. Before Task 6.5 the same guarantee was
+    reached by simply not injecting a coordinator (the default was 1);
+    since the default is 3, opting out is an explicit config value, and
+    this test now pins that value rather than the absence of an injection.
+    What it guarantees is unchanged: at a cap of 1 no coordinator is
+    built, the child runs inline and synchronously, and `spawn` itself
+    returns the child's answer instead of a handle.
     """
     service, _chat = make_inline_service(
         db,
@@ -664,6 +633,7 @@ def test_without_a_coordinator_spawn_stays_inline(db):
             "sub answer: 42",  # consumed by the child, INLINE and in order
             "The sub-agent says 42.",
         ],
+        monkeypatch,
     )
     run_id, outcome = service.run_turn(
         conversation_id="c",
@@ -672,6 +642,7 @@ def test_without_a_coordinator_spawn_stays_inline(db):
         api_endpoint="llama_cpp",
     )
     assert outcome.status == RUN_DONE
+    assert service._fleet is None
     spawn_results = _tool_results(db.get_run(run_id), SPAWN_TOOL_NAME)
     # The spawn call itself returned the child's answer -- no handle.
     assert spawn_results == ["sub answer: 42"]
@@ -679,8 +650,9 @@ def test_without_a_coordinator_spawn_stays_inline(db):
     assert child["result"] == "sub answer: 42"
 
 
-def test_fleet_tools_are_not_offered_without_a_coordinator(db):
-    service, chat = make_inline_service(db, ["just answering"])
+def test_fleet_tools_are_not_offered_at_max_live_of_one(db, monkeypatch):
+    """Same kill-switch pin: at a cap of 1 neither fleet tool is disclosed."""
+    service, chat = make_inline_service(db, ["just answering"], monkeypatch)
     service.run_turn(
         conversation_id="c",
         messages=[{"role": "user", "content": "go"}],
@@ -733,10 +705,11 @@ def test_fleet_tools_are_primary_only(db):
 
 # -- the config switch: the ONLY production-reachable path ----------------
 #
-# Every other test in this file injects a coordinator. In production
-# nothing does (yet), so `[agents] max_live_subagents` -> `run_turn`'s
-# `max_live > 1` branch is the only way a real user turns the fleet on --
-# and it is the exact line the eventual default-flip will change.
+# Every other test in this file injects a coordinator. Nothing in
+# production does, so `[agents] max_live_subagents` -> `run_turn`'s
+# `max_live > 1` branch is the whole of a real user's control over the
+# fleet. Task 6.5 moved DEFAULT_MAX_LIVE_SUBAGENTS 1 -> 3, so that branch
+# is now taken by DEFAULT and a cap of 1 is the opt-OUT.
 
 
 @pytest.mark.parametrize(
@@ -760,21 +733,6 @@ def test_fleet_tools_are_primary_only(db):
 )
 def test_coerce_max_live_subagents(configured, expected):
     assert agent_service._coerce_max_live_subagents(configured) == expected
-
-
-def _patch_max_live(monkeypatch, value):
-    """Make `[agents] max_live_subagents` read as `value`.
-
-    Every OTHER `_setting` key (the run-log eviction knobs read by
-    `_make_call_model`) must keep returning its own default, or this
-    fixture would silently reconfigure unrelated behaviour.
-    """
-    real_key = agent_service.MAX_LIVE_SUBAGENTS_KEY
-
-    def fake_setting(key, default):
-        return value if key == real_key else default
-
-    monkeypatch.setattr(agent_service, "_setting", fake_setting)
 
 
 def test_config_above_one_builds_a_fleet_and_threads_spawns(db, monkeypatch):
@@ -811,15 +769,20 @@ def test_config_above_one_builds_a_fleet_and_threads_spawns(db, monkeypatch):
     assert waits and "answer one" in waits[0]
 
 
-@pytest.mark.parametrize("configured", ["1", 1, 0, "nonsense", None])
-def test_config_of_one_or_junk_keeps_the_inline_path(db, monkeypatch, configured):
-    """Anything that resolves to <= 1 -- including junk -- means no fleet.
+@pytest.mark.parametrize("configured", ["1", 1, 0, -5])
+def test_config_of_one_or_less_keeps_the_inline_path(db, monkeypatch, configured):
+    """Anything that RESOLVES to <= 1 means no fleet: the opt-out.
 
-    This is the shipped default, and the guarantee the pre-existing spawn
-    suites rely on: no coordinator, no fleet tools, spawn returns the
-    child's own answer.
+    Before Task 6.5 this parametrization also carried `"nonsense"` and
+    `None`, because unparseable config fell back to a default of 1. The
+    default is now 3, so junk resolves to a FLEET -- that half moved to
+    `test_config_of_junk_now_lands_on_the_default_fleet` below rather than
+    being dropped. `-5` replaces them here: a negative is still floored to
+    1 by `_coerce_max_live_subagents`, so it still means inline.
+
+    The guarantee itself is unchanged and is what a user opting out gets:
+    no coordinator, no fleet tools, spawn returns the child's own answer.
     """
-    _patch_max_live(monkeypatch, configured)
     service, chat = make_inline_service(
         db,
         [
@@ -827,6 +790,8 @@ def test_config_of_one_or_junk_keeps_the_inline_path(db, monkeypatch, configured
             "sub answer: 42",
             "The sub-agent says 42.",
         ],
+        monkeypatch,
+        max_live=configured,
     )
     run_id, outcome = service.run_turn(
         conversation_id="c",
@@ -841,6 +806,42 @@ def test_config_of_one_or_junk_keeps_the_inline_path(db, monkeypatch, configured
     system_prompt = chat.calls[0]["messages_payload"][0]["content"]
     assert WAIT_AGENTS_TOOL_NAME not in system_prompt
     assert CHECK_AGENTS_TOOL_NAME not in system_prompt
+
+
+@pytest.mark.parametrize("configured", ["nonsense", None, ""])
+def test_config_of_junk_now_lands_on_the_default_fleet(db, monkeypatch, configured):
+    """Junk config still never raises -- it lands on the DEFAULT, now 3.
+
+    The other half of the old `test_config_of_one_or_junk_keeps_the_
+    inline_path`: its junk cases asserted "no fleet" only because the
+    default they fall back to WAS 1. The coverage worth keeping is that a
+    malformed `[agents] max_live_subagents` never stops a run and always
+    resolves to a defined size -- so this asserts the same inputs against
+    what the default now is: a live fleet, threading its spawns.
+    """
+    _patch_max_live(monkeypatch, configured)
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    chat = FleetChat(
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {"task one": ["answer one"]},
+    )
+    service = AgentService(db=db, registry=registry, chat_call=chat)
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert service._fleet is not None
+    assert service._fleet._max_live == agent_service.DEFAULT_MAX_LIVE_SUBAGENTS
+    spawn_results = _tool_results(db.get_run(run_id), SPAWN_TOOL_NAME)
+    assert spawn_results and spawn_results[0].startswith("started ")
 
 
 def test_injected_coordinator_wins_over_the_config(db, monkeypatch):

--- a/Tests/Agents/test_fleet_runtime.py
+++ b/Tests/Agents/test_fleet_runtime.py
@@ -21,6 +21,7 @@ every assertion here is deterministic under real threads.
 
 import threading
 import time
+from collections import Counter
 
 import pytest
 
@@ -40,6 +41,7 @@ from tldw_chatbook.Agents.agent_models import (
 from tldw_chatbook.Agents.agent_models import (
     CHECK_AGENTS_TOOL_NAME,
     FENCE_TOOL_RESULT_PREFIX,
+    RUN_SKILL_SCRIPT_TOOL_NAME,
     RUNTIME_TOOL_NAMES,
     WAIT_AGENTS_TOOL_NAME,
 )
@@ -182,6 +184,7 @@ def make_fleet_service(
     providers=(),
     revoke_approvals=None,
     review_tool_calls=None,
+    run_skill_script_tool=None,
 ):
     """An AgentService wired for the fleet (explicit coordinator = opt in)."""
     registry = ToolCatalogRegistry()
@@ -197,6 +200,7 @@ def make_fleet_service(
         fleet_coordinator=coordinator,
         revoke_approvals=revoke_approvals,
         review_tool_calls=review_tool_calls,
+        run_skill_script_tool=run_skill_script_tool,
     )
     return service, chat, coordinator
 
@@ -1106,9 +1110,16 @@ def test_cancelling_and_abandoning_a_child_revokes_its_approval_cards(db):
         assert child_run_ids and all(child_run_ids), (
             "precondition: the child's run id reached its handle"
         )
-        # Revoked for exactly the children this turn stopped -- never for
-        # the parent, whose own card (if any) belongs to a live run.
-        assert set(revoked) == set(child_run_ids)
+        # Counted, not set-collapsed (review M2): the two revoke sites are
+        # SEPARATE moments and each must be pinned on its own. A set
+        # comparison stayed green when either one was deleted. This child
+        # is wedged, so it is revoked exactly twice -- once by
+        # `_cancel_fleet_handles`' cooperative cancel, once by
+        # `_settle_fleet`'s abandon of what the join could not reclaim.
+        assert Counter(revoked) == Counter({run: 2 for run in child_run_ids}), (
+            f"expected each stopped child revoked at both moments: {revoked}"
+        )
+        # Never the parent, whose own card (if any) belongs to a live run.
         assert _run_id not in revoked
     finally:
         never.set()
@@ -1410,6 +1421,62 @@ def test_child_tool_call_binds_the_childs_own_run_id(db):
     child = next(r for r in db.list_runs("c") if r["agent_kind"] == "subagent")
     assert probe.seen == [child["id"]]
     assert probe.seen[0] != ""
+
+
+def test_an_in_loop_runtime_tool_sees_its_own_runs_id(db):
+    """`run_skill_script` is dispatched IN-LOOP, and it arms a confirm card.
+
+    Review M1: unlike a provider tool, the runtime tools never go through
+    ``invoke_tool``'s per-call daemon thread -- ``run_agent_loop`` calls
+    them directly on the run's own thread. ``run_skill_script`` raises a
+    consent card whose round records ``current_run_id()`` so a cancelled
+    child's confirm can be revoked; if the loop thread had no binding,
+    that ownership would read ``""``, the revoke would silently match
+    nothing, and a clicked Allow would still execute the script.
+
+    The tool is all-agents scope, so the CHILD is the case that matters.
+    """
+    seen: list[str] = []
+
+    def run_skill_script_tool(skill_name, script_path, args):
+        seen.append(current_run_id())
+        return ToolResult(ok=True, content="exit_code: 0")
+
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(max_steps=40, max_model_turns=40, max_subagents=2),
+    )
+    service, _chat, _coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "script task"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {
+            "script task": [
+                fence(
+                    RUN_SKILL_SCRIPT_TOOL_NAME,
+                    {"skill_name": "demo", "script_path": "run.sh", "args": []},
+                ),
+                "child done",
+            ]
+        },
+        run_skill_script_tool=run_skill_script_tool,
+    )
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=cfg,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    child = next(r for r in db.list_runs("c") if r["agent_kind"] == "subagent")
+    assert seen == [child["id"]], (
+        f"the child's in-loop runtime tool ran unbound or as another run: {seen}"
+    )
 
 
 def test_the_review_hook_runs_with_its_own_runs_id_bound(db):

--- a/Tests/Agents/test_fleet_runtime.py
+++ b/Tests/Agents/test_fleet_runtime.py
@@ -1239,6 +1239,77 @@ def test_child_thread_exception_finishes_the_handle_as_error(db):
     assert "child thread blew up" in handle.error
 
 
+def test_setup_phase_exception_still_persists_a_terminal_db_status(
+    db, monkeypatch
+):
+    """A setup-phase exception must not leave the child's DB row `running`.
+
+    `_run_one`'s own `except Exception` (which calls `_persist`) wraps
+    ONLY the `run_agent_loop(...)` call. Anything between `create_run()`
+    and that try block -- notably `initial_disclosure`, which walks the
+    tool catalog's cache/lock path -- is unprotected: raising there
+    unwinds `_run_one` entirely, past `_persist`, straight into
+    `run_child`'s `except BaseException`. Unlike
+    `test_child_thread_exception_finishes_the_handle_as_error` above
+    (which replaces the whole of `_run_one`, so `create_run()` never
+    runs and no DB row ever exists), this raises AFTER `create_run()`
+    and `attach_run()` have already fired -- a DB row exists, in
+    `running` status, and nothing but `run_child`'s `finally` can ever
+    mark it terminal. Before the fix that `finally` only called
+    `fleet.finish()` (in-memory), so the row stayed `running` for the
+    life of the process -- only `reconcile_orphaned_runs` on the NEXT
+    app restart would clear it, violating spec Sec 3 invariant 3
+    ("DB is truth").
+    """
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "boom"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "handled",
+        ],
+        # "never reached" is literal: initial_disclosure blows up before
+        # the child ever asks the model for a reply.
+        {"boom": ["never reached"]},
+        allow_unconsumed=True,
+    )
+    real_initial_disclosure = agent_service.initial_disclosure
+
+    def exploding_initial_disclosure(registry, budget):
+        # Only a depth-1 CHILD's budget is clamped to max_subagents == 0
+        # (`clamp_child_budget`); the primary's is > 0. This fires only
+        # for the child -- standing in for a misbehaving provider's
+        # `list_catalog()` recursing into the tool catalog's RLock
+        # (Task 4's own documented trigger for this exact exception).
+        if budget.max_subagents == 0:
+            raise RecursionError("setup-phase blew up")
+        return real_initial_disclosure(registry, budget)
+
+    monkeypatch.setattr(
+        agent_service, "initial_disclosure", exploding_initial_disclosure
+    )
+
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE  # the PARENT survives
+    assert coordinator.all_finished()
+
+    handle = coordinator.snapshot()[0]
+    assert handle.status == RUN_ERROR
+    assert handle.run_id, "attach_run must have fired before the exception"
+
+    # The headline assertion: the child's DB row reached a terminal
+    # status. Before the fix this read "running" forever.
+    child_row = db.get_run(handle.run_id)
+    assert child_row is not None
+    assert child_row["status"] in TERMINAL_RUN_STATUSES
+    assert child_row["status"] != "running"
+
+
 class _SpyRunLogWriter:
     """Minimal stand-in recording the run tree's two cleanup calls."""
 

--- a/Tests/Agents/test_fleet_runtime.py
+++ b/Tests/Agents/test_fleet_runtime.py
@@ -122,13 +122,22 @@ def make_fleet_service(
     revoke_approvals=None,
     review_tool_calls=None,
     run_skill_script_tool=None,
+    allow_unconsumed=False,
 ):
-    """An AgentService wired for the fleet (explicit coordinator = opt in)."""
+    """An AgentService wired for the fleet (explicit coordinator = opt in).
+
+    `allow_unconsumed` forwards to `FleetChat`: set it in a test that
+    deliberately strands scripted turns (a cancelled, wedged, or exploding
+    child), so the teardown consumption sweep does not flag them. Mis-keyed
+    scripts stay fatal either way.
+    """
     registry = ToolCatalogRegistry()
     registry.register_provider(BuiltinToolProvider())
     for provider in providers:
         registry.register_provider(provider)
-    chat = FleetChat(parent_replies, child_replies)
+    chat = FleetChat(
+        parent_replies, child_replies, allow_unconsumed=allow_unconsumed
+    )
     coordinator = FleetCoordinator(max_live=max_live, clock=time.monotonic)
     service = AgentService(
         db=db,
@@ -1040,6 +1049,9 @@ def test_wait_agents_cancellation_stops_children_and_ends_the_run(db):
                 fence("calculator", {"expression": f"1+{n}"}) for n in range(60)
             ]
         },
+        # The child is CANCELLED mid-flight: its remaining scripted turns
+        # are meant to go unused -- that is the point of the test.
+        allow_unconsumed=True,
     )
     _run_id, outcome = service.run_turn(
         conversation_id="c",
@@ -1158,6 +1170,9 @@ def test_wait_agents_is_bounded_by_the_runs_remaining_wall_clock(
             "gave up",
         ],
         {"wedged": [wedged_child]},
+        # The run is cut short by its 1s wall clock, so the parent's last
+        # scripted turn ("gave up") is deliberately never reached.
+        allow_unconsumed=True,
     )
     try:
         started_at = time.monotonic()
@@ -1197,7 +1212,10 @@ def test_child_thread_exception_finishes_the_handle_as_error(db):
             fence(WAIT_AGENTS_TOOL_NAME, {}),
             "handled",
         ],
+        # "never reached" is literal: _run_one is monkeypatched to raise
+        # before the child ever asks for a reply.
         {"boom": ["never reached"]},
+        allow_unconsumed=True,
     )
     real_run_one = service._run_one
 

--- a/Tests/Agents/test_fleet_runtime.py
+++ b/Tests/Agents/test_fleet_runtime.py
@@ -590,8 +590,17 @@ def test_end_of_turn_cancels_and_abandons_a_wedged_child(db):
         never.set()
 
 
-def test_single_child_path_is_unchanged(db):
-    """One spawn + wait produces the same run rows and result as inline."""
+def test_single_child_under_a_live_fleet_routes_through_wait_agents(db):
+    """One child, fleet ON: same run rows as inline, result via wait_agents.
+
+    Deliberately NOT named "path is unchanged": under a live fleet the
+    path is NOT unchanged. The run ROWS match the inline path exactly
+    (lineage, task, status, result, clean context), but the supervisor
+    reaches the result through an extra wait_agents call instead of
+    getting it back from spawn. The byte-identical acceptance criterion
+    is guarded by ``test_without_a_coordinator_spawn_stays_inline`` below
+    and by the untouched pre-existing spawn suites -- not by this test.
+    """
     service, chat, _coordinator = make_fleet_service(
         db,
         [
@@ -708,6 +717,141 @@ def test_fleet_tools_are_primary_only(db):
     refusals = _tool_results(child, WAIT_AGENTS_TOOL_NAME)
     assert refusals and "not permitted" in refusals[0]
     assert db.get_run(run_id)["status"] == RUN_DONE
+
+
+# -- the config switch: the ONLY production-reachable path ----------------
+#
+# Every other test in this file injects a coordinator. In production
+# nothing does (yet), so `[agents] max_live_subagents` -> `run_turn`'s
+# `max_live > 1` branch is the only way a real user turns the fleet on --
+# and it is the exact line the eventual default-flip will change.
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("3", 3),
+        (3, 3),
+        # A TOML float must not silently disable the fleet.
+        (3.0, 3),
+        ("2.9", 2),
+        ("1", 1),
+        (0, 1),
+        (-5, 1),
+        # Unparseable -> the documented default, never a raise.
+        ("plenty", agent_service.DEFAULT_MAX_LIVE_SUBAGENTS),
+        (None, agent_service.DEFAULT_MAX_LIVE_SUBAGENTS),
+        ("", agent_service.DEFAULT_MAX_LIVE_SUBAGENTS),
+        (float("inf"), agent_service.DEFAULT_MAX_LIVE_SUBAGENTS),
+        (float("nan"), agent_service.DEFAULT_MAX_LIVE_SUBAGENTS),
+    ],
+)
+def test_coerce_max_live_subagents(configured, expected):
+    assert agent_service._coerce_max_live_subagents(configured) == expected
+
+
+def _patch_max_live(monkeypatch, value):
+    """Make `[agents] max_live_subagents` read as `value`.
+
+    Every OTHER `_setting` key (the run-log eviction knobs read by
+    `_make_call_model`) must keep returning its own default, or this
+    fixture would silently reconfigure unrelated behaviour.
+    """
+    real_key = agent_service.MAX_LIVE_SUBAGENTS_KEY
+
+    def fake_setting(key, default):
+        return value if key == real_key else default
+
+    monkeypatch.setattr(agent_service, "_setting", fake_setting)
+
+
+def test_config_above_one_builds_a_fleet_and_threads_spawns(db, monkeypatch):
+    """`max_live_subagents = 3` with NO injected coordinator: fleet ON."""
+    _patch_max_live(monkeypatch, "3")
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    chat = FleetChat(
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {"task one": ["answer one"]},
+    )
+    service = AgentService(db=db, registry=registry, chat_call=chat)
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert service._fleet is not None
+    # Threaded, not inline: spawn handed back a handle ...
+    spawn_results = _tool_results(db.get_run(run_id), SPAWN_TOOL_NAME)
+    assert spawn_results and spawn_results[0].startswith("started ")
+    # ... the tools were offered ...
+    system_prompt = chat.calls[0]["messages_payload"][0]["content"]
+    assert WAIT_AGENTS_TOOL_NAME in system_prompt
+    assert CHECK_AGENTS_TOOL_NAME in system_prompt
+    # ... and the result still came back.
+    waits = _tool_results(db.get_run(run_id), WAIT_AGENTS_TOOL_NAME)
+    assert waits and "answer one" in waits[0]
+
+
+@pytest.mark.parametrize("configured", ["1", 1, 0, "nonsense", None])
+def test_config_of_one_or_junk_keeps_the_inline_path(db, monkeypatch, configured):
+    """Anything that resolves to <= 1 -- including junk -- means no fleet.
+
+    This is the shipped default, and the guarantee the pre-existing spawn
+    suites rely on: no coordinator, no fleet tools, spawn returns the
+    child's own answer.
+    """
+    _patch_max_live(monkeypatch, configured)
+    service, chat = make_inline_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "compute 6*7"}),
+            "sub answer: 42",
+            "The sub-agent says 42.",
+        ],
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert service._fleet is None
+    spawn_results = _tool_results(db.get_run(run_id), SPAWN_TOOL_NAME)
+    assert spawn_results == ["sub answer: 42"]
+    system_prompt = chat.calls[0]["messages_payload"][0]["content"]
+    assert WAIT_AGENTS_TOOL_NAME not in system_prompt
+    assert CHECK_AGENTS_TOOL_NAME not in system_prompt
+
+
+def test_injected_coordinator_wins_over_the_config(db, monkeypatch):
+    """An injected coordinator is the opt-in; config sizing is the fallback."""
+    _patch_max_live(monkeypatch, "1")
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {"task one": ["answer one"]},
+    )
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert service._fleet is coordinator
+    assert len(coordinator.snapshot()) == 1
 
 
 # -- result budgeting (spec §5) -------------------------------------------
@@ -993,6 +1137,128 @@ def test_child_thread_exception_finishes_the_handle_as_error(db):
     handle = coordinator.snapshot()[0]
     assert handle.status == RUN_ERROR
     assert "child thread blew up" in handle.error
+
+
+class _SpyRunLogWriter:
+    """Minimal stand-in recording the run tree's two cleanup calls."""
+
+    def __init__(self):
+        self.is_active = False
+        self.log_dir = None
+        self.bound: str | None = None
+        self.manifests: list[dict] = []
+        self.closed = 0
+
+    def bind(self, run_id):
+        self.bound = run_id
+
+    def append(self, **kwargs):
+        return None
+
+    def write_manifest(self, data):
+        self.manifests.append(data)
+
+    def close(self):
+        self.closed += 1
+
+
+def test_thread_start_failure_is_contained_and_the_turn_still_finalizes(
+    db, monkeypatch
+):
+    """Thread exhaustion must not strand a handle or skip run finalization.
+
+    Registering the thread before ``start()`` succeeded meant
+    ``_settle_fleet`` would later join an unstarted thread -- a
+    RuntimeError out of ``run_turn`` that skips ``write_manifest()`` and
+    ``run_log_writer.close()``, leaking a file descriptor. The reserved
+    handle was never finished either, so the settle loop first burned the
+    whole remaining wall-clock waiting for a child that does not exist.
+    """
+    db.create_agent_definition(
+        AgentDefinition(
+            name="researcher",
+            description="Searches.",
+            instructions="Cite sources.",
+        )
+    )
+    # Fail only the FIRST fleet thread, and only fleet threads: everything
+    # else in the process (including _call_with_timeout's "tool-*" workers,
+    # sqlite, and loguru) must keep working normally.
+    real_start = threading.Thread.start
+    failures: list[str] = []
+
+    def flaky_start(self):
+        if self.name.startswith("fleet-") and not failures:
+            failures.append(self.name)
+            raise RuntimeError("can't start new thread")
+        return real_start(self)
+
+    monkeypatch.setattr(threading.Thread, "start", flaky_start)
+
+    spy = _SpyRunLogWriter()
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    chat = FleetChat(
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "doomed", "agent": "researcher"}),
+            fence(SPAWN_TOOL_NAME, {"task": "task two", "agent": "researcher"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {"task two": ["answer two"]},
+    )
+    coordinator = FleetCoordinator(max_live=3, clock=time.monotonic)
+    service = AgentService(
+        db=db,
+        registry=registry,
+        chat_call=chat,
+        run_log_writer=spy,
+        fleet_coordinator=coordinator,
+    )
+    # ONE spawn slot: the failed spawn must give its slot back, or the
+    # second (real) spawn would be refused as budget-exhausted.
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(
+            max_steps=40,
+            max_model_turns=40,
+            max_subagents=1,
+            max_wall_seconds=60.0,
+        ),
+    )
+    started_at = time.monotonic()
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=cfg,
+        api_endpoint="llama_cpp",
+    )
+    elapsed = time.monotonic() - started_at
+
+    assert failures, "the fleet thread's start() was never exercised"
+    assert outcome.status == RUN_DONE
+    # The turn was NOT held open by a handle nobody would ever finish.
+    assert elapsed < 10.0
+    # Finalization still happened -- manifest written, writer closed once.
+    assert len(spy.manifests) == 1
+    assert spy.manifests[0]["run_id"] == run_id
+    assert spy.closed == 1
+    # The stranded handle was finished, not left live.
+    assert coordinator.all_finished()
+    doomed = next(h for h in coordinator.snapshot() if h.task == "doomed")
+    assert doomed.status == RUN_ERROR
+    assert "could not start" in doomed.error
+    # The model was told, and no child run row was ever created for it.
+    spawn_results = _tool_results(db.get_run(run_id), SPAWN_TOOL_NAME)
+    assert len(spawn_results) == 2
+    assert "could not start sub-agent" in spawn_results[0]
+    # The spawn slot was given back: the second spawn started for real.
+    assert spawn_results[1].startswith("started ")
+    assert db.count_subagent_runs("c") == 1
+    waits = _tool_results(db.get_run(run_id), WAIT_AGENTS_TOOL_NAME)
+    assert waits and "answer two" in waits[0]
 
 
 def test_failed_child_is_reported_in_wait_result(db):

--- a/Tests/Agents/test_fleet_runtime.py
+++ b/Tests/Agents/test_fleet_runtime.py
@@ -1,0 +1,1201 @@
+# Tests/Agents/test_fleet_runtime.py
+"""Fleet runtime: threaded sub-agents + ``wait_agents``/``check_agents``.
+
+PR2a Task 6. These exercise the CONCURRENT spawn path, which is opt-in:
+a run is threaded only when the service was handed a ``FleetCoordinator``
+(or ``[agents] max_live_subagents`` is raised above 1). Every test here
+therefore builds its service with an explicit coordinator; the inline
+path -- unchanged, byte-identical, and guarded by the pre-existing
+``Tests/Agents/test_agent_service.py`` spawn suite -- is re-asserted once
+here too (``test_without_a_coordinator_spawn_stays_inline``) so a
+regression in the gate itself is caught in this file rather than only in
+the older one.
+
+Scripting note: ``test_agent_service.ScriptedChat`` pops one shared
+ordered list, which stops being deterministic the moment children run on
+their own threads (whichever thread wins the race takes the next reply).
+``FleetChat`` below keeps the same shape but ADDRESSES replies -- an
+ordered script for the parent, a per-task script for each child -- so
+every assertion here is deterministic under real threads.
+"""
+
+import threading
+import time
+
+import pytest
+
+from tldw_chatbook.Agents.agent_models import (
+    RUN_CANCELLED,
+    RUN_DONE,
+    RUN_ERROR,
+    SPAWN_TOOL_NAME,
+    TERMINAL_RUN_STATUSES,
+    AgentConfig,
+    AgentDefinition,
+    RunBudget,
+    ToolCatalogEntry,
+    ToolResult,
+    ToolSchema,
+)
+from tldw_chatbook.Agents.agent_models import (
+    CHECK_AGENTS_TOOL_NAME,
+    FENCE_TOOL_RESULT_PREFIX,
+    RUNTIME_TOOL_NAMES,
+    WAIT_AGENTS_TOOL_NAME,
+)
+from tldw_chatbook.Agents import agent_service
+from tldw_chatbook.Agents.agent_service import (
+    SUBAGENT_SYSTEM_PROMPT,
+    AgentService,
+)
+from tldw_chatbook.Agents.fleet_coordinator import FleetCoordinator
+from tldw_chatbook.Agents.run_context import current_run_id
+from tldw_chatbook.Agents.tool_catalog import (
+    CHECK_AGENTS_SCHEMA,
+    WAIT_AGENTS_SCHEMA,
+    BuiltinToolProvider,
+    SkillToolProvider,
+    ToolCatalogRegistry,
+)
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+from Tests.Agents.test_agent_service import ScriptedChat, fence, provider_reply
+
+# The child's system prompt is the sub-agent prompt (plus, for a named
+# agent, its instructions) followed by the rendered fence protocol -- so a
+# prefix match on its first sentence is what identifies a child's provider
+# call, the same identity contract `console_agent_bridge._is_subagent`
+# relies on.
+_SUBAGENT_PREFIX = SUBAGENT_SYSTEM_PROMPT.split(".")[0]
+
+_JOIN_TIMEOUT = 5.0
+
+
+def _child_task(payload: list[dict]) -> str | None:
+    """The task text of the child whose provider call this payload is.
+
+    Args:
+        payload: The ``messages_payload`` handed to ``chat_api_call``.
+
+    Returns:
+        The child's task text (its first user message), or ``None`` when
+        this payload belongs to the primary agent.
+    """
+    if not payload:
+        return None
+    system = payload[0]
+    if system.get("role") != "system":
+        return None
+    if not str(system.get("content", "")).startswith(_SUBAGENT_PREFIX):
+        return None
+    for message in payload[1:]:
+        if message.get("role") == "user":
+            return str(message.get("content", ""))
+    return None
+
+
+class FleetChat:
+    """Addressed scripted provider: one script per agent, not one queue.
+
+    Replies may be plain strings/dicts (as ``ScriptedChat``) or zero-arg
+    callables, which are invoked at call time -- that is how a test gates a
+    child on an ``Event`` or a ``Barrier`` while the parent keeps running.
+    """
+
+    def __init__(self, parent_replies, child_replies=None):
+        self.parent_replies = list(parent_replies)
+        self.child_replies = {
+            task: list(script) for task, script in (child_replies or {}).items()
+        }
+        self.calls: list[dict] = []
+        self.child_calls: dict[str, list[dict]] = {}
+        self._lock = threading.Lock()
+
+    def __call__(self, **kwargs):
+        payload = kwargs["messages_payload"]
+        task = _child_task(payload)
+        with self._lock:
+            self.calls.append(kwargs)
+            if task is None:
+                assert self.parent_replies, "parent script exhausted"
+                item = self.parent_replies.pop(0)
+            else:
+                self.child_calls.setdefault(task, []).append(kwargs)
+                script = self.child_replies.get(task)
+                assert script, f"no scripted reply left for child task {task!r}"
+                item = script.pop(0)
+        # Called OUTSIDE the lock: a gated reply blocks here, and holding
+        # the lock would serialize the very concurrency under test.
+        if callable(item):
+            item = item()
+        return provider_reply(item)
+
+
+class RunIdProbeProvider:
+    """A one-tool provider that records the run id bound at invoke time.
+
+    The PR2a Task 5 carry-forward guard: a tool dispatched from a child's
+    own thread must see the CHILD's run id, or every approval stamp the
+    gates keyed by run becomes unreachable and an approved tool fails
+    closed.
+    """
+
+    def __init__(self):
+        self.seen: list[str] = []
+        self._lock = threading.Lock()
+
+    def list_catalog(self):
+        return [
+            ToolCatalogEntry(
+                id="probe:whoami",
+                name="whoami",
+                one_line_description="Report the dispatching run id.",
+                source="probe",
+            )
+        ]
+
+    def load_schema(self, tool_id):
+        return ToolSchema(
+            id="probe:whoami",
+            name="whoami",
+            description="Report the dispatching run id.",
+            parameters={"type": "object", "properties": {}},
+        )
+
+    def invoke(self, tool_id, args):
+        run_id = current_run_id()
+        with self._lock:
+            self.seen.append(run_id)
+        return ToolResult(ok=True, content=run_id or "<none>")
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return AgentRunsDB(tmp_path / "runs.db", client_id="test")
+
+
+def make_fleet_service(
+    db, parent_replies, child_replies=None, max_live=3, providers=()
+):
+    """An AgentService wired for the fleet (explicit coordinator = opt in)."""
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    for provider in providers:
+        registry.register_provider(provider)
+    chat = FleetChat(parent_replies, child_replies)
+    coordinator = FleetCoordinator(max_live=max_live, clock=time.monotonic)
+    service = AgentService(
+        db=db,
+        registry=registry,
+        chat_call=chat,
+        fleet_coordinator=coordinator,
+    )
+    return service, chat, coordinator
+
+
+def make_inline_service(db, replies):
+    """An AgentService with NO coordinator -- the pre-PR inline path.
+
+    Uses the ORDINARY single-queue ``ScriptedChat``: with no fleet there
+    are no threads, so strict reply ordering is exactly what should still
+    hold -- and asserting against it is the point.
+    """
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    chat = ScriptedChat(replies)
+    return AgentService(db=db, registry=registry, chat_call=chat), chat
+
+
+# max_steps/max_model_turns raised off the 8-step default: a fleet turn
+# spends 3 steps per round (model + tool_call + tool_result) and these
+# scripts run several rounds. max_subagents is raised above the fleet cap
+# under test so the CAP, not the per-turn spawn budget, is what refuses.
+FLEET_CFG = AgentConfig(
+    model="test-model",
+    system_prompt="You are helpful.",
+    allowed_tools=("calculator", "get_current_datetime", SPAWN_TOOL_NAME),
+    budget=RunBudget(max_steps=40, max_model_turns=40, max_subagents=4),
+)
+
+
+def _tool_results(run: dict, tool_name: str) -> list[str]:
+    """That tool's results as recorded in the run's STEP log.
+
+    Note the step log caps each result at 2000 chars, so this is only
+    usable for short-substring assertions -- anything about result SIZE
+    must read history via ``_history_tool_results`` instead.
+    """
+    return [
+        step["result"]
+        for step in run["steps"]
+        if step["kind"] == "tool_result" and step["tool_name"] == tool_name
+    ]
+
+
+def _history_tool_results(chat: FleetChat, tool_name: str) -> list[str]:
+    """That tool's results exactly as they entered the model's history.
+
+    This is the seam the result budget is enforced at
+    (``agent_runtime._truncate_tool_result``), so it is the only honest
+    place to assert what the supervisor actually received.
+    """
+    prefix = f"{FENCE_TOOL_RESULT_PREFIX}{tool_name}: "
+    payload = chat.calls[-1]["messages_payload"]
+    return [
+        str(message["content"])[len(prefix) :]
+        for message in payload
+        if str(message.get("content", "")).startswith(prefix)
+    ]
+
+
+# -- registration (the runtime-tool mandate: name + set + schema) ---------
+
+
+def test_both_fleet_tools_are_registered_runtime_tools():
+    assert WAIT_AGENTS_TOOL_NAME == "wait_agents"
+    assert CHECK_AGENTS_TOOL_NAME == "check_agents"
+    assert WAIT_AGENTS_TOOL_NAME in RUNTIME_TOOL_NAMES
+    assert CHECK_AGENTS_TOOL_NAME in RUNTIME_TOOL_NAMES
+    assert WAIT_AGENTS_SCHEMA.name == WAIT_AGENTS_TOOL_NAME
+    assert CHECK_AGENTS_SCHEMA.name == CHECK_AGENTS_TOOL_NAME
+    # `ids` is OPTIONAL: an omitted `ids` means "every child".
+    assert WAIT_AGENTS_SCHEMA.parameters.get("required", []) == []
+    assert WAIT_AGENTS_SCHEMA.parameters["properties"]["ids"]["type"] == "array"
+    assert CHECK_AGENTS_SCHEMA.parameters["properties"] == {}
+
+
+# -- the core concurrency behaviours --------------------------------------
+
+
+def test_two_children_run_concurrently_and_wait_collects_both(db):
+    # A 2-party barrier is the concurrency PROOF: if the children were
+    # still serialized, the first would block on it until the timeout and
+    # break the barrier, failing the run instead of answering.
+    barrier = threading.Barrier(2, timeout=_JOIN_TIMEOUT)
+
+    def gated(text):
+        def reply():
+            barrier.wait()
+            return text
+
+        return reply
+
+    service, chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one"}),
+            fence(SPAWN_TOOL_NAME, {"task": "task two"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "combined answer",
+        ],
+        {
+            "task one": [gated("answer one")],
+            "task two": [gated("answer two")],
+        },
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert outcome.final_text == "combined answer"
+    assert db.count_subagent_runs("c") == 2
+    # Both children's results reached the parent's wait result.
+    wait_results = _tool_results(db.get_run(run_id), WAIT_AGENTS_TOOL_NAME)
+    assert len(wait_results) == 1
+    assert "answer one" in wait_results[0]
+    assert "answer two" in wait_results[0]
+    # ... and therefore into the payload of the parent's final call.
+    final_payload = str(chat.calls[-1]["messages_payload"])
+    assert "answer one" in final_payload and "answer two" in final_payload
+    assert coordinator.all_finished()
+    assert [h.status for h in coordinator.snapshot()] == [RUN_DONE, RUN_DONE]
+
+
+def test_spawn_returns_handle_without_blocking(db):
+    """The spawn tool result names a handle, not the child's answer."""
+    release = threading.Event()
+
+    def blocked_child():
+        assert release.wait(_JOIN_TIMEOUT)
+        return "answer one"
+
+    def final_answer():
+        release.set()
+        return "done"
+
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one"}),
+            # Still running here -- the parent got control straight back.
+            fence(CHECK_AGENTS_TOOL_NAME, {}),
+            final_answer,
+        ],
+        {"task one": [blocked_child]},
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    spawn_results = _tool_results(db.get_run(run_id), SPAWN_TOOL_NAME)
+    assert len(spawn_results) == 1
+    handle_id = coordinator.snapshot()[0].handle_id
+    assert spawn_results[0].startswith("started ")
+    assert handle_id in spawn_results[0]
+    assert "task one" in spawn_results[0]
+    # The child's answer is NOT what spawn returned.
+    assert "answer one" not in spawn_results[0]
+    # The check_agents call ran while the child was still blocked, proving
+    # the parent kept control rather than waiting on the child.
+    check_results = _tool_results(db.get_run(run_id), CHECK_AGENTS_TOOL_NAME)
+    assert check_results and "running" in check_results[0]
+
+
+def test_check_agents_reports_status_without_blocking(db):
+    release = threading.Event()
+
+    def blocked_child():
+        assert release.wait(_JOIN_TIMEOUT)
+        return "child answer"
+
+    def release_then_wait():
+        release.set()
+        return fence(WAIT_AGENTS_TOOL_NAME, {})
+
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "slow task"}),
+            fence(CHECK_AGENTS_TOOL_NAME, {}),  # while the child is blocked
+            release_then_wait,
+            fence(CHECK_AGENTS_TOOL_NAME, {}),  # after it finished
+            "done",
+        ],
+        {"slow task": [blocked_child]},
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    checks = _tool_results(db.get_run(run_id), CHECK_AGENTS_TOOL_NAME)
+    assert len(checks) == 2
+    handle_id = coordinator.snapshot()[0].handle_id
+    assert handle_id in checks[0] and "running" in checks[0]
+    assert "slow task" in checks[0]
+    # check_agents never blocks: the first snapshot was taken while the
+    # child was still gated, and it did NOT contain the child's answer.
+    assert "child answer" not in checks[0]
+    assert handle_id in checks[1] and RUN_DONE in checks[1]
+
+
+def test_live_cap_refuses_beyond_max_live_subagents(db):
+    release = threading.Event()
+
+    def blocked_child():
+        assert release.wait(_JOIN_TIMEOUT)
+        return "answer one"
+
+    def final_answer():
+        release.set()
+        return "done"
+
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one"}),
+            fence(SPAWN_TOOL_NAME, {"task": "task two"}),  # refused: at cap
+            final_answer,
+        ],
+        {"task one": [blocked_child]},
+        max_live=1,
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    spawn_results = _tool_results(db.get_run(run_id), SPAWN_TOOL_NAME)
+    assert len(spawn_results) == 2
+    assert spawn_results[0].startswith("started ")
+    assert "ERROR" in spawn_results[1]
+    assert "wait_agents" in spawn_results[1]  # tells the model how to recover
+    # The refused spawn created no run and reserved no handle.
+    assert db.count_subagent_runs("c") == 1
+    assert len(coordinator.snapshot()) == 1
+
+
+def test_live_cap_refusal_does_not_burn_the_per_turn_spawn_budget(db):
+    """A cap refusal is retryable, so it must not consume a spawn slot.
+
+    The per-turn ceiling here is 2 spawns; the fleet cap is 1. Three spawn
+    calls are made and the middle one is refused at the cap -- if that
+    refusal consumed a slot, the third (made after the first child was
+    collected) would hit "sub-agent budget exhausted" instead of starting.
+
+    Named spawns, deliberately: ``run_agent_loop`` keeps its own redundant
+    secondary counter, which for an UNNAMED spawn increments even on a
+    refusal (pre-existing, byte-identical behaviour this PR does not
+    touch). Only the named path lets the service's authoritative counter
+    be observed on its own.
+    """
+    db.create_agent_definition(
+        AgentDefinition(
+            name="researcher",
+            description="Searches.",
+            instructions="Cite sources.",
+        )
+    )
+    release_one = threading.Event()
+
+    def first_child():
+        assert release_one.wait(_JOIN_TIMEOUT)
+        return "answer one"
+
+    def release_then_wait():
+        release_one.set()
+        return fence(WAIT_AGENTS_TOOL_NAME, {})
+
+    tight = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(max_steps=40, max_model_turns=40, max_subagents=2),
+    )
+    service, _chat, _coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one", "agent": "researcher"}),
+            # Refused at the cap -- no run, no handle, no spawn slot.
+            fence(SPAWN_TOOL_NAME, {"task": "task two", "agent": "researcher"}),
+            release_then_wait,
+            fence(SPAWN_TOOL_NAME, {"task": "task three", "agent": "researcher"}),
+            "done",
+        ],
+        {"task one": [first_child], "task three": ["answer three"]},
+        max_live=1,
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=tight,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    spawn_results = _tool_results(db.get_run(run_id), SPAWN_TOOL_NAME)
+    assert len(spawn_results) == 3
+    assert spawn_results[0].startswith("started ")
+    assert "wait_agents" in spawn_results[1]  # the cap refusal
+    assert spawn_results[2].startswith("started ")  # NOT budget-exhausted
+    assert "budget exhausted" not in spawn_results[2]
+    assert db.count_subagent_runs("c") == 2
+
+
+def test_end_of_turn_waits_for_stragglers(db):
+    """The turn must not return with a child still running."""
+    started = threading.Event()
+
+    def slow_child():
+        started.set()
+        time.sleep(0.2)
+        return "late answer"
+
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "slow task"}),
+            "parent answered early",  # never calls wait_agents
+        ],
+        {"slow task": [slow_child]},
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert outcome.final_text == "parent answered early"
+    assert started.is_set()
+    # No handle and no run row may be left live once run_turn returns.
+    assert coordinator.all_finished()
+    assert [h.status for h in coordinator.snapshot()] == [RUN_DONE]
+    rows = db.list_runs("c", include_superseded=True)
+    assert rows and all(row["status"] in TERMINAL_RUN_STATUSES for row in rows)
+    child = next(row for row in rows if row["agent_kind"] == "subagent")
+    assert child["status"] == RUN_DONE
+    assert child["result"] == "late answer"
+    assert child["parent_run_id"] == run_id
+
+
+def test_end_of_turn_cancels_and_abandons_a_wedged_child(db):
+    """A child that never returns is cancelled, abandoned, and recorded.
+
+    The parent's wall-clock budget is 1s, so the end-of-turn wait expires
+    almost immediately; the child ignores its cooperative cancel entirely
+    (it is blocked inside the provider call), so it must be abandoned after
+    the join timeout with its handle AND its run row marked cancelled --
+    never left ``running``.
+    """
+    never = threading.Event()
+    entered = threading.Event()
+
+    def wedged_child():
+        entered.set()
+        never.wait(30.0)  # released in the finally below, not by the run
+        return "unreachable"
+
+    short = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(
+            max_steps=40,
+            max_model_turns=40,
+            max_subagents=2,
+            max_wall_seconds=1.0,
+        ),
+    )
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [fence(SPAWN_TOOL_NAME, {"task": "wedged"}), "parent done"],
+        {"wedged": [wedged_child]},
+    )
+    try:
+        _run_id, outcome = service.run_turn(
+            conversation_id="c",
+            messages=[{"role": "user", "content": "go"}],
+            config=short,
+            api_endpoint="llama_cpp",
+        )
+        assert entered.is_set()
+        assert outcome.status == RUN_DONE
+        assert coordinator.all_finished()
+        assert [h.status for h in coordinator.snapshot()] == [RUN_CANCELLED]
+        rows = db.list_runs("c", include_superseded=True)
+        assert all(row["status"] in TERMINAL_RUN_STATUSES for row in rows)
+        child = next(row for row in rows if row["agent_kind"] == "subagent")
+        assert child["status"] == RUN_CANCELLED
+    finally:
+        never.set()
+
+
+def test_single_child_path_is_unchanged(db):
+    """One spawn + wait produces the same run rows and result as inline."""
+    service, chat, _coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "compute 6*7"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "The sub-agent says 42.",
+        ],
+        {"compute 6*7": ["sub answer: 42"]},
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "delegate this"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert outcome.final_text == "The sub-agent says 42."
+    assert outcome.subagents_spawned == 1
+    # Same run rows as the inline path (cf.
+    # test_agent_service.test_spawn_creates_linked_child_with_clean_context).
+    runs = db.list_runs("c")
+    child = next(r for r in runs if r["agent_kind"] == "subagent")
+    assert child["parent_run_id"] == run_id
+    assert child["task"] == "compute 6*7"
+    assert child["status"] == RUN_DONE and child["result"] == "sub answer: 42"
+    assert db.count_subagent_runs("c") == 1
+    # Same clean context: the child saw only its task + its own prompt.
+    child_call = chat.child_calls["compute 6*7"][0]["messages_payload"]
+    assert child_call[0]["role"] == "system"
+    assert child_call[0]["content"].startswith(_SUBAGENT_PREFIX)
+    assert child_call[1] == {"role": "user", "content": "compute 6*7"}
+    assert not any("delegate this" in m["content"] for m in child_call)
+    # Same result text reaches the parent -- via wait_agents rather than
+    # via the spawn call's own return value.
+    wait_results = _tool_results(db.get_run(run_id), WAIT_AGENTS_TOOL_NAME)
+    assert wait_results and "sub answer: 42" in wait_results[0]
+
+
+def test_without_a_coordinator_spawn_stays_inline(db):
+    """No coordinator => the pre-PR inline path, result returned by spawn.
+
+    This is the gate that keeps the existing spawn suites byte-identical:
+    the fleet is opt-in, and an un-opted-in service must not thread.
+    """
+    service, _chat = make_inline_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "compute 6*7"}),
+            "sub answer: 42",  # consumed by the child, INLINE and in order
+            "The sub-agent says 42.",
+        ],
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "delegate this"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    spawn_results = _tool_results(db.get_run(run_id), SPAWN_TOOL_NAME)
+    # The spawn call itself returned the child's answer -- no handle.
+    assert spawn_results == ["sub answer: 42"]
+    child = next(r for r in db.list_runs("c") if r["agent_kind"] == "subagent")
+    assert child["result"] == "sub answer: 42"
+
+
+def test_fleet_tools_are_not_offered_without_a_coordinator(db):
+    service, chat = make_inline_service(db, ["just answering"])
+    service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    system_prompt = chat.calls[0]["messages_payload"][0]["content"]
+    assert WAIT_AGENTS_TOOL_NAME not in system_prompt
+    assert CHECK_AGENTS_TOOL_NAME not in system_prompt
+
+
+def test_fleet_tools_are_primary_only(db):
+    """A child never receives wait_agents/check_agents (isolation)."""
+    service, chat, _coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "child task"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {
+            "child task": [
+                fence(WAIT_AGENTS_TOOL_NAME, {}),  # the child tries anyway
+                "child recovered",
+            ]
+        },
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    parent_prompt = chat.calls[0]["messages_payload"][0]["content"]
+    assert WAIT_AGENTS_TOOL_NAME in parent_prompt
+    assert CHECK_AGENTS_TOOL_NAME in parent_prompt
+    child_prompt = chat.child_calls["child task"][0]["messages_payload"][0][
+        "content"
+    ]
+    assert WAIT_AGENTS_TOOL_NAME not in child_prompt
+    assert CHECK_AGENTS_TOOL_NAME not in child_prompt
+    # The child's hallucinated call falls through to the ordinary
+    # permission path, exactly like any other undisclosed tool name.
+    child = next(r for r in db.list_runs("c") if r["agent_kind"] == "subagent")
+    refusals = _tool_results(child, WAIT_AGENTS_TOOL_NAME)
+    assert refusals and "not permitted" in refusals[0]
+    assert db.get_run(run_id)["status"] == RUN_DONE
+
+
+# -- result budgeting (spec §5) -------------------------------------------
+
+
+def test_wait_agents_splits_the_history_budget_across_children(db):
+    """5 children x 4000 chars must not blow (or be cut by) the 16k cap."""
+    bodies = {f"task {i}": ["Z" * 4000] for i in range(1, 6)}
+    parent = [fence(SPAWN_TOOL_NAME, {"task": f"task {i}"}) for i in range(1, 6)]
+    parent += [fence(WAIT_AGENTS_TOOL_NAME, {}), "done"]
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(
+            max_steps=60,
+            max_model_turns=60,
+            max_subagents=5,
+            max_tool_result_chars=6000,
+        ),
+    )
+    service, chat, coordinator = make_fleet_service(db, parent, bodies, max_live=5)
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=cfg,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    wait_results = _history_tool_results(chat, WAIT_AGENTS_TOOL_NAME)
+    assert len(wait_results) == 1
+    combined = wait_results[0]
+    # Budgeted BEFORE the history-append seam, so that seam never fired:
+    # its trailer is absent and every child is still identified. Without
+    # the even split the first children would have filled the 6000 chars
+    # and the last ones would have been cut away entirely.
+    assert len(combined) <= cfg.budget.max_tool_result_chars
+    assert "[truncated: wait_agents returned" not in combined
+    for handle in coordinator.snapshot():
+        assert handle.handle_id in combined
+    # Each child got an EQUAL share of the body budget (and each was
+    # shortened, since 5 x 4000 cannot fit in 6000) -- not "the first two
+    # children in full, the rest cut off".
+    entries = combined.split("\n\n")
+    bodies = [entry.split("\n", 1)[1] for entry in entries[:5]]
+    assert len({len(body) for body in bodies}) == 1
+    assert all(body.endswith("[truncated]") for body in bodies)
+    assert all(len(body) > 500 for body in bodies)
+    assert combined.count("[truncated]") == 5
+    # ... and the model is told how to get one child's full result.
+    assert "wait_agents" in combined
+
+
+def test_wait_agents_refetches_one_child_at_the_full_per_child_cap(db):
+    """`wait_agents([id])` returns that child at max_subagent_result_chars."""
+    bodies = {"task one": ["A" * 3000], "task two": ["B" * 3000]}
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(
+            max_steps=40,
+            max_model_turns=40,
+            max_subagents=2,
+            max_subagent_result_chars=4000,
+            max_tool_result_chars=4000,
+        ),
+    )
+    captured: dict[str, str] = {}
+
+    def refetch_first():
+        # The handle ids only exist once both children have been started,
+        # so the id to re-fetch is read at call time from the coordinator.
+        handle = next(
+            h for h in coordinator.snapshot() if h.task == "task one"
+        )
+        captured["handle_id"] = handle.handle_id
+        return fence(WAIT_AGENTS_TOOL_NAME, {"ids": [handle.handle_id]})
+
+    service, chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one"}),
+            fence(SPAWN_TOOL_NAME, {"task": "task two"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),  # both, budget-split
+            refetch_first,  # one, at the full per-child cap
+            "done",
+        ],
+        bodies,
+        max_live=2,
+    )
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=cfg,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    waits = _history_tool_results(chat, WAIT_AGENTS_TOOL_NAME)
+    assert len(waits) == 2
+    combined, refetched = waits
+    # Split: each of the two got roughly half, so neither is complete.
+    assert combined.count("A") < 3000 and combined.count("B") < 3000
+    # Re-fetch: the whole 3000-char body, and only that child.
+    assert refetched.count("A") == 3000
+    assert "B" not in refetched
+    assert captured["handle_id"] in refetched
+
+
+def test_wait_agents_reports_unknown_ids(db):
+    service, _chat, _coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {"ids": ["nope"]}),
+            "done",
+        ],
+        {"task one": ["answer one"]},
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    waits = _tool_results(db.get_run(run_id), WAIT_AGENTS_TOOL_NAME)
+    assert waits and "nope" in waits[0] and "ERROR" in waits[0]
+
+
+def test_wait_agents_with_no_children_says_so(db):
+    service, _chat, _coordinator = make_fleet_service(
+        db, [fence(WAIT_AGENTS_TOOL_NAME, {}), "done"], {}
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    waits = _tool_results(db.get_run(run_id), WAIT_AGENTS_TOOL_NAME)
+    assert waits and "spawn_subagent" in waits[0]
+
+
+# -- cancellation and the wall-clock bound --------------------------------
+
+
+def test_wait_agents_cancellation_stops_children_and_ends_the_run(db):
+    """User cancellation while waiting propagates to the children.
+
+    The child keeps calling a tool (with varying arguments, so the cycle
+    detector never fires), which gives it the step boundaries at which a
+    cooperative cancel is actually noticed.
+    """
+    cancelled = threading.Event()
+
+    def cancel_then_wait():
+        cancelled.set()
+        return fence(WAIT_AGENTS_TOOL_NAME, {})
+
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=("calculator", SPAWN_TOOL_NAME),
+        budget=RunBudget(max_steps=200, max_model_turns=200, max_subagents=2),
+    )
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [fence(SPAWN_TOOL_NAME, {"task": "busy"}), cancel_then_wait],
+        {
+            "busy": [
+                fence("calculator", {"expression": f"1+{n}"}) for n in range(60)
+            ]
+        },
+    )
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=cfg,
+        api_endpoint="llama_cpp",
+        should_cancel=cancelled.is_set,
+    )
+    assert outcome.status == RUN_CANCELLED
+    assert coordinator.all_finished()
+    assert coordinator.snapshot()[0].status == RUN_CANCELLED
+    rows = db.list_runs("c", include_superseded=True)
+    assert all(row["status"] in TERMINAL_RUN_STATUSES for row in rows)
+    child = next(row for row in rows if row["agent_kind"] == "subagent")
+    assert child["status"] == RUN_CANCELLED
+
+
+def test_wait_agents_is_bounded_by_the_runs_remaining_wall_clock(
+    db, monkeypatch
+):
+    """A wedged child must not hold wait_agents past the run's budget."""
+    # Keep the post-cancel drain short: the behaviour under test is the
+    # wall-clock BOUND, not how long an abandoned thread is humoured.
+    monkeypatch.setattr(agent_service, "FLEET_JOIN_TIMEOUT_SECONDS", 0.2)
+    never = threading.Event()
+
+    def wedged_child():
+        never.wait(30.0)
+        return "unreachable"
+
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=(SPAWN_TOOL_NAME,),
+        budget=RunBudget(
+            max_steps=40,
+            max_model_turns=40,
+            max_subagents=2,
+            max_wall_seconds=1.0,
+        ),
+    )
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "wedged"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "gave up",
+        ],
+        {"wedged": [wedged_child]},
+    )
+    try:
+        started_at = time.monotonic()
+        run_id, outcome = service.run_turn(
+            conversation_id="c",
+            messages=[{"role": "user", "content": "go"}],
+            config=cfg,
+            api_endpoint="llama_cpp",
+        )
+        elapsed = time.monotonic() - started_at
+        # Bounded by the 1s budget (plus the shortened drain/join), not by
+        # the child's own 30s block.
+        assert elapsed < 10.0
+        # The wait burned the run's remaining wall-clock, so the loop's own
+        # budget check ends the run -- terminal either way, never hung.
+        assert outcome.status in TERMINAL_RUN_STATUSES
+        # Read the step log, not history: the run may end before another
+        # provider call carries this result into a payload.
+        waits = _tool_results(db.get_run(run_id), WAIT_AGENTS_TOOL_NAME)
+        assert waits and "time budget ran out" in waits[0]
+        assert coordinator.all_finished()
+        rows = db.list_runs("c", include_superseded=True)
+        assert all(row["status"] in TERMINAL_RUN_STATUSES for row in rows)
+    finally:
+        never.set()
+
+
+# -- failure isolation -----------------------------------------------------
+
+
+def test_child_thread_exception_finishes_the_handle_as_error(db):
+    """An exception ESCAPING _run_one must never strand the parent's join."""
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "boom"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "handled",
+        ],
+        {"boom": ["never reached"]},
+    )
+    real_run_one = service._run_one
+
+    def exploding_run_one(**kwargs):
+        if kwargs.get("agent_kind") == "subagent":
+            raise RuntimeError("child thread blew up")
+        return real_run_one(**kwargs)
+
+    service._run_one = exploding_run_one
+
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE  # the PARENT survives
+    assert coordinator.all_finished()
+    handle = coordinator.snapshot()[0]
+    assert handle.status == RUN_ERROR
+    assert "child thread blew up" in handle.error
+
+
+def test_failed_child_is_reported_in_wait_result(db):
+    service, _chat, _coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "good"}),
+            fence(SPAWN_TOOL_NAME, {"task": "bad"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {
+            "good": ["good answer"],
+            # An empty final text with no tool call ends the run DONE, so
+            # force a non-done child by exhausting its model turns instead.
+            "bad": [
+                fence("calculator", {"expression": "1+1"}),
+                fence("calculator", {"expression": "1+1"}),
+                fence("calculator", {"expression": "1+1"}),
+            ],
+        },
+    )
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=("calculator", SPAWN_TOOL_NAME),
+        budget=RunBudget(
+            max_steps=40, max_model_turns=40, max_subagents=3
+        ),
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=cfg,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    waits = _tool_results(db.get_run(run_id), WAIT_AGENTS_TOOL_NAME)
+    assert waits and "good answer" in waits[0]
+    # The failed child is named with its terminal status, not silently
+    # dropped -- the supervisor decides what to do about it.
+    assert "stuck" in waits[0]
+
+
+# -- the PR2a Task 5 carry-forward guard ----------------------------------
+
+
+def test_child_tool_call_binds_the_childs_own_run_id(db):
+    """A tool run from a child's thread must see the CHILD's run id.
+
+    Both permission gates key this turn's verdicts by ``(run_id, tool)``.
+    A child thread that failed to bind its own run id would read ``""``,
+    find no stamp, and fail an APPROVED tool closed -- silently.
+    """
+    probe = RunIdProbeProvider()
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=("whoami", SPAWN_TOOL_NAME),
+        budget=RunBudget(max_steps=40, max_model_turns=40, max_subagents=2),
+    )
+    service, _chat, _coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "probe task"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {"probe task": [fence("whoami", {}), "child done"]},
+        providers=(probe,),
+    )
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=cfg,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    child = next(r for r in db.list_runs("c") if r["agent_kind"] == "subagent")
+    assert probe.seen == [child["id"]]
+    assert probe.seen[0] != ""
+
+
+# -- deferred self-review items -------------------------------------------
+
+
+class _MutuallyExclusiveProbeRunner:
+    """A SkillRunner that calls spawn with both mutually exclusive kwargs."""
+
+    def __init__(self):
+        self.raised: Exception | None = None
+
+    def is_skill_tool(self, name):
+        return name == "code-review"
+
+    def run(self, name, args, spawn):
+        try:
+            spawn("t", allowed_tools=("calculator",), agent="researcher")
+        except Exception as exc:  # noqa: BLE001 — recorded, then asserted
+            self.raised = exc
+            return ToolResult(ok=True, content="refused as expected")
+        return ToolResult(ok=False, error="spawn accepted both kwargs")
+
+
+def test_spawn_rejects_agent_and_allowed_tools_together(db):
+    """The structural invariant raises explicitly -- never a bare assert.
+
+    A bare ``assert`` is stripped under ``python -O``, which would turn a
+    future caller's mistake into a silently mis-configured child instead
+    of a loud refusal.
+    """
+    db.create_agent_definition(
+        AgentDefinition(
+            name="researcher",
+            description="Searches.",
+            instructions="Cite sources.",
+        )
+    )
+    runner = _MutuallyExclusiveProbeRunner()
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    # "code-review" must be a real catalog entry so it is DISCLOSED, not
+    # merely permitted -- otherwise invoke_tool's skill branch refuses it
+    # before the runner (and therefore the spawn closure) is ever reached.
+    registry.register_provider(
+        SkillToolProvider(
+            [
+                {
+                    "name": "code-review",
+                    "description": "Reviews a diff.",
+                    "argument_hint": "the diff",
+                }
+            ]
+        )
+    )
+    chat = FleetChat([fence("code-review", {"args": "the diff"}), "done"], {})
+    service = AgentService(
+        db=db,
+        registry=registry,
+        chat_call=chat,
+        skill_runner=runner,
+        fleet_coordinator=FleetCoordinator(max_live=3, clock=time.monotonic),
+    )
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="You are helpful.",
+        allowed_tools=("calculator", "code-review", SPAWN_TOOL_NAME),
+        budget=RunBudget(max_steps=40, max_model_turns=40, max_subagents=2),
+    )
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=cfg,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert isinstance(runner.raised, ValueError)
+    assert "mutually exclusive" in str(runner.raised)
+    # No child was created for the rejected call.
+    assert db.count_subagent_runs("c") == 0
+
+
+def test_agent_definitions_are_loaded_once_per_turn(db):
+    """Fleet spec §4: the roster loads ONCE per turn, not once per spawn.
+
+    A call-count guard, not a behavioural proxy: the previous coverage
+    only proved the roster the model SEES is stable, which a per-spawn
+    re-read would also satisfy while quietly issuing one DB query per
+    child.
+    """
+    db.create_agent_definition(
+        AgentDefinition(
+            name="researcher",
+            description="Searches.",
+            instructions="Cite sources.",
+        )
+    )
+    calls: list[tuple] = []
+    real = db.list_agent_definitions
+
+    def counting(*args, **kwargs):
+        calls.append((args, kwargs))
+        return real(*args, **kwargs)
+
+    db.list_agent_definitions = counting
+
+    service, _chat, _coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one", "agent": "researcher"}),
+            fence(SPAWN_TOOL_NAME, {"task": "task two", "agent": "researcher"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {"task one": ["answer one"], "task two": ["answer two"]},
+    )
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    assert db.count_subagent_runs("c") == 2
+    assert len(calls) == 1, f"roster re-read {len(calls)} times in one turn"
+    assert calls[0][1] == {"enabled_only": True}

--- a/Tests/Agents/test_gate_run_scoping.py
+++ b/Tests/Agents/test_gate_run_scoping.py
@@ -1,0 +1,72 @@
+"""Both permission gates must key verdicts per RUN, not per tool name.
+
+Pre-fix, `BuiltinToolGate.begin_turn()` cleared a dict keyed by tool name
+on a SHARED gate instance, and `MCPToolProvider.apply_batch_decisions`
+REPLACED its dict wholesale -- so with concurrent children, one child's
+turn wipes or overwrites a verdict a sibling (or the parent) already
+decided and has not yet consumed.
+"""
+
+import threading
+
+from tldw_chatbook.Agents.builtin_tool_gate import BuiltinToolGate
+from tldw_chatbook.Agents.mcp_tool_provider import MCPToolProvider
+
+
+def test_builtin_gate_stamps_do_not_leak_across_runs():
+    gate = BuiltinToolGate(service=None)
+    gate.begin_turn("run-parent")
+    gate.stamp("run-parent", "calculator", "proceed")
+    # A concurrent child starts its own turn on the SAME gate instance.
+    gate.begin_turn("run-child")
+    gate.stamp("run-child", "calculator", "deny")
+    # The parent's verdict must survive the child's turn untouched.
+    assert gate.stamped("run-parent", "calculator") == "proceed"
+    assert gate.stamped("run-child", "calculator") == "deny"
+
+
+def test_builtin_gate_begin_turn_clears_only_its_own_run():
+    gate = BuiltinToolGate(service=None)
+    gate.begin_turn("run-a")
+    gate.stamp("run-a", "calculator", "proceed")
+    gate.begin_turn("run-b")
+    assert gate.stamped("run-a", "calculator") == "proceed"
+    gate.begin_turn("run-a")  # a's NEXT turn clears a's stamps
+    assert gate.stamped("run-a", "calculator") is None
+
+
+def test_mcp_decisions_do_not_clobber_across_runs():
+    provider = MCPToolProvider.__new__(MCPToolProvider)
+    provider._init_decision_state()  # helper added by this task
+    provider.apply_batch_decisions("run-parent", {"srv__tool": "proceed"})
+    provider.apply_batch_decisions("run-child", {"srv__tool": "deny"})
+    assert provider.stamped_decision("run-parent", "srv__tool") == "proceed"
+    assert provider.stamped_decision("run-child", "srv__tool") == "deny"
+
+
+def test_concurrent_runs_keep_their_own_verdicts():
+    gate = BuiltinToolGate(service=None)
+    errors = []
+
+    def worker(i):
+        run = f"run-{i}"
+        # try/except, not a bare body: a raise inside a Thread target is
+        # swallowed by threading (pytest only warns), so without this the
+        # whole test passes vacuously whenever the gate's signature is
+        # wrong -- exactly the pre-fix state this test is meant to catch.
+        try:
+            gate.begin_turn(run)
+            gate.stamp(run, "calculator", f"verdict-{i}")
+            for _ in range(200):
+                if gate.stamped(run, "calculator") != f"verdict-{i}":
+                    errors.append(run)
+                    return
+        except Exception as exc:  # noqa: BLE001 -- surfaced as a failure below
+            errors.append(f"{run}: {exc!r}")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []

--- a/Tests/Agents/test_gate_run_scoping.py
+++ b/Tests/Agents/test_gate_run_scoping.py
@@ -10,6 +10,7 @@ decided and has not yet consumed.
 import threading
 
 from tldw_chatbook.Agents.builtin_tool_gate import BuiltinToolGate
+from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider
 from tldw_chatbook.Agents.mcp_tool_provider import MCPToolProvider
 
 
@@ -42,6 +43,33 @@ def test_mcp_decisions_do_not_clobber_across_runs():
     provider.apply_batch_decisions("run-child", {"srv__tool": "deny"})
     assert provider.stamped_decision("run-parent", "srv__tool") == "proceed"
     assert provider.stamped_decision("run-child", "srv__tool") == "deny"
+
+
+def test_local_decisions_do_not_clobber_across_runs(tmp_path):
+    """The THIRD gate with this exact shape, and the one with no other
+    coverage of its per-run keying.
+
+    ``LocalToolProvider`` shares one instance across a parent run and every
+    sub-agent it spawns, exactly like the two gates above, and its stamps
+    were name-keyed and REPLACED wholesale for the same reasons. Review of
+    the first cut found both of its per-run mutations survived the entire
+    suite (1012 passed): reverting ``apply_batch_decisions`` to a
+    whole-dict replace, and making ``stamped`` ignore ``run_id`` -- the
+    latter a genuine FAIL-OPEN, since a sibling's ``approve_once`` would
+    then permit this run's call. Both are red against this test.
+    """
+    provider = LocalToolProvider(workspace_root=tmp_path)
+    provider.apply_batch_decisions("run-parent", {"fs_list": "approve_once"})
+    provider.apply_batch_decisions("run-child", {"fs_list": "deny"})
+
+    # The child's turn must not have replaced the parent's slice.
+    assert provider.stamped("run-parent", "fs_list") == "approve_once"
+    assert provider.stamped("run-child", "fs_list") == "deny"
+    # The fail-open direction, stated explicitly: a run that was never
+    # granted anything must never READ a sibling's verdict, permitting or
+    # otherwise. A name-keyed lookup would hand this run one of the two
+    # above.
+    assert provider.stamped("run-other", "fs_list") is None
 
 
 def test_concurrent_runs_keep_their_own_verdicts():

--- a/Tests/Agents/test_install_skill_runtime_tool.py
+++ b/Tests/Agents/test_install_skill_runtime_tool.py
@@ -9,8 +9,10 @@ runtime_schemas (never disclosure-gated) only for the top-level agent
 import json
 
 from tldw_chatbook.Agents.agent_models import (
+    CHECK_AGENTS_TOOL_NAME,
     INSTALL_SKILL_TOOL_NAME,
     RUNTIME_TOOL_NAMES,
+    WAIT_AGENTS_TOOL_NAME,
     RUN_LOG_SLICE_TOOL_NAME,
     RUN_LOG_STATS_TOOL_NAME,
     RUN_SKILL_SCRIPT_TOOL_NAME,
@@ -43,6 +45,8 @@ def test_install_skill_name_in_runtime_tool_names():
         SEARCH_RUN_LOG_TOOL_NAME,
         RUN_LOG_STATS_TOOL_NAME,
         RUN_LOG_SLICE_TOOL_NAME,
+        WAIT_AGENTS_TOOL_NAME,
+        CHECK_AGENTS_TOOL_NAME,
     }
 
 

--- a/Tests/Agents/test_install_skill_runtime_tool.py
+++ b/Tests/Agents/test_install_skill_runtime_tool.py
@@ -32,6 +32,8 @@ from tldw_chatbook.Agents.agent_models import (
 from tldw_chatbook.Agents.tool_catalog import INSTALL_SKILL_TOOL_SCHEMA
 from tldw_chatbook.Agents.agent_runtime import LoopDeps, run_agent_loop
 
+from Tests.Agents.test_agent_service import FleetChat, verbatim
+
 
 def test_install_skill_name_in_runtime_tool_names():
     assert INSTALL_SKILL_TOOL_NAME == "install_skill"
@@ -184,15 +186,25 @@ def test_subagent_cannot_call_install_skill(tmp_path):
     def installer(url):
         raise AssertionError("subagent must never reach the installer")
 
-    script = [
-        _svc_fence(SPAWN_TOOL_NAME, {"task": "native task"}),   # parent spawns
-        _svc_fence("install_skill", {"url": "https://github.com/o/r"}),  # child tries
-        {"choices": [{"message": {"content": "child gave up"}}]},
-        {"choices": [{"message": {"content": "final"}}]},
-    ]
-    service = AgentService(
-        db, reg, chat_call=lambda **k: script.pop(0), install_skill_tool=installer
+    # PR2a Task 6.5: the fleet is ON by default, so the child runs on its
+    # own thread -- one ordered queue is no longer deterministic. Addressed
+    # per agent instead; the replies themselves are unchanged.
+    chat = FleetChat(
+        [
+            _svc_fence(SPAWN_TOOL_NAME, {"task": "native task"}),   # parent spawns
+            {"choices": [{"message": {"content": "final"}}]},
+        ],
+        {
+            "native task": [
+                _svc_fence(
+                    "install_skill", {"url": "https://github.com/o/r"}
+                ),  # child tries
+                {"choices": [{"message": {"content": "child gave up"}}]},
+            ]
+        },
+        reply=verbatim,
     )
+    service = AgentService(db, reg, chat_call=chat, install_skill_tool=installer)
     _rid, outcome = service.run_turn(
         conversation_id="c1",
         messages=[{"role": "user", "content": "go"}],

--- a/Tests/Agents/test_local_tool_provider.py
+++ b/Tests/Agents/test_local_tool_provider.py
@@ -11,12 +11,30 @@ from tldw_chatbook.Agents.local_tool_provider import (
     LOCAL_TIMEOUT_REFUSAL,
     LocalToolProvider,
 )
+from tldw_chatbook.Agents.run_context import use_run_id
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
 from tldw_chatbook.Tools import web_tool_impls
 
 ALLOW = EffectiveToolState(state="allow", origin="tool_override")
 ASK = EffectiveToolState(state="ask", origin="global_default")
 DENY = EffectiveToolState(state="deny", origin="tool_override")
+
+#: PR2a Task 5: per-turn stamps are keyed by RUN. Every test here drives a
+#: single run, so it stamps and dispatches under this one id.
+RUN = "run-1"
+
+
+@pytest.fixture(autouse=True)
+def _dispatching_run():
+    """Bind ``RUN`` as the dispatching run for every test in this module.
+
+    ``invoke()`` reads the run whose call it is executing from
+    ``run_context`` (bound in production by ``AgentService`` around each
+    invocation), so a test that stamps for ``RUN`` and then invokes must
+    be running as ``RUN`` -- exactly as production does.
+    """
+    with use_run_id(RUN):
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -363,7 +381,7 @@ def test_timeout_verdict_keeps_pinned_copy_even_with_override(tmp_path):
     # Only the "no_callback" verdict maps to the override; a real "timeout"
     # verdict ALWAYS keeps the pinned LOCAL_TIMEOUT_REFUSAL.
     p = make_provider(state=ASK, root=tmp_path, no_callback_refusal="custom")
-    p.apply_batch_decisions({"fs_list": "timeout"})
+    p.apply_batch_decisions(RUN, {"fs_list": "timeout"})
     r = p.invoke("local:fs_list", {"path": "."})
     assert not r.ok and r.error == LOCAL_TIMEOUT_REFUSAL
 
@@ -371,14 +389,14 @@ def test_timeout_verdict_keeps_pinned_copy_even_with_override(tmp_path):
 def test_ask_with_approve_once_stamp_executes(tmp_path):
     (tmp_path / "a.txt").write_text("a")
     p = make_provider(state=ASK, root=tmp_path)
-    p.apply_batch_decisions({"fs_list": "approve_once"})
+    p.apply_batch_decisions(RUN, {"fs_list": "approve_once"})
     assert p.invoke("local:fs_list", {"path": "."}).ok
 
 
 def test_stamps_replace_not_merge(tmp_path):
     p = make_provider(state=ASK, root=tmp_path)
-    p.apply_batch_decisions({"fs_list": "approve_once"})
-    p.apply_batch_decisions({})  # next turn cleared first
+    p.apply_batch_decisions(RUN, {"fs_list": "approve_once"})
+    p.apply_batch_decisions(RUN, {})  # next turn cleared first
     r = p.invoke("local:fs_list", {"path": "."})
     assert not r.ok and r.error == LOCAL_TIMEOUT_REFUSAL
 
@@ -394,8 +412,8 @@ def test_pending_gate_for_ask_returns_pending_call(tmp_path):
 
 def test_stamp_scope_isolates_nested_run(tmp_path):
     p = make_provider(state=ASK, root=tmp_path)
-    p.apply_batch_decisions({"fs_list": "approve_once"})
-    with p.stamp_scope():
+    p.apply_batch_decisions(RUN, {"fs_list": "approve_once"})
+    with p.stamp_scope(RUN):
         assert not p.invoke("local:fs_list", {"path": "."}).ok  # child: no stamps
     assert p.invoke("local:fs_list", {"path": "."}).ok  # parent stamps restored
 
@@ -425,7 +443,7 @@ def test_approve_session_stamp_persists(tmp_path):
         root=tmp_path,
         persist_approval=lambda hub, decision: persisted.append((hub.name, decision)),
     )
-    p.apply_batch_decisions({"fs_list": "approve_session"})
+    p.apply_batch_decisions(RUN, {"fs_list": "approve_session"})
     assert p.invoke("local:fs_list", {"path": "."}).ok
     assert persisted == [("fs_list", "approve_session")]
 
@@ -438,7 +456,7 @@ def test_always_allow_stamp_persists(tmp_path):
         root=tmp_path,
         persist_approval=lambda hub, decision: persisted.append((hub.name, decision)),
     )
-    p.apply_batch_decisions({"fs_list": "always_allow"})
+    p.apply_batch_decisions(RUN, {"fs_list": "always_allow"})
     assert p.invoke("local:fs_list", {"path": "."}).ok
     assert persisted == [("fs_list", "always_allow")]
 
@@ -451,7 +469,7 @@ def test_approve_once_stamp_does_not_persist(tmp_path):
         root=tmp_path,
         persist_approval=lambda hub, decision: persisted.append((hub.name, decision)),
     )
-    p.apply_batch_decisions({"fs_list": "approve_once"})
+    p.apply_batch_decisions(RUN, {"fs_list": "approve_once"})
     assert p.invoke("local:fs_list", {"path": "."}).ok
     assert persisted == []
 
@@ -476,7 +494,7 @@ def test_persist_failure_does_not_block_execution(tmp_path):
         raise RuntimeError("store write failed")
 
     p = make_provider(state=ASK, root=tmp_path, persist_approval=boom)
-    p.apply_batch_decisions({"fs_list": "always_allow"})
+    p.apply_batch_decisions(RUN, {"fs_list": "always_allow"})
     assert p.invoke("local:fs_list", {"path": "."}).ok
 
 
@@ -702,7 +720,7 @@ def test_kill_switch_records_denied(tmp_path):
 
 def test_timeout_stamp_records_denied_timeout(tmp_path):
     p, recorded = _recording_provider(tmp_path, state=ASK)
-    p.apply_batch_decisions({"fs_list": "timeout"})
+    p.apply_batch_decisions(RUN, {"fs_list": "timeout"})
     r = p.invoke("local:fs_list", {"path": "."})
     assert not r.ok and r.error == LOCAL_TIMEOUT_REFUSAL
     assert [(h.name, d) for h, d in recorded] == [("fs_list", "denied-timeout")]
@@ -719,7 +737,7 @@ def test_ask_without_callback_records_denied_timeout(tmp_path):
 
 def test_deny_stamp_records_denied(tmp_path):
     p, recorded = _recording_provider(tmp_path, state=ASK)
-    p.apply_batch_decisions({"fs_list": "deny"})
+    p.apply_batch_decisions(RUN, {"fs_list": "deny"})
     r = p.invoke("local:fs_list", {"path": "."})
     assert not r.ok and r.error == LOCAL_DENY_REFUSAL
     assert [(h.name, d) for h, d in recorded] == [("fs_list", "denied")]

--- a/Tests/Agents/test_mcp_tool_provider.py
+++ b/Tests/Agents/test_mcp_tool_provider.py
@@ -26,6 +26,7 @@ from tldw_chatbook.Agents.mcp_tool_provider import (
     USER_DENY_REFUSAL,
     UNRESOLVED_REFUSAL,
 )
+from tldw_chatbook.Agents.run_context import use_run_id
 from tldw_chatbook.MCP.hub_tool_catalog import HubTool
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
 
@@ -160,6 +161,26 @@ class FakeMCPService:
         if self.execute_raises is not None:
             raise self.execute_raises
         return self.execute_result
+
+
+#: PR2a Task 5: verdict stamps are keyed by RUN. Every test in this file
+#: exercises a single run, so it stamps and reads under this one id.
+RUN = "run-1"
+
+
+@pytest.fixture(autouse=True)
+def _dispatching_run():
+    """Bind ``RUN`` as the dispatching run for every test in this module.
+
+    ``invoke()`` reads the run whose call it is executing from
+    ``run_context`` (bound in production by ``AgentService`` around each
+    invocation), so a test that stamps a verdict for ``RUN`` and then calls
+    ``invoke()`` must be running as ``RUN`` -- exactly as production does.
+    Assertions are unchanged: a stamp this run made is a stamp this run
+    consumes.
+    """
+    with use_run_id(RUN):
+        yield
 
 
 @pytest.fixture
@@ -327,9 +348,9 @@ def test_apply_batch_decisions_then_stamped_decision_is_a_peek_not_a_pop():
     provider = MCPToolProvider(
         service=FakeMCPService(), main_loop=asyncio.new_event_loop()
     )
-    provider.apply_batch_decisions({"mcp__srv__run": "deny"})
-    assert provider.stamped_decision("mcp__srv__run") == "deny"
-    assert provider.stamped_decision("mcp__srv__run") == "deny"
+    provider.apply_batch_decisions(RUN, {"mcp__srv__run": "deny"})
+    assert provider.stamped_decision(RUN, "mcp__srv__run") == "deny"
+    assert provider.stamped_decision(RUN, "mcp__srv__run") == "deny"
 
 
 def test_apply_batch_decisions_replaces_rather_than_merges_prior_stamps():
@@ -339,11 +360,11 @@ def test_apply_batch_decisions_replaces_rather_than_merges_prior_stamps():
     provider = MCPToolProvider(
         service=FakeMCPService(), main_loop=asyncio.new_event_loop()
     )
-    provider.apply_batch_decisions({"mcp__srv__run": "approve_once"})
-    assert provider.stamped_decision("mcp__srv__run") == "approve_once"
+    provider.apply_batch_decisions(RUN, {"mcp__srv__run": "approve_once"})
+    assert provider.stamped_decision(RUN, "mcp__srv__run") == "approve_once"
 
-    provider.apply_batch_decisions({})  # next turn: nothing needed gating
-    assert provider.stamped_decision("mcp__srv__run") is None
+    provider.apply_batch_decisions(RUN, {})  # next turn: nothing needed gating
+    assert provider.stamped_decision(RUN, "mcp__srv__run") is None
 
 
 def test_compose_catalog_clears_stale_stamped_decisions():
@@ -357,12 +378,12 @@ def test_compose_catalog_clears_stale_stamped_decisions():
 
     # Stamp a bogus tool name not in the catalog.
     bogus_name = "mcp__srv__nonexistent"
-    provider.apply_batch_decisions({bogus_name: "approve_once"})
-    assert provider.stamped_decision(bogus_name) == "approve_once"
+    provider.apply_batch_decisions(RUN, {bogus_name: "approve_once"})
+    assert provider.stamped_decision(RUN, bogus_name) == "approve_once"
 
     # Recompose: stale decision should be cleared.
     _compose(provider)
-    assert provider.stamped_decision(bogus_name) is None
+    assert provider.stamped_decision(RUN, bogus_name) is None
 
 
 # ---------------------------------------------------------------------------
@@ -838,7 +859,7 @@ def test_invoke_stamped_deny_wins_for_every_call_this_turn_until_cleared(running
     provider = MCPToolProvider(service=service, main_loop=running_loop)
     _compose(provider)
     tool_id = provider.list_catalog()[0].id
-    provider.apply_batch_decisions({tool_id: "deny"})
+    provider.apply_batch_decisions(RUN, {tool_id: "deny"})
 
     result = provider.invoke(tool_id, {})
 
@@ -858,7 +879,7 @@ def test_invoke_stamped_deny_wins_for_every_call_this_turn_until_cleared(running
 
     # Next turn: the closure clears the stamp set (even with `{}`) -- a
     # further call now re-gates fresh instead of reusing the stale stamp.
-    provider.apply_batch_decisions({})
+    provider.apply_batch_decisions(RUN, {})
     result3 = provider.invoke(tool_id, {})
     assert result3.ok is False  # default "ask" state, no callback -> fail closed
     assert len(service.record_tool_decision_calls) == 3
@@ -871,7 +892,7 @@ def test_invoke_stamped_timeout_uses_exact_model_facing_copy(running_loop):
     provider = MCPToolProvider(service=service, main_loop=running_loop)
     _compose(provider)
     tool_id = provider.list_catalog()[0].id
-    provider.apply_batch_decisions({tool_id: "timeout"})
+    provider.apply_batch_decisions(RUN, {tool_id: "timeout"})
 
     result = provider.invoke(tool_id, {})
 
@@ -888,7 +909,7 @@ def test_invoke_stamped_approve_once_executes(running_loop):
     provider = MCPToolProvider(service=service, main_loop=running_loop)
     _compose(provider)
     tool_id = provider.list_catalog()[0].id
-    provider.apply_batch_decisions({tool_id: "approve_once"})
+    provider.apply_batch_decisions(RUN, {tool_id: "approve_once"})
 
     result = provider.invoke(tool_id, {})
 
@@ -911,7 +932,7 @@ def test_invoke_stamped_approve_once_applies_to_every_same_name_call_this_turn(
     _compose(provider)
     tool_id = provider.list_catalog()[0].id
     # One batch-review round trip, one card, one verdict for both calls.
-    provider.apply_batch_decisions({tool_id: "approve_once"})
+    provider.apply_batch_decisions(RUN, {tool_id: "approve_once"})
 
     result1 = provider.invoke(tool_id, {"query": "first"})
     result2 = provider.invoke(tool_id, {"query": "second"})
@@ -1378,7 +1399,7 @@ def test_invoke_refuses_when_kill_switch_flips_even_with_a_stamped_verdict(
     provider = MCPToolProvider(service=service, main_loop=running_loop)
     _compose(provider)
     tool_id = provider.list_catalog()[0].id
-    provider.apply_batch_decisions({tool_id: "approve_once"})
+    provider.apply_batch_decisions(RUN, {tool_id: "approve_once"})
 
     service.kill_switch = True
 

--- a/Tests/Agents/test_run_log_cross_run_search.py
+++ b/Tests/Agents/test_run_log_cross_run_search.py
@@ -37,6 +37,8 @@ from tldw_chatbook.Agents.tool_catalog import (
 )
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
+from Tests.Agents.test_agent_service import FleetChat, verbatim
+
 
 def _fence(name, args):
     return f"```tool_call\n{json.dumps({'name': name, 'arguments': args})}\n```"
@@ -351,19 +353,24 @@ def test_subagent_cannot_call_search_run_log_with_conversation_scope(
     reg = ToolCatalogRegistry()
     reg.register_provider(BuiltinToolProvider())
 
-    calls = []
-    script = [
-        _svc_fence(SPAWN_TOOL_NAME, {"task": "native task"}),  # parent spawns
-        _svc_fence(
-            SEARCH_RUN_LOG_TOOL_NAME, {"contains": "x", "scope": "conversation"}
-        ),  # child tries cross-run reach
-        {"choices": [{"message": {"content": "child gave up"}}]},
-        {"choices": [{"message": {"content": "final"}}]},
-    ]
-
-    def chat(**kwargs):
-        calls.append(kwargs)
-        return script.pop(0)
+    # PR2a Task 6.5: the fleet is ON by default, so the child runs on its
+    # own thread -- one ordered queue is no longer deterministic. Addressed
+    # per agent instead; the replies themselves are unchanged.
+    chat = FleetChat(
+        [
+            _svc_fence(SPAWN_TOOL_NAME, {"task": "native task"}),  # parent spawns
+            {"choices": [{"message": {"content": "final"}}]},
+        ],
+        {
+            "native task": [
+                _svc_fence(
+                    SEARCH_RUN_LOG_TOOL_NAME, {"contains": "x", "scope": "conversation"}
+                ),  # child tries cross-run reach
+                {"choices": [{"message": {"content": "child gave up"}}]},
+            ]
+        },
+        reply=verbatim,
+    )
 
     service = AgentService(db, reg, chat_call=chat)
     _rid, outcome = service.run_turn(
@@ -380,8 +387,13 @@ def test_subagent_cannot_call_search_run_log_with_conversation_scope(
     assert outcome.status == RUN_DONE
 
     # (a) schema gate: the child never sees search_run_log at all (scope is
-    # just an argument on an undisclosed tool).
-    child_system_prompt = calls[1]["messages_payload"][0]["content"]
+    # just an argument on an undisclosed tool). Addressed by task text
+    # rather than by `calls[1]`: under the fleet the child's call is no
+    # longer guaranteed to be the second chat_call overall, but it is still
+    # THE call this assertion always meant.
+    child_system_prompt = chat.child_calls["native task"][0]["messages_payload"][0][
+        "content"
+    ]
     assert SEARCH_RUN_LOG_TOOL_NAME not in child_system_prompt
 
     # (b) dispatch gate: the child's call, made regardless of (a), is

--- a/Tests/Agents/test_run_log_sandbox_isolation.py
+++ b/Tests/Agents/test_run_log_sandbox_isolation.py
@@ -72,7 +72,7 @@ class _AllowGate:
     trip, so the provider is handed a gate that always allows.
     """
 
-    def check(self, tool, run_id=""):
+    def check(self, tool, run_id):
         return None
 
 

--- a/Tests/Agents/test_run_log_sandbox_isolation.py
+++ b/Tests/Agents/test_run_log_sandbox_isolation.py
@@ -72,7 +72,7 @@ class _AllowGate:
     trip, so the provider is handed a gate that always allows.
     """
 
-    def check(self, tool):
+    def check(self, tool, run_id=""):
         return None
 
 

--- a/Tests/Agents/test_run_log_sandbox_isolation.py
+++ b/Tests/Agents/test_run_log_sandbox_isolation.py
@@ -60,6 +60,8 @@ from tldw_chatbook.Agents.agent_service import AgentService
 from tldw_chatbook.Agents.run_log import RunLogWriter
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+from Tests.Agents.test_agent_service import FleetChat, verbatim
 from tldw_chatbook.Tools.file_operation_tools import GrepFiles
 
 
@@ -303,26 +305,35 @@ def test_spawned_subagent_cannot_read_parents_log_via_grep_files(tmp_path, monke
 
     secret = "PARENT_SECRET_API_KEY=sk-live-abc123"
     task = "search the sandbox for anything interesting"
-    script = [
-        {
-            "choices": [
-                {
-                    "message": {
-                        "content": (
-                            f"Noting {secret} before delegating.\n"
-                            + _fence(SPAWN_TOOL_NAME, {"task": task})
-                        )
+    # PR2a Task 6.5: the fleet is ON by default, so the child runs on its
+    # own thread -- one ordered queue is no longer deterministic. Addressed
+    # per agent instead; the replies themselves are unchanged.
+    chat = FleetChat(
+        [
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                f"Noting {secret} before delegating.\n"
+                                + _fence(SPAWN_TOOL_NAME, {"task": task})
+                            )
+                        }
                     }
-                }
+                ]
+            },
+            {"choices": [{"message": {"content": "done"}}]},  # parent's answer
+        ],
+        {
+            task: [
+                _svc_fence("grep_files", {"pattern": "PARENT_SECRET"}),  # child tries
+                {
+                    "choices": [{"message": {"content": "found nothing"}}]
+                },  # child's answer
             ]
         },
-        _svc_fence("grep_files", {"pattern": "PARENT_SECRET"}),  # child tries
-        {"choices": [{"message": {"content": "found nothing"}}]},  # child's answer
-        {"choices": [{"message": {"content": "done"}}]},  # parent's answer
-    ]
-
-    def chat(**kwargs):
-        return script.pop(0)
+        reply=verbatim,
+    )
 
     service = AgentService(db, reg, chat_call=chat)
     _rid, outcome = service.run_turn(

--- a/Tests/Agents/test_run_log_service_wiring.py
+++ b/Tests/Agents/test_run_log_service_wiring.py
@@ -121,7 +121,7 @@ def test_disabled_writer_leaves_the_run_untouched(wired, monkeypatch):
     assert not (root / "agent-runs").exists()
 
 
-def test_a_real_spawn_shares_the_parent_log_directory_and_counter(wired):
+def test_a_real_spawn_shares_the_parent_log_directory_and_counter(wired, inline_spawns):
     """Round-1 review fix: the prior version of this suite only ever proved
     sharing by manually calling ``writer.append`` on the object the test
     already held -- a real ``spawn()`` never ran. A mutation giving
@@ -168,7 +168,9 @@ def test_a_real_spawn_shares_the_parent_log_directory_and_counter(wired):
     )
 
 
-def test_parent_spawn_tool_call_record_precedes_the_childs_own_records(wired):
+def test_parent_spawn_tool_call_record_precedes_the_childs_own_records(
+    wired, inline_spawns
+):
     """F5 (Qodo #5, PR #1066 review): end-to-end counterpart of the pure-loop
     test in test_run_log_on_record.py, driven through a REAL nested spawn
     and the REAL RunLogWriter. `deps.spawn()` runs the child's ENTIRE loop

--- a/Tests/Agents/test_run_log_stats_slice_runtime_tools.py
+++ b/Tests/Agents/test_run_log_stats_slice_runtime_tools.py
@@ -38,6 +38,7 @@ from tldw_chatbook.Agents.tool_catalog import (
 )
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 from Tests.Agents.test_agent_runtime import make_deps
+from Tests.Agents.test_agent_service import FleetChat, verbatim
 
 
 def _fence(name, args):
@@ -178,18 +179,27 @@ def test_subagent_cannot_call_run_log_stats_or_run_log_slice(tmp_path, monkeypat
     reg = ToolCatalogRegistry()
     reg.register_provider(BuiltinToolProvider())
 
-    script = [
-        _svc_fence(SPAWN_TOOL_NAME, {"task": "native task"}),  # parent spawns
-        _svc_fence(RUN_LOG_STATS_TOOL_NAME, {"group_by": "tool"}),  # child tries stats
-        _svc_fence(RUN_LOG_SLICE_TOOL_NAME, {"from_record": 1}),  # child tries slice
-        {"choices": [{"message": {"content": "child gave up"}}]},
-        {"choices": [{"message": {"content": "final"}}]},
-    ]
-    calls = []
-
-    def chat(**kwargs):
-        calls.append(kwargs)
-        return script.pop(0)
+    # PR2a Task 6.5: the fleet is ON by default, so the child runs on its
+    # own thread -- one ordered queue is no longer deterministic. Addressed
+    # per agent instead; the replies themselves are unchanged.
+    chat = FleetChat(
+        [
+            _svc_fence(SPAWN_TOOL_NAME, {"task": "native task"}),  # parent spawns
+            {"choices": [{"message": {"content": "final"}}]},
+        ],
+        {
+            "native task": [
+                _svc_fence(
+                    RUN_LOG_STATS_TOOL_NAME, {"group_by": "tool"}
+                ),  # child tries stats
+                _svc_fence(
+                    RUN_LOG_SLICE_TOOL_NAME, {"from_record": 1}
+                ),  # child tries slice
+                {"choices": [{"message": {"content": "child gave up"}}]},
+            ]
+        },
+        reply=verbatim,
+    )
 
     service = AgentService(db, reg, chat_call=chat)
     _rid, outcome = service.run_turn(
@@ -205,11 +215,13 @@ def test_subagent_cannot_call_run_log_stats_or_run_log_slice(tmp_path, monkeypat
     )
     assert outcome.status == RUN_DONE
 
-    # (a) schema gate: the child's own system prompt (calls[1] -- the
-    # parent's spawn dispatch runs the child's whole loop inline before
-    # dispatch returns, so this is the second chat_call invocation overall)
-    # must never mention either tool.
-    child_system_prompt = calls[1]["messages_payload"][0]["content"]
+    # (a) schema gate: the child's own system prompt must never mention
+    # either tool. Addressed by task text rather than by `calls[1]`: under
+    # the fleet the child's call is no longer guaranteed to be the second
+    # chat_call overall, but it is still THE call this assertion meant.
+    child_system_prompt = chat.child_calls["native task"][0]["messages_payload"][0][
+        "content"
+    ]
     assert RUN_LOG_STATS_TOOL_NAME not in child_system_prompt
     assert RUN_LOG_SLICE_TOOL_NAME not in child_system_prompt
 

--- a/Tests/Agents/test_run_log_workspace_isolation.py
+++ b/Tests/Agents/test_run_log_workspace_isolation.py
@@ -50,6 +50,8 @@ from tldw_chatbook.Agents.run_log_format import RunLogRecord, encode_record
 from tldw_chatbook.Agents.run_log_search import load_records
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+from Tests.Agents.test_agent_service import FleetChat, verbatim
 from tldw_chatbook.Tools.file_operation_tools import GlobFiles, GrepFiles
 
 
@@ -228,36 +230,45 @@ def test_spawned_subagent_cannot_read_parents_log_via_grep_files_in_bound_worksp
 
     secret = "PARENT_SECRET_API_KEY=sk-live-workspace321"
     task = "search the workspace for anything interesting"
-    script = [
-        {
-            "choices": [
-                {
-                    "message": {
-                        "content": (
-                            f"Noting {secret} before delegating.\n"
-                            + _fence(SPAWN_TOOL_NAME, {"task": task})
-                        )
+    # PR2a Task 6.5: the fleet is ON by default, so the child runs on its
+    # own thread -- one ordered queue is no longer deterministic. Addressed
+    # per agent instead; the replies themselves are unchanged.
+    chat = FleetChat(
+        [
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                f"Noting {secret} before delegating.\n"
+                                + _fence(SPAWN_TOOL_NAME, {"task": task})
+                            )
+                        }
                     }
-                }
+                ]
+            },
+            {"choices": [{"message": {"content": "done"}}]},  # parent's answer
+        ],
+        {
+            task: [
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": _fence(
+                                    "grep_files", {"pattern": "PARENT_SECRET"}
+                                )
+                            }
+                        }
+                    ]
+                },
+                {
+                    "choices": [{"message": {"content": "found nothing"}}]
+                },  # child's answer
             ]
         },
-        {
-            "choices": [
-                {
-                    "message": {
-                        "content": _fence(
-                            "grep_files", {"pattern": "PARENT_SECRET"}
-                        )
-                    }
-                }
-            ]
-        },
-        {"choices": [{"message": {"content": "found nothing"}}]},  # child's answer
-        {"choices": [{"message": {"content": "done"}}]},  # parent's answer
-    ]
-
-    def chat(**kwargs):
-        return script.pop(0)
+        reply=verbatim,
+    )
 
     service = AgentService(db, reg, chat_call=chat)
     _rid, outcome = service.run_turn(

--- a/Tests/Agents/test_run_log_workspace_isolation.py
+++ b/Tests/Agents/test_run_log_workspace_isolation.py
@@ -62,7 +62,7 @@ class _AllowGate:
     approval round trip.
     """
 
-    def check(self, tool, run_id=""):
+    def check(self, tool, run_id):
         return None
 
 

--- a/Tests/Agents/test_run_log_workspace_isolation.py
+++ b/Tests/Agents/test_run_log_workspace_isolation.py
@@ -62,7 +62,7 @@ class _AllowGate:
     approval round trip.
     """
 
-    def check(self, tool):
+    def check(self, tool, run_id=""):
         return None
 
 

--- a/Tests/Agents/test_run_skill_script_runtime_tool.py
+++ b/Tests/Agents/test_run_skill_script_runtime_tool.py
@@ -46,6 +46,8 @@ from tldw_chatbook.Agents.tool_catalog import (
 )
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
+from Tests.Agents.test_agent_service import FleetChat, verbatim
+
 # --- Step 1 unit tests (name + schema shape) --------------------------------
 
 
@@ -349,24 +351,29 @@ def test_subagent_can_also_dispatch_and_be_pinned_run_skill_script(tmp_path):
         seen.append((skill_name, script_path, args))
         return ToolResult(ok=True, content="stdout: hi")
 
-    script = [
-        _svc_fence(SPAWN_TOOL_NAME, {"task": "child task"}),  # parent spawns
-        _svc_fence(
-            "run_skill_script",
-            {
-                "skill_name": "demo",
-                "script_path": "scripts/hello.py",
-                "args": ["x"],
-            },
-        ),  # child dispatches
-        {"choices": [{"message": {"content": "child done"}}]},
-        {"choices": [{"message": {"content": "parent done"}}]},
-    ]
-    calls = []
-
-    def chat_call(**kwargs):
-        calls.append(kwargs)
-        return script.pop(0)
+    # PR2a Task 6.5: the fleet is ON by default, so the child runs on its
+    # own thread -- one ordered queue is no longer deterministic. Addressed
+    # per agent instead; the replies themselves are unchanged.
+    chat_call = FleetChat(
+        [
+            _svc_fence(SPAWN_TOOL_NAME, {"task": "child task"}),  # parent spawns
+            {"choices": [{"message": {"content": "parent done"}}]},
+        ],
+        {
+            "child task": [
+                _svc_fence(
+                    "run_skill_script",
+                    {
+                        "skill_name": "demo",
+                        "script_path": "scripts/hello.py",
+                        "args": ["x"],
+                    },
+                ),  # child dispatches
+                {"choices": [{"message": {"content": "child done"}}]},
+            ]
+        },
+        reply=verbatim,
+    )
 
     service = AgentService(db, reg, chat_call=chat_call, run_skill_script_tool=runner)
     _rid, outcome = service.run_turn(
@@ -385,10 +392,13 @@ def test_subagent_can_also_dispatch_and_be_pinned_run_skill_script(tmp_path):
     # Dispatch reached the CHILD.
     assert seen == [("demo", "scripts/hello.py", ["x"])]
 
-    # The schema was pinned into the CHILD's own first turn too. calls[0] is
-    # the parent's first call (before it spawns); calls[1] is the child's
-    # first call.
-    child_first_system_content = calls[1]["messages_payload"][0]["content"]
+    # The schema was pinned into the CHILD's own first turn too. Addressed
+    # by task text rather than by `calls[1]`: under the fleet the child's
+    # call is no longer guaranteed to be the second chat_call overall, but
+    # it is still THE call this assertion always meant.
+    child_first_system_content = chat_call.child_calls["child task"][0][
+        "messages_payload"
+    ][0]["content"]
     assert RUN_SKILL_SCRIPT_TOOL_NAME in child_first_system_content
 
     child_runs = [r for r in db.list_runs("c1") if r["agent_kind"] == "subagent"]

--- a/Tests/Agents/test_search_run_log_runtime_tool.py
+++ b/Tests/Agents/test_search_run_log_runtime_tool.py
@@ -13,6 +13,7 @@ from tldw_chatbook.Agents.agent_models import (
     RUNTIME_TOOL_NAMES,
     SEARCH_RUN_LOG_TOOL_NAME,
     SPAWN_TOOL_NAME,
+    WAIT_AGENTS_TOOL_NAME,
     AgentConfig,
     ModelTurn,
     RunBudget,
@@ -29,6 +30,7 @@ from tldw_chatbook.Agents.tool_catalog import (
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
 from Tests.Agents.test_agent_runtime import make_deps
+from Tests.Agents.test_agent_service import FleetChat, verbatim
 
 
 def test_name_is_registered_as_a_runtime_tool():
@@ -148,18 +150,24 @@ def test_subagent_cannot_call_search_run_log(tmp_path, monkeypatch):
     reg = ToolCatalogRegistry()
     reg.register_provider(BuiltinToolProvider())
 
-    calls = []
-    script = [
-        _svc_fence(SPAWN_TOOL_NAME, {"task": "native task"}),  # parent spawns
-        _svc_fence(SEARCH_RUN_LOG_TOOL_NAME, {"contains": "x"}),  # child tries
-        {"choices": [{"message": {"content": "child gave up"}}]},
-        {"choices": [{"message": {"content": "final"}}]},
-    ]
-
-    def chat(**kwargs):
-        calls.append(kwargs)
-        return script.pop(0)
-
+    # PR2a Task 6.5: the fleet is ON by default, so the child runs on its
+    # own thread and its provider call may interleave with the parent's.
+    # An ADDRESSED script (one queue per agent) replaces the single ordered
+    # queue this test used to pop; every reply below still goes to exactly
+    # the agent it was written for.
+    chat = FleetChat(
+        [
+            _svc_fence(SPAWN_TOOL_NAME, {"task": "native task"}),  # parent spawns
+            {"choices": [{"message": {"content": "final"}}]},
+        ],
+        {
+            "native task": [
+                _svc_fence(SEARCH_RUN_LOG_TOOL_NAME, {"contains": "x"}),  # child tries
+                {"choices": [{"message": {"content": "child gave up"}}]},
+            ]
+        },
+        reply=verbatim,
+    )
     service = AgentService(db, reg, chat_call=chat)
     _rid, outcome = service.run_turn(
         conversation_id="c1",
@@ -174,11 +182,14 @@ def test_subagent_cannot_call_search_run_log(tmp_path, monkeypatch):
     )
     assert outcome.status == RUN_DONE
 
-    # (a) schema gate: the child's OWN call (calls[1] -- the parent's spawn
-    # dispatch runs the child's whole loop inline before dispatch returns,
-    # so this is the second chat_call invocation overall) must never have
-    # been offered search_run_log at all.
-    child_system_prompt = calls[1]["messages_payload"][0]["content"]
+    # (a) schema gate: the child's OWN first call must never have been
+    # offered search_run_log at all. Addressed by task text rather than by
+    # `calls[1]`: under the fleet the child's call is no longer guaranteed
+    # to be the second chat_call overall, but it is still THE call this
+    # assertion always meant.
+    child_system_prompt = chat.child_calls["native task"][0]["messages_payload"][0][
+        "content"
+    ]
     assert SEARCH_RUN_LOG_TOOL_NAME not in child_system_prompt
 
     # (b) dispatch gate: the child's call, made regardless of (a), must be
@@ -340,15 +351,22 @@ def test_parent_can_filter_its_log_to_subagent_records_via_kind(tmp_path, monkey
     reg.register_provider(BuiltinToolProvider())
 
     child_marker = "CHILD_ONLY_MARKER_4b8e"
-    script = [
-        _svc_fence(SPAWN_TOOL_NAME, {"task": "investigate"}),  # parent spawns
-        {"choices": [{"message": {"content": child_marker}}]},  # child's final answer
-        _svc_fence(SEARCH_RUN_LOG_TOOL_NAME, {"kind": "subagent"}),  # parent searches
-        {"choices": [{"message": {"content": "done"}}]},  # parent's final answer
-    ]
-
-    def chat(**kwargs):
-        return script.pop(0)
+    # PR2a Task 6.5: with the fleet ON the child runs on its own thread, so
+    # (a) the script is ADDRESSED per agent instead of one ordered queue,
+    # and (b) the parent must `wait_agents` before searching -- previously
+    # the inline spawn guaranteed the child's records were already in the
+    # log by the time spawn returned. The step budget is raised to fit that
+    # extra round; nothing here ever asserted on the budget.
+    chat = FleetChat(
+        [
+            _svc_fence(SPAWN_TOOL_NAME, {"task": "investigate"}),  # parent spawns
+            _svc_fence(WAIT_AGENTS_TOOL_NAME, {}),  # ... and collects
+            _svc_fence(SEARCH_RUN_LOG_TOOL_NAME, {"kind": "subagent"}),  # then searches
+            {"choices": [{"message": {"content": "done"}}]},  # parent's final answer
+        ],
+        {"investigate": [{"choices": [{"message": {"content": child_marker}}]}]},
+        reply=verbatim,
+    )
 
     service = AgentService(db, reg, chat_call=chat)
     _rid, outcome = service.run_turn(
@@ -358,7 +376,7 @@ def test_parent_can_filter_its_log_to_subagent_records_via_kind(tmp_path, monkey
             model="m",
             system_prompt="s",
             allowed_tools=("calculator", SPAWN_TOOL_NAME),
-            budget=RunBudget(),
+            budget=RunBudget(max_steps=16),
         ),
         api_endpoint="llama_cpp",
     )

--- a/Tests/Agents/test_search_run_log_runtime_tool.py
+++ b/Tests/Agents/test_search_run_log_runtime_tool.py
@@ -215,7 +215,7 @@ class _AllowGate:
     allows.
     """
 
-    def check(self, tool, run_id=""):
+    def check(self, tool, run_id):
         return None
 
 

--- a/Tests/Agents/test_search_run_log_runtime_tool.py
+++ b/Tests/Agents/test_search_run_log_runtime_tool.py
@@ -215,7 +215,7 @@ class _AllowGate:
     allows.
     """
 
-    def check(self, tool):
+    def check(self, tool, run_id=""):
         return None
 
 

--- a/Tests/Agents/test_skill_tool_spawn.py
+++ b/Tests/Agents/test_skill_tool_spawn.py
@@ -19,6 +19,7 @@ from tldw_chatbook.Agents.tool_catalog import (
 )
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
+from Tests.Agents.conftest import pin_max_live_subagents
 from Tests.Agents.test_agent_service import FleetChat, verbatim
 
 
@@ -450,3 +451,70 @@ def test_native_spawn_child_cannot_call_a_skill_tool(tmp_path):
     ]
     assert any("Tool not permitted: code-review" in r for r in tool_results)
     assert not any("sub-agent budget exhausted" in r for r in tool_results)
+
+
+# --- PR2a Task 6.5: a SKILL call keeps its contract under a live fleet ---
+
+
+def test_skill_call_runs_inline_and_returns_the_output_not_a_handle(
+    tmp_path, monkeypatch
+):
+    """With the fleet ON, a skill call still returns the skill's OUTPUT.
+
+    `spawn_subagent` and a skill tool share one `spawn` closure, so turning
+    the fleet on would have made a skill call return `started <id>: ...`
+    and require `wait_agents` to collect. That silently breaks the skill
+    contract: nothing tells the model a skill is asynchronous, so it
+    answers from the literal handle string while `_settle_fleet` discards
+    the real work -- a wrong answer, not an error. The service therefore
+    hands `skill_runner.run` a spawn pre-bound to the inline path.
+
+    Pinned end-to-end through a REAL fleet (max_live_subagents = 3, no
+    injected coordinator), because "the fleet is on" is the precondition
+    that makes this regressable at all.
+    """
+    pin_max_live_subagents(monkeypatch, 3)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    reg = _registry_with_code_review_skill()
+    chat = FleetChat(
+        [
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": _fence("code-review", {"args": "the diff"})
+                        }
+                    }
+                ]
+            },
+            {"choices": [{"message": {"content": "Done reviewing."}}]},
+        ],
+        {"RENDERED[the diff]": [{"choices": [{"message": {"content": "child answer"}}]}]},
+        reply=verbatim,
+    )
+    runner = _FakeSkillRunner()
+    service = AgentService(db, reg, chat_call=chat, skill_runner=runner)
+    run_id, outcome = service.run_turn(
+        conversation_id="c1",
+        messages=[{"role": "user", "content": "review"}],
+        config=AgentConfig(
+            model="m",
+            system_prompt="s",
+            allowed_tools=("calculator", "code-review", SPAWN_TOOL_NAME),
+            budget=RunBudget(),
+        ),
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    # A fleet really was built for this turn ...
+    assert service._fleet is not None
+    # ... and the skill call still came back with the child's own answer,
+    # in the SKILL's own tool_result -- no handle, no wait_agents needed.
+    results = [
+        s["result"]
+        for s in db.get_run(run_id)["steps"]
+        if s["kind"] == "tool_result" and s["tool_name"] == "code-review"
+    ]
+    assert results == ["child answer"]
+    assert not any("started " in r for r in results)
+    assert db.count_subagent_runs("c1") == 1

--- a/Tests/Agents/test_skill_tool_spawn.py
+++ b/Tests/Agents/test_skill_tool_spawn.py
@@ -19,6 +19,8 @@ from tldw_chatbook.Agents.tool_catalog import (
 )
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
+from Tests.Agents.test_agent_service import FleetChat, verbatim
+
 
 def _fence(name, args):
     return f"{FENCE_OPEN}\n{json.dumps({'name': name, 'arguments': args})}\n```"
@@ -264,28 +266,39 @@ def test_skill_tool_executes_after_find_load_discloses_it(tmp_path):
 def test_combined_budget_native_spawn_then_skill_call(tmp_path):
     db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
     reg = _registry_with_code_review_skill()
-    script = [
-        {
-            "choices": [
-                {
-                    "message": {
-                        "content": _fence(SPAWN_TOOL_NAME, {"task": "native task"})
+    # PR2a Task 6.5: the fleet is ON by default, so the native child runs
+    # on its own thread -- one ordered queue is no longer deterministic.
+    # Addressed per agent instead; the replies themselves are unchanged,
+    # and the COMBINED ceiling this test is about is unaffected by where
+    # the child runs (the counter is incremented in the one shared `spawn`
+    # closure, before either path branches).
+    chat = FleetChat(
+        [
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": _fence(SPAWN_TOOL_NAME, {"task": "native task"})
+                        }
                     }
-                }
-            ]
-        },
-        {"choices": [{"message": {"content": "native child answer"}}]},
-        {
-            "choices": [
-                {"message": {"content": _fence("code-review", {"args": "the diff"})}}
-            ]
-        },
-        {"choices": [{"message": {"content": "final"}}]},
-    ]
-    runner = _FakeSkillRunner()
-    service = AgentService(
-        db, reg, chat_call=lambda **k: script.pop(0), skill_runner=runner
+                ]
+            },
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": _fence("code-review", {"args": "the diff"})
+                        }
+                    }
+                ]
+            },
+            {"choices": [{"message": {"content": "final"}}]},
+        ],
+        {"native task": [{"choices": [{"message": {"content": "native child answer"}}]}]},
+        reply=verbatim,
     )
+    runner = _FakeSkillRunner()
+    service = AgentService(db, reg, chat_call=chat, skill_runner=runner)
     _r, outcome = service.run_turn(
         conversation_id="c1",
         messages=[{"role": "user", "content": "go"}],
@@ -308,28 +321,41 @@ def test_combined_budget_native_spawn_then_skill_call(tmp_path):
 def test_combined_budget_skill_call_then_native_spawn(tmp_path):
     db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
     reg = _registry_with_code_review_skill()
-    script = [
-        {
-            "choices": [
-                {"message": {"content": _fence("code-review", {"args": "the diff"})}}
-            ]
-        },
-        {"choices": [{"message": {"content": "skill child answer"}}]},
-        {
-            "choices": [
-                {
-                    "message": {
-                        "content": _fence(SPAWN_TOOL_NAME, {"task": "native task"})
+    # PR2a Task 6.5: addressed per agent (see the sibling test above). The
+    # SKILL's own spawn is threaded too -- both paths go through the one
+    # `spawn` closure -- so the skill child is addressed by the task text
+    # `_FakeSkillRunner.run` renders for it.
+    chat = FleetChat(
+        [
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": _fence("code-review", {"args": "the diff"})
+                        }
                     }
-                }
+                ]
+            },
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": _fence(SPAWN_TOOL_NAME, {"task": "native task"})
+                        }
+                    }
+                ]
+            },
+            {"choices": [{"message": {"content": "final"}}]},
+        ],
+        {
+            "RENDERED[the diff]": [
+                {"choices": [{"message": {"content": "skill child answer"}}]}
             ]
         },
-        {"choices": [{"message": {"content": "final"}}]},
-    ]
-    runner = _FakeSkillRunner()
-    service = AgentService(
-        db, reg, chat_call=lambda **k: script.pop(0), skill_runner=runner
+        reply=verbatim,
     )
+    runner = _FakeSkillRunner()
+    service = AgentService(db, reg, chat_call=chat, skill_runner=runner)
     _r, outcome = service.run_turn(
         conversation_id="c1",
         messages=[{"role": "user", "content": "go"}],
@@ -369,29 +395,39 @@ def test_native_spawn_child_cannot_call_a_skill_tool(tmp_path):
     never reached (the counting fake's `spawned_with` stays ``None``)."""
     db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
     reg = _registry_with_code_review_skill()
-    script = [
-        {
-            "choices": [
-                {
-                    "message": {
-                        "content": _fence(SPAWN_TOOL_NAME, {"task": "native task"})
+    # PR2a Task 6.5: addressed per agent (see the sibling tests above).
+    chat = FleetChat(
+        [
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": _fence(SPAWN_TOOL_NAME, {"task": "native task"})
+                        }
                     }
-                }
-            ]
-        },
-        # Inside the child: the model attempts the skill tool directly.
+                ]
+            },
+            {"choices": [{"message": {"content": "final"}}]},
+        ],
         {
-            "choices": [
-                {"message": {"content": _fence("code-review", {"args": "the diff"})}}
+            "native task": [
+                # Inside the child: the model attempts the skill tool directly.
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": _fence("code-review", {"args": "the diff"})
+                            }
+                        }
+                    ]
+                },
+                {"choices": [{"message": {"content": "child gave up"}}]},
             ]
         },
-        {"choices": [{"message": {"content": "child gave up"}}]},
-        {"choices": [{"message": {"content": "final"}}]},
-    ]
-    runner = _FakeSkillRunner()
-    service = AgentService(
-        db, reg, chat_call=lambda **k: script.pop(0), skill_runner=runner
+        reply=verbatim,
     )
+    runner = _FakeSkillRunner()
+    service = AgentService(db, reg, chat_call=chat, skill_runner=runner)
     _r, outcome = service.run_turn(
         conversation_id="c1",
         messages=[{"role": "user", "content": "go"}],

--- a/Tests/Agents/test_tool_catalog.py
+++ b/Tests/Agents/test_tool_catalog.py
@@ -193,7 +193,7 @@ def test_builtin_provider_refuses_when_gate_denies():
     from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
 
     class DenyGate:
-        def check(self, tool):
+        def check(self, tool, run_id=""):
             return "nope"
 
     out = BuiltinToolProvider(gate=DenyGate()).invoke(
@@ -207,7 +207,7 @@ def test_builtin_provider_runs_when_gate_permits():
     from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
 
     class AllowGate:
-        def check(self, tool):
+        def check(self, tool, run_id=""):
             return None
 
     out = BuiltinToolProvider(gate=AllowGate()).invoke(
@@ -221,7 +221,7 @@ def test_gate_none_is_not_ungated(monkeypatch):
     import tldw_chatbook.Agents.tool_catalog as tc
 
     class DenyGate:
-        def check(self, tool):
+        def check(self, tool, run_id=""):
             return "denied by default gate"
 
     monkeypatch.setattr(tc, "build_builtin_gate", lambda: DenyGate())
@@ -234,7 +234,7 @@ def test_gate_failure_does_not_raise_into_the_loop():
     from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
 
     class BoomGate:
-        def check(self, tool):
+        def check(self, tool, run_id=""):
             raise RuntimeError("gate exploded")
 
     out = BuiltinToolProvider(gate=BoomGate()).invoke(
@@ -247,7 +247,7 @@ class _OpenGate:
     """Approval gate that never refuses -- isolates the ephemeral check
     below from the (separately tested) approval-gate machinery."""
 
-    def check(self, tool):
+    def check(self, tool, run_id=""):
         return None
 
 

--- a/Tests/Agents/test_tool_catalog.py
+++ b/Tests/Agents/test_tool_catalog.py
@@ -193,7 +193,7 @@ def test_builtin_provider_refuses_when_gate_denies():
     from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
 
     class DenyGate:
-        def check(self, tool, run_id=""):
+        def check(self, tool, run_id):
             return "nope"
 
     out = BuiltinToolProvider(gate=DenyGate()).invoke(
@@ -207,7 +207,7 @@ def test_builtin_provider_runs_when_gate_permits():
     from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
 
     class AllowGate:
-        def check(self, tool, run_id=""):
+        def check(self, tool, run_id):
             return None
 
     out = BuiltinToolProvider(gate=AllowGate()).invoke(
@@ -221,7 +221,7 @@ def test_gate_none_is_not_ungated(monkeypatch):
     import tldw_chatbook.Agents.tool_catalog as tc
 
     class DenyGate:
-        def check(self, tool, run_id=""):
+        def check(self, tool, run_id):
             return "denied by default gate"
 
     monkeypatch.setattr(tc, "build_builtin_gate", lambda: DenyGate())
@@ -234,7 +234,7 @@ def test_gate_failure_does_not_raise_into_the_loop():
     from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
 
     class BoomGate:
-        def check(self, tool, run_id=""):
+        def check(self, tool, run_id):
             raise RuntimeError("gate exploded")
 
     out = BuiltinToolProvider(gate=BoomGate()).invoke(
@@ -247,7 +247,7 @@ class _OpenGate:
     """Approval gate that never refuses -- isolates the ephemeral check
     below from the (separately tested) approval-gate machinery."""
 
-    def check(self, tool, run_id=""):
+    def check(self, tool, run_id):
         return None
 
 

--- a/Tests/Agents/test_tool_catalog_concurrency.py
+++ b/Tests/Agents/test_tool_catalog_concurrency.py
@@ -1,11 +1,23 @@
 # Tests/Agents/test_tool_catalog_concurrency.py
-"""Registry cache under concurrent lookups (fleet PR 2a).
+"""Registry cache lock under concurrent/interleaved lookups (fleet PR 2a).
 
-The registry's own comment (tool_catalog.py:893-907) documents that
-`_owner_cache` and `_name_to_id_cache` are rebuilt without a lock, so two
-concurrent lookups can observe different generations. With N children on
-their own threads sharing the bridge's long-lived registry, that stops
-being exotic.
+The registry's own comment (tool_catalog.py __init__) documents that
+`_owner_cache`/`_name_to_id_cache`/`_source_cache` used to be rebuilt
+without a lock, so two overlapping lookups -- in particular
+`invoke_by_name()`'s old resolve_name() + _owner_and_id() pair -- could
+observe different generations of the catalog. With N fleet children on
+their own threads sharing the bridge's long-lived registry for a whole
+session, that stopped being exotic.
+
+The two tests below are DETERMINISTIC (no threads, no sleeps, no
+Barrier/timing dependence): they monkeypatch `_ensure_catalog_cache` to
+count calls / inject a `reset_catalog_cache()` right in the historical race
+window, so they are red pre-fix and green post-fix on every run, not just
+some fraction of runs under scheduler luck. A stochastic threaded test
+follows as a deadlock canary only -- it does NOT reliably reproduce the
+race (confirmed: 40/40 clean runs against the pre-fix code, including with
+`sys.setswitchinterval(1e-6)`), so it must not be read as a race regression
+guard.
 """
 
 import threading
@@ -13,7 +25,64 @@ import threading
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
 
 
-def test_concurrent_resolution_never_sees_a_torn_cache():
+def test_invoke_by_name_takes_exactly_one_catalog_snapshot():
+    """invoke_by_name() must resolve name -> id -> provider from ONE
+    locked snapshot, not from two independent _ensure_catalog_cache()
+    calls (the old resolve_name() then _owner_and_id() pair). Pre-fix this
+    counts 2; post-fix, 1."""
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    registry._ensure_catalog_cache()  # warm the cache first
+
+    real_ensure = registry._ensure_catalog_cache
+    snapshots = []
+
+    def counting():
+        snapshots.append(1)
+        return real_ensure()
+
+    registry._ensure_catalog_cache = counting
+
+    name = registry.list_catalog()[0].name
+    registry.invoke_by_name(name, {})
+
+    assert len(snapshots) == 1  # pre-fix: 2
+
+
+def test_reset_landing_in_the_window_cannot_break_a_lookup():
+    """Simulate a `reset_catalog_cache()` from another thread landing in
+    the exact window between a snapshot being taken and the caller using
+    it. Pre-fix, resolve_name()'s own internal snapshot read happened
+    AFTER this window (so a reset here could zero `_owner_cache` out from
+    under `_owner_and_id()`, raising AttributeError on `.get()` against
+    `None`); post-fix, the snapshot is the return value itself, immune to
+    a reset that happens after it was captured."""
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    name = registry.list_catalog()[0].name
+    tool_id = registry.resolve_name(name)
+
+    real_ensure = registry._ensure_catalog_cache
+
+    def ensure_then_reset():
+        snapshot = real_ensure()
+        registry.reset_catalog_cache()  # racing thread lands HERE
+        return snapshot
+
+    registry._ensure_catalog_cache = ensure_then_reset
+
+    assert registry.resolve_name(name) == tool_id
+    assert registry._owner_and_id(tool_id) is not None  # pre-fix: AttributeError
+    assert registry._source_for(tool_id) == "builtin"
+    assert registry.load_schema(tool_id).name == name
+
+
+def test_concurrent_lookups_do_not_deadlock():
+    """Deadlock canary, NOT a race-regression guard (see module docstring):
+    hammer reset_catalog_cache()/resolve_name() from 8 threads and confirm
+    the run completes (no deadlock) and every resolution succeeds. This
+    passed 40/40 runs against the pre-fix code too, so a green result here
+    proves absence of deadlock, not presence of the lock fix."""
     registry = ToolCatalogRegistry()
     registry.register_provider(BuiltinToolProvider())
     known = [e.name for e in registry.list_catalog()]
@@ -36,5 +105,6 @@ def test_concurrent_resolution_never_sees_a_torn_cache():
     for t in threads:
         t.start()
     for t in threads:
-        t.join()
+        t.join(timeout=30)
+    assert not any(t.is_alive() for t in threads), "deadlock: a thread never finished"
     assert errors == []

--- a/Tests/Agents/test_tool_catalog_concurrency.py
+++ b/Tests/Agents/test_tool_catalog_concurrency.py
@@ -1,0 +1,40 @@
+# Tests/Agents/test_tool_catalog_concurrency.py
+"""Registry cache under concurrent lookups (fleet PR 2a).
+
+The registry's own comment (tool_catalog.py:893-907) documents that
+`_owner_cache` and `_name_to_id_cache` are rebuilt without a lock, so two
+concurrent lookups can observe different generations. With N children on
+their own threads sharing the bridge's long-lived registry, that stops
+being exotic.
+"""
+
+import threading
+
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
+
+
+def test_concurrent_resolution_never_sees_a_torn_cache():
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    known = [e.name for e in registry.list_catalog()]
+    assert known, "catalog must be non-empty for this test to mean anything"
+
+    errors = []
+    barrier = threading.Barrier(8)
+
+    def hammer():
+        barrier.wait()
+        for _ in range(200):
+            registry.reset_catalog_cache()
+            for name in known:
+                tool_id = registry.resolve_name(name)
+                if tool_id is None:
+                    errors.append(f"resolve_name({name}) -> None")
+                    return
+
+    threads = [threading.Thread(target=hammer) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []

--- a/Tests/Chat/test_change_turn_tracking.py
+++ b/Tests/Chat/test_change_turn_tracking.py
@@ -373,7 +373,9 @@ def test_baseline_completes_before_the_first_tool_executes(tmp_path, root):
     gateway = _SideEffectGateway([[fence], ["42."]])
     bridge, db, store, session, aid = _bridge_with(tmp_path, gateway, tracker)
 
-    def probe_review(calls):
+    # PR2a Task 5: an AgentService-wired hook takes `(calls, run_id)` --
+    # the change-tracker wrapper passes it straight through.
+    def probe_review(calls, run_id):
         events.append("review-called")
         return {}
 

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -108,12 +108,13 @@ class _FakeMCPProvider:
         return ToolResult(ok=True, content=f"mcp-result:{tool_id}")
 
     @contextlib.contextmanager
-    def stamp_scope(self):
+    def stamp_scope(self, run_id):
         # C1 (probe-verified security regression): stands in for
         # MCPToolProvider.stamp_scope -- a no-op snapshot/restore here since
         # this fake carries no per-turn stamp state of its own, just a call
         # counter so bridge-level wiring tests can assert `run_reply` threads
-        # it through to AgentService(review_state_scope=...).
+        # it through to AgentService(review_state_scope=...). PR2a Task 5:
+        # the scope takes the run id whose slice it guards.
         self.stamp_scope_calls += 1
         yield
 
@@ -287,7 +288,7 @@ class _RefusingBuiltinGate:
     def __init__(self) -> None:
         self.checked: list[str] = []
 
-    def check(self, tool):
+    def check(self, tool, run_id=""):
         self.checked.append(tool.name)
         return f"disabled for test: {tool.name}"
 
@@ -1939,7 +1940,7 @@ class _FakeBuiltinGateForRegistry:
         self.refuse = refuse
         self.checked: list[str] = []
 
-    def check(self, tool):
+    def check(self, tool, run_id=""):
         self.checked.append(tool.name)
         return f"disabled for test: {tool.name}" if self.refuse else None
 
@@ -2524,7 +2525,8 @@ def test_run_reply_forwards_review_tool_calls_hook_to_agent_service(tmp_path):
     bridge, _db, store, session, aid = _bridge(tmp_path, scripts)
     captured_batches = []
 
-    def hook(calls):
+    # PR2a Task 5: an AgentService-wired hook takes `(calls, run_id)`.
+    def hook(calls, run_id):
         captured_batches.append(list(calls))
         return {"calculator": "blocked by test hook"}
 
@@ -3045,7 +3047,7 @@ def test_combine_state_scopes_enters_and_exits_both():
 
     def _make(name):
         @contextlib.contextmanager
-        def _scope():
+        def _scope(run_id):
             events.append(f"enter:{name}")
             try:
                 yield
@@ -3055,7 +3057,8 @@ def test_combine_state_scopes_enters_and_exits_both():
         return _scope
 
     combined = _combine_state_scopes([_make("mcp"), _make("builtin")])
-    with combined():
+    # PR2a Task 5: each scope takes the run id whose slice it guards.
+    with combined("run-1"):
         events.append("child-run")
 
     # Both entered, both exited, unwinding in reverse order.
@@ -3077,7 +3080,7 @@ def test_combine_state_scopes_restores_both_when_the_nested_run_raises():
 
     def _make(name):
         @contextlib.contextmanager
-        def _scope():
+        def _scope(run_id):
             try:
                 yield
             finally:
@@ -3088,7 +3091,7 @@ def test_combine_state_scopes_restores_both_when_the_nested_run_raises():
     combined = _combine_state_scopes([_make("mcp"), _make("builtin")])
     raised = False
     try:
-        with combined():
+        with combined("run-1"):
             raise RuntimeError("child blew up")
     except RuntimeError:
         raised = True

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -288,7 +288,7 @@ class _RefusingBuiltinGate:
     def __init__(self) -> None:
         self.checked: list[str] = []
 
-    def check(self, tool, run_id=""):
+    def check(self, tool, run_id):
         self.checked.append(tool.name)
         return f"disabled for test: {tool.name}"
 
@@ -1940,7 +1940,7 @@ class _FakeBuiltinGateForRegistry:
         self.refuse = refuse
         self.checked: list[str] = []
 
-    def check(self, tool, run_id=""):
+    def check(self, tool, run_id):
         self.checked.append(tool.name)
         return f"disabled for test: {tool.name}" if self.refuse else None
 

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -2995,15 +2995,12 @@ def _discovery_heavy_shout_scripts():
     -> load_tools({"ids": ["skill:shout"]}) -> shout({"args": "hello"})
     -> the sub-agent's own turn -> the primary's final wrap-up reply.
 
-    Two things changed when the fleet went ON by default. The child now
-    runs on its OWN thread, so the five turns are no longer one ordered
-    queue -- they are the primary's four and the child's one. And a skill
-    call, which goes through the very same `spawn` closure as
-    `spawn_subagent`, now returns a HANDLE instead of the skill's output,
-    so the primary has to `wait_agents` to collect it: that is the extra
-    round in the parent script below, and it makes this test's own subject
-    (does the bridge's budget leave headroom to reach the wrap-up reply?)
-    strictly harder than it was.
+    The ROUND COUNT is unchanged from before the fleet: a skill call runs
+    its child INLINE and returns the skill's output, so there is no
+    collection round (see `AgentService`'s `invoke_tool` skill branch).
+    Only the SHAPE changed -- the five turns are addressed per agent (the
+    primary's four, the child's one) rather than popped off one queue,
+    which is how they should always have been written.
 
     Returns:
         (parent_script, child_script) for `_FleetChunkGateway`.
@@ -3012,7 +3009,6 @@ def _discovery_heavy_shout_scripts():
         [_fence("find_tools", {"query": "shout"})],
         [_fence("load_tools", {"ids": ["skill:shout"]})],
         [_fence("shout", {"args": "hello"})],
-        [_fence("wait_agents", {})],  # collect the skill child's result
         ["Shouted: HELLO"],  # primary final answer
     ]
     child = [["HELLO"]]  # sub-agent turn (never streamed to the store)

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import json
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -49,12 +50,16 @@ from tldw_chatbook.Agents.agent_models import (
     ToolSchema,
 )
 from tldw_chatbook.Agents.agent_runtime import FENCE_OPEN
+from tldw_chatbook.Agents import agent_service
 from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.run_context import current_run_id
 from tldw_chatbook.Agents.tool_catalog import (
     SkillToolProvider,
     ToolCatalogRegistry,
 )
 from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
+
+from Tests.Agents.test_agent_service import SUBAGENT_PROMPT_PREFIX
 
 
 @pytest.fixture(autouse=True)
@@ -146,6 +151,74 @@ class _ChunkGateway:
         self.calls += 1
         for chunk in chunks:
             yield chunk
+
+
+class _FleetChunkGateway:
+    """A gateway that addresses scripts by AGENT, not by arrival order.
+
+    PR2a Task 6.5: `_ChunkGateway` indexes its scripts by call count
+    (`self._scripts[self.calls]`), which stops being deterministic once the
+    fleet is ON by default -- a spawned child runs on its own thread and
+    its turn can land before, after, or between the parent's. This keeps
+    the same chunk-list-per-turn shape but keeps ONE queue for the primary
+    agent and one per child, so each turn's script reaches the agent it was
+    written for.
+
+    Children are identified exactly as ``_StreamingModelAdapter.
+    _is_subagent`` identifies them -- a system prompt starting with the
+    sub-agent prompt -- so the addressing follows the production contract
+    rather than a test-only convention.
+
+    Args:
+        parent_script: turns for the primary agent, in order.
+        child_script: turns for THE child, in order. These suites spawn
+            exactly one, and its task text is an implementation detail of
+            whatever spawned it (a skill's rendered prompt, say), so
+            addressing on "is a child" is both sufficient and stabler than
+            addressing on that text.
+    """
+
+    def __init__(self, parent_script, child_script=()):
+        self._parent = list(parent_script)
+        self._child = list(child_script)
+        self.calls = 0
+        self.tools_seen = []
+        self.child_calls = 0
+        self._lock = threading.Lock()
+
+    async def stream_chat(self, resolution, messages, tools=None, **kwargs):
+        system = str(messages[0].get("content", "")) if messages else ""
+        is_child = system.startswith(SUBAGENT_PROMPT_PREFIX)
+        with self._lock:
+            self.tools_seen.append(tools)
+            self.calls += 1
+            if is_child:
+                self.child_calls += 1
+                assert self._child, "child script exhausted"
+                chunks = self._child.pop(0)
+            else:
+                assert self._parent, "parent script exhausted"
+                chunks = self._parent.pop(0)
+        # Resolved OUTSIDE the lock: a turn may be a zero-arg callable that
+        # BLOCKS on an Event, which is how a test pins an interleaving; the
+        # lock would serialize the very concurrency under test.
+        if callable(chunks):
+            chunks = chunks()
+        for chunk in chunks:
+            yield chunk
+
+
+def _join_fleet_threads(timeout=5.0):
+    """Block until every live fleet child thread has fully finished.
+
+    `AgentService` names them ``fleet-<handle>``. "Fully finished" is the
+    point: a child's own run row goes terminal slightly BEFORE its thread
+    unwinds, so joining the thread -- not polling the DB -- is what
+    guarantees any context manager wrapping that run has already exited.
+    """
+    for thread in list(threading.enumerate()):
+        if thread.name.startswith("fleet-"):
+            thread.join(timeout)
 
 
 class _SignalChunkGateway(_ChunkGateway):
@@ -569,6 +642,86 @@ def test_multi_turn_run_reuses_one_event_loop_across_chat_call_turns(tmp_path):
     assert seen_loops[0].is_closed(), (
         "the run's shared loop must be closed once run_reply returns"
     )
+
+
+def test_a_concurrent_child_can_use_the_runs_shared_event_loop(tmp_path):
+    """PR2a Task 6.5: a fleet child's turn must survive overlapping the
+    parent's on the run's ONE shared event loop.
+
+    Found by probe when the fleet default was flipped, and it failed every
+    overlapping child: `chat_call` drove the shared loop with
+    `run_until_complete` from whichever thread was calling, which is only
+    sound while the whole run tree is single-threaded. A loop may be driven
+    by exactly one thread, so the second concurrent caller got
+    ``RuntimeError: This event loop is already running``, its coroutine was
+    dropped un-awaited, and the child's run row persisted `error` -- silent
+    from the parent's side, which just saw a failed sub-agent. `chat_call`
+    now submits with `run_coroutine_threadsafe` to a loop running on its
+    own thread.
+
+    The gateway awaits inside every turn so the parent and the child really
+    are in flight together (a turn that yields without awaiting can slip
+    through the window); the child additionally blocks until the parent has
+    entered its own next turn, so the overlap is pinned rather than raced
+    for. PR #629 Fix 1(c) is re-asserted here too: it is still ONE loop.
+    """
+    parent_in_flight = threading.Event()
+    seen_loops = []
+
+    class _OverlappingGateway(_FleetChunkGateway):
+        async def stream_chat(self, resolution, messages, tools=None, **kwargs):
+            system = str(messages[0].get("content", "")) if messages else ""
+            if not system.startswith(SUBAGENT_PROMPT_PREFIX):
+                parent_in_flight.set()
+            seen_loops.append(asyncio.get_running_loop())
+            # Yield control so the other agent's coroutine can be scheduled
+            # onto this same loop while this one is still open.
+            await asyncio.sleep(0.01)
+            async for chunk in super().stream_chat(resolution, messages, tools=tools):
+                yield chunk
+
+    def gated_child_turn():
+        assert parent_in_flight.wait(5), "the parent never started a turn"
+        return ["child answer"]
+
+    gateway = _OverlappingGateway(
+        [
+            [_fence("spawn_subagent", {"task": "child work"})],
+            [_fence("wait_agents", {})],
+            ["parent final"],
+        ],
+        [gated_child_turn],
+    )
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db, store=store, provider_gateway=gateway
+    )
+
+    outcome = _run(
+        bridge, store, session, assistant.id, conversation_id="conv-overlap"
+    )
+
+    assert outcome.status == "done"
+    assert outcome.final_text == "parent final"
+    # The child completed -- it did NOT die on the loop.
+    child_runs = [
+        r for r in db.list_runs("conv-overlap") if r["agent_kind"] == "subagent"
+    ]
+    assert len(child_runs) == 1
+    assert child_runs[0]["status"] == RUN_DONE
+    assert child_runs[0]["result"] == "child answer"
+    # ... and its answer really reached the parent, through wait_agents.
+    assert "child answer" in str(outcome.steps)
+    # Still ONE loop for the whole run tree, children included (Fix 1(c)).
+    assert len(seen_loops) == 4  # 3 parent turns + 1 child turn
+    assert all(loop is seen_loops[0] for loop in seen_loops)
+    assert seen_loops[0].is_closed()
 
 
 def test_provider_stream_signal_survives_primary_tool_and_final_turns(tmp_path):
@@ -2542,19 +2695,32 @@ def test_run_reply_forwards_review_tool_calls_hook_to_agent_service(tmp_path):
     assert any("blocked by test hook" in row.content for row in tool_rows)
 
 
-def test_run_reply_wires_mcp_provider_stamp_scope_around_a_spawned_child(tmp_path):
-    """C1 (probe-verified security regression): `run_reply` must thread
-    `mcp_provider.stamp_scope` through to `AgentService(review_state_scope=
-    ...)` whenever an MCP provider is composed for this run -- that seam is
-    what protects a parent turn's MCP approval stamps from being clobbered by
-    a sub-agent's own inline nested run (see `MCPToolProvider.stamp_scope`'s
-    own docstring and `Tests/Agents/test_agent_service_review_state_scope.py`
-    for the full adversarial reproduction). This is the bridge-level wiring
-    check: a run that spawns exactly one sub-agent must enter/exit the
-    composed MCP provider's `stamp_scope()` exactly once around that spawn."""
+def test_run_reply_still_wires_stamp_scope_for_the_inline_kill_switch_path(
+    tmp_path, monkeypatch
+):
+    """`run_reply` must still thread `mcp_provider.stamp_scope` through to
+    `AgentService(review_state_scope=...)` whenever an MCP provider is
+    composed for this run.
+
+    This is the surviving half of the old
+    `test_run_reply_wires_mcp_provider_stamp_scope_around_a_spawned_child`
+    (C1, probe-verified security regression). Its guarantee -- one
+    enter/exit of the composed provider's `stamp_scope()` around a spawned
+    child -- is UNCHANGED on the inline path, which is what a user who sets
+    `[agents] max_live_subagents = 1` gets, so the assertion is unchanged
+    too; only the pinning of that path is new (before Task 6.5 it was the
+    shipped default and needed no pinning). The concurrent path is the
+    companion test below -- where holding this scope would be actively
+    harmful, not merely unnecessary.
+    """
+    monkeypatch.setattr(
+        agent_service, "_setting", lambda key, default: (
+            1 if key == agent_service.MAX_LIVE_SUBAGENTS_KEY else default
+        )
+    )
     scripts = [
         [_fence("spawn_subagent", {"task": "compute 1+1"})],  # primary turn 1
-        ["2"],  # sub-agent turn
+        ["2"],  # sub-agent turn (inline, so strictly ordered)
         ["Done: ", "2."],  # primary final
     ]
     bridge, _db, store, session, aid = _bridge(tmp_path, scripts)
@@ -2564,6 +2730,150 @@ def test_run_reply_wires_mcp_provider_stamp_scope_around_a_spawned_child(tmp_pat
 
     assert outcome.status == "done"
     assert mcp_provider.stamp_scope_calls == 1
+
+
+class _StampingMCPProvider(_FakeMCPProvider):
+    """A `_FakeMCPProvider` that models the REAL per-run stamp bookkeeping.
+
+    `_FakeMCPProvider.stamp_scope` is a bare call counter, which cannot
+    show what the scope actually DOES. This one mirrors
+    `MCPToolProvider`'s two documented behaviours that matter here:
+
+    * verdicts are keyed by ``(run_id, llm_name)``, so a run can only ever
+      reach its own slice (PR2a Task 5);
+    * ``stamp_scope(run_id)`` snapshots that run's slice on enter, CLEARS
+      it, and restores the snapshot on exit.
+
+    That second behaviour is exactly why the threaded spawn path must not
+    take the scope: entering it mid-turn wipes the parent's live verdicts,
+    and with concurrent siblings there is no LIFO order in which the
+    restore could put them back correctly.
+    """
+
+    def __init__(self, entries, on_invoke=None):
+        super().__init__(entries)
+        self.stamps: dict[tuple[str, str], str] = {}
+        self.refusals: list[str] = []
+        # Runs at the top of invoke, BEFORE the stamp is consumed -- the
+        # seam a test uses to pin what has happened by the time the parent
+        # cashes in its verdict.
+        self._on_invoke = on_invoke
+
+    def stamp(self, run_id, llm_name, verdict):
+        self.stamps[(run_id, llm_name)] = verdict
+
+    def invoke(self, tool_id, args):
+        if self._on_invoke is not None:
+            self._on_invoke()
+        # Fails CLOSED on a missing stamp, like the real gate: that is what
+        # makes a wiped verdict observable rather than silently benign.
+        run_id = current_run_id()
+        if self.stamps.get((run_id, tool_id)) != "approve_once":
+            self.refusals.append(tool_id)
+            return ToolResult(ok=False, error=f"no stamped approval for {tool_id}")
+        return super().invoke(tool_id, args)
+
+    @contextlib.contextmanager
+    def stamp_scope(self, run_id):
+        self.stamp_scope_calls += 1
+        snapshot = {k: v for k, v in self.stamps.items() if k[0] == run_id}
+        self.stamps = {k: v for k, v in self.stamps.items() if k[0] != run_id}
+        try:
+            yield
+        finally:
+            self.stamps = {k: v for k, v in self.stamps.items() if k[0] != run_id}
+            self.stamps.update(snapshot)
+
+
+def test_run_reply_keeps_the_parents_mcp_verdict_across_a_concurrent_child(tmp_path):
+    """The parent's own approval SURVIVES a concurrently-running child.
+
+    Replaces `test_run_reply_wires_mcp_provider_stamp_scope_around_a_
+    spawned_child`'s spawn-path half. That test pinned the scope being
+    entered around a child, which PR2a Task 6 deliberately stopped doing on
+    the threaded path -- not as a relaxation but because it is now unsafe:
+    `stamp_scope` CLEARS the parent's slice on enter, so holding it across
+    siblings would wipe verdicts the parent is still going to consume, and
+    with no LIFO order the restore cannot repair it.
+
+    The protection that replaces it is Task 5's per-run keying, and this
+    asserts THAT, at the same bridge level.
+
+    The interleaving is pinned, not hoped for, because only ONE ordering
+    is dangerous: the child must still be live when the parent stamps, and
+    must finish before the parent consumes. The child therefore blocks
+    until the parent's own MCP invoke releases it, and that invoke joins
+    the child's thread before reading the stamp. Under the mutation
+    (re-wrapping the fleet path in `review_state_scope`) the child's scope
+    is open across the parent's stamp, so its exit-restore rolls the
+    parent's slice back to a snapshot taken before that stamp existed and
+    the parent's own call is refused -- verified red both behaviourally
+    (`refusals`) and structurally (`stamp_scope_calls`).
+    """
+    release_child = threading.Event()
+
+    def gated_child_turn():
+        assert release_child.wait(5), "the parent never released the child"
+        return ["2"]
+
+    scripts = [
+        [_fence("spawn_subagent", {"task": "compute 1+1"})],  # primary turn 1
+        [_fence("mcp__srv_a__search", {"query": "weather"})],  # parent's own call
+        ["Done."],  # primary final
+    ]
+    child_script = [gated_child_turn]  # the child's single turn, on its own thread
+    gateway = _FleetChunkGateway(scripts, child_script)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db, store=store, provider_gateway=gateway
+    )
+
+    def release_then_settle():
+        # The parent is about to cash in its verdict. Let the child finish
+        # first, and wait until its THREAD is gone -- that is the moment any
+        # context manager wrapping the child's run would have exited.
+        release_child.set()
+        _join_fleet_threads()
+
+    mcp_provider = _StampingMCPProvider(
+        [("mcp__srv_a__search", "Search the web")], on_invoke=release_then_settle
+    )
+
+    # The parent's verdict, stamped under ITS run id, while the child is
+    # still live. The review hook is what does this in production; here it
+    # stamps directly so the test is about the scope, not about the hook.
+    def review(calls, run_id):
+        for call in calls:
+            if call.name == "mcp__srv_a__search":
+                mcp_provider.stamp(run_id, call.name, "approve_once")
+        return {}
+
+    outcome = _run(
+        bridge,
+        store,
+        session,
+        assistant.id,
+        conversation_id="conv-fleet-stamp",
+        mcp_provider=mcp_provider,
+        review_tool_calls=review,
+    )
+
+    assert outcome.status == "done"
+    assert db.count_subagent_runs("conv-fleet-stamp") == 1  # the child really ran
+    assert gateway.child_calls == 1  # ... concurrently, on its own thread
+    # The parent's own approved call executed: its verdict outlived the
+    # concurrent child.
+    assert mcp_provider.refusals == []
+    assert mcp_provider.invoke_calls == [("mcp__srv_a__search", {"query": "weather"})]
+    # ... and the threaded child was NOT wrapped in the parent's scope,
+    # which is what would have wiped that verdict.
+    assert mcp_provider.stamp_scope_calls == 0
 
 
 def test_skill_named_like_a_runtime_tool_never_shadows_it_at_invocation(tmp_path):
@@ -2679,16 +2989,34 @@ class _ManySkillsService:
 
 
 def _discovery_heavy_shout_scripts():
-    # Mirrors the gate's live raw step log: find_tools({"query": "shout"})
-    # -> load_tools({"ids": ["skill:shout"]}) -> shout({"args": "hello"})
-    # -> the sub-agent's own turn -> the primary's final wrap-up reply.
-    return [
+    """The gate's live shape, split per agent (PR2a Task 6.5).
+
+    Mirrors the gate's live raw step log: find_tools({"query": "shout"})
+    -> load_tools({"ids": ["skill:shout"]}) -> shout({"args": "hello"})
+    -> the sub-agent's own turn -> the primary's final wrap-up reply.
+
+    Two things changed when the fleet went ON by default. The child now
+    runs on its OWN thread, so the five turns are no longer one ordered
+    queue -- they are the primary's four and the child's one. And a skill
+    call, which goes through the very same `spawn` closure as
+    `spawn_subagent`, now returns a HANDLE instead of the skill's output,
+    so the primary has to `wait_agents` to collect it: that is the extra
+    round in the parent script below, and it makes this test's own subject
+    (does the bridge's budget leave headroom to reach the wrap-up reply?)
+    strictly harder than it was.
+
+    Returns:
+        (parent_script, child_script) for `_FleetChunkGateway`.
+    """
+    parent = [
         [_fence("find_tools", {"query": "shout"})],
         [_fence("load_tools", {"ids": ["skill:shout"]})],
         [_fence("shout", {"args": "hello"})],
-        ["HELLO"],  # sub-agent turn (never streamed to the store)
+        [_fence("wait_agents", {})],  # collect the skill child's result
         ["Shouted: HELLO"],  # primary final answer
     ]
+    child = [["HELLO"]]  # sub-agent turn (never streamed to the store)
+    return parent, child
 
 
 def test_discovery_heavy_skill_run_completes_done_not_stuck(tmp_path):
@@ -2703,7 +3031,7 @@ def test_discovery_heavy_skill_run_completes_done_not_stuck(tmp_path):
     wrap-up reply, even though every tool call already succeeded. The
     Console bridge must give this exact shape enough headroom to actually
     reach the final answer and persist `done`."""
-    scripts = _discovery_heavy_shout_scripts()
+    parent_script, child_script = _discovery_heavy_shout_scripts()
     db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
     store = ConsoleChatStore()
     session = store.ensure_session()
@@ -2715,7 +3043,7 @@ def test_discovery_heavy_skill_run_completes_done_not_stuck(tmp_path):
     bridge = ConsoleAgentBridge(
         agent_runs_db=db,
         store=store,
-        provider_gateway=_ChunkGateway(scripts),
+        provider_gateway=_FleetChunkGateway(parent_script, child_script),
         skills_service=skills_service,
     )
 

--- a/Tests/Chat/test_console_agent_bridge_local.py
+++ b/Tests/Chat/test_console_agent_bridge_local.py
@@ -107,7 +107,7 @@ def test_combined_stamp_scope_isolates_both(tmp_path):
             self.log = []
 
         @contextmanager
-        def stamp_scope(self):
+        def stamp_scope(self, run_id):
             saved = self.stamps
             self.stamps = {}
             self.log.append("enter")
@@ -120,7 +120,8 @@ def test_combined_stamp_scope_isolates_both(tmp_path):
     p1, p2 = FakeProvider(), FakeProvider()
     scope = _combine_state_scopes([p1.stamp_scope, p2.stamp_scope])
     assert scope is not None
-    with scope():
+    # PR2a Task 5: each scope takes the run id whose slice it guards.
+    with scope("run-1"):
         assert p1.stamps == {} and p2.stamps == {}
     assert p1.stamps == {"x": "approve_once"} and p2.stamps == {"x": "approve_once"}
     assert p1.log == ["enter", "exit"] and p2.log == ["enter", "exit"]
@@ -142,7 +143,7 @@ def test_provider_without_stamp_scope_is_skipped():
             self.log = []
 
         @contextmanager
-        def stamp_scope(self):
+        def stamp_scope(self, run_id):
             self.log.append("enter")
             try:
                 yield
@@ -166,7 +167,7 @@ def test_provider_without_stamp_scope_is_skipped():
     real = WithScope()
     scope = _combine_state_scopes(_scopes_for(NoScope(), real))
     assert scope is not None
-    with scope():
+    with scope("run-1"):
         pass
     assert real.log == ["enter", "exit"]
 

--- a/Tests/Chat/test_console_agent_bridge_local.py
+++ b/Tests/Chat/test_console_agent_bridge_local.py
@@ -41,6 +41,8 @@ from tldw_chatbook.Chat.console_agent_bridge import (
 )
 from tldw_chatbook.Chat.console_chat_controller import build_local_review_hook
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+from Tests.Agents.test_agent_service import FleetChat
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
 
 
@@ -317,13 +319,22 @@ def test_skill_run_child_still_approval_gated(tmp_path):
         approval_calls.append(pending)
         return {"web_fetch": "approve_once"}
 
-    chat = _ScriptedChat(
+    # PR2a Task 6.5: the fleet is ON by default and a SKILL's spawn goes
+    # through the same `spawn` closure as `spawn_subagent`, so the skill
+    # child runs on its own thread. Addressed per agent instead of one
+    # ordered queue; the child is keyed by the task text `_StubSkillsService`
+    # renders for it. The replies themselves are unchanged.
+    chat = FleetChat(
         [
             _fence("web-research", {"args": "the question"}),  # primary: skill
-            _fence("web_fetch", {"url": "http://example.com/"}),  # child: local
-            "child synthesis",  # child final
             "primary final",
-        ]
+        ],
+        {
+            "RENDERED[web-research](the question)": [
+                _fence("web_fetch", {"url": "http://example.com/"}),  # child: local
+                "child synthesis",  # child final
+            ]
+        },
     )
     service = AgentService(
         db=AgentRunsDB(tmp_path / "runs.db", client_id="t"),

--- a/Tests/Chat/test_console_agent_diff_channel.py
+++ b/Tests/Chat/test_console_agent_diff_channel.py
@@ -38,7 +38,7 @@ class _ChunkGateway:
 class _AllowAllBuiltinGate:
     """Minimal ``BuiltinToolGate`` double that permits every tool."""
 
-    def check(self, tool):
+    def check(self, tool, run_id=""):
         return None
 
 

--- a/Tests/Chat/test_console_agent_diff_channel.py
+++ b/Tests/Chat/test_console_agent_diff_channel.py
@@ -38,7 +38,7 @@ class _ChunkGateway:
 class _AllowAllBuiltinGate:
     """Minimal ``BuiltinToolGate`` double that permits every tool."""
 
-    def check(self, tool, run_id=""):
+    def check(self, tool, run_id):
         return None
 
 

--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -1306,7 +1306,7 @@ class _SentinelBuiltinGate:
     def __init__(self) -> None:
         self.begin_turn_calls = 0
 
-    def begin_turn(self) -> None:
+    def begin_turn(self, run_id: str) -> None:
         self.begin_turn_calls += 1
 
 
@@ -1340,7 +1340,10 @@ async def test_review_hook_and_run_reply_share_one_builtin_gate(tmp_path, monkey
 
     review_hook = captured[0]["review_tool_calls"]
     assert sentinel.begin_turn_calls == 0
-    review_hook([])  # empty batch: nothing to resolve, only begin_turn() matters
+    # PR2a Task 5: the hook takes the reviewing run's id (unused here --
+    # this test is purely about gate IDENTITY, and an empty batch resolves
+    # nothing either way).
+    review_hook([], "run-1")  # empty batch: only begin_turn() matters
     assert sentinel.begin_turn_calls == 1
 
 

--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -29,10 +29,12 @@ from tldw_chatbook.Agents.agent_models import (
     SPAWN_TOOL_NAME,
     STEP_ERROR,
     STEP_TOOL_RESULT,
+    WAIT_AGENTS_TOOL_NAME,
 )
 from tldw_chatbook.Agents.mcp_tool_provider import MCPToolProvider
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
 
+from Tests.Agents.test_agent_service import SUBAGENT_PROMPT_PREFIX
 from Tests.Agents.test_mcp_tool_provider import (
     FakeMCPService,
     _catalog_record,
@@ -45,9 +47,20 @@ def _fence(name, args):
 
 
 class _Gateway:
-    def __init__(self, scripts):
+    """Scripted gateway, addressed by AGENT rather than arrival order.
+
+    PR2a Task 6.5: `child_scripts` holds the spawned child's own turns.
+    With the fleet ON by default the child runs on its own thread, so a
+    single call-indexed queue would hand the child's scripted turn to
+    whichever agent happened to call second.
+    """
+
+    def __init__(self, scripts, child_scripts=()):
         self._scripts = list(scripts)
+        self._child_scripts = list(child_scripts)
         self.calls = 0
+        self.parent_calls = 0
+        self.child_calls = 0
 
     async def resolve_for_send(self, selection):
         class _R:
@@ -58,17 +71,46 @@ class _Gateway:
         return _R()
 
     async def stream_chat(self, resolution, messages, **kwargs):
-        chunks = self._scripts[self.calls]
+        system = str(messages[0].get("content", "")) if messages else ""
+        if system.startswith(SUBAGENT_PROMPT_PREFIX):
+            chunks = self._child_scripts[self.child_calls]
+            self.child_calls += 1
+        else:
+            chunks = self._scripts[self.parent_calls]
+            self.parent_calls += 1
         self.calls += 1
         for chunk in chunks:
             yield chunk
 
 
 class _SignalGateway:
-    def __init__(self, scripts, *, mark_fallback_calls=frozenset()):
+    """Scripted gateway that records the shared out-of-band signal.
+
+    PR2a Task 6.5: scripts are addressed by AGENT rather than by arrival
+    order. With the fleet ON by default a spawned child runs on its own
+    thread, so "the second call overall" is no longer reliably the child's
+    turn -- and marking the synthetic fallback on the wrong turn is exactly
+    the kind of silent mis-aim that would leave a test green while testing
+    nothing. `mark_fallback_calls` therefore holds ``(who, index)`` pairs,
+    where `who` is ``"parent"`` or ``"child"`` and `index` counts THAT
+    agent's own turns, which are strictly sequential.
+
+    Args:
+        scripts: turns for the primary agent, in order.
+        child_scripts: turns for the child, in order.
+        mark_fallback_calls: ``(who, index)`` pairs whose turn marks the
+            shared synthetic-fallback signal.
+    """
+
+    def __init__(
+        self, scripts, *, child_scripts=(), mark_fallback_calls=frozenset()
+    ):
         self._scripts = list(scripts)
+        self._child_scripts = list(child_scripts)
         self._mark_fallback_calls = mark_fallback_calls
         self.calls = []
+        self.parent_calls = 0
+        self.child_calls = 0
         self.resolution = ConsoleProviderResolution(
             provider="openai",
             base_url="https://provider.invalid/v1",
@@ -97,7 +139,8 @@ class _SignalGateway:
         return self.resolution
 
     async def stream_chat(self, resolution, messages, tools=None, signals=None):
-        call_index = len(self.calls)
+        system = str(messages[0].get("content", "")) if messages else ""
+        is_child = system.startswith(SUBAGENT_PROMPT_PREFIX)
         self.calls.append(
             {
                 "resolution": resolution,
@@ -106,9 +149,17 @@ class _SignalGateway:
                 "signals": signals,
             }
         )
-        if call_index in self._mark_fallback_calls:
+        if is_child:
+            who, index = "child", self.child_calls
+            self.child_calls += 1
+            chunks = self._child_scripts[index]
+        else:
+            who, index = "parent", self.parent_calls
+            self.parent_calls += 1
+            chunks = self._scripts[index]
+        if (who, index) in self._mark_fallback_calls:
             signals.mark_synthetic_fallback()
-        for chunk in self._scripts[call_index]:
+        for chunk in chunks:
             yield chunk
 
 
@@ -125,10 +176,12 @@ async def _real_agent_citation_controller(
     tmp_path,
     scripts,
     *,
+    child_scripts=(),
     mark_fallback_calls=frozenset(),
 ):
     gateway = _SignalGateway(
         scripts,
+        child_scripts=child_scripts,
         mark_fallback_calls=mark_fallback_calls,
     )
     store = ConsoleChatStore()
@@ -161,8 +214,8 @@ async def _real_agent_citation_controller(
     return result, controller, store, gateway
 
 
-def _controller(tmp_path, scripts, *, enabled=True):
-    gateway = _Gateway(scripts)
+def _controller(tmp_path, scripts, *, child_scripts=(), enabled=True):
+    gateway = _Gateway(scripts, child_scripts)
     store = ConsoleChatStore()
     db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
     bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
@@ -178,7 +231,7 @@ def _controller(tmp_path, scripts, *, enabled=True):
 
 
 @pytest.mark.parametrize(
-    ("scripts", "fallback_call"),
+    ("scripts", "child_scripts", "fallback_call", "expected_calls"),
     (
         (
             [
@@ -189,7 +242,9 @@ def _controller(tmp_path, scripts, *, enabled=True):
                 ["Primary final answer"],
                 ["Primary final answer [S1]"],
             ],
-            0,
+            (),
+            ("parent", 0),
+            2,
         ),
         (
             [
@@ -201,16 +256,24 @@ def _controller(tmp_path, scripts, *, enabled=True):
                 ["Primary final answer"],
                 ["Primary final answer [S1]"],
             ],
-            1,
+            (),
+            ("parent", 1),
+            3,
         ),
+        # PR2a Task 6.5: the sub-agent's turn is now the CHILD's own first
+        # turn on its own thread, not "the second call overall". Same
+        # scenario, addressed rather than counted -- and the parent gains a
+        # wait_agents round, since a threaded spawn returns a handle.
         (
             [
                 [_fence(SPAWN_TOOL_NAME, {"task": "answer briefly"})],
-                [NO_PROVIDER_CONTENT_COPY],
+                [_fence(WAIT_AGENTS_TOOL_NAME, {})],
                 ["Primary final answer"],
                 ["Primary final answer [S1]"],
             ],
-            1,
+            ([NO_PROVIDER_CONTENT_COPY],),
+            ("child", 0),
+            4,
         ),
     ),
     ids=("first-tool-turn", "intermediate-tool-turn", "subagent-turn"),
@@ -219,11 +282,14 @@ def _controller(tmp_path, scripts, *, enabled=True):
 async def test_citation_repair_agent_shared_fallback_signal_bypasses_after_any_earlier_turn(
     tmp_path,
     scripts,
+    child_scripts,
     fallback_call,
+    expected_calls,
 ):
     result, _controller, store, gateway = await _real_agent_citation_controller(
         tmp_path,
         scripts,
+        child_scripts=child_scripts,
         mark_fallback_calls=frozenset({fallback_call}),
     )
 
@@ -233,7 +299,9 @@ async def test_citation_repair_agent_shared_fallback_signal_bypasses_after_any_e
         if message.role is ConsoleMessageRole.ASSISTANT
     )
     assert result.visible_copy == assistant.content == "Primary final answer"
-    assert len(gateway.calls) == len(scripts) - 1
+    # The repair turn (the last parent script) is bypassed, which is the
+    # whole point -- so the run stops one parent turn short.
+    assert len(gateway.calls) == expected_calls
     signals = [call["signals"] for call in gateway.calls]
     assert signals[0] is not None
     assert all(signal is signals[0] for signal in signals)
@@ -1612,13 +1680,16 @@ async def test_mcp_tool_call_gates_subagent_call_same_as_primary(tmp_path):
     `AgentService._run_one`'s `spawn` closure threads the SAME ctor-level
     `review_tool_calls` hook (and the same `self.registry`) into the
     child's own `LoopDeps`/`invoke_tool`, not a bespoke unwired path."""
+    # PR2a Task 6.5: addressed per agent -- the child is on its own thread.
     scripts = [
         [_fence(SPAWN_TOOL_NAME, {"task": "please run it"})],  # primary: spawn a child
-        [_fence("mcp__srv__run", {"x": 1})],  # child: call the MCP tool
-        ["child refused."],  # child: final answer
         ["primary done."],  # primary: final answer
     ]
-    controller, store, db = _controller(tmp_path, scripts)
+    child_scripts = [
+        [_fence("mcp__srv__run", {"x": 1})],  # child: call the MCP tool
+        ["child refused."],  # child: final answer
+    ]
+    controller, store, db = _controller(tmp_path, scripts, child_scripts=child_scripts)
     service = FakeMCPService(
         catalog_records=[_catalog_record("srv", [_tool_dict("run")])]
     )

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -2268,13 +2268,21 @@ def test_history_image_with_empty_mime_type_falls_back_to_default_mime(monkeypat
 # ---------------------------------------------------------------------------
 
 
+#: PR2a Task 5: the review hooks take the id of the run whose batch they
+#: are reviewing, and every gate mutation they make is scoped to it. These
+#: hook-level tests each drive ONE run, so they name it once here -- their
+#: assertions are unchanged (what a run stamps is what that run reads);
+#: cross-run isolation is pinned by `Tests/Agents/test_gate_run_scoping.py`.
+RUN = "run-1"
+
+
 class _FakeReviewProvider:
     """Stands in for `MCPToolProvider` in `build_mcp_review_hook` unit tests."""
 
     def __init__(self, gated_names: set[str]) -> None:
         self._gated_names = gated_names
         self.apply_batch_decisions_calls: list[dict[str, str]] = []
-        self._stamped: dict[str, str] = {}
+        self._stamped: dict[tuple[str, str], str] = {}
 
     def pending_gate_for(
         self, name: str, args: dict, call_id: str = ""
@@ -2294,14 +2302,20 @@ class _FakeReviewProvider:
             reason="ask",
         )
 
-    def apply_batch_decisions(self, decisions: dict[str, str]) -> None:
+    def apply_batch_decisions(self, run_id: str, decisions: dict[str, str]) -> None:
         self.apply_batch_decisions_calls.append(dict(decisions))
         # Mirrors MCPToolProvider.apply_batch_decisions' REPLACE semantics
-        # (not merge) -- see that method's own docstring (Finding F1).
-        self._stamped = dict(decisions or {})
+        # (not merge) -- see that method's own docstring (Finding F1) --
+        # and, since PR2a Task 5, that the replace is scoped to ONE run:
+        # other runs' slices survive.
+        self._stamped = {
+            key: value for key, value in self._stamped.items() if key[0] != run_id
+        }
+        for name, verdict in (decisions or {}).items():
+            self._stamped[(run_id, name)] = verdict
 
-    def stamped_decision(self, name: str) -> str | None:
-        return self._stamped.get(name)
+    def stamped_decision(self, run_id: str, name: str) -> str | None:
+        return self._stamped.get((run_id, name))
 
 
 def test_build_mcp_review_hook_clears_stamps_even_when_nothing_needs_gating():
@@ -2316,7 +2330,7 @@ def test_build_mcp_review_hook_clears_stamps_even_when_nothing_needs_gating():
     hook = build_mcp_review_hook(provider, lambda pending: {})
 
     calls = [ToolCall(name="local_only_tool", args={}, call_id="1")]
-    verdicts = hook(calls)
+    verdicts = hook(calls, RUN)
 
     assert verdicts == {}
     assert provider.apply_batch_decisions_calls == [{}]
@@ -2333,7 +2347,7 @@ def test_build_mcp_review_hook_stamps_decisions_when_gating_needed():
     hook = build_mcp_review_hook(provider, _approve)
     calls = [ToolCall(name="mcp__srv__run", args={"x": 1}, call_id="1")]
 
-    verdicts = hook(calls)
+    verdicts = hook(calls, RUN)
 
     assert verdicts == {"mcp__srv__run": "proceed"}
     # I3: the hook clears at ENTRY (unconditionally, before the round trip)
@@ -2364,7 +2378,7 @@ def test_build_mcp_review_hook_shares_one_verdict_for_same_name_calls_this_turn(
         ToolCall(name="mcp__srv__run", args={"x": 2}, call_id="2"),
     ]
 
-    verdicts = hook(calls)
+    verdicts = hook(calls, RUN)
 
     assert verdicts == {"mcp__srv__run": "proceed"}
     assert len(round_trips) == 1  # ONE request_mcp_approvals round trip
@@ -2394,8 +2408,8 @@ def test_build_mcp_review_hook_clears_stamp_at_entry_before_a_raising_round_trip
     hook = build_mcp_review_hook(
         provider, lambda pending: {"mcp__srv__run": "approve_once"}
     )
-    hook([ToolCall(name="mcp__srv__run", args={}, call_id="1")])
-    assert provider.stamped_decision("mcp__srv__run") == "approve_once"
+    hook([ToolCall(name="mcp__srv__run", args={}, call_id="1")], RUN)
+    assert provider.stamped_decision(RUN, "mcp__srv__run") == "approve_once"
 
     # Turn 2: same tool, but request_mcp_approvals now raises mid-round-trip.
     def _raise(pending):
@@ -2403,10 +2417,10 @@ def test_build_mcp_review_hook_clears_stamp_at_entry_before_a_raising_round_trip
 
     hook2 = build_mcp_review_hook(provider, _raise)
     with pytest.raises(RuntimeError):
-        hook2([ToolCall(name="mcp__srv__run", args={}, call_id="2")])
+        hook2([ToolCall(name="mcp__srv__run", args={}, call_id="2")], RUN)
 
     # No stale stamp from turn 1 must survive the raise for invoke() to peek.
-    assert provider.stamped_decision("mcp__srv__run") is None
+    assert provider.stamped_decision(RUN, "mcp__srv__run") is None
 
 
 # ---------------------------------------------------------------------------
@@ -2424,7 +2438,7 @@ class _FakeBuiltinGate:
         self.turns = 0
         self.stamped: list[tuple[str, str]] = []
 
-    def begin_turn(self) -> None:
+    def begin_turn(self, run_id: str) -> None:
         self.turns += 1
 
     def resolve(self, tool) -> EffectiveToolState:
@@ -2434,7 +2448,7 @@ class _FakeBuiltinGate:
             risk_floored=self._floored,
         )
 
-    def stamp(self, name: str, decision: str) -> None:
+    def stamp(self, run_id: str, name: str, decision: str) -> None:
         self.stamped.append((name, decision))
 
     def is_session_approved(self, name: str) -> bool:
@@ -2486,7 +2500,7 @@ def test_review_hook_gates_builtins_with_no_mcp_provider():
     hook = build_tool_review_hook(
         gate, _FakeBuiltinProvider(_FakeMutatingTool()), None, request_approvals
     )
-    verdicts = hook([_builtin_call("write_thing")])
+    verdicts = hook([_builtin_call("write_thing")], RUN)
 
     assert gate.turns == 1  # begin_turn ran first
     assert gate.stamped == [("write_thing", "approve_once")]
@@ -2545,7 +2559,7 @@ def test_review_hook_flags_read_file_path_outside_roots(monkeypatch, tmp_path):
         gate, _FakeBuiltinProvider(_file_tool("read_file")), None, request_approvals
     )
     verdicts = hook(
-        [ToolCall(name="read_file", args={"file_path": str(outside)})]
+        [ToolCall(name="read_file", args={"file_path": str(outside)})], RUN
     )
 
     row = asked["pending"][0]
@@ -2585,7 +2599,7 @@ def test_review_hook_does_not_flag_read_file_path_inside_roots(monkeypatch, tmp_
     hook = build_tool_review_hook(
         gate, _FakeBuiltinProvider(_file_tool("read_file")), None, request_approvals
     )
-    hook([ToolCall(name="read_file", args={"file_path": str(inside)})])
+    hook([ToolCall(name="read_file", args={"file_path": str(inside)})], RUN)
 
     row = asked["pending"][0]
     assert row.path_precheck_failed is False
@@ -2607,7 +2621,7 @@ def test_review_hook_leaves_non_file_builtins_unflagged():
     hook = build_tool_review_hook(
         gate, _FakeBuiltinProvider(_FakeMutatingTool()), None, request_approvals
     )
-    hook([_builtin_call("write_thing")])
+    hook([_builtin_call("write_thing")], RUN)
 
     row = asked["pending"][0]
     assert row.path_precheck_failed is False
@@ -2682,7 +2696,7 @@ def test_review_hook_precheck_uses_the_runs_workspace_not_the_active_one(
         request_approvals,
         workspace_id="ws-a",
     )
-    hook([ToolCall(name="read_file", args={"file_path": str(target_in_a)})])
+    hook([ToolCall(name="read_file", args={"file_path": str(target_in_a)})], RUN)
 
     row = asked["pending"][0]
     assert row.path_precheck_failed is False
@@ -2726,7 +2740,7 @@ def test_review_hook_precheck_does_not_fall_back_to_the_active_workspace(
         request_approvals,
         workspace_id="ws-a",
     )
-    hook([ToolCall(name="read_file", args={"file_path": str(target_in_b)})])
+    hook([ToolCall(name="read_file", args={"file_path": str(target_in_b)})], RUN)
 
     row = asked["pending"][0]
     assert row.path_precheck_failed is True
@@ -2742,7 +2756,7 @@ def test_allow_resolved_builtin_never_prompts():
         None,
         lambda pending: calls.append(pending) or {},
     )
-    assert hook([_builtin_call("write_thing")]) == {}
+    assert hook([_builtin_call("write_thing")], RUN) == {}
     assert calls == []  # no card shown
 
 
@@ -2756,7 +2770,7 @@ def test_deny_resolved_builtin_is_not_offered_to_the_user():
         None,
         lambda pending: calls.append(pending) or {},
     )
-    hook([_builtin_call("write_thing")])
+    hook([_builtin_call("write_thing")], RUN)
     assert calls == []  # a tool that is Off gets no approval card
 
 
@@ -2773,7 +2787,7 @@ def test_begin_turn_runs_even_when_approvals_raise():
         gate, _FakeBuiltinProvider(_FakeMutatingTool()), None, boom
     )
     with pytest.raises(RuntimeError):
-        hook([_builtin_call("write_thing")])
+        hook([_builtin_call("write_thing")], RUN)
     assert gate.turns == 1
 
 
@@ -2787,7 +2801,7 @@ def test_unknown_names_are_returned_unreviewed():
         None,
         lambda pending: {},
     )
-    assert hook([_builtin_call("some_skill")]) == {}
+    assert hook([_builtin_call("some_skill")], RUN) == {}
 
 
 def test_mcp_and_builtin_share_one_round_trip():
@@ -2811,7 +2825,7 @@ def test_mcp_and_builtin_share_one_round_trip():
         _builtin_call("write_thing"),
     ]
 
-    verdicts = hook(calls)
+    verdicts = hook(calls, RUN)
 
     assert len(round_trips) == 1
     names_asked = {row.llm_name for row in round_trips[0]}
@@ -2885,7 +2899,7 @@ def test_approve_for_session_is_not_re_prompted_next_turn():
 
     # Turn 1: no session approval yet -- a card IS shown, and the user
     # approves for session.
-    verdict1 = hook([_builtin_call("write_thing")])
+    verdict1 = hook([_builtin_call("write_thing")], RUN)
     assert len(round_trips) == 1
     assert round_trips[0][0].llm_name == "write_thing"
     assert verdict1 == {"write_thing": "proceed"}
@@ -2893,7 +2907,7 @@ def test_approve_for_session_is_not_re_prompted_next_turn():
     # Turn 2: `begin_turn()` clears the turn-scoped `_stamps` dict, but the
     # SESSION approval lives on the fake service, not in `_stamps` -- no
     # second round trip.
-    verdict2 = hook([_builtin_call("write_thing")])
+    verdict2 = hook([_builtin_call("write_thing")], RUN)
     assert len(round_trips) == 1  # still just the one round trip
     # Nothing needed gating this turn, so the call is absent from the
     # returned map entirely -- purely documentary, exactly like an
@@ -2903,7 +2917,7 @@ def test_approve_for_session_is_not_re_prompted_next_turn():
     assert verdict2 == {}
     # And the call genuinely still proceeds: this is the EXACT verdict
     # `BuiltinToolProvider.invoke()` consults on dispatch.
-    assert gate.check(tool) is None
+    assert gate.check(tool, RUN) is None
 
 
 # ---------------------------------------------------------------------------
@@ -4272,10 +4286,10 @@ def test_kill_switch_refuses_unclaimed_tool_calls_at_the_review_hook():
     )
 
     class _Gate:
-        def begin_turn(self): pass
+        def begin_turn(self, run_id): pass
         def resolve(self, tool):
             return SimpleNamespace(state="ask", risk_floored=False)
-        def stamp(self, name, decision): pass
+        def stamp(self, run_id, name, decision): pass
         def is_session_approved(self, name): return False
         def options_for(self, tool):
             return ("approve_once", "approve_session", "deny")
@@ -4298,7 +4312,7 @@ def test_kill_switch_refuses_unclaimed_tool_calls_at_the_review_hook():
         ToolCall(name="spawn_subagent", args={"task": "x"}, call_id="c1"),
         ToolCall(name="skill__notes__summarize", args={}, call_id="c2"),
         ToolCall(name="find_tools", args={"query": "q"}),
-    ])
+    ], RUN)
 
     assert not prompted, "the kill switch must refuse, not prompt"
     assert verdicts.get("c1") == KILL_SWITCH_REFUSAL
@@ -4318,10 +4332,10 @@ def test_kill_switch_off_changes_nothing():
     from tldw_chatbook.Chat.console_chat_controller import build_tool_review_hook
 
     class _Gate:
-        def begin_turn(self): pass
+        def begin_turn(self, run_id): pass
         def resolve(self, tool):
             return SimpleNamespace(state="ask", risk_floored=False)
-        def stamp(self, name, decision): pass
+        def stamp(self, run_id, name, decision): pass
         def is_session_approved(self, name): return False
         def options_for(self, tool):
             return ("approve_once", "approve_session", "deny")
@@ -4339,7 +4353,7 @@ def test_kill_switch_off_changes_nothing():
             kill_switch=switch,
         )
         verdicts = hook(
-            [ToolCall(name="read_file", args={"path": "a"}, call_id="c1")]
+            [ToolCall(name="read_file", args={"path": "a"}, call_id="c1")], RUN
         )
         assert verdicts.get("c1", "proceed") == "proceed", (switch, verdicts)
 
@@ -4363,10 +4377,10 @@ def test_unclaimed_names_pass_through_the_hook_unreviewed_switch_off():
     from tldw_chatbook.Chat.console_chat_controller import build_tool_review_hook
 
     class _Gate:
-        def begin_turn(self): pass
+        def begin_turn(self, run_id): pass
         def resolve(self, tool):
             return SimpleNamespace(state="ask", risk_floored=False)
-        def stamp(self, name, decision): pass
+        def stamp(self, run_id, name, decision): pass
         def is_session_approved(self, name): return False
         def options_for(self, tool):
             return ("approve_once", "approve_session", "deny")
@@ -4386,7 +4400,7 @@ def test_unclaimed_names_pass_through_the_hook_unreviewed_switch_off():
         ToolCall(name="find_tools", args={"query": "q"}, call_id="c2"),
         ToolCall(name="load_tools", args={"names": []}, call_id="c3"),
         ToolCall(name="skill__notes__summarize", args={}, call_id="c4"),
-    ])
+    ], RUN)
 
     assert not prompted, "unclaimed names must not be offered a card"
     assert verdicts == {}, (

--- a/Tests/Chat/test_console_local_review_hook.py
+++ b/Tests/Chat/test_console_local_review_hook.py
@@ -11,6 +11,7 @@ import pytest
 import tldw_chatbook.Chat.console_chat_controller as controller_mod
 from tldw_chatbook.Agents.agent_models import ToolCall
 from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider
+from tldw_chatbook.Agents.run_context import use_run_id
 from tldw_chatbook.Chat.console_chat_controller import (
     ConsoleChatController,
     build_combined_review_hook,
@@ -21,6 +22,24 @@ from tldw_chatbook.MCP.permission_store import EffectiveToolState
 ASK = EffectiveToolState(state="ask", origin="global_default")
 ALLOW = EffectiveToolState(state="allow", origin="tool_override")
 
+#: PR2a Task 5: the hook takes the reviewing run's id and every stamp it
+#: writes is keyed by it. These tests each drive ONE run; the assertions
+#: are unchanged apart from that key.
+RUN = "run-1"
+
+
+@pytest.fixture(autouse=True)
+def _dispatching_run():
+    """Bind ``RUN`` as the dispatching run for every test in this module.
+
+    ``LocalToolProvider.invoke()`` reads the run whose call it is
+    executing from ``run_context`` (bound in production by
+    ``AgentService`` around each invocation), so a test that stamps for
+    ``RUN`` and then invokes must be running as ``RUN``.
+    """
+    with use_run_id(RUN):
+        yield
+
 
 def provider(state, tmp_path):
     return LocalToolProvider(workspace_root=tmp_path, resolve_state=lambda hub: state)
@@ -28,9 +47,9 @@ def provider(state, tmp_path):
 
 def test_hook_clears_stamps_before_gating(tmp_path):
     p = provider(ASK, tmp_path)
-    p.apply_batch_decisions({"fs_list": "approve_once"})
+    p.apply_batch_decisions(RUN, {"fs_list": "approve_once"})
     hook = build_local_review_hook(p, lambda pending: {})
-    hook([])  # a turn with no calls still clears
+    hook([], RUN)  # a turn with no calls still clears
     assert p._stamps == {}
 
 
@@ -39,16 +58,16 @@ def test_hook_gates_ask_calls_in_one_batch(tmp_path):
     seen = []
     hook = build_local_review_hook(p, lambda pending: seen.append(pending) or {"fs_list": "approve_once"})
     verdicts = hook([ToolCall(name="fs_list", args={"path": "."}),
-                     ToolCall(name="fs_list", args={"path": "sub"})])
+                     ToolCall(name="fs_list", args={"path": "sub"})], RUN)
     assert len(seen) == 1 and len(seen[0]) == 2  # ONE round trip for the batch
     assert verdicts == {"fs_list": "proceed"}
-    assert p._stamps == {"fs_list": "approve_once"}
+    assert p._stamps == {(RUN, "fs_list"): "approve_once"}
 
 
 def test_hook_skips_non_ask_calls(tmp_path):
     p = provider(ALLOW, tmp_path)
     hook = build_local_review_hook(p, lambda pending: (_ for _ in ()).throw(AssertionError("must not ask")))
-    assert hook([ToolCall(name="fs_list", args={"path": "."})]) == {}
+    assert hook([ToolCall(name="fs_list", args={"path": "."})], RUN) == {}
 
 
 def test_combined_hook_merges_verdicts(tmp_path):
@@ -58,21 +77,21 @@ def test_combined_hook_merges_verdicts(tmp_path):
         build_local_review_hook(p2, lambda pending: {"fs_list": "deny"}),
     ])
     # each provider only gates what it owns; both see the batch
-    out = hook([ToolCall(name="fs_list", args={"path": "."})])
+    out = hook([ToolCall(name="fs_list", args={"path": "."})], RUN)
     assert out == {"fs_list": "proceed"}
 
 
 def test_combined_hook_empty_list_is_noop():
     hook = build_combined_review_hook([])
-    assert hook([ToolCall(name="fs_list", args={"path": "."})]) == {}
+    assert hook([ToolCall(name="fs_list", args={"path": "."})], RUN) == {}
 
 
 def test_combined_hook_clears_later_providers_when_earlier_hook_raises(tmp_path):
     """I3 across providers: a raising hook must not strand a LATER provider's
     stale prior-turn stamp for the fail-open runtime to hand to invoke()."""
     p1, p2 = provider(ASK, tmp_path), provider(ASK, tmp_path)
-    p1.apply_batch_decisions({"fs_list": "approve_once"})  # stale, prior turn
-    p2.apply_batch_decisions({"fs_list": "approve_once"})  # stale, prior turn
+    p1.apply_batch_decisions(RUN, {"fs_list": "approve_once"})  # stale, prior turn
+    p2.apply_batch_decisions(RUN, {"fs_list": "approve_once"})  # stale, prior turn
 
     def raising_approvals(pending):
         raise RuntimeError("mid-shutdown")
@@ -82,7 +101,7 @@ def test_combined_hook_clears_later_providers_when_earlier_hook_raises(tmp_path)
         build_local_review_hook(p2, raising_approvals),
     ])
     with pytest.raises(RuntimeError):
-        hook([ToolCall(name="fs_list", args={"path": "."})])
+        hook([ToolCall(name="fs_list", args={"path": "."})], RUN)
     # the exception propagates to run_agent_loop's fail-open handling, but
     # BOTH providers' stamps were cleared first -- no stale stamp survives.
     assert p1._stamps == {}
@@ -102,9 +121,9 @@ def test_combined_hook_runs_remaining_hooks_after_a_raise(tmp_path):
         build_local_review_hook(p2, lambda pending: {"fs_list": "deny"}),
     ])
     with pytest.raises(RuntimeError):
-        hook([ToolCall(name="fs_list", args={"path": "."})])
+        hook([ToolCall(name="fs_list", args={"path": "."})], RUN)
     assert p1._stamps == {}  # cleared at entry, round trip raised
-    assert p2._stamps == {"fs_list": "deny"}  # fresh THIS-turn decision
+    assert p2._stamps == {(RUN, "fs_list"): "deny"}  # fresh THIS-turn decision
 
 
 # -- _compose_local_provider -------------------------------------------------
@@ -321,11 +340,11 @@ def test_compose_local_provider_persists_session_and_always_allow(
 
     (tmp_path / "a.txt").write_text("a")
 
-    local_provider.apply_batch_decisions({"fs_list": "approve_session"})
+    local_provider.apply_batch_decisions(RUN, {"fs_list": "approve_session"})
     assert local_provider.invoke("local:fs_list", {"path": "."}).ok
     assert ("local:__local__", "fs_list") in service.session_approvals
 
-    local_provider.apply_batch_decisions({"fs_list": "always_allow"})
+    local_provider.apply_batch_decisions(RUN, {"fs_list": "always_allow"})
     assert local_provider.invoke("local:fs_list", {"path": "."}).ok
     assert service.persisted_states == [("local:__local__", "fs_list", "allow")]
 
@@ -380,7 +399,7 @@ def test_compose_local_provider_records_deny_via_service(monkeypatch, tmp_path):
 def test_compose_local_provider_records_timeout_via_service(monkeypatch, tmp_path):
     service = _FakeService()  # ASK state
     local_provider = _composed(monkeypatch, tmp_path, service)
-    local_provider.apply_batch_decisions({"fs_list": "timeout"})
+    local_provider.apply_batch_decisions(RUN, {"fs_list": "timeout"})
 
     r = local_provider.invoke("local:fs_list", {"path": "."})
 

--- a/Tests/Chat/test_console_skill_script_confirm.py
+++ b/Tests/Chat/test_console_skill_script_confirm.py
@@ -943,3 +943,209 @@ def test_confirm_payload_shows_the_canonical_skill_name_not_the_raw_one(
     result = env.closure("  DEMO-Skill ", "scripts/hello.py", [])
     assert result.ok is True
     assert env.confirm_calls[0]["skill_name"] == "demo-skill"
+
+
+# -- PR2a Task 7 (review M1): cancellation revokes skill-script confirms ----
+#
+# `run_skill_script` is all-agents scope (no agent_kind gate in
+# `_run_one`) and runtime schemas are not filtered by `config.allowed_
+# tools`, so a fleet CHILD is offered it unconditionally. The bridge
+# closure runs `scope.run_skill_script(...)` as the very next statement
+# after the confirm returns Allow, with no cancellation checkpoint in
+# between, and the confirm's only stop signal (`_is_session_cancelled`)
+# never fires for a fleet-internal cancel. A cancelled child's confirm
+# card, if clicked, therefore executed an arbitrary skill script for
+# real -- a wider blast radius than the tool-call hazard Task 7 closed
+# first. These pin the fix.
+
+RUN_A = "run-child-a"
+RUN_B = "run-child-b"
+
+
+def test_revoking_a_run_denies_its_skill_script_confirm_and_spares_a_sibling(
+    make_controller,
+):
+    """Two children of one turn share the console session; only run-A's
+    confirm is revoked, and run-B's stays armed and still decidable."""
+    from tldw_chatbook.Agents.run_context import use_run_id
+
+    controller = make_controller()
+    controller.skill_script_confirm_timeout_seconds = lambda: 30.0
+    session_id = controller.store.ensure_session().id
+    controller.store.switch_session(session_id)
+    results: dict[str, dict[str, bool]] = {}
+
+    def _worker(run_id: str, skill: str):
+        def _run() -> None:
+            with use_run_id(run_id):
+                results[run_id] = controller.request_skill_script_confirm(
+                    {"skill_name": skill, "script_path": "scripts/hello.py"},
+                    session_id=session_id,
+                )
+
+        thread = threading.Thread(target=_run)
+        thread.start()
+        return thread
+
+    worker_a = _worker(RUN_A, "alpha")
+    worker_b = _worker(RUN_B, "beta")
+    _wait_until(lambda: len(controller.pending_skill_script_ids()) == 2)
+
+    rounds = {
+        state["run_id"]: request_id
+        for request_id, state in controller._pending_skill_script_rounds.items()
+    }
+    assert set(rounds) == {RUN_A, RUN_B}
+    assert controller._pending_approvals[session_id] == {rounds[RUN_A], rounds[RUN_B]}
+
+    assert controller.revoke_approval_rounds_for_run(RUN_A) == 1
+
+    worker_a.join(timeout=5)
+    assert not worker_a.is_alive(), "the revoked confirm never released its thread"
+    assert results[RUN_A] == {"allow": False, "remember": False}
+
+    # The sibling child is untouched: armed, counted, still blocking.
+    assert controller.pending_skill_script_ids() == [rounds[RUN_B]]
+    assert controller._pending_approvals[session_id] == {rounds[RUN_B]}
+    assert worker_b.is_alive()
+
+    controller.resolve_pending_skill_script(True, False, request_id=rounds[RUN_B])
+    worker_b.join(timeout=5)
+    assert results[RUN_B] == {"allow": True, "remember": False}
+    assert session_id not in controller._pending_approvals
+
+
+def test_revoking_an_unknown_run_leaves_a_skill_script_confirm_armed(make_controller):
+    """The common case -- a cancelled child with no confirm outstanding --
+    must not disturb anyone else's card."""
+    from tldw_chatbook.Agents.run_context import use_run_id
+
+    controller = make_controller()
+    controller.skill_script_confirm_timeout_seconds = lambda: 30.0
+    session_id = controller.store.ensure_session().id
+    controller.store.switch_session(session_id)
+    result: dict[str, dict[str, bool]] = {}
+
+    def _run() -> None:
+        with use_run_id(RUN_A):
+            result["decision"] = controller.request_skill_script_confirm(
+                {"skill_name": "demo"}, session_id=session_id
+            )
+
+    thread = threading.Thread(target=_run)
+    thread.start()
+    _wait_until(lambda: bool(controller.pending_skill_script_ids()))
+    request_id = controller.pending_skill_script_ids()[0]
+
+    assert controller.revoke_approval_rounds_for_run("run-nobody") == 0
+    assert controller.revoke_approval_rounds_for_run("") == 0
+    assert controller.pending_skill_script_ids() == [request_id]
+    assert thread.is_alive()
+
+    controller.resolve_pending_skill_script(True, False, request_id=request_id)
+    thread.join(timeout=5)
+    assert result["decision"] == {"allow": True, "remember": False}
+
+
+def test_a_late_allow_after_a_revoke_cannot_run_the_script(tmp_path, monkeypatch):
+    """END TO END: the cancelled child's card is clicked Allow, and the
+    script still does not run.
+
+    Drives the REAL closure ``console_agent_bridge.run_reply`` builds (the
+    one that calls ``scope.run_skill_script`` with no cancellation
+    checkpoint after the confirm) against the REAL controller bridge. The
+    worker is parked inside its own mount callback so the ordering is
+    exact: revoke lands first, then the Allow arrives -- both by request
+    id AND written straight into the shared decision box a pre-revoke
+    snapshot would hold.
+
+    The observable is the fake scope service's ``run_calls``: empty means
+    nothing executed.
+    """
+    from tldw_chatbook.Agents.run_context import use_run_id
+
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=object())
+    controller.app = _FakeApp()
+    controller.skill_script_confirm_timeout_seconds = lambda: 30.0
+    session_id = store.ensure_session().id
+    store.switch_session(session_id)
+
+    mounted: list[dict[str, Any] | None] = []
+    release = threading.Event()
+
+    def _mount(payload):
+        mounted.append(payload)
+        if payload is not None:
+            # Hold the worker just before it enters its wait loop.
+            release.wait(5.0)
+
+    controller.set_pending_skill_script = _mount
+
+    run_calls: list[tuple[str, str, list[str]]] = []
+    trust_service = _FakeTrustService(granted=False)
+    scope = _FakeScopeService(
+        trust_service=trust_service,
+        enforce_side_effect=None,
+        describe_side_effect=None,
+        run_result=ScriptRunResult(
+            exit_code=0,
+            stdout="pwned",
+            stderr="",
+            timed_out=False,
+            output_capped=False,
+            duration_seconds=0.01,
+            truncated_stdout=False,
+            truncated_stderr=False,
+            sandbox_warnings=(),
+        ),
+        run_calls=run_calls,
+    )
+
+    import functools
+
+    closure = _capture_run_skill_script_tool(
+        tmp_path,
+        monkeypatch,
+        scope=scope,
+        request_skill_script_confirm=functools.partial(
+            controller.request_skill_script_confirm, session_id=session_id
+        ),
+    )
+    assert closure is not None
+
+    outcome: dict[str, Any] = {}
+
+    def _run_tool() -> None:
+        with use_run_id(RUN_A):
+            outcome["result"] = closure("demo", "scripts/hello.py", [])
+
+    worker = threading.Thread(target=_run_tool)
+    worker.start()
+    try:
+        _wait_until(lambda: bool(mounted) and mounted[0] is not None)
+        request_id = mounted[0]["request_id"]
+        decision_box = controller._pending_skill_script_rounds[request_id]["decision"]
+
+        # The fleet cancels/abandons this child.
+        assert controller.revoke_approval_rounds_for_run(RUN_A) == 1
+
+        # ... and the user presses Allow + Remember anyway.
+        controller.resolve_pending_skill_script(True, True, request_id=request_id)
+        decision_box["allow"] = True
+        decision_box["remember"] = True
+    finally:
+        release.set()
+
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+
+    assert run_calls == [], (
+        "a revoked confirm executed the skill script for real"
+    )
+    assert trust_service.granted_names == [], (
+        "a revoked confirm persisted a standing script-execution grant"
+    )
+    result = outcome["result"]
+    assert result.ok is False
+    assert "declined" in result.error

--- a/Tests/DB/test_agent_runs_db.py
+++ b/Tests/DB/test_agent_runs_db.py
@@ -635,3 +635,28 @@ def test_agent_runs_columns_backfilled_on_old_file(tmp_path):
             for row in conn.execute("PRAGMA table_info(agent_runs)").fetchall()
         }
     assert {"agent_definition", "definition_fingerprint"} <= columns
+
+
+# --- Task 2: terminal-status guard on set_status (first-writer-wins) ---
+
+
+def test_set_status_first_terminal_write_wins(db):
+    # A child abandoned after a join timeout can persist LATE; it must not
+    # overwrite the terminal status the coordinator already recorded.
+    run_id = db.create_run(conversation_id="c", agent_kind="subagent", task="t")
+    assert db.set_status(run_id, "cancelled") is True
+    assert db.set_status(run_id, "done", result="late answer") is False
+    run = db.get_run(run_id)
+    assert run["status"] == "cancelled"
+    assert run["result"] is None
+
+
+def test_set_status_still_updates_a_running_run(db):
+    run_id = db.create_run(conversation_id="c", agent_kind="primary")
+    assert db.set_status(run_id, "done", result="ok") is True
+    assert db.get_run(run_id)["status"] == "done"
+    assert db.get_run(run_id)["result"] == "ok"
+
+
+def test_set_status_missing_run_returns_false(db):
+    assert db.set_status("nope", "done") is False

--- a/Tests/Tools/test_write_file_diff_capture.py
+++ b/Tests/Tools/test_write_file_diff_capture.py
@@ -173,7 +173,7 @@ class TestWriteFileDiffCapture:
 class AllowAllGate:
     """Provider gate stub that permits every tool."""
 
-    def check(self, tool, run_id=""):
+    def check(self, tool, run_id):
         return None
 
 

--- a/Tests/Tools/test_write_file_diff_capture.py
+++ b/Tests/Tools/test_write_file_diff_capture.py
@@ -173,7 +173,7 @@ class TestWriteFileDiffCapture:
 class AllowAllGate:
     """Provider gate stub that permits every tool."""
 
-    def check(self, tool):
+    def check(self, tool, run_id=""):
         return None
 
 

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -26,6 +26,7 @@ from textual.widgets import Button, Select, Static
 
 import tldw_chatbook
 from tldw_chatbook.Agents.mcp_tool_provider import MCPPendingCall
+from tldw_chatbook.Agents.run_context import use_run_id
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.console_chat_models import ConsoleRunMarker
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
@@ -2595,4 +2596,328 @@ def test_the_broadest_approval_scope_for_a_tool_survives_collapsing():
     assert stamped == [("read_file", "approve_session")], (
         "the session grant the user chose was downgraded to approve_once, so "
         f"the next call re-prompts: {stamped}"
+    )
+
+
+# -- PR2a Task 7: cancellation revokes a child's pending approval cards ----
+#
+# The hazard: the approval wait blocks inside `_call_with_timeout`'s per-call
+# daemon thread. When the fleet cancels or abandons a child while its card is
+# still on screen, the user can still press Approve -- and the tool would
+# EXECUTE FOR REAL (file written, message sent) for a run that already reads
+# `cancelled`. `revoke_approval_rounds_for_run` is the fail-closed answer.
+
+#: Two concurrent children of one turn. They share the console SESSION (the
+#: fleet's children all run under the parent's session) and differ only by
+#: run id -- which is exactly why round ownership had to become run-keyed.
+RUN_A = "run-child-a"
+RUN_B = "run-child-b"
+
+
+def _arm_round(controller, *, run_id, session_id, llm_name, results):
+    """Arm one approval round on a worker thread, owned by ``run_id``.
+
+    Mirrors production: `request_mcp_approvals` runs on the agent bridge's
+    worker thread, and the dispatching run's id reaches it through the
+    `run_context` ContextVar that `AgentService` binds around the review
+    hook and around each tool invocation.
+    """
+
+    def _run() -> None:
+        with use_run_id(run_id):
+            results[run_id] = controller.request_mcp_approvals(
+                [_pending(llm_name=llm_name)], session_id=session_id
+            )
+
+    thread = threading.Thread(target=_run)
+    thread.start()
+    return thread
+
+
+def _round_id_for(controller, run_id: str) -> str:
+    rounds = [
+        rid
+        for rid, state in controller._pending_approval_rounds.items()
+        if state.get("run_id") == run_id
+    ]
+    assert len(rounds) == 1, f"expected exactly one armed round for {run_id}: {rounds}"
+    return rounds[0]
+
+
+def test_revoking_a_run_denies_its_rounds_and_leaves_another_runs_untouched():
+    """Two concurrent children, one cancelled: only its own card is revoked.
+
+    Both rounds belong to the SAME console session, so nothing session-keyed
+    could tell them apart -- the round has to record which RUN armed it.
+    """
+    controller, store = _build_controller()
+    session_id = store.create_session(title="Fleet").id
+    store.switch_session(session_id)
+    controller.app = _FakeApp()
+    controller.set_pending_approval = lambda payload: None
+    controller.mcp_approval_timeout_seconds = lambda: 30.0
+
+    results: dict[str, dict[str, str]] = {}
+    worker_a = _arm_round(
+        controller,
+        run_id=RUN_A,
+        session_id=session_id,
+        llm_name="mcp__srv__a",
+        results=results,
+    )
+    worker_b = _arm_round(
+        controller,
+        run_id=RUN_B,
+        session_id=session_id,
+        llm_name="mcp__srv__b",
+        results=results,
+    )
+    time.sleep(0.15)
+
+    round_a = _round_id_for(controller, RUN_A)
+    round_b = _round_id_for(controller, RUN_B)
+    assert controller._pending_approvals[session_id] == {round_a, round_b}
+
+    assert controller.revoke_approval_rounds_for_run(RUN_A) == 1
+
+    worker_a.join(timeout=3.0)
+    assert not worker_a.is_alive(), "the revoked round never released its thread"
+    assert results[RUN_A] == {"mcp__srv__a": "deny"}
+
+    # The sibling child is mid-approval and must be completely undisturbed:
+    # still armed, still counted for the badge, still blocking its thread.
+    assert worker_b.is_alive()
+    assert round_a not in controller._pending_approval_rounds
+    assert round_b in controller._pending_approval_rounds
+    assert controller._pending_approvals[session_id] == {round_b}
+    assert controller.run_marker_for(session_id) is ConsoleRunMarker.NEEDS_APPROVAL
+
+    controller.resolve_pending_approval(
+        {"mcp__srv__b": "approve_once"}, round_id=round_b
+    )
+    worker_b.join(timeout=3.0)
+    assert results[RUN_B] == {"mcp__srv__b": "approve_once"}
+    assert session_id not in controller._pending_approvals
+
+
+def test_revoking_a_run_unblocks_its_waiting_thread_and_clears_the_card():
+    """Revocation resolves the round NOW -- not at the 120s auto-deny -- and
+    takes the card down through the same clear a resolved card uses."""
+    controller, store = _build_controller()
+    session_id = store.create_session(title="Child").id
+    store.switch_session(session_id)
+    controller.app = _FakeApp()
+    mounted: list[dict | None] = []
+    controller.set_pending_approval = mounted.append
+    controller.mcp_approval_timeout_seconds = lambda: 30.0
+
+    results: dict[str, dict[str, str]] = {}
+    worker = _arm_round(
+        controller,
+        run_id=RUN_A,
+        session_id=session_id,
+        llm_name="mcp__srv__tool",
+        results=results,
+    )
+    time.sleep(0.15)
+    assert mounted and mounted[-1] is not None, "precondition: the card is on screen"
+
+    started = time.monotonic()
+    assert controller.revoke_approval_rounds_for_run(RUN_A) == 1
+    worker.join(timeout=3.0)
+    elapsed = time.monotonic() - started
+
+    assert not worker.is_alive()
+    assert results[RUN_A] == {"mcp__srv__tool": "deny"}
+    # Nowhere near the 30s deadline: the Event was set, not waited out.
+    assert elapsed < 2.5
+    assert mounted[-1] is None, "the revoked card was left on screen"
+    assert session_id not in controller._pending_approvals
+    assert session_id not in controller._parked_approval_payloads
+
+
+def test_revoking_an_unknown_run_is_a_zero_return_noop():
+    """Safe for a run that never armed a card (the overwhelmingly common
+    case: every cancelled child with no approval outstanding)."""
+    controller, store = _build_controller()
+    session_id = store.create_session(title="Child").id
+    store.switch_session(session_id)
+    controller.app = _FakeApp()
+    controller.set_pending_approval = lambda payload: None
+    controller.mcp_approval_timeout_seconds = lambda: 30.0
+
+    # Nothing armed at all.
+    assert controller.revoke_approval_rounds_for_run(RUN_A) == 0
+
+    results: dict[str, dict[str, str]] = {}
+    worker = _arm_round(
+        controller,
+        run_id=RUN_A,
+        session_id=session_id,
+        llm_name="mcp__srv__tool",
+        results=results,
+    )
+    time.sleep(0.15)
+    round_a = _round_id_for(controller, RUN_A)
+
+    assert controller.revoke_approval_rounds_for_run("run-nobody") == 0
+    # An empty/absent run id must never match the rounds armed outside any
+    # run (a direct provider call) -- fail closed by refusing to sweep.
+    assert controller.revoke_approval_rounds_for_run("") == 0
+
+    assert round_a in controller._pending_approval_rounds
+    assert controller._pending_approvals[session_id] == {round_a}
+    assert worker.is_alive()
+
+    controller.resolve_pending_approval(
+        {"mcp__srv__tool": "approve_once"}, round_id=round_a
+    )
+    worker.join(timeout=3.0)
+    assert results[RUN_A] == {"mcp__srv__tool": "approve_once"}
+
+
+def test_a_decision_landing_after_a_revoke_cannot_reopen_the_round():
+    """The in-flight-click race, pinned deterministically.
+
+    `ApprovalDecided` travels as an async Textual message, so a user click
+    can be delivered AFTER the fleet cancelled the child -- and
+    `resolve_pending_approval` snapshots the round's shared decisions dict,
+    so a write can even land in that dict after the round was torn down.
+    The waiting thread must still return "deny".
+
+    The worker is held inside its own mount callback (which runs on the
+    worker thread, after the round is registered and before the wait loop),
+    which makes the ordering exact rather than hopeful.
+    """
+    controller, store = _build_controller()
+    session_id = store.create_session(title="Child").id
+    store.switch_session(session_id)
+    controller.app = _FakeApp()
+    mounted: list[dict | None] = []
+    release = threading.Event()
+
+    def _mount(payload):
+        mounted.append(payload)
+        if payload is not None:
+            # Park the worker just before it enters the wait loop.
+            release.wait(5.0)
+
+    controller.set_pending_approval = _mount
+    controller.mcp_approval_timeout_seconds = lambda: 30.0
+
+    results: dict[str, dict[str, str]] = {}
+    worker = _arm_round(
+        controller,
+        run_id=RUN_A,
+        session_id=session_id,
+        llm_name="mcp__srv__tool",
+        results=results,
+    )
+    try:
+        deadline = time.monotonic() + 3.0
+        while not mounted and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert mounted and mounted[0] is not None
+        round_a = _round_id_for(controller, RUN_A)
+        decisions_box = controller._pending_approval_rounds[round_a]["decisions"]
+
+        assert controller.revoke_approval_rounds_for_run(RUN_A) == 1
+        # The stale click is delivered now: by round id (a no-op, the round
+        # is gone) AND straight into the shared box a pre-revoke snapshot
+        # would still hold. Neither may resurrect the approval.
+        controller.resolve_pending_approval(
+            {"mcp__srv__tool": "approve_once"}, round_id=round_a
+        )
+        decisions_box["mcp__srv__tool"] = "approve_once"
+    finally:
+        release.set()
+
+    worker.join(timeout=3.0)
+    assert not worker.is_alive()
+    assert results[RUN_A] == {"mcp__srv__tool": "deny"}, (
+        "a click that landed after cancellation re-opened a revoked round"
+    )
+
+
+@pytest.mark.unit
+def test_a_revoked_childs_card_can_no_longer_execute_its_tool(tmp_path, monkeypatch):
+    """End to end, with the real gate, the real provider and a real file.
+
+    The whole point of the task: a child cancelled mid-approval must not be
+    able to write to disk when the user presses Approve afterwards. Drives
+    the production chain -- `build_tool_review_hook` -> `request_mcp_
+    approvals` -> `BuiltinToolGate` stamp -> `BuiltinToolProvider.invoke`.
+    """
+    import tldw_chatbook.config as config_module
+    import tldw_chatbook.Tools.file_operation_tools as fot
+    from tldw_chatbook.Agents.agent_models import ToolCall
+    from tldw_chatbook.Agents.builtin_tool_gate import BuiltinToolGate
+    from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
+    from tldw_chatbook.Chat.console_chat_controller import build_tool_review_hook
+
+    from Tests.Agents.test_builtin_tool_gate import _FakeService
+
+    def _tools_setting(section, key=None, default=None):
+        if section == "tools" and key == "write_file_enabled":
+            return True
+        return default
+
+    monkeypatch.setattr(config_module, "get_cli_setting", _tools_setting)
+    monkeypatch.setattr(fot, "_resolve_sandbox_config", lambda: str(tmp_path))
+
+    controller, store = _build_controller()
+    session_id = store.create_session(title="Child").id
+    store.switch_session(session_id)
+    controller.app = _FakeApp()
+    mounted: list[dict | None] = []
+    controller.set_pending_approval = mounted.append
+    controller.mcp_approval_timeout_seconds = lambda: 30.0
+
+    gate = BuiltinToolGate(service=_FakeService())
+    provider = BuiltinToolProvider(gate=gate)
+    hook = build_tool_review_hook(
+        gate,
+        provider,
+        None,
+        lambda pending: controller.request_mcp_approvals(
+            pending, session_id=session_id
+        ),
+        workspace_id=None,
+    )
+    args = {"file_path": "owned.txt", "content": "written by a cancelled child"}
+    target = tmp_path / "owned.txt"
+
+    verdicts: dict[str, str] = {}
+
+    def _review() -> None:
+        with use_run_id(RUN_A):
+            verdicts.update(
+                hook([ToolCall(name="write_file", args=args, call_id="call-1")], RUN_A)
+            )
+
+    worker = threading.Thread(target=_review)
+    worker.start()
+    time.sleep(0.2)
+    assert mounted and mounted[-1] is not None, "precondition: the card is on screen"
+    round_a = mounted[-1]["round_id"]
+
+    # The fleet cancels/abandons this child while its card is still up.
+    assert controller.revoke_approval_rounds_for_run(RUN_A) == 1
+    worker.join(timeout=3.0)
+    assert not worker.is_alive()
+
+    # ... and the user presses Approve anyway.
+    controller.resolve_pending_approval(
+        {"call-1": "approve_once", "write_file": "approve_once"}, round_id=round_a
+    )
+
+    with use_run_id(RUN_A):
+        result = provider.invoke("builtin:write_file", args)
+
+    assert verdicts["call-1"] != "proceed", (
+        f"the revoked call was cleared for dispatch: {verdicts}"
+    )
+    assert result.ok is False
+    assert not target.exists(), (
+        "a revoked approval executed the tool for real -- the file was written"
     )

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -35,6 +35,12 @@ from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import ChatApprovalCa
 
 from Tests.UI.app_factory import _build_test_app
 
+#: PR2a Task 5: the review hook takes the id of the run whose batch it is
+#: reviewing (both gates key their per-turn verdicts by run). These
+#: hook-level tests drive ONE run each, so they name it once here; every
+#: assertion below is unchanged.
+RUN = "run-1"
+
 _CSS_ROOT = Path(tldw_chatbook.__file__).parent / "css"
 _AGENTIC_TERMINAL_TCSS = _CSS_ROOT / "components" / "_agentic_terminal.tcss"
 _BUNDLED_STYLESHEET = _CSS_ROOT / "tldw_cli_modular.tcss"
@@ -2266,13 +2272,13 @@ def test_call_id_keyed_decision_still_stamps_the_builtin_gate():
     stamped: list[tuple[str, str]] = []
 
     class _Gate:
-        def begin_turn(self):
+        def begin_turn(self, run_id):
             pass
 
         def resolve(self, tool):
             return SimpleNamespace(state="ask", risk_floored=False)
 
-        def stamp(self, name, decision):
+        def stamp(self, run_id, name, decision):
             stamped.append((name, decision))
 
         def is_session_approved(self, name):
@@ -2293,7 +2299,7 @@ def test_call_id_keyed_decision_still_stamps_the_builtin_gate():
     hook = build_tool_review_hook(
         _Gate(), _Provider(), None, request_approvals, workspace_id=None
     )
-    hook([ToolCall(name="read_file", args={"path": "spec.md"}, call_id="call-1")])
+    hook([ToolCall(name="read_file", args={"path": "spec.md"}, call_id="call-1")], RUN)
 
     assert stamped == [("read_file", "approve_session")], (
         f"the call-id-keyed decision never reached the gate: {stamped}"
@@ -2396,10 +2402,10 @@ def test_refusing_one_call_does_not_get_overwritten_by_approving_another():
     stamped: list[tuple[str, str]] = []
 
     class _Gate:
-        def begin_turn(self): pass
+        def begin_turn(self, run_id): pass
         def resolve(self, tool):
             return SimpleNamespace(state="ask", risk_floored=False)
-        def stamp(self, name, decision): stamped.append((name, decision))
+        def stamp(self, run_id, name, decision): stamped.append((name, decision))
         def is_session_approved(self, name): return False
         def options_for(self, tool):
             return ("approve_once", "approve_session", "deny")
@@ -2424,7 +2430,7 @@ def test_refusing_one_call_does_not_get_overwritten_by_approving_another():
     verdicts = hook([
         ToolCall(name="read_file", args={"path": "secrets.md"}, call_id="call-1"),
         ToolCall(name="read_file", args={"path": "spec.md"}, call_id="call-2"),
-    ])
+    ], RUN)
 
     refusal = verdicts.get("call-1")
     assert refusal and refusal != "proceed", (
@@ -2499,10 +2505,10 @@ def test_a_refusal_never_stamps_the_name_even_when_it_is_decided_last():
     stamped: list[tuple[str, str]] = []
 
     class _Gate:
-        def begin_turn(self): pass
+        def begin_turn(self, run_id): pass
         def resolve(self, tool):
             return SimpleNamespace(state="ask", risk_floored=False)
-        def stamp(self, name, decision): stamped.append((name, decision))
+        def stamp(self, run_id, name, decision): stamped.append((name, decision))
         def is_session_approved(self, name): return False
         def options_for(self, tool):
             return ("approve_once", "approve_session", "deny")
@@ -2525,7 +2531,7 @@ def test_a_refusal_never_stamps_the_name_even_when_it_is_decided_last():
     verdicts = hook([
         ToolCall(name="read_file", args={"path": "spec.md"}, call_id="c-ok"),
         ToolCall(name="read_file", args={"path": "secrets.md"}, call_id="c-no"),
-    ])
+    ], RUN)
 
     assert stamped == [("read_file", "approve_session")], (
         "the refusal was stamped against the tool NAME, which also blocks "
@@ -2558,10 +2564,10 @@ def test_the_broadest_approval_scope_for_a_tool_survives_collapsing():
     stamped: list[tuple[str, str]] = []
 
     class _Gate:
-        def begin_turn(self): pass
+        def begin_turn(self, run_id): pass
         def resolve(self, tool):
             return SimpleNamespace(state="ask", risk_floored=False)
-        def stamp(self, name, decision): stamped.append((name, decision))
+        def stamp(self, run_id, name, decision): stamped.append((name, decision))
         def is_session_approved(self, name): return False
         def options_for(self, tool):
             return ("approve_once", "approve_session", "deny")
@@ -2584,7 +2590,7 @@ def test_the_broadest_approval_scope_for_a_tool_survives_collapsing():
     hook([
         ToolCall(name="read_file", args={"path": "a.md"}, call_id="c1"),
         ToolCall(name="read_file", args={"path": "b.md"}, call_id="c2"),
-    ])
+    ], RUN)
 
     assert stamped == [("read_file", "approve_session")], (
         "the session grant the user chose was downgraded to approve_once, so "

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -982,3 +982,43 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "live" in item.keywords:
                 item.add_marker(skip_live)
+
+
+@pytest.fixture(autouse=True)
+def _fleet_chat_scripts_fully_consumed():
+    """Fail any test that mis-scripted a `FleetChat` (PR2a Task 6.5 review).
+
+    `Tests/Agents/test_agent_service.FleetChat` addresses provider replies
+    per agent, and is the load-bearing harness for every suite that spawns
+    a sub-agent. Two of its failure modes are otherwise SILENT:
+
+    * a fault raised on a CHILD's thread is swallowed by `AgentService`'s
+      `run_child` (BaseException by design) into `status=error`, so a test
+      that does not assert the child's own result still passes;
+    * a scripted turn nobody ever asks for -- e.g. after a task-text
+      rename leaves the key stale -- simply goes unused, and the test
+      passes while exercising nothing it claims to.
+
+    Autouse and repo-wide on purpose: this must not be something a future
+    test can forget to opt into. It is a no-op (one empty list check) for
+    the thousands of tests that never touch `FleetChat`, and it never
+    imports it -- the class registers its own instances.
+    """
+    # Looked up through sys.modules rather than imported: a test that
+    # never pulled the harness in must not pay to import the whole agent
+    # stack, nor gain its import side effects. No module -> nothing to check.
+    module = sys.modules.get("Tests.Agents.test_agent_service")
+    fleet_chat = getattr(module, "FleetChat", None) if module else None
+    if fleet_chat is None:
+        yield
+        return
+
+    fleet_chat._live_instances.clear()
+    yield
+    instances = list(fleet_chat._live_instances)
+    fleet_chat._live_instances.clear()
+    problems = []
+    for chat in instances:
+        problems.extend(chat.harness_errors)
+        problems.extend(chat.unconsumed())
+    assert not problems, "FleetChat scripting fault(s): " + "; ".join(problems)

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -21,8 +21,18 @@ known, expensive to rediscover. Every entry states the incident that produced it
   collision; fixing the gate required tracing both files' add commits and renumbering
   the later task to `TASK-3791` across its code, tests, plan, and task record.
 
+- **2026-08-10, supervisor-fleet PR 2a.** Two distinct failures in one branch. (i) The
+  branch was cut from dev *before* a `task-3401` renumber merged, so Backlog Guard went
+  red on a duplicate **dev had already fixed** — the branch introduced neither side, and
+  the fix was `git rebase origin/dev`, not renumbering anything. (ii) A task filed
+  mid-session as `13213` collided with a task another session landed on dev while the PR
+  was in flight. The ceiling moved from **13,212 to 14,826 in a few hours** of concurrent
+  work — an ID scanned at the start of a long PR is not safe at the end of it.
+
 Checking `origin/dev` *feels* like diligence. It is not: parallel agents hold IDs on
-unmerged branches.
+unmerged branches. And a *green* Backlog Guard at branch time proves nothing later —
+a duplicate can arrive from dev moving underneath you, in which case rebasing is the
+fix and renumbering is actively wrong.
 
 **What to do.** Before filing, sweep **every remote ref** plus every worktree, and
 re-check at merge time — dev moves under you. Never trust the CLI's auto-assignment.

--- a/backlog/tasks/task-13213 - CI-xdist-INTERNALERROR-serializing-websockets-ServerConnection-fails-the-Core-Tests-job.md
+++ b/backlog/tasks/task-13213 - CI-xdist-INTERNALERROR-serializing-websockets-ServerConnection-fails-the-Core-Tests-job.md
@@ -1,0 +1,26 @@
+---
+id: TASK-13213
+title: >-
+  CI: xdist INTERNALERROR serializing websockets ServerConnection fails the Core
+  Tests job
+status: To Do
+assignee: []
+created_date: '2026-08-09 21:50'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The 'Core Tests (all but UI)' CI job intermittently reports 22 failed / 12163 passed with an execnet INTERNALERROR: "DumpError: can't serialize <class 'websockets.asyncio.server.ServerConnection'>", attributed to Tests/LLM_Calls/test_openai_realtime_session.py::test_connect_sends_session_update_and_fires_ready on worker gw0. Observed on PR #1467, whose diff touches ONLY backlog/*.md (zero Python files), so the failures cannot originate from the branch. The same test file passes locally: 35 passed in 4.70s. Under pytest-xdist a test that leaves a live websockets ServerConnection reachable from something xdist tries to serialize (e.g. an assertion-rewritten repr or a failure payload) crashes the worker protocol, which can cascade into unrelated reported failures and mask real regressions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Root cause identified: what xdist is attempting to serialize and why the ServerConnection is reachable from it
+- [ ] #2 The realtime-session test cleans up (or avoids exposing) its ServerConnection so xdist can serialize any failure payload
+- [ ] #3 Core Tests job passes on an unmodified dev checkout across three consecutive runs
+- [ ] #4 If the 22 failures have a cause distinct from the INTERNALERROR, they are enumerated and filed separately
+<!-- AC:END -->

--- a/backlog/tasks/task-13214 - Library-shadow-name-drift-guard-is-red-on-generate-video-stream-video-masking-later-drift.md
+++ b/backlog/tasks/task-13214 - Library-shadow-name-drift-guard-is-red-on-generate-video-stream-video-masking-later-drift.md
@@ -1,0 +1,25 @@
+---
+id: TASK-13214
+title: >-
+  Library shadow-name drift guard is red on generate-video/stream-video, masking
+  later drift
+status: To Do
+assignee: []
+created_date: '2026-08-10 00:29'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Tests/Library/test_library_skills_state.py::test_shadow_name_set_stays_in_sync_with_real_sources fails on origin/dev: ConsoleCommandRegistry names not covered: {'stream-video', 'generate-video'} — both present in console_command_grammar.py but absent from _SHADOWED_BUILTIN_NAMES (library_skills_state.py). Introduced by the video-generation work. Impact beyond the two names: the guard asserts three subsets IN ORDER, so whichever fires first masks every gap underneath it. Demonstrated during supervisor-fleet PR 2a — two newly added runtime tools (wait_agents/check_agents) were missing from the same set, and the RUNTIME_TOOL_NAMES assertion fired first, completely hiding the video gap until the tool names were fixed. While this guard is red, anyone adding a runtime tool or console command gets no drift signal at all, which is precisely the erosion the test's own message warns about ('do not accept this as a baseline failure (task-580)').
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 generate-video and stream-video are covered by _SHADOWED_BUILTIN_NAMES (or deliberately exempted with a documented reason)
+- [ ] #2 The guard passes on a clean dev checkout
+- [ ] #3 The assertion reports ALL uncovered names across the three sources in one failure rather than short-circuiting on the first subset, so one gap cannot mask another
+<!-- AC:END -->

--- a/backlog/tasks/task-13215 - Fleet-approval-revocation-add-a-revoked-run-tombstone-and-close-the-residual-arm-read-windows.md
+++ b/backlog/tasks/task-13215 - Fleet-approval-revocation-add-a-revoked-run-tombstone-and-close-the-residual-arm-read-windows.md
@@ -1,0 +1,25 @@
+---
+id: TASK-13215
+title: >-
+  Fleet approval revocation: add a revoked-run tombstone and close the residual
+  arm/read windows
+status: To Do
+assignee: []
+created_date: '2026-08-10 01:37'
+labels: []
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up from supervisor-fleet PR 2a Task 7 review. Revocation sweeps rounds that are already armed, which leaves two narrow fail-open windows: (a) revoke-then-arm — an in-flight provider invoke() that reaches its single-call approval fallback AFTER the last revoke pass arms a card nobody will ever revoke (bounded only by the 120s approval timeout); (b) the worker can read was_revoked==False and have revocation land before it returns, and on the MCPToolProvider.invoke/LocalToolProvider fallback paths there is no later cancellation checkpoint. A set of revoked run ids consulted at ARM time (return all-deny immediately when the owner is already revoked) closes (a) outright and narrows (b). Also from the same review: the sibling retained-payload rule is correct but untested — replacing its guard with an unconditional _parked_approval_payloads.pop leaves all 235 tests green, and regressing it reproduces TASK-1050 Defect B (a live sibling child's card unrecoverable on switch-away/back, badge lit until timeout). And a round armed with an empty run-id owner (lost ContextVar binding) is silently unrevocable — worth a warning log.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A revoked-run registry is consulted at arm time so a card armed after revocation resolves all-deny immediately
+- [ ] #2 The sibling retained-payload rule has a regression test (unconditional pop must fail it)
+- [ ] #3 Arming a round with an empty run-id owner logs a warning
+<!-- AC:END -->

--- a/backlog/tasks/task-13215 - Fleet-approval-revocation-add-a-revoked-run-tombstone-and-close-the-residual-arm-read-windows.md
+++ b/backlog/tasks/task-13215 - Fleet-approval-revocation-add-a-revoked-run-tombstone-and-close-the-residual-arm-read-windows.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-08-10 01:37'
+updated_date: '2026-08-10 02:15'
 labels: []
 dependencies: []
 priority: medium
@@ -22,4 +23,5 @@ Follow-up from supervisor-fleet PR 2a Task 7 review. Revocation sweeps rounds th
 - [ ] #1 A revoked-run registry is consulted at arm time so a card armed after revocation resolves all-deny immediately
 - [ ] #2 The sibling retained-payload rule has a regression test (unconditional pop must fail it)
 - [ ] #3 Arming a round with an empty run-id owner logs a warning
+- [ ] #4 _revoke_skill_script_rounds' cross-lock window is closed: it snapshots still_armed under _pending_skill_script_lock, releases it, then pops _parked_skill_script_payloads under _approval_state_lock — a sibling confirm armed in that window has its payload popped (TASK-1050 Defect B: card unrecoverable on switch-away/back, badge lit until timeout). Fix with an identity-guarded pop (only when the stored payload's request_id is among the revoked ids), matching _clear_pending_skill_script_if_round_is_current. Note the same window pre-exists in request_skill_script_confirm's own teardown.
 <!-- AC:END -->

--- a/backlog/tasks/task-13216 - LocalToolProvider-todo_write-is-last-write-wins-under-concurrent-fleet-children.md
+++ b/backlog/tasks/task-13216 - LocalToolProvider-todo_write-is-last-write-wins-under-concurrent-fleet-children.md
@@ -1,0 +1,24 @@
+---
+id: TASK-13216
+title: >-
+  LocalToolProvider todo_write is last-write-wins under concurrent fleet
+  children
+status: To Do
+assignee: []
+created_date: '2026-08-10 20:48'
+labels: []
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PR2a Task 8's provider thread-safety audit found LocalToolProvider safe for concurrent invoke() (read-only specs dict, stamps already lock-guarded, handlers are pure per-call functions) with one narrow exception: the todo_write handler does an unguarded 'store[:] = items' on the session's shared todos list, which is the SAME LocalToolProvider instance's todo_store across a parent run and every fleet child it spawns (PR2a Task 6). Two concurrent todo_write calls race last-write-wins -- memory-safe (no corruption, no crash) but one caller's update can be silently discarded. Not locked as part of Task 8 because it is a single-tool, single-field hazard, not a proof that the whole provider is unsafe, and locking the entire provider would throttle every unrelated local tool (fs_read, fs_grep, web_fetch, ...) fleet-wide to protect one list splice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Either todo_write's read-modify-write is made safe under concurrent calls (e.g. its own small lock, or a compare-and-swap/merge policy), or the last-write-wins behavior is deliberately documented as accepted and out of scope
+- [ ] #2 If fixed, a concurrency test proves two overlapping todo_write calls from different runs cannot silently lose one caller's update
+<!-- AC:END -->

--- a/backlog/tasks/task-14876 - CI-xdist-INTERNALERROR-serializing-websockets-ServerConnection-fails-the-Core-Tests-job.md
+++ b/backlog/tasks/task-14876 - CI-xdist-INTERNALERROR-serializing-websockets-ServerConnection-fails-the-Core-Tests-job.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-13213
+id: TASK-14876
 title: >-
   CI: xdist INTERNALERROR serializing websockets ServerConnection fails the Core
   Tests job

--- a/backlog/tasks/task-14877 - Dev-baseline-9-failing-tests-in-Tests-Chat-mask-real-regressions.md
+++ b/backlog/tasks/task-14877 - Dev-baseline-9-failing-tests-in-Tests-Chat-mask-real-regressions.md
@@ -1,0 +1,23 @@
+---
+id: TASK-14877
+title: 'Dev baseline: 9 failing tests in Tests/Chat mask real regressions'
+status: To Do
+assignee: []
+created_date: '2026-08-10 22:46'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+origin/dev at 59cf35d6e fails 9 tests in Tests/Chat with zero related changes in flight. Verified twice on a pristine detached checkout of origin/dev: Tests/Chat + Tests/MCP gives 9 failed / 4331 passed / 62 skipped, and the same 9 names fail when their files are run in isolation. Groups: (a) 5x Tests/Chat/test_console_agent_swap.py::test_mcp_tool_call_* (executes_end_to_end_when_state_allows, ask_state_routes_through_review_hook_and_approves, session_approval_suppresses_card_on_next_turn, ask_state_times_out_denies, gates_subagent_call_same_as_primary); (b) 1x Tests/Chat/test_console_ephemeral.py::test_promotion_restores_ephemeral_flag_if_persist_returns_none_unexpectedly; (c) 3x Tests/Chat/test_tool_output_disclosure.py (full_tool_output_is_reachable_from_the_mounted_transcript, pressing_o_expands_the_selected_marker, two_calls_in_one_turn_expand_independently). Cost already incurred: supervisor-fleet PR 2a (#1477) rebased onto dev and its battery went from 0 failures to 9, which had to be individually traced against a pristine dev checkout to prove none belonged to the branch — roughly 30 minutes of comparison runs that a green baseline would have made unnecessary. The MCP group is the most dangerous: it covers the tool-call permission path, so a genuine permission regression landing there would be indistinguishable from this noise.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Root cause identified for each of the three groups (they may have distinct causes)
+- [ ] #2 All 9 tests pass on a clean origin/dev checkout, or any that encode obsolete behavior are deliberately rewritten with the change documented
+- [ ] #3 Tests/Chat is green on dev across two consecutive runs
+<!-- AC:END -->

--- a/tldw_chatbook/Agents/agent_models.py
+++ b/tldw_chatbook/Agents/agent_models.py
@@ -46,6 +46,14 @@ SEARCH_RUN_LOG_TOOL_NAME = "search_run_log"
 # `compute_stats`/`slice_records` for the implementations these dispatch to.
 RUN_LOG_STATS_TOOL_NAME = "run_log_stats"
 RUN_LOG_SLICE_TOOL_NAME = "run_log_slice"
+# Fleet (PR2a Task 6): the two tools a supervisor uses to manage children
+# that now run CONCURRENTLY on their own threads instead of inline. Both
+# are primary-only (pinned like install_skill) and both are dispatched
+# IN-LOOP like spawn_subagent -- never through invoke_tool's per-call
+# timeout wrapper, whose daemon thread would abandon a wait that is
+# supposed to be bounded by the parent's own wall-clock instead.
+WAIT_AGENTS_TOOL_NAME = "wait_agents"
+CHECK_AGENTS_TOOL_NAME = "check_agents"
 RUNTIME_TOOL_NAMES = frozenset(
     {
         SPAWN_TOOL_NAME,
@@ -57,6 +65,8 @@ RUNTIME_TOOL_NAMES = frozenset(
         SEARCH_RUN_LOG_TOOL_NAME,
         RUN_LOG_STATS_TOOL_NAME,
         RUN_LOG_SLICE_TOOL_NAME,
+        WAIT_AGENTS_TOOL_NAME,
+        CHECK_AGENTS_TOOL_NAME,
     }
 )
 

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -13,6 +13,7 @@ from typing import Callable
 from loguru import logger
 
 from .agent_models import (
+    CHECK_AGENTS_TOOL_NAME,
     FENCE_TOOL_RESULT_PREFIX,
     FIND_TOOLS_NAME,
     INSTALL_SKILL_TOOL_NAME,
@@ -40,6 +41,7 @@ from .agent_models import (
     ToolCall,
     ToolResult,
     ToolSchema,
+    WAIT_AGENTS_TOOL_NAME,
 )
 
 FENCE_OPEN = "```tool_call"
@@ -283,6 +285,28 @@ class LoopDeps:
     # (the default) means the run is not wired for it and a call by that
     # name falls through to the generic deps.invoke_tool path.
     run_log_slice: Callable[[dict], ToolResult] | None = None
+    # wait_agents / check_agents: the fleet runtime tools (PR2a Task 6).
+    # Wired ONLY for the top-level agent of a run that actually has a
+    # fleet coordinator -- same primary-only reasoning as install_skill
+    # (a depth-1 child has max_subagents clamped to 0, so it has no
+    # children to wait on) plus the obvious one: without a coordinator
+    # there is nothing to wait on at all. `None` (the default) means the
+    # run is not wired for them and a call by either name falls through
+    # to the generic deps.invoke_tool path.
+    #
+    # Dispatched IN-LOOP beside spawn_subagent below, deliberately NOT
+    # through deps.invoke_tool: that path wraps every call in
+    # agent_service._call_with_timeout's per-call daemon thread, which
+    # would abandon a wait at `max_tool_call_seconds` and leave the
+    # children it was waiting for running unattended. wait_agents is
+    # bounded by the parent's own remaining wall-clock and polls
+    # should_cancel itself, which is the correct bound for a call whose
+    # entire purpose is to block.
+    #
+    # `wait_agents` takes the requested handle ids, or None for "every
+    # child of this run"; `check_agents` takes nothing.
+    wait_agents: Callable[[list[str] | None], ToolResult] | None = None
+    check_agents: Callable[[], ToolResult] | None = None
     # on_record: full-fidelity capture for the run log (run_log.py). Called
     # with (record_type, payload) at the two points where the COMPLETE value
     # exists -- which the step log does not carry, since `add()` truncates
@@ -748,6 +772,34 @@ def run_agent_loop(
                             #   budget check.
                             if result.ok or not agent_name:
                                 spawned += 1
+                elif (
+                    call.name == WAIT_AGENTS_TOOL_NAME
+                    and deps.wait_agents is not None
+                ):
+                    add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
+                    # Same defensive coercion as load_tools' `ids` right
+                    # below: an unreliable local model may send one bare
+                    # string, a JSON null, or junk. A bare string is ONE
+                    # id (never char-split); anything unusable becomes
+                    # None, which the service reads as "every child" --
+                    # the same thing an omitted `ids` means, and the
+                    # safest reading of an ambiguous request to wait.
+                    raw_ids = call.args.get("ids")
+                    if isinstance(raw_ids, str):
+                        wait_ids: list[str] | None = [raw_ids]
+                    elif isinstance(raw_ids, list):
+                        # An explicitly EMPTY list is "no ids given",
+                        # i.e. all of them -- not "wait for nothing".
+                        wait_ids = [str(x) for x in raw_ids] or None
+                    else:
+                        wait_ids = None
+                    result = deps.wait_agents(wait_ids)
+                elif (
+                    call.name == CHECK_AGENTS_TOOL_NAME
+                    and deps.check_agents is not None
+                ):
+                    add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
+                    result = deps.check_agents()
                 elif call.name == FIND_TOOLS_NAME:
                     add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
                     entries = deps.find_tools(str(call.args.get("query", "")))

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -17,6 +17,8 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Callable, Protocol
 
+from loguru import logger
+
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 from tldw_chatbook.Internal_Prompts import get_internal_prompt
 from tldw_chatbook.Internal_Prompts.catalog import CATALOG
@@ -25,10 +27,12 @@ from tldw_chatbook.Utils.token_counter import count_tokens_messages, estimate_to
 from .agent_models import (
     AGENT_KIND_PRIMARY,
     AGENT_KIND_SUBAGENT,
+    RUN_CANCELLED,
     RUN_DONE,
     RUN_ERROR,
     SPAWN_TOOL_NAME,
     STEP_ERROR,
+    TERMINAL_RUN_STATUSES,
     AgentConfig,
     AgentDefinition,
     AgentStep,
@@ -49,6 +53,7 @@ from .agent_models import (
     definition_fingerprint as compute_definition_fingerprint,
 )
 from .agent_runtime import LoopDeps, render_tool_protocol, run_agent_loop
+from .fleet_coordinator import FleetCoordinator, FleetHandle
 from .native_tools import (
     ensure_tool_call_ids,
     parse_native_tool_calls,
@@ -65,6 +70,7 @@ from .run_log_eviction import (
     coerce_min_recent_rounds,
 )
 from .tool_catalog import (
+    CHECK_AGENTS_SCHEMA,
     FIND_TOOLS_SCHEMA,
     INSTALL_SKILL_TOOL_SCHEMA,
     LOAD_TOOLS_SCHEMA,
@@ -74,6 +80,7 @@ from .tool_catalog import (
     SEARCH_RUN_LOG_TOOL_SCHEMA,
     SKILL_FILE_TOOL_SCHEMA,
     SPAWN_TOOL_SCHEMA,
+    WAIT_AGENTS_SCHEMA,
     ToolCatalogRegistry,
     build_spawn_schema,
     initial_disclosure,
@@ -85,6 +92,45 @@ from .tool_catalog import (
 SUBAGENT_SYSTEM_PROMPT = CATALOG["agents.subagent_system"].default
 
 TRUNCATION_NOTICE = "\n[truncated]"
+
+#: ``[agents]`` key sizing the fleet: how many sub-agents of one turn may
+#: be live at once. **1 (the default) means the fleet is OFF** and every
+#: spawn runs the child INLINE, synchronously, exactly as it did before
+#: PR2a -- see `AgentService.__init__`'s `fleet_coordinator` for why the
+#: switch is here and not at the coordinator's cap.
+MAX_LIVE_SUBAGENTS_KEY = "max_live_subagents"
+DEFAULT_MAX_LIVE_SUBAGENTS = 1
+#: How long a poll loop sleeps between coordinator checks. Small enough
+#: that a cancelled run is not held up perceptibly, large enough not to
+#: spin a core while several children work.
+_FLEET_POLL_SECONDS = 0.05
+#: Grace period for a cancelled child to notice and unwind before its
+#: thread is ABANDONED. Same precedent (and same reasoning) as
+#: `_call_with_timeout`'s daemon abandonment: Python cannot kill a thread,
+#: and a wedged one must not hold the turn open forever.
+FLEET_JOIN_TIMEOUT_SECONDS = 5.0
+#: Longest task snippet echoed back in a `started ...` spawn result.
+_SPAWN_ECHO_CHARS = 120
+
+
+def _coerce_max_live_subagents(value) -> int:
+    """Read the fleet size from config, tolerating any junk in the file.
+
+    Args:
+        value: Whatever ``_setting`` returned -- an env var is always a
+            string, a TOML value may be any type, and a hand-edited file
+            may hold nonsense.
+
+    Returns:
+        The configured cap, floored at 1 (which disables the fleet).
+        Unparseable values fall back to the default rather than raising:
+        a malformed config key must never stop an agent run.
+    """
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_LIVE_SUBAGENTS
+    return max(parsed, 1)
 
 # Task 7: appended to config.system_prompt only when THIS run wired the
 # search_run_log tool (see the `log_active` gate in _run_one, reused
@@ -297,6 +343,7 @@ class AgentService:
         run_skill_script_tool: Callable[[str, str, list[str]], ToolResult]
         | None = None,
         run_log_writer: "RunLogWriter | None" = None,
+        fleet_coordinator: FleetCoordinator | None = None,
     ) -> None:
         self.db = db
         self.registry = registry
@@ -382,6 +429,35 @@ class AgentService:
         # `run_turn` call; a service that never calls `run_turn` (none in
         # production) keeps spawn_subagent's identity-path schema.
         self._turn_definitions: list[AgentDefinition] = []
+        # PR2a Task 6 -- THE FLEET SWITCH.
+        #
+        # An explicitly injected coordinator turns concurrent sub-agents
+        # ON for every turn this service runs; the caller owns its
+        # lifecycle (same convention as `_injected_run_log_writer`).
+        # `None` -- every caller before this task, and the Console bridge
+        # today -- makes `run_turn` size a fresh coordinator per turn from
+        # `[agents] max_live_subagents`, and **a cap of 1 (the shipped
+        # default) means no fleet at all**: `spawn` keeps running the
+        # child inline, synchronously, and neither wait_agents nor
+        # check_agents is offered.
+        #
+        # Why the switch is "is there a fleet" rather than "how big is
+        # it": a non-blocking spawn is only coherent for a supervisor
+        # that can COLLECT, and collecting requires wait_agents. The two
+        # ship together or not at all -- a run that got a handle id back
+        # from spawn but no way to redeem it would simply lose its
+        # children's work. Sizing the fleet at 1 therefore means "one
+        # child at a time, inline" -- observably identical to pre-PR2a
+        # behaviour, which is this PR's stated acceptance criterion and
+        # what keeps the pre-existing spawn suites passing unmodified.
+        self._injected_fleet_coordinator = fleet_coordinator
+        # Per-TURN fleet state, all owned by the primary run's thread (a
+        # child never spawns -- clamp_child_budget zeroes max_subagents),
+        # so no lock is needed on these three. Reset at the top of every
+        # `run_turn`.
+        self._fleet: FleetCoordinator | None = None
+        self._fleet_threads: list[threading.Thread] = []
+        self._fleet_cancels: dict[str, threading.Event] = {}
 
     # -- internals -------------------------------------------------------
 
@@ -560,6 +636,215 @@ class AgentService:
 
         return invoke_tool
 
+    # -- fleet helpers (PR2a Task 6) --------------------------------------
+
+    @staticmethod
+    def _pending_handles(
+        fleet: FleetCoordinator, handle_ids: list[str]
+    ) -> list[str]:
+        """The subset of ``handle_ids`` not yet in a terminal status.
+
+        Args:
+            fleet: This turn's coordinator.
+            handle_ids: Handles to check.
+
+        Returns:
+            Ids still running, in the order given. A handle that has
+            vanished (impossible today -- the coordinator never forgets
+            one) counts as finished rather than blocking a wait forever.
+        """
+        pending = []
+        for handle_id in handle_ids:
+            handle = fleet.get(handle_id)
+            if handle is not None and handle.status not in TERMINAL_RUN_STATUSES:
+                pending.append(handle_id)
+        return pending
+
+    def _cancel_fleet_handles(self, handle_ids: list[str]) -> None:
+        """Ask the named children to stop, cooperatively.
+
+        Sets each child's own cancel Event; the child notices at its next
+        step or tool-call boundary and unwinds itself, persisting whatever
+        it reached. Nothing is forced here -- forcing happens only at end
+        of turn, and even then only as abandonment.
+
+        Args:
+            handle_ids: The handles to cancel.
+        """
+        for handle_id in handle_ids:
+            event = self._fleet_cancels.get(handle_id)
+            if event is not None:
+                event.set()
+
+    def _drain_fleet_handles(
+        self, fleet: FleetCoordinator, handle_ids: list[str]
+    ) -> None:
+        """Give just-cancelled children a bounded chance to record a status.
+
+        Args:
+            fleet: This turn's coordinator.
+            handle_ids: The handles being waited on.
+        """
+        deadline = time.monotonic() + FLEET_JOIN_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            if not self._pending_handles(fleet, handle_ids):
+                return
+            time.sleep(_FLEET_POLL_SECONDS)
+
+    def _format_wait_result(
+        self,
+        fleet: FleetCoordinator,
+        handle_ids: list[str],
+        budget,
+        note: str,
+    ) -> str:
+        """Render collected children within BOTH result budgets.
+
+        Per-child results are capped at ``max_subagent_result_chars`` as
+        they always have been, but the combined result must ALSO fit
+        ``max_tool_result_chars`` -- otherwise five 4000-char children
+        would be cut mid-result by the loop's history-append truncation,
+        losing the tail children entirely rather than shortening each one
+        fairly. The history budget is therefore divided evenly across the
+        children being returned, after subtracting the fixed per-entry
+        headers and the re-fetch hint.
+
+        Args:
+            fleet: This turn's coordinator.
+            handle_ids: The handles to render, in call order.
+            budget: This run's ``RunBudget``.
+            note: A cancellation/timeout sentence to append, or "".
+
+        Returns:
+            The rendered text, always within ``max_tool_result_chars``
+            (when that is non-zero).
+        """
+        handles = [
+            handle
+            for handle in (fleet.get(handle_id) for handle_id in handle_ids)
+            if handle is not None
+        ]
+        if not handles:  # pragma: no cover — handle_ids are pre-validated
+            return "No sub-agents to report." + note
+        headers = [
+            f"[{handle.handle_id}] {handle.agent or 'sub-agent'} — "
+            f"{handle.status}"
+            for handle in handles
+        ]
+        bodies = [
+            (handle.result or handle.error or "(no result)")
+            for handle in handles
+        ]
+        hint = (
+            "\n\n(Each result above was shortened to share this turn's "
+            "result budget. Call wait_agents with a single id for one "
+            "sub-agent's full result.)"
+        )
+        cap = budget.max_subagent_result_chars
+        if budget.max_tool_result_chars > 0:
+            # Reserve the fixed cost -- every header, the blank lines
+            # between entries, the hint, and the note -- before dividing
+            # what is left. The hint is reserved unconditionally even when
+            # nothing ends up truncated: over-reserving by one sentence is
+            # harmless, while under-reserving would push the whole result
+            # back over the ceiling it exists to respect.
+            fixed = (
+                # Each entry is "<header>\n<body>" ...
+                sum(len(header) + 1 for header in headers)
+                # ... and entries are joined by a blank line.
+                + 2 * (len(handles) - 1)
+                + len(hint)
+                + len(note)
+            )
+            share = (budget.max_tool_result_chars - fixed) // len(handles)
+            cap = max(min(cap, share - len(TRUNCATION_NOTICE)), 0)
+        truncated = False
+        entries = []
+        for header, body in zip(headers, bodies):
+            if len(body) > cap:
+                body = body[:cap] + TRUNCATION_NOTICE
+                truncated = True
+            entries.append(f"{header}\n{body}")
+        rendered = "\n\n".join(entries)
+        if truncated and len(handles) > 1:
+            rendered += hint
+        return rendered + note
+
+    def _settle_fleet(
+        self,
+        config: AgentConfig,
+        should_cancel: Callable[[], bool],
+        turn_started: float,
+    ) -> None:
+        """End-of-turn safety net: no child outlives the turn (phase 2).
+
+        Waits for stragglers within the parent's remaining wall-clock,
+        then cooperative-cancels them, then ABANDONS whatever is still
+        wedged after ``FLEET_JOIN_TIMEOUT_SECONDS`` -- marking those
+        handles and their run rows ``cancelled`` so nothing is left
+        ``running``. ``AgentRunsDB.set_status`` is first-writer-wins
+        (PR2a Task 2), so an abandoned thread that later persists its own
+        status is a no-op rather than a resurrection.
+
+        Args:
+            config: The primary run's config (its wall-clock budget).
+            should_cancel: The run-wide cancellation probe.
+            turn_started: ``self.clock()`` as of the start of the turn.
+        """
+        fleet = self._fleet
+        if fleet is None:
+            return
+        # This turn's handles only -- an injected coordinator may be
+        # long-lived (PR 3a), and settling a turn must never reach into
+        # another turn's children.
+        mine = list(self._fleet_cancels)
+        deadline = turn_started + config.budget.max_wall_seconds
+        # `self.clock` is injectable and some callers freeze it, which
+        # would make the budget deadline above unreachable. A real-time
+        # bound of the same length runs alongside it so this loop always
+        # terminates whatever the injected clock does.
+        wall_deadline = time.monotonic() + config.budget.max_wall_seconds
+        while self._pending_handles(fleet, mine):
+            if (
+                should_cancel()
+                or self.clock() >= deadline
+                or time.monotonic() >= wall_deadline
+            ):
+                break
+            time.sleep(_FLEET_POLL_SECONDS)
+        # Cancel unconditionally: for an already-finished fleet every
+        # Event set here is inert, and for a straggler it is the only
+        # cooperative stop signal there is.
+        self._cancel_fleet_handles(mine)
+        # ONE join budget shared across every thread, not 5s each: N
+        # wedged children must not hold the turn open for 5N seconds.
+        join_deadline = time.monotonic() + FLEET_JOIN_TIMEOUT_SECONDS
+        for thread in self._fleet_threads:
+            thread.join(max(join_deadline - time.monotonic(), 0.0))
+        for handle_id in self._pending_handles(fleet, mine):
+            handle = fleet.get(handle_id)
+            if handle is None:  # pragma: no cover — never forgotten
+                continue
+            logger.warning(
+                f"abandoning wedged sub-agent {handle.handle_id} "
+                f"(run {handle.run_id}) at end of turn"
+            )
+            fleet.finish(
+                handle.handle_id,
+                RUN_CANCELLED,
+                error="abandoned: still running at end of turn",
+            )
+            if not handle.run_id:
+                continue
+            try:
+                self.db.set_status(handle.run_id, RUN_CANCELLED)
+            except Exception:  # noqa: BLE001 — a DB failure here must not
+                # take down a turn that has already produced its answer.
+                logger.opt(exception=True).warning(
+                    f"could not mark abandoned sub-agent run "
+                    f"{handle.run_id} cancelled"
+                )
+
     def _persist(self, run_id: str, outcome: RunOutcome) -> None:
         stamp = _now_iso()
         step_dicts = []
@@ -584,6 +869,7 @@ class AgentService:
         assistant_message_id: str | None = None,
         agent_definition: str | None = None,
         definition_fingerprint: str | None = None,
+        on_run_id: Callable[[str], None] | None = None,
     ) -> tuple[str, RunOutcome]:
         run_id = self.db.create_run(
             conversation_id=conversation_id,
@@ -595,6 +881,19 @@ class AgentService:
             agent_definition=agent_definition,
             definition_fingerprint=definition_fingerprint,
         )
+        # PR2a Task 6: a threaded child's run id does not exist until this
+        # line, and its spawning parent has long since returned a handle to
+        # the model. This hook is how the id gets back to the coordinator
+        # (`FleetCoordinator.attach_run`) so an abandoned child's run row
+        # can still be marked cancelled at end of turn. Never allowed to
+        # break the run it is reporting on.
+        if on_run_id is not None:
+            try:
+                on_run_id(run_id)
+            except Exception:  # noqa: BLE001 — bookkeeping is not load-bearing
+                logger.opt(exception=True).warning(
+                    f"on_run_id hook raised for run {run_id}; continuing"
+                )
         # Two-phase: the writer was constructed before any run id existed.
         # Only the PRIMARY run binds; a child finds it already bound.
         if agent_kind == AGENT_KIND_PRIMARY:
@@ -608,8 +907,23 @@ class AgentService:
         active = [schema for schema in active if schema.name in config.allowed_tools]
         disclosed_names = {schema.name for schema in active}
         runtime_schemas = []
+        # PR2a Task 6: this run's fleet, or None when there is none. A
+        # sub-agent NEVER gets one -- depth-1 is structural (a child's
+        # max_subagents is clamped to 0, so it has nothing to wait on),
+        # and handing a child the parent's coordinator would let it
+        # observe, and wait on, its siblings.
+        fleet = self._fleet if agent_kind == AGENT_KIND_PRIMARY else None
+        # Both fleet tools are pinned under the SAME predicate the spawn
+        # schema uses (`max_subagents > 0`) plus the primary-only gate
+        # `install_skill` established -- and additionally on there BEING a
+        # fleet, since without one `spawn` still runs children inline and
+        # there is never anything live to wait on or check.
+        fleet_active = fleet is not None and config.budget.max_subagents > 0
         if config.budget.max_subagents > 0:
             runtime_schemas.append(build_spawn_schema(self._turn_definitions))
+        if fleet_active:
+            runtime_schemas.append(WAIT_AGENTS_SCHEMA)
+            runtime_schemas.append(CHECK_AGENTS_SCHEMA)
         if offer_find_load:
             runtime_schemas.extend([FIND_TOOLS_SCHEMA, LOAD_TOOLS_SCHEMA])
         if (
@@ -734,6 +1048,13 @@ class AgentService:
             return accepted
 
         sub_agent_spawns = 0
+        # Handles THIS run started, in spawn order. The coordinator is
+        # deliberately not run-scoped (PR 3a wants children that outlive
+        # their spawning turn), so "all my sub-agents" has to be tracked
+        # here rather than read off `snapshot()` -- otherwise a long-lived
+        # injected coordinator would show, and make this run wait on,
+        # another run's children.
+        my_handle_ids: list[str] = []
 
         def spawn(
             spawn_task: str,
@@ -758,10 +1079,24 @@ class AgentService:
             # Fleet spec §4: the skill path (allowed_tools override) and
             # the named-definition path are disjoint by construction --
             # skills never pass `agent`.
-            # Structural invariant, not input validation: unreachable in
-            # production (both call sites are internal, neither can supply
-            # both kwargs at once) and stripped entirely under `python -O`.
-            assert not (agent and allowed_tools is not None)
+            #
+            # A structural invariant, not input validation: unreachable in
+            # production today (both call sites are internal and neither
+            # can supply both kwargs at once). It is an explicit `raise`
+            # rather than an `assert` because an `assert` is STRIPPED
+            # under `python -O`, and the failure it guards is silent --
+            # `resolved.tool_allowlist` would intersect against the
+            # skill's own narrowed override below, quietly producing a
+            # child with neither party's intended allow-list. A future
+            # caller that gets this wrong must fail loudly in every
+            # interpreter mode, not just a non-optimised one.
+            if agent and allowed_tools is not None:
+                raise ValueError(
+                    "spawn(): `agent` and `allowed_tools` are mutually "
+                    "exclusive -- a named agent definition supplies its own "
+                    "tool allow-list, so passing both leaves the child's "
+                    "permissions ambiguous."
+                )
             resolved = None
             if agent:
                 resolved = next(
@@ -861,37 +1196,271 @@ class AgentService:
             # protection: both gates key verdicts by run, so the child
             # writes to its own slice and cannot reach this one. Retained
             # as belt-and-braces for the inline path.
-            scope = (
-                self.review_state_scope(run_id)
-                if self.review_state_scope
-                else contextlib.nullcontext()
+            child_kwargs = dict(
+                conversation_id=conversation_id,
+                messages=[{"role": "user", "content": spawn_task}],
+                config=child_config,
+                api_endpoint=api_endpoint,
+                agent_kind=AGENT_KIND_SUBAGENT,
+                task=spawn_task,
+                parent_run_id=run_id,
+                agent_definition=(resolved.name if resolved else None),
+                definition_fingerprint=(
+                    compute_definition_fingerprint(resolved) if resolved else None
+                ),
             )
-            with scope:
-                _child_id, child_outcome = self._run_one(
-                    conversation_id=conversation_id,
-                    messages=[{"role": "user", "content": spawn_task}],
-                    config=child_config,
-                    api_endpoint=api_endpoint,
-                    should_cancel=should_cancel,
-                    agent_kind=AGENT_KIND_SUBAGENT,
-                    task=spawn_task,
-                    parent_run_id=run_id,
-                    agent_definition=(resolved.name if resolved else None),
-                    definition_fingerprint=(
-                        compute_definition_fingerprint(resolved)
-                        if resolved
-                        else None
+            if fleet is None:
+                # -- INLINE path: byte-identical to every release before
+                # PR2a. Kept, not merely tolerated: with no fleet there is
+                # no wait_agents, so a handle id would be unredeemable and
+                # the child's work simply lost.
+                scope = (
+                    self.review_state_scope(run_id)
+                    if self.review_state_scope
+                    else contextlib.nullcontext()
+                )
+                with scope:
+                    _child_id, child_outcome = self._run_one(
+                        should_cancel=should_cancel, **child_kwargs
+                    )
+                text = child_outcome.final_text
+                cap = config.budget.max_subagent_result_chars
+                if len(text) > cap:
+                    text = text[:cap] + TRUNCATION_NOTICE
+                if child_outcome.status != RUN_DONE:
+                    return ToolResult(
+                        ok=False, error=f"sub-agent {child_outcome.status}: {text}"
+                    )
+                return ToolResult(ok=True, content=text)
+
+            # -- FLEET path: register, launch, return a handle.
+            handle = fleet.reserve(
+                task=spawn_task, agent=(resolved.name if resolved else None)
+            )
+            if handle is None:
+                # At the live cap. Unlike a budget refusal this is
+                # RETRYABLE -- collecting a finished child frees a slot --
+                # so it must not consume a spawn from the per-turn
+                # ceiling, exactly like the unknown-agent refusal above
+                # ("a typo costs no sub-agent slot"). The check/increment
+                # itself stays where it has always been; only this one
+                # no-child-was-created path unwinds it.
+                sub_agent_spawns -= 1
+                return ToolResult(
+                    ok=False,
+                    error=(
+                        f"live sub-agent limit reached ({fleet.live_count()} "
+                        "already running); call wait_agents to collect a "
+                        "finished sub-agent before starting another"
                     ),
                 )
-            text = child_outcome.final_text
-            cap = config.budget.max_subagent_result_chars
-            if len(text) > cap:
-                text = text[:cap] + TRUNCATION_NOTICE
-            if child_outcome.status != RUN_DONE:
+            # Cooperative cancellation for THIS child specifically, on top
+            # of the run-wide `should_cancel` it also honours. wait_agents
+            # and the end-of-turn settle both set it to unwind stragglers
+            # without cancelling the parent.
+            child_cancel = threading.Event()
+            self._fleet_cancels[handle.handle_id] = child_cancel
+            my_handle_ids.append(handle.handle_id)
+
+            def child_should_cancel() -> bool:
+                return should_cancel() or child_cancel.is_set()
+
+            def run_child(
+                handle: FleetHandle = handle,
+                child_kwargs: dict = child_kwargs,
+                child_should_cancel=child_should_cancel,
+            ) -> None:
+                """Run one child to completion, then release its handle.
+
+                Deliberately NOT wrapped in the parent's
+                `review_state_scope`, which the inline path above still
+                takes. That scope snapshots and RESTORES the parent's
+                verdict slice, which is sound only for a strictly nested
+                (LIFO) inline child: with siblings running concurrently,
+                one child's exit would roll the parent's slice back to a
+                snapshot taken before another child -- or before the
+                parent's own later turn -- had stamped anything, wiping
+                live verdicts. PR2a Task 5 made per-run keying the
+                load-bearing protection precisely so this scope is not
+                needed here: the child stamps `(child_run_id, tool)` and
+                cannot reach the parent's keys at all.
+                """
+                status = RUN_ERROR
+                result_text = ""
+                error_text = ""
+                try:
+                    _child_id, child_outcome = self._run_one(
+                        should_cancel=child_should_cancel,
+                        on_run_id=(
+                            lambda rid: fleet.attach_run(handle.handle_id, rid)
+                        ),
+                        **child_kwargs,
+                    )
+                    status = child_outcome.status
+                    result_text = child_outcome.final_text
+                    if status != RUN_DONE:
+                        error_text = f"sub-agent {status}"
+                except BaseException as exc:  # noqa: BLE001 — see below
+                    # EVERY exception, including BaseException: this runs
+                    # on a daemon thread whose exception would otherwise
+                    # go to the default excepthook and leave the handle
+                    # live forever -- stranding the parent's end-of-turn
+                    # join until its own timeout, every time, for what may
+                    # be a trivial bug. Same containment rule as
+                    # `_call_with_timeout._runner`.
+                    error_text = f"sub-agent failed: {exc}"
+                    logger.opt(exception=True).warning(
+                        f"sub-agent thread for handle {handle.handle_id} raised"
+                    )
+                finally:
+                    fleet.finish(
+                        handle.handle_id,
+                        status,
+                        result=result_text,
+                        error=error_text,
+                    )
+
+            thread = threading.Thread(
+                target=run_child,
+                name=f"fleet-{handle.handle_id[:8]}",
+                daemon=True,
+            )
+            self._fleet_threads.append(thread)
+            thread.start()
+            snippet = spawn_task[:_SPAWN_ECHO_CHARS]
+            return ToolResult(
+                ok=True,
+                content=(
+                    f"started {handle.handle_id}: {snippet}\n"
+                    "It is running now. Call wait_agents to collect its "
+                    "result before you answer."
+                ),
+            )
+
+        def wait_agents(ids: list[str] | None = None) -> ToolResult:
+            """Block until the named (or all) children finish; collect them.
+
+            Bounded by the parent's own remaining wall-clock and polling
+            ``should_cancel`` every ``_FLEET_POLL_SECONDS``, because this
+            is dispatched IN-LOOP rather than through ``invoke_tool``'s
+            per-call daemon wrapper (see ``LoopDeps.wait_agents``).
+
+            Args:
+                ids: Handle ids to wait for, or ``None`` for every child
+                    this run has started.
+
+            Returns:
+                One entry per child -- handle id, agent, terminal status,
+                and result -- each capped at
+                ``max_subagent_result_chars`` and the whole thing
+                additionally budgeted to ``max_tool_result_chars`` split
+                evenly across the children returned, so five 4000-char
+                results are shortened fairly here instead of being cut
+                mid-result by the history-append seam. Never raises.
+            """
+            if fleet is None:  # pragma: no cover — not wired without a fleet
                 return ToolResult(
-                    ok=False, error=f"sub-agent {child_outcome.status}: {text}"
+                    ok=False, error="wait_agents: this run has no sub-agents"
                 )
-            return ToolResult(ok=True, content=text)
+            known = {
+                handle.handle_id: handle
+                for handle in (
+                    fleet.get(handle_id) for handle_id in my_handle_ids
+                )
+                if handle is not None
+            }
+            if not known:
+                return ToolResult(
+                    ok=False,
+                    error=(
+                        "wait_agents: no sub-agents have been started; call "
+                        "spawn_subagent first"
+                    ),
+                )
+            if ids is None:
+                targets = list(known)
+            else:
+                targets = [hid for hid in dict.fromkeys(ids) if hid in known]
+                unknown = [hid for hid in dict.fromkeys(ids) if hid not in known]
+                if unknown:
+                    return ToolResult(
+                        ok=False,
+                        error=(
+                            "wait_agents: unknown sub-agent id(s): "
+                            + ", ".join(unknown)
+                            + ". Known ids: "
+                            + ", ".join(known)
+                        ),
+                    )
+            note = ""
+            # See `_settle_fleet`: a real-time bound runs alongside the
+            # budget deadline so an injected (possibly frozen) clock can
+            # never turn this into an unbounded wait.
+            wall_deadline = time.monotonic() + config.budget.max_wall_seconds
+            while True:
+                pending = self._pending_handles(fleet, targets)
+                if not pending:
+                    break
+                if should_cancel():
+                    note = "\n(The run was cancelled; sub-agents were stopped.)"
+                    self._cancel_fleet_handles(pending)
+                    break
+                if (
+                    self.clock() - started >= config.budget.max_wall_seconds
+                    or time.monotonic() >= wall_deadline
+                ):
+                    note = (
+                        "\n(This run's time budget ran out; sub-agents still "
+                        "working were stopped.)"
+                    )
+                    self._cancel_fleet_handles(pending)
+                    break
+                time.sleep(_FLEET_POLL_SECONDS)
+            if note:
+                # Give the children just cancelled a bounded chance to
+                # unwind and record a real status before we report them.
+                self._drain_fleet_handles(fleet, targets)
+            return ToolResult(
+                ok=True,
+                content=self._format_wait_result(
+                    fleet, targets, config.budget, note
+                ),
+            )
+
+        def check_agents() -> ToolResult:
+            """Non-blocking status snapshot of every child of this run.
+
+            Returns:
+                One compact line per child (handle id, agent, status,
+                elapsed seconds, task snippet), or a plain sentence when
+                nothing has been started yet. Never blocks, never raises.
+            """
+            if fleet is None:  # pragma: no cover — not wired without a fleet
+                return ToolResult(
+                    ok=False, error="check_agents: this run has no sub-agents"
+                )
+            handles = [
+                handle
+                for handle in (
+                    fleet.get(handle_id) for handle_id in my_handle_ids
+                )
+                if handle is not None
+            ]
+            if not handles:
+                return ToolResult(
+                    ok=True, content="No sub-agents have been started yet."
+                )
+            now = self.clock()
+            lines = []
+            for handle in handles:
+                end = handle.finished_at if handle.finished_at is not None else now
+                elapsed = max(end - handle.started_at, 0.0)
+                lines.append(
+                    f"[{handle.handle_id}] {handle.agent or 'sub-agent'} — "
+                    f"{handle.status} ({elapsed:.1f}s) — "
+                    f"{handle.task[:_SPAWN_ECHO_CHARS]}"
+                )
+            return ToolResult(ok=True, content="\n".join(lines))
 
         # Skill-aware invoke_tool, built AFTER spawn (it closes over it): a
         # skill-tool call never reaches the registry/ToolProvider.invoke
@@ -1478,6 +2047,12 @@ class AgentService:
             run_log_slice=(
                 run_log_slice if agent_kind == AGENT_KIND_PRIMARY else None
             ),
+            # PR2a Task 6: wired under the SAME `fleet_active` predicate
+            # that pinned their schemas above, so the model is never told
+            # about a tool this run cannot dispatch (and never dispatches
+            # one it was not told about).
+            wait_agents=wait_agents if fleet_active else None,
+            check_agents=check_agents if fleet_active else None,
             on_record=on_record,
         )
         try:
@@ -1588,6 +2163,26 @@ class AgentService:
             definition_from_row(row)
             for row in self.db.list_agent_definitions(enabled_only=True)
         ]
+        # PR2a Task 6: this turn's fleet. An injected coordinator is
+        # honored as-is (the injector owns its lifecycle, and its presence
+        # is itself the opt-in); otherwise the size comes from
+        # `[agents] max_live_subagents`, read through the same `_setting`
+        # helper the run-log knobs use, and a size of 1 -- the shipped
+        # default -- means NO fleet: spawn keeps running children inline.
+        self._fleet_threads = []
+        self._fleet_cancels = {}
+        if self._injected_fleet_coordinator is not None:
+            self._fleet = self._injected_fleet_coordinator
+        else:
+            max_live = _coerce_max_live_subagents(
+                _setting(MAX_LIVE_SUBAGENTS_KEY, DEFAULT_MAX_LIVE_SUBAGENTS)
+            )
+            self._fleet = (
+                FleetCoordinator(max_live=max_live, clock=self.clock)
+                if max_live > 1
+                else None
+            )
+        turn_started = self.clock()
         run_id, outcome = self._run_one(
             conversation_id=conversation_id,
             messages=messages,
@@ -1599,6 +2194,12 @@ class AgentService:
             parent_run_id=None,
             assistant_message_id=assistant_message_id,
         )
+        # Phase 2 keeps children TURN-SCOPED: the turn does not return
+        # while one is still running. Must happen BEFORE the manifest is
+        # written and the writer closed below -- a child still running
+        # would otherwise be appending records to a closed writer, and its
+        # own run row would still read `running` after this call returns.
+        self._settle_fleet(config, should_cancel, turn_started)
         # Manifest needs run-level metadata the writer itself does not have
         # (including supersession), so it is written once the whole run
         # tree finishes, here rather than inside _run_one.

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -55,6 +55,7 @@ from .native_tools import (
     provider_supports_native_tools,
     schemas_to_openai_tools,
 )
+from .run_context import use_run_id
 from .run_log import _setting
 from .run_log_eviction import (
     DEFAULT_MIN_RECENT_ROUNDS,
@@ -288,8 +289,9 @@ class AgentService:
         on_step: Callable[[AgentStep, str, str], None] | None = None,
         skill_runner: SkillRunner | None = None,
         skill_file_bindings: SkillFileBindings | None = None,
-        review_tool_calls: Callable[[list[ToolCall]], dict[str, str]] | None = None,
-        review_state_scope: Callable[[], "contextlib.AbstractContextManager"]
+        review_tool_calls: Callable[[list[ToolCall], str], dict[str, str]]
+        | None = None,
+        review_state_scope: Callable[[str], "contextlib.AbstractContextManager"]
         | None = None,
         install_skill_tool: Callable[[str], ToolResult] | None = None,
         run_skill_script_tool: Callable[[str, str, list[str]], ToolResult]
@@ -314,6 +316,14 @@ class AgentService:
         # should_cancel flows through run_turn/_run_one). MCP-specific
         # wiring (Task 6) builds the callable passed here; this service
         # stays agnostic to what it does.
+        #
+        # PR2a Task 5: the hook takes `(calls, run_id)`. `LoopDeps.
+        # review_tool_calls` is unchanged (`(calls) -> verdicts`) -- the
+        # pure runtime has no business knowing about run ids; `_run_one`
+        # binds ITS OWN run id into the callable it puts on LoopDeps. That
+        # is the whole seam: the gates key their per-turn verdicts by run,
+        # and this is where a run's identity reaches the review hook that
+        # writes them.
         self.review_tool_calls = review_tool_calls
         # C1 (probe-verified security regression, pre-merge review of the
         # Phase 5 chat bridge): an optional, generically-shaped seam a
@@ -332,6 +342,14 @@ class AgentService:
         # `contextlib.nullcontext()`. See `MCPToolProvider.stamp_scope` for
         # the concrete MCP-specific context manager wired here by
         # `console_agent_bridge.ConsoleAgentBridge.run_reply`.
+        #
+        # PR2a Task 5: takes the run id to scope, and is NO LONGER the
+        # load-bearing protection -- both gates now key their per-turn
+        # verdicts by `(run_id, tool_name)`, so a child cannot reach the
+        # parent's slice in the first place. Snapshot/restore is sound
+        # only for a strictly nested (LIFO) inline child; per-run keying
+        # is what survives N children on their own threads. Kept because
+        # the seam is public and composes three providers' scopes.
         self.review_state_scope = review_state_scope
         # Agent-callable skill install (5th runtime tool). A ready-built
         # closure (enforce -> classify -> confirm -> install -> wrap) supplied
@@ -492,7 +510,25 @@ class AgentService:
         config: AgentConfig,
         disclosed_names: set,
         should_cancel: Callable[[], bool] = lambda: False,
+        run_id: str = "",
     ):
+        """Build this run's ``LoopDeps.invoke_tool``.
+
+        Args:
+            config: This run's config (allow-list and budgets).
+            disclosed_names: The tool names whose schemas this run has.
+            should_cancel: Cooperative cancellation probe.
+            run_id: THIS run's id, bound via ``run_context.use_run_id``
+                around each invocation so the permission gates can find
+                this run's own approval stamps (PR2a Task 5). Bound
+                INSIDE the callable handed to ``_call_with_timeout``, so
+                it is established on the per-call daemon thread that
+                actually runs the tool -- a ``ContextVar`` set on this
+                thread would not be visible there. ``""`` (the default)
+                binds the no-run key, matching the pre-Task-5 behavior
+                for a service built without a run.
+        """
+
         def invoke_tool(call: ToolCall) -> ToolResult:
             if (
                 call.name not in config.allowed_tools
@@ -502,14 +538,19 @@ class AgentService:
             timeout = self.registry.timeout_for(call.name) or (
                 config.budget.max_tool_call_seconds
             )
+
+            def _invoke() -> ToolResult:
+                with use_run_id(run_id):
+                    return self.registry.invoke_by_name(call.name, call.args)
+
             if timeout and timeout > 0:
                 return _call_with_timeout(
-                    lambda: self.registry.invoke_by_name(call.name, call.args),
+                    _invoke,
                     timeout,
                     call.name,
                     should_cancel,
                 )
-            return self.registry.invoke_by_name(call.name, call.args)
+            return _invoke()
 
         return invoke_tool
 
@@ -806,8 +847,16 @@ class AgentService:
             # decisions) mutated once control returns here. A no-op
             # contextlib.nullcontext() when no scope was wired (every
             # non-MCP run, and every caller before this task).
+            #
+            # PR2a Task 5: scoped to THIS (the PARENT's) run id -- it is
+            # the parent's own already-decided verdicts a nested run must
+            # not disturb, and the child's id does not exist yet here
+            # anyway (`_run_one` mints it). No longer the load-bearing
+            # protection: both gates key verdicts by run, so the child
+            # writes to its own slice and cannot reach this one. Retained
+            # as belt-and-braces for the inline path.
             scope = (
-                self.review_state_scope()
+                self.review_state_scope(run_id)
                 if self.review_state_scope
                 else contextlib.nullcontext()
             )
@@ -847,7 +896,7 @@ class AgentService:
         # sub_agent_spawns counter -- see Finding 2 above), cancellable, and
         # DB-lineage-tracked exactly like a spawn_subagent call.
         builtin_invoke_tool = self._make_invoke_tool(
-            config, disclosed_names, should_cancel
+            config, disclosed_names, should_cancel, run_id
         )
 
         def invoke_tool(call: ToolCall) -> ToolResult:
@@ -1381,7 +1430,16 @@ class AgentService:
                 if self._on_step is not None
                 else (lambda s: None)
             ),
-            review_tool_calls=self.review_tool_calls,
+            # PR2a Task 5: bind THIS run's id into the hook. `LoopDeps`
+            # keeps its `(calls) -> verdicts` shape (the pure runtime stays
+            # ignorant of run ids); the service, which owns the run
+            # identity, is what supplies it -- so the review hook can stamp
+            # its verdicts against the run that will consume them.
+            review_tool_calls=(
+                (lambda calls: self.review_tool_calls(calls, run_id))
+                if self.review_tool_calls is not None
+                else None
+            ),
             # Qodo/PR#814: wired under the SAME predicate as the schema pin
             # above (~:356-360) -- bindings with an EMPTY authorized set
             # must never reach the named-refusal dispatch either; a

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
+import functools
 import sys
 import threading
 import time
@@ -213,6 +214,12 @@ class SkillRunner(Protocol):
             spawn: This run's own spawn closure -- ``spawn(task, *,
                 allowed_tools=None)`` -- so the rendered skill prompt runs
                 as a normal budget-counted sub-agent of THIS run.
+
+                PR2a Task 6.5: what the service actually hands over is
+                that closure PRE-BOUND to the inline path, so a skill call
+                returns the skill's output rather than a fleet handle. A
+                runner neither chooses nor needs to know: call it exactly
+                as before.
 
         Returns:
             The sub-agent's result, wrapped as a ``ToolResult`` exactly the
@@ -1157,6 +1164,7 @@ class AgentService:
             *,
             allowed_tools: tuple[str, ...] | None = None,
             agent: str | None = None,
+            inline: bool = False,
         ) -> ToolResult:
             nonlocal sub_agent_spawns
             # Task-12 review Finding 2: this closure is THE single spawn
@@ -1305,11 +1313,32 @@ class AgentService:
                     compute_definition_fingerprint(resolved) if resolved else None
                 ),
             )
-            if fleet is None:
+            if fleet is None or inline:
                 # -- INLINE path: byte-identical to every release before
                 # PR2a. Kept, not merely tolerated: with no fleet there is
                 # no wait_agents, so a handle id would be unredeemable and
                 # the child's work simply lost.
+                #
+                # `inline` takes this branch even WITH a live fleet, and is
+                # how a SKILL call keeps its contract (PR2a Task 6.5). See
+                # `invoke_tool`'s skill branch for why the caller, not the
+                # runner, decides.
+                #
+                # Why `review_state_scope(run_id)` is still sound here even
+                # when fleet siblings are running RIGHT NOW: the scope
+                # snapshots and restores only THIS parent's slice -- the
+                # restore rewrites exactly the keys where `key[0] ==
+                # run_id`, under the provider's own `_decisions_lock` (see
+                # `MCPToolProvider.stamp_scope`). A concurrent sibling
+                # stamps under its OWN run id, so it is never in the
+                # snapshot and never in the rewritten set; and the parent
+                # itself is BLOCKED inside this call for the whole window,
+                # so it cannot stamp anything the restore would roll back.
+                # This is precisely the reasoning that does NOT hold on the
+                # threaded path -- there the scope would be entered around
+                # a child while the parent keeps running and stamping, so
+                # Task 6 dropped it there. Writing it down because the two
+                # branches now differ deliberately, not accidentally.
                 scope = (
                     self.review_state_scope(run_id)
                     if self.review_state_scope
@@ -1631,8 +1660,32 @@ class AgentService:
                 # render/trust round-trip once the shared budget is spent.
                 if sub_agent_spawns >= config.budget.max_subagents:
                     return ToolResult(ok=False, error="sub-agent budget exhausted")
+                # PR2a Task 6.5: a SKILL call runs its child INLINE even
+                # when the fleet is on, so it still returns the skill's
+                # OUTPUT rather than a handle. `spawn_subagent` is a
+                # request to delegate and the model knows to collect it;
+                # a skill call is "run this and give me the result", and
+                # nothing tells the model otherwise -- a handle would make
+                # it either answer from the literal "started <id>: ..."
+                # string (a silently wrong answer, since `_settle_fleet`
+                # then discards the real work) or burn an extra provider
+                # round on exactly the shape the Console already had to
+                # raise its step budget for.
+                #
+                # The decision is made HERE, by the caller that already
+                # knows this is a skill, and handed over pre-bound. It is
+                # deliberately NOT inferred from the `allowed_tools`
+                # override the runner happens to pass: that works only by
+                # luck today (`intersect_skill_tools` never returns None)
+                # and the `SkillRunner` Protocol explicitly advertises
+                # `allowed_tools=None`, so a conforming runner would
+                # silently get the fleet. A runner cannot get this wrong
+                # because it never chooses -- it just calls what it was
+                # given.
                 return self.skill_runner.run(
-                    call.name, str(call.args.get("args", "")), spawn
+                    call.name,
+                    str(call.args.get("args", "")),
+                    functools.partial(spawn, inline=True),
                 )
             return builtin_invoke_tool(call)
 

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -285,7 +285,7 @@ class AgentService:
         registry: ToolCatalogRegistry,
         chat_call: Callable | None = None,
         clock: Callable[[], float] = time.monotonic,
-        on_step: Callable[[AgentStep, str], None] | None = None,
+        on_step: Callable[[AgentStep, str, str], None] | None = None,
         skill_runner: SkillRunner | None = None,
         skill_file_bindings: SkillFileBindings | None = None,
         review_tool_calls: Callable[[list[ToolCall]], dict[str, str]] | None = None,
@@ -1377,7 +1377,7 @@ class AgentService:
             should_cancel=should_cancel,
             clock=self.clock,
             on_step=(
-                (lambda s: self._on_step(s, agent_kind))
+                (lambda s: self._on_step(s, agent_kind, run_id))
                 if self._on_step is not None
                 else (lambda s: None)
             ),

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -510,7 +510,8 @@ class AgentService:
         config: AgentConfig,
         disclosed_names: set,
         should_cancel: Callable[[], bool] = lambda: False,
-        run_id: str = "",
+        *,
+        run_id: str,
     ):
         """Build this run's ``LoopDeps.invoke_tool``.
 
@@ -524,9 +525,14 @@ class AgentService:
                 INSIDE the callable handed to ``_call_with_timeout``, so
                 it is established on the per-call daemon thread that
                 actually runs the tool -- a ``ContextVar`` set on this
-                thread would not be visible there. ``""`` (the default)
-                binds the no-run key, matching the pre-Task-5 behavior
-                for a service built without a run.
+                thread would not be visible there.
+
+                Keyword-REQUIRED, with no default, deliberately: a
+                defaulted ``""`` would turn a future caller that forgets
+                it (PR2a Task 6 adds dispatch paths) into a SILENT
+                fail-closed degradation -- every approved tool refused
+                for want of a stamp it can no longer find -- instead of
+                a loud ``TypeError`` at the call site.
         """
 
         def invoke_tool(call: ToolCall) -> ToolResult:
@@ -896,7 +902,7 @@ class AgentService:
         # sub_agent_spawns counter -- see Finding 2 above), cancellable, and
         # DB-lineage-tracked exactly like a spawn_subagent call.
         builtin_invoke_tool = self._make_invoke_tool(
-            config, disclosed_names, should_cancel, run_id
+            config, disclosed_names, should_cancel, run_id=run_id
         )
 
         def invoke_tool(call: ToolCall) -> ToolResult:

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -1444,6 +1444,40 @@ class AgentService:
                         result=result_text,
                         error=error_text,
                     )
+                    # Review fix (PR2a final review): `_persist` -- called
+                    # from INSIDE `_run_one`'s own try/except -- is
+                    # normally the only thing that writes this child's
+                    # terminal DB status. But `_run_one`'s try/except
+                    # wraps ONLY the `run_agent_loop(...)` call; an
+                    # exception raised between `create_run()` and that
+                    # try block (e.g. `initial_disclosure` recursing into
+                    # the tool catalog's RLock and raising RecursionError)
+                    # unwinds `_run_one` entirely, past `_persist`, and
+                    # lands in the `except BaseException` above instead --
+                    # leaving the DB row `running` for the life of the
+                    # process, violating "DB is truth" (spec Sec 3
+                    # invariant 3). `attach_run` has already fired by the
+                    # time any post-`create_run` exception can, so
+                    # `fleet.get()` (re-fetched, not the possibly-stale
+                    # `handle` closed over above) reliably has the run id.
+                    # `set_status` is first-writer-wins (AgentRunsDB), so
+                    # this call is a safe no-op on the normal path where
+                    # `_persist` already wrote a terminal status -- it
+                    # only matters on the setup-phase-exception path,
+                    # where it is the only writer. Same defensive shape as
+                    # `_settle_fleet`'s abandonment path: a DB failure
+                    # here must not take down a turn that has already
+                    # produced its answer.
+                    current = fleet.get(handle.handle_id)
+                    child_run_id = current.run_id if current is not None else None
+                    if child_run_id:
+                        try:
+                            self.db.set_status(child_run_id, status)
+                        except Exception:  # noqa: BLE001
+                            logger.opt(exception=True).warning(
+                                "could not persist terminal status for "
+                                f"sub-agent run {child_run_id}"
+                            )
 
             thread = threading.Thread(
                 target=run_child,

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -94,12 +94,21 @@ SUBAGENT_SYSTEM_PROMPT = CATALOG["agents.subagent_system"].default
 TRUNCATION_NOTICE = "\n[truncated]"
 
 #: ``[agents]`` key sizing the fleet: how many sub-agents of one turn may
-#: be live at once. **1 (the default) means the fleet is OFF** and every
-#: spawn runs the child INLINE, synchronously, exactly as it did before
-#: PR2a -- see `AgentService.__init__`'s `fleet_coordinator` for why the
-#: switch is here and not at the coordinator's cap.
+#: be live at once. **A value of 1 means the fleet is OFF** and every spawn
+#: runs the child INLINE, synchronously, exactly as it did before PR2a --
+#: see `AgentService.__init__`'s `fleet_coordinator` for why the switch is
+#: here and not at the coordinator's cap.
+#:
+#: PR2a Task 6.5 raised the DEFAULT from 1 to 3, turning the fleet ON for
+#: every user who has not opted out. Task 6 shipped the runtime dark at 1
+#: so the conversion of the ordered spawn suites could land as its own
+#: reviewable change; at 1 the feature was unreachable in production and
+#: its live verification unperformable. Setting `[agents]
+#: max_live_subagents = 1` restores the pre-PR2a inline path exactly --
+#: that is the supported kill switch, and it stays guarded by the
+#: `max_live=1` / config-of-one tests in `Tests/Agents/test_fleet_runtime`.
 MAX_LIVE_SUBAGENTS_KEY = "max_live_subagents"
-DEFAULT_MAX_LIVE_SUBAGENTS = 1
+DEFAULT_MAX_LIVE_SUBAGENTS = 3
 #: How long a poll loop sleeps between coordinator checks. Small enough
 #: that a cancelled run is not held up perceptibly, large enough not to
 #: spin a core while several children work.
@@ -457,10 +466,11 @@ class AgentService:
         # lifecycle (same convention as `_injected_run_log_writer`).
         # `None` -- every caller before this task, and the Console bridge
         # today -- makes `run_turn` size a fresh coordinator per turn from
-        # `[agents] max_live_subagents`, and **a cap of 1 (the shipped
-        # default) means no fleet at all**: `spawn` keeps running the
-        # child inline, synchronously, and neither wait_agents nor
-        # check_agents is offered.
+        # `[agents] max_live_subagents`, and **a cap of 1 means no fleet at
+        # all**: `spawn` keeps running the child inline, synchronously, and
+        # neither wait_agents nor check_agents is offered. Since Task 6.5
+        # the shipped DEFAULT is 3, so the Console gets a fleet unless the
+        # user opts out with that cap of 1.
         #
         # Why the switch is "is there a fleet" rather than "how big is
         # it": a non-blocking spawn is only coherent for a supervisor
@@ -469,8 +479,7 @@ class AgentService:
         # from spawn but no way to redeem it would simply lose its
         # children's work. Sizing the fleet at 1 therefore means "one
         # child at a time, inline" -- observably identical to pre-PR2a
-        # behaviour, which is this PR's stated acceptance criterion and
-        # what keeps the pre-existing spawn suites passing unmodified.
+        # behaviour, which is exactly what makes it a usable kill switch.
         self._injected_fleet_coordinator = fleet_coordinator
         # PR2a Task 7 -- the cancellation half of the approval gate.
         #
@@ -2320,8 +2329,9 @@ class AgentService:
         # honored as-is (the injector owns its lifecycle, and its presence
         # is itself the opt-in); otherwise the size comes from
         # `[agents] max_live_subagents`, read through the same `_setting`
-        # helper the run-log knobs use, and a size of 1 -- the shipped
-        # default -- means NO fleet: spawn keeps running children inline.
+        # helper the run-log knobs use, and a size of 1 -- the opt-out,
+        # since Task 6.5 made the default 3 -- means NO fleet: spawn keeps
+        # running children inline.
         self._fleet_threads = []
         self._fleet_cancels = {}
         if self._injected_fleet_coordinator is not None:

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -125,11 +125,27 @@ def _coerce_max_live_subagents(value) -> int:
         The configured cap, floored at 1 (which disables the fleet).
         Unparseable values fall back to the default rather than raising:
         a malformed config key must never stop an agent run.
+
+        A float is accepted and truncated (``3.0`` -> ``3``). TOML has no
+        way to distinguish "3" from "3.0" once a user writes the latter,
+        and an int-only parse would silently fall back to 1 -- turning a
+        perfectly reasonable ``max_live_subagents = 3.0`` into a switched
+        OFF fleet, which is exactly the kind of quiet downgrade nobody
+        would think to look for.
     """
+    text = str(value).strip()
     try:
-        parsed = int(str(value).strip())
+        parsed = int(text)
     except (TypeError, ValueError):
-        return DEFAULT_MAX_LIVE_SUBAGENTS
+        try:
+            parsed = int(float(text))
+        except (TypeError, ValueError, OverflowError):
+            # OverflowError: float("inf") parses but does not convert.
+            logger.warning(
+                f"[agents] {MAX_LIVE_SUBAGENTS_KEY}={value!r} is not a "
+                f"number; using {DEFAULT_MAX_LIVE_SUBAGENTS}"
+            )
+            return DEFAULT_MAX_LIVE_SUBAGENTS
     return max(parsed, 1)
 
 # Task 7: appended to config.system_prompt only when THIS run wired the
@@ -1325,8 +1341,41 @@ class AgentService:
                 name=f"fleet-{handle.handle_id[:8]}",
                 daemon=True,
             )
+            try:
+                thread.start()
+            except Exception as exc:  # noqa: BLE001 — thread exhaustion
+                # `Thread.start()` raises RuntimeError ("can't start new
+                # thread") when the process is out of thread slots. Every
+                # piece of state this spawn reserved has to be unwound
+                # here, because NOTHING else will: `run_child` never runs,
+                # so the handle would stay live forever -- making the
+                # end-of-turn settle burn the ENTIRE remaining wall-clock
+                # waiting for a child that does not exist. Registering the
+                # thread only AFTER a successful start is the other half:
+                # `_settle_fleet` joins every registered thread, and
+                # joining an unstarted one raises RuntimeError out of
+                # `run_turn`, skipping `write_manifest()` and
+                # `run_log_writer.close()` (leaking a file descriptor).
+                fleet.finish(
+                    handle.handle_id,
+                    RUN_ERROR,
+                    error=f"could not start sub-agent thread: {exc}",
+                )
+                self._fleet_cancels.pop(handle.handle_id, None)
+                if my_handle_ids and my_handle_ids[-1] == handle.handle_id:
+                    my_handle_ids.pop()
+                # No child was created, so this spawn costs no slot --
+                # same rule as the cap refusal above.
+                sub_agent_spawns -= 1
+                logger.opt(exception=True).warning(
+                    f"could not start sub-agent thread for handle "
+                    f"{handle.handle_id}"
+                )
+                return ToolResult(
+                    ok=False,
+                    error=f"could not start sub-agent: {exc}",
+                )
             self._fleet_threads.append(thread)
-            thread.start()
             snippet = spawn_task[:_SPAWN_ECHO_CHARS]
             return ToolResult(
                 ok=True,
@@ -2199,7 +2248,18 @@ class AgentService:
         # written and the writer closed below -- a child still running
         # would otherwise be appending records to a closed writer, and its
         # own run row would still read `running` after this call returns.
-        self._settle_fleet(config, should_cancel, turn_started)
+        try:
+            self._settle_fleet(config, should_cancel, turn_started)
+        except Exception:  # noqa: BLE001 — the answer is already produced
+            # Defence in depth for the class of bug the `thread.start()`
+            # guard above fixes one instance of: whatever goes wrong while
+            # settling children, it must not cost this turn its manifest or
+            # leak the run-log writer's file descriptor. The two calls
+            # below are the run tree's only cleanup.
+            logger.opt(exception=True).error(
+                "settling sub-agents at end of turn failed; finalizing the "
+                "run anyway"
+            )
         # Manifest needs run-level metadata the writer itself does not have
         # (including supersession), so it is written once the whole run
         # tree finishes, here rather than inside _run_one.

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -360,6 +360,7 @@ class AgentService:
         | None = None,
         run_log_writer: "RunLogWriter | None" = None,
         fleet_coordinator: FleetCoordinator | None = None,
+        revoke_approvals: Callable[[str], None] | None = None,
     ) -> None:
         self.db = db
         self.registry = registry
@@ -467,6 +468,19 @@ class AgentService:
         # behaviour, which is this PR's stated acceptance criterion and
         # what keeps the pre-existing spawn suites passing unmodified.
         self._injected_fleet_coordinator = fleet_coordinator
+        # PR2a Task 7 -- the cancellation half of the approval gate.
+        #
+        # An optional seam (same injected-callable convention as
+        # `review_tool_calls`/`on_step`) called with the run id of every
+        # child this service cancels or abandons, so whatever surface is
+        # holding that child's pending approval card can take it down and
+        # fail it closed. The Console bridge wires `ConsoleChatController.
+        # revoke_approval_rounds_for_run`; `None` -- every caller before
+        # this task, and every headless/test caller -- simply means no
+        # cards exist to revoke, so cancellation behaves exactly as
+        # before. Never load-bearing for the run itself: a raise here is
+        # logged and swallowed (see `_revoke_run_approvals`).
+        self._revoke_approvals = revoke_approvals
         # Per-TURN fleet state, all owned by the primary run's thread (a
         # child never spawns -- clamp_child_budget zeroes max_subagents),
         # so no lock is needed on these three. Reset at the top of every
@@ -597,6 +611,44 @@ class AgentService:
 
         return call_model
 
+    def _review_calls_for_run(self, calls: list[ToolCall], run_id: str) -> dict:
+        """Run the injected review hook with THIS run bound as the context.
+
+        PR2a Task 5 hands the hook its ``run_id`` as a parameter, which is
+        all the hook itself needs to scope its gate writes. Task 7 adds
+        the second consumer: the approval bridge the hook calls (Console's
+        ``request_mcp_approvals``) has to record which run armed each
+        card, so a cancelled child's card can be revoked without touching
+        its live siblings' -- and it is reached through a callable whose
+        signature the hook builders do not control (a bound
+        ``functools.partial``, also used as ``MCPToolProvider``'s
+        single-call ``approval_callback``, which has no run id to pass at
+        all). Binding the SAME ``run_context`` ContextVar that
+        ``_make_invoke_tool`` already binds around tool execution covers
+        both arming paths through one mechanism, with no signature churn.
+
+        The binding is per-call and reset in ``use_run_id``'s own
+        ``finally``: the hook is called synchronously from
+        ``run_agent_loop``, on this run's own thread, so a concurrent
+        sibling on its own thread simply sets its own value and a nested
+        inline child unwinds LIFO.
+
+        Args:
+            calls: This turn's batch of tool calls, as the runtime parsed
+                them.
+            run_id: THIS run's id.
+
+        Returns:
+            The hook's verdict map, unchanged; ``{}`` (every call
+            proceeds, the runtime's own no-hook default) if the hook was
+            cleared after this closure was built.
+        """
+        hook = self.review_tool_calls
+        if hook is None:  # pragma: no cover -- guarded at the call site
+            return {}
+        with use_run_id(run_id):
+            return hook(calls, run_id)
+
     def _make_invoke_tool(
         self,
         config: AgentConfig,
@@ -691,6 +743,51 @@ class AgentService:
             event = self._fleet_cancels.get(handle_id)
             if event is not None:
                 event.set()
+        # PR2a Task 7: the cancel Event alone does not reach a child that
+        # is BLOCKED on a human approval -- that wait sits on the child's
+        # own per-call daemon thread with a card still on screen, and the
+        # user could approve it (executing the tool for real) long after
+        # this cancel. Revoking here both fails those cards closed and
+        # releases the wait immediately, which is also what lets the join
+        # below succeed instead of abandoning. Cancel first, revoke
+        # second: the child then sees the cancellation at the very next
+        # checkpoint rather than burning a model turn on the denials.
+        self._revoke_handle_approvals(handle_ids)
+
+    def _revoke_handle_approvals(self, handle_ids: list[str]) -> None:
+        """Revoke any pending approval card belonging to these children.
+
+        Args:
+            handle_ids: Handles whose runs are being stopped. A handle
+                with no run id yet (spawned, but not past ``create_run``)
+                cannot have armed a card, so it is skipped.
+        """
+        fleet = self._fleet
+        if self._revoke_approvals is None or fleet is None:
+            return
+        for handle_id in handle_ids:
+            handle = fleet.get(handle_id)
+            run_id = getattr(handle, "run_id", None) if handle is not None else None
+            if run_id:
+                self._revoke_run_approvals(run_id)
+
+    def _revoke_run_approvals(self, run_id: str) -> None:
+        """Fail this run's outstanding approval cards closed. Never raises.
+
+        Args:
+            run_id: The cancelled/abandoned run.
+        """
+        revoke = self._revoke_approvals
+        if revoke is None or not run_id:
+            return
+        try:
+            revoke(run_id)
+        except Exception:  # noqa: BLE001 — a UI-side failure must not take
+            # down the cancellation path; the card's own approval timeout
+            # remains the backstop.
+            logger.opt(exception=True).warning(
+                f"could not revoke pending approvals for run {run_id}"
+            )
 
     def _drain_fleet_handles(
         self, fleet: FleetCoordinator, handle_ids: list[str]
@@ -852,6 +949,14 @@ class AgentService:
             )
             if not handle.run_id:
                 continue
+            # PR2a Task 7: an abandoned child's thread is still alive and
+            # still holds whatever it was blocked on. If that is a human
+            # approval, the card is STILL on screen for a run that now
+            # reads `cancelled` -- revoke it again here (the cancel pass
+            # above already tried, but a card can be armed in the window
+            # between the two, and this is the last moment anyone looks
+            # at this child).
+            self._revoke_run_approvals(handle.run_id)
             try:
                 self.db.set_status(handle.run_id, RUN_CANCELLED)
             except Exception:  # noqa: BLE001 — a DB failure here must not
@@ -2060,7 +2165,7 @@ class AgentService:
             # identity, is what supplies it -- so the review hook can stamp
             # its verdicts against the run that will consume them.
             review_tool_calls=(
-                (lambda calls: self.review_tool_calls(calls, run_id))
+                (lambda calls: self._review_calls_for_run(calls, run_id))
                 if self.review_tool_calls is not None
                 else None
             ),

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -360,7 +360,11 @@ class AgentService:
         | None = None,
         run_log_writer: "RunLogWriter | None" = None,
         fleet_coordinator: FleetCoordinator | None = None,
-        revoke_approvals: Callable[[str], None] | None = None,
+        # `-> object`, not `-> None`: the Console's implementation returns
+        # the number of rounds it revoked (which this service ignores), and
+        # a `Callable[[str], None]` annotation would make that a type error
+        # at the wiring site.
+        revoke_approvals: Callable[[str], object] | None = None,
     ) -> None:
         self.db = db
         self.registry = registry
@@ -610,44 +614,6 @@ class AgentService:
             )
 
         return call_model
-
-    def _review_calls_for_run(self, calls: list[ToolCall], run_id: str) -> dict:
-        """Run the injected review hook with THIS run bound as the context.
-
-        PR2a Task 5 hands the hook its ``run_id`` as a parameter, which is
-        all the hook itself needs to scope its gate writes. Task 7 adds
-        the second consumer: the approval bridge the hook calls (Console's
-        ``request_mcp_approvals``) has to record which run armed each
-        card, so a cancelled child's card can be revoked without touching
-        its live siblings' -- and it is reached through a callable whose
-        signature the hook builders do not control (a bound
-        ``functools.partial``, also used as ``MCPToolProvider``'s
-        single-call ``approval_callback``, which has no run id to pass at
-        all). Binding the SAME ``run_context`` ContextVar that
-        ``_make_invoke_tool`` already binds around tool execution covers
-        both arming paths through one mechanism, with no signature churn.
-
-        The binding is per-call and reset in ``use_run_id``'s own
-        ``finally``: the hook is called synchronously from
-        ``run_agent_loop``, on this run's own thread, so a concurrent
-        sibling on its own thread simply sets its own value and a nested
-        inline child unwinds LIFO.
-
-        Args:
-            calls: This turn's batch of tool calls, as the runtime parsed
-                them.
-            run_id: THIS run's id.
-
-        Returns:
-            The hook's verdict map, unchanged; ``{}`` (every call
-            proceeds, the runtime's own no-hook default) if the hook was
-            cleared after this closure was built.
-        """
-        hook = self.review_tool_calls
-        if hook is None:  # pragma: no cover -- guarded at the call site
-            return {}
-        with use_run_id(run_id):
-            return hook(calls, run_id)
 
     def _make_invoke_tool(
         self,
@@ -2164,8 +2130,12 @@ class AgentService:
             # ignorant of run ids); the service, which owns the run
             # identity, is what supplies it -- so the review hook can stamp
             # its verdicts against the run that will consume them.
+            # (PR2a Task 7 binds this run's id as the `run_context` for the
+            # whole loop below, so the approval bridge this hook calls can
+            # record which run armed each card -- see the `use_run_id`
+            # wrapper on `run_agent_loop`.)
             review_tool_calls=(
-                (lambda calls: self._review_calls_for_run(calls, run_id))
+                (lambda calls: self.review_tool_calls(calls, run_id))
                 if self.review_tool_calls is not None
                 else None
             ),
@@ -2210,7 +2180,36 @@ class AgentService:
             on_record=on_record,
         )
         try:
-            outcome = run_agent_loop(config, messages, active, deps)
+            # PR2a Task 7: bind THIS run as the dispatching run for the
+            # whole loop, on the loop's own thread.
+            #
+            # `_make_invoke_tool` already binds it around each provider
+            # tool call, but that binding is established on the per-call
+            # daemon thread and covers only what runs there. Two things
+            # that arm HUMAN APPROVAL CARDS run here, on the loop thread,
+            # instead:
+            #
+            #   1. `review_tool_calls` -- one batch-approval round trip
+            #      per turn (`ConsoleChatController.request_mcp_approvals`).
+            #   2. The in-loop runtime tools, of which `run_skill_script`
+            #      raises a confirm card of its own (see agent_runtime's
+            #      RUN_SKILL_SCRIPT dispatch: called straight from the
+            #      loop, never through `invoke_tool`).
+            #
+            # Both bridges record `current_run_id()` at arm time so a
+            # cancelled child's card can be revoked without touching a
+            # live sibling's -- and neither can be handed the id as a
+            # parameter (the approval bridge is a pre-bound partial shared
+            # with `MCPToolProvider.approval_callback`; the runtime-tool
+            # closures are built by the bridge, one layer below any run
+            # identity). One binding here covers both, and every future
+            # loop-thread consumer, with no signature churn.
+            #
+            # Nested inline sub-agent runs unwind LIFO (`use_run_id`
+            # resets in its own `finally`), and a threaded child simply
+            # sets its own value on its own thread.
+            with use_run_id(run_id):
+                outcome = run_agent_loop(config, messages, active, deps)
         except Exception as exc:  # noqa: BLE001 — a run never raises out
             from tldw_chatbook.Chat.provider_failures import describe_stream_failure
 

--- a/tldw_chatbook/Agents/builtin_tool_gate.py
+++ b/tldw_chatbook/Agents/builtin_tool_gate.py
@@ -10,6 +10,7 @@ See ``Docs/superpowers/specs/2026-07-25-builtin-tool-permission-gate-design.md``
 from __future__ import annotations
 
 import contextlib
+import threading
 
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -54,70 +55,149 @@ def tool_ref(tool: Tool) -> GatedToolRef:
 class BuiltinToolGate:
     """Resolves and enforces allow/ask/deny for built-in tools.
 
-    One instance per run. ``begin_turn()`` clears the previous turn's
-    stamps and cached payload; ``resolve()`` reports a state (used by the
-    review hook to build the approval card); ``check()`` is the
+    One instance per RUN TREE -- the console bridge builds one per user
+    turn and shares it with every sub-agent that turn spawns.
+    ``begin_turn(run_id)`` clears that ONE run's stamps and invalidates the
+    cached payload; ``resolve()`` reports a state (used by the review hook
+    to build the approval card); ``check(tool, run_id)`` is the
     execution-time verdict used by ``BuiltinToolProvider.invoke``.
+
+    Per-run keying (PR2a Task 5): stamps live in one dict keyed
+    ``(run_id, tool_name)``. Before this, they were keyed by tool name
+    alone and ``begin_turn()`` cleared the dict wholesale, so a sub-agent
+    starting its own turn wiped verdicts the parent (or, once children run
+    concurrently, a sibling) had already been granted and not yet
+    consumed -- with no per-call approval fallback to degrade to, that
+    fails an approved call CLOSED. ``stamp_scope`` used to be the only
+    protection; it is a snapshot/restore, which is sound only for a
+    strictly nested (LIFO) inline child. Per-run keying is what makes N
+    concurrent children safe.
     """
 
     def __init__(self, service: Any | None) -> None:
         self._service = service
+        # CONFIG, not per-run state: the permission-store payload is the
+        # same for every run in the tree (one file, one profile), so it
+        # stays a single shared cache rather than being keyed by run id.
+        # `begin_turn` still drops it -- that is a cache INVALIDATION, and
+        # the worst a concurrent child's invalidation can cost a sibling
+        # is one extra `store.load()`, never a wrong answer.
         self._payload: dict | None = None
-        self._stamps: dict[str, str] = {}
+        self._stamps: dict[tuple[str, str], str] = {}
+        # RLock, not Lock. To be precise about why, since a plain Lock
+        # would work today: NOTHING here currently re-enters the lock --
+        # `check()` deliberately does not hold it across `resolve()`,
+        # `stamped()`, or its service reads. But those public methods DO
+        # compose (`check` -> `resolve` -> `_load_payload`, `check` ->
+        # `stamped`), so a plain Lock would turn any later edit that
+        # widens one of them into a silent self-deadlock instead of a
+        # visible bug, for a saving of one owner check per acquire.
+        #
+        # The invariant that actually matters, and must be preserved: no
+        # critical section holds this lock across a call into
+        # `self._service` -- `stamp`'s session approval and `check`'s
+        # kill-switch/session reads are all made OUTSIDE it. The single
+        # deliberate exception is `_load_payload`'s `store.load()`, held
+        # so N concurrent children cannot stampede the permission store;
+        # that store never calls back into this gate.
+        self._lock = threading.RLock()
 
-    def begin_turn(self) -> None:
-        """Drop this run's cached payload and the previous turn's stamps.
+    def begin_turn(self, run_id: str) -> None:
+        """Drop ``run_id``'s stamps and invalidate the cached payload.
 
         Clearing stamps at turn start (not after a round trip) means a
         raising approval path can never leave a stale prior-turn stamp
         live for the next turn to consume -- the same discipline
         ``build_mcp_review_hook`` applies to its own stamps.
+
+        Only ``run_id``'s own stamps are dropped. A sibling or parent run
+        sharing this instance keeps whatever its user already decided:
+        that is the whole point of keying by run.
+
+        Args:
+            run_id: The run whose turn is starting.
         """
-        self._payload = None
-        self._stamps.clear()
+        with self._lock:
+            self._payload = None
+            self._stamps = {
+                key: value
+                for key, value in self._stamps.items()
+                if key[0] != run_id
+            }
 
     @contextlib.contextmanager
-    def stamp_scope(self) -> Iterator[None]:
-        """Snapshot this turn's stamps on enter; RESTORE (not merge) on exit.
+    def stamp_scope(self, run_id: str) -> Iterator[None]:
+        """Snapshot ``run_id``'s stamps on enter; RESTORE (not merge) on exit.
 
-        task-628. Wired as part of ``AgentService``'s ``review_state_scope``
-        so it wraps every NESTED sub-agent run, mirroring
-        ``MCPToolProvider.stamp_scope``.
+        task-628, re-scoped by PR2a Task 5. Wired as part of
+        ``AgentService``'s ``review_state_scope`` so it wraps every NESTED
+        sub-agent run, mirroring ``MCPToolProvider.stamp_scope``.
 
-        ``spawn_subagent`` runs the child's entire loop INLINE and
-        synchronously on the parent's own call stack, before the parent's
-        remaining same-batch tool calls are dispatched, and the child
-        invokes the SAME shared review hook — whose first act is
-        ``begin_turn()``, which clears ``_stamps``. Without this scope a
-        child wipes the verdicts the parent's user just gave for this turn.
+        **Per-run keying is now the real mechanism.** A child's
+        ``begin_turn(child_run_id)`` no longer touches the parent's
+        stamps at all, so the clobber this scope was introduced to prevent
+        cannot happen even with the scope unwired. This remains for the
+        nested/inline path as belt-and-braces -- it guarantees the
+        parent's slice is byte-identical after a nested run regardless of
+        what that run did -- and because the seam is public: other
+        providers implement ``stamp_scope`` and
+        ``console_agent_bridge._combine_state_scopes`` composes three of
+        them into the one ``review_state_scope`` the service holds.
 
-        That is worse for built-ins than the MCP case it mirrors: MCP's
-        ``invoke`` has a per-call ``_approval_callback`` fallback, so a lost
-        stamp merely re-prompts. ``BuiltinToolGate.check`` has no such
-        fallback — its only approval sources are ``_stamps`` (set solely by
-        the batch review hook) and a live session approval — so a clobbered
-        stamp fails CLOSED outright, making an approved tool unusable from
-        inside any sub-agent.
+        Unlike the pre-Task-5 version this does NOT restore ``_payload``.
+        That is a shared config cache, not per-run state; restoring a
+        snapshot of it could resurrect a payload a CONCURRENT sibling's
+        ``begin_turn`` had deliberately invalidated, and the only cost of
+        leaving it invalidated is one extra permission-store load.
 
-        ``_payload`` is restored too: it is a per-turn cache the child's
-        ``begin_turn()`` also drops, and restoring it keeps the parent's
-        "one permission-store load per turn" property intact.
+        Args:
+            run_id: The run whose slice is snapshotted and restored --
+                normally the PARENT's, since it is the parent's already
+                decided verdicts a nested run must not disturb.
 
         Yields:
-            None. On exit the parent's stamps and cached payload are put
-            back exactly as they were, discarding whatever the nested run
-            recorded — a restore, never a merge.
+            None. On exit ``run_id``'s stamps are put back exactly as they
+            were, discarding whatever the nested run recorded against that
+            same run id -- a restore, never a merge. Other runs' slices
+            are untouched in both directions.
         """
-        stamps = dict(self._stamps)
-        payload = self._payload
+        with self._lock:
+            snapshot = {
+                key: value
+                for key, value in self._stamps.items()
+                if key[0] == run_id
+            }
         try:
             yield
         finally:
-            self._stamps = stamps
-            self._payload = payload
+            with self._lock:
+                self._stamps = {
+                    key: value
+                    for key, value in self._stamps.items()
+                    if key[0] != run_id
+                }
+                self._stamps.update(snapshot)
 
-    def stamp(self, tool_name: str, decision: str) -> None:
-        """Record this turn's decision for ``tool_name``.
+    def stamped(self, run_id: str, tool_name: str) -> str | None:
+        """Peek at ``run_id``'s stamped decision for ``tool_name``, if any.
+
+        Non-destructive: several calls to the same tool within one turn
+        must all observe the same verdict, so reading never removes it --
+        only ``begin_turn`` clears (mirrors
+        ``MCPToolProvider.stamped_decision``'s Finding F1 contract).
+
+        Args:
+            run_id: The run whose verdict is being read.
+            tool_name: The built-in tool's LLM-facing name.
+
+        Returns:
+            The decision string this run stamped this turn, or ``None``.
+        """
+        with self._lock:
+            return self._stamps.get((run_id, tool_name))
+
+    def stamp(self, run_id: str, tool_name: str, decision: str) -> None:
+        """Record ``run_id``'s decision for ``tool_name`` this turn.
 
         ``"always_allow"`` is accepted as a permitting stamp for THIS
         call only -- Constraint 3 (P1 is session-scoped only) means it is
@@ -125,8 +205,18 @@ class BuiltinToolGate:
         card does not offer that option in the first place, but the gate
         does not trust the caller to have enforced that and simply never
         makes the call that would write it.
+
+        Args:
+            run_id: The run this decision belongs to. A stamp is only ever
+                visible to that run's own ``check()``.
+            tool_name: The built-in tool's LLM-facing name.
+            decision: The verdict string from the approval card.
         """
-        self._stamps[tool_name] = decision
+        with self._lock:
+            self._stamps[(run_id, tool_name)] = decision
+        # Outside the lock on purpose: a session approval calls into the
+        # control-plane service, and no gate lock is ever held across a
+        # call into foreign code.
         if decision == "approve_session" and self._service is not None:
             approve = getattr(self._service, "approve_for_session", None)
             if approve is not None:
@@ -147,18 +237,25 @@ class BuiltinToolGate:
         # `unified_control_plane_service.py`'s `effective_tool_states`,
         # `gate_tool_test`, etc., which all follow this same
         # `store = self.permission_store; ...; store.load()` shape).
-        if self._payload is None:
-            self._payload = {}
-            if self._service is not None:
-                try:
-                    store = getattr(self._service, "permission_store", None)
-                    if store is not None:
-                        loaded = store.load()
-                        if isinstance(loaded, dict):
-                            self._payload = loaded
-                except Exception as exc:  # noqa: BLE001 — fail to the floor
-                    logger.warning(f"builtin permission load failed: {exc}")
-        return self._payload
+        #
+        # Held under `self._lock` for the whole check-then-fill so N
+        # concurrent children cannot each miss the cache and stampede the
+        # store; the lock is reentrant, so a caller already holding it is
+        # fine. `store.load()` is a local file read that never calls back
+        # into this gate.
+        with self._lock:
+            if self._payload is None:
+                self._payload = {}
+                if self._service is not None:
+                    try:
+                        store = getattr(self._service, "permission_store", None)
+                        if store is not None:
+                            loaded = store.load()
+                            if isinstance(loaded, dict):
+                                self._payload = loaded
+                    except Exception as exc:  # noqa: BLE001 — fail to the floor
+                        logger.warning(f"builtin permission load failed: {exc}")
+            return self._payload
 
     def resolve(self, tool: Tool) -> EffectiveToolState:
         """Resolve ``tool``'s effective state (no stamps, no kill switch)."""
@@ -209,8 +306,20 @@ class BuiltinToolGate:
         """
         return self._session_approved(tool_name)
 
-    def check(self, tool: Tool) -> str | None:
-        """Execution-time verdict.
+    def check(self, tool: Tool, run_id: str) -> str | None:
+        """Execution-time verdict for ``run_id``'s call to ``tool``.
+
+        Args:
+            tool: The built-in tool about to execute.
+            run_id: The run dispatching this call -- the ONLY run whose
+                stamps may permit it. ``BuiltinToolProvider.invoke``
+                supplies this from ``run_context.current_run_id()`` (the
+                ``ToolProvider.invoke`` Protocol has no run parameter to
+                thread it through; see that module's docstring). ``""``
+                means "no agent run bound one", which matches no stamp any
+                review hook ever writes -- such a call falls through to
+                the resolved state exactly as it did before per-run
+                keying.
 
         Returns:
             ``None`` when the call may proceed, else a human-readable
@@ -239,7 +348,7 @@ class BuiltinToolGate:
         if state.state == "deny":
             return f"tool is set to Off: {tool.name}"
 
-        stamp = self._stamps.get(tool.name)
+        stamp = self.stamped(run_id, tool.name)
         if stamp == "deny":
             return f"tool call denied by the user: {tool.name}"
         if stamp in _PERMITTING:

--- a/tldw_chatbook/Agents/fleet_coordinator.py
+++ b/tldw_chatbook/Agents/fleet_coordinator.py
@@ -96,7 +96,15 @@ class FleetCoordinator:
             agent: Agent name, if applicable.
 
         Returns:
-            A new FleetHandle if a slot is available, else None.
+            A copy of the new FleetHandle if a slot is available, else
+            None. A copy -- not the live, internally-stored object -- for
+            the same reason `get()`/`snapshot()` return copies: it stops
+            a caller from racing a concurrent `finish()`/`attach_run()`
+            by reading a mutating object instead of a point-in-time
+            snapshot. Every current consumer reads only the immutable
+            `.handle_id` off the returned handle, or re-fetches a fresh
+            copy via `get()` when it needs live state (e.g. `run_id`
+            attached later) -- so this is safe.
         """
         with self._lock:
             if len(self._live_ids) >= self._max_live:
@@ -126,7 +134,7 @@ class FleetCoordinator:
                     status="running",
                 )
             )
-            return handle
+            return dataclasses.replace(handle)
 
     def attach_run(self, handle_id: str, run_id: str) -> None:
         """Attach a run ID to an existing handle.

--- a/tldw_chatbook/Agents/fleet_coordinator.py
+++ b/tldw_chatbook/Agents/fleet_coordinator.py
@@ -2,7 +2,7 @@
 
 No DB, Textual, app, or I/O imports — stdlib only (threading, dataclasses, uuid,
 typing) plus agent_models constants. The impure thread-launching lives in
-agent_service. Thread-safe: every public method holds an RLock.
+agent_service. Thread-safe: every public method holds a Lock.
 """
 
 from __future__ import annotations
@@ -81,7 +81,7 @@ class FleetCoordinator:
         """
         self._max_live = max_live
         self._clock = clock
-        self._lock = threading.RLock()
+        self._lock = threading.Lock()  # No reentrant calls, lock to catch bugs
         self._handles: dict[str, FleetHandle] = {}
         self._live_ids: set[str] = set()  # handle_ids with status != terminal
         self._events: list[FleetEvent] = []
@@ -136,7 +136,7 @@ class FleetCoordinator:
             run_id: The run ID to attach.
         """
         with self._lock:
-            if handle_id in self._handles:
+            if handle_id in self._handles and handle_id in self._live_ids:
                 self._handles[handle_id].run_id = run_id
 
     def finish(
@@ -160,11 +160,15 @@ class FleetCoordinator:
             if handle_id not in self._handles:
                 return
 
-            handle = self._handles[handle_id]
-
-            # First-writer-wins: ignore if already terminal
-            if handle.status in TERMINAL_RUN_STATUSES:
+            # First-writer-wins: ignore if handle is no longer live.
+            # This check is based on liveness, not status vocabulary, so it
+            # protects against any status (e.g., "timeout") that a Task 6
+            # abandonment handler might use, not just the closed set in
+            # TERMINAL_RUN_STATUSES.
+            if handle_id not in self._live_ids:
                 return
+
+            handle = self._handles[handle_id]
 
             # Transition to terminal
             finished_at = self._clock()

--- a/tldw_chatbook/Agents/fleet_coordinator.py
+++ b/tldw_chatbook/Agents/fleet_coordinator.py
@@ -1,0 +1,244 @@
+"""Pure state machine for concurrent sub-agent handles.
+
+No DB, Textual, app, or I/O imports — stdlib only (threading, dataclasses, uuid,
+typing) plus agent_models constants. The impure thread-launching lives in
+agent_service. Thread-safe: every public method holds an RLock.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import threading
+import uuid
+from typing import Callable
+
+from tldw_chatbook.Agents.agent_models import TERMINAL_RUN_STATUSES
+
+FLEET_STARTED = "fleet_started"
+FLEET_FINISHED = "fleet_finished"
+
+
+@dataclasses.dataclass(frozen=True)
+class FleetEvent:
+    """Event emitted by FleetCoordinator on handle state changes.
+
+    Attributes:
+        kind: Event type (FLEET_STARTED or FLEET_FINISHED).
+        handle_id: The handle this event concerns.
+        run_id: The run_id attached to the handle, if any.
+        agent: The agent name attached to the handle, if any.
+        status: The status of the handle at event time.
+    """
+
+    kind: str
+    handle_id: str
+    run_id: str | None
+    agent: str | None
+    status: str
+
+
+@dataclasses.dataclass
+class FleetHandle:
+    """Track state and metadata for a concurrent sub-agent task.
+
+    Attributes:
+        handle_id: Unique identifier for this handle.
+        run_id: The agent run ID, attached later via attach_run().
+        agent: The agent name, if specified at reserve time.
+        task: Human-readable task description.
+        status: Current status (initially "running").
+        result: Result string on completion (empty until finish).
+        error: Error message on failure (empty until finish).
+        started_at: Timestamp when handle was created.
+        finished_at: Timestamp when handle reached terminal status.
+    """
+
+    handle_id: str
+    run_id: str | None
+    agent: str | None
+    task: str
+    status: str
+    result: str = ""
+    error: str = ""
+    started_at: float = 0.0
+    finished_at: float | None = None
+
+
+class FleetCoordinator:
+    """State machine managing concurrent sub-agent task handles.
+
+    Enforces live-task cap, emits events on state changes, and ensures
+    idempotent finish (first-writer-wins: late finishes to already-terminal
+    handles are ignored).
+    """
+
+    def __init__(self, max_live: int, clock: Callable[[], float]) -> None:
+        """Initialize the coordinator.
+
+        Args:
+            max_live: Maximum number of concurrently live handles.
+            clock: Callable returning a float timestamp (for testing).
+        """
+        self._max_live = max_live
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._handles: dict[str, FleetHandle] = {}
+        self._live_ids: set[str] = set()  # handle_ids with status != terminal
+        self._events: list[FleetEvent] = []
+
+    def reserve(self, task: str, agent: str | None) -> FleetHandle | None:
+        """Reserve a slot for a new task, returning a handle or None if at cap.
+
+        Emits FLEET_STARTED event on success.
+
+        Args:
+            task: Human-readable task description.
+            agent: Agent name, if applicable.
+
+        Returns:
+            A new FleetHandle if a slot is available, else None.
+        """
+        with self._lock:
+            if len(self._live_ids) >= self._max_live:
+                return None
+
+            handle_id = uuid.uuid4().hex
+            started_at = self._clock()
+            handle = FleetHandle(
+                handle_id=handle_id,
+                run_id=None,
+                agent=agent,
+                task=task,
+                status="running",
+                result="",
+                error="",
+                started_at=started_at,
+                finished_at=None,
+            )
+            self._handles[handle_id] = handle
+            self._live_ids.add(handle_id)
+            self._events.append(
+                FleetEvent(
+                    kind=FLEET_STARTED,
+                    handle_id=handle_id,
+                    run_id=None,
+                    agent=agent,
+                    status="running",
+                )
+            )
+            return handle
+
+    def attach_run(self, handle_id: str, run_id: str) -> None:
+        """Attach a run ID to an existing handle.
+
+        Args:
+            handle_id: The handle's ID.
+            run_id: The run ID to attach.
+        """
+        with self._lock:
+            if handle_id in self._handles:
+                self._handles[handle_id].run_id = run_id
+
+    def finish(
+        self, handle_id: str, status: str, result: str = "", error: str = ""
+    ) -> None:
+        """Mark a handle as finished with terminal status.
+
+        Idempotent: if the handle is already terminal, this call is ignored
+        (first-writer-wins). This protects abandoned children from overwriting
+        a coordinator-issued cancellation after a timeout.
+
+        Emits FLEET_FINISHED event only if the handle transitions to terminal.
+
+        Args:
+            handle_id: The handle's ID.
+            status: Terminal status to record.
+            result: Result string (ignored if already terminal).
+            error: Error message (ignored if already terminal).
+        """
+        with self._lock:
+            if handle_id not in self._handles:
+                return
+
+            handle = self._handles[handle_id]
+
+            # First-writer-wins: ignore if already terminal
+            if handle.status in TERMINAL_RUN_STATUSES:
+                return
+
+            # Transition to terminal
+            finished_at = self._clock()
+            handle.status = status
+            handle.result = result
+            handle.error = error
+            handle.finished_at = finished_at
+            self._live_ids.discard(handle_id)
+
+            # Emit event with current run_id and agent
+            self._events.append(
+                FleetEvent(
+                    kind=FLEET_FINISHED,
+                    handle_id=handle_id,
+                    run_id=handle.run_id,
+                    agent=handle.agent,
+                    status=status,
+                )
+            )
+
+    def get(self, handle_id: str) -> FleetHandle | None:
+        """Retrieve a handle by ID.
+
+        Returns a copy to prevent external mutation.
+
+        Args:
+            handle_id: The handle's ID.
+
+        Returns:
+            A copy of the handle, or None if not found.
+        """
+        with self._lock:
+            if handle_id not in self._handles:
+                return None
+            return dataclasses.replace(self._handles[handle_id])
+
+    def snapshot(self) -> list[FleetHandle]:
+        """Return a snapshot of all handles.
+
+        Returns copies to prevent external mutation.
+
+        Returns:
+            A list of copies of all FleetHandle objects.
+        """
+        with self._lock:
+            return [
+                dataclasses.replace(h) for h in self._handles.values()
+            ]
+
+    def live_count(self) -> int:
+        """Return the number of live (non-terminal) handles.
+
+        Returns:
+            Count of handles not in terminal status.
+        """
+        with self._lock:
+            return len(self._live_ids)
+
+    def drain_events(self) -> list[FleetEvent]:
+        """Return and clear all pending events.
+
+        Returns:
+            A list of FleetEvent objects, clearing the internal queue.
+        """
+        with self._lock:
+            events = self._events
+            self._events = []
+            return events
+
+    def all_finished(self) -> bool:
+        """Check if all handles are in terminal status.
+
+        Returns:
+            True if no live (non-terminal) handles exist.
+        """
+        with self._lock:
+            return len(self._live_ids) == 0

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -9,6 +9,7 @@ methods are sync and worker-thread safe; no Textual/event-loop imports.
 
 from __future__ import annotations
 
+import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -23,6 +24,7 @@ from tldw_chatbook.MCP.permission_store import EffectiveToolState
 from ..config import coerce_bool_setting, get_cli_setting
 from .agent_models import ToolCatalogEntry, ToolResult, ToolSchema
 from .mcp_tool_provider import MCPPendingCall
+from .run_context import current_run_id
 
 # Module-level (not the function-local imports the other `_default_specs`
 # tool modules use) SPECIFICALLY so tests can patch this one name via
@@ -198,7 +200,17 @@ class LocalToolProvider:
         self._persist_approval = persist_approval
         self._record_decision = record_decision
         self._no_callback_refusal = no_callback_refusal
-        self._stamps: dict[str, str] = {}
+        # PR2a Task 5: keyed (run_id, tool_name), not tool_name -- one
+        # provider instance is shared by a parent run and every sub-agent
+        # it spawns, so a name-keyed dict let any run's turn clear or
+        # overwrite verdicts another run had been granted and not yet
+        # consumed. Same treatment, same reasons, as MCPToolProvider's
+        # `_stamped_decisions` and BuiltinToolGate's `_stamps`.
+        self._stamps: dict[tuple[str, str], str] = {}
+        # Lock (not RLock): flat, self-contained critical sections over one
+        # dict; no locked method calls another, and `stamp_scope` never
+        # holds it across its `yield`.
+        self._stamps_lock = threading.Lock()
 
     # -- catalog ------------------------------------------------------
 
@@ -322,25 +334,71 @@ class LocalToolProvider:
 
     # -- approval stamps (mirror MCPToolProvider) ----------------------
 
-    def apply_batch_decisions(self, decisions: dict[str, str]) -> None:
-        """REPLACE this turn's stamps (never merge) — clear-first discipline."""
-        self._stamps = dict(decisions)
+    def apply_batch_decisions(self, run_id: str, decisions: dict[str, str]) -> None:
+        """REPLACE ``run_id``'s stamps (never merge) — clear-first discipline.
+
+        REPLACE within that run's slice only (PR2a Task 5): ``{}`` still
+        clears this run's prior turn, which is what the hook's I3
+        clear-at-entry relies on, but another run's verdicts survive.
+
+        Args:
+            run_id: The run whose turn these decisions belong to.
+            decisions: ``{tool_name: verdict}`` for this turn.
+        """
+        with self._stamps_lock:
+            self._stamps = {
+                key: value
+                for key, value in self._stamps.items()
+                if key[0] != run_id
+            }
+            for name, verdict in (decisions or {}).items():
+                self._stamps[(run_id, name)] = verdict
+
+    def stamped(self, run_id: str, name: str) -> str | None:
+        """Peek at ``run_id``'s stamped verdict for ``name``, if any."""
+        with self._stamps_lock:
+            return self._stamps.get((run_id, name))
 
     @contextmanager
-    def stamp_scope(self) -> Iterator[None]:
-        """Snapshot/restore stamps around a nested sub-agent run.
+    def stamp_scope(self, run_id: str) -> Iterator[None]:
+        """Snapshot/restore ``run_id``'s stamps around a nested sub-agent run.
 
-        Clears on entry -- a deliberate divergence from a pure snapshot:
-        the child run starts stamp-less and re-checks permissions itself,
-        so a parent's verdict can never leak into nested invocations.
-        The parent's stamps are restored on exit, even on exception.
+        Clears ``run_id``'s slice on entry -- a deliberate divergence from
+        a pure snapshot, preserved from the pre-Task-5 version: a nested
+        run that somehow reused this run id would start stamp-less and
+        re-check permissions itself. The run's stamps are restored on exit,
+        even on exception; other runs' slices are untouched in both
+        directions.
+
+        Per-run keying is the real protection now (a child stamps under
+        its OWN run id and never sees this one's), and it is the only one
+        that holds once children run concurrently -- snapshot/restore is
+        sound only for a strictly nested inline child.
+
+        Args:
+            run_id: The run whose slice is cleared, then restored.
         """
-        saved = self._stamps
-        self._stamps = {}
+        with self._stamps_lock:
+            saved = {
+                key: value
+                for key, value in self._stamps.items()
+                if key[0] == run_id
+            }
+            self._stamps = {
+                key: value
+                for key, value in self._stamps.items()
+                if key[0] != run_id
+            }
         try:
             yield
         finally:
-            self._stamps = saved
+            with self._stamps_lock:
+                self._stamps = {
+                    key: value
+                    for key, value in self._stamps.items()
+                    if key[0] != run_id
+                }
+                self._stamps.update(saved)
 
     def pending_gate_for(self, name: str, args: dict) -> MCPPendingCall | None:
         """The approval payload when this call needs human gating, else None.
@@ -459,7 +517,12 @@ class LocalToolProvider:
         if self._kill_switch_engaged():
             self._record_decision_safe(self.hub_tool_for(name), "denied")
             return ToolResult(ok=False, error=LOCAL_KILL_SWITCH_REFUSAL)
-        verdict = self._verdict_for(name, args)
+        # PR2a Task 5: only the DISPATCHING run's own stamp may resolve
+        # this call. `ToolProvider.invoke` has no run parameter, so the run
+        # id rides `run_context` (bound by `AgentService` around each
+        # invocation); `""` outside any run matches no stamp a review hook
+        # writes, so such a call resolves through the fresh gate below.
+        verdict = self._verdict_for(name, args, current_run_id())
         if verdict == "allow":
             try:
                 return ToolResult(ok=True, content=_fit_result(spec.handler(args)))
@@ -510,11 +573,17 @@ class LocalToolProvider:
             logger.warning(f"LocalToolProvider: kill_switch read failed: {exc}")
             return True
 
-    def _verdict_for(self, name: str, args: dict) -> str:
+    def _verdict_for(self, name: str, args: dict, run_id: str) -> str:
         """Resolve this call's gate decision: only "allow" executes.
 
         Never raises: every injected callable is guarded, and a guard trip
         resolves to a refusing verdict.
+
+        Args:
+            name: The bare local tool name.
+            args: The call's arguments.
+            run_id: The dispatching run -- the only run whose per-turn
+                stamp may resolve this call (PR2a Task 5).
         """
         hub = self.hub_tool_for(name)
         try:
@@ -532,7 +601,7 @@ class LocalToolProvider:
             return "deny"
         # ask: per-turn stamp wins; then a live session approval; then the
         # single-call fallback; then fail closed.
-        stamp = self._stamps.get(name)
+        stamp = self.stamped(run_id, name)
         if stamp in ("approve_once", "approve_session", "always_allow"):
             if stamp != "approve_once":
                 self._persist_approval_safe(hub, stamp)

--- a/tldw_chatbook/Agents/mcp_tool_provider.py
+++ b/tldw_chatbook/Agents/mcp_tool_provider.py
@@ -26,6 +26,13 @@ cross-thread round trip for each one.
 documented to run ON the main loop at registration time (T6 awaits it
 directly, before spawning the worker thread), so it is declared ``async def``
 and does not need any cross-thread submission of its own.
+
+PR2a Task 8: with the fleet, this ONE provider instance's ``invoke()`` can
+now be called from several worker threads at once (a parent run and its
+live children). ``invoke()`` serializes every call to this provider
+instance behind ``self._invoke_lock`` -- see its docstring (and
+``_invoke_locked``'s) for exactly what that protects and what would let a
+future task remove it.
 """
 
 from __future__ import annotations
@@ -209,7 +216,8 @@ class MCPToolProvider:
         self._init_decision_state()
 
     def _init_decision_state(self) -> None:
-        """Initialize the per-turn verdict stamps and their lock.
+        """Initialize the per-turn verdict stamps, their lock, and the
+        provider-wide execution lock.
 
         Called from ``__init__``. Factored out so a test can build a bare
         instance (``MCPToolProvider.__new__``) and exercise the stamp
@@ -239,6 +247,14 @@ class MCPToolProvider:
         # deadlock loudly instead of silently permitting a non-atomic
         # critical section.
         self._decisions_lock = threading.Lock()
+        # PR2a Task 8 (provider thread-safety audit): a SEPARATE lock,
+        # entirely unrelated to `_decisions_lock` above -- see `invoke()`'s
+        # own docstring for what it protects and why. Defined here (not
+        # only in `__init__`) for the same bare-instance-test reason
+        # `_decisions_lock` is: a double it constructs via
+        # `MCPToolProvider.__new__` + `_init_decision_state()` must not
+        # `AttributeError` if it goes on to call `invoke()`.
+        self._invoke_lock = threading.Lock()
 
     # -- composition (main loop, once per registration) -------------------
 
@@ -595,6 +611,11 @@ class MCPToolProvider:
         to `self._approval_callback` as a single-call list (no callback ->
         fail closed to deny).
 
+        PR2a Task 8 (provider thread-safety audit): this whole call runs
+        under `self._invoke_lock`, so at most ONE call into this provider
+        instance executes at a time, fleet-wide -- see `_invoke_locked`
+        (just below) for why.
+
         Args:
             tool_id: The LLM-facing tool id to invoke (a
                 `ToolCatalogEntry.id`/`.name`).
@@ -605,6 +626,51 @@ class MCPToolProvider:
             length-capped result content on success; `ok=False` with a
             length-capped, always-non-empty `error` on refusal or
             failure. Never raises.
+        """
+        with self._invoke_lock:
+            return self._invoke_locked(tool_id, args)
+
+    def _invoke_locked(self, tool_id: str, args: dict) -> ToolResult:
+        """``invoke()``'s actual body -- entered ONLY while holding
+        `self._invoke_lock`. Do not call this directly; call `invoke()`.
+
+        Per spec (Docs/superpowers/specs/2026-08-08-supervisor-agent-fleet-
+        design.md) §5's corrections table: "Tool providers were written
+        under one-run-at-a-time dispatch ... Phase-2 thread-safety audit
+        (MCP control-plane client, local tools, gated builtins). Unaudited
+        provider => per-provider execution lock on invoke (throttle, not
+        break). MCP starts locked until proven otherwise." PR2a Task 8's
+        audit (see that task's report) found `BuiltinToolProvider` and
+        `LocalToolProvider` safe under concurrent `invoke()` by inspection
+        (read-only/immutable per-instance state, or state already guarded
+        by its own lock) and left them unlocked; THIS provider is the one
+        the spec calls out by name, for a reason the audit could not rule
+        out by reading Python alone: `_execute()` below hands off to
+        `self._service.execute_hub_tool(...)`, which for a LOCAL external
+        MCP server ultimately reads/writes that server's own stdio pipe
+        through an `MCPClient` session -- a request/response protocol this
+        codebase has never exercised with two requests in flight on the
+        same session at once (server-source tools are explicitly out of
+        scope per this module's own docstring, i.e. genuinely unaudited,
+        not merely unlikely to be a problem). Two concurrent fleet agents
+        both calling an MCP tool is exactly the scenario the fleet makes
+        routine.
+
+        This lock SERIALIZES every call into this ONE provider instance
+        across the whole fleet -- a throughput throttle on MCP tool calls
+        specifically (a call blocks for up to the provider's own timeout
+        plus its result-wait slack while holding the lock), not a break in
+        concurrency: builtin, local, and Library tool calls from the same
+        fleet turn have their own provider instances and are unaffected,
+        and a queued MCP call still eventually runs rather than failing.
+
+        What would let a future task remove this: proving (not assuming)
+        that `MCPClient`'s local-server transport safely multiplexes
+        concurrent request/response pairs on one session -- e.g. a
+        request-id-keyed reader loop in `MCPClient` itself -- or giving
+        each concurrently-live run its own subprocess/session instead of
+        sharing this provider's one `self._service`. Absent either, this
+        lock is the correctness boundary, not merely a performance choice.
         """
         entry = self._entry_by_llm_name.get(tool_id)
         if entry is None:

--- a/tldw_chatbook/Agents/mcp_tool_provider.py
+++ b/tldw_chatbook/Agents/mcp_tool_provider.py
@@ -34,6 +34,7 @@ import asyncio
 import concurrent.futures
 import contextlib
 import json
+import threading
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -51,6 +52,7 @@ from tldw_chatbook.MCP.redaction import redact_mapping
 from tldw_chatbook.MCP.tool_naming import dedupe_names, llm_tool_name
 
 from .agent_models import ToolCatalogEntry, ToolResult, ToolSchema
+from .run_context import current_run_id
 
 SOURCE = "mcp"
 
@@ -204,14 +206,39 @@ class MCPToolProvider:
         # lookup (task-201's don't-re-list-per-lookup note).
         self._entry_by_llm_name: dict[str, tuple[HubTool, EffectiveToolState]] = {}
         self._not_connected_count = 0
-        # Per-turn verdict stamps set by T6's batch-review closure via
-        # apply_batch_decisions(). PEEKED (not popped) by invoke() via
-        # stamped_decision() so every call sharing an llm_name within the
-        # SAME turn sees the same verdict (Finding F1) -- apply_batch_
-        # decisions() itself is what clears the previous turn's stamps
-        # (REPLACE semantics, called every turn including with `{}` by
-        # build_mcp_review_hook), not a per-read pop.
-        self._stamped_decisions: dict[str, str] = {}
+        self._init_decision_state()
+
+    def _init_decision_state(self) -> None:
+        """Initialize the per-turn verdict stamps and their lock.
+
+        Called from ``__init__``. Factored out so a test can build a bare
+        instance (``MCPToolProvider.__new__``) and exercise the stamp
+        contract without a service or a running event loop -- see
+        ``Tests/Agents/test_gate_run_scoping.py``.
+
+        Stamps are set by the batch-review closure via
+        ``apply_batch_decisions()`` and PEEKED (not popped) by ``invoke()``
+        via ``stamped_decision()``, so every call sharing an llm_name
+        within the SAME turn of the SAME run sees the same verdict
+        (Finding F1) -- ``apply_batch_decisions()`` itself is what clears
+        that run's previous turn (REPLACE-within-the-run semantics, called
+        every turn including with ``{}`` by ``build_mcp_review_hook``),
+        not a per-read pop.
+
+        PR2a Task 5: the dict is keyed ``(run_id, llm_name)``, not
+        ``llm_name``. It is shared by every run in a tree (parent and all
+        sub-agents use ONE provider), and the old whole-dict REPLACE meant
+        any run's turn destroyed every other run's verdicts.
+        """
+        self._stamped_decisions: dict[tuple[str, str], str] = {}
+        # Lock, not RLock: every critical section below is a short,
+        # self-contained mutation of this one dict, and no locked method
+        # calls another locked method (`stamp_scope` explicitly does NOT
+        # hold the lock across its `yield` -- a nested run must never
+        # block on it). A plain Lock makes an accidental future nesting
+        # deadlock loudly instead of silently permitting a non-atomic
+        # critical section.
+        self._decisions_lock = threading.Lock()
 
     # -- composition (main loop, once per registration) -------------------
 
@@ -231,8 +258,11 @@ class MCPToolProvider:
         `{llm_name: (HubTool, EffectiveToolState)}` lookup table.
         """
         # Clear stale stamped decisions from prior catalogs to prevent
-        # auto-approval of tools not in the new catalog (Finding 3).
-        self._stamped_decisions.clear()
+        # auto-approval of tools not in the new catalog (Finding 3). Every
+        # run's slice, deliberately: this runs at registration time, before
+        # any run of the new catalog exists, so there is nothing to keep.
+        with self._decisions_lock:
+            self._stamped_decisions.clear()
 
         if self._service.get_kill_switch():
             self._catalog = []
@@ -362,31 +392,53 @@ class MCPToolProvider:
             parameters=parameters,
         )
 
-    # -- per-turn verdict stamps (set/read same-thread by T6's closure) ----
+    # -- per-turn verdict stamps, keyed (run_id, llm_name) -----------------
+    #
+    # No longer same-thread: PR2a Task 6 runs sub-agents on their own
+    # threads against this one shared provider, so every access below goes
+    # through `_decisions_lock` and every entry is scoped to the run that
+    # wrote it.
 
-    def apply_batch_decisions(self, decisions: dict[str, str]) -> None:
-        """Replace this turn's verdict stamps with `decisions`.
+    def apply_batch_decisions(self, run_id: str, decisions: dict[str, str]) -> None:
+        """Replace `run_id`'s turn verdict stamps with `decisions`.
 
-        REPLACE, not merge: any stamp left over from a prior turn is
-        always cleared first (Finding F1) -- `build_mcp_review_hook` calls
-        this exactly once per turn that has any tool calls at all,
-        including with `{}` when none of them needed gating, specifically
-        so a stale stamp can never survive into a later turn and be
-        misread by `invoke()`'s `stamped_decision()` peek as this turn's
-        verdict. Also cleared wholesale by `compose_catalog()` at
-        registration time (a different, coarser-grained clear for stale
-        catalogs, not a substitute for this per-turn one).
+        REPLACE **within that run's slice**, not merge: any stamp `run_id`
+        left over from a PRIOR turn is always cleared first (Finding F1) --
+        `build_mcp_review_hook` calls this exactly once per turn that has
+        any tool calls at all, including with `{}` when none of them needed
+        gating, specifically so a stale stamp can never survive into a
+        later turn and be misread by `invoke()`'s `stamped_decision()` peek
+        as this turn's verdict. Passing `{}` therefore still CLEARS; that
+        is what makes the clear-at-entry (I3) discipline work.
+
+        What it no longer does is clear OTHER runs' slices (PR2a Task 5).
+        The whole dict is shared by a parent and every sub-agent it spawns,
+        so the old whole-dict replace meant any run's routine clear
+        destroyed verdicts a concurrent sibling -- or the parent -- had
+        already been granted and not yet consumed. Also cleared wholesale
+        by `compose_catalog()` at registration time (a different,
+        coarser-grained clear for stale catalogs, not a substitute for this
+        per-turn one).
 
         Args:
+            run_id: The run whose turn these decisions belong to. Only
+                that run's own `invoke()` can consume them.
             decisions: This turn's `{llm_name: verdict}` map, as returned
                 by the batch-approval round trip
                 (`ConsoleChatController.request_mcp_approvals`). Falsy
-                clears without setting anything new.
+                clears this run's slice without setting anything new.
         """
-        self._stamped_decisions = dict(decisions or {})
+        with self._decisions_lock:
+            self._stamped_decisions = {
+                key: value
+                for key, value in self._stamped_decisions.items()
+                if key[0] != run_id
+            }
+            for llm_name, verdict in (decisions or {}).items():
+                self._stamped_decisions[(run_id, llm_name)] = verdict
 
-    def stamped_decision(self, llm_name: str) -> str | None:
-        """Peek at this turn's stamped verdict for `llm_name`, if any.
+    def stamped_decision(self, run_id: str, llm_name: str) -> str | None:
+        """Peek at `run_id`'s stamped verdict for `llm_name`, if any.
 
         Non-destructive on purpose (Finding F1): multiple calls to the
         same tool within one turn must ALL observe the identical stamped
@@ -395,43 +447,69 @@ class MCPToolProvider:
         stamp.
 
         Args:
+            run_id: The run consuming the verdict. A verdict stamped by a
+                different run in the same tree is invisible here -- that
+                isolation is the point of the per-run key.
             llm_name: The LLM-facing tool id to look up.
 
         Returns:
             The stamped verdict string for `llm_name` this turn, or
             `None` if it has no stamp.
         """
-        return self._stamped_decisions.get(llm_name)
+        with self._decisions_lock:
+            return self._stamped_decisions.get((run_id, llm_name))
 
     @contextlib.contextmanager
-    def stamp_scope(self):
-        """Snapshot `_stamped_decisions` on enter; RESTORE (not merge) on exit.
+    def stamp_scope(self, run_id: str):
+        """Snapshot `run_id`'s stamps on enter; RESTORE (not merge) on exit.
 
-        C1 (probe-verified security regression): wired as `AgentService`'s
-        `review_state_scope` (see that class's own docstring comment) by
+        C1 (probe-verified security regression), re-scoped by PR2a Task 5:
+        wired as `AgentService`'s `review_state_scope` (see that class's
+        own docstring comment) by
         `console_agent_bridge.ConsoleAgentBridge.run_reply`, wrapping every
         NESTED sub-agent run this provider's turn spawns. `spawn_subagent`
         runs the child's entire loop INLINE, synchronously, before the
         parent's own remaining same-batch tool calls are dispatched
         (`agent_service.AgentService._run_one`'s `spawn` closure, called
-        from `agent_runtime.run_agent_loop`'s per-call dispatch loop). Since
-        `apply_batch_decisions` REPLACES `_stamped_decisions` every turn
-        (Finding F1 -- never merges), the child's OWN turn(s) would
-        otherwise silently clobber whatever the PARENT's turn had already
-        stamped for a same-named tool before the parent gets to consume it
-        -- letting a call the user just denied execute anyway (the child
-        happens to approve the same tool name), or wiping a genuine parent
-        approval (the child's own routine `apply_batch_decisions({})` clear
-        for an unrelated, non-MCP tool call). Snapshotting on enter and
-        unconditionally restoring that exact snapshot on exit (regardless of
-        what the child did in between) undoes every mutation the child made
-        to this shared dict the instant it returns control to the parent.
+        from `agent_runtime.run_agent_loop`'s per-call dispatch loop).
+        `apply_batch_decisions` used to REPLACE the WHOLE dict every turn
+        (Finding F1 -- never merged), so the child's OWN turn(s) silently
+        clobbered whatever the PARENT's turn had already stamped for a
+        same-named tool before the parent got to consume it -- letting a
+        call the user just denied execute anyway (the child happens to
+        approve the same tool name), or wiping a genuine parent approval
+        (the child's own routine `apply_batch_decisions({})` clear for an
+        unrelated, non-MCP tool call).
+
+        **Per-run keying is now the real mechanism**: a child's own turn
+        only ever rewrites its own `(child_run_id, ...)` keys, which is
+        also the only thing that works once children run CONCURRENTLY --
+        snapshot/restore is sound only for a strictly nested (LIFO) inline
+        child. This is kept as belt-and-braces for that inline path, and
+        because the seam is public (`_combine_state_scopes` composes this
+        with the built-in gate's and the local provider's).
+
+        Args:
+            run_id: The run whose slice is snapshotted and restored --
+                normally the PARENT's, whose verdicts a nested run must
+                not disturb.
         """
-        snapshot = dict(self._stamped_decisions)
+        with self._decisions_lock:
+            snapshot = {
+                key: value
+                for key, value in self._stamped_decisions.items()
+                if key[0] == run_id
+            }
         try:
             yield
         finally:
-            self._stamped_decisions = snapshot
+            with self._decisions_lock:
+                self._stamped_decisions = {
+                    key: value
+                    for key, value in self._stamped_decisions.items()
+                    if key[0] != run_id
+                }
+                self._stamped_decisions.update(snapshot)
 
     # -- gate resolution for the batch-review hook (worker thread) --------
 
@@ -545,7 +623,14 @@ class MCPToolProvider:
             self._record_decision_safe(tool, decision="denied")
             return ToolResult(ok=False, error=KILL_SWITCH_REFUSAL)
 
-        stamped = self.stamped_decision(tool_id)
+        # PR2a Task 5: only THIS run's own stamp may resolve this call. The
+        # `ToolProvider.invoke` Protocol has no run parameter, so the
+        # dispatching run id rides `run_context` (bound by `AgentService`
+        # around each invocation -- see that module's docstring). Outside
+        # any run this is `""`, which matches no stamp a review hook ever
+        # writes, so such a call falls through to the fresh gate below --
+        # the same path it took before batch review existed.
+        stamped = self.stamped_decision(current_run_id(), tool_id)
         if stamped is not None:
             return self._apply_verdict(stamped, tool, call_args)
 

--- a/tldw_chatbook/Agents/run_context.py
+++ b/tldw_chatbook/Agents/run_context.py
@@ -1,11 +1,40 @@
-"""The dispatching run's id, bound for the duration of one tool invocation.
+"""The dispatching run's id, bound around a run's tool-facing work.
 
-PR2a Task 5. Both permission gates now key this turn's verdict stamps by
-``(run_id, tool_name)`` instead of by tool name alone, so that concurrent
-sub-agent runs sharing ONE gate instance cannot clear or overwrite each
-other's verdicts. The WRITE side gets its run id explicitly: the review
-hook is a callable ``AgentService`` wires per run, so ``run_id`` is just a
-parameter (see ``AgentService.review_tool_calls``).
+Two bindings exist, both established by ``AgentService`` and both reading
+back through ``current_run_id()``. They are not redundant: they cover
+different THREADS, because the work they guard runs in different places.
+
+1. **Per-invocation** (PR2a Task 5, ``_make_invoke_tool``) -- bound around
+   each ``ToolProvider.invoke``, so the permission gates can find this
+   run's own approval stamps when a tool executes. It must be established
+   inside the callable handed to ``_call_with_timeout``, because that
+   helper runs the tool on a fresh per-call daemon thread which does NOT
+   inherit the caller's context; a binding set on the loop thread would
+   simply be invisible there.
+
+2. **Loop-wide** (PR2a Task 7, around ``run_agent_loop`` in ``_run_one``)
+   -- bound for the whole run, on the loop thread. The per-invocation
+   binding above cannot cover this: the two things that ARM HUMAN
+   APPROVAL CARDS run on the loop thread rather than inside a provider
+   invoke -- ``review_tool_calls`` (one batch-approval round trip per
+   turn) and the in-loop runtime tools, of which ``run_skill_script``
+   raises a confirm card of its own. Both record ``current_run_id()`` at
+   arm time so a cancelled child's card can be revoked without touching a
+   live sibling's, and neither can be handed the id as a parameter (the
+   approval bridge is a pre-bound partial shared with
+   ``MCPToolProvider.approval_callback``; the runtime-tool closures are
+   built one layer below any run identity). One binding there covers both
+   -- and every future loop-thread consumer -- with no signature churn.
+
+The two nest harmlessly: the inner binding sets the same id the outer one
+holds, on a different thread.
+
+WHY A ContextVar AT ALL (PR2a Task 5). Both permission gates key this
+turn's verdict stamps by ``(run_id, tool_name)`` instead of by tool name
+alone, so that concurrent sub-agent runs sharing ONE gate instance cannot
+clear or overwrite each other's verdicts. The WRITE side gets its run id
+explicitly: the review hook is a callable ``AgentService`` wires per run,
+so ``run_id`` is just a parameter (see ``AgentService.review_tool_calls``).
 
 The READ side cannot. A stamp is consumed inside ``ToolProvider.invoke``
 (``BuiltinToolProvider.invoke`` -> ``BuiltinToolGate.check``,
@@ -20,13 +49,10 @@ each invocation instead -- the same shape, and for the same reason, as
 ``Tools/workspace_file_roots.run_workspace``, which already binds THIS
 run's workspace around ``BuiltinToolProvider.invoke``'s tool execution.
 
-Why a per-invocation binding is sound: the binding is established inside
-the callable ``AgentService._make_invoke_tool`` hands to
-``_call_with_timeout``, i.e. *on the thread that actually runs the tool*
-(``_call_with_timeout`` runs it on a fresh per-call daemon thread, which
-does NOT inherit the caller's context), and it is reset in its own
-``finally``. Nested inline runs are therefore LIFO-safe on one thread, and
-a run on its own thread (PR2a Task 6) simply sets its own value.
+Why either binding is sound under concurrency: each is reset in its own
+``finally``, so nested inline runs unwind LIFO on one thread, and a run on
+its own thread (PR2a Task 6, ON by default since Task 6.5) simply sets its
+own value in its own context -- siblings never see each other's.
 
 ``current_run_id()`` returns ``""`` outside any agent run -- e.g. a direct
 ``provider.invoke()`` from the MCP workbench's Test Tool. That is a

--- a/tldw_chatbook/Agents/run_context.py
+++ b/tldw_chatbook/Agents/run_context.py
@@ -1,0 +1,77 @@
+"""The dispatching run's id, bound for the duration of one tool invocation.
+
+PR2a Task 5. Both permission gates now key this turn's verdict stamps by
+``(run_id, tool_name)`` instead of by tool name alone, so that concurrent
+sub-agent runs sharing ONE gate instance cannot clear or overwrite each
+other's verdicts. The WRITE side gets its run id explicitly: the review
+hook is a callable ``AgentService`` wires per run, so ``run_id`` is just a
+parameter (see ``AgentService.review_tool_calls``).
+
+The READ side cannot. A stamp is consumed inside ``ToolProvider.invoke``
+(``BuiltinToolProvider.invoke`` -> ``BuiltinToolGate.check``,
+``MCPToolProvider.invoke`` -> ``stamped_decision``,
+``LocalToolProvider.invoke`` -> ``_verdict_for``), and that method's
+signature is a Protocol (``tool_catalog.ToolProvider``) implemented by
+every provider and called generically by
+``ToolCatalogRegistry.invoke_by_name``; widening it would touch every
+provider and hundreds of call sites for a value only three of them want.
+So the run id rides a ``ContextVar`` that ``AgentService`` binds around
+each invocation instead -- the same shape, and for the same reason, as
+``Tools/workspace_file_roots.run_workspace``, which already binds THIS
+run's workspace around ``BuiltinToolProvider.invoke``'s tool execution.
+
+Why a per-invocation binding is sound: the binding is established inside
+the callable ``AgentService._make_invoke_tool`` hands to
+``_call_with_timeout``, i.e. *on the thread that actually runs the tool*
+(``_call_with_timeout`` runs it on a fresh per-call daemon thread, which
+does NOT inherit the caller's context), and it is reset in its own
+``finally``. Nested inline runs are therefore LIFO-safe on one thread, and
+a run on its own thread (PR2a Task 6) simply sets its own value.
+
+``current_run_id()`` returns ``""`` outside any agent run -- e.g. a direct
+``provider.invoke()`` from the MCP workbench's Test Tool. That is a
+distinct key no review hook ever writes, so such a caller finds no stamp
+and falls through to the provider's own gate, which is exactly what it did
+before this module existed.
+
+Stdlib only, no project imports: this is consumed by ``tool_catalog`` and
+the providers, which are all deliberately dependency-light.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator
+
+#: The run id whose tool call is executing on this thread, or "" for none.
+_CURRENT_RUN_ID: ContextVar[str] = ContextVar("tldw_agent_run_id", default="")
+
+
+def current_run_id() -> str:
+    """The run id whose tool call is executing here.
+
+    Returns:
+        The bound run id, or ``""`` when no agent run bound one on this
+        thread (a direct provider call outside any run). Never raises.
+    """
+    return _CURRENT_RUN_ID.get()
+
+
+@contextmanager
+def use_run_id(run_id: str) -> Iterator[None]:
+    """Bind ``run_id`` as the dispatching run for the duration of the block.
+
+    Args:
+        run_id: The run whose tool call is about to execute. A falsy value
+            binds ``""`` (the no-run key), never ``None``.
+
+    Yields:
+        None. The previous binding is restored on exit, including on an
+        exception, so nested inline runs on one thread unwind correctly.
+    """
+    token = _CURRENT_RUN_ID.set(run_id or "")
+    try:
+        yield
+    finally:
+        _CURRENT_RUN_ID.reset(token)

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from collections.abc import Sequence
 from typing import Any, Callable, Iterable, Mapping, NamedTuple, Protocol
 
@@ -905,6 +906,18 @@ class ToolCatalogRegistry:
         # invalidation, with no lock guarding `_owner_cache`/
         # `_name_to_id_cache` — two concurrent lookups CAN observe different
         # generations of the catalog.
+        #
+        # PR2a (fleet children each on their own thread, sharing this
+        # bridge-owned registry across a WHOLE session rather than a single
+        # run) makes that no longer a corner case, so `_cache_lock` below
+        # closes it: every read of and invalidation to the three caches now
+        # goes through the lock, and `_ensure_catalog_cache()` hands callers
+        # one coherent (owner, name_to_id, source) snapshot as a tuple
+        # instead of letting them re-read the instance attributes
+        # separately after the lock has already been released.
+        # `invoke_by_name()` takes exactly one such snapshot for its whole
+        # name -> id -> provider lookup, so the two-read gap described above
+        # can no longer produce a torn generation.
         self._owner_cache: dict[str, ToolProvider] | None = None
         self._name_to_id_cache: dict[str, str] | None = None
         # tool_id -> the owning catalog entry's `source` ("builtin"/"skill"/
@@ -913,14 +926,32 @@ class ToolCatalogRegistry:
         # from this map resolves to `None`, which that gate treats as
         # "unknown source" and refuses — the fail-toward-not-writing default.
         self._source_cache: dict[str, str] | None = None
+        # Guards the three caches above. RLock, not Lock: rebuilding calls
+        # out to each provider's list_catalog() (see _build_owner_cache())
+        # WHILE the lock is held, and the provider interface is a plugin
+        # seam (MCP/Skills register here, per the module docstring, and
+        # more will). None of the three providers shipped today --
+        # BuiltinToolProvider, MCPToolProvider, LocalToolProvider -- call
+        # back into this registry from list_catalog() (each just returns an
+        # already-built in-memory list), but a future provider that DOES
+        # re-enter -- e.g. resolving another tool's schema while composing
+        # its own catalog, on the same thread -- would deadlock a plain
+        # Lock. RLock makes same-thread reentrance safe while still
+        # serializing distinct threads, which is the property this cache
+        # actually needs, and correctness (no deadlock) outranks closing
+        # every last theoretical reentrant-lock hole.
+        self._cache_lock = threading.RLock()
 
     def register_provider(self, provider: ToolProvider) -> None:
         self._providers.append(provider)
         # A newly registered provider's tools aren't reflected in any
         # cache already built — invalidate so the next lookup rebuilds it.
-        self._owner_cache = None
-        self._name_to_id_cache = None
-        self._source_cache = None
+        # Locked so a concurrent reader can't observe one store already
+        # cleared while another still holds the previous generation.
+        with self._cache_lock:
+            self._owner_cache = None
+            self._name_to_id_cache = None
+            self._source_cache = None
 
     def reset_catalog_cache(self) -> None:
         """Drop the owner-map/name-map cache; call once at the start of a run.
@@ -931,9 +962,10 @@ class ToolCatalogRegistry:
         picked up. No cross-run invalidation signal is needed beyond this
         single reset — see the skills spec's Catalog scale section.
         """
-        self._owner_cache = None
-        self._name_to_id_cache = None
-        self._source_cache = None
+        with self._cache_lock:
+            self._owner_cache = None
+            self._name_to_id_cache = None
+            self._source_cache = None
 
     def list_catalog(self) -> list[ToolCatalogEntry]:
         entries: list[ToolCatalogEntry] = []
@@ -973,7 +1005,9 @@ class ToolCatalogRegistry:
                     source_by_id.setdefault(entry.id, entry.source)
         return owner, name_to_id, source_by_id
 
-    def _ensure_catalog_cache(self) -> None:
+    def _ensure_catalog_cache(
+        self,
+    ) -> tuple[dict[str, ToolProvider], dict[str, str], dict[str, str]]:
         # This is the fix MCP (task-201) also needs: a network-backed
         # provider must not re-list_catalog() per lookup. Both the owner
         # map (id -> provider, used by load_schema()/_owner_and_id()) and
@@ -993,20 +1027,32 @@ class ToolCatalogRegistry:
         # was reset to None. A single-cache guard would then skip the
         # rebuild and leave _name_to_id_cache (or _owner_cache) permanently
         # None for the rest of the run.
-        if (
-            self._owner_cache is None
-            or self._name_to_id_cache is None
-            or self._source_cache is None
-        ):
-            (
-                self._owner_cache,
-                self._name_to_id_cache,
-                self._source_cache,
-            ) = self._build_owner_cache()
+        #
+        # PR2a: the whole check-and-rebuild runs under `_cache_lock`, and
+        # the three maps are returned as a tuple rather than left for the
+        # caller to re-read off `self` afterwards — a read of `self.
+        # _owner_cache` two lines after the lock is released could still
+        # observe a DIFFERENT generation than a `self._name_to_id_cache`
+        # read right after it, if another thread's reset/rebuild lands in
+        # between. Callers (resolve_name(), _owner_and_id(), _source_for(),
+        # invoke_by_name()) must use the returned tuple, not the instance
+        # attributes, to get one coherent snapshot.
+        with self._cache_lock:
+            if (
+                self._owner_cache is None
+                or self._name_to_id_cache is None
+                or self._source_cache is None
+            ):
+                (
+                    self._owner_cache,
+                    self._name_to_id_cache,
+                    self._source_cache,
+                ) = self._build_owner_cache()
+            return self._owner_cache, self._name_to_id_cache, self._source_cache
 
     def _owner_and_id(self, tool_id: str):
-        self._ensure_catalog_cache()
-        return self._owner_cache.get(tool_id)
+        owner, _name_to_id, _source = self._ensure_catalog_cache()
+        return owner.get(tool_id)
 
     def _source_for(self, tool_id: str) -> str | None:
         """Return the catalog ``source`` that owns ``tool_id``, if known.
@@ -1014,9 +1060,8 @@ class ToolCatalogRegistry:
         ``None`` when the id is absent from the cache — which the ephemeral
         gate treats as an unaudited source and refuses, never as "allow".
         """
-        self._ensure_catalog_cache()
-        cache = self._source_cache
-        return cache.get(tool_id) if cache else None
+        _owner, _name_to_id, source = self._ensure_catalog_cache()
+        return source.get(tool_id)
 
     def load_schema(self, tool_id: str) -> ToolSchema:
         provider = self._owner_and_id(tool_id)
@@ -1025,26 +1070,31 @@ class ToolCatalogRegistry:
         return provider.load_schema(tool_id)
 
     def resolve_name(self, name: str) -> str | None:
-        self._ensure_catalog_cache()
-        cache = self._name_to_id_cache
-        return cache.get(name) if cache else None
+        _owner, name_to_id, _source = self._ensure_catalog_cache()
+        return name_to_id.get(name)
 
     def invoke_by_name(self, name: str, args: dict) -> ToolResult:
-        tool_id = self.resolve_name(name)
+        # PR2a: name -> id, id -> owner, and id -> source all come from ONE
+        # locked snapshot (`_ensure_catalog_cache()` returns the three maps
+        # as a tuple, built or read under `_cache_lock`), instead of the
+        # previous resolve_name() + _owner_and_id() pair, each independently
+        # acquiring (and releasing) its own view of the cache. That closed
+        # the specific gap this method used to have: a reset landing between
+        # the two separate reads could leave `tool_id` resolved against a
+        # generation the owner map no longer had.
+        owner, name_to_id, source = self._ensure_catalog_cache()
+        tool_id = name_to_id.get(name)
         if tool_id is None:
             return ToolResult(ok=False, error=f"Unknown tool: {name}")
-        provider = self._owner_and_id(tool_id)
+        provider = owner.get(tool_id)
         if provider is None:
-            # resolve_name()/_owner_and_id() share one cache built from a
-            # single list_catalog() sweep, so within one SERIALIZED lookup
-            # a name resolved above is always present in the owner map too.
-            # That no longer makes this branch unreachable, though: this
-            # registry has no lock, and task-327's per-call timeout can run
-            # invoke_by_name() calls concurrently (one call's cache read
-            # racing another call's, or a register_provider() rebuild), so
-            # `tool_id` above can genuinely belong to a since-superseded
-            # generation by the time this line runs. This fallback never
-            # lets a `None` owner surface as an AttributeError either way.
+            # name_to_id/owner/source above are one coherent snapshot from a
+            # single locked call, so within this one invocation a resolved
+            # `tool_id` is always present in `owner` too -- the lock makes
+            # this branch unreachable in-process. Kept anyway as defense in
+            # depth (e.g. a future _build_owner_cache() change that lets the
+            # two maps diverge): this fallback never lets a `None` owner
+            # surface as an AttributeError either way.
             return ToolResult(ok=False, error=f"Tool provider not found for: {name}")
         # THE choke point for the temporary-session ("not saved locally")
         # guarantee. Every provider's invoke() is reached through this one
@@ -1059,7 +1109,7 @@ class ToolCatalogRegistry:
             from tldw_chatbook.Chat.console_ephemeral import tool_blocked_reason
 
             reason = tool_blocked_reason(
-                name, source=self._source_for(tool_id), ephemeral=True
+                name, source=source.get(tool_id), ephemeral=True
             )
             if reason is not None:
                 return ToolResult(ok=False, error=reason)

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -995,8 +995,12 @@ class ToolCatalogRegistry:
         #     below hasn't run yet) and it recurses into ANOTHER
         #     _build_owner_cache() call, which calls the re-entrant
         #     provider's list_catalog() again, forever -- until Python's
-        #     recursion limit ends it with a RecursionError (measured at 73
-        #     nested calls). The `with self._cache_lock:` blocks still
+        #     recursion limit ends it with a RecursionError. (The exact
+        #     depth is environment-dependent -- one measurement saw 73
+        #     nested calls, a later re-measurement on different stack
+        #     state saw 322; the number itself isn't the point. What
+        #     matters is fail-fast-on-one-thread vs. a fleet-wide hang.)
+        #     The `with self._cache_lock:` blocks still
         #     unwind correctly through that exception (each nested `with`
         #     releases its RLock count as the stack pops), so the lock is
         #     NOT left held: the crash is confined to the one thread that

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -35,6 +35,7 @@ from .agent_models import (
     ToolResult,
     ToolSchema,
 )
+from .run_context import current_run_id
 from .run_log_search import (
     MAX_CROSS_RUN_RUNS,
     MAX_SLICE_RECORDS,
@@ -679,8 +680,16 @@ class BuiltinToolProvider:
         # reaches invoke() without going through it must still not execute
         # ungated. A gate that raises fails CLOSED -- never into the pure
         # loop, which must not see exceptions from tool invocation.
+        # PR2a Task 5: the gate keys this turn's stamps by run, and only
+        # the DISPATCHING run's own stamp may permit this call. The
+        # `ToolProvider.invoke` Protocol has no run parameter, so the run
+        # id rides `run_context` (bound by `AgentService` around each
+        # invocation -- see that module's docstring for why). Outside any
+        # run this resolves to `""`, which matches no stamp a review hook
+        # ever writes, so such a call falls through to the resolved
+        # permission state exactly as it did before per-run keying.
         try:
-            refusal = self._resolve_gate().check(tool)
+            refusal = self._resolve_gate().check(tool, current_run_id())
         except Exception as exc:  # noqa: BLE001 — fail closed
             return ToolResult(ok=False, error=f"permission check failed: {exc}")
         if refusal is not None:

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -926,29 +926,63 @@ class ToolCatalogRegistry:
         # from this map resolves to `None`, which that gate treats as
         # "unknown source" and refuses — the fail-toward-not-writing default.
         self._source_cache: dict[str, str] | None = None
-        # Guards the three caches above. RLock, not Lock: rebuilding calls
-        # out to each provider's list_catalog() (see _build_owner_cache())
-        # WHILE the lock is held, and the provider interface is a plugin
-        # seam (MCP/Skills register here, per the module docstring, and
-        # more will). None of the three providers shipped today --
-        # BuiltinToolProvider, MCPToolProvider, LocalToolProvider -- call
-        # back into this registry from list_catalog() (each just returns an
-        # already-built in-memory list), but a future provider that DOES
-        # re-enter -- e.g. resolving another tool's schema while composing
-        # its own catalog, on the same thread -- would deadlock a plain
-        # Lock. RLock makes same-thread reentrance safe while still
-        # serializing distinct threads, which is the property this cache
-        # actually needs, and correctness (no deadlock) outranks closing
-        # every last theoretical reentrant-lock hole.
+        # Guards the three caches above. RLock, not Lock -- and NOT because
+        # same-thread reentrance is actually safe here. A live probe (task-4
+        # review) built a deliberately re-entrant provider (one whose
+        # list_catalog() calls back into this registry) and measured both
+        # primitives against it:
+        #   - Lock: the reentrant call blocks forever on a lock its own
+        #     thread already holds -- a PERMANENT hang. Because this one
+        #     lock is shared by the whole registry, that stalls every other
+        #     fleet child's tool lookups too, forever.
+        #   - RLock: the reentrant call is let through (same thread), but it
+        #     re-enters _ensure_catalog_cache() BEFORE _build_owner_cache()
+        #     has returned, so `_owner_cache` is still `None` (the publish
+        #     below hasn't run yet) and it recurses into ANOTHER
+        #     _build_owner_cache() call, which calls the re-entrant
+        #     provider's list_catalog() again, forever -- until Python's
+        #     recursion limit ends it with a RecursionError (measured at 73
+        #     nested calls). The `with self._cache_lock:` blocks still
+        #     unwind correctly through that exception (each nested `with`
+        #     releases its RLock count as the stack pops), so the lock is
+        #     NOT left held: the crash is confined to the one thread that
+        #     owned the misbehaving provider, and every other fleet child
+        #     keeps running and can still acquire the lock once that
+        #     thread's stack finishes unwinding.
+        # RLock is still the right choice, but for THAT reason -- it turns
+        # an unbounded, fleet-wide hang into a fail-fast crash confined to
+        # one thread -- not because this class means to support reentrant
+        # callers.
+        #
+        # Atomic publish: _build_owner_cache() builds `owner`/`name_to_id`/
+        # `source_by_id` as fresh LOCAL dicts and returns them only once
+        # fully populated; _ensure_catalog_cache() assigns all three
+        # instance attributes together, still holding the lock, before
+        # returning. A thread blocked on the lock can therefore only ever
+        # observe the caches in one of two states -- the previous complete
+        # generation, or the next complete one -- never a partially-built
+        # map with some providers swept and others not.
+        #
+        # Provider contract this all depends on: list_catalog() must NOT
+        # re-enter this registry (see above) and must NOT block. Today that
+        # holds only by convention -- BuiltinToolProvider, MCPToolProvider,
+        # and LocalToolProvider each return an already-built in-memory
+        # list/dict with no I/O -- but nothing enforces it. A future
+        # provider that does network I/O inside list_catalog() would run
+        # that I/O WHILE `_cache_lock` is held, stalling every other fleet
+        # child's tool lookup for however long the call takes.
         self._cache_lock = threading.RLock()
 
     def register_provider(self, provider: ToolProvider) -> None:
-        self._providers.append(provider)
-        # A newly registered provider's tools aren't reflected in any
-        # cache already built — invalidate so the next lookup rebuilds it.
-        # Locked so a concurrent reader can't observe one store already
-        # cleared while another still holds the previous generation.
+        # The append lives inside the lock too, alongside the three
+        # invalidations: a concurrent reader must never be able to observe
+        # the new provider in `self._providers` while still holding a
+        # cache built before it was appended (or vice versa).
         with self._cache_lock:
+            self._providers.append(provider)
+            # A newly registered provider's tools aren't reflected in any
+            # cache already built — invalidate so the next lookup rebuilds
+            # it.
             self._owner_cache = None
             self._name_to_id_cache = None
             self._source_cache = None
@@ -1128,10 +1162,14 @@ class ToolCatalogRegistry:
         Returns:
             A positive seconds value, or None to use the run default.
         """
-        tool_id = self.resolve_name(name)
+        # One locked snapshot, like invoke_by_name() -- this was the last
+        # unlocked two-read pair left in the class (resolve_name() then
+        # _owner_and_id(), each its own _ensure_catalog_cache() call).
+        owner, name_to_id, _source = self._ensure_catalog_cache()
+        tool_id = name_to_id.get(name)
         if tool_id is None:
             return None
-        provider = self._owner_and_id(tool_id)
+        provider = owner.get(tool_id)
         getter = getattr(provider, "timeout_for", None)
         return getter(tool_id) if getter is not None else None
 

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -20,6 +20,7 @@ from tldw_chatbook.Tools.tool_executor import CalculatorTool, DateTimeTool
 
 from .agent_models import (
     AgentDefinition,
+    CHECK_AGENTS_TOOL_NAME,
     DIRECT_DISCLOSE_THRESHOLD,
     FIND_TOOLS_NAME,
     INSTALL_SKILL_TOOL_NAME,
@@ -34,6 +35,7 @@ from .agent_models import (
     ToolCatalogEntry,
     ToolResult,
     ToolSchema,
+    WAIT_AGENTS_TOOL_NAME,
 )
 from .run_context import current_run_id
 from .run_log_search import (
@@ -103,6 +105,49 @@ def build_spawn_schema(definitions: Sequence[AgentDefinition]) -> ToolSchema:
         description=SPAWN_TOOL_SCHEMA.description,
         parameters=parameters,
     )
+
+
+# Fleet (PR2a Task 6). Pinned together with the spawn schema, and only
+# for a run that actually has a fleet coordinator -- a model told it can
+# wait on children it can never start has been handed a dead end.
+WAIT_AGENTS_SCHEMA = ToolSchema(
+    id="runtime:wait_agents",
+    name=WAIT_AGENTS_TOOL_NAME,
+    description=(
+        "Wait for sub-agents you started with spawn_subagent and collect "
+        "their results. Omit 'ids' to wait for every sub-agent still "
+        "running, or pass the handle ids spawn_subagent returned to wait "
+        "for just those. Results that arrive after your final answer are "
+        "wasted, so always call this before you answer. When several "
+        "results come back together each one is shortened to share this "
+        "turn's result budget -- call wait_agents with a single id to get "
+        "that one sub-agent's full result."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Handle ids to wait for (omit for all of them)."
+                ),
+            }
+        },
+        "required": [],
+    },
+)
+
+CHECK_AGENTS_SCHEMA = ToolSchema(
+    id="runtime:check_agents",
+    name=CHECK_AGENTS_TOOL_NAME,
+    description=(
+        "List every sub-agent you have started in this turn with its "
+        "handle id, status, and elapsed time. Returns immediately and "
+        "never waits -- use wait_agents to actually collect results."
+    ),
+    parameters={"type": "object", "properties": {}, "required": []},
+)
 
 
 FIND_TOOLS_SCHEMA = ToolSchema(

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1928,7 +1928,13 @@ class ConsoleAgentBridge:
         # previously cached historical (DB-derived) summary is stale.
         self._historical_cache.pop(conversation_id, None)
 
-        def on_step(step: AgentStep, agent_kind: str) -> None:
+        def on_step(step: AgentStep, agent_kind: str, run_id: str) -> None:
+            # PR 2a (task-3): AgentService now attributes every step to its
+            # run id so a fleet of concurrent children can be told apart.
+            # This bridge is still single-run-at-a-time -- `run_id` is
+            # accepted here but not yet used; PR 2b routes fleet rows by it
+            # (keying `live_steps`/`self._live` per run_id instead of per
+            # conversation_id).
             live_steps.append(
                 AgentLiveStep(step.kind, self._summarize(step), agent_kind)
             )

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -16,6 +16,7 @@ import os
 import threading
 import time
 from collections import deque
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -91,6 +92,16 @@ _KNOWN_SUBAGENT_PREFIXES: set[str] = {SUBAGENT_SYSTEM_PROMPT}
 #: should return instantly -- it exists so a wedged straggler leaks a loop
 #: instead of hanging the Console.
 _LOOP_THREAD_JOIN_SECONDS = 5.0
+
+#: Ceiling on ONE submitted provider turn (`_StreamingModelAdapter.
+#: chat_call`). Deliberately generous -- this is not a request timeout (the
+#: gateway and the run's own `max_wall_seconds` own that) but a deadlock
+#: backstop for an abandoned fleet child still waiting on a loop that
+#: `run_reply` has already stopped. Set to TWICE
+#: `CONSOLE_RUN_BUDGET.max_wall_seconds` (1800) so it can never pre-empt a
+#: legitimately slow turn -- by the time it could fire, the run's own wall
+#: budget has long since ended the run.
+_CHAT_CALL_TIMEOUT_SECONDS = 3600.0
 
 # Skills Phase-2 gate finding 1 (Task-14 report, scenario 5: "Find a skill
 # that can shout, load it, and use it on: hello"): a discovery-heavy run --
@@ -895,7 +906,26 @@ class _StreamingModelAdapter:
         # `run_until_complete` did, including re-raising the coroutine's
         # exception) while the loop, on its own thread, interleaves this
         # turn with whatever other agents of this run have in flight.
-        asyncio.run_coroutine_threadsafe(_consume(), self._loop).result()
+        #
+        # The wait is BOUNDED. A bare `.result()` deadlocks forever in one
+        # real case: a child ABANDONED by `_settle_fleet` (which gives a
+        # wedged child `FLEET_JOIN_TIMEOUT_SECONDS` and then walks away)
+        # can still be sitting here when `run_reply`'s finally stops the
+        # loop -- after which its coroutine is never scheduled again and
+        # nothing will ever complete this future. The child's thread is a
+        # daemon, so the process still exits, but it would hold its
+        # provider connection and any locks it owns for the life of the
+        # session. Timing out turns that into an ordinary turn failure the
+        # run loop already knows how to report.
+        future = asyncio.run_coroutine_threadsafe(_consume(), self._loop)
+        try:
+            future.result(timeout=_CHAT_CALL_TIMEOUT_SECONDS)
+        except FuturesTimeoutError:
+            future.cancel()
+            raise TimeoutError(
+                "provider turn did not complete within "
+                f"{_CHAT_CALL_TIMEOUT_SECONDS}s"
+            ) from None
         if any_streamed and not is_subagent:
             # Finding A: this turn leaked prose to the store before it was
             # known to be a tool call (a well-behaved fence-first tool call
@@ -2180,11 +2210,15 @@ class ConsoleAgentBridge:
                         "content": f"{content}\n\n{turn_bundle_block}",
                     }
                     break
-        # The run's loop starts driving HERE, immediately inside the
-        # try/finally that stops, joins and closes it -- see its
-        # construction above for why not sooner.
-        loop_thread.start()
         try:
+            # FIRST statement in the block that owns this thread's
+            # shutdown -- see its construction above. Not merely *before*
+            # the try: one inserted line there would silently re-open the
+            # leak. If start() itself raises (thread exhaustion), the
+            # finally still runs and still closes the loop; `is_alive()`
+            # is False for a never-started thread, so the close branch is
+            # the one taken and no fd leaks.
+            loop_thread.start()
             run_id, outcome = service.run_turn(
                 conversation_id=conversation_id,
                 messages=run_messages,
@@ -2227,8 +2261,15 @@ class ConsoleAgentBridge:
             # bounded anyway so an abandoned straggler can never wedge the
             # Console. The thread is a daemon, so even a wedged one dies
             # with the process rather than holding it open.
-            run_loop.call_soon_threadsafe(run_loop.stop)
-            loop_thread.join(timeout=_LOOP_THREAD_JOIN_SECONDS)
+            #
+            # `ident` is None only if `start()` itself never succeeded
+            # (thread exhaustion): `join()` on a never-started thread
+            # raises RuntimeError, which would escape this finally and
+            # skip the close below -- leaking the loop's fd. Nothing was
+            # ever scheduled in that case, so close it directly.
+            if loop_thread.ident is not None:
+                run_loop.call_soon_threadsafe(run_loop.stop)
+                loop_thread.join(timeout=_LOOP_THREAD_JOIN_SECONDS)
             if loop_thread.is_alive():
                 # Leave it (and its loop) rather than closing a loop its
                 # own thread is still inside -- a leaked loop is survivable,

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1527,7 +1527,11 @@ class ConsoleAgentBridge:
         supersede_previous: bool = False,
         mcp_provider: Any | None = None,
         builtin_gate: Any | None = None,
-        review_tool_calls: Callable[[list[ToolCall]], dict[str, str]] | None = None,
+        # PR2a Task 5: `(calls, run_id)` -- forwarded straight to
+        # `AgentService(review_tool_calls=...)`, which binds each run's own
+        # id in before handing it to `LoopDeps`.
+        review_tool_calls: Callable[[list[ToolCall], str], dict[str, str]]
+        | None = None,
         change_roots: Sequence[Path] | None = None,
         turn_skill_bindings: tuple[str, ...] = (),
         turn_bundle_block: str = "",

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1539,6 +1539,13 @@ class ConsoleAgentBridge:
         request_skill_script_confirm: Callable[[dict], dict] | None = None,
         local_provider: Any | None = None,
         library_provider: Any | None = None,
+        # PR2a Task 7: called with the run id of every sub-agent this turn
+        # cancels or abandons, so its still-armed approval cards are failed
+        # closed and taken off screen instead of staying pressable for a
+        # run that is already over. Forwarded straight to
+        # `AgentService(revoke_approvals=...)`; `None` (a caller with no UI)
+        # leaves cancellation exactly as it was.
+        revoke_approvals: Callable[[str], None] | None = None,
     ) -> tuple[str, RunOutcome]:
         # Per-run tool registry + allow-list (Task 12, extended by P5-T6 for
         # MCP, by task-545/T6 for a per-run builtin_gate, and extended again
@@ -2092,6 +2099,7 @@ class ConsoleAgentBridge:
             review_state_scope=review_state_scope,
             install_skill_tool=install_skill_tool,
             run_skill_script_tool=run_skill_script_tool,
+            revoke_approvals=revoke_approvals,
         )
 
         supersede_run_id = (

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1545,7 +1545,7 @@ class ConsoleAgentBridge:
         # run that is already over. Forwarded straight to
         # `AgentService(revoke_approvals=...)`; `None` (a caller with no UI)
         # leaves cancellation exactly as it was.
-        revoke_approvals: Callable[[str], None] | None = None,
+        revoke_approvals: Callable[[str], object] | None = None,
     ) -> tuple[str, RunOutcome]:
         # Per-run tool registry + allow-list (Task 12, extended by P5-T6 for
         # MCP, by task-545/T6 for a per-run builtin_gate, and extended again

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import threading
 import time
 from collections import deque
 from collections.abc import Mapping
@@ -82,6 +83,14 @@ CONSOLE_AGENT_OPERATING_PROMPT = CATALOG["agents.console_agent_operating"].defau
 # `_StreamingModelAdapter._is_subagent` for why a single current-value
 # check is not enough.
 _KNOWN_SUBAGENT_PREFIXES: set[str] = {SUBAGENT_SYSTEM_PROMPT}
+
+#: How long `run_reply` waits for this run's event-loop thread to stop
+#: before giving up on closing the loop. Matched to
+#: `agent_service.FLEET_JOIN_TIMEOUT_SECONDS`, and for the same reason:
+#: every fleet child is already settled by the time we get here, so this
+#: should return instantly -- it exists so a wedged straggler leaks a loop
+#: instead of hanging the Console.
+_LOOP_THREAD_JOIN_SECONDS = 5.0
 
 # Skills Phase-2 gate finding 1 (Task-14 report, scenario 5: "Find a skill
 # that can shout, load it, and use it on: hello"): a discovery-heavy run --
@@ -791,6 +800,21 @@ class _StreamingModelAdapter:
     ``chat_call``, which forced the gateway's owned ``httpx.AsyncClient`` to
     swap (see ``ConsoleProviderGateway._active_http_client``) once per turn
     instead of at most once per run.
+
+    PR2a Task 6.5: that shared loop is now driven by its OWN thread
+    (``run_forever``, started in ``run_reply``) and every turn is submitted
+    with ``asyncio.run_coroutine_threadsafe``. It used to be driven by
+    ``run_until_complete`` on whichever thread happened to call — sound
+    only while the whole run tree was single-threaded. Under the fleet a
+    child runs on its own thread and calls ``chat_call`` while the parent
+    is inside its own call, and a second ``run_until_complete`` on an
+    already-running loop raises ``RuntimeError: This event loop is already
+    running``: PROBED, and it failed EVERY overlapping child (the child's
+    run row persisted `error` and its coroutine was dropped un-awaited).
+    Submitting instead keeps exactly one loop and one httpx client per run
+    — Fix 1(c) intact — while letting the parent's and the children's
+    turns be genuinely in flight at once, which is the whole point of the
+    fleet.
     """
 
     def __init__(
@@ -862,12 +886,16 @@ class _StreamingModelAdapter:
                 self._store.append_stream_chunk(self._assistant_message_id, tail)
                 any_streamed = True
 
-        # The service runs on a worker thread with no running loop of its
-        # own, so `run_until_complete` on this run's shared loop is safe
-        # here (the loop is never touched concurrently — every chat_call
-        # for this run_reply happens synchronously, one at a time, on this
-        # same thread; see ConsoleAgentBridge.run_reply).
-        self._loop.run_until_complete(_consume())
+        # PR2a Task 6.5: submit to the run's loop rather than driving it
+        # from this thread. Every caller — the primary run's worker thread
+        # and each fleet child's own thread — may be inside `chat_call`
+        # simultaneously, and only ONE thread may ever drive a loop.
+        # `run_coroutine_threadsafe` is the documented cross-thread entry
+        # point; `.result()` blocks THIS thread (exactly as
+        # `run_until_complete` did, including re-raising the coroutine's
+        # exception) while the loop, on its own thread, interleaves this
+        # turn with whatever other agents of this run have in flight.
+        asyncio.run_coroutine_threadsafe(_consume(), self._loop).result()
         if any_streamed and not is_subagent:
             # Finding A: this turn leaked prose to the store before it was
             # known to be a tool call (a well-behaved fence-first tool call
@@ -1920,13 +1948,33 @@ class ConsoleAgentBridge:
         # One event loop for the whole run (PR #629 Fix 1(c)): every turn
         # this run makes -- primary tool-call turns, any sub-agent turns,
         # and the final-answer turn -- bridges through this same loop via
-        # `_StreamingModelAdapter.chat_call`'s `run_until_complete`, instead
-        # of each turn spinning up (and tearing down) its own loop via
-        # `asyncio.run()`. That per-turn churn forced a client swap on the
-        # gateway's owned httpx client every single turn (see
+        # `_StreamingModelAdapter.chat_call`, instead of each turn spinning
+        # up (and tearing down) its own loop via `asyncio.run()`. That
+        # per-turn churn forced a client swap on the gateway's owned httpx
+        # client every single turn (see
         # `ConsoleProviderGateway._active_http_client`); reusing one loop
         # for the whole run means at most one swap per run.
+        #
+        # PR2a Task 6.5: the loop gets its OWN thread. It is no longer
+        # driven by `run_until_complete` from whichever agent's thread is
+        # calling, because with the fleet ON by default several of them
+        # call at once and a loop may only ever be driven by one thread --
+        # the second concurrent driver raises "This event loop is already
+        # running" and kills that child's run. `chat_call` now submits
+        # with `run_coroutine_threadsafe`, so this thread is the single
+        # driver and the callers merely wait on their own futures.
+        # Constructed here (with the loop it drives) but STARTED only just
+        # before the try/finally that owns its shutdown, a few hundred
+        # lines below: a raise in the composition work between the two
+        # would otherwise leave a daemon thread spinning `run_forever`
+        # forever with nothing to stop it. Same ordering rule -- and the
+        # same failure -- as `AgentService`'s own `thread.start()` guard.
         run_loop = asyncio.new_event_loop()
+        loop_thread = threading.Thread(
+            target=run_loop.run_forever,
+            name="console-agent-loop",
+            daemon=True,
+        )
         adapter = _StreamingModelAdapter(
             store=self._store,
             provider_gateway=self._gateway,
@@ -2132,6 +2180,10 @@ class ConsoleAgentBridge:
                         "content": f"{content}\n\n{turn_bundle_block}",
                     }
                     break
+        # The run's loop starts driving HERE, immediately inside the
+        # try/finally that stops, joins and closes it -- see its
+        # construction above for why not sooner.
+        loop_thread.start()
         try:
             run_id, outcome = service.run_turn(
                 conversation_id=conversation_id,
@@ -2166,7 +2218,28 @@ class ConsoleAgentBridge:
                 supersede_run_id=supersede_run_id,
             )
         finally:
-            run_loop.close()
+            # PR2a Task 6.5: stop the driver thread before closing, and
+            # join it -- `close()` on a still-running loop raises, and a
+            # loop closed out from under its own thread is undefined. By
+            # this point `run_turn` has already settled every fleet child
+            # (`AgentService._settle_fleet` joins/abandons them before it
+            # returns), so nothing should still be submitting; the join is
+            # bounded anyway so an abandoned straggler can never wedge the
+            # Console. The thread is a daemon, so even a wedged one dies
+            # with the process rather than holding it open.
+            run_loop.call_soon_threadsafe(run_loop.stop)
+            loop_thread.join(timeout=_LOOP_THREAD_JOIN_SECONDS)
+            if loop_thread.is_alive():
+                # Leave it (and its loop) rather than closing a loop its
+                # own thread is still inside -- a leaked loop is survivable,
+                # a segfaulting one is not.
+                logger.warning(
+                    "console agent run loop did not stop within "
+                    f"{_LOOP_THREAD_JOIN_SECONDS}s; leaving it to the "
+                    "daemon thread"
+                )
+            else:
+                run_loop.close()
             # TASK-1971: E snapshot on EVERY terminal path -- completed,
             # failed, cancelled, or crashed. A run that died halfway through
             # editing is when review matters most. `run_id` is unbound when

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -189,16 +189,22 @@ def _combine_state_scopes(scopes: list) -> "Any | None":
     """Combine per-turn state scopes into the one ``review_state_scope`` seam.
 
     ``AgentService.review_state_scope`` holds a single
-    ``Callable[[], AbstractContextManager]``, but more than one component
-    can own per-turn stamp state that a nested sub-agent run would clobber
-    (task-628): the MCP provider's ``_stamped_decisions`` and the built-in
-    gate's ``_stamps``. Entering them together keeps the seam's shape while
-    guarding both.
+    ``Callable[[str], AbstractContextManager]``, but more than one
+    component can own per-turn stamp state that a nested sub-agent run
+    would clobber (task-628): the MCP provider's ``_stamped_decisions``,
+    the built-in gate's ``_stamps``, and the local provider's own stamps.
+    Entering them together keeps the seam's shape while guarding all
+    three.
+
+    PR2a Task 5: each scope now takes the run id whose slice it should
+    snapshot and restore (all three key their stamps by ``(run_id,
+    name)``), and the scope is no longer the load-bearing protection --
+    per-run keying is. See ``MCPToolProvider.stamp_scope``.
 
     Args:
-        scopes: Zero or more zero-argument callables, each returning a
-            context manager that snapshots and restores its owner's
-            per-turn state.
+        scopes: Zero or more one-argument callables, each taking a run id
+            and returning a context manager that snapshots and restores
+            that run's slice of its owner's per-turn state.
 
     Returns:
         ``None`` when ``scopes`` is empty (the service then uses a
@@ -213,10 +219,10 @@ def _combine_state_scopes(scopes: list) -> "Any | None":
         return scopes[0]
 
     @contextlib.contextmanager
-    def _combined():
+    def _combined(run_id: str):
         with contextlib.ExitStack() as stack:
             for scope in scopes:
-                stack.enter_context(scope())
+                stack.enter_context(scope(run_id))
             yield
 
     return _combined
@@ -2061,11 +2067,15 @@ class ConsoleAgentBridge:
             _inner_review = review_tool_calls
             _handle = change_handle
 
-            def review_tool_calls(calls):  # type: ignore[no-redef]
+            def review_tool_calls(calls, run_id):  # type: ignore[no-redef]
+                # PR2a Task 5: pass the run id straight through -- this
+                # wrapper only gates on the baseline snapshot; the inner
+                # hook is what needs the run identity to scope its gate
+                # writes.
                 _handle.await_baseline()
                 if _inner_review is None:
                     return {}
-                return _inner_review(calls)
+                return _inner_review(calls, run_id)
         service = AgentService(
             self._db,
             registry,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -3632,23 +3632,35 @@ class ConsoleChatController:
         session: session-keyed teardown could not tell a cancelled child's
         card from its live sibling's.
 
+        Covers BOTH card registries a cancelled child can be holding:
+        ``_pending_approval_rounds`` (tool-call approvals) and
+        ``_pending_skill_script_rounds`` (run_skill_script confirms). The
+        skill-script leg is the wider hazard of the two -- that tool is
+        all-agents scope, its schema is not filtered by
+        ``config.allowed_tools``, and ``console_agent_bridge``'s closure
+        runs the script on the very next line after the confirm returns
+        Allow, with no cancellation checkpoint in between. (Skill-INSTALL
+        confirms are deliberately not swept: ``install_skill`` is wired
+        for the primary agent only, so no sub-agent can arm one.)
+
         Each revoked round is (a) marked ``revoked`` so the waiting thread
-        returns "deny" for every name even if a click lands in its shared
-        decisions box afterwards, (b) filled with "deny" for every name it
-        was asked about, (c) removed from ``_pending_approval_rounds``, so
-        a late ``resolve_pending_approval`` finds nothing to resolve, (d)
+        fails closed even if a click lands in its shared decision box
+        afterwards, (b) pre-filled with the closed verdict, (c) removed
+        from its registry, so a late ``resolve_pending_approval``/
+        ``resolve_pending_skill_script`` finds nothing to resolve, (d)
         released via its Event, so the waiting thread returns immediately
-        rather than at its 120s auto-deny, (e) discarded from
+        rather than at its auto-deny deadline, (e) discarded from
         ``_pending_approvals`` so the session's NEEDS_APPROVAL badge
         clears once its last round is gone, and (f) taken off screen
-        through ``_clear_pending_approval_if_round_is_current`` -- the
-        SAME round-identity-guarded clear a resolved round's own teardown
-        uses, so a sibling round's card is never clobbered.
+        through the SAME round-identity-guarded clear that round's own
+        teardown uses, so a sibling round's card is never clobbered.
 
-        Thread-safe: the registry mutations happen under
-        ``_approval_state_lock``; ``discard_pending_round`` and the UI
-        clear take that same (non-reentrant) lock themselves and are
-        therefore deliberately called after it is released.
+        Thread-safe. Each registry is swept under its own lock, and the
+        two locks are taken SEQUENTIALLY, never nested -- the ordering
+        contract ``_clear_pending_skill_script_if_round_is_current``
+        already documents. ``discard_pending_round`` and both UI clears
+        take those (non-reentrant) locks themselves, so they are
+        deliberately called after every critical section is released.
 
         Args:
             run_id: The cancelled/abandoned run whose cards must die. A
@@ -3657,16 +3669,65 @@ class ConsoleChatController:
                 sweeping those would deny cards no run owns.
 
         Returns:
-            How many rounds were revoked (``0`` when the run had none).
+            How many rounds were revoked across both registries (``0``
+            when the run had none).
         """
         if not run_id:
             return 0
+        revoked = self._revoke_tool_approval_rounds(run_id)
+        script_revoked = self._revoke_skill_script_rounds(run_id)
+        for round_id, session_id in revoked:
+            if session_id is not None:
+                self.discard_pending_round(session_id, round_id)
+            try:
+                self._clear_pending_approval_if_round_is_current(
+                    round_id, session_id
+                )
+            except Exception:  # noqa: BLE001 -- a UI clear must never
+                # break the cancellation path that called us.
+                logger.opt(exception=True).debug(
+                    "Failed to marshal approval clear during revocation"
+                )
+        for request_id, session_id in script_revoked:
+            if session_id is not None:
+                self.discard_pending_round(session_id, request_id)
+            try:
+                self._clear_pending_skill_script_if_round_is_current(
+                    request_id, session_id
+                )
+            except Exception:  # noqa: BLE001 -- as above.
+                logger.opt(exception=True).debug(
+                    "Failed to clear skill-script confirm during revocation"
+                )
+        total = len(revoked) + len(script_revoked)
+        if total:
+            logger.info(
+                f"revoked {total} pending approval round(s) for "
+                f"cancelled run {run_id}"
+            )
+        return total
+
+    def _revoke_tool_approval_rounds(self, run_id: str) -> list[tuple[str, str | None]]:
+        """Fail this run's tool-approval rounds closed. Registry work only.
+
+        Args:
+            run_id: The cancelled/abandoned run.
+
+        Returns:
+            ``(round_id, session_id)`` for each revoked round, for the
+            caller's badge/card teardown (which must run outside the lock
+            held here).
+        """
         revoked: list[tuple[str, str | None]] = []
         with self._approval_state_lock:
             for round_id, state in list(self._pending_approval_rounds.items()):
                 if state.get("run_id") != run_id:
                     continue
                 state["revoked"] = True
+                # Defense in depth only: the post-wait `revoked` guard in
+                # `request_mcp_approvals` is the actual mechanism (it
+                # ignores this box entirely). Filling it keeps the box
+                # honest for anything that reads it directly.
                 decisions = state.get("decisions")
                 if isinstance(decisions, dict):
                     for name in state.get("names") or ():
@@ -3692,24 +3753,50 @@ class ConsoleChatController:
                     for state in self._pending_approval_rounds.values()
                 ):
                     self._parked_approval_payloads.pop(session_id, None)
-        for round_id, session_id in revoked:
-            if session_id is not None:
-                self.discard_pending_round(session_id, round_id)
-            try:
-                self._clear_pending_approval_if_round_is_current(
-                    round_id, session_id
-                )
-            except Exception:  # noqa: BLE001 -- a UI clear must never
-                # break the cancellation path that called us.
-                logger.opt(exception=True).debug(
-                    "Failed to marshal approval clear during revocation"
-                )
+        return revoked
+
+    def _revoke_skill_script_rounds(self, run_id: str) -> list[tuple[str, str | None]]:
+        """Fail this run's ``run_skill_script`` confirms closed.
+
+        Registry work only, under ``_pending_skill_script_lock`` and then
+        (sequentially, never nested -- see
+        ``_clear_pending_skill_script_if_round_is_current``)
+        ``_approval_state_lock`` for the retained-payload slot.
+
+        Args:
+            run_id: The cancelled/abandoned run.
+
+        Returns:
+            ``(request_id, session_id)`` for each revoked confirm.
+        """
+        revoked: list[tuple[str, str | None]] = []
+        with self._pending_skill_script_lock:
+            for request_id, state in list(self._pending_skill_script_rounds.items()):
+                if state.get("run_id") != run_id:
+                    continue
+                state["revoked"] = True
+                # Defense in depth -- the post-wait `revoked` guard in
+                # `request_skill_script_confirm` is what actually denies.
+                decision = state.get("decision")
+                if isinstance(decision, dict):
+                    decision["allow"] = False
+                    decision["remember"] = False
+                self._pending_skill_script_rounds.pop(request_id, None)
+                session_id = state.get("session_id") or None
+                revoked.append((request_id, session_id))
+                event = state.get("event")
+                if event is not None:
+                    event.set()
+            still_armed = {
+                state.get("session_id")
+                for state in self._pending_skill_script_rounds.values()
+            }
         if revoked:
-            logger.info(
-                f"revoked {len(revoked)} pending approval round(s) for "
-                f"cancelled run {run_id}"
-            )
-        return len(revoked)
+            with self._approval_state_lock:
+                for _request_id, session_id in revoked:
+                    if session_id is not None and session_id not in still_armed:
+                        self._parked_skill_script_payloads.pop(session_id, None)
+        return revoked
 
     # -- Skill-install confirm bridge (task-5, parked TASK-910) --------------
 
@@ -4056,12 +4143,27 @@ class ConsoleChatController:
         owning_session_id = session_id if session_id is not None else (
             self.store.active_session_id or ""
         )
+        # PR2a Task 7 (review M1): same run-ownership stamp
+        # `request_mcp_approvals` carries, and for a WIDER hazard --
+        # `run_skill_script` is all-agents scope (no agent_kind gate in
+        # `AgentService._run_one`) and runtime schemas are not filtered by
+        # `config.allowed_tools`, so a fleet child is offered it
+        # unconditionally; the bridge closure then runs the script as the
+        # very next statement after this confirm returns Allow, with no
+        # cancellation checkpoint in between. `current_run_id()` is bound
+        # for the whole loop by `AgentService` (this tool is dispatched
+        # IN-LOOP, not through `invoke_tool`'s per-call thread).
+        script_round_state: dict[str, Any] = {
+            "event": event,
+            "decision": decision,
+            "session_id": owning_session_id,
+            "run_id": current_run_id(),
+            # Re-read after the wait: a late Allow must not stick. See
+            # `revoke_approval_rounds_for_run`.
+            "revoked": False,
+        }
         with self._pending_skill_script_lock:
-            self._pending_skill_script_rounds[request_id] = {
-                "event": event,
-                "decision": decision,
-                "session_id": owning_session_id,
-            }
+            self._pending_skill_script_rounds[request_id] = script_round_state
 
         timeout_seconds = (
             self.skill_script_confirm_timeout_seconds()
@@ -4095,6 +4197,18 @@ class ConsoleChatController:
                     break
                 if time.monotonic() >= deadline:
                     break
+            # PR2a Task 7 (review M1): a revoked round denies
+            # unconditionally, without consulting `decision` at all --
+            # `resolve_pending_skill_script` writes into that shared box
+            # after snapshotting the round, so an Allow delivered just
+            # after the child was cancelled could otherwise reach the
+            # `asyncio.run(scope.run_skill_script(...))` call the bridge
+            # makes on the very next line. Mirrors `request_mcp_
+            # approvals`' identical post-wait guard.
+            with self._pending_skill_script_lock:
+                was_revoked = bool(script_round_state.get("revoked"))
+            if was_revoked:
+                return {"allow": False, "remember": False}
             return {
                 "allow": bool(decision.get("allow", False)),
                 "remember": bool(decision.get("remember", False)),

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -357,7 +357,7 @@ def build_mcp_review_hook(
         `AgentService(review_tool_calls=...)`.
     """
 
-    def review_tool_calls(calls: list["ToolCall"]) -> dict[str, str]:
+    def review_tool_calls(calls: list["ToolCall"], run_id: str) -> dict[str, str]:
         # I3: clear THIS turn's stamps FIRST, before pending_gate_for/the
         # approval round trip even run -- subsumes the `if not pending`
         # branch's own clear below (every invocation of this hook clears,
@@ -365,13 +365,15 @@ def build_mcp_review_hook(
         # clear must happen at entry, not only after a successful round
         # trip: a raising `request_mcp_approvals` must never leave a stale
         # prior-turn stamp live for the fail-open runtime to hand straight
-        # to `invoke()`.
-        provider.apply_batch_decisions({})
+        # to `invoke()`. PR2a Task 5: that clear is scoped to `run_id` --
+        # it still wipes THIS run's prior turn, and no longer wipes a
+        # concurrent sibling's live verdicts.
+        provider.apply_batch_decisions(run_id, {})
         pending = _collect_mcp_pending(provider, calls)
         if not pending:
             return {}
         decisions = request_mcp_approvals(pending)
-        provider.apply_batch_decisions(decisions)
+        provider.apply_batch_decisions(run_id, decisions)
         return {call.llm_name: "proceed" for call in pending}
 
     return review_tool_calls
@@ -461,20 +463,29 @@ def build_tool_review_hook(
     was).
 
     Mirrors `build_mcp_review_hook`'s I3 clear-at-entry discipline, extended
-    to the built-in side: `builtin_gate.begin_turn()` runs FIRST,
+    to the built-in side: `builtin_gate.begin_turn(run_id)` runs FIRST,
     unconditionally -- before the MCP stamp clear, before any
     `pending_gate_for`/`resolve` call, before the `request_approvals` round
     trip -- so a raising round trip can never leave a stale built-in stamp
     (or a stale cached permission payload) live for the next turn to
-    consume. `mcp_provider.apply_batch_decisions({})` follows the same
-    reasoning for the MCP side, only when a provider was actually composed
-    this run.
+    consume. `mcp_provider.apply_batch_decisions(run_id, {})` follows the
+    same reasoning for the MCP side, only when a provider was actually
+    composed this run.
+
+    PR2a Task 5: every one of those mutations is scoped to `run_id`, the
+    second argument this hook now receives (`AgentService` binds its own
+    run id into the callable it hands `LoopDeps`). The gate and the MCP
+    provider are shared by a parent run and every sub-agent it spawns, so
+    an unscoped clear here wipes -- and an unscoped stamp overwrites --
+    verdicts another run in the tree has already been granted and has not
+    yet consumed. It still clears THIS run's own previous turn, which is
+    what the I3 discipline above requires.
 
     Exactly ONE `request_approvals` round trip is made per turn, carrying
     BOTH the MCP and built-in pending rows together -- never one call per
     owner. Decisions are then applied back to each owner separately:
-    `mcp_provider.apply_batch_decisions(...)` for MCP rows,
-    `builtin_gate.stamp(name, decision)` for built-in rows. The returned
+    `mcp_provider.apply_batch_decisions(run_id, ...)` for MCP rows,
+    `builtin_gate.stamp(run_id, name, decision)` for built-in rows. The returned
     verdict map carries "proceed" for approved calls and REFUSAL STRINGS
     for per-call denials (TASK-1861) and kill-switch blocks (TASK-631) --
     the runtime enforces those directly, skipping dispatch. Approvals are
@@ -523,8 +534,14 @@ def build_tool_review_hook(
         `AgentService(review_tool_calls=...)`.
     """
 
-    def review_tool_calls(calls: list["ToolCall"]) -> dict[str, str]:
-        builtin_gate.begin_turn()
+    def review_tool_calls(calls: list["ToolCall"], run_id: str) -> dict[str, str]:
+        # PR2a Task 5: every gate mutation below is scoped to `run_id` --
+        # the run whose batch this is, supplied by `AgentService` (which
+        # binds its own run id into the hook it puts on `LoopDeps`). The
+        # gate and provider instances are shared by a parent and every
+        # sub-agent it spawns, so an unscoped clear/stamp here reaches
+        # verdicts a concurrent sibling has not yet consumed.
+        builtin_gate.begin_turn(run_id)
         # TASK-631: the kill switch outranks everything -- no prompting, no
         # stamps, every call refused. Per-call keys where the runtime can
         # address them; an id-less (fence-path) call is refused by NAME,
@@ -541,7 +558,7 @@ def build_tool_review_hook(
                 switch_on = True
             if switch_on:
                 if mcp_provider is not None:
-                    mcp_provider.apply_batch_decisions({})
+                    mcp_provider.apply_batch_decisions(run_id, {})
                 return {
                     (str(getattr(call, "call_id", "") or "") or call.name): (
                         KILL_SWITCH_REFUSAL
@@ -549,7 +566,7 @@ def build_tool_review_hook(
                     for call in calls
                 }
         if mcp_provider is not None:
-            mcp_provider.apply_batch_decisions({})
+            mcp_provider.apply_batch_decisions(run_id, {})
 
         mcp_pending = (
             _collect_mcp_pending(mcp_provider, calls)
@@ -688,12 +705,13 @@ def build_tool_review_hook(
 
         if mcp_provider is not None:
             mcp_provider.apply_batch_decisions(
+                run_id,
                 _stamps_for(
                     [r for r in mcp_pending if r.llm_name in mcp_claimed_names]
-                )
+                ),
             )
         for name, decision in _stamps_for(builtin_pending).items():
-            builtin_gate.stamp(name, decision)
+            builtin_gate.stamp(run_id, name, decision)
 
         # The refusal half, enforced HERE rather than through the stamps.
         # The runtime resolves `call_id` before name and turns any
@@ -748,9 +766,11 @@ def build_local_review_hook(
         `AgentService(review_tool_calls=...)`.
     """
 
-    def review_tool_calls(calls: list["ToolCall"]) -> dict[str, str]:
+    def review_tool_calls(calls: list["ToolCall"], run_id: str) -> dict[str, str]:
         # I3: clear THIS turn's stamps FIRST -- see build_mcp_review_hook.
-        provider.apply_batch_decisions({})
+        # PR2a Task 5: scoped to `run_id`, so the clear cannot reach a
+        # concurrent sibling run's live verdicts.
+        provider.apply_batch_decisions(run_id, {})
         pending: list["MCPPendingCall"] = []
         for call in calls:
             gate = provider.pending_gate_for(call.name, call.args)
@@ -759,7 +779,7 @@ def build_local_review_hook(
         if not pending:
             return {}
         decisions = request_approvals(pending)
-        provider.apply_batch_decisions(decisions)
+        provider.apply_batch_decisions(run_id, decisions)
         return {call.llm_name: "proceed" for call in pending}
 
     return review_tool_calls
@@ -800,12 +820,12 @@ def build_combined_review_hook(
         verdict map into one.
     """
 
-    def review_tool_calls(calls: list["ToolCall"]) -> dict[str, str]:
+    def review_tool_calls(calls: list["ToolCall"], run_id: str) -> dict[str, str]:
         verdicts: dict[str, str] = {}
         first_exc: Exception | None = None
         for hook in hooks:
             try:
-                verdicts.update(hook(calls))
+                verdicts.update(hook(calls, run_id))
             except Exception as exc:  # noqa: BLE001 -- re-raised after ALL hooks ran
                 logger.opt(exception=True).warning(
                     "combined review_tool_calls: a provider hook raised; "

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -92,6 +92,7 @@ from tldw_chatbook.Agents.builtin_tool_gate import (
 )
 from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider
 from tldw_chatbook.Agents.mcp_tool_provider import MCPPendingCall, MCPToolProvider
+from tldw_chatbook.Agents.run_context import current_run_id
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
 from tldw_chatbook.config import coerce_bool_setting, get_cli_setting
 from tldw_chatbook.Internal_Prompts import get_internal_prompt
@@ -2786,17 +2787,42 @@ class ConsoleChatController:
             if session_id is not None
             else (self.store.active_session_id or "")
         )
+        # PR2a Task 7: which RUN armed this round. Read from the
+        # `run_context` ContextVar, which `AgentService` binds around both
+        # arming paths -- the per-turn review hook (`build_tool_review_
+        # hook`/`build_mcp_review_hook`/`build_local_review_hook`, which
+        # call straight through to this method on their own run's thread)
+        # and each tool invocation (the single-call fallback approval
+        # `MCPToolProvider.invoke` raises through `approval_callback`,
+        # which has no run_id parameter to thread at all). A session id
+        # cannot substitute: every child of a fleet turn shares the
+        # parent's session, so only the run id can tell a cancelled
+        # child's card apart from its live sibling's. `""` (no run bound
+        # -- e.g. the MCP workbench's Test Tool) is never revocable, which
+        # is correct: no run owns it.
+        owning_run_id = current_run_id()
+        round_state: dict[str, Any] = {
+            "event": event,
+            "decisions": decisions,
+            "session_id": owning_session_id,
+            "run_id": owning_run_id,
+            # The names this round must answer for -- what `revoke_
+            # approval_rounds_for_run` fills with "deny".
+            "names": tuple(unique_names),
+            # Flipped by revocation. Re-read after the wait below so a
+            # decision that lands in `decisions` AFTER the revoke (the
+            # `ApprovalDecided` message is async, and `resolve_pending_
+            # approval` snapshots the box before writing to it) can never
+            # turn a revoked round back into an approval.
+            "revoked": False,
+        }
         # F2b fix (Qodo wave): guard the round registration -- the UI
         # thread's `resolve_pending_approval` (TASK-913: fails closed by
         # round_id now, no more active-session scan) and the
         # `fleet_summary_counts` sync tick can read/iterate this map
         # concurrently with this worker thread's own writes.
         with self._approval_state_lock:
-            self._pending_approval_rounds[round_id] = {
-                "event": event,
-                "decisions": decisions,
-                "session_id": owning_session_id,
-            }
+            self._pending_approval_rounds[round_id] = round_state
 
         timeout_seconds = self._resolve_mcp_approval_timeout_seconds()
         deadline = time.monotonic() + timeout_seconds
@@ -2896,6 +2922,27 @@ class ConsoleChatController:
                     for name in unique_names:
                         decisions.setdefault(name, "timeout")
                     break
+            # PR2a Task 7: a revoked round answers "deny" for every name,
+            # unconditionally -- it does not consult `decisions` at all.
+            # The run this round belongs to has been cancelled or
+            # abandoned, and `resolve_pending_approval` can still write
+            # into the shared `decisions` box after revocation (it
+            # snapshots the box under the lock, then updates it outside),
+            # so honouring that box here would let a click delivered
+            # microseconds after the cancellation execute the tool for
+            # real. `revoke_approval_rounds_for_run` already filled every
+            # name with "deny"; this is the guard that makes it stick.
+            with self._approval_state_lock:
+                was_revoked = bool(round_state.get("revoked"))
+            if was_revoked:
+                # Same audit gap Finding I3 documents for the cancellation
+                # branch above: the child's loop is being torn down, so
+                # these calls never reach `invoke()`'s own gate and would
+                # otherwise leave no record of having been denied.
+                self._record_cancelled_approval_decisions(
+                    list(unique_names), call_by_name
+                )
+                return {name: "deny" for name in unique_names}
             # Any name the resolution path above didn't already cover (e.g.
             # a partial/empty decisions dict handed to `resolve_pending_
             # approval`) fails closed to "deny" rather than silently
@@ -3559,6 +3606,110 @@ class ConsoleChatController:
         approval_event = round_state["event"]
         decisions_dict.update(decisions or {})
         approval_event.set()
+
+    def revoke_approval_rounds_for_run(self, run_id: str) -> int:
+        """Fail every approval round owned by ``run_id`` closed, right now.
+
+        PR2a Task 7 (safety). The approval wait blocks inside
+        ``_call_with_timeout``'s per-call daemon thread, which keeps
+        running after the fleet cooperatively cancels -- or outright
+        ABANDONS -- the child that owns it. Until this existed, that
+        child's card stayed on screen and stayed live: pressing Approve
+        resolved the round, the waiting thread returned the approval, and
+        the tool EXECUTED FOR REAL (a file written, a message sent) for a
+        run whose handle and run row already read ``cancelled``. The
+        documented ``approval_timeout < max_tool_call_seconds`` invariant
+        (see ``_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS``) bounds the same
+        class of hazard for the timeout path; this closes the
+        cancellation path.
+
+        Called by ``AgentService`` (through its injected
+        ``revoke_approvals`` seam) at both moments a child stops being
+        allowed to act: the cooperative cancel and the end-of-turn
+        abandon. Safe to call for a run that never armed a card -- the
+        common case -- and never touches another run's rounds, which
+        matters because every child of a fleet turn shares ONE console
+        session: session-keyed teardown could not tell a cancelled child's
+        card from its live sibling's.
+
+        Each revoked round is (a) marked ``revoked`` so the waiting thread
+        returns "deny" for every name even if a click lands in its shared
+        decisions box afterwards, (b) filled with "deny" for every name it
+        was asked about, (c) removed from ``_pending_approval_rounds``, so
+        a late ``resolve_pending_approval`` finds nothing to resolve, (d)
+        released via its Event, so the waiting thread returns immediately
+        rather than at its 120s auto-deny, (e) discarded from
+        ``_pending_approvals`` so the session's NEEDS_APPROVAL badge
+        clears once its last round is gone, and (f) taken off screen
+        through ``_clear_pending_approval_if_round_is_current`` -- the
+        SAME round-identity-guarded clear a resolved round's own teardown
+        uses, so a sibling round's card is never clobbered.
+
+        Thread-safe: the registry mutations happen under
+        ``_approval_state_lock``; ``discard_pending_round`` and the UI
+        clear take that same (non-reentrant) lock themselves and are
+        therefore deliberately called after it is released.
+
+        Args:
+            run_id: The cancelled/abandoned run whose cards must die. A
+                falsy id is a no-op -- ``""`` is the "no run bound" key
+                that rounds armed outside any agent run carry, and
+                sweeping those would deny cards no run owns.
+
+        Returns:
+            How many rounds were revoked (``0`` when the run had none).
+        """
+        if not run_id:
+            return 0
+        revoked: list[tuple[str, str | None]] = []
+        with self._approval_state_lock:
+            for round_id, state in list(self._pending_approval_rounds.items()):
+                if state.get("run_id") != run_id:
+                    continue
+                state["revoked"] = True
+                decisions = state.get("decisions")
+                if isinstance(decisions, dict):
+                    for name in state.get("names") or ():
+                        decisions[name] = "deny"
+                self._pending_approval_rounds.pop(round_id, None)
+                session_id = state.get("session_id") or None
+                revoked.append((round_id, session_id))
+                event = state.get("event")
+                if event is not None:
+                    # Last, and only once the round is unreachable: the
+                    # thread this releases returns the moment it wakes.
+                    event.set()
+            # Mirrors `request_mcp_approvals`' `finally` exactly: the
+            # retained payload is a SINGLE per-session slot, so it may
+            # only be dropped once NO armed round is left for that
+            # session -- otherwise a still-armed sibling loses the only
+            # copy of its card and a switch away/back mounts nothing.
+            for _round_id, session_id in revoked:
+                if session_id is None:
+                    continue
+                if not any(
+                    state.get("session_id") == session_id
+                    for state in self._pending_approval_rounds.values()
+                ):
+                    self._parked_approval_payloads.pop(session_id, None)
+        for round_id, session_id in revoked:
+            if session_id is not None:
+                self.discard_pending_round(session_id, round_id)
+            try:
+                self._clear_pending_approval_if_round_is_current(
+                    round_id, session_id
+                )
+            except Exception:  # noqa: BLE001 -- a UI clear must never
+                # break the cancellation path that called us.
+                logger.opt(exception=True).debug(
+                    "Failed to marshal approval clear during revocation"
+                )
+        if revoked:
+            logger.info(
+                f"revoked {len(revoked)} pending approval round(s) for "
+                f"cancelled run {run_id}"
+            )
+        return len(revoked)
 
     # -- Skill-install confirm bridge (task-5, parked TASK-910) --------------
 
@@ -7507,6 +7658,14 @@ class ConsoleChatController:
                     if self.set_pending_skill_script is not None
                     else None
                 ),
+                # PR2a Task 7: the fleet cancels/abandons children on the
+                # bridge's worker thread and hands each stopped run's id
+                # here, so a card still on screen for a child that is
+                # already `cancelled` is denied and cleared rather than
+                # left pressable (an approval that would still EXECUTE the
+                # tool for real). Run-keyed, so a live sibling child --
+                # which shares this same session -- keeps its own card.
+                revoke_approvals=self.revoke_approval_rounds_for_run,
             )
         except asyncio.CancelledError:
             if cancel_event.is_set():

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -22,6 +22,7 @@ from loguru import logger
 
 from tldw_chatbook.Agents.agent_models import (
     AgentDefinition,
+    TERMINAL_RUN_STATUSES,
     validate_agent_definition,
 )
 from .base_db import BaseDB
@@ -644,8 +645,12 @@ class AgentRunsDB(BaseDB):
                 (json.dumps(existing), _now_iso(), run_id),
             )
 
-    def set_status(self, run_id: str, status: str, result: str | None = None) -> None:
+    def set_status(self, run_id: str, status: str, result: str | None = None) -> bool:
         """Update a run's terminal (or in-progress) status.
+
+        A run already in a terminal status is never rewritten (first-writer-wins),
+        because an abandoned child thread can persist after the coordinator recorded
+        a terminal status, and we must not overwrite that with a late update.
 
         Args:
             run_id: The run to update.
@@ -655,13 +660,20 @@ class AgentRunsDB(BaseDB):
                 text; when ``None`` the existing ``result`` column is left
                 unchanged (``COALESCE``), so a status-only update never
                 clobbers a previously recorded result.
+
+        Returns:
+            True if the run was updated (a row changed), False if the run is
+            already terminal or does not exist.
         """
+        placeholders = ",".join("?" for _ in TERMINAL_RUN_STATUSES)
         with self.transaction() as conn:
-            conn.execute(
+            cursor = conn.execute(
                 "UPDATE agent_runs SET status = ?, "
-                "result = COALESCE(?, result), updated_at = ? WHERE id = ?",
-                (status, result, _now_iso(), run_id),
+                "result = COALESCE(?, result), updated_at = ? "
+                f"WHERE id = ? AND status NOT IN ({placeholders})",
+                (status, result, _now_iso(), run_id, *sorted(TERMINAL_RUN_STATUSES)),
             )
+        return cursor.rowcount > 0
 
     def reconcile_orphaned_runs(self) -> int:
         """Mark runs left ``running`` by a crashed process as ``error``.

--- a/tldw_chatbook/Library/library_skills_state.py
+++ b/tldw_chatbook/Library/library_skills_state.py
@@ -65,6 +65,13 @@ _SHADOWED_BUILTIN_NAMES = frozenset(
         # share the same reserved runtime namespace.
         "run_log_stats",
         "run_log_slice",
+        # The fleet tools (PR2a): the supervisor collects concurrent
+        # sub-agents with these, so a skill installed under either name
+        # would shadow the runtime tool the moment it is invoked by name.
+        # Same reserved-namespace rule as every other RUNTIME_TOOL_NAMES
+        # entry above.
+        "wait_agents",
+        "check_agents",
         # task-580: console commands from the /rewind and image-generation
         # features. These were added to the command registry without updating
         # this set, so the drift guard below failed and was carried as an


### PR DESCRIPTION
Phase 2 of the supervisor agent fleet (spec `Docs/superpowers/specs/2026-08-08-supervisor-agent-fleet-design.md` §5, plan `Docs/superpowers/plans/2026-08-09-supervisor-fleet-pr2a-concurrency-runtime.md`). Builds on PR #1461.

## What this adds

Sub-agents now run **concurrently on their own threads** under a new `FleetCoordinator`. `spawn_subagent` returns a handle immediately; the supervisor collects results with **`wait_agents`** and polls status with **`check_agents`** (both primary-only, dispatched in-loop). Fleet size is `[agents] max_live_subagents`, default 3.

**Skill calls deliberately stay inline** and return their output directly — a skill's contract is "run it and give me the result", and under the fleet the model would otherwise answer from the literal handle string while the real work got discarded. Discriminated by an explicit pre-bound `inline=True`, not inferred from permissions.

## Correctness work this required

Concurrency broke several things that were sound only while children ran inline:

- **Both permission gates re-keyed per run.** `_stamps`/`_stamped_decisions` were keyed by tool name on shared instances, protected by a snapshot/restore scheme that is only sound for a nested LIFO child. With siblings there is no LIFO — one child's turn wiped verdicts another child or the parent had not yet consumed. Verdicts are now `(run_id, name)`; the run id rides a ContextVar bound both per-invocation and loop-wide.
- **`ConsoleAgentBridge`'s event loop.** It drove one loop with `run_until_complete` from whichever thread called. Overlapping children raised "event loop is already running", dropped the coroutine un-awaited, and persisted `error` on the child **while the parent returned `done`** — silent wrong answers. Now a dedicated loop thread + `run_coroutine_threadsafe`, preserving the one-loop/one-httpx-client property.
- **First-writer-wins**, twice: `FleetCoordinator.finish` (liveness-based) and `AgentRunsDB.set_status` (SQL `WHERE status NOT IN (terminal)`), so a child abandoned after a join timeout cannot overwrite its own terminal state.
- **Approval-card revocation.** Cancelling or abandoning a child now revokes its pending approval cards *and* its skill-script confirms — previously a user could approve a card for an already-dead child and the tool executed for real. The skill-script path was the worse one: it runs the script immediately after the confirm with no cancellation checkpoint.
- **Tool-catalog cache lock** (the pre-existing race threw an `AttributeError` out of `invoke_by_name`, violating its own never-raise contract), `run_id` on `on_step`, and an `MCPToolProvider` execution lock (unaudited stdio-pipe session; Builtin/Local/Library proven safe with evidence instead).

## Verification

Battery **5,291 passed / 62 skipped / 0 failed**; collect-only 35,344 clean.

Live against a real Anthropic model, 5/5: one reply spawned two sub-agents, both appeared in the rail, both results reached the final answer, both persisted as terminal DB rows, and Stop mid-fleet left **zero** runs in `running`.

Executed via subagent-driven development — nine tasks, each spec+quality reviewed, with fix rounds. Findings the reviews caught and the code now guards: a first-writer-wins guard keyed on the status *string* (a `"timeout"` would have defeated it), a concurrency test that never failed pre-fix across 40 runs, a `LocalToolProvider` fail-open mutation that survived all 1,012 tests, a converted test whose guarantee had silently moved onto already-covered ground, and a setup-phase exception that left a DB row `running` while the coordinator reported terminal.

## Follow-ups filed

task-13213 (xdist crash that can mask CI failures), task-13214 (drift guard red on the video work), task-13215 (approval-revocation hardening), task-13216 (`todo_write` race). One spec gap deferred to PR 2b: approval cards don't visually name the agent — the docs describe actual behavior rather than the spec's claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run sub-agents concurrently under a new `FleetCoordinator`, with `wait_agents`/`check_agents` runtime tools. Default parallelism is on (`[agents] max_live_subagents = 3`); set to `1` to restore the old inline path. Skills still run inline for direct results.

- **New Features**
  - Sub-agents run on their own threads via `FleetCoordinator`. `spawn_subagent` returns a handle; collect with `wait_agents`, poll with `check_agents`.
  - Default concurrency: `[agents] max_live_subagents = 3`.
  - Skill calls remain inline and share the parent budget. The parent turn waits within its wall clock, cancels cooperatively, then abandons after a short join; no runs are left `running`.
  - Steps carry `run_id` in `on_step(step, agent_kind, run_id)` to distinguish concurrent children.

- **Bug Fixes**
  - Permission gates key per-run decisions for Builtin, MCP, and Local providers; `AgentService.review_tool_calls` passes `(calls, run_id)`. Tool execution reads the dispatching run via `run_context`.
  - Console bridge runs each reply on a dedicated event-loop thread and submits via `run_coroutine_threadsafe`, fixing “event loop is already running” under overlap.
  - First-writer-wins: `FleetCoordinator.finish` guards by liveness; `AgentRunsDB.set_status` refuses to overwrite terminal statuses and returns a bool.
  - Cancelling/abandoning a child revokes its approval cards and skill-script confirms; pending rounds resolve to all-deny.
  - Tool catalog caches are lock-guarded and read as one coherent snapshot, fixing the intermittent race in `invoke_by_name`.
  - `MCPToolProvider.invoke` is serialized with a per-instance lock. Child setup failures persist a terminal status to the DB. Reserved the runtime names `wait_agents`/`check_agents` in the Library to prevent skill shadowing. Docs updated (PR2a plan, Console guide); backlog hygiene notes added.
  - Backlog: filed task-14877 for 9 pre-existing Tests/Chat failures on `dev` to avoid masking regressions.

<sup>Written for commit 2c08192e643f452f98858e1b540f68196abba312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

