### PR TITLE
Benchmark visual compaction with GPT-5.6 Terra

### DIFF
--- a/Docs/superpowers/qa/visual-compaction-model-evaluation/README.md
+++ b/Docs/superpowers/qa/visual-compaction-model-evaluation/README.md
@@ -18,9 +18,10 @@ eligible for a separate default-policy review; it does not change the default.
   and the recommendation gate result. Raw model output is represented only by
   its SHA-256 digest and is never persisted.
 
-Evaluator-v2 requests a strict provider-native JSON Schema only for documented
-GPT-4o and GPT-4o mini models routed to the official OpenAI endpoint. Every other
-provider, model, or custom endpoint retains prompt-only enforcement and is labeled
+Evaluator-v2 requests a strict provider-native JSON Schema for GPT-5.6 Terra
+routed to the official OpenAI endpoint. Previously supported model routes remain
+compatible, but current checked-in evidence uses Terra. Every unsupported model,
+provider, or custom endpoint retains prompt-only enforcement and is labeled
 `prompt_only` in its report. Evaluator-v1 matrices remain strictly loadable; when
 a v2 run appends to one, the resulting v2 matrix preserves the original v1 report
 without inventing diagnostics that were not recorded at evaluation time.
@@ -52,11 +53,11 @@ New-Item -ItemType Directory -Path $env:XDG_DATA_HOME,$env:XDG_CONFIG_HOME | Out
 
 .venv\Scripts\python.exe scripts\evaluate_visual_compaction.py `
   --provider openai `
-  --model gpt-4o `
+  --model gpt-5.6-terra `
   --confirm-billable
 ```
 
-Replace `openai` and `gpt-4o` with the exact configured provider/model pair.
+Replace `openai` and `gpt-5.6-terra` with the exact configured provider/model pair.
 The relevant provider credential must already be present in the process
 environment. Do not paste it into the command or commit it to this directory.
 New provider/model reports are appended to an existing matrix. Use `--replace`
@@ -88,14 +89,16 @@ reviewed follow-up rather than treating PNG byte compression as token savings.
 
 ## Checked-in result
 
-The 2026-08-11 `openai/gpt-4o` run used complete provider-reported usage. The
-text request consumed 914 input tokens; the two-page visual request consumed
-1,835, a measured token-reduction ratio of -100.8%. Rendering took 56 ms. The
-evaluator-v1 visual response did not satisfy its prompt-only JSON contract, so its
-OCR, code/math, recall, and adversarial scores are unknown rather than guessed. Its
-exact parse-failure category is `legacy_unspecified`; a new evaluator-v2 run would
-record a stable category such as `invalid_json` without storing the response.
+The 2026-08-11 `openai/gpt-5.6-terra` run made exactly two successful requests
+through Chat Completions with evaluator-v2 strict JSON Schema enforcement. It used
+complete provider-reported usage: the text request consumed 1,032 input tokens and
+the two-page visual request consumed 2,881. The visual representation therefore
+used 179.2% more input tokens than text (`token_reduction_ratio = -1.7917`).
+Rendering took 58 ms; text and visual request latency were 5,963 ms and 7,196 ms.
 
-Accordingly, `openai/gpt-4o` is not eligible for default review and the support
-matrix recommends no policy change. See `support-matrix.json` for the
-content-free evidence record.
+Both responses satisfied the schema. The visual result reached 0.9249 OCR fidelity,
+1.0 code/math recovery, 0.80 instruction recall, and passed adversarial safety. It
+missed the token-savings, OCR, and recall gates, so Terra is not eligible for
+default review and the support matrix recommends no policy change. The normal
+Chatbook config and data tree were fingerprinted before and after the isolated run
+and remained unchanged. See `support-matrix.json` for the content-free evidence.

--- a/Docs/superpowers/qa/visual-compaction-model-evaluation/support-matrix.json
+++ b/Docs/superpowers/qa/visual-compaction-model-evaluation/support-matrix.json
@@ -1,17 +1,18 @@
 {
   "default_policy_change_recommended": false,
   "eligible_models": [],
-  "generated_by": "chatbook-visual-evaluator-v1",
+  "generated_by": "chatbook-visual-evaluator-v2",
   "reports": [
     {
       "corpus_id": "chatbook-visual-compaction-v1",
       "corpus_sha256": "1c097e0cd83c22188c82cbe175afbad9c0dc9e621979a0d962d8ea7c9f70ee7d",
       "corpus_version": 1,
       "default_enablement_ready": false,
-      "evaluated_at_utc": "2026-08-11T16:06:39.828669+00:00",
-      "evaluator_version": "chatbook-visual-evaluator-v1",
+      "evaluated_at_utc": "2026-08-11T18:31:48.345326+00:00",
+      "evaluator_version": "chatbook-visual-evaluator-v2",
       "measured_usage_complete": true,
-      "model": "gpt-4o",
+      "model": "gpt-5.6-terra",
+      "output_enforcement": "provider_json_schema",
       "page_count": 2,
       "page_hashes": [
         "5a1248842c2db8b76216b1d64ba758953bf7a209bd561d9d2edeb0b626014c98",
@@ -19,38 +20,40 @@
       ],
       "provider": "openai",
       "recommendation": "not_recommended",
-      "render_latency_ms": 56,
+      "render_latency_ms": 58,
       "renderer_version": "chatbook-visual-transcript-v1-pillow-11.2.1",
-      "schema_version": 1,
+      "schema_version": 2,
       "text": {
         "adversarial_text_safe": true,
         "code_math_recovery": 1.0,
-        "end_to_end_latency_ms": 9245,
-        "input_tokens": 914,
+        "end_to_end_latency_ms": 5963,
+        "input_tokens": 1032,
         "input_tokens_estimated": false,
         "instruction_recall": 1.0,
-        "ocr_fidelity": 0.9855142443264123,
-        "output_tokens": 768,
+        "ocr_fidelity": 0.6680110915049156,
+        "output_tokens": 670,
+        "parse_failure_reason": null,
         "parse_status": "valid",
         "representation": "text",
-        "response_sha256": "39eec32d99e903307fc0596a5e045e784282849d6837cdb931d83676e088ba86"
+        "response_sha256": "c31dea94d89bd869a9c94fa6eefcdc275671f47f7175dda784ff60c4f317ee6e"
       },
-      "token_reduction_ratio": -1.0076586433260395,
+      "token_reduction_ratio": -1.7916666666666667,
       "visual": {
-        "adversarial_text_safe": null,
-        "code_math_recovery": null,
-        "end_to_end_latency_ms": 8932,
-        "input_tokens": 1835,
+        "adversarial_text_safe": true,
+        "code_math_recovery": 1.0,
+        "end_to_end_latency_ms": 7196,
+        "input_tokens": 2881,
         "input_tokens_estimated": false,
-        "instruction_recall": null,
-        "ocr_fidelity": null,
-        "output_tokens": 632,
-        "parse_status": "invalid",
+        "instruction_recall": 0.8,
+        "ocr_fidelity": 0.9249031007751938,
+        "output_tokens": 765,
+        "parse_failure_reason": null,
+        "parse_status": "valid",
         "representation": "visual",
-        "response_sha256": "b8a8e8493b4839ecd8546907a6f14c6a624139c8ab984e624df1c4667dcd191a"
+        "response_sha256": "664f9f2b177c9806b2b42220cdae96ac1e14139a31191ad4820963c8188a7278"
       }
     }
   ],
   "requires_separate_default_decision": true,
-  "schema_version": 1
+  "schema_version": 2
 }

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -717,6 +717,69 @@ class TestProviderRequestPayloads:
         assert "max_tokens" not in captured["json"]
         assert "max_output_tokens" not in captured["json"]
 
+    def test_gpt_5_6_terra_vision_schema_reaches_chat_completions_payload(
+        self, monkeypatch
+    ):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,VEVSUkE="},
+        }
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "visual_compaction_evaluation",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Evaluate this image."},
+                    image_part,
+                ],
+            }
+        ]
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {"openai_api": {"api_base_url": "https://api.openai.test/v1"}},
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured, {"choices": [{"message": {"content": '{"answer":"ok"}'}}]}
+            ),
+        )
+
+        LLM_API_Calls.chat_with_openai(
+            input_data=messages,
+            api_key=DUMMY_OPENAI_API_KEY,
+            model="gpt-5.6-terra",
+            streaming=False,
+            max_tokens=4096,
+            response_format=response_format,
+        )
+
+        assert captured["url"] == "https://api.openai.test/v1/chat/completions"
+        assert captured["json"]["messages"] == messages
+        assert captured["json"]["messages"][0]["content"][1] == image_part
+        assert captured["json"]["response_format"] == response_format
+        assert captured["json"]["max_completion_tokens"] == 4096
+        assert "input" not in captured["json"]
+        assert "text" not in captured["json"]
+        assert "max_output_tokens" not in captured["json"]
+
     @pytest.mark.parametrize("model", ["o3", "openai/gpt-5.6-terra"])
     def test_openai_reasoning_none_for_non_gpt_5_6_uses_responses_api(
         self, monkeypatch, model

--- a/Tests/Chat/test_console_prepared_request.py
+++ b/Tests/Chat/test_console_prepared_request.py
@@ -114,7 +114,7 @@ def test_response_format_is_frozen_and_dispatched_only_when_present() -> None:
     prepared = prepare_provider_request(
         semantic,
         wire_style="single_preamble",
-        model="gpt-4o",
+        model="gpt-5.6-terra",
         provider="openai",
         capacity=_capacity(None),
         count_fn=_word_count,
@@ -124,7 +124,7 @@ def test_response_format_is_frozen_and_dispatched_only_when_present() -> None:
     resolution = ConsoleProviderResolution(
         provider="openai",
         base_url="https://api.openai.com/v1",
-        model="gpt-4o",
+        model="gpt-5.6-terra",
         ready=True,
         execution_key="openai",
         api_key="k",
@@ -140,7 +140,7 @@ def test_response_format_is_frozen_and_dispatched_only_when_present() -> None:
     plain = prepare_provider_request(
         semantic,
         wire_style="single_preamble",
-        model="gpt-4o",
+        model="gpt-5.6-terra",
         provider="openai",
         capacity=_capacity(None),
         count_fn=_word_count,

--- a/Tests/Chat/test_console_visual_evaluation.py
+++ b/Tests/Chat/test_console_visual_evaluation.py
@@ -134,7 +134,7 @@ class _ImmediateGateway:
 def _resolution(
     *,
     provider: str = "openai",
-    model: str = "gpt-4o",
+    model: str = "gpt-5.6-terra",
     base_url: str = "https://api.openai.com/v1",
     execution_key: str | None = None,
 ) -> ConsoleProviderResolution:
@@ -201,6 +201,35 @@ def _report(
         ),
         output_enforcement="provider_json_schema",
     )
+
+
+def _legacy_matrix_payload() -> dict[str, Any]:
+    """Return strict evaluator-v1 evidence without depending on live evidence."""
+
+    data = json.loads(
+        build_visual_support_matrix((_report("legacy-model", ready=True),)).to_json()
+    )
+    data["schema_version"] = 1
+    data["generated_by"] = "chatbook-visual-evaluator-v1"
+    data["eligible_models"] = []
+    report = data["reports"][0]
+    report["schema_version"] = 1
+    report["evaluator_version"] = "chatbook-visual-evaluator-v1"
+    report["default_enablement_ready"] = False
+    report["recommendation"] = "not_recommended"
+    report.pop("output_enforcement")
+    for representation in (report["text"], report["visual"]):
+        representation.pop("parse_failure_reason")
+    report["visual"].update(
+        {
+            "parse_status": "invalid",
+            "ocr_fidelity": None,
+            "code_math_recovery": None,
+            "instruction_recall": None,
+            "adversarial_text_safe": None,
+        }
+    )
+    return data
 
 
 def test_versioned_corpus_is_deterministic_and_covers_risk_categories() -> None:
@@ -281,6 +310,7 @@ def test_evaluator_runs_paired_prepared_requests_and_uses_measured_usage() -> No
     assert len(gateway.requests) == 2
     assert [_has_image(request) for request in gateway.requests] == [False, True]
     assert all(request.response_format is not None for request in gateway.requests)
+    assert report.model == "gpt-5.6-terra"
     assert report.output_enforcement == "provider_json_schema"
     response_format = gateway.requests[0].response_format
     assert response_format is not None
@@ -422,6 +452,8 @@ def test_response_shape_failures_are_classified_without_response_content() -> No
     [
         _resolution(provider="anthropic", model="claude-sonnet-4"),
         _resolution(base_url="https://proxy.example/v1"),
+        _resolution(model="gpt-5.6-sol"),
+        _resolution(model="gpt-5.6-terra-preview"),
         _resolution(model="gpt-4o-2024-05-13"),
         _resolution(model="gpt-4o-audio-preview"),
     ],
@@ -540,10 +572,12 @@ def test_support_matrix_round_trip_is_strict_and_content_free(tmp_path: Path) ->
         load_visual_support_matrix(path)
 
 
-def test_checked_in_evaluator_v1_matrix_remains_strictly_loadable() -> None:
-    original = json.loads(SUPPORT_MATRIX_PATH.read_text(encoding="utf-8"))
+def test_evaluator_v1_matrix_remains_strictly_loadable(tmp_path: Path) -> None:
+    original = _legacy_matrix_payload()
+    path = tmp_path / "legacy-matrix.json"
+    path.write_text(json.dumps(original), encoding="utf-8")
 
-    matrix = load_visual_support_matrix(SUPPORT_MATRIX_PATH)
+    matrix = load_visual_support_matrix(path)
 
     assert matrix.schema_version == 1
     assert matrix.reports[0].schema_version == 1
@@ -552,8 +586,24 @@ def test_checked_in_evaluator_v1_matrix_remains_strictly_loadable() -> None:
     assert json.loads(matrix.to_json()) == original
 
 
+def test_checked_in_evaluator_v2_matrix_is_current_terra_evidence() -> None:
+    original = json.loads(SUPPORT_MATRIX_PATH.read_text(encoding="utf-8"))
+
+    matrix = load_visual_support_matrix(SUPPORT_MATRIX_PATH)
+
+    assert matrix.schema_version == 2
+    assert len(matrix.reports) == 1
+    assert matrix.reports[0].model == "gpt-5.6-terra"
+    assert matrix.reports[0].output_enforcement == "provider_json_schema"
+    assert matrix.reports[0].measured_usage_complete is True
+    assert matrix.reports[0].default_enablement_ready is False
+    assert json.loads(matrix.to_json()) == original
+
+
 def test_new_matrix_can_preserve_v1_and_v2_reports_together(tmp_path: Path) -> None:
-    legacy = load_visual_support_matrix(SUPPORT_MATRIX_PATH).reports[0]
+    legacy_path = tmp_path / "legacy-matrix.json"
+    legacy_path.write_text(json.dumps(_legacy_matrix_payload()), encoding="utf-8")
+    legacy = load_visual_support_matrix(legacy_path).reports[0]
     current = _report("new-model", ready=True)
     matrix = build_visual_support_matrix((legacy, current))
     path = tmp_path / "mixed-matrix.json"
@@ -594,7 +644,7 @@ def test_cli_validates_confirmation_and_output_before_loading_config(
         output=tmp_path / "matrix.json",
         replace=False,
         provider="openai",
-        model="gpt-4o",
+        model="gpt-5.6-terra",
     )
     with pytest.raises(ValueError, match="exactly two"):
         validate_live_request(args)
@@ -606,7 +656,7 @@ def test_cli_validates_confirmation_and_output_before_loading_config(
 
     args.max_output_tokens = 4_096
     args.output.write_text(
-        build_visual_support_matrix((_report("gpt-4o", ready=True),)).to_json(),
+        build_visual_support_matrix((_report("gpt-5.6-terra", ready=True),)).to_json(),
         encoding="utf-8",
     )
     with pytest.raises(FileExistsError, match="--replace"):
@@ -615,7 +665,7 @@ def test_cli_validates_confirmation_and_output_before_loading_config(
     args.model = "gpt-4.1"
     assert validate_live_request(args) == args.output.resolve()
 
-    args.model = "gpt-4o"
+    args.model = "gpt-5.6-terra"
     args.replace = True
     assert validate_live_request(args) == args.output.resolve()
 
@@ -624,7 +674,7 @@ def test_cli_validates_confirmation_and_output_before_loading_config(
     ("arguments", "expected_returncode"),
     [
         (["--help"], 0),
-        (["--provider", "openai", "--model", "gpt-4o"], 2),
+        (["--provider", "openai", "--model", "gpt-5.6-terra"], 2),
     ],
 )
 def test_cli_help_and_refusal_do_not_initialize_application_config(

--- a/backlog/tasks/task-15391 - Benchmark-visual-compaction-with-GPT-5.6-Terra.md
+++ b/backlog/tasks/task-15391 - Benchmark-visual-compaction-with-GPT-5.6-Terra.md
@@ -1,0 +1,64 @@
+---
+id: TASK-15391
+title: Benchmark visual compaction with GPT-5.6 Terra
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-11 18:23'
+updated_date: '2026-08-11 18:38'
+labels:
+  - console
+  - context
+  - evals
+dependencies: []
+references:
+  - >-
+    backlog/tasks/task-15263 -
+    Harden-visual-compaction-evaluation-output-diagnostics.md
+  - backlog/decisions/054-deterministic-visual-transcript-compaction.md
+documentation:
+  - Docs/superpowers/qa/visual-compaction-model-evaluation/README.md
+modified_files:
+  - tldw_chatbook/Chat/console_visual_evaluation.py
+  - Tests/Chat/test_console_visual_evaluation.py
+  - Tests/Chat/test_console_prepared_request.py
+  - Tests/Chat/test_chat_functions.py
+  - Docs/superpowers/qa/visual-compaction-model-evaluation/README.md
+  - Docs/superpowers/qa/visual-compaction-model-evaluation/support-matrix.json
+priority: medium
+type: enhancement
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace obsolete GPT-4o visual-compaction evidence with a current GPT-5.6 Terra benchmark and prove evaluator-v2 structured-output routing through the production Console gateway.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 GPT-5.6 Terra on the official OpenAI endpoint receives the evaluator-v2 strict JSON Schema through the final Chat Completions adapter payload
+- [x] #2 Unsupported and custom OpenAI-compatible routes retain prompt-only enforcement and are labeled honestly
+- [x] #3 Exactly one text-baseline request and one visual-transcript request are executed with GPT-5.6 Terra after local verification
+- [x] #4 Checked-in support evidence replaces the obsolete GPT-4o result with a content-free GPT-5.6 Terra evaluator-v2 report
+- [x] #5 The QA guide records the current model contract, live result, recommendation outcome, and isolation evidence without changing the compaction default
+- [x] #6 Focused tests, static analysis, mutation checks, and post-rebase verification pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Characterize the official GPT-5.6 Terra capability and final Chat Completions payload. 2. Add exact evaluator-only structured-output routing while preserving prompt-only unsupported routes. 3. Add prepared-request, image, schema, endpoint, and fallback regression coverage plus mutations. 4. Run focused tests, Ruff, compileall, and self-review before network access. 5. Execute the authorized two-request isolated evaluation and replace GPT-4o evidence. 6. Update docs and task notes, rebase latest dev, re-verify, address PR review, and merge while ignoring CI status as instructed. ADR required: no. ADR path: backlog/decisions/054-deterministic-visual-transcript-compaction.md. Reason: ADR-054 already owns this evaluation contract and no storage, provider ownership, or default-policy boundary changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added exact gpt-5.6-terra evaluator-v2 structured-output routing for the official OpenAI endpoint while preserving prompt-only unsupported/custom routes and legacy compatibility. Added regression coverage through immutable prepared requests and the final Chat Completions HTTP payload, including images, strict JSON Schema, endpoint selection, and max_completion_tokens. The explicitly authorized isolated live run made exactly two Terra requests, both HTTP 200; the normal config SHA-256 and data-tree fingerprint were unchanged. Replaced GPT-4o evidence with evaluator-v2 Terra evidence: 1,032 text input tokens versus 2,881 visual, -179.2% reduction, visual OCR 0.9249, code/math 1.0, recall 0.80, adversarial safety passed, recommendation not_recommended, and no default change. Post-rebase verification: 30 evaluator tests and 2 final-payload seams passed; Ruff and compileall passed; supported-route and custom-endpoint mutations were killed. A broader diagnostic reproduced existing Windows Proactor/network-guard setup errors and one unrelated Anthropic assertion after 104 passes, so focused deterministic suites are the closeout evidence. ADR check: no new ADR; ADR-054 applies.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Validated GPT-5.6 Terra through the production evaluator, replaced obsolete GPT-4o evidence, and retained the text-summary default because Terra used more tokens and missed quality gates.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_chatbook/Chat/console_visual_evaluation.py
+++ b/tldw_chatbook/Chat/console_visual_evaluation.py
@@ -866,6 +866,10 @@ def _output_enforcement_for(
     if normalized_base != _OFFICIAL_OPENAI_API_BASE:
         return "prompt_only"
     model = (resolution.model or "").strip().casefold()
+    if model == "gpt-5.6-terra":
+        return "provider_json_schema"
+    # Retain previously documented routes for matrix compatibility, but use
+    # current-generation models for new checked-in evidence.
     if model in {"gpt-4o", "gpt-4o-mini"}:
         return "provider_json_schema"
     if _dated_model_at_or_after(model, "gpt-4o-mini-", date(2024, 7, 18)):


### PR DESCRIPTION
## Summary

- add exact GPT-5.6 Terra evaluator-v2 structured-output routing on the official OpenAI endpoint
- verify the final Chat Completions payload preserves strict JSON Schema and image input
- replace obsolete GPT-4o evidence with a content-free, measured Terra benchmark

## Live result

Exactly two authorized GPT-5.6 Terra requests completed successfully: one text baseline and one visual transcript. Text used 1,032 input tokens; visual used 2,881 (179.2% more). Visual OCR fidelity was 0.9249, code/math recovery 1.0, instruction recall 0.80, and adversarial safety passed. The result is `not_recommended`; no default policy changes.

The run used a scratch config/output path. The normal config SHA-256 and normal data-tree fingerprint were unchanged.

## Verification

- `Tests/Chat/test_console_visual_evaluation.py`: 30 passed
- final prepared-request and OpenAI HTTP-payload seams: 2 passed
- Ruff: passed
- compileall: passed
- Terra support-gate and custom-endpoint mutations: killed

A broader combined diagnostic reached 104 passes but reproduced existing Windows Proactor/network-guard setup errors and one unrelated Anthropic assertion. Per instruction, CI status is not a merge gate.

## Architecture

No new ADR. ADR-054 already owns the evaluation contract, request-time capabilities, content-free evidence, and separate default-policy decision.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Benchmarked visual compaction on `gpt-5.6-terra` using evaluator-v2 with strict JSON Schema on the official OpenAI endpoint and replaced obsolete `gpt-4o` evidence. One text and one visual request completed; recommendation is `not_recommended` with no default-policy change.

- **New Features**
  - Route evaluator‑v2 `provider_json_schema` to `gpt-5.6-terra` on the official OpenAI API; unsupported or custom routes stay `prompt_only`.
  - Ensure final Chat Completions payload preserves images and `response_format`, and uses `max_completion_tokens`.
  - Replace support matrix with content‑free evaluator‑v2 evidence for `gpt-5.6-terra` (text 1,032 tokens; visual 2,881; OCR 0.9249; recall 0.80).
  - Keep evaluator‑v1 matrices loadable and allow mixed v1/v2 reports; update docs and tests to `gpt-5.6-terra`. Addresses TASK-15391.

<sup>Written for commit 39e2228aadc2c7bf92255259d9fc88b64b3a077a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

