### PR TITLE
fix(tts): route custom OpenAI model ids by prefix so external OpenAI-compatible servers work from Console (TASK-15420)

### DIFF
--- a/Docs/User_Guide/openai-compatible-tts.md
+++ b/Docs/User_Guide/openai-compatible-tts.md
@@ -203,4 +203,12 @@ section added; labels cross-checked against
 and `stts_profile_library.py` / `personas_character_tts_widget.py` /
 `personas_screen.py` for the "No catalog check" / "no catalog check"
 copy — this page's own default-profile precedence bullet above was not
-re-verified live in this pass).*
+re-verified live in this pass). Re-verified live 2026-08-11 with the
+TASK-15420 fix: a Console 🔊 speak with an exact custom model AND custom
+voice name reached a mock OpenAI-compatible server at a custom Base URL
+with both passed through unmodified (between roughly 2026-07-26 and this
+fix, an internal model-route allowlist rejected any non-official model
+name on the Console path before the request was sent, so this page's
+Model-value instruction did not work there; the Speech Lab playground's
+quick Model/Voice dropdowns still cannot express custom names —
+TASK-15421).*

--- a/Tests/Subscriptions/test_briefing_audio_synthesis.py
+++ b/Tests/Subscriptions/test_briefing_audio_synthesis.py
@@ -721,24 +721,23 @@ async def test_legacy_path_provider_failure_is_wrapped_naming_speaker_and_index(
     assert "turn 10" in message
 
 
-async def test_legacy_path_unmapped_openai_model_raises_a_wrapped_unknown_legacy_model_error() -> (
-    None
-):
-    """A realistic failure, not a hand-rolled test double.
+async def test_legacy_path_unknown_legacy_model_error_is_wrapped() -> None:
+    """`UnknownLegacyModelError` from the stream is wrapped like any failure.
 
-    An OpenAI TTS profile whose model id is not one of the four the
-    compatibility bridge enumerates (`legacy_bridge.py`'s
-    `OPENAI_INTERNAL_IDS`) -- for example `"gpt-4o-mini-tts"` -- makes
-    `build_legacy_speech_request` emit an internal model id
-    (`"openai_official_gpt-4o-mini-tts"`) that `resolve_legacy_route` does
-    not recognize, raising a genuine `UnknownLegacyModelError` from inside
-    `generate_audio_stream` itself (the fake reproduces that same first
-    step -- see `_FakeTTSService`'s docstring).
+    This used to arise genuinely from an OpenAI profile whose model id was
+    outside the four the bridge enumerated. Since TASK-15420 custom OpenAI
+    model ids route by prefix (so OpenAI-compatible servers' own model
+    names pass through), and every other selection `synthesize_turn`
+    admits maps to a fixed enumerated internal id, no in-tree selection
+    reaches the error through `build_legacy_speech_request` any more --
+    so it is injected at the same seam other adapter failures use, to keep
+    the wrapping contract (cause preserved, speaker and turn named) pinned
+    should the bridge ever reject an id again.
     """
-    selection = _legacy_selection(
-        speaker="Narrator", provider_id="openai", model_id="gpt-4o-mini-tts"
+    selection = _legacy_selection(speaker="Narrator", provider_id="kokoro")
+    service = _FakeTTSService(
+        legacy_error=UnknownLegacyModelError("The selected TTS model is not available")
     )
-    service = _FakeTTSService()
 
     with pytest.raises(TurnSynthesisError) as caught:
         await synthesize_turn(service, selection, "hello", turn_index=2)

--- a/Tests/TTS/test_legacy_bridge.py
+++ b/Tests/TTS/test_legacy_bridge.py
@@ -479,8 +479,32 @@ def test_route_table_is_exact() -> None:
 @pytest.mark.parametrize(
     "internal_id",
     [
+        "openai_official_pocket-tts-model",
+        "openai_official_kokoro-82m",
+    ],
+)
+def test_resolver_routes_custom_openai_models_by_prefix(
+    internal_id: str,
+) -> None:
+    """Non-catalog OpenAI model ids route to the openai provider.
+
+    Custom OpenAI-compatible endpoints define their own model names
+    (TASK-2260); the resolver must not re-impose the official model
+    list on them (TASK-15420).
+    """
+    route = resolve_legacy_route(internal_id)
+
+    assert route.provider_id == "openai"
+    assert route.internal_model_id == internal_id
+
+
+@pytest.mark.parametrize(
+    "internal_id",
+    [
+        # A bare "openai_official_" prefix names no model at all, so it is
+        # still rejected; ids WITH a model suffix route by prefix instead
+        # (see test_resolver_routes_custom_openai_models_by_prefix).
         "openai_official_",
-        "openai_official_new-model",
         "elevenlabs_custom_unknown",
         "local_kokoro_evil",
         "local_chatterbox_",

--- a/Tests/TTS/test_tts_request_admission.py
+++ b/Tests/TTS/test_tts_request_admission.py
@@ -737,6 +737,59 @@ async def test_explicit_provider_without_global_uses_provider_fallback_axes() ->
 
 
 @pytest.mark.asyncio
+async def test_openai_exact_custom_model_default_is_admitted_with_passthrough() -> (
+    None
+):
+    """A custom OpenAI model id must survive admission untouched.
+
+    OpenAI-compatible servers (TASK-2260) define their own model and voice
+    names; the Console default path resolves them as exact global values, so
+    admission must route on the provider and pass both through rather than
+    re-imposing the official-catalog model list (TASK-15420).
+    """
+    adapter = _CapturingAdapter("openai")
+    registry = _RecordingRegistry(
+        specs=(
+            TTSProviderSpec(
+                descriptor=TTSProviderDescriptor(
+                    provider_id="openai",
+                    display_name="OpenAI",
+                    native=False,
+                ),
+                factory=lambda _config: adapter,
+                initial_config={},
+            ),
+        ),
+        aliases={},
+    )
+    service = _test_service(
+        registry,
+        preferences_snapshot=_snapshot(
+            provider_id="openai",
+            model_id="pocket-tts-model",
+            voice_mode="exact",
+            voice_id="pocket-voice",
+        ),
+    )
+    response: TTSAudioResponse | None = None
+
+    try:
+        response = await service.synthesize_default(
+            text="Speak through the custom endpoint.",
+        )
+
+        assert response.provider_id == "openai"
+        assert response.model_id == "pocket-tts-model"
+        assert adapter.requests[0].model_id == "pocket-tts-model"
+        assert adapter.requests[0].voice == "pocket-voice"
+    finally:
+        if response is not None:
+            await response.aclose()
+        await service.close()
+        await service.wait_closed()
+
+
+@pytest.mark.asyncio
 async def test_audio_cpp_exact_default_is_admitted_without_rewriting_values() -> None:
     adapter = _CapturingAdapter("audio_cpp")
     snapshot = _snapshot(

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9,7 +9,34 @@ decays into folklore, and folklore is ignored. If you add one, bring the inciden
 
 ---
 
-## A shutdown lease counter can stop seeing work before ownership ends
+## A fix proven at one layer can be unreachable through the product path
+
+**TASK-15420, 2026-08-11.** TASK-2260 (2026-08-04) shipped custom-endpoint
+model/voice passthrough in `OpenAITTSBackend`, pinned by mutation-verified
+backend tests and a real-socket keyless server test, and its user guide was
+live-verified — by varying the *voice*. The Console speak path, however, had
+been rerouted through the request-admission layer (2026-07-26), whose
+`resolve_legacy_route` allowlist rejected every non-official OpenAI *model id*
+before the backend was even constructed. The documented flow (exact custom
+model name) failed on every Console speak for weeks while all ~2,900 TTS-area
+tests stayed green: the tests proved the backend layer, the live check varied
+the one axis the upstream layer did not constrain, and nothing exercised the
+full admitted path with a custom model. Found only by end-to-end UAT driving
+the real TUI against a request-recording mock server.
+
+Sub-trap from the same session: `TTSAudioResponse.byte_stream` is lazy — a
+probe that calls `synthesize_default` and prints the response "succeeding"
+proves nothing, because the HTTP request only fires when the stream is
+consumed. The first counterfactual probe "passed" with zero requests at the
+server; only draining the stream produced the real request.
+
+**What to do.** A regression test for a passthrough/compatibility contract
+must enter at the outermost admitted path (here: `synthesize_default` down to
+the adapter), not the layer that was fixed — any layer added above the fix
+inherits the chance to re-impose the constraint. When live-verifying, vary the
+axis the bug is about (the model, not just the voice). And never trust a
+lazy-stream API's return value as evidence of I/O — consume it and assert at
+the far end (the recording server).
 
 **TASK-13204, 2026-08-10.** A clone-shutdown regression initially asserted
 `TTSAdapterRegistry._total_leases()` while the provider was past its bounded

--- a/backlog/tasks/task-15420 - Console-TTS-rejects-custom-OpenAI-model-ids-before-any-request.md
+++ b/backlog/tasks/task-15420 - Console-TTS-rejects-custom-OpenAI-model-ids-before-any-request.md
@@ -1,0 +1,134 @@
+---
+id: TASK-15420
+title: >-
+  Console TTS rejects custom OpenAI model ids before any request, breaking
+  external OpenAI-compatible servers
+status: Done
+assignee: []
+created_date: '2026-08-11 12:00'
+labels:
+  - tts
+  - speech
+  - bug
+  - uat
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Live UAT on `origin/dev` `82b595049` (2026-08-11), reproducing a user report that
+TTS settings "don't work" for an externally hosted OpenAI-compatible server.
+
+**Every Console/default speak with a custom OpenAI model id fails before any HTTP
+request is made.** The admission layer builds
+`internal_model_id = f"openai_official_{request.model}"`
+(`TTS/request_admission.py` `_legacy_request`) and then
+`resolve_legacy_route()` looks it up in the closed `LEGACY_ROUTES` dict
+(`TTS/legacy_bridge.py`, `OPENAI_INTERNAL_IDS` = tts-1 / tts-1-hd / tts1 /
+tts1hd only). Any other model id raises
+`UnknownLegacyModelError("The selected TTS model is not available")`.
+
+This is the TASK-2260 defect class reintroduced one layer up: the
+`OpenAITTSBackend` passthrough for custom endpoints (PR #1332) is intact but
+**unreachable** — the request dies in admission before the backend is even
+constructed. The user guide (`Docs/User_Guide/openai-compatible-tts.md`)
+explicitly instructs users to set Model policy = Exact with *their server's*
+model name, so following the docs guarantees the failure.
+
+Evidence (mock OpenAI-compatible server recording all requests; clean profile via
+`TLDW_CONFIG_PATH`):
+
+- Settings ▸ Speech & TTS saved Base URL / exact model `mock-model` / exact voice
+  `mock-voice` correctly to `app_tts` (config verified on disk).
+- Console 🔊 on an assistant message → zero requests at the server; in-app log:
+  `TTS_Events.tts_events ERROR TTS generation failed (outcome_code=generation_failed)`.
+- Headless `service.synthesize_default(...)` with the same config → traceback
+  ending `legacy_bridge.UnknownLegacyModelError` from
+  `request_admission.py:600 resolve_legacy_route`.
+- Counterfactual: model set to `tts-1`, everything else identical → request
+  reached the custom Base URL with `voice: "mock-voice"` passed through and no
+  `Authorization` header when keyless. **Custom voice, custom base URL, and
+  keyless operation all work; the model-id route allowlist is the only blocker.**
+
+Note for the fix: the route only needs the *provider*, which the effective
+selection already knows (`selection.provider_id == "openai"`); deriving routing
+from the model string re-imposes an official-catalog constraint that custom
+endpoints must not have.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: admission-level test (`test_tts_request_admission.py`) — global default
+   provider openai + exact custom model/voice → `synthesize_default` must reach
+   the adapter with both passed through; unit test
+   (`test_legacy_bridge.py`) — `resolve_legacy_route("openai_official_<custom>")`
+   routes to provider openai. Watch both fail on `UnknownLegacyModelError`.
+2. GREEN: in `legacy_bridge.resolve_legacy_route`, when the id is absent from
+   `LEGACY_ROUTES` but carries the `openai_official_` prefix with a non-empty
+   model suffix, route to provider "openai" (the provider is fully determined
+   by the prefix; the model string itself is the server's business). A bare
+   `openai_official_` still rejects. No route-table changes.
+3. Deliberately flip the pinned rejection of `openai_official_new-model` in
+   `test_resolver_rejects_unlisted_internal_ids` (same precedent as
+   task-2260's org-header flip).
+4. Verify downstream: `BackendRegistry.get` wildcard (`openai_official_*`)
+   accepts arbitrary suffixes; official-endpoint guardrails live in the
+   backend and are untouched.
+5. Live re-verification of the original repro: headless
+   `synthesize_default` + full TUI Console 🔊 against a mock
+   OpenAI-compatible server recording requests.
+<!-- SECTION:PLAN:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] With a custom OpenAI Base URL and an exact model name outside OpenAI's official list, Console 🔊 speech reaches the configured server with the model and voice passed through unmodified
+- [x] The official-endpoint guardrails (model/voice fallback against api.openai.com) are unchanged
+- [x] A regression test covers the admission path (not just the backend) with a non-official model id
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD: both new tests were watched failing on the real defect
+(`UnknownLegacyModelError` at `legacy_bridge.py:257`) before the change.
+
+**Fix** (`tldw_chatbook/TTS/legacy_bridge.py`, `resolve_legacy_route`): when an
+internal model id is absent from `LEGACY_ROUTES` but carries the
+`openai_official_` prefix with a non-empty model suffix, route it to provider
+"openai" by prefix. The provider is fully determined by the prefix; the model
+string is the server's business (custom OpenAI-compatible endpoints define
+their own names — TASK-2260). A bare `openai_official_` still rejects; the
+route table, all other providers, and the backend's official-endpoint
+guardrails (model/voice fallback against api.openai.com, decided by
+`_is_official_openai_endpoint` in `TTS/backends/openai.py`) are untouched.
+`BackendRegistry.get`'s existing `openai_official_*` wildcard already accepted
+arbitrary suffixes downstream.
+
+**Tests**: new admission-level test
+(`test_tts_request_admission.py::test_openai_exact_custom_model_default_is_admitted_with_passthrough`)
+drives `synthesize_default` with global exact custom model/voice and asserts
+both reach the adapter unmodified; new unit test
+(`test_legacy_bridge.py::test_resolver_routes_custom_openai_models_by_prefix`).
+Two deliberate expectation flips: `openai_official_new-model` removed from
+`test_resolver_rejects_unlisted_internal_ids` (bare-prefix case kept), and
+`test_briefing_audio_synthesis.py`'s realistic UnknownLegacyModelError specimen
+became unreachable through `synthesize_turn` entirely (unknown providers are
+rejected earlier; all admitted selections now map to routable ids), so that
+test now injects the error at the established fake seam to keep pinning the
+wrapping contract, with the reachability change documented in its docstring.
+
+**Verified live** against a mock OpenAI-compatible server recording requests:
+the exact pre-fix repro (Console 🔊, global exact model `mock-model`, voice
+`mock-voice`, custom Base URL) now produces "Speaking message." and the server
+receives `{"model": "mock-model", "voice": "mock-voice", ...}`; before the fix
+the same click failed pre-request with outcome_code=generation_failed. Test
+sweep: branch-relevant files 218 passed; full Tests/TTS + dependents 2901
+passed with 4 failures + 1 error reproduced byte-identically on pristine
+origin/dev (pre-existing, unrelated); repo-wide `--collect-only` clean (37,685
+collected). Docs: user-guide verification trailer updated with the re-verify
+stamp and the affected-window note.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15421 - TTS-Playground-cannot-express-custom-OpenAI-model-voice-and-ignores-saved-exact-preferences.md
+++ b/backlog/tasks/task-15421 - TTS-Playground-cannot-express-custom-OpenAI-model-voice-and-ignores-saved-exact-preferences.md
@@ -1,0 +1,62 @@
+---
+id: TASK-15421
+title: >-
+  TTS Playground cannot express custom OpenAI model/voice and ignores saved
+  exact preferences
+status: To Do
+assignee: []
+created_date: '2026-08-11 12:00'
+labels:
+  - tts
+  - speech
+  - lab
+  - ux
+  - uat
+priority: medium
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Live UAT on `origin/dev` `82b595049` (2026-08-11), custom OpenAI Base URL
+pointing at a mock OpenAI-compatible server.
+
+The Speech Lab TTS Playground's quick controls for provider OpenAI are closed
+catalogs: Model offers only "TTS-1 (Standard)" / "TTS-1-HD (High Quality)" and
+Voice only the six official OpenAI voices. There is no way to type a custom
+model or voice name, even though:
+
+- Settings ▸ Speech & TTS Global defaults were saved as Exact `mock-model` /
+  Exact `mock-voice`, and
+- Studio TTS Preferences were saved as Model policy Exact with Exact model ID
+  `studio-model` (the pane itself correctly shows the inherited global values).
+
+On Generate the playground sent `model: "tts-1", voice: "alloy"` — its dropdown
+defaults — on first open, after Refresh, after saving studio preferences, and
+after a full app restart. **Format and Speed do seed from the saved preferences
+(Format showed WAV), which makes the model/voice divergence look like the saved
+settings simply don't work.** Against a server that rejects unknown model names
+(the docs' pocket-tts case in reverse), the playground can never produce audio;
+against a permissive server it silently tests the wrong model/voice. The
+playground worked fine at the transport level: requests hit the custom Base URL
+keyless with no org header.
+
+Two candidate shapes (pick one deliberately): seed the quick controls from the
+effective exact selection and render non-catalog values as selectable entries,
+or add an explicit free-text "Exact…" affordance mirroring the Studio pane's
+Exact model/voice ID fields.
+
+Minor adjacent polish seen on the Studio pane: the "Exact model ID" /
+"Exact voice ID" inputs render as a 2-row bordered box whose content line is
+invisible while focused (typed text only appears after focus leaves — it had
+silently accepted a double paste as `studio-modelstudio-model`).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] A user whose saved OpenAI selection is an exact non-catalog model/voice can generate in the TTS Playground with those exact values sent to the server
+- [ ] The playground's displayed model/voice never silently diverges from what its Generate request sends
+- [ ] Typed text in the Studio Exact model/voice ID inputs is visible while the field is focused
+<!-- AC:END -->

--- a/backlog/tasks/task-15422 - TTS-model-route-failure-surfaces-as-Unexpected-generation-failure-and-fires-twice-per-speak.md
+++ b/backlog/tasks/task-15422 - TTS-model-route-failure-surfaces-as-Unexpected-generation-failure-and-fires-twice-per-speak.md
@@ -1,0 +1,53 @@
+---
+id: TASK-15422
+title: >-
+  TTS model-route failure surfaces as "Unexpected TTS generation failure" and
+  fires twice per speak
+status: To Do
+assignee: []
+created_date: '2026-08-11 12:00'
+labels:
+  - tts
+  - speech
+  - ux
+  - uat
+priority: medium
+dependencies:
+  - TASK-15420
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Live UAT on `origin/dev` `82b595049` (2026-08-11), companion to TASK-15420.
+
+When Console speak fails on `UnknownLegacyModelError` (a deterministic
+configuration/selection problem):
+
+1. **The toast is misleading.** `UnknownLegacyModelError` subclasses
+   `LookupError`, so `_tts_outcome_code` buckets it as `generation_failed` and
+   `_tts_error_copy` falls through to "Unexpected TTS generation failure;
+   retry" (`Event_Handlers/TTS_Events/tts_events.py`). Retrying can never help;
+   the actionable copy family ("TTS is not configured; open STTS Settings")
+   exists but is not reached. A user who followed the OpenAI-compatible-server
+   doc gets no hint that their model name is what was rejected.
+2. **One 🔊 click logs the failure twice.** Every observed click produced two
+   back-to-back `ERROR TTS generation failed (outcome_code=generation_failed)`
+   entries with the same timestamp (4 clicks → 8 errors across two app
+   sessions), implying two generation attempts or a double-reported failure
+   path per click — worth tracing regardless of the copy fix, since it doubles
+   metric counts (`tts_generation_total`).
+3. Once, in the first session, the message's speak control stayed on
+   "⏹ Stop speech" for minutes after the instant failure (fresh selection of
+   the same message still showed ⏹ ~4 minutes later); in a later controlled
+   repro the control recovered within ~10s. Intermittent, lower priority, but
+   noted since a stuck ⏹ hides the retry affordance entirely.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] A model/selection rejection surfaces copy that points at the TTS model configuration rather than a generic retry
+- [ ] One speak action produces exactly one generation attempt and one failure log/metric on failure
+- [ ] After a synchronous failure the message speak control returns to 🔊 promptly and deterministically
+<!-- AC:END -->

--- a/backlog/tasks/task-15423 - Library-Open-in-Console-does-not-navigate-or-load-the-conversation.md
+++ b/backlog/tasks/task-15423 - Library-Open-in-Console-does-not-navigate-or-load-the-conversation.md
@@ -1,0 +1,51 @@
+---
+id: TASK-15423
+title: >-
+  Library "Open in Console" does not navigate or load the conversation
+status: To Do
+assignee: []
+created_date: '2026-08-11 12:00'
+labels:
+  - library
+  - console
+  - bug
+  - uat
+priority: medium
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Observed twice during TTS UAT on `origin/dev` `82b595049` (2026-08-11), clean
+profile, 235x52 tmux, conversation seeded directly into ChaChaNotes
+(`add_conversation` + two `add_message`, no character).
+
+Library ▸ Conversations ▸ conversation detail shows an "Open in Console"
+button. Clicking it (button visibly takes focus) and pressing Enter did
+nothing: the app stayed on the Library screen, and after manually switching to
+Console the conversation was not loaded there. Reproduced in two app sessions —
+one with the Console provider-setup gate active (no LLM configured) and one
+with Console fully unlocked and a session live.
+
+Two adjacent observations from the same UAT, possibly the same root or worth
+splitting during triage:
+
+- Console's rail "Search conversations" for the seeded title returned
+  "0 matches" while Library search/browse found it fine — so Console could not
+  reach the conversation by either route.
+- No error, toast, or log line was observed for the failed open (in-app Logs
+  Errors count did not change).
+
+Needs verification of the intended contract first: if "Open in Console" is
+expected to attach the DB conversation to a Console session, it silently does
+nothing; if Console deliberately only lists its own session-created chats, the
+button (and the search asymmetry) misleads.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] Activating "Open in Console" on a conversation either opens it in Console or surfaces a visible, accurate reason it cannot
+- [ ] Console's conversation search finds DB conversations that Library finds, or the two surfaces' differing scopes are made explicit in the UI
+<!-- AC:END -->

--- a/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+++ b/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
@@ -40,7 +40,10 @@ from tldw_chatbook.TTS.adapter_types import (
 from tldw_chatbook.TTS.audio_cpp_guided_config import (
     project_audio_cpp_settings_config,
 )
-from tldw_chatbook.TTS.legacy_bridge import legacy_provider_config
+from tldw_chatbook.TTS.legacy_bridge import (
+    legacy_provider_config,
+    openai_internal_model_id,
+)
 from tldw_chatbook.TTS.playground_types import (
     PROFILE_SAVE_BLOCK_PROVIDER_OPTIONS,
     ProfileSaveBlockCode,
@@ -1056,7 +1059,7 @@ class STTSEventHandler:
         provider_id = snapshot.provider_id
         if provider_id == "openai":
             model_id = snapshot.model_id.lower().replace("-", "")
-            return f"openai_official_{model_id}"
+            return openai_internal_model_id(model_id)
         if provider_id == "elevenlabs":
             return f"elevenlabs_{snapshot.model_id}"
         if provider_id == "kokoro":

--- a/tldw_chatbook/TTS/audiobook_generator.py
+++ b/tldw_chatbook/TTS/audiobook_generator.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field
 # Local imports
 from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
 from tldw_chatbook.TTS import get_tts_service
+from tldw_chatbook.TTS.legacy_bridge import openai_internal_model_id
 from tldw_chatbook.TTS.audio_service import get_audio_service
 
 # Text processing is handled by AdvancedTextProcessor
@@ -896,7 +897,7 @@ class AudioBookGenerator:
     def _get_internal_model_id(self, provider: str, model: str) -> str:
         """Map provider and model to internal model ID"""
         if provider == "openai":
-            return f"openai_official_{model}"
+            return openai_internal_model_id(model)
         elif provider == "elevenlabs":
             return f"elevenlabs_{model}"
         elif provider == "kokoro":

--- a/tldw_chatbook/TTS/legacy_bridge.py
+++ b/tldw_chatbook/TTS/legacy_bridge.py
@@ -251,8 +251,18 @@ def legacy_provider_config(
     return {"app_config": projected}
 
 
+_OPENAI_INTERNAL_ID_PREFIX = "openai_official_"
+
+
 def resolve_legacy_route(internal_model_id: str) -> LegacyRoute:
     provider_id = LEGACY_ROUTES.get(internal_model_id)
+    if provider_id is None and internal_model_id.removeprefix(
+        _OPENAI_INTERNAL_ID_PREFIX
+    ) not in ("", internal_model_id):
+        # Custom OpenAI-compatible endpoints (TASK-2260) define their own
+        # model names; the provider is already known from the prefix, so an
+        # exact-catalog check here would wrongly reject them (TASK-15420).
+        provider_id = "openai"
     if provider_id is None:
         raise UnknownLegacyModelError("The selected TTS model is not available")
     return LegacyRoute(provider_id, internal_model_id)

--- a/tldw_chatbook/TTS/legacy_bridge.py
+++ b/tldw_chatbook/TTS/legacy_bridge.py
@@ -37,13 +37,29 @@ _DELEGATED_CLEANUP_FAILURE_NOTE = (
 
 
 class UnknownLegacyModelError(LookupError):
-    """Raised when a compatibility internal model ID is not enumerated."""
+    """Raised when a compatibility internal model ID cannot be routed.
+
+    Enumerated ids route through ``LEGACY_ROUTES``; OpenAI ids also route
+    by their ``OPENAI_INTERNAL_ID_PREFIX`` alone, since custom
+    OpenAI-compatible endpoints define their own model names (TASK-15420).
+    """
 
 
 @dataclass(frozen=True, slots=True)
 class LegacyRoute:
     provider_id: str
     internal_model_id: str
+
+
+#: The one place the OpenAI internal-id shape is defined; every builder of
+#: these ids must use :func:`openai_internal_model_id` so the resolver's
+#: prefix routing and the builders cannot drift apart.
+OPENAI_INTERNAL_ID_PREFIX = "openai_official_"
+
+
+def openai_internal_model_id(model_id: str) -> str:
+    """Compose the internal compatibility id for an OpenAI model."""
+    return f"{OPENAI_INTERNAL_ID_PREFIX}{model_id}"
 
 
 OPENAI_INTERNAL_IDS = (
@@ -251,13 +267,10 @@ def legacy_provider_config(
     return {"app_config": projected}
 
 
-_OPENAI_INTERNAL_ID_PREFIX = "openai_official_"
-
-
 def resolve_legacy_route(internal_model_id: str) -> LegacyRoute:
     provider_id = LEGACY_ROUTES.get(internal_model_id)
     if provider_id is None and internal_model_id.removeprefix(
-        _OPENAI_INTERNAL_ID_PREFIX
+        OPENAI_INTERNAL_ID_PREFIX
     ) not in ("", internal_model_id):
         # Custom OpenAI-compatible endpoints (TASK-2260) define their own
         # model names; the provider is already known from the prefix, so an

--- a/tldw_chatbook/TTS/legacy_request_builder.py
+++ b/tldw_chatbook/TTS/legacy_request_builder.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from typing import Literal, cast
 
 from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
+from tldw_chatbook.TTS.legacy_bridge import openai_internal_model_id
 
 _AudioFormat = Literal["mp3", "opus", "aac", "flac", "wav", "pcm"]
 _VALID_AUDIO_FORMATS = frozenset({"mp3", "opus", "aac", "flac", "wav", "pcm"})
@@ -103,7 +104,7 @@ def build_legacy_speech_request(
         speed=speed,
     )
     if provider_id == "openai":
-        internal_model_id = f"openai_official_{request.model}"
+        internal_model_id = openai_internal_model_id(request.model)
     elif provider_id == "elevenlabs":
         internal_model_id = f"elevenlabs_{request.model}"
     elif provider_id == "kokoro":

--- a/tldw_chatbook/TTS/request_admission.py
+++ b/tldw_chatbook/TTS/request_admission.py
@@ -31,7 +31,10 @@ from tldw_chatbook.TTS.effective_settings import (
     TTSSelectionSource,
     TTSStudioDraftSelection,
 )
-from tldw_chatbook.TTS.legacy_bridge import resolve_legacy_route
+from tldw_chatbook.TTS.legacy_bridge import (
+    openai_internal_model_id,
+    resolve_legacy_route,
+)
 from tldw_chatbook.TTS.playground_types import TTSRequestedSelectionSnapshot
 from tldw_chatbook.TTS.preferences import TTSPreferencesSnapshot
 from tldw_chatbook.TTS.profile_reference_types import TTSCloneReference
@@ -639,7 +642,7 @@ def _legacy_request(
         ),
     )
     if provider_id == "openai":
-        internal_model_id = f"openai_official_{request.model}"
+        internal_model_id = openai_internal_model_id(request.model)
     elif provider_id == "elevenlabs":
         internal_model_id = f"elevenlabs_{request.model}"
     elif provider_id == "kokoro":


### PR DESCRIPTION
## Summary

Re-investigation of the user report "TTS settings don't work for an externally hosted OpenAI TTS server" (UAT on dev `82b595049`, mock request-recording server, clean profile). The claim was **real and precisely scoped**: every Console/default speak with a model id outside OpenAI's official four failed **before any HTTP request**, because `request_admission` builds `openai_official_<model>` and `legacy_bridge.resolve_legacy_route` rejected anything not in its closed `LEGACY_ROUTES` dict. This is TASK-2260's defect class reintroduced one layer up — the backend passthrough from PR #1332 is intact but was **unreachable**, and the user guide's own instruction (Model policy Exact + your server's model name) guaranteed the failure. Custom voice, custom Base URL, and keyless auth all worked; the model-route allowlist was the only blocker (counterfactual with `tts-1` + custom voice reached the server).

## Fix

`resolve_legacy_route` now routes any `openai_official_`-prefixed id with a non-empty model suffix to the `openai` provider — the prefix alone determines the provider; the model string belongs to the server. A bare `openai_official_` still rejects. No route-table changes; other providers and the backend's official-endpoint model/voice guardrails (`_is_official_openai_endpoint`) are untouched; `BackendRegistry`'s `openai_official_*` wildcard already accepted arbitrary suffixes downstream.

## Tests (TDD — both watched failing on the real defect first)

- New admission-level regression: `synthesize_default` with global exact custom model/voice must reach the adapter with both unmodified (`test_tts_request_admission.py`).
- New unit test: `resolve_legacy_route` prefix routing (`test_legacy_bridge.py`).
- Two deliberate expectation flips, both documented in-place: `openai_official_new-model` leaves the rejection param list (bare-prefix case kept), and the briefing-synthesis wrapped-`UnknownLegacyModelError` test now injects the error at its established fake seam — after this fix no in-tree selection reaches that error through `synthesize_turn` at all.

## Verification

- Live end-to-end: the exact pre-fix repro (Console 🔊, exact model `mock-model`, voice `mock-voice`, custom Base URL) now shows "Speaking message." and the mock server receives `{"model": "mock-model", "voice": "mock-voice", ...}`. Before the fix, the same click died pre-request with `outcome_code=generation_failed`.
- Branch-relevant files: 218 passed. Full `Tests/TTS/` + dependents: 2,901 passed; the 4 failures + 1 error reproduce byte-identically on pristine `origin/dev` (pre-existing, unrelated). Repo-wide `--collect-only`: clean (37,685 collected).

## Also in this PR

- User-guide verification trailer re-stamped with the live re-verify and the affected window.
- Follow-up tasks from the same UAT: **15421** (playground quick-controls can't express custom model/voice and ignore saved exact prefs), **15422** (misleading failure copy + double generation per speak click), **15423** (Library "Open in Console" no-op). Task 15420 marked Done with full notes.
- `lessons-testing-evidence.md`: layer-reachability lesson (a fix proven at one layer was unreachable through the product path for weeks while ~2,900 area tests stayed green) + the lazy `byte_stream` false-pass trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes custom OpenAI TTS model IDs by prefix so Console speech works with OpenAI-compatible servers. Also single-sources the OpenAI internal-id prefix via a helper to prevent drift (TASK-15420).

- **Bug Fixes**
  - Prefix-route `openai_official_<custom>` to `openai`; a bare `openai_official_` still rejects; no route-table changes and backend guardrails stay the same.
  - Tests: admission path ensures `synthesize_default` passes exact custom model and voice; resolver unit test; briefing error-wrapping test now injects `UnknownLegacyModelError`.
  - Verification/docs: end-to-end check from Console; updated `Docs/User_Guide/openai-compatible-tts.md`; follow-ups filed (TASK-15421–15423).

- **Refactors**
  - Single-source the OpenAI internal-id prefix via `openai_internal_model_id`; update `request_admission`, `legacy_request_builder`, `audiobook_generator`, and `stts_events` to use it (Interop/Media mappers remain literal by design).

<sup>Written for commit ef764ecefdfe27f5c2d9010502f9ff83e832bcda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

