### PR TITLE
Fix File Notes warning and navigation consistency

### DIFF
--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -1495,6 +1495,10 @@ async def test_commit_footer_keeps_disclosure_edit_cancel_confirm_order_and_geom
     panel.styles.display = "block"
     app = _PanelHarness(panel)
     async with app.run_test(size=size) as pilot:
+        # Let Textual's initial screen focus settle before exercising the
+        # feature-owned review transition. Otherwise the screen's one-time
+        # autofocus may race the review callback and focus the scroll owner.
+        await pilot.pause()
         panel.render_commit_review(_commit_review_projection())
         await pilot.pause()
 
@@ -1525,6 +1529,28 @@ async def test_commit_footer_keeps_disclosure_edit_cancel_confirm_order_and_geom
             assert confirm.region.right == footer.content_region.right
         else:
             assert edit.region.y == cancel.region.y == confirm.region.y
+
+
+@pytest.mark.asyncio
+async def test_medium_commit_review_transition_reliably_focuses_edit() -> None:
+    """Stress the mounted form-to-review focus handoff at medium width."""
+    panel = LibraryFileNotesGitPanel()
+    panel.styles.display = "block"
+    app = _PanelHarness(panel)
+    draft = _commit_draft_projection(subject="Stable focus")
+    review = _commit_review_projection()
+
+    async with app.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        for _iteration in range(25):
+            panel.render_commit_form(draft)
+            await pilot.pause()
+            panel.render_commit_review(review)
+            await pilot.pause()
+            assert panel.query_one(
+                "#file-notes-git-commit-edit",
+                Button,
+            ).has_focus
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -33,6 +33,7 @@ from tldw_chatbook.Notes.file_notes_service import (  # noqa: E402
     FileNotesService,
     OperationResult,
     ReconcileResult,
+    ScanResult,
 )
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen  # noqa: E402
 from tldw_chatbook.Widgets.Library.library_file_notes_workspace import (  # noqa: E402
@@ -149,6 +150,19 @@ def test_reconcile_tolerates_projection_disappearing_during_unmount(
     assert projection_attempts == [False]
     assert workspace.entries == {}
     assert workspace._deleted_paths == ("deleted.md",)
+
+
+def test_scan_and_reconcile_clear_stale_replica_warning() -> None:
+    """A clean service result must clear a warning from the prior result."""
+    workspace = LibraryFileNotesWorkspace(root=None, replica=None)
+
+    workspace._runtime_warning = "stale scan warning"
+    workspace._adopt_scan_state(ScanResult(status="ok"), ())
+    assert workspace._runtime_warning == ""
+
+    workspace._runtime_warning = "stale reconcile warning"
+    workspace._apply_reconcile(ReconcileResult(status="ok"), ())
+    assert workspace._runtime_warning == ""
 
 
 async def _wait_until(
@@ -465,8 +479,13 @@ async def test_file_notes_root_details_preserve_exact_path_and_warning(
 
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
-        workspace._runtime_warning = "Recovery unavailable: replica locked"
-        workspace._update_root_surface(offline=False)
+        workspace._apply_reconcile(
+            ReconcileResult(
+                status="ok",
+                replica_warning="Recovery unavailable: replica locked",
+            ),
+            (),
+        )
         await pilot.pause()
 
         assert (
@@ -491,9 +510,9 @@ async def test_file_notes_root_details_preserve_exact_path_and_warning(
         assert str(root.resolve()) in exact
         assert "Recovery unavailable: replica locked" in exact
 
-        workspace._runtime_warning = ""
-        workspace._update_root_surface(offline=False)
+        workspace._apply_reconcile(ReconcileResult(status="ok"), ())
         await pilot.pause()
+        assert workspace._runtime_warning == ""
         assert not root_status.has_class("-warning")
 
     replica.close()

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -473,6 +473,10 @@ async def test_file_notes_root_details_preserve_exact_path_and_warning(
             _static_text(workspace, "#file-notes-root-status")
             == "Warning · Local folder: Research Notes"
         )
+        root_status = workspace.query_one("#file-notes-root-status")
+        assert root_status.has_class("-warning")
+        assert "#file-notes-root-status.-warning" in workspace.DEFAULT_CSS
+        assert "color: $warning;" in workspace.DEFAULT_CSS
         tooltip = workspace.query_one("#file-notes-root-status").tooltip
         assert tooltip is not None
         assert str(root.resolve()) in str(tooltip)
@@ -487,7 +491,31 @@ async def test_file_notes_root_details_preserve_exact_path_and_warning(
         assert str(root.resolve()) in exact
         assert "Recovery unavailable: replica locked" in exact
 
+        workspace._runtime_warning = ""
+        workspace._update_root_surface(offline=False)
+        await pilot.pause()
+        assert not root_status.has_class("-warning")
+
     replica.close()
+
+
+@pytest.mark.asyncio
+async def test_file_notes_navigation_and_key_guidance_use_one_phrase() -> None:
+    """Keep return navigation and key guidance consistent across File Notes."""
+    workspace = LibraryFileNotesWorkspace(root=None)
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor_back = workspace.query_one("#file-notes-back", Button)
+        git_back = workspace.query_one("#file-notes-git-back", Button)
+        guide = _static_text(workspace, "#file-notes-git-guide")
+
+        assert str(editor_back.label) == "Back to navigator"
+        assert str(git_back.label) == "Back to navigator"
+        assert guide == "Up/Down select · Tab actions · Enter run · Esc back"
+        assert "|" not in guide
+
+    await workspace.shutdown()
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-15483 - Harden-File-Notes-navigation-warnings-and-review-transition-focus.md
+++ b/backlog/tasks/task-15483 - Harden-File-Notes-navigation-warnings-and-review-transition-focus.md
@@ -1,0 +1,65 @@
+---
+id: TASK-15483
+title: 'Harden File Notes navigation, warnings, and review-transition focus'
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-11 19:38'
+updated_date: '2026-08-11 19:57'
+labels:
+  - notes
+  - library
+  - ux
+  - accessibility
+dependencies: []
+priority: medium
+type: enhancement
+references:
+  - .impeccable/critique/2026-08-11T06-03-15Z__ok-widgets-library-library-file-notes-workspace-py.md
+documentation:
+  - backlog/decisions/011-chatbook-workbench-ui-system.md
+  - backlog/decisions/029-file-notes-disk-authority.md
+  - backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md
+  - backlog/decisions/035-file-notes-session-git-index-controls.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Close the remaining low-severity findings from the File Notes Impeccable critique so navigation language, keyboard guidance, warning semantics, and the commit-review focus transition are consistent and trustworthy without changing local-file or Session Git authority.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Linked-root warnings use the existing warning semantic token while retaining explicit warning text
+- [x] #2 File Notes uses one consistent navigator-return phrase across the workspace and Session Git surfaces
+- [x] #3 Keyboard guidance uses the repository's standard grouped hint grammar instead of pipe-separated telemetry
+- [x] #4 The medium-width commit-review transition is stress-repeated and either fixed with a deterministic focus regression or documented as non-reproducible with repeat evidence
+- [x] #5 Focused mounted tests and targeted static checks pass without changing disk, replica, staging, commit, or push behavior
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A; conform to `backlog/decisions/011-chatbook-workbench-ui-system.md`, `backlog/decisions/029-file-notes-disk-authority.md`, `backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md`, and `backlog/decisions/035-file-notes-session-git-index-controls.md`.
+Reason: this is a scoped semantic-color, navigation-copy, guidance-contract, and focus-verification pass within existing UI, disk, and Session Git authority.
+
+1. Characterize current dev and stress-repeat the medium-width commit-review footer transition before changing focus behavior.
+2. Add mounted regressions for warning-state class and semantic token use, one navigator-return phrase, the already-current grouped key-guide grammar, and stable review focus.
+3. Apply warning styling and navigation-copy changes only; change focus logic only if the repeated test reproduces a deterministic defect.
+4. Run focused workspace and Git panel tests, mutation-check the new guards, and run targeted Ruff, Python compilation, CSS integrity, and diff checks.
+5. Record dissolved and non-reproduced findings honestly, complete task documentation, and close TASK-15483 only when every criterion is evidenced.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a linked-root warning state class that uses the existing $warning token plus bold text while retaining the explicit Warning label, so color reinforces rather than carries the state. Standardized both editor and Session Git return controls on Back to navigator. Current dev already used the approved middle-dot key-guide grammar, so that critique observation was treated as dissolved and pinned with a mounted regression instead of duplicating a change.
+
+The reported medium-width commit-review focus failure reproduced only when the test rendered review before Textual completed its one-time screen autofocus; the late autofocus selected the scroll owner. After settling mount, 25 consecutive mounted form-to-review transitions preserved focus on Edit message. The existing footer test now models that lifecycle, and the new stress regression fails when the production review-focus handoff is removed. No runtime focus logic or disk, replica, staging, commit, or push authority changed.
+
+Verification: 52 File Notes workspace tests passed; 5 focused Session Git tests passed; 100 shared non-obscuring focus-contract tests passed; 9 CSS integrity tests passed. Warning-state, navigation-copy, and review-focus guards were mutation-checked and failed when their production behavior was removed. Targeted Ruff, Python compilation, and `git diff --check` passed. Only existing dependency, SQLite privacy, and pytest-asyncio warnings were reported.
+
+ADR required: no. The implementation conforms to ADR-011, ADR-029, ADR-031, and ADR-035. Modified the File Notes workspace plus its workspace and Session Git mounted regression suites. No new lessons entry was warranted; the autofocus distinction is recorded in the regression comment and this task note.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15483 - Harden-File-Notes-navigation-warnings-and-review-transition-focus.md
+++ b/backlog/tasks/task-15483 - Harden-File-Notes-navigation-warnings-and-review-transition-focus.md
@@ -5,22 +5,23 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-11 19:38'
-updated_date: '2026-08-11 19:57'
+updated_date: '2026-08-11 20:19'
 labels:
   - notes
   - library
   - ux
   - accessibility
 dependencies: []
-priority: medium
-type: enhancement
 references:
-  - .impeccable/critique/2026-08-11T06-03-15Z__ok-widgets-library-library-file-notes-workspace-py.md
+  - >-
+    .impeccable/critique/2026-08-11T06-03-15Z__ok-widgets-library-library-file-notes-workspace-py.md
 documentation:
   - backlog/decisions/011-chatbook-workbench-ui-system.md
   - backlog/decisions/029-file-notes-disk-authority.md
   - backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md
   - backlog/decisions/035-file-notes-session-git-index-controls.md
+priority: medium
+type: enhancement
 ---
 
 ## Description
@@ -62,4 +63,6 @@ The reported medium-width commit-review focus failure reproduced only when the t
 Verification: 52 File Notes workspace tests passed; 5 focused Session Git tests passed; 100 shared non-obscuring focus-contract tests passed; 9 CSS integrity tests passed. Warning-state, navigation-copy, and review-focus guards were mutation-checked and failed when their production behavior was removed. Targeted Ruff, Python compilation, and `git diff --check` passed. Only existing dependency, SQLite privacy, and pytest-asyncio warnings were reported.
 
 ADR required: no. The implementation conforms to ADR-011, ADR-029, ADR-031, and ADR-035. Modified the File Notes workspace plus its workspace and Session Git mounted regression suites. No new lessons entry was warranted; the autofocus distinction is recorded in the regression comment and this task note.
+
+Qodo follow-up identified that a clean scan or reconcile result did not clear a warning retained from the preceding result. Both service-result adoption paths now replace the warning state unconditionally, and regressions cover warning-to-clean transitions in the unmounted state path and the mounted root-status surface. The focused state regression and direct mounted warning regression pass; targeted Ruff, Python compilation, and diff checks pass.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -403,6 +403,11 @@ class LibraryFileNotesWorkspace(Vertical):
         overflow: hidden hidden;
     }
 
+    #file-notes-root-status.-warning {
+        color: $warning;
+        text-style: bold;
+    }
+
     /* task-2850: the "no root chosen yet" empty state is a prompt +
        adjacent action, not a status toolbar -- the ``1fr`` above is
        correct once a root is linked (it reserves room for a Details/
@@ -840,7 +845,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 yield self._git_panel_widget
             with Vertical(id="file-notes-editor-pane"):
                 back = Button(
-                    "‹ Navigator",
+                    "Back to navigator",
                     id="file-notes-back",
                     compact=True,
                 )
@@ -1337,12 +1342,14 @@ class LibraryFileNotesWorkspace(Vertical):
             status.tooltip = None
             status.update(self._root_status_summary)
             status.set_class(True, "-empty-root")
+            status.set_class(False, "-warning")
             body.display = False
             details.display = False
             choose.label = "Choose folder…"
             choose.display = True
             return
         status.set_class(False, "-empty-root")
+        status.set_class(bool(self._runtime_warning), "-warning")
         is_offline = self._root_offline if offline is None else offline
         state = (
             "Checking"

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -1264,8 +1264,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._entries = {entry.relative_path: entry for entry in result.entries}
         self._deleted_paths = deleted
         self._root_offline = result.offline
-        if result.replica_warning:
-            self._runtime_warning = result.replica_warning
+        self._runtime_warning = result.replica_warning or ""
 
     def _render_projection(
         self,
@@ -1309,8 +1308,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._entries = new_entries
         self._deleted_paths = deleted
         self._root_offline = result.offline
-        if result.replica_warning:
-            self._runtime_warning = result.replica_warning
+        self._runtime_warning = result.replica_warning or ""
         return self._render_projection(
             offline=result.offline,
             rebuild_tree=navigator_changed,


### PR DESCRIPTION
## Summary
- render linked-root warnings with the existing semantic warning token while retaining explicit text
- standardize File Notes return controls on Back to navigator
- pin the existing grouped keyboard guide and harden the mounted commit-review focus regression

## Verification
- 52 File Notes workspace tests
- 5 focused Session Git tests
- 100 shared non-obscuring focus-contract tests
- 9 CSS integrity tests
- 6 focused post-rebase tests
- targeted Ruff, Python compilation, mutation checks, and diff checks

Backlog: TASK-15483

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve File Notes warnings and navigation, and make the commit-review focus transition reliable. Completes TASK-15483 with consistent "Back to navigator" copy, semantic warning styling, and automatic clearing of resolved warnings, plus a stabilized mount-to-review focus handoff.

- **Bug Fixes**
  - Linked-root status uses a `-warning` class with `$warning` color and bold text; clean scan/reconcile results now clear stale warnings and remove the class while keeping explicit "Warning" text.
  - Standardized return controls to "Back to navigator" and pinned grouped key guidance; commit review consistently focuses Edit after mount with a medium-width stress regression.

<sup>Written for commit 25b7d570642c233dcc7df358c7894fabc1242cc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

