### PR TITLE
test: block test network I/O by default; follow the send-button contract rename (tasks 15111/15121)

### DIFF
--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -1833,6 +1833,10 @@ def test_aclose_does_not_let_a_later_loop_adopt_a_previously_claimed_client():
     asyncio.run(gateway.aclose())
 
 
+# About the gateway's REAL owned client, so it opts out of the autouse
+# offline-client guard (Tests/conftest.py, task-15111). Constructs a client;
+# never connects.
+@pytest.mark.owned_http_client
 @pytest.mark.asyncio
 async def test_owned_http_client_uses_generous_generation_read_timeout():
     """The owned client must not cap slow local generations at the old 30s."""
@@ -1959,6 +1963,12 @@ def local_http_server():
         thread.join(timeout=2)
 
 
+# Real owned client AND a real socket: the whole point is httpx's per-loop
+# connection-pool binding against a server this test starts itself
+# (`local_http_server`, ephemeral loopback port). Opts out of both autouse
+# guards (Tests/conftest.py, task-15111).
+@pytest.mark.owned_http_client
+@pytest.mark.allow_network
 def test_owned_http_client_survives_agent_bridge_style_loop_swap(local_http_server):
     """Regression (Task 8 live gate): every agent turn crashed against a real
     llama.cpp server with ``RuntimeError: <asyncio.locks.Event ...> is bound
@@ -2217,6 +2227,9 @@ def test_aclose_closes_current_loop_client_and_schedules_others(monkeypatch):
         other_loop.close()
 
 
+# Same as above: real owned client + this test's own `local_http_server`.
+@pytest.mark.owned_http_client
+@pytest.mark.allow_network
 def test_active_http_client_concurrent_swap_never_leaves_client_bound_to_wrong_loop(
     local_http_server,
     monkeypatch,

--- a/Tests/Chat/test_local_server_discovery.py
+++ b/Tests/Chat/test_local_server_discovery.py
@@ -16,6 +16,13 @@ from tldw_chatbook.Chat.local_server_discovery import (
 )
 
 
+# These ARE the tests of the probe implementation, so they opt out of the
+# autouse `_no_local_server_probes` guard (Tests/conftest.py, task-15111).
+# They never touch the network: every client below is an injected
+# httpx.MockTransport, which the socket guard independently confirms.
+pytestmark = pytest.mark.local_server_probe
+
+
 def _client(handler) -> httpx.AsyncClient:
     return httpx.AsyncClient(transport=httpx.MockTransport(handler))
 

--- a/Tests/Local_Ingestion/test_parakeet_v2_artifact.py
+++ b/Tests/Local_Ingestion/test_parakeet_v2_artifact.py
@@ -23,6 +23,12 @@ from tldw_chatbook.Model_Artifacts.service import ModelArtifactService
 
 from Tests.Model_Artifacts.fixture_http import FixtureArtifactServer
 
+# Network opt-in (task-15111): this module fetches artifacts from an in-
+# process HTTP server on an ephemeral loopback port.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = pytest.mark.allow_network
+
 
 _EXPECTED_ROOTS = {
     ("nemo-parakeet-tdt-0.6b-v2", "int8"): {

--- a/Tests/Model_Artifacts/test_credentials_and_boundaries.py
+++ b/Tests/Model_Artifacts/test_credentials_and_boundaries.py
@@ -46,6 +46,13 @@ from tldw_chatbook.Model_Artifacts.acquisition import (
 from tldw_chatbook.Model_Artifacts.fetch import stream_fetch
 from tldw_chatbook.Model_Artifacts.service import ModelArtifactService
 
+# Network opt-in (task-15111): this module fetches from
+# `FixtureArtifactServer`, an in-process HTTP server on an ephemeral
+# loopback port.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = pytest.mark.allow_network
+
 TOKEN = "tok-secret-9f3c4a"
 
 

--- a/Tests/Model_Artifacts/test_preflight.py
+++ b/Tests/Model_Artifacts/test_preflight.py
@@ -27,6 +27,13 @@ from tldw_chatbook.Model_Artifacts.acquisition import (
 )
 from tldw_chatbook.Model_Artifacts.service import ModelArtifactService
 
+# Network opt-in (task-15111): this module fetches from
+# `FixtureArtifactServer`, an in-process HTTP server on an ephemeral
+# loopback port.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = pytest.mark.allow_network
+
 
 @pytest.mark.asyncio
 async def test_preflight_aggregates_and_grants(tmp_path):

--- a/Tests/Model_Artifacts/test_provision_crash_recovery.py
+++ b/Tests/Model_Artifacts/test_provision_crash_recovery.py
@@ -41,7 +41,12 @@ from tldw_chatbook.Model_Artifacts.service import (
     ModelArtifactService,
 )
 
-pytestmark = pytest.mark.integration
+# Network opt-in (task-15111): this module fetches from
+# `FixtureArtifactServer`, an in-process HTTP server on an ephemeral
+# loopback port.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = [pytest.mark.integration, pytest.mark.allow_network]
 
 
 def _trusted_hostname(srv: FixtureArtifactServer) -> str:

--- a/Tests/Model_Artifacts/test_provision_fetch.py
+++ b/Tests/Model_Artifacts/test_provision_fetch.py
@@ -47,6 +47,13 @@ from tldw_chatbook.Model_Artifacts.service import (
 )
 from tldw_chatbook.Utils.atomic_file_ops import atomic_write_json
 
+# Network opt-in (task-15111): this module fetches from
+# `FixtureArtifactServer`, an in-process HTTP server on an ephemeral
+# loopback port.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = pytest.mark.allow_network
+
 
 def _make_two_file_descriptor(source_url: str) -> ArtifactDescriptor:
     """A 2-file descriptor -- ``make_descriptor`` only ever builds one file.

--- a/Tests/Model_Artifacts/test_provision_install.py
+++ b/Tests/Model_Artifacts/test_provision_install.py
@@ -44,6 +44,13 @@ from tldw_chatbook.Model_Artifacts.acquisition import (
 from tldw_chatbook.Model_Artifacts.service import ModelArtifactService
 from tldw_chatbook.Utils.atomic_file_ops import atomic_write_json
 
+# Network opt-in (task-15111): this module fetches from
+# `FixtureArtifactServer`, an in-process HTTP server on an ephemeral
+# loopback port.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = pytest.mark.allow_network
+
 
 def _descriptor(
     ref: ArtifactRef,

--- a/Tests/Model_Artifacts/test_source_map.py
+++ b/Tests/Model_Artifacts/test_source_map.py
@@ -45,6 +45,13 @@ from tldw_chatbook.Model_Artifacts.acquisition import (
 )
 from tldw_chatbook.Model_Artifacts.service import ModelArtifactService
 
+# Network opt-in (task-15111): this module fetches from
+# `FixtureArtifactServer`, an in-process HTTP server on an ephemeral
+# loopback port.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = pytest.mark.allow_network
+
 
 def _forbid_client() -> httpx.AsyncClient:
     """``client_factory`` stub that fails any test proving "no network yet".

--- a/Tests/Model_Artifacts/test_stream_fetch.py
+++ b/Tests/Model_Artifacts/test_stream_fetch.py
@@ -13,6 +13,13 @@ from tldw_chatbook.Model_Artifacts.fetch import (
     stream_fetch,
 )
 
+# Network opt-in (task-15111): this module fetches from
+# `FixtureArtifactServer`, an in-process HTTP server on an ephemeral
+# loopback port.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = pytest.mark.allow_network
+
 BODY = b"0123456789" * 1000  # 10 KB
 
 

--- a/Tests/Subscriptions/test_feed_server.py
+++ b/Tests/Subscriptions/test_feed_server.py
@@ -39,7 +39,11 @@ from tldw_chatbook.Subscriptions.feed_server import (
     is_loopback_bind,
 )
 
-pytestmark = pytest.mark.unit
+# Network opt-in (task-15111): this module binds a real briefings feed
+# server on an ephemeral loopback port and fetches from it.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = [pytest.mark.unit, pytest.mark.allow_network]
 
 
 def _raw_http_request(port: int, request_bytes: bytes, timeout: float = 5.0) -> bytes:

--- a/Tests/TTS/test_audio_cpp_managed_integration.py
+++ b/Tests/TTS/test_audio_cpp_managed_integration.py
@@ -69,6 +69,12 @@ from tldw_chatbook.TTS.TTS_Generation import (
     TTSSettingsPersistenceOutcome,
 )
 
+# Network opt-in (task-15111): this module talks to `fake_audiocpp_server`,
+# an in-process HTTP server on an ephemeral loopback port.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = pytest.mark.allow_network
+
 
 def _wav() -> bytes:
     data = b"\x00\x00\x00\x00"

--- a/Tests/TTS/test_audio_cpp_supervisor.py
+++ b/Tests/TTS/test_audio_cpp_supervisor.py
@@ -32,6 +32,12 @@ from tldw_chatbook.TTS.audio_cpp_supervisor import (
     _OwnedAudioCppProcess,
 )
 
+# Network opt-in (task-15111): this module talks to `fake_audiocpp_server`,
+# an in-process HTTP server on an ephemeral loopback port.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = pytest.mark.allow_network
+
 
 class _FakeReader:
     def __init__(self) -> None:

--- a/Tests/TTS/test_openai_compatible_endpoint.py
+++ b/Tests/TTS/test_openai_compatible_endpoint.py
@@ -13,6 +13,12 @@ import pytest
 from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
 from tldw_chatbook.TTS.backends.openai import OpenAITTSBackend
 
+# Network opt-in (task-15111): this module talks to an in-process HTTP
+# server on an ephemeral loopback port.
+# The autouse guard in Tests/conftest.py denies egress by default; every address
+# these tests reach is a port this process itself is listening on.
+pytestmark = pytest.mark.allow_network
+
 CUSTOM_URL = "http://127.0.0.1:8123/v1/audio/speech"
 
 

--- a/Tests/UI/test_console_local_server_probe_isolation.py
+++ b/Tests/UI/test_console_local_server_probe_isolation.py
@@ -1,0 +1,137 @@
+"""Mounting the Console must not probe a live localhost server (task-15111).
+
+The defect, measured on a dev machine with an `audiocpp` server bound to
+`127.0.0.1:8080`: a record-only socket shim over `Tests/UI` logged real TCP
+connections to `127.0.0.1:8080` and `127.0.0.1:11434` from **every** test that
+mounted `ChatScreen` with an unconfigured provider -- 56 tests apiece in the
+first 6% of the suite alone.
+
+Mechanism: an unconfigured provider makes the setup card blocking, which starts
+`_maybe_start_console_local_discovery` -> `discover_local_servers`. Its
+candidate list ALWAYS leads with the two well-known localhost defaults
+regardless of config (`build_local_server_candidates`), and
+`probe_models_endpoint` builds a real `httpx.AsyncClient` when none is
+injected. Only ONE test in the suite (`test_console_local_server_discovery_card`)
+ever stubbed the `console_local_server_discovery` app seam; everything else
+fell through to the network.
+
+These tests pin both halves of the fix: the probe chokepoint is neutralized for
+tests (`Tests/conftest.py::_no_local_server_probes`) and the socket guard
+(`Tests/network_guard.py`) proves it rather than trusting it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App
+
+from Tests import network_guard
+from Tests.UI.app_factory import _build_test_app
+from tldw_chatbook.Chat.local_server_discovery import (
+    DEFAULT_LLAMACPP_DISCOVERY_URL,
+    DEFAULT_OLLAMA_DISCOVERY_URL,
+    build_local_server_candidates,
+    discover_local_servers,
+)
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+
+class ConsoleHarness(App):
+    """Real ChatScreen harness (mirrors test_console_setup_lock_polish)."""
+
+    def __init__(self, app_instance):
+        super().__init__()
+        self.app_instance = app_instance
+
+    async def on_mount(self) -> None:
+        await self.push_screen(ChatScreen(self.app_instance))
+
+
+def _blocked_provider_app():
+    """Test app whose Console provider is blocked (empty OpenAI key).
+
+    The blocked state is what makes the setup card blocking, which is what
+    starts local-server discovery.
+    """
+    app = _build_test_app()
+    app.app_config = {
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-4.1-2025-04-14"},
+        "api_settings": {"openai": {"api_key": ""}},
+    }
+    app.chat_api_provider_value = "OpenAI"
+    app.chat_api_model_value = "gpt-4.1-2025-04-14"
+    return app
+
+
+async def _wait_for(predicate, pilot, attempts: int = 300) -> None:
+    for _ in range(attempts):
+        if predicate():
+            return
+        await pilot.pause(0.01)
+    raise AssertionError("condition was not met in time")
+
+
+def test_discovery_candidates_still_target_the_wellknown_localhost_ports() -> None:
+    """Anti-vacuity: the candidate list really does lead with 8080 and 11434.
+
+    If this ever stops being true the isolation tests below could pass for the
+    wrong reason (nothing to probe), so it is asserted explicitly.
+    """
+    candidates = [candidate.base_url for candidate in build_local_server_candidates({})]
+
+    assert candidates[:2] == [
+        DEFAULT_LLAMACPP_DISCOVERY_URL,
+        DEFAULT_OLLAMA_DISCOVERY_URL,
+    ]
+    assert DEFAULT_LLAMACPP_DISCOVERY_URL == "http://127.0.0.1:8080"
+
+
+@pytest.mark.local_server_probe
+async def test_unguarded_discovery_really_reaches_localhost_8080_and_11434() -> None:
+    """The defect itself, pinned: without the probe guard, egress is attempted.
+
+    Marked `local_server_probe` to opt OUT of `_no_local_server_probes`, i.e.
+    it runs the production probe exactly as `chat_screen` does. The socket
+    guard catches the attempt, so this documents the escape without performing
+    it -- and it is the reason the next test is not vacuous.
+    """
+    servers = await discover_local_servers({})
+
+    attempted = {address for _call, address in network_guard.drain_blocked_attempts()}
+    assert {"127.0.0.1:8080", "127.0.0.1:11434"} <= attempted, (
+        f"expected probes at the two well-known ports, saw {sorted(attempted)}"
+    )
+    # Blocked egress degrades down the ordinary "nothing listening" path.
+    assert servers == ()
+
+
+async def test_guarded_discovery_makes_no_connection_attempt() -> None:
+    """With the autouse guard in place (default), nothing leaves the process."""
+    servers = await discover_local_servers({})
+
+    assert servers == ()
+    assert network_guard.blocked_attempts() == ()
+
+
+@pytest.mark.asyncio
+async def test_mounting_the_blocked_console_probes_no_live_server(monkeypatch) -> None:
+    """End-to-end: the blocking setup card starts discovery and touches nothing.
+
+    Asserts the worker actually ran (`_console_local_discovery_started`) so the
+    "no connection" half cannot pass by simply never getting there.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    host = ConsoleHarness(_blocked_provider_app())
+
+    async with host.run_test(size=(120, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for(lambda: console._console_setup_modal_blocking(), pilot)
+        await _wait_for(lambda: console._console_local_discovery_started, pilot)
+        # Let the discovery worker run to completion.
+        for _ in range(20):
+            await pilot.pause(0.01)
+
+        assert console._console_local_discovery_started is True
+        assert console._console_detected_local_server is None
+
+    assert network_guard.blocked_attempts() == ()

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -2767,11 +2767,23 @@ async def test_console_composer_stop_is_subdued_when_idle():
         await _wait_for_text(console, pilot, "partial")
 
         # TASK-2154.6: a blocked Send is now genuinely disabled, not just
-        # class-subdued -- the classes below keep their old contract.
+        # class-subdued.
+        # TASK-15121 (contract change, not a rename): since TASK-14808 /
+        # ADR-046 an ACCEPTED live turn no longer blocks Send -- it re-labels
+        # it to "Queue" and admits the draft as a FIFO follow-up turn. So
+        # `console-send-blocked` is no longer reachable here; it now covers
+        # only the states that genuinely refuse a draft (Preparing before
+        # acceptance, Queue full, setup/attachment blocks -- see
+        # `derive_prompt_queue_presentation`). The original claim of this
+        # assertion block is kept where it is still true: with the draft
+        # consumed by the send, Send is genuinely disabled and non-primary --
+        # it just fails the empty-draft gate now, not the run gate.
         assert send_button.disabled is True
         assert send_button.has_class("console-action-disabled")
-        assert send_button.has_class("console-send-blocked")
+        assert send_button.has_class("console-send-inactive")
+        assert not send_button.has_class("console-send-blocked")
         assert not send_button.has_class("console-action-primary")
+        assert send_button.label.plain == "Queue"
         assert stop_button.disabled is False
         assert stop_button.has_class("console-stop-active")
         assert not stop_button.has_class("console-action-disabled")
@@ -2806,14 +2818,35 @@ async def test_console_duplicate_send_during_stream_does_not_break_stop_control(
         # TASK-2154.6: genuinely disabled while the run blocks sends; the
         # direct handler dispatch below (not `press()`, which no-ops on a
         # disabled control) is exactly how the Enter hotkey still reaches it.
-        assert send_button.disabled is True
-        assert send_button.has_class("console-send-blocked")
+        # TASK-15121: superseded by TASK-14808 / ADR-046 -- "once accepted,
+        # the normal Send action becomes Queue; Enter and the button both
+        # enqueue the exact canonical text draft". A second draft mid-stream
+        # is therefore no longer REFUSED, so the disabled/`console-send-blocked`
+        # pin below is gone. What this test is named for is unchanged and is
+        # asserted harder below: the duplicate send must not start a second
+        # run, must not be silently eaten, and must not break Stop.
+        assert send_button.disabled is False
+        assert not send_button.has_class("console-send-blocked")
+        assert send_button.label.plain == "Queue"
+        controller = console._ensure_console_chat_controller()
+        session_id = controller.store.active_session_id
+        assert (
+            controller.prompt_queue_registry.snapshot(session_id).total_count == 0
+        )
+
         await console.handle_console_send_message(Button.Pressed(send_button))
         await pilot.pause(0.1)
+        # The live turn is untouched -- one run, still streaming, never a
+        # second concurrent generation.
         assert (
             console._ensure_console_chat_controller().run_state.status.value
             == "streaming"
         )
+        # ...and the duplicate landed in the bounded queue rather than being
+        # dropped: admission (not an attempted enqueue) is what clears the
+        # draft, so an empty composer here is evidence the text was accepted.
+        assert controller.prompt_queue_registry.snapshot(session_id).total_count == 1
+        assert composer.draft_text() == ""
 
         console.query_one("#console-stop-generation", Button).press()
         await _wait_for_text(console, pilot, "stopped")

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -75,6 +75,16 @@ PROJECT_ROOT = Path(__file__).parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+# Network egress is denied for the whole session from this point on (task-15111).
+# Installed at conftest IMPORT time, not from a fixture, so module import,
+# collection, fixture teardown and worker threads that outlive a test are all
+# covered. Opt in per test with @pytest.mark.allow_network; see
+# Tests/network_guard.py for the incident that motivated it.
+from Tests import network_guard  # noqa: E402
+
+network_guard.install()
+
+
 # Hypothesis: no per-example deadline (TASK-1260).
 #
 # Several property tests do real work per example -- `test_safe_paths_always_validate`
@@ -466,6 +476,139 @@ def _no_real_audio_device(request: pytest.FixtureRequest, monkeypatch: pytest.Mo
     import tldw_chatbook.Audio.streaming_sink as streaming_sink
 
     monkeypatch.setattr(streaming_sink, "_import_sounddevice", lambda: None)
+
+
+@pytest.fixture(autouse=True)
+def _no_network_io(request: pytest.FixtureRequest) -> Iterator[None]:
+    """No test reaches a live endpoint unless it explicitly opts in (task-15111).
+
+    The socket patch itself is installed once at conftest import time and is
+    denied by default; this fixture only (a) lifts the denial for a test that
+    opted in, and (b) turns a *swallowed* block into a failure.
+
+    (b) is the load-bearing half. `BlockedNetworkAccess` is an `OSError`, so
+    `local_server_discovery._get_models_payload`'s `except Exception` absorbs
+    it and discovery simply reports "no models endpoint" -- exactly what a
+    green run looks like today with nothing listening. Without the recorded
+    attempts a future regression would reintroduce the escape silently, which
+    is the whole defect. Failing on a non-empty record makes the guard
+    unswallowable.
+
+    Opt in with `@pytest.mark.allow_network`. `live` (real paid external APIs,
+    already gated behind `--run-live`) counts as an implicit opt-in.
+
+    Yields:
+        None. The blocked-attempt record is asserted empty at teardown.
+    """
+    opted_in = bool(
+        request.node.get_closest_marker("allow_network")
+        or request.node.get_closest_marker("live")
+    )
+    network_guard.drain_blocked_attempts()
+    network_guard.set_allowed(opted_in)
+    try:
+        yield
+    finally:
+        network_guard.set_allowed(False)
+        attempts = network_guard.drain_blocked_attempts()
+    if attempts:
+        detail = ", ".join(f"{call} -> {address}" for call, address in attempts)
+        raise AssertionError(
+            "test attempted network egress (blocked): "
+            + detail
+            + " — stub the client seam, or mark the test "
+            "@pytest.mark.allow_network if it genuinely needs a socket."
+        )
+
+
+@pytest.fixture(autouse=True)
+def _no_local_server_probes(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Neutralize the local-server discovery probe's one network chokepoint.
+
+    The mechanism behind task-15111: mounting the Console chat screen with an
+    unconfigured provider blocks the setup card, which starts
+    `_maybe_start_console_local_discovery` -> `discover_local_servers`. That
+    candidate list ALWAYS leads with `http://127.0.0.1:8080` and
+    `http://127.0.0.1:11434` regardless of config, and `probe_models_endpoint`
+    builds a real `httpx.AsyncClient` when none is injected -- so every such
+    test made two live TCP connections, and on a machine with a server on 8080
+    the setup card grew a "detected server" affordance CI never sees.
+
+    `_get_models_payload` is the single chokepoint: all three production
+    import sites (`chat_screen`, `FirstRunSetupWizard`, `console_settings_modal`)
+    funnel through `probe_models_endpoint`, which resolves it as a module
+    global at call time, so patching it here covers callers that imported
+    `probe_models_endpoint`/`discover_local_servers` by name. Returning the
+    ordinary "no models endpoint" failure drives the already-tested
+    nothing-listening path, so no test's LOGICAL coverage changes -- only its
+    network access. `Tests/network_guard.py` is the backstop that proves it.
+
+    A test that exercises the real probe implementation against an injected
+    `httpx.MockTransport` client marks itself `@pytest.mark.local_server_probe`
+    to opt out (see `Tests/Chat/test_local_server_discovery.py`).
+    """
+    if request.node.get_closest_marker("local_server_probe"):
+        return
+    from tldw_chatbook.Chat import local_server_discovery
+
+    async def _no_endpoint(http_client, url, timeout, display):
+        return None, f"No models endpoint at {display}."
+
+    monkeypatch.setattr(local_server_discovery, "_get_models_payload", _no_endpoint)
+
+
+@pytest.fixture(autouse=True)
+def _console_gateway_http_client_is_offline(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Console provider gateway never owns a network-capable client in tests.
+
+    Sharper half of task-15111. `Tests/UI`'s send-path tests configure a
+    "ready" llama.cpp Console at `http://127.0.0.1:9099`
+    (`_configure_native_ready_console`) and then drive a REAL send through
+    `ConsoleProviderGateway`. On CI nothing listens there, `_is_reachable`'s
+    GET `/health` fails, and the send stops. Measured against a stand-in
+    server bound to 9099,
+    `test_console_command_popup::test_enter_with_popup_closed_sends_normally`
+    went on to send **two POSTs to `/v1/chat/completions`** (streaming, then
+    the non-streaming fallback) carrying the test's prompt. So the escape was
+    never merely a stray GET: with a llama.cpp on that port a test run would
+    have driven real inference on the developer's server.
+
+    `_new_owned_http_client` is the single construction site for every client
+    the gateway owns (`__init__` and the per-loop cache both call it), and
+    injected clients set `_owns_http_client = False` and are left alone -- so
+    MockTransport-based gateway tests are unaffected. Substituting a transport
+    that raises `httpx.ConnectError` reproduces the CI "nothing is listening"
+    outcome deterministically, on every machine, with no socket: `_is_reachable`
+    and `resolve_llamacpp` already catch `httpx.HTTPError`.
+
+    A test that is ABOUT the owned client itself (its timeouts, its per-loop
+    cache) marks itself `@pytest.mark.owned_http_client` to opt out;
+    `allow_network` implies the same, since a test allowed a real socket
+    plainly wants a real client.
+    """
+    if request.node.get_closest_marker("owned_http_client") or request.node.get_closest_marker(
+        "allow_network"
+    ):
+        return
+    import httpx
+
+    from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderGateway
+
+    def _refuse(http_request: "httpx.Request") -> "httpx.Response":
+        raise httpx.ConnectError(
+            "network access blocked in tests (Tests/conftest.py, task-15111)",
+            request=http_request,
+        )
+
+    monkeypatch.setattr(
+        ConsoleProviderGateway,
+        "_new_owned_http_client",
+        staticmethod(lambda: httpx.AsyncClient(transport=httpx.MockTransport(_refuse))),
+    )
 
 
 # ========== Async Cleanup Fixtures ==========

--- a/Tests/network_guard.py
+++ b/Tests/network_guard.py
@@ -1,0 +1,178 @@
+"""Process-wide network egress guard for the test suite (task-15111).
+
+Why this exists
+---------------
+`Tests/UI`'s Console suites were making **real TCP connections to
+``127.0.0.1:8080`` and ``127.0.0.1:11434``** on every test that mounted the
+Console chat screen with an unconfigured provider. The mechanism:
+``chat_screen._maybe_start_console_local_discovery`` starts a worker that calls
+``Chat.local_server_discovery.discover_local_servers``, whose candidate list
+*always* begins with the two well-known localhost defaults regardless of
+config, and ``probe_models_endpoint`` builds a real ``httpx.AsyncClient`` when
+none is injected. A developer with a llama.cpp/Ollama/audio.cpp server on
+those ports therefore ran **different behaviour** from CI (the probe answers,
+a "detected server" affordance appears on the setup card) and nothing told
+either of them. Measured on this machine with an ``audiocpp`` server on 8080:
+one record-only run logged hundreds of such connects across ``Tests/UI``.
+
+Design
+------
+* The patch is installed at ``Tests/conftest.py`` **import** time and defaults
+  to BLOCKED, so collection, module import, fixture setup/teardown and any
+  worker thread that outlives a test are all covered — not just the window a
+  function-scoped fixture happens to span.
+* Only ``AF_INET``/``AF_INET6`` egress is blocked. ``AF_UNIX`` is local IPC
+  (system libraries use it) and is not what this guard is about.
+* The raised error subclasses ``OSError`` so that client libraries treat it as
+  an ordinary connection failure and degrade down their already-tested
+  "endpoint unreachable" path instead of exploding somewhere unrelated.
+* Because that degradation means a broad ``except Exception`` can *swallow*
+  the block (``local_server_discovery._get_models_payload`` does exactly
+  that), every blocked attempt is also **recorded**. The autouse fixture in
+  ``Tests/conftest.py`` fails the test at teardown on a non-empty record, so
+  the guard cannot be silently absorbed by the code under test.
+
+Opting in
+---------
+A test that genuinely needs a socket marks itself
+``@pytest.mark.allow_network`` (registered in ``pyproject.toml``). The
+``live`` marker — real paid external APIs, already gated behind
+``--run-live`` — is treated as an implicit opt-in.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+__all__ = [
+    "BlockedNetworkAccess",
+    "blocked_attempts",
+    "drain_blocked_attempts",
+    "install",
+    "is_allowed",
+    "set_allowed",
+]
+
+
+class BlockedNetworkAccess(OSError):
+    """Raised when a test attempts network egress without opting in.
+
+    Subclasses ``OSError`` deliberately: ``httpx``/``requests``/``urllib`` all
+    translate an ``OSError`` from ``connect()`` into their own connection
+    error, so a guarded test exercises the same code path it would take
+    against a dead port rather than an unrelated crash.
+    """
+
+
+#: ``(call, address)`` pairs recorded since the last drain. Consulted by the
+#: autouse fixture so a swallowed block still fails its test.
+_blocked_attempts: list[tuple[str, str]] = []
+
+#: Egress is denied unless a test explicitly opted in.
+_allowed = False
+
+_installed = False
+
+_real_connect = socket.socket.connect
+_real_connect_ex = socket.socket.connect_ex
+_real_create_connection = socket.create_connection
+_real_sendto = socket.socket.sendto
+
+_INET_FAMILIES = frozenset({socket.AF_INET, socket.AF_INET6})
+
+
+def is_allowed() -> bool:
+    """Return whether network egress is currently permitted."""
+    return _allowed
+
+
+def set_allowed(allowed: bool) -> None:
+    """Permit or deny network egress process-wide.
+
+    Args:
+        allowed: ``True`` to let connections through (opt-in tests only).
+    """
+    global _allowed
+    _allowed = bool(allowed)
+
+
+def blocked_attempts() -> tuple[tuple[str, str], ...]:
+    """Return the blocked egress attempts recorded so far."""
+    return tuple(_blocked_attempts)
+
+
+def drain_blocked_attempts() -> tuple[tuple[str, str], ...]:
+    """Return the recorded blocked attempts and clear the record."""
+    recorded = tuple(_blocked_attempts)
+    _blocked_attempts.clear()
+    return recorded
+
+
+def _describe(address: Any) -> str:
+    """Return a short, stable description of a socket address."""
+    if isinstance(address, tuple) and len(address) >= 2:
+        return f"{address[0]}:{address[1]}"
+    return repr(address)
+
+
+def _deny(call: str, address: Any) -> BlockedNetworkAccess:
+    """Record a blocked attempt and build the error to raise.
+
+    Args:
+        call: Name of the socket API that was intercepted.
+        address: The address the caller tried to reach.
+
+    Returns:
+        The ``BlockedNetworkAccess`` the caller should raise.
+    """
+    described = _describe(address)
+    _blocked_attempts.append((call, described))
+    return BlockedNetworkAccess(
+        f"network access blocked in tests: {call}({described}). "
+        "Tests must not touch a live endpoint — stub the client seam, or mark "
+        "the test @pytest.mark.allow_network if it genuinely needs a socket "
+        "(see Tests/network_guard.py, task-15111)."
+    )
+
+
+def _should_block(family: Any) -> bool:
+    """Return whether egress on this address family is guarded."""
+    return not _allowed and family in _INET_FAMILIES
+
+
+def _guarded_connect(self: socket.socket, address: Any):  # noqa: ANN401
+    if _should_block(self.family):
+        raise _deny("socket.connect", address)
+    return _real_connect(self, address)
+
+
+def _guarded_connect_ex(self: socket.socket, address: Any):  # noqa: ANN401
+    if _should_block(self.family):
+        raise _deny("socket.connect_ex", address)
+    return _real_connect_ex(self, address)
+
+
+def _guarded_sendto(self: socket.socket, *args: Any, **kwargs: Any):  # noqa: ANN401
+    if _should_block(self.family):
+        # sendto() is the one egress path that never calls connect().
+        raise _deny("socket.sendto", args[-1] if args else None)
+    return _real_sendto(self, *args, **kwargs)
+
+
+def _guarded_create_connection(address: Any, *args: Any, **kwargs: Any):  # noqa: ANN401
+    if not _allowed:
+        raise _deny("socket.create_connection", address)
+    return _real_create_connection(address, *args, **kwargs)
+
+
+def install() -> None:
+    """Patch the socket egress points. Idempotent."""
+    global _installed
+    if _installed:
+        return
+    socket.socket.connect = _guarded_connect  # type: ignore[method-assign]
+    socket.socket.connect_ex = _guarded_connect_ex  # type: ignore[method-assign]
+    socket.socket.sendto = _guarded_sendto  # type: ignore[method-assign]
+    socket.create_connection = _guarded_create_connection  # type: ignore[assignment]
+    _installed = True

--- a/Tests/test_network_guard.py
+++ b/Tests/test_network_guard.py
@@ -1,0 +1,181 @@
+"""The test suite's network egress guard actually bites (task-15111).
+
+Background: `Tests/UI`'s Console suites were opening real TCP connections to
+`127.0.0.1:8080` / `127.0.0.1:11434` on every test that mounted the chat screen
+with an unconfigured provider (see `Tests/network_guard.py` for the mechanism).
+A guard that can be reintroduced silently is no guard, so these tests pin the
+guard's own behaviour: egress is refused by default, the refusal is *recorded*
+so a `except Exception` in the code under test cannot absorb it, and the
+explicit opt-in works.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+
+import pytest
+
+from Tests import network_guard
+
+
+def _drain_expecting(*, at_least: int = 1) -> tuple[tuple[str, str], ...]:
+    """Consume the blocked-attempt record and assert something was recorded.
+
+    The autouse `_no_network_io` fixture fails any test that leaves a
+    non-empty record, so a test that *deliberately* trips the guard must
+    consume its own evidence.
+
+    Args:
+        at_least: Minimum number of blocked attempts expected.
+
+    Returns:
+        The drained ``(call, address)`` records.
+    """
+    recorded = network_guard.drain_blocked_attempts()
+    assert len(recorded) >= at_least, (
+        f"guard recorded {len(recorded)} blocked attempts, expected >= {at_least}"
+    )
+    return recorded
+
+
+def test_guard_is_installed_and_denies_by_default() -> None:
+    """The patch is in place from conftest import time, denied by default."""
+    assert socket.socket.connect is not network_guard._real_connect
+    assert socket.create_connection is not network_guard._real_create_connection
+    assert network_guard.is_allowed() is False
+
+
+def test_create_connection_to_the_llamacpp_default_port_is_refused() -> None:
+    """`127.0.0.1:8080` is the exact address the Console discovery probe used.
+
+    This is the address that made the suite environment-dependent: on a
+    machine running llama.cpp/Ollama/audio.cpp it answered, and the Console
+    setup card grew a "detected server" affordance CI never sees.
+    """
+    with pytest.raises(network_guard.BlockedNetworkAccess) as excinfo:
+        socket.create_connection(("127.0.0.1", 8080), timeout=1)
+
+    assert "127.0.0.1:8080" in str(excinfo.value)
+    recorded = _drain_expecting()
+    assert ("socket.create_connection", "127.0.0.1:8080") in recorded
+
+
+def test_socket_connect_is_refused_for_loopback_and_remote_alike() -> None:
+    """Both the app's loopback ports and ordinary remote hosts are blocked."""
+    for address in (("127.0.0.1", 11434), ("93.184.216.34", 80)):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            with pytest.raises(network_guard.BlockedNetworkAccess):
+                sock.connect(address)
+        finally:
+            sock.close()
+
+    recorded = _drain_expecting(at_least=2)
+    assert {address for _call, address in recorded} == {
+        "127.0.0.1:11434",
+        "93.184.216.34:80",
+    }
+
+
+def test_connect_ex_is_refused_too() -> None:
+    """`connect_ex` returns an errno instead of raising, so it needs its own patch."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(network_guard.BlockedNetworkAccess):
+            sock.connect_ex(("127.0.0.1", 8080))
+    finally:
+        sock.close()
+
+    _drain_expecting()
+
+
+def test_blocked_access_is_an_oserror_so_clients_degrade_normally() -> None:
+    """httpx/requests/urllib translate an OSError into their own connect error.
+
+    That is deliberate: a guarded probe should walk the same
+    "endpoint unreachable" path it would take against a dead port, not blow up
+    somewhere unrelated. It is also exactly why the record exists -- see
+    `test_a_swallowed_block_still_fails_the_test`.
+    """
+    assert issubclass(network_guard.BlockedNetworkAccess, OSError)
+
+
+def test_a_swallowed_block_still_fails_the_test() -> None:
+    """A caller that eats the error cannot hide the escape.
+
+    `local_server_discovery._get_models_payload` really does `except
+    Exception: return None, ...`, so the raise alone is invisible. The record
+    is what the autouse fixture asserts on.
+    """
+    try:
+        socket.create_connection(("127.0.0.1", 8080), timeout=1)
+    except Exception:  # noqa: BLE001 - reproducing the swallowing caller
+        pass
+
+    recorded = _drain_expecting()
+    assert recorded[0][1] == "127.0.0.1:8080"
+
+
+def test_unix_domain_sockets_are_not_blocked(tmp_path, monkeypatch) -> None:
+    """AF_UNIX is local IPC used by system libraries, not network egress."""
+    # Bound by a RELATIVE name from inside tmp_path: macOS caps sun_path at
+    # ~104 bytes and pytest's absolute tmp_path already exceeds it.
+    monkeypatch.chdir(tmp_path)
+    sock_path = "guard.sock"
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        server.bind(sock_path)
+        server.listen(1)
+        client.connect(sock_path)  # must not raise
+    finally:
+        client.close()
+        server.close()
+
+    assert network_guard.blocked_attempts() == ()
+
+
+@pytest.mark.allow_network
+def test_opted_in_test_may_open_a_real_socket() -> None:
+    """`@pytest.mark.allow_network` lifts the denial for the marked test only.
+
+    Connects to a listener this test owns, so the opt-in is proven without
+    depending on anything outside the process.
+    """
+    assert network_guard.is_allowed() is True
+
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    accepted: list[socket.socket] = []
+
+    def _accept() -> None:
+        conn, _addr = server.accept()
+        accepted.append(conn)
+
+    thread = threading.Thread(target=_accept, daemon=True)
+    thread.start()
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=5):
+            thread.join(timeout=5)
+    finally:
+        for conn in accepted:
+            conn.close()
+        server.close()
+
+    assert accepted, "opted-in test could not complete a real connection"
+    assert network_guard.blocked_attempts() == ()
+
+
+def test_denial_is_restored_after_an_opted_in_test() -> None:
+    """The opt-in is per test; the next test is denied again.
+
+    Ordering-dependent by construction: it only means anything when it runs
+    after `test_opted_in_test_may_open_a_real_socket` in the same file.
+    """
+    assert network_guard.is_allowed() is False
+    with pytest.raises(network_guard.BlockedNetworkAccess):
+        socket.create_connection(("127.0.0.1", 8080), timeout=1)
+    _drain_expecting()

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -2523,3 +2523,85 @@ class _CharacterHandoffStore(ConsoleChatStore):      # real store, persistence=N
 The greeting text then comes from production's own template expansion, so the assertion
 `== ["Hello User, I am Elara."]` is a live end-to-end claim (mutation-checked: passing
 `global_default="Zed"` turns it red) instead of a re-implementation of the thing under test.
+
+## Two tests failing on the SAME missing class can have opposite causes — and the feature commit's own test diff is the authority (TASK-15121, 2026-08-11)
+
+**Incident.** Two tests in `Tests/UI/test_console_native_chat_flow.py` went red on dev with
+what looked like one symptom: the Console send button no longer carried
+`console-send-blocked`. The obvious reading was a CSS-vocabulary rename — follow it in both
+tests and move on. Both readings were wrong in different directions:
+
+- `test_console_composer_stop_is_subdued_when_idle` mid-stream with an EMPTY draft: the
+  button was still genuinely `disabled`, just for a different reason
+  (`console-send-inactive`, the empty-draft gate) than the one pinned.
+- `test_console_duplicate_send_during_stream_does_not_break_stop_control` mid-stream with a
+  draft loaded: the button was `disabled is False` and `console-send-ready`. The single
+  `composer.load_draft("second send")` between the two tests is the whole difference.
+
+Had both been "fixed" as a rename, the second would have kept asserting a control was
+unavailable when it is now deliberately available — the exact class of silent claim
+task-14920 lost a real bug behind for four days.
+
+Neither the class name nor the production code said which reading was right. What settled
+it was the **test diff of the commit that caused it**: `git log -S 'send_blocked = not
+queue_presentation.send_enabled'` named `14cc326e4` ("feat(console): add visible prompt
+queue"), and that commit's own diff to a SIBLING test file
+(`Tests/UI/test_console_send_disabled_state.py`) rewrote the same assertions to the new
+contract and renamed a test from `..._while_run_blocked_still_shows_feedback` to
+`..._queues_draft_behind_accepted_run`. The author changed the contract deliberately
+(ADR-046: "once accepted, the normal `Send` action becomes `Queue`") and updated one test
+file, not two.
+
+**What to do.** On a post-merge test failure that looks cosmetic, `git log -S` the assertion's
+symbol, then read that commit's *test* diff before its production diff — an author who meant
+the change usually left the new contract written out somewhere. And classify each failure
+separately even when the symptom string is identical: same missing class, different inputs,
+different truth. Where a pinned behaviour really was removed, say so in the test and pin what
+replaced it (here: the duplicate send must still not start a second run, must land in the
+bounded queue, and must not break Stop) rather than deleting the assertion.
+
+---
+
+## What is LISTENING on your machine can change what the test suite does (2026-08-11)
+
+**The trap.** A suite can be environment-dependent in a direction nobody checks: not a
+missing dependency, but an *extra* process. If production code probes a hardcoded
+localhost port, then whether a developer happens to be running a local server decides
+which branch the tests take — and the difference is invisible, because the escape's
+failure mode is *success*.
+
+**What happened.** task-15111. `Tests/UI`'s Console suites were opening real TCP
+connections to `127.0.0.1:8080` and `127.0.0.1:11434` on every test that mounted
+`ChatScreen` with an unconfigured provider. Mechanism: a blocking setup card starts
+`_maybe_start_console_local_discovery` → `discover_local_servers`, whose candidate list
+*always* leads with those two well-known defaults regardless of config, and
+`probe_models_endpoint` builds a real `httpx.AsyncClient` when none is injected. A
+record-only socket shim logged **386 connect attempts across 20 test files in the first
+12% of `Tests/UI` alone** — on a machine that happened to have an `audiocpp` server bound
+to 8080. Exactly one test in the suite had ever stubbed the `console_local_server_discovery`
+seam; every other Console test fell through to the network.
+
+Two things made it worse than "a stray GET":
+
+- **The escape was self-concealing.** `_get_models_payload` ends in
+  `except Exception: return None, "No models endpoint..."`. Blocking the socket, raising,
+  timing out and answering all look identical from outside. A guard that only *raises* is
+  therefore not enough — the guard has to **record** the attempt and something has to
+  assert on the record, or the code under test simply eats it.
+- **It could have POSTed.** `_configure_native_ready_console` points the Console at
+  `http://127.0.0.1:9099` and several tests then drive a REAL send through
+  `ConsoleProviderGateway`. On CI nothing listens, `_is_reachable`'s `GET /health` fails,
+  and the send stops — so the suite looked read-only. Standing up a stand-in server on
+  9099 and re-running one such test showed it going on to send **two POSTs to
+  `/v1/chat/completions`** (streaming, then the non-streaming fallback) carrying the
+  test's prompt. With a real llama.cpp on that port, `pytest` would have driven inference
+  on the developer's server.
+
+**What to do.** Default-deny sockets in the test configuration (`Tests/network_guard.py`,
+installed at conftest *import* time so collection and post-test worker threads are covered
+too), with an explicit `@pytest.mark.allow_network` opt-in, and fix the seams that build a
+real client so the guard is a backstop rather than the mechanism. And when you want to know
+what a suite would do against a live endpoint, do not reason about it: **bind a stand-in
+server on the port and read what it receives.** Recording connects tells you a socket
+opened; recording requests tells you the verb, the path and the body — which is the
+difference between "reads something" and "writes to your server".

--- a/backlog/tasks/task-15111 - Tests-UI-reaches-a-live-localhost-8080-endpoint-when-one-is-listening.md
+++ b/backlog/tasks/task-15111 - Tests-UI-reaches-a-live-localhost-8080-endpoint-when-one-is-listening.md
@@ -1,15 +1,16 @@
 ---
 id: TASK-15111
-title: >-
-  Tests/UI reaches a live localhost:8080 endpoint when one is listening
-status: To Do
-assignee: []
+title: 'Tests/UI reaches a live localhost:8080 endpoint when one is listening'
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 04:00'
+updated_date: '2026-08-11 14:24'
 labels:
   - tests
   - test-infrastructure
-priority: high
 dependencies: []
+priority: high
 ---
 
 ## Description
@@ -23,9 +24,48 @@ Worth checking as part of this: whether any test can *mutate* state on a live en
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 No test in the suite performs network I/O to a live local endpoint; the boundary is stubbed or blocked
-- [ ] #2 A guard makes the escape impossible to reintroduce silently (e.g. sockets blocked by default in the UI test configuration, with an explicit opt-in for any test that genuinely needs one)
-- [ ] #3 The check covers whether any such call could mutate state on the endpoint it reached, not just read from it
+- [x] #1 No test in the suite performs network I/O to a live local endpoint; the boundary is stubbed or blocked
+- [x] #2 A guard makes the escape impossible to reintroduce silently (e.g. sockets blocked by default in the UI test configuration, with an explicit opt-in for any test that genuinely needs one)
+- [x] #3 The check covers whether any such call could mutate state on the endpoint it reached, not just read from it
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Establish the truth: run Tests/UI under a record-only socket shim; capture every connect with its address; identify the production code path that builds a live client during a test.
+2. Inventory every network-reachable point (not just /v1/models, not just Tests/UI): grep/AST the client-construction seams and record HTTP verbs, not just connects.
+3. Fix the mechanism at the seams that build a REAL client in tests (local-server discovery probe chokepoint; ConsoleProviderGateway's owned-client factory), preserving the CI 'nothing is listening' behaviour exactly.
+4. Add a default-deny socket guard installed at conftest import time, with an explicit @pytest.mark.allow_network opt-in; record blocked attempts so a broad 'except Exception' in the code under test cannot swallow the guard.
+5. Prove the guard bites: tests that attempt a connection and assert refusal; mutation-check by disabling the guard and by disabling each mechanism fix.
+6. Answer AC#3 empirically: stand up a stand-in local server and observe what the test-reachable client actually SENDS (verb + path + body).
+7. Sweep for tests the guard exposes as network-dependent; stub or mark each with the opt-in and report counts.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Tests no longer reach a live local endpoint, and the escape now cannot come back silently.
+
+**What was actually happening.** Confirmed empirically first, not taken on faith: a record-only socket shim over `Tests/UI` logged **386 real TCP connect attempts across 20 test files in the first 12% of the suite** on a machine with an `audiocpp` server bound to `127.0.0.1:8080`. Two distinct mechanisms, not one:
+
+1. *Discovery.* Mounting `ChatScreen` with an unconfigured provider makes the setup card blocking, which starts `_maybe_start_console_local_discovery` -> `discover_local_servers`. `build_local_server_candidates` **always** leads with `http://127.0.0.1:8080` and `http://127.0.0.1:11434` regardless of config, and `probe_models_endpoint` builds a real `httpx.AsyncClient` when none is injected. Exactly one test in the suite (`test_console_local_server_discovery_card`) had ever stubbed the `console_local_server_discovery` app seam; every other Console test fell through to the network. On a machine where 8080 answers, the setup card grows a "detected server" affordance CI never sees.
+2. *The provider gateway.* `_configure_native_ready_console` points the Console at `http://127.0.0.1:9099` and several tests then drive a REAL send through `ConsoleProviderGateway`, whose `_new_owned_http_client` is a real client. On CI nothing listens, `_is_reachable`'s `GET /health` fails, and the send stops -- which is why it looked read-only.
+
+**AC#3, answered by measurement.** A stand-in llama.cpp was bound to 127.0.0.1:9099 and `test_console_command_popup::test_enter_with_popup_closed_sends_normally` re-run against it. The server received `GET /health` **and two `POST /v1/chat/completions`** (streaming, then the non-streaming fallback) carrying the test's prompt. So the reachable client was never read-only: with a real llama.cpp on that port, `pytest` would have driven inference on the developer's own server. The gateway's reachable surface is `_is_reachable` (GET /health), `resolve_llamacpp` (GET /v1/models), and `stream_llamacpp_chat` / `complete_llamacpp_chat` / `complete_auxiliary` / `stream_chat` (POST /v1/chat/completions).
+
+**Fixes.** Both mechanisms are fixed at the seam that builds a real client, and a default-deny socket guard proves it rather than being the only thing standing between the suite and the network:
+
+- `Tests/network_guard.py` (new): patches `socket.connect`/`connect_ex`/`sendto`/`create_connection` for AF_INET/AF_INET6 at conftest **import** time (so collection, fixture teardown and worker threads outliving a test are covered), denied by default. `BlockedNetworkAccess` subclasses `OSError` so clients degrade down their existing "unreachable" path -- and because `_get_models_payload` really does `except Exception`, every block is also **recorded**; the autouse `_no_network_io` fixture fails the test on a non-empty record, which is what makes the guard unswallowable. `pytest-socket` is not in this repo's dev extras, so this is hand-rolled rather than a new dependency.
+- `_no_local_server_probes` (autouse, `Tests/conftest.py`): stubs `local_server_discovery._get_models_payload`, the single chokepoint all three production import sites funnel through. Opt-out marker `local_server_probe` for the MockTransport probe tests.
+- `_console_gateway_http_client_is_offline` (autouse): substitutes an `httpx.MockTransport` that raises `ConnectError` for `ConsoleProviderGateway._new_owned_http_client`, the single owned-client construction site; injected clients are untouched. Opt-out marker `owned_http_client` (plus `allow_network`).
+- Opt-in marker `allow_network` (and `live`, implicitly) for tests that genuinely need a socket.
+
+**Evidence.** RED first: the shim's 386 connects, and with the guard disabled `test_create_connection_to_the_llamacpp_default_port_is_refused` DID NOT RAISE -- it really connected to the live 8080 server. Mutation-checked twice: commenting out `network_guard.install()` turns 6 of 9 guard tests red; disabling `_no_local_server_probes` turns the two isolation tests red. With the fake 9099 server still running, the whole guarded Console run left its request log unchanged.
+
+**Other tests the guard exposed (not weakened).** Failure *sets* compared against an identical unguarded baseline over `Tests/Model_Artifacts Tests/Subscriptions Tests/Notes Tests/Local_Ingestion Tests/Media_DB/test_sync_client_integration.py Tests/TTS`: baseline 21 failed / 5712 passed / 6 errors; guarded 94 failed / 5639 passed / 90 errors. Every newly failing test was in one of 12 modules that stand up an **in-process** HTTP server (`FixtureArtifactServer`, `fake_audiocpp_server`, the briefings feed server) -- all 84 blocked addresses were ephemeral loopback ports this process was itself listening on. Those 12 modules got a `pytestmark = pytest.mark.allow_network` with a comment saying why: 903 passed, 0 failed afterwards. Three `Tests/Chat/test_console_provider_gateway.py` tests that are *about* the owned client got `owned_http_client` (two also `allow_network`, since they use their own `local_http_server`). The 21 pre-existing failures sit in 6 modules none of this touches.
+
+**Files:** added `Tests/network_guard.py`, `Tests/test_network_guard.py`, `Tests/UI/test_console_local_server_probe_isolation.py`; changed `Tests/conftest.py`, `pyproject.toml` (3 markers), `Tests/Chat/test_local_server_discovery.py`, `Tests/Chat/test_console_provider_gateway.py`, 12 fixture-server modules, `backlog/docs/lessons-testing-evidence.md`.
+
+**Final counts (READ).** `Tests/test_network_guard.py` + `Tests/UI/test_console_local_server_probe_isolation.py` + `Tests/Chat/test_local_server_discovery.py`: **37 passed**. Coordinator keep-green set (`test_background_signal_bounds`, `test_console_moved_seam_guard`, `test_screen_navigation`, `test_personas_workbench`) plus the new tests and both discovery/gateway suites: **629 passed, 3 failed** -> the 3 were the owned-client tests, now marked `owned_http_client`: **4 passed**. The 12 fixture-server modules after marking: **903 passed, 0 failed**. Nine of the Console modules the record-only shim caught red-handed (setup-lock-polish, product-maturity empty setup states, discovery card, agent rail, button routing, character avatar, composer menu, auto-rag-on-send, edit/resend): **147 passed, 4 failed, ZERO blocked-egress hits** -- and those same 4 fail identically with the guard AND both mechanism fixtures disabled, so they are pre-existing stale contracts (`section:starred` collapse pref, `ConsoleChatController._turn_context_provider`, two auto-RAG ordering contracts), not caused here. `test_console_command_popup`'s one remaining failure is likewise pre-existing: it pins a 6-item slash-command list that `/generate-video` + `/stream-video` (task-3401.5, already on dev) grew to 8. A full `Tests/UI` sweep was started in halves but abandoned unfinished -- the machine was running 4+ concurrent pytest sessions from other agents and neither half got past ~6%; the targeted runs above cover every module the shim proved was reaching the network.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15121 - Console-send-button-state-assertions-fail-on-dev.md
+++ b/backlog/tasks/task-15121 - Console-send-button-state-assertions-fail-on-dev.md
@@ -1,16 +1,17 @@
 ---
 id: TASK-15121
-title: >-
-  Console send-button state assertions fail on dev
-status: To Do
-assignee: []
+title: Console send-button state assertions fail on dev
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 05:20'
+updated_date: '2026-08-11 13:57'
 labels:
   - console
   - tests
   - dev-baseline
-priority: medium
 dependencies: []
+priority: medium
 ---
 
 ## Description
@@ -27,9 +28,83 @@ Triage is the work: the class vocabulary may have been deliberately renamed (`co
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 Each failure is classified as a stale class-name pin or a real send/stop control regression, with the commit that changed the behaviour named
-- [ ] #2 A real regression is fixed in the product; a rename is followed in the test while preserving the original claim (that the control is genuinely unavailable, not merely styled differently)
-- [ ] #3 `Tests/UI/test_console_native_chat_flow.py` runs whole with a READ pass count and no unexpected failures
+- [x] #1 Each failure is classified as a stale class-name pin or a real send/stop control regression, with the commit that changed the behaviour named
+- [x] #2 A real regression is fixed in the product; a rename is followed in the test while preserving the original claim (that the control is genuinely unavailable, not merely styled differently)
+- [x] #3 `Tests/UI/test_console_native_chat_flow.py` runs whole with a READ pass count and no unexpected failures
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce both failures and read the exact assertion lines that fail (RED).
+2. Find the commit that changed send-button state: `git log -S` over the class names and over the `send_blocked` computation.
+3. Read that commit's intent (task/ADR/spec) and classify each failure: stale pin vs real regression.
+4. Verify the send-block state machine has no hole (every run state vs the queue presentation) before accepting the contract-change reading.
+5. Repair the tests to the shipped contract while preserving each test's original safety claim; mutation-check every new assertion.
+6. Run the whole file for a READ pass count with the task-15120 xfail intact.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Verdict: neither failure is a class rename, and neither is a regression. Both are stale
+pins of a contract that was deliberately replaced.** No product change was needed; the
+repair is test-only, in `Tests/UI/test_console_native_chat_flow.py`.
+
+**Cause (both failures): `14cc326e4` "feat(console): add visible prompt queue"**
+(TASK-14808, ADR-046 §"Visible bounded Console prompt queue"). Found with
+`git log -S 'send_blocked = not queue_presentation.send_enabled' -- tldw_chatbook/UI/Screens/chat_screen.py`
+and `git log --diff-filter=A -- tldw_chatbook/UI/Console_Modules/prompt_queue.py` (same commit).
+Intent, quoted from ADR-046: *"Queueing begins only after the active turn crosses the existing
+accepted-send boundary. During provider and skill validation the action remains unavailable and
+reads `Preparing...`. Once accepted, the normal `Send` action becomes `Queue`; Enter and the
+button both enqueue the exact canonical text draft."* That commit rewrote the same assertions in
+the sibling file `Tests/UI/test_console_send_disabled_state.py` (including renaming
+`test_enter_hotkey_while_run_blocked_still_shows_feedback` →
+`test_enter_hotkey_queues_draft_behind_accepted_run`) but missed these two.
+
+**Per-failure classification**
+
+1. `test_console_composer_stop_is_subdued_when_idle` — stale pin, control still unavailable.
+   Mid-stream with the draft consumed, `send_button.disabled is True` still passes; the button
+   fails the *empty-draft* gate (`console-send-inactive`), not the run gate. `console-send-blocked`
+   is simply unreachable in an accepted-turn state now. Repaired to keep the original claim
+   (`disabled is True`, `console-action-disabled`, not `console-action-primary`) and pin the
+   reason honestly (`console-send-inactive`, not `console-send-blocked`, label `"Queue"`).
+2. `test_console_duplicate_send_during_stream_does_not_break_stop_control` — pinned behaviour
+   deliberately REMOVED. With a draft loaded mid-stream the button is legitimately enabled as
+   `Queue`; a second send is admitted to the bounded FIFO queue instead of refused. The single
+   `composer.load_draft("second send")` is the only difference from failure 1 — same symptom,
+   opposite cause. The test's named claim is preserved and asserted harder: the duplicate send
+   must not start a second run (`run_state.status == "streaming"`), must land in the queue
+   (`prompt_queue_registry.snapshot(...).total_count` 0 → 1), must not be eaten
+   (`composer.draft_text() == ""`, since admission is what clears the draft), and Stop must still
+   work.
+
+**New contract and where it is enforced instead of `console-send-blocked`:**
+`derive_prompt_queue_presentation` in `tldw_chatbook/UI/Console_Modules/prompt_queue.py` is the
+sole decider of `send_enabled`/`send_label`; `chat_screen.py::_sync_console_composer_action_state`
+replaces the run-state-derived `send_blocked` with `not queue_presentation.send_enabled`, then
+re-ORs the setup/attachment blocks. Checked for a hole before accepting the reading: every
+non-`is_send_allowed` run status maps to either `occupies_slot and not queue_owned` →
+`"Preparing..."`/disabled (VALIDATING, RETRYING, and STREAMING before acceptance) or
+`accepted_live_turn` → `"Queue"`/enabled-but-queued. There is no state where a send is admitted
+as a second concurrent run. `console-send-blocked` remains live and tested for Preparing/Queue
+full/setup blocks — `test_console_streaming_chunks_render_after_slow_provider_validation` in this
+same file still asserts it during VALIDATING and passes untouched.
+
+**Evidence.** RED before: both tests failed at lines 2773 and 2809. GREEN after: both pass.
+Whole file: **308 passed, 1 xfailed in 270.76s**, with task-15120's `xfail(strict=True)` still
+XFAIL (not XPASS). `Tests/UI/test_console_send_disabled_state.py`: 9 passed. Mutation-checked
+every new assertion against the product (each restored byte-identical afterwards):
+dropping `set_class(not has_draft, "console-send-inactive")` kills the class assertion;
+forcing `send_label = "Send"` in the queue-owned branch kills both `label.plain == "Queue"`
+assertions; forcing `send_enabled = False` there kills `disabled is False` and the
+`not console-send-blocked` assertion; disabling the `accepted_live_turn` admission branch kills
+`total_count == 1`.
+
+**Files changed:** `Tests/UI/test_console_native_chat_flow.py` (two assertion blocks),
+`backlog/docs/lessons-testing-evidence.md` (new lesson: two tests failing on the same missing
+class can have opposite causes; the causing commit's own *test* diff is the authority on intent).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15210 - Five-pre-existing-Console-contract-failures-surfaced-by-the-network-guard.md
+++ b/backlog/tasks/task-15210 - Five-pre-existing-Console-contract-failures-surfaced-by-the-network-guard.md
@@ -1,0 +1,37 @@
+---
+id: TASK-15210
+title: >-
+  Five pre-existing Console contract failures surfaced by the network guard
+status: To Do
+assignee: []
+created_date: '2026-08-11 07:00'
+labels:
+  - console
+  - tests
+  - dev-baseline
+priority: medium
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while implementing task-15111. Running the nine Console modules the socket shim had caught reaching the network gave `147 passed, 4 failed, 0 blocked-egress hits` — the four failures are **not** caused by the guard: they were re-run with the guard and both mechanism fixtures disabled and failed identically. A fifth was found in the same sweep.
+
+1. `section:starred` collapse preference.
+2. `ConsoleChatController._turn_context_provider` — `AttributeError`.
+3. and 4. Two auto-RAG ordering contracts.
+5. `test_console_command_popup::test_slash_opens_popup_and_typing_filters` pins a **6-item** slash list; `/generate-video` and `/stream-video` (task-3401.5, already on dev) grew it to **8**.
+
+The fifth is the clearest and sets the pattern: a list-length pin that a legitimate feature addition broke, sitting red until something happened to run the file whole. That is the same stale-contract class as task-14920, where twenty such failures had accumulated unnoticed and one of them was hiding a real product bug that shipped.
+
+Triage before repair, as in task-14920: a pinned count or attribute that a deliberate change moved is a test fix, but `_turn_context_provider` raising `AttributeError` and auto-RAG *ordering* changing are both shapes that can be real regressions. Do not rewrite to green without naming the commit that changed each behaviour and reading its intent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Each of the five is classified as a stale pin or a real regression, with the causing commit named and its intent read
+- [ ] #2 Real regressions are fixed in the product; stale pins are updated while preserving the original claim (assert the behaviour, not a count or a class string that the next honest change breaks again)
+- [ ] #3 The affected Console test modules run WHOLE with READ pass counts and no unexpected failures
+<!-- AC:END -->

--- a/backlog/tasks/task-15211 - Complete-the-full-Tests-UI-sweep-under-the-network-guard.md
+++ b/backlog/tasks/task-15211 - Complete-the-full-Tests-UI-sweep-under-the-network-guard.md
@@ -1,0 +1,31 @@
+---
+id: TASK-15211
+title: >-
+  Complete the full Tests/UI sweep under the network guard
+status: To Do
+assignee: []
+created_date: '2026-08-11 07:00'
+labels:
+  - tests
+  - test-infrastructure
+priority: medium
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Debt acknowledged by task-15111 rather than papered over. That task blocked test network I/O by default and verified the guard against every module its socket shim had proven was reaching the network, plus the twelve modules that legitimately stand up in-process loopback servers (`903 passed`). What it could **not** finish was a full `Tests/UI` sweep under the guard: the machine was carrying four or more concurrent pytest sessions from other agents and neither half of the split run passed roughly 6%.
+
+So the guard is verified where it was known to matter, and unverified across the rest of `Tests/UI`. The specific risk is not a false block — it is a module that stands up a fixture server, lacks `@pytest.mark.allow_network`, and therefore **hangs until the 300s timeout** (client blocked while the server thread sits in `accept()`) instead of failing fast. Under this repo's `timeout_method = thread` a hang kills the whole process, which is exactly the failure mode task-14912 was created to eliminate.
+
+Run it on a quiet machine, in disjoint halves if needed, and record READ counts for each.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The full `Tests/UI` suite completes under the network guard with READ pass counts (disjoint halves acceptable, stated as such)
+- [ ] #2 Any module that hangs or blocks is fixed at its source — marked `allow_network` with a reason if it legitimately needs a loopback server, or stubbed if it does not
+- [ ] #3 A fixture-server module missing the marker fails fast rather than hanging, so this cannot reintroduce the run-killing hang class
+<!-- AC:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -531,6 +531,9 @@ markers = [
     "requires_display: tests that require a display (may fail in CI)",
     "requires_cleanup: tests that need a gc pass immediately after running",
     "real_audio_device: opts out of the autouse _no_real_audio_device guard (Tests/conftest.py) to exercise a real sounddevice OutputStream",
+    "allow_network: opts out of the autouse _no_network_io guard (Tests/conftest.py) to open a real socket; justify it in the test's docstring",
+    "local_server_probe: opts out of the autouse _no_local_server_probes guard (Tests/conftest.py) to exercise the real /v1/models probe against an injected httpx.MockTransport client",
+    "owned_http_client: opts out of the autouse _console_gateway_http_client_is_offline guard (Tests/conftest.py) for tests that are ABOUT the gateway's real owned httpx client",
     "live: marks tests that call real paid external APIs (require key files + TLDW_LIVE_SEARCH_TESTS=1 + --run-live)",
 ]
 


### PR DESCRIPTION
Two tasks: block test network I/O by default (15111, HIGH) and triage the send-button assertions (15121).

## task-15111 — the filed observation understated it

The report was "the UI suites reach `127.0.0.1:8080` when something is listening." A record-only socket shim measured **386 real TCP connects across 20 test files in the first 12% of `Tests/UI`**, through **two independent mechanisms**:

1. **Discovery** — mounting `ChatScreen` with an unconfigured provider triggers local-server discovery, and `build_local_server_candidates` **always** leads with `127.0.0.1:8080` and `:11434` regardless of config, while `probe_models_endpoint` builds a real `httpx.AsyncClient` when none is injected. **Exactly one test in the repo had ever stubbed that seam.**
2. **The provider gateway** — tests point the Console at `127.0.0.1:9099` and then drive a real send through `ConsoleProviderGateway`, whose owned client is real.

### AC#3: it could mutate, and that is the finding

Binding a stand-in llama.cpp on 9099 and re-running one ordinary test showed the server receive `GET /health` **and two `POST /v1/chat/completions` carrying the test's prompt**. It only ever *looked* read-only because nothing listens on 9099 in CI, so the reachability check failed and the send stopped. **On a developer running llama.cpp there, `pytest` would have driven real inference on their server.**

### The guard

`pytest-socket` is not in this repo's dev extras, so `Tests/network_guard.py` patches `connect`/`connect_ex`/`sendto`/`create_connection` at conftest **import** time — covering collection, teardown, and worker threads that outlive a test — denied by default with an explicit `allow_network` marker opt-in.

The subtle part: `BlockedNetworkAccess` subclasses `OSError` so clients degrade normally rather than exploding, but the discovery path catches broad exceptions, which would make a raise **invisible**. So every block is **recorded**, and an autouse fixture fails the test on a non-empty record. Both mechanisms are also fixed at their chokepoints, so the guard is a backstop rather than the fix.

Comparing failure **sets** against an identical unguarded baseline: every new failure landed in **12 modules that stand up in-process HTTP servers** — all 84 blocked addresses were ephemeral loopback ports the test process was itself listening on. Those are marked with reasons (**903 passed**).

## task-15121 — no product regression, and the naive fix would have lied

Both failures trace to `14cc326e4` (ADR-046, the visible prompt queue). The decisive evidence is **that commit's own test diff**: it rewrote these exact assertions in the *sibling* contract file and updated one test file, not two.

The two failures had **identical symptoms and opposite causes** — the only difference between the tests is a single `load_draft(...)`. One was a stale pin (the control *is* still unavailable, now failing the empty-draft gate rather than the run gate). The other pinned a **deliberately removed** behaviour: mid-stream with a draft, Send is legitimately enabled as **Queue**. Treating both as a rename would have shipped a false claim.

So the safety claim in the second test's *name* — "duplicate send during stream does not break stop control" — is asserted harder instead: the duplicate must not start a second run, must land in the queue, must not be silently eaten, and Stop must still work. Every status was enumerated through the queue presentation to confirm **no state admits a send as a second concurrent run**. `git diff -- tldw_chatbook/` is empty for this task.

## Verification

**489 passed, 1 xfailed** across both agents' suites (the xfail is task-15120's strict marker, correctly xfailing). Guard mutation-checked twice; RED evidence recorded — with the guard disabled, the "connection is refused" test *did not raise*, because it connected to the live server.

## Filed, not absorbed

- **task-15210** — 5 pre-existing Console contract failures the sweep surfaced (including a 6-item slash-list pin that `/generate-video` + `/stream-video` grew to 8). Same stale-contract class as task-14920; triage required, not a rewrite to green.
- **task-15211** — the full `Tests/UI` sweep under the guard was **not** completed (four-plus concurrent pytest sessions from other agents; neither half passed ~6%). The specific residual risk is stated: a fixture-server module missing the marker would *hang* rather than fail fast, which is the run-killing class task-14912 exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks test network I/O by default and hardens UI tests to prevent accidental localhost access; also updates Console send-button tests to match the visible prompt queue contract where Send becomes Queue mid-stream. This fulfills tasks 15111 (network isolation with proof it prevented real POSTs) and 15121 (align tests to ADR-046 without changing product code).

- **Bug Fixes**
  - Added `Tests/network_guard.py` and installed it at `conftest` import to deny AF_INET/AF_INET6 by default, record blocked attempts, and allow opt-in via `@pytest.mark.allow_network` (`live` implies allowed).
  - Stubbed the local-server discovery probe in tests and forced the Console provider gateway’s owned `httpx` client offline using `httpx.MockTransport`; opt-outs via `@pytest.mark.local_server_probe` and `@pytest.mark.owned_http_client`.
  - Marked modules that spin up in-process loopback servers with `@pytest.mark.allow_network`; added isolation tests for discovery and guard behavior.
  - Updated two assertions in `test_console_native_chat_flow`: mid-stream with empty draft uses `console-send-inactive` and label "Queue"; with a draft, Send is enabled as "Queue", enqueues the draft, never starts a second run, and Stop still works.

- **Migration**
  - For tests that truly need sockets: add `@pytest.mark.allow_network`.
  - To exercise the real discovery probe with an injected `httpx.MockTransport`, add `@pytest.mark.local_server_probe`.
  - For tests about the gateway’s real owned client, add `@pytest.mark.owned_http_client`.
  - Markers are registered in `pyproject.toml`.

<sup>Written for commit 990df53d0e951ec8e59420b308fc6e6f4612f6d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

