### PR TITLE
Fix compact Library Notes chrome consistency

### DIFF
--- a/Tests/Library/test_library_shell_state.py
+++ b/Tests/Library/test_library_shell_state.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_CANVAS_KIND_NOTES_CREATE,
     LIBRARY_EXPORT_SERVER_DISABLED_TOOLTIP,
     LIBRARY_ROW_BROWSE_PROMPTS,
     LIBRARY_ROW_BROWSE_SKILLS,
@@ -101,7 +102,7 @@ def test_shell_sections_rows_and_targets_are_fixed():
         shell.sections[1].rows[0].target_id,
     ) == (
         "canvas",
-        "notes-create",
+        LIBRARY_CANVAS_KIND_NOTES_CREATE,
     )
     # F-017: the Study rows are handoffs ("Continue in Study"), grouped in
     # their own section -- not under Create, which is for making things.
@@ -345,6 +346,7 @@ def test_browse_prompts_row_targets_prompts_canvas():
 
 
 def test_create_note_row_targets_notes_create_canvas():
+    assert LIBRARY_CANVAS_KIND_NOTES_CREATE == "notes-create"
     shell = build_library_shell_state(
         LibraryShellInput(), selected_row_id="create-note"
     )
@@ -355,8 +357,11 @@ def test_create_note_row_targets_notes_create_canvas():
         if r.row_id == "create-note"
     )
     assert row.target_kind == "canvas"
-    assert row.target_id == "notes-create"
-    assert (shell.canvas_kind, shell.canvas_target) == ("notes-create", "")
+    assert row.target_id == LIBRARY_CANVAS_KIND_NOTES_CREATE
+    assert (shell.canvas_kind, shell.canvas_target) == (
+        LIBRARY_CANVAS_KIND_NOTES_CREATE,
+        "",
+    )
     assert shell.selected_row_id == "create-note"
 
 

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -12399,9 +12399,7 @@ async def test_library_note_failed_discard_clears_shortcut_lock_status() -> None
 # TASK-1333 Task 8: exact compact Notes geometry and dynamic-state budgets.
 
 
-def _assert_task8_compact_chrome(
-    screen: LibraryScreen, *, source_strip: bool = True
-) -> None:
+def _assert_task8_compact_chrome(screen: LibraryScreen) -> None:
     """Pin the terminal-level row allocation at 60x20.
 
     task-3315 re-pin -- dev-baseline drift, NOT the media-ingest arc: the
@@ -12414,20 +12412,9 @@ def _assert_task8_compact_chrome(
     screen recompose runs while ``shell.canvas_kind`` is "notes", so the
     settled allocation on those routes is 3 + 1 + 1 + 14 + 1.
 
-    task-3315 re-pin round 2 (rebase onto dev ``f6911b37b``) -- again
-    dev-side, verified by running THIS file against a ``git archive``
-    extraction of dev ``f6911b37b``'s product tree, where both re-pinned
-    cases fail identically. Dev ``d1df7d0a7`` ("restore file notes source
-    access", TASK-13213) closed the per-route chrome asymmetry this
-    docstring used to record as task-3317: ``_replace_library_browse_
-    canvas`` now refuses its targeted swap whenever the mounted contextual
-    chrome disagrees with the destination
-    (``notes_source_strip_mounted != (shell.canvas_kind == "notes")``), so
-    the plain rail-press into the notes LIST also lands via the full
-    recompose and carries the strip. Every Database-notes route therefore
-    settles at 3 + 1 + 1 + 14 + 1 and ``source_strip=False`` now survives
-    only for the create-note canvas (canvas_kind "notes-create", which
-    never composes the strip), which keeps 3 + 1 + 15 + 1.
+    TASK-3317 resolves the remaining route fork: every Database Notes route,
+    including Create, owns the one-row source-authority strip. Compact Notes
+    therefore has one terminal-level allocation: 3 + 1 + 1 + 14 + 1.
     """
     navigation = screen.query_one("MainNavigationBar")
     header = screen.query_one("#library-header-line")
@@ -12440,16 +12427,10 @@ def _assert_task8_compact_chrome(
     )
     footer = screen.query_one("#screen-footer-status")
 
-    if source_strip:
-        strip = screen.query_one("#library-notes-source-strip")
-        strip_height = strip.region.height
-        assert strip_height == 1
-    else:
-        assert not screen.query("#library-notes-source-strip"), (
-            "source strip unexpectedly mounted on a fast-path route"
-        )
-        strip_height = 0
-    shell_height = 15 - strip_height
+    strip = screen.query_one("#library-notes-source-strip")
+    strip_height = strip.region.height
+    assert strip_height == 1
+    shell_height = 14
 
     assert screen.region.height == 20
     assert navigation.region.height == 3
@@ -12479,10 +12460,9 @@ async def _assert_task8_rows(
     expected: dict[str, int],
     *,
     focused_selector: str,
-    source_strip: bool = True,
 ) -> None:
     """Assert exact visible row heights, bounds, and focus visibility."""
-    _assert_task8_compact_chrome(screen, source_strip=source_strip)
+    _assert_task8_compact_chrome(screen)
     for selector, height in expected.items():
         widget = screen.query_one(selector)
         assert widget.display is True, selector
@@ -12550,81 +12530,62 @@ async def _enter_task8_navigator_state(screen, pilot, state: str) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("state", "expected", "focused_selector", "source_strip"),
-    # task-3315 re-pin, causes named (both pre-date the media-ingest arc --
-    # identical failures reproduce at 6b4ccf475, the PR #1439 merge that
-    # brought these tests to dev, and at dev base ebeae1440):
-    # - every list state now carries #library-notes-database-purpose, the
-    #   LIB-19 placement sentence (task-2858, a3591b503, merged 2026-08-07
-    #   in PR #1420 -- AFTER these pins were authored on the PR #1439
-    #   branch): 3 wrapped rows at width 60 plus its 1-row bottom margin,
-    #   so the list loses 4 rows;
-    # - every state settles with the 1-row source strip (see
-    #   _assert_task8_compact_chrome), costing 1 more row. Round 2, after
-    #   the rebase onto dev f6911b37b: "normal" joined them -- dev
-    #   d1df7d0a7 routes the plain rail press through the full recompose
-    #   too, so its list drops 6 -> 5. Reproduced against an extracted dev
-    #   f6911b37b product tree, so this is dev's change, not the arc's.
+    ("state", "expected", "focused_selector"),
+    # TASK-3317: supporting Database-purpose prose is hidden at compact,
+    # restoring its four-row cost to the primary list while the one-row
+    # Database | Files source-authority strip remains visible.
     (
         (
             "normal",
             {
                 "#library-notes-header": 1,
-                "#library-notes-database-purpose": 3,
                 "#library-notes-filter-row": 1,
                 "#library-notes-browse-actions": 1,
                 "#library-notes-transfer-actions": 1,
                 "#library-notes-status-row": 1,
-                "#library-notes-list": 5,
+                "#library-notes-list": 9,
             },
             "#library-notes-filter",
-            True,  # dev d1df7d0a7: rail entry now recomposes with the strip
         ),
         (
             "filtered-empty",
             {
                 "#library-notes-header": 1,
-                "#library-notes-database-purpose": 3,
                 "#library-notes-filter-row": 1,
                 "#library-notes-browse-actions": 1,
                 "#library-notes-transfer-actions": 1,
                 "#library-notes-status-row": 1,
-                "#library-notes-empty": 5,
+                "#library-notes-empty": 9,
             },
             "#library-notes-filter-clear",
-            True,
         ),
         (
             "sort-choice",
             {
                 "#library-notes-header": 1,
-                "#library-notes-database-purpose": 3,
                 "#library-notes-filter-row": 1,
                 "#library-notes-sort-choices": 1,
                 "#library-notes-transfer-actions": 1,
                 "#library-notes-status-row": 1,
-                "#library-notes-list": 5,
+                "#library-notes-list": 9,
             },
             "#library-notes-sort-newest",
-            True,
         ),
         (
             "selection",
             {
                 "#library-notes-header": 1,
-                "#library-notes-database-purpose": 3,
                 "#library-notes-filter-row": 1,
                 "#library-notes-selection-actions": 1,
                 "#library-notes-selection-status": 1,
-                "#library-notes-list": 6,
+                "#library-notes-list": 10,
             },
             "#library-notes-select-toggle",
-            True,
         ),
     ),
 )
 async def test_library_note_60x20_navigator_state_allocation(
-    state: str, expected: dict[str, int], focused_selector: str, source_strip: bool
+    state: str, expected: dict[str, int], focused_selector: str
 ) -> None:
     app = _build_test_app()
     notes = _two_notes() + [
@@ -12652,8 +12613,10 @@ async def test_library_note_60x20_navigator_state_allocation(
             pilot,
             expected,
             focused_selector=focused_selector,
-            source_strip=source_strip,
         )
+        purpose = screen.query_one("#library-notes-database-purpose")
+        assert purpose.display is False
+        assert purpose.region.height == 0
         if state == "selection":
             assert screen.query_one("#library-notes-status").display is False
         if state == "sort-choice":
@@ -12686,14 +12649,10 @@ async def test_library_note_60x20_temporary_region_allocation(state: str) -> Non
             viewport = "#library-notes-sync-viewport"
             focus = "#library-notes-sync-folder"
 
-        # task-3315: entering Sync forces a full recompose (view != "list"),
-        # which mounts the 1-row source strip -- the sync canvas settles at
-        # 14 rows. The create-note canvas (canvas_kind "notes-create") never
-        # composes the strip and keeps the full 15. See
-        # _assert_task8_compact_chrome for the cause chain.
-        source_strip = state == "sync"
-        canvas_height = 14 if source_strip else 15
-        _assert_task8_compact_chrome(screen, source_strip=source_strip)
+        # TASK-3317: Create and Sync share the same Notes source-authority
+        # chrome and therefore the same 14-row canvas allocation.
+        canvas_height = 14
+        _assert_task8_compact_chrome(screen)
         owner = screen.query_one("#library-notes-canvas")
         header = screen.query_one(heading)
         assert header.region.height == 1
@@ -12706,7 +12665,6 @@ async def test_library_note_60x20_temporary_region_allocation(state: str) -> Non
                 "#library-notes-canvas": canvas_height,
             },
             focused_selector=focus,
-            source_strip=source_strip,
         )
         scroll_owner = screen.query_one(viewport)
         assert str(owner.styles.overflow_y) == "hidden"
@@ -12767,6 +12725,42 @@ async def test_library_note_compact_labels_round_trip_without_recompose(
         await _wait_for_library_notes_compact(screen, pilot, True)
         assert screen.query_one("#library-notes-canvas") is canvas
         assert str(control.label) == compact_label
+
+
+@pytest.mark.asyncio
+async def test_library_note_database_purpose_round_trips_at_breakpoint_without_recompose() -> (
+    None
+):
+    """TASK-3317: supporting purpose copy yields only in compact Notes."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(60, 20)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        await _enter_task8_navigator_state(screen, pilot, "normal")
+
+        canvas = screen.query_one("#library-notes-canvas")
+        purpose = screen.query_one("#library-notes-database-purpose", Static)
+        assert purpose.display is False
+        assert purpose.region.height == 0
+
+        await pilot.resize_terminal(170, 48)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        assert screen.query_one("#library-notes-canvas") is canvas
+        assert screen.query_one("#library-notes-database-purpose") is purpose
+        assert purpose.display is True
+        assert purpose.region.height > 0
+        assert "Library's own database" in str(purpose.renderable)
+
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        assert screen.query_one("#library-notes-canvas") is canvas
+        assert screen.query_one("#library-notes-database-purpose") is purpose
+        assert purpose.display is False
+        assert purpose.region.height == 0
 
 
 @pytest.mark.asyncio
@@ -20198,19 +20192,11 @@ async def test_library_note_same_side_resize_does_no_presentation_work(
         "owner_height_at_100x30",
     ),
     (
-        # task-3315 re-pin (pre-arc dev drift, same causes as the 60x20
-        # family -- see _assert_task8_compact_chrome): the navigator list
-        # loses 3 rows to the LIB-19 database-purpose sentence (2 wrapped
-        # rows + 1 margin at widths 80/100); the editor/context routes lose
-        # 1 row to the source strip mounted by their full recompose.
-        # Round 2 (rebase onto dev f6911b37b): the navigator loses that
-        # source-strip row too -- dev d1df7d0a7 gated the targeted canvas
-        # swap on matching contextual chrome, so the rail press into the
-        # notes list now recomposes with the Database|Files strip (11 -> 10
-        # at 80x24, 17 -> 16 at 100x30). Reproduced against an extracted
-        # dev f6911b37b product tree, so this is dev's change, not the
-        # arc's. The invariant under test -- surplus goes ONLY to the named
-        # owner, growth exactly +6 for +6 terminal rows -- is unchanged.
+        # TASK-3317: compact mode hides the supporting Database-purpose
+        # sentence, so the three rows it previously consumed at 80/100
+        # columns return to the navigator list. The invariant under test --
+        # surplus goes ONLY to the named owner, growth exactly +6 for +6
+        # terminal rows -- remains unchanged.
         (
             "navigator",
             "#library-notes-list",
@@ -20221,8 +20207,8 @@ async def test_library_note_same_side_resize_does_no_presentation_work(
                 "#library-notes-transfer-actions",
                 "#library-notes-status-row",
             ),
-            10,
-            16,
+            13,
+            19,
         ),
         (
             "editor",

--- a/backlog/tasks/task-3317 - Notes-60x20-chrome-inconsistency-source-strip-recompose-asymmetry-and-LIB-19-purpose-line-compact-cost.md
+++ b/backlog/tasks/task-3317 - Notes-60x20-chrome-inconsistency-source-strip-recompose-asymmetry-and-LIB-19-purpose-line-compact-cost.md
@@ -7,7 +7,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-09 09:45'
-updated_date: '2026-08-11 16:30'
+updated_date: '2026-08-11 19:26'
 labels:
   - library
   - notes
@@ -74,5 +74,6 @@ per-route `source_strip` fork survives for the create-note canvas
 - Extended the route-owned source-strip contract to both `notes` and `notes-create`, so List, Editor, Sync, loading, and Create all retain the visible `Database | Files` authority control and the same 14-row compact canvas allocation.
 - Simplified the task-8 geometry helpers to one source-strip truth, restored the 60x20 navigator list from 5 to 9 rows (selection from 6 to 10), and added a compact/wide/compact identity-preserving regression.
 - Verification: 24 responsive Library shell tests passed; 2 `LibraryNotesCanvas` widget tests passed; both new guards were mutation-checked and failed when individually removed, then the two focused regressions passed again after restoration. Scoped Ruff checks passed for production and test changes (the test-file run excluded its pre-existing unrelated F401 import).
+- Qodo review remediation: introduced canonical `LIBRARY_CANVAS_KIND_NOTES_CREATE` ownership in `library_shell_state.py` and replaced every behavior-critical `notes-create` literal in the shell builder and Library screen. The 30-test shell-state suite, both focused mounted-UI regressions, and scoped Ruff checks passed after the change.
 - ADR: no new ADR; the change conforms to ADR-011 and ADR-015. Documentation is complete in this task record; no reusable incident warranted a new lessons entry.
-- Modified files: `tldw_chatbook/UI/Screens/library_screen.py`, `tldw_chatbook/Widgets/Library/library_notes_canvas.py`, `Tests/UI/test_library_shell.py`, and this task record.
+- Modified files: `tldw_chatbook/Library/library_shell_state.py`, `tldw_chatbook/UI/Screens/library_screen.py`, `tldw_chatbook/Widgets/Library/library_notes_canvas.py`, `Tests/Library/test_library_shell_state.py`, `Tests/UI/test_library_shell.py`, and this task record.

--- a/backlog/tasks/task-3317 - Notes-60x20-chrome-inconsistency-source-strip-recompose-asymmetry-and-LIB-19-purpose-line-compact-cost.md
+++ b/backlog/tasks/task-3317 - Notes-60x20-chrome-inconsistency-source-strip-recompose-asymmetry-and-LIB-19-purpose-line-compact-cost.md
@@ -1,17 +1,32 @@
 ---
 id: TASK-3317
 title: >-
-  Notes 60x20 chrome inconsistency: source strip renders only after a full recompose, and the LIB-19 purpose line eats 4 of 10 compact list rows
-status: To Do
-assignee: []
+  Notes 60x20 chrome inconsistency: source strip renders only after a full
+  recompose, and the LIB-19 purpose line eats 4 of 10 compact list rows
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-09 09:45'
+updated_date: '2026-08-11 16:30'
 labels:
   - library
   - notes
   - ux
-priority: medium
 dependencies: []
+priority: medium
 ---
+
+## Implementation Plan
+
+ADR required: no
+ADR path: N/A (conforms to ADR-011 and ADR-015)
+Reason: This is a compact presentation and route-chrome consistency correction within the existing Library Notes ownership and responsive boundary; it introduces no new storage, service, or long-lived application boundary.
+
+1. Pin the current 60x20 list and Create chrome in failing mounted geometry tests.
+2. Keep the Database | Files source-authority strip mounted for every Database Notes route, including Create.
+3. Hide the supportive Database-purpose sentence in compact mode while preserving the full copy at wide widths and across live breakpoint transitions.
+4. Collapse the task-3315 per-route source-strip test fork to one deterministic compact contract and restore the Notes list row budget.
+5. Run focused Library shell and responsive Notes tests, static checks, a mutation check of each guard, and self-review the scoped diff.
 
 ## Description
 
@@ -27,8 +42,8 @@ Found while repairing `Tests/UI/test_library_shell.py` against the merged surfac
 
 <!-- AC:BEGIN -->
 - [x] #1 The source strip's presence for notes routes is deterministic across entry paths (always or never per terminal class), with the chosen direction recorded
-- [ ] #2 The database-purpose sentence has an explicit compact-mode treatment (kept, truncated, or hidden) chosen by the owner, not by layout accident
-- [ ] #3 `Tests/UI/test_library_shell.py`'s task8 pins are updated to the single ruled truth (removing the per-route `source_strip` fork task-3315 had to pin)
+- [x] #2 The database-purpose sentence has an explicit compact-mode treatment (kept, truncated, or hidden) chosen by the owner, not by layout accident
+- [x] #3 `Tests/UI/test_library_shell.py`'s task8 pins are updated to the single ruled truth (removing the per-route `source_strip` fork task-3315 had to pin)
 <!-- AC:END -->
 
 ## Update — AC#1 closed dev-side (2026-08-09)
@@ -52,3 +67,12 @@ AC#2 is untouched (the LIB-19 sentence still costs 4 of the compact list's rows;
 at 60x20 the navigator list is now 5). AC#3 is only partly satisfied: the
 per-route `source_strip` fork survives for the create-note canvas
 (`canvas_kind "notes-create"`), which still never composes the strip.
+
+## Implementation Notes
+
+- Chose the compact treatment explicitly: the Database-purpose sentence is hidden below the existing 120-column Notes breakpoint and restored on the same mounted canvas at wide widths. This returns four 60x20 rows to the primary list without discarding the explanatory copy.
+- Extended the route-owned source-strip contract to both `notes` and `notes-create`, so List, Editor, Sync, loading, and Create all retain the visible `Database | Files` authority control and the same 14-row compact canvas allocation.
+- Simplified the task-8 geometry helpers to one source-strip truth, restored the 60x20 navigator list from 5 to 9 rows (selection from 6 to 10), and added a compact/wide/compact identity-preserving regression.
+- Verification: 24 responsive Library shell tests passed; 2 `LibraryNotesCanvas` widget tests passed; both new guards were mutation-checked and failed when individually removed, then the two focused regressions passed again after restoration. Scoped Ruff checks passed for production and test changes (the test-file run excluded its pre-existing unrelated F401 import).
+- ADR: no new ADR; the change conforms to ADR-011 and ADR-015. Documentation is complete in this task record; no reusable incident warranted a new lessons entry.
+- Modified files: `tldw_chatbook/UI/Screens/library_screen.py`, `tldw_chatbook/Widgets/Library/library_notes_canvas.py`, `Tests/UI/test_library_shell.py`, and this task record.

--- a/tldw_chatbook/Library/library_shell_state.py
+++ b/tldw_chatbook/Library/library_shell_state.py
@@ -29,6 +29,7 @@ LIBRARY_ROW_BROWSE_SKILLS = "browse-skills"
 LIBRARY_ROW_BROWSE_SEARCH = "browse-search"
 LIBRARY_ROW_BROWSE_COLLECTIONS = "browse-collections"
 LIBRARY_ROW_CREATE_NOTE = "create-note"
+LIBRARY_CANVAS_KIND_NOTES_CREATE = "notes-create"
 # The three Study staging (handoff) rows -- consumers that need "is this a
 # study handoff row" import these rather than repeating the literals
 # (Qodo PR-1488 #2; the study_rows definitions below are the canonical use).
@@ -441,7 +442,7 @@ def build_library_shell_state(
             section_id="create",
             title="New note",
             target_kind="canvas",
-            target_id="notes-create",
+            target_id=LIBRARY_CANVAS_KIND_NOTES_CREATE,
             count=None,
             count_known=True,
         ),

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -561,6 +561,9 @@ LIBRARY_NOTES_COMPACT_BREAKPOINT = 120
 LIBRARY_NOTES_SOURCE_DATABASE = "database"
 LIBRARY_NOTES_SOURCE_FILES = "files"
 LIBRARY_CANVAS_KIND_NOTES = "notes"
+LIBRARY_NOTES_SOURCE_STRIP_CANVAS_KINDS = frozenset(
+    {LIBRARY_CANVAS_KIND_NOTES, "notes-create"}
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -7611,7 +7614,7 @@ class LibraryScreen(BaseAppScreen):
         )
         install_progress.display = self._parakeet_v2_install_progress is not None
         yield install_progress
-        if shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES:
+        if shell.canvas_kind in LIBRARY_NOTES_SOURCE_STRIP_CANVAS_KINDS:
             with Horizontal(id="library-notes-source-strip"):
                 database_selected = (
                     self._library_notes_source == LIBRARY_NOTES_SOURCE_DATABASE
@@ -11952,7 +11955,7 @@ class LibraryScreen(BaseAppScreen):
         try:
             notes_source_strip_mounted = bool(self.query("#library-notes-source-strip"))
             destination_uses_notes_source_strip = (
-                shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES
+                shell.canvas_kind in LIBRARY_NOTES_SOURCE_STRIP_CANVAS_KINDS
             )
             if notes_source_strip_mounted != destination_uses_notes_source_strip:
                 return False

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -236,6 +236,7 @@ from ...Library.library_rail_state import (
     serialize_library_rail_preferences,
 )
 from ...Library.library_shell_state import (
+    LIBRARY_CANVAS_KIND_NOTES_CREATE,
     LIBRARY_DELETE_SELECTED_DISABLED_TOOLTIP,
     LIBRARY_DELETE_SELECTED_TOOLTIP,
     LIBRARY_EXPORT_SELECTED_DISABLED_TOOLTIP,
@@ -562,7 +563,7 @@ LIBRARY_NOTES_SOURCE_DATABASE = "database"
 LIBRARY_NOTES_SOURCE_FILES = "files"
 LIBRARY_CANVAS_KIND_NOTES = "notes"
 LIBRARY_NOTES_SOURCE_STRIP_CANVAS_KINDS = frozenset(
-    {LIBRARY_CANVAS_KIND_NOTES, "notes-create"}
+    {LIBRARY_CANVAS_KIND_NOTES, LIBRARY_CANVAS_KIND_NOTES_CREATE}
 )
 
 
@@ -7855,7 +7856,7 @@ class LibraryScreen(BaseAppScreen):
                         compact=self._library_notes_compact,
                         id="library-notes-canvas",
                     )
-                elif shell.canvas_kind == "notes-create":
+                elif shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES_CREATE:
                     yield LibraryNotesCanvas(
                         mode="create",
                         compact=self._library_notes_compact,
@@ -8109,7 +8110,7 @@ class LibraryScreen(BaseAppScreen):
                                 "New note",
                                 "Create a new note.",
                                 LIBRARY_ROW_CREATE_NOTE,
-                                "notes-create",
+                                LIBRARY_CANVAS_KIND_NOTES_CREATE,
                                 "library-hub-action-new-note",
                             ),
                         ):

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -179,13 +179,15 @@ class LibraryNotesCanvas(Vertical):
         )
         # Database mode persists notes in the Library; Files edits a folder
         # directly, while Sync mirrors a folder into this database.
-        yield Static(
+        database_purpose = Static(
             "These notes live in the Library's own database — for notes "
             "that live in a folder on disk, switch to Files, or use Sync "
             "to mirror one in.",
             id="library-notes-database-purpose",
             markup=False,
         )
+        database_purpose.display = not self.compact
+        yield database_purpose
         with Horizontal(id="library-notes-filter-row"):
             yield Static("Filter", id="library-notes-filter-label", markup=False)
             yield Input(
@@ -660,6 +662,9 @@ class LibraryNotesCanvas(Vertical):
         if not self.is_mounted:
             return
         if self.mode == "list" and self.list_state is not None:
+            database_purpose = self.query("#library-notes-database-purpose")
+            if database_purpose:
+                database_purpose.first(Static).display = not compact
             rendered_count = len(self.list_state.rows)
             select_all = self.query("#library-notes-select-all")
             if select_all:


### PR DESCRIPTION
## Summary

- keep the `Database | Files` source-authority strip visible on every Library Notes route, including Create
- hide the supporting database placement sentence at the compact breakpoint while restoring it on the same mounted canvas at wide widths
- simplify the 60x20 geometry contract to one deterministic source-strip allocation and restore four rows to the Notes list

## Verification

- 24 responsive Library shell tests passed
- 2 `LibraryNotesCanvas` widget tests passed
- both new guards were mutation-checked
- post-rebase focused regressions passed
- scoped Ruff checks passed

## Backlog

- TASK-3317

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes compact Library Notes chrome consistency by always showing the Database | Files strip on all Notes routes (including Create) and hiding the database-purpose copy at compact; unifies the 60x20 layout and restores list rows. Addresses TASK-3317.

- **Bug Fixes**
  - Keep the source-authority strip mounted for `notes` and `notes-create`; Create and Sync now share the same 14-row compact canvas.
  - Hide `#library-notes-database-purpose` in compact and restore it on the same mounted canvas at wider widths; add a breakpoint round-trip test.
  - Simplify the compact contract to one allocation (3 + 1 + 1 + 14 + 1) and restore list rows (5→9; selection 6→10).

- **Refactors**
  - Introduce `LIBRARY_CANVAS_KIND_NOTES_CREATE` and `LIBRARY_NOTES_SOURCE_STRIP_CANVAS_KINDS`; replace `"notes-create"` literals in shell, screen, and tests, and update the targeted canvas swap guard.

<sup>Written for commit 5582c87b8702a4e07a0c876b51a698023de4ce52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

