### PR TITLE
fix(notes): clarify local folder authority

### DIFF
--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -349,7 +349,13 @@ async def test_file_notes_authority_copy_is_complete_and_bounded(
     size: tuple[int, int],
     expected_height: int,
 ) -> None:
-    """Authority copy uses one moderate row and at most two compact rows."""
+    """Verify authority copy uses bounded rows at supported terminal sizes.
+
+    Args:
+        tmp_path: Temporary directory used as the linked File Notes root.
+        size: Terminal dimensions used to mount the workspace.
+        expected_height: Expected rendered height of the authority copy.
+    """
     root = tmp_path / "notes"
     root.mkdir()
     replica = FileNotesReplica(":memory:")
@@ -383,6 +389,12 @@ async def test_file_notes_linked_root_leads_with_friendly_folder_identity(
     tmp_path: Path,
     size: tuple[int, int],
 ) -> None:
+    """Verify the persistent root row favors a friendly folder identity.
+
+    Args:
+        tmp_path: Temporary directory used to construct the linked root.
+        size: Terminal dimensions used to mount the workspace.
+    """
     root = tmp_path / "deep" / "nested" / "Research Notes"
     root.mkdir(parents=True)
     replica = FileNotesReplica(":memory:")
@@ -408,6 +420,11 @@ async def test_file_notes_linked_root_leads_with_friendly_folder_identity(
 async def test_file_notes_root_details_preserve_exact_path_and_warning(
     tmp_path: Path,
 ) -> None:
+    """Verify root details retain exact telemetry and recovery warnings.
+
+    Args:
+        tmp_path: Temporary directory used to construct the linked root.
+    """
     root = tmp_path / "deep" / "nested" / "Research Notes"
     root.mkdir(parents=True)
     replica = FileNotesReplica(":memory:")

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -333,9 +333,114 @@ async def test_files_mode_carries_a_placement_sentence_relating_it_to_sync(
     async with _WorkspaceHarness(workspace).run_test() as pilot:
         await pilot.pause()
         purpose = _static_text(workspace, "#file-notes-purpose")
-        assert "Files mode" in purpose
+        assert "Files" in purpose
         assert "directly" in purpose
         assert "Sync" in purpose
+    replica.close()
+
+
+@pytest.mark.parametrize(
+    ("size", "expected_height"),
+    (((160, 45), 1), ((120, 40), 1), ((60, 20), 2)),
+)
+@pytest.mark.asyncio
+async def test_file_notes_authority_copy_is_complete_and_bounded(
+    tmp_path: Path,
+    size: tuple[int, int],
+    expected_height: int,
+) -> None:
+    """Authority copy uses one moderate row and at most two compact rows."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        poll_interval=10,
+    )
+    expected = (
+        "Files edits this folder directly. Sync mirrors files into Library."
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=size) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        purpose = workspace.query_one("#file-notes-purpose")
+        rendered = " ".join(
+            purpose.render_line(row).text.strip()
+            for row in range(purpose.region.height)
+        )
+        assert " ".join(rendered.split()) == expected
+        assert purpose.region.height == expected_height
+        assert purpose.region.height <= 2
+        assert workspace.query_one("#file-notes-body").region.height >= 8
+
+    replica.close()
+
+
+@pytest.mark.parametrize("size", ((160, 45), (120, 40), (60, 20)))
+@pytest.mark.asyncio
+async def test_file_notes_linked_root_leads_with_friendly_folder_identity(
+    tmp_path: Path,
+    size: tuple[int, int],
+) -> None:
+    root = tmp_path / "deep" / "nested" / "Research Notes"
+    root.mkdir(parents=True)
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=size) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await pilot.pause()
+        summary = _static_text(workspace, "#file-notes-root-status")
+        assert summary == "Linked · Local folder: Research Notes"
+        assert str(root.resolve()) not in summary
+        assert str(root.resolve()) in workspace._root_status_detail
+        assert workspace.query_one("#file-notes-root-details", Button).display
+
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_file_notes_root_details_preserve_exact_path_and_warning(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "deep" / "nested" / "Research Notes"
+    root.mkdir(parents=True)
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        workspace._runtime_warning = "Recovery unavailable: replica locked"
+        workspace._update_root_surface(offline=False)
+        await pilot.pause()
+
+        assert (
+            _static_text(workspace, "#file-notes-root-status")
+            == "Warning · Local folder: Research Notes"
+        )
+        tooltip = workspace.query_one("#file-notes-root-status").tooltip
+        assert tooltip is not None
+        assert str(root.resolve()) in str(tooltip)
+        assert "Recovery unavailable: replica locked" in str(tooltip)
+        details = workspace.query_one("#file-notes-root-details", Button)
+        details.press()
+        await pilot.pause()
+        exact = workspace.app.screen.query_one(
+            "#file-notes-root-details-text",
+            TextArea,
+        ).text
+        assert str(root.resolve()) in exact
+        assert "Recovery unavailable: replica locked" in exact
+
     replica.close()
 
 

--- a/backlog/tasks/task-14880 - Clarify-File-Notes-local-folder-authority-at-moderate-and-compact-widths.md
+++ b/backlog/tasks/task-14880 - Clarify-File-Notes-local-folder-authority-at-moderate-and-compact-widths.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-10 18:45'
-updated_date: '2026-08-10 18:52'
+updated_date: '2026-08-10 19:08'
 labels:
   - notes
   - library
@@ -50,4 +50,5 @@ Reason: this is an atomic copy and responsive-presentation refinement within the
 - Preserved the root chooser, Change and Details actions, empty/offline behavior, responsive navigator/editor body, replica ownership, disk saves, Sync boundary, and Session Git behavior. No storage, service, or generated CSS bundle changed.
 - Added seven mounted cases covering complete copy, bounded height, retained body capacity, friendly identity at three supported sizes, warning visibility, tooltip detail, and the keyboard-reachable Details dialog. The pre-implementation run failed all seven against the old clipped/path-heavy presentation.
 - Verification: the complete affected battery passed with 157 tests (`test_library_file_notes_workspace.py`, `test_non_obscuring_focus_contract.py`, and `test_css_build_integrity.py`); targeted Ruff, Python compilation, `git diff --check`, and self-review passed. Only pre-existing dependency, SQLite privacy, pytest-cache permission, and pytest-asyncio warnings were reported.
+- Qodo follow-up: added Google-style `Args:` documentation to all three newly introduced async tests, satisfying compliance rule 497152 without changing runtime behavior or task scope.
 - ADR required: no. The implementation conforms to ADR-011 and ADR-029 without changing disk authority, synchronization, ownership, or long-lived application structure.

--- a/backlog/tasks/task-14880 - Clarify-File-Notes-local-folder-authority-at-moderate-and-compact-widths.md
+++ b/backlog/tasks/task-14880 - Clarify-File-Notes-local-folder-authority-at-moderate-and-compact-widths.md
@@ -1,0 +1,53 @@
+---
+id: TASK-14880
+title: Clarify File Notes local-folder authority at moderate and compact widths
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-10 18:45'
+updated_date: '2026-08-10 18:52'
+labels:
+  - notes
+  - library
+  - ux
+  - accessibility
+priority: medium
+references:
+  - .impeccable/critique/2026-08-10T06-12-44Z__ok-widgets-library-library-file-notes-workspace-py.md
+documentation:
+  - backlog/decisions/011-chatbook-workbench-ui-system.md
+  - backlog/decisions/029-file-notes-disk-authority.md
+---
+
+## Description
+
+Make the Library File Notes surface answer where edits happen without clipping its authority explanation or reducing the linked root to middle-elided path telemetry. Preserve exact-path access, disk authority, recovery warnings, retained navigation, and compact-terminal capacity.
+
+## Acceptance Criteria
+
+- [x] The Files/Sync placement sentence is complete at 120x40 and has an intentional treatment of at most two lines at 60x20 instead of silent clipping.
+- [x] A linked root presents its state and a friendly local-folder name in the persistent root row; the exact canonical path and any detailed warning remain available through Details and pointer help.
+- [x] Empty, checking, offline, warning, Choose folder, and Change flows remain explicit and keyboard reachable without changing disk, replica, Sync, or Session Git behavior.
+- [x] Mounted regressions prove complete authority copy, friendly root identity, exact-detail preservation, and stable body geometry at wide, moderate, and compact supported sizes.
+- [x] Focused tests, targeted Ruff, Python compilation, CSS/diff integrity, and self-review pass.
+
+## Implementation Plan
+
+ADR required: no
+ADR path: N/A; conform to `backlog/decisions/011-chatbook-workbench-ui-system.md` and `backlog/decisions/029-file-notes-disk-authority.md`.
+Reason: this is an atomic copy and responsive-presentation refinement within the existing workbench and disk-authority contracts; it changes no storage, synchronization, ownership, or service boundary.
+
+1. Add mounted regressions at 160x45, 120x40, and 60x20 for purpose-copy completeness, bounded wrapping, friendly root identity, exact details, and retained body capacity.
+2. Replace the long contrastive sentence with concise Files/Sync authority copy and allow one or two natural rows based on available width.
+3. Separate the human root summary from exact root telemetry so the persistent row leads with state and folder name while Details retains the canonical path and warning.
+4. Run the complete affected File Notes and CSS contract suites, mutation-check the new geometry/identity guards, and verify no storage or Git path changed.
+5. Self-review, record implementation evidence, mark every acceptance criterion complete, and move TASK-14880 to Done.
+
+## Implementation Notes
+
+- Replaced the clipped contrastive purpose sentence with two parallel authority statements: Files edits the selected folder directly; Sync mirrors files into Library. The purpose Static now sizes to one row at 160x45 and 120x40 and wraps completely into exactly two rows at 60x20.
+- Split persistent root presentation from exact telemetry. The root row now leads with `Linked`, `Offline`, `Checking`, or `Warning` plus `Local folder: <name>`; the existing Details dialog and pointer help retain the canonical path and full recovery warning.
+- Preserved the root chooser, Change and Details actions, empty/offline behavior, responsive navigator/editor body, replica ownership, disk saves, Sync boundary, and Session Git behavior. No storage, service, or generated CSS bundle changed.
+- Added seven mounted cases covering complete copy, bounded height, retained body capacity, friendly identity at three supported sizes, warning visibility, tooltip detail, and the keyboard-reachable Details dialog. The pre-implementation run failed all seven against the old clipped/path-heavy presentation.
+- Verification: the complete affected battery passed with 157 tests (`test_library_file_notes_workspace.py`, `test_non_obscuring_focus_contract.py`, and `test_css_build_integrity.py`); targeted Ruff, Python compilation, `git diff --check`, and self-review passed. Only pre-existing dependency, SQLite privacy, pytest-cache permission, and pytest-asyncio warnings were reported.
+- ADR required: no. The implementation conforms to ADR-011 and ADR-029 without changing disk authority, synchronization, ownership, or long-lived application structure.

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -368,17 +368,19 @@ class LibraryFileNotesWorkspace(Vertical):
         max-height: 1;
     }
 
-    /* LIB-19: placement sentence relating Files mode to Database/Sync --
-       same muted one-line treatment as #library-notes-database-purpose
+    /* LIB-19 / TASK-14880: placement sentence relating Files mode to
+       Database/Sync. Keep the muted treatment used by
+       #library-notes-database-purpose
        and #library-notes-sync-purpose (library_notes_canvas.py /
-       css/components/_agentic_terminal.tcss). */
+       css/components/_agentic_terminal.tcss), but allow the concise copy
+       one additional row at compact widths rather than clipping it. */
     #file-notes-purpose {
         width: 100%;
-        height: 1;
+        height: auto;
         min-height: 1;
-        max-height: 1;
+        max-height: 2;
         color: $text-muted;
-        text-wrap: nowrap;
+        text-wrap: wrap;
         overflow: hidden hidden;
     }
 
@@ -574,6 +576,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._service: FileNotesService | None = None
         self._runtime_warning = ""
         self._root_status_detail = "Choose a notes folder."
+        self._root_status_summary = "Choose a notes folder."
 
         self._poll_interval = max(0.02, poll_interval)
         self._autosave_delay = max(0.01, autosave_delay)
@@ -772,8 +775,7 @@ class LibraryFileNotesWorkspace(Vertical):
         # sub-canvas are three folder-notes concepts never related to each
         # other anywhere in the UI -- one placement sentence per surface.
         yield Static(
-            "Files mode edits a folder directly — unlike Sync, which "
-            "mirrors a folder into the Library.",
+            "Files edits this folder directly. Sync mirrors files into Library.",
             id="file-notes-purpose",
             markup=False,
         )
@@ -1304,8 +1306,9 @@ class LibraryFileNotesWorkspace(Vertical):
         )
         if self._root is None:
             self._root_status_detail = "Choose a notes folder."
+            self._root_status_summary = self._root_status_detail
             status.tooltip = None
-            status.update(self._root_status_detail)
+            status.update(self._root_status_summary)
             status.set_class(True, "-empty-root")
             body.display = False
             details.display = False
@@ -1323,8 +1326,13 @@ class LibraryFileNotesWorkspace(Vertical):
         if self._runtime_warning:
             detail = f"{detail} · {self._runtime_warning}"
         self._root_status_detail = detail
+        folder_name = self._root.name or self._root.anchor or str(self._root)
+        display_state = "Warning" if self._runtime_warning else state
+        self._root_status_summary = (
+            f"{display_state} · Local folder: {folder_name}"
+        )
         status.tooltip = Text(detail)
-        status.update(detail)
+        status.update(self._root_status_summary)
         body.display = True
         details.display = True
         choose.label = "Change…"
@@ -1333,7 +1341,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self.call_after_refresh(self._fit_root_status)
 
     def _fit_root_status(self) -> None:
-        """Keep the linked-root summary to one row and retain exact detail."""
+        """Fit the friendly root summary while retaining exact detail."""
         if not self._active or not self.is_mounted or not self.children:
             return
         try:
@@ -1342,7 +1350,7 @@ class LibraryFileNotesWorkspace(Vertical):
             return
         width = status.content_region.width
         if width > 0:
-            status.update(_middle_elide_cells(self._root_status_detail, width))
+            status.update(_middle_elide_cells(self._root_status_summary, width))
 
     def _apply_responsive_layout(self, width: int) -> None:
         if not self._active or not self.is_mounted:


### PR DESCRIPTION
## Summary

- replace clipped File Notes authority copy with concise Files and Sync statements
- show linked roots as a readable local-folder name instead of path telemetry
- preserve exact canonical paths and recovery warnings in Details and pointer help
- complete TASK-14880 without changing disk, replica, Sync, or Session Git behavior

## Verification

- 157 affected File Notes, focus-contract, and CSS-integrity tests passed
- seven new mounted cases cover 160x45, 120x40, and 60x20 layouts
- targeted Ruff, Python compilation, diff integrity, and self-review passed
- all seven new cases were observed failing before implementation

## Architecture

No ADR required. The change conforms to ADR-011 and ADR-029 and does not alter disk authority, synchronization, ownership, or service boundaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies File Notes authority text and root display so users see where edits happen and a friendly local-folder name, without clipping at moderate or compact widths. Keeps exact paths and warnings in Details/tooltips and leaves disk, replica, Sync, and Git behavior unchanged; completes `TASK-14880`.

- **Bug Fixes**
  - Replaced the long contrastive sentence with: “Files edits this folder directly. Sync mirrors files into Library.”
  - Allowed the purpose copy to wrap (max two lines at compact widths) instead of clipping.
  - Root summary now leads with state and “Local folder: <name>”; canonical path and any warning remain in Details and the tooltip, with the summary neatly elided when needed.
  - Added seven mounted tests for 160x45, 120x40, and 60x20 and documented the new UI cases; all affected tests pass.

<sup>Written for commit a989e4a2b3c32646576f1b4a4bd4233577bf39d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

