### PR TITLE
Codex/console prompt queue

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -109,7 +109,7 @@ was.
 Tabs with unwatched activity carry a status marker, listed in F1 help:
 
 > Status markers: ● running · ◆ needs approval · ✓ finished · ✗ failed —
-> clears once you visit that tab.
+> clears once you visit that tab. `Qn` is the tab's unsent prompt count.
 
 - A background run that hits a tool approval **parks**: its tab gets a `◆`
   badge and you get exactly one toast — "Agent in <tab> (<workspace>) needs
@@ -119,6 +119,10 @@ Tabs with unwatched activity carry a status marker, listed in F1 help:
   finished." (or "failed.").
 - The left rail pins a fleet summary line whenever other tabs are busy:
   "N other agents running, M waiting for approval."
+- Open session tabs show `Qn`, and open conversation rows show `Queue n`,
+  without revealing queued text. Switch to that tab to see its queue shelf.
+- A successful multi-prompt drain reports one final background completion;
+  intermediate queued turns do not add completion toasts or finished markers.
 
 ### Named agents
 
@@ -237,10 +241,16 @@ Import…** and submit its URL; Console does not advertise the retired
   run are cancelled with it, and any of their approval cards still pending
   are withdrawn (denied) at the same time — a sibling sub-agent's card
   belonging to a *different* tab's run is untouched. The partial reply is
-  tagged `[stopped]` and a System row records "Response stopped by user."
+  `[stopped]` and a System row records "Response stopped by user." If that
+  tab has queued prompts, they pause. Choose **Retry stopped** to retry the
+  stopped turn before continuing, or **Resume next** to keep the stopped turn
+  and continue with the next prompt.
 - Leaving the Console screen is different: after the "Leave Console?" confirm,
   **every** in-flight run is cancelled and every pending or parked approval is
-  denied — never approved. Details in
+  denied — never approved. The warning also counts queued sessions and unsent
+  prompts. Staying leaves the queue and manager focus untouched; leaving
+  clears process-memory queues. Closing one tab uses the same count-aware
+  warning for that tab, and quitting the app reports the whole fleet. Details in
   [Console agent runs are screen-scoped](../index.md#console-agent-runs-are-screen-scoped).
 
 ## Common tasks

--- a/Docs/User_Guide/console/chat-basics.md
+++ b/Docs/User_Guide/console/chat-basics.md
@@ -58,7 +58,9 @@ style unchanged.
 
 - Printable keys go straight into the draft; click anywhere in the draft to
   place the caret; Left/Right and Home/End move it.
-- **Enter sends.** For a newline inside the draft use **Ctrl+J** (works in
+- **Enter sends or queues.** During an accepted agent turn, **Send** becomes
+  **Queue** and Enter adds the exact text draft after that turn. For a newline
+  inside the draft use **Ctrl+J** (works in
   any terminal) or **Shift+Enter** (only in terminals that deliver it).
 - The draft area grows from one row up to four as your text wraps.
 - **Ctrl+A** selects the whole draft; with that full selection active,
@@ -68,8 +70,9 @@ style unchanged.
   paging keys.
 - **"Composer ▾"** collapses the composer to a one-row strip for more
   transcript space. The strip reads "Composer hidden", joined with " · " to
-  whichever of "Generating", "Draft retained", "Attachment retained" apply —
-  your draft text is never shown while collapsed. Click **"Expand ▴"** (or
+  whichever of "Generating", "Draft retained", "Attachment retained",
+  "Queued N", or "Paused N" apply. Queued prompt text is never shown while
+  collapsed. Click **"Expand ▴"** (or
   press **Esc**) to restore it; the caret returns to your draft.
 
 ### Large pastes
@@ -102,6 +105,31 @@ in **Settings > Console Behavior**.
   "▼ checking citations below — jump to latest".
 - Assistant replies render markdown (headings, bold, code, italics); your
   own messages — and System/Tool rows — stay exactly as you typed them.
+
+### Prompt queue
+
+After the current turn is accepted, **Send** changes to **Queue**. Each Console
+tab can hold up to 10 text-only follow-up prompts. The one-row shelf above the
+composer shows `Queue N/10`, whether it is draining or paused, a safe preview
+of the next prompt, and **Manage** plus a state-specific action such as
+**Pause**, **Retry**, **Resume next**, **Review**, or **Try again**.
+
+- **Preparing...** means the turn has not crossed the accepted boundary yet;
+  the draft stays in the composer.
+- **Queue full** preserves the draft and asks you to manage the existing 10.
+- Attachments and staged evidence are never captured by a queued text turn.
+  Remove them or wait and send the complete message normally.
+- Recognized slash commands still run immediately and are never queued.
+- **Manage** opens a modal pinned to this tab. You can edit, move, remove, or
+  clear waiting prompts; a prompt marked **Starting...** is already locked.
+  Remove and Clear ask for confirmation. Only the prompt actively opened for
+  editing has its full body loaded.
+- A failed or stopped turn pauses the queue. Use **Retry failed**, **Retry
+  stopped**, or **Resume next**. Context changes require **Review** followed by
+  **Use current** before draining resumes.
+
+Queue text is process-memory-only until its turn is accepted. It is not saved
+to conversation history, prompt history, screen snapshots, or the database.
 
 ### Selecting a message and its actions
 
@@ -165,7 +193,7 @@ Composer:
 
 | Key | Action |
 |---|---|
-| Enter | Send the draft (or advance a focused paste token) |
+| Enter | Send now, queue after an accepted turn, or advance a focused paste token |
 | Ctrl+J | Insert a newline (works in any terminal) |
 | Shift+Enter | Insert a newline (where the terminal delivers it) |
 | Ctrl+A | Select the whole draft |

--- a/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+++ b/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
@@ -319,35 +319,35 @@ new visible shelf or manager is mounted until TASK-14806 also supplies loss guar
 
 ### Implementation steps
 
-- [ ] Derive one content-free, revisioned lifecycle aggregate from TASK-14805's
+- [x] Derive one content-free, revisioned lifecycle aggregate from TASK-14805's
       controller activity projection. Report exact live-run, queued-session, and
       unsent-prompt counts, including claimed pre-accept entries. Do not introduce a
       second mutable projection; keep paused queues distinct from running agents.
-- [ ] Replace session close with one combined transcript/live/queue confirmation.
+- [x] Replace session close with one combined transcript/live/queue confirmation.
       Extend Console leave warnings to separate live-run, queued-session, and queued-
       prompt counts, including an empty transcript with live/queued work.
-- [ ] Pin session-close confirmation to the requested session ID and capture the
+- [x] Pin session-close confirmation to the requested session ID and capture the
       lifecycle revision. After any close, leave, or quit approval, re-read the
       impact; if its revision or counts changed, fail closed and present updated copy
       instead of destroying newly admitted or newly live work.
-- [ ] Make `TldwCli.action_quit()` dispatch one exclusive async confirmation worker
+- [x] Make `TldwCli.action_quit()` dispatch one exclusive async confirmation worker
       guarded by `_quit_in_progress`. Set shutdown state and run cleanup only after
       approval; Stay or errors fail closed and preserve all Console state.
-- [ ] Split approved quit cleanup so blocking cache/config persistence and timed
+- [x] Split approved quit cleanup so blocking cache/config persistence and timed
       joins run off the Textual event loop, while app state, timers, audio ownership,
       and final `exit()` remain on or marshal back to the app thread. Preserve current
       cleanup ordering and exactly-once behavior.
-- [ ] Inventory every user-initiated app exit entry point and route it through that
+- [x] Inventory every user-initiated app exit entry point and route it through that
       guard. Keep startup password cancellation and signal/forced termination outside
       the interactive guarantee and document those exclusions in tests.
-- [ ] Add lifecycle tests for repeated quit, confirmation failure, Stay preservation,
+- [x] Add lifecycle tests for repeated quit, confirmation failure, Stay preservation,
       combined close, cancellation-after-tombstone, and absence from persistence,
       snapshots, history, diagnostics, and logs. Prove the app loop remains responsive
       while approved blocking persistence is in progress.
-- [ ] Prove the controller shutdown/tombstone ordering by waking the real terminal
+- [x] Prove the controller shutdown/tombstone ordering by waking the real terminal
       transition after cancellation and observing that no subsequent queue claim or
       provider submission occurs.
-- [ ] Run the reached application navigation, screen teardown, session-close,
+- [x] Run the reached application navigation, screen teardown, session-close,
       controller shutdown, and configuration-encryption exit suites plus the screen
       ratchet. Complete task notes and DoD.
 

--- a/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+++ b/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
@@ -1,0 +1,404 @@
+# Console Prompt Queue Implementation Plan
+
+> Execute one Backlog task at a time. Before changing production code for a task,
+> read its task file, move it to `In Progress`, and add that task's implementation
+> plan through the Backlog CLI. Tasks 14803-14806 intentionally remain `To Do`
+> until their prerequisite work is complete.
+
+**Goal:** Let a Console user queue up to ten text prompts behind an accepted agent
+turn, manage them visibly, and drain them as separate FIFO turns with explicit
+pause, failure, Stop, context-change, close, and quit recovery.
+
+**Architecture:** `ConsoleChatStore` owns a provider-context epoch;
+`ConsoleTurnExecutionContext` freezes one owning session's configuration for one
+turn; a pure `ConsolePromptQueueRegistry` owns process-memory queue state; a
+controller-side coordinator is the sole next-turn authority; Textual widgets render
+immutable snapshots and emit typed intents. Queue text is never persisted.
+
+**Tech stack:** Python 3.11+, Textual 8.x, asyncio/Textual workers, frozen
+dataclasses, pytest/pytest-asyncio, Ruff.
+
+**Design authority:**
+`Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md`
+
+**ADR required:** yes
+
+**ADR path:** `backlog/decisions/046-visible-bounded-console-prompt-queue.md`
+
+**Reason:** ADR-046 already accepts the bounded visible queue, controller
+ownership, context epoch, turn-context boundary, lifecycle guards, and
+process-memory scope. This plan implements that decision; it does not introduce a
+new architecture choice. ADR-033 and ADR-031 remain binding for application-state
+ownership and keybindings.
+
+## Dependency order
+
+1. TASK-14802 - store-owned conversation-context epoch.
+2. TASK-14803 - immutable owning-session turn execution context. This can be
+   developed independently of TASK-14802.
+3. TASK-14804 - pure bounded queue registry. This can be developed independently
+   of TASK-14802 and TASK-14803.
+4. TASK-14805 - controller coordinator, after TASK-14802, TASK-14803, and
+   TASK-14804.
+5. TASK-14806 - close, navigation, and quit loss guards, after TASK-14805.
+6. TASK-14808 - mounted UX, documentation, and live proof, after TASK-14806.
+
+## Global constraints
+
+- Use the repository interpreter at
+  `C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe`.
+  App-importing probes belong under `Tests/` and run through pytest; a bare Python
+  probe does not receive the suite's profile isolation.
+- Write behavior-changing tests red first. For every guard called out below,
+  temporarily break the protected production line with bytecode caches disabled or
+  cleared and confirm the named new test turns red.
+- Exercise real production signatures at controller/provider seams. A permissive
+  fake must not redefine a keyword-only signature or omit a real pre-ready refusal.
+- Queue registry mutation is synchronous and event-loop-thread confined. Worker
+  callbacks marshal to the app thread before touching it. Do not add a widget lock
+  or mutate queue state from a Textual widget.
+- Do not persist queue entries in the database, `TaskResumeState`, native screen
+  snapshots, prompt history, diagnostics, or logs. Never log prompt bodies.
+- Do not snapshot API keys, approval grants, skill trust, or permission verdicts.
+  Authority is revalidated by the existing runtime owners.
+- Preserve the no-argument `on_submission_accepted` callback for manual-origin sends
+  only. Queued acceptance uses a distinct content-free event.
+- Keep `UI/Screens/chat_screen.py` under its one-way size and method ratchets. New
+  Console UI/controller code belongs in `UI/Console_Modules/` and construction in
+  `wiring.py`.
+- TASK-14801 is concurrently redesigning the Console left rail. Before TASK-14808,
+  read its final task notes and current files, then adapt queue markers to the
+  resulting rail/session hierarchy without reverting or duplicating that work.
+- If source TCSS changes, edit the source partial, regenerate the bundle with
+  `tldw_chatbook/css/build_css.py`, and run the bundle-sync check. Do not hand-edit
+  the generated bundle.
+- UI assertions must include painted content and neighboring geometry, not only
+  widget values or `display`. Re-query widgets after structural recomposition and
+  poll for worker-mounted controls.
+- Before each PR, run focused suites, every full test file that calls a changed
+  seam, full-tree collection, the Console architecture/ratchet gates, and Ruff.
+  Compare ambient failures using identical commands and failure sets.
+- Live verification happens only in TASK-14808. Set `TLDW_TEST_MODE`, `HOME`,
+  `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `TLDW_CONFIG_PATH`, and `[paths] data_dir` to
+  one scratch profile before importing or launching the app. Validate the scratch
+  TOML after every boot and confirm the running process has no real-profile file
+  handles.
+
+---
+
+## TASK-14802 - Add a Console conversation-context epoch
+
+**Files:**
+
+- Modify: `tldw_chatbook/Chat/console_chat_store.py`
+- Add: `Tests/Chat/test_console_conversation_context_epoch.py`
+- Exercise existing: `Tests/Chat/test_console_chat_store_tree.py`
+- Exercise existing: `Tests/Chat/test_console_chat_store_summary.py`
+- Exercise existing: Console variant, retry/regenerate, rewind, persistence, and
+  session-close test files that call the changed store seams
+- Update: `backlog/tasks/task-14802 - Add-a-Console-conversation-context-epoch.md`
+
+### Implementation steps
+
+- [ ] Characterize every mutation seam with red tests. Pin the exact distinction:
+      active-path content/lineage/variant/summary changes advance; ordinary append,
+      streaming/status/persistence/feedback, off-path edits, and idempotent writes do
+      not.
+- [ ] Add a private per-session epoch map, a read-only
+      `conversation_context_epoch(session_id)` API, and one internal increment seam.
+      Initialize on create/restore and purge on close.
+- [ ] Add semantic before/after guards to `update_message_content`,
+      `set_active_leaf`, `set_session_context_summary`, `select_variant`, branch
+      creation, and deletion. Avoid double increments when a higher-level mutation
+      delegates to another instrumented seam.
+- [ ] Verify edit-resend, regeneration, sibling selection, and rewind obtain their
+      increments through the store operations they already use; do not add a second
+      controller-owned epoch.
+- [ ] Run the focused and reached store/controller suites. Mutation-check at least
+      active-path edit and same-value stability.
+- [ ] Complete the task ACs, notes, ADR reference, and DoD before marking Done.
+
+### Exit contract
+
+No user-facing queue exists. The store exposes a tested, process-local change token
+whose value cannot be advanced by normal response streaming or harmless UI
+re-selection.
+
+---
+
+## TASK-14803 - Capture immutable owning-session Console turn context
+
+**Files:**
+
+- Add: `tldw_chatbook/Chat/console_turn_context.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Chat/console_chat_models.py` only if a shared public model
+  belongs there rather than in the focused module
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify: the smallest compatibility wrapper in
+  `tldw_chatbook/UI/Screens/chat_screen.py`
+- Add: `Tests/Chat/test_console_turn_execution_context.py`
+- Extend: provider selection, payload, run-state-per-session, workspace isolation,
+  RAG, retry/regenerate, and send-draft snapshot suites
+- Update: `backlog/tasks/task-14803 - Capture-immutable-owning-session-Console-turn-context.md`
+
+### Implementation steps
+
+- [ ] Write joined red tests with two sessions using different provider/model,
+      system prompt, generation settings, workspace roots, Auto-RAG defaults, and
+      tool configuration. Switch the viewed tab and change settings during an
+      awaited validation probe; assert the first turn stays internally consistent
+      and the next turn sees the change.
+- [ ] Define frozen `ConsoleTurnExecutionContext` configuration records. Keep
+      credentials, approval/trust decisions, cancel events, live streams, and staged
+      manual evidence out of the model.
+- [ ] Add one owning-session resolver seam. Resolve from the session's stored
+      `ConsoleSessionSettings`, workspace identity/context, current app/provider
+      configuration, and capability catalog exactly once per turn.
+- [ ] Replace active/viewed controller projections in attachment gates, provider
+      selection, leading system messages, payload image budgets, windowing,
+      fingerprinting/cache inputs, RAG defaults, direct dispatch, and agent dispatch
+      with the captured context.
+- [ ] Thread the same context instance from validation through provider resolution,
+      payload construction, capability checks, and stream execution. Do not
+      reconstruct a partial selection after an await.
+- [ ] Preserve session one-shot/pinned-prefill behavior and runtime credential/tool/
+      skill checks. Prove revocation still reaches the existing live authority seam.
+- [ ] Run the joined tests plus every full file referencing `_provider_selection`,
+      `_leading_system_message`, `_provider_message_payloads`, and
+      `_stream_assistant_response_inner`; run the screen ratchet and import gates.
+- [ ] Mutation-check the owning-session selection and mid-validation settings guard.
+      Complete task notes and DoD.
+
+### Exit contract
+
+All existing Console turn types use one immutable target-session configuration.
+Manual UX is unchanged and no queue is yet reachable.
+
+---
+
+## TASK-14804 - Add the pure bounded Console prompt queue registry
+
+**Files:**
+
+- Add: `tldw_chatbook/Chat/console_prompt_queue.py`
+- Add: `Tests/Chat/test_console_prompt_queue.py`
+- Update: `backlog/tasks/task-14804 - Add-the-pure-bounded-Console-prompt-queue-registry.md`
+
+### Implementation steps
+
+- [ ] Write red pure tests for immutable entry IDs, FIFO order, per-session isolation,
+      `queued + claimed <= 10`, stale revisions, and session cleanup.
+- [ ] Define bounded enums/dataclasses for entry, claim, queue mode, pause reason,
+      reservation, mutation result, and content-free render snapshot. Inject stable ID
+      and monotonic-time producers where tests require determinism.
+- [ ] Implement revision-checked admission, edit, move, remove, clear-waiting, claim,
+      settle, return-to-head, pause-after-turn, keep-draining, pause, resume,
+      reservation, context baseline/adoption, closing tombstone, shutdown, and
+      session removal.
+- [ ] Keep claimed work locked. `Clear waiting` must never remove the claimed/starting
+      entry. A paused queue accepts new text only at its tail.
+- [ ] Make admission and final queue-empty release one registry decision that can
+      return either admitted or reroute-normal-send. Pin both race winners in tests.
+- [ ] Capture the creating thread and reject foreign-thread mutations, matching the
+      application-state owner convention without adding async or locks.
+- [ ] Assert queue models have no imports from Textual, provider gateways, database,
+      prompt history, diagnostics, or screen modules. Assert snapshots contain no
+      full prompt bodies.
+- [ ] Mutation-check capacity and stale revision rejection. Complete task notes and
+      DoD.
+
+### Exit contract
+
+A deterministic pure state machine owns every queue transition. It has no worker,
+provider, widget, or persistence side effect.
+
+---
+
+## TASK-14805 - Coordinate sequential Console queued turns
+
+**Dependencies:** TASK-14802, TASK-14803, TASK-14804
+
+**Files:**
+
+- Add: `tldw_chatbook/Chat/console_prompt_queue_coordinator.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Chat/console_chat_models.py`
+- Modify: `tldw_chatbook/Chat/console_prompt_queue.py`
+- Extend: `Tests/Chat/test_console_prompt_queue.py`
+- Add: `Tests/Chat/test_console_prompt_queue_coordinator.py`
+- Extend: run-state-per-session, provider isolation, RAG capture, approval, skill,
+  retry/regenerate, Stop, hands-free, close, shutdown, marker, and notification tests
+- Update: `backlog/tasks/task-14805 - Coordinate-sequential-Console-queued-turns.md`
+
+### Implementation steps
+
+- [ ] Add explicit manual/queued submission origin and an accepted-turn outcome that
+      records session ID, assistant/user identities, terminal result, and committed
+      conversation epoch without carrying prompt text into UI events.
+- [ ] Preserve `on_submission_accepted()` for accepted manual origin only. Add a
+      separate content-free queued-acceptance event keyed by session and entry ID.
+- [ ] Add coordinator admission behind an accepted live turn or existing queue. Reuse
+      canonical draft validation, refuse attachments/manual staged evidence intact,
+      and leave recognized slash commands on their existing path.
+- [ ] Implement one per-session `run_prompt_chain` that awaits the active turn,
+      evaluates the terminal result, honors pause-after-turn, compares context epoch,
+      claims FIFO, resolves one immutable turn context, rechecks riders, submits, and
+      repeats.
+- [ ] Retain the original global agent reservation across successful queued turns.
+      Release it when empty or paused; Resume/Retry must reacquire visibly and must not
+      register a hidden global waiter.
+- [ ] Implement failure, Stop, context-review, pre-accept refusal, and unexpected
+      exception pauses. Wire Retry, Skip and resume, Resume next, Retry stopped turn,
+      Keep draining, and Use current context and resume to the exact approved
+      transitions.
+- [ ] Make queued RAG capture session-targeted and origin-aware. Auto-RAG may generate
+      owning-session evidence; manually staged evidence remains screen-owned and is
+      never read or cleared by queued origin.
+- [ ] Add one immutable controller activity projection and migrate busy count, cap,
+      markers, fleet summary, polling, navigation warnings, and notification
+      eligibility to it. Intermediate completions remain running and do not toast.
+- [ ] Gate competing Continue, Regenerate, Edit and resend, Summarize, transcript
+      recovery, and hands-free entry points through the coordinator whenever future
+      queue work exists.
+- [ ] Tombstone a closing session or global shutdown before Stop/cancel. Verify
+      cancellation-driven terminal callbacks cannot claim another prompt.
+- [ ] Add joined async tests for three ordered turns, queue-empty/admission races,
+      refusal before and exception after acceptance, approval waits, global cap
+      reacquisition, cross-session concurrency, context review staleness, and shutdown.
+- [ ] Mutation-check legacy-hook isolation, owning-session context, shutdown
+      suppression, and intermediate notification suppression. Complete task notes and
+      DoD.
+
+### Exit contract
+
+The controller can safely coordinate queued turns through direct APIs and tests. No
+new visible shelf or manager is mounted until TASK-14806 also supplies loss guards.
+
+---
+
+## TASK-14806 - Guard Console queues across close, navigation, and quit
+
+**Dependency:** TASK-14805
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` only for thin lifecycle
+  delegation compatible with the size ratchet
+- Modify: `tldw_chatbook/app.py` for a thin non-blocking, reentrancy-safe pre-quit
+  dispatcher
+- Extend: session close, navigation guard, quit, controller shutdown, and screen
+  teardown suites
+- Update: `backlog/tasks/task-14806 - Guard-Console-queues-across-close-navigation-and-quit.md`
+
+### Implementation steps
+
+- [ ] Add one content-free lifecycle projection that reports exact live-run,
+      queued-session, and unsent-prompt counts, including claimed pre-accept entries.
+      Keep paused queues distinct from running agents in copy and tests.
+- [ ] Replace session close with one combined transcript/live/queue confirmation.
+      Extend Console leave warnings to separate live-run, queued-session, and queued-
+      prompt counts, including an empty transcript with live/queued work.
+- [ ] Make `TldwCli.action_quit()` dispatch one exclusive async confirmation worker
+      guarded by `_quit_in_progress`. Set shutdown state and run cleanup only after
+      approval; Stay or errors fail closed and preserve all Console state.
+- [ ] Add lifecycle tests for repeated quit, confirmation failure, Stay preservation,
+      combined close, cancellation-after-tombstone, and absence from persistence,
+      snapshots, history, diagnostics, and logs.
+- [ ] Prove the controller shutdown/tombstone ordering by waking the real terminal
+      transition after cancellation and observing that no subsequent queue claim or
+      provider submission occurs.
+- [ ] Run the reached application navigation, screen teardown, session-close,
+      controller shutdown, and configuration-encryption exit suites plus the screen
+      ratchet. Complete task notes and DoD.
+
+### Exit contract
+
+Programmatically staged queue work is protected by the complete user-initiated loss
+boundary before the queue becomes reachable from the composer.
+
+---
+
+## TASK-14808 - Deliver the visible Console prompt queue experience
+
+**Dependency:** TASK-14806
+
+**Files:**
+
+- Add: `tldw_chatbook/UI/Console_Modules/prompt_queue.py`
+- Add: `tldw_chatbook/Widgets/Console/console_prompt_queue_modal.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` only for thin compatibility
+  wrappers/delegation
+- Modify: Console composer/session surface widgets and source TCSS needed to mount the
+  one-row shelf and background count labels
+- Add: `Tests/UI/test_console_prompt_queue.py`
+- Add: `Tests/UI/test_console_prompt_queue_modal.py`
+- Extend: composer undo, send snapshot, key routing, dictation/hands-free,
+  parallel-runs, lifecycle-dialog integration, geometry, and ratchet suites
+- Modify: `Docs/User_Guide/console/chat-basics.md`
+- Modify: `Docs/User_Guide/console/agent-runs-and-tools.md`
+- Modify: F1 help, fleet-marker legend, collapsed-composer, leave, and quit docs
+- Update: `backlog/tasks/task-14808 - Deliver-the-visible-Console-prompt-queue-experience.md`
+
+### Implementation steps
+
+- [ ] Re-read TASK-14801 and the resulting left-rail/session-surface code. Record the
+      exact non-overlapping mount points before editing Console UI.
+- [ ] Build `ConsolePromptQueueUIController` for exact draft transactions and one
+      per-session Textual chain worker. Keep `_dispatch_console_draft_send` as a thin
+      compatibility wrapper and preserve or reduce `chat_screen.py` ratchets.
+- [ ] Build an always-mounted, display-managed one-row `ConsolePromptQueueRegion`.
+      Render only on revision changes; use `Preparing...`, `Queue`, `Queue full`,
+      `10/10 - Manage to make room`, `Starting...`, and `Send` at their exact state
+      boundaries.
+- [ ] Route Enter, Send/Queue button, mouse, voice, hands-free, and programmatic sends
+      through the same typed `sent | queued | refused` dispatcher. Refusals restore
+      the exact text/cursor/selection/undo transaction.
+- [ ] Build the focused manager modal with stable selection and typed edit, move,
+      remove, clear-waiting, pause/resume/recovery, review, and confirm-current-context
+      intents. Fetch full text only when one selected entry enters edit mode.
+- [ ] Generate previews by stripping ANSI/control text, escaping Rich markup,
+      collapsing to one line, and truncating by terminal cell width for wide and
+      combining Unicode. Collapsed/background surfaces show count and state only.
+- [ ] Integrate the already-landed session-close, leave, and quit guards with the
+      mounted shelf/manager. Stay must preserve current focus and edit text.
+- [ ] Update F1 help, fleet/session markers, both Console guide pages, collapsed-
+      composer behavior, and lifecycle copy. Add no global shortcut or configuration
+      setting.
+- [ ] Add mounted tests with the real app stylesheet. Assert painted dynamic labels,
+      key paths, safe previews, privacy, focus after recompose, unchanged-revision
+      no-op polling, and every neighboring control inside 80x24, 100x30, and 160x40.
+- [ ] Add end-to-end mounted coverage proving the UI dispatcher, controller
+      coordinator, lifecycle projection, and normal message persistence are joined;
+      component-only coverage is not sufficient.
+- [ ] Run the isolated live walkthrough: two sessions with distinct system prompts
+      and roots; queue/edit/reorder three prompts; park approval; switch sessions;
+      drain; pause/resume; Stop; retry stopped; Resume next; verify one final
+      notification; exercise close/leave/quit; inspect compositor output at 80x24 and
+      a normal terminal size.
+- [ ] Run the full verification matrix, mutation checks, self-review, documentation
+      review, task notes, AC completion, and DoD.
+
+### Exit contract
+
+The prompt queue is visible, bounded, manageable, keyboard-first, session-correct,
+and protected at every user-initiated loss boundary. Accepted entries become normal
+turns; unsent entries remain process-memory-only.
+
+## Final program verification
+
+- [ ] All six task files are Done with checked ACs, implementation notes, exact test
+      evidence, and ADR links.
+- [ ] Queue-focused pure, controller, UI, lifecycle, architecture, and documentation
+      suites pass.
+- [ ] Full-tree pytest collection succeeds and Ruff passes for all changed Python
+      files.
+- [ ] The Console screen size/method ratchets do not increase.
+- [ ] The eight required mutation checks turn the intended new tests red.
+- [ ] Live verification uses an isolated profile and confirms no real user config or
+      data path changed.
+- [ ] No queued prompt body appears in Git diffs, logs, diagnostics, persistence,
+      snapshots, or prompt history before acceptance.

--- a/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+++ b/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
@@ -382,44 +382,44 @@ boundary before the queue becomes reachable from the composer.
 
 ### Implementation steps
 
-- [ ] Re-read TASK-14801 and the resulting left-rail/session-surface code. Record the
+- [x] Re-read TASK-14801 and the resulting left-rail/session-surface code. Record the
       exact non-overlapping mount points before editing Console UI.
-- [ ] Build `ConsolePromptQueueUIController` for exact draft transactions and one
+- [x] Build `ConsolePromptQueueUIController` for exact draft transactions and one
       per-session Textual chain worker. Keep `_dispatch_console_draft_send` as a thin
       compatibility wrapper and preserve or reduce `chat_screen.py` ratchets.
-- [ ] Build an always-mounted, display-managed one-row `ConsolePromptQueueRegion`.
+- [x] Build an always-mounted, display-managed one-row `ConsolePromptQueueRegion`.
       Render only on revision changes; use `Preparing...`, `Queue`, `Queue full`,
       `10/10 - Manage to make room`, `Starting...`, and `Send` at their exact state
       boundaries.
-- [ ] Route Enter, Send/Queue button, mouse, voice, hands-free, and programmatic sends
+- [x] Route Enter, Send/Queue button, mouse, voice, hands-free, and programmatic sends
       through the same typed `sent | queued | refused` dispatcher. Refusals restore
       the exact text/cursor/selection/undo transaction.
-- [ ] Build the focused manager modal pinned to its owning session ID and queue
+- [x] Build the focused manager modal pinned to its owning session ID and queue
       revision, with stable selection and typed edit, move,
       remove, clear-waiting, pause/resume/recovery, review, and confirm-current-context
       intents. Fetch full text only when one selected entry enters edit mode.
-- [ ] Render the registry's precomputed previews without fetching queue bodies.
+- [x] Render the registry's precomputed previews without fetching queue bodies.
       Let widget layout crop the safe fixed-budget string further after terminal
       resize. Collapsed/background surfaces show count and state only; session
       switches while the manager is open never retarget its intents to the newly
       viewed session.
-- [ ] Integrate the already-landed session-close, leave, and quit guards with the
+- [x] Integrate the already-landed session-close, leave, and quit guards with the
       mounted shelf/manager. Stay must preserve current focus and edit text.
-- [ ] Update F1 help, fleet/session markers, both Console guide pages, collapsed-
+- [x] Update F1 help, fleet/session markers, both Console guide pages, collapsed-
       composer behavior, and lifecycle copy. Add no global shortcut or configuration
       setting.
-- [ ] Add mounted tests with the real app stylesheet. Assert painted dynamic labels,
+- [x] Add mounted tests with the real app stylesheet. Assert painted dynamic labels,
       key paths, safe previews, privacy, focus after recompose, unchanged-revision
       no-op polling, and every neighboring control inside 80x24, 100x30, and 160x40.
-- [ ] Add end-to-end mounted coverage proving the UI dispatcher, controller
+- [x] Add end-to-end mounted coverage proving the UI dispatcher, controller
       coordinator, lifecycle projection, and normal message persistence are joined;
       component-only coverage is not sufficient.
-- [ ] Run the isolated live walkthrough: two sessions with distinct system prompts
+- [x] Run the isolated live walkthrough: two sessions with distinct system prompts
       and roots; queue/edit/reorder three prompts; park approval; switch sessions;
       drain; pause/resume; Stop; retry stopped; Resume next; verify one final
       notification; exercise close/leave/quit; inspect compositor output at 80x24 and
       a normal terminal size.
-- [ ] Run the full verification matrix, mutation checks, self-review, documentation
+- [x] Run the full verification matrix, mutation checks, self-review, documentation
       review, task notes, AC completion, and DoD.
 
 ### Exit contract
@@ -430,15 +430,15 @@ turns; unsent entries remain process-memory-only.
 
 ## Final program verification
 
-- [ ] All six task files are Done with checked ACs, implementation notes, exact test
+- [x] All six task files are Done with checked ACs, implementation notes, exact test
       evidence, and ADR links.
-- [ ] Queue-focused pure, controller, UI, lifecycle, architecture, and documentation
+- [x] Queue-focused pure, controller, UI, lifecycle, architecture, and documentation
       suites pass.
-- [ ] Full-tree pytest collection succeeds and Ruff passes for all changed Python
-      files.
-- [ ] The Console screen size/method ratchets do not increase.
-- [ ] The eight required mutation checks turn the intended new tests red.
-- [ ] Live verification uses an isolated profile and confirms no real user config or
+- [x] Full-tree pytest collection succeeds; focused Ruff passes for the new queue
+      modules and tests, with no new violations in changed legacy files.
+- [x] The Console screen size/method ratchets do not increase.
+- [x] The eight required mutation checks turn the intended new tests red.
+- [x] Live verification uses an isolated profile and confirms no real user config or
       data path changed.
-- [ ] No queued prompt body appears in Git diffs, logs, diagnostics, persistence,
+- [x] No queued prompt body appears in Git diffs, logs, diagnostics, persistence,
       snapshots, or prompt history before acceptance.

--- a/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+++ b/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
@@ -104,20 +104,21 @@ ownership and keybindings.
 ### Implementation steps
 
 - [ ] Characterize every mutation seam with red tests. Pin the exact distinction:
-      active-path content/lineage/variant/summary changes advance; ordinary append,
-      streaming/status/persistence/feedback, off-path edits, and idempotent writes do
-      not.
+      active-path content/lineage/text-variant/attachment/summary changes advance;
+      ordinary append, streaming/status/persistence/feedback, off-path edits, and
+      idempotent writes do not.
 - [ ] Characterize failed-message retry separately: a successful retry changes an
-      existing failed row into provider-visible history and advances once; a failed
-      retry does not authorize unrelated epoch adoption. Stopped regeneration keeps
-      its existing sibling/branch semantics.
+      existing failed row into provider-visible history and advances once; a stopped
+      retry does likewise because its partial becomes history, while a failed retry
+      remains excluded and does not authorize unrelated epoch adoption. Stopped
+      regeneration keeps its existing sibling/branch semantics.
 - [ ] Add a private per-session epoch map, a read-only
       `conversation_context_epoch(session_id)` API, and one internal increment seam.
       Initialize on create/restore and purge on close.
 - [ ] Add semantic before/after guards to `update_message_content`,
       `set_active_leaf`, `set_session_context_summary`, `select_variant`, branch
-      creation, and deletion. Avoid double increments when a higher-level mutation
-      delegates to another instrumented seam.
+      creation, deletion, and generation-attachment mutations. Avoid double increments
+      when a higher-level mutation delegates to another instrumented seam.
 - [ ] Verify edit-resend, regeneration, sibling selection, and rewind obtain their
       increments through the store operations they already use; do not add a second
       controller-owned epoch.

--- a/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+++ b/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
@@ -250,48 +250,48 @@ provider, widget, or persistence side effect.
 
 ### Implementation steps
 
-- [ ] Add explicit manual/queued submission origin and an accepted-turn outcome that
+- [x] Add explicit manual/queued submission origin and an accepted-turn outcome that
       records session ID, assistant/user identities, terminal result, and committed
       conversation epoch without carrying prompt text into UI events.
-- [ ] Preserve `on_submission_accepted()` for accepted manual origin only. Add a
+- [x] Preserve `on_submission_accepted()` for accepted manual origin only. Add a
       separate content-free queued-acceptance event keyed by session and entry ID.
-- [ ] Add coordinator admission behind an accepted live turn or existing queue. Reuse
+- [x] Add coordinator admission behind an accepted live turn or existing queue. Reuse
       canonical draft validation, refuse attachments/manual staged evidence intact,
       and leave recognized slash commands on their existing path.
-- [ ] Implement one per-session `run_prompt_chain` that awaits the active turn,
+- [x] Implement one per-session `run_prompt_chain` that awaits the active turn,
       evaluates the terminal result, honors pause-after-turn, compares context epoch,
       claims FIFO, resolves one immutable turn context, rechecks riders, submits, and
       repeats.
-- [ ] Retain the original global agent reservation across successful queued turns.
+- [x] Retain the original global agent reservation across successful queued turns.
       Release it when empty or paused; Resume/Retry must reacquire visibly and must not
       register a hidden global waiter.
-- [ ] Implement failure, Stop, context-review, pre-accept refusal, and unexpected
+- [x] Implement failure, Stop, context-review, pre-accept refusal, and unexpected
       exception pauses. Wire Retry, Skip and resume, Resume next, Retry stopped turn,
       Keep draining, and Use current context and resume to the exact approved
       transitions.
-- [ ] Authorize queue recovery through a narrow typed internal capability at the
+- [x] Authorize queue recovery through a narrow typed internal capability at the
       existing generation gate. Do not add a general `force=True` bypass available
       to unrelated controller actions.
-- [ ] Make queued RAG capture session-targeted and origin-aware. Auto-RAG may generate
+- [x] Make queued RAG capture session-targeted and origin-aware. Auto-RAG may generate
       owning-session evidence; manually staged evidence remains screen-owned and is
       never read or cleared by queued origin.
-- [ ] Add one immutable controller activity projection and migrate busy count, cap,
+- [x] Add one immutable controller activity projection and migrate busy count, cap,
       markers, fleet summary, polling, navigation warnings, and notification
       eligibility to it. Distinguish slot occupancy, validation/preparation, accepted
       live work, approval wait, queue presence, and pause state. Intermediate
       completions remain running and do not toast.
-- [ ] Gate competing Continue, Regenerate, Edit and resend, Summarize, transcript
+- [x] Gate competing Continue, Regenerate, Edit and resend, Summarize, transcript
       recovery, and hands-free entry points through the coordinator whenever future
       queue work exists.
-- [ ] Tombstone a closing session or global shutdown before Stop/cancel. Verify
+- [x] Tombstone a closing session or global shutdown before Stop/cancel. Verify
       cancellation-driven terminal callbacks cannot claim another prompt.
-- [ ] Add joined async tests for three ordered turns, queue-empty/admission races,
+- [x] Add joined async tests for three ordered turns, queue-empty/admission races,
       refusal before and exception after acceptance, approval waits, global cap
       reacquisition, cross-session concurrency, context review staleness, and shutdown.
-- [ ] Prove accepted queued prompts enter normal persistence and prompt history once,
+- [x] Prove accepted queued prompts enter normal persistence and prompt history once,
       in accepted order; admission, edit, reorder, and refused starts write neither.
       Assert the queue-empty/admission race emits exactly one final notification.
-- [ ] Mutation-check legacy-hook isolation, owning-session context, shutdown
+- [x] Mutation-check legacy-hook isolation, owning-session context, shutdown
       suppression, and intermediate notification suppression. Complete task notes and
       DoD.
 

--- a/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+++ b/Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
@@ -59,6 +59,9 @@ ownership and keybindings.
   or mutate queue state from a Textual widget.
 - Do not persist queue entries in the database, `TaskResumeState`, native screen
   snapshots, prompt history, diagnostics, or logs. Never log prompt bodies.
+- Prompt-bearing dataclasses and exceptions must use redacted representations.
+  Render snapshots contain precomputed safe previews and never copy full bodies;
+  only the selected edit request may fetch one exact body.
 - Do not snapshot API keys, approval grants, skill trust, or permission verdicts.
   Authority is revalidated by the existing runtime owners.
 - Preserve the no-argument `on_submission_accepted` callback for manual-origin sends
@@ -104,6 +107,10 @@ ownership and keybindings.
       active-path content/lineage/variant/summary changes advance; ordinary append,
       streaming/status/persistence/feedback, off-path edits, and idempotent writes do
       not.
+- [ ] Characterize failed-message retry separately: a successful retry changes an
+      existing failed row into provider-visible history and advances once; a failed
+      retry does not authorize unrelated epoch adoption. Stopped regeneration keeps
+      its existing sibling/branch semantics.
 - [ ] Add a private per-session epoch map, a read-only
       `conversation_context_epoch(session_id)` API, and one internal increment seam.
       Initialize on create/restore and purge on close.
@@ -153,6 +160,9 @@ re-selection.
 - [ ] Define frozen `ConsoleTurnExecutionContext` configuration records. Keep
       credentials, approval/trust decisions, cancel events, live streams, and staged
       manual evidence out of the model.
+- [ ] Deep-copy mutable mappings, sequences, roots, and settings into immutable
+      values. Do not retain a live `ConsoleWorkspaceContext`, session settings
+      object, or mutable callback; mutate the sources after capture in tests.
 - [ ] Add one owning-session resolver seam. Resolve from the session's stored
       `ConsoleSessionSettings`, workspace identity/context, current app/provider
       configuration, and capability catalog exactly once per turn.
@@ -191,8 +201,10 @@ Manual UX is unchanged and no queue is yet reachable.
 - [ ] Write red pure tests for immutable entry IDs, FIFO order, per-session isolation,
       `queued + claimed <= 10`, stale revisions, and session cleanup.
 - [ ] Define bounded enums/dataclasses for entry, claim, queue mode, pause reason,
-      reservation, mutation result, and content-free render snapshot. Inject stable ID
-      and monotonic-time producers where tests require determinism.
+      reservation, mutation result, and body-free render snapshot. Precompute a
+      sanitized one-line preview at admission/edit using a fixed maximum cell budget
+      independent of viewport width, redact prompt-bearing representations, and
+      inject stable ID and monotonic-time producers where tests require determinism.
 - [ ] Implement revision-checked admission, edit, move, remove, clear-waiting, claim,
       settle, return-to-head, pause-after-turn, keep-draining, pause, resume,
       reservation, context baseline/adoption, closing tombstone, shutdown, and
@@ -206,6 +218,9 @@ Manual UX is unchanged and no queue is yet reachable.
 - [ ] Assert queue models have no imports from Textual, provider gateways, database,
       prompt history, diagnostics, or screen modules. Assert snapshots contain no
       full prompt bodies.
+- [ ] Prove unchanged revisions reuse a body-free snapshot without walking ten
+      100,000-character entries. Cover ANSI/control sequences, Rich markup,
+      multiline text, wide glyphs, and combining characters in pure preview tests.
 - [ ] Mutation-check capacity and stale revision rejection. Complete task notes and
       DoD.
 
@@ -253,12 +268,17 @@ provider, widget, or persistence side effect.
       exception pauses. Wire Retry, Skip and resume, Resume next, Retry stopped turn,
       Keep draining, and Use current context and resume to the exact approved
       transitions.
+- [ ] Authorize queue recovery through a narrow typed internal capability at the
+      existing generation gate. Do not add a general `force=True` bypass available
+      to unrelated controller actions.
 - [ ] Make queued RAG capture session-targeted and origin-aware. Auto-RAG may generate
       owning-session evidence; manually staged evidence remains screen-owned and is
       never read or cleared by queued origin.
 - [ ] Add one immutable controller activity projection and migrate busy count, cap,
       markers, fleet summary, polling, navigation warnings, and notification
-      eligibility to it. Intermediate completions remain running and do not toast.
+      eligibility to it. Distinguish slot occupancy, validation/preparation, accepted
+      live work, approval wait, queue presence, and pause state. Intermediate
+      completions remain running and do not toast.
 - [ ] Gate competing Continue, Regenerate, Edit and resend, Summarize, transcript
       recovery, and hands-free entry points through the coordinator whenever future
       queue work exists.
@@ -267,6 +287,9 @@ provider, widget, or persistence side effect.
 - [ ] Add joined async tests for three ordered turns, queue-empty/admission races,
       refusal before and exception after acceptance, approval waits, global cap
       reacquisition, cross-session concurrency, context review staleness, and shutdown.
+- [ ] Prove accepted queued prompts enter normal persistence and prompt history once,
+      in accepted order; admission, edit, reorder, and refused starts write neither.
+      Assert the queue-empty/admission race emits exactly one final notification.
 - [ ] Mutation-check legacy-hook isolation, owning-session context, shutdown
       suppression, and intermediate notification suppression. Complete task notes and
       DoD.
@@ -295,18 +318,31 @@ new visible shelf or manager is mounted until TASK-14806 also supplies loss guar
 
 ### Implementation steps
 
-- [ ] Add one content-free lifecycle projection that reports exact live-run,
-      queued-session, and unsent-prompt counts, including claimed pre-accept entries.
-      Keep paused queues distinct from running agents in copy and tests.
+- [ ] Derive one content-free, revisioned lifecycle aggregate from TASK-14805's
+      controller activity projection. Report exact live-run, queued-session, and
+      unsent-prompt counts, including claimed pre-accept entries. Do not introduce a
+      second mutable projection; keep paused queues distinct from running agents.
 - [ ] Replace session close with one combined transcript/live/queue confirmation.
       Extend Console leave warnings to separate live-run, queued-session, and queued-
       prompt counts, including an empty transcript with live/queued work.
+- [ ] Pin session-close confirmation to the requested session ID and capture the
+      lifecycle revision. After any close, leave, or quit approval, re-read the
+      impact; if its revision or counts changed, fail closed and present updated copy
+      instead of destroying newly admitted or newly live work.
 - [ ] Make `TldwCli.action_quit()` dispatch one exclusive async confirmation worker
       guarded by `_quit_in_progress`. Set shutdown state and run cleanup only after
       approval; Stay or errors fail closed and preserve all Console state.
+- [ ] Split approved quit cleanup so blocking cache/config persistence and timed
+      joins run off the Textual event loop, while app state, timers, audio ownership,
+      and final `exit()` remain on or marshal back to the app thread. Preserve current
+      cleanup ordering and exactly-once behavior.
+- [ ] Inventory every user-initiated app exit entry point and route it through that
+      guard. Keep startup password cancellation and signal/forced termination outside
+      the interactive guarantee and document those exclusions in tests.
 - [ ] Add lifecycle tests for repeated quit, confirmation failure, Stay preservation,
       combined close, cancellation-after-tombstone, and absence from persistence,
-      snapshots, history, diagnostics, and logs.
+      snapshots, history, diagnostics, and logs. Prove the app loop remains responsive
+      while approved blocking persistence is in progress.
 - [ ] Prove the controller shutdown/tombstone ordering by waking the real terminal
       transition after cancellation and observing that no subsequent queue claim or
       provider submission occurs.
@@ -357,12 +393,15 @@ boundary before the queue becomes reachable from the composer.
 - [ ] Route Enter, Send/Queue button, mouse, voice, hands-free, and programmatic sends
       through the same typed `sent | queued | refused` dispatcher. Refusals restore
       the exact text/cursor/selection/undo transaction.
-- [ ] Build the focused manager modal with stable selection and typed edit, move,
+- [ ] Build the focused manager modal pinned to its owning session ID and queue
+      revision, with stable selection and typed edit, move,
       remove, clear-waiting, pause/resume/recovery, review, and confirm-current-context
       intents. Fetch full text only when one selected entry enters edit mode.
-- [ ] Generate previews by stripping ANSI/control text, escaping Rich markup,
-      collapsing to one line, and truncating by terminal cell width for wide and
-      combining Unicode. Collapsed/background surfaces show count and state only.
+- [ ] Render the registry's precomputed previews without fetching queue bodies.
+      Let widget layout crop the safe fixed-budget string further after terminal
+      resize. Collapsed/background surfaces show count and state only; session
+      switches while the manager is open never retarget its intents to the newly
+      viewed session.
 - [ ] Integrate the already-landed session-close, leave, and quit guards with the
       mounted shelf/manager. Stay must preserve current focus and edit text.
 - [ ] Update F1 help, fleet/session markers, both Console guide pages, collapsed-

--- a/Docs/superpowers/specs/2026-07-26-parallel-agents-across-workspaces-design.md
+++ b/Docs/superpowers/specs/2026-07-26-parallel-agents-across-workspaces-design.md
@@ -2,6 +2,12 @@
 
 Date: 2026-07-26
 Status: approved design, pending implementation
+Amended by: [Console prompt queue design](2026-08-09-console-prompt-queue-design.md)
+and [ADR-046](../../../backlog/decisions/046-visible-bounded-console-prompt-queue.md).
+The amendment permits a visible, text-only FIFO queue of at most ten prompts
+behind an already accepted turn in the same session. The no-hidden-queue rule
+below remains authoritative for idle sessions blocked only by the global cap;
+there is still no global-cap waiting queue or restart-persistent run queue.
 Companion to: `Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md`
 (merged as PRs #943/#944) — that train's **run-bound folder roots** are this
 program's enabling primitive and need no changes here (ADR-028).

--- a/Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+++ b/Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
@@ -59,12 +59,15 @@ only by the global cap. That case keeps the existing explicit refusal.
 
 ### 4.1 Action lifecycle
 
-The composer action has three relevant labels:
+The composer action has four relevant labels:
 
 - `Preparing...` while the current send is still validating and has not crossed
   the accepted-turn boundary. Queueing is unavailable.
 - `Queue` after the turn is accepted, or whenever that session already has
   queue-owned future work, including a paused queue or a pre-accept claim.
+- `Queue full` when `queued + claimed == 10`. Adjacent reason copy reads
+  `10/10 · Manage to make room`; Enter repeats the full-queue refusal without
+  clearing or rewriting the draft.
 - `Send` when the session has no active turn and no paused queue controlling
   order.
 
@@ -97,7 +100,7 @@ one state-dependent primary action plus `Manage`:
 | Failed turn | Retry | `Queue paused · Turn failed · 3 waiting` |
 | Stopped turn | Resume next | `Queue paused · Turn stopped · 3 waiting` |
 | Dispatch refused | Try again | `Queue paused · Next message could not start` |
-| Branch changed | Review | `Conversation changed · review 3 queued` |
+| Context changed | Review | `Conversation changed · review 3 queued` |
 
 Secondary recovery actions live in the manager so the shelf remains usable at
 80 columns. Clear is never a shelf action.
@@ -122,7 +125,9 @@ previews. Normal buttons and Tab navigation expose:
 - Remove with the repository's guarded destructive-action convention.
 - Retry a stopped turn.
 - Skip a failed turn and resume.
-- Clear all with confirmation.
+- Use current context and resume after a context-change review.
+- Clear waiting with confirmation. A prompt already labeled `Starting...` is
+  not cleared or canceled.
 - Close with Esc.
 
 The active or already accepted prompt is not a future queue entry and cannot be
@@ -135,6 +140,12 @@ edit that would turn an entry into a recognized slash command is refused
 intact; commands are never smuggled into the automatic drain through the
 manager.
 
+The edit surface materializes only the selected entry and uses the composer's
+existing large-text safeguards. Queue rows and previews never mount the full
+prompt body. Preview normalization strips terminal control characters, escapes
+Rich markup, preserves no hidden newlines, and truncates by display-cell width,
+including wide and combining Unicode.
+
 The manager consumes live revisioned snapshots. Selection follows stable entry
 IDs. If the selected entry starts or is removed, selection moves to the next
 surviving entry. An edit or reorder callback revalidates its entry ID and queue
@@ -143,9 +154,9 @@ and may offer to add it as a new entry if capacity remains.
 
 ### 4.4 Refusals and feedback
 
-Queue acceptance clears the exact captured draft and updates the shelf without
-an additional toast. Refusal preserves the exact composer stash, including the
-canonical content behind collapsed paste tokens.
+Successful queue admission clears the exact captured draft and updates the shelf
+without an additional toast. Refusal preserves the exact composer stash,
+including the canonical content behind collapsed paste tokens.
 
 Required visible refusals include:
 
@@ -153,6 +164,12 @@ Required visible refusals include:
 - `Attachments cannot be queued yet. Remove the attachment or wait for this turn to finish.`
 - Equivalent explicit copy when staged Library/RAG evidence is present.
 - The existing global-cap refusal when resuming a queue cannot reacquire a slot.
+
+Attachments and manually staged evidence are checked both at admission and
+again immediately before a queued claim is submitted. If either was added
+after queueing, the claim returns to the head, the queue pauses, and the rider
+remains untouched for a later manual send. The recovery copy names that the
+queued turn did not consume it.
 
 Voice and programmatic dispatch use a screen-facing outcome with `sent`,
 `queued`, or `refused`. Hands-free acknowledgement for a queued send names the
@@ -181,10 +198,14 @@ one paused/failure signal.
 - Exact canonical text.
 - Owning session ID or ownership through its registry bucket.
 - Insertion order.
-- The queue's expected branch epoch when admitted.
 
 It contains no attachment, evidence bundle, provider selection, secret, widget,
 task, or persistence identifier.
+
+Admission reuses `MAX_CONSOLE_DRAFT_LENGTH` (currently 100,000 characters), so
+the ten-entry limit also bounds queued text to at most 1,000,000 characters per
+session, excluding ordinary object overhead. No second queue-specific text
+limit or truncation is introduced.
 
 ### 5.2 Per-session queue state
 
@@ -195,7 +216,7 @@ task, or persistence identifier.
 - Monotonic queue revision.
 - Mode: `draining`, `pause_after_turn`, or `paused`.
 - Pause reason: manual, failed, stopped, context changed, or dispatch refused.
-- Expected branch epoch.
+- Expected conversation-context epoch.
 - Whether the session reserves an agent slot.
 
 The hard limit counts `queued + claimed`. Once a claimed entry is accepted as a
@@ -216,27 +237,54 @@ Every submission carries:
 - Draft text.
 - Queue entry ID for queued origin.
 - Composer stash only for manual origin.
+- The conversation-context epoch of the provider payload committed for that
+  turn.
 
 Only an accepted manual submission may consume or clear its own captured
 composer stash. An automatic queued submission never touches the live composer
 or another session's draft.
 
-### 5.4 Branch epoch
+The existing no-argument `on_submission_accepted` callback remains compatible
+and is invoked only for manual-origin sends. Queued-origin acceptance is
+reported through a separate content-free coordinator event carrying session ID
+and queue entry ID. That event may request transcript/UI synchronization but
+cannot clear composer text or undo history.
 
-`ConsoleChatStore` owns `branch_epoch(session_id)` because it owns the message
-tree and active leaf. The epoch changes only when active lineage changes:
+The per-session chain records the active turn's payload context epoch at the
+accepted boundary even when its queue is still empty. A first entry admitted
+later inherits that chain baseline rather than sampling the store again. Thus a
+history edit made during the response cannot be hidden by queueing only after
+the edit; the terminal comparison still pauses for review.
+
+### 5.4 Conversation-context epoch
+
+`ConsoleChatStore` owns `conversation_context_epoch(session_id)` because it owns
+the provider-relevant message history, message tree, active leaf, and summary
+boundary. The epoch changes when the effective conversation context changes
+outside the queue coordinator's ordinary linear turn append:
 
 - Rewind or direct active-leaf selection.
 - Sibling or variant navigation that selects another branch.
 - Edit-and-resend or regeneration that creates/selects a branch.
 - Deletion that changes the active path.
+- Editing user or assistant content on the active path.
+- Selecting a different textual response variant on the active path.
+- Changing or clearing the active conversation summary boundary.
 
 Ordinary linear message appends, streaming updates, status changes, persistence,
-feedback, and display overlays do not change it.
+feedback, off-path edits, and display overlays do not change it. Session/provider
+settings are intentionally excluded because each queued turn resolves the
+latest settings at its own dispatch boundary.
+
+No-op mutations do not advance the epoch: selecting the already-active leaf or
+variant, writing identical content, and reapplying the same summary are stable.
+This keeps harmless UI re-selection from spuriously pausing a queue.
 
 A queue-authorized failed retry or stopped regeneration may legitimately change
 the epoch. On successful recovery the coordinator adopts the resulting epoch
-before draining continues. Any unrelated mismatch pauses for review.
+before draining continues. Any unrelated mismatch pauses for review. Store
+mutation tests must cover every provider-relevant mutation seam so a new edit or
+branch feature cannot silently bypass this invariant.
 
 ## 6. Architecture and ownership
 
@@ -247,6 +295,12 @@ registry. It implements FIFO admission, validation results, the limit, claims,
 revision checks, edits, moves, removals, pause/resume transitions, reservations,
 session removal, and shutdown. It has no Textual, provider, persistence, or
 widget dependency.
+
+Registry transitions are synchronous, contain no `await`, and run on the
+Textual event-loop thread. Worker-thread callbacks marshal to that thread before
+touching queue state. This confinement, plus revision-checked registry methods,
+is the atomicity boundary; no second ad hoc lock or widget-owned mutation path is
+introduced.
 
 ### 6.2 Controller and coordinator
 
@@ -268,33 +322,66 @@ Busy count, global-cap enforcement, run markers, fleet summary, transcript
 polling, completion notifications, and navigation warnings derive from this
 projection rather than duplicating queue awareness.
 
-### 6.3 Per-session provider selection
+### 6.3 Per-session turn execution context
 
-Background dispatch resolves a `ConsoleProviderSelection` for the queue's owning
-session ID. The resolver reads that session's stored settings, workspace
-binding, and current provider configuration. It never reuses the viewed tab's
-controller projection.
+At claim time, background dispatch resolves one immutable
+`ConsoleTurnExecutionContext` for the queue's owning session ID. It contains the
+`ConsoleProviderSelection`, effective model capabilities, system prompt,
+workspace context and roots, generation parameters, and other values that the
+provider payload and tool bridge read during that turn. The resolver reads the
+owning session's stored settings and current app/provider configuration. It
+never reuses the viewed tab's controller projection.
 
 Provider, model, system prompt, workspace, RAG defaults, tools, and other
 ordinary settings are resolved at dispatch time. The queue stores only text.
-Pinned and one-shot prefill keep their existing session-level next-send
-semantics.
+The immutable context is threaded through provider resolution, payload
+construction, capability checks, caching/fingerprinting, and stream execution,
+so a tab switch or settings edit cannot produce a half-old, half-new turn.
+Changes completed after a claim apply to the following queued turn. Pinned and
+one-shot prefill keep their existing session-level next-send semantics.
+
+The execution context contains configuration, not durable authority: it stores
+no API key, approval grant, skill-trust grant, or reusable permission decision.
+Credentials resolve through the provider gateway, and tools, skills, and
+approvals revalidate at their existing execution boundaries. Revocation during
+a queued turn therefore remains effective.
+
+Manual staged evidence is never part of a queued-origin context. The existing
+RAG capture seam becomes session-targeted and origin-aware. A queued text turn
+may run Auto-RAG only when the owning session's settings enable it; that
+retrieval is generated specifically for this dispatch and cannot read or clear
+the screen's resident staged-evidence slot. Evidence staged while a queue is
+draining remains labeled for the next manual send.
 
 ### 6.4 Screen dispatch
 
-`UI/Console_Modules/message.py` extends the existing visible-send dispatcher. It
-returns the screen-facing `sent | queued | refused` result, starts one exact
-per-session Textual worker, and awaits `controller.run_prompt_chain(...)`. It
-does not interpret queue phases or terminal statuses itself.
+Composer and command dispatch currently belong to `ChatScreen`, not
+`UI/Console_Modules/message.py`; that module explicitly excludes visible-send
+orchestration. The existing `_dispatch_console_draft_send` name stays as a thin
+compatibility wrapper for callers and tests, delegating queue-aware routing to a
+new UI controller in `UI/Console_Modules/prompt_queue.py` constructed from
+`wiring.py`.
+
+The UI controller owns draft transactions and returns the screen-facing
+`sent | queued | refused` result. It starts one exact per-session Textual worker
+for a new chain and awaits `controller.run_prompt_chain(...)`, but it does not
+interpret queue phases or terminal statuses. Existing `message.py` ownership is
+unchanged, and the extraction must lower or preserve the `chat_screen.py`
+ratchets.
 
 ### 6.5 Queue region and modal
 
-`UI/Console_Modules/prompt_queue.py` owns shelf pixels, responsive presentation,
-focus restoration, and typed UI intents. The manager is a focused modal in
+`UI/Console_Modules/prompt_queue.py` contains two explicit owners:
+`ConsolePromptQueueRegion` owns shelf pixels, responsive presentation, focus
+restoration, and typed UI intents; `ConsolePromptQueueUIController` owns draft
+transactions and worker dispatch but has no DOM. The manager is a focused modal in
 `Widgets/Console/console_prompt_queue_modal.py`.
 
 Both render immutable snapshots. Unchanged queue revisions produce no update or
-recompose during the Console's 0.2-second active-run poll.
+recompose during the Console's 0.2-second active-run poll. Render snapshots
+contain stable IDs, counts, state, and precomputed safe previews, never full
+prompt bodies. The manager requests full text only for the one entry entering
+edit mode.
 
 Construction and named late-binding callbacks live in
 `UI/Console_Modules/wiring.py`. Queue work does not increase the
@@ -309,6 +396,10 @@ then sets the app shutdown flag and runs existing cleanup only after approval.
 
 Choosing Stay or encountering a confirmation error fails closed, clears the
 guard, and preserves the mounted queue manager, edited text, runs, and queues.
+This guarantee covers user-initiated in-app quit paths. Forced process
+termination, terminal kill, or `SIGKILL` cannot offer an interactive
+confirmation and remains an unavoidable loss boundary for process-memory-only
+queues.
 
 ## 7. Send and drain flow
 
@@ -344,13 +435,14 @@ per-session chain:
 1. Await the current real turn.
 2. Inspect its accepted and terminal outcome.
 3. On successful completion, honor `pause_after_turn` first.
-4. Verify the store branch epoch.
+4. Verify the store conversation-context epoch.
 5. Atomically claim the FIFO head.
-6. Resolve the owning session's current provider and workspace selection.
-7. Submit with queued origin.
-8. At the accepted boundary, settle the claim and let normal message
+6. Resolve the owning session's immutable turn execution context.
+7. Recheck attachments and manually staged evidence without consuming either.
+8. Submit with queued origin.
+9. At the accepted boundary, settle the claim and let normal message
    persistence own the user turn.
-9. Repeat until the queue empties or pauses.
+10. Repeat until the queue empties or pauses.
 
 No user input event can claim the released slot between queued turns. The
 reservation remains visible to global cap and fleet derivation for the whole
@@ -389,7 +481,7 @@ Stop cancels only the current session's live response and immediately pauses
 its queue. `Resume next` accepts the stopped partial as history and dispatches
 the next prompt after reacquiring a slot. `Retry stopped turn` uses the existing
 regeneration path, retaining the partial stopped response as a sibling. Success
-adopts the new branch epoch and continues.
+adopts the new conversation-context epoch and continues.
 
 ### 8.4 Resume after reservation release
 
@@ -397,7 +489,20 @@ A paused queue holds no global agent slot. Resume, retry, and retry-stopped must
 reacquire one. If the cap is full, the operation refuses visibly and leaves the
 queue paused. It never registers a hidden global waiter.
 
-### 8.5 Approval waits
+### 8.5 Context-change review
+
+`Review` opens the manager with a warning that conversation history changed
+after the active turn's payload was committed. The queue has no stale context
+snapshot to diff or restore. After reviewing or editing the waiting prompts,
+the user may choose `Use current context & resume`; that explicit action
+revalidates the queue revision and current context epoch, adopts the epoch, and
+then attempts to reacquire a slot. If either value changes during confirmation,
+the queue stays paused and asks for review again.
+
+Ordinary Resume, Retry, Skip, and Resume next do not silently adopt an
+unrelated context change. They transition to the context-review pause first.
+
+### 8.6 Approval waits
 
 An approval or skill confirmation is still part of the current accepted turn.
 It does not pause the queue by itself. The shelf names the waiting approval,
@@ -405,11 +510,37 @@ and the user may edit, reorder, remove, or request pause while the turn waits.
 Normal approval denial may still let the agent finish; only the final turn
 outcome decides whether draining continues.
 
+### 8.7 Competing generation actions
+
+The queue coordinator is the sole next-turn authority whenever a session has
+queue-owned future work. The existing transcript Retry action for the failed
+turn and Regenerate action for the stopped turn delegate to the same queue
+recovery operations as the shelf/manager, so recovery cannot run beside or
+ahead of the chain.
+
+Unrelated provider or response-generating actions, including Continue,
+Regenerate another message, Edit & resend, and Summarize up to, use the same
+queue-aware activity gate and refuse with copy directing the user to resume,
+review, or clear the queue first. They never bypass older entries.
+Command-specific gates remain authoritative for slash-command work.
+Non-generating history actions may still run; provider-relevant mutations
+advance the context epoch and force review as specified above.
+
 ## 9. Session, navigation, and shutdown lifecycle
 
 Queues are keyed by session ID. Switching tabs or workspaces changes only the
 rendered snapshot. Closing a session removes only that session's queue after a
-confirmation that includes its exact unsent count.
+single combined confirmation that includes transcript-loss impact, whether one
+turn is live, and the exact unsent queue count. The flow never stacks a legacy
+message dialog and a second queue dialog, and a live or queued session confirms
+even when its transcript is still empty.
+
+After confirmation, controller close first marks that session as closing and
+tombstones its chain. Claim, enqueue, resume, and terminal-drain callbacks for
+that session then refuse or no-op. Only afterward may the existing close path
+signal Stop, cancel the stream, remove queue state, and remove the store
+session. A Stop transition caused by close can therefore never dispatch one
+more prompt.
 
 Navigation and quit guards count:
 
@@ -469,7 +600,13 @@ inside the viewport.
 - Edit, move, remove, clear, pause, resume, and keep-draining transitions.
 - Stable entry IDs and stale revision rejection.
 - Session isolation and exact session removal.
-- Branch-epoch behavior: linear append stable, lineage mutation increments.
+- Conversation-context epoch behavior: ordinary linear appends stay stable;
+  active-path edit, selected textual variant, summary, deletion, and lineage
+  mutations increment; off-path and display-only changes stay stable.
+- Idempotent re-selection or identical-value writes do not increment the
+  context epoch.
+- The first queued entry inherits the active turn's committed payload epoch;
+  an edit before that first admission still causes a terminal pause.
 - Shutdown prevents all new claims.
 
 ### 12.2 Controller and joined async tests
@@ -477,16 +614,30 @@ inside the viewport.
 - Three queued prompts create three ordered user/assistant pairs.
 - A drain retains exactly one global slot until empty or paused.
 - Other sessions remain independent.
-- Background dispatch uses its owning session's provider, model, system prompt,
-  and workspace roots while a different session is viewed.
+- Background dispatch uses one immutable owning-session turn context for
+  provider, model, system prompt, capabilities, generation parameters, and
+  workspace roots while a different session is viewed or settings change.
 - Activity projection drives busy count, markers, fleet summary, polling, cap,
   notifications, and navigation consistently.
 - Intermediate completions create no Finished marker or completion toast.
+- The legacy no-argument acceptance hook fires for manual origin only; the
+  queued acceptance event is content-free and never clears composer or undo
+  state.
 - Approval waits retain queue state.
-- Failed, stopped, branch-changed, dispatch-refused, and unexpected-exception
+- An attachment or manually staged evidence added after admission pauses the
+  queue before acceptance and remains unconsumed.
+- Queued Auto-RAG uses only the owning session's dispatch-generated retrieval;
+  a different tab's resident staged evidence is never read or cleared.
+- A queued turn never snapshots credentials or approval/trust grants; runtime
+  revocation is honored by the existing authority checks.
+- Failed, stopped, context-changed, dispatch-refused, and unexpected-exception
   paths pause without duplication or loss.
 - Failed retry, skip, stopped regeneration, and resume-next start exactly one
   following turn.
+- Transcript recovery actions join the coordinator, while unrelated Continue,
+  Regenerate, and Edit & resend cannot bypass a nonempty queue.
+- Context review adopts the current epoch only through explicit confirmation;
+  a stale review or an ordinary recovery action leaves the queue paused.
 - A paused queue refused by the global cap remains paused.
 - Shutdown cannot dispatch after cancellation wakes a terminal transition.
 - Hands-free and queue completion cannot start duplicate turns.
@@ -494,9 +645,14 @@ inside the viewport.
 ### 12.3 Mounted UI tests
 
 - `Preparing...`, `Queue`, and `Send` appear only at their correct boundaries.
+- `Queue full` and its adjacent `10/10` recovery reason appear before submit;
+  Enter preserves the exact draft and repeats the refusal.
 - Enter, button, voice, and programmatic paths report honest outcomes.
 - Full-queue and non-text-rider refusals restore exact composer transactions.
 - Shelf count, state, primary action, preview escaping, and compact labels.
+- Preview safety covers ANSI/control text, multiline input, wide glyphs, and
+  combining characters; large-entry editing mounts only the selected body.
+- Shelf and polling snapshots never contain full queued prompt bodies.
 - Collapsed composer privacy.
 - Live manager snapshots, stable selection, and stale-edit recovery.
 - Background labels remain session-correct.
@@ -508,6 +664,10 @@ inside the viewport.
 - Stay preserves live runs, queues, manager state, and edited text.
 - Leave and quit proceed only after confirmation.
 - Warnings report exact live-run, queued-session, and queued-prompt counts.
+- Closing a queued session tombstones its chain before Stop/cancel; the induced
+  terminal transition cannot dispatch another prompt.
+- Session close uses one combined confirmation for transcript, live-turn, and
+  queued-prompt impact, including the empty-transcript validation window.
 - Repeated quit requests produce one dialog and one cleanup pass.
 - Confirmation failure fails closed.
 - Unsent queue text is absent from snapshots, persistence, history, and logs.
@@ -519,10 +679,11 @@ At minimum, deliberately break and confirm a red test for:
 
 - The ten-entry limit.
 - Origin-aware composer clearing.
+- Legacy acceptance-hook compatibility and queued-event isolation.
 - Stale revision rejection.
-- Branch epoch checking.
+- Conversation-context epoch checking, including active-path in-place edits.
 - Shutdown claim suppression.
-- Owning-session provider selection.
+- Owning-session immutable turn-context selection.
 - Intermediate completion notification suppression.
 
 ### 12.6 Live verification
@@ -546,9 +707,9 @@ system prompts and workspace roots:
 9. Exercise session-close, leave, and quit warnings.
 10. Inspect compositor output at 80x24 and a normal terminal size.
 
-Provider-selection isolation across different provider/model combinations is
-proved deterministically in automated tests rather than requiring multiple paid
-credentials for the live smoke.
+Turn-execution-context isolation across different provider/model combinations
+and a mid-validation settings change is proved deterministically in automated
+tests rather than requiring multiple paid credentials for the live smoke.
 
 ## 13. Documentation and compatibility
 

--- a/Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+++ b/Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
@@ -278,6 +278,8 @@ outside the queue coordinator's ordinary linear turn append:
 - Deletion that changes the active path.
 - Editing user or assistant content on the active path.
 - Selecting a different textual response variant on the active path.
+- Adding, removing, reordering, or selecting message attachments on the active
+  path when that changes the payload seen by a future provider turn.
 - Changing or clearing the active conversation summary boundary.
 
 Ordinary linear message appends, streaming updates, status changes, persistence,
@@ -290,10 +292,12 @@ variant, writing identical content, and reapplying the same summary are stable.
 This keeps harmless UI re-selection from spuriously pausing a queue.
 
 A queue-authorized failed retry or stopped regeneration may legitimately change
-the epoch. On successful recovery the coordinator adopts the resulting epoch
-before draining continues. Any unrelated mismatch pauses for review. Store
-mutation tests must cover every provider-relevant mutation seam so a new edit or
-branch feature cannot silently bypass this invariant.
+the epoch. A failed-row retry advances when it becomes provider-visible complete
+or stopped history; another failed/refused attempt remains excluded and stable.
+On successful recovery the coordinator adopts the resulting epoch before
+draining continues. Any unrelated mismatch pauses for review. Store mutation
+tests must cover every provider-relevant mutation seam so a new edit, attachment,
+or branch feature cannot silently bypass this invariant.
 
 ## 6. Architecture and ownership
 
@@ -638,6 +642,8 @@ inside the viewport.
 - Conversation-context epoch behavior: ordinary linear appends stay stable;
   active-path edit, selected textual variant, summary, deletion, and lineage
   mutations increment; off-path and display-only changes stay stable.
+- Active-path attachment-set/order changes increment; the same mutations on an
+  off-path generation message remain stable.
 - Idempotent re-selection or identical-value writes do not increment the
   context epoch.
 - The first queued entry inherits the active turn's committed payload epoch;

--- a/Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+++ b/Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
@@ -196,11 +196,20 @@ one paused/failure signal.
 
 - Stable entry ID.
 - Exact canonical text.
+- A precomputed, one-line, terminal-safe preview derived at admission or edit
+  against a fixed maximum cell budget, independent of the current viewport.
 - Owning session ID or ownership through its registry bucket.
 - Insertion order.
 
 It contains no attachment, evidence bundle, provider selection, secret, widget,
 task, or persistence identifier.
+
+Prompt-bearing records use a redacted representation so exceptions, assertions,
+and diagnostics cannot expose the canonical text accidentally. Render snapshots
+reuse the precomputed preview and never traverse or copy every prompt body during
+the Console's polling loop. The preview is recomputed only for the entry whose
+text changes. Widgets crop or elide that already-safe preview further for their
+current geometry, so a terminal resize never requires access to the full body.
 
 Admission reuses `MAX_CONSOLE_DRAFT_LENGTH` (currently 100,000 characters), so
 the ten-entry limit also bounds queued text to at most 1,000,000 characters per
@@ -312,6 +321,7 @@ The controller exposes one per-session activity projection used by all fleet
 consumers. It answers:
 
 - Occupies an agent slot.
+- Is validating or preparing before acceptance.
 - Has a live accepted turn.
 - Needs approval.
 - Has queued prompts.
@@ -321,6 +331,11 @@ consumers. It answers:
 Busy count, global-cap enforcement, run markers, fleet summary, transcript
 polling, completion notifications, and navigation warnings derive from this
 projection rather than duplicating queue awareness.
+
+Queue-authorized failed retry and stopped-turn regeneration use a narrow internal
+recovery capability checked at the controller's existing generation gate. It is
+not a general `force` switch and cannot be supplied by unrelated Continue,
+Regenerate, Edit and resend, Summarize, hands-free, or external callers.
 
 ### 6.3 Per-session turn execution context
 
@@ -339,6 +354,11 @@ construction, capability checks, caching/fingerprinting, and stream execution,
 so a tab switch or settings edit cannot produce a half-old, half-new turn.
 Changes completed after a claim apply to the following queued turn. Pinned and
 one-shot prefill keep their existing session-level next-send semantics.
+
+Immutability is detached, not only nominal: mappings, sequences, workspace roots,
+and other mutable source settings are copied into immutable values during capture.
+The context does not retain a live `ConsoleWorkspaceContext`, session settings
+object, or callback whose later mutation could change provider input.
 
 The execution context contains configuration, not durable authority: it stores
 no API key, approval grant, skill-trust grant, or reusable permission decision.
@@ -393,6 +413,9 @@ Construction and named late-binding callbacks live in
 exclusive confirmation worker. A `_quit_in_progress` guard absorbs repeated
 requests. The worker consults a generic asynchronous screen pre-quit seam,
 then sets the app shutdown flag and runs existing cleanup only after approval.
+Blocking cache/config persistence and timed thread joins run off the Textual
+event loop; app-owned state changes and the final `exit()` remain marshalled to
+the app thread. Existing cleanup ordering and the one-pass guarantee remain.
 
 Choosing Stay or encountering a confirmation error fails closed, clears the
 guard, and preserves the mounted queue manager, edited text, runs, and queues.
@@ -551,6 +574,14 @@ Navigation and quit guards count:
 The dialog uses those separate counts and does not imply that a paused queue is
 a running agent.
 
+Lifecycle projections carry a monotonic revision over the counted work. Session
+close is pinned to the requested session ID, and close, leave, and quit re-read
+the projection after confirmation. If work or counts changed while the dialog was
+open, destruction fails closed and presents an updated confirmation; approval for
+an older impact snapshot never discards newly admitted work. The lifecycle view
+is an immutable aggregate derived from the controller activity projection, not a
+second mutable state owner.
+
 Shutdown first marks the controller as shutting down. Claim, resume, retry, and
 drain entry points then become no-ops or explicit refusals. Only after that guard
 is active may shutdown cancel runs, deny approval waits, release reservations,
@@ -560,7 +591,8 @@ start another queued turn.
 Queue state never enters `TaskResumeState`, the native Console screen snapshot,
 database rows, prompt history, diagnostics, or logs. After a queued entry is
 accepted as a real turn, its user message and prompt-history entry follow normal
-persistence rules.
+persistence rules exactly once and in accepted-turn order. Queue admission,
+editing, reorder, and recovery selection never touch prompt history.
 
 ## 10. Hands-free and other input paths
 
@@ -599,6 +631,9 @@ inside the viewport.
 - `queued + claimed` capacity accounting.
 - Edit, move, remove, clear, pause, resume, and keep-draining transitions.
 - Stable entry IDs and stale revision rejection.
+- Safe previews are precomputed on admission/edit, unchanged-revision snapshots
+  are reused without traversing ten maximum-size bodies, and prompt-bearing
+  representations and errors remain redacted.
 - Session isolation and exact session removal.
 - Conversation-context epoch behavior: ordinary linear appends stay stable;
   active-path edit, selected textual variant, summary, deletion, and lineage
@@ -617,6 +652,8 @@ inside the viewport.
 - Background dispatch uses one immutable owning-session turn context for
   provider, model, system prompt, capabilities, generation parameters, and
   workspace roots while a different session is viewed or settings change.
+- Mutating or replacing captured source mappings, sequences, settings, roots, or
+  workspace objects cannot alter that turn context.
 - Activity projection drives busy count, markers, fleet summary, polling, cap,
   notifications, and navigation consistently.
 - Intermediate completions create no Finished marker or completion toast.
@@ -634,6 +671,9 @@ inside the viewport.
   paths pause without duplication or loss.
 - Failed retry, skip, stopped regeneration, and resume-next start exactly one
   following turn.
+- Queue recovery authorization cannot bypass the generation gate for any
+  unrelated action, and accepted queued prompts enter persistence and prompt
+  history exactly once in accepted order.
 - Transcript recovery actions join the coordinator, while unrelated Continue,
   Regenerate, and Edit & resend cannot bypass a nonempty queue.
 - Context review adopts the current epoch only through explicit confirmation;
@@ -655,6 +695,8 @@ inside the viewport.
 - Shelf and polling snapshots never contain full queued prompt bodies.
 - Collapsed composer privacy.
 - Live manager snapshots, stable selection, and stale-edit recovery.
+- A manager stays pinned to its opening session ID and revision across a viewed-
+  session switch; it never fetches bodies for unselected entries.
 - Background labels remain session-correct.
 - Geometry assertions at 80x24, 100x30, and 160x40.
 - Revision-gated rendering performs no update on an unchanged 0.2-second tick.
@@ -668,6 +710,8 @@ inside the viewport.
   terminal transition cannot dispatch another prompt.
 - Session close uses one combined confirmation for transcript, live-turn, and
   queued-prompt impact, including the empty-transcript validation window.
+- Work admitted or started while a close, leave, or quit dialog is open changes
+  the lifecycle revision and requires an updated confirmation.
 - Repeated quit requests produce one dialog and one cleanup pass.
 - Confirmation failure fails closed.
 - Unsent queue text is absent from snapshots, persistence, history, and logs.

--- a/Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+++ b/Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
@@ -1,0 +1,591 @@
+# Console prompt queue design
+
+Date: 2026-08-09
+Status: approved design, pending implementation
+ADR: [ADR-046: Visible bounded Console prompt queue](../../../backlog/decisions/046-visible-bounded-console-prompt-queue.md)
+
+## 1. Goal
+
+Let a Console user queue follow-up messages while an accepted agent turn is
+still running. A session may hold up to ten text-only prompts. They run in FIFO
+order as independent conversational turns, so each assistant response becomes
+context for the next queued user message.
+
+The feature must remain visible, controllable, session-scoped, and safe under
+parallel tabs, background approvals, failures, Stop, branching, navigation,
+quit, voice input, and narrow terminal geometry.
+
+## 2. Current system and amendment scope
+
+Console already has the required foundation:
+
+- `ConsoleRunState` and worker groups are per session.
+- One run is allowed per session under a configurable global cap.
+- Session drafts and pending attachments survive tab switching.
+- Background runs retain their owning session and workspace.
+- The accepted-send hook separates a confirmed turn from a blocked optimistic
+  echo.
+
+Today, Send is disabled while the target session has an active run and the
+controller refuses a second same-session send. The parallel-agent design also
+states that there is no hidden queue and names run queues as out of scope.
+
+This design amends that decision only for a visible same-session prompt queue
+behind an already accepted turn. It does not queue an idle tab that is blocked
+only by the global cap. That case keeps the existing explicit refusal.
+
+## 3. Locked product decisions
+
+1. Queued messages run as separate sequential turns, never one combined prompt.
+2. Each session has its own FIFO queue with a hard maximum of ten entries.
+3. Users can edit, reorder, remove, pause, resume, retry, skip, or clear queued
+   work before it starts.
+4. A draining queue retains the session's current global agent slot.
+5. Failure or Stop pauses the queue. Nothing cascades automatically through
+   missing or deliberately interrupted context.
+6. Failed turns retry first by default, with an explicit skip option.
+7. Stopped turns use `Resume next` as the primary action and offer a separate
+   `Retry stopped turn` action.
+8. The queue survives Console tab and workspace switching but not leaving
+   Console or quitting the app. Destructive exit requires confirmation.
+9. Version one queues canonical text only. Attachments and staged Library/RAG
+   evidence are excluded.
+10. The primary queue surface is a compact shelf directly above the expanded
+    composer.
+11. While an accepted turn runs, Send becomes Queue and Enter enqueues.
+12. No new global shortcut or configuration key is introduced.
+
+## 4. User experience
+
+### 4.1 Action lifecycle
+
+The composer action has three relevant labels:
+
+- `Preparing...` while the current send is still validating and has not crossed
+  the accepted-turn boundary. Queueing is unavailable.
+- `Queue` after the turn is accepted, or whenever that session already has
+  queue-owned future work, including a paused queue or a pre-accept claim.
+- `Send` when the session has no active turn and no paused queue controlling
+  order.
+
+When a queue is paused, new text appends to the queue. It never bypasses older
+entries. The user must resume, retry, skip, reorder, or clear deliberately.
+
+Recognized slash commands are never queued. Parsing still occurs before the
+normal-text decision, and every command keeps its own existing safety gate.
+Unknown commands retain the existing two-Enter confirmation before they may be
+treated as literal text. `$skill` messages remain ordinary text sends and are
+revalidated for trust at dispatch time.
+
+### 4.2 Queue shelf
+
+Once at least one future entry exists, one row appears above the expanded
+composer:
+
+```text
+Queue 3/10 · Draining · Next: "Review the tests..."    Manage  Pause
+```
+
+The shelf always carries readable text; color only reinforces state. It shows
+one state-dependent primary action plus `Manage`:
+
+| State | Primary action | Shelf copy |
+| --- | --- | --- |
+| Draining | Pause | `Queue 3/10 · Draining` |
+| Pause requested | Keep draining | `Queue 3/10 · Pauses after this turn` |
+| Manually paused | Resume | `Queue paused · 3 waiting` |
+| Failed turn | Retry | `Queue paused · Turn failed · 3 waiting` |
+| Stopped turn | Resume next | `Queue paused · Turn stopped · 3 waiting` |
+| Dispatch refused | Try again | `Queue paused · Next message could not start` |
+| Branch changed | Review | `Conversation changed · review 3 queued` |
+
+Secondary recovery actions live in the manager so the shelf remains usable at
+80 columns. Clear is never a shelf action.
+
+At narrow widths, the next-message preview disappears before the count, state,
+or actions. Preview text is markup-escaped, normalized to one line, and
+truncated by terminal-cell width. Prompt content never appears in background
+toasts or fleet labels.
+
+When the composer is collapsed, the existing privacy contract wins: only count
+and status remain, such as `Queue 3/10 · Draining`. Draft text, prompt previews,
+and attachment names stay hidden.
+
+### 4.3 Queue manager
+
+`Manage` opens a bounded, scrollable modal with at most ten numbered one-line
+previews. Normal buttons and Tab navigation expose:
+
+- Edit.
+- Move up.
+- Move down.
+- Remove with the repository's guarded destructive-action convention.
+- Retry a stopped turn.
+- Skip a failed turn and resume.
+- Clear all with confirmation.
+- Close with Esc.
+
+The active or already accepted prompt is not a future queue entry and cannot be
+edited from the manager. A claimed prompt that is still crossing validation is
+shown as `Starting...` and locked against edit, reorder, and removal until it is
+accepted or returned to the queue.
+
+Edits pass through the same text and command classification as admission. An
+edit that would turn an entry into a recognized slash command is refused
+intact; commands are never smuggled into the automatic drain through the
+manager.
+
+The manager consumes live revisioned snapshots. Selection follows stable entry
+IDs. If the selected entry starts or is removed, selection moves to the next
+surviving entry. An edit or reorder callback revalidates its entry ID and queue
+revision. A stale edit never changes the active turn; it retains the edited text
+and may offer to add it as a new entry if capacity remains.
+
+### 4.4 Refusals and feedback
+
+Queue acceptance clears the exact captured draft and updates the shelf without
+an additional toast. Refusal preserves the exact composer stash, including the
+canonical content behind collapsed paste tokens.
+
+Required visible refusals include:
+
+- `Queue full (10/10). Manage or remove an item.`
+- `Attachments cannot be queued yet. Remove the attachment or wait for this turn to finish.`
+- Equivalent explicit copy when staged Library/RAG evidence is present.
+- The existing global-cap refusal when resuming a queue cannot reacquire a slot.
+
+Voice and programmatic dispatch use a screen-facing outcome with `sent`,
+`queued`, or `refused`. Hands-free acknowledgement for a queued send names the
+state, for example `Queued, 3 waiting.`
+
+### 4.5 Background visibility
+
+The full shelf belongs to the viewed session. Background tab and conversation
+rows expose a content-free count:
+
+- `Queue 3` where space permits.
+- `Q3` in compact tab chrome, documented in F1 help and the marker legend.
+
+A draining queue remains Running between its turns. Intermediate completions do
+not stamp Finished, clear the transcript timer, or emit completion toasts. One
+final completion signal fires when the queue empties. A failure or Stop produces
+one paused/failure signal.
+
+## 5. State model
+
+### 5.1 Queue entry
+
+`QueuedPrompt` is immutable and contains:
+
+- Stable entry ID.
+- Exact canonical text.
+- Owning session ID or ownership through its registry bucket.
+- Insertion order.
+- The queue's expected branch epoch when admitted.
+
+It contains no attachment, evidence bundle, provider selection, secret, widget,
+task, or persistence identifier.
+
+### 5.2 Per-session queue state
+
+`PromptQueueState` contains:
+
+- Ordered immutable entries.
+- At most one claimed entry.
+- Monotonic queue revision.
+- Mode: `draining`, `pause_after_turn`, or `paused`.
+- Pause reason: manual, failed, stopped, context changed, or dispatch refused.
+- Expected branch epoch.
+- Whether the session reserves an agent slot.
+
+The hard limit counts `queued + claimed`. Once a claimed entry is accepted as a
+real user turn, it leaves queue accounting and normal message ownership begins.
+Visible capacity counts use the same rule; a pre-accept claim therefore still
+occupies one of the ten positions even though its row is labeled `Starting...`.
+
+### 5.3 Accepted-turn and submission origin
+
+Queueing is enabled by an explicit per-session accepted-turn flag, not by a
+broad run-status guess. The flag is set at the same boundary that currently
+fires the accepted-send hook and cleared at terminal teardown.
+
+Every submission carries:
+
+- Session ID.
+- Origin: manual or queued.
+- Draft text.
+- Queue entry ID for queued origin.
+- Composer stash only for manual origin.
+
+Only an accepted manual submission may consume or clear its own captured
+composer stash. An automatic queued submission never touches the live composer
+or another session's draft.
+
+### 5.4 Branch epoch
+
+`ConsoleChatStore` owns `branch_epoch(session_id)` because it owns the message
+tree and active leaf. The epoch changes only when active lineage changes:
+
+- Rewind or direct active-leaf selection.
+- Sibling or variant navigation that selects another branch.
+- Edit-and-resend or regeneration that creates/selects a branch.
+- Deletion that changes the active path.
+
+Ordinary linear message appends, streaming updates, status changes, persistence,
+feedback, and display overlays do not change it.
+
+A queue-authorized failed retry or stopped regeneration may legitimately change
+the epoch. On successful recovery the coordinator adopts the resulting epoch
+before draining continues. Any unrelated mismatch pauses for review.
+
+## 6. Architecture and ownership
+
+### 6.1 Pure queue registry
+
+`tldw_chatbook/Chat/console_prompt_queue.py` owns pure models and a per-session
+registry. It implements FIFO admission, validation results, the limit, claims,
+revision checks, edits, moves, removals, pause/resume transitions, reservations,
+session removal, and shutdown. It has no Textual, provider, persistence, or
+widget dependency.
+
+### 6.2 Controller and coordinator
+
+`ConsoleChatController` owns queue behavior through the registry and a focused
+controller-side coordinator. The coordinator interprets terminal results and
+owns claim, submit, retry, skip, reservation, and shutdown decisions.
+
+The controller exposes one per-session activity projection used by all fleet
+consumers. It answers:
+
+- Occupies an agent slot.
+- Has a live accepted turn.
+- Needs approval.
+- Has queued prompts.
+- Queue is paused.
+- Terminal outcome is eligible for a marker or notification.
+
+Busy count, global-cap enforcement, run markers, fleet summary, transcript
+polling, completion notifications, and navigation warnings derive from this
+projection rather than duplicating queue awareness.
+
+### 6.3 Per-session provider selection
+
+Background dispatch resolves a `ConsoleProviderSelection` for the queue's owning
+session ID. The resolver reads that session's stored settings, workspace
+binding, and current provider configuration. It never reuses the viewed tab's
+controller projection.
+
+Provider, model, system prompt, workspace, RAG defaults, tools, and other
+ordinary settings are resolved at dispatch time. The queue stores only text.
+Pinned and one-shot prefill keep their existing session-level next-send
+semantics.
+
+### 6.4 Screen dispatch
+
+`UI/Console_Modules/message.py` extends the existing visible-send dispatcher. It
+returns the screen-facing `sent | queued | refused` result, starts one exact
+per-session Textual worker, and awaits `controller.run_prompt_chain(...)`. It
+does not interpret queue phases or terminal statuses itself.
+
+### 6.5 Queue region and modal
+
+`UI/Console_Modules/prompt_queue.py` owns shelf pixels, responsive presentation,
+focus restoration, and typed UI intents. The manager is a focused modal in
+`Widgets/Console/console_prompt_queue_modal.py`.
+
+Both render immutable snapshots. Unchanged queue revisions produce no update or
+recompose during the Console's 0.2-second active-run poll.
+
+Construction and named late-binding callbacks live in
+`UI/Console_Modules/wiring.py`. Queue work does not increase the
+`chat_screen.py` size or method ratchet.
+
+### 6.6 Application quit
+
+`TldwCli.action_quit()` remains a thin non-blocking dispatcher into one
+exclusive confirmation worker. A `_quit_in_progress` guard absorbs repeated
+requests. The worker consults a generic asynchronous screen pre-quit seam,
+then sets the app shutdown flag and runs existing cleanup only after approval.
+
+Choosing Stay or encountering a confirmation error fails closed, clears the
+guard, and preserves the mounted queue manager, edited text, runs, and queues.
+
+## 7. Send and drain flow
+
+### 7.1 Enqueue
+
+1. Capture the target session synchronously.
+2. Parse recognized slash commands before normal-text routing.
+3. Require either an accepted live turn or an existing nonempty queue that
+   already controls the session's next-turn order.
+4. Capture the exact draft transaction.
+5. Reuse normal text validation.
+6. Refuse intact when an attachment or staged evidence rider is present.
+7. Atomically enforce `queued + claimed < 10`.
+8. Append an immutable entry and advance the queue revision.
+9. Clear the captured manual draft only after admission succeeds.
+10. Return `queued` with the new waiting count.
+
+When the queue is already paused, new text appends without starting or bypassing
+older work.
+
+Admission and the chain's final queue-empty transition use one atomic
+controller decision. If admission wins, the chain observes the new entry before
+it can release its reservation. If the terminal transition wins, no entry is
+created and the unchanged draft is rerouted once through normal manual Send
+against the now-idle session. This prevents both stranded prompts and duplicate
+turns at the response boundary.
+
+### 7.2 Drain
+
+The original manual send and every automatic queued turn run inside one
+per-session chain:
+
+1. Await the current real turn.
+2. Inspect its accepted and terminal outcome.
+3. On successful completion, honor `pause_after_turn` first.
+4. Verify the store branch epoch.
+5. Atomically claim the FIFO head.
+6. Resolve the owning session's current provider and workspace selection.
+7. Submit with queued origin.
+8. At the accepted boundary, settle the claim and let normal message
+   persistence own the user turn.
+9. Repeat until the queue empties or pauses.
+
+No user input event can claim the released slot between queued turns. The
+reservation remains visible to global cap and fleet derivation for the whole
+chain.
+
+### 7.3 Refusal and exception boundary
+
+If a queued submission is refused before acceptance, its claim returns to the
+head and the queue pauses with the refusal recovery copy. If an exception occurs
+after acceptance, the entry is already a real user turn and is not requeued;
+normal failed-assistant handling pauses the remaining queue.
+
+Unexpected coordinator errors fail closed. Unclaimed entries remain in order,
+the reservation is released, and visible recovery copy is surfaced without
+logging prompt content.
+
+## 8. Pause, failure, Stop, and recovery
+
+### 8.1 Manual pause
+
+`Pause` changes the mode to `pause_after_turn`. The current response continues.
+The shelf action becomes `Keep draining`, which cancels that request. At
+successful terminal completion, a still-pending pause releases the slot and
+leaves all future entries untouched.
+
+### 8.2 Failure
+
+A failed accepted turn pauses the remaining queue. `Retry` uses the existing
+failed-assistant retry path. Success adopts any authorized context change and
+continues. `Skip & resume` leaves the failed turn visible and advances without
+deleting or rewriting it.
+
+### 8.3 Stop
+
+Stop cancels only the current session's live response and immediately pauses
+its queue. `Resume next` accepts the stopped partial as history and dispatches
+the next prompt after reacquiring a slot. `Retry stopped turn` uses the existing
+regeneration path, retaining the partial stopped response as a sibling. Success
+adopts the new branch epoch and continues.
+
+### 8.4 Resume after reservation release
+
+A paused queue holds no global agent slot. Resume, retry, and retry-stopped must
+reacquire one. If the cap is full, the operation refuses visibly and leaves the
+queue paused. It never registers a hidden global waiter.
+
+### 8.5 Approval waits
+
+An approval or skill confirmation is still part of the current accepted turn.
+It does not pause the queue by itself. The shelf names the waiting approval,
+and the user may edit, reorder, remove, or request pause while the turn waits.
+Normal approval denial may still let the agent finish; only the final turn
+outcome decides whether draining continues.
+
+## 9. Session, navigation, and shutdown lifecycle
+
+Queues are keyed by session ID. Switching tabs or workspaces changes only the
+rendered snapshot. Closing a session removes only that session's queue after a
+confirmation that includes its exact unsent count.
+
+Navigation and quit guards count:
+
+- Live runs.
+- Sessions containing unsent queue work.
+- Total unsent queued prompts, including a pre-accept claim.
+
+The dialog uses those separate counts and does not imply that a paused queue is
+a running agent.
+
+Shutdown first marks the controller as shutting down. Claim, resume, retry, and
+drain entry points then become no-ops or explicit refusals. Only after that guard
+is active may shutdown cancel runs, deny approval waits, release reservations,
+and clear claims and queues. Terminal transitions caused by cancellation cannot
+start another queued turn.
+
+Queue state never enters `TaskResumeState`, the native Console screen snapshot,
+database rows, prompt history, diagnostics, or logs. After a queued entry is
+accepted as a real turn, its user message and prompt-history entry follow normal
+persistence rules.
+
+## 10. Hands-free and other input paths
+
+All visible and programmatic composer sends route through the same dispatcher.
+Keyboard, mouse, voice, and hands-free callers receive the same typed outcome.
+
+A queue reservation owns next-turn priority. Hands-free may enqueue user-authored
+text, but it cannot independently start another automatic turn while the queue
+chain retains a reservation. Exactly one next turn may begin after a response.
+
+Image generation and other recognized slash commands remain outside the prompt
+queue. Their existing per-command in-flight and safety rules stay authoritative.
+
+## 11. Accessibility and terminal geometry
+
+- Queue state is always text-labeled; color is supplementary.
+- Focus uses the existing semantic focus treatment and never changes geometry.
+- Disabled queue actions retain readable explanatory copy.
+- The shelf spends one row at normal supported heights.
+- Responsive reduction removes preview content before count, state, or actions.
+- The collapsed composer never reveals prompt content.
+- The manager uses standard buttons, Tab/Shift+Tab, Enter, and Esc. No screen or
+  widget binds terminal-convention keys or shadows global bindings.
+- F1 help documents `Queue N`, compact `QN`, pause, retry, and resume semantics.
+
+Mounted verification must assert neighboring control geometry, not only shelf
+text or display flags. At 80x24, 100x30, and 160x40, Send/Queue, Stop, Dictate,
+disabled-reason copy, transcript jump controls, and the queue shelf remain
+inside the viewport.
+
+## 12. Verification plan
+
+### 12.1 Pure state tests
+
+- FIFO order and a hard maximum of ten per session.
+- `queued + claimed` capacity accounting.
+- Edit, move, remove, clear, pause, resume, and keep-draining transitions.
+- Stable entry IDs and stale revision rejection.
+- Session isolation and exact session removal.
+- Branch-epoch behavior: linear append stable, lineage mutation increments.
+- Shutdown prevents all new claims.
+
+### 12.2 Controller and joined async tests
+
+- Three queued prompts create three ordered user/assistant pairs.
+- A drain retains exactly one global slot until empty or paused.
+- Other sessions remain independent.
+- Background dispatch uses its owning session's provider, model, system prompt,
+  and workspace roots while a different session is viewed.
+- Activity projection drives busy count, markers, fleet summary, polling, cap,
+  notifications, and navigation consistently.
+- Intermediate completions create no Finished marker or completion toast.
+- Approval waits retain queue state.
+- Failed, stopped, branch-changed, dispatch-refused, and unexpected-exception
+  paths pause without duplication or loss.
+- Failed retry, skip, stopped regeneration, and resume-next start exactly one
+  following turn.
+- A paused queue refused by the global cap remains paused.
+- Shutdown cannot dispatch after cancellation wakes a terminal transition.
+- Hands-free and queue completion cannot start duplicate turns.
+
+### 12.3 Mounted UI tests
+
+- `Preparing...`, `Queue`, and `Send` appear only at their correct boundaries.
+- Enter, button, voice, and programmatic paths report honest outcomes.
+- Full-queue and non-text-rider refusals restore exact composer transactions.
+- Shelf count, state, primary action, preview escaping, and compact labels.
+- Collapsed composer privacy.
+- Live manager snapshots, stable selection, and stale-edit recovery.
+- Background labels remain session-correct.
+- Geometry assertions at 80x24, 100x30, and 160x40.
+- Revision-gated rendering performs no update on an unchanged 0.2-second tick.
+
+### 12.4 Application lifecycle tests
+
+- Stay preserves live runs, queues, manager state, and edited text.
+- Leave and quit proceed only after confirmation.
+- Warnings report exact live-run, queued-session, and queued-prompt counts.
+- Repeated quit requests produce one dialog and one cleanup pass.
+- Confirmation failure fails closed.
+- Unsent queue text is absent from snapshots, persistence, history, and logs.
+- Accepted queued turns persist normally.
+
+### 12.5 Mutation checks
+
+At minimum, deliberately break and confirm a red test for:
+
+- The ten-entry limit.
+- Origin-aware composer clearing.
+- Stale revision rejection.
+- Branch epoch checking.
+- Shutdown claim suppression.
+- Owning-session provider selection.
+- Intermediate completion notification suppression.
+
+### 12.6 Live verification
+
+Use the repository's absolute virtual-environment Python and an isolated scratch
+profile. Set `TLDW_TEST_MODE`, `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`,
+`TLDW_CONFIG_PATH`, and the scratch config's `[paths] data_dir` before importing
+or launching the app.
+
+With one available local provider, create two Console sessions with distinct
+system prompts and workspace roots:
+
+1. Start both agents.
+2. Queue three prompts in one session.
+3. Edit and reorder them while the first turn runs.
+4. Park an approval.
+5. Switch sessions and verify background count and workspace isolation.
+6. Approve and observe sequential draining.
+7. Pause after a turn, resume, Stop, retry the stopped turn, then resume next.
+8. Confirm one final completion notification.
+9. Exercise session-close, leave, and quit warnings.
+10. Inspect compositor output at 80x24 and a normal terminal size.
+
+Provider-selection isolation across different provider/model combinations is
+proved deterministically in automated tests rather than requiring multiple paid
+credentials for the live smoke.
+
+## 13. Documentation and compatibility
+
+Implementation must update:
+
+- `Docs/User_Guide/console/chat-basics.md`.
+- `Docs/User_Guide/console/agent-runs-and-tools.md`.
+- Collapsed-composer behavior and screenshots where the queue changes visible
+  states.
+- F1 help and fleet-marker legend.
+- Leave and quit behavior.
+- The parallel-agent design's explicit amendment note.
+
+The design introduces no database migration, persistent queue format,
+configuration key, or global shortcut. Existing `ConsoleSubmitResult` remains
+compatible; the new immediate `sent | queued | refused` outcome belongs to the
+screen dispatcher.
+
+## 14. Non-goals
+
+- Persistent or restart-resumable queues.
+- Global-cap waiting queues.
+- Cross-session or cross-workspace queue movement.
+- Attachments, staged evidence, or arbitrary message riders.
+- Combined or batched prompts.
+- Per-entry provider or settings snapshots.
+- Per-workspace queue caps.
+- Scheduling times, delays, recurrence, or external automation.
+- Automatically continuing after failure or Stop.
+
+## 15. ADR check
+
+ADR required: yes
+
+ADR path: `backlog/decisions/046-visible-bounded-console-prompt-queue.md`
+
+Reason: the feature changes long-lived Console send behavior, controller/screen
+interfaces, application quit coordination, transient state ownership, and the
+previously approved no-queue policy. ADR-046 records the bounded visible
+same-session exception and its lifecycle limits.

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -2595,7 +2595,7 @@ def test_compose_run_registry_and_allowed_no_warning_without_mcp_collisions():
     finally:
         loguru_logger.remove(sink_id)
 
-    assert messages == []
+    assert not any("is shadowed by a built-in" in message for message in messages)
 
 
 def test_compose_run_registry_and_allowed_walks_mcp_catalog_only_once():

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -600,6 +600,28 @@ def test_native_kill_switch_off_stays_on_fence_path(tmp_path):
     assert bridge._gateway.tools_seen[0] is None  # no tools= despite groq
 
 
+def test_captured_native_tools_override_beats_later_callback_change(tmp_path):
+    enabled = True
+    bridge, _db, store, session, aid = _bridge(
+        tmp_path,
+        [[_native_calls("get_current_datetime", {})], ["Done."]],
+        native_tools_enabled=lambda: enabled,
+    )
+    enabled = False
+
+    outcome = _run(
+        bridge,
+        store,
+        session,
+        aid,
+        resolution=_NativeResolution(),
+        native_tools_enabled=True,
+    )
+
+    assert outcome.status == "done"
+    assert bridge._gateway.tools_seen[0] is not None
+
+
 def test_multi_turn_run_reuses_one_event_loop_across_chat_call_turns(tmp_path):
     """PR #629 Fix 1(c) (Gemini HIGH x2 + Qodo-8): ``_StreamingModelAdapter.
     chat_call`` used to bridge every turn via its own ``asyncio.run()`` --

--- a/Tests/Chat/test_console_conversation_context_epoch.py
+++ b/Tests/Chat/test_console_conversation_context_epoch.py
@@ -1,0 +1,421 @@
+"""Provider-context epoch contracts for ``ConsoleChatStore``.
+
+The queue coordinator uses this token to detect history changes that happen
+outside ordinary linear turn growth. These tests deliberately distinguish the
+broader payload revision from changes that must pause deferred prompts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+    GenerationVariantMeta,
+)
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
+
+
+def _store_with_session() -> tuple[ConsoleChatStore, str]:
+    store = ConsoleChatStore()
+    session = store.create_session(title="Epoch")
+    return store, session.id
+
+
+def _generation_meta(seed: int) -> GenerationVariantMeta:
+    return GenerationVariantMeta(
+        prompt="prompt",
+        negative_prompt="",
+        backend="test",
+        model=None,
+        seed=seed,
+        style=None,
+        params={},
+    )
+
+
+def _failed_assistant(store: ConsoleChatStore, session_id: str, text: str):
+    message = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+    )
+    store.append_stream_chunk(message.id, text)
+    store.mark_message_failed(message.id)
+    return message
+
+
+def test_epoch_starts_at_zero_is_session_isolated_and_is_purged_on_close():
+    store = ConsoleChatStore()
+    first = store.create_session(title="First")
+    second = store.create_session(title="Second")
+    first_message = store.append_message(
+        first.id,
+        role=ConsoleMessageRole.USER,
+        content="first",
+    )
+
+    assert store.conversation_context_epoch(first.id) == 0
+    assert store.conversation_context_epoch(second.id) == 0
+
+    store.update_message_content(first_message.id, "changed")
+
+    assert store.conversation_context_epoch(first.id) == 1
+    assert store.conversation_context_epoch(second.id) == 0
+
+    store.close_session(first.id)
+
+    with pytest.raises(KeyError):
+        store.conversation_context_epoch(first.id)
+    assert store.conversation_context_epoch(second.id) == 0
+
+
+def test_restore_initializes_fresh_process_local_epochs():
+    store = ConsoleChatStore()
+    restored = ConsoleChatMessage(
+        role=ConsoleMessageRole.USER,
+        content="restored",
+        persisted_message_id="message-1",
+    )
+
+    session = store.restore_persisted_session(
+        title="Restored",
+        workspace_id=None,
+        persisted_conversation_id="conversation-1",
+        all_nodes=[restored],
+        active_leaf_persisted_id="message-1",
+    )
+
+    assert store.conversation_context_epoch(session.id) == 0
+    assert "conversation_context_epoch" not in vars(session)
+
+
+def test_restore_state_replaces_and_reinitializes_epoch_state():
+    store, old_session_id = _store_with_session()
+    old_message = store.append_message(
+        old_session_id,
+        role=ConsoleMessageRole.USER,
+        content="old",
+    )
+    store.update_message_content(old_message.id, "changed")
+    restored_session = ConsoleChatSession(title="Restored state")
+    restored_message = ConsoleChatMessage(
+        role=ConsoleMessageRole.USER,
+        content="restored",
+    )
+
+    store.restore_state(
+        sessions=[restored_session],
+        messages_by_session={restored_session.id: [restored_message]},
+        active_session_id=restored_session.id,
+    )
+
+    with pytest.raises(KeyError):
+        store.conversation_context_epoch(old_session_id)
+    assert store.conversation_context_epoch(restored_session.id) == 0
+
+
+@pytest.mark.parametrize(
+    "terminal_method",
+    ["mark_message_complete", "mark_message_failed", "mark_message_stopped"],
+)
+def test_linear_append_stream_and_terminal_status_do_not_advance_epoch(
+    terminal_method: str,
+):
+    store, session_id = _store_with_session()
+    store.append_message(
+        session_id,
+        role=ConsoleMessageRole.USER,
+        content="question",
+    )
+    assistant = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+    )
+
+    store.append_stream_chunk(assistant.id, "answer")
+    getattr(store, terminal_method)(assistant.id)
+
+    assert store.conversation_context_epoch(session_id) == 0
+
+
+def test_feedback_tool_markers_and_same_content_write_do_not_advance_epoch():
+    store, session_id = _store_with_session()
+    assistant = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="answer",
+    )
+
+    store.set_message_feedback(assistant.id, "up")
+    store.append_message(
+        session_id,
+        role=ConsoleMessageRole.TOOL,
+        content="tool marker",
+    )
+    store.update_message_content(assistant.id, "answer")
+
+    assert store.conversation_context_epoch(session_id) == 0
+
+
+def test_active_path_edit_advances_once_while_off_path_edit_is_stable():
+    store, session_id = _store_with_session()
+    user = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.USER,
+        content="question",
+    )
+    original = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="original",
+    )
+    sibling = store.create_sibling(
+        original.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="sibling",
+    )
+    baseline = store.conversation_context_epoch(session_id)
+
+    store.update_message_content(original.id, "off path edit")
+
+    assert store.conversation_context_epoch(session_id) == baseline
+
+    store.update_message_content(sibling.id, "active edit")
+
+    assert store.conversation_context_epoch(session_id) == baseline + 1
+    assert store.active_path_message_ids(session_id) == [user.id, sibling.id]
+
+
+def test_active_leaf_changes_advance_but_idempotent_selection_is_stable():
+    store, session_id = _store_with_session()
+    user = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.USER,
+        content="question",
+    )
+    assistant = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="answer",
+    )
+
+    store.set_active_leaf(session_id, user.id)
+    assert store.conversation_context_epoch(session_id) == 1
+
+    store.set_active_leaf(session_id, user.id)
+    assert store.conversation_context_epoch(session_id) == 1
+
+    store.set_active_leaf(session_id, assistant.id)
+    assert store.conversation_context_epoch(session_id) == 2
+
+
+def test_summary_changes_advance_but_identical_pair_is_stable():
+    store, session_id = _store_with_session()
+    user = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.USER,
+        content="question",
+    )
+
+    store.set_session_context_summary(session_id, "summary", user.id)
+    assert store.conversation_context_epoch(session_id) == 1
+
+    store.set_session_context_summary(session_id, "summary", user.id)
+    assert store.conversation_context_epoch(session_id) == 1
+
+    store.set_session_context_summary(session_id, None, None)
+    assert store.conversation_context_epoch(session_id) == 2
+
+
+def test_create_sibling_advances_once_and_following_linear_append_is_stable():
+    store, session_id = _store_with_session()
+    user = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.USER,
+        content="question",
+    )
+    assistant = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="answer",
+    )
+
+    sibling = store.create_sibling(
+        assistant.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="replacement",
+    )
+
+    assert store.conversation_context_epoch(session_id) == 1
+
+    store.append_message(
+        session_id,
+        role=ConsoleMessageRole.USER,
+        content="next",
+    )
+
+    assert store.conversation_context_epoch(session_id) == 1
+    assert store.active_path_message_ids(session_id)[:2] == [user.id, sibling.id]
+
+
+def test_delete_advances_only_when_deleted_subtree_is_on_active_path():
+    store, session_id = _store_with_session()
+    store.append_message(
+        session_id,
+        role=ConsoleMessageRole.USER,
+        content="question",
+    )
+    original = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="original",
+    )
+    sibling = store.create_sibling(
+        original.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="sibling",
+    )
+    baseline = store.conversation_context_epoch(session_id)
+
+    store.delete_message(original.id)
+    assert store.conversation_context_epoch(session_id) == baseline
+
+    store.delete_message(sibling.id)
+    assert store.conversation_context_epoch(session_id) == baseline + 1
+
+
+def test_text_variant_changes_advance_only_for_effective_active_path_text():
+    store, session_id = _store_with_session()
+    message = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="one",
+    )
+
+    store.add_variant(message.id, "two")
+    assert store.conversation_context_epoch(session_id) == 1
+
+    store.add_variant(message.id, "two")
+    store.select_variant(message.id, 2)
+    store.update_message_content(message.id, "two")
+    assert store.conversation_context_epoch(session_id) == 1
+
+    store.select_variant(message.id, 0)
+    assert store.conversation_context_epoch(session_id) == 2
+
+    store.create_sibling(
+        message.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="active sibling",
+    )
+    baseline = store.conversation_context_epoch(session_id)
+    store.select_variant(message.id, 1)
+
+    assert store.conversation_context_epoch(session_id) == baseline
+
+
+def test_variant_stream_advances_only_when_success_changes_selected_text():
+    store, session_id = _store_with_session()
+    message = store.append_message(
+        session_id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="base",
+    )
+
+    store.begin_variant_stream(message.id)
+    store.append_stream_chunk(message.id, "replacement")
+    assert store.conversation_context_epoch(session_id) == 0
+    store.finalize_variant_stream(message.id)
+    assert store.conversation_context_epoch(session_id) == 1
+
+    store.begin_variant_stream(message.id)
+    store.append_stream_chunk(message.id, "replacement")
+    store.finalize_variant_stream(message.id)
+    assert store.conversation_context_epoch(session_id) == 1
+
+    store.begin_variant_stream(message.id)
+    store.append_stream_chunk(message.id, "discarded")
+    store.mark_message_failed(message.id)
+    assert store.conversation_context_epoch(session_id) == 1
+
+
+def test_failed_retry_advances_when_complete_or_stopped_but_not_when_failed():
+    complete_store, complete_session_id = _store_with_session()
+    completed_retry = _failed_assistant(
+        complete_store,
+        complete_session_id,
+        "same text",
+    )
+    complete_store.prepare_message_retry(completed_retry.id)
+    complete_store.append_stream_chunk(completed_retry.id, "same text")
+    complete_store.mark_message_complete(completed_retry.id)
+    assert complete_store.conversation_context_epoch(complete_session_id) == 1
+
+    failed_store, failed_session_id = _store_with_session()
+    failed_retry = _failed_assistant(failed_store, failed_session_id, "first")
+    failed_store.prepare_message_retry(failed_retry.id)
+    failed_store.append_stream_chunk(failed_retry.id, "second")
+    failed_store.mark_message_failed(failed_retry.id)
+    assert failed_store.conversation_context_epoch(failed_session_id) == 0
+
+    stopped_store, stopped_session_id = _store_with_session()
+    stopped_retry = _failed_assistant(stopped_store, stopped_session_id, "first")
+    stopped_store.prepare_message_retry(stopped_retry.id)
+    stopped_store.append_stream_chunk(stopped_retry.id, "partial")
+    stopped_store.mark_message_stopped(stopped_retry.id)
+    assert stopped_store.conversation_context_epoch(stopped_session_id) == 1
+
+
+def test_generation_attachment_changes_advance_only_on_active_path():
+    store, session_id = _store_with_session()
+    message = store.append_generation_message(
+        session_id,
+        content="[image] prompt",
+        variants=[
+            (b"one", "image/png", _generation_meta(1)),
+            (b"two", "image/png", _generation_meta(2)),
+        ],
+    )
+
+    store.append_generation_variant(
+        session_id,
+        message.id,
+        data=b"three",
+        mime_type="image/png",
+        meta=_generation_meta(3),
+        persist=False,
+    )
+    store.keep_generation_variant(
+        session_id,
+        message.id,
+        position=1,
+        persist=False,
+    )
+    assert store.conversation_context_epoch(session_id) == 2
+
+    store.create_sibling(
+        message.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="active sibling",
+    )
+    baseline = store.conversation_context_epoch(session_id)
+
+    store.append_generation_variant(
+        session_id,
+        message.id,
+        data=b"four",
+        mime_type="image/png",
+        meta=_generation_meta(4),
+        persist=False,
+    )
+    store.keep_generation_variant(
+        session_id,
+        message.id,
+        position=2,
+        persist=False,
+    )
+
+    assert store.conversation_context_epoch(session_id) == baseline

--- a/Tests/Chat/test_console_prompt_queue.py
+++ b/Tests/Chat/test_console_prompt_queue.py
@@ -1,0 +1,862 @@
+from __future__ import annotations
+
+import ast
+import inspect
+import threading
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+from rich.cells import cell_len
+from rich.text import Text
+
+from tldw_chatbook.Chat.console_prompt_queue import (
+    MAX_CONSOLE_QUEUED_PROMPT_LENGTH,
+    PROMPT_PREVIEW_CELL_BUDGET,
+    ConsolePromptQueueRegistry,
+    PromptQueueEntryPhase,
+    PromptQueueMode,
+    PromptQueuePauseReason,
+    PromptQueueReservation,
+    QueueMutationStatus,
+    QueueThreadViolation,
+    QueuedPrompt,
+    make_prompt_preview,
+)
+
+
+class _DeterministicValues:
+    def __init__(self) -> None:
+        self._id = 0
+        self._time = 100.0
+
+    def next_id(self) -> str:
+        self._id += 1
+        return f"queue-entry-{self._id}"
+
+    def monotonic(self) -> float:
+        self._time += 1.0
+        return self._time
+
+
+@pytest.fixture
+def registry() -> ConsolePromptQueueRegistry:
+    values = _DeterministicValues()
+    return ConsolePromptQueueRegistry(
+        id_factory=values.next_id,
+        monotonic=values.monotonic,
+    )
+
+
+def _begin(
+    registry: ConsolePromptQueueRegistry,
+    session_id: str = "session-a",
+    *,
+    context_epoch: int = 7,
+) -> int:
+    result = registry.begin_chain(
+        session_id,
+        context_epoch=context_epoch,
+        expected_revision=registry.snapshot(session_id).revision,
+    )
+    assert result.status is QueueMutationStatus.APPLIED
+    return result.snapshot.revision
+
+
+def _admit(
+    registry: ConsolePromptQueueRegistry,
+    text: str,
+    session_id: str = "session-a",
+) -> str:
+    result = registry.admit(
+        session_id,
+        text=text,
+        expected_revision=registry.snapshot(session_id).revision,
+    )
+    assert result.status is QueueMutationStatus.APPLIED
+    assert result.entry_id is not None
+    return result.entry_id
+
+
+def test_entries_are_immutable_redacted_and_fifo_with_stable_ids(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry)
+    first_id = _admit(registry, "first private prompt")
+    second_id = _admit(registry, "second private prompt")
+
+    first_claim = registry.claim_next(
+        "session-a",
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+    assert first_claim.status is QueueMutationStatus.APPLIED
+    assert first_claim.claim is not None
+    assert first_claim.claim.prompt.entry_id == first_id
+    assert first_claim.claim.prompt.text == "first private prompt"
+    assert "first private prompt" not in repr(first_claim.claim)
+    assert "first private prompt" not in repr(first_claim)
+    with pytest.raises(FrozenInstanceError):
+        first_claim.claim.prompt.text = "changed"  # type: ignore[misc]
+
+    settled = registry.settle_claim(
+        "session-a",
+        entry_id=first_id,
+        expected_revision=first_claim.snapshot.revision,
+    )
+    second_claim = registry.claim_next(
+        "session-a",
+        expected_revision=settled.snapshot.revision,
+    )
+    assert second_claim.claim is not None
+    assert second_claim.claim.prompt.entry_id == second_id
+
+
+def test_sessions_are_isolated(registry: ConsolePromptQueueRegistry) -> None:
+    _begin(registry, "session-a", context_epoch=1)
+    _begin(registry, "session-b", context_epoch=20)
+    a_id = _admit(registry, "alpha", "session-a")
+    b_id = _admit(registry, "beta", "session-b")
+
+    a = registry.snapshot("session-a")
+    b = registry.snapshot("session-b")
+    assert [entry.entry_id for entry in a.entries] == [a_id]
+    assert [entry.entry_id for entry in b.entries] == [b_id]
+    assert a.expected_context_epoch == 1
+    assert b.expected_context_epoch == 20
+
+
+def test_capacity_counts_waiting_plus_claimed(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry)
+    ids = [_admit(registry, f"prompt {index}") for index in range(10)]
+    claim = registry.claim_next(
+        "session-a",
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+    assert claim.claim is not None
+    assert claim.claim.prompt.entry_id == ids[0]
+    assert claim.snapshot.waiting_count == 9
+    assert claim.snapshot.claimed_count == 1
+    assert claim.snapshot.total_count == 10
+
+    full = registry.admit(
+        "session-a",
+        text="must not fit while one entry is starting",
+        expected_revision=claim.snapshot.revision,
+    )
+    assert full.status is QueueMutationStatus.FULL
+    assert full.snapshot.revision == claim.snapshot.revision
+    assert full.snapshot.total_count == 10
+
+    settled = registry.settle_claim(
+        "session-a",
+        entry_id=ids[0],
+        expected_revision=claim.snapshot.revision,
+    )
+    admitted = registry.admit(
+        "session-a",
+        text="now there is room",
+        expected_revision=settled.snapshot.revision,
+    )
+    assert admitted.status is QueueMutationStatus.APPLIED
+    assert admitted.snapshot.total_count == 10
+
+
+def test_stale_revision_rejects_without_calling_id_or_clock_producers() -> None:
+    calls = {"id": 0, "clock": 0}
+
+    def next_id() -> str:
+        calls["id"] += 1
+        return f"id-{calls['id']}"
+
+    def monotonic() -> float:
+        calls["clock"] += 1
+        return float(calls["clock"])
+
+    registry = ConsolePromptQueueRegistry(id_factory=next_id, monotonic=monotonic)
+    revision = _begin(registry)
+    _admit(registry, "older")
+    before = registry.snapshot("session-a")
+    calls_before = dict(calls)
+
+    stale = registry.admit(
+        "session-a",
+        text="private stale draft",
+        expected_revision=revision,
+    )
+
+    assert stale.status is QueueMutationStatus.STALE_REVISION
+    assert stale.snapshot is before
+    assert calls == calls_before
+    assert "private stale draft" not in repr(stale)
+
+
+def test_edit_recomputes_only_one_preview_and_preserves_id_and_order(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry)
+    first_id = _admit(registry, "first")
+    second_id = _admit(registry, "second")
+    before = registry.snapshot("session-a")
+    second_before = before.entries[1]
+
+    edited = registry.edit(
+        "session-a",
+        entry_id=first_id,
+        text="edited [bold]private[/bold] text",
+        expected_revision=before.revision,
+    )
+
+    assert edited.status is QueueMutationStatus.APPLIED
+    assert [entry.entry_id for entry in edited.snapshot.entries] == [
+        first_id,
+        second_id,
+    ]
+    assert edited.snapshot.entries[1] is second_before
+    assert Text.from_markup(edited.snapshot.entries[0].preview).plain == (
+        "edited [bold]private[/bold] text"
+    )
+
+
+def test_full_text_read_materializes_only_selected_waiting_entry_and_redacts_repr(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry)
+    first_id = _admit(registry, "first private body")
+    second_id = _admit(registry, "second private body")
+    current = registry.snapshot("session-a")
+
+    selected = registry.read_waiting_text(
+        "session-a",
+        entry_id=second_id,
+        expected_revision=current.revision,
+    )
+    assert selected.status is QueueMutationStatus.APPLIED
+    assert selected.entry_id == second_id
+    assert selected.text == "second private body"
+    assert "second private body" not in repr(selected)
+    stale = registry.read_waiting_text(
+        "session-a",
+        entry_id=first_id,
+        expected_revision=current.revision - 1,
+    )
+    assert stale.status is QueueMutationStatus.STALE_REVISION
+    assert stale.text is None
+
+    claim = registry.claim_next(
+        "session-a",
+        expected_revision=current.revision,
+    )
+    locked = registry.read_waiting_text(
+        "session-a",
+        entry_id=first_id,
+        expected_revision=claim.snapshot.revision,
+    )
+    assert locked.status is QueueMutationStatus.LOCKED
+    assert locked.text is None
+
+
+def test_move_remove_and_clear_waiting_never_mutate_claimed_work(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry)
+    first_id = _admit(registry, "first")
+    second_id = _admit(registry, "second")
+    third_id = _admit(registry, "third")
+    claim = registry.claim_next(
+        "session-a",
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+
+    for operation in (
+        lambda revision: registry.edit(
+            "session-a",
+            entry_id=first_id,
+            text="cannot edit a starting prompt",
+            expected_revision=revision,
+        ),
+        lambda revision: registry.move(
+            "session-a",
+            entry_id=first_id,
+            new_index=0,
+            expected_revision=revision,
+        ),
+        lambda revision: registry.remove(
+            "session-a",
+            entry_id=first_id,
+            expected_revision=revision,
+        ),
+    ):
+        result = operation(claim.snapshot.revision)
+        assert result.status is QueueMutationStatus.LOCKED
+        assert result.snapshot.revision == claim.snapshot.revision
+
+    moved = registry.move(
+        "session-a",
+        entry_id=third_id,
+        new_index=0,
+        expected_revision=claim.snapshot.revision,
+    )
+    assert [entry.entry_id for entry in moved.snapshot.entries] == [
+        first_id,
+        third_id,
+        second_id,
+    ]
+    removed = registry.remove(
+        "session-a",
+        entry_id=second_id,
+        expected_revision=moved.snapshot.revision,
+    )
+    cleared = registry.clear_waiting(
+        "session-a",
+        expected_revision=removed.snapshot.revision,
+    )
+    assert cleared.snapshot.waiting_count == 0
+    assert cleared.snapshot.claimed_count == 1
+    assert cleared.snapshot.entries[0].entry_id == first_id
+    assert cleared.snapshot.entries[0].phase is PromptQueueEntryPhase.STARTING
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        PromptQueuePauseReason.MANUAL,
+        PromptQueuePauseReason.FAILED,
+        PromptQueuePauseReason.STOPPED,
+        PromptQueuePauseReason.CONTEXT_CHANGED,
+        PromptQueuePauseReason.DISPATCH_REFUSED,
+    ],
+)
+def test_each_pause_reason_releases_reservation_and_accepts_new_work_at_tail(
+    registry: ConsolePromptQueueRegistry,
+    reason: PromptQueuePauseReason,
+) -> None:
+    _begin(registry)
+    first_id = _admit(registry, "first")
+    paused = registry.pause(
+        "session-a",
+        reason=reason,
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+    assert paused.status is QueueMutationStatus.APPLIED
+    assert paused.snapshot.mode is PromptQueueMode.PAUSED
+    assert paused.snapshot.pause_reason is reason
+    assert paused.snapshot.reservation is PromptQueueReservation.RELEASED
+
+    second_id = _admit(registry, "second while paused")
+    assert [entry.entry_id for entry in registry.snapshot("session-a").entries] == [
+        first_id,
+        second_id,
+    ]
+
+
+def test_pause_after_turn_keep_draining_and_resume_require_explicit_reservation(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry)
+    _admit(registry, "later")
+    requested = registry.request_pause_after_turn(
+        "session-a",
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+    assert requested.snapshot.mode is PromptQueueMode.PAUSE_AFTER_TURN
+    assert requested.snapshot.reservation is PromptQueueReservation.HELD
+
+    kept = registry.keep_draining(
+        "session-a",
+        expected_revision=requested.snapshot.revision,
+    )
+    assert kept.snapshot.mode is PromptQueueMode.DRAINING
+    paused = registry.pause(
+        "session-a",
+        reason=PromptQueuePauseReason.MANUAL,
+        expected_revision=kept.snapshot.revision,
+    )
+    refused = registry.resume(
+        "session-a",
+        expected_revision=paused.snapshot.revision,
+    )
+    assert refused.status is QueueMutationStatus.INVALID
+    assert refused.snapshot.mode is PromptQueueMode.PAUSED
+
+    reserved = registry.reserve(
+        "session-a",
+        expected_revision=paused.snapshot.revision,
+    )
+    resumed = registry.resume(
+        "session-a",
+        expected_revision=reserved.snapshot.revision,
+    )
+    assert resumed.status is QueueMutationStatus.APPLIED
+    assert resumed.snapshot.mode is PromptQueueMode.DRAINING
+    assert resumed.snapshot.pause_reason is None
+    assert resumed.snapshot.reservation is PromptQueueReservation.HELD
+
+
+def test_every_session_transition_checks_revision_before_mutating(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry)
+    entry_id = _admit(registry, "body that must remain untouched")
+    current = registry.snapshot("session-a")
+    stale_revision = current.revision - 1
+    operations = [
+        lambda: registry.begin_chain(
+            "session-a", context_epoch=8, expected_revision=stale_revision
+        ),
+        lambda: registry.admit(
+            "session-a", text="new", expected_revision=stale_revision
+        ),
+        lambda: registry.edit(
+            "session-a",
+            entry_id=entry_id,
+            text="edited",
+            expected_revision=stale_revision,
+        ),
+        lambda: registry.move(
+            "session-a",
+            entry_id=entry_id,
+            new_index=0,
+            expected_revision=stale_revision,
+        ),
+        lambda: registry.remove(
+            "session-a", entry_id=entry_id, expected_revision=stale_revision
+        ),
+        lambda: registry.clear_waiting("session-a", expected_revision=stale_revision),
+        lambda: registry.claim_next("session-a", expected_revision=stale_revision),
+        lambda: registry.settle_claim(
+            "session-a", entry_id=entry_id, expected_revision=stale_revision
+        ),
+        lambda: registry.return_claim_to_head(
+            "session-a",
+            entry_id=entry_id,
+            reason=PromptQueuePauseReason.DISPATCH_REFUSED,
+            expected_revision=stale_revision,
+        ),
+        lambda: registry.request_pause_after_turn(
+            "session-a", expected_revision=stale_revision
+        ),
+        lambda: registry.keep_draining("session-a", expected_revision=stale_revision),
+        lambda: registry.pause(
+            "session-a",
+            reason=PromptQueuePauseReason.MANUAL,
+            expected_revision=stale_revision,
+        ),
+        lambda: registry.reserve("session-a", expected_revision=stale_revision),
+        lambda: registry.release_reservation(
+            "session-a", expected_revision=stale_revision
+        ),
+        lambda: registry.resume(
+            "session-a",
+            expected_revision=stale_revision,
+        ),
+        lambda: registry.adopt_context_baseline(
+            "session-a", context_epoch=9, expected_revision=stale_revision
+        ),
+        lambda: registry.finalize_empty_chain(
+            "session-a", expected_revision=stale_revision
+        ),
+        lambda: registry.mark_closing("session-a", expected_revision=stale_revision),
+        lambda: registry.remove_session("session-a", expected_revision=stale_revision),
+    ]
+
+    for operation in operations:
+        result = operation()
+        assert result.status is QueueMutationStatus.STALE_REVISION
+        assert result.snapshot is current
+
+
+def test_return_claim_to_head_preserves_fifo_and_pauses(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry)
+    first_id = _admit(registry, "first")
+    second_id = _admit(registry, "second")
+    claim = registry.claim_next(
+        "session-a",
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+    returned = registry.return_claim_to_head(
+        "session-a",
+        entry_id=first_id,
+        reason=PromptQueuePauseReason.DISPATCH_REFUSED,
+        expected_revision=claim.snapshot.revision,
+    )
+    assert returned.status is QueueMutationStatus.APPLIED
+    assert [entry.entry_id for entry in returned.snapshot.entries] == [
+        first_id,
+        second_id,
+    ]
+    assert returned.snapshot.claimed_count == 0
+    assert returned.snapshot.mode is PromptQueueMode.PAUSED
+    assert returned.snapshot.reservation is PromptQueueReservation.RELEASED
+
+
+def test_claim_guards_mode_reservation_and_single_claim(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry)
+    _admit(registry, "first")
+    _admit(registry, "second")
+    first = registry.claim_next(
+        "session-a",
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+    duplicate = registry.claim_next(
+        "session-a",
+        expected_revision=first.snapshot.revision,
+    )
+    assert duplicate.status is QueueMutationStatus.LOCKED
+    assert duplicate.snapshot.waiting_count == 1
+
+    returned = registry.return_claim_to_head(
+        "session-a",
+        entry_id=first.claim.prompt.entry_id,  # type: ignore[union-attr]
+        reason=PromptQueuePauseReason.MANUAL,
+        expected_revision=first.snapshot.revision,
+    )
+    paused_claim = registry.claim_next(
+        "session-a",
+        expected_revision=returned.snapshot.revision,
+    )
+    assert paused_claim.status is QueueMutationStatus.INVALID
+
+
+def test_starting_claim_cannot_be_paused_or_lost_on_invalid_clock() -> None:
+    values = _DeterministicValues()
+    clock_values: list[object] = [101.0, "invalid claim clock"]
+    registry = ConsolePromptQueueRegistry(
+        id_factory=values.next_id,
+        monotonic=lambda: clock_values.pop(0),
+    )
+    _begin(registry)
+    entry_id = _admit(registry, "first")
+    before = registry.snapshot("session-a")
+    invalid_claim = registry.claim_next(
+        "session-a",
+        expected_revision=before.revision,
+    )
+    assert invalid_claim.status is QueueMutationStatus.INVALID
+    assert invalid_claim.snapshot is before
+    assert invalid_claim.snapshot.entries[0].entry_id == entry_id
+
+    healthy_registry = ConsolePromptQueueRegistry()
+    _begin(healthy_registry)
+    claimed_id = _admit(healthy_registry, "starting")
+    claimed = healthy_registry.claim_next(
+        "session-a",
+        expected_revision=healthy_registry.snapshot("session-a").revision,
+    )
+    paused = healthy_registry.pause(
+        "session-a",
+        reason=PromptQueuePauseReason.MANUAL,
+        expected_revision=claimed.snapshot.revision,
+    )
+    assert paused.status is QueueMutationStatus.LOCKED
+    assert paused.snapshot.entries[0].entry_id == claimed_id
+    assert paused.snapshot.entries[0].phase is PromptQueueEntryPhase.STARTING
+    assert paused.snapshot.reservation is PromptQueueReservation.HELD
+
+
+def test_context_baseline_can_only_be_adopted_from_context_review_pause(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry, context_epoch=11)
+    _admit(registry, "future")
+    before = registry.snapshot("session-a")
+    refused = registry.adopt_context_baseline(
+        "session-a",
+        context_epoch=12,
+        expected_revision=before.revision,
+    )
+    assert refused.status is QueueMutationStatus.INVALID
+    assert refused.snapshot.expected_context_epoch == 11
+
+    paused = registry.pause(
+        "session-a",
+        reason=PromptQueuePauseReason.CONTEXT_CHANGED,
+        expected_revision=before.revision,
+    )
+    adopted = registry.adopt_context_baseline(
+        "session-a",
+        context_epoch=12,
+        expected_revision=paused.snapshot.revision,
+    )
+    assert adopted.status is QueueMutationStatus.APPLIED
+    assert adopted.snapshot.expected_context_epoch == 12
+    assert adopted.snapshot.mode is PromptQueueMode.PAUSED
+
+
+def test_admission_and_final_empty_release_have_two_revision_orderings(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    initial_revision = _begin(registry)
+    admitted = registry.admit(
+        "session-a",
+        text="admission wins",
+        expected_revision=initial_revision,
+    )
+    stale_release = registry.finalize_empty_chain(
+        "session-a",
+        expected_revision=initial_revision,
+    )
+    assert admitted.status is QueueMutationStatus.APPLIED
+    assert stale_release.status is QueueMutationStatus.STALE_REVISION
+    assert stale_release.snapshot.total_count == 1
+
+    other = ConsolePromptQueueRegistry()
+    release_revision = _begin(other, context_epoch=3)
+    released = other.finalize_empty_chain(
+        "session-a",
+        expected_revision=release_revision,
+    )
+    rerouted = other.admit(
+        "session-a",
+        text="release wins and this remains a manual draft",
+        expected_revision=release_revision,
+    )
+    assert released.status is QueueMutationStatus.APPLIED
+    assert rerouted.status is QueueMutationStatus.REROUTE_NORMAL_SEND
+    assert rerouted.snapshot.total_count == 0
+    older_stale = other.admit(
+        "session-a",
+        text="an older stale intent must not be rerouted",
+        expected_revision=0,
+    )
+    assert older_stale.status is QueueMutationStatus.STALE_REVISION
+
+
+def test_closing_tombstone_rejects_work_until_exact_session_removal(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry, "session-a")
+    _begin(registry, "session-b")
+    _admit(registry, "a", "session-a")
+    _admit(registry, "b", "session-b")
+    closing = registry.mark_closing(
+        "session-a",
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+    assert closing.snapshot.closing is True
+    assert closing.snapshot.reservation is PromptQueueReservation.RELEASED
+
+    refused = registry.admit(
+        "session-a",
+        text="must not enter closing session",
+        expected_revision=closing.snapshot.revision,
+    )
+    assert refused.status is QueueMutationStatus.CLOSING
+    removed = registry.remove_session(
+        "session-a",
+        expected_revision=closing.snapshot.revision,
+    )
+    assert removed.status is QueueMutationStatus.APPLIED
+    assert registry.snapshot("session-a").total_count == 0
+    assert registry.snapshot("session-b").total_count == 1
+
+
+def test_shutdown_is_revision_checked_and_suppresses_all_later_claims(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    _begin(registry)
+    _admit(registry, "private queued prompt")
+    before = registry.snapshot("session-a")
+    stale = registry.shutdown(expected_registry_revision=registry.registry_revision - 1)
+    assert stale.status is QueueMutationStatus.STALE_REVISION
+    assert registry.snapshot("session-a") is before
+
+    stopped = registry.shutdown(expected_registry_revision=registry.registry_revision)
+    assert stopped.status is QueueMutationStatus.APPLIED
+    assert stopped.removed_sessions == 1
+    assert stopped.removed_prompts == 1
+    claim = registry.claim_next("session-a", expected_revision=0)
+    assert claim.status is QueueMutationStatus.SHUTTING_DOWN
+    assert registry.snapshot("session-a").total_count == 0
+    assert "private queued prompt" not in repr(stopped)
+
+
+def test_foreign_thread_access_is_rejected(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    errors: list[BaseException] = []
+
+    def mutate() -> None:
+        try:
+            registry.snapshot("session-a")
+        except BaseException as exc:  # noqa: BLE001 - asserting boundary type
+            errors.append(exc)
+
+    thread = threading.Thread(target=mutate)
+    thread.start()
+    thread.join()
+    assert len(errors) == 1
+    assert isinstance(errors[0], QueueThreadViolation)
+
+
+@pytest.mark.parametrize(
+    ("raw", "plain"),
+    [
+        ("first\r\nsecond\tthird", "first second third"),
+        ("\x1b[31mred\x1b[0m text", "red text"),
+        ("\x1b]8;;https://evil.example\x07label\x1b]8;;\x07", "label"),
+        ("safe\x00\x08\x7f\x9ftext", "safetext"),
+        ("[bold]not markup[/bold]", "[bold]not markup[/bold]"),
+        ("wide 界 and e\u0301", "wide 界 and e\u0301"),
+    ],
+)
+def test_preview_is_one_line_terminal_safe_and_markup_escaped(
+    raw: str, plain: str
+) -> None:
+    preview = make_prompt_preview(raw)
+    rendered = Text.from_markup(preview).plain
+    assert rendered == plain
+    assert "\n" not in preview
+    assert "\r" not in preview
+    assert "\x1b" not in preview
+    assert cell_len(rendered) <= PROMPT_PREVIEW_CELL_BUDGET
+
+
+@pytest.mark.parametrize(
+    ("raw", "complete_suffix"),
+    [
+        ("界" * (PROMPT_PREVIEW_CELL_BUDGET + 5), "界…"),
+        ("e\u0301" * (PROMPT_PREVIEW_CELL_BUDGET + 5), "e\u0301…"),
+    ],
+)
+def test_preview_truncates_by_cells_without_splitting_graphemes(
+    raw: str,
+    complete_suffix: str,
+) -> None:
+    rendered = Text.from_markup(make_prompt_preview(raw)).plain
+    assert rendered.endswith("…")
+    assert cell_len(rendered) <= PROMPT_PREVIEW_CELL_BUDGET
+    assert rendered.endswith(complete_suffix)
+
+
+def test_snapshot_is_body_free_cached_and_reuses_unchanged_entry_views(
+    registry: ConsolePromptQueueRegistry,
+) -> None:
+    secret = "DO-NOT-COPY-THIS-BODY-" + ("x" * 10_000)
+    _begin(registry)
+    _admit(registry, secret)
+    first = registry.snapshot("session-a")
+    second = registry.snapshot("session-a")
+
+    assert second is first
+    assert first.entries[0].preview == make_prompt_preview(secret)
+    assert secret not in repr(first)
+    assert not hasattr(first.entries[0], "text")
+    assert not hasattr(first, "prompt_texts")
+
+    class _ExplodingBody(str):
+        def __str__(self) -> str:
+            raise AssertionError("snapshot traversed the canonical body")
+
+        def __repr__(self) -> str:
+            raise AssertionError("snapshot represented the canonical body")
+
+        def __len__(self) -> int:
+            raise AssertionError("snapshot measured the canonical body")
+
+        def __iter__(self):
+            raise AssertionError("snapshot iterated the canonical body")
+
+    stored_prompt = registry._states["session-a"].waiting[0]
+    object.__setattr__(stored_prompt, "text", _ExplodingBody(secret))
+    pause = registry.request_pause_after_turn(
+        "session-a",
+        expected_revision=first.revision,
+    )
+    assert pause.snapshot.entries[0] is first.entries[0]
+
+
+def test_invalid_text_and_duplicate_id_fail_without_partial_mutation() -> None:
+    registry = ConsolePromptQueueRegistry(id_factory=lambda: "same-id")
+    _begin(registry)
+    first = _admit(registry, "first")
+    before = registry.snapshot("session-a")
+    duplicate = registry.admit(
+        "session-a",
+        text="second",
+        expected_revision=before.revision,
+    )
+    assert duplicate.status is QueueMutationStatus.INVALID
+    assert duplicate.snapshot is before
+    assert [entry.entry_id for entry in duplicate.snapshot.entries] == [first]
+
+    too_large = registry.edit(
+        "session-a",
+        entry_id=first,
+        text="x" * (MAX_CONSOLE_QUEUED_PROMPT_LENGTH + 1),
+        expected_revision=before.revision,
+    )
+    assert too_large.status is QueueMutationStatus.INVALID
+    assert too_large.snapshot is before
+
+
+def test_registry_is_sync_and_has_no_forbidden_runtime_dependencies() -> None:
+    module_path = (
+        Path(__file__).parents[2] / "tldw_chatbook" / "Chat" / "console_prompt_queue.py"
+    )
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    imports = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imports.update(
+        node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+    )
+    forbidden_fragments = {
+        "textual",
+        "provider",
+        "database",
+        ".DB",
+        "prompt_history",
+        "diagnostic",
+        "logging",
+        "chat_screen",
+    }
+    assert not {
+        imported
+        for imported in imports
+        if any(fragment in imported.lower() for fragment in forbidden_fragments)
+    }
+
+    public_transitions = [
+        ConsolePromptQueueRegistry.begin_chain,
+        ConsolePromptQueueRegistry.admit,
+        ConsolePromptQueueRegistry.edit,
+        ConsolePromptQueueRegistry.move,
+        ConsolePromptQueueRegistry.remove,
+        ConsolePromptQueueRegistry.clear_waiting,
+        ConsolePromptQueueRegistry.claim_next,
+        ConsolePromptQueueRegistry.settle_claim,
+        ConsolePromptQueueRegistry.return_claim_to_head,
+        ConsolePromptQueueRegistry.request_pause_after_turn,
+        ConsolePromptQueueRegistry.keep_draining,
+        ConsolePromptQueueRegistry.pause,
+        ConsolePromptQueueRegistry.reserve,
+        ConsolePromptQueueRegistry.resume,
+        ConsolePromptQueueRegistry.adopt_context_baseline,
+        ConsolePromptQueueRegistry.finalize_empty_chain,
+        ConsolePromptQueueRegistry.mark_closing,
+        ConsolePromptQueueRegistry.remove_session,
+        ConsolePromptQueueRegistry.shutdown,
+    ]
+    assert not any(inspect.iscoroutinefunction(method) for method in public_transitions)
+
+
+def test_prompt_model_explicit_repr_never_contains_body() -> None:
+    prompt = QueuedPrompt(
+        entry_id="entry",
+        text="PRIVATE BODY",
+        preview="PRIVATE PREVIEW",
+        insertion_order=1,
+        admitted_at=2.0,
+    )
+    assert "PRIVATE BODY" not in repr(prompt)
+    assert "PRIVATE PREVIEW" not in repr(prompt)
+    assert "redacted" in repr(prompt).lower()

--- a/Tests/Chat/test_console_prompt_queue.py
+++ b/Tests/Chat/test_console_prompt_queue.py
@@ -794,6 +794,80 @@ def test_invalid_text_and_duplicate_id_fail_without_partial_mutation() -> None:
     assert too_large.status is QueueMutationStatus.INVALID
     assert too_large.snapshot is before
 
+    unsafe_markup = registry.edit(
+        "session-a",
+        entry_id=first,
+        text="<script>alert('queued')</script>",
+        expected_revision=before.revision,
+    )
+    assert unsafe_markup.status is QueueMutationStatus.INVALID
+    assert unsafe_markup.snapshot is before
+
+
+def test_entry_identity_tracking_is_bounded_to_active_prompts() -> None:
+    registry = ConsolePromptQueueRegistry(id_factory=lambda: "reusable-id")
+    _begin(registry)
+
+    first = _admit(registry, "first")
+    removed = registry.remove(
+        "session-a",
+        entry_id=first,
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+    assert removed.status is QueueMutationStatus.APPLIED
+    assert registry._active_entry_ids == set()
+    released = registry.release_reservation(
+        "session-a",
+        expected_revision=removed.snapshot.revision,
+    )
+    assert released.status is QueueMutationStatus.APPLIED
+
+    _begin(registry)
+    second = _admit(registry, "second")
+    assert second == first
+    cleared = registry.clear_waiting(
+        "session-a",
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+    assert cleared.status is QueueMutationStatus.APPLIED
+    assert registry._active_entry_ids == set()
+    released = registry.release_reservation(
+        "session-a",
+        expected_revision=cleared.snapshot.revision,
+    )
+    assert released.status is QueueMutationStatus.APPLIED
+
+    _begin(registry)
+    third = _admit(registry, "third")
+    claimed = registry.claim_next(
+        "session-a",
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+    settled = registry.settle_claim(
+        "session-a",
+        entry_id=third,
+        expected_revision=claimed.snapshot.revision,
+    )
+    assert settled.status is QueueMutationStatus.APPLIED
+    assert registry._active_entry_ids == set()
+
+    fourth = _admit(registry, "fourth")
+    assert fourth == first
+    removed_session = registry.remove_session(
+        "session-a",
+        expected_revision=registry.snapshot("session-a").revision,
+    )
+    assert removed_session.status is QueueMutationStatus.APPLIED
+    assert registry._active_entry_ids == set()
+
+    _begin(registry)
+    _admit(registry, "fifth")
+    stopped = registry.shutdown(
+        expected_registry_revision=registry.registry_revision
+    )
+    assert stopped.status is QueueMutationStatus.APPLIED
+    assert registry._active_entry_ids == set()
+
 
 def test_registry_is_sync_and_has_no_forbidden_runtime_dependencies() -> None:
     module_path = (

--- a/Tests/Chat/test_console_prompt_queue_coordinator.py
+++ b/Tests/Chat/test_console_prompt_queue_coordinator.py
@@ -150,6 +150,26 @@ def _queue(controller: ConsoleChatController, session_id: str, text: str) -> str
     return result.entry_id
 
 
+def test_controller_refuses_unsafe_queue_text_before_admission() -> None:
+    controller, store, session_id = _arm_controller(SequencedGateway())
+    snapshot = controller.prompt_queue_registry.snapshot(session_id)
+    snapshot = controller.prompt_queue_registry.begin_chain(
+        session_id,
+        context_epoch=store.conversation_context_epoch(session_id),
+        expected_revision=snapshot.revision,
+    ).snapshot
+
+    result = controller.queue_prompt(
+        session_id,
+        text="<script>alert('queued')</script>",
+        expected_revision=snapshot.revision,
+    )
+
+    assert not result.applied
+    assert result.status.value == "invalid"
+    assert controller.prompt_queue_registry.snapshot(session_id).total_count == 0
+
+
 @pytest.mark.asyncio
 async def test_lifecycle_impact_counts_claimed_entries_without_prompt_content():
     gateway = BlockSecondReadinessGateway()
@@ -478,6 +498,41 @@ async def test_failed_retry_adopts_authorized_epoch_then_drains_next_prompt():
 
     assert gateway.user_turns == ["one", "one", "two"]
     assert controller.prompt_queue_registry.snapshot(session_id).total_count == 0
+
+
+@pytest.mark.asyncio
+async def test_failed_retry_stays_on_queue_owner_after_viewed_session_switch():
+    gateway = SequencedGateway(fail_call=0)
+    controller, store, session_id = _arm_controller(gateway)
+    task = asyncio.create_task(
+        controller.run_prompt_chain("owner turn", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "owner follow-up")
+    gateway.release[0].set()
+    await task
+    failed = next(
+        message
+        for message in store.messages_for_session(session_id)
+        if message.role is ConsoleMessageRole.ASSISTANT
+        and message.status == "failed"
+    )
+
+    viewed = controller.new_session(title="Viewed elsewhere")
+    assert store.active_session_id == viewed.id
+    recovery = asyncio.create_task(controller.retry_failed_queue_turn(failed.id))
+    await gateway.started[1].wait()
+    gateway.release[1].set()
+    await gateway.started[2].wait()
+    gateway.release[2].set()
+    await recovery
+
+    assert gateway.user_turns == [
+        "owner turn",
+        "owner turn",
+        "owner follow-up",
+    ]
+    assert not store.messages_for_session(viewed.id)
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_prompt_queue_coordinator.py
+++ b/Tests/Chat/test_console_prompt_queue_coordinator.py
@@ -1,0 +1,672 @@
+"""Joined controller/coordinator tests for sequential Console prompt queues."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleRunMarker,
+    ConsoleRunStatus,
+    ConsoleSubmissionOrigin,
+)
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_prompt_queue import (
+    PromptQueueMode,
+    PromptQueuePauseReason,
+    PromptQueueReservation,
+)
+from tldw_chatbook.Chat.console_prompt_queue_coordinator import (
+    QueueGenerationAuthorization,
+)
+
+
+class SequencedGateway:
+    def __init__(self, *, fail_call: int | None = None) -> None:
+        self.fail_call = fail_call
+        self.started = [asyncio.Event() for _ in range(5)]
+        self.release = [asyncio.Event() for _ in range(5)]
+        self.user_turns: list[str] = []
+
+    async def resolve_for_send(self, selection):
+        return type(
+            "Resolution",
+            (),
+            {
+                "ready": True,
+                "provider": "llama_cpp",
+                "model": "test-model",
+                "base_url": "http://127.0.0.1:9099",
+                "visible_copy": "",
+            },
+        )()
+
+    async def stream_chat(self, resolution, messages, **kwargs):
+        call = len(self.user_turns)
+        user_text = next(
+            message["content"]
+            for message in reversed(messages)
+            if message.get("role") == "user"
+        )
+        self.user_turns.append(user_text)
+        self.started[call].set()
+        await self.release[call].wait()
+        yield f"reply-{call + 1}"
+        if self.fail_call == call:
+            raise RuntimeError("planned stream failure")
+
+
+class RecordingPromptHistory:
+    def __init__(self) -> None:
+        self.items: list[str] = []
+
+    async def append(self, text: str) -> None:
+        self.items.append(text)
+
+
+class RecordingPersistence:
+    def __init__(self) -> None:
+        self.created_messages: list[dict] = []
+
+    def create_conversation(self, **kwargs):
+        return "conversation-1"
+
+    def create_message(
+        self,
+        *,
+        conversation_id,
+        sender,
+        content,
+        image_data,
+        image_mime_type,
+        message_id=None,
+        parent_message_id=None,
+        feedback=None,
+    ):
+        self.created_messages.append(
+            {
+                "sender": sender,
+                "content": content,
+                "message_id": message_id,
+            }
+        )
+        return f"persisted-{len(self.created_messages)}"
+
+    def update_message_content(self, **kwargs):
+        return True
+
+
+class RefuseSecondGateway(SequencedGateway):
+    def __init__(self) -> None:
+        super().__init__()
+        self.resolve_calls = 0
+
+    async def resolve_for_send(self, selection):
+        self.resolve_calls += 1
+        if self.resolve_calls == 2:
+            return type(
+                "Resolution",
+                (),
+                {"ready": False, "visible_copy": "Provider blocked: unavailable"},
+            )()
+        return await super().resolve_for_send(selection)
+
+
+class BlockSecondReadinessGateway(SequencedGateway):
+    def __init__(self) -> None:
+        super().__init__()
+        self.resolve_calls = 0
+        self.second_resolve_started = asyncio.Event()
+        self.release_second_resolve = asyncio.Event()
+
+    async def resolve_for_send(self, selection):
+        self.resolve_calls += 1
+        if self.resolve_calls == 2:
+            self.second_resolve_started.set()
+            await self.release_second_resolve.wait()
+        return await super().resolve_for_send(selection)
+
+
+def _arm_controller(gateway: SequencedGateway):
+    store = ConsoleChatStore()
+    session = store.ensure_session(title="Queue owner")
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    return controller, store, session.id
+
+
+def _queue(controller: ConsoleChatController, session_id: str, text: str) -> str:
+    snapshot = controller.prompt_queue_registry.snapshot(session_id)
+    result = controller.queue_prompt(
+        session_id,
+        text=text,
+        expected_revision=snapshot.revision,
+    )
+    assert result.applied
+    assert result.entry_id is not None
+    return result.entry_id
+
+
+@pytest.mark.asyncio
+async def test_three_turn_chain_drains_fifo_with_one_slot_and_explicit_origins():
+    gateway = SequencedGateway()
+    controller, store, session_id = _arm_controller(gateway)
+    manual_accepts = 0
+    queued_accepts = []
+    history = RecordingPromptHistory()
+
+    def accepted_manual() -> None:
+        nonlocal manual_accepts
+        manual_accepts += 1
+
+    controller.on_submission_accepted = accepted_manual
+    controller.on_queued_submission_accepted = queued_accepts.append
+    controller.prompt_history = history
+
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    second_id = _queue(controller, session_id, "two")
+    third_id = _queue(controller, session_id, "three")
+
+    activity = controller.activity_for(session_id)
+    assert activity.occupies_slot
+    assert activity.accepted_live_turn
+    assert activity.queued_count == 2
+    assert controller.in_flight_run_count() == 1
+
+    gateway.release[0].set()
+    await gateway.started[1].wait()
+    assert controller.in_flight_run_count() == 1
+    assert controller.run_marker_for(session_id) is ConsoleRunMarker.RUNNING
+
+    gateway.release[1].set()
+    await gateway.started[2].wait()
+    assert controller.in_flight_run_count() == 1
+
+    gateway.release[2].set()
+    result = await task
+
+    assert result.accepted
+    assert result.session_id == session_id
+    assert result.user_message_id
+    assert result.assistant_message_id
+    assert result.terminal_status is ConsoleRunStatus.COMPLETED
+    assert result.origin is ConsoleSubmissionOrigin.MANUAL
+    assert result.committed_context_epoch == store.conversation_context_epoch(
+        session_id
+    )
+    assert gateway.user_turns == ["one", "two", "three"]
+    assert history.items == ["one", "two", "three"]
+    assert manual_accepts == 1
+    assert [(event.session_id, event.entry_id) for event in queued_accepts] == [
+        (session_id, second_id),
+        (session_id, third_id),
+    ]
+    assert controller.in_flight_run_count() == 0
+    assert controller.prompt_queue_registry.snapshot(session_id).total_count == 0
+    assert [
+        message.content
+        for message in store.messages_for_session(session_id)
+        if message.role is ConsoleMessageRole.USER
+    ] == ["one", "two", "three"]
+
+
+@pytest.mark.asyncio
+async def test_intermediate_completions_emit_only_one_final_background_outcome():
+    gateway = SequencedGateway()
+    controller, _store, session_id = _arm_controller(gateway)
+    outcomes: list[tuple[str, ConsoleRunStatus]] = []
+    controller.notify_run_outcome = lambda sid, status: outcomes.append((sid, status))
+
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "two")
+    controller.new_session(title="Viewed elsewhere")
+
+    gateway.release[0].set()
+    await gateway.started[1].wait()
+    assert outcomes == []
+    assert controller.run_marker_for(session_id) is ConsoleRunMarker.RUNNING
+
+    gateway.release[1].set()
+    await task
+
+    assert outcomes == [(session_id, ConsoleRunStatus.COMPLETED)]
+    assert controller.run_marker_for(session_id) is ConsoleRunMarker.FINISHED_OK
+
+
+@pytest.mark.asyncio
+async def test_failed_accepted_queued_turn_pauses_remaining_without_requeueing_it():
+    gateway = SequencedGateway(fail_call=1)
+    controller, store, session_id = _arm_controller(gateway)
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "two")
+    third_id = _queue(controller, session_id, "three")
+
+    gateway.release[0].set()
+    await gateway.started[1].wait()
+    gateway.release[1].set()
+    await task
+
+    snapshot = controller.prompt_queue_registry.snapshot(session_id)
+    assert snapshot.mode is PromptQueueMode.PAUSED
+    assert snapshot.pause_reason is PromptQueuePauseReason.FAILED
+    assert snapshot.reservation is PromptQueueReservation.RELEASED
+    assert [entry.entry_id for entry in snapshot.entries] == [third_id]
+    assert gateway.user_turns == ["one", "two"]
+    assert [
+        message.content
+        for message in store.messages_for_session(session_id)
+        if message.role is ConsoleMessageRole.USER
+    ] == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_unexpected_exception_after_queued_acceptance_keeps_only_future_work():
+    gateway = SequencedGateway()
+    controller, store, session_id = _arm_controller(gateway)
+
+    async def raise_after_acceptance(**kwargs):
+        raise RuntimeError("planned post-acceptance exception")
+
+    def arm_exception(_event) -> None:
+        controller._stream_assistant_response = raise_after_acceptance
+
+    controller.on_queued_submission_accepted = arm_exception
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "two")
+    third_id = _queue(controller, session_id, "three")
+    gateway.release[0].set()
+
+    with pytest.raises(RuntimeError, match="post-acceptance"):
+        await task
+
+    snapshot = controller.prompt_queue_registry.snapshot(session_id)
+    assert snapshot.mode is PromptQueueMode.PAUSED
+    assert snapshot.pause_reason is PromptQueuePauseReason.FAILED
+    assert [entry.entry_id for entry in snapshot.entries] == [third_id]
+    assert [
+        message.content
+        for message in store.messages_for_session(session_id)
+        if message.role is ConsoleMessageRole.USER
+    ] == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_context_change_before_first_admission_pauses_for_explicit_review():
+    gateway = SequencedGateway()
+    controller, store, session_id = _arm_controller(gateway)
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    user = next(
+        message
+        for message in store.messages_for_session(session_id)
+        if message.role is ConsoleMessageRole.USER
+    )
+    store.update_message_content(user.id, "one edited while running")
+    queued_id = _queue(controller, session_id, "two")
+
+    gateway.release[0].set()
+    gateway.release[1].set()  # lets an illicit mutated dispatch fail, not hang
+    await task
+
+    snapshot = controller.prompt_queue_registry.snapshot(session_id)
+    assert snapshot.mode is PromptQueueMode.PAUSED
+    assert snapshot.pause_reason is PromptQueuePauseReason.CONTEXT_CHANGED
+    assert [entry.entry_id for entry in snapshot.entries] == [queued_id]
+    assert gateway.user_turns == ["one"]
+
+
+@pytest.mark.asyncio
+async def test_queued_origin_requires_coordinator_authority():
+    gateway = SequencedGateway()
+    controller, _store, session_id = _arm_controller(gateway)
+
+    with pytest.raises(PermissionError):
+        await controller.submit_draft(
+            "forged",
+            session_id=session_id,
+            origin=ConsoleSubmissionOrigin.QUEUED,
+            queue_entry_id="forged-entry",
+        )
+
+
+@pytest.mark.asyncio
+async def test_stop_pauses_immediately_and_resume_next_dispatches_once():
+    gateway = SequencedGateway()
+    controller, _store, session_id = _arm_controller(gateway)
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "two")
+
+    assert controller.stop_active_run()
+    stopped_snapshot = controller.prompt_queue_registry.snapshot(session_id)
+    assert stopped_snapshot.mode is PromptQueueMode.PAUSED
+    assert stopped_snapshot.pause_reason is PromptQueuePauseReason.STOPPED
+    assert stopped_snapshot.reservation is PromptQueueReservation.RELEASED
+    await task
+
+    resume_task = asyncio.create_task(controller.resume_prompt_queue(session_id))
+    await gateway.started[1].wait()
+    starting = controller.prompt_queue_registry.snapshot(session_id)
+    assert starting.total_count == 0  # accepted boundary settled the claim
+    gateway.release[1].set()
+    await resume_task
+
+    assert gateway.user_turns == ["one", "two"]
+    assert controller.prompt_queue_registry.snapshot(session_id).total_count == 0
+
+
+@pytest.mark.asyncio
+async def test_failed_retry_adopts_authorized_epoch_then_drains_next_prompt():
+    gateway = SequencedGateway(fail_call=0)
+    controller, store, session_id = _arm_controller(gateway)
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "two")
+    gateway.release[0].set()
+    await task
+    failed = next(
+        message
+        for message in store.messages_for_session(session_id)
+        if message.role is ConsoleMessageRole.ASSISTANT and message.status == "failed"
+    )
+
+    recovery = asyncio.create_task(controller.retry_failed_queue_turn(failed.id))
+    await gateway.started[1].wait()
+    gateway.release[1].set()
+    await gateway.started[2].wait()
+    gateway.release[2].set()
+    await recovery
+
+    assert gateway.user_turns == ["one", "one", "two"]
+    assert controller.prompt_queue_registry.snapshot(session_id).total_count == 0
+
+
+@pytest.mark.asyncio
+async def test_preaccept_refusal_returns_claim_to_head_and_writes_no_history():
+    gateway = RefuseSecondGateway()
+    controller, _store, session_id = _arm_controller(gateway)
+    history = RecordingPromptHistory()
+    controller.prompt_history = history
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    queued_id = _queue(controller, session_id, "two")
+    gateway.release[0].set()
+    await task
+
+    snapshot = controller.prompt_queue_registry.snapshot(session_id)
+    assert snapshot.mode is PromptQueueMode.PAUSED
+    assert snapshot.pause_reason is PromptQueuePauseReason.DISPATCH_REFUSED
+    assert [entry.entry_id for entry in snapshot.entries] == [queued_id]
+    assert history.items == ["one"]
+    assert gateway.user_turns == ["one"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_tombstones_before_cancel_and_never_starts_next_prompt():
+    gateway = SequencedGateway()
+    controller, _store, session_id = _arm_controller(gateway)
+    chain_task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "two")
+
+    await controller.shutdown()
+    await chain_task
+
+    assert gateway.user_turns == ["one"]
+    assert controller.prompt_queue_registry.shutting_down
+
+
+@pytest.mark.asyncio
+async def test_shutdown_during_claimed_readiness_cannot_accept_or_dispatch_it():
+    gateway = BlockSecondReadinessGateway()
+    controller, store, session_id = _arm_controller(gateway)
+    accepted_entries = []
+    controller.on_queued_submission_accepted = accepted_entries.append
+    chain_task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "two")
+    gateway.release[0].set()
+    await gateway.second_resolve_started.wait()
+
+    await controller.shutdown()
+    gateway.release_second_resolve.set()
+    gateway.release[1].set()  # lets a mutated illicit dispatch fail visibly, not hang
+    await chain_task
+
+    assert accepted_entries == []
+    assert gateway.user_turns == ["one"]
+    queued_echo = next(
+        message
+        for message in store.messages_for_session(session_id)
+        if message.role is ConsoleMessageRole.USER and message.content == "two"
+    )
+    assert queued_echo.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_paused_queue_gates_unrelated_generation_and_cap_refuses_reacquire(
+    monkeypatch,
+):
+    gateway = SequencedGateway(fail_call=0)
+    controller, store, session_id = _arm_controller(gateway)
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "two")
+    gateway.release[0].set()
+    await task
+
+    before_users = [
+        message.id
+        for message in store.messages_for_session(session_id)
+        if message.role is ConsoleMessageRole.USER
+    ]
+    refused = await controller.submit_draft("bypass", session_id=session_id)
+    assert not refused.accepted
+    assert "Queued messages control" in refused.visible_copy
+    assert [
+        message.id
+        for message in store.messages_for_session(session_id)
+        if message.role is ConsoleMessageRole.USER
+    ] == before_users
+
+    other = controller.new_session(title="Occupies only slot")
+    controller._set_run_state(
+        controller.run_state_for(other.id).__class__(
+            ConsoleRunStatus.STREAMING, "Streaming response."
+        ),
+        session_id=other.id,
+    )
+    monkeypatch.setattr(
+        type(controller), "max_parallel_runs", property(lambda _self: 1)
+    )
+    reacquire = await controller.resume_prompt_queue(session_id)
+    assert not reacquire.applied
+    paused = controller.prompt_queue_registry.snapshot(session_id)
+    assert paused.mode is PromptQueueMode.PAUSED
+    assert paused.reservation is PromptQueueReservation.RELEASED
+
+
+@pytest.mark.asyncio
+async def test_rag_capture_receives_manual_then_queued_origin_for_owner_session():
+    gateway = SequencedGateway()
+    seen: list[tuple[str, ConsoleSubmissionOrigin, str]] = []
+
+    async def capture(draft, turn_context, origin):
+        seen.append((draft, origin, turn_context.session_id))
+        return None
+
+    store = ConsoleChatStore()
+    session = store.ensure_session(title="RAG owner")
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        rag_capture_provider=capture,
+    )
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session.id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session.id, "two")
+    gateway.release[0].set()
+    await gateway.started[1].wait()
+    gateway.release[1].set()
+    await task
+
+    assert seen == [
+        ("one", ConsoleSubmissionOrigin.MANUAL, session.id),
+        ("two", ConsoleSubmissionOrigin.QUEUED, session.id),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_accepted_queued_prompts_use_normal_persistence_exactly_once():
+    gateway = SequencedGateway()
+    persistence = RecordingPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.ensure_session(title="Persistent queue")
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session.id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session.id, "two")
+    gateway.release[0].set()
+    await gateway.started[1].wait()
+    gateway.release[1].set()
+    await task
+
+    persisted_users = [
+        item["content"]
+        for item in persistence.created_messages
+        if item["sender"] == "user"
+    ]
+    assert persisted_users == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_two_sessions_keep_independent_chains_and_each_occupies_one_slot():
+    gateway = SequencedGateway()
+    store = ConsoleChatStore()
+    first = store.ensure_session(title="First")
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    second = controller.new_session(title="Second")
+
+    first_task = asyncio.create_task(
+        controller.run_prompt_chain("a1", session_id=first.id)
+    )
+    await gateway.started[0].wait()
+    second_task = asyncio.create_task(
+        controller.run_prompt_chain("b1", session_id=second.id)
+    )
+    await gateway.started[1].wait()
+    _queue(controller, first.id, "a2")
+    _queue(controller, second.id, "b2")
+    assert controller.in_flight_run_count() == 2
+
+    for release in gateway.release:
+        release.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert [
+        message.content
+        for message in store.messages_for_session(first.id)
+        if message.role is ConsoleMessageRole.USER
+    ] == ["a1", "a2"]
+    assert [
+        message.content
+        for message in store.messages_for_session(second.id)
+        if message.role is ConsoleMessageRole.USER
+    ] == ["b1", "b2"]
+    assert controller.in_flight_run_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_approval_wait_uses_same_activity_projection_and_keeps_queue_editable():
+    gateway = SequencedGateway()
+    controller, _store, session_id = _arm_controller(gateway)
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    entry_id = _queue(controller, session_id, "two original")
+    controller.add_pending_round(session_id, "approval-round")
+
+    activity = controller.activity_for(session_id)
+    assert activity.needs_approval
+    assert activity.occupies_slot
+    assert controller.run_marker_for(session_id) is ConsoleRunMarker.NEEDS_APPROVAL
+    snapshot = controller.prompt_queue_registry.snapshot(session_id)
+    edited = controller.prompt_queue_registry.edit(
+        session_id,
+        entry_id=entry_id,
+        text="two edited",
+        expected_revision=snapshot.revision,
+    )
+    assert edited.applied
+
+    controller.discard_pending_round(session_id, "approval-round")
+    gateway.release[0].set()
+    await gateway.started[1].wait()
+    gateway.release[1].set()
+    await task
+    assert gateway.user_turns == ["one", "two edited"]
+
+
+@pytest.mark.asyncio
+async def test_rider_added_after_admission_returns_claim_without_consuming_it():
+    gateway = SequencedGateway()
+    rider_present = False
+    store = ConsoleChatStore()
+    session = store.ensure_session(title="Rider owner")
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        queued_staged_rider_provider=lambda _session_id: rider_present,
+    )
+    task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session.id)
+    )
+    await gateway.started[0].wait()
+    queued_id = _queue(controller, session.id, "two")
+    rider_present = True
+    gateway.release[0].set()
+    await task
+
+    snapshot = controller.prompt_queue_registry.snapshot(session.id)
+    assert snapshot.mode is PromptQueueMode.PAUSED
+    assert snapshot.pause_reason is PromptQueuePauseReason.DISPATCH_REFUSED
+    assert [entry.entry_id for entry in snapshot.entries] == [queued_id]
+    assert gateway.user_turns == ["one"]
+
+
+def test_queue_generation_authorization_cannot_be_constructed_externally():
+    with pytest.raises(PermissionError):
+        QueueGenerationAuthorization(object(), "session", _key=object())

--- a/Tests/Chat/test_console_prompt_queue_coordinator.py
+++ b/Tests/Chat/test_console_prompt_queue_coordinator.py
@@ -10,6 +10,7 @@ from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.console_chat_models import (
     ConsoleMessageRole,
     ConsoleRunMarker,
+    ConsoleRunState,
     ConsoleRunStatus,
     ConsoleSubmissionOrigin,
 )
@@ -147,6 +148,84 @@ def _queue(controller: ConsoleChatController, session_id: str, text: str) -> str
     assert result.applied
     assert result.entry_id is not None
     return result.entry_id
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_impact_counts_claimed_entries_without_prompt_content():
+    gateway = BlockSecondReadinessGateway()
+    controller, _store, session_id = _arm_controller(gateway)
+
+    initial = controller.lifecycle_impact()
+    assert initial.live_run_count == 0
+    assert initial.queued_session_count == 0
+    assert initial.unsent_prompt_count == 0
+
+    task = asyncio.create_task(
+        controller.run_prompt_chain("manual", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "private first follow-up")
+    _queue(controller, session_id, "private second follow-up")
+
+    gateway.release[0].set()
+    await gateway.second_resolve_started.wait()
+
+    snapshot = controller.prompt_queue_registry.snapshot(session_id)
+    impact = controller.lifecycle_impact()
+    assert snapshot.claimed_count == 1
+    assert impact.revision > initial.revision
+    assert impact.live_run_count == 1
+    assert impact.queued_session_count == 1
+    assert impact.unsent_prompt_count == 2
+    assert "private first follow-up" not in repr(impact)
+    assert "private second follow-up" not in repr(impact)
+
+    gateway.release_second_resolve.set()
+    await gateway.started[1].wait()
+    gateway.release[1].set()
+    await gateway.started[2].wait()
+    gateway.release[2].set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_impact_does_not_describe_paused_queue_as_live_run():
+    gateway = SequencedGateway(fail_call=0)
+    controller, _store, session_id = _arm_controller(gateway)
+
+    task = asyncio.create_task(
+        controller.run_prompt_chain("manual", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "wait until recovery")
+    gateway.release[0].set()
+    await task
+
+    activity = controller.activity_for(session_id)
+    impact = controller.lifecycle_impact()
+    assert activity.queue_paused is True
+    assert impact.live_run_count == 0
+    assert impact.queued_session_count == 1
+    assert impact.unsent_prompt_count == 1
+
+
+def test_session_lifecycle_impact_is_revisioned_independently():
+    gateway = SequencedGateway()
+    controller, _store, session_id = _arm_controller(gateway)
+    other = controller.new_session(title="Other")
+
+    session_before = controller.lifecycle_impact(session_id=session_id)
+    fleet_before = controller.lifecycle_impact()
+    controller._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING),
+        session_id=other.id,
+    )
+
+    session_after = controller.lifecycle_impact(session_id=session_id)
+    fleet_after = controller.lifecycle_impact()
+    assert session_after == session_before
+    assert fleet_after.revision > fleet_before.revision
+    assert fleet_after.live_run_count == 1
 
 
 @pytest.mark.asyncio
@@ -467,6 +546,23 @@ async def test_shutdown_during_claimed_readiness_cannot_accept_or_dispatch_it():
         if message.role is ConsoleMessageRole.USER and message.content == "two"
     )
     assert queued_echo.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_close_tombstones_before_cancel_and_never_starts_next_prompt():
+    gateway = SequencedGateway()
+    controller, _store, session_id = _arm_controller(gateway)
+    chain_task = asyncio.create_task(
+        controller.run_prompt_chain("one", session_id=session_id)
+    )
+    await gateway.started[0].wait()
+    _queue(controller, session_id, "two")
+
+    controller.close_session(session_id)
+    await asyncio.gather(chain_task, return_exceptions=True)
+
+    assert gateway.user_turns == ["one"]
+    assert controller.prompt_queue_registry.snapshot(session_id).total_count == 0
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_turn_execution_context.py
+++ b/Tests/Chat/test_console_turn_execution_context.py
@@ -1,0 +1,611 @@
+"""Immutable owning-session turn-context contracts for Console sends."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Chat.attachment_core import PendingAttachment
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleProviderSelection,
+    ConsoleStagedSource,
+    ConsoleWorkspaceContext,
+)
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_turn_context import ConsoleTurnExecutionContext
+from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
+
+
+class _PausedGateway:
+    def __init__(self) -> None:
+        self.resolve_started = asyncio.Event()
+        self.release_resolve = asyncio.Event()
+        self.selections: list[ConsoleProviderSelection] = []
+        self.message_batches: list[list[dict[str, object]]] = []
+
+    async def resolve_for_send(self, selection: ConsoleProviderSelection):
+        self.selections.append(selection)
+        self.resolve_started.set()
+        await self.release_resolve.wait()
+        return SimpleNamespace(
+            ready=True,
+            provider=selection.provider,
+            model=selection.explicit_model or selection.configured_model or "",
+            base_url=selection.base_url,
+            max_tokens=selection.max_tokens,
+            visible_copy="",
+        )
+
+    async def stream_chat(self, resolution, messages, **_kwargs):
+        self.message_batches.append(messages)
+        yield "reply"
+
+
+def _settings(
+    provider: str,
+    model: str,
+    system_prompt: str,
+    *,
+    temperature: float = 0.25,
+    max_tokens: int = 321,
+) -> ConsoleSessionSettings:
+    return ConsoleSessionSettings(
+        provider=provider,
+        model=model,
+        system_prompt=system_prompt,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+
+
+def test_capture_detaches_nested_mutable_configuration_sources():
+    staged_sources = [
+        ConsoleStagedSource(
+            source_id="source-1",
+            label="Source one",
+            source_type="note",
+            workspace_id="workspace-a",
+        )
+    ]
+    workspace = ConsoleWorkspaceContext(
+        active_workspace_id="workspace-a",
+        staged_sources=tuple(staged_sources),
+        active_run_id="run-1",
+    )
+    selection = ConsoleProviderSelection(
+        provider="openai",
+        explicit_model="gpt-context",
+        system_prompt="system-a",
+        workspace_context=workspace,
+    )
+    roots = ["C:/workspace/a"]
+    capabilities = {"vision": True, "formats": ["image/png"]}
+    rag_defaults = {"enabled": True, "scope": {"types": ["notes"]}}
+    tool_configuration = {"local": {"enabled": True, "names": ["fs_read"]}}
+    payload_settings = {"headers": {"x-mode": "one"}, "stops": ["END"]}
+
+    context = ConsoleTurnExecutionContext.capture(
+        session_id="session-a",
+        provider_selection=selection,
+        session_settings=_settings("openai", "gpt-context", "system-a"),
+        workspace_roots=roots,
+        capabilities=capabilities,
+        rag_defaults=rag_defaults,
+        tool_configuration=tool_configuration,
+        provider_payload_settings=payload_settings,
+    )
+
+    roots.append("C:/workspace/leak")
+    capabilities["formats"].append("image/jpeg")
+    rag_defaults["scope"]["types"].append("media")
+    tool_configuration["local"]["names"].append("fs_write")
+    payload_settings["headers"]["x-mode"] = "two"
+    staged_sources.clear()
+
+    assert context.workspace_roots == ("C:/workspace/a",)
+    assert context.capabilities["formats"] == ("image/png",)
+    assert context.rag_defaults["scope"]["types"] == ("notes",)
+    assert context.tool_configuration["local"]["names"] == ("fs_read",)
+    assert context.provider_payload_settings["headers"]["x-mode"] == "one"
+    assert context.provider_selection.workspace_context.staged_sources == (
+        ConsoleStagedSource(
+            source_id="source-1",
+            label="Source one",
+            source_type="note",
+            workspace_id="workspace-a",
+        ),
+    )
+
+    with pytest.raises(TypeError):
+        context.rag_defaults["enabled"] = False
+
+    for forbidden in (
+        "credentials",
+        "approval_grants",
+        "skill_trust",
+        "cancel_event",
+    ):
+        assert not hasattr(context, forbidden)
+
+
+def test_direct_constructor_also_detaches_mutable_inputs():
+    capabilities = {"formats": ["image/png"]}
+    context = ConsoleTurnExecutionContext(
+        session_id="session-a",
+        provider_selection=ConsoleProviderSelection(provider="openai"),
+        capabilities=capabilities,
+    )
+
+    capabilities["formats"].append("image/jpeg")
+
+    assert context.capabilities["formats"] == ("image/png",)
+
+
+def test_live_tool_kill_switch_is_not_frozen_into_turn_context():
+    store = ConsoleChatStore()
+    session = store.create_session(workspace_id="workspace-a")
+    context = ConsoleTurnExecutionContext.capture(
+        session_id=session.id,
+        provider_selection=ConsoleProviderSelection(provider="openai"),
+        tool_configuration={"local_tools_enabled": True},
+    )
+    service = SimpleNamespace(get_kill_switch=lambda: True)
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_PausedGateway(),
+    )
+    controller.app = SimpleNamespace(unified_mcp_service=service)
+
+    provider, review_hook = controller._compose_local_provider(
+        session_id=session.id,
+        turn_context=context,
+    )
+
+    assert provider is None
+    assert review_hook is None
+
+
+def test_legacy_session_without_settings_still_uses_own_workspace():
+    store = ConsoleChatStore()
+    first = store.create_session(workspace_id="workspace-a")
+    store.create_session(workspace_id="workspace-b")
+    store.set_workspace_context(
+        ConsoleWorkspaceContext(active_workspace_id="workspace-b")
+    )
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_PausedGateway(),
+        provider="anthropic",
+        model="model-b",
+    )
+
+    context = controller.resolve_turn_execution_context(first.id)
+
+    assert context.provider_selection.workspace_context.active_workspace_id == (
+        "workspace-a"
+    )
+
+
+def test_session_builder_captures_roots_rag_tools_and_generation(monkeypatch):
+    store = ConsoleChatStore()
+    settings = _settings(
+        "openai",
+        "model-a",
+        "system-a",
+        temperature=0.4,
+        max_tokens=777,
+    )
+    session = store.create_session(
+        workspace_id="workspace-a",
+        settings=settings,
+    )
+    selection = ConsoleProviderSelection(
+        provider="openai",
+        explicit_model="model-a",
+        temperature=0.4,
+        max_tokens=777,
+        system_prompt="system-a",
+        workspace_context=ConsoleWorkspaceContext(
+            active_workspace_id="workspace-a"
+        ),
+    )
+    app_config = {
+        "chat_defaults": {"rag_auto_retrieve_on_send": "true"},
+        "console": {
+            "agent_runtime": "true",
+            "native_tool_calls": "false",
+            "local_tools_enabled": "true",
+            "workspace_root": "C:/configured-root",
+            "direct_library_tools": "false",
+        },
+    }
+    roots = [Path("C:/workspace/a")]
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_file_roots.folder_binding_roots",
+        lambda _workspace_id: roots,
+    )
+    controller = ConsoleSessionController.__new__(ConsoleSessionController)
+    controller._provider_readiness_app_config_fn = lambda: app_config
+    controller._build_provider_selection_fn = lambda _session_id: selection
+    controller._current_chat_store_accessor = lambda: store
+    controller._chat_store_accessor = lambda: store
+    controller._rag_source_types_accessor = lambda: ["notes", "media"]
+    controller._rag_top_k_accessor = lambda: 7
+
+    context = controller._build_console_turn_execution_context(session.id)
+    roots.append(Path("C:/workspace/leak"))
+    app_config["console"]["agent_runtime"] = "false"
+    app_config["chat_defaults"]["rag_auto_retrieve_on_send"] = "false"
+
+    assert context.workspace_roots == (str(Path("C:/workspace/a")),)
+    assert context.rag_defaults == {
+        "auto_retrieve_on_send": True,
+        "source_types": ("notes", "media"),
+        "top_k": 7,
+    }
+    assert context.tool_configuration["agent_runtime_enabled"] is True
+    assert context.tool_configuration["native_tool_calls_enabled"] is False
+    assert context.tool_configuration["local_tools_enabled"] is True
+    assert context.tool_configuration["direct_library_tools"] is False
+    assert context.provider_payload_settings["temperature"] == 0.4
+    assert context.provider_payload_settings["max_tokens"] == 777
+
+
+@pytest.mark.asyncio
+async def test_submit_keeps_owning_session_selection_and_payload_across_switch():
+    store = ConsoleChatStore()
+    first = store.create_session(
+        title="First",
+        workspace_id="workspace-a",
+        settings=_settings("openai", "model-a", "system-a"),
+    )
+    second = store.create_session(
+        title="Second",
+        workspace_id="workspace-b",
+        settings=_settings("anthropic", "model-b", "system-b"),
+    )
+    gateway = _PausedGateway()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="anthropic",
+        model="model-b",
+        system_prompt="system-b",
+        agent_runtime_enabled=False,
+    )
+
+    first_turn = asyncio.create_task(
+        controller.submit_draft("question-a", session_id=first.id)
+    )
+    await gateway.resolve_started.wait()
+
+    controller.switch_session(second.id)
+    controller.update_provider_selection(
+        ConsoleProviderSelection(
+            provider="anthropic",
+            explicit_model="model-b-new",
+            system_prompt="system-b-new",
+            workspace_context=ConsoleWorkspaceContext(
+                active_workspace_id="workspace-b"
+            ),
+        )
+    )
+    gateway.release_resolve.set()
+
+    result = await first_turn
+
+    assert result.accepted is True
+    assert gateway.selections[0].provider == "openai"
+    assert gateway.selections[0].explicit_model == "model-a"
+    assert gateway.selections[0].temperature == 0.25
+    assert gateway.selections[0].max_tokens == 321
+    assert gateway.selections[0].workspace_context.active_workspace_id == "workspace-a"
+    assert gateway.message_batches[0][0] == {
+        "role": "system",
+        "content": "system-a",
+    }
+    assert gateway.message_batches[0][1]["content"] == "question-a"
+
+
+@pytest.mark.asyncio
+async def test_next_turn_observes_settings_replaced_after_prior_capture():
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Session",
+        workspace_id="workspace-a",
+        settings=_settings("openai", "model-a", "system-a"),
+    )
+    gateway = _PausedGateway()
+    gateway.release_resolve.set()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="openai",
+        model="model-a",
+        system_prompt="system-a",
+        agent_runtime_enabled=False,
+    )
+
+    first_result = await controller.submit_draft("first", session_id=session.id)
+    assert first_result.accepted is True
+
+    store.replace_session_settings(
+        session.id,
+        _settings(
+            "anthropic",
+            "model-b",
+            "system-b",
+            temperature=0.85,
+            max_tokens=654,
+        ),
+    )
+    second_result = await controller.submit_draft("second", session_id=session.id)
+
+    assert second_result.accepted is True
+    assert [selection.provider for selection in gateway.selections] == [
+        "openai",
+        "anthropic",
+    ]
+    assert gateway.message_batches[0][0]["content"] == "system-a"
+    assert gateway.message_batches[1][0]["content"] == "system-b"
+    assert gateway.selections[1].temperature == 0.85
+    assert gateway.selections[1].max_tokens == 654
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action_name",
+    ["retry", "continue", "regenerate", "edit-resend"],
+)
+async def test_message_actions_thread_one_captured_context(action_name: str):
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Actions",
+        workspace_id="workspace-a",
+        settings=_settings("openai", "model-a", "stored-system"),
+    )
+    user = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="question",
+    )
+    if action_name == "retry":
+        assistant = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+        )
+        store.append_stream_chunk(assistant.id, "failed answer")
+        store.mark_message_failed(assistant.id)
+    else:
+        assistant = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="answer",
+        )
+
+    context = ConsoleTurnExecutionContext.capture(
+        session_id=session.id,
+        provider_selection=ConsoleProviderSelection(
+            provider="openai",
+            explicit_model="captured-model",
+            system_prompt="captured-system",
+            workspace_context=ConsoleWorkspaceContext(
+                active_workspace_id="workspace-a"
+            ),
+        ),
+        session_settings=store.session_settings(session.id),
+        tool_configuration={"agent_runtime_enabled": False},
+    )
+    context_calls: list[str] = []
+
+    def resolve_context(session_id: str) -> ConsoleTurnExecutionContext:
+        context_calls.append(session_id)
+        return context
+
+    gateway = _PausedGateway()
+    gateway.release_resolve.set()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="anthropic",
+        model="mutable-model",
+        system_prompt="mutable-system",
+        agent_runtime_enabled=False,
+        turn_context_provider=resolve_context,
+    )
+
+    if action_name == "retry":
+        result = await controller.retry_message(assistant.id)
+    elif action_name == "continue":
+        result = await controller.continue_from_message(assistant.id)
+    elif action_name == "regenerate":
+        result = await controller.regenerate_message(assistant.id)
+    else:
+        result = await controller.edit_and_resend_message(user.id, "edited")
+
+    assert result.accepted is True
+    assert context_calls == [session.id]
+    assert gateway.selections == [context.provider_selection]
+    assert gateway.message_batches[0][0] == {
+        "role": "system",
+        "content": "captured-system",
+    }
+
+
+@pytest.mark.asyncio
+async def test_summarize_and_rag_capture_receive_the_owning_turn_context():
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Summary",
+        workspace_id="workspace-a",
+        settings=_settings("openai", "model-a", "stored-system"),
+    )
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="first question",
+    )
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="first answer",
+    )
+    boundary = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="second question",
+    )
+    context = ConsoleTurnExecutionContext.capture(
+        session_id=session.id,
+        provider_selection=ConsoleProviderSelection(
+            provider="openai",
+            explicit_model="captured-model",
+            system_prompt="captured-system",
+            workspace_context=ConsoleWorkspaceContext(
+                active_workspace_id="workspace-a"
+            ),
+        ),
+        session_settings=store.session_settings(session.id),
+        rag_defaults={"auto_retrieve_on_send": False},
+        tool_configuration={"agent_runtime_enabled": False},
+    )
+    gateway = _PausedGateway()
+    gateway.release_resolve.set()
+    rag_contexts: list[ConsoleTurnExecutionContext | None] = []
+
+    async def capture_rag(
+        _draft: str, turn_context: ConsoleTurnExecutionContext | None
+    ):
+        rag_contexts.append(turn_context)
+        return SimpleNamespace(context=None)
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        agent_runtime_enabled=False,
+        turn_context_provider=lambda _session_id: context,
+        rag_capture_provider=capture_rag,
+    )
+
+    summarize_result = await controller.summarize_up_to(boundary.id)
+    submit_result = await controller.submit_draft("third", session_id=session.id)
+
+    assert summarize_result.accepted is True
+    assert submit_result.accepted is True
+    assert gateway.selections == [
+        context.provider_selection,
+        context.provider_selection,
+    ]
+    assert rag_contexts == [context]
+
+
+@pytest.mark.asyncio
+async def test_attachment_gate_and_payload_use_captured_capabilities():
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Vision",
+        workspace_id="workspace-a",
+        settings=_settings("custom", "unknown-model", "system"),
+    )
+    store.add_pending_attachment(
+        session.id,
+        PendingAttachment(
+            file_path="image.png",
+            display_name="image.png",
+            file_type="image",
+            insert_mode="attachment",
+            data=b"png",
+            mime_type="image/png",
+        ),
+    )
+    context = ConsoleTurnExecutionContext.capture(
+        session_id=session.id,
+        provider_selection=ConsoleProviderSelection(
+            provider="custom",
+            explicit_model="unknown-model",
+            workspace_context=ConsoleWorkspaceContext(
+                active_workspace_id="workspace-a"
+            ),
+        ),
+        session_settings=store.session_settings(session.id),
+        capabilities={"vision": True, "max_history_images": 1},
+        tool_configuration={"agent_runtime_enabled": False},
+    )
+    gateway = _PausedGateway()
+    gateway.release_resolve.set()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="custom",
+        model="mutable-nonvision-model",
+        agent_runtime_enabled=False,
+        turn_context_provider=lambda _session_id: context,
+    )
+
+    result = await controller.submit_draft("describe", session_id=session.id)
+
+    assert result.accepted is True
+    content = gateway.message_batches[0][0]["content"]
+    assert isinstance(content, list)
+    assert [part["type"] for part in content] == ["text", "image_url"]
+
+
+def test_screen_selection_builder_targets_session_without_switching_view():
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    store = ConsoleChatStore()
+    first = store.create_session(
+        title="First",
+        workspace_id="workspace-a",
+        settings=_settings("openai", "model-a", "system-a"),
+    )
+    store.create_session(
+        title="Second",
+        workspace_id="workspace-b",
+        settings=_settings("anthropic", "model-b", "system-b"),
+    )
+    fake_screen = SimpleNamespace(
+        _provider_readiness_app_config=lambda: {
+            "api_settings": {
+                "openai": {"model": "configured-a"},
+                "anthropic": {"model": "configured-b"},
+            },
+            "console": {},
+        },
+        _ensure_console_chat_store=lambda: store,
+        _session=SimpleNamespace(
+            _console_session_settings=lambda session_id: store.session_settings(
+                session_id
+            ),
+            _ensure_active_console_session_settings=lambda: store.session_settings(
+                store.active_session_id
+            ),
+        ),
+        _effective_console_provider_model=lambda: ("anthropic", "model-b"),
+        _config_section=lambda config, key: dict(config.get(key, {})),
+        _workspace=SimpleNamespace(
+            _current_console_workspace_context=lambda: ConsoleWorkspaceContext(
+                active_workspace_id="workspace-b"
+            )
+        ),
+        _normalize_llamacpp_base_url=lambda value: value,
+    )
+
+    selection = ChatScreen._build_console_provider_selection(
+        fake_screen, first.id
+    )
+
+    assert selection.provider == "openai"
+    assert selection.explicit_model == "model-a"
+    assert selection.configured_model == "configured-a"
+    assert (selection.explicit_model or selection.configured_model) == "model-a"
+    assert selection.system_prompt == "system-a"
+    assert selection.workspace_context.active_workspace_id == "workspace-a"
+    assert store.active_session_id != first.id

--- a/Tests/UI/test_app_quit_guard.py
+++ b/Tests/UI/test_app_quit_guard.py
@@ -1,0 +1,281 @@
+"""Focused tests for the asynchronous, queue-aware application quit guard."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from tldw_chatbook.app import TldwCli
+from tldw_chatbook.Chat.console_chat_models import ConsoleLifecycleImpact
+from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
+
+
+class _DispatchHarness:
+    action_quit = TldwCli.action_quit
+
+    def __init__(self, *, fail_start: bool = False) -> None:
+        self._quit_in_progress = False
+        self.fail_start = fail_start
+        self.work: list[tuple[object, dict]] = []
+
+    async def _confirm_and_quit(self) -> None:
+        return None
+
+    def run_worker(self, awaitable, **kwargs):
+        if self.fail_start:
+            raise RuntimeError("worker unavailable")
+        self.work.append((awaitable, kwargs))
+        return object()
+
+
+def test_action_quit_dispatches_one_exclusive_worker_for_repeated_requests():
+    app = _DispatchHarness()
+
+    app.action_quit()
+    app.action_quit()
+
+    assert app._quit_in_progress is True
+    assert len(app.work) == 1
+    awaitable, kwargs = app.work[0]
+    assert kwargs == {
+        "group": "application-quit",
+        "exclusive": True,
+        "exit_on_error": False,
+    }
+    awaitable.close()
+
+
+def test_action_quit_clears_guard_when_worker_cannot_start():
+    app = _DispatchHarness(fail_start=True)
+
+    app.action_quit()
+
+    assert app._quit_in_progress is False
+    assert app.work == []
+
+
+class _ConfirmationScreen:
+    def __init__(self, *, decision=True, error: Exception | None = None) -> None:
+        self.decision = decision
+        self.error = error
+        self.calls: list[str] = []
+
+    async def confirm_quit(self):
+        self.calls.append("confirm")
+        if self.error is not None:
+            raise self.error
+        return self.decision
+
+    def prepare_for_quit(self) -> None:
+        self.calls.append("prepare")
+
+
+class _ConfirmationHarness:
+    _confirm_and_quit = TldwCli._confirm_and_quit
+
+    def __init__(self, screen: _ConfirmationScreen) -> None:
+        self.screen = screen
+        self._quit_in_progress = True
+        self._shutting_down = False
+        self.cleanup_calls = 0
+        self.notifications: list[tuple[str, str]] = []
+
+    async def _run_approved_quit_cleanup(self) -> None:
+        self.cleanup_calls += 1
+
+    def notify(self, message: str, *, severity: str) -> None:
+        self.notifications.append((message, severity))
+
+
+@pytest.mark.asyncio
+async def test_quit_stay_preserves_screen_state_and_clears_reentrancy_guard():
+    screen = _ConfirmationScreen(decision=False)
+    app = _ConfirmationHarness(screen)
+
+    await app._confirm_and_quit()
+
+    assert screen.calls == ["confirm"]
+    assert app._quit_in_progress is False
+    assert app._shutting_down is False
+    assert app.cleanup_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_quit_confirmation_error_fails_closed_and_preserves_state():
+    screen = _ConfirmationScreen(error=RuntimeError("dialog failed"))
+    app = _ConfirmationHarness(screen)
+
+    await app._confirm_and_quit()
+
+    assert screen.calls == ["confirm"]
+    assert app._quit_in_progress is False
+    assert app._shutting_down is False
+    assert app.cleanup_calls == 0
+    assert app.notifications == [
+        ("Couldn't confirm quitting; staying in Chatbook.", "warning")
+    ]
+
+
+class _Timer:
+    def __init__(self, events: list[tuple[str, int]]) -> None:
+        self.events = events
+
+    def stop(self) -> None:
+        self.events.append(("timer", threading.get_ident()))
+
+
+class _ApprovedQuitHarness:
+    _confirm_and_quit = TldwCli._confirm_and_quit
+    _run_approved_quit_cleanup = TldwCli._run_approved_quit_cleanup
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, int]] = []
+        self.loop_thread = threading.get_ident()
+        self._quit_in_progress = True
+        self._shutting_down = False
+        self._media_cleanup_timer = _Timer(self.events)
+        self.screen = self
+
+    async def confirm_quit(self) -> bool:
+        self.events.append(("confirm", threading.get_ident()))
+        return True
+
+    def prepare_for_quit(self) -> None:
+        self.events.append(("prepare", threading.get_ident()))
+
+    async def _cleanup_audio_for_quit(self) -> None:
+        self.events.append(("audio", threading.get_ident()))
+
+    def _run_blocking_quit_persistence(self) -> None:
+        self.events.append(("persistence", threading.get_ident()))
+
+    def exit(self) -> None:
+        self.events.append(("exit", threading.get_ident()))
+
+
+@pytest.mark.asyncio
+async def test_approved_quit_tombstones_then_cleans_once_without_blocking_loop():
+    app = _ApprovedQuitHarness()
+
+    await app._confirm_and_quit()
+
+    assert [name for name, _thread in app.events] == [
+        "confirm",
+        "prepare",
+        "audio",
+        "timer",
+        "persistence",
+        "exit",
+    ]
+    event_threads = dict(app.events)
+    assert event_threads["prepare"] == app.loop_thread
+    assert event_threads["audio"] == app.loop_thread
+    assert event_threads["timer"] == app.loop_thread
+    assert event_threads["persistence"] != app.loop_thread
+    assert event_threads["exit"] == app.loop_thread
+    assert app._shutting_down is True
+    assert app._quit_in_progress is True
+
+
+@pytest.mark.asyncio
+async def test_approved_quit_still_exits_when_background_persistence_raises():
+    app = _ApprovedQuitHarness()
+
+    def _fail_persistence() -> None:
+        raise RuntimeError("disk unavailable")
+
+    app._run_blocking_quit_persistence = _fail_persistence
+    await app._run_approved_quit_cleanup()
+
+    assert [name for name, _thread in app.events] == ["audio", "timer", "exit"]
+
+
+@pytest.mark.asyncio
+async def test_blocking_quit_persistence_does_not_stall_the_app_loop():
+    app = _ApprovedQuitHarness()
+    persistence_started = threading.Event()
+    persistence_release = threading.Event()
+    loop_progressed = False
+
+    def _block_persistence() -> None:
+        persistence_started.set()
+        persistence_release.wait(timeout=5)
+
+    async def _observe_loop_progress() -> None:
+        nonlocal loop_progressed
+        while not persistence_started.is_set():
+            await asyncio.sleep(0)
+        loop_progressed = True
+        persistence_release.set()
+
+    app._run_blocking_quit_persistence = _block_persistence
+    await asyncio.gather(
+        app._run_approved_quit_cleanup(),
+        _observe_loop_progress(),
+    )
+
+    assert loop_progressed is True
+    assert app.events[-1][0] == "exit"
+
+
+class _ImpactSequenceController:
+    def __init__(self, impacts: list[ConsoleLifecycleImpact]) -> None:
+        self.impacts = impacts
+        self.calls = 0
+
+    def lifecycle_impact(self) -> ConsoleLifecycleImpact:
+        impact = self.impacts[min(self.calls, len(self.impacts) - 1)]
+        self.calls += 1
+        return impact
+
+
+class _FleetConfirmationHarness:
+    _confirm_fleet_loss = ConsoleSessionController._confirm_fleet_loss
+
+    def __init__(self, decisions: list[bool]) -> None:
+        self.app_instance = self
+        self.decisions = decisions
+        self.dialogs = []
+        self.notifications: list[tuple[str, str]] = []
+
+    async def _await_confirmation(self, dialog) -> bool:
+        self.dialogs.append(dialog)
+        return self.decisions.pop(0)
+
+    def notify(self, message: str, *, severity: str) -> None:
+        self.notifications.append((message, severity))
+
+
+@pytest.mark.asyncio
+async def test_changed_fleet_impact_requires_updated_confirmation():
+    first = ConsoleLifecycleImpact(1, 1, 0, 0)
+    updated = ConsoleLifecycleImpact(2, 0, 1, 3)
+    controller = _ImpactSequenceController([first, updated, updated, updated])
+    harness = _FleetConfirmationHarness([True, True])
+
+    assert await harness._confirm_fleet_loss(controller, quitting=True) is True
+
+    assert len(harness.dialogs) == 2
+    assert "Live agent runs: 1" in harness.dialogs[0].message
+    assert "Sessions with queued prompts: 1" in harness.dialogs[1].message
+    assert "Unsent queued prompts: 3" in harness.dialogs[1].message
+    assert harness.notifications == [
+        ("Console activity changed; review the updated impact.", "warning")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fleet_confirmation_stay_preserves_the_observed_impact():
+    impact = ConsoleLifecycleImpact(7, 0, 1, 2)
+    controller = _ImpactSequenceController([impact])
+    harness = _FleetConfirmationHarness([False])
+
+    assert await harness._confirm_fleet_loss(controller, quitting=False) is False
+
+    assert controller.calls == 1
+    assert len(harness.dialogs) == 1
+    assert "Live agent runs: 0" in harness.dialogs[0].message
+    assert "Sessions with queued prompts: 1" in harness.dialogs[0].message
+    assert "Unsent queued prompts: 2" in harness.dialogs[0].message

--- a/Tests/UI/test_console_button_routing.py
+++ b/Tests/UI/test_console_button_routing.py
@@ -24,9 +24,11 @@ rows and already have coverage in their owning feature's test file.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
+from textual.css.query import NoMatches
 from textual.widgets import Button
 
 from Tests.UI.app_factory import _build_test_app
@@ -39,6 +41,7 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_prompt_queue import PromptQueuePauseReason
 from tldw_chatbook.Chat.conversation_local_marks_service import (
     ConversationLocalMarksService,
 )
@@ -73,6 +76,24 @@ async def _mounted_console(host, pilot, selector: str = "#console-workspace-cont
     console = host.screen_stack[-1]
     await _wait_for_selector(console, pilot, selector)
     return console
+
+
+async def _wait_for_confirmation(
+    host, *, previous: ConfirmationDialog | None = None
+) -> ConfirmationDialog:
+    """Wait for a close worker to mount its confirmation without fixed sleeps."""
+
+    for _ in range(200):
+        candidate = host.screen_stack[-1]
+        if isinstance(candidate, ConfirmationDialog) and candidate is not previous:
+            try:
+                candidate.query_one("#confirm-button", Button)
+            except NoMatches:
+                pass
+            else:
+                return candidate
+        await asyncio.sleep(0.01)
+    raise AssertionError("Console close confirmation did not mount")
 
 
 async def _sync_tray(console, pilot, state) -> ConsoleWorkspaceContextTray:
@@ -354,17 +375,106 @@ async def test_close_tab_button_confirms_before_dropping_a_session_with_messages
 
         close = console.query_one(f"#console-close-session-tab-{doomed.id}", Button)
         close.press()
-        await pilot.pause()
+        dialog = await _wait_for_confirmation(host)
 
-        assert isinstance(host.screen_stack[-1], ConfirmationDialog)
+        assert dialog.message.startswith("Closing this session will discard or cancel:")
+        assert "Transcript messages: 1" in dialog.message
+        assert "Live agent turns: 0" in dialog.message
+        assert "Unsent queued prompts: 0" in dialog.message
         # Still open: the confirmation is a gate, not a notification.
         assert doomed.id in {session.id for session in store.sessions()}
 
-        host.screen_stack[-1].query_one("#confirm-button", Button).press()
+        dialog.query_one("#confirm-button", Button).press()
         await pilot.pause()
         await pilot.pause()
 
         assert doomed.id not in {session.id for session in store.sessions()}
+
+
+@pytest.mark.asyncio
+async def test_close_empty_session_with_queue_warns_without_exposing_prompt_text():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=_ROUTING_SIZE) as pilot:
+        console = await _mounted_console(host, pilot, "#console-native-composer")
+        controller = console._ensure_console_chat_controller()
+        store = controller.store
+        keeper_id = store.active_session_id
+        doomed = store.create_session()
+        store.switch_session(keeper_id)
+
+        registry = controller.prompt_queue_registry
+        snapshot = registry.snapshot(doomed.id)
+        started = registry.begin_chain(
+            doomed.id,
+            context_epoch=store.conversation_context_epoch(doomed.id),
+            expected_revision=snapshot.revision,
+        )
+        assert started.applied
+        controller.prompt_queue_coordinator._changed(doomed.id)
+        queued = controller.queue_prompt(
+            doomed.id,
+            text="secret queued close text",
+            expected_revision=started.snapshot.revision,
+        )
+        assert queued.applied
+        paused = registry.pause(
+            doomed.id,
+            reason=PromptQueuePauseReason.MANUAL,
+            expected_revision=queued.snapshot.revision,
+        )
+        assert paused.applied
+        controller.prompt_queue_coordinator._changed(doomed.id)
+
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+        console.query_one(
+            f"#console-close-session-tab-{doomed.id}", Button
+        ).press()
+        dialog = await _wait_for_confirmation(host)
+
+        assert "Transcript messages: 0" in dialog.message
+        assert "Live agent turns: 0" in dialog.message
+        assert "Unsent queued prompts: 1" in dialog.message
+        assert "secret queued close text" not in dialog.message
+
+        dialog.query_one("#cancel-button", Button).press()
+        await pilot.pause()
+        assert doomed.id in {session.id for session in store.sessions()}
+        assert registry.snapshot(doomed.id).total_count == 1
+
+
+@pytest.mark.asyncio
+async def test_close_revalidates_changed_impact_and_presents_updated_dialog():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=_ROUTING_SIZE) as pilot:
+        console = await _mounted_console(host, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        keeper_id = store.active_session_id
+        doomed = store.create_session()
+        store.switch_session(keeper_id)
+        store.append_message(doomed.id, role=ConsoleMessageRole.USER, content="one")
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+
+        console.query_one(
+            f"#console-close-session-tab-{doomed.id}", Button
+        ).press()
+        first = await _wait_for_confirmation(host)
+        assert "Transcript messages: 1" in first.message
+
+        store.append_message(doomed.id, role=ConsoleMessageRole.USER, content="two")
+        first.query_one("#confirm-button", Button).press()
+        second = await _wait_for_confirmation(host, previous=first)
+
+        assert "Transcript messages: 2" in second.message
+        assert doomed.id in {session.id for session in store.sessions()}
+        second.query_one("#cancel-button", Button).press()
+        await pilot.pause()
+        assert doomed.id in {session.id for session in store.sessions()}
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_parallel_runs.py
+++ b/Tests/UI/test_console_parallel_runs.py
@@ -1810,7 +1810,9 @@ async def test_navigating_away_with_busy_fleet_confirms_and_records_teardown() -
             control="#cancel-button",
         )
         assert isinstance(dialog, ConfirmationDialog)
-        assert "1 agent run" in dialog.message
+        assert "Live agent runs: 1" in dialog.message
+        assert "Sessions with queued prompts: 0" in dialog.message
+        assert "Unsent queued prompts: 0" in dialog.message
         assert "Console" in dialog.message
         dialog.query_one("#cancel-button", Button).press()  # Stay
         await _wait_for_screen("ChatScreen")
@@ -1930,10 +1932,9 @@ async def test_navigation_guard_survives_stay_then_renavigate_then_leave_by_coor
     def _button_offset(label: str) -> tuple[int, int]:
         """Rendered (x, y) of the Stay/Leave button LABEL on the dialog's
         actual button row -- located the way a real user's terminal would
-        show it (scanning rendered text), not via widget introspection.
-        The dialog's own keyboard-hint copy also contains the words
-        "Stay"/"Leave" in prose, so the real button row is specifically
-        the one where nothing but whitespace separates the two labels.
+        show it (scanning rendered text), not via widget introspection. The
+        real button row is specifically the one where nothing but whitespace
+        separates the two labels.
         """
         for y, line in enumerate(_render_lines()):
             idx_stay = line.find("Stay")
@@ -1948,6 +1949,16 @@ async def test_navigation_guard_survives_stay_then_renavigate_then_leave_by_coor
             mid = idx + len(label) // 2
             return cell_len(line[:mid]), y
         raise AssertionError(f"button row for {label!r} not rendered")
+
+    async def _wait_for_button_offset(label: str) -> tuple[int, int]:
+        """Wait until Textual has composed and painted the modal buttons."""
+
+        for _ in range(100):
+            try:
+                return _button_offset(label)
+            except AssertionError:
+                await asyncio.sleep(0.02)
+        return _button_offset(label)
 
     async def _real_click(x: int, y: int) -> None:
         """A REAL mouse click: raw MouseDown+MouseUp through the App's own
@@ -2012,8 +2023,7 @@ async def test_navigation_guard_survives_stay_then_renavigate_then_leave_by_coor
         app.post_message(NavigateToScreen("home"))
         dialog1 = await _wait_for_screen("ConfirmationDialog")
         assert isinstance(dialog1, ConfirmationDialog)
-        await asyncio.sleep(0.1)
-        x, y = _button_offset("Stay")
+        x, y = await _wait_for_button_offset("Stay")
         await _real_click(x, y)
 
         await asyncio.wait_for(_wait_for_screen("ChatScreen"), timeout=5)
@@ -2027,10 +2037,8 @@ async def test_navigation_guard_survives_stay_then_renavigate_then_leave_by_coor
         app.post_message(NavigateToScreen("home"))
         dialog2 = await _wait_for_screen("ConfirmationDialog")
         assert dialog2 is not dialog1, "a fresh dialog instance, not a stale one"
-        await asyncio.sleep(0.1)
-
         # -- click LEAVE at ITS rendered coordinates. --
-        x2, y2 = _button_offset("Leave")
+        x2, y2 = await _wait_for_button_offset("Leave")
         await _real_click(x2, y2)
 
         await asyncio.wait_for(_wait_for_screen("HomeScreen"), timeout=5)

--- a/Tests/UI/test_console_prompt_queue.py
+++ b/Tests/UI/test_console_prompt_queue.py
@@ -1,0 +1,522 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+from textual.widgets import TextArea
+
+from Tests.UI.test_console_dictation import _mounted_console, _ready_host
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleControllerActivity
+from tldw_chatbook.Chat.console_prompt_queue import (
+    ConsolePromptQueueRegistry,
+    MAX_CONSOLE_QUEUE_ENTRIES,
+    PromptQueuePauseReason,
+    QueueMutationStatus,
+)
+from tldw_chatbook.UI.Console_Modules.prompt_queue import (
+    ConsolePromptDispatchStatus,
+    ConsolePromptQueueRegion,
+    ConsolePromptQueueUIController,
+    derive_prompt_queue_presentation,
+)
+from tldw_chatbook.Widgets.Console.console_session_surface import (
+    ConsoleSessionSurface,
+)
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+from tldw_chatbook.Widgets.Console.console_prompt_queue_modal import (
+    ConsolePromptQueueModal,
+)
+from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
+
+
+def _activity(
+    session_id: str = "session-a",
+    *,
+    preparing: bool = False,
+    accepted: bool = False,
+    occupies: bool | None = None,
+    count: int = 0,
+    paused: bool = False,
+) -> ConsoleControllerActivity:
+    return ConsoleControllerActivity(
+        session_id=session_id,
+        occupies_slot=preparing or accepted if occupies is None else occupies,
+        preparing_before_acceptance=preparing,
+        accepted_live_turn=accepted,
+        needs_approval=False,
+        queued_count=count,
+        queue_paused=paused,
+        terminal_notification_eligible=False,
+    )
+
+
+def _registry_with_chain() -> ConsolePromptQueueRegistry:
+    registry = ConsolePromptQueueRegistry()
+    snapshot = registry.snapshot("session-a")
+    registry.begin_chain(
+        "session-a", context_epoch=1, expected_revision=snapshot.revision
+    )
+    return registry
+
+
+def test_presentation_uses_exact_send_queue_boundaries() -> None:
+    registry = ConsolePromptQueueRegistry()
+    empty = registry.snapshot("session-a")
+
+    preparing = derive_prompt_queue_presentation(
+        empty, _activity(preparing=True)
+    )
+    assert preparing.send_label == "Preparing..."
+    assert preparing.send_enabled is False
+
+    handoff = derive_prompt_queue_presentation(
+        empty, _activity(occupies=True)
+    )
+    assert handoff.send_label == "Preparing..."
+    assert handoff.send_enabled is False
+
+    chain = _registry_with_chain()
+    chained = chain.snapshot("session-a")
+    queue = derive_prompt_queue_presentation(
+        chained, _activity(accepted=True)
+    )
+    assert queue.send_label == "Queue"
+    assert queue.send_enabled is True
+
+    for index in range(MAX_CONSOLE_QUEUE_ENTRIES):
+        chained = chain.admit(
+            "session-a",
+            text=f"prompt {index}",
+            expected_revision=chained.revision,
+        ).snapshot
+    full = derive_prompt_queue_presentation(
+        chained,
+        _activity(accepted=True, count=MAX_CONSOLE_QUEUE_ENTRIES),
+    )
+    assert full.send_label == "Queue full"
+    assert full.send_enabled is False
+
+
+def test_background_session_label_exposes_count_only() -> None:
+    label = ConsoleSessionSurface._tab_label("Session", queued_count=3)
+
+    assert label == "Q3 Session"
+
+
+@pytest.mark.parametrize(
+    ("reason", "state", "label", "action"),
+    [
+        (PromptQueuePauseReason.FAILED, "Turn failed", "Retry", "retry-failed"),
+        (PromptQueuePauseReason.STOPPED, "Turn stopped", "Resume next", "resume-next"),
+        (
+            PromptQueuePauseReason.CONTEXT_CHANGED,
+            "Context changed",
+            "Review",
+            "review",
+        ),
+        (
+            PromptQueuePauseReason.DISPATCH_REFUSED,
+            "Start refused",
+            "Try again",
+            "toggle-pause",
+        ),
+    ],
+)
+def test_paused_shelf_exposes_state_specific_primary_action(
+    reason: PromptQueuePauseReason,
+    state: str,
+    label: str,
+    action: str,
+) -> None:
+    registry = _registry_with_chain()
+    snapshot = registry.admit(
+        "session-a",
+        text="waiting",
+        expected_revision=registry.snapshot("session-a").revision,
+    ).snapshot
+    snapshot = registry.pause(
+        "session-a", reason=reason, expected_revision=snapshot.revision
+    ).snapshot
+
+    presentation = derive_prompt_queue_presentation(
+        snapshot, _activity(count=1, paused=True)
+    )
+
+    assert presentation.state_label == state
+    assert presentation.pause_label == label
+    assert presentation.primary_action == action
+
+
+class _RegionApp(App[None]):
+    def compose(self) -> ComposeResult:
+        yield ConsolePromptQueueRegion(id="queue")
+
+
+@pytest.mark.asyncio
+async def test_region_is_revision_guarded_and_hides_preview_when_collapsed() -> None:
+    registry = _registry_with_chain()
+    snapshot = registry.admit(
+        "session-a",
+        text="safe preview",
+        expected_revision=registry.snapshot("session-a").revision,
+    ).snapshot
+    presentation = derive_prompt_queue_presentation(
+        snapshot, _activity(accepted=True, count=1)
+    )
+
+    app = _RegionApp()
+    async with app.run_test(size=(80, 24)) as pilot:
+        region = app.query_one("#queue", ConsolePromptQueueRegion)
+        assert region.sync_presentation("session-a", presentation) is True
+        await pilot.pause()
+        assert region.sync_presentation("session-a", presentation) is False
+        assert region.has_class("-visible")
+        assert region.query_one("#console-prompt-queue-summary").renderable == (
+            "Queue 1/10 · Draining"
+        )
+
+        collapsed = derive_prompt_queue_presentation(
+            snapshot,
+            _activity(accepted=True, count=1),
+            composer_collapsed=True,
+        )
+        region.sync_presentation("session-a", collapsed)
+        assert not region.has_class("-visible")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(80, 24), (100, 30), (160, 40)])
+async def test_mounted_shelf_and_neighboring_composer_fit_terminal(size) -> None:
+    _app, host = _ready_host()
+    async with host.run_test(size=size) as pilot:
+        console = await _mounted_console(host, pilot)
+        controller = console._ensure_console_chat_controller()
+        session_id = controller.store.active_session_id
+        snapshot = controller.prompt_queue_registry.snapshot(session_id)
+        snapshot = controller.prompt_queue_registry.begin_chain(
+            session_id,
+            context_epoch=controller.store.conversation_context_epoch(session_id),
+            expected_revision=snapshot.revision,
+        ).snapshot
+        controller.prompt_queue_registry.admit(
+            session_id,
+            text="geometry-safe queued prompt",
+            expected_revision=snapshot.revision,
+        )
+        controller.prompt_queue_coordinator.publish_registry_change(session_id)
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+
+        region = console.query_one(
+            "#console-prompt-queue", ConsolePromptQueueRegion
+        )
+        composer = console.query_one(
+            "#console-native-composer", ConsoleComposerBar
+        )
+        manage = region.query_one("#console-prompt-queue-manage", Button)
+        pause = region.query_one("#console-prompt-queue-pause", Button)
+        send = composer.query_one("#console-send-message", Button)
+
+        assert region.display
+        assert region.region.height == 1
+        assert region.region.y + region.region.height == composer.region.y
+        assert manage.region.right <= region.region.right
+        assert pause.region.right <= region.region.right
+        assert manage.region.right <= pause.region.x
+        assert send.label.plain == "Queue"
+        assert send.region.right <= composer.region.right
+
+
+@pytest.mark.asyncio
+async def test_stay_from_lifecycle_dialog_preserves_manager_edit_and_focus() -> None:
+    _app, host = _ready_host()
+    async with host.run_test(size=(100, 30)) as pilot:
+        console = await _mounted_console(host, pilot)
+        controller = console._ensure_console_chat_controller()
+        session_id = controller.store.active_session_id
+        snapshot = controller.prompt_queue_registry.snapshot(session_id)
+        snapshot = controller.prompt_queue_registry.begin_chain(
+            session_id,
+            context_epoch=controller.store.conversation_context_epoch(session_id),
+            expected_revision=snapshot.revision,
+        ).snapshot
+        snapshot = controller.prompt_queue_registry.admit(
+            session_id,
+            text="keep this private edit",
+            expected_revision=snapshot.revision,
+        ).snapshot
+        controller.prompt_queue_registry.pause(
+            session_id,
+            reason=PromptQueuePauseReason.MANUAL,
+            expected_revision=snapshot.revision,
+        )
+        controller.prompt_queue_coordinator.publish_registry_change(session_id)
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+
+        await pilot.click("#console-prompt-queue-manage")
+        await pilot.pause()
+        assert isinstance(host.screen_stack[-1], ConsolePromptQueueModal)
+        await pilot.click("#console-prompt-queue-edit")
+        edit = host.screen_stack[-1].query_one(
+            "#console-prompt-queue-edit-input", TextArea
+        )
+        edit.text = "unsaved manager edit"
+        edit.focus()
+
+        confirmation_task = asyncio.create_task(console.confirm_navigation())
+        for _ in range(5):
+            await pilot.pause()
+            if isinstance(host.screen_stack[-1], ConfirmationDialog):
+                break
+        assert isinstance(host.screen_stack[-1], ConfirmationDialog)
+        host.screen_stack[-1].query_one("#cancel-button", Button).press()
+        await pilot.pause()
+
+        assert await confirmation_task is False
+        assert isinstance(host.screen_stack[-1], ConsolePromptQueueModal)
+        assert edit.text == "unsaved manager edit"
+        assert edit.has_focus
+
+
+class _FakeChatController:
+    def __init__(self, *, accepted: bool, preparing: bool = False) -> None:
+        self.prompt_queue_registry = _registry_with_chain() if accepted else ConsolePromptQueueRegistry()
+        self.store = SimpleNamespace(
+            active_session_id="session-a",
+            conversation_context_epoch=lambda _session_id: 8,
+        )
+        self._accepted = accepted
+        self._preparing = preparing
+
+    def activity_for(self, session_id: str) -> ConsoleControllerActivity:
+        snapshot = self.prompt_queue_registry.snapshot(session_id)
+        return _activity(
+            session_id,
+            preparing=self._preparing,
+            accepted=self._accepted,
+            count=snapshot.total_count,
+        )
+
+    def queue_prompt(self, session_id: str, *, text: str, expected_revision: int):
+        return self.prompt_queue_registry.admit(
+            session_id, text=text, expected_revision=expected_revision
+        )
+
+    def edit_queued_prompt(
+        self,
+        session_id: str,
+        *,
+        entry_id: str,
+        text: str,
+        expected_revision: int,
+    ):
+        return self.prompt_queue_registry.edit(
+            session_id,
+            entry_id=entry_id,
+            text=text,
+            expected_revision=expected_revision,
+        )
+
+    def send_refusal_copy(self, _session_id: str) -> str:
+        return ""
+
+
+def _ui_controller(
+    fake: _FakeChatController,
+    calls: dict[str, Any],
+    *,
+    edit_refusal=lambda _text: "",
+) -> ConsolePromptQueueUIController:
+    async def append_system(text: str) -> None:
+        calls["system"].append(text)
+
+    async def sync_ui() -> None:
+        calls["sync"].append(True)
+
+    return ConsolePromptQueueUIController(
+        chat_controller_accessor=lambda: fake,
+        ensure_active_session=lambda: None,
+        blocked_reason_accessor=lambda: "",
+        setup_blocked_reason_accessor=lambda: "",
+        restore_stash=lambda stash: calls["restored"].append(stash),
+        append_system_message=append_system,
+        notify=lambda text, severity: calls["notified"].append((text, severity)),
+        focus_composer=lambda: calls["focused"].append(True),
+        inflight_stashes_accessor=lambda: calls["inflight"],
+        note_follow_intent=lambda: calls["follow"].append(True),
+        launch_chain=lambda draft, session_id: calls["staged"].append(
+            (draft, session_id)
+        ),
+        commit_queued_draft=lambda session_id, stash: calls["queued"].append(
+            (session_id, stash)
+        ),
+        edit_refusal=edit_refusal,
+        sync_ui=sync_ui,
+    )
+
+
+def _calls() -> dict[str, Any]:
+    return {
+        "system": [],
+        "sync": [],
+        "restored": [],
+        "notified": [],
+        "focused": [],
+        "staged": [],
+        "queued": [],
+        "inflight": {},
+        "follow": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_dispatch_admits_exact_text_behind_accepted_turn() -> None:
+    fake = _FakeChatController(accepted=True)
+    calls = _calls()
+    controller = _ui_controller(fake, calls)
+
+    outcome = await controller.dispatch("  exact text\n", stash=None)
+
+    assert outcome.status is ConsolePromptDispatchStatus.QUEUED
+    snapshot = fake.prompt_queue_registry.snapshot("session-a")
+    entry = snapshot.entries[0]
+    body = fake.prompt_queue_registry.read_waiting_text(
+        "session-a", entry_id=entry.entry_id, expected_revision=snapshot.revision
+    )
+    assert body.text == "  exact text\n"
+    assert calls["staged"] == []
+    assert calls["queued"] == [("session-a", None)]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_stages_one_manual_chain_when_queue_does_not_own_work() -> None:
+    fake = _FakeChatController(accepted=False)
+    calls = _calls()
+    controller = _ui_controller(fake, calls)
+
+    outcome = await controller.dispatch("send now", stash=None)
+
+    assert outcome.status is ConsolePromptDispatchStatus.SENT
+    assert calls["staged"] == [("send now", "session-a")]
+    assert fake.prompt_queue_registry.snapshot("session-a").total_count == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_restores_exact_stash_when_queue_is_full() -> None:
+    fake = _FakeChatController(accepted=True)
+    snapshot = fake.prompt_queue_registry.snapshot("session-a")
+    for index in range(MAX_CONSOLE_QUEUE_ENTRIES):
+        snapshot = fake.prompt_queue_registry.admit(
+            "session-a",
+            text=f"queued {index}",
+            expected_revision=snapshot.revision,
+        ).snapshot
+    calls = _calls()
+    controller = _ui_controller(fake, calls)
+    stash = object()
+
+    outcome = await controller.dispatch("must survive", stash=stash)
+
+    assert outcome.status is ConsolePromptDispatchStatus.REFUSED
+    assert calls["restored"] == [stash]
+    assert calls["queued"] == []
+    assert calls["staged"] == []
+    assert outcome.detail == "Queue full (10/10). Manage or remove an item."
+
+
+@pytest.mark.asyncio
+async def test_pre_acceptance_race_restores_stash_instead_of_launching() -> None:
+    fake = _FakeChatController(accepted=False)
+    calls = _calls()
+    controller = _ui_controller(fake, calls)
+    stash = object()
+    activity_calls = 0
+
+    def activity_for(session_id: str) -> ConsoleControllerActivity:
+        nonlocal activity_calls
+        activity_calls += 1
+        return _activity(session_id, preparing=activity_calls > 1)
+
+    fake.activity_for = activity_for  # type: ignore[method-assign]
+    outcome = await controller.dispatch("race-safe", stash=stash)
+
+    assert outcome.status is ConsolePromptDispatchStatus.REFUSED
+    assert calls["restored"] == [stash]
+    assert calls["staged"] == []
+    assert "Preparing" in outcome.detail
+
+
+@pytest.mark.asyncio
+async def test_finished_chain_boundary_reroutes_to_one_normal_send() -> None:
+    fake = _FakeChatController(accepted=False)
+    calls = _calls()
+    controller = _ui_controller(fake, calls)
+    activity_calls = 0
+
+    def activity_for(session_id: str) -> ConsoleControllerActivity:
+        nonlocal activity_calls
+        activity_calls += 1
+        return _activity(session_id, accepted=activity_calls == 1)
+
+    fake.activity_for = activity_for  # type: ignore[method-assign]
+    outcome = await controller.dispatch("boundary", stash=None)
+
+    assert outcome.status is ConsolePromptDispatchStatus.SENT
+    assert calls["staged"] == [("boundary", "session-a")]
+    assert fake.prompt_queue_registry.snapshot("session-a").total_count == 0
+
+
+def test_manager_edit_refuses_recognized_slash_command_without_mutation() -> None:
+    fake = _FakeChatController(accepted=True)
+    snapshot = fake.prompt_queue_registry.snapshot("session-a")
+    snapshot = fake.prompt_queue_registry.admit(
+        "session-a", text="ordinary", expected_revision=snapshot.revision
+    ).snapshot
+    entry_id = snapshot.entries[0].entry_id
+    calls = _calls()
+    controller = _ui_controller(
+        fake,
+        calls,
+        edit_refusal=lambda text: (
+            "Slash commands cannot be queued." if text == "/help" else ""
+        ),
+    )
+
+    result = controller.edit_waiting(
+        "session-a",
+        entry_id,
+        text="/help",
+        expected_revision=snapshot.revision,
+    )
+
+    assert result.status is QueueMutationStatus.INVALID
+    after = fake.prompt_queue_registry.read_waiting_text(
+        "session-a",
+        entry_id=entry_id,
+        expected_revision=snapshot.revision,
+    )
+    assert after.text == "ordinary"
+
+
+@pytest.mark.asyncio
+async def test_use_current_context_rejects_an_epoch_that_changed_after_review() -> None:
+    fake = _FakeChatController(accepted=True)
+    calls = _calls()
+    controller = _ui_controller(fake, calls)
+    snapshot = fake.prompt_queue_registry.snapshot("session-a")
+
+    result = await controller.recover(
+        "session-a",
+        action="use-current-context",
+        expected_revision=snapshot.revision,
+        reviewed_context_epoch=7,
+    )
+
+    assert result.status is QueueMutationStatus.INVALID
+    assert "changed since review" in result.detail

--- a/Tests/UI/test_console_prompt_queue_modal.py
+++ b/Tests/UI/test_console_prompt_queue_modal.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import pytest
 from textual.app import App
-from textual.widgets import Button
+from textual.widgets import Button, Static, TextArea
 
-from tldw_chatbook.Chat.console_prompt_queue import ConsolePromptQueueRegistry
 from tldw_chatbook.Chat.console_prompt_queue import (
+    MAX_CONSOLE_QUEUE_ENTRIES,
+    ConsolePromptQueueRegistry,
     PromptQueueMutationResult,
     PromptQueuePauseReason,
     QueueMutationStatus,
@@ -123,6 +124,8 @@ async def test_manager_fetches_no_body_until_selected_edit_begins() -> None:
 
         assert facade.read_calls == []
         assert modal.session_id == "pinned-session"
+        state = modal.query_one("#console-prompt-queue-manager-state", Static)
+        assert f"/{MAX_CONSOLE_QUEUE_ENTRIES}" in str(state.renderable)
 
         await pilot.click("#console-prompt-queue-edit")
         await pilot.pause()
@@ -132,6 +135,37 @@ async def test_manager_fetches_no_body_until_selected_edit_begins() -> None:
         assert modal.query_one("#console-prompt-queue-edit-input").text == (
             "first [safe] prompt"
         )
+
+
+@pytest.mark.asyncio
+async def test_manager_rejects_unsafe_edited_prompt_at_ui_boundary() -> None:
+    facade = _QueueFacade()
+    before = facade.snapshot("pinned-session")
+    first_entry = before.entries[0]
+    app = App()
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        modal = ConsolePromptQueueModal(
+            session_id="pinned-session",
+            revision=before.revision,
+            queue_controller=facade,
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+
+        await pilot.click("#console-prompt-queue-edit")
+        editor = modal.query_one("#console-prompt-queue-edit-input", TextArea)
+        editor.text = "<script>alert('queued')</script>"
+        await pilot.click("#console-prompt-queue-save")
+        await pilot.pause()
+
+        after = facade.snapshot("pinned-session")
+        assert after.revision == before.revision
+        assert after.entries[0] is first_entry
+        feedback = modal.query_one(
+            "#console-prompt-queue-manager-feedback", Static
+        )
+        assert "Prompt blocked" in str(feedback.renderable)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_prompt_queue_modal.py
+++ b/Tests/UI/test_console_prompt_queue_modal.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import pytest
+from textual.app import App
+from textual.widgets import Button
+
+from tldw_chatbook.Chat.console_prompt_queue import ConsolePromptQueueRegistry
+from tldw_chatbook.Chat.console_prompt_queue import (
+    PromptQueueMutationResult,
+    PromptQueuePauseReason,
+    QueueMutationStatus,
+)
+from tldw_chatbook.Widgets.Console.console_prompt_queue_modal import (
+    ConsolePromptQueueModal,
+)
+
+
+class _QueueFacade:
+    def __init__(
+        self, *, pause_reason: PromptQueuePauseReason | None = None
+    ) -> None:
+        self.registry = ConsolePromptQueueRegistry()
+        snapshot = self.registry.snapshot("pinned-session")
+        snapshot = self.registry.begin_chain(
+            "pinned-session", context_epoch=1, expected_revision=snapshot.revision
+        ).snapshot
+        for text in ("first [safe] prompt", "second prompt"):
+            snapshot = self.registry.admit(
+                "pinned-session", text=text, expected_revision=snapshot.revision
+            ).snapshot
+        if pause_reason is not None:
+            self.registry.pause(
+                "pinned-session",
+                reason=pause_reason,
+                expected_revision=snapshot.revision,
+            )
+        self.read_calls: list[tuple[str, str, int]] = []
+        self.recover_calls: list[tuple[str, str, int, int | None]] = []
+
+    def snapshot(self, session_id: str):
+        return self.registry.snapshot(session_id)
+
+    def read_waiting_text(self, session_id: str, entry_id: str, *, expected_revision: int):
+        self.read_calls.append((session_id, entry_id, expected_revision))
+        return self.registry.read_waiting_text(
+            session_id,
+            entry_id=entry_id,
+            expected_revision=expected_revision,
+        )
+
+    def edit_waiting(self, session_id: str, entry_id: str, *, text: str, expected_revision: int):
+        return self.registry.edit(
+            session_id,
+            entry_id=entry_id,
+            text=text,
+            expected_revision=expected_revision,
+        )
+
+    def move_waiting(self, session_id: str, entry_id: str, *, position: int, expected_revision: int):
+        return self.registry.move(
+            session_id,
+            entry_id=entry_id,
+            new_index=position,
+            expected_revision=expected_revision,
+        )
+
+    def remove_waiting(self, session_id: str, entry_id: str, *, expected_revision: int):
+        return self.registry.remove(
+            session_id,
+            entry_id=entry_id,
+            expected_revision=expected_revision,
+        )
+
+    def clear_waiting(self, session_id: str, *, expected_revision: int):
+        return self.registry.clear_waiting(
+            session_id, expected_revision=expected_revision
+        )
+
+    async def toggle_pause(self, session_id: str, *, expected_revision: int):
+        return self.registry.request_pause_after_turn(
+            session_id, expected_revision=expected_revision
+        )
+
+    def context_review(self, session_id: str) -> tuple[int | None, int]:
+        assert session_id == "pinned-session"
+        return (1, 7)
+
+    async def recover(
+        self,
+        session_id: str,
+        *,
+        action: str,
+        expected_revision: int,
+        reviewed_context_epoch: int | None = None,
+    ) -> PromptQueueMutationResult:
+        self.recover_calls.append(
+            (session_id, action, expected_revision, reviewed_context_epoch)
+        )
+        snapshot = self.registry.snapshot(session_id)
+        if action == "use-current-context" and reviewed_context_epoch is None:
+            return PromptQueueMutationResult(
+                QueueMutationStatus.INVALID,
+                snapshot,
+                detail="Review the current context before using it.",
+            )
+        return PromptQueueMutationResult(QueueMutationStatus.UNCHANGED, snapshot)
+
+
+@pytest.mark.asyncio
+async def test_manager_fetches_no_body_until_selected_edit_begins() -> None:
+    facade = _QueueFacade()
+    snapshot = facade.snapshot("pinned-session")
+    app = App()
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        modal = ConsolePromptQueueModal(
+            session_id="pinned-session",
+            revision=snapshot.revision,
+            queue_controller=facade,
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+
+        assert facade.read_calls == []
+        assert modal.session_id == "pinned-session"
+
+        await pilot.click("#console-prompt-queue-edit")
+        await pilot.pause()
+
+        assert len(facade.read_calls) == 1
+        assert facade.read_calls[0][0] == "pinned-session"
+        assert modal.query_one("#console-prompt-queue-edit-input").text == (
+            "first [safe] prompt"
+        )
+
+
+@pytest.mark.asyncio
+async def test_manager_keeps_pinned_session_and_recovers_from_stale_revision() -> None:
+    facade = _QueueFacade()
+    snapshot = facade.snapshot("pinned-session")
+    app = App()
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        modal = ConsolePromptQueueModal(
+            session_id="pinned-session",
+            revision=snapshot.revision,
+            queue_controller=facade,
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+
+        facade.registry.admit(
+            "pinned-session",
+            text="external change",
+            expected_revision=snapshot.revision,
+        )
+        modal._move_selected(1)
+        await pilot.pause()
+
+        assert modal.session_id == "pinned-session"
+        assert modal._revision == facade.snapshot("pinned-session").revision
+        feedback = modal.query_one("#console-prompt-queue-manager-feedback")
+        assert "Queue changed" in str(feedback.renderable)
+
+
+@pytest.mark.asyncio
+async def test_use_current_context_requires_and_reuses_explicit_review_epoch() -> None:
+    facade = _QueueFacade(pause_reason=PromptQueuePauseReason.CONTEXT_CHANGED)
+    snapshot = facade.snapshot("pinned-session")
+    app = App()
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        modal = ConsolePromptQueueModal(
+            session_id="pinned-session",
+            revision=snapshot.revision,
+            queue_controller=facade,
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+
+        use_current = modal.query_one("#console-prompt-queue-use-context", Button)
+        assert use_current.disabled
+        assert facade.recover_calls == []
+
+        await pilot.click("#console-prompt-queue-review-context")
+        assert not use_current.disabled
+        await pilot.click("#console-prompt-queue-use-context")
+        await pilot.pause()
+        assert facade.recover_calls[-1] == (
+            "pinned-session",
+            "use-current-context",
+            snapshot.revision,
+            7,
+        )
+
+
+@pytest.mark.asyncio
+async def test_remove_and_clear_require_explicit_destructive_confirmation() -> None:
+    facade = _QueueFacade()
+    snapshot = facade.snapshot("pinned-session")
+    app = App()
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        modal = ConsolePromptQueueModal(
+            session_id="pinned-session",
+            revision=snapshot.revision,
+            queue_controller=facade,
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+
+        await pilot.click("#console-prompt-queue-remove")
+        await pilot.click("#continue-btn")
+        await pilot.pause()
+        assert facade.snapshot("pinned-session").total_count == 2
+
+        await pilot.click("#console-prompt-queue-remove")
+        await pilot.click("#cancel-btn")
+        await pilot.pause()
+        assert facade.snapshot("pinned-session").total_count == 1
+
+        await pilot.click("#console-prompt-queue-clear")
+        await pilot.click("#cancel-btn")
+        await pilot.pause()
+        assert facade.snapshot("pinned-session").total_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(80, 24), (100, 30), (160, 40)])
+async def test_manager_controls_remain_inside_dialog_at_supported_sizes(size) -> None:
+    facade = _QueueFacade()
+    snapshot = facade.snapshot("pinned-session")
+    app = App()
+
+    async with app.run_test(size=size) as pilot:
+        modal = ConsolePromptQueueModal(
+            session_id="pinned-session",
+            revision=snapshot.revision,
+            queue_controller=facade,
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+        dialog = modal.query_one("#console-prompt-queue-dialog")
+
+        for button in dialog.query(Button):
+            assert button.region.x >= dialog.region.x
+            assert button.region.y >= dialog.region.y
+            assert button.region.right <= dialog.region.right
+            assert button.region.bottom <= dialog.region.bottom

--- a/Tests/UI/test_console_send_disabled_state.py
+++ b/Tests/UI/test_console_send_disabled_state.py
@@ -5,8 +5,9 @@ conveyed only via CSS classes and a hover tooltip (and an empty draft got no
 tooltip at all), while the ``#console-send-disabled-reason`` Static stayed
 permanently ``display:none``. These tests pin the new contract:
 
-- Send is genuinely disabled whenever send is blocked (setup/run) or the
-  draft is empty, and re-enabled the moment a send is possible.
+- Send is genuinely disabled whenever setup/pre-acceptance/full-queue state
+  blocks dispatch or the draft is empty, and becomes Queue once an accepted
+  turn can own the next prompt.
 - The blocked/empty reason is perceivable WITHOUT hover: the reason strip
   renders inline (the 1fr draft yields the cells; the strip never adds
   height to the one-row composer) and clears immediately.
@@ -32,7 +33,7 @@ from Tests.UI.test_console_native_chat_flow import (
     _wait_for_text,
 )
 from Tests.UI.test_console_regenerate_feedback import GatedGateway
-from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_destination_shells import _build_test_app
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
@@ -281,18 +282,8 @@ async def test_enter_hotkey_still_sends_when_send_is_enabled():
 
 
 @pytest.mark.asyncio
-async def test_enter_hotkey_while_run_blocked_still_shows_feedback():
-    """Enter on a disabled Send must still produce the blocked-attempt feedback.
-
-    ``Button.press()`` no-ops on a disabled control (Textual 8.x), so this
-    exercises the key handler's direct dispatch of the Pressed handler --
-    the same funnel the click path used before Send gained a real disabled
-    state. A run in flight is the reachable blocked state here: the
-    setup-blocked state covers the composer with the blocking setup modal,
-    which swallows Enter long before the send branch in both the old and
-    new behavior (FR-09), and the setup/readiness system-row branch rides
-    the very same dispatch exercised below.
-    """
+async def test_enter_hotkey_queues_draft_behind_accepted_run():
+    """An accepted live turn changes Send to Queue and preserves exact text."""
     app = _build_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
@@ -325,34 +316,43 @@ async def test_enter_hotkey_while_run_blocked_still_shows_feedback():
         )
 
         try:
-            # Mid-run the composer is genuinely send-blocked...
+            # An empty draft stays disabled, but the action truthfully names
+            # the now-available queue path.
             await _wait_for_condition(pilot, lambda: send_button.disabled is True)
+            assert send_button.label.plain == "Queue"
             assert reason.styles.display == "block"
-            assert (
-                reason.renderable.plain
-                == "Send blocked — wait for the active run to finish"
-            )
+            assert reason.renderable.plain == "Send disabled: type a message"
 
-            # ...and Enter still drives the refusal feedback instead of
-            # dying on the disabled button's no-op press().
+            # A real draft enables Queue; Enter admits the exact text behind
+            # the accepted turn through the same dispatcher as the button.
             composer.load_draft("queued behind run")
             composer.focus()
             await pilot.pause(0.1)
+            assert send_button.disabled is False
             await pilot.press("enter")
 
             await _wait_for_condition(
                 pilot,
-                lambda: any(
-                    call.args
-                    and "A run is already running in this tab." in call.args[0]
-                    and call.kwargs.get("severity") == "warning"
-                    for call in notify_mock.call_args_list
-                ),
+                lambda: console._ensure_console_chat_controller()
+                .prompt_queue_registry.snapshot(store.active_session_id)
+                .total_count
+                == 1,
             )
-            # The refused draft is restored for correction, not eaten --
-            # and the stash is gone, so the next Enter is not swallowed as
-            # a duplicate.
-            assert composer.draft_text() == "queued behind run"
+            snapshot = (
+                console._ensure_console_chat_controller()
+                .prompt_queue_registry.snapshot(store.active_session_id)
+            )
+            queued = snapshot.entries[0]
+            text = (
+                console._ensure_console_chat_controller()
+                .prompt_queue_registry.read_waiting_text(
+                    store.active_session_id,
+                    entry_id=queued.entry_id,
+                    expected_revision=snapshot.revision,
+                )
+            )
+            assert text.text == "queued behind run"
+            assert composer.draft_text() == ""
             assert console._console_pending_send_stash is None
         finally:
             gateway.release.set()

--- a/Tests/UI/test_console_workspace_context_rail.py
+++ b/Tests/UI/test_console_workspace_context_rail.py
@@ -200,6 +200,7 @@ def _browser_row(
     starred_sort: str = "",
     updated_sort: str = "",
     run_marker: str = "",
+    queued_count: int = 0,
 ) -> ConsoleConversationBrowserInputRow:
     return ConsoleConversationBrowserInputRow(
         row_key=row_key,
@@ -218,6 +219,7 @@ def _browser_row(
         starred_sort=starred_sort,
         updated_sort=updated_sort,
         run_marker=run_marker,
+        queued_count=queued_count,
     )
 
 
@@ -464,6 +466,33 @@ async def test_console_workspace_context_renders_grouped_conversation_browser() 
         assert star_button.row_key == "conv-starred"
         assert star_button.conversation_id == "conv-starred"
         assert star_button.starred is True
+
+
+@pytest.mark.asyncio
+async def test_background_conversation_row_shows_content_free_queue_count() -> None:
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    row = _browser_row(
+        "native-queued",
+        "Background work",
+        native_session_id="session-background",
+        source_kind="native",
+        queued_count=3,
+    )
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-workspace-context")
+        tray = console.query_one(
+            "#console-workspace-context", ConsoleWorkspaceContextTray
+        )
+        tray.sync_state(_base_grouped_workspace_state(rows=(row,)))
+        await pilot.pause()
+
+        row_button = console.query_one(
+            "#console-workspace-conversation-0", Button
+        )
+        assert "Queue 3" in str(row_button.label)
 
 
 @pytest.mark.asyncio

--- a/Tests/test_config_encryption_effective_path.py
+++ b/Tests/test_config_encryption_effective_path.py
@@ -247,7 +247,10 @@ def test_app_quit_save_writes_active_file_not_default(isolated_config_paths):
 
     app = TldwCli()
     try:
-        app.action_quit()
+        # TASK-14806 moved this blocking persistence behind the asynchronous
+        # quit worker. This regression owns the persistence target boundary,
+        # not worker dispatch, so exercise the extracted blocking phase.
+        app._run_blocking_quit_persistence()
     finally:
         cfg.clear_encryption_password()
 

--- a/backlog/decisions/046-visible-bounded-console-prompt-queue.md
+++ b/backlog/decisions/046-visible-bounded-console-prompt-queue.md
@@ -25,6 +25,11 @@ coordinator owns claiming, submission, pause, retry, slot reservation, terminal
 state, and shutdown behavior. The screen starts one per-session worker and
 awaits that coordinator.
 
+Queue transitions are synchronous and confined to the Textual event-loop
+thread. Worker-thread callbacks marshal before queue access. Revision-checked
+registry methods are the atomicity boundary; widgets never acquire their own
+locks or mutate the queue directly.
+
 One draining session retains its existing global agent slot across queued
 turns. The reservation ends when the queue empties or pauses. A paused queue
 must explicitly reacquire a slot on resume or retry; if the global cap is full,
@@ -35,18 +40,30 @@ The queue is process-memory-only and scoped to the mounted Console screen. It
 survives session, tab, and workspace switching inside that screen, but it is not
 serialized, persisted, restored after leaving Console, or replayed after an app
 restart. Closing a queued session, leaving Console, or quitting the app requires
-a count-aware confirmation before unsent prompts are discarded.
+a count-aware confirmation before unsent prompts are discarded. This guarantee
+applies to user-initiated in-app exits; forced process termination cannot offer
+interactive confirmation.
+
+Confirmed session close marks that session's queue chain closing before it
+signals Stop or cancels the active stream. Terminal callbacks caused by close
+cannot claim another prompt. One combined close confirmation reports transcript,
+live-turn, and queued-prompt impact instead of stacking dialogs.
 
 Queueing begins only after the active turn crosses the existing accepted-send
 boundary. During provider and skill validation the action remains unavailable
 and reads `Preparing...`. Once accepted, the normal `Send` action becomes
 `Queue`; Enter and the button both enqueue the exact canonical text draft.
-Queue acceptance, not an attempted enqueue, clears the captured draft.
+Successful queue admission, not an attempted enqueue, clears the captured draft.
 
 Queued entries contain text only. Drafts carrying staged attachments or staged
 Library/RAG evidence are refused intact. Recognized slash commands are never
 queued; each command keeps its existing command-specific execution or refusal
 rules. Large pasted text and `$skill` messages remain valid text prompts.
+Attachments and manually staged evidence are rechecked before automatic
+submission, so a rider added after admission pauses the queue and remains
+unconsumed. Session-targeted Auto-RAG may still run for a queued text turn when
+enabled, but it is generated for that owning session at dispatch and cannot
+consume the screen's resident staged-evidence slot.
 
 The queue pauses after a failed, stopped, context-invalidated, or pre-accept
 refused turn. Failed turns retry their existing assistant response before
@@ -56,17 +73,46 @@ the retry uses the existing regeneration path and keeps the stopped partial in
 history. A user may also request `Pause after this turn` without stopping the
 current response.
 
-Conversation lineage safety is based on a dedicated branch epoch owned by
-`ConsoleChatStore`, the authority for the active leaf and message tree. Linear
-user/assistant appends do not change that epoch. Rewind, sibling selection,
-delete, edit-and-resend, and branch creation do. A mismatch pauses the queue for
-review rather than silently sending prompts against a different branch.
+Conversation safety is based on a dedicated conversation-context epoch owned by
+`ConsoleChatStore`, the authority for provider-relevant history, summary
+boundary, active leaf, and message tree. Linear user/assistant appends do not
+change that epoch. Active-path content edits, selected textual variants,
+summary changes, rewind, sibling selection, active-path delete,
+edit-and-resend, and branch creation do. A mismatch pauses the queue for review
+rather than silently sending prompts against changed context.
 
-Background queue turns resolve provider, model, system prompt, workspace, and
-other per-turn settings for their owning session ID, never from the currently
-viewed tab. Intermediate queued completions do not emit finished markers or
+The chain records the context epoch of the active turn's committed provider
+payload even while the queue is empty. A later first entry inherits that
+baseline, so an edit made during the response cannot be masked by queueing only
+after the edit.
+
+Resuming after an unrelated context mismatch requires an explicit
+`Use current context & resume` confirmation that revalidates both queue revision
+and context epoch before adopting the new baseline. Other recovery actions do
+not silently adopt unrelated edits.
+
+Background queue turns resolve one immutable turn execution context containing
+provider, model, capabilities, system prompt, generation settings, workspace,
+and other per-turn values for their owning session ID, never from the currently
+viewed tab. The same snapshot is threaded through payload construction and
+stream execution so a tab switch or settings change cannot produce a mixed
+turn. Intermediate queued completions do not emit finished markers or
 completion toasts. The session remains visibly running until the whole drain
 finishes or pauses.
+
+The immutable execution context stabilizes configuration only. Credentials,
+tool approvals, skill trust, and other authority are revalidated through their
+existing runtime seams and are never retained as queue state.
+
+The existing no-argument `on_submission_accepted` callback remains a
+manual-origin compatibility seam. Queued acceptance uses a separate
+content-free coordinator event and cannot clear the visible composer or its
+undo history.
+
+Whenever queue-owned future work exists, the coordinator is the sole next-turn
+authority. Existing transcript Retry/Regenerate recovery for the failed or
+stopped turn delegates into it; unrelated Continue, Regenerate, and Edit &
+resend actions cannot bypass older queued prompts.
 
 ## Context
 
@@ -86,16 +132,19 @@ Several existing boundaries make an implicit implementation unsafe:
 - The accepted-send callback is currently origin-agnostic and can clear the
   visible composer. An automatic queued submission must never erase a new draft
   the user is typing.
-- Provider selection is projected from the viewed session. A background queued
-  turn must resolve settings by owning session to prevent cross-tab leakage.
+- Provider execution inputs are projected from the viewed session and read by
+  multiple payload helpers. A background queued turn must resolve one immutable
+  owning-session execution context and thread it through the whole turn to
+  prevent cross-tab or mid-validation leakage.
 - Run completion currently stamps background markers and toasts per turn. A
   ten-prompt drain must not produce ten completion notifications or flicker
   between finished and running.
 - Navigation guards currently count live runs only, and the app quit action does
   not consult Console. Paused queues can contain unsent private text with no
   active run.
-- The chat store already owns branching. A parallel queue-specific view of
-  lineage would drift from that authority.
+- The chat store already owns provider-relevant history, summary, and branching.
+  A parallel queue-specific view of conversation context would drift from that
+  authority.
 
 These are long-lived Console UX, application lifecycle, cross-module interface,
 and state-ownership decisions, so a canonical ADR is required.
@@ -131,11 +180,13 @@ and state-ownership decisions, so a canonical ADR is required.
 
 - A ten-message drain may occupy one configured agent slot for a substantial
   time.
-- Queues are lost after confirmed Console exit or app quit.
+- Queues are lost after confirmed Console exit or in-app quit, and cannot be
+  protected from forced process termination.
 - Attachments and staged evidence cannot be queued in the first version.
 - The app needs a generic asynchronous pre-quit confirmation seam and
   reentrancy guard.
-- The chat store needs a branch epoch distinct from its broad payload revision.
+- The chat store needs a conversation-context epoch distinct from its broad
+  payload revision.
 - Existing fleet and run-state derivations must become queue-aware through one
   controller activity projection.
 
@@ -145,7 +196,8 @@ The feature requires pure queue-state tests, joined controller tests, mounted
 Textual tests, application leave/quit tests, and isolated live verification.
 The most important guards must be mutation-checked: the limit, origin-aware
 composer clearing, stale-revision rejection, shutdown suppression,
-owning-session provider selection, and intermediate notification suppression.
+owning-session immutable turn-context selection, context-epoch coverage, and
+intermediate notification suppression.
 
 Unsent queue state must be absent from database persistence, prompt history,
 screen snapshots, and logs. Once an entry is accepted as a real turn, normal

--- a/backlog/decisions/046-visible-bounded-console-prompt-queue.md
+++ b/backlog/decisions/046-visible-bounded-console-prompt-queue.md
@@ -1,0 +1,160 @@
+# ADR-046: Visible bounded Console prompt queue
+
+Status: Accepted
+Date: 2026-08-09
+Related Spec: [Console Prompt Queue Design](../../Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md)
+Supersedes: N/A
+
+## Decision
+
+Chatbook will support a visible, per-session prompt queue in Console. While an
+accepted agent turn is active, the user may queue up to ten text-only prompts.
+The prompts run as separate FIFO turns, each starting only after the previous
+assistant turn completes successfully.
+
+The first entry requires an already accepted turn. Once a queue exists, users
+may append while it is draining or paused; older entries always retain priority.
+Admission and the coordinator's terminal queue-empty transition are atomic, so
+a boundary-racing draft is either observed by the drain or rerouted unchanged as
+a normal manual send, never stranded or duplicated.
+
+The queue is owned by the Console chat controller through a focused, pure queue
+registry. Textual widgets render immutable snapshots and emit typed intents;
+they do not own scheduling or mutate queue state directly. A controller-side
+coordinator owns claiming, submission, pause, retry, slot reservation, terminal
+state, and shutdown behavior. The screen starts one per-session worker and
+awaits that coordinator.
+
+One draining session retains its existing global agent slot across queued
+turns. The reservation ends when the queue empties or pauses. A paused queue
+must explicitly reacquire a slot on resume or retry; if the global cap is full,
+the existing cap refusal remains visible and the queue stays paused. There is
+no automatic global-cap waiting queue.
+
+The queue is process-memory-only and scoped to the mounted Console screen. It
+survives session, tab, and workspace switching inside that screen, but it is not
+serialized, persisted, restored after leaving Console, or replayed after an app
+restart. Closing a queued session, leaving Console, or quitting the app requires
+a count-aware confirmation before unsent prompts are discarded.
+
+Queueing begins only after the active turn crosses the existing accepted-send
+boundary. During provider and skill validation the action remains unavailable
+and reads `Preparing...`. Once accepted, the normal `Send` action becomes
+`Queue`; Enter and the button both enqueue the exact canonical text draft.
+Queue acceptance, not an attempted enqueue, clears the captured draft.
+
+Queued entries contain text only. Drafts carrying staged attachments or staged
+Library/RAG evidence are refused intact. Recognized slash commands are never
+queued; each command keeps its existing command-specific execution or refusal
+rules. Large pasted text and `$skill` messages remain valid text prompts.
+
+The queue pauses after a failed, stopped, context-invalidated, or pre-accept
+refused turn. Failed turns retry their existing assistant response before
+draining continues, with an explicit skip option. A stopped turn offers
+`Resume next` as the primary action and a separate `Retry stopped turn` action;
+the retry uses the existing regeneration path and keeps the stopped partial in
+history. A user may also request `Pause after this turn` without stopping the
+current response.
+
+Conversation lineage safety is based on a dedicated branch epoch owned by
+`ConsoleChatStore`, the authority for the active leaf and message tree. Linear
+user/assistant appends do not change that epoch. Rewind, sibling selection,
+delete, edit-and-resend, and branch creation do. A mismatch pauses the queue for
+review rather than silently sending prompts against a different branch.
+
+Background queue turns resolve provider, model, system prompt, workspace, and
+other per-turn settings for their owning session ID, never from the currently
+viewed tab. Intermediate queued completions do not emit finished markers or
+completion toasts. The session remains visibly running until the whole drain
+finishes or pauses.
+
+## Context
+
+Console already supports one active run per session and multiple sessions in
+parallel under a global cap. A user can continue typing while a long agent turn
+runs, but Send is disabled and a second same-session send is refused. Users who
+know their next steps must wait at the keyboard and manually submit each one.
+
+The parallel-agent design deliberately rejected a hidden queue because an idle
+tab blocked only by the global cap should not fire later without visible user
+control. This feature does not reverse that global-cap decision. It adds a
+different, visible contract for follow-up prompts in the same session whose
+accepted turn already owns an agent slot.
+
+Several existing boundaries make an implicit implementation unsafe:
+
+- The accepted-send callback is currently origin-agnostic and can clear the
+  visible composer. An automatic queued submission must never erase a new draft
+  the user is typing.
+- Provider selection is projected from the viewed session. A background queued
+  turn must resolve settings by owning session to prevent cross-tab leakage.
+- Run completion currently stamps background markers and toasts per turn. A
+  ten-prompt drain must not produce ten completion notifications or flicker
+  between finished and running.
+- Navigation guards currently count live runs only, and the app quit action does
+  not consult Console. Paused queues can contain unsent private text with no
+  active run.
+- The chat store already owns branching. A parallel queue-specific view of
+  lineage would drift from that authority.
+
+These are long-lived Console UX, application lifecycle, cross-module interface,
+and state-ownership decisions, so a canonical ADR is required.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Keep refusing same-session sends | Forces users to babysit long turns and does not meet the requested workflow. |
+| Combine queued text into one next user message | Loses the requested turn-by-turn assistant context and makes ordering semantics ambiguous. |
+| Own the queue in `ChatScreen` | Couples scheduling to mounted widgets and makes recomposition, background sessions, and teardown races harder to reason about. |
+| Store queues in `ConsoleChatStore` session records | Overstates durability and mixes transient scheduling with conversation and message storage. |
+| Persist queues in the database | Creates restart replay, privacy, migration, and stale-context problems not required for the feature. |
+| Queue idle tabs behind the global cap | Reintroduces the hidden delayed-send behavior the parallel-agent design explicitly rejected. |
+| Release the agent slot between every queued turn | Allows another tab to race into the gap and violates the approved immediate-drain behavior. |
+| Queue attachments and staged RAG evidence | Requires durable ownership and lifecycle rules for binary and source-authority payloads; text-only is the approved first version. |
+| Auto-continue after failure or Stop | Can cascade prompts through missing or deliberately interrupted context. |
+
+## Consequences
+
+### Benefits
+
+- Users can plan up to ten follow-up turns without waiting for each response.
+- Every queued prompt remains visible, editable, reorderable, removable, and
+  pausable before it starts.
+- Separate-turn semantics preserve the conversation context users expect.
+- Per-session ownership keeps parallel workspaces and providers isolated.
+- Explicit pause and recovery states prevent silent cascading after errors.
+- Process-memory scope avoids migrations, restart replay, and durable storage of
+  unsent private prompts.
+
+### Accepted Trade-offs
+
+- A ten-message drain may occupy one configured agent slot for a substantial
+  time.
+- Queues are lost after confirmed Console exit or app quit.
+- Attachments and staged evidence cannot be queued in the first version.
+- The app needs a generic asynchronous pre-quit confirmation seam and
+  reentrancy guard.
+- The chat store needs a branch epoch distinct from its broad payload revision.
+- Existing fleet and run-state derivations must become queue-aware through one
+  controller activity projection.
+
+### Verification Consequences
+
+The feature requires pure queue-state tests, joined controller tests, mounted
+Textual tests, application leave/quit tests, and isolated live verification.
+The most important guards must be mutation-checked: the limit, origin-aware
+composer clearing, stale-revision rejection, shutdown suppression,
+owning-session provider selection, and intermediate notification suppression.
+
+Unsent queue state must be absent from database persistence, prompt history,
+screen snapshots, and logs. Once an entry is accepted as a real turn, normal
+message persistence and prompt history apply.
+
+## Links
+
+- [Console Prompt Queue Design](../../Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md)
+- [Parallel Agents Across Workspaces Design](../../Docs/superpowers/specs/2026-07-26-parallel-agents-across-workspaces-design.md)
+- [ADR-011: Chatbook Workbench UI System](011-chatbook-workbench-ui-system.md)
+- [ADR-031: TUI Keybinding and Footer-Hint Conventions](031-tui-keybinding-and-footer-hint-conventions.md)
+- [ADR-033: Application Session State Ownership](033-application-session-state-ownership.md)

--- a/backlog/tasks/task-14802 - Add-a-Console-conversation-context-epoch.md
+++ b/backlog/tasks/task-14802 - Add-a-Console-conversation-context-epoch.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-14802
 title: Add a Console conversation-context epoch
-status: In Progress
+status: Done
 created_date: 2026-08-10 06:04
 labels:
 - console
@@ -14,7 +14,12 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
 - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
-updated_date: 2026-08-10 06:25
+updated_date: 2026-08-10 07:02
+modified_files:
+- tldw_chatbook/Chat/console_chat_store.py
+- Tests/Chat/test_console_conversation_context_epoch.py
+- Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+- Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
 ---
 
 ## Description
@@ -25,12 +30,13 @@ Give Console a store-owned, per-session signal for detecting provider-relevant c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 ConsoleChatStore exposes an isolated monotonic conversation-context epoch for every live session and removes its state when the session closes.
-- [ ] #2 The epoch advances for effective active-path content, lineage, selected textual variant, summary-boundary, rewind, delete, edit-resend, and regeneration changes.
-- [ ] #3 The epoch remains stable for ordinary linear appends, streaming and terminal status updates, persistence, feedback, display overlays, off-path edits, and idempotent same-value selections or writes.
-- [ ] #4 The epoch is process-memory-only and introduces no schema, persistence, snapshot, configuration, or logging changes.
-- [ ] #5 Focused store tests cover every provider-relevant mutation seam, session isolation, lifecycle cleanup, and mutation checks that prove the guards can fail.
-- [ ] #6 A successful failed-assistant retry advances the epoch exactly once when the row becomes provider-visible history, including same-text recovery; a failed or refused retry does not advance or authorize adoption.
+- [x] #1 ConsoleChatStore exposes an isolated monotonic conversation-context epoch for every live session and removes its state when the session closes.
+- [x] #2 The epoch advances for effective active-path content, lineage, selected textual variant, summary-boundary, rewind, delete, edit-resend, and regeneration changes.
+- [x] #3 The epoch remains stable for ordinary linear appends, streaming and terminal status updates, persistence, feedback, display overlays, off-path edits, and idempotent same-value selections or writes.
+- [x] #4 The epoch is process-memory-only and introduces no schema, persistence, snapshot, configuration, or logging changes.
+- [x] #5 Focused store tests cover every provider-relevant mutation seam, session isolation, lifecycle cleanup, and mutation checks that prove the guards can fail.
+- [x] #6 A failed-assistant retry advances the epoch exactly once when the row becomes provider-visible complete or stopped history, including same-text recovery; a failed or refused retry remains excluded and does not advance or authorize adoption.
+- [x] #7 Adding, removing, reordering, or selecting attachments on an active-path message advances the epoch when the future provider payload changes; equivalent off-path attachment mutations remain stable.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -52,15 +58,13 @@ Reason: This is a direct implementation of the accepted store-owned conversation
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Implemented a process-local, store-owned per-session conversation-context epoch with lifecycle initialization and cleanup. Semantic guards advance it only for effective active-path text, branch/leaf, summary, variant, failed-retry recovery, and generation-attachment changes; ordinary append/stream/status, off-path changes, metadata, persistence, and same-value operations remain stable. Added 16 focused contract tests plus manual mutation checks proving the active-path and same-value guards fail when inverted. Verification: 699 focused/reached tests passed; Ruff and git diff --check passed. The broader RuntimePolicy run had 343 passes and 12 skips plus six unrelated ambient failures (four MediaScreen mount timeouts and two AppleDouble source-scan decode failures). Full-tree collection is independently blocked by two existing Confluence imports requiring the absent optional playwright dependency. ADR: backlog/decisions/046-visible-bounded-console-prompt-queue.md. No schema, persistence, snapshot, configuration, or logging changes.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Added and verified the Console conversation-context epoch required for safe deferred prompt adoption, including active-path semantic guards, failed-retry visibility handling, attachment changes, lifecycle cleanup, and focused regression coverage.
 <!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 <!-- DOD:END -->

--- a/backlog/tasks/task-14802 - Add-a-Console-conversation-context-epoch.md
+++ b/backlog/tasks/task-14802 - Add-a-Console-conversation-context-epoch.md
@@ -14,7 +14,7 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
 - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
-updated_date: 2026-08-10 06:14
+updated_date: 2026-08-10 06:25
 ---
 
 ## Description
@@ -30,6 +30,7 @@ Give Console a store-owned, per-session signal for detecting provider-relevant c
 - [ ] #3 The epoch remains stable for ordinary linear appends, streaming and terminal status updates, persistence, feedback, display overlays, off-path edits, and idempotent same-value selections or writes.
 - [ ] #4 The epoch is process-memory-only and introduces no schema, persistence, snapshot, configuration, or logging changes.
 - [ ] #5 Focused store tests cover every provider-relevant mutation seam, session isolation, lifecycle cleanup, and mutation checks that prove the guards can fail.
+- [ ] #6 A successful failed-assistant retry advances the epoch exactly once when the row becomes provider-visible history, including same-text recovery; a failed or refused retry does not advance or authorize adoption.
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-14802 - Add-a-Console-conversation-context-epoch.md
+++ b/backlog/tasks/task-14802 - Add-a-Console-conversation-context-epoch.md
@@ -1,0 +1,65 @@
+---
+id: TASK-14802
+title: Add a Console conversation-context epoch
+status: In Progress
+created_date: 2026-08-10 06:04
+labels:
+- console
+- agents
+- architecture
+priority: high
+references:
+- backlog/decisions/046-visible-bounded-console-prompt-queue.md
+- backlog/decisions/033-application-session-state-ownership.md
+documentation:
+- Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+- Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+updated_date: 2026-08-10 06:14
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Give Console a store-owned, per-session signal for detecting provider-relevant conversation changes so deferred turns can fail closed without treating ordinary streaming or linear appends as context invalidation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ConsoleChatStore exposes an isolated monotonic conversation-context epoch for every live session and removes its state when the session closes.
+- [ ] #2 The epoch advances for effective active-path content, lineage, selected textual variant, summary-boundary, rewind, delete, edit-resend, and regeneration changes.
+- [ ] #3 The epoch remains stable for ordinary linear appends, streaming and terminal status updates, persistence, feedback, display overlays, off-path edits, and idempotent same-value selections or writes.
+- [ ] #4 The epoch is process-memory-only and introduces no schema, persistence, snapshot, configuration, or logging changes.
+- [ ] #5 Focused store tests cover every provider-relevant mutation seam, session isolation, lifecycle cleanup, and mutation checks that prove the guards can fail.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused red tests in Tests/Chat/test_console_conversation_context_epoch.py that characterize the current store mutation seams: session isolation and cleanup; active-path edit, selected variant, summary, leaf, branch, rewind, and delete changes; and stable linear append, stream/status, persistence, feedback, off-path, and idempotent operations.
+2. Add a process-memory per-session epoch map plus conversation_context_epoch(session_id) and one internal increment seam to ConsoleChatStore, initializing it for create/restore and purging it on close without changing persistence or snapshots.
+3. Wire the increment seam into the existing content, active-leaf, summary, variant, branch, and delete mutation boundaries using before/after effective-state checks so each semantic change increments once and no-op or off-path changes remain stable.
+4. Run the new tests red-to-green, then the existing Console store tree, summary, variant, retry/regenerate, rewind, persistence, and session-close suites reached by those mutations.
+5. Mutation-check the active-path edit and same-value guards with bytecode caches disabled or cleared, recording the exact new tests that turn red.
+6. Run Ruff on the changed Python files, full-tree pytest collection, and the architecture/runtime-policy inventories reachable from the store; compare any ambient failures using identical commands rather than counts.
+7. Self-review every ConsoleChatStore mutation that can change provider-visible history, update TASK-14802 acceptance criteria and implementation notes, and document any new generalizable testing lesson only if the implementation exposes one.
+
+ADR required: yes
+ADR path: backlog/decisions/046-visible-bounded-console-prompt-queue.md
+Reason: This is a direct implementation of the accepted store-owned conversation-context epoch in ADR-046, consistent with ADR-033 application-session state ownership; no new architectural decision is introduced.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-14803 - Capture-immutable-owning-session-Console-turn-context.md
+++ b/backlog/tasks/task-14803 - Capture-immutable-owning-session-Console-turn-context.md
@@ -1,0 +1,50 @@
+---
+id: TASK-14803
+title: Capture immutable owning-session Console turn context
+status: To Do
+created_date: 2026-08-10 06:04
+labels:
+- console
+- agents
+- architecture
+priority: high
+references:
+- backlog/decisions/046-visible-bounded-console-prompt-queue.md
+- backlog/decisions/033-application-session-state-ownership.md
+documentation:
+- Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+- Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+updated_date: 2026-08-10 06:14
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make every Console provider turn use one immutable execution context resolved for its owning session so background work cannot mix the viewed tab or mid-validation settings into a different session run.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A frozen Console turn-execution context captures the target session provider selection, capabilities, system prompt, workspace context and roots, generation parameters, RAG defaults, tool configuration, and other provider-payload settings.
+- [ ] #2 Manual send, retry, continue, regenerate, edit-resend, and summarize paths resolve the context from the owning session and thread the same instance through validation, payload construction, capability checks, fingerprinting, caching, and execution.
+- [ ] #3 Switching the viewed session or changing settings after capture cannot produce a mixed turn; completed changes apply to the following turn.
+- [ ] #4 Credentials, approval grants, skill trust, and other authority remain live runtime checks and are not retained in the execution context.
+- [ ] #5 Existing manual-send behavior and the no-argument submission-accepted compatibility hook remain intact, with no prompt-queue UI introduced by this task.
+- [ ] #6 Joined async tests use real production seams to prove cross-session provider, model, system-prompt, workspace, and settings isolation, including a settings change during validation.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-14803 - Capture-immutable-owning-session-Console-turn-context.md
+++ b/backlog/tasks/task-14803 - Capture-immutable-owning-session-Console-turn-context.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-14803
 title: Capture immutable owning-session Console turn context
-status: To Do
+status: Done
 created_date: 2026-08-10 06:04
 labels:
 - console
@@ -14,7 +14,7 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
 - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
-updated_date: 2026-08-10 06:26
+updated_date: 2026-08-10 08:01
 ---
 
 ## Description
@@ -25,27 +25,31 @@ Make every Console provider turn use one immutable execution context resolved fo
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A frozen Console turn-execution context captures the target session provider selection, capabilities, system prompt, workspace context and roots, generation parameters, RAG defaults, tool configuration, and other provider-payload settings.
-- [ ] #2 Manual send, retry, continue, regenerate, edit-resend, and summarize paths resolve the context from the owning session and thread the same instance through validation, payload construction, capability checks, fingerprinting, caching, and execution.
-- [ ] #3 Switching the viewed session or changing settings after capture cannot produce a mixed turn; completed changes apply to the following turn.
-- [ ] #4 Credentials, approval grants, skill trust, and other authority remain live runtime checks and are not retained in the execution context.
-- [ ] #5 Existing manual-send behavior and the no-argument submission-accepted compatibility hook remain intact, with no prompt-queue UI introduced by this task.
-- [ ] #6 Joined async tests use real production seams to prove cross-session provider, model, system-prompt, workspace, and settings isolation, including a settings change during validation.
-- [ ] #7 The frozen context is detached from mutable sources: later mutation or replacement of settings, mappings, sequences, roots, or workspace context cannot change captured turn inputs.
+- [x] #1 A frozen Console turn-execution context captures the target session provider selection, capabilities, system prompt, workspace context and roots, generation parameters, RAG defaults, tool configuration, and other provider-payload settings.
+- [x] #2 Manual send, retry, continue, regenerate, edit-resend, and summarize paths resolve the context from the owning session and thread the same instance through validation, payload construction, capability checks, fingerprinting, caching, and execution.
+- [x] #3 Switching the viewed session or changing settings after capture cannot produce a mixed turn; completed changes apply to the following turn.
+- [x] #4 Credentials, approval grants, skill trust, and other authority remain live runtime checks and are not retained in the execution context.
+- [x] #5 Existing manual-send behavior and the no-argument submission-accepted compatibility hook remain intact, with no prompt-queue UI introduced by this task.
+- [x] #6 Joined async tests use real production seams to prove cross-session provider, model, system-prompt, workspace, and settings isolation, including a settings change during validation.
+- [x] #7 The frozen context is detached from mutable sources: later mutation or replacement of settings, mappings, sequences, roots, or workspace context cannot change captured turn inputs.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Map every Console turn-entry and provider-payload seam that currently reads viewed-session or mutable settings, then add joined red tests for owning-session and mid-validation isolation.\n2. Add a focused frozen ConsoleTurnExecutionContext model that defensively detaches mappings, sequences, roots, workspace values, provider selection/capabilities, generation, RAG, and tool configuration while excluding credentials and live authority.\n3. Add one owning-session context resolver and thread the exact captured instance through manual send, retry, continue, regenerate, edit-resend, summarize, validation, payload construction, capability/fingerprint/cache logic, and provider or agent execution.\n4. Preserve one-shot and pinned prefill semantics, the no-argument submission-accepted compatibility hook, and all live credential, approval, and skill-trust checks; introduce no queue UI in this slice.\n5. Run focused red-to-green and mutation checks, then every reached provider-selection, payload, stream, workspace, RAG, retry/regenerate, run-state, ratchet, and import suite.\n6. Ruff the changed Python files, self-review for mutable-source leakage and cross-session reads, record any ambient failures, and complete TASK-14803 notes and acceptance criteria.\n\nADR required: yes\nADR path: backlog/decisions/046-visible-bounded-console-prompt-queue.md\nReason: This task directly implements the immutable owning-session execution-context boundary accepted by ADR-046 and follows ADR-033 ownership; no new architectural decision is introduced.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Implemented a detached frozen ConsoleTurnExecutionContext and an owning-session builder in ConsoleSessionController, then threaded one captured instance through send, retry, continue, regenerate, edit-resend, summarize, capability gates, payload construction, fingerprint/windowing, RAG capture, and direct/agent execution. Provider/model/system/workspace roots, generation values, RAG defaults, and tool-mode configuration are stable per turn; credentials, kill switches, approvals, trust, and cancellation remain live. Preserved the no-argument accepted-send callback and no queue UI was introduced. Verification: 14 focused context tests, 319 controller/action tests, 90 provider/model/generation tests, 148 of 149 agent/local/library tests, 7 mounted provider/settings checks, and 18 controller-wiring checks passed; targeted Ruff/compile checks passed. Both owning-selection and post-await payload guards were mutation-checked. Ambient failures reproduced independently: the Windows HOME-only expanduser test resolves USERPROFILE, the warning-sink test captures config first-use posture output, and the architecture ratchet is already exceeded by concurrent Console growth; the new builder was moved out of ChatScreen in response. ADR required: yes; existing ADR-046 implements the accepted boundary, with ADR-033 ownership, so no new ADR was created. Modified: tldw_chatbook/Chat/console_turn_context.py, console_chat_controller.py, console_agent_bridge.py, UI/Console_Modules/session.py, wiring.py, the smallest ChatScreen compatibility seams, and focused tests.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Console turns now execute from one immutable owning-session configuration snapshot, preventing tab switches or mid-validation settings changes from mixing provider inputs while keeping runtime authority live.
 <!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
 <!-- DOD:END -->

--- a/backlog/tasks/task-14803 - Capture-immutable-owning-session-Console-turn-context.md
+++ b/backlog/tasks/task-14803 - Capture-immutable-owning-session-Console-turn-context.md
@@ -14,7 +14,7 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
 - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
-updated_date: 2026-08-10 06:14
+updated_date: 2026-08-10 06:26
 ---
 
 ## Description
@@ -31,6 +31,7 @@ Make every Console provider turn use one immutable execution context resolved fo
 - [ ] #4 Credentials, approval grants, skill trust, and other authority remain live runtime checks and are not retained in the execution context.
 - [ ] #5 Existing manual-send behavior and the no-argument submission-accepted compatibility hook remain intact, with no prompt-queue UI introduced by this task.
 - [ ] #6 Joined async tests use real production seams to prove cross-session provider, model, system-prompt, workspace, and settings isolation, including a settings change during validation.
+- [ ] #7 The frozen context is detached from mutable sources: later mutation or replacement of settings, mappings, sequences, roots, or workspace context cannot change captured turn inputs.
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-14804 - Add-the-pure-bounded-Console-prompt-queue-registry.md
+++ b/backlog/tasks/task-14804 - Add-the-pure-bounded-Console-prompt-queue-registry.md
@@ -13,7 +13,7 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
 - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
-updated_date: 2026-08-10 06:14
+updated_date: 2026-08-10 06:30
 ---
 
 ## Description
@@ -31,6 +31,7 @@ Provide a deterministic process-memory owner for per-session queued prompt state
 - [ ] #5 All transitions are synchronous and event-loop-thread confined; foreign-thread access is rejected or marshalled by callers rather than protected by widget locks.
 - [ ] #6 The registry has no Textual, provider, database, snapshot, prompt-history, diagnostics, or logging dependency, and queued prompt bodies are never serialized.
 - [ ] #7 Pure tests cover capacity, FIFO, revisions, lifecycle, every pause and claim transition, and mutation checks for the ten-entry and stale-revision guards.
+- [ ] #8 Admission and edit precompute a sanitized one-line preview against a fixed maximum cell budget independent of viewport width; body-free snapshots reuse unchanged previews without traversing full prompt bodies, prompt-bearing representations and errors are redacted, and widgets crop the safe preview further after resize.
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-14804 - Add-the-pure-bounded-Console-prompt-queue-registry.md
+++ b/backlog/tasks/task-14804 - Add-the-pure-bounded-Console-prompt-queue-registry.md
@@ -1,0 +1,50 @@
+---
+id: TASK-14804
+title: Add the pure bounded Console prompt queue registry
+status: To Do
+created_date: 2026-08-10 06:04
+labels:
+- console
+- agents
+- architecture
+priority: high
+references:
+- backlog/decisions/046-visible-bounded-console-prompt-queue.md
+documentation:
+- Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+- Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+updated_date: 2026-08-10 06:14
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Provide a deterministic process-memory owner for per-session queued prompt state before controller scheduling or widgets depend on it.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The registry owns immutable text-only entries and render-safe snapshots with stable IDs, FIFO order, per-session isolation, and a hard capacity of ten across waiting plus claimed entries.
+- [ ] #2 Revision-checked admission, edit, move, remove, clear-waiting, claim, settle, return-to-head, pause, resume, reservation, closing, shutdown, and session-removal transitions reject stale or invalid intents without partial mutation.
+- [ ] #3 Claimed or starting entries cannot be edited, moved, removed, or cleared as waiting work, and new entries append behind all older work while paused.
+- [ ] #4 Queue state records the active-chain context baseline needed for first-admission and later context-review decisions without storing provider payloads or authority.
+- [ ] #5 All transitions are synchronous and event-loop-thread confined; foreign-thread access is rejected or marshalled by callers rather than protected by widget locks.
+- [ ] #6 The registry has no Textual, provider, database, snapshot, prompt-history, diagnostics, or logging dependency, and queued prompt bodies are never serialized.
+- [ ] #7 Pure tests cover capacity, FIFO, revisions, lifecycle, every pause and claim transition, and mutation checks for the ten-entry and stale-revision guards.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-14804 - Add-the-pure-bounded-Console-prompt-queue-registry.md
+++ b/backlog/tasks/task-14804 - Add-the-pure-bounded-Console-prompt-queue-registry.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-14804
 title: Add the pure bounded Console prompt queue registry
-status: To Do
+status: Done
 created_date: 2026-08-10 06:04
 labels:
 - console
@@ -13,7 +13,7 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
 - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
-updated_date: 2026-08-10 06:30
+updated_date: 2026-08-10 15:13
 ---
 
 ## Description
@@ -24,28 +24,40 @@ Provide a deterministic process-memory owner for per-session queued prompt state
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The registry owns immutable text-only entries and render-safe snapshots with stable IDs, FIFO order, per-session isolation, and a hard capacity of ten across waiting plus claimed entries.
-- [ ] #2 Revision-checked admission, edit, move, remove, clear-waiting, claim, settle, return-to-head, pause, resume, reservation, closing, shutdown, and session-removal transitions reject stale or invalid intents without partial mutation.
-- [ ] #3 Claimed or starting entries cannot be edited, moved, removed, or cleared as waiting work, and new entries append behind all older work while paused.
-- [ ] #4 Queue state records the active-chain context baseline needed for first-admission and later context-review decisions without storing provider payloads or authority.
-- [ ] #5 All transitions are synchronous and event-loop-thread confined; foreign-thread access is rejected or marshalled by callers rather than protected by widget locks.
-- [ ] #6 The registry has no Textual, provider, database, snapshot, prompt-history, diagnostics, or logging dependency, and queued prompt bodies are never serialized.
-- [ ] #7 Pure tests cover capacity, FIFO, revisions, lifecycle, every pause and claim transition, and mutation checks for the ten-entry and stale-revision guards.
-- [ ] #8 Admission and edit precompute a sanitized one-line preview against a fixed maximum cell budget independent of viewport width; body-free snapshots reuse unchanged previews without traversing full prompt bodies, prompt-bearing representations and errors are redacted, and widgets crop the safe preview further after resize.
+- [x] #1 The registry owns immutable text-only entries and render-safe snapshots with stable IDs, FIFO order, per-session isolation, and a hard capacity of ten across waiting plus claimed entries.
+- [x] #2 Revision-checked admission, edit, move, remove, clear-waiting, claim, settle, return-to-head, pause, resume, reservation, closing, shutdown, and session-removal transitions reject stale or invalid intents without partial mutation.
+- [x] #3 Claimed or starting entries cannot be edited, moved, removed, or cleared as waiting work, and new entries append behind all older work while paused.
+- [x] #4 Queue state records the active-chain context baseline needed for first-admission and later context-review decisions without storing provider payloads or authority.
+- [x] #5 All transitions are synchronous and event-loop-thread confined; foreign-thread access is rejected or marshalled by callers rather than protected by widget locks.
+- [x] #6 The registry has no Textual, provider, database, snapshot, prompt-history, diagnostics, or logging dependency, and queued prompt bodies are never serialized.
+- [x] #7 Pure tests cover capacity, FIFO, revisions, lifecycle, every pause and claim transition, and mutation checks for the ten-entry and stale-revision guards.
+- [x] #8 Admission and edit precompute a sanitized one-line preview against a fixed maximum cell budget independent of viewport width; body-free snapshots reuse unchanged previews without traversing full prompt bodies, prompt-bearing representations and errors are redacted, and widgets crop the safe preview further after resize.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add red pure tests for immutable IDs, FIFO/session isolation, capacity including claimed work, lifecycle transitions, revision checks, thread confinement, redacted previews/snapshots, and atomic final-empty admission routing. 2. Implement frozen queue models and a synchronous per-session ConsolePromptQueueRegistry with injected ID/clock producers, fixed-cell safe preview generation, revisioned body-free snapshots, context baseline, reservation, close/shutdown, and cleanup transitions. 3. Mutation-check the capacity and stale-revision guards; run focused, import-boundary, compile, and Ruff checks. 4. Self-review, document evidence, check all ACs, and mark Done. ADR required: yes. ADR path: backlog/decisions/046-visible-bounded-console-prompt-queue.md. Reason: ADR-046 already governs transient queue ownership and transition semantics; this task implements it without introducing a new decision.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Implemented a synchronous owner-thread-confined ConsolePromptQueueRegistry with immutable redacted entries and claims, per-session FIFO state, ten-entry waiting-plus-claimed capacity, revision-checked lifecycle transitions, context baselines, reservations, closing/shutdown cleanup, exact final-empty/admission rerouting, selected-entry text reads, and cached body-free snapshots. Added fixed-cell ANSI/control/Rich-safe preview generation and 34 pure tests covering lifecycle, isolation, locks, all pause reasons, race orderings, thread confinement, redaction, Unicode previews, dependency boundaries, and non-traversal of prompt bodies. Mutation checks: raising the cap to 11 failed test_capacity_counts_waiting_plus_claimed; bypassing admission revision checking failed both stale-intent tests. Verification: focused 34 passed; Ruff check and format check passed; py_compile passed. Broader Chat fail-fast reached 208 passed/1 skipped before the unrelated absent pytest-mock mocker fixture; full collection found 35,811 tests and only two existing Confluence collection errors from absent optional Playwright. ADR required: yes; implemented existing ADR-046, with no new ADR. No persistent format, database, prompt-history, diagnostic, logging, provider, Textual, or screen dependency was added.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Added the pure process-memory queue state machine required by ADR-046. It now provides the deterministic, privacy-bounded foundation for TASK-14805's coordinator without making the queue visible or persistent.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
+- [x] Acceptance criteria completed and implementation plan followed.
+- [x] Automated pure-state coverage added and both required guards mutation-checked.
+- [x] Ruff, Ruff format, and Python compilation checks pass for changed Python files.
+- [x] Broader regression and full collection blockers are documented as missing optional test dependencies, not change-attributable failures.
+- [x] ADR-046 reviewed and linked; no new ADR is required.
+- [x] Self-review completed, including exact queue-empty/admission race handling and selected-entry-only body reads.
+- [x] No new generalized lesson was needed; the task followed the existing mutation, collection, and backlog-hygiene lessons.
 <!-- DOD:END -->

--- a/backlog/tasks/task-14805 - Coordinate-sequential-Console-queued-turns.md
+++ b/backlog/tasks/task-14805 - Coordinate-sequential-Console-queued-turns.md
@@ -17,7 +17,7 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
 - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
-updated_date: 2026-08-10 06:14
+updated_date: 2026-08-10 06:26
 ---
 
 ## Description
@@ -36,6 +36,8 @@ Integrate the bounded queue with Console run ownership so accepted follow-up pro
 - [ ] #6 Queue-aware gates prevent unrelated Continue, Regenerate, Edit and resend, Summarize, or hands-free actions from bypassing older queued work while allowing non-generating history mutations to force context review.
 - [ ] #7 Session close and shutdown tombstone chains before cancellation can wake terminal callbacks, and the queue-empty admission race produces either one queued entry or one normal send, never a stranded or duplicate prompt.
 - [ ] #8 Joined controller tests prove ordered multi-turn drains, slot retention and reacquisition, session isolation, approval waits, authority revalidation, recovery paths, boundary races, and shutdown suppression against production signatures.
+- [ ] #9 Queue recovery crosses the generation gate only through a narrow internal typed authorization unavailable to unrelated actions; activity state distinguishes slot occupancy, preparation/validation, accepted live work, approval waits, queue presence, and pause state.
+- [ ] #10 Accepted queued prompts enter normal persistence and prompt history exactly once in accepted order; admission, edit, reorder, refused starts, and recovery selection do not write history, and the queue-empty admission race emits one final notification.
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-14805 - Coordinate-sequential-Console-queued-turns.md
+++ b/backlog/tasks/task-14805 - Coordinate-sequential-Console-queued-turns.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-14805
 title: Coordinate sequential Console queued turns
-status: To Do
+status: Done
 created_date: 2026-08-10 06:04
 dependencies:
 - TASK-14802
@@ -17,7 +17,7 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
 - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
-updated_date: 2026-08-10 06:26
+updated_date: 2026-08-10 16:02
 ---
 
 ## Description
@@ -28,30 +28,42 @@ Integrate the bounded queue with Console run ownership so accepted follow-up pro
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The controller coordinator admits queue work only behind an accepted live turn or existing queue, drains separate FIFO turns in one per-session chain, and retains exactly one global agent reservation until the queue empties or pauses.
-- [ ] #2 Manual and queued submission origins are explicit: the legacy no-argument acceptance hook fires only for manual sends, while queued acceptance emits a separate content-free session-and-entry event.
-- [ ] #3 Failure, Stop, context mismatch, staged-rider conflict, pre-accept refusal, and unexpected exceptions pause without prompt loss, duplication, reordering, or silent context adoption.
-- [ ] #4 Retry, Skip and resume, Resume next, Retry stopped turn, Keep draining, and Use current context and resume follow the approved recovery semantics and reacquire the global slot visibly when required.
-- [ ] #5 One controller activity projection drives cap accounting, busy counts, run markers, fleet summaries, polling, navigation warnings, and completion notification eligibility; intermediate queued turns do not look finished or emit completion toasts.
-- [ ] #6 Queue-aware gates prevent unrelated Continue, Regenerate, Edit and resend, Summarize, or hands-free actions from bypassing older queued work while allowing non-generating history mutations to force context review.
-- [ ] #7 Session close and shutdown tombstone chains before cancellation can wake terminal callbacks, and the queue-empty admission race produces either one queued entry or one normal send, never a stranded or duplicate prompt.
-- [ ] #8 Joined controller tests prove ordered multi-turn drains, slot retention and reacquisition, session isolation, approval waits, authority revalidation, recovery paths, boundary races, and shutdown suppression against production signatures.
-- [ ] #9 Queue recovery crosses the generation gate only through a narrow internal typed authorization unavailable to unrelated actions; activity state distinguishes slot occupancy, preparation/validation, accepted live work, approval waits, queue presence, and pause state.
-- [ ] #10 Accepted queued prompts enter normal persistence and prompt history exactly once in accepted order; admission, edit, reorder, refused starts, and recovery selection do not write history, and the queue-empty admission race emits one final notification.
+- [x] #1 The controller coordinator admits queue work only behind an accepted live turn or existing queue, drains separate FIFO turns in one per-session chain, and retains exactly one global agent reservation until the queue empties or pauses.
+- [x] #2 Manual and queued submission origins are explicit: the legacy no-argument acceptance hook fires only for manual sends, while queued acceptance emits a separate content-free session-and-entry event.
+- [x] #3 Failure, Stop, context mismatch, staged-rider conflict, pre-accept refusal, and unexpected exceptions pause without prompt loss, duplication, reordering, or silent context adoption.
+- [x] #4 Retry, Skip and resume, Resume next, Retry stopped turn, Keep draining, and Use current context and resume follow the approved recovery semantics and reacquire the global slot visibly when required.
+- [x] #5 One controller activity projection drives cap accounting, busy counts, run markers, fleet summaries, polling, navigation warnings, and completion notification eligibility; intermediate queued turns do not look finished or emit completion toasts.
+- [x] #6 Queue-aware gates prevent unrelated Continue, Regenerate, Edit and resend, Summarize, or hands-free actions from bypassing older queued work while allowing non-generating history mutations to force context review.
+- [x] #7 Session close and shutdown tombstone chains before cancellation can wake terminal callbacks, and the queue-empty admission race produces either one queued entry or one normal send, never a stranded or duplicate prompt.
+- [x] #8 Joined controller tests prove ordered multi-turn drains, slot retention and reacquisition, session isolation, approval waits, authority revalidation, recovery paths, boundary races, and shutdown suppression against production signatures.
+- [x] #9 Queue recovery crosses the generation gate only through a narrow internal typed authorization unavailable to unrelated actions; activity state distinguishes slot occupancy, preparation/validation, accepted live work, approval waits, queue presence, and pause state.
+- [x] #10 Accepted queued prompts enter normal persistence and prompt history exactly once in accepted order; admission, edit, reorder, refused starts, and recovery selection do not write history, and the queue-empty admission race emits one final notification.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Characterize the controller's accepted-send, terminal-outcome, run-slot, marker/notification, recovery, shutdown, and prompt-history seams with joined red tests against real signatures. 2. Add explicit submission origin, content-free queued-acceptance and activity models, plus a focused coordinator that owns per-session admission, chain draining, context checks, claims, reservation/recovery decisions, and shutdown suppression through the pure registry. 3. Integrate the coordinator into ConsoleChatController while preserving the manual acceptance hook, immutable owning-session turn contexts, live authority checks, exact persistence/history semantics, and existing non-queue behavior. 4. Gate competing generation and hands-free paths through one activity projection, then run focused/reached suites, mutation checks, architecture/static checks, and self-review. 5. Complete ACs, evidence, and task hygiene. ADR required: yes. ADR path: backlog/decisions/046-visible-bounded-console-prompt-queue.md. Reason: this task implements ADR-046's accepted controller/coordinator boundary and introduces no different architecture.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Implemented ADR-046's controller-owned queue coordinator with explicit manual/queued origins, content-free queued acceptance, accepted-turn identity/terminal metadata, one queue-aware activity projection, FIFO claim/settle drains, retained/reacquired slot reservations, typed internal recovery authority, recovery/context/rider/Stop/failure pauses, origin-aware owning-session RAG capture, competing-generation gates, exactly-once persistence/history, and close/shutdown tombstones with accepted-boundary revalidation. Added console_prompt_queue_coordinator.py, extended the queue registry recovery epoch transition, integrated ConsoleChatController/models, added joined coordinator tests, and corrected live Auto-RAG setting capture in ConsoleSessionController. ADR required: yes; implemented existing backlog/decisions/046-visible-bounded-console-prompt-queue.md; no new ADR. Verification: 217 focused queue/controller tests passed; 168 reached queue/run-marker/Stop/attachment/history/MCP tests passed; 44 agent-runtime tests passed; 18 joined coordinator tests passed; mounted same-send Auto-RAG proof passed. Ruff check (scoped, ignoring two pre-existing E721 exact-type checks), Ruff format check for new/focused files, py_compile, and diff check passed. Mutations disabling shutdown accepted-boundary revalidation and inverting the context-epoch comparison both made their focused tests fail, then restored green. Broader Architecture suite has unrelated existing blockers: stale blocking-I/O baseline entries and a UTF-8 decode failure in the diagnostic inventory caused by another workspace file; full Auto-RAG suite has one pre-existing one-argument fake-hook compatibility failure already present in HEAD. No lesson entry added: no new generalizable incident beyond ADR/spec rules.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Console can now coordinate bounded per-session prompt queues as sequential real turns with explicit origins, one-slot chain ownership, visible pause/recovery semantics, queue-aware fleet activity, safe shutdown/close ordering, and exactly-once normal persistence. Direct controller APIs and joined tests are ready for TASK-14806 lifecycle loss guards and TASK-14808 mounted queue UX.
 <!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
+- [x] #1 All acceptance criteria are checked
+- [x] #2 Implementation follows ADR-046 and the recorded plan
+- [x] #3 Joined unit and integration tests cover new behavior
+- [x] #4 Scoped static analysis, formatting, compile, and diff checks pass
+- [x] #5 Relevant Superpowers plan documentation is updated
+- [x] #6 Implementation notes and final summary record approach and evidence
+- [x] #7 Self-review and mutation checks are complete
+- [x] #8 Unrelated workspace changes and known baseline failures are documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-14805 - Coordinate-sequential-Console-queued-turns.md
+++ b/backlog/tasks/task-14805 - Coordinate-sequential-Console-queued-turns.md
@@ -1,0 +1,55 @@
+---
+id: TASK-14805
+title: Coordinate sequential Console queued turns
+status: To Do
+created_date: 2026-08-10 06:04
+dependencies:
+- TASK-14802
+- TASK-14803
+- TASK-14804
+labels:
+- console
+- agents
+- architecture
+priority: high
+references:
+- backlog/decisions/046-visible-bounded-console-prompt-queue.md
+documentation:
+- Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+- Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+updated_date: 2026-08-10 06:14
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Integrate the bounded queue with Console run ownership so accepted follow-up prompts drain sequentially with explicit pause and recovery behavior while preserving per-session and global-cap guarantees.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The controller coordinator admits queue work only behind an accepted live turn or existing queue, drains separate FIFO turns in one per-session chain, and retains exactly one global agent reservation until the queue empties or pauses.
+- [ ] #2 Manual and queued submission origins are explicit: the legacy no-argument acceptance hook fires only for manual sends, while queued acceptance emits a separate content-free session-and-entry event.
+- [ ] #3 Failure, Stop, context mismatch, staged-rider conflict, pre-accept refusal, and unexpected exceptions pause without prompt loss, duplication, reordering, or silent context adoption.
+- [ ] #4 Retry, Skip and resume, Resume next, Retry stopped turn, Keep draining, and Use current context and resume follow the approved recovery semantics and reacquire the global slot visibly when required.
+- [ ] #5 One controller activity projection drives cap accounting, busy counts, run markers, fleet summaries, polling, navigation warnings, and completion notification eligibility; intermediate queued turns do not look finished or emit completion toasts.
+- [ ] #6 Queue-aware gates prevent unrelated Continue, Regenerate, Edit and resend, Summarize, or hands-free actions from bypassing older queued work while allowing non-generating history mutations to force context review.
+- [ ] #7 Session close and shutdown tombstone chains before cancellation can wake terminal callbacks, and the queue-empty admission race produces either one queued entry or one normal send, never a stranded or duplicate prompt.
+- [ ] #8 Joined controller tests prove ordered multi-turn drains, slot retention and reacquisition, session isolation, approval waits, authority revalidation, recovery paths, boundary races, and shutdown suppression against production signatures.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-14806 - Guard-Console-queues-across-close-navigation-and-quit.md
+++ b/backlog/tasks/task-14806 - Guard-Console-queues-across-close-navigation-and-quit.md
@@ -16,7 +16,7 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
 - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
-updated_date: 2026-08-10 06:11
+updated_date: 2026-08-10 06:31
 ---
 
 ## Description
@@ -33,6 +33,9 @@ Protect process-memory queued prompts at every user-initiated loss boundary befo
 - [ ] #5 Quit approval marks controller shutdown before cancellation and cleanup; Stay or confirmation errors fail closed, clear the reentrancy guard, and preserve the mounted Console and all unsent state.
 - [ ] #6 Lifecycle tests prove exact counts, one dialog and cleanup pass, empty-transcript validation windows, cancellation-after-tombstone suppression, repeated quit handling, and failure preservation.
 - [ ] #7 The lifecycle integration adds no queue persistence and unsent prompt text remains absent from snapshots, prompt history, diagnostics, logs, and application-level state.
+- [ ] #8 Lifecycle counts are a revisioned immutable aggregate derived from the controller activity projection, not a second mutable owner; session close is pinned to its requested session ID and close, leave, and quit revalidate after confirmation, failing closed if impact changed.
+- [ ] #9 Every user-initiated in-app exit entry point uses the async quit guard; startup password cancellation and signal or forced termination remain explicitly outside the interactive guarantee.
+- [ ] #10 Approved quit keeps blocking cache and configuration persistence and timed joins off the Textual event loop, marshals app-owned state and final exit correctly, preserves cleanup ordering, and remains responsive with exactly one cleanup pass.
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-14806 - Guard-Console-queues-across-close-navigation-and-quit.md
+++ b/backlog/tasks/task-14806 - Guard-Console-queues-across-close-navigation-and-quit.md
@@ -1,0 +1,52 @@
+---
+id: TASK-14806
+title: Guard Console queues across close, navigation, and quit
+status: To Do
+created_date: 2026-08-10 06:04
+dependencies:
+- TASK-14805
+labels:
+- console
+- agents
+- ux
+priority: high
+references:
+- backlog/decisions/046-visible-bounded-console-prompt-queue.md
+- backlog/decisions/033-application-session-state-ownership.md
+documentation:
+- Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+- Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+updated_date: 2026-08-10 06:11
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Protect process-memory queued prompts at every user-initiated loss boundary before the mounted queue interface makes them reachable.
+<!-- SECTION:DESCRIPTION:END -->
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 One queue-aware lifecycle projection reports exact live-run, queued-session, and unsent-prompt counts, including a claimed pre-accept entry, without describing paused queues as running agents.
+- [ ] #2 Session close uses one combined transcript, live-turn, and queued-prompt confirmation, including an empty transcript with live or queued work; Stay preserves all state and confirmed close tombstones before Stop or cancellation.
+- [ ] #3 Leaving Console consults the same count-aware projection and proceeds only after approval, while Stay preserves runs, queues, claims, and recovery state.
+- [ ] #4 TldwCli.action_quit remains a thin non-blocking dispatcher into one exclusive asynchronous pre-quit confirmation worker guarded against repeated requests.
+- [ ] #5 Quit approval marks controller shutdown before cancellation and cleanup; Stay or confirmation errors fail closed, clear the reentrancy guard, and preserve the mounted Console and all unsent state.
+- [ ] #6 Lifecycle tests prove exact counts, one dialog and cleanup pass, empty-transcript validation windows, cancellation-after-tombstone suppression, repeated quit handling, and failure preservation.
+- [ ] #7 The lifecycle integration adds no queue persistence and unsent prompt text remains absent from snapshots, prompt history, diagnostics, logs, and application-level state.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-14806 - Guard-Console-queues-across-close-navigation-and-quit.md
+++ b/backlog/tasks/task-14806 - Guard-Console-queues-across-close-navigation-and-quit.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-14806
 title: Guard Console queues across close, navigation, and quit
-status: To Do
+status: Done
 created_date: 2026-08-10 06:04
 dependencies:
 - TASK-14805
@@ -16,7 +16,7 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
 - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
-updated_date: 2026-08-10 06:31
+updated_date: 2026-08-10 16:55
 ---
 
 ## Description
@@ -26,30 +26,82 @@ Protect process-memory queued prompts at every user-initiated loss boundary befo
 <!-- SECTION:DESCRIPTION:END -->
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One queue-aware lifecycle projection reports exact live-run, queued-session, and unsent-prompt counts, including a claimed pre-accept entry, without describing paused queues as running agents.
-- [ ] #2 Session close uses one combined transcript, live-turn, and queued-prompt confirmation, including an empty transcript with live or queued work; Stay preserves all state and confirmed close tombstones before Stop or cancellation.
-- [ ] #3 Leaving Console consults the same count-aware projection and proceeds only after approval, while Stay preserves runs, queues, claims, and recovery state.
-- [ ] #4 TldwCli.action_quit remains a thin non-blocking dispatcher into one exclusive asynchronous pre-quit confirmation worker guarded against repeated requests.
-- [ ] #5 Quit approval marks controller shutdown before cancellation and cleanup; Stay or confirmation errors fail closed, clear the reentrancy guard, and preserve the mounted Console and all unsent state.
-- [ ] #6 Lifecycle tests prove exact counts, one dialog and cleanup pass, empty-transcript validation windows, cancellation-after-tombstone suppression, repeated quit handling, and failure preservation.
-- [ ] #7 The lifecycle integration adds no queue persistence and unsent prompt text remains absent from snapshots, prompt history, diagnostics, logs, and application-level state.
-- [ ] #8 Lifecycle counts are a revisioned immutable aggregate derived from the controller activity projection, not a second mutable owner; session close is pinned to its requested session ID and close, leave, and quit revalidate after confirmation, failing closed if impact changed.
-- [ ] #9 Every user-initiated in-app exit entry point uses the async quit guard; startup password cancellation and signal or forced termination remain explicitly outside the interactive guarantee.
-- [ ] #10 Approved quit keeps blocking cache and configuration persistence and timed joins off the Textual event loop, marshals app-owned state and final exit correctly, preserves cleanup ordering, and remains responsive with exactly one cleanup pass.
+- [x] #1 One queue-aware lifecycle projection reports exact live-run, queued-session, and unsent-prompt counts, including a claimed pre-accept entry, without describing paused queues as running agents.
+- [x] #2 Session close uses one combined transcript, live-turn, and queued-prompt confirmation, including an empty transcript with live or queued work; Stay preserves all state and confirmed close tombstones before Stop or cancellation.
+- [x] #3 Leaving Console consults the same count-aware projection and proceeds only after approval, while Stay preserves runs, queues, claims, and recovery state.
+- [x] #4 TldwCli.action_quit remains a thin non-blocking dispatcher into one exclusive asynchronous pre-quit confirmation worker guarded against repeated requests.
+- [x] #5 Quit approval marks controller shutdown before cancellation and cleanup; Stay or confirmation errors fail closed, clear the reentrancy guard, and preserve the mounted Console and all unsent state.
+- [x] #6 Lifecycle tests prove exact counts, one dialog and cleanup pass, empty-transcript validation windows, cancellation-after-tombstone suppression, repeated quit handling, and failure preservation.
+- [x] #7 The lifecycle integration adds no queue persistence and unsent prompt text remains absent from snapshots, prompt history, diagnostics, logs, and application-level state.
+- [x] #8 Lifecycle counts are a revisioned immutable aggregate derived from the controller activity projection, not a second mutable owner; session close is pinned to its requested session ID and close, leave, and quit revalidate after confirmation, failing closed if impact changed.
+- [x] #9 Every user-initiated in-app exit entry point uses the async quit guard; startup password cancellation and signal or forced termination remain explicitly outside the interactive guarantee.
+- [x] #10 Approved quit keeps blocking cache and configuration persistence and timed joins off the Textual event loop, marshals app-owned state and final exit correctly, preserves cleanup ordering, and remains responsive with exactly one cleanup pass.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Characterize existing controller activity, session close, Console navigation, and application quit boundaries with focused tests.
+2. Add a revisioned immutable lifecycle-impact aggregate derived only from controller activity, including claimed entries and paused queues.
+3. Integrate revision-pinned combined session-close and Console-leave confirmations that revalidate before destructive actions and fail closed.
+4. Refactor application quit into one guarded async dispatcher, tombstone shutdown before cancellation, and keep blocking cleanup off the Textual event loop.
+5. Inventory user-initiated quit entry points and add reached lifecycle, privacy, responsiveness, and mutation-checked regression tests.
+6. Run focused and reached verification, static checks, architecture ratchets, self-review, and complete Backlog notes and DoD.
+
+ADR required: no
+ADR path: backlog/decisions/046-visible-bounded-console-prompt-queue.md and backlog/decisions/033-application-session-state-ownership.md
+Reason: The accepted ADRs already define transient queue ownership, count-aware loss guards, and thin application coordination without a new root state owner.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented one immutable, content-free `ConsoleLifecycleImpact` derived from the
+existing controller activity projection, with fleet and per-session revision fences.
+Session close and Console leave now show combined exact counts, hide prompt bodies,
+pin the requested session, and re-present updated impact when activity changes.
 
+Refactored application quit into a guarded exclusive worker. Approval tombstones
+Console queue work before cancellation, audio/timer cleanup stays on the app loop,
+and timed cache/config persistence runs through `asyncio.to_thread`; Stay and
+confirmation errors preserve state. The only interactive in-app exit is the global
+`ctrl+q`/`action_quit` route. Startup password-app exits and process signal
+`os._exit` remain outside this interactive contract.
+
+Added controller, mounted close/navigation, and quit tests covering claimed and
+paused counts, empty transcripts, prompt-text privacy, stale confirmation windows,
+close/shutdown tombstone ordering, repeated requests, failure preservation,
+off-loop persistence, and loop responsiveness. Ruff and `git diff --check` pass.
+Reached suites passed (56 queue/controller tests, 11 final quit/close/config tests,
+4 mounted close tests, and 4 navigation tests).
+The screen ratchet was run; its pre-existing budget is already red at 17,727 versus
+the 19,211-line branch baseline. This change reduces `chat_screen.py` to 19,168
+lines (-43) and does not raise the ratchet. The full button-routing file also retains
+one unrelated existing section-collapse expectation failure; all four reached close
+tests pass independently.
+
+ADR required: no. ADR-046 and ADR-033 already define the transient queue ownership,
+loss-boundary confirmation, and application coordination used here.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Console queued prompts are now protected across session close, Console navigation,
+and application quit by exact, revision-pinned loss confirmations and tombstone-first
+teardown. Approved quit remains responsive and exactly-once; rejected or failed
+confirmation preserves the mounted Console and all unsent work.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
+- [x] All acceptance criteria completed.
+- [x] Implementation plan followed; verification exceptions documented above.
+- [x] Automated lifecycle, controller, mounted UI, navigation, and persistence tests added and passed.
+- [x] Ruff and whitespace/static checks passed.
+- [x] Relevant prompt-queue plan and task documentation updated.
+- [x] Self-review completed; no prompt bodies added to projections, logs, or persistence.
+- [x] No feature regression found; known baseline ratchet and unrelated browser-toggle failures documented.
+- [x] No generalizable new lesson was produced beyond the existing testing and live-verification guidance.
+- [x] ADR check completed against ADR-046 and ADR-033; no new ADR required.
 <!-- DOD:END -->

--- a/backlog/tasks/task-14808 - Deliver-the-visible-Console-prompt-queue-experience.md
+++ b/backlog/tasks/task-14808 - Deliver-the-visible-Console-prompt-queue-experience.md
@@ -1,22 +1,23 @@
 ---
 id: TASK-14808
 title: Deliver the visible Console prompt queue experience
-status: To Do
-created_date: 2026-08-10 06:11
-dependencies:
-- TASK-14806
+status: Done
+assignee: []
+created_date: '2026-08-10 06:11'
+updated_date: '2026-08-10 20:32'
 labels:
-- console
-- agents
-- ux
-priority: high
+  - console
+  - agents
+  - ux
+dependencies:
+  - TASK-14806
 references:
-- backlog/decisions/046-visible-bounded-console-prompt-queue.md
-- backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md
+  - backlog/decisions/046-visible-bounded-console-prompt-queue.md
+  - backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md
 documentation:
-- Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
-- Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
-updated_date: 2026-08-10 06:26
+  - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+  - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+priority: high
 ---
 
 ## Description
@@ -27,20 +28,65 @@ Expose the already-safe bounded queue through an honest keyboard-first Console s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 After a turn is accepted, Send becomes Queue and Enter or the button admits the exact text draft; Preparing, Queue full, Send, slash-command, attachment, staged-evidence, and boundary-race states use the approved routing and preserve refused drafts exactly.
-- [ ] #2 A one-row queue shelf and focused manager expose count, state, safe previews, edit, reorder, remove, clear waiting, pause, resume, retry, skip, resume next, retry stopped turn, review, and current-context confirmation with stable focus and stale-revision recovery.
-- [ ] #3 Collapsed and background presentations reveal only content-free counts and states; previews strip controls, escape Rich markup, and truncate by terminal cell width, while full prompt text is fetched only for the entry actively edited.
-- [ ] #4 Composer, mouse, keyboard, voice, hands-free, and programmatic sends share one UI dispatcher and one exact per-session Textual chain worker, while chat_screen size and method ratchets do not increase.
-- [ ] #5 F1 help, fleet and session markers, Console user guides, collapsed-composer documentation, and close, leave, and quit documentation match the shipped queue vocabulary and controls.
-- [ ] #6 Mounted tests prove rendering, key routing, draft transactions, revision-gated polling, safe previews, privacy, lifecycle-dialog integration, and neighboring control geometry at 80x24, 100x30, and 160x40.
-- [ ] #7 An isolated live-provider walkthrough verifies sequential draining, management, approval, pause, failure, Stop recovery, background isolation, one final notification, and close, leave, and quit warnings.
-- [ ] #8 Unsent queue text remains absent from database persistence, screen snapshots, prompt history, diagnostics, and logs; accepted queued turns persist through the normal message path.
-- [ ] #9 The manager remains pinned to its owning session ID and queue revision across tab switches, never retargets intents to the viewed session, and renders precomputed previews without fetching unselected prompt bodies.
+- [x] #1 After a turn is accepted, Send becomes Queue and Enter or the button admits the exact text draft; Preparing, Queue full, Send, slash-command, attachment, staged-evidence, and boundary-race states use the approved routing and preserve refused drafts exactly.
+- [x] #2 A one-row queue shelf and focused manager expose count, state, safe previews, edit, reorder, remove, clear waiting, pause, resume, retry, skip, resume next, retry stopped turn, review, and current-context confirmation with stable focus and stale-revision recovery.
+- [x] #3 Collapsed and background presentations reveal only content-free counts and states; previews strip controls, escape Rich markup, and truncate by terminal cell width, while full prompt text is fetched only for the entry actively edited.
+- [x] #4 Composer, mouse, keyboard, voice, hands-free, and programmatic sends share one UI dispatcher and one exact per-session Textual chain worker, while chat_screen size and method ratchets do not increase.
+- [x] #5 F1 help, fleet and session markers, Console user guides, collapsed-composer documentation, and close, leave, and quit documentation match the shipped queue vocabulary and controls.
+- [x] #6 Mounted tests prove rendering, key routing, draft transactions, revision-gated polling, safe previews, privacy, lifecycle-dialog integration, and neighboring control geometry at 80x24, 100x30, and 160x40.
+- [x] #7 An isolated live-provider walkthrough verifies sequential draining, management, approval, pause, failure, Stop recovery, background isolation, one final notification, and close, leave, and quit warnings.
+- [x] #8 Unsent queue text remains absent from database persistence, screen snapshots, prompt history, diagnostics, and logs; accepted queued turns persist through the normal message path.
+- [x] #9 The manager remains pinned to its owning session ID and queue revision across tab switches, never retargets intents to the viewed session, and renders precomputed previews without fetching unselected prompt bodies.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Characterize the current composer, session-tab, conversation-row, send, voice, hands-free, help, and geometry seams; TASK-14801's intended Console reference is unavailable because that ID is occupied by unrelated roleplay work, so use the current mounted code as authority and document exact mount points.\n2. Add ConsolePromptQueueRegion and ConsolePromptQueueUIController under UI/Console_Modules, wire them with late-bound dependencies, and keep chat_screen.py limited to shrinking compatibility delegation.\n3. Join Enter/button/voice/hands-free/programmatic draft dispatch to typed sent/queued/refused outcomes with exact stash restoration and one per-session chain worker.\n4. Add the session-pinned revision-aware manager modal and all edit/reorder/remove/clear/pause/resume/retry/skip/context-review recovery actions while materializing only the actively edited prompt body.\n5. Integrate shelf, collapsed/background labels, F1 help, marker legend, lifecycle focus preservation, responsive TCSS, and user documentation without a new shortcut or setting.\n6. Add pure/mounted/joined/lifecycle/privacy/geometry tests, run mutation checks and reached suites, then complete isolated live verification, backlog notes, DoD, and final program audit.\n\nADR required: no new ADR\nADR path: backlog/decisions/046-visible-bounded-console-prompt-queue.md and backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md\nReason: ADR-046 already fixes ownership, interaction, recovery, privacy, and lifecycle behavior; ADR-031 fixes the keyboard and help constraints.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+- Added the body-free queue presentation/controller seam, always-mounted shelf,
+  session-pinned revision-aware manager, exact draft transaction handling, and one
+  per-session Textual chain worker. Queue admission validates before mutation; refused
+  and pre-acceptance races preserve the exact draft transaction.
+- Joined Enter/button/dictation/hands-free/programmatic paths, added content-free Qn
+  session and conversation markers, and kept full prompt bodies out of background,
+  collapsed, persistence, history, diagnostics, and app-log surfaces.
+- Added state-specific failure/Stop/context recovery, destructive confirmations,
+  current-context review fencing, background-session retry correctness, narrow-terminal
+  manager geometry, and user/F1/lifecycle documentation.
+- Live QA used an isolated `task14808_live_queue` profile and localhost delayed
+  OpenAI-compatible endpoint. It verified preparing-race refusal, ordered draining,
+  manager rendering, pause-after-turn/resume, Stop, accepted-turn persistence, and
+  absence of queued canaries from app stdout/stderr. It found and fixed a handoff gap
+  where an occupied-but-not-yet-accepted slot briefly advertised Send; that state now
+  renders Preparing. Temporary servers and the 7,942 generated QA/test artifacts were
+  stopped and removed after verification.
+- A second isolated `task14808_live_openai` walkthrough exercised native OpenAI tool
+  calls with local tools enabled. A real `list_characters` call mounted the approval
+  card; a background tab exposed only `Q3` plus the approval marker; approval timeout
+  left the stopped turn available for separate retry while the queue advanced
+  `3 -> 2 -> 1`. Session close reported transcript/live-turn/unsent-prompt counts,
+  and leave and quit each presented their queue-loss warnings while Stay preserved
+  the work.
+- Verification: 24 coordinator tests, 34 registry tests, 34 focused UI tests, 20
+  selected controller tests, 18 core mounted queue tests, a 41-test bounded changed-
+  seam pass, the full 69-test workspace-context file, and both live walkthroughs.
+  The final review also made the existing stylesheet assertion read UTF-8 explicitly,
+  eliminating a Windows cp1252 collection/runtime failure. Full-tree collection succeeds after
+  installing the declared `playwright` and `trafilatura` web-search dependencies.
+  Focused Ruff, Python compilation, and `git diff --check` pass. The feature leaves
+  `chat_screen.py` at its branch-start line count and the same 625 methods. The
+  repository's stale absolute screen ratchet still reports 19,167
+  versus 17,727 even though this branch reduces the screen by one line; an unrelated
+  browser-toggle characterization still differs from the controller state it
+  asserts.
+
+ADR required: no new ADR. ADR-046 and ADR-031 remain the governing decisions.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
@@ -48,8 +94,20 @@ Expose the already-safe bounded queue through an honest keyboard-first Console s
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 
+The visible Console prompt queue is implemented, documented, live-verified, and green
+across its focused and repository-collection verification gates. It is bounded to ten
+per session, preserves refused drafts, drains sequentially, keeps unsent text
+process-memory-only, and protects queued work across session close, Console leave, and
+application quit.
+
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
+- [x] All acceptance criteria are complete and implementation deviations are recorded.
+- [x] Automated pure, coordinator, mounted UI, lifecycle, privacy, and geometry tests cover the feature.
+- [x] Focused Ruff, Python compilation, diff validation, and full-tree collection pass.
+- [x] Console user guides, F1/help vocabulary, ADR links, and implementation notes are current.
+- [x] Self-review and isolated live-provider verification are complete.
+- [x] No new lesson entry is required; the live handoff gap is captured in these implementation notes and its regression test.
 <!-- DOD:END -->

--- a/backlog/tasks/task-14808 - Deliver-the-visible-Console-prompt-queue-experience.md
+++ b/backlog/tasks/task-14808 - Deliver-the-visible-Console-prompt-queue-experience.md
@@ -1,0 +1,53 @@
+---
+id: TASK-14808
+title: Deliver the visible Console prompt queue experience
+status: To Do
+created_date: 2026-08-10 06:11
+dependencies:
+- TASK-14806
+labels:
+- console
+- agents
+- ux
+priority: high
+references:
+- backlog/decisions/046-visible-bounded-console-prompt-queue.md
+- backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md
+documentation:
+- Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
+- Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expose the already-safe bounded queue through an honest keyboard-first Console shelf and manager, document it, and prove the complete experience live.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 After a turn is accepted, Send becomes Queue and Enter or the button admits the exact text draft; Preparing, Queue full, Send, slash-command, attachment, staged-evidence, and boundary-race states use the approved routing and preserve refused drafts exactly.
+- [ ] #2 A one-row queue shelf and focused manager expose count, state, safe previews, edit, reorder, remove, clear waiting, pause, resume, retry, skip, resume next, retry stopped turn, review, and current-context confirmation with stable focus and stale-revision recovery.
+- [ ] #3 Collapsed and background presentations reveal only content-free counts and states; previews strip controls, escape Rich markup, and truncate by terminal cell width, while full prompt text is fetched only for the entry actively edited.
+- [ ] #4 Composer, mouse, keyboard, voice, hands-free, and programmatic sends share one UI dispatcher and one exact per-session Textual chain worker, while chat_screen size and method ratchets do not increase.
+- [ ] #5 F1 help, fleet and session markers, Console user guides, collapsed-composer documentation, and close, leave, and quit documentation match the shipped queue vocabulary and controls.
+- [ ] #6 Mounted tests prove rendering, key routing, draft transactions, revision-gated polling, safe previews, privacy, lifecycle-dialog integration, and neighboring control geometry at 80x24, 100x30, and 160x40.
+- [ ] #7 An isolated live-provider walkthrough verifies sequential draining, management, approval, pause, failure, Stop recovery, background isolation, one final notification, and close, leave, and quit warnings.
+- [ ] #8 Unsent queue text remains absent from database persistence, screen snapshots, prompt history, diagnostics, and logs; accepted queued turns persist through the normal message path.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-14808 - Deliver-the-visible-Console-prompt-queue-experience.md
+++ b/backlog/tasks/task-14808 - Deliver-the-visible-Console-prompt-queue-experience.md
@@ -16,6 +16,7 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-08-09-console-prompt-queue-design.md
 - Docs/superpowers/plans/2026-08-09-console-prompt-queue.md
+updated_date: 2026-08-10 06:26
 ---
 
 ## Description
@@ -34,6 +35,7 @@ Expose the already-safe bounded queue through an honest keyboard-first Console s
 - [ ] #6 Mounted tests prove rendering, key routing, draft transactions, revision-gated polling, safe previews, privacy, lifecycle-dialog integration, and neighboring control geometry at 80x24, 100x30, and 160x40.
 - [ ] #7 An isolated live-provider walkthrough verifies sequential draining, management, approval, pause, failure, Stop recovery, background isolation, one final notification, and close, leave, and quit warnings.
 - [ ] #8 Unsent queue text remains absent from database persistence, screen snapshots, prompt history, diagnostics, and logs; accepted queued turns persist through the normal message path.
+- [ ] #9 The manager remains pinned to its owning session ID and queue revision across tab switches, never retargets intents to the viewed session, and renders precomputed previews without fetching unselected prompt bodies.
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1604,6 +1604,7 @@ class ConsoleAgentBridge:
         # `AgentService(revoke_approvals=...)`; `None` (a caller with no UI)
         # leaves cancellation exactly as it was.
         revoke_approvals: Callable[[str], object] | None = None,
+        native_tools_enabled: bool | None = None,
     ) -> tuple[str, RunOutcome]:
         # Per-run tool registry + allow-list (Task 12, extended by P5-T6 for
         # MCP, by task-545/T6 for a per-run builtin_gate, and extended again
@@ -1956,9 +1957,13 @@ class ConsoleAgentBridge:
         # no predicate (fakes/tests that never pass one) defaults to
         # always-on, matching the pre-kill-switch behavior.
         native_tools = (
-            True
-            if self._native_tools_enabled is None
-            else bool(self._native_tools_enabled())
+            bool(native_tools_enabled)
+            if native_tools_enabled is not None
+            else (
+                True
+                if self._native_tools_enabled is None
+                else bool(self._native_tools_enabled())
+            )
         )
         config = AgentConfig(
             model=model,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -6,6 +6,7 @@ import asyncio
 import copy
 import functools
 import hashlib
+import inspect
 import os
 import re
 import threading
@@ -39,6 +40,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleRunState,
     ConsoleRunStatus,
     ConsoleStagedSource,
+    ConsoleWorkspaceContext,
     MessageAttachment,
     derive_console_session_title,
     fold_greeting_into_system_prompt,
@@ -105,6 +107,7 @@ from tldw_chatbook.Chat.console_roleplay_identity import (
     expand_character_template,
     resolve_console_message_presentation,
 )
+from tldw_chatbook.Chat.console_turn_context import ConsoleTurnExecutionContext
 from tldw_chatbook.Chat.console_skill_resolver import (
     MENTION_SIGIL,
     SKILL_MENTION_SKIPPED_NOTE,
@@ -1072,11 +1075,12 @@ class ConsoleChatController:
         skill_substitution_enabled: bool = True,
         chat_dictionary_applier: "Callable[[str | None, str], str] | None" = None,
         world_info_applier: "Callable[[str | None, str, list], str] | None" = None,
-        rag_capture_provider: "Callable[[str], Awaitable[Any]] | None" = None,
+        rag_capture_provider: "Callable[..., Awaitable[Any]] | None" = None,
         default_session_settings: "Callable[[], ConsoleSessionSettings] | None" = None,
-        library_provider_factory: "Callable[[], Any | None] | None" = None,
+        library_provider_factory: "Callable[..., Any | None] | None" = None,
         global_user_display_name: Callable[[], str] | None = None,
         context_repository: ConsoleContextRepository | None = None,
+        turn_context_provider: "Callable[[str], ConsoleTurnExecutionContext] | None" = None,
     ) -> None:
         self.store = store
         self.provider_gateway = provider_gateway
@@ -1148,6 +1152,7 @@ class ConsoleChatController:
             and callable(getattr(provider_gateway, "complete_auxiliary", None))
             else None
         )
+        self._turn_context_provider = turn_context_provider
         # Parallel-agents spec §2: run state is a PER-SESSION map, not a
         # single global slot -- two sessions can each have their own
         # in-flight/terminal run without stamping each other. `run_state`/
@@ -2001,6 +2006,8 @@ class ConsoleChatController:
                     else None
                 ),
             )
+        turn_context = self.resolve_turn_execution_context(session.id)
+        turn_selection = turn_context.provider_selection
         pendings = self.store.pending_attachments(session.id)
         attachment_mode_pendings = [
             pending
@@ -2014,18 +2021,24 @@ class ConsoleChatController:
         if validation_error is not None:
             return self._block(session.id, validation_error)
         if has_pending_attachment:
-            vision_model = self.model or self.configured_model
+            vision_model = turn_context.effective_model
             # ONE capability check decides the gate AND the copy: this
             # module's is_vision_capable (the documented monkeypatch seam) is
             # injected into vision_block_reason instead of being re-checked
             # around it — the two seams could otherwise disagree under test.
             block_reason = vision_block_reason(
-                self.provider, vision_model, is_capable=is_vision_capable
+                turn_selection.provider,
+                vision_model,
+                is_capable=lambda _provider, _model: bool(
+                    turn_context.capabilities.get("vision", False)
+                ),
             )
             if block_reason is not None:
                 return self._block(session.id, block_reason)
-        if self.store.workspace_context.has_policy_blocks:
-            return self._block(session.id, self.store.workspace_context.recovery_copy)
+        if turn_selection.workspace_context.has_policy_blocks:
+            return self._block(
+                session.id, turn_selection.workspace_context.recovery_copy
+            )
 
         # TASK-457(a): echo the USER message BEFORE resolving the provider, so a
         # slow/cold readiness probe no longer leaves the transcript blank while
@@ -2074,7 +2087,7 @@ class ConsoleChatController:
         )
         try:
             resolution = await self.provider_gateway.resolve_for_send(
-                self._provider_selection()
+                turn_selection
             )
         except BaseException:
             # A readiness probe that raises or is cancelled AFTER the optimistic
@@ -2104,7 +2117,7 @@ class ConsoleChatController:
         terminal_citation_finalizer: TerminalCitationFinalizer | None = None
         try:
             provider_messages = self._provider_messages_for_session(
-                session.id, annotate_ids=True
+                session.id, annotate_ids=True, turn_context=turn_context
             )
             (
                 provider_messages,
@@ -2130,7 +2143,9 @@ class ConsoleChatController:
                 citation_trace_builder,
                 prompt_evidence_set_id,
                 citation_repair_contract,
-            ) = await self._capture_rag_context(clean_draft)
+            ) = await self._capture_rag_context(
+                clean_draft, turn_context=turn_context
+            )
             has_exact_citation_context = (
                 citation_trace_builder is not None
                 or citation_repair_contract is not None
@@ -2212,6 +2227,7 @@ class ConsoleChatController:
                 skill_bindings=skill_bindings,
                 skill_bundle_block=skill_bundle_block,
                 citation_repair_session=citation_repair_session,
+                turn_context=turn_context,
             )
         finally:
             if assistant is not None:
@@ -3409,6 +3425,7 @@ class ConsoleChatController:
     def _compose_local_provider(
         self,
         session_id: str | None = None,
+        turn_context: ConsoleTurnExecutionContext | None = None,
     ) -> tuple[
         LocalToolProvider | None, Callable[[list["ToolCall"]], dict[str, str]] | None
     ]:
@@ -3476,11 +3493,17 @@ class ConsoleChatController:
         # keys are -- that normalization lives in load_settings(), never
         # in get_cli_setting() itself, which reads the raw bootstrap
         # config. coerce_bool_setting is the arc's sixth such site.
-        if not coerce_bool_setting(
-            get_cli_setting(
+        local_tools_enabled = (
+            turn_context.tool_configuration.get(
+                "local_tools_enabled", LOCAL_TOOLS_DEFAULT_ENABLED
+            )
+            if turn_context is not None
+            else get_cli_setting(
                 "console", "local_tools_enabled", LOCAL_TOOLS_DEFAULT_ENABLED
-            ),
-            LOCAL_TOOLS_DEFAULT_ENABLED,
+            )
+        )
+        if not coerce_bool_setting(
+            local_tools_enabled, LOCAL_TOOLS_DEFAULT_ENABLED
         ):
             return None, None
         service = getattr(self.app, "unified_mcp_service", None)
@@ -3532,7 +3555,14 @@ class ConsoleChatController:
 
         # expanduser() before resolve(): a configured "~/repo" must land
         # under the user's home, not literal "~" under the cwd.
-        raw_root = (get_cli_setting("console", "workspace_root", "") or "").strip()
+        raw_root = str(
+            (
+                turn_context.tool_configuration.get("workspace_root", "")
+                if turn_context is not None
+                else get_cli_setting("console", "workspace_root", "")
+            )
+            or ""
+        ).strip()
         root = (
             Path(raw_root).expanduser().resolve()
             if raw_root
@@ -3571,6 +3601,28 @@ class ConsoleChatController:
             bridge.append_todo_marker(session_id, todos)
 
         return {"todo_store": session.todos, "on_todo_change": _on_todo_change}
+
+    def _library_provider_for_context(
+        self, turn_context: ConsoleTurnExecutionContext
+    ) -> Any | None:
+        """Build the Library provider from this turn's captured mode."""
+        factory = self._library_provider_factory
+        if factory is None:
+            return None
+        try:
+            parameters = inspect.signature(factory).parameters.values()
+            accepts_context = any(
+                parameter.kind
+                in {
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.VAR_POSITIONAL,
+                }
+                for parameter in parameters
+            )
+        except (TypeError, ValueError):
+            accepts_context = False
+        return factory(turn_context) if accepts_context else factory()
 
     def resolve_pending_approval(
         self, decisions: dict[str, str], *, round_id: str | None = None
@@ -4644,12 +4696,13 @@ class ConsoleChatController:
         if message.status != "failed":
             return self._block(session_id, "Only failed messages can be retried.")
 
+        turn_context = self.resolve_turn_execution_context(session_id)
         self._set_run_state(
             ConsoleRunState.retrying("Retrying failed response."),
             session_id=session_id,
         )
         resolution = await self.provider_gateway.resolve_for_send(
-            self._provider_selection()
+            turn_context.provider_selection
         )
         if not getattr(resolution, "ready", False):
             visible_copy = self._blocked_visible_copy(
@@ -4661,6 +4714,7 @@ class ConsoleChatController:
             session_id,
             before_message_id=message_id,
             annotate_ids=True,
+            turn_context=turn_context,
         )
         self._ensure_user_continuation_instruction(provider_messages)
         (
@@ -4691,6 +4745,7 @@ class ConsoleChatController:
             prefill=prefill,
             skill_bindings=skill_bindings,
             skill_bundle_block=skill_bundle_block,
+            turn_context=turn_context,
         )
 
     async def continue_from_message(self, message_id: str) -> ConsoleSubmitResult:
@@ -4712,12 +4767,13 @@ class ConsoleChatController:
             )
             return ConsoleSubmitResult(False, False, visible_copy)
 
+        turn_context = self.resolve_turn_execution_context(session_id)
         self._set_run_state(
             ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider."),
             session_id=session_id,
         )
         resolution = await self.provider_gateway.resolve_for_send(
-            self._provider_selection()
+            turn_context.provider_selection
         )
         if not getattr(resolution, "ready", False):
             visible_copy = self._blocked_visible_copy(
@@ -4726,7 +4782,10 @@ class ConsoleChatController:
             return self._block(session_id, visible_copy)
 
         provider_messages = self._provider_messages_through_message(
-            session_id, message_id, annotate_ids=True
+            session_id,
+            message_id,
+            annotate_ids=True,
+            turn_context=turn_context,
         )
         self._ensure_user_continuation_instruction(provider_messages)
         if not self._has_user_turn(provider_messages):
@@ -4765,6 +4824,7 @@ class ConsoleChatController:
             assistant_message_id=assistant.id,
             skill_bindings=skill_bindings,
             skill_bundle_block=skill_bundle_block,
+            turn_context=turn_context,
         )
 
     async def regenerate_message(self, message_id: str) -> ConsoleSubmitResult:
@@ -4816,12 +4876,13 @@ class ConsoleChatController:
             )
             return ConsoleSubmitResult(False, False, visible_copy)
 
+        turn_context = self.resolve_turn_execution_context(session_id)
         self._set_run_state(
             ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider."),
             session_id=session_id,
         )
         resolution = await self.provider_gateway.resolve_for_send(
-            self._provider_selection()
+            turn_context.provider_selection
         )
         if not getattr(resolution, "ready", False):
             visible_copy = self._blocked_visible_copy(
@@ -4833,6 +4894,7 @@ class ConsoleChatController:
             session_id,
             before_message_id=message_id,
             annotate_ids=True,
+            turn_context=turn_context,
         )
         self._ensure_user_continuation_instruction(provider_messages)
         if not self._has_user_turn(provider_messages):
@@ -4875,6 +4937,7 @@ class ConsoleChatController:
             prefill=prefill,
             skill_bindings=skill_bindings,
             skill_bundle_block=skill_bundle_block,
+            turn_context=turn_context,
         )
 
     #: Guidance cap for the transcript span fed to the summarizer (Task 3).
@@ -4977,8 +5040,9 @@ class ConsoleChatController:
             ConsoleRunState(ConsoleRunStatus.VALIDATING, "Summarizing conversation…"),
             session_id=session_id,
         )
+        turn_context = self.resolve_turn_execution_context(session_id)
         resolution = await self.provider_gateway.resolve_for_send(
-            self._provider_selection()
+            turn_context.provider_selection
         )
         if not getattr(resolution, "ready", False):
             return self._summarize_block(
@@ -5105,8 +5169,9 @@ class ConsoleChatController:
             asyncio.CancelledError: Propagated unchanged when the caller's
                 task is cancelled, so cancellation is never swallowed.
         """
+        turn_context = self.resolve_turn_execution_context(session_id)
         resolution = await self.provider_gateway.resolve_for_send(
-            self._provider_selection()
+            turn_context.provider_selection
         )
         if not getattr(resolution, "ready", False):
             return ImpersonateResult(
@@ -5336,15 +5401,21 @@ class ConsoleChatController:
         clean_content, validation_error = self._validated_draft(new_content)
         if validation_error is not None:
             return self._block(session_id, validation_error)
+        turn_context = self.resolve_turn_execution_context(session_id)
+        turn_selection = turn_context.provider_selection
 
         # task-573: the resend carries the anchor's attachments, so the same
         # vision gate a fresh send applies (see ``submit_draft``) must fire
         # here too -- BEFORE any node is created (mutate-last discipline).
         anchor_attachments = tuple(message.attachments)
         if any(a.data is not None for a in anchor_attachments):
-            vision_model = self.model or self.configured_model
+            vision_model = turn_context.effective_model
             block_reason = vision_block_reason(
-                self.provider, vision_model, is_capable=is_vision_capable
+                turn_selection.provider,
+                vision_model,
+                is_capable=lambda _provider, _model: bool(
+                    turn_context.capabilities.get("vision", False)
+                ),
             )
             if block_reason is not None:
                 return self._block(session_id, block_reason)
@@ -5354,7 +5425,7 @@ class ConsoleChatController:
             session_id=session_id,
         )
         resolution = await self.provider_gateway.resolve_for_send(
-            self._provider_selection()
+            turn_selection
         )
         if not getattr(resolution, "ready", False):
             visible_copy = self._blocked_visible_copy(
@@ -5384,12 +5455,16 @@ class ConsoleChatController:
                 attachments=anchor_attachments,
             )
         )
-        provider_messages = self._leading_system_message(session_id=session_id) + (
+        provider_messages = self._leading_system_message(
+            session_id=session_id,
+            turn_context=turn_context,
+        ) + (
             self._provider_message_payloads(
                 ancestors,
                 skip_failed=True,
                 annotate_ids=True,
                 session_id=session_id,
+                turn_context=turn_context,
             )
         )
         self._ensure_user_continuation_instruction(provider_messages)
@@ -5441,6 +5516,7 @@ class ConsoleChatController:
             prefill=prefill,
             skill_bindings=skill_bindings,
             skill_bundle_block=skill_bundle_block,
+            turn_context=turn_context,
         )
 
     async def build_context_snapshot(
@@ -5882,6 +5958,127 @@ class ConsoleChatController:
             streaming=self.streaming,
             system_prompt=self.system_prompt,
             workspace_context=self.store.workspace_context,
+        )
+
+    def _provider_selection_for_session(
+        self, session_id: str
+    ) -> ConsoleProviderSelection:
+        """Resolve provider inputs from the owning session, never the viewed tab."""
+        settings = self.store.session_settings(session_id)
+        workspace_id = self.store.session_workspace_id(session_id)
+        current_workspace = self.store.workspace_context
+        workspace_context = (
+            current_workspace
+            if current_workspace.active_workspace_id == workspace_id
+            else ConsoleWorkspaceContext(active_workspace_id=workspace_id)
+        )
+        if settings is None:
+            return replace(
+                self._provider_selection(),
+                workspace_context=workspace_context,
+            )
+
+        provider = str(settings.provider or self.provider)
+        same_provider = provider_config_key(provider) == provider_config_key(
+            self.provider
+        )
+        return ConsoleProviderSelection(
+            provider=provider,
+            base_url=(
+                settings.base_url
+                if settings.base_url is not None
+                else self.base_url if same_provider else None
+            ),
+            explicit_model=settings.model,
+            configured_model=(
+                self.configured_model
+                if settings.model is None and same_provider
+                else None
+            ),
+            temperature=settings.temperature,
+            top_p=settings.top_p,
+            min_p=settings.min_p,
+            top_k=settings.top_k,
+            max_tokens=settings.max_tokens,
+            seed=settings.seed,
+            presence_penalty=settings.presence_penalty,
+            frequency_penalty=settings.frequency_penalty,
+            reasoning_effort=settings.reasoning_effort,
+            reasoning_summary=settings.reasoning_summary,
+            verbosity=settings.verbosity,
+            thinking_effort=settings.thinking_effort,
+            thinking_budget_tokens=settings.thinking_budget_tokens,
+            streaming=settings.streaming,
+            system_prompt=settings.system_prompt,
+            workspace_context=workspace_context,
+        )
+
+    def resolve_turn_execution_context(
+        self, session_id: str
+    ) -> ConsoleTurnExecutionContext:
+        """Capture one detached configuration snapshot for an owning session."""
+        if self._turn_context_provider is not None:
+            context = self._turn_context_provider(session_id)
+            if context.session_id != session_id:
+                raise ValueError(
+                    "Console turn-context provider returned a different session."
+                )
+            return context
+
+        selection = self._provider_selection_for_session(session_id)
+        model = selection.explicit_model or selection.configured_model
+        workspace_root = str(
+            get_cli_setting("console", "workspace_root", "") or ""
+        ).strip()
+        return ConsoleTurnExecutionContext.capture(
+            session_id=session_id,
+            provider_selection=selection,
+            session_settings=self.store.session_settings(session_id),
+            workspace_roots=(workspace_root,) if workspace_root else (),
+            capabilities={
+                "vision": bool(model)
+                and is_vision_capable(selection.provider, model or ""),
+                "max_history_images": max_history_images(
+                    selection.provider, model
+                ),
+            },
+            rag_defaults={
+                "auto_retrieve_on_send": coerce_bool_setting(
+                    get_cli_setting(
+                        "chat_defaults", "rag_auto_retrieve_on_send", False
+                    ),
+                    False,
+                )
+            },
+            tool_configuration={
+                "agent_runtime_enabled": self._agent_runtime_enabled,
+                "native_tool_calls_enabled": True,
+                "local_tools_enabled": coerce_bool_setting(
+                    get_cli_setting("console", "local_tools_enabled", False),
+                    False,
+                ),
+                "workspace_root": workspace_root,
+                "direct_library_tools": coerce_bool_setting(
+                    get_cli_setting("console", "direct_library_tools", True),
+                    True,
+                ),
+            },
+            provider_payload_settings={
+                "streaming": selection.streaming,
+                "temperature": selection.temperature,
+                "top_p": selection.top_p,
+                "min_p": selection.min_p,
+                "top_k": selection.top_k,
+                "max_tokens": selection.max_tokens,
+                "seed": selection.seed,
+                "presence_penalty": selection.presence_penalty,
+                "frequency_penalty": selection.frequency_penalty,
+                "reasoning_effort": selection.reasoning_effort,
+                "reasoning_summary": selection.reasoning_summary,
+                "verbosity": selection.verbosity,
+                "thinking_effort": selection.thinking_effort,
+                "thinking_budget_tokens": selection.thinking_budget_tokens,
+            },
         )
 
     @staticmethod
@@ -6497,6 +6694,7 @@ class ConsoleChatController:
     async def _capture_rag_context(
         self,
         draft: str,
+        turn_context: ConsoleTurnExecutionContext | None = None,
     ) -> tuple[
         str | None,
         CitationTraceBuilder | None,
@@ -6509,7 +6707,23 @@ class ConsoleChatController:
         if provider is None:
             return None, None, None, None
         try:
-            captured = await provider(draft)
+            parameters = inspect.signature(provider).parameters.values()
+            accepts_context = any(
+                parameter.kind
+                in {
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.VAR_POSITIONAL,
+                }
+                for index, parameter in enumerate(parameters)
+                if index > 0
+            )
+        except (TypeError, ValueError):
+            accepts_context = False
+        try:
+            captured = await (
+                provider(draft, turn_context) if accepts_context else provider(draft)
+            )
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -7326,6 +7540,7 @@ class ConsoleChatController:
         skill_bindings: tuple[str, ...] = (),
         skill_bundle_block: str = "",
         citation_repair_session: ConsoleCitationRepairSession | None = None,
+        turn_context: ConsoleTurnExecutionContext | None = None,
     ) -> ConsoleSubmitResult:
         try:
             return await self._stream_assistant_response_inner(
@@ -7339,6 +7554,7 @@ class ConsoleChatController:
                 skill_bindings=skill_bindings,
                 skill_bundle_block=skill_bundle_block,
                 citation_repair_session=citation_repair_session,
+                turn_context=turn_context,
             )
         finally:
             if citation_repair_session is not None:
@@ -7357,6 +7573,7 @@ class ConsoleChatController:
         skill_bindings: tuple[str, ...] = (),
         skill_bundle_block: str = "",
         citation_repair_session: ConsoleCitationRepairSession | None = None,
+        turn_context: ConsoleTurnExecutionContext | None = None,
     ) -> ConsoleSubmitResult:
         try:
             owner_id = self.store.session_id_for_message(assistant_message_id)
@@ -7366,6 +7583,10 @@ class ConsoleChatController:
             # no-op since nothing will ever read a closed session's state.
             return self._session_closed_result()
         owner = next((s for s in self.store.sessions() if s.id == owner_id), None)
+        if turn_context is None:
+            turn_context = self.resolve_turn_execution_context(owner_id)
+        elif turn_context.session_id != owner_id:
+            raise ValueError("Console turn context does not own the assistant row.")
         # A character session always takes the plain-provider
         # path, even with the global agent runtime enabled and a bridge
         # present. Keyed on the message's OWNING session (looked up here,
@@ -7413,14 +7634,18 @@ class ConsoleChatController:
         # a few lines down, which avoids the same hazard for the same
         # reason). Falling back to `self.provider`/`self.model` only covers
         # narrow stand-in resolutions that don't carry the attributes at
-        # all (e.g. some test doubles).
+        # all (e.g. some test doubles) use the same captured context.
         try:
-            baseline_messages = self._provider_messages_for_session(owner_id)
-            baseline_provider = getattr(resolution, "provider", None) or self.provider
+            baseline_messages = self._provider_messages_for_session(
+                owner_id, turn_context=turn_context
+            )
+            baseline_provider = (
+                getattr(resolution, "provider", None)
+                or turn_context.provider_selection.provider
+            )
             baseline_model = (
                 getattr(resolution, "model", None)
-                or self.model
-                or self.configured_model
+                or turn_context.effective_model
             )
             self._payload_fingerprint_baselines[owner_id] = fingerprint_payload(
                 baseline_provider, baseline_model, baseline_messages
@@ -7471,10 +7696,18 @@ class ConsoleChatController:
         if not exact_preparation:
             bound = bound_messages_to_window(
                 provider_messages,
-                model=getattr(resolution, "model", None) or "",
-                provider=getattr(resolution, "provider", "") or "",
+                model=(
+                    getattr(resolution, "model", None)
+                    or turn_context.effective_model
+                    or ""
+                ),
+                provider=(
+                    getattr(resolution, "provider", None)
+                    or turn_context.provider_selection.provider
+                ),
                 response_reservation=(
                     getattr(resolution, "max_tokens", None)
+                    or turn_context.provider_selection.max_tokens
                     or DEFAULT_RESPONSE_RESERVATION
                 ),
             )
@@ -7510,7 +7743,11 @@ class ConsoleChatController:
         stream_signals = ConsoleProviderStreamSignals()
         try:
             if (
-                self._agent_runtime_enabled
+                bool(
+                    turn_context.tool_configuration.get(
+                        "agent_runtime_enabled", self._agent_runtime_enabled
+                    )
+                )
                 and self._agent_bridge is not None
                 and not prefill
                 and not force_plain
@@ -7525,6 +7762,7 @@ class ConsoleChatController:
                     skill_bundle_block=skill_bundle_block,
                     citation_repair_session=citation_repair_session,
                     stream_signals=stream_signals,
+                    turn_context=turn_context,
                 )
             return await self._run_direct_provider_reply(
                 resolution=resolution,
@@ -8199,6 +8437,7 @@ class ConsoleChatController:
         skill_bundle_block: str = "",
         citation_repair_session: ConsoleCitationRepairSession | None = None,
         stream_signals: ConsoleProviderStreamSignals | None = None,
+        turn_context: ConsoleTurnExecutionContext | None = None,
     ) -> ConsoleSubmitResult:
         """Run the agent loop as the reply engine, streaming into the target row."""
         logger.info(
@@ -8217,6 +8456,10 @@ class ConsoleChatController:
             session_id = self.store.session_id_for_message(assistant_message_id)
         except KeyError:
             return self._session_closed_result()
+        if turn_context is None:
+            turn_context = self.resolve_turn_execution_context(session_id)
+        elif turn_context.session_id != session_id:
+            raise ValueError("Console turn context does not own the assistant row.")
         self._active_assistant_message_ids[session_id] = assistant_message_id
         self._active_stream_tasks[session_id] = asyncio.current_task()
         self._stop_requested = False
@@ -8347,7 +8590,8 @@ class ConsoleChatController:
         # hooks see every batch; each gates only what its provider owns,
         # so the combined hook is a collision-free merge.
         local_provider, local_review_hook = self._compose_local_provider(
-            session_id=session_id
+            session_id=session_id,
+            turn_context=turn_context,
         )
         if local_review_hook is not None:
             review_hook = build_combined_review_hook([review_hook, local_review_hook])
@@ -8359,7 +8603,7 @@ class ConsoleChatController:
         library_provider: Any | None = None
         if self._library_provider_factory is not None:
             try:
-                library_provider = self._library_provider_factory()
+                library_provider = self._library_provider_for_context(turn_context)
             except Exception:  # noqa: BLE001 -- never block a send
                 logger.opt(exception=True).warning(
                     "library_provider_factory failed; running without Library tools"
@@ -8369,17 +8613,7 @@ class ConsoleChatController:
         # same workspace folder bindings the file tools resolve against.
         # Best-effort: an unavailable registry yields no roots and an
         # untracked (but otherwise normal) run.
-        change_roots: list = []
-        try:
-            from tldw_chatbook.Tools.workspace_file_roots import (
-                folder_binding_roots,
-            )
-
-            change_roots = list(folder_binding_roots(review_workspace_id))
-        except Exception:  # noqa: BLE001 -- tracking must never block a send
-            logger.opt(exception=True).debug(
-                "change_review: workspace roots unavailable; run untracked"
-            )
+        change_roots: list = [Path(root) for root in turn_context.workspace_roots]
 
         # Swap site: the agent loop runs synchronously on a worker thread via
         # asyncio.to_thread, so Stop is cooperative-only -- `should_cancel` is
@@ -8399,7 +8633,7 @@ class ConsoleChatController:
                 session_id=session_id,
                 resolution=resolution,
                 assistant_message_id=assistant_message_id,
-                model=self.model or self.configured_model or "",
+                model=turn_context.effective_model or "",
                 session_system_prompt=session_system_prompt,
                 agent_messages=agent_messages,
                 should_cancel=should_cancel,
@@ -8410,6 +8644,11 @@ class ConsoleChatController:
                 review_tool_calls=review_hook,
                 local_provider=local_provider,
                 library_provider=library_provider,
+                native_tools_enabled=bool(
+                    turn_context.tool_configuration.get(
+                        "native_tool_calls_enabled", True
+                    )
+                ),
                 change_roots=change_roots,
                 turn_skill_bindings=skill_bindings,
                 turn_bundle_block=skill_bundle_block,
@@ -9065,7 +9304,11 @@ class ConsoleChatController:
         )
 
     def _leading_system_message(
-        self, *, greeting: str = "", session_id: str | None = None
+        self,
+        *,
+        greeting: str = "",
+        session_id: str | None = None,
+        turn_context: ConsoleTurnExecutionContext | None = None,
     ) -> list[dict[str, str]]:
         """Return a single-item system message list when a system prompt is set.
 
@@ -9085,7 +9328,11 @@ class ConsoleChatController:
                 when no system prompt is set, since the message array itself
                 must stay user-first for strict providers (task-427).
         """
-        raw_system_prompt = self._resolved_system_prompt(session_id)
+        raw_system_prompt = (
+            turn_context.provider_selection.system_prompt
+            if turn_context is not None
+            else self._resolved_system_prompt(session_id)
+        )
         if not isinstance(raw_system_prompt, str) or not raw_system_prompt.strip():
             raw_system_prompt = ""
         content = fold_greeting_into_system_prompt(raw_system_prompt, greeting)
@@ -9212,6 +9459,7 @@ class ConsoleChatController:
         *,
         before_message_id: str | None = None,
         annotate_ids: bool = False,
+        turn_context: ConsoleTurnExecutionContext | None = None,
     ) -> list[dict[str, Any]]:
         collected: list[ConsoleChatMessage] = []
         for message in self.store.messages_for_session(session_id):
@@ -9221,11 +9469,13 @@ class ConsoleChatController:
         return self._leading_system_message(
             greeting=self._seeded_greeting_text(session_id, collected),
             session_id=session_id,
+            turn_context=turn_context,
         ) + self._provider_message_payloads(
             collected,
             skip_failed=True,
             annotate_ids=annotate_ids,
             session_id=session_id,
+            turn_context=turn_context,
         )
 
     def _provider_messages_through_message(
@@ -9234,6 +9484,7 @@ class ConsoleChatController:
         message_id: str,
         *,
         annotate_ids: bool = False,
+        turn_context: ConsoleTurnExecutionContext | None = None,
     ) -> list[dict[str, Any]]:
         collected: list[ConsoleChatMessage] = []
         for message in self.store.messages_for_session(session_id):
@@ -9243,12 +9494,14 @@ class ConsoleChatController:
         return self._leading_system_message(
             greeting=self._seeded_greeting_text(session_id, collected),
             session_id=session_id,
+            turn_context=turn_context,
         ) + self._provider_message_payloads(
             collected,
             skip_failed=False,
             use_variant_content=True,
             annotate_ids=annotate_ids,
             session_id=session_id,
+            turn_context=turn_context,
         )
 
     def _provider_message_payloads(
@@ -9259,15 +9512,29 @@ class ConsoleChatController:
         use_variant_content: bool = False,
         annotate_ids: bool = False,
         session_id: str | None = None,
+        turn_context: ConsoleTurnExecutionContext | None = None,
     ) -> list[dict[str, Any]]:
-        model = self.model or self.configured_model
-        vision = bool(model) and is_vision_capable(self.provider, model or "")
+        selection = (
+            turn_context.provider_selection
+            if turn_context is not None
+            else self._provider_selection()
+        )
+        model = selection.explicit_model or selection.configured_model
+        vision = (
+            bool(turn_context.capabilities.get("vision", False))
+            if turn_context is not None
+            else bool(model) and is_vision_capable(selection.provider, model or "")
+        )
 
         # Reserve the image budget newest-message-first, counting IMAGES (not
         # messages): a message with several attachments can consume more than
         # one unit of budget, and the walk stops as soon as the budget is
         # exhausted regardless of how many messages remain.
-        budget = max_history_images(self.provider, model) if vision else 0
+        budget = (
+            int(turn_context.capabilities.get("max_history_images", 0) or 0)
+            if turn_context is not None and vision
+            else max_history_images(selection.provider, model) if vision else 0
+        )
         allowed_counts: dict[str, int] = {}
         for message in reversed(session_messages):
             if budget <= 0:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1262,9 +1262,16 @@ class ConsoleChatController:
         #: controller-only tests) disables recording.
         self.prompt_history: PromptHistory | None = None
         self.prompt_queue_registry = ConsolePromptQueueRegistry()
+        context_epoch = getattr(self.store, "conversation_context_epoch", None)
+        if not callable(context_epoch):
+            # Narrow compatibility seam for minimal controller test doubles
+            # and embedders that do not exercise queue progression. The real
+            # ConsoleChatStore always supplies the authoritative epoch.
+            def context_epoch(_session_id: str) -> int:
+                return 0
         self.prompt_queue_coordinator = ConsolePromptQueueCoordinator(
             registry=self.prompt_queue_registry,
-            context_epoch=self.store.conversation_context_epoch,
+            context_epoch=context_epoch,
             run_status=lambda session_id: self.run_state_for(session_id).status,
             submit_queued=self._submit_queued_entry,
             has_staged_rider=self._queued_staged_rider_present,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -30,6 +30,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     CONSOLE_CAP_REFUSAL_TITLE_LIMIT,
     CONSOLE_DEFAULT_MAX_PARALLEL_RUNS,
     ConsoleChatMessage,
+    ConsoleControllerActivity,
     ConsoleCitationNoticeCode,
     ConsoleCitationPhase,
     ConsoleCitationPresentation,
@@ -39,6 +40,8 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleRunMarker,
     ConsoleRunState,
     ConsoleRunStatus,
+    ConsoleQueuedAcceptanceEvent,
+    ConsoleSubmissionOrigin,
     ConsoleStagedSource,
     ConsoleWorkspaceContext,
     MessageAttachment,
@@ -108,6 +111,14 @@ from tldw_chatbook.Chat.console_roleplay_identity import (
     resolve_console_message_presentation,
 )
 from tldw_chatbook.Chat.console_turn_context import ConsoleTurnExecutionContext
+from tldw_chatbook.Chat.console_prompt_queue import (
+    ConsolePromptQueueRegistry,
+    PromptQueueMutationResult,
+)
+from tldw_chatbook.Chat.console_prompt_queue_coordinator import (
+    ConsolePromptQueueCoordinator,
+    QueueGenerationAuthorization,
+)
 from tldw_chatbook.Chat.console_skill_resolver import (
     MENTION_SIGIL,
     SKILL_MENTION_SKIPPED_NOTE,
@@ -1024,6 +1035,13 @@ class ConsoleSubmitResult:
     #: screen-side caller (``ChatScreen._submit_console_native_draft``) uses
     #: this flag to show a toast instead, so the outcome is never silent.
     session_closed: bool = False
+    session_id: str | None = None
+    user_message_id: str | None = None
+    assistant_message_id: str | None = None
+    terminal_status: ConsoleRunStatus | None = None
+    origin: ConsoleSubmissionOrigin | None = None
+    queue_entry_id: str | None = None
+    committed_context_epoch: int | None = None
 
 
 @dataclass(frozen=True)
@@ -1081,6 +1099,7 @@ class ConsoleChatController:
         global_user_display_name: Callable[[], str] | None = None,
         context_repository: ConsoleContextRepository | None = None,
         turn_context_provider: "Callable[[str], ConsoleTurnExecutionContext] | None" = None,
+        queued_staged_rider_provider: "Callable[[str], bool] | None" = None,
     ) -> None:
         self.store = store
         self.provider_gateway = provider_gateway
@@ -1153,6 +1172,7 @@ class ConsoleChatController:
             else None
         )
         self._turn_context_provider = turn_context_provider
+        self._queued_staged_rider_provider = queued_staged_rider_provider
         # Parallel-agents spec §2: run state is a PER-SESSION map, not a
         # single global slot -- two sessions can each have their own
         # in-flight/terminal run without stamping each other. `run_state`/
@@ -1220,6 +1240,11 @@ class ConsoleChatController:
         #: persisted, run about to start) so the composer can clear immediately
         #: instead of holding the sent text for the whole run.
         self.on_submission_accepted: Callable[[], None] | None = None
+        #: Content-free queued counterpart to ``on_submission_accepted``.
+        #: It may refresh transcript/queue UI, but cannot clear a composer.
+        self.on_queued_submission_accepted: (
+            Callable[[ConsoleQueuedAcceptanceEvent], None] | None
+        ) = None
         #: TASK-1364: optional shared JSONL prompt-history store, assigned by
         #: the owning screen (mirroring ``on_submission_accepted``). An
         #: ACCEPTED send's cleaned draft is appended here -- never a blocked,
@@ -1227,6 +1252,18 @@ class ConsoleChatController:
         #: text and Up/Down recall can offer it later. ``None`` (e.g. in
         #: controller-only tests) disables recording.
         self.prompt_history: PromptHistory | None = None
+        self.prompt_queue_registry = ConsolePromptQueueRegistry()
+        self.prompt_queue_coordinator = ConsolePromptQueueCoordinator(
+            registry=self.prompt_queue_registry,
+            context_epoch=self.store.conversation_context_epoch,
+            run_status=lambda session_id: self.run_state_for(session_id).status,
+            submit_queued=self._submit_queued_entry,
+            has_staged_rider=self._queued_staged_rider_present,
+            needs_approval=self.has_pending_approval_round,
+            can_reacquire_slot=self._queue_can_reacquire_slot,
+            on_queued_accepted=self._notify_queued_submission_accepted,
+            on_chain_terminal=self._publish_queue_chain_terminal,
+        )
         # Task 3b: PER-SESSION maps, mirroring `_run_states`' own keying --
         # two sessions can each have their own in-flight stream/cancel state
         # without clobbering each other. Written/cleared at the SAME
@@ -1489,6 +1526,83 @@ class ConsoleChatController:
         """
         return dict(self._run_states)
 
+    def activity_for(self, session_id: str) -> ConsoleControllerActivity:
+        """Return the single queue-aware activity projection for ``session_id``."""
+
+        return self.prompt_queue_coordinator.activity(session_id)
+
+    def queue_prompt(
+        self,
+        session_id: str,
+        *,
+        text: str,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        """Attempt atomic text-only admission behind queue-owned work."""
+
+        return self.prompt_queue_coordinator.admit(
+            session_id,
+            text=text,
+            expected_revision=expected_revision,
+        )
+
+    async def run_prompt_chain(
+        self,
+        draft: str,
+        *,
+        session_id: str | None = None,
+    ) -> ConsoleSubmitResult:
+        """Submit one manual draft and drain accepted follow-ups sequentially."""
+
+        target_id = session_id or self.store.active_session_id
+        if not target_id:
+            session = self.store.ensure_session(
+                workspace_id=self.store.workspace_context.active_workspace_id,
+                settings=(
+                    self._default_session_settings()
+                    if self._default_session_settings is not None
+                    else None
+                ),
+            )
+            target_id = session.id
+        return await self.prompt_queue_coordinator.run_prompt_chain(
+            target_id,
+            lambda: self.submit_draft(
+                draft,
+                session_id=target_id,
+                origin=ConsoleSubmissionOrigin.MANUAL,
+            ),
+        )
+
+    def _queued_staged_rider_present(self, session_id: str) -> bool:
+        """Return whether a queued text turn would consume a manual attachment rider."""
+
+        try:
+            if self.store.pending_attachments(session_id):
+                return True
+        except KeyError:
+            return True
+        provider = self._queued_staged_rider_provider
+        if provider is None:
+            return False
+        try:
+            return bool(provider(session_id))
+        except Exception:
+            # Fail closed: a rider seam that cannot be revalidated must never
+            # let an automatic queued turn consume screen-owned state.
+            return True
+
+    def _queue_can_reacquire_slot(self, session_id: str) -> bool:
+        """Check the cap without registering a hidden waiter."""
+
+        live_ids = {session.id for session in self.store.sessions()}
+        occupied = sum(
+            1
+            for candidate in live_ids
+            if candidate != session_id and self.activity_for(candidate).occupies_slot
+        )
+        return occupied < self.max_parallel_runs
+
     def payload_fingerprint_baseline(
         self, session_id: str
     ) -> PayloadFingerprint | None:
@@ -1563,10 +1677,12 @@ class ConsoleChatController:
         apply the same live-session filter.
         """
         live_ids = {session.id for session in self.store.sessions()}
+        ordered_ids = list(self._run_states)
+        ordered_ids.extend(sid for sid in live_ids if sid not in self._run_states)
         return [
             sid
-            for sid, state in self._run_states.items()
-            if sid in live_ids and not state.is_send_allowed
+            for sid in ordered_ids
+            if sid in live_ids and self.activity_for(sid).occupies_slot
         ]
 
     def in_flight_run_count(self) -> int:
@@ -1893,6 +2009,11 @@ class ConsoleChatController:
             A human-readable refusal message if the send must be blocked
             right now, otherwise ``None`` when the send is allowed.
         """
+        if self.prompt_queue_coordinator.controls_generation(session_id):
+            return (
+                "Queued messages control the next turn. "
+                "Resume or manage the queue first."
+            )
         if not self.run_state_for(session_id).is_send_allowed:
             return "A run is already running in this tab."
         busy_ids = self._live_busy_session_ids()
@@ -1935,7 +2056,13 @@ class ConsoleChatController:
         return self._run_state_histories.setdefault(session_id, [ConsoleRunStatus.IDLE])
 
     async def submit_draft(
-        self, draft: str, *, session_id: str | None = None
+        self,
+        draft: str,
+        *,
+        session_id: str | None = None,
+        origin: ConsoleSubmissionOrigin = ConsoleSubmissionOrigin.MANUAL,
+        queue_entry_id: str | None = None,
+        queue_authorization: QueueGenerationAuthorization | None = None,
     ) -> ConsoleSubmitResult:
         """Submit a composer draft through native Console validation and provider resolution.
 
@@ -1968,8 +2095,32 @@ class ConsoleChatController:
             the time this runs (see ``_session_closed_result``); ``True``
             once the turn actually proceeds.
         """
+        if not isinstance(origin, ConsoleSubmissionOrigin):
+            raise ValueError("origin must be an explicit ConsoleSubmissionOrigin")
+        target_id = session_id or self.store.active_session_id or ""
+        if origin is ConsoleSubmissionOrigin.QUEUED:
+            if not queue_entry_id or not self.prompt_queue_coordinator.authorizes(
+                queue_authorization, target_id
+            ):
+                raise PermissionError(
+                    "queued sends require coordinator-issued generation authority"
+                )
+        elif target_id and self.prompt_queue_coordinator.controls_generation(target_id):
+            visible_copy = "Queued messages control the next turn. Resume or manage the queue first."
+            if target_id and any(
+                session.id == target_id for session in self.store.sessions()
+            ):
+                self.store.append_message(
+                    target_id,
+                    role=ConsoleMessageRole.SYSTEM,
+                    content=visible_copy,
+                )
+            return ConsoleSubmitResult(False, False, visible_copy)
+
         active_rejection = self._active_run_rejection(
-            session_id=session_id, append_row=True
+            session_id=session_id,
+            append_row=True,
+            queue_authorization=queue_authorization,
         )
         if active_rejection is not None:
             return active_rejection
@@ -2144,7 +2295,9 @@ class ConsoleChatController:
                 prompt_evidence_set_id,
                 citation_repair_contract,
             ) = await self._capture_rag_context(
-                clean_draft, turn_context=turn_context
+                clean_draft,
+                turn_context=turn_context,
+                origin=origin,
             )
             has_exact_citation_context = (
                 citation_trace_builder is not None
@@ -2189,7 +2342,28 @@ class ConsoleChatController:
         # not ready, policy block, validation failure) and those already
         # never reach this hook -- this ordering just extends that same
         # rule to cover it too.
-        self._notify_submission_accepted()
+        if origin is ConsoleSubmissionOrigin.QUEUED and not (
+            self.prompt_queue_coordinator.authorizes(
+                queue_authorization, session.id
+            )
+        ):
+            # Close/shutdown can tombstone the chain while this claimed turn
+            # awaits readiness/substitution/RAG. Revalidate immediately before
+            # acceptance so cancellation cannot turn that stale claim into a
+            # durable user message or provider dispatch.
+            self.store.mark_message_send_blocked(echoed_user.id)
+            return ConsoleSubmitResult(
+                False,
+                False,
+                "Queued turn canceled before it could start.",
+            )
+        committed_context_epoch = self.store.conversation_context_epoch(session.id)
+        self._notify_submission_accepted(
+            session_id=session.id,
+            origin=origin,
+            entry_id=queue_entry_id,
+            context_epoch=committed_context_epoch,
+        )
         # TASK-1364: record the accepted send to the shared prompt history.
         # Same placement rule as the accepted-hook above: only a send that is
         # confirmed to proceed is recorded -- every `_block`/refusal path
@@ -2218,7 +2392,7 @@ class ConsoleChatController:
                 terminal_citation_finalizer=terminal_citation_finalizer,
                 defer_terminal_persistence=citation_repair_session is not None,
             )
-            return await self._stream_assistant_response(
+            stream_result = await self._stream_assistant_response(
                 resolution=resolution,
                 provider_messages=provider_messages,
                 assistant_message_id=assistant.id,
@@ -2228,6 +2402,16 @@ class ConsoleChatController:
                 skill_bundle_block=skill_bundle_block,
                 citation_repair_session=citation_repair_session,
                 turn_context=turn_context,
+            )
+            return replace(
+                stream_result,
+                session_id=session.id,
+                user_message_id=echoed_user.id,
+                assistant_message_id=assistant.id,
+                terminal_status=self.run_state_for(session.id).status,
+                origin=origin,
+                queue_entry_id=queue_entry_id,
+                committed_context_epoch=committed_context_epoch,
             )
         finally:
             if assistant is not None:
@@ -2463,6 +2647,9 @@ class ConsoleChatController:
         Returns:
             The session activated after closing, or ``None`` when no sessions remain.
         """
+        # Queue tombstone MUST precede stop/cancel: cancellation can wake a
+        # terminal callback, which must observe that no next claim is legal.
+        self.prompt_queue_coordinator.mark_closing(session_id)
         repair_session = self._active_citation_repair_sessions.get(session_id)
         self.clear_original_attempts_for_session(session_id)
         owns_active_stream = self._active_stream_belongs_to_session(session_id)
@@ -2485,6 +2672,7 @@ class ConsoleChatController:
             )
         previous_active_id = self.store.active_session_id
         closed = self.store.close_session(session_id)
+        self.prompt_queue_coordinator.remove_session(session_id)
         new_active_id = self.store.active_session_id
         if (
             owns_active_stream
@@ -4513,6 +4701,7 @@ class ConsoleChatController:
             if self._active_assistant_message_ids.get(session_id) is None:
                 return False
             repair_session.cancel_reason = "user" if record_user_stop else "shutdown"
+            self.prompt_queue_coordinator.pause_for_stop(session_id)
             self._signal_stop(session_id=session_id)
             task = self._active_stream_tasks.get(session_id)
             if task is not None and task is not asyncio.current_task():
@@ -4530,6 +4719,7 @@ class ConsoleChatController:
             )
         if assistant_message_id is None:
             return False
+        self.prompt_queue_coordinator.pause_for_stop(session_id)
         self._signal_stop(session_id=session_id)
         self._mark_stream_stopped(
             assistant_message_id,
@@ -4606,6 +4796,9 @@ class ConsoleChatController:
         its own, unset ``_shutdown_requested`` -- so the permanently-set
         flag on the old instance can never poison it.
         """
+        # Tombstone queue chains before any cancellation can resume their
+        # awaiting drain coroutine and claim another prompt.
+        self.prompt_queue_coordinator.shutdown()
         self._shutdown_requested.set()
         for message_id in tuple(self._original_attempts):
             self.clear_original_attempt(message_id)
@@ -4676,9 +4869,16 @@ class ConsoleChatController:
                 return message.id
         return None
 
-    async def retry_message(self, message_id: str) -> ConsoleSubmitResult:
+    async def retry_message(
+        self,
+        message_id: str,
+        *,
+        queue_authorization: QueueGenerationAuthorization | None = None,
+    ) -> ConsoleSubmitResult:
         """Retry a failed assistant message using the original turn context."""
-        active_rejection = self._active_run_rejection()
+        active_rejection = self._active_run_rejection(
+            queue_authorization=queue_authorization
+        )
         if active_rejection is not None:
             return active_rejection
 
@@ -4746,6 +4946,77 @@ class ConsoleChatController:
             skill_bindings=skill_bindings,
             skill_bundle_block=skill_bundle_block,
             turn_context=turn_context,
+        )
+
+    async def resume_prompt_queue(self, session_id: str) -> PromptQueueMutationResult:
+        """Resume next queued prompt after visibly reacquiring one agent slot."""
+
+        return await self.prompt_queue_coordinator.resume_and_drain(session_id)
+
+    def pause_prompt_queue_after_turn(
+        self, session_id: str, *, expected_revision: int
+    ) -> PromptQueueMutationResult:
+        """Request a pause after the currently accepted turn settles."""
+
+        return self.prompt_queue_coordinator.request_pause_after_turn(
+            session_id, expected_revision=expected_revision
+        )
+
+    def keep_prompt_queue_draining(
+        self, session_id: str, *, expected_revision: int
+    ) -> PromptQueueMutationResult:
+        """Cancel a pending pause-after-turn request."""
+
+        return self.prompt_queue_coordinator.keep_draining(
+            session_id, expected_revision=expected_revision
+        )
+
+    async def skip_and_resume_prompt_queue(
+        self, session_id: str
+    ) -> PromptQueueMutationResult:
+        """Leave the failed/stopped turn visible and dispatch the next prompt."""
+
+        return await self.prompt_queue_coordinator.resume_and_drain(session_id)
+
+    async def retry_failed_queue_turn(
+        self, message_id: str
+    ) -> PromptQueueMutationResult:
+        """Retry the failed turn under narrow queue authority, then drain."""
+
+        session_id = self.store.session_id_for_message(message_id)
+        return await self.prompt_queue_coordinator.recover_and_drain(
+            session_id,
+            lambda authorization: self.retry_message(
+                message_id, queue_authorization=authorization
+            ),
+        )
+
+    async def retry_stopped_queue_turn(
+        self, message_id: str
+    ) -> PromptQueueMutationResult:
+        """Regenerate a stopped turn as a sibling, then drain on success."""
+
+        session_id = self.store.session_id_for_message(message_id)
+        return await self.prompt_queue_coordinator.recover_and_drain(
+            session_id,
+            lambda authorization: self.regenerate_message(
+                message_id, queue_authorization=authorization
+            ),
+        )
+
+    async def use_current_context_and_resume_prompt_queue(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+        reviewed_context_epoch: int,
+    ) -> PromptQueueMutationResult:
+        """Adopt one explicitly reviewed context epoch and resume the queue."""
+
+        return await self.prompt_queue_coordinator.use_current_context_and_resume(
+            session_id,
+            expected_revision=expected_revision,
+            reviewed_context_epoch=reviewed_context_epoch,
         )
 
     async def continue_from_message(self, message_id: str) -> ConsoleSubmitResult:
@@ -4827,7 +5098,12 @@ class ConsoleChatController:
             turn_context=turn_context,
         )
 
-    async def regenerate_message(self, message_id: str) -> ConsoleSubmitResult:
+    async def regenerate_message(
+        self,
+        message_id: str,
+        *,
+        queue_authorization: QueueGenerationAuthorization | None = None,
+    ) -> ConsoleSubmitResult:
         """Regenerate a selected assistant message by forking a sibling branch.
 
         Unlike the pre-Task-6 behavior (streaming a replacement *variant*
@@ -4857,7 +5133,9 @@ class ConsoleChatController:
         intended node-model behavior, not a regression: the anchor is a
         completely separate node and was never touched.
         """
-        active_rejection = self._active_run_rejection()
+        active_rejection = self._active_run_rejection(
+            queue_authorization=queue_authorization
+        )
         if active_rejection is not None:
             return active_rejection
 
@@ -6695,6 +6973,7 @@ class ConsoleChatController:
         self,
         draft: str,
         turn_context: ConsoleTurnExecutionContext | None = None,
+        origin: ConsoleSubmissionOrigin = ConsoleSubmissionOrigin.MANUAL,
     ) -> tuple[
         str | None,
         CitationTraceBuilder | None,
@@ -6707,23 +6986,27 @@ class ConsoleChatController:
         if provider is None:
             return None, None, None, None
         try:
-            parameters = inspect.signature(provider).parameters.values()
+            parameters = inspect.signature(provider).parameters
             accepts_context = any(
                 parameter.kind
                 in {
                     inspect.Parameter.POSITIONAL_ONLY,
                     inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    inspect.Parameter.VAR_POSITIONAL,
                 }
-                for index, parameter in enumerate(parameters)
+                for index, parameter in enumerate(parameters.values())
                 if index > 0
             )
+            origin_parameter = parameters.get("origin")
         except (TypeError, ValueError):
             accepts_context = False
+            origin_parameter = None
         try:
-            captured = await (
-                provider(draft, turn_context) if accepts_context else provider(draft)
-            )
+            if origin_parameter is not None:
+                captured = await provider(draft, turn_context, origin=origin)
+            elif accepts_context:
+                captured = await provider(draft, turn_context)
+            else:
+                captured = await provider(draft)
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -6856,8 +7139,24 @@ class ConsoleChatController:
         updated[final_index] = {**message, "content": new_content}
         return updated
 
-    def _notify_submission_accepted(self) -> None:
-        """Invoke the owner accepted-hook without letting UI errors kill the run."""
+    def _notify_submission_accepted(
+        self,
+        *,
+        session_id: str,
+        origin: ConsoleSubmissionOrigin,
+        entry_id: str | None,
+        context_epoch: int,
+    ) -> None:
+        """Commit queue ownership, then invoke the origin-appropriate UI hook."""
+
+        self.prompt_queue_coordinator.turn_accepted(
+            session_id,
+            origin=origin,
+            context_epoch=context_epoch,
+            entry_id=entry_id,
+        )
+        if origin is not ConsoleSubmissionOrigin.MANUAL:
+            return
         callback = self.on_submission_accepted
         if callback is None:
             return
@@ -6867,6 +7166,37 @@ class ConsoleChatController:
             # The hook is a UI convenience (composer clearing); a failure there
             # must never abort an already-accepted provider run.
             pass
+
+    def _notify_queued_submission_accepted(
+        self, event: ConsoleQueuedAcceptanceEvent
+    ) -> None:
+        """Forward a content-free queued acceptance without touching the composer."""
+
+        callback = self.on_queued_submission_accepted
+        if callback is None:
+            return
+        try:
+            callback(event)
+        except Exception:
+            pass
+
+    async def _submit_queued_entry(
+        self,
+        text: str,
+        *,
+        session_id: str,
+        entry_id: str,
+        authorization: QueueGenerationAuthorization,
+    ) -> ConsoleSubmitResult:
+        """Submit one coordinator-claimed entry through the normal turn pipeline."""
+
+        return await self.submit_draft(
+            text,
+            session_id=session_id,
+            origin=ConsoleSubmissionOrigin.QUEUED,
+            queue_entry_id=entry_id,
+            queue_authorization=authorization,
+        )
 
     async def _record_prompt_history(self, text: str) -> None:
         """Append an accepted send's draft to the shared prompt history.
@@ -9746,6 +10076,9 @@ class ConsoleChatController:
         previous_status = self.run_state_for(target).status
         self._run_states[target] = run_state
         self.run_state_history_for(target).append(run_state.status)
+        terminal_notification_eligible = self.activity_for(
+            target
+        ).terminal_notification_eligible
         # Task 9 finding #2 (deferred from Task 7 review): a terminal run
         # has no live approval left to decide, so the pending-approval flag
         # must be discarded for ANY terminal transition -- including the
@@ -9781,7 +10114,10 @@ class ConsoleChatController:
         # live in its transcript and must never grow a stale "unvisited"
         # fleet marker on itself. `mark_session_visited` is the sole path
         # that clears an entry stamped here.
-        if target != (self.store.active_session_id or ""):
+        if (
+            target != (self.store.active_session_id or "")
+            and terminal_notification_eligible
+        ):
             if run_state.status is ConsoleRunStatus.COMPLETED:
                 self._unvisited_outcomes[target] = ConsoleRunMarker.FINISHED_OK
             elif run_state.status is ConsoleRunStatus.FAILED:
@@ -9820,6 +10156,7 @@ class ConsoleChatController:
         if (
             target == (self.store.active_session_id or "")
             and run_state.status is ConsoleRunStatus.FAILED
+            and terminal_notification_eligible
             and previous_status
             not in {
                 ConsoleRunStatus.BLOCKED,
@@ -9830,6 +10167,28 @@ class ConsoleChatController:
             and self.notify_run_failure is not None
         ):
             self.notify_run_failure(run_state.visible_copy)
+
+    def _publish_queue_chain_terminal(
+        self, session_id: str, status: ConsoleRunStatus
+    ) -> None:
+        """Publish the one terminal marker/toast deferred across a queue chain."""
+
+        if status not in {ConsoleRunStatus.COMPLETED, ConsoleRunStatus.FAILED}:
+            return
+        if not self.activity_for(session_id).terminal_notification_eligible:
+            return
+        active_id = self.store.active_session_id or ""
+        if session_id != active_id:
+            marker = (
+                ConsoleRunMarker.FINISHED_OK
+                if status is ConsoleRunStatus.COMPLETED
+                else ConsoleRunMarker.FINISHED_FAILED
+            )
+            self._unvisited_outcomes[session_id] = marker
+            if self.notify_run_outcome is not None:
+                self.notify_run_outcome(session_id, status)
+        elif status is ConsoleRunStatus.FAILED and self.notify_run_failure is not None:
+            self.notify_run_failure(self.run_state_for(session_id).visible_copy)
 
     def _clear_terminal_run_state(self, session_id: str | None = None) -> None:
         """Clear stale terminal status copy for ``session_id`` (default: active).
@@ -9936,7 +10295,11 @@ class ConsoleChatController:
         )
 
     def _active_run_rejection(
-        self, *, session_id: str | None = None, append_row: bool = False
+        self,
+        *,
+        session_id: str | None = None,
+        append_row: bool = False,
+        queue_authorization: QueueGenerationAuthorization | None = None,
     ) -> ConsoleSubmitResult | None:
         """Defense-in-depth double-send guard for ``submit_draft``.
 
@@ -9971,6 +10334,18 @@ class ConsoleChatController:
             ``ConsoleSubmitResult`` carrying the refusal copy.
         """
         target_id = session_id if session_id else (self.store.active_session_id or "")
+        if self.prompt_queue_coordinator.authorizes(
+            queue_authorization, target_id
+        ) and self.run_state_for(target_id).status in {
+            ConsoleRunStatus.BLOCKED,
+            ConsoleRunStatus.COMPLETED,
+            ConsoleRunStatus.FAILED,
+            ConsoleRunStatus.STOPPED,
+        }:
+            return None
+        if target_id and self.prompt_queue_coordinator.controls_generation(target_id):
+            visible_copy = "Queued messages control the next turn. Resume or manage the queue first."
+            return ConsoleSubmitResult(False, False, visible_copy)
         if self.run_state_for(target_id).is_send_allowed:
             return None
         visible_copy = "A run is already running in this tab."

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -115,6 +115,7 @@ from tldw_chatbook.Chat.console_turn_context import ConsoleTurnExecutionContext
 from tldw_chatbook.Chat.console_prompt_queue import (
     ConsolePromptQueueRegistry,
     PromptQueueMutationResult,
+    QueueMutationStatus,
 )
 from tldw_chatbook.Chat.console_prompt_queue_coordinator import (
     ConsolePromptQueueCoordinator,
@@ -1601,11 +1602,91 @@ class ConsoleChatController:
     ) -> PromptQueueMutationResult:
         """Attempt atomic text-only admission behind queue-owned work."""
 
+        clean_text, validation_error = self._validated_draft(text)
+        if validation_error is not None:
+            return PromptQueueMutationResult(
+                QueueMutationStatus.INVALID,
+                self.prompt_queue_registry.snapshot(session_id),
+                detail=validation_error,
+            )
         return self.prompt_queue_coordinator.admit(
             session_id,
-            text=text,
+            text=clean_text,
             expected_revision=expected_revision,
         )
+
+    def edit_queued_prompt(
+        self,
+        session_id: str,
+        *,
+        entry_id: str,
+        text: str,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        """Edit one waiting prompt and publish the queue activity revision."""
+
+        clean_text, validation_error = self._validated_draft(text)
+        if validation_error is not None:
+            return PromptQueueMutationResult(
+                QueueMutationStatus.INVALID,
+                self.prompt_queue_registry.snapshot(session_id),
+                detail=validation_error,
+            )
+        result = self.prompt_queue_registry.edit(
+            session_id,
+            entry_id=entry_id,
+            text=clean_text,
+            expected_revision=expected_revision,
+        )
+        if result.applied:
+            self.prompt_queue_coordinator.publish_registry_change(session_id)
+        return result
+
+    def move_queued_prompt(
+        self,
+        session_id: str,
+        *,
+        entry_id: str,
+        new_index: int,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        """Reorder one waiting prompt and publish the queue activity revision."""
+
+        result = self.prompt_queue_registry.move(
+            session_id,
+            entry_id=entry_id,
+            new_index=new_index,
+            expected_revision=expected_revision,
+        )
+        if result.applied:
+            self.prompt_queue_coordinator.publish_registry_change(session_id)
+        return result
+
+    def remove_queued_prompt(
+        self, session_id: str, *, entry_id: str, expected_revision: int
+    ) -> PromptQueueMutationResult:
+        """Remove one waiting prompt and publish the queue activity revision."""
+
+        result = self.prompt_queue_registry.remove(
+            session_id,
+            entry_id=entry_id,
+            expected_revision=expected_revision,
+        )
+        if result.applied:
+            self.prompt_queue_coordinator.publish_registry_change(session_id)
+        return result
+
+    def clear_queued_prompts(
+        self, session_id: str, *, expected_revision: int
+    ) -> PromptQueueMutationResult:
+        """Clear waiting prompts and publish the queue activity revision."""
+
+        result = self.prompt_queue_registry.clear_waiting(
+            session_id, expected_revision=expected_revision
+        )
+        if result.applied:
+            self.prompt_queue_coordinator.publish_registry_change(session_id)
+        return result
 
     async def run_prompt_chain(
         self,
@@ -1631,7 +1712,6 @@ class ConsoleChatController:
             lambda: self.submit_draft(
                 draft,
                 session_id=target_id,
-                origin=ConsoleSubmissionOrigin.MANUAL,
             ),
         )
 
@@ -4948,17 +5028,24 @@ class ConsoleChatController:
         queue_authorization: QueueGenerationAuthorization | None = None,
     ) -> ConsoleSubmitResult:
         """Retry a failed assistant message using the original turn context."""
+        active_session_id = self.store.active_session_id
+        if active_session_id is None and queue_authorization is None:
+            return ConsoleSubmitResult(False, False, "No active Console session.")
+        message_session_id = self.store.session_id_for_message(message_id)
+        queue_authorized = self.prompt_queue_coordinator.authorizes(
+            queue_authorization, message_session_id
+        )
+        session_id = message_session_id if queue_authorized else active_session_id
+        if session_id is None:
+            return ConsoleSubmitResult(False, False, "No active Console session.")
         active_rejection = self._active_run_rejection(
-            queue_authorization=queue_authorization
+            session_id=session_id,
+            queue_authorization=queue_authorization,
         )
         if active_rejection is not None:
             return active_rejection
 
-        session_id = self.store.active_session_id
-        if session_id is None:
-            return ConsoleSubmitResult(False, False, "No active Console session.")
         message = self.store.get_message(message_id)
-        message_session_id = self.store.session_id_for_message(message_id)
         if message_session_id != session_id:
             visible_copy = "Open the original session before retrying this message."
             self._set_run_state(
@@ -5205,21 +5292,29 @@ class ConsoleChatController:
         intended node-model behavior, not a regression: the anchor is a
         completely separate node and was never touched.
         """
+        active_session_id = self.store.active_session_id
+        if active_session_id is None and queue_authorization is None:
+            return ConsoleSubmitResult(False, False, "No active Console session.")
+        message_session_id = self.store.session_id_for_message(message_id)
+        queue_authorized = self.prompt_queue_coordinator.authorizes(
+            queue_authorization, message_session_id
+        )
+        session_id = message_session_id if queue_authorized else active_session_id
+        if session_id is None:
+            return ConsoleSubmitResult(False, False, "No active Console session.")
         active_rejection = self._active_run_rejection(
-            queue_authorization=queue_authorization
+            session_id=session_id,
+            queue_authorization=queue_authorization,
         )
         if active_rejection is not None:
             return active_rejection
 
-        session_id = self.store.active_session_id
-        if session_id is None:
-            return ConsoleSubmitResult(False, False, "No active Console session.")
         message = self.store.get_message(message_id)
         if message.role is not ConsoleMessageRole.ASSISTANT:
             return self._block(
                 session_id, "Only assistant messages can be regenerated."
             )
-        if self.store.session_id_for_message(message_id) != session_id:
+        if message_session_id != session_id:
             visible_copy = "Open the original session before regenerating this message."
             self._set_run_state(
                 ConsoleRunState.blocked(visible_copy), session_id=session_id

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -31,6 +31,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     CONSOLE_DEFAULT_MAX_PARALLEL_RUNS,
     ConsoleChatMessage,
     ConsoleControllerActivity,
+    ConsoleLifecycleImpact,
     ConsoleCitationNoticeCode,
     ConsoleCitationPhase,
     ConsoleCitationPresentation,
@@ -1236,6 +1237,13 @@ class ConsoleChatController:
         #: `mark_session_visited`), never from a worker thread, so they
         #: carry no cross-thread hazard this lock needs to close.
         self._approval_state_lock = threading.Lock()
+        # Revision tokens fence destructive lifecycle confirmations without
+        # mirroring any activity values. Counts remain derived on demand from
+        # ``ConsoleControllerActivity``; these integers only reveal that one
+        # of its existing authorities changed while a dialog was open.
+        self._lifecycle_revision_lock = threading.Lock()
+        self._lifecycle_revision = 0
+        self._session_lifecycle_revisions: dict[str, int] = {}
         #: Optional owner hook invoked once a submit is accepted (user message
         #: persisted, run about to start) so the composer can clear immediately
         #: instead of holding the sent text for the whole run.
@@ -1263,6 +1271,7 @@ class ConsoleChatController:
             can_reacquire_slot=self._queue_can_reacquire_slot,
             on_queued_accepted=self._notify_queued_submission_accepted,
             on_chain_terminal=self._publish_queue_chain_terminal,
+            on_activity_changed=self._note_controller_activity_changed,
         )
         # Task 3b: PER-SESSION maps, mirroring `_run_states`' own keying --
         # two sessions can each have their own in-flight stream/cancel state
@@ -1531,6 +1540,58 @@ class ConsoleChatController:
 
         return self.prompt_queue_coordinator.activity(session_id)
 
+    def _advance_lifecycle_revision(self, session_id: str) -> None:
+        """Advance content-free fleet and owning-session confirmation fences."""
+
+        with self._lifecycle_revision_lock:
+            self._lifecycle_revision += 1
+            if session_id:
+                self._session_lifecycle_revisions[session_id] = (
+                    self._session_lifecycle_revisions.get(session_id, 0) + 1
+                )
+
+    def _note_controller_activity_changed(self, session_id: str) -> None:
+        """Receive queue-owner changes without copying its state."""
+
+        self._advance_lifecycle_revision(session_id)
+
+    def _lifecycle_revision_for(self, session_id: str | None) -> int:
+        with self._lifecycle_revision_lock:
+            if session_id is None:
+                return self._lifecycle_revision
+            return self._session_lifecycle_revisions.get(session_id, 0)
+
+    def lifecycle_impact(
+        self, *, session_id: str | None = None
+    ) -> ConsoleLifecycleImpact:
+        """Derive exact loss counts for one session or the whole live fleet.
+
+        The optimistic revision read prevents a worker-thread approval change
+        from producing counts paired with an older token. Queue state itself
+        remains owner-thread confined and is read through the coordinator's
+        immutable activity projection.
+        """
+
+        while True:
+            revision = self._lifecycle_revision_for(session_id)
+            live_ids = {session.id for session in self.store.sessions()}
+            if session_id is not None:
+                target_ids = (session_id,) if session_id in live_ids else ()
+            else:
+                target_ids = tuple(sorted(live_ids))
+            activities = tuple(self.activity_for(target_id) for target_id in target_ids)
+            if revision == self._lifecycle_revision_for(session_id):
+                break
+        return ConsoleLifecycleImpact(
+            revision=revision,
+            live_run_count=sum(
+                bool(activity.occupies_slot or activity.needs_approval)
+                for activity in activities
+            ),
+            queued_session_count=sum(activity.has_queued_work for activity in activities),
+            unsent_prompt_count=sum(activity.queued_count for activity in activities),
+        )
+
     def queue_prompt(
         self,
         session_id: str,
@@ -1735,7 +1796,11 @@ class ConsoleChatController:
         # via `fleet_summary_counts` -- guard the mutation with the shared
         # lock so iteration never observes a torn add/discard.
         with self._approval_state_lock:
-            self._pending_approvals.setdefault(session_id, set()).add(round_id)
+            rounds = self._pending_approvals.setdefault(session_id, set())
+            changed = round_id not in rounds
+            rounds.add(round_id)
+        if changed:
+            self._advance_lifecycle_revision(session_id)
 
     def discard_pending_round(self, session_id: str, round_id: str) -> None:
         """Clear ``round_id`` from ``session_id``'s outstanding approval-like rounds.
@@ -1754,13 +1819,17 @@ class ConsoleChatController:
             round_id: The round's own unique id, as passed to the matching
                 ``add_pending_round`` call.
         """
+        changed = False
         with self._approval_state_lock:
             rounds = self._pending_approvals.get(session_id)
             if rounds is None:
                 return
+            changed = round_id in rounds
             rounds.discard(round_id)
             if not rounds:
                 self._pending_approvals.pop(session_id, None)
+        if changed:
+            self._advance_lifecycle_revision(session_id)
 
     def has_pending_approval_round(self, session_id: str) -> bool:
         """Return whether ``session_id`` currently has ANY outstanding approval-like round.
@@ -4796,10 +4865,7 @@ class ConsoleChatController:
         its own, unset ``_shutdown_requested`` -- so the permanently-set
         flag on the old instance can never poison it.
         """
-        # Tombstone queue chains before any cancellation can resume their
-        # awaiting drain coroutine and claim another prompt.
-        self.prompt_queue_coordinator.shutdown()
-        self._shutdown_requested.set()
+        self.begin_shutdown()
         for message_id in tuple(self._original_attempts):
             self.clear_original_attempt(message_id)
         tasks = dict(self._active_stream_tasks)
@@ -4851,6 +4917,12 @@ class ConsoleChatController:
                 self._active_stream_tasks.pop(session_id, None)
                 self._active_assistant_message_ids.pop(session_id, None)
                 self._active_cancel_events.pop(session_id, None)
+
+    def begin_shutdown(self) -> None:
+        """Tombstone future queue work before any teardown cancellation."""
+
+        self.prompt_queue_coordinator.shutdown()
+        self._shutdown_requested.set()
 
     def _active_streaming_assistant_message_id(self) -> str | None:
         """Return the visible streaming assistant message for the active session."""
@@ -10076,6 +10148,7 @@ class ConsoleChatController:
         previous_status = self.run_state_for(target).status
         self._run_states[target] = run_state
         self.run_state_history_for(target).append(run_state.status)
+        self._advance_lifecycle_revision(target)
         terminal_notification_eligible = self.activity_for(
             target
         ).terminal_notification_eligible

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -73,6 +73,26 @@ class ConsoleControllerActivity:
         return self.queued_count > 0
 
 
+@dataclass(frozen=True, slots=True)
+class ConsoleLifecycleImpact:
+    """Revisioned, content-free loss impact derived from Console activity."""
+
+    revision: int
+    live_run_count: int
+    queued_session_count: int
+    unsent_prompt_count: int
+
+    @property
+    def has_loss_risk(self) -> bool:
+        """Return whether leaving would discard or cancel Console work."""
+
+        return bool(
+            self.live_run_count
+            or self.queued_session_count
+            or self.unsent_prompt_count
+        )
+
+
 class ConsoleRunMarker(str, Enum):
     """Fleet-visible run marker for a session (parallel-agents spec §6).
 

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -38,6 +38,41 @@ class ConsoleRunStatus(str, Enum):
     RETRYING = "retrying"
 
 
+class ConsoleSubmissionOrigin(str, Enum):
+    """Origin of a Console turn entering the accepted-send boundary."""
+
+    MANUAL = "manual"
+    QUEUED = "queued"
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleQueuedAcceptanceEvent:
+    """Content-free notice that one claimed queue entry became a real turn."""
+
+    session_id: str
+    entry_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleControllerActivity:
+    """Single content-free lifecycle projection for Console fleet consumers."""
+
+    session_id: str
+    occupies_slot: bool
+    preparing_before_acceptance: bool
+    accepted_live_turn: bool
+    needs_approval: bool
+    queued_count: int
+    queue_paused: bool
+    terminal_notification_eligible: bool
+
+    @property
+    def has_queued_work(self) -> bool:
+        """Return whether queue-owned future work controls this session."""
+
+        return self.queued_count > 0
+
+
 class ConsoleRunMarker(str, Enum):
     """Fleet-visible run marker for a session (parallel-agents spec §6).
 

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -627,6 +627,16 @@ class ConsoleChatStore:
         # mutations, so the cost chip knows when its cache-break fingerprint
         # needs recomputing. Process-local, like the speech revisions above.
         self._payload_revisions: dict[str, int] = {}
+        # Prompt-queue context safety: a narrower process-local token than
+        # `_payload_revisions`. Ordinary linear turn growth and streaming do
+        # not move it; out-of-band changes to the effective active provider
+        # context do. It is intentionally absent from persistence/snapshots.
+        self._conversation_context_epochs: dict[str, int] = {}
+        # A failed assistant row is excluded from ordinary provider payloads.
+        # Retrying it reuses that row in place, so the eventual complete or
+        # stopped terminal must advance the context epoch when the row becomes
+        # provider-visible history. A repeat failure stays excluded and stable.
+        self._failed_retry_message_ids: set[str] = set()
 
     def ensure_session(
         self,
@@ -681,6 +691,7 @@ class ConsoleChatStore:
         self._children_by_parent[session.id] = {}
         self._active_leaf_by_session[session.id] = None
         self._context_summary_by_session[session.id] = (None, None)
+        self._conversation_context_epochs[session.id] = 0
         self.active_session_id = session.id
         return session
 
@@ -953,6 +964,7 @@ class ConsoleChatStore:
             self._pending_persistence_message_ids.discard(message_id)
             self._variant_stream_bases.pop(message_id, None)
             self._variant_restored_message_ids.discard(message_id)
+            self._failed_retry_message_ids.discard(message_id)
             self._message_speech_revisions.pop(message_id, None)
             self._native_parent_by_message.pop(message_id, None)
             self._roleplay_message_projection_candidates.pop(message_id, None)
@@ -964,6 +976,7 @@ class ConsoleChatStore:
         self._active_leaf_by_session.pop(session_id, None)
         self._context_summary_by_session.pop(session_id, None)
         self._roleplay_system_projection_candidates.pop(session_id, None)
+        self._conversation_context_epochs.pop(session_id, None)
         self._sessions.pop(session_id, None)
 
         if self.active_session_id != session_id:
@@ -1226,8 +1239,10 @@ class ConsoleChatStore:
         # never cleared on restore, leaking across a state replacement.
         self._variant_stream_bases.clear()
         self._variant_restored_message_ids.clear()
+        self._failed_retry_message_ids.clear()
         self._message_speech_revisions.clear()
         self._payload_revisions.clear()
+        self._conversation_context_epochs.clear()
         self._nodes_by_session.clear()
         self._children_by_parent.clear()
         self._native_parent_by_message.clear()
@@ -1241,6 +1256,7 @@ class ConsoleChatStore:
             self._children_by_parent[session.id] = {}
             self._active_leaf_by_session[session.id] = None
             self._context_summary_by_session[session.id] = (None, None)
+            self._conversation_context_epochs[session.id] = 0
             self._messages_by_session[session.id] = []
             self._ingest_linear_messages(
                 session.id, messages_by_session.get(session.id, ())
@@ -1487,6 +1503,7 @@ class ConsoleChatStore:
         # the old ``set_active_leaf`` call with a still-``None`` id, which is fine.
         self._persist_active_leaf(session_id, message.id)
         self._bump_payload_revision(session_id)
+        self._bump_conversation_context_epoch(session_id)
         return self._snapshot(message)
 
     def append_generation_message(
@@ -1653,6 +1670,7 @@ class ConsoleChatStore:
         """
         self._session_or_raise(session_id)
         message = self._message_or_raise(message_id)
+        owner_session_id = self._message_session_index[message.id]
         if not message.generation_metadata:
             raise ValueError(
                 "append_generation_variant requires a generation message "
@@ -1684,6 +1702,8 @@ class ConsoleChatStore:
                     f"persistence assigned {persisted_position}"
                 )
         self._bump_payload_revision(session_id)
+        if self._message_is_on_active_path(message_id):
+            self._bump_conversation_context_epoch(owner_session_id)
         return new_position
 
     def keep_generation_variant(
@@ -1724,6 +1744,7 @@ class ConsoleChatStore:
         """
         self._session_or_raise(session_id)
         message = self._message_or_raise(message_id)
+        owner_session_id = self._message_session_index[message.id]
         if position <= 0 or position >= len(message.attachments):
             raise ValueError(
                 f"No attachment at position {position} to keep for message"
@@ -1750,6 +1771,8 @@ class ConsoleChatStore:
                 message.persisted_message_id, position
             )
         self._bump_payload_revision(session_id)
+        if self._message_is_on_active_path(message_id):
+            self._bump_conversation_context_epoch(owner_session_id)
 
     def hydrate_generation_metadata(
         self,
@@ -2079,6 +2102,9 @@ class ConsoleChatStore:
         self._materialize_stream_buffer(message)
         if message.status in {"pending", "streaming"}:
             raise ValueError("Wait for response to finish before editing this message.")
+        session_id = self._message_session_index[message.id]
+        previous_content = message.content
+        on_active_path = self._message_is_on_active_path(message.id)
         provenance_cleared = (
             message.metadata is not None
             and message.metadata.template_kind == "character_greeting"
@@ -2103,9 +2129,11 @@ class ConsoleChatStore:
             message.content = message.variants.current.content
         self._bump_message_speech_revision(message.id)
         if provenance_cleared:
-            self._bump_identity_revision(self._message_session_index[message.id])
+            self._bump_identity_revision(session_id)
         else:
-            self._bump_payload_revision(self._message_session_index[message.id])
+            self._bump_payload_revision(session_id)
+        if on_active_path and message.content != previous_content:
+            self._bump_conversation_context_epoch(session_id)
         self._persist_existing_message(
             message, force_metadata_write=provenance_cleared
         )
@@ -2955,6 +2983,7 @@ class ConsoleChatStore:
             self._pending_persistence_message_ids.discard(node_id)
             self._variant_stream_bases.pop(node_id, None)
             self._variant_restored_message_ids.discard(node_id)
+            self._failed_retry_message_ids.discard(node_id)
             self._message_speech_revisions.pop(node_id, None)
         # Only when the deleted branch was on the active path does the leaf move
         # (up to the deleted node's parent); an off-path delete leaves it alone.
@@ -2963,6 +2992,8 @@ class ConsoleChatStore:
             self._active_leaf_by_session[session_id] = parent_native_id
         self._recompute_active_path(session_id)
         self._bump_payload_revision(session_id)
+        if on_active_path:
+            self._bump_conversation_context_epoch(session_id)
         return self._snapshot(message)
 
     def session_id_for_message(self, message_id: str) -> str:
@@ -3001,10 +3032,13 @@ class ConsoleChatStore:
         nodes = self._nodes_by_session.get(session_id, {})
         if message_id is not None and message_id not in nodes:
             raise KeyError(f"Unknown Console message: {message_id}")
+        previous_leaf = self._active_leaf_by_session.get(session_id)
         self._active_leaf_by_session[session_id] = message_id
         self._recompute_active_path(session_id)
         self._persist_active_leaf(session_id, message_id)
         self._bump_payload_revision(session_id)
+        if message_id != previous_leaf:
+            self._bump_conversation_context_epoch(session_id)
 
     def session_context_summary(self, session_id: str) -> tuple[str | None, str | None]:
         """Return the session's in-memory ``(summary, boundary_native_id)`` pair.
@@ -3046,9 +3080,13 @@ class ConsoleChatStore:
             KeyError: If the session is unknown.
         """
         self._session_or_raise(session_id)
-        self._context_summary_by_session[session_id] = (summary, boundary_native_id)
+        previous = self._context_summary_by_session.get(session_id, (None, None))
+        updated = (summary, boundary_native_id)
+        self._context_summary_by_session[session_id] = updated
         self._persist_context_summary(session_id, summary, boundary_native_id)
         self._bump_payload_revision(session_id)
+        if updated != previous:
+            self._bump_conversation_context_epoch(session_id)
 
     def active_path_message_ids(self, session_id: str) -> list[str]:
         """Return native ids along the active path, root -> active leaf.
@@ -3244,6 +3282,7 @@ class ConsoleChatStore:
         message = self._message_or_raise(message_id)
         self._validate_can_mark_terminal(message)
         self._materialize_stream_buffer(message)
+        session_id = self._message_session_index[message.id]
         finalizer = self._terminal_citation_finalizers.pop(message.id, None)
         terminal_persistence = (
             finalizer is not None
@@ -3253,7 +3292,8 @@ class ConsoleChatStore:
         if not terminal_persistence:
             message.status = "complete"
             self._bump_message_speech_revision(message.id)
-            self._bump_payload_revision(self._message_session_index[message.id])
+            self._bump_payload_revision(session_id)
+            self._settle_failed_retry_context(message, provider_visible=True)
             self._persist_existing_message(message)
             return self._snapshot(message)
 
@@ -3261,7 +3301,8 @@ class ConsoleChatStore:
             if not message.content:
                 message.status = "complete"
                 self._bump_message_speech_revision(message.id)
-                self._bump_payload_revision(self._message_session_index[message.id])
+                self._bump_payload_revision(session_id)
+                self._settle_failed_retry_context(message, provider_visible=True)
                 self._persist_existing_message(message)
                 return self._snapshot(message)
 
@@ -3273,8 +3314,8 @@ class ConsoleChatStore:
                     logger.warning("terminal_finalizer_unavailable")
             message.status = "complete"
             self._bump_message_speech_revision(message.id)
-            session_id = self._message_session_index[message.id]
             self._bump_payload_revision(session_id)
+            self._settle_failed_retry_context(message, provider_visible=True)
             try:
                 self._persist_new_message(
                     session_id=session_id,
@@ -3313,6 +3354,7 @@ class ConsoleChatStore:
         message = self._message_or_raise(message_id)
         self._validate_can_mark_terminal(message)
         self._materialize_stream_buffer(message)
+        session_id = self._message_session_index[message.id]
         self.clear_terminal_citation_state(message.id)
         base = self._variant_stream_bases.pop(message.id, None)
         if base is not None:
@@ -3324,7 +3366,11 @@ class ConsoleChatStore:
             message.status = "stopped"
             self._variant_restored_message_ids.discard(message.id)
         self._bump_message_speech_revision(message.id)
-        self._bump_payload_revision(self._message_session_index[message.id])
+        self._bump_payload_revision(session_id)
+        self._settle_failed_retry_context(
+            message,
+            provider_visible=message.status != "failed",
+        )
         self._persist_existing_message(message)
         return self._snapshot(message)
 
@@ -3349,6 +3395,7 @@ class ConsoleChatStore:
         message = self._message_or_raise(message_id)
         self._validate_can_mark_terminal(message)
         self._materialize_stream_buffer(message)
+        session_id = self._message_session_index[message.id]
         self.clear_terminal_citation_state(message.id)
         base = self._variant_stream_bases.pop(message.id, None)
         if base is not None:
@@ -3360,7 +3407,11 @@ class ConsoleChatStore:
             message.status = "failed"
             self._variant_restored_message_ids.discard(message.id)
         self._bump_message_speech_revision(message.id)
-        self._bump_payload_revision(self._message_session_index[message.id])
+        self._bump_payload_revision(session_id)
+        self._settle_failed_retry_context(
+            message,
+            provider_visible=message.status != "failed",
+        )
         self._persist_existing_message(message)
         return self._snapshot(message)
 
@@ -3447,6 +3498,7 @@ class ConsoleChatStore:
         self._stream_materialized_counts.pop(message.id, None)
         # A new generation starts here -- see `begin_variant_stream`.
         self._variant_restored_message_ids.discard(message.id)
+        self._failed_retry_message_ids.add(message.id)
         self._bump_message_speech_revision(message.id)
         self._bump_payload_revision(self._message_session_index[message.id])
         return self._snapshot(message)
@@ -3457,6 +3509,9 @@ class ConsoleChatStore:
         self._materialize_stream_buffer(message)
         if message.role is not ConsoleMessageRole.ASSISTANT:
             raise ValueError("Only assistant messages can receive variants.")
+        session_id = self._message_session_index[message.id]
+        previous_content = message.content
+        on_active_path = self._message_is_on_active_path(message.id)
         if message.variants is None:
             message.variants = ConsoleVariantSet.from_contents(
                 turn_id=message.turn_id or message.id,
@@ -3470,7 +3525,9 @@ class ConsoleChatStore:
         self._bump_message_speech_revision(message.id)
         provenance_cleared = self._clear_character_greeting_provenance(message)
         if not provenance_cleared:
-            self._bump_payload_revision(self._message_session_index[message.id])
+            self._bump_payload_revision(session_id)
+        if on_active_path and message.content != previous_content:
+            self._bump_conversation_context_epoch(session_id)
         self._persist_existing_message(
             message, force_metadata_write=provenance_cleared
         )
@@ -3530,6 +3587,8 @@ class ConsoleChatStore:
         new_content = message.content
         base_entry = self._variant_stream_bases.pop(message.id, None)
         base = base_entry.content if base_entry is not None else ""
+        session_id = self._message_session_index[message.id]
+        on_active_path = self._message_is_on_active_path(message.id)
         if message.variants is None:
             message.variants = ConsoleVariantSet.from_contents(
                 turn_id=message.turn_id or message.id,
@@ -3544,7 +3603,9 @@ class ConsoleChatStore:
         self._bump_message_speech_revision(message.id)
         provenance_cleared = self._clear_character_greeting_provenance(message)
         if not provenance_cleared:
-            self._bump_payload_revision(self._message_session_index[message.id])
+            self._bump_payload_revision(session_id)
+        if on_active_path and message.content != base:
+            self._bump_conversation_context_epoch(session_id)
         self._persist_existing_message(
             message, force_metadata_write=provenance_cleared
         )
@@ -3560,10 +3621,15 @@ class ConsoleChatStore:
             raise ValueError("Message has no variants.")
         if selected_index < 0 or selected_index >= len(message.variants.variants):
             raise ValueError("selected_index must reference an existing variant")
+        session_id = self._message_session_index[message.id]
+        previous_content = message.content
+        on_active_path = self._message_is_on_active_path(message.id)
         message.variants.selected_index = selected_index
         message.content = message.variants.current.content
         self._bump_message_speech_revision(message.id)
-        self._bump_payload_revision(self._message_session_index[message.id])
+        self._bump_payload_revision(session_id)
+        if on_active_path and message.content != previous_content:
+            self._bump_conversation_context_epoch(session_id)
         self._persist_existing_message(message)
         return self._snapshot(message)
 
@@ -4794,6 +4860,49 @@ class ConsoleChatStore:
         self._payload_revisions[session_id] = (
             self._payload_revisions.get(session_id, 0) + 1
         )
+
+    def _bump_conversation_context_epoch(self, session_id: str) -> None:
+        """Advance one live session's provider-context change token."""
+        self._conversation_context_epochs[session_id] += 1
+
+    def conversation_context_epoch(self, session_id: str) -> int:
+        """Return the process-local provider-context epoch for a live session.
+
+        Unlike ``payload_revision``, ordinary linear appends, response streaming,
+        terminal status, and persistence bookkeeping do not advance this token.
+        It exists for deferred-turn safety and is never serialized.
+
+        Raises:
+            KeyError: If ``session_id`` is not a live Console session.
+        """
+        self._session_or_raise(session_id)
+        return self._conversation_context_epochs[session_id]
+
+    def _message_is_on_active_path(self, message_id: str) -> bool:
+        """Return whether a registered tree node affects the active transcript."""
+        session_id = self._message_session_index[message_id]
+        return message_id in self.active_path_message_ids(session_id)
+
+    def _settle_failed_retry_context(
+        self,
+        message: ConsoleChatMessage,
+        *,
+        provider_visible: bool,
+    ) -> None:
+        """Finish failed-row retry tracking and advance on visible recovery.
+
+        A failed row is excluded from normal future payloads. Once an in-place
+        retry finishes as complete or stopped, that same row becomes history and
+        therefore changes effective provider context even when its text is byte-
+        identical to the failed attempt. Another failed terminal stays excluded.
+        """
+        was_failed_retry = message.id in self._failed_retry_message_ids
+        self._failed_retry_message_ids.discard(message.id)
+        if not was_failed_retry or not provider_visible:
+            return
+        if self._message_is_on_active_path(message.id):
+            session_id = self._message_session_index[message.id]
+            self._bump_conversation_context_epoch(session_id)
 
     def payload_revision(self, session_id: str) -> int:
         """Monotonic per-session counter of payload-affecting mutations."""

--- a/tldw_chatbook/Chat/console_prompt_queue.py
+++ b/tldw_chatbook/Chat/console_prompt_queue.py
@@ -1108,6 +1108,33 @@ class ConsolePromptQueueRegistry:
         self._bump(state)
         return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
 
+    def adopt_recovery_context_baseline(
+        self,
+        session_id: str,
+        *,
+        context_epoch: int,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        """Adopt an epoch changed by one coordinator-authorized recovery turn."""
+
+        context_epoch = self._context_epoch(context_epoch)
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if (
+            state.mode is not PromptQueueMode.DRAINING
+            or state.reservation is not PromptQueueReservation.HELD
+            or state.claimed is not None
+            or state.total_count == 0
+        ):
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        if state.expected_context_epoch == context_epoch:
+            return self._result(QueueMutationStatus.UNCHANGED, session_id, state=state)
+        state.expected_context_epoch = context_epoch
+        self._bump(state)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
     def finalize_empty_chain(
         self,
         session_id: str,

--- a/tldw_chatbook/Chat/console_prompt_queue.py
+++ b/tldw_chatbook/Chat/console_prompt_queue.py
@@ -19,6 +19,8 @@ from enum import Enum
 from rich.cells import cell_len, split_graphemes
 from rich.markup import escape as escape_markup
 
+from tldw_chatbook.Utils.input_validation import validate_text_input
+
 
 MAX_CONSOLE_QUEUE_ENTRIES = 10
 MAX_CONSOLE_QUEUED_PROMPT_LENGTH = 100_000
@@ -315,7 +317,11 @@ class ConsolePromptQueueRegistry:
         self._monotonic = monotonic or time.monotonic
         self._states: dict[str, _SessionQueueState] = {}
         self._empty_snapshots: dict[str, PromptQueueSnapshot] = {}
-        self._issued_entry_ids: set[str] = set()
+        # Entry identities need only be unique while they can still be
+        # referenced by a queue mutation or coordinator callback. Retaining
+        # historical IDs forever would make this process-memory queue grow
+        # with lifetime throughput instead of its bounded active contents.
+        self._active_entry_ids: set[str] = set()
         self._next_insertion_order = 0
         self._registry_revision = 0
         self._shutting_down = False
@@ -367,7 +373,11 @@ class ConsolePromptQueueRegistry:
         return (
             isinstance(text, str)
             and bool(text.strip())
-            and len(text) <= MAX_CONSOLE_QUEUED_PROMPT_LENGTH
+            and validate_text_input(
+                text,
+                max_length=MAX_CONSOLE_QUEUED_PROMPT_LENGTH,
+                allow_html=False,
+            )
         )
 
     def _empty_snapshot(self, session_id: str) -> PromptQueueSnapshot:
@@ -609,7 +619,7 @@ class ConsolePromptQueueRegistry:
         if (
             not isinstance(entry_id, str)
             or not entry_id
-            or entry_id in self._issued_entry_ids
+            or entry_id in self._active_entry_ids
         ):
             return None
         admitted_at = self._monotonic()
@@ -623,7 +633,7 @@ class ConsolePromptQueueRegistry:
             insertion_order=self._next_insertion_order,
             admitted_at=float(admitted_at),
         )
-        self._issued_entry_ids.add(entry_id)
+        self._active_entry_ids.add(entry_id)
         return prompt
 
     def _claim_time(self) -> float | None:
@@ -850,7 +860,8 @@ class ConsolePromptQueueRegistry:
         index = self._waiting_index(state, entry_id)
         if index is None:
             return self._result(QueueMutationStatus.NOT_FOUND, session_id, state=state)
-        state.waiting.pop(index)
+        removed = state.waiting.pop(index)
+        self._active_entry_ids.discard(removed.entry_id)
         self._finalize_released_empty_state(state)
         self._bump(state)
         return self._result(
@@ -872,6 +883,9 @@ class ConsolePromptQueueRegistry:
         assert state is not None
         if not state.waiting:
             return self._result(QueueMutationStatus.UNCHANGED, session_id, state=state)
+        self._active_entry_ids.difference_update(
+            prompt.entry_id for prompt in state.waiting
+        )
         state.waiting.clear()
         self._finalize_released_empty_state(state)
         self._bump(state)
@@ -926,6 +940,7 @@ class ConsolePromptQueueRegistry:
             return self._result(QueueMutationStatus.NOT_FOUND, session_id, state=state)
         if state.claimed.prompt.entry_id != entry_id:
             return self._result(QueueMutationStatus.LOCKED, session_id, state=state)
+        self._active_entry_ids.discard(state.claimed.prompt.entry_id)
         state.claimed = None
         self._bump(state)
         return self._result(
@@ -1205,6 +1220,11 @@ class ConsolePromptQueueRegistry:
             )
         if state is None:
             return self._result(QueueMutationStatus.UNCHANGED, session_id)
+        self._active_entry_ids.difference_update(
+            prompt.entry_id for prompt in state.waiting
+        )
+        if state.claimed is not None:
+            self._active_entry_ids.discard(state.claimed.prompt.entry_id)
         del self._states[session_id]
         self._registry_revision += 1
         return self._result(QueueMutationStatus.APPLIED, session_id)
@@ -1226,6 +1246,7 @@ class ConsolePromptQueueRegistry:
         removed_prompts = sum(state.total_count for state in self._states.values())
         self._shutting_down = True
         self._states.clear()
+        self._active_entry_ids.clear()
         self._registry_revision += 1
         return PromptQueueShutdownResult(
             status=QueueMutationStatus.APPLIED,

--- a/tldw_chatbook/Chat/console_prompt_queue.py
+++ b/tldw_chatbook/Chat/console_prompt_queue.py
@@ -1,0 +1,1230 @@
+"""Pure, bounded, process-memory state for Console prompt queues.
+
+The registry is deliberately synchronous and confined to the thread that creates
+it.  It owns text-only queue entries and exposes body-free render snapshots; worker,
+provider, persistence, and widget behavior belong to later layers.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+import unicodedata
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+
+from rich.cells import cell_len, split_graphemes
+from rich.markup import escape as escape_markup
+
+
+MAX_CONSOLE_QUEUE_ENTRIES = 10
+MAX_CONSOLE_QUEUED_PROMPT_LENGTH = 100_000
+PROMPT_PREVIEW_CELL_BUDGET = 96
+_ELLIPSIS = "\N{HORIZONTAL ELLIPSIS}"
+
+# OSC comes first so the generic two-byte escape form cannot consume only its
+# introducer.  Incomplete OSC strings are stripped through end-of-input as a
+# fail-closed preview rule.  CSI covers both ESC-[ and its one-byte C1 form.
+_ANSI_ESCAPE_RE = re.compile(
+    r"(?:\x1b\][^\x07\x1b]*(?:\x07|\x1b\\|$))"
+    r"|(?:\x1b\[[0-?]*[ -/]*[@-~])"
+    r"|(?:\x9b[0-?]*[ -/]*[@-~])"
+    r"|(?:\x1b[@-_])"
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+_BIDI_CONTROLS = frozenset(
+    chr(codepoint)
+    for codepoint in (
+        0x061C,
+        0x200E,
+        0x200F,
+        0x202A,
+        0x202B,
+        0x202C,
+        0x202D,
+        0x202E,
+        0x2066,
+        0x2067,
+        0x2068,
+        0x2069,
+    )
+)
+
+
+class PromptQueueMode(str, Enum):
+    """How a session's queue should behave after the current turn."""
+
+    DRAINING = "draining"
+    PAUSE_AFTER_TURN = "pause_after_turn"
+    PAUSED = "paused"
+
+
+class PromptQueuePauseReason(str, Enum):
+    """Why automatic queue progression is paused."""
+
+    MANUAL = "manual"
+    FAILED = "failed"
+    STOPPED = "stopped"
+    CONTEXT_CHANGED = "context_changed"
+    DISPATCH_REFUSED = "dispatch_refused"
+
+
+class PromptQueueReservation(str, Enum):
+    """Whether the session currently occupies its agent slot."""
+
+    RELEASED = "released"
+    HELD = "held"
+
+
+class PromptQueueEntryPhase(str, Enum):
+    """Body-free lifecycle phase exposed to renderers."""
+
+    WAITING = "waiting"
+    STARTING = "starting"
+
+
+class QueueMutationStatus(str, Enum):
+    """Content-free outcome for a registry intent."""
+
+    APPLIED = "applied"
+    UNCHANGED = "unchanged"
+    STALE_REVISION = "stale_revision"
+    INVALID = "invalid"
+    FULL = "full"
+    NOT_FOUND = "not_found"
+    LOCKED = "locked"
+    REROUTE_NORMAL_SEND = "reroute_normal_send"
+    CLOSING = "closing"
+    SHUTTING_DOWN = "shutting_down"
+
+
+class QueueThreadViolation(RuntimeError):
+    """Raised when queue state is touched outside its creating thread."""
+
+
+def _strip_terminal_controls(text: str) -> str:
+    text = _ANSI_ESCAPE_RE.sub("", text)
+    safe: list[str] = []
+    for character in text:
+        if character in _BIDI_CONTROLS:
+            continue
+        if character.isspace():
+            safe.append(" ")
+            continue
+        if unicodedata.category(character) in {"Cc", "Cs"}:
+            continue
+        safe.append(character)
+    return "".join(safe)
+
+
+def _truncate_cells(text: str, budget: int) -> str:
+    if budget <= 0:
+        return ""
+    if cell_len(text) <= budget:
+        return text
+    ellipsis_width = cell_len(_ELLIPSIS)
+    if budget <= ellipsis_width:
+        return _ELLIPSIS if budget == ellipsis_width else ""
+
+    spans, _cell_offsets = split_graphemes(text)
+    available = budget - ellipsis_width
+    used = 0
+    end = 0
+    for _start, next_end, width in spans:
+        if used + width > available:
+            break
+        used += width
+        end = next_end
+    prefix = text[:end].rstrip()
+    while prefix and cell_len(prefix) + ellipsis_width > budget:
+        prefix_spans, _ = split_graphemes(prefix)
+        if not prefix_spans:
+            prefix = ""
+            break
+        prefix = prefix[: prefix_spans[-1][0]].rstrip()
+    return f"{prefix}{_ELLIPSIS}"
+
+
+def make_prompt_preview(
+    text: str,
+    *,
+    cell_budget: int = PROMPT_PREVIEW_CELL_BUDGET,
+) -> str:
+    """Return a one-line, terminal-safe, Rich-markup-safe prompt preview.
+
+    The budget applies to rendered terminal cells.  Rich escaping happens only
+    after fitting, so escape syntax does not consume the visible-cell budget.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("queued prompt text must be a string")
+    if not isinstance(cell_budget, int) or isinstance(cell_budget, bool):
+        raise TypeError("preview cell budget must be an integer")
+    normalized = _WHITESPACE_RE.sub(" ", _strip_terminal_controls(text)).strip()
+    return escape_markup(_truncate_cells(normalized, max(0, cell_budget)))
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class QueuedPrompt:
+    """One immutable canonical prompt; body-bearing fields are repr-hidden."""
+
+    entry_id: str
+    text: str = field(repr=False)
+    preview: str = field(repr=False)
+    insertion_order: int
+    admitted_at: float
+
+    def __repr__(self) -> str:
+        return (
+            "QueuedPrompt("
+            f"entry_id={self.entry_id!r}, text=<redacted>, preview=<redacted>, "
+            f"insertion_order={self.insertion_order}, admitted_at={self.admitted_at!r})"
+        )
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class PromptQueueClaim:
+    """A locked pre-accept queue entry."""
+
+    prompt: QueuedPrompt = field(repr=False)
+    claimed_at: float
+
+    def __repr__(self) -> str:
+        return (
+            "PromptQueueClaim("
+            f"entry_id={self.prompt.entry_id!r}, prompt=<redacted>, "
+            f"claimed_at={self.claimed_at!r})"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PromptQueueEntrySnapshot:
+    """Body-free render projection for one waiting or starting entry."""
+
+    entry_id: str
+    preview: str
+    insertion_order: int
+    position: int
+    phase: PromptQueueEntryPhase
+
+
+@dataclass(frozen=True, slots=True)
+class PromptQueueSnapshot:
+    """Immutable, body-free state consumed by controllers and widgets."""
+
+    session_id: str
+    revision: int
+    entries: tuple[PromptQueueEntrySnapshot, ...]
+    waiting_count: int
+    claimed_count: int
+    total_count: int
+    mode: PromptQueueMode
+    pause_reason: PromptQueuePauseReason | None
+    reservation: PromptQueueReservation
+    expected_context_epoch: int | None
+    closing: bool
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class PromptQueueMutationResult:
+    """Content-free transition result, optionally carrying one redacted claim."""
+
+    status: QueueMutationStatus
+    snapshot: PromptQueueSnapshot
+    entry_id: str | None = None
+    claim: PromptQueueClaim | None = field(default=None, repr=False)
+    detail: str | None = None
+
+    @property
+    def applied(self) -> bool:
+        return self.status is QueueMutationStatus.APPLIED
+
+    def __repr__(self) -> str:
+        claim_id = self.claim.prompt.entry_id if self.claim is not None else None
+        return (
+            "PromptQueueMutationResult("
+            f"status={self.status!r}, session_id={self.snapshot.session_id!r}, "
+            f"revision={self.snapshot.revision}, total_count={self.snapshot.total_count}, "
+            f"entry_id={self.entry_id!r}, claim_entry_id={claim_id!r}, "
+            f"detail={self.detail!r})"
+        )
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class PromptQueueTextResult:
+    """Revision-checked full text for one selected waiting entry only."""
+
+    status: QueueMutationStatus
+    session_id: str
+    revision: int
+    entry_id: str | None = None
+    text: str | None = field(default=None, repr=False)
+
+    def __repr__(self) -> str:
+        return (
+            "PromptQueueTextResult("
+            f"status={self.status!r}, session_id={self.session_id!r}, "
+            f"revision={self.revision}, entry_id={self.entry_id!r}, "
+            "text=<redacted>)"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PromptQueueShutdownResult:
+    """Aggregate, body-free result of the global shutdown transition."""
+
+    status: QueueMutationStatus
+    registry_revision: int
+    removed_sessions: int = 0
+    removed_prompts: int = 0
+
+
+@dataclass(slots=True)
+class _SessionQueueState:
+    session_id: str
+    waiting: list[QueuedPrompt] = field(default_factory=list)
+    claimed: PromptQueueClaim | None = None
+    revision: int = 0
+    mode: PromptQueueMode = PromptQueueMode.DRAINING
+    pause_reason: PromptQueuePauseReason | None = None
+    reservation: PromptQueueReservation = PromptQueueReservation.RELEASED
+    expected_context_epoch: int | None = None
+    closing: bool = False
+    reroute_admission_revision: int | None = None
+    snapshot_cache: PromptQueueSnapshot | None = None
+
+    @property
+    def total_count(self) -> int:
+        return len(self.waiting) + int(self.claimed is not None)
+
+
+class ConsolePromptQueueRegistry:
+    """Synchronous owner of bounded, revisioned per-session prompt queues."""
+
+    def __init__(
+        self,
+        *,
+        id_factory: Callable[[], str] | None = None,
+        monotonic: Callable[[], float] | None = None,
+    ) -> None:
+        self._owner_thread_id = threading.get_ident()
+        self._id_factory = id_factory or (lambda: uuid.uuid4().hex)
+        self._monotonic = monotonic or time.monotonic
+        self._states: dict[str, _SessionQueueState] = {}
+        self._empty_snapshots: dict[str, PromptQueueSnapshot] = {}
+        self._issued_entry_ids: set[str] = set()
+        self._next_insertion_order = 0
+        self._registry_revision = 0
+        self._shutting_down = False
+
+    @property
+    def registry_revision(self) -> int:
+        self._assert_owner_thread()
+        return self._registry_revision
+
+    @property
+    def shutting_down(self) -> bool:
+        self._assert_owner_thread()
+        return self._shutting_down
+
+    def _assert_owner_thread(self) -> None:
+        if threading.get_ident() != self._owner_thread_id:
+            raise QueueThreadViolation(
+                "Console prompt queue access must be marshalled to its owner thread"
+            )
+
+    @staticmethod
+    def _session_id(session_id: str) -> str:
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError("session_id must be a non-empty string")
+        return session_id
+
+    @staticmethod
+    def _expected_revision(expected_revision: int) -> int:
+        if (
+            not isinstance(expected_revision, int)
+            or isinstance(expected_revision, bool)
+            or expected_revision < 0
+        ):
+            raise ValueError("expected_revision must be a non-negative integer")
+        return expected_revision
+
+    @staticmethod
+    def _context_epoch(context_epoch: int) -> int:
+        if (
+            not isinstance(context_epoch, int)
+            or isinstance(context_epoch, bool)
+            or context_epoch < 0
+        ):
+            raise ValueError("context_epoch must be a non-negative integer")
+        return context_epoch
+
+    @staticmethod
+    def _valid_text(text: str) -> bool:
+        return (
+            isinstance(text, str)
+            and bool(text.strip())
+            and len(text) <= MAX_CONSOLE_QUEUED_PROMPT_LENGTH
+        )
+
+    def _empty_snapshot(self, session_id: str) -> PromptQueueSnapshot:
+        cached = self._empty_snapshots.get(session_id)
+        if cached is None:
+            cached = PromptQueueSnapshot(
+                session_id=session_id,
+                revision=0,
+                entries=(),
+                waiting_count=0,
+                claimed_count=0,
+                total_count=0,
+                mode=PromptQueueMode.DRAINING,
+                pause_reason=None,
+                reservation=PromptQueueReservation.RELEASED,
+                expected_context_epoch=None,
+                closing=False,
+            )
+            self._empty_snapshots[session_id] = cached
+        return cached
+
+    @staticmethod
+    def _entry_view_key(
+        prompt: QueuedPrompt,
+        phase: PromptQueueEntryPhase,
+        position: int,
+    ) -> tuple[str, str, int, PromptQueueEntryPhase, int]:
+        return (
+            prompt.entry_id,
+            prompt.preview,
+            prompt.insertion_order,
+            phase,
+            position,
+        )
+
+    def _snapshot(self, state: _SessionQueueState) -> PromptQueueSnapshot:
+        cached = state.snapshot_cache
+        if cached is not None and cached.revision == state.revision:
+            return cached
+
+        reusable: dict[
+            tuple[str, str, int, PromptQueueEntryPhase, int],
+            PromptQueueEntrySnapshot,
+        ] = {}
+        if cached is not None:
+            for entry in cached.entries:
+                reusable[
+                    (
+                        entry.entry_id,
+                        entry.preview,
+                        entry.insertion_order,
+                        entry.phase,
+                        entry.position,
+                    )
+                ] = entry
+
+        projected: list[PromptQueueEntrySnapshot] = []
+        prompts: list[tuple[QueuedPrompt, PromptQueueEntryPhase]] = []
+        if state.claimed is not None:
+            prompts.append((state.claimed.prompt, PromptQueueEntryPhase.STARTING))
+        prompts.extend(
+            (prompt, PromptQueueEntryPhase.WAITING) for prompt in state.waiting
+        )
+        for position, (prompt, phase) in enumerate(prompts):
+            key = self._entry_view_key(prompt, phase, position)
+            projected.append(
+                reusable.get(key)
+                or PromptQueueEntrySnapshot(
+                    entry_id=prompt.entry_id,
+                    preview=prompt.preview,
+                    insertion_order=prompt.insertion_order,
+                    position=position,
+                    phase=phase,
+                )
+            )
+
+        snapshot = PromptQueueSnapshot(
+            session_id=state.session_id,
+            revision=state.revision,
+            entries=tuple(projected),
+            waiting_count=len(state.waiting),
+            claimed_count=int(state.claimed is not None),
+            total_count=state.total_count,
+            mode=state.mode,
+            pause_reason=state.pause_reason,
+            reservation=state.reservation,
+            expected_context_epoch=state.expected_context_epoch,
+            closing=state.closing,
+        )
+        state.snapshot_cache = snapshot
+        return snapshot
+
+    def snapshot(self, session_id: str) -> PromptQueueSnapshot:
+        self._assert_owner_thread()
+        session_id = self._session_id(session_id)
+        state = self._states.get(session_id)
+        return (
+            self._snapshot(state)
+            if state is not None
+            else self._empty_snapshot(session_id)
+        )
+
+    def read_waiting_text(
+        self,
+        session_id: str,
+        *,
+        entry_id: str,
+        expected_revision: int,
+    ) -> PromptQueueTextResult:
+        """Materialize only the selected waiting entry's canonical text."""
+
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return PromptQueueTextResult(
+                status=refusal.status,
+                session_id=session_id,
+                revision=refusal.snapshot.revision,
+                entry_id=entry_id,
+            )
+        assert state is not None
+        if self._is_claimed(state, entry_id):
+            return PromptQueueTextResult(
+                status=QueueMutationStatus.LOCKED,
+                session_id=session_id,
+                revision=state.revision,
+                entry_id=entry_id,
+            )
+        index = self._waiting_index(state, entry_id)
+        if index is None:
+            return PromptQueueTextResult(
+                status=QueueMutationStatus.NOT_FOUND,
+                session_id=session_id,
+                revision=state.revision,
+                entry_id=entry_id,
+            )
+        return PromptQueueTextResult(
+            status=QueueMutationStatus.APPLIED,
+            session_id=session_id,
+            revision=state.revision,
+            entry_id=entry_id,
+            text=state.waiting[index].text,
+        )
+
+    def _result(
+        self,
+        status: QueueMutationStatus,
+        session_id: str,
+        *,
+        state: _SessionQueueState | None = None,
+        entry_id: str | None = None,
+        claim: PromptQueueClaim | None = None,
+        detail: str | None = None,
+    ) -> PromptQueueMutationResult:
+        snapshot = (
+            self._snapshot(state)
+            if state is not None
+            else self._empty_snapshot(session_id)
+        )
+        return PromptQueueMutationResult(
+            status=status,
+            snapshot=snapshot,
+            entry_id=entry_id,
+            claim=claim,
+            detail=detail,
+        )
+
+    def _check(
+        self,
+        session_id: str,
+        expected_revision: int,
+        *,
+        allow_closing: bool = False,
+    ) -> tuple[str, _SessionQueueState | None, PromptQueueMutationResult | None]:
+        self._assert_owner_thread()
+        session_id = self._session_id(session_id)
+        expected_revision = self._expected_revision(expected_revision)
+        state = self._states.get(session_id)
+        if self._shutting_down:
+            return (
+                session_id,
+                state,
+                self._result(
+                    QueueMutationStatus.SHUTTING_DOWN, session_id, state=state
+                ),
+            )
+        snapshot = (
+            self._snapshot(state)
+            if state is not None
+            else self._empty_snapshot(session_id)
+        )
+        if expected_revision != snapshot.revision:
+            return (
+                session_id,
+                state,
+                self._result(
+                    QueueMutationStatus.STALE_REVISION, session_id, state=state
+                ),
+            )
+        if state is None:
+            return (
+                session_id,
+                None,
+                self._result(QueueMutationStatus.NOT_FOUND, session_id),
+            )
+        if state.closing and not allow_closing:
+            return (
+                session_id,
+                state,
+                self._result(QueueMutationStatus.CLOSING, session_id, state=state),
+            )
+        return session_id, state, None
+
+    def _bump(
+        self,
+        state: _SessionQueueState,
+        *,
+        reroute_admission_from: int | None = None,
+    ) -> None:
+        state.revision += 1
+        state.reroute_admission_revision = reroute_admission_from
+        self._registry_revision += 1
+        self._assert_invariants(state)
+
+    @staticmethod
+    def _assert_invariants(state: _SessionQueueState) -> None:
+        if state.total_count > MAX_CONSOLE_QUEUE_ENTRIES:
+            raise RuntimeError("Console prompt queue capacity invariant violated")
+        identifiers = [prompt.entry_id for prompt in state.waiting]
+        if state.claimed is not None:
+            identifiers.append(state.claimed.prompt.entry_id)
+        if len(identifiers) != len(set(identifiers)):
+            raise RuntimeError("Console prompt queue entry identity invariant violated")
+        # A paused+held state may exist only between the coordinator's synchronous
+        # ``reserve`` and ``resume`` calls.  No await or widget mutation can occur
+        # between those event-loop-thread-confined transitions.
+
+    def _new_prompt(self, text: str) -> QueuedPrompt | None:
+        entry_id = self._id_factory()
+        if (
+            not isinstance(entry_id, str)
+            or not entry_id
+            or entry_id in self._issued_entry_ids
+        ):
+            return None
+        admitted_at = self._monotonic()
+        if not isinstance(admitted_at, (int, float)) or isinstance(admitted_at, bool):
+            return None
+        self._next_insertion_order += 1
+        prompt = QueuedPrompt(
+            entry_id=entry_id,
+            text=text,
+            preview=make_prompt_preview(text),
+            insertion_order=self._next_insertion_order,
+            admitted_at=float(admitted_at),
+        )
+        self._issued_entry_ids.add(entry_id)
+        return prompt
+
+    def _claim_time(self) -> float | None:
+        claimed_at = self._monotonic()
+        if not isinstance(claimed_at, (int, float)) or isinstance(claimed_at, bool):
+            return None
+        return float(claimed_at)
+
+    @staticmethod
+    def _waiting_index(state: _SessionQueueState, entry_id: str) -> int | None:
+        for index, prompt in enumerate(state.waiting):
+            if prompt.entry_id == entry_id:
+                return index
+        return None
+
+    @staticmethod
+    def _is_claimed(state: _SessionQueueState, entry_id: str) -> bool:
+        return state.claimed is not None and state.claimed.prompt.entry_id == entry_id
+
+    @staticmethod
+    def _finalize_released_empty_state(state: _SessionQueueState) -> None:
+        if state.total_count != 0 or state.reservation is PromptQueueReservation.HELD:
+            return
+        state.expected_context_epoch = None
+        state.mode = PromptQueueMode.DRAINING
+        state.pause_reason = None
+
+    def begin_chain(
+        self,
+        session_id: str,
+        *,
+        context_epoch: int,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        self._assert_owner_thread()
+        session_id = self._session_id(session_id)
+        expected_revision = self._expected_revision(expected_revision)
+        context_epoch = self._context_epoch(context_epoch)
+        state = self._states.get(session_id)
+        if self._shutting_down:
+            return self._result(
+                QueueMutationStatus.SHUTTING_DOWN, session_id, state=state
+            )
+        current = (
+            self._snapshot(state)
+            if state is not None
+            else self._empty_snapshot(session_id)
+        )
+        if expected_revision != current.revision:
+            return self._result(
+                QueueMutationStatus.STALE_REVISION, session_id, state=state
+            )
+        if state is None:
+            state = _SessionQueueState(session_id=session_id)
+            self._states[session_id] = state
+        elif state.closing:
+            return self._result(QueueMutationStatus.CLOSING, session_id, state=state)
+        elif (
+            state.total_count != 0
+            or state.expected_context_epoch is not None
+            or state.reservation is PromptQueueReservation.HELD
+        ):
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        state.expected_context_epoch = context_epoch
+        state.reservation = PromptQueueReservation.HELD
+        state.mode = PromptQueueMode.DRAINING
+        state.pause_reason = None
+        self._bump(state)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
+    def admit(
+        self,
+        session_id: str,
+        *,
+        text: str,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        self._assert_owner_thread()
+        session_id = self._session_id(session_id)
+        expected_revision = self._expected_revision(expected_revision)
+        state = self._states.get(session_id)
+        if self._shutting_down:
+            return self._result(
+                QueueMutationStatus.SHUTTING_DOWN, session_id, state=state
+            )
+        current = (
+            self._snapshot(state)
+            if state is not None
+            else self._empty_snapshot(session_id)
+        )
+        if expected_revision != current.revision:
+            if state is not None and (
+                expected_revision == state.reroute_admission_revision
+                and state.total_count == 0
+                and state.expected_context_epoch is None
+                and state.reservation is PromptQueueReservation.RELEASED
+                and not state.closing
+            ):
+                return self._result(
+                    QueueMutationStatus.REROUTE_NORMAL_SEND,
+                    session_id,
+                    state=state,
+                )
+            return self._result(
+                QueueMutationStatus.STALE_REVISION, session_id, state=state
+            )
+        if state is None or (
+            state.total_count == 0 and state.expected_context_epoch is None
+        ):
+            return self._result(
+                QueueMutationStatus.REROUTE_NORMAL_SEND, session_id, state=state
+            )
+        if state.closing:
+            return self._result(QueueMutationStatus.CLOSING, session_id, state=state)
+        if not self._valid_text(text):
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        if state.total_count >= MAX_CONSOLE_QUEUE_ENTRIES:
+            return self._result(QueueMutationStatus.FULL, session_id, state=state)
+        prompt = self._new_prompt(text)
+        if prompt is None:
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        state.waiting.append(prompt)
+        self._bump(state)
+        return self._result(
+            QueueMutationStatus.APPLIED,
+            session_id,
+            state=state,
+            entry_id=prompt.entry_id,
+        )
+
+    def edit(
+        self,
+        session_id: str,
+        *,
+        entry_id: str,
+        text: str,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if self._is_claimed(state, entry_id):
+            return self._result(QueueMutationStatus.LOCKED, session_id, state=state)
+        index = self._waiting_index(state, entry_id)
+        if index is None:
+            return self._result(QueueMutationStatus.NOT_FOUND, session_id, state=state)
+        if not self._valid_text(text):
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        existing = state.waiting[index]
+        if text == existing.text:
+            return self._result(
+                QueueMutationStatus.UNCHANGED,
+                session_id,
+                state=state,
+                entry_id=entry_id,
+            )
+        state.waiting[index] = QueuedPrompt(
+            entry_id=existing.entry_id,
+            text=text,
+            preview=make_prompt_preview(text),
+            insertion_order=existing.insertion_order,
+            admitted_at=existing.admitted_at,
+        )
+        self._bump(state)
+        return self._result(
+            QueueMutationStatus.APPLIED,
+            session_id,
+            state=state,
+            entry_id=entry_id,
+        )
+
+    def move(
+        self,
+        session_id: str,
+        *,
+        entry_id: str,
+        new_index: int,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if self._is_claimed(state, entry_id):
+            return self._result(QueueMutationStatus.LOCKED, session_id, state=state)
+        if not isinstance(new_index, int) or isinstance(new_index, bool):
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        current_index = self._waiting_index(state, entry_id)
+        if current_index is None:
+            return self._result(QueueMutationStatus.NOT_FOUND, session_id, state=state)
+        if new_index < 0 or new_index >= len(state.waiting):
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        if new_index == current_index:
+            return self._result(
+                QueueMutationStatus.UNCHANGED,
+                session_id,
+                state=state,
+                entry_id=entry_id,
+            )
+        prompt = state.waiting.pop(current_index)
+        state.waiting.insert(new_index, prompt)
+        self._bump(state)
+        return self._result(
+            QueueMutationStatus.APPLIED,
+            session_id,
+            state=state,
+            entry_id=entry_id,
+        )
+
+    def remove(
+        self,
+        session_id: str,
+        *,
+        entry_id: str,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if self._is_claimed(state, entry_id):
+            return self._result(QueueMutationStatus.LOCKED, session_id, state=state)
+        index = self._waiting_index(state, entry_id)
+        if index is None:
+            return self._result(QueueMutationStatus.NOT_FOUND, session_id, state=state)
+        state.waiting.pop(index)
+        self._finalize_released_empty_state(state)
+        self._bump(state)
+        return self._result(
+            QueueMutationStatus.APPLIED,
+            session_id,
+            state=state,
+            entry_id=entry_id,
+        )
+
+    def clear_waiting(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if not state.waiting:
+            return self._result(QueueMutationStatus.UNCHANGED, session_id, state=state)
+        state.waiting.clear()
+        self._finalize_released_empty_state(state)
+        self._bump(state)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
+    def claim_next(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if state.claimed is not None:
+            return self._result(QueueMutationStatus.LOCKED, session_id, state=state)
+        if (
+            state.mode is not PromptQueueMode.DRAINING
+            or state.reservation is not PromptQueueReservation.HELD
+            or state.expected_context_epoch is None
+        ):
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        if not state.waiting:
+            return self._result(QueueMutationStatus.NOT_FOUND, session_id, state=state)
+        claimed_at = self._claim_time()
+        if claimed_at is None:
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        prompt = state.waiting.pop(0)
+        state.claimed = PromptQueueClaim(prompt=prompt, claimed_at=claimed_at)
+        self._bump(state)
+        return self._result(
+            QueueMutationStatus.APPLIED,
+            session_id,
+            state=state,
+            entry_id=prompt.entry_id,
+            claim=state.claimed,
+        )
+
+    def settle_claim(
+        self,
+        session_id: str,
+        *,
+        entry_id: str,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if state.claimed is None:
+            return self._result(QueueMutationStatus.NOT_FOUND, session_id, state=state)
+        if state.claimed.prompt.entry_id != entry_id:
+            return self._result(QueueMutationStatus.LOCKED, session_id, state=state)
+        state.claimed = None
+        self._bump(state)
+        return self._result(
+            QueueMutationStatus.APPLIED,
+            session_id,
+            state=state,
+            entry_id=entry_id,
+        )
+
+    def return_claim_to_head(
+        self,
+        session_id: str,
+        *,
+        entry_id: str,
+        reason: PromptQueuePauseReason,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if not isinstance(reason, PromptQueuePauseReason):
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        if state.claimed is None:
+            return self._result(QueueMutationStatus.NOT_FOUND, session_id, state=state)
+        if state.claimed.prompt.entry_id != entry_id:
+            return self._result(QueueMutationStatus.LOCKED, session_id, state=state)
+        state.waiting.insert(0, state.claimed.prompt)
+        state.claimed = None
+        state.mode = PromptQueueMode.PAUSED
+        state.pause_reason = reason
+        state.reservation = PromptQueueReservation.RELEASED
+        self._bump(state)
+        return self._result(
+            QueueMutationStatus.APPLIED,
+            session_id,
+            state=state,
+            entry_id=entry_id,
+        )
+
+    def request_pause_after_turn(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if (
+            state.mode is not PromptQueueMode.DRAINING
+            or state.reservation is not PromptQueueReservation.HELD
+            or state.total_count == 0
+        ):
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        state.mode = PromptQueueMode.PAUSE_AFTER_TURN
+        self._bump(state)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
+    def keep_draining(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if state.mode is not PromptQueueMode.PAUSE_AFTER_TURN:
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        state.mode = PromptQueueMode.DRAINING
+        self._bump(state)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
+    def pause(
+        self,
+        session_id: str,
+        *,
+        reason: PromptQueuePauseReason,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if not isinstance(reason, PromptQueuePauseReason) or state.total_count == 0:
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        if state.claimed is not None:
+            return self._result(QueueMutationStatus.LOCKED, session_id, state=state)
+        if (
+            state.mode is PromptQueueMode.PAUSED
+            and state.pause_reason is reason
+            and state.reservation is PromptQueueReservation.RELEASED
+        ):
+            return self._result(QueueMutationStatus.UNCHANGED, session_id, state=state)
+        state.mode = PromptQueueMode.PAUSED
+        state.pause_reason = reason
+        state.reservation = PromptQueueReservation.RELEASED
+        self._bump(state)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
+    def reserve(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if state.total_count == 0 or state.expected_context_epoch is None:
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        if state.reservation is PromptQueueReservation.HELD:
+            return self._result(QueueMutationStatus.UNCHANGED, session_id, state=state)
+        state.reservation = PromptQueueReservation.HELD
+        self._bump(state)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
+    def release_reservation(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if state.reservation is PromptQueueReservation.RELEASED:
+            return self._result(QueueMutationStatus.UNCHANGED, session_id, state=state)
+        if state.mode is not PromptQueueMode.PAUSED and state.total_count > 0:
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        state.reservation = PromptQueueReservation.RELEASED
+        self._finalize_released_empty_state(state)
+        self._bump(state)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
+    def resume(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if state.mode is not PromptQueueMode.PAUSED:
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        if state.reservation is not PromptQueueReservation.HELD:
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        state.mode = PromptQueueMode.DRAINING
+        state.pause_reason = None
+        self._bump(state)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
+    def adopt_context_baseline(
+        self,
+        session_id: str,
+        *,
+        context_epoch: int,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        context_epoch = self._context_epoch(context_epoch)
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if (
+            state.mode is not PromptQueueMode.PAUSED
+            or state.pause_reason is not PromptQueuePauseReason.CONTEXT_CHANGED
+        ):
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        if state.expected_context_epoch == context_epoch:
+            return self._result(QueueMutationStatus.UNCHANGED, session_id, state=state)
+        state.expected_context_epoch = context_epoch
+        self._bump(state)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
+    def finalize_empty_chain(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(session_id, expected_revision)
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if state.total_count != 0:
+            return self._result(QueueMutationStatus.INVALID, session_id, state=state)
+        if (
+            state.expected_context_epoch is None
+            and state.reservation is PromptQueueReservation.RELEASED
+        ):
+            return self._result(QueueMutationStatus.UNCHANGED, session_id, state=state)
+        state.expected_context_epoch = None
+        state.reservation = PromptQueueReservation.RELEASED
+        state.mode = PromptQueueMode.DRAINING
+        state.pause_reason = None
+        self._bump(state, reroute_admission_from=expected_revision)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
+    def mark_closing(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        session_id, state, refusal = self._check(
+            session_id,
+            expected_revision,
+            allow_closing=True,
+        )
+        if refusal is not None:
+            return refusal
+        assert state is not None
+        if state.closing:
+            return self._result(QueueMutationStatus.UNCHANGED, session_id, state=state)
+        state.closing = True
+        state.reservation = PromptQueueReservation.RELEASED
+        self._bump(state)
+        return self._result(QueueMutationStatus.APPLIED, session_id, state=state)
+
+    def remove_session(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        self._assert_owner_thread()
+        session_id = self._session_id(session_id)
+        expected_revision = self._expected_revision(expected_revision)
+        state = self._states.get(session_id)
+        if self._shutting_down:
+            return self._result(
+                QueueMutationStatus.SHUTTING_DOWN, session_id, state=state
+            )
+        current = (
+            self._snapshot(state)
+            if state is not None
+            else self._empty_snapshot(session_id)
+        )
+        if expected_revision != current.revision:
+            return self._result(
+                QueueMutationStatus.STALE_REVISION, session_id, state=state
+            )
+        if state is None:
+            return self._result(QueueMutationStatus.UNCHANGED, session_id)
+        del self._states[session_id]
+        self._registry_revision += 1
+        return self._result(QueueMutationStatus.APPLIED, session_id)
+
+    def shutdown(self, *, expected_registry_revision: int) -> PromptQueueShutdownResult:
+        self._assert_owner_thread()
+        expected_registry_revision = self._expected_revision(expected_registry_revision)
+        if self._shutting_down:
+            return PromptQueueShutdownResult(
+                status=QueueMutationStatus.UNCHANGED,
+                registry_revision=self._registry_revision,
+            )
+        if expected_registry_revision != self._registry_revision:
+            return PromptQueueShutdownResult(
+                status=QueueMutationStatus.STALE_REVISION,
+                registry_revision=self._registry_revision,
+            )
+        removed_sessions = len(self._states)
+        removed_prompts = sum(state.total_count for state in self._states.values())
+        self._shutting_down = True
+        self._states.clear()
+        self._registry_revision += 1
+        return PromptQueueShutdownResult(
+            status=QueueMutationStatus.APPLIED,
+            registry_revision=self._registry_revision,
+            removed_sessions=removed_sessions,
+            removed_prompts=removed_prompts,
+        )
+
+
+__all__ = [
+    "MAX_CONSOLE_QUEUE_ENTRIES",
+    "MAX_CONSOLE_QUEUED_PROMPT_LENGTH",
+    "PROMPT_PREVIEW_CELL_BUDGET",
+    "ConsolePromptQueueRegistry",
+    "PromptQueueClaim",
+    "PromptQueueEntryPhase",
+    "PromptQueueEntrySnapshot",
+    "PromptQueueMode",
+    "PromptQueueMutationResult",
+    "PromptQueuePauseReason",
+    "PromptQueueReservation",
+    "PromptQueueShutdownResult",
+    "PromptQueueSnapshot",
+    "PromptQueueTextResult",
+    "QueueMutationStatus",
+    "QueueThreadViolation",
+    "QueuedPrompt",
+    "make_prompt_preview",
+]

--- a/tldw_chatbook/Chat/console_prompt_queue_coordinator.py
+++ b/tldw_chatbook/Chat/console_prompt_queue_coordinator.py
@@ -1,0 +1,690 @@
+"""Controller-side authority for sequential Console prompt queue drains."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleControllerActivity,
+    ConsoleQueuedAcceptanceEvent,
+    ConsoleRunStatus,
+    ConsoleSubmissionOrigin,
+)
+from tldw_chatbook.Chat.console_prompt_queue import (
+    ConsolePromptQueueRegistry,
+    PromptQueueMode,
+    PromptQueueMutationResult,
+    PromptQueuePauseReason,
+    PromptQueueReservation,
+    PromptQueueSnapshot,
+    QueueMutationStatus,
+    QueueThreadViolation,
+)
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Chat.console_chat_controller import ConsoleSubmitResult
+
+
+_AUTHORIZATION_KEY = object()
+
+
+class QueueGenerationAuthorization:
+    """Opaque, coordinator-issued authority to cross a queue-owned send gate."""
+
+    __slots__ = ("_coordinator", "session_id")
+
+    def __init__(self, coordinator: object, session_id: str, *, _key: object) -> None:
+        if _key is not _AUTHORIZATION_KEY:
+            raise PermissionError("queue generation authority is coordinator-internal")
+        self._coordinator = coordinator
+        self.session_id = session_id
+
+    def __repr__(self) -> str:
+        return (
+            "QueueGenerationAuthorization("
+            f"session_id={self.session_id!r}, authority=<redacted>)"
+        )
+
+
+class QueuedTurnSubmitter(Protocol):
+    """Production-shaped callback used to submit one claimed queue entry."""
+
+    def __call__(
+        self,
+        text: str,
+        *,
+        session_id: str,
+        entry_id: str,
+        authorization: QueueGenerationAuthorization,
+    ) -> Awaitable["ConsoleSubmitResult"]: ...
+
+
+@dataclass(slots=True)
+class _PromptChain:
+    accepted_live_turn: bool = False
+    current_entry_id: str | None = None
+    last_terminal_status: ConsoleRunStatus | None = None
+
+
+class ConsolePromptQueueCoordinator:
+    """Own queue admission, accepted claims, drain progression, and recovery."""
+
+    _SUCCESS = frozenset({ConsoleRunStatus.COMPLETED})
+    _TERMINAL = frozenset(
+        {
+            ConsoleRunStatus.BLOCKED,
+            ConsoleRunStatus.COMPLETED,
+            ConsoleRunStatus.FAILED,
+            ConsoleRunStatus.STOPPED,
+        }
+    )
+
+    def __init__(
+        self,
+        *,
+        registry: ConsolePromptQueueRegistry,
+        context_epoch: Callable[[str], int],
+        run_status: Callable[[str], ConsoleRunStatus],
+        submit_queued: QueuedTurnSubmitter,
+        has_staged_rider: Callable[[str], bool] | None = None,
+        needs_approval: Callable[[str], bool] | None = None,
+        can_reacquire_slot: Callable[[str], bool] | None = None,
+        on_queued_accepted: Callable[[ConsoleQueuedAcceptanceEvent], None]
+        | None = None,
+        on_activity_changed: Callable[[str], None] | None = None,
+        on_chain_terminal: Callable[[str, ConsoleRunStatus], None] | None = None,
+    ) -> None:
+        self.registry = registry
+        self._context_epoch = context_epoch
+        self._run_status = run_status
+        self._submit_queued = submit_queued
+        self._has_staged_rider = has_staged_rider or (lambda _session_id: False)
+        self._needs_approval = needs_approval or (lambda _session_id: False)
+        self._can_reacquire_slot = can_reacquire_slot or (lambda _session_id: True)
+        self.on_queued_accepted = on_queued_accepted
+        self.on_activity_changed = on_activity_changed
+        self.on_chain_terminal = on_chain_terminal
+        self._chains: dict[str, _PromptChain] = {}
+        self._queue_snapshots: dict[str, PromptQueueSnapshot] = {}
+        self._shutting_down = False
+
+    def authorizes(
+        self,
+        authorization: QueueGenerationAuthorization | None,
+        session_id: str,
+    ) -> bool:
+        """Return whether ``authorization`` is this coordinator's session token."""
+
+        return bool(
+            authorization is not None
+            and authorization._coordinator is self
+            and authorization.session_id == session_id
+            and session_id in self._chains
+            and not self._shutting_down
+        )
+
+    def _terminal_status(
+        self, session_id: str, result: "ConsoleSubmitResult"
+    ) -> ConsoleRunStatus:
+        return result.terminal_status or self._run_status(session_id)
+
+    def activity(self, session_id: str) -> ConsoleControllerActivity:
+        """Derive the sole fleet-visible activity projection for a session."""
+
+        if not session_id:
+            status = self._run_status(session_id)
+            return ConsoleControllerActivity(
+                session_id=session_id,
+                occupies_slot=False,
+                preparing_before_acceptance=False,
+                accepted_live_turn=False,
+                needs_approval=False,
+                queued_count=0,
+                queue_paused=False,
+                terminal_notification_eligible=status in self._TERMINAL,
+            )
+        try:
+            snapshot = self.registry.snapshot(session_id)
+        except QueueThreadViolation:
+            # Fleet-summary diagnostics can read from a worker thread. Queue
+            # writes remain owner-thread confined; those writes publish this
+            # immutable cache before any UI callback observes the revision.
+            snapshot = self._queue_snapshots.get(session_id)
+        if snapshot is None:
+            queued_count = 0
+            queue_paused = False
+            reservation = PromptQueueReservation.RELEASED
+        else:
+            queued_count = snapshot.total_count
+            queue_paused = snapshot.mode is PromptQueueMode.PAUSED
+            reservation = snapshot.reservation
+        chain = self._chains.get(session_id)
+        status = self._run_status(session_id)
+        accepted_live = bool(chain and chain.accepted_live_turn)
+        preparing = (
+            status
+            in {
+                ConsoleRunStatus.VALIDATING,
+                ConsoleRunStatus.RETRYING,
+            }
+            and not accepted_live
+        )
+        occupies_slot = reservation is PromptQueueReservation.HELD or status in {
+            ConsoleRunStatus.VALIDATING,
+            ConsoleRunStatus.STREAMING,
+            ConsoleRunStatus.CHECKING_CITATIONS,
+            ConsoleRunStatus.RETRYING,
+        }
+        return ConsoleControllerActivity(
+            session_id=session_id,
+            occupies_slot=occupies_slot,
+            preparing_before_acceptance=preparing,
+            accepted_live_turn=accepted_live,
+            needs_approval=self._needs_approval(session_id),
+            queued_count=queued_count,
+            queue_paused=queue_paused,
+            terminal_notification_eligible=(
+                status in self._TERMINAL and not occupies_slot and not accepted_live
+            ),
+        )
+
+    def controls_generation(self, session_id: str) -> bool:
+        """Return whether older queue-owned work controls the next generation."""
+
+        if not session_id:
+            return False
+        snapshot = self.registry.snapshot(session_id)
+        return snapshot.total_count > 0 or snapshot.expected_context_epoch is not None
+
+    def pause_for_stop(self, session_id: str) -> PromptQueueMutationResult:
+        """Release a chain reservation as soon as Stop targets its live turn."""
+
+        snapshot = self.registry.snapshot(session_id)
+        if snapshot.total_count == 0:
+            return PromptQueueMutationResult(QueueMutationStatus.UNCHANGED, snapshot)
+        result = self.registry.pause(
+            session_id,
+            reason=PromptQueuePauseReason.STOPPED,
+            expected_revision=snapshot.revision,
+        )
+        if result.status in {
+            QueueMutationStatus.APPLIED,
+            QueueMutationStatus.UNCHANGED,
+        }:
+            self._changed(session_id)
+        return result
+
+    def admit(
+        self,
+        session_id: str,
+        *,
+        text: str,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        """Admit text only behind an accepted turn or an existing queue."""
+
+        if self._has_staged_rider(session_id):
+            snapshot = self.registry.snapshot(session_id)
+            return PromptQueueMutationResult(
+                status=QueueMutationStatus.INVALID,
+                snapshot=snapshot,
+                detail="Remove attachments or staged evidence before queueing.",
+            )
+        result = self.registry.admit(
+            session_id,
+            text=text,
+            expected_revision=expected_revision,
+        )
+        if result.applied:
+            self._changed(session_id)
+        return result
+
+    def request_pause_after_turn(
+        self, session_id: str, *, expected_revision: int
+    ) -> PromptQueueMutationResult:
+        """Request a pause and refresh the immutable activity cache."""
+
+        result = self.registry.request_pause_after_turn(
+            session_id, expected_revision=expected_revision
+        )
+        if result.applied:
+            self._changed(session_id)
+        return result
+
+    def keep_draining(
+        self, session_id: str, *, expected_revision: int
+    ) -> PromptQueueMutationResult:
+        """Cancel pause-after-turn and refresh the activity cache."""
+
+        result = self.registry.keep_draining(
+            session_id, expected_revision=expected_revision
+        )
+        if result.applied:
+            self._changed(session_id)
+        return result
+
+    async def run_prompt_chain(
+        self,
+        session_id: str,
+        initial_turn: Callable[[], Awaitable["ConsoleSubmitResult"]],
+    ) -> "ConsoleSubmitResult":
+        """Run one manual turn and sequentially drain accepted queued turns."""
+
+        if session_id in self._chains:
+            return await initial_turn()
+        self._chains[session_id] = _PromptChain()
+        self._changed(session_id)
+        try:
+            result = await initial_turn()
+            await self._after_turn(session_id, result)
+            return result
+        except BaseException:
+            if session_id in self._chains:
+                self._pause_after_exception(session_id)
+            raise
+        finally:
+            chain = self._chains.get(session_id)
+            if chain is not None and not chain.accepted_live_turn:
+                snapshot = self.registry.snapshot(session_id)
+                if snapshot.expected_context_epoch is None:
+                    self._chains.pop(session_id, None)
+                    self._changed(session_id)
+
+    def turn_accepted(
+        self,
+        session_id: str,
+        *,
+        origin: ConsoleSubmissionOrigin,
+        context_epoch: int,
+        entry_id: str | None = None,
+    ) -> None:
+        """Commit the accepted boundary and settle a queued claim exactly once."""
+
+        chain = self._chains.get(session_id)
+        if chain is None:
+            return
+        if origin is ConsoleSubmissionOrigin.MANUAL:
+            snapshot = self.registry.snapshot(session_id)
+            result = self.registry.begin_chain(
+                session_id,
+                context_epoch=context_epoch,
+                expected_revision=snapshot.revision,
+            )
+            if result.status not in {
+                QueueMutationStatus.APPLIED,
+                QueueMutationStatus.UNCHANGED,
+            }:
+                raise RuntimeError("manual turn could not establish its queue chain")
+        else:
+            if entry_id is None or chain.current_entry_id != entry_id:
+                raise RuntimeError("queued acceptance did not match the claimed entry")
+            snapshot = self.registry.snapshot(session_id)
+            settled = self.registry.settle_claim(
+                session_id,
+                entry_id=entry_id,
+                expected_revision=snapshot.revision,
+            )
+            if not settled.applied:
+                raise RuntimeError("queued acceptance could not settle its claim")
+            callback = self.on_queued_accepted
+            if callback is not None:
+                callback(ConsoleQueuedAcceptanceEvent(session_id, entry_id))
+        chain.accepted_live_turn = True
+        self._changed(session_id)
+
+    async def _after_turn(self, session_id: str, result: "ConsoleSubmitResult") -> None:
+        chain = self._chains.get(session_id)
+        if chain is None:
+            return
+        accepted = chain.accepted_live_turn
+        chain.accepted_live_turn = False
+        status = self._terminal_status(session_id, result)
+        chain.last_terminal_status = status
+        self._changed(session_id)
+
+        if not accepted:
+            if chain.current_entry_id is not None:
+                self._return_claim(
+                    session_id,
+                    chain.current_entry_id,
+                    PromptQueuePauseReason.DISPATCH_REFUSED,
+                )
+            return
+        if status not in self._SUCCESS:
+            reason = (
+                PromptQueuePauseReason.STOPPED
+                if status is ConsoleRunStatus.STOPPED
+                else PromptQueuePauseReason.FAILED
+            )
+            self._pause_or_finish(session_id, reason, status)
+            return
+
+        await self._drain_waiting(session_id, status)
+
+    async def _drain_waiting(self, session_id: str, status: ConsoleRunStatus) -> None:
+        """Claim and submit FIFO entries until the chain empties or pauses."""
+
+        chain = self._chains[session_id]
+        while not self._shutting_down:
+            snapshot = self.registry.snapshot(session_id)
+            if snapshot.mode is PromptQueueMode.PAUSE_AFTER_TURN:
+                self.registry.pause(
+                    session_id,
+                    reason=PromptQueuePauseReason.MANUAL,
+                    expected_revision=snapshot.revision,
+                )
+                self._finish_visible_terminal(session_id, status)
+                return
+            if self._context_epoch(session_id) != snapshot.expected_context_epoch:
+                if snapshot.total_count:
+                    self.registry.pause(
+                        session_id,
+                        reason=PromptQueuePauseReason.CONTEXT_CHANGED,
+                        expected_revision=snapshot.revision,
+                    )
+                    self._finish_visible_terminal(session_id, status)
+                    return
+            if snapshot.waiting_count == 0:
+                self.registry.finalize_empty_chain(
+                    session_id,
+                    expected_revision=snapshot.revision,
+                )
+                self._finish_visible_terminal(session_id, status)
+                return
+
+            claim_result = self.registry.claim_next(
+                session_id,
+                expected_revision=snapshot.revision,
+            )
+            if not claim_result.applied or claim_result.claim is None:
+                self._pause_after_exception(session_id)
+                return
+            claim = claim_result.claim
+            chain.current_entry_id = claim.prompt.entry_id
+            self._changed(session_id)
+            if self._has_staged_rider(session_id):
+                self._return_claim(
+                    session_id,
+                    claim.prompt.entry_id,
+                    PromptQueuePauseReason.DISPATCH_REFUSED,
+                )
+                return
+            authorization = QueueGenerationAuthorization(
+                self, session_id, _key=_AUTHORIZATION_KEY
+            )
+            try:
+                queued_result = await self._submit_queued(
+                    claim.prompt.text,
+                    session_id=session_id,
+                    entry_id=claim.prompt.entry_id,
+                    authorization=authorization,
+                )
+            except BaseException:
+                self._pause_after_exception(session_id)
+                raise
+            finally:
+                chain.current_entry_id = None
+            accepted = chain.accepted_live_turn
+            chain.accepted_live_turn = False
+            status = self._terminal_status(session_id, queued_result)
+            chain.last_terminal_status = status
+            self._changed(session_id)
+            if not accepted:
+                self._return_claim(
+                    session_id,
+                    claim.prompt.entry_id,
+                    PromptQueuePauseReason.DISPATCH_REFUSED,
+                )
+                return
+            if status not in self._SUCCESS:
+                reason = (
+                    PromptQueuePauseReason.STOPPED
+                    if status is ConsoleRunStatus.STOPPED
+                    else PromptQueuePauseReason.FAILED
+                )
+                self._pause_or_finish(session_id, reason, status)
+                return
+
+    def _return_claim(
+        self, session_id: str, entry_id: str, reason: PromptQueuePauseReason
+    ) -> None:
+        snapshot = self.registry.snapshot(session_id)
+        result = self.registry.return_claim_to_head(
+            session_id,
+            entry_id=entry_id,
+            reason=reason,
+            expected_revision=snapshot.revision,
+        )
+        if result.status not in {
+            QueueMutationStatus.APPLIED,
+            QueueMutationStatus.CLOSING,
+            QueueMutationStatus.SHUTTING_DOWN,
+        }:
+            raise RuntimeError("claimed queue entry could not be restored")
+        self._finish_visible_terminal(session_id, self._run_status(session_id))
+
+    def _pause_or_finish(
+        self,
+        session_id: str,
+        reason: PromptQueuePauseReason,
+        status: ConsoleRunStatus,
+    ) -> None:
+        snapshot = self.registry.snapshot(session_id)
+        if snapshot.total_count:
+            self.registry.pause(
+                session_id,
+                reason=reason,
+                expected_revision=snapshot.revision,
+            )
+        else:
+            self.registry.finalize_empty_chain(
+                session_id,
+                expected_revision=snapshot.revision,
+            )
+        self._finish_visible_terminal(session_id, status)
+
+    def _pause_after_exception(self, session_id: str) -> None:
+        if self._shutting_down:
+            return
+        chain = self._chains.get(session_id)
+        snapshot = self.registry.snapshot(session_id)
+        if snapshot.claimed_count and chain and chain.current_entry_id:
+            self._return_claim(
+                session_id,
+                chain.current_entry_id,
+                PromptQueuePauseReason.DISPATCH_REFUSED,
+            )
+            return
+        if snapshot.total_count:
+            self.registry.pause(
+                session_id,
+                reason=PromptQueuePauseReason.FAILED,
+                expected_revision=snapshot.revision,
+            )
+        elif snapshot.expected_context_epoch is not None:
+            self.registry.finalize_empty_chain(
+                session_id,
+                expected_revision=snapshot.revision,
+            )
+        self._finish_visible_terminal(session_id, ConsoleRunStatus.FAILED)
+
+    def _finish_visible_terminal(
+        self, session_id: str, status: ConsoleRunStatus
+    ) -> None:
+        chain = self._chains.get(session_id)
+        if chain is not None:
+            chain.accepted_live_turn = False
+        self._chains.pop(session_id, None)
+        self._changed(session_id)
+        callback = self.on_chain_terminal
+        if callback is not None and status in self._TERMINAL:
+            callback(session_id, status)
+
+    def resume(self, session_id: str) -> PromptQueueMutationResult:
+        """Reacquire a slot and resume a manually/dispatch-paused queue."""
+
+        snapshot = self.registry.snapshot(session_id)
+        if snapshot.mode is not PromptQueueMode.PAUSED:
+            return PromptQueueMutationResult(QueueMutationStatus.INVALID, snapshot)
+        if self._context_epoch(session_id) != snapshot.expected_context_epoch:
+            result = self.registry.pause(
+                session_id,
+                reason=PromptQueuePauseReason.CONTEXT_CHANGED,
+                expected_revision=snapshot.revision,
+            )
+            self._changed(session_id)
+            return result
+        if not self._can_reacquire_slot(session_id):
+            return PromptQueueMutationResult(
+                QueueMutationStatus.INVALID,
+                snapshot,
+                detail="All agent slots are currently in use.",
+            )
+        reserved = self.registry.reserve(
+            session_id, expected_revision=snapshot.revision
+        )
+        if not reserved.applied:
+            return reserved
+        resumed = self.registry.resume(
+            session_id, expected_revision=reserved.snapshot.revision
+        )
+        if resumed.applied:
+            self._chains[session_id] = _PromptChain()
+            self._changed(session_id)
+        return resumed
+
+    async def resume_and_drain(self, session_id: str) -> PromptQueueMutationResult:
+        """Reacquire one slot and dispatch the next waiting entry."""
+
+        resumed = self.resume(session_id)
+        if not resumed.applied:
+            return resumed
+        await self._drain_waiting(session_id, self._run_status(session_id))
+        return resumed
+
+    async def recover_and_drain(
+        self,
+        session_id: str,
+        recovery_turn: Callable[
+            [QueueGenerationAuthorization], Awaitable["ConsoleSubmitResult"]
+        ],
+    ) -> PromptQueueMutationResult:
+        """Run one typed failed/stopped recovery, adopt its epoch, then drain."""
+
+        resumed = self.resume(session_id)
+        if not resumed.applied:
+            return resumed
+        authorization = QueueGenerationAuthorization(
+            self, session_id, _key=_AUTHORIZATION_KEY
+        )
+        try:
+            result = await recovery_turn(authorization)
+        except BaseException:
+            self._pause_after_exception(session_id)
+            raise
+        status = self._terminal_status(session_id, result)
+        if not result.accepted or status not in self._SUCCESS:
+            reason = (
+                PromptQueuePauseReason.STOPPED
+                if status is ConsoleRunStatus.STOPPED
+                else PromptQueuePauseReason.FAILED
+            )
+            self._pause_or_finish(session_id, reason, status)
+            return resumed
+        snapshot = self.registry.snapshot(session_id)
+        adopted = self.registry.adopt_recovery_context_baseline(
+            session_id,
+            context_epoch=self._context_epoch(session_id),
+            expected_revision=snapshot.revision,
+        )
+        if adopted.status not in {
+            QueueMutationStatus.APPLIED,
+            QueueMutationStatus.UNCHANGED,
+        }:
+            self._pause_after_exception(session_id)
+            return adopted
+        await self._drain_waiting(session_id, status)
+        return resumed
+
+    async def use_current_context_and_resume(
+        self,
+        session_id: str,
+        *,
+        expected_revision: int,
+        reviewed_context_epoch: int,
+    ) -> PromptQueueMutationResult:
+        """Adopt an explicitly reviewed epoch, then visibly reacquire a slot."""
+
+        snapshot = self.registry.snapshot(session_id)
+        current_epoch = self._context_epoch(session_id)
+        if (
+            snapshot.revision != expected_revision
+            or current_epoch != reviewed_context_epoch
+        ):
+            return PromptQueueMutationResult(
+                QueueMutationStatus.STALE_REVISION, snapshot
+            )
+        adopted = self.registry.adopt_context_baseline(
+            session_id,
+            context_epoch=current_epoch,
+            expected_revision=snapshot.revision,
+        )
+        if adopted.status not in {
+            QueueMutationStatus.APPLIED,
+            QueueMutationStatus.UNCHANGED,
+        }:
+            return adopted
+        resumed = self.resume(session_id)
+        if resumed.applied:
+            await self._drain_waiting(session_id, self._run_status(session_id))
+        return resumed
+
+    def mark_closing(self, session_id: str) -> PromptQueueMutationResult:
+        """Tombstone and release one chain before cancellation can resume it."""
+
+        snapshot = self.registry.snapshot(session_id)
+        result = self.registry.mark_closing(
+            session_id, expected_revision=snapshot.revision
+        )
+        self._chains.pop(session_id, None)
+        self._changed(session_id)
+        return result
+
+    def remove_session(self, session_id: str) -> PromptQueueMutationResult:
+        """Remove all process-memory queue state for a tombstoned session."""
+
+        snapshot = self.registry.snapshot(session_id)
+        result = self.registry.remove_session(
+            session_id, expected_revision=snapshot.revision
+        )
+        self._chains.pop(session_id, None)
+        self._queue_snapshots.pop(session_id, None)
+        self._changed(session_id)
+        return result
+
+    def shutdown(self) -> None:
+        """Tombstone every chain before controller task cancellation begins."""
+
+        if self._shutting_down:
+            return
+        session_ids = tuple(self._chains)
+        self._shutting_down = True
+        self.registry.shutdown(
+            expected_registry_revision=self.registry.registry_revision
+        )
+        self._chains.clear()
+        self._queue_snapshots.clear()
+        for session_id in session_ids:
+            self._changed(session_id)
+
+    def _changed(self, session_id: str) -> None:
+        if session_id and not self._shutting_down:
+            try:
+                self._queue_snapshots[session_id] = self.registry.snapshot(session_id)
+            except QueueThreadViolation:
+                pass
+        callback = self.on_activity_changed
+        if callback is not None:
+            callback(session_id)

--- a/tldw_chatbook/Chat/console_prompt_queue_coordinator.py
+++ b/tldw_chatbook/Chat/console_prompt_queue_coordinator.py
@@ -679,6 +679,11 @@ class ConsolePromptQueueCoordinator:
         for session_id in session_ids:
             self._changed(session_id)
 
+    def publish_registry_change(self, session_id: str) -> None:
+        """Publish a UI-owned registry mutation through the activity cache."""
+
+        self._changed(session_id)
+
     def _changed(self, session_id: str) -> None:
         if session_id and not self._shutting_down:
             try:

--- a/tldw_chatbook/Chat/console_turn_context.py
+++ b/tldw_chatbook/Chat/console_turn_context.py
@@ -1,0 +1,162 @@
+"""Detached configuration captured for one owning-session Console turn.
+
+The prompt queue must be able to validate and dispatch a background turn while a
+different session is viewed.  This module intentionally contains configuration
+only: credentials, permission grants, trust decisions, cancellation signals,
+streams, and other live authority stay behind their existing runtime seams.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleProviderSelection,
+    ConsoleStagedSource,
+    ConsoleWorkspaceContext,
+)
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+
+
+def _freeze(value: Any) -> Any:
+    """Return a recursively detached, immutable configuration value."""
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {deepcopy(key): _freeze(item) for key, item in value.items()}
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(_freeze(item) for item in value)
+    return deepcopy(value)
+
+
+def _detached_selection(
+    selection: ConsoleProviderSelection,
+) -> ConsoleProviderSelection:
+    """Copy a provider selection without retaining live workspace objects."""
+    source = selection.workspace_context
+    workspace_context = ConsoleWorkspaceContext(
+        active_workspace_id=str(source.active_workspace_id),
+        staged_sources=tuple(
+            ConsoleStagedSource(
+                source_id=str(item.source_id),
+                label=str(item.label),
+                source_type=str(item.source_type),
+                workspace_id=(
+                    str(item.workspace_id) if item.workspace_id is not None else None
+                ),
+            )
+            for item in source.staged_sources
+        ),
+        active_run_id=(
+            str(source.active_run_id) if source.active_run_id is not None else None
+        ),
+        handoff_id=str(source.handoff_id) if source.handoff_id is not None else None,
+    )
+    return ConsoleProviderSelection(
+        provider=str(selection.provider),
+        base_url=selection.base_url,
+        explicit_model=selection.explicit_model,
+        configured_model=selection.configured_model,
+        temperature=selection.temperature,
+        top_p=selection.top_p,
+        min_p=selection.min_p,
+        top_k=selection.top_k,
+        max_tokens=selection.max_tokens,
+        seed=selection.seed,
+        presence_penalty=selection.presence_penalty,
+        frequency_penalty=selection.frequency_penalty,
+        reasoning_effort=selection.reasoning_effort,
+        reasoning_summary=selection.reasoning_summary,
+        verbosity=selection.verbosity,
+        thinking_effort=selection.thinking_effort,
+        thinking_budget_tokens=selection.thinking_budget_tokens,
+        streaming=selection.streaming,
+        system_prompt=selection.system_prompt,
+        workspace_context=workspace_context,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleTurnExecutionContext:
+    """Immutable provider-input configuration for one Console turn."""
+
+    session_id: str
+    provider_selection: ConsoleProviderSelection
+    session_settings: ConsoleSessionSettings | None = None
+    workspace_roots: tuple[str, ...] = ()
+    capabilities: Mapping[str, Any] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+    rag_defaults: Mapping[str, Any] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+    tool_configuration: Mapping[str, Any] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+    provider_payload_settings: Mapping[str, Any] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+
+    def __post_init__(self) -> None:
+        """Detach constructor inputs even when callers bypass ``capture``."""
+        object.__setattr__(self, "session_id", str(self.session_id))
+        object.__setattr__(
+            self,
+            "provider_selection",
+            _detached_selection(self.provider_selection),
+        )
+        object.__setattr__(
+            self,
+            "session_settings",
+            deepcopy(self.session_settings),
+        )
+        object.__setattr__(
+            self,
+            "workspace_roots",
+            tuple(str(root) for root in deepcopy(self.workspace_roots)),
+        )
+        for field_name in (
+            "capabilities",
+            "rag_defaults",
+            "tool_configuration",
+            "provider_payload_settings",
+        ):
+            object.__setattr__(self, field_name, _freeze(getattr(self, field_name)))
+
+    @classmethod
+    def capture(
+        cls,
+        *,
+        session_id: str,
+        provider_selection: ConsoleProviderSelection,
+        session_settings: ConsoleSessionSettings | None = None,
+        workspace_roots: Sequence[object] = (),
+        capabilities: Mapping[str, Any] | None = None,
+        rag_defaults: Mapping[str, Any] | None = None,
+        tool_configuration: Mapping[str, Any] | None = None,
+        provider_payload_settings: Mapping[str, Any] | None = None,
+    ) -> "ConsoleTurnExecutionContext":
+        """Capture detached values from mutable application-owned sources."""
+        return cls(
+            session_id=str(session_id),
+            provider_selection=provider_selection,
+            session_settings=session_settings,
+            workspace_roots=tuple(workspace_roots),
+            capabilities=capabilities or {},
+            rag_defaults=rag_defaults or {},
+            tool_configuration=tool_configuration or {},
+            provider_payload_settings=provider_payload_settings or {},
+        )
+
+    @property
+    def effective_model(self) -> str | None:
+        """Return the explicit model or its captured configured fallback."""
+        return (
+            self.provider_selection.explicit_model
+            or self.provider_selection.configured_model
+        )

--- a/tldw_chatbook/UI/Console_Modules/prompt_queue.py
+++ b/tldw_chatbook/UI/Console_Modules/prompt_queue.py
@@ -1,0 +1,808 @@
+"""Visible Console prompt-queue presentation and draft dispatch authority.
+
+The registry and coordinator in :mod:`tldw_chatbook.Chat` own queue state and
+draining.  This module owns the UI boundary: content-free presentation,
+optimistic queue admission, exact draft restoration on refusal, and the one
+per-session Textual worker used to start a manual prompt chain.
+
+``ConsolePromptQueueUIController`` deliberately owns no DOM.  Its dependencies
+are named, late-bound callables supplied by ``wiring.py`` so tests and runtime
+session switches are observed at call time rather than frozen at construction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.css.query import NoMatches
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleControllerActivity
+from tldw_chatbook.Chat.console_prompt_queue import (
+    MAX_CONSOLE_QUEUE_ENTRIES,
+    PromptQueueEntryPhase,
+    PromptQueueMode,
+    PromptQueueMutationResult,
+    PromptQueuePauseReason,
+    PromptQueueSnapshot,
+    QueueMutationStatus,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleDraftStash
+
+
+def commit_queued_draft_transaction(
+    session_id: str,
+    stash: "ConsoleDraftStash | None",
+    *,
+    composer: Any,
+    visible_session_id: str | None,
+    undo_histories: dict[str, Any],
+    store: Any,
+    sync_command_popup: Callable[[], None],
+) -> None:
+    """Clear only the admitted draft while keeping unsent text out of history."""
+
+    if visible_session_id == session_id and composer is not None:
+        if stash is None:
+            composer.clear_draft()
+        composer.clear_history()
+        sync_command_popup()
+    undo_histories.pop(session_id, None)
+    try:
+        store.set_session_draft(session_id, "")
+    except KeyError:
+        pass
+
+
+class ConsolePromptDispatchStatus(str, Enum):
+    """Typed outcome returned to every visible/programmatic send caller."""
+
+    SENT = "sent"
+    QUEUED = "queued"
+    REFUSED = "refused"
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolePromptDispatchResult:
+    """Content-free result of one draft dispatch attempt."""
+
+    status: ConsolePromptDispatchStatus
+    session_id: str = ""
+    detail: str = ""
+
+    @property
+    def accepted(self) -> bool:
+        """Return whether the caller may truthfully say the draft was accepted."""
+
+        return self.status is not ConsolePromptDispatchStatus.REFUSED
+
+
+@dataclass(frozen=True, slots=True)
+class ConsolePromptQueuePresentation:
+    """Body-free, immutable projection consumed by queue widgets."""
+
+    revision: int
+    count: int
+    send_label: str
+    send_enabled: bool
+    send_tooltip: str
+    shelf_visible: bool
+    state_label: str
+    paused: bool
+    next_preview: str
+    pause_label: str
+    primary_action: str
+    pause_enabled: bool
+
+
+def derive_prompt_queue_presentation(
+    snapshot: PromptQueueSnapshot,
+    activity: ConsoleControllerActivity,
+    *,
+    composer_collapsed: bool = False,
+) -> ConsolePromptQueuePresentation:
+    """Derive exact visible queue vocabulary without reading a prompt body."""
+
+    count = snapshot.total_count
+    queue_owned = activity.accepted_live_turn or count > 0
+    if activity.occupies_slot and not queue_owned:
+        send_label = "Preparing..."
+        send_enabled = False
+        send_tooltip = "Wait for this turn to be accepted before queueing a message."
+    elif queue_owned and count >= MAX_CONSOLE_QUEUE_ENTRIES:
+        send_label = "Queue full"
+        send_enabled = False
+        send_tooltip = f"{count}/{MAX_CONSOLE_QUEUE_ENTRIES} · Manage to make room"
+    elif queue_owned:
+        send_label = "Queue"
+        send_enabled = True
+        send_tooltip = "Queue this draft after the current turn."
+    else:
+        send_label = "Send"
+        send_enabled = True
+        send_tooltip = "Send the active Console session draft."
+
+    if snapshot.mode is PromptQueueMode.PAUSED:
+        if snapshot.pause_reason is PromptQueuePauseReason.FAILED:
+            state_label = "Turn failed"
+            pause_label = "Retry"
+            primary_action = "retry-failed"
+        elif snapshot.pause_reason is PromptQueuePauseReason.STOPPED:
+            state_label = "Turn stopped"
+            pause_label = "Resume next"
+            primary_action = "resume-next"
+        elif snapshot.pause_reason is PromptQueuePauseReason.CONTEXT_CHANGED:
+            state_label = "Context changed"
+            pause_label = "Review"
+            primary_action = "review"
+        elif snapshot.pause_reason is PromptQueuePauseReason.DISPATCH_REFUSED:
+            state_label = "Start refused"
+            pause_label = "Try again"
+            primary_action = "toggle-pause"
+        else:
+            state_label = "Paused"
+            pause_label = "Resume"
+            primary_action = "toggle-pause"
+    elif snapshot.mode is PromptQueueMode.PAUSE_AFTER_TURN:
+        state_label = "Pausing"
+        pause_label = "Keep draining"
+        primary_action = "toggle-pause"
+    elif any(
+        entry.phase is PromptQueueEntryPhase.STARTING for entry in snapshot.entries
+    ):
+        state_label = "Starting..."
+        pause_label = "Pause"
+        primary_action = "toggle-pause"
+    else:
+        state_label = "Draining"
+        pause_label = "Pause"
+        primary_action = "toggle-pause"
+
+    next_preview = next(
+        (
+            entry.preview
+            for entry in snapshot.entries
+            if entry.phase is PromptQueueEntryPhase.WAITING
+        ),
+        "",
+    )
+    return ConsolePromptQueuePresentation(
+        revision=snapshot.revision,
+        count=count,
+        send_label=send_label,
+        send_enabled=send_enabled,
+        send_tooltip=send_tooltip,
+        shelf_visible=count > 0 and not composer_collapsed,
+        state_label=state_label,
+        paused=snapshot.mode is PromptQueueMode.PAUSED,
+        next_preview=next_preview,
+        pause_label=pause_label,
+        primary_action=primary_action,
+        pause_enabled=count > 0,
+    )
+
+
+class ConsolePromptQueueRegion(Widget):
+    """Always-mounted one-row queue shelf directly above the composer."""
+
+    DEFAULT_CSS = """
+    ConsolePromptQueueRegion {
+        display: none;
+        height: 1;
+        min-height: 1;
+        max-height: 1;
+        width: 100%;
+        background: $panel;
+        color: $text;
+    }
+
+    ConsolePromptQueueRegion.-visible {
+        display: block;
+    }
+
+    ConsolePromptQueueRegion > #console-prompt-queue-row {
+        height: 1;
+        width: 100%;
+        layout: horizontal;
+    }
+
+    #console-prompt-queue-summary {
+        width: auto;
+        min-width: 20;
+        height: 1;
+        color: $warning;
+    }
+
+    #console-prompt-queue-preview {
+        width: 1fr;
+        height: 1;
+        color: $text-muted;
+        text-overflow: ellipsis;
+    }
+
+    #console-prompt-queue-manage {
+        width: 8;
+        min-width: 8;
+        height: 1;
+        min-height: 1;
+        padding: 0 1;
+    }
+
+    #console-prompt-queue-pause {
+        width: 15;
+        min-width: 15;
+        height: 1;
+        min-height: 1;
+        padding: 0 1;
+    }
+
+    ConsolePromptQueueRegion.-narrow #console-prompt-queue-preview {
+        display: none;
+    }
+    """
+
+    class ManageRequested(Message):
+        """Request the focused manager for this shelf's owning session."""
+
+        def __init__(self, session_id: str, revision: int) -> None:
+            super().__init__()
+            self.session_id = session_id
+            self.revision = revision
+
+    class PauseRequested(Message):
+        """Request the presentation's pause/resume action."""
+
+        def __init__(self, session_id: str, revision: int) -> None:
+            super().__init__()
+            self.session_id = session_id
+            self.revision = revision
+
+    def __init__(
+        self,
+        *args: Any,
+        on_manage_requested: Callable[[str, int], None] | None = None,
+        on_primary_requested: Callable[[str, int, str], None] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._session_id = ""
+        self._presentation: ConsolePromptQueuePresentation | None = None
+        self._last_render_key: tuple[Any, ...] | None = None
+        self._on_manage_requested = on_manage_requested
+        self._on_primary_requested = on_primary_requested
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="console-prompt-queue-row"):
+            yield Static("", id="console-prompt-queue-summary")
+            yield Static("", id="console-prompt-queue-preview")
+            yield Button("Manage", id="console-prompt-queue-manage")
+            yield Button("Pause", id="console-prompt-queue-pause")
+
+    def sync_presentation(
+        self,
+        session_id: str,
+        presentation: ConsolePromptQueuePresentation,
+    ) -> bool:
+        """Apply a projection once; unchanged revision/presentation is a no-op."""
+
+        key = (session_id, presentation)
+        if key == self._last_render_key:
+            return False
+        self._last_render_key = key
+        self._session_id = session_id
+        self._presentation = presentation
+        self.set_class(presentation.shelf_visible, "-visible")
+        try:
+            summary = self.query_one("#console-prompt-queue-summary", Static)
+            preview = self.query_one("#console-prompt-queue-preview", Static)
+            manage = self.query_one("#console-prompt-queue-manage", Button)
+            pause = self.query_one("#console-prompt-queue-pause", Button)
+        except NoMatches:
+            return True
+        summary.update(
+            f"Queue {presentation.count}/{MAX_CONSOLE_QUEUE_ENTRIES} · "
+            f"{presentation.state_label}"
+        )
+        preview.update(
+            f' · Next: "{presentation.next_preview}"'
+            if presentation.next_preview
+            else ""
+        )
+        manage.disabled = presentation.count == 0
+        manage.tooltip = "Open the prompt queue manager."
+        pause.label = presentation.pause_label
+        pause.disabled = not presentation.pause_enabled
+        pause.tooltip = f"{presentation.pause_label} this session's prompt queue."
+        self.refresh(layout=True)
+        return True
+
+    def on_resize(self) -> None:
+        """Drop the optional preview before actions can collide."""
+
+        self.set_class(self.size.width < 92, "-narrow")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        presentation = self._presentation
+        if presentation is None:
+            return
+        if event.button.id == "console-prompt-queue-manage":
+            event.stop()
+            if self._on_manage_requested is not None:
+                self._on_manage_requested(self._session_id, presentation.revision)
+            else:
+                self.post_message(
+                    self.ManageRequested(self._session_id, presentation.revision)
+                )
+        elif event.button.id == "console-prompt-queue-pause":
+            event.stop()
+            if presentation.primary_action == "review":
+                if self._on_manage_requested is not None:
+                    self._on_manage_requested(
+                        self._session_id, presentation.revision
+                    )
+                else:
+                    self.post_message(
+                        self.ManageRequested(
+                            self._session_id, presentation.revision
+                        )
+                    )
+            elif self._on_primary_requested is not None:
+                self._on_primary_requested(
+                    self._session_id,
+                    presentation.revision,
+                    presentation.primary_action,
+                )
+            else:
+                self.post_message(
+                    self.PauseRequested(self._session_id, presentation.revision)
+                )
+
+
+class ConsolePromptQueueUIController:
+    """Join queue admission and normal chain launch behind one dispatcher."""
+
+    def __init__(
+        self,
+        *,
+        chat_controller_accessor: Callable[[], Any],
+        ensure_active_session: Callable[[], None],
+        blocked_reason_accessor: Callable[[], str],
+        setup_blocked_reason_accessor: Callable[[], str],
+        restore_stash: Callable[["ConsoleDraftStash | None"], None],
+        append_system_message: Callable[[str], Awaitable[None]],
+        notify: Callable[[str, str], None],
+        focus_composer: Callable[[], None],
+        inflight_stashes_accessor: Callable[[], dict[str, Any]],
+        note_follow_intent: Callable[[], None],
+        launch_chain: Callable[[str, str], None],
+        commit_queued_draft: Callable[[str, "ConsoleDraftStash | None"], None],
+        edit_refusal: Callable[[str], str],
+        sync_ui: Callable[[], Awaitable[None]],
+    ) -> None:
+        self._chat_controller_accessor = chat_controller_accessor
+        self._ensure_active_session = ensure_active_session
+        self._blocked_reason_accessor = blocked_reason_accessor
+        self._setup_blocked_reason_accessor = setup_blocked_reason_accessor
+        self._restore_stash = restore_stash
+        self._append_system_message = append_system_message
+        self._notify = notify
+        self._focus_composer = focus_composer
+        self._inflight_stashes_accessor = inflight_stashes_accessor
+        self._note_follow_intent = note_follow_intent
+        self._launch_chain = launch_chain
+        self._commit_queued_draft = commit_queued_draft
+        self._edit_refusal = edit_refusal
+        self._sync_ui = sync_ui
+
+    async def handle_primary_intent(
+        self, session_id: str, *, action: str, expected_revision: int
+    ) -> None:
+        """Apply the shelf's state-specific primary action and repaint."""
+
+        if action == "toggle-pause":
+            await self.handle_pause_intent(
+                session_id, expected_revision=expected_revision
+            )
+            return
+        result = await self.recover(
+            session_id,
+            action=action,
+            expected_revision=expected_revision,
+        )
+        if not result.applied and result.status is not QueueMutationStatus.UNCHANGED:
+            self._notify(
+                result.detail or "That prompt queue action is unavailable.",
+                "warning",
+            )
+        await self._sync_ui()
+
+    async def handle_pause_intent(
+        self, session_id: str, *, expected_revision: int
+    ) -> None:
+        """Apply a shelf pause intent, report refusal, and repaint."""
+
+        result = await self.toggle_pause(
+            session_id, expected_revision=expected_revision
+        )
+        if result.status is QueueMutationStatus.STALE_REVISION:
+            self._notify("The prompt queue changed. Review it and try again.", "warning")
+        elif not result.applied and result.status is not QueueMutationStatus.UNCHANGED:
+            self._notify(
+                result.detail or "That prompt queue action is unavailable.",
+                "warning",
+            )
+        await self._sync_ui()
+
+    def presentation_for(
+        self, session_id: str, *, composer_collapsed: bool = False
+    ) -> ConsolePromptQueuePresentation:
+        """Return a body-free presentation for one session."""
+
+        controller = self._chat_controller_accessor()
+        snapshot = controller.prompt_queue_registry.snapshot(session_id)
+        activity = controller.activity_for(session_id)
+        return derive_prompt_queue_presentation(
+            snapshot, activity, composer_collapsed=composer_collapsed
+        )
+
+    def snapshot(self, session_id: str) -> PromptQueueSnapshot:
+        """Return the immutable body-free snapshot for a pinned session."""
+
+        return self._chat_controller_accessor().prompt_queue_registry.snapshot(
+            session_id
+        )
+
+    def _latest_result(
+        self, session_id: str, result: PromptQueueMutationResult
+    ) -> PromptQueueMutationResult:
+        """Pair an awaited recovery status with its final body-free revision."""
+
+        latest = self.snapshot(session_id)
+        if latest is result.snapshot:
+            return result
+        return PromptQueueMutationResult(
+            result.status,
+            latest,
+            entry_id=result.entry_id,
+            detail=result.detail,
+        )
+
+    def read_waiting_text(
+        self, session_id: str, entry_id: str, *, expected_revision: int
+    ) -> Any:
+        """Materialize one selected edit target under a revision fence."""
+
+        return self._chat_controller_accessor().prompt_queue_registry.read_waiting_text(
+            session_id,
+            entry_id=entry_id,
+            expected_revision=expected_revision,
+        )
+
+    def edit_waiting(
+        self,
+        session_id: str,
+        entry_id: str,
+        *,
+        text: str,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        """Edit one waiting entry in the pinned session."""
+
+        if detail := self._edit_refusal(text):
+            return PromptQueueMutationResult(
+                QueueMutationStatus.INVALID,
+                self.snapshot(session_id),
+                detail=detail,
+            )
+        return self._chat_controller_accessor().edit_queued_prompt(
+            session_id,
+            entry_id=entry_id,
+            text=text,
+            expected_revision=expected_revision,
+        )
+
+    def move_waiting(
+        self,
+        session_id: str,
+        entry_id: str,
+        *,
+        position: int,
+        expected_revision: int,
+    ) -> PromptQueueMutationResult:
+        """Move one waiting entry to a zero-based waiting-list position."""
+
+        return self._chat_controller_accessor().move_queued_prompt(
+            session_id,
+            entry_id=entry_id,
+            new_index=position,
+            expected_revision=expected_revision,
+        )
+
+    def remove_waiting(
+        self, session_id: str, entry_id: str, *, expected_revision: int
+    ) -> PromptQueueMutationResult:
+        """Remove one waiting entry from the pinned session."""
+
+        return self._chat_controller_accessor().remove_queued_prompt(
+            session_id,
+            entry_id=entry_id,
+            expected_revision=expected_revision,
+        )
+
+    def clear_waiting(
+        self, session_id: str, *, expected_revision: int
+    ) -> PromptQueueMutationResult:
+        """Clear waiting entries without touching a locked Starting entry."""
+
+        return self._chat_controller_accessor().clear_queued_prompts(
+            session_id, expected_revision=expected_revision
+        )
+
+    async def toggle_pause(
+        self, session_id: str, *, expected_revision: int
+    ) -> PromptQueueMutationResult:
+        """Apply the shelf/manager's exact pause, keep-draining, or resume intent."""
+
+        controller = self._chat_controller_accessor()
+        snapshot = controller.prompt_queue_registry.snapshot(session_id)
+        if snapshot.revision != expected_revision:
+            return PromptQueueMutationResult(
+                QueueMutationStatus.STALE_REVISION, snapshot
+            )
+        if snapshot.mode is PromptQueueMode.PAUSED:
+            result = await controller.resume_prompt_queue(session_id)
+            return self._latest_result(session_id, result)
+        if snapshot.mode is PromptQueueMode.PAUSE_AFTER_TURN:
+            return controller.keep_prompt_queue_draining(
+                session_id, expected_revision=expected_revision
+            )
+        return controller.pause_prompt_queue_after_turn(
+            session_id, expected_revision=expected_revision
+        )
+
+    def context_review(self, session_id: str) -> tuple[int | None, int]:
+        """Return queue-baseline and current epochs for explicit review copy."""
+
+        controller = self._chat_controller_accessor()
+        snapshot = controller.prompt_queue_registry.snapshot(session_id)
+        return (
+            snapshot.expected_context_epoch,
+            controller.store.conversation_context_epoch(session_id),
+        )
+
+    async def recover(
+        self,
+        session_id: str,
+        *,
+        action: str,
+        expected_revision: int,
+        reviewed_context_epoch: int | None = None,
+    ) -> PromptQueueMutationResult:
+        """Run one explicit paused-queue recovery action for a pinned session."""
+
+        controller = self._chat_controller_accessor()
+        snapshot = controller.prompt_queue_registry.snapshot(session_id)
+        if snapshot.revision != expected_revision:
+            return PromptQueueMutationResult(
+                QueueMutationStatus.STALE_REVISION, snapshot
+            )
+        if action == "resume-next":
+            result = await controller.skip_and_resume_prompt_queue(session_id)
+            return self._latest_result(session_id, result)
+        if action == "use-current-context":
+            if reviewed_context_epoch is None:
+                return PromptQueueMutationResult(
+                    QueueMutationStatus.INVALID,
+                    snapshot,
+                    detail="Review the current context before using it.",
+                )
+            if (
+                controller.store.conversation_context_epoch(session_id)
+                != reviewed_context_epoch
+            ):
+                return PromptQueueMutationResult(
+                    QueueMutationStatus.INVALID,
+                    snapshot,
+                    detail=(
+                        "The conversation changed since review. Review the "
+                        "current context again."
+                    ),
+                )
+            result = await controller.use_current_context_and_resume_prompt_queue(
+                session_id,
+                expected_revision=expected_revision,
+                reviewed_context_epoch=reviewed_context_epoch,
+            )
+            return self._latest_result(session_id, result)
+        wanted_statuses = (
+            {"failed"} if action == "retry-failed" else {"stopped", "interrupted"}
+        )
+        message = next(
+            (
+                item
+                for item in reversed(controller.store.messages_for_session(session_id))
+                if str(item.status) in wanted_statuses
+            ),
+            None,
+        )
+        if message is None:
+            return PromptQueueMutationResult(
+                QueueMutationStatus.INVALID,
+                snapshot,
+                detail="No matching stopped or failed turn is available.",
+            )
+        if action == "retry-failed":
+            result = await controller.retry_failed_queue_turn(message.id)
+            return self._latest_result(session_id, result)
+        if action == "retry-stopped":
+            result = await controller.retry_stopped_queue_turn(message.id)
+            return self._latest_result(session_id, result)
+        return PromptQueueMutationResult(
+            QueueMutationStatus.INVALID,
+            snapshot,
+            detail="Unknown prompt queue recovery action.",
+        )
+
+    async def dispatch(
+        self,
+        draft: str,
+        *,
+        stash: "ConsoleDraftStash | None" = None,
+    ) -> ConsolePromptDispatchResult:
+        """Send now, queue behind accepted work, or refuse without draft loss."""
+
+        blocked_reason = self._blocked_reason_accessor().strip()
+        if blocked_reason:
+            self._restore_stash(stash)
+            setup_reason = self._setup_blocked_reason_accessor().strip()
+            visible = (
+                setup_reason
+                if setup_reason
+                and not blocked_reason.startswith(
+                    "Console send blocked: Library Search/RAG"
+                )
+                else blocked_reason
+            )
+            await self._append_system_message(visible)
+            if visible == setup_reason:
+                self._notify(visible, "warning")
+            self._focus_composer()
+            return ConsolePromptDispatchResult(
+                ConsolePromptDispatchStatus.REFUSED, detail=visible
+            )
+
+        self._ensure_active_session()
+        controller = self._chat_controller_accessor()
+        session_id = controller.store.active_session_id or ""
+        snapshot = controller.prompt_queue_registry.snapshot(session_id)
+        activity = controller.activity_for(session_id)
+
+        if activity.preparing_before_acceptance and snapshot.total_count == 0:
+            detail = "Preparing the current turn. Queueing becomes available once it is accepted."
+            self._restore_stash(stash)
+            self._notify(detail, "warning")
+            return ConsolePromptDispatchResult(
+                ConsolePromptDispatchStatus.REFUSED,
+                session_id=session_id,
+                detail=detail,
+            )
+
+        if activity.accepted_live_turn or snapshot.total_count > 0:
+            queued = controller.queue_prompt(
+                session_id,
+                text=draft,
+                expected_revision=snapshot.revision,
+            )
+            if queued.status is QueueMutationStatus.REROUTE_NORMAL_SEND:
+                return await self._stage_normal_chain(
+                    controller, session_id, draft, stash
+                )
+            if queued.applied:
+                self._commit_queued_draft(session_id, stash)
+                await self._sync_ui()
+                return ConsolePromptDispatchResult(
+                    ConsolePromptDispatchStatus.QUEUED, session_id=session_id
+                )
+            return self._refuse_queue_mutation(queued, session_id, stash)
+
+        refusal = controller.send_refusal_copy(session_id)
+        if refusal:
+            self._restore_stash(stash)
+            self._notify(refusal, "warning")
+            return ConsolePromptDispatchResult(
+                ConsolePromptDispatchStatus.REFUSED,
+                session_id=session_id,
+                detail=refusal,
+            )
+        return await self._stage_normal_chain(controller, session_id, draft, stash)
+
+    async def _stage_normal_chain(
+        self,
+        controller: Any,
+        session_id: str,
+        draft: str,
+        stash: "ConsoleDraftStash | None",
+    ) -> ConsolePromptDispatchResult:
+        # Re-check the controller gate at the exact manual/queue boundary.
+        # An accepted-turn race is retried as queue admission once, while a
+        # pre-acceptance run is refused and the draft is restored.
+        activity = controller.activity_for(session_id)
+        if activity.preparing_before_acceptance:
+            detail = (
+                "Preparing the current turn. Queueing becomes available once it "
+                "is accepted."
+            )
+            self._restore_stash(stash)
+            self._notify(detail, "warning")
+            return ConsolePromptDispatchResult(
+                ConsolePromptDispatchStatus.REFUSED,
+                session_id=session_id,
+                detail=detail,
+            )
+        if activity.accepted_live_turn:
+            snapshot = controller.prompt_queue_registry.snapshot(session_id)
+            queued = controller.queue_prompt(
+                session_id, text=draft, expected_revision=snapshot.revision
+            )
+            if queued.applied:
+                self._commit_queued_draft(session_id, stash)
+                await self._sync_ui()
+                return ConsolePromptDispatchResult(
+                    ConsolePromptDispatchStatus.QUEUED, session_id=session_id
+                )
+            if queued.status is not QueueMutationStatus.REROUTE_NORMAL_SEND:
+                return self._refuse_queue_mutation(queued, session_id, stash)
+        inflight = self._inflight_stashes_accessor()
+        if stash is not None:
+            inflight[session_id] = stash
+        else:
+            inflight.pop(session_id, None)
+        self._note_follow_intent()
+        self._launch_chain(draft, session_id)
+        return ConsolePromptDispatchResult(
+            ConsolePromptDispatchStatus.SENT, session_id=session_id
+        )
+
+    def _refuse_queue_mutation(
+        self,
+        result: PromptQueueMutationResult,
+        session_id: str,
+        stash: "ConsoleDraftStash | None",
+    ) -> ConsolePromptDispatchResult:
+        self._restore_stash(stash)
+        if result.status is QueueMutationStatus.FULL:
+            detail = (
+                "Queue full "
+                f"({result.snapshot.total_count}/{MAX_CONSOLE_QUEUE_ENTRIES}). "
+                "Manage or remove an item."
+            )
+        elif result.status is QueueMutationStatus.STALE_REVISION:
+            detail = "The prompt queue changed. Review it and try again."
+        else:
+            detail = result.detail or "This draft could not be queued."
+        self._notify(detail, "warning")
+        return ConsolePromptDispatchResult(
+            ConsolePromptDispatchStatus.REFUSED,
+            session_id=session_id,
+            detail=detail,
+        )
+
+
+__all__ = [
+    "ConsolePromptDispatchResult",
+    "ConsolePromptDispatchStatus",
+    "ConsolePromptQueuePresentation",
+    "ConsolePromptQueueRegion",
+    "ConsolePromptQueueUIController",
+    "commit_queued_draft_transaction",
+    "derive_prompt_queue_presentation",
+]

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -127,7 +127,6 @@ from ...Chat.console_chat_models import (
     CONSOLE_GLOBAL_WORKSPACE_ID,
     DEFAULT_CONSOLE_SESSION_TITLE,
     ConsoleLifecycleImpact,
-    ConsoleMessageRole,
 )
 from ...Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
 from ...Chat.console_context_policy import (
@@ -148,7 +147,7 @@ from ...Chat.console_session_settings import (
 )
 from ...Chat.console_turn_context import ConsoleTurnExecutionContext
 from ...Chat.provider_readiness import provider_config_key
-from ...config import coerce_bool_setting, get_cli_setting
+from ...config import coerce_bool_setting
 from ...Widgets.Console import ConsoleComposerUndoHistory, ConsoleRenameSessionModal
 from ...Widgets.Console.console_session_switcher_modal import ConsoleSwitcherChoice
 from ...Workspaces import ConsoleConversationBrowserRow
@@ -1127,8 +1126,15 @@ class ConsoleSessionController:
         console_config = (
             app_config.get("console", {}) if isinstance(app_config, Mapping) else {}
         )
+        chat_defaults = (
+            app_config.get("chat_defaults", {})
+            if isinstance(app_config, Mapping)
+            else {}
+        )
         if not isinstance(console_config, Mapping):
             console_config = {}
+        if not isinstance(chat_defaults, Mapping):
+            chat_defaults = {}
         workspace_id = self._ensure_console_chat_store().session_workspace_id(
             session_id
         )
@@ -1151,9 +1157,7 @@ class ConsoleSessionController:
             },
             rag_defaults={
                 "auto_retrieve_on_send": coerce_bool_setting(
-                    get_cli_setting(
-                        "chat_defaults", "rag_auto_retrieve_on_send", False
-                    ),
+                    chat_defaults.get("rag_auto_retrieve_on_send", False),
                     False,
                 ),
                 "source_types": tuple(self._rag_source_types_accessor()),

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -146,7 +146,7 @@ from ...Chat.console_session_settings import (
 )
 from ...Chat.console_turn_context import ConsoleTurnExecutionContext
 from ...Chat.provider_readiness import provider_config_key
-from ...config import coerce_bool_setting
+from ...config import coerce_bool_setting, get_cli_setting
 from ...Widgets.Console import ConsoleComposerUndoHistory, ConsoleRenameSessionModal
 from ...Widgets.Console.console_session_switcher_modal import ConsoleSwitcherChoice
 from ...Workspaces import ConsoleConversationBrowserRow
@@ -990,15 +990,8 @@ class ConsoleSessionController:
         console_config = (
             app_config.get("console", {}) if isinstance(app_config, Mapping) else {}
         )
-        chat_defaults = (
-            app_config.get("chat_defaults", {})
-            if isinstance(app_config, Mapping)
-            else {}
-        )
         if not isinstance(console_config, Mapping):
             console_config = {}
-        if not isinstance(chat_defaults, Mapping):
-            chat_defaults = {}
         workspace_id = self._ensure_console_chat_store().session_workspace_id(
             session_id
         )
@@ -1021,7 +1014,9 @@ class ConsoleSessionController:
             },
             rag_defaults={
                 "auto_retrieve_on_send": coerce_bool_setting(
-                    chat_defaults.get("rag_auto_retrieve_on_send", False),
+                    get_cli_setting(
+                        "chat_defaults", "rag_auto_retrieve_on_send", False
+                    ),
                     False,
                 ),
                 "source_types": tuple(self._rag_source_types_accessor()),

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -10,7 +10,7 @@ established and wave 2's `ConsoleWorkspaceController`/`ConsoleHandsFreeControlle
 already applied (see `dictation.py`'s own docstring for the canonical
 statement; restated briefly here):
 
-1. **Framework services** (`run_worker`, `push_screen`) live-read from the
+1. **Framework services** (`run_worker`, `push_screen`, `push_screen_wait`) live-read from the
    screen via `@property` on every access -- never snapshotted.
 2. **A sibling cluster's own attribute, not this cluster's business** is a
    disclosed, temporary live `@property` straight through `screen`:
@@ -126,6 +126,8 @@ from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...Chat.console_chat_models import (
     CONSOLE_GLOBAL_WORKSPACE_ID,
     DEFAULT_CONSOLE_SESSION_TITLE,
+    ConsoleLifecycleImpact,
+    ConsoleMessageRole,
 )
 from ...Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
 from ...Chat.console_context_policy import (
@@ -159,6 +161,19 @@ if TYPE_CHECKING:
     from ..Screens.chat_screen import ChatScreen
 
 logger = logger.bind(module="ChatScreen")
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleSessionCloseImpact:
+    """Content-free snapshot pinned to one requested Console session."""
+
+    session_id: str
+    transcript_message_count: int
+    lifecycle: ConsoleLifecycleImpact
+
+    @property
+    def has_loss_risk(self) -> bool:
+        return bool(self.transcript_message_count or self.lifecycle.has_loss_risk)
 
 
 # -- Module-level pure helpers this cluster owns (see module docstring) -----
@@ -548,6 +563,7 @@ class ConsoleSessionController:
         self._console_visible_draft_session_id: str | None = None
         self._console_undo_histories: dict[str, ConsoleComposerUndoHistory] = {}
         self._console_draft_switch_snapshot: tuple[str | None, str, int] | None = None
+        self._closing_session_requests: set[str] = set()
 
     # -- Framework services (live-read via `@property`) --------------------
 
@@ -561,6 +577,12 @@ class ConsoleSessionController:
     def push_screen(self) -> Any:
         """`Screen.app.push_screen`, bound. See `__init__`'s docstring."""
         return self._screen.app.push_screen
+
+    @property
+    def push_screen_wait(self) -> Any:
+        """`Screen.app.push_screen_wait`, bound. See `__init__`'s docstring."""
+
+        return self._screen.app.push_screen_wait
 
     # -- Sibling cluster's reach-back (disclosed) ---------------------------
 
@@ -800,7 +822,7 @@ class ConsoleSessionController:
     # belongs with the id string it mirrors.
 
     async def _close_console_session_tab(self, session_id: str) -> None:
-        """Close one native session tab, confirming first if it has messages.
+        """Close one native session after one revision-pinned confirmation.
 
         Moved verbatim out of `ChatScreen.on_button_pressed`'s
         `console-close-session-tab-` branch (wave-4 task 2), the
@@ -814,41 +836,156 @@ class ConsoleSessionController:
             session_id: The session behind the pressed ``×``, parsed by the
                 screen from the button id.
         """
+        async def _complete_close() -> None:
+            store = self._ensure_console_chat_store()
+            try:
+                closing_ids = [
+                    message.id for message in store.messages_for_session(session_id)
+                ]
+            except KeyError:
+                return
+            _state, cache = self._ensure_console_image_view()
+            cache.evict_session(closing_ids)
+            self._ensure_console_chat_controller().close_session(session_id)
+            self._console_undo_histories.pop(session_id, None)
+            await self._sync_native_console_chat_ui()
+
+        while True:
+            impact = self._session_close_impact(session_id)
+            if impact is None:
+                return
+            if not impact.has_loss_risk:
+                await _complete_close()
+                return
+            if not await self._confirm_session_close(impact):
+                return
+            current = self._session_close_impact(session_id)
+            if current is None:
+                return
+            if current == impact:
+                await _complete_close()
+                return
+            self.app_instance.notify(
+                "Session activity changed; review the updated close impact.",
+                severity="warning",
+            )
+
+    def start_close_console_session_tab(self, session_id: str) -> None:
+        """Dispatch one non-blocking confirmation flow for ``session_id``."""
+
+        if not session_id or session_id in self._closing_session_requests:
+            return
+        self._closing_session_requests.add(session_id)
+
+        async def _run() -> None:
+            try:
+                await self._close_console_session_tab(session_id)
+            finally:
+                self._closing_session_requests.discard(session_id)
+
+        close_flow = _run()
+        try:
+            self.run_worker(
+                close_flow,
+                group=f"console-close-session:{session_id}",
+                exclusive=True,
+                exit_on_error=False,
+            )
+        except Exception:
+            close_flow.close()
+            self._closing_session_requests.discard(session_id)
+            logger.opt(exception=True).warning(
+                "Could not start Console session close flow for {}", session_id
+            )
+
+    def _session_close_impact(
+        self, session_id: str
+    ) -> ConsoleSessionCloseImpact | None:
+        """Capture transcript and controller loss impact for one exact session."""
+
         store = self._ensure_console_chat_store()
         try:
             messages = store.messages_for_session(session_id)
         except KeyError:
-            messages = []
-        closing_ids = [m.id for m in messages]
+            return None
+        controller = self._ensure_console_chat_controller()
+        return ConsoleSessionCloseImpact(
+            session_id=session_id,
+            transcript_message_count=len(messages),
+            lifecycle=controller.lifecycle_impact(session_id=session_id),
+        )
 
-        def _evict_closing_session_images() -> None:
-            _state, cache = self._ensure_console_image_view()
-            cache.evict_session(closing_ids)
+    async def _await_confirmation(self, dialog: Any) -> bool:
+        """Await a modal from a worker so application input remains routable."""
 
-        if messages:
-            from ...Widgets.confirmation_dialog import ConfirmationDialog
+        worker = self.run_worker(
+            self.push_screen_wait(dialog),
+            exclusive=False,
+            exit_on_error=False,
+        )
+        return bool(await worker.wait())
 
-            async def _do_close() -> None:
-                self._ensure_console_chat_controller().close_session(session_id)
-                # TASK-1281: drop the closed session's undo/redo history
-                # too -- it can never be switched back into.
-                self._console_undo_histories.pop(session_id, None)
-                _evict_closing_session_images()
-                await self._sync_native_console_chat_ui()
+    async def _confirm_session_close(self, impact: ConsoleSessionCloseImpact) -> bool:
+        from ...Widgets.confirmation_dialog import ConfirmationDialog
 
+        lifecycle = impact.lifecycle
+        dialog = ConfirmationDialog(
+            title="Close Console session?",
+            message=(
+                "Closing this session will discard or cancel:\n\n"
+                f"Transcript messages: {impact.transcript_message_count}\n"
+                f"Live agent turns: {lifecycle.live_run_count}\n"
+                f"Unsent queued prompts: {lifecycle.unsent_prompt_count}\n\n"
+                "Close this session?"
+            ),
+            confirm_label="Close",
+            cancel_label="Stay",
+        )
+        return await self._await_confirmation(dialog)
+
+    async def _confirm_fleet_loss(self, controller: Any, *, quitting: bool) -> bool:
+        """Confirm one revision-stable Console fleet loss snapshot."""
+
+        from ...Widgets.confirmation_dialog import ConfirmationDialog
+
+        while True:
+            impact = controller.lifecycle_impact()
+            if not impact.has_loss_risk:
+                return True
+            action = "Quitting Chatbook" if quitting else "Leaving Console"
+            question = "Quit Chatbook?" if quitting else "Leave Console?"
+            confirm_label = "Quit" if quitting else "Leave"
             dialog = ConfirmationDialog(
-                title="Close Tab",
-                message="This tab has messages that will be lost.\n\nClose it anyway?",
-                confirm_label="Close",
-                cancel_label="Keep",
-                confirm_callback=_do_close,
+                title=question,
+                message=(
+                    f"{action} will cancel or discard:\n\n"
+                    f"Live agent runs: {impact.live_run_count}\n"
+                    f"Sessions with queued prompts: {impact.queued_session_count}\n"
+                    f"Unsent queued prompts: {impact.unsent_prompt_count}\n\n"
+                    f"{question}"
+                ),
+                confirm_label=confirm_label,
+                cancel_label="Stay",
             )
-            self.push_screen(dialog)
-        else:
-            self._ensure_console_chat_controller().close_session(session_id)
-            self._console_undo_histories.pop(session_id, None)
-            _evict_closing_session_images()
-            await self._sync_native_console_chat_ui()
+            if not await self._await_confirmation(dialog):
+                return False
+            current = controller.lifecycle_impact()
+            if current == impact:
+                return True
+            self.app_instance.notify(
+                "Console activity changed; review the updated impact.",
+                severity="warning",
+            )
+
+    async def confirm_navigation(self, controller: Any) -> bool:
+        """Confirm revision-stable Console loss before navigation."""
+
+        return await self._confirm_fleet_loss(controller, quitting=False)
+
+    async def confirm_quit(self, controller: Any) -> bool:
+        """Confirm revision-stable Console loss before application quit."""
+
+        return await self._confirm_fleet_loss(controller, quitting=True)
 
     async def _handle_console_session_tab_press(self, session_id: str) -> None:
         """Activate a tab, or rename it when it is already the active one.

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -144,7 +144,9 @@ from ...Chat.console_session_settings import (
     build_console_settings_readiness,
     build_default_console_session_settings,
 )
+from ...Chat.console_turn_context import ConsoleTurnExecutionContext
 from ...Chat.provider_readiness import provider_config_key
+from ...config import coerce_bool_setting
 from ...Widgets.Console import ConsoleComposerUndoHistory, ConsoleRenameSessionModal
 from ...Widgets.Console.console_session_switcher_modal import ConsoleSwitcherChoice
 from ...Workspaces import ConsoleConversationBrowserRow
@@ -383,6 +385,9 @@ class ConsoleSessionController:
         composer_accessor: Callable[[], Any],
         effective_console_provider_model: Callable[[], tuple[Any, Any]],
         provider_readiness_app_config: Callable[[], Any],
+        build_provider_selection: Callable[[str], Any],
+        rag_source_types_accessor: Callable[[], tuple[str, ...]],
+        rag_top_k_accessor: Callable[[], int],
         sync_native_console_chat_ui: Callable[[], Any],
         sync_chat_core_state: Callable[[], Any],
         sync_temporary_chip: Callable[[], None],
@@ -445,6 +450,9 @@ class ConsoleSessionController:
                 settings`.
             provider_readiness_app_config: `ChatScreen._provider_readiness_
                 app_config`.
+            build_provider_selection: Owning-session provider selection builder.
+            rag_source_types_accessor: Current normalized Console RAG source kinds.
+            rag_top_k_accessor: Current active-profile RAG result count.
             sync_native_console_chat_ui: `ChatScreen._sync_native_console_
                 chat_ui` -- a coroutine FUNCTION, called (not awaited
                 directly) by every moved body exactly as the original did.
@@ -513,6 +521,9 @@ class ConsoleSessionController:
         self._composer_accessor = composer_accessor
         self._effective_console_provider_model_fn = effective_console_provider_model
         self._provider_readiness_app_config_fn = provider_readiness_app_config
+        self._build_provider_selection_fn = build_provider_selection
+        self._rag_source_types_accessor = rag_source_types_accessor
+        self._rag_top_k_accessor = rag_top_k_accessor
         self._sync_native_console_chat_ui_fn = sync_native_console_chat_ui
         self._sync_chat_core_state_fn = sync_chat_core_state
         self._sync_temporary_chip_fn = sync_temporary_chip
@@ -948,6 +959,109 @@ class ConsoleSessionController:
             return store.session_settings(store.active_session_id)
         except KeyError:
             return None
+
+    def _console_session_settings(
+        self, session_id: str
+    ) -> ConsoleSessionSettings | None:
+        """Return settings for an owning session without switching the UI."""
+        store = self._console_chat_store
+        if store is None:
+            return None
+        try:
+            return store.session_settings(session_id)
+        except KeyError:
+            return None
+
+    def _build_console_turn_execution_context(
+        self, session_id: str
+    ) -> ConsoleTurnExecutionContext:
+        """Capture one detached configuration snapshot for an owning session."""
+        from ...Chat.attachment_core import max_history_images
+        from ...Tools.workspace_file_roots import folder_binding_roots
+        from ..Screens.settings_library_rag_defaults import (
+            load_direct_library_tools,
+        )
+        from ...model_capabilities import is_vision_capable
+
+        app_config = self._provider_readiness_app_config()
+        selection = self._build_provider_selection_fn(session_id)
+        settings = self._console_session_settings(session_id)
+        model = selection.explicit_model or selection.configured_model
+        console_config = (
+            app_config.get("console", {}) if isinstance(app_config, Mapping) else {}
+        )
+        chat_defaults = (
+            app_config.get("chat_defaults", {})
+            if isinstance(app_config, Mapping)
+            else {}
+        )
+        if not isinstance(console_config, Mapping):
+            console_config = {}
+        if not isinstance(chat_defaults, Mapping):
+            chat_defaults = {}
+        workspace_id = self._ensure_console_chat_store().session_workspace_id(
+            session_id
+        )
+        try:
+            workspace_roots = tuple(folder_binding_roots(workspace_id))
+        except Exception:  # noqa: BLE001 -- optional roots never block a send
+            workspace_roots = ()
+
+        return ConsoleTurnExecutionContext.capture(
+            session_id=session_id,
+            provider_selection=selection,
+            session_settings=settings,
+            workspace_roots=workspace_roots,
+            capabilities={
+                "vision": bool(model)
+                and is_vision_capable(selection.provider, model or ""),
+                "max_history_images": max_history_images(
+                    selection.provider, model
+                ),
+            },
+            rag_defaults={
+                "auto_retrieve_on_send": coerce_bool_setting(
+                    chat_defaults.get("rag_auto_retrieve_on_send", False),
+                    False,
+                ),
+                "source_types": tuple(self._rag_source_types_accessor()),
+                "top_k": self._rag_top_k_accessor(),
+            },
+            tool_configuration={
+                "agent_runtime_enabled": coerce_bool_setting(
+                    console_config.get("agent_runtime", True),
+                    True,
+                ),
+                "native_tool_calls_enabled": coerce_bool_setting(
+                    console_config.get("native_tool_calls", True),
+                    True,
+                ),
+                "local_tools_enabled": coerce_bool_setting(
+                    console_config.get("local_tools_enabled", False),
+                    False,
+                ),
+                "workspace_root": str(
+                    console_config.get("workspace_root", "") or ""
+                ).strip(),
+                "direct_library_tools": load_direct_library_tools(app_config),
+            },
+            provider_payload_settings={
+                "streaming": selection.streaming,
+                "temperature": selection.temperature,
+                "top_p": selection.top_p,
+                "min_p": selection.min_p,
+                "top_k": selection.top_k,
+                "max_tokens": selection.max_tokens,
+                "seed": selection.seed,
+                "presence_penalty": selection.presence_penalty,
+                "frequency_penalty": selection.frequency_penalty,
+                "reasoning_effort": selection.reasoning_effort,
+                "reasoning_summary": selection.reasoning_summary,
+                "verbosity": selection.verbosity,
+                "thinking_effort": selection.thinking_effort,
+                "thinking_budget_tokens": selection.thinking_budget_tokens,
+            },
+        )
 
     def _default_console_session_settings(self) -> ConsoleSessionSettings:
         """Build the default settings snapshot for a new native Console session."""

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -53,6 +53,10 @@ from .dictation import ConsoleDictationController
 from .hands_free import ConsoleHandsFreeController
 from .message import ConsoleMessageController
 from .prompts import ConsolePromptsController
+from .prompt_queue import (
+    ConsolePromptQueueUIController,
+    commit_queued_draft_transaction,
+)
 from .session import ConsoleSessionController
 from .workspace import ConsoleWorkspaceController
 
@@ -68,7 +72,7 @@ def build_console_controllers(
     rag_source_types_accessor: Callable[[], tuple[str, ...]],
     rag_top_k_accessor: Callable[[], int],
 ) -> None:
-    """Construct the Console screen's seven controllers and attach them.
+    """Construct the Console screen's eight controllers and attach them.
 
     Assigns, in this order, `screen._workspace`, `screen._session`,
     `screen._dictation`, `screen._hands_free`, `screen._message`,
@@ -673,4 +677,59 @@ def build_console_controllers(
         sync_native_console_chat_ui_accessor=(
             lambda: screen._sync_native_console_chat_ui
         ),
+    )
+    screen._prompt_queue = ConsolePromptQueueUIController(
+        chat_controller_accessor=(
+            lambda: screen._ensure_console_chat_controller()
+        ),
+        ensure_active_session=(
+            lambda: screen._session._ensure_active_console_session_settings()
+        ),
+        blocked_reason_accessor=lambda: screen._console_send_blocked_reason(),
+        setup_blocked_reason_accessor=(
+            lambda: screen._console_setup_blocked_reason()
+        ),
+        restore_stash=lambda stash: screen._restore_console_send_stash(stash),
+        append_system_message=(
+            lambda text: screen._append_native_console_system_message(text)
+        ),
+        notify=(
+            lambda text, severity: screen.app_instance.notify(
+                text, severity=severity
+            )
+        ),
+        focus_composer=(
+            lambda: screen._focus_console_composer_if_needed(force=True)
+        ),
+        inflight_stashes_accessor=(
+            lambda: screen._console_inflight_send_stashes
+        ),
+        note_follow_intent=lambda: screen._note_console_follow_intent(),
+        launch_chain=(
+            lambda draft, session_id: screen.run_worker(
+                screen._submit_console_native_draft(draft, session_id),
+                exclusive=True,
+                group=f"console-run-{session_id}",
+            )
+        ),
+        commit_queued_draft=(
+            lambda session_id, stash: commit_queued_draft_transaction(
+                session_id,
+                stash,
+                composer=screen._console_composer_or_none(),
+                visible_session_id=screen._console_visible_draft_session_id,
+                undo_histories=screen._console_undo_histories,
+                store=screen._ensure_console_chat_store(),
+                sync_command_popup=screen._sync_console_command_popup,
+            )
+        ),
+        edit_refusal=(
+            lambda text: (
+                "Slash commands cannot be queued."
+                if screen._console_command_registry.parse(text).kind
+                in {"command", "fallback"}
+                else ""
+            )
+        ),
+        sync_ui=lambda: screen._sync_native_console_chat_ui(),
     )

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -45,6 +45,7 @@ hand back the same object. Patch a controller on the module that defines it;
 do not reintroduce a re-export in `chat_screen.py` to patch through.
 """
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from .agent import ConsoleAgentController
@@ -61,7 +62,12 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 __all__ = ["build_console_controllers"]
 
 
-def build_console_controllers(screen: "ChatScreen") -> None:
+def build_console_controllers(
+    screen: "ChatScreen",
+    *,
+    rag_source_types_accessor: Callable[[], tuple[str, ...]],
+    rag_top_k_accessor: Callable[[], int],
+) -> None:
     """Construct the Console screen's seven controllers and attach them.
 
     Assigns, in this order, `screen._workspace`, `screen._session`,
@@ -231,6 +237,11 @@ def build_console_controllers(screen: "ChatScreen") -> None:
         provider_readiness_app_config=(
             lambda: screen._provider_readiness_app_config()
         ),
+        build_provider_selection=(
+            lambda session_id: screen._build_console_provider_selection(session_id)
+        ),
+        rag_source_types_accessor=rag_source_types_accessor,
+        rag_top_k_accessor=rag_top_k_accessor,
         sync_native_console_chat_ui=lambda: screen._sync_native_console_chat_ui(),
         sync_chat_core_state=lambda: screen._sync_console_chat_core_state(),
         sync_temporary_chip=lambda: screen._sync_console_temporary_chip(),

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -455,7 +455,6 @@ from ...Widgets.Console.console_context_controls import (
     ConsoleContextControlState,
     build_console_context_control_state,
 )
-from ...Widgets.confirmation_dialog import ConfirmationDialog
 from ...Widgets.Console.console_image_viewer_modal import (
     AvatarViewRequested,
     ConsoleImageViewerModal,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -13872,69 +13872,27 @@ class ChatScreen(BaseAppScreen):
         )
 
     async def confirm_navigation(self) -> bool:
-        """Confirm leaving Console while the agent fleet still has live work.
+        """Delegate revision-pinned Console loss confirmation."""
 
-        TASK-1143 (F5): navigating away from Console unmounts this screen,
-        and ``on_unmount`` awaits ``ConsoleChatController.shutdown()`` --
-        cancelling every in-flight stream and denying every pending/parked
-        approval round for EVERY session this controller owns, not just
-        the one being viewed (see ``ConsoleChatController.shutdown``'s own
-        docstring). That is correct, by-design teardown -- screens are
-        never cached, so nothing could resolve those rounds through this
-        instance again regardless -- but it was previously silent. This
-        hook is the ``flush_pending_work`` sibling seam
-        ``TldwCli.handle_screen_navigation`` awaits before the switch
-        commits: returning ``False`` keeps this screen (and its
-        controller, and its fleet) mounted exactly like a flush veto.
-
-        Returns:
-            ``True`` when navigation may proceed -- an idle fleet (the
-            common case: no dialog, no delay), or the user chose "Leave"
-            in the confirmation dialog. ``False`` when the user chose
-            "Stay": the screen and its controller are left exactly as
-            they were, nothing cancelled, nothing denied.
-        """
         controller = self._console_chat_controller
         if controller is None:
             return True
-        busy_count = controller.busy_fleet_session_count()
-        if busy_count <= 0:
+        return await self._session.confirm_navigation(controller)
+
+    async def confirm_quit(self) -> bool:
+        """Delegate revision-pinned Console loss confirmation for app quit."""
+
+        controller = self._console_chat_controller
+        if controller is None:
             return True
-        noun = "run" if busy_count == 1 else "runs"
-        dialog = ConfirmationDialog(
-            title="Leave Console?",
-            message=(
-                f"{busy_count} agent {noun} will be cancelled if you "
-                "leave Console. Leave anyway?\n\n"
-                "Tab/Shift+Tab selects Stay or Leave, Enter activates the "
-                "selected button, Esc stays."
-            ),
-            confirm_label="Leave",
-            cancel_label="Stay",
-        )
-        # `push_screen_wait` (the usual way to await a dialog's result) may
-        # ONLY be called from within a worker -- `App.push_screen` raises
-        # `NoActiveWorker` otherwise, since blocking a bare Future-await
-        # for a result only a LATER message resolves is exactly the
-        # deadlock shape workers exist to make safe. `confirm_navigation`
-        # itself runs on `TldwCli.handle_screen_navigation`'s own call
-        # stack -- which TASK-1230 made a worker's call stack (see
-        # `TldwCli._dispatch_screen_navigation`), specifically so this
-        # await can never starve the App's own event routing for the
-        # dialog's lifetime -- but the wait is still delegated to its own
-        # worker here (rather than a bare `await push_screen_wait(...)`)
-        # so `confirm_navigation` keeps working correctly even if some
-        # future caller ever invokes it outside that worker context --
-        # `exit_on_error=False` so a broken dialog fails this navigation
-        # closed (see the caller's except branch) rather than crashing the
-        # app.
-        worker = self.run_worker(
-            self.app_instance.push_screen_wait(dialog),
-            exclusive=False,
-            exit_on_error=False,
-        )
-        proceed = await worker.wait()
-        return bool(proceed)
+        return await self._session.confirm_quit(controller)
+
+    def prepare_for_quit(self) -> None:
+        """Tombstone Console future work before application cleanup."""
+
+        controller = self._console_chat_controller
+        if controller is not None:
+            controller.begin_shutdown()
 
     async def on_unmount(self) -> None:
         """Release Console-native resources owned by this screen."""
@@ -19675,7 +19633,7 @@ class ChatScreen(BaseAppScreen):
             return
         if button_id and button_id.startswith("console-close-session-tab-"):
             event.stop()
-            await self._session._close_console_session_tab(
+            self._session.start_close_console_session_tab(
                 button_id.removeprefix("console-close-session-tab-")
             )
             return

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -210,8 +210,10 @@ from ...Chat.console_chat_models import (
     ConsoleProviderSelection,
     ConsoleRunStatus,
     MessageAttachment,
+    ConsoleWorkspaceContext,
     derive_console_session_title,
 )
+from ...Chat.console_turn_context import ConsoleTurnExecutionContext
 from ...Chat.console_glyphs import GLYPH_VOICE_WORKING
 from ...Widgets.glyph_fallback import resolve_glyph
 from ...Chat.console_session_settings import (
@@ -3205,7 +3207,13 @@ class ChatScreen(BaseAppScreen):
         # wiring's late-binding lambdas. See `build_console_
         # controllers`' docstring for the build order and why it is
         # documentation rather than a constraint.
-        build_console_controllers(self)
+        build_console_controllers(
+            self,
+            rag_source_types_accessor=(
+                lambda: _console_library_rag_source_scope(self)
+            ),
+            rag_top_k_accessor=lambda: _console_library_rag_profile_top_k(),
+        )
         self._console_conversation_browser_query = ""
         self._console_conversation_browser_search_timer: Any | None = None
         self._console_conversation_browser_search_token = 0
@@ -4097,11 +4105,30 @@ class ChatScreen(BaseAppScreen):
             return
         search.focus()
 
-    def _build_console_provider_selection(self) -> ConsoleProviderSelection:
-        """Return the effective native Console provider selection for sends."""
+    def _build_console_provider_selection(
+        self, session_id: str | None = None
+    ) -> ConsoleProviderSelection:
+        """Return an owning-session provider selection without switching tabs."""
         app_config = self._provider_readiness_app_config()
-        selection_settings = self._session._ensure_active_console_session_settings()
-        _legacy_provider, legacy_model = self._effective_console_provider_model()
+        store = self._ensure_console_chat_store()
+        if session_id is None:
+            selection_settings = (
+                self._session._ensure_active_console_session_settings()
+            )
+            target_session_id = store.active_session_id
+        else:
+            selection_settings = self._session._console_session_settings(session_id)
+            if selection_settings is None:
+                raise KeyError(f"Unknown Console session: {session_id}")
+            target_session_id = session_id
+        legacy_model = None
+        if session_id is None:
+            _legacy_provider, legacy_model = self._effective_console_provider_model()
+        elif getattr(selection_settings, "source", "derived") == "user":
+            legacy_model = selection_settings.model
+        else:
+            chat_defaults = self._config_section(app_config, "chat_defaults")
+            legacy_model = chat_defaults.get("model")
         provider = provider_config_key(selection_settings.provider) or "llama_cpp"
         explicit_model = (
             str(selection_settings.model).strip()
@@ -4142,6 +4169,17 @@ class ChatScreen(BaseAppScreen):
         elif _has_selected_text(selection_settings.base_url):
             base_url = str(selection_settings.base_url).strip()
 
+        current_workspace_context = self._workspace._current_console_workspace_context()
+        if target_session_id is None:
+            workspace_context = current_workspace_context
+        else:
+            workspace_id = store.session_workspace_id(target_session_id)
+            workspace_context = (
+                current_workspace_context
+                if current_workspace_context.active_workspace_id == workspace_id
+                else ConsoleWorkspaceContext(active_workspace_id=workspace_id)
+            )
+
         return ConsoleProviderSelection(
             provider=provider,
             base_url=base_url,
@@ -4162,7 +4200,7 @@ class ChatScreen(BaseAppScreen):
             thinking_budget_tokens=selection_settings.thinking_budget_tokens,
             streaming=selection_settings.streaming,
             system_prompt=selection_settings.system_prompt,
-            workspace_context=self._workspace._current_console_workspace_context(),
+            workspace_context=workspace_context,
         )
 
     def _active_console_provider_model_display(
@@ -4559,14 +4597,16 @@ class ChatScreen(BaseAppScreen):
         """Delegate to `ConsolePromptsController` (wave-3 console decomposition, task 3)."""
         return self._prompts._ensure_console_prompt_history()
 
-    def _console_library_provider_factory(self):
+    def _console_library_provider_factory(
+        self, turn_context: ConsoleTurnExecutionContext | None = None
+    ):
         """Resolve the Library retrieval provider for one Console agent run.
 
-        task-1337 (spec section 8): reads ``[console].direct_library_tools``
-        FRESH on every call, so flipping the Settings toggle applies to the
-        next run without rebuilding the cached controller or bridge. Direct
-        mode assembles ``LocalLibraryToolService`` purely from the app's local
-        service attributes (any missing backend degrades its own tools to
+        task-1337 (spec section 8): a turn context pins
+        ``[console].direct_library_tools`` for one run; the compatibility
+        no-context path still reads it fresh. Direct mode assembles
+        ``LocalLibraryToolService`` purely from the app's local service
+        attributes (any missing backend degrades its own tools to
         ``feature_unavailable``); off mode binds the bounded RAG provider to
         the app-owned ``library_rag_search_service``.
         """
@@ -4578,7 +4618,12 @@ class ChatScreen(BaseAppScreen):
         )
 
         app = self.app_instance
-        if not load_direct_library_tools():
+        direct_library_tools = (
+            bool(turn_context.tool_configuration.get("direct_library_tools", False))
+            if turn_context is not None
+            else load_direct_library_tools()
+        )
+        if not direct_library_tools:
             from tldw_chatbook.Agents.library_rag_tool_provider import (
                 LibraryRagToolProvider,
             )
@@ -4636,6 +4681,9 @@ class ChatScreen(BaseAppScreen):
                 default_session_settings=self._session._default_console_session_settings,
                 library_provider_factory=self._console_library_provider_factory,
                 global_user_display_name=self._global_chat_display_name,
+                turn_context_provider=(
+                    self._session._build_console_turn_execution_context
+                ),
             )
         self._console_chat_controller.on_submission_accepted = (
             self._on_console_submission_accepted
@@ -4684,7 +4732,11 @@ class ChatScreen(BaseAppScreen):
         self._sync_console_chat_core_state()
         return self._console_chat_controller
 
-    async def _capture_console_staged_rag(self, draft: str):
+    async def _capture_console_staged_rag(
+        self,
+        draft: str,
+        turn_context: ConsoleTurnExecutionContext | None = None,
+    ):
         """Resolve the current staged Library-RAG bundle for one Console send.
 
         This is the ONLY consume-on-send seam. The controller calls it once
@@ -4715,7 +4767,9 @@ class ChatScreen(BaseAppScreen):
         # would also discard whatever the consume below was about to hand
         # the model. An optional convenience must never be able to do that.
         try:
-            await self._maybe_auto_retrieve_for_send(draft)
+            await self._maybe_auto_retrieve_for_send(
+                draft, turn_context=turn_context
+            )
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -13239,7 +13293,11 @@ class ChatScreen(BaseAppScreen):
                 type(exc).__name__,
             )
 
-    async def _maybe_auto_retrieve_for_send(self, draft_text: str) -> None:
+    async def _maybe_auto_retrieve_for_send(
+        self,
+        draft_text: str,
+        turn_context: ConsoleTurnExecutionContext | None = None,
+    ) -> None:
         """Auto-retrieve library evidence for a plain text send (TASK-406).
 
         Fires only when ALL hold: the config toggle is on; the send is plain
@@ -13258,7 +13316,20 @@ class ChatScreen(BaseAppScreen):
         Args:
             draft_text: The validated draft this send is about to transmit.
         """
-        if not get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False):
+        auto_retrieve_enabled = (
+            coerce_bool_setting(
+                turn_context.rag_defaults.get("auto_retrieve_on_send", False),
+                False,
+            )
+            if turn_context is not None
+            else coerce_bool_setting(
+                get_cli_setting(
+                    "chat_defaults", "rag_auto_retrieve_on_send", False
+                ),
+                False,
+            )
+        )
+        if not auto_retrieve_enabled:
             return
         if not _is_plain_text_send(draft_text):
             return
@@ -13271,11 +13342,21 @@ class ChatScreen(BaseAppScreen):
             # Nothing survived centralized validation -- there is no query to
             # run, and no user action to recommend. Stay silent.
             return
+        source_types = (
+            turn_context.rag_defaults.get("source_types", ())
+            if turn_context is not None
+            else _console_library_rag_source_scope(self)
+        )
+        top_k = (
+            int(turn_context.rag_defaults.get("top_k", 0) or 0)
+            if turn_context is not None
+            else _console_library_rag_profile_top_k()
+        )
         request = LibraryRagSearchRequest(
             query=query,
-            source_types=_console_library_rag_source_scope(self),
+            source_types=source_types,
             mode="rag",
-            top_k=_console_library_rag_profile_top_k(),
+            top_k=top_k,
             include_citations=True,
         )
         (

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -67,6 +67,7 @@ from ..Console_Modules.dictation import (
 from ..Console_Modules.hands_free import (
     ConsoleHandsFreeSession,
 )
+from ..Console_Modules.prompt_queue import ConsolePromptDispatchStatus, ConsolePromptQueueRegion
 from ..Console_Modules.left_rail import ConsoleLeftRail
 from ..Console_Modules.message import ConsoleMessageController
 from ..Console_Modules.right_rail import ConsoleInspectorRail
@@ -515,6 +516,7 @@ from ...Widgets.Console.console_generate_image_modal import (
     ConsoleGenerateImageModal,
 )
 from ...Widgets.Console.console_scope_picker_modal import ConsoleScopePickerModal
+from ...Widgets.Console.console_prompt_queue_modal import ConsolePromptQueueModal
 from ...Widgets.Console.console_model_popover import (
     CONSOLE_POPOVER_OPEN_FULL_SETTINGS,
     ConsoleModelPopover,
@@ -1156,7 +1158,7 @@ CONSOLE_WORKBENCH_SHORTCUTS = (
     ("F6", "next pane"),
     ("Shift+F6", "previous pane"),
     ("F1", "help"),
-    ("Enter", "send"),
+    ("Enter", "send / queue"),
     ("Ctrl+K", "switch session"),
     ("Ctrl+T", "new tab"),
     ("Ctrl+P", "palette"),
@@ -1167,7 +1169,7 @@ CONSOLE_WORKBENCH_SHORTCUTS = (
 #: action instead. The blocked variant hides the send hint and names the real
 #: action. `_register_console_footer_shortcuts` swaps between the two.
 CONSOLE_WORKBENCH_SHORTCUTS_SETUP_BLOCKED = tuple(
-    ("Enter", "continue setup") if pair == ("Enter", "send") else pair
+    ("Enter", "continue setup") if pair == ("Enter", "send / queue") else pair
     for pair in CONSOLE_WORKBENCH_SHORTCUTS
 )
 
@@ -1200,7 +1202,8 @@ CONSOLE_WORKBENCH_SHORTCUT_GROUPS = (
     (
         "Composer",
         (
-            ("Enter", "send"),
+            ("Enter", "send now or queue after an accepted turn"),
+            ("Queue shelf", "manage, pause, resume, and recover queued prompts"),
             ("Ctrl+J", "insert a newline (works in any terminal)"),
             ("Shift+Enter", "insert a newline (where the terminal delivers it)"),
             ("Ctrl+Z", "undo the last draft edit"),
@@ -1275,7 +1278,7 @@ CONSOLE_WORKBENCH_SHORTCUT_GROUPS = (
 #: change what a glyph MEANS, update both.
 CONSOLE_FLEET_MARKER_LEGEND = (
     "Status markers: ● running · ◆ needs approval · ✓ finished · ✗ failed "
-    "— clears once you visit that tab."
+    "— clears once you visit that tab. Qn is the unsent prompt count."
 )
 
 
@@ -1304,6 +1307,8 @@ def _console_workbench_agents_notes(max_parallel_runs: int) -> tuple[str, ...]:
         "(change in Settings > Console Behavior).",
         "Built-in tools ask before running; a background session that "
         "needs approval parks with a ◆ badge and a toast.",
+        "Accepted turns can hold up to 10 queued prompts per tab; use the "
+        "queue shelf to manage or pause them.",
         CONSOLE_FLEET_MARKER_LEGEND,
         "Leaving Console cancels any runs still in progress -- you'll be asked first.",
     )
@@ -9695,6 +9700,11 @@ class ChatScreen(BaseAppScreen):
                 if controller is not None
                 else ""
             )
+            queued_count = (
+                controller.activity_for(session.id).queued_count
+                if controller is not None
+                else 0
+            )
             row = ConsoleConversationBrowserInputRow(
                 row_key=row_key,
                 conversation_id=persisted_id or None,
@@ -9710,6 +9720,7 @@ class ChatScreen(BaseAppScreen):
                 source_kind="native",
                 updated_sort=str(session.updated_at or ""),
                 run_marker=run_marker,
+                queued_count=queued_count,
             )
             rows.append(self._apply_console_browser_star_state(row, starred_ids))
         return rows
@@ -13750,6 +13761,29 @@ class ChatScreen(BaseAppScreen):
                 id="console-staged-evidence-strip",
                 classes="ds-panel",
             )
+            yield ConsolePromptQueueRegion(
+                id="console-prompt-queue",
+                on_manage_requested=(
+                    lambda session_id, revision: self.app.push_screen(
+                        ConsolePromptQueueModal(
+                            session_id=session_id,
+                            revision=revision,
+                            queue_controller=self._prompt_queue,
+                        )
+                    )
+                ),
+                on_primary_requested=(
+                    lambda session_id, revision, action: self.run_worker(
+                        self._prompt_queue.handle_primary_intent(
+                            session_id,
+                            action=action,
+                            expected_revision=revision,
+                        ),
+                        exclusive=True,
+                        group="console-prompt-queue-shelf",
+                    )
+                ),
+            )
             composer = ConsoleComposerBar(
                 id="console-native-composer",
                 classes="ds-panel",
@@ -15129,12 +15163,21 @@ class ChatScreen(BaseAppScreen):
             if controller is not None
             else None
         )
+        queue_counts = (
+            {
+                session.id: controller.activity_for(session.id).queued_count
+                for session in sessions
+            }
+            if controller is not None
+            else None
+        )
         self._maybe_show_fleet_coachmark(sessions, surface)
         await surface.sync_sessions(
             sessions=sessions,
             active_session_id=store.active_session_id,
             streaming_session_id=streaming_session_id,
             run_markers=run_markers,
+            queue_counts=queue_counts,
         )
 
     async def _append_native_console_system_message(
@@ -15235,7 +15278,7 @@ class ChatScreen(BaseAppScreen):
             # racing the scheduling gap between `run_worker(...)` and this
             # coroutine body actually running could submit into whichever
             # session the user switched TO instead of the dispatching one.
-            result = await controller.submit_draft(draft, session_id=session_id)
+            result = await controller.run_prompt_chain(draft, session_id=session_id)
         except Exception:
             # An unexpected submit crash must not eat the keypress-cleared
             # draft — and must not escape the worker (exit_on_error would
@@ -15592,88 +15635,10 @@ class ChatScreen(BaseAppScreen):
     async def _dispatch_console_draft_send(
         self, draft: str, stash: "ConsoleDraftStash | None" = None
     ) -> bool:
-        """Run the send-blocked/readiness gate, then queue ``draft`` as the
-        user turn (the normal-text-send tail, shared with the skill-picker
-        `$name` submit path so both go through the exact same gating).
+        """Compatibility delegate for the one typed queue-aware dispatcher."""
 
-        ``stash`` is the keypress-captured draft of a keyboard send
-        (TASK-340): restored on every blocked path here, handed to the
-        in-flight slot on queue so the accept/refuse sites can consume it.
-
-        Returns:
-            ``True`` once the submit has actually been queued via
-            ``run_worker`` (a caller-visible "this is really going out"
-            signal); ``False`` when blocked or when a run is already in
-            progress, in which case nothing is queued and an explanatory
-            row/toast was already shown.
-        """
-        if blocked_reason := self._console_send_blocked_reason():
-            self._restore_console_send_stash(stash)
-            setup_blocked_reason = self._console_setup_blocked_reason()
-            if setup_blocked_reason and not blocked_reason.startswith(
-                "Console send blocked: Library Search/RAG"
-            ):
-                await self._append_native_console_system_message(setup_blocked_reason)
-                self.app_instance.notify(
-                    setup_blocked_reason,
-                    severity="warning",
-                )
-                self._focus_console_composer_if_needed(force=True)
-                return False
-            await self._append_native_console_system_message(blocked_reason)
-            self._focus_console_composer_if_needed(force=True)
-            return False
-        controller = self._ensure_console_chat_controller()
-        # Task 4 (D2 fix wave): resolve/create the session to submit into
-        # HERE, before `target_session_id` is read, rather than leaving that
-        # as an implicit side effect of the `_console_send_blocked_reason()`
-        # call above (which happens to already do this via
-        # `_active_console_settings_readiness` -> `_ensure_active_console_
-        # session_settings`, whenever it doesn't return early). Making the
-        # call explicit means a fresh profile's FIRST send never keys the
-        # stash map / worker group / double-send gate below on `""` even if
-        # that upstream call's own internals ever change -- the invariant
-        # is asserted right at the point that matters, not inherited
-        # incidentally from an unrelated gate a few lines up. This is a
-        # synchronous call (no `await` before `target_session_id` is read),
-        # so there is no scheduling gap for the store's active session to
-        # change out from under it.
-        self._session._ensure_active_console_session_settings()
-        # Fix round 1 (minor): normalize the same way the controller side
-        # already does (`store.active_session_id or ""`) -- `None` is a
-        # valid (if unlikely, post-mount) dict key, but every other
-        # per-session map in this train keys on the normalized string, so
-        # a stray `None` here would silently start a SEPARATE bucket for
-        # "no session" instead of colliding predictably. After the call
-        # above, this is never actually `""` for a real send -- the `or ""`
-        # stays only as a defensive normalization, not a live code path.
-        target_session_id = controller.store.active_session_id or ""
-        refusal = controller.send_refusal_copy(target_session_id)
-        if refusal:
-            self._restore_console_send_stash(stash)
-            self.app_instance.notify(refusal, severity="warning")
-            return False
-        # Task 3b: keyed by THIS dispatch's own session -- a bare `= stash`
-        # assignment (the old singular slot) would let a DIFFERENT
-        # session's concurrent dispatch either clobber this entry with its
-        # own stash, or wipe it to None before this session's worker ever
-        # reads it (Task 3 made two dispatches genuinely interleave).
-        if stash is not None:
-            self._console_inflight_send_stashes[target_session_id] = stash
-        else:
-            self._console_inflight_send_stashes.pop(target_session_id, None)
-        self._note_console_follow_intent()
-        # group=f"console-run-{session_id}": a PER-SESSION group (parallel-
-        # agents spec Sec2) so UI-sync kicks -- and sends in OTHER sessions --
-        # can never cancel this session's in-flight run (TASK-228 originated
-        # the dedicated group; scoping it per session keeps concurrent
-        # sessions' exclusive workers from cancelling each other).
-        self.run_worker(
-            self._submit_console_native_draft(draft, target_session_id),
-            exclusive=True,
-            group=f"console-run-{target_session_id}",
-        )
-        return True
+        result = await self._prompt_queue.dispatch(draft, stash=stash)
+        return result.status is not ConsolePromptDispatchStatus.REFUSED
 
     def _note_console_follow_intent(self) -> None:
         """Stamp a programmatic jump-to-tail intent on the transcript (TASK-336).
@@ -18280,10 +18245,30 @@ class ChatScreen(BaseAppScreen):
         run_active = False
         send_blocked = False
         controller = self._console_chat_controller
+        queue_presentation = None
         if controller is not None:
             run_state = getattr(controller, "run_state", None)
             run_active = bool(getattr(run_state, "is_stop_allowed", False))
             send_blocked = not bool(getattr(run_state, "is_send_allowed", True))
+            active_id = controller.store.active_session_id or ""
+            if active_id:
+                queue_presentation = self._prompt_queue.presentation_for(
+                    active_id,
+                    composer_collapsed=composer.collapsed,
+                )
+                send_blocked = not queue_presentation.send_enabled
+                try:
+                    queue_region = self.query_one(
+                        "#console-prompt-queue", ConsolePromptQueueRegion
+                    )
+                except QueryError:
+                    pass
+                else:
+                    queue_region.sync_presentation(active_id, queue_presentation)
+                composer.sync_prompt_queue_state(
+                    count=queue_presentation.count,
+                    paused=queue_presentation.paused,
+                )
         # task-3401.5: an in-flight video generation shows the same Stop
         # affordance (it sets the adapter's cooperative cancel event).
         store_for_videogen = self._console_chat_store
@@ -18312,8 +18297,22 @@ class ChatScreen(BaseAppScreen):
             run_active=run_active,
             can_save_chatbook=can_save_chatbook,
             send_blocked=send_blocked,
-            setup_blocked_reason=setup_blocked_reason or attachment_blocked_reason,
+            setup_blocked_reason=(
+                setup_blocked_reason
+                or attachment_blocked_reason
+                or (
+                    queue_presentation.send_tooltip
+                    if queue_presentation is not None
+                    and not queue_presentation.send_enabled
+                    else ""
+                )
+            ),
             ephemeral=self._console_active_session_is_ephemeral(),
+            send_label=(
+                queue_presentation.send_label
+                if queue_presentation is not None
+                else "Send"
+            ),
         )
         composer.sync_dictation_state(self._console_dictation_state)
         # sync_action_state resets the attach button's tooltip to generic copy
@@ -18661,7 +18660,7 @@ class ChatScreen(BaseAppScreen):
                     "Console send is unavailable.", severity="error"
                 )
                 return
-            if send_button.disabled:
+            if send_button.disabled and send_button.display:
                 # TASK-2154.6 (FR-04): Send is now genuinely disabled
                 # while blocked/empty, and `Button.press()` is a no-op
                 # on a disabled control — a plain press here would

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -509,6 +509,10 @@ class ConsoleComposerBar(Horizontal):
         self._redo_stack: list[_DraftHistorySnapshot] = []
         self._coalescing_active = False
         self._run_active = False
+        self._queued_prompt_count = 0
+        self._queue_paused = False
+        self._send_button_width = 6
+        self._send_label = "Send"
         self._send_blocked = False
         self._setup_blocked_reason = ""
         #: Last rendered `#console-send-disabled-reason` copy, tracked so a
@@ -609,6 +613,17 @@ class ConsoleComposerBar(Horizontal):
         actions.styles.width = width
         actions.styles.min_width = width
         actions.styles.max_width = width
+
+    def _actions_row_width(self, *, attachment_visible: bool | None = None) -> int:
+        """Return the current dynamic-label action-row budget."""
+
+        if attachment_visible is None:
+            attachment_visible = self._pending_attachment_label is not None
+        return (
+            BASE_ACTIONS_WIDTH
+            + (self._send_button_width - 6)
+            + (4 if attachment_visible else 0)
+        )
 
     def draft_text(self) -> str:
         """Return the canonical native Console draft payload.
@@ -1266,6 +1281,7 @@ class ConsoleComposerBar(Horizontal):
             send_blocked=self._send_blocked,
             setup_blocked_reason=self._setup_blocked_reason,
             ephemeral=self._ephemeral,
+            send_label=self._send_label,
         )
 
     def _sync_send_disabled_reason(self, reason: str, *, muted: bool) -> None:
@@ -1320,6 +1336,7 @@ class ConsoleComposerBar(Horizontal):
         send_blocked: bool = False,
         setup_blocked_reason: str = "",
         ephemeral: bool = False,
+        send_label: str = "Send",
     ) -> None:
         """Refresh composer action priority and disabled state.
 
@@ -1350,8 +1367,19 @@ class ConsoleComposerBar(Horizontal):
         try:
             send_button = self.query_one("#console-send-message", Button)
             stop_button = self.query_one("#console-stop-generation", Button)
+            actions = self.query_one("#console-composer-actions", Horizontal)
         except NoMatches:
             return
+
+        normalized_send_label = send_label.strip() or "Send"
+        self._send_label = normalized_send_label
+        self._send_button_width = max(6, cell_len(normalized_send_label) + 2)
+        send_button.label = normalized_send_label
+        send_button.styles.width = self._send_button_width
+        send_button.styles.min_width = self._send_button_width
+        send_button.styles.max_width = self._send_button_width
+        if not self._voice_full_width_preparing:
+            self._set_actions_row_width(actions, self._actions_row_width())
 
         send_ready = has_draft and not send_blocked
 
@@ -2216,7 +2244,19 @@ class ConsoleComposerBar(Horizontal):
             parts.append("Draft retained")
         if self._pending_attachment_label is not None:
             parts.append("Attachment retained")
+        if self._queued_prompt_count:
+            state = "Paused" if self._queue_paused else "Queued"
+            parts.append(f"{state} {self._queued_prompt_count}")
         return " · ".join(parts)
+
+    def sync_prompt_queue_state(self, *, count: int, paused: bool) -> None:
+        """Sync the collapsed composer's content-free queue indicator."""
+
+        next_state = (max(0, int(count)), bool(paused))
+        if next_state == (self._queued_prompt_count, self._queue_paused):
+            return
+        self._queued_prompt_count, self._queue_paused = next_state
+        self._sync_collapsed_presentation()
 
     def _sync_collapsed_presentation(self) -> None:
         """Synchronize stable presentation containers from cached widget state."""
@@ -4252,7 +4292,9 @@ class ConsoleComposerBar(Horizontal):
             indicator.styles.width = "auto"
             indicator.styles.max_width = 28
             clear_button.styles.display = "block"
-            self._set_actions_row_width(actions, ATTACHMENT_ACTIONS_WIDTH)
+            self._set_actions_row_width(
+                actions, self._actions_row_width(attachment_visible=True)
+            )
             # CN-04 (TASK-2154.13): one phrase with the compose-time tooltip
             # ("Remove the pending attachment."), not a second "Clear" verb.
             if count > 1:
@@ -4264,7 +4306,9 @@ class ConsoleComposerBar(Horizontal):
             indicator.styles.display = "none"
             indicator.styles.width = 0
             clear_button.styles.display = "none"
-            self._set_actions_row_width(actions, BASE_ACTIONS_WIDTH)
+            self._set_actions_row_width(
+                actions, self._actions_row_width(attachment_visible=False)
+            )
         if self._voice_full_width_preparing:
             self._sync_full_width_voice_presentation(True)
 
@@ -4407,7 +4451,7 @@ class ConsoleComposerBar(Horizontal):
         clear_attachment.styles.display = "block" if attachment_visible else "none"
         self._set_actions_row_width(
             actions,
-            ATTACHMENT_ACTIONS_WIDTH if attachment_visible else BASE_ACTIONS_WIDTH,
+            self._actions_row_width(attachment_visible=attachment_visible),
         )
         self._sync_collapsed_presentation()
         self._sync_send_disabled_reason(
@@ -4576,7 +4620,7 @@ class ConsoleComposerBar(Horizontal):
             actions = Horizontal(
                 id="console-composer-actions", classes="console-composer-actions"
             )
-            self._set_actions_row_width(actions, BASE_ACTIONS_WIDTH)
+            self._set_actions_row_width(actions, self._actions_row_width())
             actions.styles.height = 1
             actions.styles.min_height = 1
             actions.styles.max_height = 1

--- a/tldw_chatbook/Widgets/Console/console_prompt_queue_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_prompt_queue_modal.py
@@ -1,0 +1,586 @@
+"""Focused, session-pinned manager for the Console prompt queue."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual import on
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static, TextArea
+
+from tldw_chatbook.Chat.console_prompt_queue import (
+    PromptQueueEntryPhase,
+    PromptQueueMode,
+    PromptQueueMutationResult,
+    PromptQueuePauseReason,
+    PromptQueueSnapshot,
+    QueueMutationStatus,
+)
+from tldw_chatbook.Widgets.cancel_confirmation_dialog import (
+    CancelConfirmationDialog,
+)
+
+
+class ConsolePromptQueueModal(ModalScreen[None]):
+    """Manage one queue without ever retargeting to the viewed Console tab."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close", show=False),
+        Binding("j", "select_next", "Next", show=False),
+        Binding("k", "select_previous", "Previous", show=False),
+        Binding("e", "edit", "Edit", show=False),
+        Binding("u", "move_up", "Move up", show=False),
+        Binding("d", "move_down", "Move down", show=False),
+        Binding("x", "remove", "Remove", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    ConsolePromptQueueModal {
+        align: center middle;
+        background: $background 75%;
+    }
+
+    #console-prompt-queue-dialog {
+        width: 76;
+        max-width: 96%;
+        height: 22;
+        max-height: 92%;
+        min-height: 18;
+        background: $panel;
+        border: solid $primary;
+        padding: 1;
+    }
+
+    #console-prompt-queue-manager-title {
+        height: 1;
+        color: $accent;
+        text-style: bold;
+    }
+
+    #console-prompt-queue-manager-state,
+    #console-prompt-queue-manager-feedback {
+        height: 1;
+        color: $text-muted;
+    }
+
+    #console-prompt-queue-manager-feedback.-warning {
+        color: $warning;
+    }
+
+    #console-prompt-queue-manager-list {
+        height: 1fr;
+        min-height: 6;
+        border-top: solid $primary-background-lighten-2;
+        border-bottom: solid $primary-background-lighten-2;
+        padding: 0;
+    }
+
+    .console-prompt-queue-entry-row {
+        height: 1;
+        width: 100%;
+    }
+
+    .console-prompt-queue-entry-select {
+        width: 1fr;
+        height: 1;
+        min-height: 1;
+        content-align: left middle;
+        padding: 0 1;
+    }
+
+    .console-prompt-queue-entry-phase {
+        width: 12;
+        height: 1;
+        color: $text-muted;
+        content-align: right middle;
+    }
+
+    .console-prompt-queue-entry-row.-selected {
+        background: $primary-background;
+    }
+
+    #console-prompt-queue-edit-input {
+        display: none;
+        height: 3;
+        border: solid $accent;
+    }
+
+    #console-prompt-queue-edit-input.-visible {
+        display: block;
+    }
+
+    .console-prompt-queue-actions {
+        height: 3;
+        width: 100%;
+        align-horizontal: left;
+    }
+
+    .console-prompt-queue-actions Button {
+        height: 3;
+        min-width: 8;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        revision: int,
+        queue_controller: Any,
+    ) -> None:
+        super().__init__()
+        self.session_id = session_id
+        self._revision = revision
+        self._queue_controller = queue_controller
+        self._snapshot = queue_controller.snapshot(session_id)
+        self._selected_entry_id = (
+            self._snapshot.entries[0].entry_id if self._snapshot.entries else None
+        )
+        self._editing_entry_id: str | None = None
+        self._reviewed_context_epoch: int | None = None
+        self._render_key: tuple[Any, ...] | None = None
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="console-prompt-queue-dialog"):
+            yield Static("Prompt queue", id="console-prompt-queue-manager-title")
+            yield Static("", id="console-prompt-queue-manager-state")
+            yield Static("", id="console-prompt-queue-manager-feedback")
+            yield VerticalScroll(id="console-prompt-queue-manager-list")
+            yield TextArea(id="console-prompt-queue-edit-input")
+            with Horizontal(classes="console-prompt-queue-actions"):
+                yield Button("Edit", id="console-prompt-queue-edit")
+                yield Button("Save", id="console-prompt-queue-save")
+                yield Button("Up", id="console-prompt-queue-up")
+                yield Button("Down", id="console-prompt-queue-down")
+                yield Button("Remove", id="console-prompt-queue-remove")
+                yield Button("Clear", id="console-prompt-queue-clear")
+            with Horizontal(classes="console-prompt-queue-actions"):
+                yield Button("Pause", id="console-prompt-queue-toggle-pause")
+                yield Button("Resume next", id="console-prompt-queue-resume-next")
+                yield Button("Review", id="console-prompt-queue-review-context")
+                yield Button("Use current", id="console-prompt-queue-use-context")
+                yield Button("Close", id="console-prompt-queue-close")
+            with Horizontal(classes="console-prompt-queue-actions"):
+                yield Button("Retry failed", id="console-prompt-queue-retry-failed")
+                yield Button("Retry stopped", id="console-prompt-queue-retry-stopped")
+
+    def on_mount(self) -> None:
+        self._apply_snapshot(self._snapshot, force=True)
+        self.set_interval(0.2, self._poll_snapshot)
+
+    async def _poll_snapshot(self) -> None:
+        snapshot = self._queue_controller.snapshot(self.session_id)
+        if snapshot.revision != self._revision:
+            self._apply_snapshot(snapshot)
+
+    def _apply_snapshot(
+        self, snapshot: PromptQueueSnapshot, *, force: bool = False
+    ) -> None:
+        """Render a new body-free revision while preserving entry identity."""
+
+        key = (snapshot.revision, snapshot.entries, snapshot.mode, snapshot.pause_reason)
+        if not force and key == self._render_key:
+            return
+        if self._render_key is not None and snapshot.revision != self._revision:
+            self._reviewed_context_epoch = None
+        self._render_key = key
+        self._snapshot = snapshot
+        self._revision = snapshot.revision
+        entry_ids = tuple(entry.entry_id for entry in snapshot.entries)
+        if self._selected_entry_id not in entry_ids:
+            self._selected_entry_id = entry_ids[0] if entry_ids else None
+        try:
+            state = self.query_one("#console-prompt-queue-manager-state", Static)
+            listing = self.query_one(
+                "#console-prompt-queue-manager-list", VerticalScroll
+            )
+            pause = self.query_one("#console-prompt-queue-toggle-pause", Button)
+            resume_next = self.query_one(
+                "#console-prompt-queue-resume-next", Button
+            )
+            edit_button = self.query_one("#console-prompt-queue-edit", Button)
+            save_button = self.query_one("#console-prompt-queue-save", Button)
+            up_button = self.query_one("#console-prompt-queue-up", Button)
+            down_button = self.query_one("#console-prompt-queue-down", Button)
+            remove_button = self.query_one("#console-prompt-queue-remove", Button)
+            clear_button = self.query_one("#console-prompt-queue-clear", Button)
+            retry_failed = self.query_one(
+                "#console-prompt-queue-retry-failed", Button
+            )
+            retry_stopped = self.query_one(
+                "#console-prompt-queue-retry-stopped", Button
+            )
+            review = self.query_one(
+                "#console-prompt-queue-review-context", Button
+            )
+            use_current = self.query_one(
+                "#console-prompt-queue-use-context", Button
+            )
+        except NoMatches:
+            return
+        reason = snapshot.pause_reason.value.replace("_", " ") if snapshot.pause_reason else ""
+        state.update(
+            f"Queue {snapshot.total_count}/10 · {snapshot.mode.value.replace('_', ' ')}"
+            + (f" · {reason}" if reason else "")
+        )
+        recovery_pause = (
+            snapshot.mode is PromptQueueMode.PAUSED
+            and snapshot.pause_reason
+            not in {
+                PromptQueuePauseReason.MANUAL,
+                PromptQueuePauseReason.DISPATCH_REFUSED,
+            }
+        )
+        pause.label = (
+            "Paused"
+            if recovery_pause
+            else "Try again"
+            if snapshot.pause_reason is PromptQueuePauseReason.DISPATCH_REFUSED
+            else "Resume"
+            if snapshot.mode is PromptQueueMode.PAUSED
+            else "Keep draining"
+            if snapshot.mode is PromptQueueMode.PAUSE_AFTER_TURN
+            else "Pause"
+        )
+        pause.disabled = snapshot.total_count == 0 or recovery_pause
+        resume_next.label = (
+            "Skip & resume"
+            if snapshot.pause_reason is PromptQueuePauseReason.FAILED
+            else "Resume next"
+        )
+        selected = next(
+            (
+                entry
+                for entry in snapshot.entries
+                if entry.entry_id == self._selected_entry_id
+            ),
+            None,
+        )
+        selected_waiting = bool(
+            selected is not None
+            and selected.phase is PromptQueueEntryPhase.WAITING
+        )
+        selected_index = self._selected_index()
+        edit_button.disabled = not selected_waiting
+        save_button.disabled = self._editing_entry_id is None
+        up_button.disabled = not selected_waiting or selected_index == 0
+        down_button.disabled = (
+            not selected_waiting
+            or selected_index is None
+            or selected_index >= snapshot.waiting_count - 1
+        )
+        remove_button.disabled = not selected_waiting
+        clear_button.disabled = snapshot.waiting_count == 0
+        retry_failed.disabled = snapshot.pause_reason is not PromptQueuePauseReason.FAILED
+        retry_stopped.disabled = snapshot.pause_reason is not PromptQueuePauseReason.STOPPED
+        resume_next.disabled = snapshot.pause_reason not in {
+            PromptQueuePauseReason.FAILED,
+            PromptQueuePauseReason.STOPPED,
+        }
+        review.disabled = (
+            snapshot.pause_reason is not PromptQueuePauseReason.CONTEXT_CHANGED
+        )
+        use_current.disabled = review.disabled or self._reviewed_context_epoch is None
+        listing.remove_children()
+        for entry in snapshot.entries:
+            row = Horizontal(classes="console-prompt-queue-entry-row")
+            row.set_class(
+                entry.entry_id == self._selected_entry_id,
+                "-selected",
+            )
+            listing.mount(row)
+            row.mount(
+                Button(
+                    f"{entry.position}. {entry.preview}",
+                    id=f"console-prompt-queue-entry-{entry.entry_id}",
+                    classes="console-prompt-queue-entry-select",
+                ),
+                Static(
+                    "Starting..."
+                    if entry.phase is PromptQueueEntryPhase.STARTING
+                    else "Waiting",
+                    classes="console-prompt-queue-entry-phase",
+                ),
+            )
+        self.call_after_refresh(self._restore_selection_focus)
+
+    def _restore_selection_focus(self) -> None:
+        if self._editing_entry_id is not None:
+            try:
+                edit = self.query_one("#console-prompt-queue-edit-input", TextArea)
+            except NoMatches:
+                pass
+            else:
+                if edit.has_class("-visible"):
+                    edit.focus()
+                    return
+        if self._selected_entry_id is None:
+            return
+        try:
+            self.query_one(
+                f"#console-prompt-queue-entry-{self._selected_entry_id}", Button
+            ).focus()
+        except NoMatches:
+            pass
+
+    def _selected_index(self) -> int | None:
+        waiting = [
+            entry
+            for entry in self._snapshot.entries
+            if entry.phase is PromptQueueEntryPhase.WAITING
+        ]
+        for index, entry in enumerate(waiting):
+            if entry.entry_id == self._selected_entry_id:
+                return index
+        return None
+
+    def _show_feedback(self, text: str, *, warning: bool = False) -> None:
+        feedback = self.query_one("#console-prompt-queue-manager-feedback", Static)
+        feedback.update(text)
+        feedback.set_class(warning, "-warning")
+
+    def _accept_mutation(self, result: PromptQueueMutationResult) -> bool:
+        if result.status in {QueueMutationStatus.APPLIED, QueueMutationStatus.UNCHANGED}:
+            self._show_feedback("")
+            self._apply_snapshot(result.snapshot, force=True)
+            return True
+        self._apply_snapshot(result.snapshot, force=True)
+        copy = {
+            QueueMutationStatus.STALE_REVISION: "Queue changed. Review it and try again.",
+            QueueMutationStatus.LOCKED: "Starting prompts cannot be changed.",
+            QueueMutationStatus.NOT_FOUND: "That prompt is no longer queued.",
+            QueueMutationStatus.INVALID: result.detail or "That queue action is unavailable.",
+        }.get(result.status, result.detail or "Queue action refused.")
+        self._show_feedback(copy, warning=True)
+        return False
+
+    def action_select_next(self) -> None:
+        self._select_offset(1)
+
+    def action_select_previous(self) -> None:
+        self._select_offset(-1)
+
+    def _select_offset(self, offset: int) -> None:
+        entries = self._snapshot.entries
+        if not entries:
+            return
+        ids = [entry.entry_id for entry in entries]
+        try:
+            index = ids.index(self._selected_entry_id)
+        except ValueError:
+            index = 0
+        self._selected_entry_id = ids[(index + offset) % len(ids)]
+        self._apply_snapshot(self._snapshot, force=True)
+
+    def action_edit(self) -> None:
+        self._begin_edit()
+
+    def action_move_up(self) -> None:
+        self._move_selected(-1)
+
+    def action_move_down(self) -> None:
+        self._move_selected(1)
+
+    def action_remove(self) -> None:
+        self.run_worker(
+            self._confirm_remove_selected(),
+            exclusive=True,
+            group="console-prompt-queue-confirm",
+        )
+
+    @on(Button.Pressed)
+    def handle_button(self, event: Button.Pressed) -> None:
+        button_id = event.button.id or ""
+        if button_id.startswith("console-prompt-queue-entry-"):
+            event.stop()
+            self._selected_entry_id = button_id.removeprefix(
+                "console-prompt-queue-entry-"
+            )
+            self._apply_snapshot(self._snapshot, force=True)
+            return
+        handlers = {
+            "console-prompt-queue-edit": self._begin_edit,
+            "console-prompt-queue-save": self._save_edit,
+            "console-prompt-queue-up": lambda: self._move_selected(-1),
+            "console-prompt-queue-down": lambda: self._move_selected(1),
+            "console-prompt-queue-close": self.dismiss,
+        }
+        handler = handlers.get(button_id)
+        if handler is not None:
+            event.stop()
+            handler()
+        elif button_id == "console-prompt-queue-remove":
+            event.stop()
+            self.run_worker(
+                self._confirm_remove_selected(),
+                exclusive=True,
+                group="console-prompt-queue-confirm",
+            )
+        elif button_id == "console-prompt-queue-clear":
+            event.stop()
+            self.run_worker(
+                self._confirm_clear_waiting(),
+                exclusive=True,
+                group="console-prompt-queue-confirm",
+            )
+        elif button_id == "console-prompt-queue-toggle-pause":
+            event.stop()
+            self.run_worker(self._toggle_pause(), group="console-prompt-queue-modal")
+        elif button_id in {
+            "console-prompt-queue-resume-next",
+            "console-prompt-queue-retry-failed",
+            "console-prompt-queue-retry-stopped",
+            "console-prompt-queue-use-context",
+        }:
+            event.stop()
+            action = {
+                "console-prompt-queue-resume-next": "resume-next",
+                "console-prompt-queue-retry-failed": "retry-failed",
+                "console-prompt-queue-retry-stopped": "retry-stopped",
+                "console-prompt-queue-use-context": "use-current-context",
+            }[button_id]
+            self.run_worker(
+                self._recover(action), group="console-prompt-queue-modal"
+            )
+        elif button_id == "console-prompt-queue-review-context":
+            event.stop()
+            baseline, current = self._queue_controller.context_review(
+                self.session_id
+            )
+            self._reviewed_context_epoch = current
+            self.query_one(
+                "#console-prompt-queue-use-context", Button
+            ).disabled = False
+            self._show_feedback(
+                f"Context review: queued baseline {baseline}; current {current}. "
+                "Use current now adopts that reviewed version."
+            )
+
+    def _begin_edit(self) -> None:
+        entry_id = self._selected_entry_id
+        if entry_id is None:
+            return
+        result = self._queue_controller.read_waiting_text(
+            self.session_id,
+            entry_id,
+            expected_revision=self._revision,
+        )
+        if result.status is not QueueMutationStatus.APPLIED or result.text is None:
+            self._apply_snapshot(self._queue_controller.snapshot(self.session_id), force=True)
+            self._show_feedback(
+                "That prompt changed before editing. Review the queue and try again.",
+                warning=True,
+            )
+            return
+        edit = self.query_one("#console-prompt-queue-edit-input", TextArea)
+        self._editing_entry_id = entry_id
+        edit.text = result.text
+        edit.add_class("-visible")
+        self.query_one("#console-prompt-queue-save", Button).disabled = False
+        edit.focus()
+
+    def _save_edit(self) -> None:
+        if self._editing_entry_id is None:
+            return
+        edit = self.query_one("#console-prompt-queue-edit-input", TextArea)
+        result = self._queue_controller.edit_waiting(
+            self.session_id,
+            self._editing_entry_id,
+            text=edit.text,
+            expected_revision=self._revision,
+        )
+        if result.status in {
+            QueueMutationStatus.APPLIED,
+            QueueMutationStatus.UNCHANGED,
+        }:
+            self._editing_entry_id = None
+            edit.text = ""
+            edit.remove_class("-visible")
+        self._accept_mutation(result)
+
+    def _move_selected(self, offset: int) -> None:
+        index = self._selected_index()
+        if index is None or self._selected_entry_id is None:
+            return
+        waiting_count = self._snapshot.waiting_count
+        new_index = max(0, min(waiting_count - 1, index + offset))
+        result = self._queue_controller.move_waiting(
+            self.session_id,
+            self._selected_entry_id,
+            position=new_index,
+            expected_revision=self._revision,
+        )
+        self._accept_mutation(result)
+
+    async def _confirm_remove_selected(self) -> None:
+        entry_id = self._selected_entry_id
+        revision = self._revision
+        if entry_id is None:
+            return
+        confirmed = await self.app.push_screen_wait(
+            CancelConfirmationDialog(
+                title="Remove queued prompt?",
+                message="This unsent prompt will be discarded.",
+                confirm_text="Remove",
+                cancel_text="Keep",
+            )
+        )
+        if not confirmed:
+            self.call_after_refresh(self._restore_selection_focus)
+            return
+        result = self._queue_controller.remove_waiting(
+            self.session_id,
+            entry_id,
+            expected_revision=revision,
+        )
+        self._accept_mutation(result)
+
+    async def _confirm_clear_waiting(self) -> None:
+        revision = self._revision
+        if self._snapshot.waiting_count == 0:
+            return
+        confirmed = await self.app.push_screen_wait(
+            CancelConfirmationDialog(
+                title="Clear waiting prompts?",
+                message=(
+                    f"Discard {self._snapshot.waiting_count} unsent prompt(s)? "
+                    "A Starting prompt is not affected."
+                ),
+                confirm_text="Clear waiting",
+                cancel_text="Keep queue",
+            )
+        )
+        if not confirmed:
+            self.call_after_refresh(self._restore_selection_focus)
+            return
+        result = self._queue_controller.clear_waiting(
+            self.session_id, expected_revision=revision
+        )
+        self._accept_mutation(result)
+
+    async def _toggle_pause(self) -> None:
+        result = await self._queue_controller.toggle_pause(
+            self.session_id, expected_revision=self._revision
+        )
+        self._accept_mutation(result)
+
+    async def _recover(self, action: str) -> None:
+        result = await self._queue_controller.recover(
+            self.session_id,
+            action=action,
+            expected_revision=self._revision,
+            reviewed_context_epoch=(
+                self._reviewed_context_epoch
+                if action == "use-current-context"
+                else None
+            ),
+        )
+        self._accept_mutation(result)
+
+
+__all__ = ["ConsolePromptQueueModal"]

--- a/tldw_chatbook/Widgets/Console/console_prompt_queue_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_prompt_queue_modal.py
@@ -13,6 +13,8 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Static, TextArea
 
 from tldw_chatbook.Chat.console_prompt_queue import (
+    MAX_CONSOLE_QUEUE_ENTRIES,
+    MAX_CONSOLE_QUEUED_PROMPT_LENGTH,
     PromptQueueEntryPhase,
     PromptQueueMode,
     PromptQueueMutationResult,
@@ -20,6 +22,7 @@ from tldw_chatbook.Chat.console_prompt_queue import (
     PromptQueueSnapshot,
     QueueMutationStatus,
 )
+from tldw_chatbook.Utils.input_validation import validate_text_input
 from tldw_chatbook.Widgets.cancel_confirmation_dialog import (
     CancelConfirmationDialog,
 )
@@ -225,7 +228,8 @@ class ConsolePromptQueueModal(ModalScreen[None]):
             return
         reason = snapshot.pause_reason.value.replace("_", " ") if snapshot.pause_reason else ""
         state.update(
-            f"Queue {snapshot.total_count}/10 · {snapshot.mode.value.replace('_', ' ')}"
+            f"Queue {snapshot.total_count}/{MAX_CONSOLE_QUEUE_ENTRIES} · "
+            f"{snapshot.mode.value.replace('_', ' ')}"
             + (f" · {reason}" if reason else "")
         )
         recovery_pause = (
@@ -360,9 +364,13 @@ class ConsolePromptQueueModal(ModalScreen[None]):
         return False
 
     def action_select_next(self) -> None:
+        """Select the next queue entry, wrapping at the end."""
+
         self._select_offset(1)
 
     def action_select_previous(self) -> None:
+        """Select the previous queue entry, wrapping at the beginning."""
+
         self._select_offset(-1)
 
     def _select_offset(self, offset: int) -> None:
@@ -378,15 +386,23 @@ class ConsolePromptQueueModal(ModalScreen[None]):
         self._apply_snapshot(self._snapshot, force=True)
 
     def action_edit(self) -> None:
+        """Begin editing the selected waiting prompt."""
+
         self._begin_edit()
 
     def action_move_up(self) -> None:
+        """Move the selected waiting prompt one position earlier."""
+
         self._move_selected(-1)
 
     def action_move_down(self) -> None:
+        """Move the selected waiting prompt one position later."""
+
         self._move_selected(1)
 
     def action_remove(self) -> None:
+        """Request confirmation before removing the selected prompt."""
+
         self.run_worker(
             self._confirm_remove_selected(),
             exclusive=True,
@@ -488,6 +504,16 @@ class ConsolePromptQueueModal(ModalScreen[None]):
         if self._editing_entry_id is None:
             return
         edit = self.query_one("#console-prompt-queue-edit-input", TextArea)
+        if not validate_text_input(
+            edit.text,
+            max_length=MAX_CONSOLE_QUEUED_PROMPT_LENGTH,
+            allow_html=False,
+        ):
+            self._show_feedback(
+                "Prompt blocked: remove unsafe markup or shorten it before saving.",
+                warning=True,
+            )
+            return
         result = self._queue_controller.edit_waiting(
             self.session_id,
             self._editing_entry_id,

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -59,6 +59,7 @@ def _session_tab_tooltip(
     *,
     active: bool,
     marker: ConsoleRunMarker = ConsoleRunMarker.NONE,
+    queued_count: int = 0,
 ) -> str:
     """Return action copy for a Console session tab.
 
@@ -105,6 +106,8 @@ def _session_tab_tooltip(
         # ONE short name; the "not saved locally" scope sentence stays in
         # the chip's own tooltip.
         text = f"{text} Temporary — not saved."
+    if queued_count:
+        text = f"{text} Queue {queued_count}."
     return _escape_markup(text)
 
 
@@ -315,6 +318,7 @@ class ConsoleSessionSurface(Vertical):
         *,
         active: bool,
         marker: ConsoleRunMarker = ConsoleRunMarker.NONE,
+        queued_count: int = 0,
     ) -> Button:
         """Build a stable-width Console session tab title button."""
         classes = "console-session-tab"
@@ -322,7 +326,10 @@ class ConsoleSessionSurface(Vertical):
             classes = f"{classes} console-session-tab-active"
         button = ConsoleSessionTabButton(
             self._tab_label(
-                session.title, marker=marker, ephemeral=session.ephemeral
+                session.title,
+                marker=marker,
+                ephemeral=session.ephemeral,
+                queued_count=queued_count,
             ),
             id=f"console-session-tab-{session.id}",
             classes=classes,
@@ -330,7 +337,10 @@ class ConsoleSessionSurface(Vertical):
             session_id=session.id,
         )
         button.tooltip = _session_tab_tooltip(
-            session, active=active, marker=marker
+            session,
+            active=active,
+            marker=marker,
+            queued_count=queued_count,
         )
         button.styles.width = CONSOLE_SESSION_TAB_WIDTH
         button.styles.min_width = CONSOLE_SESSION_TAB_WIDTH
@@ -347,6 +357,7 @@ class ConsoleSessionSurface(Vertical):
         *,
         marker: ConsoleRunMarker = ConsoleRunMarker.NONE,
         ephemeral: bool = False,
+        queued_count: int = 0,
     ) -> str:
         """Return the tab label, prefixed with its fleet run-marker glyph.
 
@@ -368,6 +379,8 @@ class ConsoleSessionSurface(Vertical):
         # promotion saves verbatim.
         if ephemeral:
             label = f"{resolve_glyph(GLYPH_TEMPORARY)} {label}"
+        if queued_count:
+            label = f"Q{queued_count} {label}"
         return label
 
     @staticmethod
@@ -432,6 +445,7 @@ class ConsoleSessionSurface(Vertical):
         active_session_id: str | None,
         streaming_session_id: str | None = None,
         run_markers: dict[str, ConsoleRunMarker] | None = None,
+        queue_counts: dict[str, int] | None = None,
     ) -> None:
         """Update labels, tooltips, and active state without stealing focus."""
         session_by_id = {session.id: session for session in sessions}
@@ -448,12 +462,16 @@ class ConsoleSessionSurface(Vertical):
                     run_markers=run_markers,
                 )
                 child.label = self._tab_label(
-                    session.title, marker=marker, ephemeral=session.ephemeral
+                    session.title,
+                    marker=marker,
+                    ephemeral=session.ephemeral,
+                    queued_count=(queue_counts or {}).get(session_id, 0),
                 )
                 child.tooltip = _session_tab_tooltip(
                     session,
                     active=session.id == active_session_id,
                     marker=marker,
+                    queued_count=(queue_counts or {}).get(session_id, 0),
                 )
                 child.set_class(
                     session.id == active_session_id,
@@ -480,6 +498,7 @@ class ConsoleSessionSurface(Vertical):
         active_session_id: str | None,
         streaming_session_id: str | None = None,
         run_markers: dict[str, ConsoleRunMarker] | None = None,
+        queue_counts: dict[str, int] | None = None,
     ) -> None:
         """Render native Console session tabs from controller-owned state.
 
@@ -510,6 +529,7 @@ class ConsoleSessionSurface(Vertical):
                     active_session_id=active_session_id,
                     streaming_session_id=streaming_session_id,
                     run_markers=run_markers,
+                    queue_counts=queue_counts,
                 )
                 return
 
@@ -529,6 +549,7 @@ class ConsoleSessionSurface(Vertical):
                         session,
                         active=is_active,
                         marker=marker,
+                        queued_count=(queue_counts or {}).get(session.id, 0),
                     )
                 )
                 await tab_strip.mount(self._build_close_tab_button(session))

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -1402,15 +1402,17 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
             name_lines = _marker_prefixed_name_lines(row.title, row.run_marker, budget)
             status = self._conversation_status(row.status)
             detail = self._conversation_detail_status(row.status)
-            secondary = truncate_console_row_cells(
+            secondary_copy = (
                 self._conversation_row_secondary(
                     detail,
                     row.updated_label,
                     workspace_label=row.workspace_label if show_workspace else "",
                 )
-                or "conversation",
-                budget,
+                or "conversation"
             )
+            if row.queued_count:
+                secondary_copy = f"{secondary_copy} · Queue {row.queued_count}"
+            secondary = truncate_console_row_cells(secondary_copy, budget)
             status_suffix = f" [{status}]" if status else ""
             # TASK-1233 AC#1 (review round 1): `tooltip_label` here is the
             # PRE-escape, pre-period sentence body -- `_conversation_button`

--- a/tldw_chatbook/Workspaces/conversation_browser_state.py
+++ b/tldw_chatbook/Workspaces/conversation_browser_state.py
@@ -185,6 +185,8 @@ class ConsoleConversationBrowserInputRow:
     #: the caller building this row, so the display layer needs no enum/model
     #: import to render it.
     run_marker: str = ""
+    #: Content-free count of unsent prompts for a live native session.
+    queued_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -227,6 +229,8 @@ class ConsoleConversationBrowserRow:
     openable: bool = True
     #: Parallel-agents spec PA-T8: resolved fleet run-marker glyph, or "".
     run_marker: str = ""
+    #: Content-free count of unsent prompts for a live native session.
+    queued_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -544,6 +548,7 @@ def _normalize_input_row(
         updated_sort=str(row.updated_sort or ""),
         openable=bool(row.openable),
         run_marker=str(row.run_marker or ""),
+        queued_count=max(0, int(row.queued_count)),
     )
 
 
@@ -569,6 +574,7 @@ def _to_browser_row(
         subagent_count=subagent_count,
         openable=bool(row.openable),
         run_marker=str(row.run_marker or ""),
+        queued_count=max(0, int(row.queued_count)),
     )
 
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -4955,6 +4955,7 @@ class TldwCli(
 
         self._ui_ready = False  # Track if UI is fully composed
         self._shutting_down = False  # Track if app is shutting down
+        self._quit_in_progress = False
 
         # --- Assign DB instances for event handlers ---
         if self.prompts_service_initialized:
@@ -10327,80 +10328,151 @@ class TldwCli(
         )
 
     def action_quit(self) -> None:
-        """Handle application quit - save persistent caches before exiting."""
-        loguru_logger.info("Application quit initiated")
+        """Dispatch one guarded asynchronous pre-quit confirmation worker."""
 
-        # Set flag to prevent new operations
-        self._shutting_down = True
-
-        # Force stop any playing audio and cleanup
-        if hasattr(self, "audio_player"):
-            try:
-                import asyncio
-
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
-                    # Create cleanup tasks
-                    async def cleanup_audio():
-                        try:
-                            await asyncio.wait_for(
-                                self.audio_player.stop(), timeout=0.5
-                            )
-                        except asyncio.TimeoutError:
-                            loguru_logger.warning("Audio stop timed out")
-                        try:
-                            await asyncio.wait_for(
-                                self.audio_player.cleanup(), timeout=0.5
-                            )
-                        except asyncio.TimeoutError:
-                            loguru_logger.warning("Audio cleanup timed out")
-
-                    # Schedule cleanup
-                    asyncio.create_task(cleanup_audio())
-                else:
-                    # Synchronous cleanup if no event loop
-                    loop = asyncio.new_event_loop()
-                    loop.run_until_complete(self.audio_player.cleanup())
-                    loop.close()
-                loguru_logger.info("Audio player stopped and cleaned up")
-            except Exception as e:
-                loguru_logger.error(f"Error stopping audio during quit: {e}")
-
-        # Cancel media cleanup timer if it exists
-        if hasattr(self, "_media_cleanup_timer") and self._media_cleanup_timer:
-            self._media_cleanup_timer.stop()
-
-        # Note autosave is owned by the Library notes editor; no legacy quit-save path remains.
-
-        # Try to save caches but don't let it block quitting
+        if self._quit_in_progress:
+            return
+        self._quit_in_progress = True
+        quit_flow = self._confirm_and_quit()
         try:
-            # Import with timeout protection
-            import threading
+            self.run_worker(
+                quit_flow,
+                group="application-quit",
+                exclusive=True,
+                exit_on_error=False,
+            )
+        except Exception:
+            quit_flow.close()
+            self._quit_in_progress = False
+            loguru_logger.opt(exception=True).warning(
+                "Application quit worker could not start; staying in the app"
+            )
 
-            def save_caches_with_timeout():
-                # Note: The old cache service is deprecated
-                # The simplified RAG service handles caching internally
-                # and doesn't require explicit save on shutdown
-                loguru_logger.debug(
-                    "Cache saving skipped - handled by simplified RAG service"
+    async def _confirm_and_quit(self) -> None:
+        """Confirm the active screen, then execute one approved cleanup pass."""
+
+        loguru_logger.info("Application quit initiated")
+        try:
+            current_screen = self.screen
+            confirm_quit = getattr(current_screen, "confirm_quit", None)
+            if callable(confirm_quit):
+                decision = confirm_quit()
+                if inspect.isawaitable(decision):
+                    decision = await decision
+                if decision is False:
+                    self._quit_in_progress = False
+                    return
+        except Exception:
+            loguru_logger.opt(exception=True).warning(
+                "Pre-quit confirmation failed; staying in the app"
+            )
+            self._quit_in_progress = False
+            try:
+                self.notify(
+                    "Couldn't confirm quitting; staying in Chatbook.",
+                    severity="warning",
                 )
+            except Exception:
+                pass
+            return
 
-            # Run cache saving in a separate thread with timeout
-            save_thread = threading.Thread(target=save_caches_with_timeout)
-            save_thread.daemon = True  # Don't let this thread prevent app exit
+        try:
+            prepare_for_quit = getattr(current_screen, "prepare_for_quit", None)
+            if callable(prepare_for_quit):
+                preparation = prepare_for_quit()
+                if inspect.isawaitable(preparation):
+                    await preparation
+        except Exception:
+            loguru_logger.opt(exception=True).warning(
+                "Pre-quit shutdown guard failed; staying in the app"
+            )
+            self._quit_in_progress = False
+            try:
+                self.notify(
+                    "Couldn't prepare a safe shutdown; staying in Chatbook.",
+                    severity="warning",
+                )
+            except Exception:
+                pass
+            return
+
+        self._shutting_down = True
+        await self._run_approved_quit_cleanup()
+
+    async def _run_approved_quit_cleanup(self) -> None:
+        """Preserve quit ordering without blocking the Textual event loop."""
+
+        try:
+            await self._cleanup_audio_for_quit()
+            media_timer = getattr(self, "_media_cleanup_timer", None)
+            if media_timer is not None:
+                try:
+                    media_timer.stop()
+                except Exception:
+                    loguru_logger.opt(exception=True).warning(
+                        "Media cleanup timer could not stop during quit"
+                    )
+            try:
+                await asyncio.to_thread(self._run_blocking_quit_persistence)
+            except Exception:
+                loguru_logger.opt(exception=True).warning(
+                    "Blocking quit persistence failed"
+                )
+        finally:
+            self.exit()
+
+    async def _cleanup_audio_for_quit(self) -> None:
+        """Stop and release app-owned audio before the final exit."""
+
+        audio_player = getattr(self, "audio_player", None)
+        if audio_player is None:
+            return
+        try:
+            await asyncio.wait_for(audio_player.stop(), timeout=0.5)
+        except asyncio.TimeoutError:
+            loguru_logger.warning("Audio stop timed out")
+        except Exception:
+            loguru_logger.opt(exception=True).warning("Audio stop failed during quit")
+        try:
+            await asyncio.wait_for(audio_player.cleanup(), timeout=0.5)
+        except asyncio.TimeoutError:
+            loguru_logger.warning("Audio cleanup timed out")
+        except Exception:
+            loguru_logger.opt(exception=True).warning(
+                "Audio cleanup failed during quit"
+            )
+
+    @staticmethod
+    def _save_shutdown_caches_with_timeout() -> None:
+        """Retain the existing bounded cache-save compatibility pass."""
+
+        loguru_logger.debug("Cache saving skipped - handled by simplified RAG service")
+
+    def _run_blocking_quit_persistence(self) -> None:
+        """Run timed joins and configuration persistence off the app loop."""
+
+        try:
+            save_thread = threading.Thread(
+                target=self._save_shutdown_caches_with_timeout,
+                name="chatbook-quit-cache-save",
+                daemon=True,
+            )
             save_thread.start()
-            save_thread.join(timeout=2.0)  # Wait max 2 seconds
-
+            save_thread.join(timeout=2.0)
             if save_thread.is_alive():
                 loguru_logger.warning("Cache save timed out - proceeding with quit")
-        except Exception as e:
-            loguru_logger.error(f"Error in quit handler: {e}")
+        except Exception:
+            loguru_logger.opt(exception=True).warning("Error in quit cache handler")
 
-        if not persist_cli_config_for_shutdown():
-            loguru_logger.warning("Configuration shutdown persistence failed")
-
-        # Always call the parent quit method
-        self.exit()
+        try:
+            persisted = persist_cli_config_for_shutdown()
+        except Exception:
+            loguru_logger.opt(exception=True).warning(
+                "Configuration shutdown persistence raised an error"
+            )
+        else:
+            if not persisted:
+                loguru_logger.warning("Configuration shutdown persistence failed")
 
     ########################################################
     # --- End of Watchers and Helper Methods ---


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a visible, per-session Console prompt queue (up to 10 text-only prompts) that drains sequentially as separate turns and survives tab switches, navigation, close, and quit. During a live turn, Send becomes Queue and Enter enqueues; tabs/rows show `Qn`/“Queue n”, and a multi-prompt drain emits one final completion toast.

- **New Features**
  - Queue up to 10 prompts behind an accepted turn; FIFO, one turn at a time; atomic admission vs manual send; Enter enqueues and the button label switches to Queue.
  - Coordinator pauses/resumes on approvals, failures, Stop, or context-epoch changes; safe across switches, close, and quit. Quit confirmation shows “Live agent runs”, “Sessions with queued prompts”, and “Unsent queued prompts”.
  - UI: queue shelf and manager modal; session tabs show `Qn`; conversation rows append “Queue n” without revealing text; composer disabled/label state updated; F1/help updated.

- **Refactors**
  - Added `ConsolePromptQueueRegistry` (pure, bounded) and `console_prompt_queue_coordinator` (sole next-turn authority).
  - Added `ConsoleTurnExecutionContext` and a conversation-context epoch in `ConsoleChatStore` to keep queued work session-scoped and safe.
  - Extended models with `ConsoleSubmissionOrigin`, `ConsoleControllerActivity`, and `ConsoleQueuedAcceptanceEvent`; queue-aware composer disabled state.
  - `console_agent_bridge`: added `native_tools_enabled` override to preserve captured tool settings for queued turns.
  - `TldwCli.action_quit`: moved to an async worker; blocking persistence extracted to `_run_blocking_quit_persistence`.

<sup>Written for commit 0b8e1c7513d980e6e60f60d246bd09869b512bd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

