### PR TITLE
test(ui): bound every background-signal wait + close server forecast residue (tasks 14912/14910/14911)

### DIFF
--- a/Docs/User_Guide/library/import-and-export.md
+++ b/Docs/User_Guide/library/import-and-export.md
@@ -94,7 +94,11 @@ In server mode the **Export** rail row is disabled, with the tooltip
   server)". "Unsupported by the server" is not "unreadable": an image
   imports fine on this machine, it simply has no place in the server's
   import API, so switching the target back to this machine changes the
-  number.
+  number. An empty (0 B) file is counted as a failure on both targets,
+  and on both targets that is this app's own doing: a server import
+  refuses a 0-byte file here rather than uploading it ("empty.txt is
+  empty; there was nothing to send."), so the count never depends on
+  what a server would have made of an empty upload.
 - **Queue** — the "Queue" heading, a per-state count line while jobs
   exist ("This queue: 1 parsing · 2 queued · 1 done" — task-2859: the
   "This queue:" prefix replaced a trailing "— in queue" suffix that
@@ -144,7 +148,7 @@ the rest of the session.
 | "Chunk content" | Governs every type: off means no retrieval chunks are stored at all; on chunks plain text / documents / HTML too (not just PDF/e-book/audio), using "Chunk size" and "Chunk overlap" — both measured in words. |
 | "Encoding" | How plain text and HTML files are decoded: "Auto-detect (UTF-8 first)" (strict UTF-8, then detection) or an explicit UTF-8 / UTF-16 / "Latin-1 (ISO-8859-1)" / "Windows-1252 (Western)". A wrong explicit choice shows up as replacement characters rather than failing the import. |
 | "Install verified Parakeet v2 INT8 (630.6 MiB)…" | In the Audio & video fold, enabled when the provider is parakeet-onnx (under any other provider the button is inert and its label ends "— needs the parakeet-onnx provider"). Opens a consent dialog listing Source, Revision, License, Download size, and Destination, ending "All four files are checked against pinned sizes and SHA-256 digests before the bundle becomes usable." Buttons: "Cancel" / "Install". |
-| "Start import" | Queues everything the pre-check found. If "⚠" tooling warnings are outstanding, the first press doesn't submit — the line beside Start turns into "⚠ Press Start again to import anyway — N files will fail without more tooling." (or "… N files may fail." when the missing package is only an optional enhancement) and a second press (or a second Enter in the path field) starts the import. See "Consent for risky imports" below. Start is unavailable, with the reason stated at the button, when the selection has nothing importable: "This folder is empty — there's nothing to import. Choose a folder with files, or a single file." for a folder that really is empty, "Nothing in this folder could be scanned — 2 entries were skipped: folder imports pass over hidden files, links, and folders they can't read. Import a file directly, or choose another folder." for a folder whose entries the scan passed over, and "Nothing in this selection can be imported — N unsupported files." when nothing in it has a handler. None of these leaves a failed row behind: the import never starts. |
+| "Start import" | Queues everything the pre-check found. If "⚠" tooling warnings are outstanding, the first press doesn't submit — the line beside Start turns into "⚠ Press Start again to import anyway — N files will fail without more tooling." (or "… N files may fail." when the missing package is only an optional enhancement) and a second press (or a second Enter in the path field) starts the import. See "Consent for risky imports" below. Start is unavailable, with the reason stated at the button, when the selection has nothing importable: "This folder is empty — there's nothing to import. Choose a folder with files, or a single file." for a folder that really is empty, "Nothing in this folder could be scanned — 2 entries were skipped: folder imports pass over hidden files, links, and folders they can't read. Import a file directly, or choose another folder." for a folder whose entries the scan passed over, and "Nothing in this selection can be imported — N unsupported files." when nothing in it has a handler. Importing on the server adds one more: a selection this machine reads perfectly well but that backend will not take at all (a folder of nothing but images) gates Start with "Nothing in this selection can be sent to the server — 3 files unsupported by the server. Switch to importing on this machine, or choose video, audio, document, PDF or e-book files." — a different sentence from the one above, because the files are fine and the destination is the problem. None of these leaves a failed row behind: the import never starts. |
 | Queue rows | "● queued / parsing / writing · name" while working, "✓ done · name · 4s" on success, "✗ failed · name · reason" (plus " · retry 1" after a retry) on failure, "⊘ cancelled · name" when stopped on purpose. Server jobs carry an " · on server" suffix. |
 | Row actions | "Open in Library" (done, local) jumps to the new media item; "View on server" (done, server); "Show details" shows the full error; "Retry" re-queues a failed job; "Cancel" stops an in-flight server job; "Dismiss" removes a failed row. |
 | "Show details" | Opens inline under the row: a plain-language reason ("Reason: No text could be extracted." / "The file couldn't be read." / "The file is empty." / "The Library couldn't be written to."), the full message when it says more than the row line, the underlying tool output once (never repeated between the message and the chain), and — only when a retry could actually change the outcome — one line of advice derived from that same reason. A deterministic failure whose text actually named a remedy says so ("Retrying now will fail the same way — install the tooling named above first, then Retry."); when nothing on screen named one, the advice states the determinism without inventing a remedy ("Retrying now will fail the same way — this file's content, or the tooling for it, has to change first."); a named missing package is named ("Missing dependency: pymupdf. Install it, then Retry."); and a cause we can't classify says nothing rather than encouraging a retry that would repeat itself. |
@@ -557,3 +561,27 @@ so it no longer claims "Everything"; the quality control is a "⇄" cycle
 button whose tooltip lists thumbnail → compressed → original; Escape on
 the Export canvas returns to the canvas whose Export… opened it, or to
 the hub when you came from the rail.)*
+*Verified against fix/ui-background-signal-bounds — 2026-08-10
+(task-14910): a 0-byte file is no longer uploaded to the server. The
+forecast has always counted one as a certain failure, which was true
+locally (the parse chain refuses an empty source before any write) and
+merely assumed on the server, where the app sent the file and only the
+server decided. The client now refuses it with the reason it already
+knows — the row reads "✗ failed · empty.txt · empty.txt is empty; there
+was nothing to send." — so the forecast's count is a statement about
+this app's own behaviour on both targets, and no round trip is spent on
+a file that is almost certainly a mistake.*
+
+*Verified against fix/ui-background-signal-bounds — 2026-08-10
+(task-14911): the Start gate now asks the backend the import is aimed at.
+A folder of nothing but images used to forecast "0 will be sent to the
+server · 3 will fail (unsupported by the server)" with **Start import**
+still live, and pressing it queued three rows that could only land as
+permanent failures — the guaranteed-failure submit the gate already
+prevented on this machine, one backend over. The gate reads the same
+forecast the commit line does, so the two cannot state different
+numbers, and it keeps its two vocabularies apart: "Nothing in this
+selection can be imported" for files nothing here can read, "Nothing in
+this selection can be sent to the server" for files that only this
+destination refuses. The refusal is enforced at the submit itself, not
+just on the button, so Enter in the path field cannot route around it.*

--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -1728,3 +1728,95 @@ class TestWriteStageFailureCategory:
             )
             == ""
         )
+
+
+class TestServerSubmitRefusesZeroByteSources:
+    """(task-14910) A 0-byte file never leaves this machine.
+
+    The forecast counts every 0-byte staged file as a certain failure on
+    both backends. On the server path that used to be an unearned claim:
+    ``_submit_server_ingest_job`` built kwargs for the empty file and sent
+    it, so only the server -- which this process cannot inspect -- decided
+    its fate. The client now refuses it with the reason it already knows,
+    which is what makes the forecast true rather than lucky.
+    """
+
+    @staticmethod
+    def _server_app() -> TldwCli:
+        app = _minimal_app(media_db="present")
+        app._sent = []  # type: ignore[attr-defined]
+        app._send_server_ingest_job = (  # type: ignore[method-assign]
+            lambda job_id, kwargs: app._sent.append((job_id, kwargs))
+        )
+        return app
+
+    def test_a_zero_byte_file_fails_locally_and_is_never_sent(
+        self, tmp_path
+    ) -> None:
+        from tldw_chatbook.Library.server_ingest_request import (
+            server_ingest_refusal,
+        )
+
+        empty = tmp_path / "empty.txt"
+        empty.write_text("")
+        app = self._server_app()
+
+        job = app._submit_server_ingest_job(
+            source_path=str(empty),
+            ingest_options={},
+            title="",
+            author="",
+            keywords=(),
+            perform_analysis=False,
+        )
+
+        assert job.state is IngestJobState.FAILED
+        assert job.error == server_ingest_refusal(str(empty))
+        assert "empty.txt" in job.error
+        assert app._sent == [], (
+            "a 0-byte file reached the wire, so the forecast's "
+            "'will fail' was a claim about someone else's machine"
+        )
+
+    def test_the_refusal_is_permanent_because_a_retry_cannot_change_it(
+        self, tmp_path
+    ) -> None:
+        """A 0-byte file fails identically on every attempt -- the same
+        reason the LOCAL path raises a ``PermanentIngestError`` for one, so
+        the queue row withholds Retry on both backends."""
+        empty = tmp_path / "empty.md"
+        empty.write_text("")
+        app = self._server_app()
+
+        job = app._submit_server_ingest_job(
+            source_path=str(empty),
+            ingest_options={},
+            title="",
+            author="",
+            keywords=(),
+            perform_analysis=False,
+        )
+
+        assert job.state is IngestJobState.FAILED
+        assert job.permanent is True
+
+    def test_a_file_with_content_still_reaches_the_wire(self, tmp_path) -> None:
+        """Guard: the refusal must not become a general server-submit
+        block."""
+        real = tmp_path / "notes.txt"
+        real.write_text("Tides are driven by the moon.")
+        app = self._server_app()
+
+        job = app._submit_server_ingest_job(
+            source_path=str(real),
+            ingest_options={},
+            title="",
+            author="",
+            keywords=(),
+            perform_analysis=False,
+        )
+
+        assert job.state is IngestJobState.QUEUED
+        assert [kwargs["file_paths"] for _job_id, kwargs in app._sent] == [
+            [str(real)]
+        ]

--- a/Tests/Library/test_library_ingest_state.py
+++ b/Tests/Library/test_library_ingest_state.py
@@ -3855,3 +3855,197 @@ def test_local_mode_keeps_the_tooling_wall():
     assert state.warning_lines
     assert state.warning_commands == ('pip install -e ".[audio]"',)
     assert state.advisory_lines == ()
+
+
+# ===========================================================================
+# task-14911: the Start gate must ask the backend the run is aimed at
+# ===========================================================================
+
+
+def _images_only_preflight(count: int = 3) -> PreflightResult:
+    """A folder the LOCAL pipeline can import and the SERVER cannot.
+
+    Images are a real local capability (the ``image`` group, OCR) that
+    task-3307 deliberately left server-unmapped, so this is the selection
+    on which the two backends' verdicts diverge completely.
+    """
+    files = [f"/tmp/shots/photo{i}.png" for i in range(count)]
+    return PreflightResult(
+        type_groups={"image": files},
+        warnings=[],
+        errors=[],
+        total_size=count * 2048,
+        truncated=False,
+        total_files=count,
+    )
+
+
+def _server_gate_state(preflight: PreflightResult):
+    return build_library_ingest_state(
+        (),
+        form=LibraryIngestFormState(path="/tmp/shots", preflight=preflight),
+        runtime_source="server",
+        ingest_backend="server",
+        server_ingest_available=True,
+    )
+
+
+def test_server_mode_gates_start_when_the_server_refuses_everything():
+    """(task-14911 AC#1) task-14823's gate asked a LOCAL question -- "did
+    the pre-flight find a supported type group" -- so a folder of nothing
+    but images forecast "0 will be sent to the server · 3 will fail
+    (unsupported by the server)" with Start still ENABLED: the guaranteed
+    failure submit that gate exists to prevent, one backend over."""
+    state = _server_gate_state(_images_only_preflight())
+
+    assert state.ingest_backend == "server"
+    assert state.forecast is not None
+    assert (state.forecast.will_import, state.forecast.will_fail_refused) == (
+        0,
+        3,
+    )
+    assert state.start_enabled is False, (
+        "Start stayed live for a selection the server refuses entirely: "
+        f"{state.commit_summary_line!r}"
+    )
+    assert state.selection_has_nothing_importable is True
+    assert state.start_quiet_line, "the gate closed without stating why"
+
+
+def test_the_server_gate_names_the_backend_that_is_refusing():
+    """(task-14911 AC#1) A file nothing can read and a file this server
+    won't take need different sentences: the image imports fine on this
+    machine. The arc already settled the vocabulary for the second case
+    ("unsupported by the server"), and the recovery differs too -- switch
+    the target, or stage something the server accepts."""
+    from tldw_chatbook.Library.library_ingest_state import (
+        INGEST_SERVER_REFUSED_COPY,
+    )
+
+    line = _server_gate_state(_images_only_preflight()).start_quiet_line
+
+    assert "sent to the server" in line, line
+    assert INGEST_SERVER_REFUSED_COPY in line, line
+    assert "can be imported" not in line, (
+        "the local gate sentence claims nothing can read these files; they "
+        f"import fine on this machine: {line!r}"
+    )
+    assert "on this machine" in line, (
+        f"the gate stated no way forward: {line!r}"
+    )
+
+
+def test_the_same_selection_is_untouched_in_local_mode():
+    """(task-14911 AC#2) The images import on this machine, so nothing
+    about this selection is doomed locally -- the gate must stay open."""
+    state = build_library_ingest_state(
+        (),
+        form=LibraryIngestFormState(
+            path="/tmp/shots", preflight=_images_only_preflight()
+        ),
+    )
+
+    assert state.ingest_backend == "local"
+    assert state.start_enabled is True
+    assert state.selection_has_nothing_importable is False
+    assert state.start_quiet_line == "", state.start_quiet_line
+
+
+def test_the_server_gate_counts_come_from_the_forecast():
+    """(task-14911 AC#3) The gate reads the existing ``IngestForecast``
+    rather than deriving a second notion of what is importable -- the
+    same "one computation" move task-14820 made for the commit and
+    consent lines. If it re-derived, the two lines could disagree on
+    screen, which is the defect that arc exists to remove."""
+    state = _server_gate_state(_images_only_preflight(count=7))
+
+    assert state.forecast is not None
+    assert f"{state.forecast.will_fail_refused} files" in (
+        state.start_quiet_line
+    ), state.start_quiet_line
+    assert f"{state.forecast.will_fail}" in state.commit_summary_line
+
+
+def test_the_server_gate_names_empty_files_separately():
+    """A 0-byte file is not "unsupported by the server" (task-14910: the
+    client refuses it before sending), so a selection blocked by both
+    states both reasons."""
+    preflight = PreflightResult(
+        type_groups={"image": ["/tmp/shots/photo0.png"]},
+        warnings=[],
+        errors=[],
+        total_size=2048,
+        truncated=False,
+        total_files=2,
+        empty_files=("/tmp/shots/blank.txt",),
+    )
+    state = _server_gate_state(preflight)
+
+    assert state.start_enabled is False
+    line = state.start_quiet_line
+    assert "1 file unsupported by the server" in line, line
+    assert "1 empty file" in line, line
+
+
+def test_a_server_selection_with_one_sendable_file_is_not_gated():
+    """Guard: the gate is "the server will take NOTHING here", not "the
+    server will refuse something here" -- a mixed folder still starts."""
+    preflight = PreflightResult(
+        type_groups={
+            "generic": ["/tmp/shots/notes.txt"],
+            "image": ["/tmp/shots/photo0.png"],
+        },
+        warnings=[],
+        errors=[],
+        total_size=4096,
+        truncated=False,
+        total_files=2,
+    )
+    state = _server_gate_state(preflight)
+
+    assert state.forecast is not None
+    assert state.forecast.will_import == 1
+    assert state.start_enabled is True
+    assert state.selection_has_nothing_importable is False
+
+
+def test_a_server_selection_that_is_all_duplicates_still_starts():
+    """Guard (task-2223 ruling, preserved): zero imports plus predicted
+    matches keeps Start ENABLED -- the duplicate probe is capped
+    best-effort, never a blocker -- so the new gate must key off "the
+    backend accepts nothing", not "will_import == 0"."""
+    preflight = PreflightResult(
+        type_groups={"generic": [f"/tmp/dupes/n{i}.txt" for i in range(3)]},
+        warnings=[],
+        errors=[],
+        total_size=3 * 128,
+        truncated=False,
+        total_files=3,
+        already_in_library=3,
+    )
+    state = _server_gate_state(preflight)
+
+    assert state.forecast is not None
+    assert (state.forecast.will_import, state.forecast.will_match) == (0, 3)
+    assert state.start_enabled is True
+    assert state.selection_has_nothing_importable is False
+
+
+def test_an_all_unsupported_folder_keeps_the_local_sentence_on_both_backends():
+    """Guard: a file nothing can read is diagnosed the same way whichever
+    target is selected -- switching to the server would not help, so the
+    server's own vocabulary would be misleading here."""
+    preflight = PreflightResult(
+        type_groups={"unsupported": ["/tmp/junk/a.xyz", "/tmp/junk/b.xyz"]},
+        warnings=[],
+        errors=[],
+        total_size=64,
+        truncated=False,
+        total_files=2,
+    )
+    state = _server_gate_state(preflight)
+
+    assert state.start_enabled is False
+    assert state.start_quiet_line == (
+        "Nothing in this selection can be imported — 2 unsupported files."
+    ), state.start_quiet_line

--- a/Tests/Library/test_server_ingest_request.py
+++ b/Tests/Library/test_server_ingest_request.py
@@ -288,3 +288,112 @@ class TestServerIngestRefusal:
         )
 
         assert server_ingest_refusal("   ") is not None
+
+
+class TestZeroByteSourcesAreRefusedBeforeTheyAreSent:
+    """(task-14910) The one claim the SERVER forecast had not earned.
+
+    ``build_ingest_forecast`` counts every 0-byte staged file as a certain
+    failure on BOTH backends. Locally that is verified -- the parse chain
+    raises ``EmptySourceIngestError`` before any write. On the server path
+    nothing verified it: ``build_server_ingest_kwargs`` happily built
+    kwargs for a 0-byte file and the app SENT it, handing the outcome to a
+    server this process cannot inspect. The forecast was asserting
+    knowledge it did not have, one line above copy that says outright
+    "server tooling isn't checked from here".
+
+    The resolution is a client-side refusal, which is knowable by
+    construction: a 0-byte file is refused here, with the reason, and
+    never leaves the machine.
+    """
+
+    def test_a_zero_byte_file_is_refused(self, tmp_path) -> None:
+        from tldw_chatbook.Library.server_ingest_request import (
+            server_ingest_refusal,
+        )
+
+        empty = tmp_path / "empty.txt"
+        empty.write_text("")
+        reason = server_ingest_refusal(str(empty))
+        assert reason is not None
+        assert "empty.txt" in reason
+        assert "empty" in reason
+
+    def test_the_submit_seam_refuses_it_with_the_same_reason(
+        self, tmp_path
+    ) -> None:
+        """The predicate the FORECAST reads and the builder the SUBMIT
+        path calls must state the same thing about the same file -- a
+        forecast that promises a refusal the submit path does not perform
+        is the divergence this task exists to remove."""
+        from tldw_chatbook.Library.server_ingest_request import (
+            server_ingest_refusal,
+        )
+
+        empty = tmp_path / "empty.txt"
+        empty.write_text("")
+        with pytest.raises(ServerIngestUnsupported) as excinfo:
+            build_server_ingest_kwargs(str(empty), options={})
+        assert str(excinfo.value) == server_ingest_refusal(str(empty))
+
+    def test_a_zero_byte_file_of_a_mapped_type_is_refused_too(
+        self, tmp_path
+    ) -> None:
+        """The refusal is about the file's CONTENT, not its extension: a
+        0-byte .mp3 maps to ``audio`` perfectly well and is still nothing
+        to send."""
+        from tldw_chatbook.Library.server_ingest_request import (
+            server_ingest_refusal,
+            server_media_type_for,
+        )
+
+        empty = tmp_path / "silence.mp3"
+        empty.write_bytes(b"")
+        assert server_media_type_for(str(empty)) == "audio"
+        assert server_ingest_refusal(str(empty)) is not None
+
+    def test_a_file_with_content_is_still_sent(self, tmp_path) -> None:
+        """Guard: the refusal is 0 bytes exactly, not "small"."""
+        from tldw_chatbook.Library.server_ingest_request import (
+            server_ingest_refusal,
+        )
+
+        one_byte = tmp_path / "tiny.txt"
+        one_byte.write_bytes(b" ")
+        assert server_ingest_refusal(str(one_byte)) is None
+        assert build_server_ingest_kwargs(str(one_byte), options={})[
+            "file_paths"
+        ] == [str(one_byte)]
+
+    def test_a_url_is_never_called_empty(self) -> None:
+        """Guard: a URL has no local size to measure -- claiming one is
+        the same class of fabrication (task-3305, MI-19: "1 file - 0 B"
+        for a URL)."""
+        from tldw_chatbook.Library.server_ingest_request import (
+            server_ingest_refusal,
+        )
+
+        assert server_ingest_refusal("https://example.com/talk.mp3") is None
+
+    def test_an_unstatable_path_is_not_called_empty(self) -> None:
+        """Guard: a path that does not exist is not a 0-byte file. The
+        pre-flight makes the same distinction (``_statted_size`` returns
+        ``None`` rather than 0 on ``OSError``), and the existing refusal
+        tests all use paths that were never created."""
+        from tldw_chatbook.Library.server_ingest_request import (
+            server_ingest_refusal,
+        )
+
+        assert server_ingest_refusal("/tmp/does-not-exist-14910.txt") is None
+
+    def test_a_directory_is_not_called_an_empty_source(self, tmp_path) -> None:
+        """Guard: a directory can stat at 0 bytes on some filesystems, and
+        "this folder is empty" is a different diagnosis with a different
+        recovery -- the ingest Start gate owns that one."""
+        from tldw_chatbook.Library.server_ingest_request import (
+            empty_source_refusal,
+        )
+
+        folder = tmp_path / "nothing"
+        folder.mkdir()
+        assert empty_source_refusal(str(folder)) is None

--- a/Tests/UI/background_signals.py
+++ b/Tests/UI/background_signals.py
@@ -1,0 +1,177 @@
+# background_signals.py
+# Description: Bounded waits for signals only background work can set (task-14912).
+#
+# WHY THIS MODULE EXISTS
+#
+# A Tests/UI test routinely drives a screen/app coroutine as background work --
+# `asyncio.create_task(...)`, or a Textual `run_worker(...)` -- and then waits on
+# an `asyncio.Event` that only that coroutine can set. A bare
+#
+#     await started.wait()
+#
+# is UNBOUNDED. Nobody retrieves a fire-and-forget task's result, so if the
+# coroutine raises, the exception is SWALLOWED and the signal becomes
+# unreachable: the wait blocks forever.
+#
+# That is not a theoretical failure. In task-3316,
+# `test_file_notes_collections_source_transition_blocks_mutation_through_recompose`
+# stubbed `_flush_library_note_save` to return `None` -- correct when written
+# (eb036a6a1). PR #1439 retyped that seam to return `NoteFlushOutcome`; the
+# awaited path then died one line in on
+# `AttributeError: 'NoneType' object has no attribute 'kind'`, the signal was
+# never set, and the test hung.
+#
+# Under this repo's configured `timeout_method = thread` a hung test CANNOT be
+# cancelled: pytest-timeout dumps stacks and terminates the WHOLE pytest
+# process, so every test after it in the file is silently never run. The file's
+# real pass count was unknowable for as long as the hang existed -- and
+# repairing that one test revealed three further failures the hang had hidden.
+#
+# Two diagnostic facts worth keeping:
+#   * The timeout stack dump does NOT name the hung test when the hang is an
+#     awaited asyncio Event. A suspended coroutine has no frames on any thread
+#     stack, so the dump shows only `MainThread` idle in `selectors.select`.
+#     Diagnose by inspecting the task object, not the dump.
+#   * A file that has ever contained a hang has an UNKNOWN pass count until it
+#     is re-run whole.
+#
+# HOW TO USE
+#
+#   task = asyncio.create_task(screen._reload_page())
+#   await wait_for_background_signal(started, task, what="the page reload")
+#   ...
+#   await await_background_task(task, what="the page reload")
+#
+# When the background work is owned by the product (a Textual worker, or a
+# `create_task` inside the app) and the test holds no task handle, use the
+# timeout-only form:
+#
+#   await wait_for_signal(started, what="the improvement worker's start")
+#
+# `Tests/UI/test_background_signal_bounds.py` enforces this by AST: an
+# `await <x>.wait()` that follows a spawn in the same function must go through
+# one of these helpers.
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+__all__ = [
+    "BACKGROUND_SIGNAL_TIMEOUT_SECONDS",
+    "await_background_task",
+    "wait_for_background_signal",
+    "wait_for_signal",
+]
+
+# Generous enough that a slow CI box never trips it, small enough that a real
+# hang fails in seconds instead of killing the process at the 300s pytest
+# timeout.
+BACKGROUND_SIGNAL_TIMEOUT_SECONDS = 10.0
+
+
+async def wait_for_background_signal(
+    signal: asyncio.Event,
+    task: "asyncio.Task[Any]",
+    *,
+    what: str,
+    timeout: float = BACKGROUND_SIGNAL_TIMEOUT_SECONDS,
+) -> None:
+    """Await ``signal``, bounded, reporting why ``task`` never set it.
+
+    Returns as soon as ``signal`` is set. If ``task`` finishes first the signal
+    can never arrive, so its exception is re-raised (or its silent early return
+    reported) rather than waited on forever.
+
+    Args:
+        signal: Event the background task is expected to set.
+        task: The background task that owns the signal.
+        what: Human-readable description used in failure messages.
+        timeout: Seconds to wait before failing the test.
+
+    Raises:
+        AssertionError: If the task returned without signalling, or neither the
+            signal nor the task settled within ``timeout``.
+    """
+    waiter = asyncio.ensure_future(signal.wait())
+    try:
+        await asyncio.wait(
+            {waiter, task},
+            timeout=timeout,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    finally:
+        if not waiter.done():
+            waiter.cancel()
+    if signal.is_set():
+        return
+    if task.done():
+        # Re-raises whatever the fire-and-forget task swallowed; a task that
+        # raised or returned early can never set the signal.
+        task.result()
+        raise AssertionError(
+            f"{what} finished without signalling -- the awaited path returned "
+            "early instead of reaching the signalling step"
+        )
+    raise AssertionError(
+        f"timed out after {timeout}s waiting for {what}; the task is still "
+        "running and the signal was never set"
+    )
+
+
+async def await_background_task(
+    task: "asyncio.Task[Any]",
+    *,
+    what: str,
+    timeout: float = BACKGROUND_SIGNAL_TIMEOUT_SECONDS,
+) -> Any:
+    """Await a background task with a bound so a stall fails instead of hangs.
+
+    Args:
+        task: The background task to await.
+        what: Human-readable description used in the failure message.
+        timeout: Seconds to wait before cancelling and failing.
+
+    Returns:
+        The task's result.
+
+    Raises:
+        AssertionError: If the task does not finish within ``timeout``.
+    """
+    try:
+        return await asyncio.wait_for(task, timeout=timeout)
+    except asyncio.TimeoutError:
+        raise AssertionError(f"timed out after {timeout}s awaiting {what}") from None
+
+
+async def wait_for_signal(
+    signal: asyncio.Event,
+    *,
+    what: str,
+    timeout: float = BACKGROUND_SIGNAL_TIMEOUT_SECONDS,
+) -> None:
+    """Await ``signal`` with a timeout when no task handle is available.
+
+    Use this when the coroutine that sets ``signal`` is launched by the product
+    (a Textual worker, or a `create_task` inside the app) so the test has
+    nothing to inspect. It cannot name the underlying exception the way
+    :func:`wait_for_background_signal` can, but it still converts an unbounded
+    hang -- which kills the whole pytest process under `timeout_method = thread`
+    -- into a named failure in seconds. Prefer the task-aware form whenever the
+    test owns the task.
+
+    Args:
+        signal: Event the background work is expected to set.
+        what: Human-readable description used in the failure message.
+        timeout: Seconds to wait before failing the test.
+
+    Raises:
+        AssertionError: If ``signal`` is not set within ``timeout``.
+    """
+    try:
+        await asyncio.wait_for(signal.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        raise AssertionError(
+            f"timed out after {timeout}s waiting for {what}; the background "
+            "work never set the signal (its exception, if any, was swallowed)"
+        ) from None

--- a/Tests/UI/test_background_signal_bounds.py
+++ b/Tests/UI/test_background_signal_bounds.py
@@ -1,0 +1,315 @@
+# test_background_signal_bounds.py
+# Description: AST guard -- no unbounded wait on a background-set signal (task-14912).
+#
+# The rule this file enforces, and why, is documented in
+# Tests/UI/background_signals.py. Short version: `await some_event.wait()` where
+# only background work can set `some_event` is an UNBOUNDED wait. If that work
+# raises, a fire-and-forget task swallows the exception, the signal never
+# arrives, and the test hangs forever. Under this repo's
+# `timeout_method = thread` a hung test kills the WHOLE pytest process, so every
+# test after it in the file silently never runs -- the file's pass count becomes
+# a lie.
+#
+# This is checked by AST rather than grep because grep cannot tell an unbounded
+# `await ev.wait()` from one already wrapped in `asyncio.wait_for`, cannot tell
+# an `asyncio.Event` from a Textual `Worker` or a `RetainedPushOperation` (both
+# of which expose a `.wait()` that re-raises, so neither can strand), and cannot
+# see whether a spawn precedes the wait in the same scope.
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+TESTS_UI_DIR = Path(__file__).resolve().parent
+
+# Calls that start background work the test does not await inline.
+SPAWN_CALLS = frozenset({"create_task", "ensure_future", "run_worker"})
+
+# Wrappers that already impose a bound. The three `*_background_*` /
+# `wait_for_signal` names are Tests/UI/background_signals.py's helpers; the
+# underscore-prefixed spellings are the pre-task-14912 aliases still re-exported
+# from test_screen_navigation.py.
+BOUNDING_CALLS = frozenset(
+    {
+        "wait_for",
+        "wait_for_signal",
+        "_wait_for_signal",
+        "wait_for_background_signal",
+        "_wait_for_background_signal",
+        "await_background_task",
+        "_await_background_task",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One unbounded `await <event>.wait()`."""
+
+    path: str
+    line: int
+    receiver: str
+    function: str
+    reason: str
+
+    def __str__(self) -> str:  # pragma: no cover - failure formatting only
+        return (
+            f"{self.path}:{self.line}  await {self.receiver}.wait()  "
+            f"in {self.function}()  [{self.reason}]"
+        )
+
+
+def _call_name(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return ""
+
+
+def _receiver(node: ast.Call) -> str:
+    func = node.func
+    return ast.unparse(func.value) if isinstance(func, ast.Attribute) else ""
+
+
+def _is_bounding(node: ast.Call) -> bool:
+    """Whether this call imposes a timeout on whatever it wraps."""
+    name = _call_name(node)
+    if name in BOUNDING_CALLS:
+        return True
+    receiver = _receiver(node)
+    if name in {"timeout", "timeout_at"} and receiver.endswith("asyncio"):
+        return True
+    if name == "wait" and receiver.endswith("asyncio"):
+        # asyncio.wait({...}, timeout=...) -- bounded only with an explicit timeout
+        return any(kw.arg == "timeout" for kw in node.keywords)
+    return False
+
+
+def _event_expressions(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """Every expression, and every attribute name, assigned an ``asyncio.Event``.
+
+    Returns:
+        (full expressions, bare attribute names). The second set exists because
+        a fake declares ``self.started = asyncio.Event()`` and the test awaits
+        ``service.started.wait()`` -- different text, same object.
+    """
+    full: set[str] = set()
+    attrs: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets, value = [node.target], node.value
+        else:
+            continue
+        if not isinstance(value, ast.Call) or _call_name(value) != "Event":
+            continue
+        source = ast.unparse(value.func)
+        if "asyncio" not in source and source != "Event":
+            continue  # threading.Event().wait(timeout=...) is already bounded
+        for target in targets:
+            if isinstance(target, ast.Name):
+                full.add(target.id)
+            elif isinstance(target, ast.Attribute):
+                full.add(ast.unparse(target))
+                attrs.add(target.attr)
+    return full, attrs
+
+
+class _FunctionScan(ast.NodeVisitor):
+    """Scan one function body, never descending into nested definitions."""
+
+    def __init__(self) -> None:
+        self.spawn_lines: list[int] = []
+        self.awaited_waits: list[tuple[int, str, bool]] = []
+        self._bounded = 0
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        return
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+    visit_Lambda = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if _call_name(node) in SPAWN_CALLS:
+            self.spawn_lines.append(node.lineno)
+        if _is_bounding(node):
+            self._bounded += 1
+            self.generic_visit(node)
+            self._bounded -= 1
+            return
+        self.generic_visit(node)
+
+    def visit_With(self, node: ast.With) -> None:
+        bounded = any(
+            isinstance(item.context_expr, ast.Call) and _is_bounding(item.context_expr)
+            for item in node.items
+        )
+        if bounded:
+            self._bounded += 1
+            self.generic_visit(node)
+            self._bounded -= 1
+            return
+        self.generic_visit(node)
+
+    visit_AsyncWith = visit_With  # type: ignore[assignment]
+
+    def visit_Await(self, node: ast.Await) -> None:
+        value = node.value
+        if (
+            isinstance(value, ast.Call)
+            and _call_name(value) == "wait"
+            and isinstance(value.func, ast.Attribute)
+            and not _is_bounding(value)
+        ):
+            self.awaited_waits.append(
+                (node.lineno, _receiver(value), self._bounded > 0)
+            )
+        self.generic_visit(node)
+
+
+def _matches_event(receiver: str, full: set[str], attrs: set[str]) -> bool:
+    if receiver in full:
+        return True
+    tail = receiver.rsplit(".", 1)[-1]
+    return "." in receiver and tail in attrs
+
+
+def _module_level_functions(tree: ast.AST) -> set[int]:
+    """Ids of functions defined directly at module level.
+
+    Only those are pytest test bodies. A ``test_``-prefixed METHOD is a service
+    fake's stub (``ToolTestHubService.test_hub_tool``), and a stub awaiting a
+    release the test sets is the inverse, safe shape.
+    """
+    return {
+        id(node)
+        for node in getattr(tree, "body", [])
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def scan_tree(tree: ast.AST, path: str) -> list[Violation]:
+    """Return every unbounded wait on a background-set ``asyncio.Event``."""
+    full, attrs = _event_expressions(tree)
+    if not full and not attrs:
+        return []
+    top_level = _module_level_functions(tree)
+    violations: list[Violation] = []
+    for function in ast.walk(tree):
+        if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        scan = _FunctionScan()
+        for statement in function.body:
+            scan.visit(statement)
+        is_test_body = function.name.startswith("test_") and id(function) in top_level
+        for line, receiver, bounded in scan.awaited_waits:
+            if bounded or not _matches_event(receiver, full, attrs):
+                continue
+            spawned_before = any(spawn <= line for spawn in scan.spawn_lines)
+            if spawned_before:
+                reason = "background work was spawned in this scope before the wait"
+            elif is_test_body:
+                reason = "a test body may only wait on a signal with a bound"
+            else:
+                # A stub awaiting a release the TEST sets is the inverse shape
+                # and cannot strand the run: the setter is the test itself.
+                continue
+            violations.append(
+                Violation(
+                    path=path,
+                    line=line,
+                    receiver=receiver,
+                    function=function.name,
+                    reason=reason,
+                )
+            )
+    return sorted(violations, key=lambda v: (v.path, v.line))
+
+
+def scan_directory(directory: Path) -> list[Violation]:
+    """Scan every Python module under ``directory``."""
+    violations: list[Violation] = []
+    for path in sorted(directory.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        violations.extend(scan_tree(ast.parse(source), str(path.relative_to(directory))))
+    return violations
+
+
+def test_no_unbounded_waits_on_background_signals():
+    """No Tests/UI wait on a background-set Event may be unbounded.
+
+    Enumerated by AST, not grep -- an asserted sweep is exactly what task-14912
+    exists to distrust. Fix a failure by routing the wait through
+    ``Tests/UI/background_signals.py``:
+
+      * the test owns the task -> ``wait_for_background_signal(ev, task, what=...)``
+        (re-raises the exception the task swallowed)
+      * the product owns the work -> ``wait_for_signal(ev, what=...)``
+        (timeout-only, but still a named failure instead of a dead process)
+    """
+    violations = scan_directory(TESTS_UI_DIR)
+    assert not violations, (
+        "unbounded waits on a signal only background work can set "
+        f"({len(violations)}):\n  " + "\n  ".join(str(v) for v in violations)
+    )
+
+
+def test_rule_detects_the_incident_shape():
+    """The AST rule must actually fire on the task-3316 shape it exists to ban."""
+    source = (
+        "import asyncio\n"
+        "async def test_thing():\n"
+        "    started = asyncio.Event()\n"
+        "    task = asyncio.create_task(screen.reload())\n"
+        "    await started.wait()\n"
+    )
+    violations = scan_tree(ast.parse(source), "<synthetic>")
+    assert [(v.line, v.receiver) for v in violations] == [(5, "started")]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # already bounded by the shared helper
+        "import asyncio\n"
+        "async def test_thing():\n"
+        "    started = asyncio.Event()\n"
+        "    task = asyncio.create_task(screen.reload())\n"
+        "    await wait_for_background_signal(started, task, what='reload')\n",
+        # already bounded by asyncio.wait_for
+        "import asyncio\n"
+        "async def test_thing():\n"
+        "    started = asyncio.Event()\n"
+        "    task = asyncio.create_task(screen.reload())\n"
+        "    await asyncio.wait_for(started.wait(), timeout=5)\n",
+        # a stub waiting on a release the test body sets -- the inverse shape
+        "import asyncio\n"
+        "release = asyncio.Event()\n"
+        "async def stub():\n"
+        "    await release.wait()\n",
+        # a Textual Worker / retained-operation handle re-raises, it cannot strand
+        "import asyncio\n"
+        "gate = asyncio.Event()\n"
+        "async def test_thing():\n"
+        "    worker = widget.run_worker(thing())\n"
+        "    await worker.wait()\n",
+        # a `test_`-prefixed METHOD is a service fake's stub, not a pytest test
+        "import asyncio\n"
+        "class Fake:\n"
+        "    def __init__(self):\n"
+        "        self.test_gate = asyncio.Event()\n"
+        "    async def test_hub_tool(self):\n"
+        "        await self.test_gate.wait()\n",
+    ],
+    ids=["helper", "wait_for", "stub-release", "worker-handle", "fake-method"],
+)
+def test_rule_does_not_fire_on_safe_shapes(source: str):
+    """Shapes that cannot strand a run must not be reported."""
+    assert scan_tree(ast.parse(source), "<synthetic>") == []

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -15,6 +15,7 @@ from textual.app import App
 from textual.content import Content
 from textual.widgets import Button, Checkbox, Input, Static, TextArea
 
+from Tests.UI.background_signals import wait_for_background_signal, wait_for_signal
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
@@ -721,7 +722,10 @@ async def test_auto_improvement_live_drift_is_reviewable_and_never_partially_app
         modal.query_one("#console-prompts-improve", Button).press()
         await pilot.pause()
         modal.query_one("#console-prompts-auto-improve", Button).press()
-        await gateway.started.wait()
+        await wait_for_signal(
+            gateway.started,
+            what="the auto-improvement gateway call starting",
+        )
 
         if drift == "session":
             store.create_session(settings=original_settings)
@@ -1018,7 +1022,11 @@ async def test_saved_recipe_source_is_not_redirected_by_late_colliding_detail() 
         await pilot.pause()
 
         late_local = asyncio.create_task(modal.open_artifact("shared-recipe"))
-        await service.local_detail_started.wait()
+        await wait_for_background_signal(
+            service.local_detail_started,
+            late_local,
+            what="the late local detail open",
+        )
         await modal.switch_source("server")
         await modal.open_artifact("shared-recipe")
         service.release_late_local_detail.set()
@@ -3194,7 +3202,11 @@ async def test_console_workspace_switch_refresh_is_not_dropped_during_inflight_s
 
         console._sync_console_native_session_tabs = blocking_sync_tabs
         first_sync_task = asyncio.create_task(console._sync_native_console_chat_ui())
-        await first_sync_blocked.wait()
+        await wait_for_background_signal(
+            first_sync_blocked,
+            first_sync_task,
+            what="the first native-console UI sync",
+        )
 
         console.query_one("#console-change-workspace", Button).press()
         modal_screen = await _wait_for_workspace_switcher_modal(host, pilot)
@@ -4749,7 +4761,11 @@ async def test_server_authenticated_context_change_during_card_fetch_aborts_sess
             ),
         )
     )
-    await card_fetch_started.wait()
+    await wait_for_background_signal(
+        card_fetch_started,
+        handoff,
+        what="the character-card fetch",
+    )
 
     runtime.authority_context_state["current"] = SimpleNamespace(account="B")
     if authenticated_transition == "a_to_b_to_a":

--- a/Tests/UI/test_console_parallel_runs.py
+++ b/Tests/UI/test_console_parallel_runs.py
@@ -13,6 +13,7 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     _visible_text,
 )
 from Tests.UI.app_factory import _build_test_app
+from Tests.UI.background_signals import wait_for_signal
 from tldw_chatbook.Agents.mcp_tool_provider import MCPPendingCall
 from tldw_chatbook.Chat.console_agent_bridge import (
     AgentLiveSnapshot,
@@ -122,13 +123,13 @@ async def test_second_session_send_does_not_cancel_first_sessions_worker() -> No
             exclusive=True,
             group=f"console-run-{session_a}",
         )
-        await started_a.wait()
+        await wait_for_signal(started_a, what="session A's run worker starting")
         worker_b = console.run_worker(
             fake_run(session_b, started_b),
             exclusive=True,
             group=f"console-run-{session_b}",
         )
-        await started_b.wait()
+        await wait_for_signal(started_b, what="session B's run worker starting")
         await pilot.pause(0.1)
 
         # If the groups collided, starting worker_b would have cancelled
@@ -212,8 +213,8 @@ async def test_stop_visible_action_only_cancels_viewed_session_background_comple
             exclusive=True,
             group=f"console-run-{session_b}",
         )
-        await started_a.wait()
-        await started_b.wait()
+        await wait_for_signal(started_a, what="session A's run worker starting")
+        await wait_for_signal(started_b, what="session B's run worker starting")
         await pilot.pause(0.1)
         assert controller.in_flight_run_count() == 2  # truly concurrent
 

--- a/Tests/UI/test_console_prompts_modal.py
+++ b/Tests/UI/test_console_prompts_modal.py
@@ -14,6 +14,7 @@ import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import Button, Checkbox, Input, Static, TextArea
 
+from Tests.UI.background_signals import wait_for_background_signal, wait_for_signal
 from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
 from tldw_chatbook.Chat.console_provider_gateway import (
     AuxiliaryCompletionRequest,
@@ -605,7 +606,9 @@ async def test_late_source_completion_is_rejected() -> None:
         await pilot.pause()
         modal._list_page = list_page
         late_local = asyncio.create_task(modal.reload_browse())
-        await local_started.wait()
+        await wait_for_background_signal(
+            local_started, late_local, what="the late local browse reload"
+        )
         await modal.switch_source("server")
         release_local.set()
         await late_local
@@ -1119,7 +1122,9 @@ async def test_late_local_detail_cannot_open_after_switching_to_server() -> None
         modal._detail = detail
 
         late_open = asyncio.create_task(modal.open_artifact("late-local"))
-        await local_started.wait()
+        await wait_for_background_signal(
+            local_started, late_open, what="the late local detail open"
+        )
         await modal.switch_source("server")
         release_local.set()
         await late_open
@@ -1154,7 +1159,9 @@ async def test_late_first_detail_cannot_replace_newer_selection() -> None:
         modal._detail = detail
 
         first_open = asyncio.create_task(modal.open_artifact("prompt-a"))
-        await first_started.wait()
+        await wait_for_background_signal(
+            first_started, first_open, what="the first detail open"
+        )
         await modal.open_artifact("prompt-b")
         release_first.set()
         await first_open
@@ -1196,7 +1203,9 @@ async def test_source_switch_clears_foreign_rows_before_unavailable_result() -> 
         assert modal.query("#console-prompts-result-local-only")
 
         switch = asyncio.create_task(modal.switch_source("server"))
-        await server_started.wait()
+        await wait_for_background_signal(
+            server_started, switch, what="the server source switch"
+        )
         foreign_rows_visible_while_loading = bool(
             modal.query("#console-prompts-result-local-only")
         )
@@ -1701,7 +1710,7 @@ async def test_recipe_editor_keeps_analysis_disclosure_bound_through_edits_and_f
         assert modal.state.dirty is True
 
         modal.query_one("#console-prompts-recipe-fill", Button).press()
-        await started.wait()
+        await wait_for_signal(started, what="the recipe-fill improvement starting")
         await pilot.pause()
 
         assert (
@@ -1844,7 +1853,7 @@ async def test_held_improve_activation_navigation_cancels_and_ignores_late_resol
         modal = app.screen
         improve = modal.query_one("#console-prompts-improve", Button)
         improve.press()
-        await started.wait()
+        await wait_for_signal(started, what="the held improvement activation starting")
         await asyncio.sleep(0.05)
 
         if navigation == "close":
@@ -1890,7 +1899,7 @@ async def test_held_improve_activation_disables_duplicate_resolution() -> None:
         modal = app.screen
         improve = modal.query_one("#console-prompts-improve", Button)
         improve.press()
-        await started.wait()
+        await wait_for_signal(started, what="the held improvement activation starting")
         await asyncio.sleep(0.05)
 
         disabled_while_held = improve.disabled
@@ -1936,7 +1945,9 @@ async def test_invalidated_activation_token_ignores_late_resolution() -> None:
         activation = asyncio.create_task(
             modal._run_improvement_activation(activation_id)
         )
-        await started.wait()
+        await wait_for_background_signal(
+            started, activation, what="the improvement activation"
+        )
 
         modal._active_activation_id = None
         release.set()
@@ -2033,7 +2044,7 @@ async def test_active_improvement_disables_duplicate_model_launches() -> None:
         auto = app.screen.query_one("#console-prompts-auto-improve", Button)
         review = app.screen.query_one("#console-prompts-review-improve", Button)
         auto.press()
-        await started.wait()
+        await wait_for_signal(started, what="the auto-improvement starting")
         await pilot.pause()
 
         assert auto.disabled is True
@@ -2191,7 +2202,7 @@ async def test_cancel_invalidates_request_and_ignores_late_completion() -> None:
         await pilot.pause()
         await app.screen.enter_mode("improve")
         app.screen.query_one("#console-prompts-auto-improve", Button).press()
-        await started.wait()
+        await wait_for_signal(started, what="the auto-improvement starting")
         app.screen.query_one("#console-prompts-improvement-cancel", Button).press()
         await pilot.pause()
         assert (
@@ -2239,7 +2250,7 @@ async def test_back_and_escape_cancel_active_improvement_before_navigation(
         await pilot.pause()
         await app.screen.enter_mode("improve")
         app.screen.query_one("#console-prompts-auto-improve", Button).press()
-        await started.wait()
+        await wait_for_signal(started, what="the auto-improvement starting")
 
         if navigation == "back":
             app.screen.query_one("#console-prompts-back", Button).press()

--- a/Tests/UI/test_library_file_notes_git_push.py
+++ b/Tests/UI/test_library_file_notes_git_push.py
@@ -19,6 +19,7 @@ sys.modules.setdefault("parakeet_mlx", types.ModuleType("parakeet_mlx"))
 from Tests.Notes.test_file_notes_git_push_service import (  # noqa: E402
     _publish_candidate_on_owner,
 )
+from Tests.UI.background_signals import wait_for_signal  # noqa: E402
 from Tests.UI.test_library_file_notes_git import (  # noqa: E402
     _FakeGitService,
     _DialogHarness,
@@ -3497,7 +3498,9 @@ async def test_workspace_back_to_files_keeps_push_publication_and_attention(
         )
 
         service.mark_push_child_started()
-        await service.actual_child_started.wait()
+        await wait_for_signal(
+            service.actual_child_started, what="the actual push-child start"
+        )
         await _until(
             pilot,
             lambda: "Pushing" in str(

--- a/Tests/UI/test_library_prompt_collections.py
+++ b/Tests/UI/test_library_prompt_collections.py
@@ -24,6 +24,7 @@ from tldw_chatbook.Widgets.Library.library_prompts_canvas import (
 )
 
 from Tests.UI.app_factory import _build_test_app
+from Tests.UI.background_signals import wait_for_background_signal, wait_for_signal
 from Tests.UI.test_library_prompts_canvas import (
     _open_prompt_editor,
     _painted_contrast,
@@ -576,7 +577,9 @@ def test_controller_rejects_late_membership_label_hydration_after_identity_switc
 
     async def exercise() -> None:
         task = asyncio.create_task(controller.load_memberships())
-        await detail_started.wait()
+        await wait_for_background_signal(
+            detail_started, task, what="the membership load"
+        )
         prompt_id[0] = 42
         detail_release.set()
         await task
@@ -1428,7 +1431,9 @@ async def test_manager_create_is_single_flight_under_rapid_double_submit():
         modal = app.screen
         modal.query_one("#prompt-collection-manager-new-name", Input).value = "One"
         first = asyncio.create_task(modal._run_mutation("create", None, "One"))
-        await app.started.wait()
+        await wait_for_background_signal(
+            app.started, first, what="the first create mutation"
+        )
         second = asyncio.create_task(modal._run_mutation("create", None, "One"))
         await pilot.pause()
 
@@ -1452,7 +1457,7 @@ async def test_manager_create_is_single_flight_under_rapid_double_submit():
 async def test_older_catalog_load_cannot_overwrite_completed_mutation():
     app = _CatalogMutationRaceHost()
     async with app.run_test(size=(80, 24)) as pilot:
-        await app.load_started.wait()
+        await wait_for_signal(app.load_started, what="the modal's on-mount catalog load")
         modal = app.screen
         await modal._run_mutation("create", None, "Created authoritative")
         await pilot.pause()

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -16,6 +16,7 @@ import pytest
 from textual.app import App
 from textual.widgets import Button, Checkbox, Input, ListView, Select, Static, TextArea
 
+from Tests.UI.background_signals import wait_for_background_signal
 import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
 import tldw_chatbook.UI.Persona_Modules.personas_conversations_controller as conversations_controller_module
 import tldw_chatbook.UI.Screens.chat_screen as chat_screen_module
@@ -4901,7 +4902,9 @@ class TestServerCharacterSourceIsolation:
             switch = asyncio.create_task(
                 screen.handle_runtime_backend_changed("server")
             )
-            await started.wait()
+            await wait_for_background_signal(
+                started, switch, what="the runtime-backend switch"
+            )
             await pilot.pause()
 
             assert screen._characters == []
@@ -5243,7 +5246,9 @@ class TestServerCharacterSourceIsolation:
         screen._display_character_page = display
 
         load = asyncio.create_task(screen._reload_character_page())
-        await started.wait()
+        await wait_for_background_signal(
+            started, load, what="the character page reload"
+        )
         screen.state.runtime_source = "server"
         release.set()
         await load
@@ -5276,7 +5281,9 @@ class TestServerCharacterSourceIsolation:
         screen._notify = notify
 
         load = asyncio.create_task(screen._reload_character_page())
-        await started.wait()
+        await wait_for_background_signal(
+            started, load, what="the character page reload"
+        )
         await screen.handle_runtime_backend_changed("server")
         assert screen._characters == []
         assert screen._character_total == 0
@@ -5324,7 +5331,9 @@ class TestServerCharacterSourceIsolation:
         screen._display_character_page = display
 
         stale = asyncio.create_task(screen._reload_character_page())
-        await started.wait()
+        await wait_for_background_signal(
+            started, stale, what="the stale character page reload"
+        )
         screen.state.page_offset = 50
         await screen._reload_character_page()
         assert screen._characters == [{"id": 50, "name": "Newer offset winner"}]
@@ -5372,7 +5381,9 @@ class TestServerCharacterSourceIsolation:
         )
 
         older_x = asyncio.create_task(screen._reload_character_page())
-        await started.wait()
+        await wait_for_background_signal(
+            started, older_x, what="the older character page reload"
+        )
         screen.state.search_query = "y"
         await screen._reload_character_page()
         screen.state.search_query = ""
@@ -5429,7 +5440,9 @@ class TestServerCharacterSourceIsolation:
             screen.state.tag_filter = "older-tag"
 
             stale = asyncio.create_task(screen._reload_character_page())
-            await stale_render_started.wait()
+            await wait_for_background_signal(
+                stale_render_started, stale, what="the stale character page render"
+            )
 
             screen.state.sort_key = "name_asc"
             screen.state.tag_filter = None
@@ -5567,10 +5580,14 @@ class TestServerCharacterSourceIsolation:
             screen.state.tag_filter = "older-tag"
 
             stale = asyncio.create_task(screen._reload_character_page())
-            await stale_render_started.wait()
+            await wait_for_background_signal(
+                stale_render_started, stale, what="the stale character page render"
+            )
 
             newer_mode = asyncio.create_task(screen._apply_mode(new_mode))
-            await mode_render_started.wait()
+            await wait_for_background_signal(
+                mode_render_started, newer_mode, what="the newer mode render"
+            )
             await pilot.pause()
 
             release_stale_render.set()
@@ -5669,10 +5686,16 @@ class TestServerCharacterSourceIsolation:
             stale_character = asyncio.create_task(
                 screen._reload_character_page()
             )
-            await character_writer_entered.wait()
+            await wait_for_background_signal(
+                character_writer_entered,
+                stale_character,
+                what="the stale character page reload",
+            )
 
             newer_mode = asyncio.create_task(screen._apply_mode(new_mode))
-            await mode_render_started.wait()
+            await wait_for_background_signal(
+                mode_render_started, newer_mode, what="the newer mode render"
+            )
             await pilot.pause()
 
             release_character_writer.set()
@@ -5782,15 +5805,25 @@ class TestServerCharacterSourceIsolation:
             stale_character = asyncio.create_task(
                 screen._reload_character_page()
             )
-            await initial_character_published.wait()
+            await wait_for_background_signal(
+                initial_character_published,
+                stale_character,
+                what="the initial character publication",
+            )
 
             screen.state.tag_filter = None
             await screen._reload_character_page()
             release_initial_character.set()
-            await cleanup_writer_entered.wait()
+            await wait_for_background_signal(
+                cleanup_writer_entered,
+                stale_character,
+                what="the stale reload's cleanup writer",
+            )
 
             newer_mode = asyncio.create_task(screen._apply_mode(new_mode))
-            await mode_render_started.wait()
+            await wait_for_background_signal(
+                mode_render_started, newer_mode, what="the newer mode render"
+            )
             await pilot.pause()
 
             release_cleanup_writer.set()
@@ -5901,7 +5934,9 @@ class TestServerCharacterSourceIsolation:
             )
 
             stale_fetch = asyncio.create_task(screen._apply_mode(source_mode))
-            await fetch_started.wait()
+            await wait_for_background_signal(
+                fetch_started, stale_fetch, what="the stale shared-mode fetch"
+            )
 
             library = screen.query_one("#personas-library-pane")
             if owner_change == "query":
@@ -6038,7 +6073,9 @@ class TestServerCharacterSourceIsolation:
             )
 
             older_x_request = asyncio.create_task(render(query="x"))
-            await fetch_started.wait()
+            await wait_for_background_signal(
+                fetch_started, older_x_request, what="the older render request"
+            )
 
             screen.state.search_query = "y"
             await render(query="y")
@@ -6141,7 +6178,9 @@ class TestServerCharacterSourceIsolation:
             )
 
             older_request = asyncio.create_task(render())
-            await fetch_started.wait()
+            await wait_for_background_signal(
+                fetch_started, older_request, what="the older render request"
+            )
 
             await screen._apply_mode("prompts")
             await screen._apply_mode(source_mode)
@@ -6254,7 +6293,9 @@ class TestServerCharacterSourceIsolation:
             )
             generation_before = screen._dictionary_lore_request_generation
             valid_request = asyncio.create_task(valid_render(query="owner"))
-            await fetch_started.wait()
+            await wait_for_background_signal(
+                fetch_started, valid_request, what="the valid render request"
+            )
             accepted_generation = screen._dictionary_lore_request_generation
 
             if stale_callback == "wrong-mode":
@@ -6367,7 +6408,9 @@ class TestServerCharacterSourceIsolation:
         screen._notify = notify
 
         older_x = asyncio.create_task(screen._reload_server_character_page())
-        await started.wait()
+        await wait_for_background_signal(
+            started, older_x, what="the older server character page load"
+        )
         mock_app_instance.active_server_id = "target-y"
         await screen._reload_server_character_page()
         mock_app_instance.active_server_id = "target-x"
@@ -6410,7 +6453,9 @@ class TestServerCharacterSourceIsolation:
         screen._character_total = 1
 
         load = asyncio.create_task(screen._reload_server_character_page())
-        await started.wait()
+        await wait_for_background_signal(
+            started, load, what="the server character page load"
+        )
         if changed_dimension == "source":
             screen.state.runtime_source = "local"
         elif changed_dimension == "target":
@@ -6460,7 +6505,9 @@ class TestServerCharacterSourceIsolation:
         screen._character_total = 1
 
         load_a = asyncio.create_task(screen._reload_server_character_page())
-        await started_a.wait()
+        await wait_for_background_signal(
+            started_a, load_a, what="the target-A server character page load"
+        )
         mock_app_instance.active_server_id = "target-b"
         await screen._reload_server_character_page()
         assert screen._characters == [{"id": 2, "name": "Target B"}]
@@ -10593,7 +10640,9 @@ async def test_character_tts_server_principal_change_rejects_late_population(
                 "server",
             )
         )
-        await started.wait()
+        await wait_for_background_signal(
+            started, task, what="the character TTS refresh worker"
+        )
         if final_authority_check == "error":
             provider.raise_on_check = True
         else:

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -2384,7 +2384,12 @@ def test_action_show_workbench_help_includes_landing_footer_keys(monkeypatch):
     assert "n" in keys
     assert "F6" in keys
     # Minor #2 (same review): the title must not leak the raw class name.
-    assert panel.state.title == "Library Shortcuts"
+    # task-4023 (dev) then added a mode suffix for F1 honesty, so the title
+    # is "Library Shortcuts — Landing" here. The claim under test is the
+    # original one -- no raw class name -- so assert THAT rather than an
+    # exact string that a later honest change breaks again.
+    assert panel.state.title.startswith("Library Shortcuts")
+    assert "LibraryScreen" not in panel.state.title
 
 
 def test_action_library_media_viewer_back_returns_to_list_and_refocuses_it():

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -1105,93 +1105,16 @@ async def test_navigation_keypress_during_splash_is_safely_ignored():
 from Tests.UI.app_factory import _build_test_app  # noqa: F401,E402
 
 
-# task-3316: several tests below drive a screen/app coroutine as a background
-# `asyncio.create_task` and then wait on an `asyncio.Event` that only that
-# coroutine can set. A bare `await event.wait()` is UNBOUNDED, so any product
-# change that makes the coroutine return early -- or raise, which a
-# fire-and-forget task swallows silently -- turns the test into a permanent
-# hang. Under this repo's `timeout_method = thread` a hung test cannot be
-# cancelled: pytest-timeout dumps stacks and kills the ENTIRE pytest process,
-# so every test after it in the file is silently never run (the task-1466
-# lesson class). Bound the wait at its source and surface the background
-# task's real failure instead.
-_BACKGROUND_SIGNAL_TIMEOUT_SECONDS = 10.0
-
-
-async def _wait_for_background_signal(
-    signal: asyncio.Event,
-    task: asyncio.Task,
-    *,
-    what: str,
-    timeout: float = _BACKGROUND_SIGNAL_TIMEOUT_SECONDS,
-) -> None:
-    """Await ``signal``, bounded, reporting why ``task`` never set it.
-
-    Returns as soon as ``signal`` is set. If ``task`` finishes first the
-    signal can never arrive, so its exception is re-raised (or its silent
-    early return reported) rather than waited on forever.
-
-    Args:
-        signal: Event the background task is expected to set.
-        task: The background task that owns the signal.
-        what: Human-readable description used in failure messages.
-        timeout: Seconds to wait before failing the test.
-
-    Raises:
-        AssertionError: If the task returned without signalling, or neither
-            the signal nor the task settled within ``timeout``.
-    """
-    waiter = asyncio.ensure_future(signal.wait())
-    try:
-        await asyncio.wait(
-            {waiter, task},
-            timeout=timeout,
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-    finally:
-        if not waiter.done():
-            waiter.cancel()
-    if signal.is_set():
-        return
-    if task.done():
-        # Re-raises whatever the fire-and-forget task swallowed; a task that
-        # raised or returned early can never set the signal.
-        task.result()
-        raise AssertionError(
-            f"{what} finished without signalling -- the awaited path returned "
-            "early instead of reaching the signalling step"
-        )
-    raise AssertionError(
-        f"timed out after {timeout}s waiting for {what}; the task is still "
-        "running and the signal was never set"
-    )
-
-
-async def _await_background_task(
-    task: asyncio.Task,
-    *,
-    what: str,
-    timeout: float = _BACKGROUND_SIGNAL_TIMEOUT_SECONDS,
-):
-    """Await a background task with a bound so a stall fails instead of hangs.
-
-    Args:
-        task: The background task to await.
-        what: Human-readable description used in the failure message.
-        timeout: Seconds to wait before cancelling and failing.
-
-    Returns:
-        The task's result.
-
-    Raises:
-        AssertionError: If the task does not finish within ``timeout``.
-    """
-    try:
-        return await asyncio.wait_for(task, timeout=timeout)
-    except asyncio.TimeoutError:
-        raise AssertionError(
-            f"timed out after {timeout}s awaiting {what}"
-        ) from None
+# task-3316 introduced `_wait_for_background_signal` / `_await_background_task`
+# here; task-14912 moved them to Tests/UI/background_signals.py so every UI test
+# gets the bound by default rather than only this file. Read that module's
+# header for the incident and the rules. Re-exported under the original private
+# names so in-flight branches that import them from this module keep working.
+from Tests.UI.background_signals import (  # noqa: E402
+    BACKGROUND_SIGNAL_TIMEOUT_SECONDS as _BACKGROUND_SIGNAL_TIMEOUT_SECONDS,  # noqa: F401
+    await_background_task as _await_background_task,  # noqa: F401
+    wait_for_background_signal as _wait_for_background_signal,  # noqa: F401
+)
 
 
 def test_local_watchlists_service_db_factory_resolves_the_same_path_as_the_eager_subscriptions_db():

--- a/Tests/UI/test_speech_playground_pane.py
+++ b/Tests/UI/test_speech_playground_pane.py
@@ -12,6 +12,7 @@ from textual.screen import Screen
 from textual.widgets import Button, Collapsible, Input, Select, Static
 
 from Tests.UI.app_factory import _build_test_app
+from Tests.UI.background_signals import wait_for_signal
 from Tests.UI.speech_playground_fixtures import (
     FakeTTSService,
     _native_profile_artifact,
@@ -790,7 +791,9 @@ async def test_auto_play_new_result_cancels_prior_start_worker_before_takeover(
         pane = app.query_one(SpeechPlaygroundPane)
         pane._store_delivered_artifact(old_artifact, announce=False)
         pane._play_audio()
-        await player.first_get_state_started.wait()
+        await wait_for_signal(
+            player.first_get_state_started, what="the first playback get_state"
+        )
 
         pane._generation_complete(new_artifact)
         await _wait_until(pilot, lambda: player.played == [new_path])
@@ -872,7 +875,9 @@ async def test_profile_navigation_fences_result_waiting_for_playback_stop(
         )
 
         pane._generation_complete(new_artifact)
-        await player.replacement_stop_started.wait()
+        await wait_for_signal(
+            player.replacement_stop_started, what="the replacement playback stop"
+        )
         pane.apply_profile_preset(_profile_preset(model_id="new-profile-model"))
         player.release_replacement_stop.set()
         await app.workers.wait_for_complete()
@@ -957,7 +962,9 @@ async def test_play_is_blocked_while_new_result_waits_for_playback_stop(
         )
 
         pane._generation_complete(new_artifact)
-        await player.replacement_stop_started.wait()
+        await wait_for_signal(
+            player.replacement_stop_started, what="the replacement playback stop"
+        )
         try:
             play = app.query_one("#audio-play-btn", Button)
             stop = app.query_one("#stop-audio-btn", Button)
@@ -1199,10 +1206,12 @@ async def test_cancelled_old_catalog_worker_cannot_clear_new_checking_state(
         monkeypatch.setattr(faked_service, "get_catalog", get_catalog)
 
         pane._load_provider_catalog("audio_cpp", refresh=True)
-        await first_started.wait()
+        await wait_for_signal(first_started, what="the first catalog worker starting")
         pane._load_provider_catalog("audio_cpp", refresh=True)
-        await first_cancelled.wait()
-        await second_started.wait()
+        await wait_for_signal(
+            first_cancelled, what="the first catalog worker's cancellation"
+        )
+        await wait_for_signal(second_started, what="the second catalog worker starting")
 
         assert "audio_cpp" in pane._catalog_checking_providers
 

--- a/Tests/UI/test_speech_playground_pane_lifecycle.py
+++ b/Tests/UI/test_speech_playground_pane_lifecycle.py
@@ -55,6 +55,7 @@ from textual.widgets import (
     TextArea,
 )
 
+from Tests.UI.background_signals import wait_for_signal
 from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
     STTSEventHandler,
     STTSPlaygroundGenerateEvent,
@@ -2027,7 +2028,7 @@ async def test_catalog_result_is_discarded_when_configuration_revision_changes(
     app = _PaneHost()
 
     async with app.run_test(size=(180, 70)) as pilot:
-        await service.catalog_started.wait()
+        await wait_for_signal(service.catalog_started, what="the catalog worker start")
         service.revisions["audio_cpp"] = 2
         service.allow_catalog.set()
         await app.workers.wait_for_complete()
@@ -2051,7 +2052,7 @@ async def test_exact_profile_revision_invalidated_catalog_projects_but_stays_blo
     app = _PaneHost(preset=_profile_preset())
 
     async with app.run_test(size=(180, 70)) as pilot:
-        await service.catalog_started.wait()
+        await wait_for_signal(service.catalog_started, what="the catalog worker start")
         service.revisions["audio_cpp"] = 2
         service.allow_catalog.set()
         await app.workers.wait_for_complete()
@@ -2118,7 +2119,7 @@ async def test_superseded_catalog_failure_cannot_overwrite_newer_success(
         monkeypatch.setattr(service, "get_catalog", get_catalog)
 
         pane._load_provider_catalog("audio_cpp", refresh=True)
-        await first_started.wait()
+        await wait_for_signal(first_started, what="the first catalog worker start")
         pane._load_provider_catalog("audio_cpp", refresh=True)
         await _wait_until(
             pilot,
@@ -2181,7 +2182,7 @@ async def test_superseded_catalog_success_cannot_invalidate_newer_success(
         monkeypatch.setattr(service, "get_catalog", get_catalog)
 
         pane._load_provider_catalog("audio_cpp", refresh=True)
-        await first_started.wait()
+        await wait_for_signal(first_started, what="the first catalog worker start")
         pane._load_provider_catalog("audio_cpp", refresh=True)
         await _wait_until(
             pilot,
@@ -2254,7 +2255,7 @@ async def test_superseded_same_model_voice_result_cannot_overwrite_newer_success
             catalog_revision,
             refresh=True,
         )
-        await first_started.wait()
+        await wait_for_signal(first_started, what="the first voice worker start")
         pane._load_provider_voices(
             "audio_cpp",
             model_id,
@@ -2329,14 +2330,17 @@ async def test_catalog_generation_is_reserved_before_exclusive_worker_cancellati
         monkeypatch.setattr(service, "get_catalog", get_catalog)
 
         pane._load_provider_catalog("audio_cpp", refresh=True)
-        await first_started.wait()
+        await wait_for_signal(first_started, what="the first catalog worker start")
         first_generation = pane._catalog_request_generations["audio_cpp"]
 
         pane._load_provider_catalog("audio_cpp", refresh=True)
 
         assert pane._catalog_request_generations["audio_cpp"] == (first_generation + 1)
-        await first_returned_on_cancel.wait()
-        await second_started.wait()
+        await wait_for_signal(
+            first_returned_on_cancel,
+            what="the cancelled first catalog worker returning",
+        )
+        await wait_for_signal(second_started, what="the second catalog worker start")
         await pilot.pause()
         assert pane._catalogs["audio_cpp"] is baseline_catalog
 
@@ -2395,7 +2399,7 @@ async def test_voice_generation_is_reserved_before_exclusive_worker_cancellation
             catalog_revision,
             refresh=True,
         )
-        await first_started.wait()
+        await wait_for_signal(first_started, what="the first voice worker start")
         first_generation = pane._voice_request_generations[request_key]
 
         pane._load_provider_voices(
@@ -2406,8 +2410,11 @@ async def test_voice_generation_is_reserved_before_exclusive_worker_cancellation
         )
 
         assert pane._voice_request_generations[request_key] == first_generation + 1
-        await first_returned_on_cancel.wait()
-        await second_started.wait()
+        await wait_for_signal(
+            first_returned_on_cancel,
+            what="the cancelled first voice worker returning",
+        )
+        await wait_for_signal(second_started, what="the second voice worker start")
         await pilot.pause()
         assert pane._discovered_voices[request_key] == baseline_voices
 
@@ -2431,7 +2438,7 @@ async def test_voice_discovery_does_not_cancel_inflight_catalog_refresh(
         pane = app.query_one(SpeechPlaygroundPane)
 
         pane._load_provider_catalog("audio_cpp", refresh=True)
-        await service.catalog_started.wait()
+        await wait_for_signal(service.catalog_started, what="the catalog worker start")
         app.query_one("#tts-model-select", Select).value = "second-model"
         await _wait_until(
             pilot,
@@ -2473,7 +2480,7 @@ async def test_catalog_revision_invalidates_old_voices_before_rediscovery(
         pane = app.query_one(SpeechPlaygroundPane)
         notices_before = list(app.notices)
         pane._load_provider_catalog("audio_cpp", refresh=True)
-        await service.voice_started.wait()
+        await wait_for_signal(service.voice_started, what="the voice worker start")
         await pilot.pause()
 
         assert _option_values(voice_select) == (
@@ -2523,7 +2530,7 @@ async def test_catalog_revision_preserves_exact_voice_removed_by_refresh(
         notices_before = list(app.notices)
         pane = app.query_one(SpeechPlaygroundPane)
         pane._load_provider_catalog("audio_cpp", refresh=True)
-        await service.voice_started.wait()
+        await wait_for_signal(service.voice_started, what="the voice worker start")
         await pilot.pause()
 
         assert app.notices == notices_before
@@ -3635,7 +3642,7 @@ async def test_exact_profile_cannot_generate_while_voice_validation_is_pending(
     app = _PaneHost(preset=preset)
 
     async with app.run_test(size=(180, 70)) as pilot:
-        await service.voice_started.wait()
+        await wait_for_signal(service.voice_started, what="the voice worker start")
         await pilot.pause()
         pane = app.query_one(SpeechPlaygroundPane)
 
@@ -4180,7 +4187,7 @@ async def test_provider_edit_during_initial_profile_catalog_load_ends_preset(
     app = _PaneHost(preset=_profile_preset())
 
     async with app.run_test(size=(180, 70)) as pilot:
-        await service.catalog_started.wait()
+        await wait_for_signal(service.catalog_started, what="the catalog worker start")
         pane = app.query_one(SpeechPlaygroundPane)
         provider = app.query_one("#tts-provider-select", Select)
         assert pane._profile_controls_applied is True

--- a/Tests/integration/test_library_ingest_flow.py
+++ b/Tests/integration/test_library_ingest_flow.py
@@ -611,10 +611,13 @@ async def test_forecast_counts_equal_the_real_receipt_for_a_server_submission(
     (:class:`_RecordingIngestTransport`) -- see its docstring for exactly
     what that means the assertions do and do not prove.
 
-    Deliberately holds no 0-byte file: the forecast counts one as a
-    failure, but on this backend the app SENDS it and only the server
-    decides, which this process cannot know and this test must not
-    invent.
+    (task-14910) It now DOES hold a 0-byte file. It deliberately held
+    none while the app sent one: the forecast counted it as a failure, but
+    the outcome belonged to a server this process cannot inspect, so any
+    assertion here would have been the stub deciding. The client refuses a
+    0-byte file itself now -- ``empty.txt`` below never reaches
+    ``transport.submitted``, and its fate is decided entirely by code this
+    test runs for real.
     """
     from tldw_chatbook.Library.ingest_capabilities import (
         get_capabilities,
@@ -654,6 +657,10 @@ async def test_forecast_counts_equal_the_real_receipt_for_a_server_submission(
     (folder / "talk.mp3").write_bytes(b"ID3 not really an mp3")
     (folder / "diagram.png").write_bytes(b"\x89PNG not really a png")
     (folder / "weird.xyz").write_bytes(b"no handler for this")
+    # (task-14910) A perfectly well-mapped type (.txt -> document) with
+    # nothing in it: the one file whose server-side fate used to be
+    # unknowable from here.
+    (folder / "empty.txt").write_text("")
 
     preflight = analyze_path(str(folder))
     forecast = build_ingest_forecast(preflight, targets_server=True)
@@ -686,7 +693,7 @@ async def test_forecast_counts_equal_the_real_receipt_for_a_server_submission(
         async with app.run_test() as pilot:
             assert app._resolve_ingest_backend() == "server"
             app.submit_library_ingest_job(source_path=str(folder))
-            assert len(app.library_ingest_jobs.jobs()) == 5
+            assert len(app.library_ingest_jobs.jobs()) == 6
 
             terminal = {
                 IngestJobState.DONE,
@@ -735,7 +742,11 @@ async def test_forecast_counts_equal_the_real_receipt_for_a_server_submission(
                 name
                 for name, job in outcomes.items()
                 if job.state is IngestJobState.FAILED
-            } == {"diagram.png", "weird.xyz"}
+            } == {"diagram.png", "weird.xyz", "empty.txt"}
+            # (task-14910) ...and the 0-byte one failed HERE, without the
+            # transport being consulted: the stub decides nothing about it.
+            assert "empty" in (outcomes["empty.txt"].error or "")
+            assert outcomes["empty.txt"].permanent is True
             # ...and the ones it promised to SEND really reached the wire,
             # under the media types the server accepts.
             assert {
@@ -748,8 +759,116 @@ async def test_forecast_counts_equal_the_real_receipt_for_a_server_submission(
             }
             # ...and the sentence that carried those numbers to the user.
             assert commit_line == (
-                "3 will be sent to the server · 2 will fail (unsupported by "
-                "the server) · server tooling isn't checked from here"
+                "3 will be sent to the server · 3 will fail (2 unsupported "
+                "by the server, 1 empty) · server tooling isn't checked "
+                "from here"
             ), commit_line
     finally:
         db.close_connection()
+
+
+# --- task-14911: the gate must ask the backend the run is aimed at ----------
+
+
+@pytest.mark.asyncio
+async def test_server_mode_start_creates_no_job_for_a_selection_the_server_refuses(
+    library_screen, tmp_path
+):
+    """(task-14911 AC#1) The server counterpart of
+    ``test_empty_folder_creates_no_job_at_all``.
+
+    A folder of nothing but images imports fine on this machine and has no
+    server media type at all (task-3307). Aimed at the server it forecast
+    "0 will be sent to the server · 2 will fail (unsupported by the
+    server)" while Start stayed ENABLED, and pressing it queued two rows
+    that could only ever land as permanent failures -- the guaranteed
+    failure submit task-14823 gated on the local path.
+
+    Driven through the REAL pre-flight and the REAL submit seam, and the
+    assertion is the registry's own contents: gating the button alone
+    would leave Enter in the path field (and every other caller) free to
+    manufacture the receipt.
+    """
+    screen, pilot = library_screen
+    folder = tmp_path / "shots"
+    folder.mkdir()
+    (folder / "one.png").write_bytes(b"\x89PNG not really a png")
+    (folder / "two.png").write_bytes(b"\x89PNG not really a png either")
+
+    app = screen.app_instance
+    app.runtime_policy = SimpleNamespace(
+        state=SimpleNamespace(active_source="server", server_configured=True)
+    )
+    app.server_media_reading_service = SimpleNamespace(
+        submit_ingest_jobs=lambda **kwargs: None
+    )
+    app._resolve_ingest_backend = lambda: "server"
+    screen._server_binding_is_shipped_placeholder = lambda: False
+    # Every OTHER gate open, so a closed Start can only mean this one: the
+    # harness leaves ``media_db`` unset, which closes it for an unrelated
+    # reason and would make this test pass vacuously.
+    app.media_db = SimpleNamespace()
+    app._top_up_ingest_parse_pool = lambda: None
+
+    form = screen._library_ingest_form
+    form.path = str(folder)
+    screen._trigger_preflight(str(folder))
+    await screen.app.workers.wait_for_complete()
+    await pilot.pause()
+
+    state = screen._build_library_ingest_state()
+    assert state.ingest_backend == "server"
+    assert state.forecast is not None
+    assert state.forecast.will_import == 0
+    assert state.start_enabled is False
+    assert state.selection_has_nothing_importable is True
+    assert "unsupported by the server" in state.start_quiet_line
+
+    screen._submit_library_ingest_form()
+    await pilot.pause()
+    await pilot.pause()
+
+    assert screen.app_instance.library_ingest_jobs.jobs() == (), (
+        "a submit the server was certain to refuse reached the queue"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_same_folder_still_imports_on_this_machine(
+    library_screen, tmp_path
+):
+    """(task-14911 AC#2) Guard, through the same real pre-flight: the gate
+    is a fact about the TARGET, not about the files. Locally these images
+    are ordinary import candidates, so Start stays live and the submit
+    reaches the queue."""
+    screen, pilot = library_screen
+    folder = tmp_path / "shots-local"
+    folder.mkdir()
+    (folder / "one.png").write_bytes(b"\x89PNG not really a png")
+
+    app = screen.app_instance
+    app.media_db = SimpleNamespace()
+    app._top_up_ingest_parse_pool = lambda: None
+
+    form = screen._library_ingest_form
+    form.path = str(folder)
+    screen._trigger_preflight(str(folder))
+    await screen.app.workers.wait_for_complete()
+    await pilot.pause()
+
+    state = screen._build_library_ingest_state()
+    assert state.ingest_backend == "local"
+    assert state.start_enabled is True
+    assert state.selection_has_nothing_importable is False
+
+    # The local press takes the CONSENT route (this venv has no OCR
+    # backend, so the image import is at risk) -- not the refusal route.
+    screen._submit_library_ingest_form()
+    await pilot.pause()
+    assert screen._library_ingest_start_confirm_armed is True
+    screen._library_ingest_start_confirm_armed_at -= 1.0
+    screen._submit_library_ingest_form()
+    await pilot.pause()
+    await pilot.pause()
+
+    assert len(screen.app_instance.library_ingest_jobs.jobs()) == 1

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -595,7 +595,58 @@ bound the loop at the *source* (here: the mocked `stream.read` flips the stop fl
 after N reads) so no gating change can make it unbounded. When a test's behavior
 depends on an optional dependency, run it in both installed and absent
 configurations before trusting green. And treat "the run died at N%" as possibly
-ONE test: the timeout stack dump names it.
+ONE test: the timeout stack dump names it — **except when the hang is an awaited
+asyncio primitive; see the next entry.**
+
+---
+
+## The timeout stack dump does NOT name the hung test when the hang is an awaited Event
+
+**TASK-3316 / TASK-14912, 2026-08-10.**
+`test_file_notes_collections_source_transition_blocks_mutation_through_recompose`
+drove `_select_library_rail_row` as a fire-and-forget `asyncio.create_task` and
+then `await`ed an `asyncio.Event` only that coroutine could set. Its stub returned
+`None` — correct when written (`eb036a6a1`) — until PR #1439 retyped
+`_flush_library_note_save` to return `NoteFlushOutcome`; the caller then died one
+line in on `AttributeError: 'NoneType' object has no attribute 'kind'`. **Nobody
+retrieves a `create_task` result, so the exception was swallowed**, the signal
+became unreachable, and `await event.wait()` blocked forever.
+
+Two things this cost, beyond the one test:
+
+1. **The stack dump was useless.** TASK-1466's advice above does not hold here: a
+   coroutine suspended at an `await` has no frames on any thread stack, so
+   pytest-timeout printed only `MainThread` idle in `selectors.select` and never
+   named the test. Diagnosis required inspecting the *task object*
+   (`task.done()` / `task.exception()`), not the dump. Reproduced deliberately
+   while writing the bound: 25s timeout, stacks dumped, process terminated,
+   **zero** tests reported in the summary line.
+2. **Every test after it in the file silently never ran**, so the file's pass
+   count was a lie for as long as the hang existed. Repairing that one test
+   revealed three further failures the hang had been hiding.
+
+**What to do.** Never `await <event>.wait()` on a signal only background work can
+set. Route it through `Tests/UI/background_signals.py`:
+`wait_for_background_signal(event, task, what=...)` when the test owns the task
+(it re-raises what the task swallowed), or `wait_for_signal(event, what=...)` when
+the product owns the work (timeout-only, but a named failure in seconds instead of
+a dead process). `Tests/UI/test_background_signal_bounds.py` enforces this by AST
+over the whole directory — grep cannot, because it cannot tell an unbounded
+`await ev.wait()` from one already inside `asyncio.wait_for`, nor an
+`asyncio.Event` from a Textual `Worker`/retained-operation handle whose `.wait()`
+re-raises and therefore cannot strand.
+
+Two corollaries worth carrying:
+
+* **A file that has ever contained a hang has an UNKNOWN pass count** until it is
+  re-run whole. A previously recorded count for such a file is not evidence.
+* **In practice the re-raise branch fires less often than you would expect.** Of
+  four sites broken deliberately with the stale-stub shape, only one propagated;
+  the other three product paths caught the `AttributeError` internally, logged it,
+  and returned early — so the bound reported "finished without signalling" rather
+  than the exception. That is still a 1-3s named failure instead of a dead run,
+  but it means the helper's early-return branch is not a corner case: do not drop
+  it in favour of "just re-raise".
 
 ---
 
@@ -2120,6 +2171,19 @@ Anything the stub would have to invent is a fixture you must leave out and name:
 this fixture holds no 0-byte file, because the app sends one and only the server
 decides.
 
+**The follow-through (TASK-14910, 2026-08-11).** That last sentence turned out to
+be the finding, not the caveat. A fixture you cannot write because the outcome is
+unknowable is usually pointing at a CLAIM the product should not be making: the
+same forecast counted that 0-byte file as a certain failure while admitting, one
+segment later, that "server tooling isn't checked from here". The fix was not a
+cleverer stub — it was to make the outcome knowable, by refusing to send a 0-byte
+file at all (the client already knows why, the local backend already refuses one,
+and the round trip buys nothing). The fixture then grew to hold `empty.txt`, whose
+fate is now decided entirely by code the test runs for real; the stub never sees
+it. So: when a governance test has to leave a case out, name it AND file it — the
+gap is evidence about the product, and the honest close is usually to remove the
+unknowability rather than to keep the fixture short forever.
+
 ---
 
 ## An `await event.wait()` on a fire-and-forget task hangs on the task's OWN exception — and the timeout dump names nothing (2026-08-10, TASK-3316/TASK-14913)
@@ -2250,3 +2314,30 @@ docstring can assert a stale number while never naming the constant that used
 to produce it — that is exactly what lets it survive a symbol-only grep, and
 exactly why an inline-literal arrow chain needs a human reading the prose, not
 a tool, to catch on the first pass.
+## A gate with several conditions can close for the WRONG one — open the others or the test pins nothing (TASK-14911, 2026-08-11)
+
+**Incident.** `start_enabled` on the Library ingest canvas is a conjunction:
+registry present AND media DB present AND a non-blank path AND nothing-importable
+false AND no option errors AND no path error. The new test staged a folder of
+images in server mode and asserted `state.start_enabled is False` — the defect
+being that it was `True`. The first run of that test, written BEFORE the fix,
+reported the gate already closed. Not because the gate worked: the shared screen
+harness (`Tests/UI/app_factory.py`) leaves `media_db = None`, so a *different*
+conjunct was False the whole time. Had the test asserted only `start_enabled`, it
+would have passed against the unfixed code, pinned nothing, and stayed green
+forever after someone later broke the backend-aware gate.
+
+It was caught only because the same test also asserted the specific flag the fix
+introduces (`selection_has_nothing_importable`) and the gate line's own wording —
+those two went red while the boolean did not.
+
+**What to do.** For any multi-condition gate:
+
+1. In the fixture, explicitly OPEN every condition except the one under test
+   (`app.media_db = SimpleNamespace()` here), and say in a comment why — a shared
+   harness's defaults are not neutral.
+2. Assert the REASON, not just the closed state: the flag the fix sets, and the
+   user-visible sentence naming it. A boolean shared by six causes cannot
+   discriminate between them.
+3. Run the test before the fix and READ which assertion fails. "It failed" is not
+   enough when the boolean can fail for free.

--- a/backlog/tasks/task-14910 - Server-mode-ingest-forecast-still-claims-0-byte-files-will-fail-without-knowing.md
+++ b/backlog/tasks/task-14910 - Server-mode-ingest-forecast-still-claims-0-byte-files-will-fail-without-knowing.md
@@ -3,9 +3,11 @@ id: TASK-14910
 title: >-
   Server-mode ingest forecast still claims 0-byte files will fail without
   knowing
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 01:59'
+updated_date: '2026-08-11 03:36'
 labels:
   - library
   - ingest
@@ -26,6 +28,35 @@ So the server forecast makes exactly one claim it has not earned. Either the cli
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A 0-byte file staged for a SERVER import has one outcome the forecast and the receipt agree on
-- [ ] #2 The server governance test in Tests/integration/test_library_ingest_flow.py covers a 0-byte file without any stubbed server behaviour deciding its fate
+- [x] #1 A 0-byte file staged for a SERVER import has one outcome the forecast and the receipt agree on
+- [x] #2 The server governance test in Tests/integration/test_library_ingest_flow.py covers a 0-byte file without any stubbed server behaviour deciding its fate
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Decide between the two honest options on the evidence and record the reasoning in the notes.
+2. Implement the decision in tldw_chatbook/Library/server_ingest_request.py: one helper both the forecast-side predicate (server_ingest_refusal) and the submit-side builder (build_server_ingest_kwargs) consult, so the claim and the enforcement cannot drift.
+3. RED tests first: the refusal predicate, the submit seam raising, the app seam recording the permanent failure with that reason, and the server governance fixture grown to hold a 0-byte file.
+4. Extend Tests/integration/test_library_ingest_flow.py's server governance test with the 0-byte file its docstring deliberately omitted, and rewrite that paragraph to say why it is now knowable.
+5. Update Docs/User_Guide/library/import-and-export.md if the user-visible copy changed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**The decision: refuse locally, keep the count.** Of the two honest options, the client now refuses to send a 0-byte file, which makes the forecast's "will fail" a statement about code this process runs rather than a guess about someone else's machine. Four pieces of evidence, not a preference:
+
+1. *The seam already exists.* `_submit_server_ingest_job` catches `ServerIngestUnsupported` and records an immediately-FAILED permanent row carrying the reason -- that is exactly the receipt the forecast predicts. Adding emptiness to that predicate is one more entry in an existing table, not new machinery. The alternative (stop counting) would have needed a new server-only branch in `build_ingest_forecast` plus new hedge copy, to say less.
+2. *The user is better off.* A 0-byte file is almost certainly a mistake; the refusal is instant and names the file, where a round trip costs an upload and returns whatever a server makes of an empty document (quite possibly a "successful" empty row -- the exact silent-empty-import outcome task-14821 removed locally).
+3. *Backend-independence.* The app now gives one answer to "what happens to a 0-byte file?" whichever target is selected. The local path already refuses one (`EmptySourceIngestError`, category `empty_source`); switching the target no longer switches the semantics.
+4. *It closes the gap the task names, rather than moving it.* Option B would leave the file sent with nothing said about it, which is a smaller lie but still an unstated outcome.
+
+**What changed** -- one new function, `empty_source_refusal` in `Library/server_ingest_request.py`, consulted by BOTH the forecast-side predicate (`server_ingest_refusal`) and the submit-side builder (`build_server_ingest_kwargs`, which raises it as `ServerIngestUnsupported`). A single helper on purpose: a promise and its enforcement stated separately is how this arc's defects have arrived. Emptiness outranks the type mapping in `server_ingest_refusal`, because the pre-flight lifts 0-byte files out of `type_groups` before classifying them -- so a 0-byte .png is counted in `will_fail_empty`, not `will_fail_refused`, and its row must give the empty reason to match. A URL is never called empty (no local size to measure), neither is an unstattable path (mirroring the pre-flight's `_statted_size`, which returns `None` rather than 0 on `OSError`), and neither is a directory -- one can stat at 0 bytes on some filesystems, and "this folder is empty" is a different diagnosis with a different recovery that the Start gate already owns.
+
+**AC#2: the fixture grew.** `test_forecast_counts_equal_the_real_receipt_for_a_server_submission` now stages `empty.txt` -- the file its docstring deliberately omitted -- and asserts it lands FAILED, permanent, with the empty reason, and is absent from `transport.submitted`. That is the honest way to cover it: the stub decides nothing about this file, because the refusal happens before the transport is reached. The docstring paragraph explaining the omission was rewritten to say why it is now knowable.
+
+**RED evidence.** Before the fix the extended governance test failed with `assert (3, 0, 3) == (4, 0, 2)` and the receipt `[..., ('empty.txt', 'done'), ...]` -- the app sent the empty file and the stub reported it done, contradicting the forecast's "1 empty" exactly as described. Mutation-checked both halves: neutering the builder's refusal returns that same failure, neutering the predicate reddens the three unit tests that read it.
+
+Modified: `Library/server_ingest_request.py`, `Library/library_ingest_state.py` (docstrings only -- `will_fail_empty` now records why it is true on both backends; the `staged_total` note's claim that the buckets overlap was stale, since `analyze_path` excludes 0-byte files from `type_groups`), `Tests/Library/test_server_ingest_request.py`, `Tests/App/test_submit_library_ingest_job.py`, `Tests/integration/test_library_ingest_flow.py`, `Docs/User_Guide/library/import-and-export.md`, `backlog/docs/lessons-testing-evidence.md` (the task-14827 entry ended by naming this very omission -- it now records the follow-through: a case a governance test cannot assert is usually a claim the product should not be making).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-14911 - Start-gate-uses-LOCAL-supported-ness-so-a-server-mode-selection-with-nothing-sendable-stays-enabled.md
+++ b/backlog/tasks/task-14911 - Start-gate-uses-LOCAL-supported-ness-so-a-server-mode-selection-with-nothing-sendable-stays-enabled.md
@@ -3,9 +3,11 @@ id: TASK-14911
 title: >-
   Start gate uses LOCAL supported-ness, so a server-mode selection with nothing
   sendable stays enabled
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 02:00'
+updated_date: '2026-08-11 03:52'
 labels:
   - library
   - ingest
@@ -26,7 +28,38 @@ The forecast already carries the answer (will_import == 0 and every staged file 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Pressing Start in server mode on a selection the server will refuse entirely is blocked, with a gate line naming the reason
-- [ ] #2 The same selection in local mode is unaffected, because those files import fine on this machine
-- [ ] #3 The gate reads the existing IngestForecast rather than deriving a second notion of what is importable
+- [x] #1 Pressing Start in server mode on a selection the server will refuse entirely is blocked, with a gate line naming the reason
+- [x] #2 The same selection in local mode is unaffected, because those files import fine on this machine
+- [x] #3 The gate reads the existing IngestForecast rather than deriving a second notion of what is importable
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED first: a state-level test that a server-mode images-only selection leaves Start enabled, and an end-to-end test that pressing Start queues doomed jobs.
+2. Make the gate backend-aware in Library/library_ingest_state.py by READING the existing IngestForecast (will_import == 0, no predicted matches, staged_total > 0) rather than re-deriving supported-ness from type groups.
+3. Give the server case its own sentence and its own recovery, distinct from the local 'nothing can be imported' wording, using the arc's established 'unsupported by the server' vocabulary.
+4. Feed the same selection_has_nothing_importable flag the submit seam already refuses on, so no entry point can route around a disabled button; prove it end to end (no job created).
+5. Mutation-check both halves separately: the state predicate and the submit-seam flag.
+6. Update Docs/User_Guide/library/import-and-export.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The gate now asks the backend the run is aimed at, by reading the forecast that already knows the answer.
+
+**The hole (AC#1).** `nothing_importable` is a LOCAL verdict -- "did the pre-flight find a supported type group" -- so a folder of nothing but images (a real local capability, deliberately left server-unmapped by task-3307) forecast `0 will be sent to the server · 3 will fail (unsupported by the server)` with Start still ENABLED. That is task-14823's guaranteed-failure submit, one backend over, and the RED run said so in those words: *"Start stayed live for a selection the server refuses entirely: '0 will be sent to the server · 3 will fail (unsupported by the server)'"*.
+
+**One computation, not two (AC#3).** A new `nothing_sendable` term reads the existing `IngestForecast`: `targets_server and staged_total > 0 and will_import == 0 and will_match == 0`. Nothing about supported-ness is re-derived, so the gate line and the commit line cannot state different numbers -- the same move task-14820 made for the commit and consent lines. The `will_match` clause preserves the task-2223 ruling: zero imports plus predicted duplicate matches keeps Start enabled, because the duplicate probe is capped best-effort and never a blocker. `will_fail_tooling` cannot reach this predicate, since a server forecast zeroes local tooling gaps (task-14827) -- a missing local extra still arms the two-press consent locally rather than a hard gate, untouched.
+
+**Two vocabularies, kept apart.** Ordered AFTER `nothing_importable` on purpose. A file nothing on this machine can read is diagnosed identically whichever target is selected, and switching to Local would not help it, so that case keeps "Nothing in this selection can be imported — N unsupported files." The new branch is the other case -- files this machine reads fine that this destination will not take -- and gets the arc's established server vocabulary plus its own recovery: "Nothing in this selection can be sent to the server — 3 files unsupported by the server. Switch to importing on this machine, or choose video, audio, document, PDF or e-book files." The recovery clause is appended only when the server's refusal is a blocker; a 0-byte file (task-14910) is refused on both backends, so switching target is not offered for it, and it is named separately ("... — 1 file unsupported by the server and 1 empty file.").
+
+**Both halves of the gate (AC#1 again).** The predicate feeds `start_enabled` AND the existing `selection_has_nothing_importable` flag, which `_submit_library_ingest_form` already refuses on with the gate's own reason -- so no new screen logic was needed and no entry point (Enter in the path field, an accelerator, a future caller) can route around a disabled button. Proven end to end: `test_server_mode_start_creates_no_job_for_a_selection_the_server_refuses` drives the real pre-flight and the real submit seam and asserts the registry holds NO job. Mutation-checked separately: disabling the state predicate reddens 4 unit tests + the integration test; leaving the state gate closed but reverting only the submit-seam flag still queued 2 jobs ("a submit the server was certain to refuse reached the queue"), which is the whole reason the seam-side refusal exists.
+
+**AC#2** is a guard at both levels: the same images-only selection in local mode keeps `start_enabled=True`, an empty gate line, and a submit that takes the CONSENT route (this venv has no OCR backend) rather than the refusal route.
+
+**Process note.** The Implementation Plan was recorded after the RED tests were written rather than before -- the tests and the plan say the same thing, but the order deviated.
+
+Modified: `Library/library_ingest_state.py`, `UI/Screens/library_screen.py` (comment only -- the seam already refuses on the shared flag), `Tests/Library/test_library_ingest_state.py`, `Tests/integration/test_library_ingest_flow.py`, `Docs/User_Guide/library/import-and-export.md`, `backlog/docs/lessons-testing-evidence.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-14912 - Bound-every-await-a-signal-a-background-task-must-set-across-Tests-UI.md
+++ b/backlog/tasks/task-14912 - Bound-every-await-a-signal-a-background-task-must-set-across-Tests-UI.md
@@ -1,15 +1,16 @@
 ---
 id: TASK-14912
-title: >-
-  Bound every "await a signal a background task must set" across Tests/UI
-status: To Do
-assignee: []
+title: Bound every "await a signal a background task must set" across Tests/UI
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 00:30'
+updated_date: '2026-08-11 04:23'
 labels:
   - tests
   - test-infrastructure
-priority: high
 dependencies: []
+priority: high
 ---
 
 ## Description
@@ -29,10 +30,102 @@ Note also the corollary this incident proved: **task-1466's advice that "the tim
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 The `_wait_for_background_signal` / `_await_background_task` helpers live somewhere shared rather than in one test file, so new tests get the bound by default
-- [ ] #2 Every `Tests/UI` site that awaits a signal a `create_task` coroutine must set is bounded, enumerated by a checkable method (AST, not grep) rather than an asserted sweep
-- [ ] #3 A background task whose exception is swallowed surfaces that exception as the test failure, instead of the test hanging
-- [ ] #4 Each file that contained a bounded site has its full pass count read and recorded — a file that has ever contained a hang has an unknown pass count until it is re-run whole
+- [x] #1 The `_wait_for_background_signal` / `_await_background_task` helpers live somewhere shared rather than in one test file, so new tests get the bound by default
+- [x] #2 Every `Tests/UI` site that awaits a signal a `create_task` coroutine must set is bounded, enumerated by a checkable method (AST, not grep) rather than an asserted sweep
+- [x] #3 A background task whose exception is swallowed surfaces that exception as the test failure, instead of the test hanging
+- [x] #4 Each file that contained a bounded site has its full pass count read and recorded — a file that has ever contained a hang has an unknown pass count until it is re-run whole
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read the existing _wait_for_background_signal/_await_background_task in test_screen_navigation.py; find where Tests/UI keeps shared helpers (app_factory.py precedent).
+2. Move the helpers to Tests/UI/background_signals.py, add a timeout-only wait_for_signal for product-owned background work, and re-export the old private names from test_screen_navigation.py.
+3. Enumerate every at-risk site by AST (not grep): unbounded 'await <asyncio.Event>.wait()' that either follows a spawn in the same scope or sits in a module-level test body. Ship the enumerator as a guard test so new tests inherit the bound.
+4. Classify each hit: at-risk (bind) vs structurally safe (Textual Worker handle / retained-operation handle / stub awaiting a release the test sets) and say why.
+5. Bind every at-risk site, file by file, so a hang in one file does not cost the others' results.
+6. Break-and-observe: deliberately break two stubbed seams and show the test fails naming the real exception in seconds rather than hanging.
+7. Mutation-check the shared helper itself (break the re-raise; confirm a bound test stops naming the cause).
+8. Run each touched file WHOLE and record the READ pass count; fix or report any previously-hidden failures.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Moved the task-3316 bound out of one test file and made it the enforced default across
+`Tests/UI`, then bound the 66 sites an AST sweep found.
+
+**Where the helpers live.** `Tests/UI/background_signals.py`, following the
+`Tests/UI/app_factory.py` precedent (task-1458 pulled `_build_test_app` out of this same
+`test_screen_navigation.py` into a purpose-named module imported by 90+ test modules).
+Rejected `Tests/UI/textual_test_helpers.py` -- it is topically right but has **zero
+importers repo-wide**, so parking the bound there would not give new tests anything --
+and `Tests/UI/conftest.py`, whose contents are fixtures, not call-site helpers.
+`test_screen_navigation.py` now imports the shared versions under the original private
+names (`_wait_for_background_signal` / `_await_background_task`), so in-flight branches
+that import them from that module keep working.
+
+A third helper, `wait_for_signal(event, what=...)`, was added for the case the original
+pair did not cover: the coroutine is launched by the *product* (a Textual `run_worker`,
+or a `create_task` inside the app), so the test holds no task handle to inspect. It
+cannot name the underlying exception, but it turns a process-killing hang into a named
+failure in seconds. 31 of the 66 sites are this shape.
+
+**The enumeration (AC#2).** `Tests/UI/test_background_signal_bounds.py` is both the
+checkable method and the guard: it ASTs every module under `Tests/UI` and fails on any
+`await <x>.wait()` where `<x>` resolves to an `asyncio.Event` (matched by full expression
+or by attribute name, so `self.started = asyncio.Event()` catches `service.started.wait()`)
+that is neither wrapped in a bound nor structurally safe. A wait is reported when a
+spawn (`create_task` / `ensure_future` / `run_worker`) precedes it in the same scope, or
+when it sits in a module-level `test_*` body. Deliberately NOT reported, with tests
+pinning each: a stub awaiting a release the test body sets (inverse shape -- the setter
+is the test); a Textual `Worker.wait()` or `RetainedPushOperation.wait()` (both await the
+task and re-raise, so neither can strand); a `test_`-prefixed *method* on a service fake;
+anything already inside `asyncio.wait_for` / `asyncio.timeout` / the shared helpers.
+
+Grep could not have done this: it cannot separate a bounded wait from an unbounded one,
+cannot type the receiver, and cannot see scope. The reported lead counts were also wrong
+in both directions -- `test_library_file_notes_git_push.py`'s 21 bare `.wait()`s are all
+retained-operation handles (safe), while the sweep found two files the lead list never
+mentioned, `test_speech_playground_pane_lifecycle.py` (16) and
+`test_speech_playground_pane.py` (6), both invisible to a `create_task`-only search
+because they use `run_worker`.
+
+**What changed.** 66 sites across 8 files: personas_workbench 21, speech_playground_pane_
+lifecycle 16, console_prompts_modal 11, speech_playground_pane 6, console_native_chat_flow
+4, console_parallel_runs 4, library_prompt_collections 3, library_file_notes_git_push 1.
+35 got the task-aware `wait_for_background_signal`; 31 got `wait_for_signal`.
+
+**Proof (AC#3).** With the bound in place, breaking a stubbed seam the incident's way
+(reading `.kind` off a value that is still `None`) fails
+`test_console_workspace_switch_refresh_is_not_dropped_during_inflight_sync` in **3.1s**
+with the real `AttributeError: 'NoneType' object has no attribute 'kind'`, re-raised
+through `background_signals.py`. The same break with the bound removed hangs: at the
+25s timeout pytest dumped stacks showing only `MainThread` in `selectors.select` -- it
+never named the test -- and terminated the process with zero tests reported. Three more
+sites broken the same way (personas, prompts_modal, prompt_collections) failed in
+0.7-1.3s; in those the product caught the `AttributeError` internally, so the helper's
+"finished without signalling" branch fired instead of the re-raise. Mutation checks:
+disabling `task.result()` makes the naming demo degrade to the generic message; forcing
+`_is_bounding` to `True` reds `test_rule_detects_the_incident_shape`; reverting one bound
+site reds the sweep with that exact line.
+
+**Pass counts, read whole (AC#4).** background_signal_bounds 7/7 (new);
+console_parallel_runs 28/28; library_prompt_collections 47/47; git_push 59/59;
+console_prompts_modal 75/75; speech_playground_pane 51/51;
+speech_playground_pane_lifecycle 123/123; screen_navigation 126/126;
+console_native_chat_flow **291 passed / 18 failed**; personas_workbench **310 passed /
+2 failed**. All 20 failures were reproduced on the pristine HEAD (`eb9708cc4`) copy of
+each file, so none is caused by this change and none was hidden by a hang. They are
+stale-contract breakage from the screen-decomposition work -- e.g.
+`AttributeError: 'ChatScreen' object has no attribute '_ensure_active_console_session_
+settings'` (the seam moved to `ChatScreen._session`) -- reported rather than fixed here,
+since repairing 20 unrelated console/persona contract failures is outside this task's ACs.
+
+**Files:** added `Tests/UI/background_signals.py`,
+`Tests/UI/test_background_signal_bounds.py`; modified `Tests/UI/test_screen_navigation.py`
+(helpers removed, re-exported from the shared module) and the 8 files listed above;
+added a lesson to `backlog/docs/lessons-testing-evidence.md` correcting TASK-1466's
+"the timeout stack dump names it".
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-14920 - Repair-20-stale-contract-failures-in-console-and-personas-UI-suites.md
+++ b/backlog/tasks/task-14920 - Repair-20-stale-contract-failures-in-console-and-personas-UI-suites.md
@@ -1,0 +1,41 @@
+---
+id: TASK-14920
+title: >-
+  Repair 20 stale-contract failures in the console and personas UI suites
+status: To Do
+assignee: []
+created_date: '2026-08-11 02:00'
+labels:
+  - tests
+  - console
+  - personas
+  - dev-baseline
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found by task-14912's sweep, which ran every affected `Tests/UI` file WHOLE for the first time (its AC#4 exists because a file that has ever contained a hang has an unknown pass count). Two files carry failures nobody had counted:
+
+- `Tests/UI/test_console_native_chat_flow.py` — **291 passed / 18 failed**
+- `Tests/UI/test_personas_workbench.py` — **310 passed / 2 failed**
+
+**These are NOT caused by the bounding work and were NOT hidden by a hang.** Every one was reproduced against the pristine `eb9708cc4` copy of each file (`git show HEAD:<path>` into a temp file, run, delete), producing identical failure sets. They are **stale-contract breakage from the screen-decomposition programme**: the tests still call seams that moved.
+
+The dominant shape (14 of the 18) is `AttributeError: 'ChatScreen' object has no attribute '_ensure_active_console_session_settings'` — that seam moved onto `ChatScreen._session` when the session controller was extracted. Others are behavioural: `assert store.identity_at_append is not None`, `assert [] == ['Hello User, I am Elara.']`.
+
+This matters beyond the count. The screen-decomposition programme's own lesson is that *extraction cannot outrun growth* and that a one-way ratchet is what makes a gain stick — but a ratchet measures size, not whether the suites that pin the extracted behaviour still run. Twenty failing tests in the console's main flow suite are twenty behaviours nobody is actually checking, and the longer they sit the more they read as background noise (the "a suite that no gate runs can rot invisibly" lesson, one directory over).
+
+Each failure needs triage before repair: a moved seam is a test fix, but `identity_at_append is None` and an empty greeting list may be real product regressions. Do not mass-rewrite to green.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Each of the 20 failures is classified as stale-contract (test fix) or real regression (product fix), with the evidence that decided it — not repaired wholesale to green
+- [ ] #2 Any classified as a real regression is fixed in the product, or filed separately with its reproduction if it needs owner judgement
+- [ ] #3 Both files run WHOLE with a READ nonzero pass count and zero failures
+- [ ] #4 If the moved-seam shape (`_ensure_active_console_session_settings` and friends) recurs across other suites, the sweep that finds them is checkable rather than asserted
+<!-- AC:END -->

--- a/tldw_chatbook/Library/library_ingest_state.py
+++ b/tldw_chatbook/Library/library_ingest_state.py
@@ -730,16 +730,27 @@ class IngestForecast:
             feature. The pre-flight already warned about that exact
             dependency, so promising these as imports was the defect.
         will_fail_empty: 0-byte files, which fail identically every time.
+            True on BOTH backends because both refuse them in code this
+            process runs: locally the parse chain raises
+            ``EmptySourceIngestError`` before any write, and (task-14910)
+            a server submission refuses one at
+            :func:`~tldw_chatbook.Library.server_ingest_request.empty_source_refusal`
+            rather than sending it and letting a server this process
+            cannot inspect decide -- which is what this count used to
+            quietly assume.
         at_risk: Files that are still forecast to import but whose group
             has an unmet OPTIONAL feature -- degraded, not doomed.
         tooling_groups: The type groups blocked by a missing required
             feature, in pre-flight order.
         staged_total: Every file in the selection, whatever its fate.
-            Carried here rather than re-counted by a caller because the
-            outcome buckets deliberately overlap (``will_fail_empty``
-            files are also inside ``will_import``'s group counts), so a
-            caller summing them would derive a second, wrong total --
-            which is the class of defect this object exists to remove.
+            Carried here rather than re-derived by a caller, because a
+            second computation of the same number is exactly the defect
+            this object exists to remove -- and because which buckets a
+            caller would have to sum is a property of the pre-flight, not
+            of this dataclass (``analyze_path`` lifts 0-byte files OUT of
+            ``type_groups``, so ``will_fail_empty`` is disjoint from the
+            group counts; a pre-flight that did not would silently make a
+            summing caller wrong).
         targets_server: Whether this forecast describes a SERVER run. A
             server import never loads a local parser, so the local tooling
             gaps that drive ``will_fail_tooling``/``at_risk`` say nothing
@@ -929,6 +940,68 @@ def server_local_tooling_advisory(missing_components: int) -> str:
         f"{missing_components} local {noun} {verb} installed — that affects "
         "imports on this machine only; this one runs on the server."
     )
+
+
+#: (task-14911) The Start gate's opening when the TARGETED backend is the
+#: server and it will take nothing in the selection. Deliberately not the
+#: local gate's "Nothing in this selection can be imported": these files
+#: may well import on this machine (an image does), so the sentence names
+#: what is actually true -- they are not going to be *sent*.
+INGEST_SERVER_NOTHING_SENDABLE_PREFIX = (
+    "Nothing in this selection can be sent to the server"
+)
+
+#: (task-14911) ...and the way out. Two of them, neither promised: the
+#: switch this canvas already offers, and the set of types the server
+#: accepts -- which IS knowable here (``SERVER_ACCEPTED_MEDIA_TYPES`` was
+#: established against a live server), unlike its tooling.
+INGEST_SERVER_NOTHING_SENDABLE_RECOVERY = (
+    "Switch to importing on this machine, or choose video, audio, "
+    "document, PDF or e-book files."
+)
+
+
+def server_nothing_sendable_line(forecast: IngestForecast | None) -> str:
+    """Render the Start gate's reason for a wholly server-refused selection.
+
+    (task-14911) Read FROM the forecast, never re-derived: task-14823's
+    gate asked whether the pre-flight had found a supported type group,
+    which is a LOCAL verdict, so a folder of nothing but images forecast
+    "0 will be sent to the server · 3 will fail (unsupported by the
+    server)" with Start still enabled. The gate and the commit line now
+    state the same numbers because there is only one of them.
+
+    Args:
+        forecast: The selection's forecast (``targets_server``).
+
+    Returns:
+        The gate sentence, naming each blocker by kind. The recovery
+        clause is appended only when the server's refusal is one of the
+        blockers -- switching target does nothing for a 0-byte file,
+        which is refused on both.
+    """
+    if forecast is None:
+        return ""
+    parts: list[str] = []
+    refused = forecast.will_fail_refused
+    empty = forecast.will_fail_empty
+    if refused:
+        noun = "file" if refused == 1 else "files"
+        parts.append(f"{refused} {noun} {INGEST_SERVER_REFUSED_COPY}")
+    if empty:
+        noun = "file" if empty == 1 else "files"
+        parts.append(f"{empty} empty {noun}")
+    if not parts:
+        # Defensive: the caller only asks when the forecast sends nothing,
+        # and every staged file is then refused or empty. Say the count
+        # rather than an empty reason.
+        staged = forecast.staged_total
+        noun = "file" if staged == 1 else "files"
+        parts.append(f"{staged} {noun} the server won't take")
+    line = f"{INGEST_SERVER_NOTHING_SENDABLE_PREFIX} — {' and '.join(parts)}."
+    if refused:
+        line += f" {INGEST_SERVER_NOTHING_SENDABLE_RECOVERY}"
+    return line
 
 
 def forecast_summary_line(forecast: IngestForecast | None) -> str:
@@ -1408,7 +1481,11 @@ class LibraryIngestCanvasState:
     retry_confirm_armed: bool = False
     #: (task-14823) Whether the pre-flight has established that NOTHING in
     #: this selection can be imported -- an empty folder, or a folder whose
-    #: files are all unsupported/0-byte. Closes the Start gate above, and
+    #: files are all unsupported/0-byte.
+    #: (task-14911) ...by the backend the run is AIMED at: in server mode
+    #: it is also True for a selection the server refuses entirely (a
+    #: folder of images), which this machine would import happily. The
+    #: gate line says which of the two it is. Closes the Start gate above, and
     #: the screen refuses a submit on it directly so no entry point can
     #: manufacture the failure receipt the pre-flight already ruled out.
     #: Distinct from ``not start_enabled``, which is also False for
@@ -2485,6 +2562,25 @@ def build_library_ingest_state(
         and not type_groups
         and (active_preflight.total_files > 0 or empty_selection)
     )
+    # (task-14911) ...and the same gate, asked of the backend this run is
+    # actually aimed at. ``nothing_importable`` above is a LOCAL verdict
+    # ("did the pre-flight find a supported type group"), so a folder of
+    # nothing but images -- which the server has no media type for at all
+    # -- forecast "0 will be sent to the server · 3 will fail (unsupported
+    # by the server)" while Start stayed ENABLED and every row landed as a
+    # permanent failure. Read from the FORECAST rather than re-deriving a
+    # second notion of importability: it already knows what this backend
+    # accepts, and the gate line and the commit line then cannot disagree.
+    # ``will_match`` guards the task-2223 ruling: zero imports plus
+    # predicted duplicate matches keeps Start enabled, because the
+    # duplicate probe is capped best-effort and never a blocker.
+    nothing_sendable = (
+        targets_server
+        and forecast is not None
+        and forecast.staged_total > 0
+        and forecast.will_import == 0
+        and forecast.will_match == 0
+    )
     # (task-2130) Invalid option values gate Start exactly like a bad path:
     # "abc" as a chunk size used to sail into a running job with only a
     # focus-only colored border as the signal.
@@ -2501,6 +2597,7 @@ def build_library_ingest_state(
         and media_db_available
         and bool(form.path.strip())
         and not nothing_importable
+        and not nothing_sendable
         and not option_errors
         and not errors_are_path_problem
     )
@@ -2548,6 +2645,14 @@ def build_library_ingest_state(
             f"Nothing in this selection can be imported — "
             f"{' and '.join(blocker_parts)}."
         )
+    elif nothing_sendable:
+        # (task-14911) Ordered AFTER ``nothing_importable`` on purpose: a
+        # file nothing on this machine can read is diagnosed the same way
+        # whichever target is selected, and switching to Local would not
+        # help. This branch is the other case -- files this machine reads
+        # perfectly well that this destination will not take -- and it
+        # needs the server's own vocabulary and its own recovery.
+        start_quiet_line = server_nothing_sendable_line(forecast)
     elif errors_are_path_problem:
         start_quiet_line = (
             "Can't find that path — check it, or use Browse… to pick a "
@@ -2778,7 +2883,9 @@ def build_library_ingest_state(
         # (xhigh review + live-verify round) Gated on visibility: a
         # stale armed flag can never label a hidden affordance.
         retry_confirm_armed=bool(retry_confirm_armed) and show_retry_last,
-        selection_has_nothing_importable=bool(nothing_importable),
+        selection_has_nothing_importable=bool(
+            nothing_importable or nothing_sendable
+        ),
     )
 
 

--- a/tldw_chatbook/Library/server_ingest_request.py
+++ b/tldw_chatbook/Library/server_ingest_request.py
@@ -17,6 +17,8 @@ the service, not here.
 
 from __future__ import annotations
 
+from pathlib import Path
+from stat import S_ISREG
 from typing import Any, Iterable, Mapping
 
 from tldw_chatbook.Library.ingest_capabilities import (
@@ -122,6 +124,52 @@ def server_media_type_for(source: str) -> str:
     return media_type
 
 
+def empty_source_refusal(source: str) -> str | None:
+    """Return why a 0-byte local file is refused before it is sent.
+
+    (task-14910) The forecast counts every 0-byte staged file as a certain
+    failure on BOTH backends. Locally that is verified -- the parse chain
+    raises ``EmptySourceIngestError`` before any write. On the server path
+    it was an unearned claim: the app built kwargs for the empty file and
+    sent it, handing the outcome to a server this process cannot inspect
+    -- the very reason the same forecast line admits "server tooling isn't
+    checked from here".
+
+    Refusing here is what makes the claim true rather than lucky, and it
+    is the better outcome anyway: a 0-byte file is almost certainly a
+    mistake, the reason is already known locally, and stating it takes no
+    round trip. Both the forecast-side predicate
+    (:func:`server_ingest_refusal`) and the submit-side builder
+    (:func:`build_server_ingest_kwargs`) call THIS function, so what the
+    canvas promises and what the queue records cannot drift.
+
+    Args:
+        source: A local file path or an http(s) URL.
+
+    Returns:
+        The refusal reason -- the exact message the failed job row will
+        carry -- or ``None`` when the source is not a 0-byte local file.
+        A URL has no local size to measure and is never called empty; nor
+        is a path that cannot be statted, mirroring the pre-flight's own
+        ``_statted_size`` (an unreadable file is not a 0 B one).
+    """
+    text = str(source or "").strip()
+    if not text or is_http_url(text):
+        return None
+    try:
+        path = Path(text).expanduser()
+        info = path.stat()
+    except (OSError, ValueError, RuntimeError):
+        return None
+    # ``S_ISREG`` because a DIRECTORY can stat at 0 bytes on some
+    # filesystems, and "this folder is empty" is a different diagnosis
+    # with a different recovery (the ingest gate owns that one).
+    if info.st_size != 0 or not S_ISREG(info.st_mode):
+        return None
+    name = path.name or text
+    return f"{name} is empty; there was nothing to send."
+
+
 def server_ingest_refusal(source: str) -> str | None:
     """Return why a SERVER-targeted submission will refuse ``source``.
 
@@ -152,6 +200,13 @@ def server_ingest_refusal(source: str) -> str | None:
         return "No source was given."
     if is_web_clip_source(text):
         return None
+    # (task-14910) Emptiness outranks the type mapping: a 0-byte .png is
+    # counted by the forecast as an EMPTY failure (the pre-flight pulls
+    # 0-byte files out before classifying them), so the row it produces
+    # must give the empty reason rather than the image one.
+    empty = empty_source_refusal(text)
+    if empty is not None:
+        return empty
     try:
         server_media_type_for(text)
     except ServerIngestUnsupported as exc:
@@ -209,8 +264,15 @@ def build_server_ingest_kwargs(
         Keyword arguments for ``ServerMediaReadingService.submit_ingest_jobs``.
 
     Raises:
-        ServerIngestUnsupported: When ``source`` has no server equivalent.
+        ServerIngestUnsupported: When ``source`` has no server equivalent,
+            or (task-14910) when it is a 0-byte file -- there is nothing
+            in it to send, and only a refusal here makes the forecast's
+            "will fail" a fact about this process rather than a guess
+            about the server's.
     """
+    empty = empty_source_refusal(source)
+    if empty is not None:
+        raise ServerIngestUnsupported(empty)
     media_type = server_media_type_for(source)
     source = source.strip()
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -20328,6 +20328,11 @@ class LibraryScreen(BaseAppScreen):
         # outcome that was predictable before the click. Enforced HERE,
         # not only on the Button's disabled flag, so no entry point
         # (Enter, accelerator, a future caller) can route around it.
+        # (task-14911) The same flag now also covers a selection the
+        # TARGETED SERVER refuses entirely -- a folder of images, which
+        # this machine imports happily -- so this one refusal serves both
+        # backends and the reason it quotes is the gate's own, whichever
+        # of the two it is.
         gate_state = self._build_library_ingest_state()
         if gate_state.selection_has_nothing_importable is True:
             reason = gate_state.start_quiet_line


### PR DESCRIPTION
Closes the hang class across `Tests/UI` (task-14912, HIGH) and the last two server-forecast residue items (14910, 14911).

## task-14912 — the sweep, and why it needed to be AST

A recent hang (task-3316) came from a fire-and-forget `create_task` whose swallowed exception made an awaited `Event` unreachable. Under `timeout_method = thread` that kills the whole pytest process, so a file containing one has an **unknown pass count**. This task generalises the fix.

`Tests/UI/test_background_signal_bounds.py` is both the enumerator and a **permanent guard**: it parses every `Tests/UI` module and reports any `await <x>.wait()` where `<x>` resolves to an `asyncio.Event` — matched by expression *or* attribute name, so `self.started = asyncio.Event()` in a fake catches `service.started.wait()` in a test — that is neither bounded nor structurally safe.

**Grep could not have done this, and the lead counts were wrong in both directions.** `test_library_file_notes_git_push.py`'s ~21 bare waits are all retained-operation handles that await the task and re-raise (safe, untouched), while two files nobody had listed — `test_speech_playground_pane_lifecycle.py` (16) and `test_speech_playground_pane.py` (6) — were invisible to a `create_task` search because they use `run_worker`.

**66 at-risk sites bound** (35 task-aware, 31 timeout-only) across 8 files. Structurally-safe classes are excluded *with pinning tests*: stubs awaiting a release the test body itself sets, `RetainedPushOperation`/`Worker.wait()`, `test_`-prefixed service methods, `threading.Event`, and anything already inside `asyncio.wait_for`.

Helpers live in `Tests/UI/background_signals.py`, following the `app_factory.py` precedent. The topically-obvious `textual_test_helpers.py` was rejected: it has **zero importers repo-wide**, so a bound placed there would reach nobody.

**AC#3 demonstrated, not asserted.** With the bound, breaking a stubbed seam fails in **3.1s** naming the real `AttributeError`. With the bound removed, the same break **hangs**, and at timeout pytest dumped a stack showing only `MainThread` in `selectors.select` — never naming the test — and reported **zero tests**.

## task-14910 / 14911 — server residue

**14910** refuses 0-byte files locally rather than dropping them from the count. The deciding argument: a server plausibly returns a *"successful" empty row* — the silent-empty-import outcome task-14821 removed on the local path. The refusal seam already existed, so "stop counting" would have been more code to say less. **The server governance fixture grew to stage one**, closing the hole its own docstring documented.

**14911** makes the Start gate backend-aware — a server-mode selection the server refuses entirely now gates instead of offering a doomed submit (task-14823's defect, one backend over), with server-specific copy and a recovery clause. Mutation proved the two-layer design: reverting only the submit-seam refusal still let **2 jobs reach the queue**.

## Verification

**604 passed** on the rebased tree. Every affected file was run WHOLE (`test_speech_playground_pane_lifecycle.py` 123, `test_console_prompts_modal.py` 75, `test_library_file_notes_git_push.py` 59, `test_library_prompt_collections.py` 47, `test_console_parallel_runs.py` 28, `test_screen_navigation.py` 126 — a count that was previously unknowable).

## Two findings, filed not absorbed

- **task-14920 (HIGH)** — running those files whole exposed **20 failures nobody had counted**: `test_console_native_chat_flow.py` 291/18 and `test_personas_workbench.py` 310/2. All reproduced against a pristine `git archive` of HEAD, so **not caused by this change and not hidden by a hang** — they are stale-contract breakage from screen decomposition (14 of 18 are `'ChatScreen' object has no attribute '_ensure_active_console_session_settings'`). Two look like real regressions rather than moved seams, so they need triage, not a mass rewrite to green.
- **One dev-side stale pin fixed here**: `test_action_show_workbench_help_includes_landing_footer_keys` pinned the exact F1 title, which dev's task-4023 mode suffix broke. Proven pre-existing by running it against a pristine dev tree. Re-asserted as the original claim ("no raw class name") so the next honest change doesn't read as a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound every wait on background-set signals in `Tests/UI` and added an AST guard to prevent hangs, so failures surface quickly instead of killing the run. Also fixed server ingest by refusing 0‑byte files client-side and making the Start gate backend-aware to block doomed server submissions with clear copy.

- **Test Infrastructure**
  - Added `Tests/UI/background_signals.py` helpers to bound `Event.wait()` calls; updated 66 sites.
  - Added `Tests/UI/test_background_signal_bounds.py` (AST-based) to enforce bounded waits and exclude structurally safe cases.
  - Addresses task-14912 by ensuring background-task errors fail fast instead of hanging pytest.

- **Bug Fixes**
  - Refuse 0‑byte sources before server submission, aligning forecast and receipt (task-14910); updated integration and unit tests.
  - Start gate now consults the targeted backend; blocks server-only unsendable selections with server-specific messaging while leaving local imports unaffected (task-14911).
  - Updated user docs to clarify empty-file handling on both backends.

<sup>Written for commit 4b1544b91e825bdbecb4bf5a17958dfcbd44a5c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

