### PR TITLE
fix(tests): stop asserting -active survives an async dictation stop (TASK-3400)

### DIFF
--- a/Tests/UI/test_console_dictation_streaming.py
+++ b/Tests/UI/test_console_dictation_streaming.py
@@ -1321,10 +1321,17 @@ async def test_the_transcribing_indication_reverts_on_a_mid_capture_stop(monkeyp
         button = await _wait_for_mic_label(composer, pilot, "Dictate")
         assert console._console_dictation_state == "idle"
         assert console._console_dictation_session is None
-        # This fake stop finishes inside Textual's 0.2 s pressed animation.
-        # Button deliberately ignores clicks while its ``-active`` class is
-        # present, so wait for that input animation rather than racing it.
-        assert button.has_class("-active")
+        # Button deliberately ignores clicks while its ``-active`` press
+        # animation is running -- a fixed ~0.2s real-clock timer Textual
+        # owns, started when the click landed, independent of how long this
+        # capture's async stop-and-transcribe unwind (asyncio.to_thread +
+        # run_worker + a posted ConsoleDictationEvent) takes to reach
+        # "Dictate". Under load that unwind can outlast the button's own
+        # animation, so ``-active`` may already be gone by the time the
+        # label changes -- asserting it is still present raced exactly that
+        # (flaky ~50% of isolated runs under load, task-3400). Waiting for
+        # it to clear is the real precondition for the next click below and
+        # is a no-op if it already has.
         while button.has_class("-active"):
             await pilot.pause(0.01)
 

--- a/backlog/tasks/task-3400 - Console-dictation-transcribing-revert-test-is-~50-flaky-under-load.md
+++ b/backlog/tasks/task-3400 - Console-dictation-transcribing-revert-test-is-~50-flaky-under-load.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-3400
 title: Console dictation transcribing-revert test is ~50% flaky under load
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-07 19:37'
+updated_date: '2026-08-11 02:40'
 labels:
   - tests
   - flaky
@@ -18,6 +19,30 @@ Tests/UI/test_console_dictation_streaming.py::test_the_transcribing_indication_r
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The test passes deterministically when run in isolation, repeated 20 times
-- [ ] #2 The fix waits on the observable state transition rather than widening the timeout
+- [x] #1 The test passes deterministically when run in isolation, repeated 20 times
+- [x] #2 The fix waits on the observable state transition rather than widening the timeout
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce in isolation under synthetic + real ambient CPU load.
+2. Instrument the test with timing marks to see which phase is slow.
+3. Identify the exact failing assertion via repeated heavy-load runs.
+4. Fix by waiting on the real observable precondition instead of asserting a wall-clock-coupled assumption.
+5. Two-arm verify (baseline vs fixed) under matched heavy load, then 20x isolated, then full files.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: not the 4.0s _wait_for_mic_label deadline named in the task description (that phrasing/'Rec dot' label predates the CN-01 button-label rename) but a hard assertion two lines below it: `assert button.has_class("-active")`, right after the stop-click's `_wait_for_mic_label(..., "Dictate")` resolves. Textual clears a Button's `-active` press-flash via its own fixed ~0.2s real-clock timer, started when the click landed, independent of this capture's async stop-and-transcribe unwind (asyncio.to_thread -> run_worker -> a posted ConsoleDictationEvent). Under load that unwind can take longer than 0.2s, so by the time the label reads "Dictate" the `-active` class has already cleared, and the bare assert fails outright (not a timeout).
+
+Evidence: could not reproduce under light/moderate synthetic CPU load (up to 28 "yes" burners x 24 isolated runs: 0 failures; timing instrumentation showed all three _wait_for_mic_label calls completing in well under 200ms even then). Reproduced reliably with much heavier contention (90 "yes" burners + `nice -n 19` on the pytest process, 14-core machine): 13/14 isolated runs failed, ALL at the identical `assert button.has_class("-active")` line, `has_class` returning False every time. Two-arm comparison under matched heavy-load conditions: baseline (unmodified) 13 FAIL / 1 PASS out of 14 runs before the harness's wall-clock cap cut the loop off; fixed version 14/14 PASS in the same run, then a second heavy-load batch ran 19/19 PASS before the same cap. AC1: 20/20 consecutive isolated passes under normal conditions.
+
+Fix (test-only, Tests/UI/test_console_dictation_streaming.py): removed the `assert button.has_class("-active")` line. The surrounding `while button.has_class("-active"): await pilot.pause(0.01)` loop already is the correct "wait on the observable transition" -- it exists to satisfy the real precondition for the next click (Textual ignores clicks while `-active` is set), and is a no-op if the class has already cleared. No change to _wait_for_mic_label or its 4.0s deadline, no widened timeout anywhere -- just deleted an assumption that isn't guaranteed and wasn't load-safe. Checked the file for the same pattern elsewhere: the other two `has_class("-active")` waits in the file (lines ~394, ~475) already loop without first asserting the flag is set, so this was the only vulnerable spot.
+
+Verification: full-file runs after the fix -- Tests/UI/test_console_dictation_streaming.py 88 passed; Tests/UI/test_console_dictation.py (untouched, shares the _wait_for_mic_label helper) 12 passed.
+
+Files changed: Tests/UI/test_console_dictation_streaming.py (one assertion removed, comment rewritten to explain the real reasoning).
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## What

Fixes the ~50%-under-load isolation flake in
`Tests/UI/test_console_dictation_streaming.py::test_the_transcribing_indication_reverts_on_a_mid_capture_stop` (TASK-3400) by removing one unsound assertion. Test-only change; no product code touched.

## Root cause (not the one the task guessed)

The task description suspected `_wait_for_mic_label`'s 4.0s deadline. Instrumented heavy-load reproduction showed every failure (13/14 isolated runs under 90 CPU burners + `nice -n 19`) at the same line, and it isn't a timeout — it's the bare `assert button.has_class("-active")` after the stop-click settles. Textual clears a Button's `-active` press-flash on its own fixed ~0.2s real-clock timer, started when the click landed — independent of how long the capture's async stop-and-transcribe unwind (`asyncio.to_thread` → `run_worker` → posted `ConsoleDictationEvent`) takes. Under load the unwind outlasts the animation, so `-active` is already gone when the label reads "Dictate", and the assert fails outright.

## Fix

Delete the assert. The `while button.has_class("-active"): await pilot.pause(0.01)` loop directly below it is already the correct wait on the observable transition — it exists because Textual ignores clicks while `-active` is set, and it no-ops when the class has already cleared. No timeout was widened anywhere (AC #2). The file's two other `-active` waits already loop without asserting first; this was the only vulnerable site.

## Verification

- Two-arm under matched heavy load (90 burners + `nice -n 19`): baseline **13 FAIL / 14**; fixed **14/14 then 19/19 PASS** — all baseline failures at the removed assert.
- AC #1: **20/20** consecutive isolated passes under normal conditions.
- Full files: `test_console_dictation_streaming.py` **88 passed**; `test_console_dictation.py` (owns the shared helper, untouched) **12 passed**.
- Post-rebase onto `33c0e4159` re-verified: isolated run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky dictation streaming test by removing an unsafe `-active` assertion and relying on the existing wait loop, making it stable under load. Addresses TASK-3400; test-only change.

- **Bug Fixes**
  - Removed `assert button.has_class("-active")` that raced Textual’s ~0.2s press animation under load.
  - Rely on the loop that waits for `-active` to clear; no timeouts widened.
  - Verified: heavy load 14/14 then 19/19 pass; 20/20 isolation passes; full files green.

<sup>Written for commit 504d9b035abe07448da1d5ffbdf4ac5425f44021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

