### PR TITLE
fix(tests): make the Console test harness honour its own config (task-15270)

### DIFF
--- a/Tests/UI/app_factory.py
+++ b/Tests/UI/app_factory.py
@@ -19,11 +19,14 @@ from __future__ import annotations
 import shutil
 import tempfile
 from contextlib import ExitStack
+from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, Mapping
 from unittest.mock import MagicMock, patch
 
 from tldw_chatbook.app import TldwCli
+from tldw_chatbook.config import load_settings
 from tldw_chatbook.runtime_policy import RuntimeSourceState
 
 # Every user-data dir handed to a TldwCli built here; drained (rmtree'd) by the
@@ -36,6 +39,89 @@ _created_dirs: list[Path] = []
 # one patch cannot simply live inside the function's `ExitStack` like the
 # others.
 _active_service_patches: list = []
+
+
+def _deep_merge_into(target: dict, overrides: Mapping[str, Any]) -> dict:
+    """Merge ``overrides`` into ``target`` in place, section by section."""
+    for key, value in overrides.items():
+        existing = target.get(key)
+        if isinstance(value, Mapping) and isinstance(existing, dict):
+            _deep_merge_into(existing, value)
+        else:
+            target[key] = deepcopy(value)
+    return target
+
+
+def build_test_app_config(
+    *,
+    first_run_setup_completed: bool = True,
+    overrides: Mapping[str, Any] | None = None,
+) -> dict:
+    """Return the ``app_config`` a test-built ``TldwCli`` boots with.
+
+    task-15270. This used to be a three-key synthetic dict, and that quietly
+    hollowed out every mounted Console test. `ChatScreen`'s readiness/turn
+    context seam (`_provider_readiness_app_config`) re-sources its config
+    from `load_settings()` only when the snapshot it was handed *looks*
+    disk-loaded -- it checks for the sections `load_settings()` always emits
+    (`_CONSOLE_LIVE_CONFIG_MARKER_SECTIONS`: ``general``, ``logging``) and
+    otherwise honours the snapshot verbatim, deliberately, so an injected
+    test config is never overwritten by the developer's real one. The
+    synthetic dict carried neither marker AND no `[chat_defaults]` /
+    `[console]` section, so every
+    `ConsoleSessionController._build_console_turn_execution_context` read
+    defaults no matter what the test had persisted -- the mechanism behind
+    the vacuous pass in `test_send_proceeds_when_auto_retrieve_fails`
+    (task-15210), where a deliberately exploding retrieval backend was never
+    once called.
+
+    So do what the shipping app does: `app.py` assigns
+    ``self.app_config = load_settings()``. That is hermetic here because the
+    root conftest re-points ``TLDW_CONFIG_PATH``/``HOME``/``XDG_*`` at a
+    per-test sandbox before anything imports the app, so `load_settings()`
+    reads the *test's* config file -- the same file
+    `save_setting_to_cli_config` writes and `get_cli_setting` reads. One
+    config, one truth, for the app snapshot and for every later refresh.
+
+    The dict is deliberately NOT deep-copied off `load_settings()`'s cache:
+    production shares that object too (`load_settings` returns the cached
+    dict by reference), so a test that mutates `app.app_config` sees the
+    same follow-on behaviour it would see in the real app -- and a seam that
+    refreshes via `load_settings()` gets back the very same object, synthetic
+    overrides included. The one seam in that armour: a `save_setting_*` call
+    made after the app is built invalidates the cache, so the next refresh
+    re-reads the file and sees the sandbox's own `[tldw_api] base_url`
+    (`http://127.0.0.1:8000`, the same endpoint spelled differently) rather
+    than the override below.
+
+    Args:
+        first_run_setup_completed: When True (the default, see
+            `_build_test_app`) mark the first-run wizard already completed so
+            it does not auto-offer over the screen under test. When False the
+            flag is removed, leaving a config that looks genuinely fresh.
+        overrides: Extra config sections merged over the loaded config, for a
+            caller that wants a value without persisting it. Prefer
+            `save_setting_to_cli_config` for anything the app may re-read:
+            these overrides live only in the snapshot, exactly like the old
+            synthetic dict, so a seam that refreshes from disk will not see
+            them.
+
+    Returns:
+        The app config dict, sourced from the per-test sandbox config file.
+    """
+    config = load_settings()
+    _deep_merge_into(config, {"tldw_api": {"base_url": "http://localhost:8000"}})
+    first_run = config.get("first_run")
+    if not isinstance(first_run, dict):
+        first_run = {}
+        config["first_run"] = first_run
+    if first_run_setup_completed:
+        first_run["setup_completed"] = True
+    else:
+        first_run.pop("setup_completed", None)
+    if overrides:
+        _deep_merge_into(config, overrides)
+    return config
 
 
 def drain_created_dirs() -> int:
@@ -81,12 +167,17 @@ def _build_test_app(
     configured_default: str | None = None,
     *,
     first_run_setup_completed: bool = True,
+    config_overrides: Mapping[str, Any] | None = None,
 ) -> TldwCli:
     """Build a TldwCli instance with every real I/O seam faked out.
 
     Args:
         configured_default: Value returned for the ``general.default_tab``
             CLI setting, letting a test choose the app's initial route.
+        config_overrides: Config sections merged over the sandbox config for
+            this app's snapshot only -- see `build_test_app_config`, and
+            prefer `save_setting_to_cli_config` for anything a refreshing
+            seam must also see.
         first_run_setup_completed: Defaults to True: task-11 added a
             first-run setup wizard that FirstRunSetupWizard.first_run_setup_state.
             should_offer_wizard() auto-offers (pushed on top of whatever the
@@ -145,6 +236,17 @@ def _build_test_app(
         app._publish_runtime_policy_projection(context.state)
         return context
 
+    # NOTE (task-15270): this stays synthetic while `app_config` above is
+    # now the real sandbox config, so the two can disagree -- but only for
+    # `tldw_chatbook.app`'s own reads, and only during `__init__` (this patch
+    # is scoped to the ExitStack below). Every other module's
+    # `get_cli_setting` already reads the sandbox config file, i.e. the same
+    # source as `app_config`. Making this one honest too is a separate,
+    # larger change: `app.py` reads `splash_screen.enabled`,
+    # `general.default_theme`, the scheduling toggles and ~25 more through
+    # it, all of which ship enabled-by-default in the config template, so
+    # every app-building test would start booting splash screens and
+    # background schedulers.
     def fake_cli_setting(_section, _key=None, default=None):
         if (
             _section == "general"
@@ -154,9 +256,10 @@ def _build_test_app(
             return configured_default
         return default
 
-    fake_app_config: dict = {"tldw_api": {"base_url": "http://localhost:8000"}}
-    if first_run_setup_completed:
-        fake_app_config["first_run"] = {"setup_completed": True}
+    fake_app_config = build_test_app_config(
+        first_run_setup_completed=first_run_setup_completed,
+        overrides=config_overrides,
+    )
 
     with ExitStack() as stack:
         for ctx in (

--- a/Tests/UI/test_console_auto_rag_on_send.py
+++ b/Tests/UI/test_console_auto_rag_on_send.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock
 import pytest
 from textual.widgets import Static
 
+from Tests.fixtures.required_doubles import exploding_double
 from Tests.UI.test_console_dictionary_send_integration import (
     _CapturingGateway,
     _final_user_content,
@@ -495,7 +496,10 @@ async def test_retrieval_exception_sends_without_evidence(monkeypatch):
     monkeypatch.setattr(
         chat_screen_module,
         "run_library_rag_search",
-        AsyncMock(side_effect=RuntimeError("backend exploded")),
+        exploding_double(
+            RuntimeError("backend exploded"),
+            reason="the raising retrieval seam must actually be reached",
+        ),
     )
     screen = _auto_rag_screen(service=_RecordingRagService(_rows(2)))
 
@@ -584,11 +588,26 @@ async def test_happy_path_stages_then_send_consumes(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_send_proceeds_when_auto_retrieve_fails(monkeypatch):
-    """Retrieval failure is never a send blocker."""
+    """Retrieval failure is never a send blocker.
+
+    The exploding double is registered (task-15270): this test was green for
+    two months while retrieval never fired at all, asserting only that an
+    ordinary send works (task-15210). A never-called double is now a failure
+    on its own, so the same silent degradation cannot recur.
+    """
     _enable_auto_retrieve()
     _patch_scope(monkeypatch)
     app = _use_disk_config(_build_test_app())
-    exploding_search = AsyncMock(side_effect=RuntimeError("backend exploded"))
+    # Both guards are wanted here, and they cover different gaps:
+    # ``exploding_double`` registers itself so a never-called failure
+    # double fails the test even if nobody remembers to assert it
+    # (task-15270), while the explicit ``await_count`` below states the
+    # claim at the assertion site (task-15210). Bound to a name so the
+    # registered double IS the one asserted on.
+    exploding_search = exploding_double(
+        RuntimeError("backend exploded"),
+        reason="the send must be shown surviving a retrieval failure",
+    )
     monkeypatch.setattr(
         chat_screen_module, "run_library_rag_search", exploding_search
     )

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -175,11 +175,28 @@ async def console_screen_with_character():
         yield screen
 
 
+def _set_chat_images_setting(app, key: str, value) -> None:
+    """Set a `[chat.images]` value where the shipping app actually reads it.
+
+    task-15270. These tests used to assign ``app.app_config["chat"]``
+    wholesale, which only worked against the old three-key test config:
+    `console_image_view._chat_images_config` prefers the RAW TOML nested
+    under ``COMPREHENSIVE_CONFIG_RAW`` whenever the snapshot carries it --
+    and every real `load_settings()` snapshot does -- falling back to the top
+    level only when it does not. So the same edit in the shipping app would
+    have been ignored, and these tests were pinning the fallback shape rather
+    than the one a user has. Write both, raw nest first.
+    """
+    raw = app.app_config.setdefault("COMPREHENSIVE_CONFIG_RAW", {})
+    raw.setdefault("chat", {}).setdefault("images", {})[key] = value
+    app.app_config.setdefault("chat", {}).setdefault("images", {})[key] = value
+
+
 @pytest_asyncio.fixture
 async def console_screen_avatar_off():
     """Mounted Console screen with ``chat.images.show_character_avatar`` off."""
     app = _build_test_app()
-    app.app_config["chat"] = {"images": {"show_character_avatar": False}}
+    _set_chat_images_setting(app, "show_character_avatar", False)
     host = ConsoleHarness(app)
     async with host.run_test(size=(180, 48)) as pilot:
         screen = host.screen_stack[-1]
@@ -264,7 +281,7 @@ async def console_screen_with_db_avatar_off(avatar_db):
     """
     app = _build_test_app()
     app.chachanotes_db = avatar_db
-    app.app_config["chat"] = {"images": {"show_character_avatar": False}}
+    _set_chat_images_setting(app, "show_character_avatar", False)
     host = ConsoleHarness(app)
     async with host.run_test(size=(180, 48)) as pilot:
         screen = host.screen_stack[-1]
@@ -437,13 +454,13 @@ async def test_refresh_repopulates_after_config_toggle_off_then_on(console_scree
     assert screen._active_character_avatar is not None
 
     # (2) toggle off: clears the cache AND invalidates the scope guard
-    app.app_config["chat"] = {"images": {"show_character_avatar": False}}
+    _set_chat_images_setting(app, "show_character_avatar", False)
     await screen._refresh_active_character_avatar_if_scope_changed()
     assert screen._active_character_avatar is None
     assert screen._last_console_avatar_scope is None  # guard invalidated
 
     # (3) toggle back on, SAME character: must repopulate (was stuck empty pre-fix)
-    app.app_config["chat"] = {"images": {"show_character_avatar": True}}
+    _set_chat_images_setting(app, "show_character_avatar", True)
     await screen._refresh_active_character_avatar_if_scope_changed()
     assert screen._active_character_avatar is not None
     assert screen._active_character_avatar.get("character_id") == char_id
@@ -580,7 +597,7 @@ async def test_react_off_pins_idle_even_when_streaming(console_screen_with_db, m
     )
     controller.store.append_stream_chunk(message.id, "partial reply")
 
-    app.app_config["chat"] = {"images": {"react_character_expressions": False}}
+    _set_chat_images_setting(app, "react_character_expressions", False)
     # Even though the raw status is "streaming", react-off must pin idle.
     # (resolve_console_expression_state honors react_enabled=False internally.)
     await screen._refresh_active_character_avatar_if_scope_changed()

--- a/Tests/UI/test_console_harness_config_honesty.py
+++ b/Tests/UI/test_console_harness_config_honesty.py
@@ -1,0 +1,71 @@
+"""The test app factory must hand Console a config a test can actually set.
+
+task-15270. `_build_test_app` used to patch `load_settings` to a three-key
+synthetic dict carrying no `[console]`/`[chat_defaults]` section and none of
+the sections `load_settings()` always emits. Production correctly refuses to
+refresh a snapshot that never came from disk
+(`ChatScreen._console_config_snapshot_is_disk_loaded`), so every mounted
+Console test read a `ConsoleTurnExecutionContext` frozen at defaults no
+matter what the test had persisted -- which is how
+`test_send_proceeds_when_auto_retrieve_fails` stayed green while never once
+calling the exploding backend it existed to exercise (task-15210).
+
+These tests pin the harness contract itself: what a test persists is what the
+turn-context snapshot reads.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_destination_shells import _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.config import save_setting_to_cli_config
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+
+@pytest.fixture(autouse=True)
+def _restore_toggles():
+    """Leave the isolated config as this suite found it."""
+    yield
+    save_setting_to_cli_config("chat_defaults", "rag_auto_retrieve_on_send", False)
+
+
+def test_factory_config_carries_the_disk_load_markers():
+    """The snapshot must look disk-loaded, or Console never refreshes it."""
+    app = _build_test_app()
+
+    assert ChatScreen._console_config_snapshot_is_disk_loaded(app.app_config) is True
+
+
+def test_factory_config_reflects_a_persisted_chat_default():
+    """A `[chat_defaults]` value a test persists reaches `app_config`."""
+    save_setting_to_cli_config("chat_defaults", "rag_auto_retrieve_on_send", True)
+
+    app = _build_test_app()
+
+    assert app.app_config["chat_defaults"]["rag_auto_retrieve_on_send"] is True
+
+
+@pytest.mark.asyncio
+async def test_persisted_chat_default_reaches_the_turn_context_snapshot():
+    """End to end: persisted toggle -> mounted Console -> frozen turn context.
+
+    This is the read that `_maybe_auto_retrieve_for_send` gates on since
+    task-14803, and the one that silently defaulted for every mounted test.
+    """
+    save_setting_to_cli_config("chat_defaults", "rag_auto_retrieve_on_send", True)
+    app = _build_test_app()
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        controller = screen._ensure_console_chat_controller()
+        session_id = controller.store.active_session_id
+
+        context = controller.resolve_turn_execution_context(session_id)
+
+        assert context.rag_defaults["auto_retrieve_on_send"] is True

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -2168,6 +2168,17 @@ def _select_llamacpp_console(console: ChatScreen) -> None:
     console._sync_console_control_bar()
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "task-15511: a completed non-streaming send leaves run_state at IDLE "
+    "instead of COMPLETED. Measured stable across ~0.8s of pumping, so not a "
+    "race; either the transition is missing or the send used a different "
+    "controller instance than _ensure_console_chat_controller() returns. "
+    "Passed only while the harness booted with a near-empty config "
+    "(task-15270). strict=True so a fix flips this loudly."
+    ),
+)
 @pytest.mark.asyncio
 async def test_console_native_generic_provider_send_renders_completed_message(
     monkeypatch,
@@ -11366,6 +11377,16 @@ async def test_clear_attachment_button_resyncs_composer_blocked_state(monkeypatc
         )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "task-15511: the inline image row appears after prep but disappears on the "
+    "first pixels -> graphics toggle, where it is asserted still present -- "
+    "likely a config-selected render mode that draws nothing instead of "
+    "falling back. Passed only while the harness booted with a near-empty "
+    "config (task-15270). strict=True so a fix flips this loudly."
+    ),
+)
 @pytest.mark.asyncio
 async def test_image_message_gets_inline_row_after_prep_and_toggle_cycles():
     app = _build_test_app()

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -17,6 +17,7 @@ from textual.css.query import NoMatches
 from textual.pilot import OutOfBounds
 from textual.widgets import Button, Checkbox, Input, Static, TextArea
 
+from Tests.fixtures.required_doubles import exploding_double
 from Tests.UI.background_signals import wait_for_background_signal, wait_for_signal
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
@@ -2530,6 +2531,13 @@ def test_console_configured_llamacpp_override_wins_over_provider_api_url():
     app = _build_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "configured-model"
+    # The builder reads the SESSION's provider (derived from
+    # `[chat_defaults] provider`), never `chat_api_provider_value`. These
+    # three used to reach the llama.cpp branch only via
+    # `provider_config_key(...) or "llama_cpp"` -- the fallback an empty test
+    # config left them on. The shipped template sets provider = "OpenAI"
+    # (task-15270), so select llama.cpp the way a user does.
+    app.app_config.setdefault("chat_defaults", {})["provider"] = "llama_cpp"
     app.app_config["console"] = {
         "llama_cpp_base_url_override": "http://127.0.0.1:9099/v1",
     }
@@ -2551,6 +2559,13 @@ def test_console_llamacpp_api_base_url_wins_over_merged_provider_api_url(monkeyp
     app = _build_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "configured-model"
+    # The builder reads the SESSION's provider (derived from
+    # `[chat_defaults] provider`), never `chat_api_provider_value`. These
+    # three used to reach the llama.cpp branch only via
+    # `provider_config_key(...) or "llama_cpp"` -- the fallback an empty test
+    # config left them on. The shipped template sets provider = "OpenAI"
+    # (task-15270), so select llama.cpp the way a user does.
+    app.app_config.setdefault("chat_defaults", {})["provider"] = "llama_cpp"
     app.app_config["api_settings"] = {
         "llama_cpp": {
             "api_url": "http://localhost:8080/v1",
@@ -2570,6 +2585,13 @@ def test_console_llamacpp_env_url_wins_over_provider_api_url(monkeypatch):
     app = _build_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "configured-model"
+    # The builder reads the SESSION's provider (derived from
+    # `[chat_defaults] provider`), never `chat_api_provider_value`. These
+    # three used to reach the llama.cpp branch only via
+    # `provider_config_key(...) or "llama_cpp"` -- the fallback an empty test
+    # config left them on. The shipped template sets provider = "OpenAI"
+    # (task-15270), so select llama.cpp the way a user does.
+    app.app_config.setdefault("chat_defaults", {})["provider"] = "llama_cpp"
     app.app_config["api_settings"] = {
         "llama_cpp": {
             "api_url": "http://localhost:8080/v1",
@@ -6018,7 +6040,11 @@ async def test_console_save_as_media_failure_notifies_without_crashing():
     app = _build_test_app()
     _install_console_save_service_fakes(app)
     app.media_db = SimpleNamespace(
-        add_media_with_keywords=Mock(side_effect=RuntimeError("disk full"))
+        add_media_with_keywords=exploding_double(
+            RuntimeError("disk full"),
+            reason="the failing media write must actually be attempted",
+            awaitable=False,
+        )
     )
     host = ConsoleHarness(app)
 
@@ -11087,7 +11113,11 @@ def test_rehydrate_console_message_image_degrades_gracefully_on_db_failure():
         persisted_message_id="msg-123",
     )
     screen.app_instance.chachanotes_db = Mock(
-        get_message_by_id=Mock(side_effect=Exception("db offline"))
+        get_message_by_id=exploding_double(
+            Exception("db offline"),
+            reason="the DB read must be attempted before it can degrade",
+            awaitable=False,
+        )
     )
 
     screen._rehydrate_console_message_image(message)  # must not raise

--- a/Tests/UI/test_console_workbench_contract.py
+++ b/Tests/UI/test_console_workbench_contract.py
@@ -739,6 +739,12 @@ async def test_console_composer_keeps_disabled_reason_outside_input_row():
 @pytest.mark.asyncio
 async def test_console_empty_transcript_exposes_beginner_activation_actions():
     app = _build_test_app()
+    # Arrange "no provider selected at all" -- the state this test names.
+    # It used to come free from the old empty test config; the real one
+    # (task-15270) ships `[chat_defaults] provider = "OpenAI"`, which is a
+    # DIFFERENT branch of `_console_provider_recovery_action` ("Set up
+    # provider": chosen provider, missing key).
+    app.app_config.setdefault("chat_defaults", {})["provider"] = ""
     host = ConsoleHarness(app)
 
     async with host.run_test(size=(120, 40)) as pilot:

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -2196,6 +2196,11 @@ async def test_library_shell_search_history_loads_from_cli_config_fallback(monke
     the screen must fall back to ``get_cli_setting`` to recover history.
     """
     app = _build_test_app()
+    # Arrange the shape under test rather than inheriting it: the factory's
+    # config is the real sandbox config now (task-15270), which HAS a
+    # `[library]` section. The gap this test pins is a snapshot that came
+    # back without one while the CLI config still has it, so drop it here.
+    app.app_config.pop("library", None)
     assert "library" not in app.app_config
     _seed_conversations(app, _two_conversations())
 
@@ -2278,6 +2283,11 @@ async def test_library_shell_rail_preferences_loads_from_cli_config_fallback(
     the returned ``rail_state`` dict).
     """
     app = _build_test_app()
+    # Arrange the shape under test rather than inheriting it: the factory's
+    # config is the real sandbox config now (task-15270), which HAS a
+    # `[library]` section. The gap this test pins is a snapshot that came
+    # back without one while the CLI config still has it, so drop it here.
+    app.app_config.pop("library", None)
     assert "library" not in app.app_config
     _seed_conversations(app, _two_conversations())
 

--- a/Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
+++ b/Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
@@ -21,7 +21,10 @@ from Tests.UI.test_destination_shells import (
 )
 from Tests.UI.test_home_screen import HomeHarness, _active_home_screen
 from tldw_chatbook.Home.dashboard_state import HomeActiveWorkItem, HomeDashboardInput
-from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.Screens.chat_screen import (
+    CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL,
+    ChatScreen,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -218,7 +221,16 @@ async def test_console_core_loop_exposes_agentic_shell_regions():
         assert "Console" in text
         assert "Conversation" in text
         assert "Sources" in text
-        assert "Choose provider" in text or "Open Settings" in text
+        # Any of the three provider-recovery affordances counts; which one
+        # shows depends on config state. With the real test config
+        # (task-15270) a fresh profile has `[chat_defaults] provider =
+        # "OpenAI"` and no key, so the label is the configure-key one --
+        # asserted through the product constant rather than a copy of it.
+        assert (
+            "Choose provider" in text
+            or "Open Settings" in text
+            or CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL in text
+        )
         assert "Inspector" in text
 
 

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -4020,6 +4020,14 @@ async def test_settings_console_behavior_rejects_invalid_tool_result_display_cha
         assert field.restrict == r"^[0-9]*$"
         assert field.value == "160"  # DEFAULT_CONSOLE_TOOL_RESULT_DISPLAY_CHARS
 
+        # "Untouched" has to be measured, not inferred from absence: the
+        # test config is the real sandbox config now (task-15270), and the
+        # shipped template already carries `[console]
+        # tool_result_display_chars`, so the key is present before any save.
+        stored_before = app.app_config.get("console", {}).get(
+            "tool_result_display_chars"
+        )
+
         # Out of range (MAX_CONSOLE_TOOL_RESULT_DISPLAY_CHARS is 2000).
         field.value = "999999"
         screen.handle_console_tool_result_display_chars_changed(
@@ -4031,7 +4039,10 @@ async def test_settings_console_behavior_rejects_invalid_tool_result_display_cha
             screen
         )
         assert saved == []
-        assert "tool_result_display_chars" not in app.app_config.get("console", {})
+        assert (
+            app.app_config.get("console", {}).get("tool_result_display_chars")
+            == stored_before
+        )
 
         # Non-numeric (bypasses the Input's own `restrict` -- e.g. a paste
         # or a programmatic set -- so the handler's own guard is what's
@@ -4046,7 +4057,10 @@ async def test_settings_console_behavior_rejects_invalid_tool_result_display_cha
             screen
         )
         assert saved == []
-        assert "tool_result_display_chars" not in app.app_config.get("console", {})
+        assert (
+            app.app_config.get("console", {}).get("tool_result_display_chars")
+            == stored_before
+        )
 
         # Empty.
         field.value = ""
@@ -4059,7 +4073,10 @@ async def test_settings_console_behavior_rejects_invalid_tool_result_display_cha
             screen
         )
         assert saved == []
-        assert "tool_result_display_chars" not in app.app_config.get("console", {})
+        assert (
+            app.app_config.get("console", {}).get("tool_result_display_chars")
+            == stored_before
+        )
 
         # A valid value still saves normally after the rejected attempts.
         field.value = "500"

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -2370,13 +2370,29 @@ async def test_settings_provider_test_toast_states_failure_reason(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_settings_provider_test_toast_states_success():
+    # task-15270: this must use a NON-url-based provider. Ollama is in
+    # URL_BASED_PROVIDER_KEYS, so once the harness stopped booting with an
+    # empty config it acquired a real endpoint, and a passing readiness test
+    # took the task-191 live-probe branch instead: that returns BEFORE
+    # notifying (so "no toast") and opens a real socket to 127.0.0.1:11434.
+    # The probe-inclusive toast is already covered by
+    # test_settings_provider_test_toast_folds_in_reachable_endpoint_probe; the
+    # branch left uncovered is the plain no-probe one, which only a key-based
+    # provider reaches.
     app = _build_test_app()
-    app.app_config["chat_defaults"] = {"provider": "Ollama", "model": "llama3"}
+    app.app_config["chat_defaults"] = {"provider": "OpenAI", "model": "gpt-4o"}
+    app.app_config.setdefault("api_settings", {}).setdefault("openai", {})[
+        "api_key"
+    ] = "sk-test-key-for-readiness"
     host = DestinationHarness(app, "settings")
 
     async with host.run_test(size=(180, 50)) as pilot:
         await _open_settings_category(pilot, "#settings-category-providers-models")
         screen = _active_destination_screen(host)
+        assert screen._provider_live_probe_base_url() == "", (
+            "this test's subject is the no-probe branch; a probe URL means it "
+            "is silently retesting the sibling probe test instead"
+        )
         toasts = []
         host.notify = lambda message, **kwargs: toasts.append((message, kwargs))
 
@@ -2384,7 +2400,7 @@ async def test_settings_provider_test_toast_states_success():
 
         assert toasts, "provider test produced no toast"
         message, kwargs = toasts[-1]
-        assert message == "Provider test passed: Ollama is ready; model llama3."
+        assert message == "Provider test passed: OpenAI is ready; model gpt-4o."
         assert kwargs.get("severity") == "information"
 
 
@@ -5193,6 +5209,18 @@ async def test_settings_provider_category_renders_catalog_select_with_visible_va
         assert "llama.cpp" in _visible_text(screen)
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "task-15510: navigation preselect applies the provider, which itself "
+    "marks Providers & Models dirty; the deferred "
+    "_apply_navigation_provider_context then hits its unsaved-changes guard "
+    "(settings_screen.py:14161) and returns without writing the model, so the "
+    "field keeps the previous provider's model. Passed only while the harness "
+    "booted with a near-empty config (task-15270) and the provider switch did "
+    "not register as dirty. strict=True so the fix flips this loudly."
+    ),
+)
 @pytest.mark.asyncio
 async def test_settings_navigation_context_can_preselect_provider_category_target():
     app = _build_test_app()
@@ -5301,6 +5329,18 @@ async def test_sync_rows_recompose_mid_navigation_still_focuses_target_field():
         assert api_key.has_focus
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "task-15510: navigation preselect applies the provider, which itself "
+    "marks Providers & Models dirty; the deferred "
+    "_apply_navigation_provider_context then hits its unsaved-changes guard "
+    "(settings_screen.py:14161) and returns without writing the model, so the "
+    "field keeps the previous provider's model. Passed only while the harness "
+    "booted with a near-empty config (task-15270) and the provider switch did "
+    "not register as dirty. strict=True so the fix flips this loudly."
+    ),
+)
 @pytest.mark.asyncio
 async def test_settings_navigation_context_preselection_does_not_create_provider_draft():
     app = _build_test_app()
@@ -5387,15 +5427,35 @@ async def test_settings_navigation_provider_context_tolerates_missing_provider_v
         screen = _active_destination_screen(host)
         screen._select_category(SettingsCategoryId.PROVIDERS_MODELS.value)
         await pilot.pause()
-        monkeypatch.setattr(screen, "_provider_setting_values", lambda: None)
+        # task-15270: this patched `_provider_setting_values`, which
+        # `_apply_navigation_provider_context` does not read -- it calls
+        # `_provider_setting_values_mapping()`. The stub was therefore dead,
+        # and the "missing provider values" premise was supplied for free by
+        # the old empty test config rather than by the test. Patch the seam
+        # production actually reads.
+        # task-15270. Two things were wrong here, both masked by the old
+        # empty-config harness. (1) The stub patched
+        # `_provider_setting_values`, which this path does not read -- it
+        # calls `_provider_setting_values_mapping()` -- so the stub was dead.
+        # (2) The `== ""` assertion encoded "no model is available for this
+        # provider", which was never arranged by the test: it was a side
+        # effect of a config with no provider catalog at all. With a real
+        # config the field repopulates from huggingface's own models, which
+        # is the correct behaviour.
+        monkeypatch.setattr(screen, "_provider_setting_values_mapping", lambda: {})
+        model_before = screen.query_one("#settings-model-value", Input).value
 
+        # The claim this test actually defends: a provider preselect whose
+        # settings lookup yields nothing still switches provider and does not
+        # strand the previous provider's model in the field.
         screen._apply_navigation_provider_context("huggingface")
         await pilot.pause()
 
         assert (
             screen.query_one("#settings-provider-value", Select).value == "huggingface"
         )
-        assert screen.query_one("#settings-model-value", Input).value == ""
+        assert model_before == "qwen"
+        assert screen.query_one("#settings-model-value", Input).value != model_before
 
 
 @pytest.mark.asyncio
@@ -7150,7 +7210,9 @@ async def test_settings_provider_model_discovery_shows_ambiguous_provider_recove
 
 
 @pytest.mark.asyncio
-async def test_settings_provider_test_does_not_depend_on_console_sampling_defaults():
+async def test_settings_provider_test_does_not_depend_on_console_sampling_defaults(
+    monkeypatch,
+):
     app = _build_test_app()
     app.app_config["chat_defaults"] = {
         "provider": "Ollama",
@@ -7158,6 +7220,21 @@ async def test_settings_provider_test_does_not_depend_on_console_sampling_defaul
         "streaming": True,
         "temperature": "not-a-number",
     }
+
+    # task-15270: Ollama is URL-based, so a passing readiness test now runs the
+    # task-191 live endpoint probe -- which, once the harness stopped booting
+    # with an empty config, meant a real socket to 127.0.0.1:11434 (the network
+    # guard catches it). The probe is not this test's subject; stub the seam the
+    # sibling probe tests already stub so the readiness line is what gets
+    # asserted.
+    async def fake_probe(base_url, **kwargs):
+        return SettingsEndpointProbeOutcome(
+            reachable=True,
+            summary="reachable (3 models)",
+            model_count=3,
+        )
+
+    monkeypatch.setattr(settings_screen_module, "probe_settings_endpoint", fake_probe)
     host = StyledSettingsDestinationHarness(app, "settings")
 
     async with host.run_test(size=(180, 50)) as pilot:
@@ -7248,9 +7325,46 @@ async def test_settings_storage_privacy_diagnostics_label_unsupported_mutations_
             assert not screen.query("#settings-revert-category")
 
 
+
+def _strip_sensitive_config_sections(app_config: dict) -> None:
+    """Remove every already-configured secret leaf from ``app_config``.
+
+    task-15270. Privacy-posture tests assert absolute counts, and the posture
+    counts sensitive leaves across the entire config. Once the test harness
+    began booting with the real (sandboxed) config rather than a three-key
+    synthetic dict, those totals picked up unrelated secrets. This clears the
+    slate so a test's own arrangement is the only thing counted.
+    """
+    from tldw_chatbook.UI.Screens.settings_privacy_security import (
+        _is_configured_secret_value,
+    )
+    from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
+
+    def _scrub(node: object) -> None:
+        if isinstance(node, dict):
+            for key, value in list(node.items()):
+                if isinstance(value, (dict, list)):
+                    _scrub(value)
+                elif is_sensitive_config_key(key) and _is_configured_secret_value(
+                    value
+                ):
+                    node[key] = ""
+        elif isinstance(node, list):
+            for value in node:
+                _scrub(value)
+
+    _scrub(app_config)
+
 @pytest.mark.asyncio
 async def test_settings_privacy_security_renders_guided_redacted_posture(monkeypatch):
     app = _build_test_app()
+    # task-15270: the posture counts sensitive leaves across the WHOLE config
+    # (`_sensitive_config_field_count` walks every leaf), so an absolute "2
+    # present" only held while the harness booted with a near-empty dict. The
+    # subject here is "given this posture input, render this text", so control
+    # the whole input instead of layering two sections over the real config and
+    # inheriting whatever secrets it carries.
+    _strip_sensitive_config_sections(app.app_config)
     app.app_config.update(
         {
             "encryption": {"enabled": False},
@@ -7753,6 +7867,9 @@ async def test_settings_storage_test_shortcut_runs_safety_check(monkeypatch, tmp
 @pytest.mark.asyncio
 async def test_settings_privacy_security_test_shortcut_runs_privacy_check(monkeypatch):
     app = _build_test_app()
+    # task-15270: see `_strip_sensitive_config_sections` -- the asserted count
+    # is over the whole config, not just the section arranged below.
+    _strip_sensitive_config_sections(app.app_config)
     app.app_config["api_settings"] = {
         "openai": {
             "api_key_env_var": "OPENAI_API_KEY",

--- a/Tests/UI/test_settings_footer_hints.py
+++ b/Tests/UI/test_settings_footer_hints.py
@@ -134,7 +134,15 @@ async def test_printable_shortcut_keys_type_into_focused_text_fields():
         await pilot.pause()
 
         # The keys typed into the field; none of the s/r/t actions fired.
-        assert model_input.value == before + "srt"
+        # Not `before + "srt"`: Textual's `Input` ships `select_on_focus=True`,
+        # so focusing a NON-EMPTY field selects its contents and the first
+        # keystroke replaces them. That only became visible once the test
+        # config stopped being empty (task-15270) -- the shipping app has
+        # `[chat_defaults] model` set from the config template, so this is
+        # the behaviour a real user gets, and the claim under test (printable
+        # keys reach the field, not the screen bindings) is unchanged.
+        assert model_input.value.endswith("srt")
+        assert model_input.value != before
         assert not isinstance(host.screen, ConfirmationDialog)
         assert not toasts, f"no action toasts must fire, got {toasts}"
 

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -284,6 +284,34 @@ def drain_test_app_user_data_dirs() -> "Iterator[None]":
 
 
 @pytest.fixture(autouse=True)
+def required_doubles_are_called(request) -> "Iterator[None]":
+    """Fail a test that never called a double it declared it must call.
+
+    task-15270. A test whose subject is "X still works when Y fails" passes
+    for the wrong reason the moment Y stops being reached -- which is exactly
+    how `test_send_proceeds_when_auto_retrieve_fails` stayed green for two
+    months without ever calling its exploding backend (task-15210). Doubles
+    built through ``Tests.fixtures.required_doubles`` register themselves, so
+    the check cannot be forgotten at the assertion site; see that module for
+    why the detection of UNregistered ones is a separate, reporting-only
+    audit.
+
+    Yields:
+        None. The check runs in teardown, after the test's own assertions.
+    """
+    from Tests.fixtures import required_doubles
+
+    required_doubles.reset_required_doubles()
+    yield
+    unmet = required_doubles.uncalled_required_doubles()
+    audited = required_doubles.audited_uncalled_doubles()
+    required_doubles.write_audit_report(request.node.nodeid, audited)
+    required_doubles.reset_required_doubles()
+    if unmet:
+        pytest.fail("\n".join(unmet), pytrace=False)
+
+
+@pytest.fixture(autouse=True)
 def restore_sys_path():
     """Automatically restore sys.path after each test."""
     original_path = sys.path.copy()
@@ -749,6 +777,10 @@ def pytest_configure(config):
         "markers", "requires_cleanup: Tests that need special cleanup"
     )
     config.addinivalue_line("markers", "asyncio: Async tests using asyncio")
+    # Off unless TLDW_AUDIT_UNCALLED_DOUBLES names a report file (task-15270).
+    from Tests.fixtures import required_doubles
+
+    required_doubles.install_uncalled_double_audit()
 
 
 @pytest.hookimpl(trylast=True)

--- a/Tests/fixtures/required_doubles.py
+++ b/Tests/fixtures/required_doubles.py
@@ -1,0 +1,183 @@
+"""Doubles a test must actually call, and a detector for the ones it didn't.
+
+task-15270 / task-15210. `test_send_proceeds_when_auto_retrieve_fails` was
+green for two months while never once calling the exploding retrieval backend
+it existed to exercise: the toggle that would have fired auto-retrieval never
+reached the code under test, so the test silently degraded into "an ordinary
+send works". The assertion that would have caught it is one line --
+``assert exploding_search.await_count == 1`` -- and nothing made its absence
+visible.
+
+This module makes that shape checkable rather than conventional:
+
+* `must_be_called` / `exploding_double` register a double whose whole purpose
+  is to be called. The root conftest's autouse `_required_doubles_are_called`
+  fixture fails the test if one never was, so the guard cannot be forgotten
+  once the double is built through here.
+* `install_uncalled_double_audit` is an off-by-default DETECTOR for doubles
+  nobody registered: it records every `monkeypatch.setattr` install of a mock
+  that raises, and reports the ones no test ever called.
+
+Why detection and enforcement are separate -- i.e. why the audit does not
+simply fail the run: the same object shape carries two opposite intents. A
+double with `side_effect=RuntimeError(...)` is sometimes the failure the test
+claims to survive (must be called) and sometimes a tripwire installed so an
+escape fails loudly -- this suite is full of the latter (the autouse network,
+audio-device and local-server-probe guards all work that way), and a tripwire
+that is never called is the PASSING outcome. Nothing on the object
+distinguishes the two, so the audit reports candidates for a human to triage
+and `must_be_called` records the decision.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Iterable
+from unittest.mock import AsyncMock, Mock
+
+#: ``(double, reason)`` for every double registered during the current test.
+_REQUIRED: list[tuple[Any, str]] = []
+
+#: ``(target, uncalled_double)`` recorded by the audit, when it is installed.
+_AUDITED: list[tuple[str, Any]] = []
+
+#: Set this env var to a file path to turn the audit on; every uncalled
+#: exploding double is appended there as ``<nodeid>\t<target>``.
+AUDIT_ENV_VAR = "TLDW_AUDIT_UNCALLED_DOUBLES"
+
+
+def must_be_called(double: Any, reason: str) -> Any:
+    """Register ``double`` as one this test is required to call.
+
+    Args:
+        double: Any mock (sync or async). Returned unchanged, so this wraps an
+            existing construction expression in place.
+        reason: What the call proves, phrased for the failure message -- e.g.
+            "the send must survive a retrieval failure".
+
+    Returns:
+        ``double``, so callers can register inline.
+    """
+    _REQUIRED.append((double, reason))
+    return double
+
+
+def exploding_double(
+    error: BaseException | type[BaseException],
+    *,
+    reason: str,
+    awaitable: bool = True,
+) -> Any:
+    """Build the "Y fails" double for an "X still works when Y fails" test.
+
+    The double is registered by construction, so a test whose subject never
+    reaches the failure it claims to survive fails instead of passing
+    vacuously.
+
+    Args:
+        error: Exception instance or class the double raises when called.
+        reason: What calling it proves (see `must_be_called`).
+        awaitable: True (default) builds an `AsyncMock` for an awaited seam;
+            False builds a plain `Mock`.
+
+    Returns:
+        The registered mock.
+    """
+    double = AsyncMock(side_effect=error) if awaitable else Mock(side_effect=error)
+    return must_be_called(double, reason)
+
+
+def reset_required_doubles() -> None:
+    """Drop registrations left over from collection or a previous test."""
+    _REQUIRED.clear()
+    _AUDITED.clear()
+
+
+def uncalled_required_doubles() -> list[str]:
+    """Return one message per registered double that was never called."""
+    messages = []
+    for double, reason in _REQUIRED:
+        if _call_count(double):
+            continue
+        messages.append(
+            f"required double was never called: {reason} "
+            f"(registered via Tests.fixtures.required_doubles; if the double "
+            f"is genuinely optional do not register it)"
+        )
+    return messages
+
+
+def _call_count(double: Any) -> int:
+    """Total calls seen by ``double``, awaited or not.
+
+    Read defensively: a plain `Mock` auto-creates `await_count` as a child
+    mock rather than raising, so an unguarded `int()` on it explodes.
+    """
+    return _as_count(getattr(double, "call_count", 0)) or _as_count(
+        getattr(double, "await_count", 0)
+    )
+
+
+def _as_count(value: Any) -> int:
+    """Return ``value`` as a count, or 0 when it is not really one."""
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def is_exploding_double(value: Any) -> bool:
+    """True when ``value`` is a mock whose only behaviour is to raise."""
+    if not isinstance(value, Mock):
+        return False
+    side_effect = getattr(value, "side_effect", None)
+    if isinstance(side_effect, BaseException):
+        return True
+    return isinstance(side_effect, type) and issubclass(side_effect, BaseException)
+
+
+def install_uncalled_double_audit() -> bool:
+    """Record every exploding double installed through ``monkeypatch.setattr``.
+
+    Off unless `AUDIT_ENV_VAR` names a report file. Wraps the `MonkeyPatch`
+    class once per session; the per-test bookkeeping is drained by
+    `audited_uncalled_doubles`.
+
+    Returns:
+        True when the audit was installed.
+    """
+    if not os.environ.get(AUDIT_ENV_VAR):
+        return False
+    from _pytest.monkeypatch import MonkeyPatch
+
+    if getattr(MonkeyPatch.setattr, "_tldw_audit_wrapped", False):
+        return True
+    original = MonkeyPatch.setattr
+
+    def audited_setattr(self, target, name=..., value=..., raising=True):
+        candidate = name if value is ... else value
+        if is_exploding_double(candidate):
+            label = getattr(target, "__name__", str(target))
+            _AUDITED.append((f"{label}.{name}" if value is not ... else label, candidate))
+        if value is ...:
+            return original(self, target, name, raising=raising)
+        return original(self, target, name, value, raising=raising)
+
+    audited_setattr._tldw_audit_wrapped = True
+    MonkeyPatch.setattr = audited_setattr
+    return True
+
+
+def audited_uncalled_doubles() -> list[str]:
+    """Return the audit's uncalled installs (targets), for reporting only."""
+    return [target for target, double in _AUDITED if not _call_count(double)]
+
+
+def write_audit_report(nodeid: str, targets: Iterable[str]) -> None:
+    """Append one ``<nodeid>\\t<target>`` line per uncalled audited double."""
+    path = os.environ.get(AUDIT_ENV_VAR)
+    if not path:
+        return
+    lines = "".join(f"{nodeid}\t{target}\n" for target in targets)
+    if not lines:
+        return
+    with Path(path).open("a", encoding="utf-8") as handle:
+        handle.write(lines)

--- a/Tests/test_required_doubles_guard.py
+++ b/Tests/test_required_doubles_guard.py
@@ -1,0 +1,120 @@
+"""The guard that makes a never-called failure double a test failure.
+
+task-15270 AC#3. `test_send_proceeds_when_auto_retrieve_fails` passed for two
+months while its exploding backend was never called (task-15210); the shape
+"X still works when Y fails" is only meaningful if Y was attempted. These
+tests pin the guard itself -- including that the root conftest's autouse
+fixture really does fail the test, not merely warn.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from _pytest.outcomes import Failed
+
+import Tests.conftest as root_conftest
+from Tests.fixtures.required_doubles import (
+    exploding_double,
+    is_exploding_double,
+    must_be_called,
+    reset_required_doubles,
+    uncalled_required_doubles,
+)
+
+
+def _fixture_body(fixture):
+    """The undecorated generator behind a `@pytest.fixture`.
+
+    pytest 9 wraps it in a `FixtureFunctionDefinition` (and pytest 8 in a
+    `__pytest_wrapped__` holder); `functools.update_wrapper` leaves
+    ``__wrapped__`` pointing at the real function in both.
+    """
+    body = getattr(fixture, "__wrapped__", None)
+    if body is None:
+        body = getattr(fixture, "_fixture_function", fixture)
+    return body
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """Keep these tests' own registrations out of the suite-wide guard."""
+    reset_required_doubles()
+    yield
+    reset_required_doubles()
+
+
+def test_registered_double_that_was_called_reports_nothing():
+    double = must_be_called(Mock(), "the retry path must run")
+
+    double()
+
+    assert uncalled_required_doubles() == []
+
+
+def test_registered_double_that_was_never_called_is_reported():
+    must_be_called(Mock(), "the retry path must run")
+
+    reported = uncalled_required_doubles()
+
+    assert len(reported) == 1
+    assert "the retry path must run" in reported[0]
+
+
+@pytest.mark.asyncio
+async def test_awaited_double_counts_as_called():
+    """An `AsyncMock` records `await_count`, not always `call_count`."""
+    double = exploding_double(RuntimeError("backend exploded"), reason="failure path")
+
+    with pytest.raises(RuntimeError):
+        await double()
+
+    assert uncalled_required_doubles() == []
+
+
+def test_exploding_double_registers_itself():
+    """The "Y fails" double is guarded by construction, not by remembering."""
+    exploding_double(RuntimeError("backend exploded"), reason="failure path")
+
+    assert len(uncalled_required_doubles()) == 1
+
+
+def test_only_raising_mocks_are_audit_candidates():
+    """The audit's classifier: a raising mock, instance or class."""
+    assert is_exploding_double(Mock(side_effect=RuntimeError("boom"))) is True
+    assert is_exploding_double(AsyncMock(side_effect=RuntimeError)) is True
+    assert is_exploding_double(Mock(return_value=3)) is False
+    assert is_exploding_double(Mock(side_effect=[1, 2])) is False
+    assert is_exploding_double(lambda: None) is False
+
+
+def test_the_autouse_fixture_fails_the_test_not_just_warns(request):
+    """Drive the real conftest fixture body: unmet registration -> Failed.
+
+    Calling the fixture's own function is deliberate -- a guard pinned only
+    through its helpers would itself be the vacuous shape this task exists to
+    remove.
+    """
+    fixture_body = _fixture_body(root_conftest.required_doubles_are_called)
+
+    generator = fixture_body(request)
+    next(generator)
+    must_be_called(Mock(), "the failure path must be attempted")
+
+    with pytest.raises(Failed) as failure:
+        next(generator)
+
+    assert "the failure path must be attempted" in str(failure.value)
+
+
+def test_the_autouse_fixture_passes_when_the_double_was_called(request):
+    fixture_body = _fixture_body(root_conftest.required_doubles_are_called)
+
+    generator = fixture_body(request)
+    next(generator)
+    double = must_be_called(Mock(), "the failure path must be attempted")
+    double()
+
+    with pytest.raises(StopIteration):
+        next(generator)

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -2957,3 +2957,44 @@ Two things follow, and the second matters more than the first:
 **What to do.** Treat every "deliberately reverted / do not reintroduce" comment as an
 experiment with a date on it. Re-run its named witnesses first; record the result in
 the task either way. Then keep the diagnosis even when the symptom is gone.
+## A synthetic test config lets tests pin states no user can reach (TASK-15270, 2026-08-11)
+
+**The trap.** A test-app factory that hands the app a small hand-written config is not a
+neutral simplification. Every default the real config file carries is *absent*, so the
+code under test takes fallback branches, and assertions written against those branches
+look like product contracts while pinning states the shipped template never produces.
+
+**What happened.** `Tests/UI/app_factory._build_test_app` patched `load_settings` to a
+three-key dict. `ChatScreen._provider_readiness_app_config` re-sources from
+`load_settings()` only when the snapshot it was handed carries the sections a real load
+always emits (`_CONSOLE_LIVE_CONFIG_MARKER_SECTIONS`: `general`, `logging`) — a
+deliberate guard so an injected test config is never overwritten by the developer's real
+one. The synthetic dict carried neither marker and no `[chat_defaults]`/`[console]`
+section, so every mounted Console test read a `ConsoleTurnExecutionContext` frozen at
+defaults. `test_send_proceeds_when_auto_retrieve_fails` was green for two months without
+once calling the exploding backend it existed to exercise (task-15210).
+
+Sourcing the factory's config from the real (per-test sandboxed) `load_settings()` turned
+**31 green tests red across 6,016**, and the interesting part is *why* — almost none were
+product regressions:
+
+- **Arranged through a seam production does not read.** `console_image_view.
+  _chat_images_config` prefers the raw TOML nested under `COMPREHENSIVE_CONFIG_RAW`
+  whenever the snapshot has it. Four avatar tests set `app_config["chat"]` instead, which
+  the shipping app would have ignored — they were pinning the fallback shape.
+- **Passing on a fallback the template removes.** Three llama.cpp URL tests reached that
+  branch only via `provider_config_key(...) or "llama_cpp"`; the template ships
+  `[chat_defaults] provider = "OpenAI"`, so the fallback never fires for a real user.
+- **Absence as arrangement.** Two "cli config fallback" tests asserted `"library" not in
+  app_config` rather than arranging the absence they needed.
+- **Copy for an unreachable state.** Several first-run/UAT replays assert "Choose
+  provider" — the branch for *no provider selected*. A genuinely fresh install has
+  `provider = "OpenAI"` and no key, so the product says "Set up provider". The tests
+  described a clean run no user has.
+
+**What to do.** Give the test app the same config source the app uses, sandboxed per
+test (the root conftest already re-points `TLDW_CONFIG_PATH`/`HOME`/`XDG_*`), so what a
+test persists is what the app reads. And when a test needs a state — no provider, no
+`[library]` section, a feature off — **arrange it explicitly**; a state you inherited
+from an empty fixture is a state you never chose, and the day the fixture gets honest you
+cannot tell which of your assertions were ever real.

--- a/backlog/tasks/task-15270 - Console-test-apps-mount-with-a-config-that-silently-defaults-every-turn-context-setting.md
+++ b/backlog/tasks/task-15270 - Console-test-apps-mount-with-a-config-that-silently-defaults-every-turn-context-setting.md
@@ -74,10 +74,37 @@ no longer disagree.
 **Blast radius, measured.** All 241 modules that use the factory (6,016 tests)
 were run with the fix, then the 51 modules containing failures were re-run with
 the legacy config behind a temporary env switch. 31 tests were genuinely
-newly-red; 14 are closed here and 17 handed off with a per-test diagnosis (see
-the task report). Two tests went from red to green: `test_happy_path_stages_then_
-send_consumes` and `test_send_proceeds_when_auto_retrieve_fails` -- the vacuous
-pair from task-15210, which now actually fire retrieval.
+newly-red across that whole sweep. Two tests went from red to green:
+`test_happy_path_stages_then_send_consumes` and
+`test_send_proceeds_when_auto_retrieve_fails` -- the vacuous pair from
+task-15210, which now actually fire retrieval.
+
+**Per-test outcome, re-measured at the rebase.** The 10 modules this branch
+touches were run whole against the branch and again against `origin/dev`, so
+"newly-red" here means red on the branch AND green on dev -- 9 tests (the wider
+sweep's 31 covers 241 modules, most of them outside this branch). Five are fixed
+outright: the two Ollama ones were opening a real socket to 127.0.0.1:11434
+because a URL-based provider now has an endpoint and readiness takes the
+task-191 live-probe branch (stubbed at the seam the sibling probe tests already
+stub, rather than marked `allow_network`); the two privacy ones asserted
+absolute sensitive-field counts over the WHOLE config, so they now scrub the
+config first and count only what they arranged; and
+`..._tolerates_missing_provider_values` was patching `_provider_setting_values`,
+a seam this path does not read -- it calls `_provider_setting_values_mapping()`
+-- so the stub was dead and the "missing values" premise had been supplied for
+free by the empty config.
+
+The remaining four are xfail(strict=True) against two filed product bugs, not
+silenced: **task-15510** (navigation preselect applies the provider, which is
+itself what marks the category dirty, so the deferred apply hits its
+unsaved-changes guard and drops the model -- measured: dirty=False before,
+dirty=True and model unchanged after) and **task-15511** (a completed
+non-streaming send leaves `run_state` at IDLE, stable across ~0.8s so not a
+race; and an inline image row vanishes on the pixels -> graphics toggle).
+
+Note for anyone re-running this: five further failures in
+`test_settings_configuration_hub.py` and `test_console_workbench_contract.py`
+reproduce on `origin/dev` untouched and are NOT from this change.
 
 Recurring cause among the newly-red: a test arranged state through a seam the
 shipping app does not read, and only the empty config let it look effective.

--- a/backlog/tasks/task-15270 - Console-test-apps-mount-with-a-config-that-silently-defaults-every-turn-context-setting.md
+++ b/backlog/tasks/task-15270 - Console-test-apps-mount-with-a-config-that-silently-defaults-every-turn-context-setting.md
@@ -1,16 +1,19 @@
 ---
 id: TASK-15270
 title: >-
-  Console test apps mount with a config that silently defaults every turn-context setting
-status: To Do
-assignee: []
+  Console test apps mount with a config that silently defaults every
+  turn-context setting
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 09:00'
+updated_date: '2026-08-11 18:55'
 labels:
   - tests
   - console
   - test-infrastructure
-priority: high
 dependencies: []
+priority: high
 ---
 
 ## Description
@@ -28,9 +31,80 @@ The fix is presumably to make `_build_test_app` produce a config the snapshot wi
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 A Console test that configures a `[chat_defaults]`/`[console]` setting sees that value through the turn-context snapshot, instead of a silent default
-- [ ] #2 Tests that turn red once the config is honoured are triaged individually (real regression vs assertion that was never exercised), not reverted wholesale
-- [ ] #3 A guard makes the vacuous-pass shape detectable: a test whose subject is "X still works when Y fails" asserts that Y was actually attempted
+- [x] #1 A Console test that configures a `[chat_defaults]`/`[console]` setting sees that value through the turn-context snapshot, instead of a silent default
+- [x] #2 Tests that turn red once the config is honoured are triaged individually (real regression vs assertion that was never exercised), not reverted wholesale
+- [x] #3 A guard makes the vacuous-pass shape detectable: a test whose subject is "X still works when Y fails" asserts that Y was actually attempted
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Locate the mechanism: which marker sections production requires (ChatScreen._CONSOLE_LIVE_CONFIG_MARKER_SECTIONS), where the turn-context snapshot is built (ConsoleSessionController._build_console_turn_execution_context, off _provider_readiness_app_config), and what _build_test_app patches.
+2. TDD: add Tests/UI/test_console_harness_config_honesty.py pinning (a) markers present, (b) a persisted [chat_defaults] value in app_config, (c) that value reaching the mounted turn context. Confirm all three RED first.
+3. Fix at the seam: source the factory's app_config from the real load_settings() -- hermetic because the root conftest sandboxes TLDW_CONFIG_PATH/HOME per test -- keeping only the deliberate synthetic overrides (tldw_api.base_url, first_run.setup_completed). One config file, one truth, for the snapshot and every later refresh.
+4. Measure the blast radius: run all 241 modules that use _build_test_app, diff against a pre-fix baseline, and triage every newly-red test individually (real product bug vs test that never ran its own scenario).
+5. AC#3: make the vacuous-pass shape checkable -- a registry-backed helper that fails a test whose 'Y fails' double was never called -- and apply it to the high-value cases.
+6. Mutation-check the harness fix; run the keep-green set with READ counts.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`_build_test_app` now boots the app on the **real sandbox config** instead of a
+three-key synthetic dict: `build_test_app_config()` calls `load_settings()` (the
+same call `app.py` makes) and merges only the two deliberate test overrides
+(`tldw_api.base_url`, `first_run.setup_completed`). That is hermetic because the
+root conftest re-points `TLDW_CONFIG_PATH`/`HOME`/`XDG_*` at a per-test sandbox
+before anything imports the app, so `load_settings()` reads the *test's* config
+file -- the same file `save_setting_to_cli_config` writes and `get_cli_setting`
+reads.
+
+**Mechanism.** `ChatScreen._provider_readiness_app_config` re-sources from
+`load_settings()` only when the snapshot it was handed looks disk-loaded --
+`_CONSOLE_LIVE_CONFIG_MARKER_SECTIONS = ("general", "logging")` -- and otherwise
+honours it verbatim, deliberately, so an injected test config is never
+overwritten by the developer's real one. The synthetic dict carried neither
+marker and no `[chat_defaults]`/`[console]` section, so
+`ConsoleSessionController._build_console_turn_execution_context` read defaults
+forever. Sourcing the snapshot from `load_settings()` satisfies the markers AND
+makes the refresh return the very same dict object, so snapshot and refresh can
+no longer disagree.
+
+**Blast radius, measured.** All 241 modules that use the factory (6,016 tests)
+were run with the fix, then the 51 modules containing failures were re-run with
+the legacy config behind a temporary env switch. 31 tests were genuinely
+newly-red; 14 are closed here and 17 handed off with a per-test diagnosis (see
+the task report). Two tests went from red to green: `test_happy_path_stages_then_
+send_consumes` and `test_send_proceeds_when_auto_retrieve_fails` -- the vacuous
+pair from task-15210, which now actually fire retrieval.
+
+Recurring cause among the newly-red: a test arranged state through a seam the
+shipping app does not read, and only the empty config let it look effective.
+`_chat_images_config` prefers `COMPREHENSIVE_CONFIG_RAW`, so
+`app_config["chat"] = {...}` never reached production; the llama.cpp URL tests
+relied on `provider_config_key(...) or "llama_cpp"`, a fallback the template's
+`provider = "OpenAI"` removes; two "cli config fallback" tests asserted the
+absence of a `[library]` section rather than arranging it.
+
+**AC#3.** `Tests/fixtures/required_doubles.py` + an autouse root-conftest fixture:
+a double built through `exploding_double(...)` is registered, and a test that
+never calls it FAILS. A fully automatic guard is impractical and the module says
+why -- `Mock(side_effect=SomeError)` carries two opposite intents in this suite
+(the failure a test claims to survive vs a tripwire that must never fire, e.g.
+`test_console_native_chat_flow.py`'s "server identity must not use local cards"),
+and nothing on the object distinguishes them. Detection of unregistered ones is
+therefore a separate, reporting-only audit (`TLDW_AUDIT_UNCALLED_DOUBLES`).
+
+Modified: `Tests/UI/app_factory.py`, `Tests/conftest.py`,
+`Tests/UI/test_console_auto_rag_on_send.py`,
+`Tests/UI/test_console_native_chat_flow.py`,
+`Tests/UI/test_console_character_avatar.py`, `Tests/UI/test_library_shell.py`,
+`Tests/UI/test_settings_configuration_hub.py`,
+`Tests/UI/test_settings_footer_hints.py`,
+`Tests/UI/test_console_workbench_contract.py`,
+`Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py`.
+Added: `Tests/fixtures/required_doubles.py`,
+`Tests/test_required_doubles_guard.py`,
+`Tests/UI/test_console_harness_config_honesty.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15510 - Settings-navigation-preselect-applies-the-provider-then-silently-drops-the-model.md
+++ b/backlog/tasks/task-15510 - Settings-navigation-preselect-applies-the-provider-then-silently-drops-the-model.md
@@ -1,0 +1,51 @@
+---
+id: task-15510
+title: Settings navigation preselect applies the provider then silently drops the model
+status: To Do
+assignee: []
+labels:
+  - bug
+  - settings
+  - navigation
+priority: high
+---
+
+## Description
+
+Navigating to Settings ▸ Providers & Models with an explicit provider AND model
+in the navigation context lands on the right provider but leaves the model field
+showing the *previous* provider's model. The model in the context is staged and
+then never applied, with no message to the user.
+
+The cause is a self-inflicted race rather than a missing feature.
+`apply_navigation_context` stages the provider and model and defers the write via
+`call_after_refresh(self._apply_navigation_provider_context, ...)`. Applying the
+provider is itself what marks the Providers & Models category dirty, and
+`_apply_navigation_provider_context` opens with an unsaved-changes guard
+(`settings_screen.py:14161`) whose purpose is to protect a user's real unsaved
+draft. By the time the deferred call runs, the guard sees the dirtiness the
+navigation just created and returns without writing the model.
+
+This was invisible while the Console test harness booted with a near-empty config
+(task-15270): with no saved provider values to differ from, the provider switch
+did not register as dirty, so the deferred apply proceeded and the tests passed.
+Fixing the harness exposed it.
+
+Measured on `fix/console-test-config-honesty` in
+`test_settings_navigation_context_can_preselect_provider_category_target`:
+`dirty=False` before the call, context staged correctly
+(`_navigation_model='meta-llama/test-model'`), then once the provider Select
+reaches `huggingface`, `dirty=True` and the model field still reads `qwen`.
+
+The fix must keep the guard's original purpose intact -- a user's genuinely
+unsaved edits must still survive a navigation -- so it needs to distinguish
+dirtiness the navigation itself just caused from dirtiness the user typed.
+Suppressing the guard outright would reintroduce the draft-clobbering it exists
+to prevent.
+
+## Acceptance Criteria
+
+- [ ] Navigating to Providers & Models with both a provider and a model applies both, with the model field showing the requested model
+- [ ] A genuinely unsaved user draft in Providers & Models is still preserved when a navigation context arrives, and the model is not force-applied over it
+- [ ] The two tests marked xfail(strict=True) for this defect in `Tests/UI/test_settings_configuration_hub.py` pass with the marker removed
+- [ ] A test distinguishes the two dirtiness sources directly, so a future change that re-suppresses the model fails loudly rather than silently

--- a/backlog/tasks/task-15511 - Console-run-state-and-image-toggle-diverge-under-a-realistic-config.md
+++ b/backlog/tasks/task-15511 - Console-run-state-and-image-toggle-diverge-under-a-realistic-config.md
@@ -1,0 +1,48 @@
+---
+id: task-15511
+title: Console run state and image toggle diverge under a realistic config
+status: To Do
+assignee: []
+labels:
+  - bug
+  - console
+  - test-health
+priority: medium
+---
+
+## Description
+
+task-15270 made the Console test harness boot with the real (sandboxed) config
+instead of a near-empty synthetic dict. Two `Tests/UI/test_console_native_chat_flow.py`
+tests went red as a result. Both had only ever exercised their subject under a
+config that supplied none of the relevant settings, so neither red is a
+harness artifact -- each is a behaviour that had never been observed.
+
+**1. `test_console_native_generic_provider_send_renders_completed_message`.**
+A non-streaming send renders its response ("generic provider response" appears,
+and `chat_api_call` is reached with the right endpoint and key), but
+`console._ensure_console_chat_controller().run_state.status` is
+`ConsoleRunStatus.IDLE` where the test expects `COMPLETED`. Measured: this is
+NOT a race -- the status is IDLE immediately after the response renders and
+stays IDLE across 40 further pumps (~0.8s). `chat_defaults.streaming` is None in
+this test, so the streaming toggle is not the trigger.
+
+Two candidate causes, neither confirmed: the completed run never transitions the
+controller's state under this path, or the send is served by a different
+controller instance than `_ensure_console_chat_controller()` returns, in which
+case the assertion is reading the wrong object. Worth distinguishing before
+fixing, because run state drives user-visible affordances (stop control,
+spinner, cost ticker) and only the first cause is user-visible.
+
+**2. `test_image_message_gets_inline_row_after_prep_and_toggle_cycles`.**
+The inline image row appears after prep, then disappears after the first
+pixels -> graphics toggle, where the test asserts it is still present. Likely a
+config-selected image rendering mode that renders nothing rather than falling
+back -- if so the user-visible symptom is an image vanishing on toggle.
+
+## Acceptance Criteria
+
+- [ ] The cause of the IDLE run state is identified as either a missing transition or a controller-identity mismatch, and stated with evidence
+- [ ] If the run state is genuinely not settling to COMPLETED after a successful send, it is fixed and the user-visible affordances driven by it are checked
+- [ ] The image row survives the pixels -> graphics toggle, or the toggle falls back to a mode that renders something and the test asserts that instead
+- [ ] Both tests pass with their xfail(strict=True) markers removed

--- a/backlog/tasks/task-15512 - Five-Settings-and-Console-contract-tests-are-red-on-dev.md
+++ b/backlog/tasks/task-15512 - Five-Settings-and-Console-contract-tests-are-red-on-dev.md
@@ -1,0 +1,51 @@
+---
+id: task-15512
+title: Five Settings and Console contract tests are red on dev
+status: To Do
+assignee: []
+labels:
+  - test-health
+  - settings
+priority: medium
+---
+
+## Description
+
+Five tests fail on `origin/dev` with no local changes. They were found while
+baselining task-15270 (running the same modules against the branch and against
+dev to tell genuinely-new failures from inherited ones), and they are not caused
+by that branch. Filed so they are not silently re-attributed to whatever change
+happens to run next to them.
+
+Measured on `origin/dev` at `d85e6cff1`:
+
+- `test_console_workbench_contract.py::test_console_registers_footer_workbench_shortcuts`
+  -- footer hint text drift: expected `... nter send | Ctrl+K ...`, actual
+  `... nter send / queue | Ctrl+K ...`. A `/ queue` affordance was added to the
+  composer hint without updating the contract test.
+- `test_settings_configuration_hub.py::test_settings_ownership_records_cover_categories_and_runtime_boundaries`
+  -- ownership records differ by one entry:
+  `model_capabilities.models.<model>.context_window` is present where the
+  expected tuple does not carry it.
+- `test_settings_configuration_hub.py::test_settings_console_behavior_saves_display_name_exactly`
+  -- times out waiting for the toast `Console behavior settings saved.`
+- `test_settings_configuration_hub.py::test_settings_provider_category_saves_provider_defaults_without_sampling`
+  -- saved-settings list comes back empty where
+  `('chat_defaults', 'provider', 'llama_cpp')` and `('chat_defaults', 'model', 'qwen')`
+  were expected.
+- `test_settings_configuration_hub.py::test_settings_provider_switch_does_not_save_stale_endpoint`
+  -- same shape: empty saved list where a `chat_defaults` provider entry was expected.
+
+The last three are the interesting cluster: two independent tests observe that a
+Settings save produced no persisted rows, and a third observes that a save toast
+never arrives. That is consistent with the Settings save path not completing,
+which would be user-visible, so triage should establish whether these are stale
+test contracts or a broken save before any of them is adjusted to match current
+behaviour.
+
+## Acceptance Criteria
+
+- [ ] Each of the five failures is attributed to its causing change, with the commit identified
+- [ ] It is established whether the three save-related failures are stale contracts or a genuine break in the Settings save path, with evidence either way
+- [ ] Any genuine product break found is fixed rather than absorbed into the tests' expectations
+- [ ] All five pass on dev

--- a/backlog/tasks/task-15512 - Five-Settings-and-Console-contract-tests-are-red-on-dev.md
+++ b/backlog/tasks/task-15512 - Five-Settings-and-Console-contract-tests-are-red-on-dev.md
@@ -1,6 +1,6 @@
 ---
 id: task-15512
-title: Five Settings and Console contract tests are red on dev
+title: Six Settings, Console and Library tests are red on dev
 status: To Do
 assignee: []
 labels:
@@ -11,7 +11,7 @@ priority: medium
 
 ## Description
 
-Five tests fail on `origin/dev` with no local changes. They were found while
+Six tests fail on `origin/dev` with no local changes. They were found while
 baselining task-15270 (running the same modules against the branch and against
 dev to tell genuinely-new failures from inherited ones), and they are not caused
 by that branch. Filed so they are not silently re-attributed to whatever change
@@ -36,7 +36,15 @@ Measured on `origin/dev` at `d85e6cff1`:
 - `test_settings_configuration_hub.py::test_settings_provider_switch_does_not_save_stale_endpoint`
   -- same shape: empty saved list where a `chat_defaults` provider entry was expected.
 
-The last three are the interesting cluster: two independent tests observe that a
+- `test_library_shell.py::test_library_shell_rail_search_submit_runs_search_canvas_query`
+  -- the rail search runs with a different scope than the test expects: got
+  `('notes', 'media', 'conversations')` where the expected call carried a
+  narrower scope. This one is NEWER than the other five: it passes at dev
+  `5bf47b2fe` and fails at dev `fe5019489`, so it was introduced by a merge in
+  between. Worth bisecting that range first -- a search silently widening its
+  scope is user-visible.
+
+The three save-related failures are the interesting cluster: two independent tests observe that a
 Settings save produced no persisted rows, and a third observes that a save toast
 never arrives. That is consistent with the Settings save path not completing,
 which would be user-visible, so triage should establish whether these are stale
@@ -45,7 +53,7 @@ behaviour.
 
 ## Acceptance Criteria
 
-- [ ] Each of the five failures is attributed to its causing change, with the commit identified
+- [ ] Each of the six failures is attributed to its causing change, with the commit identified
 - [ ] It is established whether the three save-related failures are stale contracts or a genuine break in the Settings save path, with evidence either way
 - [ ] Any genuine product break found is fixed rather than absorbed into the tests' expectations
-- [ ] All five pass on dev
+- [ ] All six pass on dev


### PR DESCRIPTION
## What

Console test apps mounted with a three-key synthetic config, so every mounted
Console test read default turn-context settings no matter what it configured.
This makes the harness boot the way the app does, then triages the fallout.

## The mechanism, measured

`ChatScreen` re-sources from `load_settings()` only when the snapshot it was
handed carries the sections a real load emits
(`_CONSOLE_LIVE_CONFIG_MARKER_SECTIONS = ("general", "logging")`) — deliberately,
so an injected test config is never overwritten by the developer's real one. The
factory's `fake_app_config` carried neither marker **and** no `[chat_defaults]` /
`[console]`, so the refresh never happened and those sections were simply absent.
`_provider_readiness_app_config()` (`chat_screen.py:3468`) fed that to
`_build_console_turn_execution_context` (`session.py:1111`), which read defaults
every time.

`build_test_app_config()` now sources from the real `load_settings()` — the same
call `app.py` makes. That is hermetic: the root conftest redirects
`TLDW_CONFIG_PATH`/`HOME`/`XDG_*` at import time (`Tests/conftest.py:61`) and
again per test (`:869`), so it reads the *test's* config file, the same one
`save_setting_to_cli_config` writes.

## Why tests going red is the point

Blast radius measured across all 241 modules using the factory (6,016 tests):
31 genuinely newly-red and **2 newly-green** — `test_happy_path_stages_then_send_consumes`
and `test_send_proceeds_when_auto_retrieve_fails`, the vacuous pair from
task-15210 that had never once fired retrieval.

The recurring cause among the reds is a test arranging state through a seam
production does not read, which only the empty config made look effective.

## Triage of this branch's 9

Measured by running the 10 touched modules whole against the branch **and**
against `origin/dev`, so "newly-red" means red here and green there.

**Fixed (5)**
- Two Ollama tests were opening a **real socket to 127.0.0.1:11434**. A URL-based
  provider now has an endpoint, so passing readiness takes the task-191 live-probe
  branch — which returns before notifying (hence "produced no toast") and probes
  for real. Stubbed at the seam the sibling probe tests already stub, *not* marked
  `allow_network`. One is retargeted to a key-based provider since the no-probe
  branch is what it uniquely covers, with an assertion that the probe URL is empty
  so it cannot drift into retesting its sibling.
- Two privacy tests asserted absolute sensitive-field counts, but the posture
  counts sensitive leaves across the **whole** config; layering two sections over
  the real config inherited its other secrets. They now scrub first.
- `..._tolerates_missing_provider_values` patched `_provider_setting_values`, which
  this path does not read — it calls `_provider_setting_values_mapping()`. Dead stub;
  the premise had been supplied for free by the empty config.

**Handed off, loudly — xfail(strict=True) + filed (4)**
- **task-15510**: navigation preselect applies the provider, and applying it is
  itself what marks Providers & Models dirty, so the deferred
  `_apply_navigation_provider_context` hits its unsaved-changes guard and drops the
  model. Measured: `dirty=False` before, context staged correctly, then `dirty=True`
  with the field still on the previous provider's model. The guard protects real
  unsaved drafts, so the fix must tell the two dirtiness sources apart.
- **task-15511**: a completed non-streaming send leaves `run_state` at IDLE (stable
  across ~0.8s of pumping, so not a race); an inline image row vanishes on the
  pixels → graphics toggle.

## Not from this change

Five failures in `test_settings_configuration_hub.py` and
`test_console_workbench_contract.py` reproduce on `origin/dev` untouched.

## AC#3 — making the vacuous shape detectable

`Tests/fixtures/required_doubles.py` + an autouse fixture: a double built via
`exploding_double(...)` is registered, and a test that never calls it fails. A
fully automatic guard is impractical and the module records why —
`Mock(side_effect=...)` carries two opposite intents in this suite (a failure the
test claims to survive vs a tripwire that must never fire) and nothing on the
object distinguishes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification

Two full runs of the 10 touched modules plus the keep-green guards
(`test_console_moved_seam_guard`, `test_background_signal_bounds`,
`test_network_guard`):

- run 1: `1332 passed, 6 failed, 5 xfailed`
- run 2: `1333 passed, 5 failed, 5 xfailed`
- run 3 (rebased onto newer dev): `1332 passed, 6 failed, 5 xfailed`

**Every remaining failure reproduces on `origin/dev` untouched** and is filed as
task-15512 -- this branch introduces no net failures. Run 3's sixth failure,
`test_library_shell_rail_search_submit_runs_search_canvas_query`, is a *new*
dev-side regression: it passes at dev `5bf47b2fe` and fails at dev `fe5019489`
with no local changes. It was checked against a dev worktree at the same commit
this branch is rebased onto -- comparing against an older dev would have
misattributed it to this PR. The five xfails are the four
filed above plus task-15120's existing one.

The extra failure in run 1
(`test_library_shell_scope_toggle_deselect_sends_only_selected_types`) is
non-deterministic, not an order dependency. It did not reproduce in run 2 of the
identical command, and passes in every sub-combination tried: in isolation, with
its module alone (553 passed), after a four-module prefix, after
`test_console_native_chat_flow.py` with just that test (307 passed), and after
`test_console_native_chat_flow.py` with the whole module (859 passed). Both full
runs were under CPU contention from a concurrent pytest, so a load-sensitive wait
is the most likely explanation.
