### PR TITLE
fix: repair 12 of 13 red tests on the dev baseline

### DIFF
--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -214,6 +214,37 @@ async def _real_agent_citation_controller(
     return result, controller, store, gateway
 
 
+@pytest.fixture(autouse=True)
+def _mcp_tests_keep_a_small_catalog(monkeypatch):
+    """Keep local tools out of these tests' catalog.
+
+    These tests exercise the MCP *permission* gate, not tool disclosure.
+    PR #1474 flipped ``[console] local_tools_enabled`` to default-true,
+    which put 16 local tools into every run's catalog and pushed it from 3
+    to 19 -- past ``DIRECT_DISCLOSE_THRESHOLD`` (16). Past that threshold
+    ``initial_disclosure`` returns no schemas and offers find_tools/
+    load_tools instead, so a scripted model that calls its tool directly
+    is refused at the disclosure gate before the permission gate is ever
+    consulted, and all five MCP tests failed for a reason none of them is
+    about. (It fails CLOSED -- ``allowed_tools`` was always correct.)
+
+    Restoring the pre-#1474 catalog size is the honest fix: it lets these
+    tests keep asserting exactly what they were written to assert, rather
+    than rewriting them to route through find/load. Production disclosure
+    behaviour is deliberately untouched -- see task-15261 for the coverage
+    gap that nothing pins an MCP tool as reachable under the shipped
+    default catalog, which is find/load-shaped and has been since before
+    #1474.
+    """
+    real_get_cli_setting = controller_module.get_cli_setting
+
+    def _small_catalog(section, key, default=None, *args, **kwargs):
+        if section == "console" and key == "local_tools_enabled":
+            return False
+        return real_get_cli_setting(section, key, default, *args, **kwargs)
+
+    monkeypatch.setattr(controller_module, "get_cli_setting", _small_catalog)
+
 def _controller(tmp_path, scripts, *, child_scripts=(), enabled=True):
     gateway = _Gateway(scripts, child_scripts)
     store = ConsoleChatStore()

--- a/Tests/Chat/test_console_ephemeral.py
+++ b/Tests/Chat/test_console_ephemeral.py
@@ -592,7 +592,15 @@ def test_promotion_restores_ephemeral_flag_if_persist_returns_none_unexpectedly(
         session = store.create_session(title="Temporary chat", ephemeral=True)
         _run_a_chat(store, session.id)
 
-        monkeypatch.setattr(store, "persist_session_if_needed", lambda session_id: None)
+        # Explicit signature, not **kwargs: production gained the keyword-only
+        # `strict_roleplay_context` in 86f74db93 and this stub silently raised
+        # TypeError one frame early, so the test stopped reaching the
+        # None-return branch it exists to cover. An explicit signature keeps
+        # failing loudly on the next change rather than absorbing it.
+        def _returns_none(session_id, *, strict_roleplay_context=False):
+            return None
+
+        monkeypatch.setattr(store, "persist_session_if_needed", _returns_none)
 
         with pytest.raises(RuntimeError):
             store.promote_ephemeral_session(session.id)

--- a/Tests/Chat/test_tool_output_disclosure.py
+++ b/Tests/Chat/test_tool_output_disclosure.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import pytest
 from textual.app import App, ComposeResult
+from textual.widgets import Static
 
 from tldw_chatbook.Chat.console_chat_models import (
     ConsoleChatMessage,
@@ -11,6 +12,20 @@ from tldw_chatbook.Chat.console_chat_models import (
 from tldw_chatbook.Chat.console_message_actions import ConsoleMessageActionService
 from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
 
+
+def _row_text(app, message_id: str) -> str:
+    """Renderer-agnostic visible text of one transcript row.
+
+    The row became a `Vertical` in 065970aa4 (roleplay speaker theming), so
+    `row.render()` now returns `Blank` and asserting against it is vacuous.
+    Read the mounted child Statics instead -- deliberately NOT the row's
+    `renderable` compatibility projection, which is derived from the row's
+    in-memory message and would pass even if the mounted children never
+    repainted, i.e. exactly the defect these tests exist to catch.
+    """
+    row = app.query_one(f"#console-message-{message_id}")
+    parts = [str(static.renderable) for static in row.query(Static)]
+    return "\n".join(parts) if parts else str(row.render())
 
 def _marker(full: str | None, content: str = "⚙ read_file → data… (+900 chars)"):
     return ConsoleChatMessage(
@@ -99,9 +114,7 @@ async def test_full_tool_output_is_reachable_from_the_mounted_transcript():
     app = _TranscriptHarness()
     async with app.run_test() as pilot:
         transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
-        row = app.query_one("#console-message-tool-1")
-
-        assert "result row 59" not in str(row.render()), (
+        assert "result row 59" not in _row_text(app, "tool-1"), (
             "precondition: the collapsed row shows a preview, not everything"
         )
 
@@ -109,7 +122,7 @@ async def test_full_tool_output_is_reachable_from_the_mounted_transcript():
         await pilot.pause()
         await pilot.pause()
 
-        expanded = str(app.query_one("#console-message-tool-1").render())
+        expanded = _row_text(app, "tool-1")
         assert "result row 59" in expanded, (
             f"the full result is still unreachable on screen: {expanded[:200]!r}"
         )
@@ -118,9 +131,7 @@ async def test_full_tool_output_is_reachable_from_the_mounted_transcript():
         transcript.toggle_tool_output("tool-1")
         await pilot.pause()
         await pilot.pause()
-        assert "result row 59" not in str(
-            app.query_one("#console-message-tool-1").render()
-        ), "expanding must be reversible"
+        assert "result row 59" not in _row_text(app, "tool-1"), "expanding must be reversible"
 
 
 @pytest.mark.asyncio
@@ -141,7 +152,7 @@ async def test_pressing_o_expands_the_selected_marker():
         await pilot.pause()
         await pilot.pause()
 
-        expanded = str(app.query_one("#console-message-tool-1").render())
+        expanded = _row_text(app, "tool-1")
         assert "result row 59" in expanded, (
             f"pressing 'o' did not reveal the full result: {expanded[:160]!r}"
         )
@@ -217,8 +228,8 @@ async def test_two_calls_in_one_turn_expand_independently():
         await pilot.pause()
         await pilot.pause()
 
-        assert "UNIQUE-A" in str(app.query_one("#console-message-t-a").render())
-        assert "UNIQUE-B" not in str(app.query_one("#console-message-t-b").render()), (
+        assert "UNIQUE-A" in _row_text(app, "t-a")
+        assert "UNIQUE-B" not in _row_text(app, "t-b"), (
             "expanding one call revealed another -- the toggle is not per row"
         )
 

--- a/Tests/UI/test_css_class_coverage_contract.py
+++ b/Tests/UI/test_css_class_coverage_contract.py
@@ -130,12 +130,6 @@ KNOWN_UNSTYLED: dict[str, str] = {
         "(`ConsoleMarkdownMessage > Static`), so the class carries no "
         "style of its own by design."
     ),
-    "console-markdown-header": (
-        "query-selector handle, same pair as console-markdown-footer "
-        "above: sync_message updates it via query_one('.console-markdown-"
-        "header', Static); styled by the `ConsoleMarkdownMessage > Static` "
-        "type rule in the widget's DEFAULT_CSS."
-    ),
     "console-save-as-context": (
         "plain descriptive Static (role/excerpt text) with no visual "
         "treatment of its own; not queried by class anywhere."
@@ -145,6 +139,18 @@ KNOWN_UNSTYLED: dict[str, str] = {
         "test_console_internals_decomposition.py:427 "
         "(button.has_class('console-send-button')), not a style hook -- "
         "visuals come from the styled `destination-action-button` base."
+    ),
+    "console-settings-context-view": (
+        "duplicates the section's own id (#console-settings-context-view), "
+        "which is what both the widget (query_one) and "
+        "Tests/UI/test_console_context_controls.py select on; the class "
+        "token itself is never used as a selector."
+    ),
+    "console-settings-model-view": (
+        "behavioural grouping marker, not a style hook: "
+        "query('.console-settings-model-view') collects the model-mode "
+        "sections to toggle their display in Python; styling comes from the "
+        "styled console-settings-modal-section class stacked alongside it."
     ),
     "console-settings-error-summary": (
         "presence pinned by test_console_session_settings.py:1764 "

--- a/backlog/tasks/task-15260 - Console-local-tools-turn-context-snapshot-defaults-False-while-the-master-switch-defaults-True.md
+++ b/backlog/tasks/task-15260 - Console-local-tools-turn-context-snapshot-defaults-False-while-the-master-switch-defaults-True.md
@@ -1,0 +1,24 @@
+---
+id: TASK-15260
+title: >-
+  Console local tools: turn-context snapshot defaults False while the master
+  switch defaults True
+status: To Do
+assignee: []
+created_date: '2026-08-11 14:40'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while repairing the dev test baseline (the MCP permission tests). PR #1474 flipped local tools on by default via LOCAL_TOOLS_DEFAULT_ENABLED = True (Agents/builtin_tool_gate.py:554), and _compose_local_provider (Chat/console_chat_controller.py:3840-3850) resolves the flag as turn_context.tool_configuration.get('local_tools_enabled', LOCAL_TOOLS_DEFAULT_ENABLED) — i.e. the turn context WINS when present. But the turn-context snapshot itself is built with the opposite default: console_chat_controller.py:6508-6510 does coerce_bool_setting(get_cli_setting('console','local_tools_enabled', False), False). Consequence for a user upgrading with an existing config.toml that lacks the key: the snapshot writes False, _compose_local_provider consumes it and disables local tools for every run, while the MCP hub's master switch reads LOCAL_TOOLS_DEFAULT_ENABLED and displays ON. Switch says enabled, tools are absent, no error. New installs are unaffected because the shipped config now writes the key explicitly, which is likely why this has gone unnoticed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Both resolution sites agree on one default constant; a config.toml missing the key produces the same answer at the snapshot, the provider, and the hub switch
+- [ ] #2 A regression test covers the upgrade shape: config with no local_tools_enabled key, assert the run actually gets local tools and the hub switch agrees
+<!-- AC:END -->

--- a/backlog/tasks/task-15261 - MCP-tool-reachability-is-unpinned-under-the-shipped-default-catalog.md
+++ b/backlog/tasks/task-15261 - MCP-tool-reachability-is-unpinned-under-the-shipped-default-catalog.md
@@ -1,0 +1,47 @@
+---
+id: TASK-15261
+title: MCP tool reachability is unpinned under the shipped default catalog
+status: To Do
+assignee: []
+created_date: '2026-08-11'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Nothing in the suite pins that an MCP tool is reachable **at all** under the
+catalog size the app actually ships with.
+
+Every MCP permission test in `Tests/Chat/test_console_agent_swap.py` runs with
+a small catalog, so the model's direct fence call is direct-disclosed and the
+permission gate is what gets exercised. Production is nothing like that: ~2
+always-on builtins + 16 local tools + ~18 Library tools (`direct_library_tools`
+defaults True, wired 2026-08-06/07 by task-1337) ≈ 36 entries, well past
+`DIRECT_DISCLOSE_THRESHOLD` (16, `Agents/agent_models.py`). Past the threshold
+`initial_disclosure` returns no schemas and offers `find_tools`/`load_tools`
+instead — so find/load is the **live production disclosure mode**, and has been
+since before PR #1474.
+
+This was surfaced while repairing the dev baseline: PR #1474 (local tools on by
+default) pushed the *test* catalog from 3 to 19 and all five MCP tests went red
+at the disclosure gate, never reaching the permission gate they exist to test.
+A fixture now keeps those tests' catalog small so they assert what they were
+written to assert — which means the production-shaped path remains uncovered.
+
+Related and worth doing in the same pass:
+`test_mcp_review_hook_raise_fails_open_but_invoke_gate_still_refuses` was GREEN
+but vacuous on dev for the same reason — it asserts `execute_calls == []` to
+prove `invoke()`'s own gate refuses, while the refusal actually came from the
+disclosure gate and `invoke()` was never reached. The fixture fix restores its
+meaning; a production-shaped test would keep it honest.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A test runs with a production-shaped catalog (> DIRECT_DISCLOSE_THRESHOLD entries) and asserts the model reaches an MCP tool via find_tools/load_tools and then executes it under the permission gate
+- [ ] #2 The same test covers at least one gated verdict (ask → approve) so the permission path is exercised in the find/load disclosure mode, not only the direct-disclosure mode
+- [ ] #3 The interaction with max_active_tools (24) and provider registration order is checked: MCP providers register last, so a large catalog must not silently truncate MCP tools out of reach
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1906,17 +1906,36 @@ class ChatScreen(BaseAppScreen):
 
     @on(Select.Changed, "#compact-api-provider")
     def on_console_compact_provider_changed(self, event: Select.Changed) -> None:
-        """Mirror native compact provider changes into Console-owned labels."""
+        """Mirror native compact provider changes into Console-owned labels.
+
+        Coalesced through task-3010's seam rather than syncing directly:
+        these two Select watchers ARE the mount-window burst that seam
+        exists to absorb. Instrumenting one screen push showed seven
+        control-bar syncs, four of them from here -- ``#compact-api-model``
+        fires three times and ``#compact-api-provider`` once while the
+        compact selects are populated, and the first three results are
+        overwritten before anything paints. Coalescing them takes that push
+        to three syncs.
+
+        Both handlers must move together: leaving one direct while the
+        other is coalesced fails ``test_requested_sync_still_executes``,
+        because the direct call satisfies the pending request's work
+        without clearing its scheduled flag.
+        """
         if not _is_empty_select_value(event.value):
             self._console_control_provider = str(event.value)
-        self._sync_console_control_bar()
+        self._request_console_control_bar_sync()
 
     @on(Select.Changed, "#compact-api-model")
     def on_console_compact_model_changed(self, event: Select.Changed) -> None:
-        """Mirror native compact model changes into Console-owned labels."""
+        """Mirror native compact model changes into Console-owned labels.
+
+        Coalesced -- see ``on_console_compact_provider_changed`` above for
+        why, and why the two cannot be split.
+        """
         if not _is_empty_select_value(event.value):
             self._console_control_model = str(event.value)
-        self._sync_console_control_bar()
+        self._request_console_control_bar_sync()
 
     @on(ConsoleLeftRail.SectionToggled)
     def on_console_left_rail_section_toggled(


### PR DESCRIPTION
Dev has been carrying 13 failing tests. Five of them sit in the MCP tool-call **permission** path, where a genuine regression would be indistinguishable from the noise — that's what motivated this.

**None of the 12 repaired here were product defects.** Each was a test measuring a route that no longer exists, and each was verified by driving the real code rather than inferred from the diff. One real product bug and one coverage hole were found along the way and filed.

## What was wrong, and why

**5× MCP permission tests** (`test_console_agent_swap.py`). PR #1474 flipped `[console] local_tools_enabled` to default-true, putting 16 local tools into every run's catalog and pushing these tests' catalog from 3 to 19 — past `DIRECT_DISCLOSE_THRESHOLD` (16). Past that, `initial_disclosure` returns no schemas and offers `find_tools`/`load_tools`, so the scripted model's direct call was refused at the **disclosure** gate before the permission gate was ever consulted. `allowed_tools` was correct throughout: this failed closed, never open. Bisected to `d2d303d69`; falsified by raising the threshold alone, which turns all five green.

Fixed by restoring the pre-#1474 catalog size for that file only, so the tests keep asserting what they were written to assert. Production disclosure is deliberately untouched — raising the threshold there would be wrong, since `max_active_tools` (24) slices the disclosed set and MCP providers register last, so a ~36-entry production catalog would silently drop MCP tools first.

This also restored meaning to a test that was **green but vacuous**: `test_mcp_review_hook_raise_fails_open_but_invoke_gate_still_refuses` asserted `execute_calls == []` to prove `invoke()`'s gate refuses, while the refusal actually came from disclosure and `invoke()` was never reached.

**3× tool-output disclosure.** `ConsoleTranscriptMessage` became a `Vertical` in `065970aa4`, so `row.render()` returns `Blank`; every assertion against it failed and the negative precondition passed *vacuously*. Now reads the mounted child Statics — deliberately not the row's `renderable` compatibility projection, which is derived from the in-memory message and would pass even if the children never repainted. The feature itself is fine: `toggle_tool_output`, the `o` binding, and independent per-row expansion all confirmed working.

**1× ephemeral rollback.** `86f74db93` added a keyword-only `strict_roleplay_context`; the stub took `session_id` only, so the test raised `TypeError` one frame before the branch it exists to cover. Fixed with an explicit signature, not `**kwargs`, so the next change fails loudly.

**2× CSS class-coverage contract.** `console-settings-{context,model}-view` are query selectors, not style hooks — allowlisted with reasons. `console-markdown-header` was a stale allowlist entry for a class no longer composed, which is exactly what that assertion asks you to delete.

**1× control-bar coalescing budget.** Seven syncs against a ceiling of six. Instrumentation found four came from the two compact-Select watchers (`#compact-api-model` fires three times during mount). Routing both through the existing coalescer takes the push to three. Both had to move together — coalescing only the bursting one fails `test_requested_sync_still_executes`, since the remaining direct call satisfies the pending request's work without clearing its flag. Recorded in the docstring.

## Not fixed

`test_screen_size_ratchet[chat_screen.py]` — a one-way size budget, not a broken test. The file is ~2,000 lines over; that's the screen-decomposition programme's work, tracked as **task-3070**.

## Filed

- **task-15260 (HIGH, product bug):** the turn-context snapshot builds `local_tools_enabled` with default `False` while `_compose_local_provider` and the hub switch default to `LOCAL_TOOLS_DEFAULT_ENABLED = True` — and the snapshot wins. A user upgrading with a `config.toml` lacking the key gets local tools **off in every run** while the master switch reads **on**, with no error. New installs are unaffected, which is likely why it went unnoticed.
- **task-15261 (HIGH, coverage):** nothing pins that an MCP tool is reachable *at all* under the shipped ~36-entry catalog, where find/load is the live disclosure mode — and has been since before #1474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs 12 of 13 failing tests on dev by aligning tests with current disclosure/UI behavior and batching control‑bar updates to meet the sync budget. Product behavior is unchanged, except the control bar now coalesces updates (7 → 3).

- **Bug Fixes**
  - MCP permission tests: keep local tools out to stay below `DIRECT_DISCLOSE_THRESHOLD`, so tests exercise the permission gate (not disclosure); restores meaning to one previously vacuous assert.
  - Transcript/ephemeral/CSS tests: read mounted child Statics instead of `row.render()` for tool output; update rollback stub to accept `strict_roleplay_context`; refresh CSS allowlist (add `console-settings-{context,model}-view`, remove stale `console-markdown-header`).
  - Follow-ups: screen-size ratchet left as is (task-3070). Filed task-15260 (default mismatch can disable local tools after upgrade) and task-15261 (pin MCP reachability under production catalog).

- **Performance**
  - Coalesced `#compact-api-{provider,model}` change handlers through the existing coalescer, reducing control‑bar syncs from 7 to 3 and keeping requested sync scheduling correct.

<sup>Written for commit 28ba06b39834f7ab89b90b3275b793917c78c956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

