### PR TITLE
Polish File Notes persistence and maintenance UX

### DIFF
--- a/.impeccable/critique/2026-08-11T06-03-15Z__ok-widgets-library-library-file-notes-workspace-py.md
+++ b/.impeccable/critique/2026-08-11T06-03-15Z__ok-widgets-library-library-file-notes-workspace-py.md
@@ -1,0 +1,120 @@
+---
+target: the post-merge local File Notes page and its elements
+total_score: 28
+p0_count: 0
+p1_count: 2
+timestamp: 2026-08-11T06-03-15Z
+slug: ok-widgets-library-library-file-notes-workspace-py
+---
+# File Notes UI critique
+
+## Design Health Score
+
+| Heuristic | Score (0–4) | Assessment |
+|---|---:|---|
+| Visibility of system status | 3 | Save and Git states are visible, but the labels do not explicitly say where normal edits persist. |
+| Match with the real world | 3 | Folder and note concepts are familiar; Git terminology remains expert-oriented. |
+| User control and freedom | 3 | Recovery, navigation, and staged Git actions provide control without hiding consequences. |
+| Consistency and standards | 3 | Most labels and control treatments are consistent, with a few navigation-copy mismatches. |
+| Error prevention | 4 | Scoped Git operations, confirmation behavior, and local draft preservation are unusually strong. |
+| Recognition rather than recall | 2 | The page exposes too many peer actions and assumes knowledge of Session Git semantics. |
+| Flexibility and efficiency | 3 | Keyboard flow and compact layouts are thoughtfully supported, though frequent file actions require extra traversal. |
+| Aesthetic and minimalist design | 2 | The workbench is purposeful, but operational copy and equal-weight controls crowd the main task. |
+| Error recognition and recovery | 3 | Recovery paths exist and are honest, but critical instructions can be compressed in small terminals. |
+| Help and documentation | 2 | Contextual guidance exists, yet autosave authority and Git scope need plainer explanations. |
+| **Total** | **28/40** | **Good, at the lower edge: structurally trustworthy but still cognitively dense.** |
+
+## Anti-pattern verdict
+
+The page passes the AI-slop check. It reads as a bespoke terminal workbench, not a generic dashboard or decorative AI interface. Its risk is the opposite: too much operational language and too many equally prominent controls.
+
+The deterministic detector could not run because its bundled detector was missing. It returned no JSON, so this is unavailable evidence—not a zero-finding result. A browser overlay was not applicable: this is a Python Textual widget rendered into terminal cells, with no equivalent HTML DOM to inspect reliably.
+
+## Overall impression
+
+The redesign has materially improved the File Notes experience. Local authority is visible, focus behavior is content-safe, compact layouts are deliberately engineered, and Session Git uses honest scope and recovery semantics. The remaining opportunity is to make those underlying guarantees legible at a glance: normal editing should unmistakably say “saved to the local folder,” recovery instructions must remain complete at small sizes, and secondary file operations should stop competing with the primary writing task.
+
+## What is working
+
+- **Authority is honest.** The UI distinguishes linked-folder state, session-scoped Git behavior, and local recovery instead of implying cloud-style magic.
+- **Progressive disclosure is substantive.** Advanced Git actions and recovery paths are available without permanently occupying the editing surface.
+- **Compact behavior is intentionally designed.** Navigator/editor alternation and focus safeguards preserve the primary task in narrow terminals.
+- **Risky actions are restrained.** Scoped paths, review-before-commit behavior, and confirmation states reduce accidental destructive work.
+- **The visual character fits Chatbook.** It is terminal-native, efficient, and restrained rather than ornamental.
+
+## Cognitive load
+
+The page passes five of eight cognitive-load checks and fails chunking, visual hierarchy, and minimal choices. Load is moderate rather than severe, but it rises exactly where users most need confidence.
+
+- A saved-note editor exposes six adjacent actions: New, Move, Delete, Protect, Reload, and Refresh.
+- A dirty, conflict, or error state can expose seven by adding Save Copy.
+- A ready Session Git flow asks the user to parse roughly five or six decisions across navigation, refresh, selection, bulk disclosure, commit, and push.
+- The core workflow is recognizable, but maintenance, recovery, and destructive actions are not sufficiently separated by frequency or consequence.
+
+## Emotional journey
+
+Entry is reassuring: the linked local folder and note context establish ownership. The confidence valley appears during ordinary editing because `Idle`, `Dirty`, `Saving`, and `Saved` do not say that the file-backed folder is the persistence authority; the later appearance of `Save Copy` can make users wonder whether normal edits were ever saved. Session Git then raises complexity through specialist language, but its scoping, review, and recovery behavior rebuild trust once understood.
+
+## Priority issues
+
+### P1 — The local persistence contract is ambiguous
+
+**Evidence:** `library_file_notes_workspace.py` composes the editor status and action row around lines 831–863. `_set_save_state` around lines 3163–3171 converts internal state to generic labels such as `Idle`, `Dirty`, `Saving`, and `Saved`. Recovery controls around lines 3460–3477 introduce `Save Copy` without distinguishing it from normal automatic persistence.
+
+**Impact:** A user can see that something was saved without knowing whether it was saved directly to the linked local file, a database, or an internal draft. This weakens the page’s central promise and makes the recovery action harder to interpret.
+
+**Recommendation:** Make authority part of every persistence state: `Auto-save: idle`, `Saving to local folder…`, `Saved to local folder`, and `Conflict: local draft preserved`. Rename `Save Copy` to `Save draft as copy` so it is unmistakably a recovery path.
+
+**Impeccable command:** clarify.
+
+### P1 — Critical Git recovery copy can be elided in compact terminals
+
+**Evidence:** `library_file_notes_git_panel.py` constrains status, repository, selected-path, and action copy to two lines with hidden overflow and no wrapping around lines 630–649. `_fit_fixed_regions` around lines 1672–1682 applies two-line fitting. This is appropriate for telemetry but risky for warning, error, and recovery instructions.
+
+**Impact:** At 40×20, the UI can preserve its geometry while withholding the end of the exact instruction needed to recover. The interface looks stable but may be operationally incomplete.
+
+**Recommendation:** Continue fitting routine telemetry, but allow warning, error, and recovery content to wrap fully inside the scrollable surface. Never truncate the action or command required to recover.
+
+**Impeccable command:** harden.
+
+### P2 — File actions lack a clear frequency and consequence hierarchy
+
+**Evidence:** The editor action row around lines 843–863, styled around lines 486–496, presents maintenance, creation, protection, and destructive actions at near-equal weight.
+
+**Impact:** Frequent writing and navigation compete with occasional maintenance. Keyboard users must traverse up to seven controls, while less experienced users must evaluate all of them before acting.
+
+**Recommendation:** Keep the primary row focused on the next likely action and place Reload/Refresh—and possibly Move/Protect—behind a `Maintenance` disclosure. Reserve semantic danger styling for Delete only when confirmation is armed.
+
+**Impeccable command:** distill.
+
+### P2 — Session Git describes its mechanism before its outcome
+
+**Evidence:** The workspace entry is `Session Git (0)`. The panel later says `Session paths only · stages complete file state`, which is accurate but requires Git vocabulary before the benefit is clear.
+
+**Impact:** New or occasional Git users must decode session paths, staging, and complete-file state before knowing why the tool is useful.
+
+**Recommendation:** Lead with the outcome: `Review and commit only notes changed during this Chatbook session.` Keep the precise Git scope as secondary supporting copy.
+
+**Impeccable command:** clarify.
+
+## Persona red flags
+
+- **Alex, the frequent keyboard user:** opening a note can lead to six or seven peer actions with no visible accelerators, increasing traversal for routine work.
+- **Jordan, the local-first non-Git user:** generic save states and terms such as `stage`, `worktree`, and `complete file state` obscure otherwise strong local guarantees.
+- **Sam, the accessibility-focused user:** focus behavior and complete labels are strong, but recovery copy fitting can hide essential information in the smallest supported viewport.
+
+## Minor observations
+
+- Use warning semantic color for the linked-root warning, not copy alone.
+- Standardize `Back to navigator` and `‹ Navigator` into one navigation phrase.
+- Replace pipe-separated key-guide copy with spacing or grouping that reads as guidance rather than telemetry.
+- The exact-path Details dialog is justified; it protects the main hierarchy while keeping verifiable authority available.
+- Wide Session Git appropriately hides unrelated toolbars and keeps the draft editor mounted.
+- One independent mounted-test sequence observed a medium-width focus assertion failure in the commit-review footer, but the exact 17-test sequence passed on immediate parent rerun. Treat this as a P3 monitoring signal, not a confirmed defect; stress-repeat the transition before changing behavior.
+
+## Questions to consider
+
+- Should the persistence line describe the linked local folder as the authority in every state, including idle?
+- Do Reload and Refresh earn permanent primary-row space, or do they belong under Maintenance?
+- Should the entry point lead with `Review session changes` and retain `Session Git` as explanatory secondary text?
+- At 40 columns, should routine telemetry yield vertical space whenever a complete recovery instruction needs it?

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -3447,6 +3447,12 @@ async def test_hidden_action_summary_is_presented_after_reopen(
             lambda: not owner.mutation_active(binding),
             "hidden Stage did not settle",
         )
+        assert _text(
+            workspace.query_one("#file-notes-git-status", Static)
+        ) == (
+            "Status: STALE — Git action finished while Review session changes "
+            "was hidden. Open it again to Refresh."
+        )
         assert len(git_service.status_calls) == 1
 
         entry.press()
@@ -4553,7 +4559,7 @@ async def test_mutation_blocks_root_and_path_while_path_lease_blocks_mutation(
         assert workspace.root == root.resolve()
         assert (
             _text(workspace.query_one("#file-notes-action-status", Static))
-            == "Session Git mutation in progress; structural actions are busy."
+            == "Git operation in progress; structural actions are busy."
         )
 
         workspace._set_action_status("")
@@ -4563,14 +4569,14 @@ async def test_mutation_blocks_root_and_path_while_path_lease_blocks_mutation(
         assert workspace._opened.relative_path == "two.md"
         assert (
             _text(workspace.query_one("#file-notes-action-status", Static))
-            == "Session Git mutation in progress; structural actions are busy."
+            == "Git operation in progress; structural actions are busy."
         )
 
         workspace._set_action_status("")
         assert not await workspace.open_path("two.md")
         assert (
             _text(workspace.query_one("#file-notes-action-status", Static))
-            == "Session Git mutation in progress; structural actions are busy."
+            == "Git operation in progress; structural actions are busy."
         )
         assert workspace.query_one("#file-notes-choose-root", Button).disabled
         assert workspace.query_one("#file-notes-save-copy", Button).disabled

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -1861,7 +1861,7 @@ async def test_panel_renders_repository_scope_and_complete_file_state() -> None:
 
         assert (
             _text(panel.query_one("#file-notes-git-title", Static))
-            == "Prepare session for commit"
+            == "Review session changes"
         )
         assert "/canonical/repository" in _text(
             panel.query_one("#file-notes-git-repository", Static)
@@ -1871,10 +1871,10 @@ async def test_panel_renders_repository_scope_and_complete_file_state() -> None:
         )
         assert (
             _text(panel.query_one("#file-notes-git-scope", Static))
-            == "Session paths only · stages complete file state"
+            == "Review and commit only notes changed during this Chatbook session."
         )
         assert _text(panel.query_one("#file-notes-git-guide", Static)) == (
-            "Up/Down Select | Tab Actions | Enter Run | Esc Back"
+            "Up/Down select · Tab actions · Enter run · Esc back"
         )
         assert _text(panel.query_one("#file-notes-git-status", Static)).startswith(
             "Status: CURRENT · READY"
@@ -2205,10 +2205,10 @@ async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> Non
     async with _PanelHarness(panel).run_test(size=(40, 20)) as pilot:
         panel.render_status(status)
         panel.set_current_status(
-            "Status: STALE · ERROR — " + long_reason + "Retry Refresh."
+            "Status: CHECKING — Checking current session notes."
         )
         panel.set_last_action(
-            "Last action: FAILED — " + long_reason + "retry the action, then Refresh"
+            "Last action: STAGED — 1 session note; unrelated changes untouched."
         )
         await pilot.pause()
         await pilot.pause()
@@ -2281,11 +2281,13 @@ async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> Non
         assert unavailable_text == "BLOCKED · Restore Git first; Refresh"
         assert cell_len(unavailable_text) <= unavailable.content_region.width
 
-        assert _text(panel.query_one("#file-notes-git-status", Static)).endswith(
-            "Retry Refresh."
-        )
-        assert _text(panel.query_one("#file-notes-git-action-status", Static)).endswith(
-            "then Refresh"
+        assert _flat_text(
+            panel.query_one("#file-notes-git-status", Static)
+        ) == "Status: CHECKING — Checking current session notes."
+        assert _flat_text(
+            panel.query_one("#file-notes-git-action-status", Static)
+        ) == (
+            "Last action: STAGED — 1 session note; unrelated changes untouched."
         )
 
         repository_rendered = _rendered_text(
@@ -2301,20 +2303,22 @@ async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> Non
         status_rendered = _rendered_text(
             panel.query_one("#file-notes-git-status", Static)
         )
-        assert status_rendered.startswith("Status: STALE · ERROR")
-        assert status_rendered.endswith("Retry Refresh.")
+        assert status_rendered.startswith("Status: CHECKING")
+        assert status_rendered.endswith("current session notes.")
 
         action_rendered = _rendered_text(
             panel.query_one("#file-notes-git-action-status", Static)
         )
-        assert action_rendered.startswith("Last action: FAILED")
-        assert action_rendered.endswith("then Refresh")
+        assert action_rendered.startswith("Last action: STAGED")
+        assert action_rendered.endswith("unrelated changes untouched.")
 
         panel.set_current_status(
-            "Status: STALE · ERROR\nstatus detail\nRetry Refresh."
+            "Status: STALE · ERROR\nstatus detail\nRetry Refresh.",
+            complete=True,
         )
         panel.set_last_action(
-            "Last action: FAILED\naction detail\nthen Refresh"
+            "Last action: FAILED\naction detail\nthen Refresh",
+            complete=True,
         )
         await pilot.pause()
         multiline_status = _rendered_text(
@@ -2322,14 +2326,14 @@ async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> Non
         )
         assert multiline_status.startswith("Status: STALE · ERROR")
         assert multiline_status.endswith("Retry Refresh.")
-        assert len(multiline_status.splitlines()) <= 2
+        assert len(multiline_status.splitlines()) >= 3
 
         multiline_action = _rendered_text(
             panel.query_one("#file-notes-git-action-status", Static)
         )
         assert multiline_action.startswith("Last action: FAILED")
         assert multiline_action.endswith("then Refresh")
-        assert len(multiline_action.splitlines()) <= 2
+        assert len(multiline_action.splitlines()) >= 3
 
         await _assert_visible_panel_buttons_fit(panel, pilot)
 
@@ -2917,7 +2921,7 @@ async def test_workspace_retains_files_search_and_git_modes_with_back_focus(
             LibraryFileNotesGitPanel,
         )
         entry = workspace.query_one("#file-notes-session-changes", Button)
-        assert str(entry.label) == "Session Git (2)"
+        assert str(entry.label) == "Review session changes (2)"
         assert entry.can_focus
 
         search.value = "needle"
@@ -3007,7 +3011,7 @@ async def test_thousand_unrelated_notes_send_only_three_session_groups_and_resto
             node.data for node in files_tree.root.children
         )
         entry = workspace.query_one("#file-notes-session-changes", Button)
-        assert str(entry.label) == "Session Git (3)"
+        assert str(entry.label) == "Review session changes (3)"
 
         entry.press()
         await _wait_until(
@@ -4295,8 +4299,8 @@ def test_action_summary_contract_matrix(tmp_path: Path) -> None:
                 message="Git is not installed",
             ),
             "Status: UNAVAILABLE — Git is not installed. Install or restore "
-            "Git, then reopen Prepare session for commit.",
-            "Install or restore Git, then reopen Prepare session for commit.",
+            "Git, then open Review session changes again.",
+            "Install or restore Git, then open Review session changes again.",
         ),
         (
             DiscoveryResult(
@@ -4952,6 +4956,50 @@ async def test_40x20_actionless_prepare_surface_is_keyboard_scrollable(
 
 
 @pytest.mark.asyncio
+async def test_review_session_entry_explains_scope_and_keeps_recovery_copy_complete(
+    tmp_path: Path,
+) -> None:
+    _root, owner, _binding, replica, git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    workspace.styles.height = 14
+
+    async with _WorkspaceHarness(workspace).run_test(size=(40, 20)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        entry = workspace.query_one("#file-notes-session-changes", Button)
+        assert str(entry.label) == "Review session changes (2)"
+        entry.press()
+        await _wait_until(
+            pilot,
+            lambda: len(git_service.status_calls) == 1,
+            "Review session changes did not request current status",
+        )
+
+        panel = workspace._git_panel_widget
+        assert _text(panel.query_one("#file-notes-git-title", Static)) == (
+            "Review session changes"
+        )
+        assert _text(panel.query_one("#file-notes-git-scope", Static)) == (
+            "Review and commit only notes changed during this Chatbook session."
+        )
+
+        recovery = (
+            "Status: CURRENT · BLOCKED: The local note changed before staging. "
+            "Return to the editor, finish saving to the local folder, then Refresh."
+        )
+        panel.set_current_status(recovery, complete=True)
+        await pilot.pause()
+        status = panel.query_one("#file-notes-git-status", Static)
+        assert _text(status) == recovery
+        assert status.has_class("-complete-copy")
+        assert status.content_region.height >= 3
+
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
 async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_remount(
     tmp_path: Path,
 ) -> None:
@@ -4964,9 +5012,13 @@ async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_
         editor = workspace.query_one("#file-notes-editor", TextArea)
         editor.cursor_location = (0, 3)
         editor.selection = editor.selection.__class__((0, 1), (0, 5))
-        toolbars = tuple(workspace.query(".file-notes-toolbar"))
-        assert len(toolbars) == 2
-        assert all(toolbar.display for toolbar in toolbars)
+        file_toolbar = workspace.query_one("#file-notes-file-actions")
+        maintenance_toolbar = workspace.query_one(
+            "#file-notes-maintenance-actions"
+        )
+        toolbars = (file_toolbar, maintenance_toolbar)
+        assert file_toolbar.display
+        assert not maintenance_toolbar.display
 
         entry = workspace.query_one("#file-notes-session-changes", Button)
         entry.focus()
@@ -5011,8 +5063,8 @@ async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_
         workspace.query_one("#file-notes-git-back", Button).press()
         await _wait_until(
             pilot,
-            lambda: all(toolbar.display for toolbar in toolbars),
-            "Back did not restore both editor toolbars",
+            lambda: file_toolbar.display and not maintenance_toolbar.display,
+            "Back did not restore the primary editor toolbar",
         )
 
         assert workspace.query_one("#file-notes-editor", TextArea) is editor
@@ -5154,7 +5206,10 @@ async def test_narrow_editor_actions_keep_complete_labels_at_40_by_20(
         assert await workspace.open_path("folder/one.md")
         await pilot.pause()
         _assert_visible_editor_actions_fit(workspace)
+        workspace.query_one("#file-notes-maintenance-toggle", Button).press()
+        await pilot.pause()
         protect = workspace.query_one("#file-notes-protect", Button)
+        assert protect.display
         assert str(protect.label) == "Protect"
         protect.press()
         await _wait_until(

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -254,14 +254,14 @@ def _assert_visible_editor_actions_fit(
     """Assert disclosed actions keep complete labels inside the editor pane."""
     pane = workspace.query_one("#file-notes-editor-pane")
     visible = tuple(
-        button
+        (toolbar, button)
         for toolbar in pane.query(".file-notes-toolbar")
         if toolbar.display
         for button in toolbar.query(Button)
         if button.display
     )
     assert visible
-    for button in visible:
+    for toolbar, button in visible:
         label = str(button.label)
         assert button.render_line(0).text.strip() == label, (
             button.id,
@@ -273,6 +273,12 @@ def _assert_visible_editor_actions_fit(
         )
         assert button.render().plain == label
         assert cell_len(label) <= button.content_region.width
+        assert toolbar.content_region.contains_region(button.region), (
+            toolbar.id,
+            toolbar.content_region,
+            button.id,
+            button.region,
+        )
         assert pane.content_region.contains_region(button.region)
 
 
@@ -2893,7 +2899,7 @@ async def test_file_notes_discloses_actions_by_editor_state_and_redirects_focus(
     replica.close()
 
 
-@pytest.mark.parametrize("size", ((160, 45), (120, 40), (64, 28)))
+@pytest.mark.parametrize("size", ((160, 45), (120, 40), (64, 28), (40, 20)))
 @pytest.mark.asyncio
 async def test_file_notes_disclosed_actions_fit_wide_and_compact_layouts(
     tmp_path: Path,

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -263,10 +263,33 @@ def _assert_visible_editor_actions_fit(
     assert visible
     for button in visible:
         label = str(button.label)
-        assert button.render_line(0).text.strip() == label
+        assert button.render_line(0).text.strip() == label, (
+            button.id,
+            label,
+            button.region,
+            button.content_region,
+            pane.region,
+            workspace.classes,
+        )
         assert button.render().plain == label
         assert cell_len(label) <= button.content_region.width
         assert pane.content_region.contains_region(button.region)
+
+
+async def _show_maintenance_actions(
+    workspace: LibraryFileNotesWorkspace,
+    pilot,
+) -> None:
+    """Open the retained secondary-action disclosure through its real control."""
+    toolbar = workspace.query_one("#file-notes-maintenance-actions")
+    if toolbar.display:
+        return
+    workspace.query_one("#file-notes-maintenance-toggle", Button).press()
+    await _wait_until(
+        pilot,
+        lambda: toolbar.display,
+        "Maintenance actions did not open",
+    )
 
 
 def _delayed_call(call):
@@ -710,7 +733,7 @@ async def test_root_transition_rebinds_after_owned_replica_reopens(
         workspace._refresh_session_changes()
         assert (
             _static_text(workspace, "#file-notes-session-changes")
-            == "Session Git (1)"
+            == "Review session changes (1)"
         )
 
     await workspace.shutdown()
@@ -1545,8 +1568,14 @@ async def test_tree_search_open_dirty_and_autosave_keep_one_editor(
         search.value = "needle"
         await _wait_until(
             pilot,
-            lambda: workspace.query_one("#file-notes-search-results", Tree).display,
-            "search results did not replace the tree",
+            lambda: (
+                workspace.query_one("#file-notes-search-results", Tree).display
+                and "folder/alpha.md"
+                in _tree_labels(
+                    workspace.query_one("#file-notes-search-results", Tree)
+                )
+            ),
+            "search results did not replace the tree with the mounted match",
         )
         assert not tree.display
         results = workspace.query_one("#file-notes-search-results", Tree)
@@ -1589,6 +1618,108 @@ async def test_tree_search_open_dirty_and_autosave_keep_one_editor(
         assert workspace.query_one("#file-notes-editor", TextArea) is editor
     await workspace.shutdown()
     assert replica.list_deleted(str(root.resolve())) == []
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_save_status_names_local_folder_and_preserved_draft(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "note.md").write_text("body", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        poll_interval=10,
+        autosave_delay=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert _static_text(workspace, "#file-notes-save-status") == (
+            "Auto-save to local folder: idle"
+        )
+
+        assert await workspace.open_path("note.md")
+        assert _static_text(workspace, "#file-notes-save-status") == (
+            "Saved to local folder"
+        )
+        workspace._set_save_state("dirty")
+        assert _static_text(workspace, "#file-notes-save-status") == (
+            "Auto-save pending for local folder"
+        )
+        workspace._set_save_state("saving")
+        assert _static_text(workspace, "#file-notes-save-status") == (
+            "Saving to local folder…"
+        )
+        workspace._set_save_state("conflict", "file changed on disk")
+        assert _static_text(workspace, "#file-notes-save-status") == (
+            "Conflict: draft preserved in editor; file changed on disk"
+        )
+        save_copy = workspace.query_one("#file-notes-save-copy", Button)
+        assert str(save_copy.label) == "Save draft as copy"
+        assert save_copy.display
+        assert workspace.query_one("#file-notes-save-status").display
+
+    await workspace.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_maintenance_disclosure_keeps_secondary_file_actions_reachable(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "note.md").write_text("body", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        poll_interval=10,
+        autosave_delay=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(40, 20)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("note.md")
+        await pilot.pause()
+
+        toggle = workspace.query_one("#file-notes-maintenance-toggle", Button)
+        maintenance = workspace.query_one("#file-notes-maintenance-actions")
+        assert str(toggle.label) == "Maintenance"
+        assert not maintenance.display
+        assert not workspace.query_one("#file-notes-move", Button).display
+        assert not workspace.query_one("#file-notes-protect", Button).display
+
+        toggle.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert str(toggle.label) == "Hide actions"
+        assert maintenance.display
+        assert toggle.has_focus
+        assert {
+            button.id
+            for button in maintenance.query(Button)
+            if button.display
+        } == {
+            "file-notes-move",
+            "file-notes-protect",
+            "file-notes-reload",
+            "file-notes-refresh",
+        }
+        _assert_visible_editor_actions_fit(workspace)
+
+        assert toggle.has_focus, repr(workspace.app.focused)
+        toggle.press()
+        await pilot.pause()
+        assert str(toggle.label) == "Maintenance"
+        assert not maintenance.display
+        assert toggle.has_focus
+
+    await workspace.shutdown()
     replica.close()
 
 
@@ -1639,6 +1770,7 @@ async def test_create_move_delete_protect_and_restore_use_real_service(
         assert state_during_create == (True, False, "start")
         assert (root / "created.md").exists()
 
+        await _show_maintenance_actions(workspace, pilot)
         workspace.query_one("#file-notes-protect", Button).press()
         await _wait_until(
             pilot,
@@ -1710,7 +1842,7 @@ async def test_create_move_delete_protect_and_restore_use_real_service(
         )
         assert (
             _static_text(workspace, "#file-notes-session-changes")
-            == "Session Git (1)"
+            == "Review session changes (1)"
         )
     replica.close()
 
@@ -1737,7 +1869,8 @@ async def test_injected_owner_retains_same_root_log_across_workspaces(
         assert service.create_file("retained.md", "retained").status == "ok"
         first._refresh_session_changes()
         assert (
-            _static_text(first, "#file-notes-session-changes") == "Session Git (1)"
+            _static_text(first, "#file-notes-session-changes")
+            == "Review session changes (1)"
         )
     await first.shutdown()
 
@@ -1759,7 +1892,8 @@ async def test_injected_owner_retains_same_root_log_across_workspaces(
             "second scan did not finish",
         )
         assert (
-            _static_text(second, "#file-notes-session-changes") == "Session Git (1)"
+            _static_text(second, "#file-notes-session-changes")
+            == "Review session changes (1)"
         )
     await second.shutdown()
     owner.shutdown()
@@ -1797,7 +1931,12 @@ async def test_direct_workspace_shuts_down_only_its_private_session_owner(
         ("#file-notes-new", "_new_file", "create_file", "Create"),
         ("#file-notes-move", "_move_file", "move_file", "Move"),
         ("#file-notes-restore", "_restore_file", "restore_file", "Restore"),
-        ("#file-notes-save-copy", "_save_copy", "save_copy", "Save Copy"),
+        (
+            "#file-notes-save-copy",
+            "_save_copy",
+            "save_copy",
+            "Save draft as copy",
+        ),
     ),
 )
 @pytest.mark.asyncio
@@ -1897,6 +2036,7 @@ async def test_conflict_reload_save_copy_and_leave_guards_preserve_draft(
             lambda: workspace.save_state == "dirty",
             "dirty Reload setup did not arm",
         )
+        await _show_maintenance_actions(workspace, pilot)
         workspace.query_one("#file-notes-reload", Button).press()
         await _wait_until(
             pilot,
@@ -2485,6 +2625,7 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
         assert screen._library_notes_source == "files"
         assert screen.query_one("#library-file-notes-workspace") is retained
 
+        await _show_maintenance_actions(retained, pilot)
         retained.query_one("#file-notes-reload", Button).press()
         await _wait_until(
             pilot,
@@ -2500,7 +2641,7 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
         assert await retained.flush_pending_work()
         assert (
             _static_text(retained, "#file-notes-session-changes")
-            == "Session Git (1)"
+            == "Review session changes (1)"
         )
         screen.query_one("#library-notes-source-database", Button).press()
         await _wait_until(
@@ -2529,7 +2670,7 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
         )
         assert (
             _static_text(retained, "#file-notes-session-changes")
-            == "Session Git (1)"
+            == "Review session changes (1)"
         )
 
         original_finish = service._finish_published_file
@@ -2669,17 +2810,14 @@ async def test_file_notes_discloses_actions_by_editor_state_and_redirects_focus(
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         assert _visible_editor_action_ids(workspace) == {
             "file-notes-new",
-            "file-notes-refresh",
+            "file-notes-maintenance-toggle",
         }
 
         assert await workspace.open_path("state.md")
         assert _visible_editor_action_ids(workspace) == {
             "file-notes-new",
-            "file-notes-move",
             "file-notes-delete",
-            "file-notes-protect",
-            "file-notes-reload",
-            "file-notes-refresh",
+            "file-notes-maintenance-toggle",
         }
 
         delete = workspace.query_one("#file-notes-delete", Button)
@@ -2703,12 +2841,9 @@ async def test_file_notes_discloses_actions_by_editor_state_and_redirects_focus(
         )
         assert _visible_editor_action_ids(workspace) == {
             "file-notes-new",
-            "file-notes-move",
             "file-notes-delete",
-            "file-notes-protect",
-            "file-notes-reload",
             "file-notes-save-copy",
-            "file-notes-refresh",
+            "file-notes-maintenance-toggle",
         }
 
         assert await workspace.flush_pending_work()
@@ -2733,7 +2868,7 @@ async def test_file_notes_discloses_actions_by_editor_state_and_redirects_focus(
         assert _visible_editor_action_ids(workspace) == {
             "file-notes-new",
             "file-notes-restore",
-            "file-notes-refresh",
+            "file-notes-maintenance-toggle",
         }
         focused = workspace.app.focused
         assert focused is not None

--- a/backlog/tasks/task-15122 - Clarify-File-Notes-persistence-and-distill-maintenance-actions.md
+++ b/backlog/tasks/task-15122 - Clarify-File-Notes-persistence-and-distill-maintenance-actions.md
@@ -66,4 +66,6 @@ Renamed the Git entry and panel to `Review session changes`, described its curre
 Verification: 50 File Notes workspace tests passed; 19 focused Git/compact-terminal tests passed; 109 shared focus/CSS integrity tests passed; final five-test copy/disclosure regression selection passed; targeted Ruff, Python compilation, and `git diff --check` passed. The full Git module remains at 144 passed and one documented pre-existing baseline failure in the unrelated Protect-button stage gate (`test_stage_flushes_then_gate_keeps_editor_back_and_one_latest_refresh`).
 
 ADR required: no. The implementation conforms to ADR-011, ADR-029, ADR-031, and ADR-035. Modified the File Notes workspace and Git panel, their focused regression suites, and the Impeccable critique artifact.
+
+Qodo follow-up: added Google-style parameter documentation for the complete-copy APIs; relaxed the stacked delete-confirmation toolbar so all dirty-state controls remain contained at 40×20; and removed retired `Prepare session` / `Session Git mutation` wording from user-visible recovery, busy, and trust copy. The review regression was reproduced before the layout fix, then the six focused mounted cases and the complete 51-test workspace suite passed. Targeted Ruff, Python compilation, and diff checks also passed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15122 - Clarify-File-Notes-persistence-and-distill-maintenance-actions.md
+++ b/backlog/tasks/task-15122 - Clarify-File-Notes-persistence-and-distill-maintenance-actions.md
@@ -1,0 +1,69 @@
+---
+id: TASK-15122
+title: Clarify File Notes persistence and distill maintenance actions
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-11 14:32'
+updated_date: '2026-08-11 15:08'
+labels:
+  - notes
+  - library
+  - ux
+  - accessibility
+dependencies:
+  - TASK-14879
+  - TASK-14880
+  - TASK-14904
+references:
+  - >-
+    .impeccable/critique/2026-08-11T06-03-15Z__ok-widgets-library-library-file-notes-workspace-py.md
+documentation:
+  - backlog/decisions/011-chatbook-workbench-ui-system.md
+  - backlog/decisions/029-file-notes-disk-authority.md
+  - backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md
+  - backlog/decisions/035-file-notes-session-git-index-controls.md
+priority: medium
+type: enhancement
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the File Notes editor state where normal edits are saved, keep recovery instructions complete in compact terminals, reduce peer file actions through progressive disclosure, and introduce Session Git through the outcome users seek. Preserve disk authority, replica behavior, Git scope, and every existing operation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Every normal persistence state explicitly identifies the linked local folder as the save authority, and recovery copy distinguishes preserved drafts from ordinary autosave.
+- [x] #2 Warning, error, and recovery instructions remain complete and keyboard reachable at 160x45, 120x40, and 40x20; routine Git telemetry may remain compact.
+- [x] #3 The primary editor row exposes only frequent actions, while all existing secondary file operations remain available through one keyboard-operable Maintenance disclosure with safe focus repair.
+- [x] #4 The Git entry and introductory copy lead with Review session changes and explain that only notes changed during the current Chatbook session are reviewed and committed.
+- [x] #5 Focused mounted regressions, compact-terminal tests, targeted Ruff, Python compilation, diff checks, and self-review pass without changing disk, replica, session-owner, staging, commit, or push behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A; conform to `backlog/decisions/011-chatbook-workbench-ui-system.md`, `backlog/decisions/029-file-notes-disk-authority.md`, `backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md`, and `backlog/decisions/035-file-notes-session-git-index-controls.md`.
+Reason: this is a presentation, copy, disclosure, focus, and compact-layout refinement within existing disk and Git authority boundaries.
+
+1. Add mounted regressions for explicit local-folder autosave states, recovery-copy visibility, the maintenance disclosure, and the outcome-led Git entry copy.
+2. Clarify persistence and recovery labels without changing autosave, conflict, replica, or disk behavior.
+3. Move secondary file actions behind one keyboard-operable Maintenance disclosure with deterministic visibility and focus repair.
+4. Let critical Git recovery copy wrap fully while keeping routine telemetry compact, and lead the Git entry with Review session changes.
+5. Run focused mounted tests, static checks, compact-terminal verification, self-review, and close the Backlog task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Clarified normal autosave states so the linked local folder is visibly authoritative and renamed the recovery operation to `Save draft as copy`. Kept frequent editor actions in the primary row and moved Move, Protect, Reload, and Refresh behind one keyboard-operable Maintenance disclosure with compact two-column layout and focus repair.
+
+Renamed the Git entry and panel to `Review session changes`, described its current-session scope, and let warning/error/recovery text wrap completely in the scrollable panel while retaining two-line fitting for routine telemetry. Disk, replica, session-owner, staging, commit, and push behavior were unchanged.
+
+Verification: 50 File Notes workspace tests passed; 19 focused Git/compact-terminal tests passed; 109 shared focus/CSS integrity tests passed; final five-test copy/disclosure regression selection passed; targeted Ruff, Python compilation, and `git diff --check` passed. The full Git module remains at 144 passed and one documented pre-existing baseline failure in the unrelated Protect-button stage gate (`test_stage_flushes_then_gate_keeps_editor_back_and_one_latest_refresh`).
+
+ADR required: no. The implementation conforms to ADR-011, ADR-029, ADR-031, and ADR-035. Modified the File Notes workspace and Git panel, their focused regression suites, and the Impeccable critique artifact.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
@@ -670,6 +670,12 @@ class LibraryFileNotesGitPanel(Vertical):
         display: none;
     }
 
+    #file-notes-git-status.-complete-copy,
+    #file-notes-git-action-status.-complete-copy {
+        max-height: 100%;
+        text-wrap: wrap;
+    }
+
     #file-notes-git-empty {
         display: none;
     }
@@ -1103,7 +1109,9 @@ class LibraryFileNotesGitPanel(Vertical):
         self._replacing_rows = False
         self._repository_text = "Repository: not checked"
         self._current_status_text = "Status: NOT CHECKED"
+        self._current_status_complete = False
         self._last_action_text = ""
+        self._last_action_complete = False
         self._selected_note_text = ""
         self._commit_phase: CommitPanelPhase = "list"
         self._commit_availability: CommitDraftProjection | None = None
@@ -1161,7 +1169,7 @@ class LibraryFileNotesGitPanel(Vertical):
                     compact=True,
                 )
             yield Static(
-                "Prepare session for commit",
+                "Review session changes",
                 id="file-notes-git-title",
                 markup=False,
             )
@@ -1171,12 +1179,12 @@ class LibraryFileNotesGitPanel(Vertical):
                 markup=False,
             )
             yield Static(
-                "Session paths only · stages complete file state",
+                "Review and commit only notes changed during this Chatbook session.",
                 id="file-notes-git-scope",
                 markup=False,
             )
             yield Static(
-                "Up/Down Select | Tab Actions | Enter Run | Esc Back",
+                "Up/Down select · Tab actions · Enter run · Esc back",
                 id="file-notes-git-guide",
                 markup=False,
             )
@@ -1670,15 +1678,28 @@ class LibraryFileNotesGitPanel(Vertical):
         return row.content_region.width or fallback
 
     def _fit_fixed_regions(self) -> None:
-        for selector, text in (
-            ("#file-notes-git-repository", self._repository_text),
-            ("#file-notes-git-status", self._current_status_text),
-            ("#file-notes-git-action-status", self._last_action_text),
-            ("#file-notes-git-selected-note", self._selected_note_text),
+        for selector, text, complete in (
+            ("#file-notes-git-repository", self._repository_text, False),
+            (
+                "#file-notes-git-status",
+                self._current_status_text,
+                self._current_status_complete,
+            ),
+            (
+                "#file-notes-git-action-status",
+                self._last_action_text,
+                self._last_action_complete,
+            ),
+            ("#file-notes-git-selected-note", self._selected_note_text, False),
         ):
             widget = self.query_one(selector, Static)
+            widget.set_class(complete, "-complete-copy")
             width = widget.content_region.width or self.content_region.width
-            fitted = text if width <= 0 else _fit_two_line_copy(text, width)
+            fitted = (
+                text
+                if complete or width <= 0
+                else _fit_two_line_copy(text, width)
+            )
             widget.update(fitted)
 
     def _set_repository_text(self, text: str) -> None:
@@ -2550,22 +2571,34 @@ class LibraryFileNotesGitPanel(Vertical):
                 if status.state == "stale"
                 else "Git status failed. Retry Refresh."
             )
-            self.set_current_status(f"Status: {token} — {detail}")
+            self.set_current_status(
+                f"Status: {token} — {detail}",
+                complete=True,
+            )
         else:
             self.clear_commit_availability()
             self._clear_rows()
             if not authority_available or status.state == "unavailable":
                 detail = status.message or "Restore Git, then Refresh."
-                self.set_current_status(f"Status: UNAVAILABLE — {detail}")
+                self.set_current_status(
+                    f"Status: UNAVAILABLE — {detail}",
+                    complete=True,
+                )
                 self.clear_last_action()
             elif status.state == "stale":
                 detail = (
                     status.message or "Session notes changed; Refresh before staging."
                 )
-                self.set_current_status(f"Status: STALE — {detail}")
+                self.set_current_status(
+                    f"Status: STALE — {detail}",
+                    complete=True,
+                )
             elif status.state == "error":
                 detail = status.message or "Git status failed. Retry Refresh."
-                self.set_current_status(f"Status: STALE · ERROR — {detail}")
+                self.set_current_status(
+                    f"Status: STALE · ERROR — {detail}",
+                    complete=True,
+                )
 
         self._sync_empty_state()
         self._update_actions()
@@ -2584,7 +2617,8 @@ class LibraryFileNotesGitPanel(Vertical):
         )
         self.set_current_status(
             "Status: TRUST REQUIRED — Trust this repository to check "
-            "current session notes."
+            "current session notes.",
+            complete=True,
         )
         self._sync_empty_state()
         self._update_actions()
@@ -2629,15 +2663,17 @@ class LibraryFileNotesGitPanel(Vertical):
         self._sync_push_availability()
         self._update_actions()
 
-    def set_current_status(self, detail: str) -> None:
+    def set_current_status(self, detail: str, *, complete: bool = False) -> None:
         """Set repository freshness/recovery without changing last action."""
         self._current_status_text = detail
+        self._current_status_complete = complete
         self._fit_fixed_regions()
 
-    def set_last_action(self, detail: str) -> None:
+    def set_last_action(self, detail: str, *, complete: bool = False) -> None:
         """Set the latest action result independently of current freshness."""
         widget = self.query_one("#file-notes-git-action-status", Static)
         self._last_action_text = detail
+        self._last_action_complete = complete
         self._fit_fixed_regions()
         widget.display = bool(detail)
 
@@ -2645,6 +2681,7 @@ class LibraryFileNotesGitPanel(Vertical):
         """Clear an obsolete latest-action presentation."""
         widget = self.query_one("#file-notes-git-action-status", Static)
         self._last_action_text = ""
+        self._last_action_complete = False
         self._fit_fixed_regions()
         widget.display = False
 
@@ -2662,7 +2699,10 @@ class LibraryFileNotesGitPanel(Vertical):
         self._clear_rows()
         self.clear_last_action()
         self._set_repository_text("Repository: unavailable")
-        self.set_current_status(f"Status: UNAVAILABLE — {detail}")
+        self.set_current_status(
+            f"Status: UNAVAILABLE — {detail}",
+            complete=True,
+        )
         self._sync_empty_state()
         self._update_actions()
 
@@ -2680,7 +2720,10 @@ class LibraryFileNotesGitPanel(Vertical):
         if not retain_rows:
             self._clear_rows()
         token = "STALE · ERROR" if error else "STALE"
-        self.set_current_status(f"Status: {token} — {detail}")
+        self.set_current_status(
+            f"Status: {token} — {detail}",
+            complete=True,
+        )
         self._sync_empty_state()
         self._update_actions()
 

--- a/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
@@ -2664,13 +2664,23 @@ class LibraryFileNotesGitPanel(Vertical):
         self._update_actions()
 
     def set_current_status(self, detail: str, *, complete: bool = False) -> None:
-        """Set repository freshness/recovery without changing last action."""
+        """Set repository freshness/recovery without changing last action.
+
+        Args:
+            detail: Status copy to render.
+            complete: Preserve the complete copy instead of fitting two lines.
+        """
         self._current_status_text = detail
         self._current_status_complete = complete
         self._fit_fixed_regions()
 
     def set_last_action(self, detail: str, *, complete: bool = False) -> None:
-        """Set the latest action result independently of current freshness."""
+        """Set the latest action result independently of current freshness.
+
+        Args:
+            detail: Latest-action copy to render.
+            complete: Preserve the complete copy instead of fitting two lines.
+        """
         widget = self.query_one("#file-notes-git-action-status", Static)
         self._last_action_text = detail
         self._last_action_complete = complete
@@ -3458,7 +3468,7 @@ class SessionGitTrustDialog(ConfirmationDialog):
             markup=True,
         )
         super().__init__(
-            title="Trust Session Git repository?",
+            title="Trust repository for session changes?",
             message=(
                 f"Repository: {display_path}\n\n"
                 "Trust lasts only for this application process. Git status "

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -93,6 +93,14 @@ from tldw_chatbook.Widgets.Library.library_file_notes_git_panel import (
 )
 
 SaveState = Literal["idle", "dirty", "saving", "saved", "conflict", "error"]
+_SAVE_STATE_COPY: dict[SaveState, str] = {
+    "idle": "Auto-save to local folder: idle",
+    "dirty": "Auto-save pending for local folder",
+    "saving": "Saving to local folder…",
+    "saved": "Saved to local folder",
+    "conflict": "Conflict: draft preserved in editor",
+    "error": "Save failed: draft preserved in editor",
+}
 _UNSET = object()
 _SESSION_GIT_MUTATION_BUSY = (
     "Session Git mutation in progress; structural actions are busy."
@@ -119,6 +127,7 @@ class _GitLastAction:
     repository: RepositoryIdentity
     changes: tuple[SequencedSessionChange, ...]
     text: str
+    complete: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -501,8 +510,8 @@ class LibraryFileNotesWorkspace(Vertical):
 
     LibraryFileNotesWorkspace.-stack-editor-actions .file-notes-toolbar {
         layout: grid;
-        grid-size: 3;
-        grid-columns: 1fr 1fr 1fr;
+        grid-size: 2;
+        grid-columns: 1fr 1fr;
         height: auto;
     }
 
@@ -512,8 +521,8 @@ class LibraryFileNotesWorkspace(Vertical):
 
     LibraryFileNotesWorkspace.-stack-editor-actions
     .file-notes-toolbar.-confirm-delete {
-        grid-size: 4;
-        grid-columns: 1fr 1fr 1fr 1fr;
+        grid-size: 2;
+        grid-columns: 1fr 1fr;
         grid-rows: 1 1;
         height: 2;
     }
@@ -528,8 +537,17 @@ class LibraryFileNotesWorkspace(Vertical):
         column-span: 2;
     }
 
+    LibraryFileNotesWorkspace.-stack-editor-actions #file-notes-save-copy {
+        column-span: 2;
+    }
+
     LibraryFileNotesWorkspace.-stack-editor-actions #file-notes-editor {
         min-height: 3;
+    }
+
+    #file-notes-delete.-confirm-delete {
+        color: $error;
+        text-style: bold underline;
     }
     """
 
@@ -618,6 +636,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._navigator_mode_before_git: Literal["files", "search"] = "files"
         self._editor_action_layout_sync_scheduled = False
         self._editor_action_focus_target: str | None = None
+        self._maintenance_expanded = False
         self._git_observed_changes: tuple[SequencedSessionChange, ...] | None = None
         self._git_refresh_timer: Timer | None = None
         self._git_refresh_after_mutation = False
@@ -815,7 +834,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 search_results.display = False
                 yield search_results
                 yield Button(
-                    "Session Git (0)",
+                    "Review session changes (0)",
                     id="file-notes-session-changes",
                     compact=True,
                 )
@@ -833,7 +852,11 @@ class LibraryFileNotesWorkspace(Vertical):
                     id="file-notes-breadcrumb",
                     markup=False,
                 )
-                yield Static("Idle", id="file-notes-save-status", markup=False)
+                yield Static(
+                    _SAVE_STATE_COPY["idle"],
+                    id="file-notes-save-status",
+                    markup=False,
+                )
                 yield Input(
                     placeholder="relative/path.md",
                     id="file-notes-path",
@@ -845,20 +868,25 @@ class LibraryFileNotesWorkspace(Vertical):
                     classes="file-notes-toolbar",
                 ):
                     yield Button("New", id="file-notes-new", compact=True)
-                    yield Button("Move", id="file-notes-move", compact=True)
                     yield Button("Delete", id="file-notes-delete", compact=True)
                     yield Button("Restore", id="file-notes-restore", compact=True)
-                    yield Button("Protect", id="file-notes-protect", compact=True)
+                    yield Button(
+                        "Save draft as copy",
+                        id="file-notes-save-copy",
+                        compact=True,
+                    )
+                    yield Button(
+                        "Maintenance",
+                        id="file-notes-maintenance-toggle",
+                        compact=True,
+                    )
                 with Horizontal(
                     id="file-notes-maintenance-actions",
                     classes="file-notes-toolbar",
                 ):
+                    yield Button("Move", id="file-notes-move", compact=True)
+                    yield Button("Protect", id="file-notes-protect", compact=True)
                     yield Button("Reload", id="file-notes-reload", compact=True)
-                    yield Button(
-                        "Save Copy",
-                        id="file-notes-save-copy",
-                        compact=True,
-                    )
                     yield Button("Refresh", id="file-notes-refresh", compact=True)
                 yield Static("", id="file-notes-action-status", markup=False)
 
@@ -1170,8 +1198,8 @@ class LibraryFileNotesWorkspace(Vertical):
                     self._git_status_task_binding = None
                     if self._active and self.is_mounted:
                         self._git_panel_widget.render_unavailable(
-                            "Selected notes root changed. Reopen Prepare "
-                            "session for commit to check the new root."
+                            "Selected notes root changed. Open Review session "
+                            "changes to check the new root."
                         )
                 service._bind_session_owner(self._session_owner, binding)
                 self._root = root
@@ -1556,7 +1584,7 @@ class LibraryFileNotesWorkspace(Vertical):
         return None if service is None else cast(_SessionGitService, service)
 
     def _render_session_git_label(self, count: int | None = None) -> None:
-        """Compose the persistent Session Git label from independent state."""
+        """Compose the outcome-led Git entry from independent session state."""
         if not self._active or not self.is_mounted:
             return
         if count is None:
@@ -1568,15 +1596,15 @@ class LibraryFileNotesWorkspace(Vertical):
             )
             count = len(coalesce_session_changes(changes))
         suffix = {
-            "checking": " — Push checking",
-            "pushing": " — Pushing",
-            "needs_attention": " — Push needs attention",
+            "checking": " · Checking push",
+            "pushing": " · Pushing",
+            "needs_attention": " · Push needs attention",
         }.get(self._push_phase, "")
         try:
             entry = self.query_one("#file-notes-session-changes", Button)
         except NoMatches:
             return
-        entry.label = f"Session Git ({count}){suffix}"
+        entry.label = f"Review session changes ({count}){suffix}"
 
     def _clear_push_presentation(self) -> None:
         """Retire visible push state without canceling service-owned work."""
@@ -2710,7 +2738,10 @@ class LibraryFileNotesWorkspace(Vertical):
             if action is None:
                 self._git_panel_widget.clear_last_action()
             else:
-                self._git_panel_widget.set_last_action(action.text)
+                self._git_panel_widget.set_last_action(
+                    action.text,
+                    complete=action.complete,
+                )
         return action is not None
 
     def _git_can_retain_rows(self, binding: SessionBinding) -> bool:
@@ -2940,16 +2971,15 @@ class LibraryFileNotesWorkspace(Vertical):
         }
         recoveries = {
             "unavailable": (
-                "Install or restore Git, then reopen Prepare session for "
-                "commit."
+                "Install or restore Git, then open Review session changes again."
             ),
             "unsupported": (
-                "Resolve Git compatibility outside Chatbook, then reopen "
-                "Prepare session for commit."
+                "Resolve Git compatibility outside Chatbook, then open Review "
+                "session changes again."
             ),
             "unsafe_root": (
-                "Select or fix a safe notes root, then reopen Prepare session "
-                "for commit."
+                "Select or fix a safe notes root, then open Review session "
+                "changes again."
             ),
         }
         reason = (
@@ -2963,7 +2993,7 @@ class LibraryFileNotesWorkspace(Vertical):
             reason += "."
         recovery = recoveries.get(
             discovery.state,
-            "Reopen Prepare session for commit.",
+            "Open Review session changes again.",
         )
         return f"{reason} {recovery}"
 
@@ -2974,7 +3004,7 @@ class LibraryFileNotesWorkspace(Vertical):
             self._clear_git_last_action()
             self._git_panel_widget.render_unavailable(
                 "Git is unavailable for the selected File Notes root. "
-                "Restore Git, then reopen Prepare session for commit."
+                "Restore Git, then open Review session changes again."
             )
             return
         discovery = await service.discover(binding)
@@ -3033,7 +3063,8 @@ class LibraryFileNotesWorkspace(Vertical):
                     )
                     self._git_panel_widget.set_current_status(
                         "Status: TRUST REQUIRED — Repository identity changed; "
-                        "retry Trust and check status."
+                        "retry Trust and check status.",
+                        complete=True,
                     )
                 return
             if not self._session_owner.publish_trust(binding, repository):
@@ -3064,8 +3095,8 @@ class LibraryFileNotesWorkspace(Vertical):
         if binding is None or service is None:
             self._clear_git_last_action()
             self._git_panel_widget.render_unavailable(
-                "Git status is unavailable. Restore Git, then reopen "
-                "Prepare session for commit."
+                "Git status is unavailable. Restore Git, then open Review "
+                "session changes again."
             )
             return
         if self._session_owner.mutation_active(binding):
@@ -3081,7 +3112,7 @@ class LibraryFileNotesWorkspace(Vertical):
             self._clear_git_last_action()
             self._git_panel_widget.render_unavailable(
                 "Repository trust is unavailable. Return to the navigator, "
-                "reopen Prepare session for commit, and trust the repository."
+                "open Review session changes again, and trust the repository."
             )
             return
         self._git_panel_widget.render_checking(
@@ -3134,7 +3165,7 @@ class LibraryFileNotesWorkspace(Vertical):
             self._clear_git_last_action()
             self._git_panel_widget.render_unavailable(
                 "Repository trust changed while checking status. Return to "
-                "the navigator, reopen Prepare session for commit, and trust "
+                "the navigator, open Review session changes again, and trust "
                 "the current repository."
             )
             return
@@ -3164,9 +3195,9 @@ class LibraryFileNotesWorkspace(Vertical):
         self._save_state = state
         self._save_detail = detail
         if self._active and self.is_mounted:
-            label = state.capitalize()
+            label = _SAVE_STATE_COPY[state]
             if detail:
-                label = f"{label} — {detail}"
+                label = f"{label}; {detail}"
             self.query_one("#file-notes-save-status", Static).update(label)
             self._update_controls()
 
@@ -3389,6 +3420,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 "file-notes-reload",
                 "file-notes-save-copy",
                 "file-notes-refresh",
+                "file-notes-maintenance-toggle",
             }
         ):
             self._editor_action_focus_target = focused.id
@@ -3415,6 +3447,9 @@ class LibraryFileNotesWorkspace(Vertical):
             not has_service or not has_deleted or not structurally_available
         )
         self.query_one("#file-notes-refresh", Button).disabled = (
+            self._service is None or not structurally_available
+        )
+        self.query_one("#file-notes-maintenance-toggle", Button).disabled = (
             self._service is None or not structurally_available
         )
         protect = self.query_one("#file-notes-protect", Button)
@@ -3475,12 +3510,33 @@ class LibraryFileNotesWorkspace(Vertical):
             ),
             "file-notes-refresh": has_service,
         }
+        maintenance_ids = {
+            "file-notes-move",
+            "file-notes-protect",
+            "file-notes-reload",
+            "file-notes-refresh",
+        }
+        maintenance_available = any(
+            visibility[action_id] for action_id in maintenance_ids
+        )
+        visibility["file-notes-maintenance-toggle"] = maintenance_available
         focused = self.app.focused
         for action_id, displayed in visibility.items():
+            if action_id in maintenance_ids:
+                displayed = displayed and self._maintenance_expanded
             button = self.query_one(f"#{action_id}", Button)
             if button is focused and not displayed:
                 self._editor_action_focus_target = action_id
             button.display = displayed
+
+        maintenance_toggle = self.query_one(
+            "#file-notes-maintenance-toggle", Button
+        )
+        maintenance_toggle.label = (
+            "Hide actions" if self._maintenance_expanded else "Maintenance"
+        )
+        maintenance = self.query_one("#file-notes-maintenance-actions")
+        maintenance.display = maintenance_available and self._maintenance_expanded
 
         for toolbar in self.query(".file-notes-toolbar"):
             toolbar.set_class(
@@ -3494,6 +3550,7 @@ class LibraryFileNotesWorkspace(Vertical):
                     f"#{self._editor_action_focus_target}",
                     "#file-notes-restore",
                     "#file-notes-new",
+                    "#file-notes-maintenance-toggle",
                     "#file-notes-refresh",
                 )
             ):
@@ -5101,7 +5158,8 @@ class LibraryFileNotesWorkspace(Vertical):
                     f"Save the note before {gerund}. Return to the editor."
                 )
             self._git_panel_widget.set_current_status(
-                f"Status: CURRENT · BLOCKED — {detail}"
+                f"Status: CURRENT · BLOCKED — {detail}",
+                complete=True,
             )
             return
         if (
@@ -5113,15 +5171,17 @@ class LibraryFileNotesWorkspace(Vertical):
             self._git_panel_widget.set_current_status(
                 "Status: CURRENT · BLOCKED — File Notes changed before "
                 f"{action.title()}. Return to the editor, finish the save or "
-                "transition, then Refresh."
+                "transition, then Refresh.",
+                complete=True,
             )
             return
         action_key = self._capture_git_action_key(binding)
         if action_key is None:
             self._git_panel_widget.set_current_status(
                 "Status: STALE · BLOCKED — Repository or session authority "
-                "changed before the action. Return to the navigator, reopen "
-                "Prepare session for commit, then Refresh."
+                "changed before the action. Return to the navigator, open "
+                "Review session changes again, then Refresh.",
+                complete=True,
             )
             return
         try:
@@ -5134,7 +5194,8 @@ class LibraryFileNotesWorkspace(Vertical):
             self._git_panel_widget.set_current_status(
                 f"Status: CURRENT · BLOCKED — {action.title()} could not "
                 f"start: {error}. Finish the active File Notes action, then "
-                "Refresh."
+                "Refresh.",
+                complete=True,
             )
             return
         action_key_after_admission = self._capture_git_action_key(binding)
@@ -5185,6 +5246,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 self._git_last_action = replace(
                     action_key,
                     text=f"Last action: FAILED — {detail}",
+                    complete=True,
                 )
                 if self._git_binding_is_current(binding):
                     self._sync_git_last_action()
@@ -5211,6 +5273,7 @@ class LibraryFileNotesWorkspace(Vertical):
                             f"Last action: {self._git_action_label(result)} — "
                             f"{summary}"
                         ),
+                        complete=result.state != "success",
                     )
                     if self._git_binding_is_current(binding):
                         self._sync_git_last_action()
@@ -5428,6 +5491,15 @@ class LibraryFileNotesWorkspace(Vertical):
             destination,
         )
 
+    @on(Button.Pressed, "#file-notes-maintenance-toggle")
+    def _toggle_maintenance_actions(self) -> None:
+        """Reveal or hide secondary file operations without moving focus."""
+        self._maintenance_expanded = not self._maintenance_expanded
+        toggle = self.query_one("#file-notes-maintenance-toggle", Button)
+        self._sync_editor_action_visibility()
+        self._schedule_editor_action_layout()
+        self.call_after_refresh(toggle.focus)
+
     @on(Button.Pressed, "#file-notes-delete")
     async def _delete_file(self, event: Button.Pressed) -> None:
         event.stop()
@@ -5554,12 +5626,12 @@ class LibraryFileNotesWorkspace(Vertical):
         service = self._service
         if service is None or opened is None:
             return
-        destination = self._validated_path_input("Save Copy")
+        destination = self._validated_path_input("Save draft as copy")
         if destination is None:
             return
         body = self.query_one("#file-notes-editor", TextArea).text
         await self._complete_path_action(
-            "Save Copy",
+            "Save draft as copy",
             destination,
             service.save_copy,
             opened,

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -103,7 +103,7 @@ _SAVE_STATE_COPY: dict[SaveState, str] = {
 }
 _UNSET = object()
 _SESSION_GIT_MUTATION_BUSY = (
-    "Session Git mutation in progress; structural actions are busy."
+    "Git operation in progress; structural actions are busy."
 )
 _TreeData = tuple[Literal["file", "folder", "deleted"], str]
 
@@ -523,8 +523,7 @@ class LibraryFileNotesWorkspace(Vertical):
     .file-notes-toolbar.-confirm-delete {
         grid-size: 2;
         grid-columns: 1fr 1fr;
-        grid-rows: 1 1;
-        height: 2;
+        height: auto;
     }
 
     LibraryFileNotesWorkspace.-stack-editor-actions
@@ -3472,7 +3471,7 @@ class LibraryFileNotesWorkspace(Vertical):
             )
         elif mutation_active:
             busy_reason = (
-                "Session Git mutation in progress; editor actions are temporarily "
+                "Git operation in progress; editor actions are temporarily "
                 "unavailable."
             )
         self.query_one("#file-notes-action-status", Static).update(
@@ -3635,7 +3634,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if expected_binding is not None and root_lease is None:
             if self._session_owner.mutation_active(expected_binding):
                 self._set_action_status(
-                    "Session Git mutation in progress; root change is busy."
+                    "Git operation in progress; root change is busy."
                 )
             return False
         self._root_generation += 1
@@ -5295,8 +5294,8 @@ class LibraryFileNotesWorkspace(Vertical):
                         self._git_refresh_after_mutation = True
                         if self._active and self.is_mounted:
                             self._git_panel_widget.mark_stale(
-                                "Git action finished while Prepare session was "
-                                "hidden. Reopen it to Refresh.",
+                                "Git action finished while Review session changes "
+                                "was hidden. Open it again to Refresh.",
                                 retain_rows=self._git_can_retain_rows(binding),
                             )
 


### PR DESCRIPTION
## Summary

- clarify that File Notes autosaves to the linked local folder
- keep recovery instructions complete in compact terminals
- move secondary file operations behind a keyboard-operable Maintenance disclosure
- rename Session Git to Review session changes and explain its current-session scope

## Verification

- 50 File Notes workspace tests passed
- 19 focused Git and compact-terminal tests passed
- 109 shared focus and CSS integrity tests passed
- targeted Ruff, Python compilation, and diff checks passed

Tracking: TASK-15122

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished File Notes persistence and distilled maintenance UI so autosave authority is obvious, secondary actions stay tucked away, and Git recovery instructions remain complete even at 40×20.

- New Features
  - Save states name the local folder in every state; conflicts/errors say “draft preserved”; “Save Copy” is now “Save draft as copy”.
  - Moved Move/Protect/Reload/Refresh behind a keyboard-friendly “Maintenance” toggle with “Maintenance/Hide actions” labels and focus retention; stacked two-column layout fits at 40×20; Delete shows danger styling only when armed.
  - Renamed the entry and panel to “Review session changes”; scope leads with “Review and commit only notes changed during this Chatbook session.”; key guide uses dot separators.
  - Status/action messages can be marked complete to wrap fully; routine telemetry stays compact; standardized recovery/trust copy to “open Review session changes again”; busy copy now says “Git operation in progress.”
  - Updated tests for save-status labels, maintenance disclosure visibility/focus, complete-copy wrapping at 40×20, and entry/guide copy.

Satisfies TASK-15122 by making disk authority explicit, preserving complete recovery copy in compact layouts, distilling maintenance actions, and leading with clear outcome-based Git copy.

<sup>Written for commit 663420e9ac7eb78af51887ec53f421b49fde34a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

