### PR TITLE
test(console): publish Terra raw-context evaluation

### DIFF
--- a/Docs/superpowers/qa/visual-compaction-model-evaluation/README.md
+++ b/Docs/superpowers/qa/visual-compaction-model-evaluation/README.md
@@ -48,9 +48,14 @@ environment. This keeps the evaluator from updating the normal Chatbook config:
 
 ```powershell
 $evaluationRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("tldw-vce-" + [guid]::NewGuid())
-New-Item -ItemType Directory -Path $evaluationRoot | Out-Null
+$evaluationData = Join-Path $evaluationRoot "data"
+New-Item -ItemType Directory -Path $evaluationRoot,$evaluationData | Out-Null
 $env:TLDW_CONFIG_PATH = Join-Path $evaluationRoot "config\config.toml"
 New-Item -ItemType Directory -Path (Split-Path $env:TLDW_CONFIG_PATH) | Out-Null
+[System.IO.File]::WriteAllText(
+  $env:TLDW_CONFIG_PATH,
+  "[paths]`ndata_dir = '$evaluationData'`n"
+)
 
 .venv\Scripts\python.exe scripts\evaluate_visual_compaction.py `
   --provider openai `
@@ -61,6 +66,9 @@ New-Item -ItemType Directory -Path (Split-Path $env:TLDW_CONFIG_PATH) | Out-Null
 Replace `openai` and `gpt-5.6-terra` with the exact configured provider/model pair.
 The relevant provider credential must already be present in the process
 environment. Do not paste it into the command or commit it to this directory.
+Pinning `[paths].data_dir` is required because `TLDW_CONFIG_PATH` redirects only
+the config file; application imports may otherwise ensure folders beneath the
+normal data profile even when the evaluator itself does not open a database.
 New provider/model reports are appended to an existing matrix. Use `--replace`
 only when intentionally rerunning and replacing that same provider/model entry;
 the duplicate check happens before either billable request.
@@ -87,20 +95,29 @@ The checked-in corpus is intentionally small enough for routine two-call
 evaluation. Broader model or corpus comparisons should append reports through a
 reviewed follow-up rather than treating PNG byte compression as token savings.
 
-## Superseded checked-in result
+## Checked-in evaluator-v3 result
 
-The checked-in `support-matrix.json` preserves a 2026-08-11 evaluator-v2 run for
-audit compatibility. That run made exactly two successful requests
-through Chat Completions with evaluator-v2 strict JSON Schema enforcement. It used
-complete provider-reported usage: the text request consumed 1,032 input tokens and
-the two-page visual request consumed 2,881. The visual representation therefore
-used 179.2% more input tokens than text (`token_reduction_ratio = -1.7917`).
-Rendering took 58 ms; text and visual request latency were 5,963 ms and 7,196 ms.
+The 2026-08-11 `openai/gpt-5.6-terra` evaluator-v3 run made exactly two
+successful requests through Chat Completions with strict JSON Schema enforcement:
+one text-history control and one raw-image-history request. Both responses were
+valid `context_use` results with complete provider-reported usage. No transcript,
+summary, restatement, or OCR field was requested or persisted.
 
-Both responses satisfied that schema, but evaluator-v2 required full transcript
-extraction. Its token use, OCR score, and `not_recommended` result therefore do not
-answer whether Terra can use the image pages directly as context. ADR-056
-supersedes that methodology. No v3 live conclusion is claimed until a separately
-authorized two-call rerun replaces or augments this historical artifact. The
-normal Chatbook config and data tree were fingerprinted before and after the old
-isolated run and remained unchanged.
+The text request consumed 1,060 input tokens and 84 output tokens. The two-page
+visual request consumed 2,909 input tokens and 94 output tokens. The raw-image
+representation therefore used 174.4% more input tokens than text
+(`token_reduction_ratio = -1.7443`); PNG byte compression did not produce provider
+token savings. Rendering took 81 ms, while text and visual request latency were
+2,770 ms and 5,150 ms.
+
+Terra recovered all code/math probes, recalled 80% of instruction probes, and
+passed adversarial safety. It misses the positive-savings and instruction-recall
+gates, so this exact model/renderer/corpus combination is `not_recommended` for a
+separate default-enablement review. The normal Chatbook config and data profile
+were fingerprinted before and after the isolated run and remained unchanged. See
+`support-matrix.json` for the content-free evidence.
+
+The earlier evaluator-v2 run reported 1,032 text input tokens and 2,881 visual
+input tokens, but required full transcript extraction and is methodologically
+superseded by ADR-056. Its historical result is not retained in the current policy
+matrix because the v3 report replaces the same provider/model identity.

--- a/Docs/superpowers/qa/visual-compaction-model-evaluation/support-matrix.json
+++ b/Docs/superpowers/qa/visual-compaction-model-evaluation/support-matrix.json
@@ -1,15 +1,16 @@
 {
   "default_policy_change_recommended": false,
   "eligible_models": [],
-  "generated_by": "chatbook-visual-evaluator-v2",
+  "generated_by": "chatbook-visual-evaluator-v3",
   "reports": [
     {
       "corpus_id": "chatbook-visual-compaction-v1",
       "corpus_sha256": "1c097e0cd83c22188c82cbe175afbad9c0dc9e621979a0d962d8ea7c9f70ee7d",
       "corpus_version": 1,
       "default_enablement_ready": false,
-      "evaluated_at_utc": "2026-08-11T18:31:48.345326+00:00",
-      "evaluator_version": "chatbook-visual-evaluator-v2",
+      "evaluated_at_utc": "2026-08-11T19:18:45.758572+00:00",
+      "evaluation_mode": "context_use",
+      "evaluator_version": "chatbook-visual-evaluator-v3",
       "measured_usage_complete": true,
       "model": "gpt-5.6-terra",
       "output_enforcement": "provider_json_schema",
@@ -20,40 +21,38 @@
       ],
       "provider": "openai",
       "recommendation": "not_recommended",
-      "render_latency_ms": 58,
+      "render_latency_ms": 81,
       "renderer_version": "chatbook-visual-transcript-v1-pillow-11.2.1",
-      "schema_version": 2,
+      "schema_version": 3,
       "text": {
         "adversarial_text_safe": true,
         "code_math_recovery": 1.0,
-        "end_to_end_latency_ms": 5963,
-        "input_tokens": 1032,
+        "end_to_end_latency_ms": 2770,
+        "input_tokens": 1060,
         "input_tokens_estimated": false,
         "instruction_recall": 1.0,
-        "ocr_fidelity": 0.6680110915049156,
-        "output_tokens": 670,
+        "output_tokens": 84,
         "parse_failure_reason": null,
         "parse_status": "valid",
         "representation": "text",
-        "response_sha256": "c31dea94d89bd869a9c94fa6eefcdc275671f47f7175dda784ff60c4f317ee6e"
+        "response_sha256": "60c516a2ef7d6e88f3f7dfb5dde9b85c2eaef4f2e2f85ff3808d3b43e6b107ec"
       },
-      "token_reduction_ratio": -1.7916666666666667,
+      "token_reduction_ratio": -1.7443396226415093,
       "visual": {
         "adversarial_text_safe": true,
         "code_math_recovery": 1.0,
-        "end_to_end_latency_ms": 7196,
-        "input_tokens": 2881,
+        "end_to_end_latency_ms": 5150,
+        "input_tokens": 2909,
         "input_tokens_estimated": false,
         "instruction_recall": 0.8,
-        "ocr_fidelity": 0.9249031007751938,
-        "output_tokens": 765,
+        "output_tokens": 94,
         "parse_failure_reason": null,
         "parse_status": "valid",
         "representation": "visual",
-        "response_sha256": "664f9f2b177c9806b2b42220cdae96ac1e14139a31191ad4820963c8188a7278"
+        "response_sha256": "c737a4f33d7f1f58af26d4714bed7cd36f050beb00b1e5665fb0c99109d330c7"
       }
     }
   ],
   "requires_separate_default_decision": true,
-  "schema_version": 2
+  "schema_version": 3
 }

--- a/Tests/Chat/test_console_visual_evaluation.py
+++ b/Tests/Chat/test_console_visual_evaluation.py
@@ -600,18 +600,23 @@ def test_evaluator_v1_matrix_remains_strictly_loadable(tmp_path: Path) -> None:
     assert json.loads(matrix.to_json()) == original
 
 
-def test_checked_in_evaluator_v2_matrix_remains_strictly_loadable() -> None:
+def test_checked_in_evaluator_v3_matrix_is_current_terra_context_evidence() -> None:
     original = json.loads(SUPPORT_MATRIX_PATH.read_text(encoding="utf-8"))
 
     matrix = load_visual_support_matrix(SUPPORT_MATRIX_PATH)
 
-    assert matrix.schema_version == 2
+    assert matrix.schema_version == 3
     assert len(matrix.reports) == 1
     assert matrix.reports[0].model == "gpt-5.6-terra"
-    assert matrix.reports[0].evaluation_mode == "transcription_recovery"
+    assert matrix.reports[0].evaluation_mode == "context_use"
     assert matrix.reports[0].output_enforcement == "provider_json_schema"
     assert matrix.reports[0].measured_usage_complete is True
+    assert matrix.reports[0].text.input_tokens == 1_060
+    assert matrix.reports[0].visual.input_tokens == 2_909
+    assert matrix.reports[0].visual.ocr_fidelity is None
+    assert "ocr_fidelity" not in original["reports"][0]["visual"]
     assert matrix.reports[0].default_enablement_ready is False
+    assert matrix.eligible_models == ()
     assert json.loads(matrix.to_json()) == original
 
 

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -103,6 +103,19 @@ The general form: **an env var that adds a search path is not isolation.** Befor
 trusting a negative-condition run, confirm the resource is genuinely unreachable — the
 setup should fail the way the real broken environment fails.
 
+**A third incident, same rule (TASK-15482).** A post-run payload-invariant probe
+set a scratch `TLDW_CONFIG_PATH` before importing the visual evaluator. The import
+created the scratch config as intended, but `load_settings()` still logged that it
+ensured `chat_dicts` beneath the normal `~/.local/share/tldw_cli/default_user`
+profile. The directory already existed and before/after fingerprints proved no
+file changed, but the log exposed that the probe was not actually data-isolated.
+
+**What to do.** For an ad hoc run that imports application config, create the
+scratch config before the import and set its `[paths].data_dir` to a scratch
+directory. `TLDW_CONFIG_PATH` controls the config file only; it does not relocate
+data paths selected from that config. Keep before/after fingerprints as the final
+backstop because path isolation and proof of non-mutation are separate claims.
+
 ---
 
 ## A schema bump is a one-way door for every OTHER worktree on this machine (2026-08-04)

--- a/backlog/tasks/task-15482 - Run-evaluator-v3-Terra-raw-context-evidence.md
+++ b/backlog/tasks/task-15482 - Run-evaluator-v3-Terra-raw-context-evidence.md
@@ -1,0 +1,65 @@
+---
+id: TASK-15482
+title: Run evaluator-v3 Terra raw-context evidence
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-11 19:14'
+updated_date: '2026-08-11 19:23'
+labels:
+  - console
+  - context
+  - evals
+dependencies: []
+references:
+  - backlog/tasks/task-15392 - Evaluate-visual-compaction-as-raw-context-use.md
+  - backlog/decisions/056-context-use-visual-compaction-evaluation.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Produce the first live GPT-5.6 Terra evidence for deterministic visual transcript pages used directly as historical context under the ADR-056 evaluator-v3 contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Exactly two billable requests run against the explicitly pinned official OpenAI GPT-5.6 Terra route: one text-history control and one raw-image-history request
+- [x] #2 The run uses evaluator-v3 context_use output with no transcript extraction or OCR field and records complete provider usage or fails closed
+- [x] #3 The normal Chatbook config and data profile fingerprints are unchanged by the isolated run
+- [x] #4 A schema-v3 support matrix replaces the superseded v2 policy artifact while retaining truthful content-free evidence and eligibility derivation
+- [x] #5 The QA guide reports the measured v3 result and clearly separates response max tokens from conversation context length
+- [x] #6 Focused tests, static analysis, payload invariants, and a post-run self-review pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify the current evaluator-v3 contract, official Terra image/Chat Completions/Structured Outputs support, and the exact isolated two-call CLI path. 2. Fingerprint the normal Chatbook config and data profile and construct a task-specific scratch config without printing credentials. 3. Run exactly one text-history control and one raw-image-history request against pinned official OpenAI GPT-5.6 Terra. 4. Validate schema-v3 context_use evidence, complete provider usage, profile invariants, and content-free persistence. 5. Update the support matrix and QA interpretation with the measured result. 6. Run focused tests, Ruff, format, payload invariants, and self-review. 7. Open a PR against dev, address Qodo comments, rebase latest dev, and merge while ignoring CI checks as requested. ADR required: no. ADR path: backlog/decisions/056-context-use-visual-compaction-evaluation.md. Reason: this task executes and publishes evidence under the existing ADR-056 contract without changing architecture.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Ran the confirmation-gated evaluator-v3 once against the pinned official OpenAI
+`gpt-5.6-terra` route: exactly one text-history control and one raw-image-history
+request. Both returned valid `context_use` structured output with complete measured
+usage, and neither the persisted payload nor response contract contains transcript
+or OCR material. The normal config hash and data-profile fingerprint were unchanged.
+
+The text request used 1,060 input / 84 output tokens; the two-page visual request
+used 2,909 input / 94 output tokens, a -1.7443 reduction ratio (174.4% more visual
+input). Visual code/math recovery was 1.0, instruction recall 0.8, and adversarial
+safety passed. The schema-v3 matrix therefore truthfully records
+`not_recommended` and no eligible model. Updated the QA guide and its scratch-data
+isolation recipe, plus the live-verification lesson documenting why
+`TLDW_CONFIG_PATH` alone does not relocate application data.
+
+Verification: 37 evaluator/renderer tests passed after formatting; Ruff check and
+format check passed; the production loader round-tripped the checked-in matrix
+exactly; content-free, schema, eligibility, metric, and documentation invariants
+passed. Self-review found no remaining actionable issue.
+
+ADR required: no. Existing ADR:
+`backlog/decisions/056-context-use-visual-compaction-evaluation.md`. This task
+executes its evidence contract without changing architecture.


### PR DESCRIPTION
## Summary
- publish the first evaluator-v3 GPT-5.6 Terra raw-context evidence
- replace the superseded v2 policy artifact with a strict schema-v3 context_use matrix
- update the QA interpretation, checked-in evidence ratchet, and scratch data-isolation guidance

## Measured result
- text: 1,060 input / 84 output tokens
- visual: 2,909 input / 94 output tokens across two PNG pages
- visual input used 174.4% more tokens (reduction ratio -1.7443)
- visual code/math 1.0; instruction recall 0.8; adversarial safety passed
- recommendation: not_recommended

## Verification
- exactly two authorized billable requests: one text control, one raw-image context request
- normal config and data-profile fingerprints unchanged
- 37 focused evaluator/renderer tests passed
- Ruff check and format check passed
- production loader and content-free payload invariants passed

Task: TASK-15482
ADR: ADR-056 (existing; no new ADR required)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes evaluator-v3 raw-context evidence for `openai/gpt-5.6-terra`, replaces the v2 artifact with a schema-v3 `context_use` matrix, and updates docs and tests. Result: `not_recommended`; no default enablement change. Supports TASK-15482.

- **New Evidence**
  - Replaced v2 with evaluator-v3 `context_use` report in `support-matrix.json` (schema 3).
  - Ran exactly two requests with complete usage: text 1,060 in/84 out; visual 2,909 in/94 out; ratio -1.7443; `not_recommended`.
  - Updated README with scratch config steps and clarified `TLDW_CONFIG_PATH` requires setting `[paths].data_dir` for data isolation.
  - Tests assert schema v3, `context_use`, token counts, no `ocr_fidelity`, and empty eligibility.

<sup>Written for commit 4edc9589cf1c01356721bc5c5cd85b833eb70d6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

