### PR TITLE
fix(console): triage 6 pre-existing contract failures — 2 real product bugs, 1 vacuous pass (task-15210)

### DIFF
--- a/Tests/Chat/test_console_command_suggestions.py
+++ b/Tests/Chat/test_console_command_suggestions.py
@@ -6,7 +6,10 @@ from tldw_chatbook.Chat.console_command_grammar import (
     ConsoleCommandRegistry,
     default_console_registry,
 )
-from tldw_chatbook.Chat.console_command_suggestions import suggestions_for_draft
+from tldw_chatbook.Chat.console_command_suggestions import (
+    COMMAND_DESCRIPTION_FALLBACK,
+    suggestions_for_draft,
+)
 from tldw_chatbook.Chat.console_skill_resolver import SkillCommandCandidate
 
 SKILLS = (
@@ -98,6 +101,23 @@ def test_builtin_command_descriptions_are_plain_language():
         assert suggestion.description.strip(), suggestion.label
     assert "Arm" not in descriptions["/prefill"]
     assert "prefill" not in descriptions["/prefill"].lower()
+
+
+def test_no_builtin_command_falls_back_to_the_extension_description():
+    """`COMMAND_DESCRIPTION_FALLBACK` is for registrations we do not ship.
+
+    `console_command_suggestions` documents the fallback as reachable "only
+    [by] non-built-in registrations (extensions, test doubles): every
+    built-in has an entry above". Nothing pinned that, so `/generate-video`
+    (task-3401.5) and `/stream-video` (task-3401.11) shipped rendering
+    "Custom command" in the popup. Assert the invariant itself rather than a
+    list of names, so the next built-in cannot repeat it.
+    """
+    result = suggestions_for_draft("/", default_console_registry(), ())
+    undescribed = [
+        s.label for s in result if s.description == COMMAND_DESCRIPTION_FALLBACK
+    ]
+    assert undescribed == []
 
 
 def test_registered_command_without_dict_entry_gets_fallback_description():

--- a/Tests/UI/test_console_auto_rag_on_send.py
+++ b/Tests/UI/test_console_auto_rag_on_send.py
@@ -27,9 +27,11 @@ from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
+from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
 from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
 from tldw_chatbook.Chat.rag_scope import EffectiveScope, scope_empty_notice
-from tldw_chatbook.config import save_setting_to_cli_config
+from tldw_chatbook.Chat.console_turn_context import ConsoleTurnExecutionContext
+from tldw_chatbook.config import load_settings, save_setting_to_cli_config
 from tldw_chatbook.Event_Handlers.Chat_Events.chat_rag_events import (
     LocalRagContextResult,
 )
@@ -74,6 +76,28 @@ def _reset_auto_retrieve_toggle():
 
 def _enable_auto_retrieve() -> None:
     save_setting_to_cli_config("chat_defaults", "rag_auto_retrieve_on_send", True)
+
+
+def _use_disk_config(app):
+    """Source the app's config snapshot from disk, exactly as `app.py` does.
+
+    `_build_test_app` hands `TldwCli` a synthetic three-key `app_config`
+    with no `[chat_defaults]` at all, and production correctly refuses to
+    "refresh" a snapshot that never came from `load_settings()`
+    (`ChatScreen._console_config_snapshot_is_disk_loaded`). That was
+    harmless while `_maybe_auto_retrieve_for_send` read the toggle live via
+    `get_cli_setting`; task-14803 (commit 5be9e6a04) moved the read onto the
+    frozen per-turn `ConsoleTurnExecutionContext`, which
+    `ConsoleSessionController._build_console_turn_execution_context` builds
+    from that app config -- so on THIS harness, and only on this harness,
+    `_enable_auto_retrieve()` stopped reaching the code under test. The
+    shipping app assigns `self.app_config = load_settings()` (app.py), whose
+    result does carry the persisted toggle; do the same here so these two
+    mounted tests exercise the real read path instead of a snapshot no real
+    user has.
+    """
+    app.app_config = load_settings()
+    return app
 
 
 class _RecordingRagService:
@@ -509,7 +533,7 @@ async def test_happy_path_stages_then_send_consumes(monkeypatch):
     """Auto-retrieval stages a bundle the SAME send consumes and prompts."""
     _enable_auto_retrieve()
     _patch_scope(monkeypatch)
-    app = _build_test_app()
+    app = _use_disk_config(_build_test_app())
     service = _RecordingRagService(_rows(2))
     app.library_rag_search_service = service
     context = "[S1] MEDIA — Source 1\nBody 1"
@@ -559,11 +583,10 @@ async def test_send_proceeds_when_auto_retrieve_fails(monkeypatch):
     """Retrieval failure is never a send blocker."""
     _enable_auto_retrieve()
     _patch_scope(monkeypatch)
-    app = _build_test_app()
+    app = _use_disk_config(_build_test_app())
+    exploding_search = AsyncMock(side_effect=RuntimeError("backend exploded"))
     monkeypatch.setattr(
-        chat_screen_module,
-        "run_library_rag_search",
-        AsyncMock(side_effect=RuntimeError("backend exploded")),
+        chat_screen_module, "run_library_rag_search", exploding_search
     )
 
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
@@ -577,6 +600,11 @@ async def test_send_proceeds_when_auto_retrieve_fails(monkeypatch):
         result = await controller.submit_draft("what changed in the notes")
         await pilot.pause()
 
+        # Retrieval was actually attempted. Without this the test passes for
+        # the wrong reason whenever the toggle fails to reach the hook -- it
+        # did exactly that between task-14803 and task-15210, silently
+        # asserting only that an ordinary send works.
+        assert exploding_search.await_count == 1
         assert result.accepted is True
         assert screen._pending_console_launch_context is None
         assert _final_user_content(gateway.captured) == "what changed in the notes"
@@ -602,8 +630,19 @@ async def test_capture_seam_calls_the_hook_before_consuming(monkeypatch):
     longer pick up.
     """
     order: list[str] = []
+    seen_contexts: list = []
+    turn_context = ConsoleTurnExecutionContext.capture(
+        session_id="s1",
+        provider_selection=ConsoleProviderSelection(provider="test-provider"),
+    )
 
-    async def _hook(_draft):
+    async def _hook(_draft, turn_context=None):
+        # Production signature since task-14803 (commit 5be9e6a04), which
+        # threads the turn's frozen context to the hook. The one-argument
+        # stub this replaced made the seam's call raise `TypeError`, which
+        # the seam's deliberate `except Exception` swallowed -- so the hook
+        # never ran and only the ordering assertion below noticed.
+        seen_contexts.append(turn_context)
         order.append("auto-retrieve")
 
     def _consume():
@@ -625,9 +664,12 @@ async def test_capture_seam_calls_the_hook_before_consuming(monkeypatch):
         ),
     )
 
-    await ChatScreen._capture_console_staged_rag(screen, "question")
+    await ChatScreen._capture_console_staged_rag(screen, "question", turn_context)
 
     assert order == ["clear-notice", "auto-retrieve", "consume"]
+    # ...and the hook retrieves for THIS turn's captured configuration, not
+    # for whatever the live settings happen to say by the time it runs.
+    assert seen_contexts == [turn_context]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_button_routing.py
+++ b/Tests/UI/test_console_button_routing.py
@@ -103,6 +103,25 @@ async def _sync_tray(console, pilot, state) -> ConsoleWorkspaceContextTray:
     return tray
 
 
+def _section_collapsed(console, group_id: str) -> bool:
+    """Whether a browser SECTION is collapsed in the state the toggle reads.
+
+    Deliberately `_build_console_workspace_context_state()` and not the tray
+    the test synced: that is the exact source
+    `_toggle_console_conversation_browser_section` consults to decide which
+    way to flip.
+    """
+    section_id = group_id.removeprefix("section:")
+    browser = console._workspace._build_console_workspace_context_state()
+    assert browser.conversation_browser is not None
+    section = next(
+        candidate
+        for candidate in browser.conversation_browser.sections
+        if candidate.section_id == section_id
+    )
+    return bool(section.collapsed)
+
+
 def _browser_config(app) -> dict:
     """The persisted grouped-browser preference dict, or an empty dict."""
     console_config = (app.app_config or {}).get("console")
@@ -187,22 +206,50 @@ async def test_browser_section_toggle_persists_its_collapse_preference():
         console = await _mounted_console(host, pilot)
         await _sync_tray(console, pilot, _base_grouped_workspace_state())
 
-        toggles = [
-            button
-            for button in console.query(Button)
-            if str(getattr(button, "id", "") or "").startswith(
-                "console-conversation-browser-section-toggle-"
-            )
-        ]
-        assert toggles, "the grouped browser must render section toggles"
-        toggle = toggles[0]
-        group_id = toggle.group_id
+        def _section_toggles() -> list[Button]:
+            # Re-queried before EVERY press: `_toggle_console_conversation_
+            # browser_section` ends in `_sync_console_workspace_context()`,
+            # which rebuilds the tray with NEW Button instances. The old
+            # object still answers `is_mounted` True but is no longer in the
+            # DOM, and pressing it is a silent no-op.
+            return [
+                button
+                for button in console.query(Button)
+                if str(getattr(button, "id", "") or "").startswith(
+                    "console-conversation-browser-section-toggle-"
+                )
+            ]
+
+        assert _section_toggles(), "the grouped browser must render section toggles"
+        group_id = _section_toggles()[0].group_id
         assert group_id.startswith("section:")
 
-        toggle.press()
-        await pilot.pause()
+        def _press_section_toggle() -> None:
+            # By group_id, not by position: a rebuild is free to reorder.
+            next(
+                button
+                for button in _section_toggles()
+                if button.group_id == group_id
+            ).press()
 
-        assert _browser_config(app).get(group_id) is True
+        # The polarity is NOT a constant. The handler flips the section's
+        # CURRENT collapsed state, taken from the screen's own rebuilt
+        # context -- not from the fabricated tray state `_sync_tray` painted
+        # above. Starred default-collapses while it holds no rows
+        # (TASK-2154.3 LY-04, commit 7dbbc401b), which is the screen's real
+        # situation here, so the first press EXPANDS and persists False.
+        # `is True` pinned the pre-2154.3 default; what this test claims is
+        # that a press persists a preference under the toggle's own key and
+        # that the preference is a genuine flip, so assert that instead.
+        before = _section_collapsed(console, group_id)
+
+        _press_section_toggle()
+        await pilot.pause()
+        assert _browser_config(app).get(group_id) is (not before)
+
+        _press_section_toggle()
+        await pilot.pause()
+        assert _browser_config(app).get(group_id) is before
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_command_popup.py
+++ b/Tests/UI/test_console_command_popup.py
@@ -13,6 +13,7 @@ from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
+from tldw_chatbook.Chat.console_command_grammar import default_console_registry
 from tldw_chatbook.Chat.console_command_suggestions import CommandSuggestion
 from tldw_chatbook.Chat.console_skill_resolver import SkillCommandCandidate
 from tldw_chatbook.Widgets.Console import ConsoleComposerBar
@@ -75,14 +76,25 @@ async def test_slash_opens_popup_and_typing_filters():
         await pilot.press("/")
         await pilot.pause()
         assert popup.is_open
-        assert _popup_labels(popup) == [
+        # The offered rows ARE the registered commands, in registry order.
+        # Pinning the list literally is what broke this test: /generate-video
+        # (task-3401.5) and /stream-video (task-3401.11) registered two more
+        # built-ins and the six-item literal here sat red until something ran
+        # the file whole. The claim was never "there are six" -- it was "the
+        # popup offers the registered commands" -- so assert that, plus the
+        # six this test was written for, and let honest additions through.
+        labels = _popup_labels(popup)
+        assert labels == [
+            f"/{name}" for name in default_console_registry().available_names()
+        ]
+        assert {
             "/prompt",
             "/system",
             "/skills",
             "/prefill",
             "/generate-image",
             "/rewind",
-        ]
+        } <= set(labels)
 
         await pilot.press("s", "y", "s")
         await pilot.pause()

--- a/Tests/UI/test_console_composer_menu.py
+++ b/Tests/UI/test_console_composer_menu.py
@@ -445,31 +445,52 @@ async def test_generate_image_modal_returns_the_composed_command():
 
 
 def _fake_controller_with(messages):
-    """Build a controller stub whose transcript is ``messages``."""
-    from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
-    from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+    """Build a controller stub whose transcript is ``messages``.
 
-    class _Msg:
-        def __init__(self, role, content, status="ok"):
-            self.role = role
-            self.content = content
-            self.status = status
+    The stub bypasses ``__init__`` deliberately (it supplies only a store),
+    so every controller collaborator the subject reaches has to be wired
+    here by hand. task-14803 (commit 5be9e6a04) made ``impersonate_user_reply``
+    resolve its provider selection through
+    ``resolve_turn_execution_context`` -> ``_turn_context_provider``, which
+    this stub then lacked entirely; the screen wires that seam in production,
+    so wire the same production seam here rather than reaching past it.
+    """
+    from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+    from tldw_chatbook.Chat.console_chat_models import (
+        ConsoleChatMessage,
+        ConsoleMessageRole,
+        ConsoleProviderSelection,
+    )
+    from tldw_chatbook.Chat.console_turn_context import ConsoleTurnExecutionContext
 
     class _Store:
         def messages_for_session(self, session_id):
+            # The REAL transcript row type, not a three-attribute stand-in:
+            # the hand-rolled one drifted twice (`metadata`, read by
+            # `_context_content_for` since commit c2038dfe3, was the second),
+            # and a stand-in for a dataclass whose fields all have defaults
+            # buys nothing but drift.
             return [
-                _Msg(
-                    ConsoleMessageRole.USER
-                    if r == "user"
-                    else ConsoleMessageRole.ASSISTANT,
-                    c,
-                    s,
+                ConsoleChatMessage(
+                    role=(
+                        ConsoleMessageRole.USER
+                        if r == "user"
+                        else ConsoleMessageRole.ASSISTANT
+                    ),
+                    content=c,
+                    status=s,
                 )
                 for r, c, s in messages
             ]
 
     controller = ConsoleChatController.__new__(ConsoleChatController)
     controller.store = _Store()
+    controller._turn_context_provider = lambda session_id: (
+        ConsoleTurnExecutionContext.capture(
+            session_id=session_id,
+            provider_selection=ConsoleProviderSelection(provider="test-provider"),
+        )
+    )
     return controller
 
 
@@ -482,7 +503,6 @@ async def test_impersonate_payload_obeys_the_provider_contract():
     providers reject (task-427); a completed turn leaves the transcript
     ending on an assistant row, which user-final providers reject.
     """
-    from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
     from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 
     captured: dict[str, list] = {}
@@ -509,9 +529,12 @@ async def test_impersonate_payload_obeys_the_provider_contract():
     controller.provider_gateway = type(
         "_G", (), {"resolve_for_send": staticmethod(_resolve)}
     )()
-    controller._provider_selection = lambda: None
     controller._collect_summary_completion = _collect
-    controller._seeded_greeting_text = ConsoleChatController._seeded_greeting_text
+    # `_seeded_greeting_text` used to be a @staticmethod(session_messages),
+    # which is why it was re-bound onto the instance here; commit c2038dfe3
+    # (roleplay identity) made it an ordinary method taking (session_id,
+    # session_messages), so the re-bind dropped `self` and the real method on
+    # the class is now the right -- and only correct -- way to reach it.
 
     result = await controller.impersonate_user_reply("s1")
     assert result.text == "drafted reply"

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -2659,3 +2659,38 @@ preconditions (each setup line asserts one fact of the attribution), and it
 pins the upstream behavior — if a dependency bump fixes the bug, the
 state-construction test fails loudly and tells you the workaround can be
 retired, which no timing-based replay could ever do.
+## Moving a config read onto the app-config snapshot silently DEFAULTS it in every `_build_test_app` test — including passing ones (TASK-15210, 2026-08-11)
+
+`ChatScreen._maybe_auto_retrieve_for_send` used to read the auto-RAG toggle live via
+`get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send")`. Task-14803 (commit
+`5be9e6a04`) moved that read onto the frozen per-turn `ConsoleTurnExecutionContext`, whose
+`rag_defaults` are built from `app.app_config`. Both sources agree in the shipping app.
+They do not agree in `Tests/UI`.
+
+`Tests/UI/app_factory._build_test_app` patches `tldw_chatbook.app.load_settings` to return
+a synthetic `{"tldw_api": ..., "first_run": ...}` — **no `[chat_defaults]`, no `[console]`**.
+Production then behaves *correctly*: `_provider_readiness_app_config` only re-sources from
+`load_settings()` when the snapshot carries the `general`/`logging` markers only a real
+disk load emits, and this one does not, so it hands back the synthetic dict verbatim. Net
+effect: `save_setting_to_cli_config(...)` still writes the toggle, `get_cli_setting` still
+reads it True, and the code under test sees False.
+
+Measured, not inferred: instrumenting one mounted test printed
+`get_cli_setting=True` / `app_config chat_defaults.rag_auto_retrieve_on_send='MISSING'` /
+`resolved ctx rag_defaults={'auto_retrieve_on_send': False, ...}` in the same run. The live
+app assigns `self.app_config = load_settings()` (app.py), whose result carries both the
+toggle and both markers — so the shipping path was fine and only the harness was blind.
+
+**The part that cost the most.** One test went red and was triaged. Its sibling,
+`test_send_proceeds_when_auto_retrieve_fails`, stayed GREEN — because with retrieval never
+firing, the exploding backend it installs is never called and the test degenerates into
+"an ordinary send works". A moved read does not announce itself by failing; it can just as
+easily hollow out a passing test, and nothing in a green run points at it.
+
+**What to do.** When you move a read from a live settings accessor onto a snapshot,
+grep the tests that *enable* that setting and check they enable it through the new source —
+a `save_setting_to_cli_config` + `_build_test_app` pair no longer reaches the code. Give
+the mounted test the app's real shape (`app.app_config = load_settings()`, exactly what
+`app.py` does) rather than teaching the product to fall back. And any test whose subject is
+"X still works when Y fails" should assert **that Y was actually attempted** — here,
+`exploding_search.await_count == 1` — or it cannot tell "handled" from "never happened".

--- a/backlog/tasks/task-15210 - Five-pre-existing-Console-contract-failures-surfaced-by-the-network-guard.md
+++ b/backlog/tasks/task-15210 - Five-pre-existing-Console-contract-failures-surfaced-by-the-network-guard.md
@@ -1,16 +1,17 @@
 ---
 id: TASK-15210
-title: >-
-  Five pre-existing Console contract failures surfaced by the network guard
-status: To Do
-assignee: []
+title: Five pre-existing Console contract failures surfaced by the network guard
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 07:00'
+updated_date: '2026-08-11 15:23'
 labels:
   - console
   - tests
   - dev-baseline
-priority: medium
 dependencies: []
+priority: medium
 ---
 
 ## Description
@@ -29,9 +30,47 @@ Triage before repair, as in task-14920: a pinned count or attribute that a delib
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 Each of the five is classified as a stale pin or a real regression, with the causing commit named and its intent read
-- [ ] #2 Real regressions are fixed in the product; stale pins are updated while preserving the original claim (assert the behaviour, not a count or a class string that the next honest change breaks again)
-- [ ] #3 The affected Console test modules run WHOLE with READ pass counts and no unexpected failures
+- [x] #1 Each of the five is classified as a stale pin or a real regression, with the causing commit named and its intent read
+- [x] #2 Real regressions are fixed in the product; stale pins are updated while preserving the original claim (assert the behaviour, not a count or a class string that the next honest change breaks again)
+- [x] #3 The affected Console test modules run WHOLE with READ pass counts and no unexpected failures
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Run the nine sweep modules + command popup WHOLE; record the real node ids and exact errors (inventory before repair).
+2. For each failure, name the causing commit via git log -S over the product files it exercises, read that commit's intent, and confirm the test fails for the reason the symptom suggests (instrument with a throwaway probe rather than assuming).
+3. Classify each independently: stale pin (update the test, preserving the ORIGINAL claim and preferring the property over a magic number/polarity), real regression (fix the product, TDD + mutation-check), or deliberately-removed behaviour (state the new contract and where it is enforced).
+4. Implement, mutation-checking every fix (revert the fix, confirm RED returns).
+5. Run each touched module WHOLE with READ pass counts, plus the coordinator keep-green set (test_console_moved_seam_guard, test_background_signal_bounds, Tests/test_network_guard). No allow_network marker added.
+6. Record findings, tick ACs, write Implementation Notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+All five reproduced exactly as described, plus a SIXTH from the same cause as #5. Every one was triaged against the commit that changed the behaviour before anything was rewritten. Two product defects were found and fixed; the other five were stale test doubles/pins, each repaired to assert the ORIGINAL claim as a property rather than a magic value.
+
+**#1 `test_console_button_routing::test_browser_section_toggle_persists_its_collapse_preference`** — STALE POLARITY PIN. Cause: 7dbbc401b (TASK-2154.3 LY-04) made an EMPTY Starred section default-collapsed. The handler flips the section's current collapsed state taken from `_build_console_workspace_context_state()` — the screen's real (row-less) state, NOT the fabricated tray state `_sync_tray` painted — so the first press expands and persists False. Product correct. Test now reads the collapsed state from the handler's own source and asserts persisted == not-that, plus a round-trip. Two sub-findings: `is True` also PASSED a set-to-constant mutation (the new form fails it), and the round-trip only works if the toggle is re-queried — the sync rebuilds the Button, and the stale object still answers `is_mounted` True while pressing it is a silent no-op.
+
+**#2 `test_console_composer_menu::test_impersonate_payload_obeys_the_provider_contract`** — STALE TEST DOUBLE, in THREE layers from TWO commits. c2038dfe3 (roleplay identity) added `message.metadata` (read by `_context_content_for`) and turned `_seeded_greeting_text` from a @staticmethod(session_messages) into a method (self, session_id, session_messages) — so the test's `controller._seeded_greeting_text = ConsoleChatController._seeded_greeting_text` re-bind dropped `self`. 5be9e6a04 (task-14803) then routed `impersonate_user_reply` through `resolve_turn_execution_context` -> `_turn_context_provider`, which the `__new__`-built stub lacked. Product correct. The stub now wires the real `_turn_context_provider` seam, uses the real `ConsoleChatMessage` instead of a 3-attribute stand-in, and drops the stale re-bind.
+
+**#3 `test_console_auto_rag_on_send::test_happy_path_stages_then_send_consumes`** — HARNESS BLIND SPOT, not a live regression, PROVEN by measurement. 5be9e6a04 moved the auto-retrieve toggle read off live `get_cli_setting` onto the frozen `ConsoleTurnExecutionContext.rag_defaults`, built from `app.app_config`. `_build_test_app` hands TldwCli a synthetic 2-key app_config with no `[chat_defaults]`, and production correctly refuses to refresh a snapshot that never came from `load_settings()`. Instrumented: `get_cli_setting`=True but the app_config key MISSING, so the context captured auto_retrieve_on_send=False. The live app does `self.app_config = load_settings()` (app.py:4730), whose result carries the toggle AND both disk-load markers — verified — so the shipping path takes the fresh branch and the toggle still works. Test now sources the app config from disk exactly as app.py does.
+
+**#3b (NEW, found in the same file)** — `test_send_proceeds_when_auto_retrieve_fails` was GREEN VACUOUSLY from the same cause: auto-retrieve never fired, so the exploding backend was never called and the test only asserted that an ordinary send works. It now asserts `exploding_search.await_count == 1`.
+
+**#4 `test_capture_seam_calls_the_hook_before_consuming`** — STALE STUB SIGNATURE. 5be9e6a04 threads `turn_context` to `_maybe_auto_retrieve_for_send`; the one-argument stub made the seam's call raise TypeError, which the seam's deliberate `except Exception` swallowed. Product correct (the ordering contract holds). The stub takes the production signature and the test now also asserts THIS turn's context reaches the hook.
+
+**#5 `test_console_command_popup::test_slash_opens_popup_and_typing_filters`** — STALE COUNT PIN, as suspected. d6c2e9756 (/generate-video, task-3401.5) and 72a2ff3c5 (/stream-video, task-3401.11) grew the registry 6 -> 8. The claim was never 'there are six'; it is 'the popup offers the registered commands, and typing filters'. Now asserts labels == the registry's own `available_names()` plus a subset check for the original six, so honest additions pass and a removal still reds (mutation-checked by deleting /rewind's registration).
+
+**PRODUCT FIX A (from #5's blast radius).** `console_command_suggestions` documents `COMMAND_DESCRIPTION_FALLBACK` as reachable 'only [by] non-built-in registrations'. Nothing pinned it, so /generate-video and /stream-video shipped rendering 'Custom command' in the popup. Added both descriptions and a guard test that asserts the invariant (no built-in falls back) rather than a name list.
+
+**PRODUCT FIX B (SIXTH failure, same cause as #5).** `Tests/Library/test_library_skills_state::test_shadow_name_set_stays_in_sync_with_real_sources` was also red: `_SHADOWED_BUILTIN_NAMES` in `Library/library_skills_state.py` — a PRODUCT set — was missing generate-video/stream-video, so `skill_name_shadows_builtin` would not warn a user installing a skill that shadows either slash command. That set already carries a task-580 comment saying this exact drift had been carried as an accepted baseline before. Fixed and mutation-checked.
+
+**Evidence.** RED confirmed for each before touching anything, and each fail-reason verified by instrumentation rather than inference (three throwaway probe files, all deleted). Mutation checks: registry deletion (#5), greeting-fold disabled (#2), turn-context toggle key broken (#3/#3b both red), hook moved after the consume (#3/#4 both red), collapse flip set to a constant (#1 — which the old `is True` pin would have passed), shadow names removed (fix B). Every mutation restored via Edit and verified with an empty `git diff`. READ counts: touched + adjacent modules whole = 225 passed; remaining sweep modules + `test_console_native_chat_flow` = 383 passed, 1 xfailed (task-15120's strict xfail intact); keep-green (`test_console_moved_seam_guard`, `test_background_signal_bounds`, `Tests/test_network_guard`, `test_console_turn_execution_context`, `test_console_local_server_probe_isolation`) = 40 passed. No `allow_network` marker was needed anywhere.
+
+**Modified:** tldw_chatbook/Chat/console_command_suggestions.py, tldw_chatbook/Library/library_skills_state.py, Tests/Chat/test_console_command_suggestions.py, Tests/UI/test_console_auto_rag_on_send.py, Tests/UI/test_console_button_routing.py, Tests/UI/test_console_command_popup.py, Tests/UI/test_console_composer_menu.py.
+
+**Left open (reported, not fixed):** every mounted `_build_test_app` Console test sees an app_config with no `[console]`/`[chat_defaults]`, so ANY feature reading through the turn-context snapshot is silently defaulted in those tests — a systemic blind spot far wider than this task. `Tests/UI/test_console_auto_rag_on_send.py` also carries a pre-existing ruff F401 (`Static`, used only inside a query string), left untouched.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15270 - Console-test-apps-mount-with-a-config-that-silently-defaults-every-turn-context-setting.md
+++ b/backlog/tasks/task-15270 - Console-test-apps-mount-with-a-config-that-silently-defaults-every-turn-context-setting.md
@@ -1,0 +1,36 @@
+---
+id: TASK-15270
+title: >-
+  Console test apps mount with a config that silently defaults every turn-context setting
+status: To Do
+assignee: []
+created_date: '2026-08-11 09:00'
+labels:
+  - tests
+  - console
+  - test-infrastructure
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while triaging task-15210, and raised rather than absorbed because the blast radius (90+ modules) is far larger than that task's scope.
+
+`_build_test_app` patches `load_settings` to a small synthetic dict that carries no `[console]` or `[chat_defaults]` section, and production *correctly* refuses to refresh a settings snapshot that lacks the disk-load markers. So every mounted Console test sees a `ConsoleTurnExecutionContext` whose `rag_defaults` are frozen at their defaults, no matter what the test believes it configured. Measured directly during 15210: `get_cli_setting=True` while the app_config key was `MISSING` and the context read `auto_retrieve_on_send: False`.
+
+The live app is unaffected — `app.py` does `self.app_config = load_settings()`, whose result carries both the toggle and the markers (verified) — so this is a test-harness defect, not a product one.
+
+**Why it is worth its own task: it can hollow out a passing test.** `test_send_proceeds_when_auto_retrieve_fails` was green **vacuously** for exactly this reason — auto-retrieval never fired, so the deliberately-exploding backend was never called, and the test only ever asserted that an ordinary send works. It was repaired in 15210 (`exploding_search.await_count == 1`), but any other test whose subject reads through the turn-context snapshot has the same exposure and would look green while asserting nothing.
+
+The fix is presumably to make `_build_test_app` produce a config the snapshot will accept (markers included), so a test that sets a `[chat_defaults]` value gets that value. That change will likely flip some currently-green tests to red — those are the ones that were never really testing their subject, and each needs the 15210 treatment rather than a revert.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A Console test that configures a `[chat_defaults]`/`[console]` setting sees that value through the turn-context snapshot, instead of a silent default
+- [ ] #2 Tests that turn red once the config is honoured are triaged individually (real regression vs assertion that was never exercised), not reverted wholesale
+- [ ] #3 A guard makes the vacuous-pass shape detectable: a test whose subject is "X still works when Y fails" asserts that Y was actually attempted
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/console_command_suggestions.py
+++ b/tldw_chatbook/Chat/console_command_suggestions.py
@@ -33,6 +33,8 @@ _COMMAND_DESCRIPTIONS: dict[str, str] = {
     "skills": "List or run a skill",
     "prefill": "Prepare the start of the assistant's reply",
     "generate-image": "Generate an image (optionally via a chosen backend)",
+    "generate-video": "Generate a video (optionally via a chosen backend)",
+    "stream-video": "Stream a video from a URL into the transcript",
     "rewind": "Rewind the session to an earlier user prompt",
 }
 

--- a/tldw_chatbook/Library/library_skills_state.py
+++ b/tldw_chatbook/Library/library_skills_state.py
@@ -79,6 +79,12 @@ _SHADOWED_BUILTIN_NAMES = frozenset(
         # signal-erosion the guard exists to prevent.
         "rewind",
         "generate-image",
+        # task-15210: and again, exactly as task-580 predicted -- the video
+        # commands (commits d6c2e9756 /generate-video, 72a2ff3c5
+        # /stream-video) were registered without updating this set, so the
+        # drift guard sat red until something ran the file whole.
+        "generate-video",
+        "stream-video",
         # The sandbox-rooted file tools. These are CONFIG-GATED (off by
         # default), so the drift guard -- which builds a BuiltinToolProvider
         # with default config -- cannot see them and would not have caught


### PR DESCRIPTION
Triages the pre-existing Console contract failures task-15111's sweep surfaced. Each decided on its own evidence with the causing commit named — the set was deliberately mixed, and the naive "they're all stale pins" reading was wrong for half of it.

## Two real product bugs, both shipped by the commits that added `/generate-video` and `/stream-video`

- **`console_command_suggestions.py`** — neither command had a description, so both rendered **"Custom command"** in the popup, via a fallback the module itself documents as reachable *only* by non-built-in registrations. Nothing pinned it.
- **`library_skills_state.py`** — `_SHADOWED_BUILTIN_NAMES` is a **product** set, not a fixture, and was missing both commands, so installing a skill that shadows either slash command would not warn the user. That set already carried a task-580 comment noting this exact drift had once been accepted as a baseline.

## A test that was passing vacuously

`test_send_proceeds_when_auto_retrieve_fails` was green because auto-retrieval **never fired** — the deliberately exploding backend was never called, so the test only asserted that an ordinary send works. Now asserts the failure path was actually attempted.

Its mechanism is systemic and filed as **task-15270**: `_build_test_app` mounts a config the turn-context snapshot correctly refuses to refresh from, so every Console test silently reads default `rag_defaults`.

## The rest: product correct, doubles and pins stale

A collapse handler reading real row-less state rather than the fabricated tray state; a stub that lost `self` when a staticmethod became a method and then missed a new turn-context seam; a one-arg hook stub whose `TypeError` was swallowed by a deliberate broad `except`; and a six-item slash-list literal grown to eight. The count pin is now **derived from the registry** plus a subset check for the original six — honest additions pass, a removal still reds.

A **sixth** failure was found from the same cause as the fifth.

## Evidence

Each RED confirmed to fail for the right reason via instrumentation, not inference (probe files deleted). Six mutations, each restored with an empty `git diff` verified — including one showing the *old* collapse assertion `is True` **passed** a set-to-constant mutation, i.e. it was decorative before this repair.

READ counts: touched + adjacent modules whole **225 passed**; remaining sweep modules + `test_console_native_chat_flow.py` **383 passed, 1 xfailed** (task-15120's strict xfail intact); keep-green trio **40 passed**. No `allow_network` marker needed anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes six pre-existing Console contract failures from task-15210: two real product bugs and a vacuous-pass test, plus tighter tests to assert behavior instead of brittle pins. Adds missing command descriptions, keeps the shadow-warning set in sync, and makes mounted tests read the same config shape as the app.

- **Bug Fixes**
  - Added descriptions for `/generate-video` and `/stream-video` so the command popup shows proper text instead of the fallback.
  - Updated the built-in shadow-name set to include the two video commands to restore user warnings when a skill name collides.

- **Refactors**
  - Console auto-retrieve tests now load the on-disk config (matching the app) and assert the failure path actually runs.
  - Command popup tests derive labels from the registry and subset-check the original six, allowing honest additions.
  - Button routing test reads the real collapsed state, re-queries toggles after tray rebuilds, and asserts a true flip + round-trip.
  - Composer menu test wires the real turn-context seam and uses the real message type to match current signatures.
  - Filed `task-15270` to track the test-app config blind spot affecting turn-context defaults.

<sup>Written for commit 7eb78bf63e75291edbee2ce611aedaedb7217138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

