### PR TITLE
perf: equality-gate the Console draft-edit workbench sync (task-15452)

### DIFF
--- a/Tests/UI/test_console_draft_sync_equality_gate.py
+++ b/Tests/UI/test_console_draft_sync_equality_gate.py
@@ -1,0 +1,389 @@
+"""The Console draft-edit sync must not repaint an unchanged Workbench.
+
+TASK-15452. `ConsoleComposerBar.DraftChanged` runs
+`_sync_console_workbench_actions_from_draft` on every printable keystroke.
+Before the equality gate that path rebuilt and re-pushed Workbench state
+unconditionally, bypassing the guard the coalesced control-bar sync has --
+measured on dev (c0c4753f8), per keystroke:
+
+    Workbench `Static.update` calls          12
+    `sort_children` calls                     2
+    screen `_nodes._updates` bumps            2   (evicts the query_one cache)
+    `_build_console_provider_selection`       7
+    `_provider_readiness_app_config`         63
+    handler wall cost                     6.405 ms
+
+`Static.update` has no equality check of its own and `NodeList._sort` bumps
+the update counter on every ancestor up to the screen -- and the screen's
+counter is part of the `query_one` LRU cache key, so two no-op sorts a
+keystroke evict every cached `#id` lookup on the largest tree in the app.
+
+These tests assert observable end state on the real mounted Console, and
+each "zero writes" claim is paired with a control that proves the counter
+can still see a write. The behavior these must NOT disturb (slash popup
+open/close, guidance dismissal, Workbench readiness across all six draft
+edit keys) is pinned separately and unchanged in
+`Tests/UI/test_console_composer_draft_changed.py`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from textual.widget import Widget
+from textual.widgets import Static
+
+from Tests.UI.test_console_dictation import _mounted_console, _ready_host
+from tldw_chatbook.UI.Workbench.workbench_widgets import CommandStrip
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+from tldw_chatbook.Widgets.Console.console_control_bar import ConsoleControlBar
+
+APP_SIZE = (140, 42)
+
+#: The four Console-mounted Workbench primitives the draft path pushes into.
+WORKBENCH_SELECTORS = (
+    "#console-workbench-header",
+    "#console-workbench-mode-strip",
+    "#console-workbench-command-strip",
+    "#workbench-recovery-callout",
+)
+
+
+async def _console(host, pilot):
+    """Mount the ready Console and focus its composer."""
+    console = await _mounted_console(host, pilot)
+    composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+    composer.focus()
+    await pilot.pause()
+    return console, composer
+
+
+def _within(widget, roots) -> bool:
+    """Return True when `widget` is one of `roots` or sits under one."""
+    node = widget
+    while node is not None:
+        if any(node is root for root in roots):
+            return True
+        node = node._parent
+    return False
+
+
+class _WorkbenchWriteCounter:
+    """Count real writes into the mounted Console Workbench primitives.
+
+    Covers all three write shapes the four sync methods use: `Static.update`
+    (header copy, mode chips, recovery copy -- Textual's `Static.update` has
+    no equality check of its own), `CommandStrip._sync_button` (the action
+    buttons, which are not Statics), and `Widget.sort_children` (which bumps
+    the DOM version up the ancestor chain). Restored on exit.
+    """
+
+    def __init__(self, console) -> None:
+        self._roots = [console.query_one(selector) for selector in WORKBENCH_SELECTORS]
+        self.static_updates = 0
+        self.button_syncs = 0
+        self.sorts = 0
+        self._original_update = Static.update
+        self._original_sort = Widget.sort_children
+        self._original_sync_button = CommandStrip._sync_button
+
+    def __enter__(self) -> "_WorkbenchWriteCounter":
+        counter = self
+        original_update = self._original_update
+        original_sort = self._original_sort
+        original_sync_button = self._original_sync_button
+
+        def counting_update(widget, *args, **kwargs):
+            if _within(widget, counter._roots):
+                counter.static_updates += 1
+            return original_update(widget, *args, **kwargs)
+
+        def counting_sort(widget, *args, **kwargs):
+            counter.sorts += 1
+            return original_sort(widget, *args, **kwargs)
+
+        def counting_sync_button(strip, *args, **kwargs):
+            if _within(strip, counter._roots):
+                counter.button_syncs += 1
+            return original_sync_button(strip, *args, **kwargs)
+
+        Static.update = counting_update
+        Widget.sort_children = counting_sort
+        CommandStrip._sync_button = counting_sync_button
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        Static.update = self._original_update
+        Widget.sort_children = self._original_sort
+        CommandStrip._sync_button = self._original_sync_button
+
+    @property
+    def writes(self) -> int:
+        return self.static_updates + self.button_syncs + self.sorts
+
+
+# ---------------------------------------------------------------------------
+# 1. An unchanged derived state writes nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_repeat_keystroke_writes_nothing_into_the_workbench():
+    """Typing the second letter of a word must not touch the Workbench.
+
+    The first character flips `can_send`, so it legitimately repaints. The
+    second changes no derived state at all -- and used to cost 12
+    `Static.update` calls plus two `sort_children` anyway.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot)
+
+        await pilot.press("a")
+        for _ in range(3):
+            await pilot.pause()
+
+        with _WorkbenchWriteCounter(console) as counter:
+            await pilot.press("b")
+            for _ in range(3):
+                await pilot.pause()
+
+        assert composer.draft_text() == "ab"
+        assert counter.static_updates == 0
+        assert counter.button_syncs == 0
+        assert counter.sorts == 0
+
+
+@pytest.mark.asyncio
+async def test_the_state_changing_keystroke_still_repaints_the_workbench():
+    """Control for the test above: the counter can still see a real write.
+
+    The first character flips the Workbench Send action from disabled to
+    primary, so the command strip must still be pushed -- and be observably
+    correct afterwards. Without this control, "zero writes" would also pass
+    against a counter that was simply never wired up, or against a gate that
+    had muted the Workbench entirely.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot)
+        send_action = console.query_one("#workbench-action-send")
+        assert send_action.disabled is True
+
+        with _WorkbenchWriteCounter(console) as counter:
+            await pilot.press("a")
+            for _ in range(3):
+                await pilot.pause()
+
+        assert composer.draft_text() == "a"
+        assert counter.writes > 0
+        assert send_action.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_a_genuinely_new_workbench_state_still_repaints_every_static():
+    """Mutation control for the widget early-outs: not a blanket mute.
+
+    Pushes a state whose header subtitle and every mode label differ, and
+    requires the Statics to be rewritten. A `sync_*` that returned early on
+    a state it had never seen would pass every "zero writes" assertion above
+    and fail here.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, _composer = await _console(host, pilot)
+
+        control_state = console._build_console_control_state(
+            console._pending_console_launch_context
+        )
+        state = console._build_console_workbench_state(control_state)
+        changed = replace(
+            state,
+            header=replace(state.header, subtitle="Changed subtitle"),
+            modes=tuple(replace(mode, label=f"{mode.label}!") for mode in state.modes),
+        )
+
+        with _WorkbenchWriteCounter(console) as counter:
+            console._sync_console_workbench_state(
+                control_state, workbench_state=changed
+            )
+
+        # Three header Statics plus one per mode chip.
+        assert counter.static_updates >= 3 + len(state.modes)
+
+
+@pytest.mark.asyncio
+async def test_a_repeat_keystroke_leaves_the_screen_query_cache_intact():
+    """An idle keystroke must not evict the screen-wide `query_one` cache.
+
+    `query_one` keys its LRU on `screen._nodes._updates`, and
+    `NodeList.updated` walks the ancestor chain -- so one no-op
+    `sort_children` on a Workbench strip invalidates every cached `#id`
+    lookup on the Console, turning the next keystroke's screen-rooted
+    queries into full DOM walks.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, _composer = await _console(host, pilot)
+
+        await pilot.press("a")
+        for _ in range(3):
+            await pilot.pause()
+
+        console.query_one("#console-native-composer")
+        version_before = console._nodes._updates
+        cache_key = (version_before, "#console-native-composer", None)
+        assert console._query_one_cache.get(cache_key) is not None
+
+        await pilot.press("b")
+        for _ in range(3):
+            await pilot.pause()
+
+        assert console._nodes._updates == version_before
+        assert console._query_one_cache.get(cache_key) is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. The popup stays outside the gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_gated_keystroke_still_refilters_the_command_popup():
+    """The slash popup filters on the draft, which moves every keystroke.
+
+    This is the test that fails if anyone folds
+    `_sync_console_command_popup` inside the equality gate: the Workbench
+    state is byte-identical between "/" and "/p" (a non-empty draft either
+    way), so a gate that swallowed the popup sync too would leave every
+    command listed after the user narrowed the search.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot)
+        popup = console.query_one("#console-command-popup")
+
+        await pilot.press("/")
+        for _ in range(3):
+            await pilot.pause()
+        assert popup.is_open is True
+        labels_before = [suggestion.label for suggestion in popup._suggestions]
+        assert len(labels_before) > 1
+        workbench_state_before = console._last_console_workbench_state
+
+        with _WorkbenchWriteCounter(console) as counter:
+            await pilot.press("p")
+            for _ in range(3):
+                await pilot.pause()
+
+        assert composer.draft_text() == "/p"
+        # The gate held: no derived Workbench state moved, nothing repainted.
+        assert console._last_console_workbench_state == workbench_state_before
+        assert counter.writes == 0
+        # ...and the popup still narrowed to the typed prefix.
+        assert popup.is_open is True
+        labels_after = [suggestion.label for suggestion in popup._suggestions]
+        assert labels_after != labels_before
+        assert len(labels_after) < len(labels_before)
+        assert all(label.startswith("/p") for label in labels_after)
+
+
+# ---------------------------------------------------------------------------
+# 3. The gate cannot desync the control bar from the recorded last state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_draft_edit_keeps_the_control_bar_in_step_with_last_state():
+    """Recording `_last_console_*` obliges the recorder to push everything.
+
+    `_last_console_workbench_state` is what makes the next
+    `_sync_console_control_bar` decide it owes no refresh. A draft path that
+    recorded it after pushing only the four Workbench widgets would strand
+    the control bar (which consumes `workbench_state.actions` too) on stale
+    actions until some unrelated state moved. Pin the invariant: after a
+    draft edit, the control bar's actions equal the recorded state's.
+    """
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, composer = await _console(host, pilot)
+        control_bar = console.query_one("#console-control-bar", ConsoleControlBar)
+
+        await pilot.press("a")
+        for _ in range(3):
+            await pilot.pause()
+
+        recorded = console._last_console_workbench_state
+        assert recorded is not None
+        assert composer.draft_text() == "a"
+        assert control_bar.actions == recorded.actions
+        assert control_bar.state == console._last_console_control_state
+
+
+# ---------------------------------------------------------------------------
+# 4. Provider state is derived once per pass, not once per leg
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_draft_sync_derives_the_provider_selection_once():
+    """One draft-edit sync used to build the provider selection 7 times."""
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, _composer = await _console(host, pilot)
+        screen_type = type(console)
+        original = screen_type._build_console_provider_selection_uncached
+        calls = []
+
+        def counting(self, *args, **kwargs):
+            calls.append(args)
+            return original(self, *args, **kwargs)
+
+        screen_type._build_console_provider_selection_uncached = counting
+        try:
+            console._sync_console_workbench_actions_from_draft()
+        finally:
+            screen_type._build_console_provider_selection_uncached = original
+
+        assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_derivation_memo_is_torn_down_even_when_a_leg_raises():
+    """A raising leg must not leave a stale selection cached for later."""
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, _composer = await _console(host, pilot)
+
+        with pytest.raises(RuntimeError):
+            with console._console_derivation_scope():
+                console._build_console_provider_selection()
+                assert console._console_derivation_memo
+                raise RuntimeError("leg blew up")
+
+        assert console._console_derivation_memo is None
+
+
+@pytest.mark.asyncio
+async def test_the_derivation_memo_is_off_outside_a_scope():
+    """Outside a scope every provider lookup is live, exactly as before."""
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, _composer = await _console(host, pilot)
+        screen_type = type(console)
+        original = screen_type._build_console_provider_selection_uncached
+        calls = []
+
+        def counting(self, *args, **kwargs):
+            calls.append(args)
+            return original(self, *args, **kwargs)
+
+        screen_type._build_console_provider_selection_uncached = counting
+        try:
+            console._build_console_provider_selection()
+            console._build_console_provider_selection()
+        finally:
+            screen_type._build_console_provider_selection_uncached = original
+
+        assert len(calls) == 2

--- a/Tests/UI/test_workbench_widgets.py
+++ b/Tests/UI/test_workbench_widgets.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+from textual.widgets import Button
 
 from tldw_chatbook.UI.Workbench.workbench_state import (
     RecoveryState,
@@ -12,9 +13,14 @@ from tldw_chatbook.UI.Workbench.workbench_state import (
 )
 from tldw_chatbook.UI.Workbench.workbench_widgets import (
     CommandStrip,
+    DestinationHeader,
+    ModeStrip,
+    RecoveryCallout,
     WorkbenchActionRequested,
     WorkbenchFrame,
+    _schedule_sort_state_children,
     _sort_state_children,
+    _UNSYNCED,
 )
 
 
@@ -142,6 +148,223 @@ def test_state_child_sorting_matches_latest_snapshot(
     assert [
         getattr(child, attribute_name) for child in widget.children
     ] == desired_ids
+
+
+# ---------------------------------------------------------------------------
+# task-15452: sorting and pushing are both skipped when nothing moved
+# ---------------------------------------------------------------------------
+
+
+def _ordered_children(attribute_name, ids):
+    return [SimpleNamespace(**{attribute_name: child_id}) for child_id in ids]
+
+
+def test_state_child_sorting_is_skipped_when_the_order_already_matches():
+    """`sort_children` is never free: it bumps the DOM version regardless.
+
+    `NodeList._sort` calls `NodeList.updated`, which increments the update
+    counter on this widget AND every ancestor up to the screen -- and that
+    counter is part of the `query_one` LRU cache key. A no-op sort therefore
+    evicts every cached `#id` lookup on the screen for nothing.
+    """
+    widget = SimpleNamespace(
+        children=_ordered_children("_workbench_action_id", ["send", "settings"]),
+        sort_children=Mock(),
+    )
+
+    _sort_state_children(
+        widget,
+        {"send": 0, "settings": 1},
+        "_workbench_action_id",
+    )
+
+    widget.sort_children.assert_not_called()
+
+
+def test_scheduling_a_state_child_sort_is_skipped_when_the_order_matches():
+    """Not even the `call_next` message is worth posting for a no-op sort."""
+    widget = SimpleNamespace(
+        children=_ordered_children("_workbench_mode_id", ["chat", "rag"]),
+        call_next=Mock(),
+    )
+
+    _schedule_sort_state_children(
+        widget,
+        {"chat": 0, "rag": 1},
+        "_workbench_mode_id",
+    )
+
+    widget.call_next.assert_not_called()
+
+
+def test_scheduling_a_state_child_sort_still_happens_when_the_order_differs():
+    widget = SimpleNamespace(
+        children=_ordered_children("_workbench_mode_id", ["rag", "chat"]),
+        call_next=Mock(),
+    )
+
+    _schedule_sort_state_children(
+        widget,
+        {"chat": 0, "rag": 1},
+        "_workbench_mode_id",
+    )
+
+    widget.call_next.assert_called_once()
+
+
+def test_a_child_queued_for_removal_never_hides_a_real_reorder():
+    """Children pending removal are still in `children` at schedule time.
+
+    They key to `len(desired_order)` -- so they can only ever ADD an
+    inversion, never mask one, and the conservative verdict is a schedule.
+    """
+    widget = SimpleNamespace(
+        children=_ordered_children(
+            "_workbench_action_id", ["stale", "settings", "send"]
+        ),
+        call_next=Mock(),
+    )
+
+    _schedule_sort_state_children(
+        widget,
+        {"send": 0, "settings": 1},
+        "_workbench_action_id",
+    )
+
+    widget.call_next.assert_called_once()
+
+
+def test_destination_header_skips_a_state_it_has_already_pushed():
+    state = WorkbenchHeaderState(title="Console", subtitle="Ready", status="ready")
+    header = SimpleNamespace(
+        state=None,
+        _synced_state=state,
+        query_one=Mock(),
+        set_class=Mock(),
+    )
+
+    DestinationHeader.sync_state(header, state)
+
+    header.query_one.assert_not_called()
+    header.set_class.assert_not_called()
+    # `self.state` is still adopted, so identity semantics are unchanged.
+    assert header.state is state
+
+
+def test_destination_header_first_sync_runs_even_for_the_constructor_state():
+    """The `on_mount` trap: `self.state` already equals the synced state.
+
+    Comparing against `self.state` instead of a dedicated sentinel would
+    turn every widget's mount-time self-sync into a no-op and leave the
+    status/density classes -- which `compose` never sets -- unapplied.
+    """
+    state = WorkbenchHeaderState(title="Console", subtitle="Ready", status="running")
+    header = SimpleNamespace(
+        state=state,
+        _synced_state=_UNSYNCED,
+        query_one=Mock(return_value=Mock()),
+        set_class=Mock(),
+    )
+
+    DestinationHeader.sync_state(header, state)
+
+    assert header.query_one.call_count == 3
+    assert header.set_class.call_count > 0
+    assert header._synced_state == state
+
+
+def test_mode_strip_skips_modes_it_has_already_pushed():
+    modes = (WorkbenchMode(id="chat", label="Chat", active=True),)
+    strip = SimpleNamespace(
+        modes=(),
+        _synced_modes=modes,
+        children=[],
+        mount=Mock(),
+        call_next=Mock(),
+    )
+
+    ModeStrip.sync_modes(strip, modes)
+
+    strip.mount.assert_not_called()
+    strip.call_next.assert_not_called()
+    assert strip.modes == modes
+
+
+def test_command_strip_skips_actions_it_has_already_pushed():
+    actions = (WorkbenchAction(id="send", label="Send", disabled=True),)
+    strip = SimpleNamespace(
+        actions=(),
+        _synced_actions=actions,
+        children=[],
+        mount=Mock(),
+        call_next=Mock(),
+        _button_ids_by_action_id={"send": "workbench-action-send"},
+    )
+
+    CommandStrip.sync_actions(strip, actions)
+
+    strip.mount.assert_not_called()
+    strip.call_next.assert_not_called()
+    assert strip.actions == actions
+    assert strip._button_ids_by_action_id == {"send": "workbench-action-send"}
+
+
+def test_command_strip_still_pushes_a_changed_action():
+    """A one-attribute change (Send flipping enabled) must still land."""
+    synced = (WorkbenchAction(id="send", label="Send", disabled=True),)
+    changed = (WorkbenchAction(id="send", label="Send", disabled=False, primary=True),)
+    button = Button("Send", id="workbench-action-send")
+    setattr(button, "_workbench_action_id", "send")
+    strip = SimpleNamespace(
+        actions=synced,
+        _synced_actions=synced,
+        children=[button],
+        mount=Mock(),
+        call_next=Mock(),
+        _button_ids_by_action_id={},
+        _button_id=CommandStrip._button_id,
+        _sync_button=Mock(),
+    )
+
+    CommandStrip.sync_actions(strip, changed)
+
+    strip._sync_button.assert_called_once_with(button, changed[0])
+    assert strip._synced_actions == changed
+
+
+def test_recovery_callout_skips_a_state_it_has_already_pushed():
+    state = RecoveryState(title="Provider required", body="Choose a provider.")
+    callout = SimpleNamespace(
+        state=None,
+        _synced_state=state,
+        query_one=Mock(),
+        set_class=Mock(),
+    )
+
+    RecoveryCallout.sync_state(callout, state)
+
+    callout.query_one.assert_not_called()
+    callout.set_class.assert_not_called()
+    assert callout.state is state
+
+
+def test_recovery_callout_first_sync_of_none_still_hides_the_callout():
+    """`None` is a real recovery state, hence the dedicated sentinel."""
+    callout = SimpleNamespace(
+        state=None,
+        _synced_state=_UNSYNCED,
+        _plain_text="stale",
+        display=True,
+        query_one=Mock(return_value=Mock()),
+        set_class=Mock(),
+    )
+
+    RecoveryCallout.sync_state(callout, None)
+
+    assert callout.display is False
+    assert callout._plain_text == ""
+    callout.set_class.assert_any_call(True, "is-hidden")
+    assert callout._synced_state is None
 
 
 def test_workbench_frame_direct_child_ids_are_stable_data_contract():

--- a/backlog/tasks/task-15452 - Equality-gate-the-Console-per-keystroke-DraftChanged-workbench-sync.md
+++ b/backlog/tasks/task-15452 - Equality-gate-the-Console-per-keystroke-DraftChanged-workbench-sync.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-15452
 title: Equality-gate the Console per-keystroke DraftChanged workbench sync
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
+updated_date: '2026-08-11 20:27'
 labels:
   - perf
   - console
@@ -20,8 +22,60 @@ Fix direction: route the draft path through the same state-equality guard as `:1
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 No Workbench widget writes occur when the derived state is unchanged (evidence)
-- [ ] #2 sort_children is not invoked when child order already matches (evidence), and the query_one cache survives idle keystrokes
-- [ ] #3 Slash popup open/close and guidance dismissal behavior unchanged (tests pinned before the gate)
-- [ ] #4 Per-keystroke handler cost measured before/after and recorded
+- [x] #1 No Workbench widget writes occur when the derived state is unchanged (evidence)
+- [x] #2 sort_children is not invoked when child order already matches (evidence), and the query_one cache survives idle keystrokes
+- [x] #3 Slash popup open/close and guidance dismissal behavior unchanged (tests pinned before the gate)
+- [x] #4 Per-keystroke handler cost measured before/after and recorded
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Pin current behavior first: run the existing slash-popup / guidance / Workbench-readiness suites (Tests/UI/test_console_composer_draft_changed.py, Tests/UI/test_console_command_popup.py) green as the pre-change baseline, and add a new instrumented characterisation module that counts Workbench widget writes, sort_children calls and screen DOM-version bumps per keystroke (red before the gate, green after).
+2. Extract the guarded push at chat_screen.py:18041-18060 into one _push_console_control_state_if_changed(control_state, workbench_state) helper and route BOTH _sync_console_control_bar and _sync_console_workbench_actions_from_draft through it, so the draft path can never leave _last_console_* ahead of the control bar / status chips. _sync_console_command_popup keeps running on every draft edit, outside the gate.
+3. Add sentinel-guarded 'state unchanged -> return' early-outs to DestinationHeader.sync_state, ModeStrip.sync_modes, CommandStrip.sync_actions and RecoveryCallout.sync_state (a dedicated last-synced-state slot, NOT self.state, so the on_mount self-sync still runs).
+4. Skip the scheduled sort_children when the children already sit in the desired order - checked both at schedule time and again inside the deferred callback.
+5. Memoize the provider selection / readiness app-config for one derivation pass so the draft path builds provider state once instead of per leg.
+6. Re-run the pinned suites plus the wider Console/Workbench suites; measure per-keystroke handler cost before/after in an isolated-HOME probe and record it in the task notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Routes the per-keystroke `ConsoleComposerBar.DraftChanged` sync through the same state-equality gate the coalesced control-bar sync already had, and makes the four Workbench widgets no-ops for a state they have already pushed.
+
+## Approach
+
+1. **One gate, one recorder.** Extracted the guarded push at `chat_screen.py:18039-18060` into `_push_console_control_state_if_changed(control_state, workbench_state) -> bool` -- now the only reader/writer of `_last_console_control_state` / `_last_console_workbench_state` -- and routed both `_sync_console_control_bar` and `_sync_console_workbench_actions_from_draft` through it. Deliberately the FULL push, not just the four Workbench widgets: the control bar consumes `workbench_state.actions` too, so a draft path that pushed only the Workbench and then recorded the new `_last_*` would make the next coalesced sync skip a control-bar refresh it still owed. That trap is pinned by `test_a_draft_edit_keeps_the_control_bar_in_step_with_last_state`.
+2. **`_sync_console_command_popup` stays outside the gate** -- it filters on the draft text, which moves on every keystroke while the derived Workbench state does not. Pinned by `test_a_gated_keystroke_still_refilters_the_command_popup` ("/" then "p": zero Workbench writes, popup still narrows).
+3. **Widget-level early-outs** in `DestinationHeader.sync_state`, `ModeStrip.sync_modes`, `CommandStrip.sync_actions`, `RecoveryCallout.sync_state`. Each compares against a dedicated `_UNSYNCED`-sentinel slot, NOT `self.state`: every one of these self-syncs its constructor state from `on_mount`, and comparing against `self.state` would turn that mount-time sync into a no-op and leave the status/density classes (which `compose` never sets) unapplied. `self.state` is still adopted before the early-out so identity semantics are unchanged.
+4. **`sort_children` skipped when the order already matches**, checked at schedule time and again in the deferred callback. Textual's `NodeList._sort` calls `NodeList.updated`, which bumps the update counter on every ancestor up to the screen -- and that counter is part of the `query_one` LRU cache key, so two no-op sorts a keystroke evicted every cached `#id` lookup on the largest tree in the app. Python's sort is stable, so it is a no-op exactly when the child key sequence is non-decreasing; children queued for removal are still present at schedule time but can only ADD an inversion, never mask one.
+5. **Per-pass derivation memo** (`_console_derivation_scope`) so the draft path derives provider selection / readiness config / provider-model display once instead of once per leg. Opt-in and scoped: outside the `with` block every lookup is live, and it is torn down in a `finally` so a raising leg cannot cache a stale selection.
+
+## Measured (isolated-HOME pytest harness, ready native Console, 40 invocations)
+
+| per keystroke | before | after |
+|---|---|---|
+| Workbench `Static.update` | 12 | 0 |
+| `sort_children` | 2 | 0 |
+| screen `_nodes._updates` bumps | 2 | 0 |
+| `_build_console_provider_selection` | 7 | 1 |
+| `_provider_readiness_app_config` | 63 | 13 (12 memo hits) |
+| handler wall cost | 6.405 ms | 3.170-3.375 ms |
+
+## Trade-offs
+
+- The draft path now refreshes the control bar / status chips in the same turn on a state-CHANGING keystroke, where it previously waited for the next coalesced sync. Both widgets own equality guards, so this is free when nothing moved and is work the next tick would have done anyway -- and it is what keeps the recorded `_last_*` honest.
+- Residual cost is now dominated by `_console_composer_or_none()`, which does an uncached `self.query("#console-native-composer")` full-DOM CSS walk twice per keystroke (61% of what is left). Out of scope here; worth its own task.
+
+## Files
+
+- `tldw_chatbook/UI/Screens/chat_screen.py` -- gate extraction, draft-path routing, derivation scope + three memoized legs
+- `tldw_chatbook/UI/Workbench/workbench_widgets.py` -- `_UNSYNCED` sentinel, four sync early-outs, `_state_children_in_desired_order` sort skip
+- `Tests/UI/test_console_draft_sync_equality_gate.py` (new) -- 9 mounted-Console tests incl. two mutation controls
+- `Tests/UI/test_workbench_widgets.py` -- 11 new unit tests for the sort skip and the four early-outs
+
+## Tests
+
+`test_console_composer_draft_changed.py` (the slash-popup / guidance / readiness pin suite) 23 passed before AND after, untouched. New: 9 + 11. Wider: 444 Console composer/flow, 323 workbench consumers, 140 Console+workbench, 505 destination shells -- green apart from two failures that reproduce unchanged on dev c0c4753f8 (`test_console_registers_footer_workbench_shortcuts`, stale footer copy from `14cc326e4`; `test_destination_action_buttons_explain_their_outcome[mcp|tools_settings]`, tooltip-less `#mcp-tools-workspace-save` from `8b4b7de8e`).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15452 - Equality-gate-the-Console-per-keystroke-DraftChanged-workbench-sync.md
+++ b/backlog/tasks/task-15452 - Equality-gate-the-Console-per-keystroke-DraftChanged-workbench-sync.md
@@ -57,11 +57,35 @@ Routes the per-keystroke `ConsoleComposerBar.DraftChanged` sync through the same
 | per keystroke | before | after |
 |---|---|---|
 | Workbench `Static.update` | 12 | 0 |
+| `CommandStrip._sync_button` | 7 | 0 |
 | `sort_children` | 2 | 0 |
 | screen `_nodes._updates` bumps | 2 | 0 |
 | `_build_console_provider_selection` | 7 | 1 |
 | `_provider_readiness_app_config` | 63 | 13 (12 memo hits) |
 | handler wall cost | 6.405 ms | 3.170-3.375 ms |
+
+### Attribution of that wall-clock win -- corrected after review
+
+The 6.405 -> ~3.2 ms is **almost entirely the derivation memo (change 5), not the
+gate**. Review reproduced the timings and measured the decomposition: reverting the
+gate + widget early-outs + sort skip while leaving the memo in place still measures
+~3.37 ms -- statistically indistinguishable from HEAD. So ~95% of the measured
+milliseconds are change 5.
+
+That is not evidence the gate is worthless -- it is a limit of the probe. The probe
+times one synchronous handler call. What changes 1-4 remove is `Static.update` /
+`sort_children` / `refresh(layout=True)` calls whose real cost is paid **later**, in
+Textual's render and layout pipeline, plus the screen-wide `query_one` LRU eviction
+that makes the *next* keystroke's screen-rooted lookups full DOM walks. None of that
+lands inside the timed call, so the probe cannot price it and does not claim to. The
+honest split:
+
+- **change 5 (memo)** -> the measured ~3.2 ms of handler CPU (the cProfile hot path
+  was `build_console_settings_readiness` -> `resolve_console_provider_identity` ->
+  ~1.0M `provider_config_key` calls per 60 invocations).
+- **changes 1-4 (gate, widget early-outs, sort skip)** -> the render/layout and
+  DOM-version churn: the 12 -> 0 / 7 -> 0 / 2 -> 0 / 2 -> 0 counter rows above, which
+  are counted directly and are the real deliverable, unpriced in ms by this probe.
 
 ## Trade-offs
 
@@ -78,4 +102,27 @@ Routes the per-keystroke `ConsoleComposerBar.DraftChanged` sync through the same
 ## Tests
 
 `test_console_composer_draft_changed.py` (the slash-popup / guidance / readiness pin suite) 23 passed before AND after, untouched. New: 9 + 11. Wider: 444 Console composer/flow, 323 workbench consumers, 140 Console+workbench, 505 destination shells -- green apart from two failures that reproduce unchanged on dev c0c4753f8 (`test_console_registers_footer_workbench_shortcuts`, stale footer copy from `14cc326e4`; `test_destination_action_buttons_explain_their_outcome[mcp|tools_settings]`, tooltip-less `#mcp-tools-workspace-save` from `8b4b7de8e`).
+
+### Known flake, recorded not omitted
+
+`Tests/UI/test_console_control_bar_coalescing.py::test_requested_sync_still_executes`
+flaked once in a batch run at HEAD ("three coalesced requests produced 4 runs
+(expected exactly 1)" -- its spy counts `_sync_console_control_bar` runs and picks up
+extra settling syncs under load). It passes in isolation and on repeat. Measured
+head-to-head afterwards, 10 whole-file runs each: **2/10 at HEAD, 3/10 with the two
+source files reverted to base c0c4753f8** -- so the flake is pre-existing on dev, and
+this diff adds no new `_sync_console_control_bar` call site. Worth its own
+deflaking task; not a gate on this one.
+
+### Lint
+
+`ruff check`: clean on all four changed/added files. `ruff format --check`: **not**
+clean on `chat_screen.py` and `Tests/UI/test_workbench_widgets.py`. Every deviation is
+pre-existing -- the `ruff format --diff` bodies for both files are byte-identical to
+the same files at base c0c4753f8 (10 hunks in `chat_screen.py`, 1 in
+`test_workbench_widgets.py`, line numbers merely shifted by this diff's insertions).
+Nothing this diff added is unformatted, and the pre-existing hunks were deliberately
+left alone rather than reformatted into an unrelated churn diff. The two files this
+diff is mostly responsible for -- `workbench_widgets.py` and the new
+`test_console_draft_sync_equality_gate.py` -- are format-clean.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3465,6 +3465,37 @@ class ChatScreen(BaseAppScreen):
     # never takes the fresh branch.
     _CONSOLE_LIVE_CONFIG_MARKER_SECTIONS = ("general", "logging")
 
+    #: Memo for ONE synchronous Console state-derivation pass, or None when
+    #: no pass is open. A CLASS attribute default because the hand-built
+    #: `ChatScreen.__new__()` test fixtures never run `__init__`.
+    _console_derivation_memo: dict[Any, Any] | None = None
+
+    @contextmanager
+    def _console_derivation_scope(self):
+        """Memoize repeated provider lookups for one derivation pass.
+
+        Building the Console control state and the Workbench state off it
+        re-derives the same provider selection and readiness config once
+        per leg: measured on dev, a single draft-edit sync ran
+        `_build_console_provider_selection` 7x and
+        `_provider_readiness_app_config` 63x (task-15452). None of those
+        legs mutate anything, and the pass is synchronous, so one memo for
+        its duration is exact rather than merely close.
+
+        Deliberately opt-in and scoped: outside a `with` block every lookup
+        is live, exactly as before. Re-entrant (an inner scope keeps the
+        outer memo) and always torn down, so a raising leg cannot leave a
+        stale selection cached for the next keystroke.
+        """
+        if self._console_derivation_memo is not None:
+            yield
+            return
+        self._console_derivation_memo = {}
+        try:
+            yield
+        finally:
+            self._console_derivation_memo = None
+
     def _provider_readiness_app_config(self) -> Any:
         """Return the freshest app config for provider-readiness checks.
 
@@ -3474,24 +3505,33 @@ class ChatScreen(BaseAppScreen):
         task-177). When the snapshot looks disk-loaded, re-source it from
         ``load_settings()`` - cheap (cached) except right after a save, which
         is exactly when the fresh read matters.
+
+        Served from the per-pass memo inside a `_console_derivation_scope`
+        (task-15452): one draft-edit sync called this 63 times.
         """
+        memo = self._console_derivation_memo
+        if memo is not None and "app_config" in memo:
+            return memo["app_config"]
         try:
             app_config = getattr(self.app, "app_config")
         except (AttributeError, NoActiveAppError):
             app_config = getattr(self.app_instance, "app_config", {}) or {}
         app_config = app_config or {}
-        if not self._console_config_snapshot_is_disk_loaded(app_config):
-            return app_config
-        try:
-            fresh = load_settings()
-        except Exception:
-            logger.debug(
-                "Console readiness refresh via load_settings() failed; using snapshot"
-            )
-            return app_config
-        if isinstance(fresh, Mapping) and fresh:
-            return fresh
-        return app_config
+        resolved = app_config
+        if self._console_config_snapshot_is_disk_loaded(app_config):
+            try:
+                fresh = load_settings()
+            except Exception:
+                logger.debug(
+                    "Console readiness refresh via load_settings() failed; "
+                    "using snapshot"
+                )
+            else:
+                if isinstance(fresh, Mapping) and fresh:
+                    resolved = fresh
+        if memo is not None:
+            memo["app_config"] = resolved
+        return resolved
 
     @classmethod
     def _console_config_snapshot_is_disk_loaded(cls, app_config: Any) -> bool:
@@ -4188,7 +4228,25 @@ class ChatScreen(BaseAppScreen):
     def _build_console_provider_selection(
         self, session_id: str | None = None
     ) -> ConsoleProviderSelection:
-        """Return an owning-session provider selection without switching tabs."""
+        """Return an owning-session provider selection without switching tabs.
+
+        Served from the per-pass memo inside a `_console_derivation_scope`
+        (task-15452): one draft-edit sync built this 7 times for the same
+        session.
+        """
+        memo = self._console_derivation_memo
+        memo_key = ("provider_selection", session_id)
+        if memo is not None and memo_key in memo:
+            return memo[memo_key]
+        selection = self._build_console_provider_selection_uncached(session_id)
+        if memo is not None:
+            memo[memo_key] = selection
+        return selection
+
+    def _build_console_provider_selection_uncached(
+        self, session_id: str | None = None
+    ) -> ConsoleProviderSelection:
+        """Derive the provider selection with no memo in front of it."""
         app_config = self._provider_readiness_app_config()
         store = self._ensure_console_chat_store()
         if session_id is None:
@@ -4286,7 +4344,24 @@ class ChatScreen(BaseAppScreen):
     def _active_console_provider_model_display(
         self,
     ) -> tuple[str, str | None, ConsoleSessionSettings]:
-        """Return provider/model labels backed by active session settings."""
+        """Return provider/model labels backed by active session settings.
+
+        Served from the per-pass memo inside a `_console_derivation_scope`
+        (task-15452): the control state and the Workbench state built off it
+        each re-derive this leg.
+        """
+        memo = self._console_derivation_memo
+        if memo is not None and "provider_model_display" in memo:
+            return memo["provider_model_display"]
+        display = self._active_console_provider_model_display_uncached()
+        if memo is not None:
+            memo["provider_model_display"] = display
+        return display
+
+    def _active_console_provider_model_display_uncached(
+        self,
+    ) -> tuple[str, str | None, ConsoleSessionSettings]:
+        """Derive provider/model labels with no memo in front of them."""
         settings = self._session._ensure_active_console_session_settings()
         selection = self._build_console_provider_selection()
         legacy_provider, _legacy_model = self._effective_console_provider_model()
@@ -4302,7 +4377,25 @@ class ChatScreen(BaseAppScreen):
     def _active_console_settings_readiness(
         self,
     ) -> tuple[ConsoleSessionSettings, ConsoleSettingsReadiness]:
-        """Return effective settings plus Console-native readiness for display/send surfaces."""
+        """Return effective settings plus Console-native readiness for display/send surfaces.
+
+        Served from the per-pass memo inside a `_console_derivation_scope`
+        (task-15452): the blocker copy, the recovery action and the setup
+        blocker each re-derive it, and `build_console_settings_readiness`
+        is the single most expensive leg of a draft-edit sync.
+        """
+        memo = self._console_derivation_memo
+        if memo is not None and "settings_readiness" in memo:
+            return memo["settings_readiness"]
+        readiness = self._active_console_settings_readiness_uncached()
+        if memo is not None:
+            memo["settings_readiness"] = readiness
+        return readiness
+
+    def _active_console_settings_readiness_uncached(
+        self,
+    ) -> tuple[ConsoleSessionSettings, ConsoleSettingsReadiness]:
+        """Derive effective settings + readiness with no memo in front."""
         settings = self._session._ensure_active_console_session_settings()
         selection = self._build_console_provider_selection()
         selected_model = selection.explicit_model or selection.configured_model
@@ -18036,28 +18129,7 @@ class ChatScreen(BaseAppScreen):
             self._pending_console_launch_context
         )
         workbench_state = self._build_console_workbench_state(control_state)
-        control_state_changed = control_state != self._last_console_control_state
-        workbench_state_changed = workbench_state != self._last_console_workbench_state
-        if control_state_changed or workbench_state_changed:
-            try:
-                control_bar = self.query_one("#console-control-bar", ConsoleControlBar)
-            except QueryError:
-                control_bar = None
-            if control_bar is not None:
-                control_bar.sync_state(control_state, actions=workbench_state.actions)
-            try:
-                status_chips = self.query_one(
-                    "#console-status-chips", ConsoleStatusChips
-                )
-            except QueryError:
-                status_chips = None
-            if status_chips is not None:
-                status_chips.sync_state(control_state)
-            self._sync_console_workbench_state(
-                control_state, workbench_state=workbench_state
-            )
-            self._last_console_control_state = control_state
-            self._last_console_workbench_state = workbench_state
+        self._push_console_control_state_if_changed(control_state, workbench_state)
         self._sync_console_transcript_guidance()
         # TASK-251 (audit P1 B1) -- DEVIATION FROM THE BRIEF, documented in
         # the task-251 report: the brief's Change 3 asked to skip this
@@ -18103,6 +18175,54 @@ class ChatScreen(BaseAppScreen):
         # `_sync_console_cost_chip` owns its own equality guard.
         self._sync_console_cost_chip()
 
+    def _push_console_control_state_if_changed(
+        self,
+        control_state: ConsoleControlState,
+        workbench_state: Any,
+    ) -> bool:
+        """Push control/Workbench state into the widgets only when it moved.
+
+        The one place `_last_console_control_state` /
+        `_last_console_workbench_state` are read and written (task-15452).
+        Every caller that pushes must go through here: the control bar
+        consumes `workbench_state.actions` as well as `control_state`, so a
+        caller that pushed only the Workbench widgets and then recorded the
+        new `_last_*` values would make the NEXT `_sync_console_control_bar`
+        see "unchanged" and skip a control-bar refresh it still owed --
+        which is exactly the trap the draft-edit path used to avoid only by
+        never recording anything.
+
+        Args:
+            control_state: Freshly built Console control/readiness state.
+            workbench_state: Workbench state built from that control state.
+
+        Returns:
+            True when the widgets were pushed, False when nothing moved.
+        """
+        if (
+            control_state == self._last_console_control_state
+            and workbench_state == self._last_console_workbench_state
+        ):
+            return False
+        try:
+            control_bar = self.query_one("#console-control-bar", ConsoleControlBar)
+        except QueryError:
+            control_bar = None
+        if control_bar is not None:
+            control_bar.sync_state(control_state, actions=workbench_state.actions)
+        try:
+            status_chips = self.query_one("#console-status-chips", ConsoleStatusChips)
+        except QueryError:
+            status_chips = None
+        if status_chips is not None:
+            status_chips.sync_state(control_state)
+        self._sync_console_workbench_state(
+            control_state, workbench_state=workbench_state
+        )
+        self._last_console_control_state = control_state
+        self._last_console_workbench_state = workbench_state
+        return True
+
     def _sync_console_workbench_state(
         self,
         control_state: ConsoleControlState,
@@ -18141,10 +18261,26 @@ class ChatScreen(BaseAppScreen):
             pass
 
     def _sync_console_workbench_actions_from_draft(self) -> None:
-        """Refresh Workbench command readiness after composer draft changes."""
-        self._sync_console_workbench_state(
-            self._build_console_control_state(self._pending_console_launch_context)
-        )
+        """Refresh Workbench command readiness after composer draft changes.
+
+        Runs on every printable keystroke, so it goes through the same
+        equality gate as `_sync_console_control_bar` (task-15452): before
+        that it rebuilt and re-pushed Workbench state unconditionally --
+        ~12 layout-invalidating `Static.update` calls plus two
+        `sort_children` (which bump the DOM version up the whole ancestor
+        chain and so evict the screen-wide `query_one` cache) for a state
+        that is identical between any two characters of a word.
+
+        `_sync_console_command_popup` stays OUTSIDE the gate: the popup
+        filters on the draft text itself, which moves on every keystroke
+        while the derived Workbench state does not.
+        """
+        with self._console_derivation_scope():
+            control_state = self._build_console_control_state(
+                self._pending_console_launch_context
+            )
+            workbench_state = self._build_console_workbench_state(control_state)
+        self._push_console_control_state_if_changed(control_state, workbench_state)
         self._sync_console_command_popup()
 
     def _console_command_popup_or_none(self) -> ConsoleCommandPopup | None:

--- a/tldw_chatbook/UI/Workbench/workbench_widgets.py
+++ b/tldw_chatbook/UI/Workbench/workbench_widgets.py
@@ -25,6 +25,15 @@ from tldw_chatbook.UI.Workbench.workbench_state import (
 )
 
 
+#: Marker for "no state has been pushed into this widget yet" (task-15452).
+#: A dedicated sentinel rather than ``None`` because ``RecoveryCallout``
+#: legitimately syncs ``None``, and rather than comparing against
+#: ``self.state`` because every ``on_mount`` self-syncs the constructor
+#: state and must still apply the status/density classes ``compose`` never
+#: sets.
+_UNSYNCED: Any = object()
+
+
 def _safe_id(value: str) -> str:
     """Return a Textual-safe ID segment for state-owned identifiers."""
     return normalize_workbench_id(value)
@@ -71,12 +80,54 @@ def _sync_density_classes(widget: Widget, density: str) -> None:
     widget.set_class(density == "compact", "density-compact")
 
 
+def _state_children_in_desired_order(
+    widget: Widget,
+    desired_order: dict[str, int],
+    attribute_name: str,
+) -> bool:
+    """Return True when the children already sit in the desired order.
+
+    ``sort_children`` is never free, even when it reorders nothing
+    (task-15452): ``NodeList._sort`` calls ``NodeList.updated``, which bumps
+    the update counter on this widget *and* on every ancestor up to the
+    screen -- and the screen's counter is part of the ``query_one`` LRU
+    cache key, so one no-op sort invalidates every cached ``#id`` lookup on
+    the largest tree in the app. It then calls ``refresh(layout=True)`` on
+    top of that.
+
+    Python's sort is stable, so the sort changes nothing exactly when the
+    child key sequence is already non-decreasing. Children queued for
+    removal are still in ``children`` at schedule time and key to
+    ``len(desired_order)``; dropping elements from a sequence can never
+    CREATE an inversion, so an "already ordered" verdict taken while they
+    are still present stays correct once they are pruned.
+
+    Args:
+        widget: Container whose children are state-owned.
+        desired_order: Map of state ID to its index in the new state.
+        attribute_name: Child attribute carrying the state ID.
+
+    Returns:
+        True when sorting would leave the child order unchanged.
+    """
+    missing = len(desired_order)
+    previous = -1
+    for child in widget.children:
+        index = desired_order.get(getattr(child, attribute_name, ""), missing)
+        if index < previous:
+            return False
+        previous = index
+    return True
+
+
 def _sort_state_children(
     widget: Widget,
     desired_order: dict[str, int],
     attribute_name: str,
 ) -> None:
     """Sort state-owned children to match the latest Workbench state order."""
+    if _state_children_in_desired_order(widget, desired_order, attribute_name):
+        return
     widget.sort_children(
         key=lambda child: desired_order.get(
             getattr(child, attribute_name, ""),
@@ -90,7 +141,15 @@ def _schedule_sort_state_children(
     desired_order: dict[str, int],
     attribute_name: str,
 ) -> None:
-    """Sort after queued mount/remove operations settle for this message."""
+    """Sort after queued mount/remove operations settle for this message.
+
+    Skipped outright when the order already matches: the deferred callback
+    would find nothing to do, and even scheduling it costs a message per
+    sync. Re-checked inside ``_sort_state_children`` because mounts and
+    removals queued by other code can still land in the gap.
+    """
+    if _state_children_in_desired_order(widget, desired_order, attribute_name):
+        return
     widget.call_next(_sort_state_children, widget, desired_order, attribute_name)
 
 
@@ -113,6 +172,10 @@ class DestinationHeader(Vertical):
         height: auto;
     }
     """
+
+    #: Last header state actually pushed into the child widgets. A CLASS
+    #: attribute default so `__new__`-built doubles never miss it.
+    _synced_state: Any = _UNSYNCED
 
     def __init__(
         self,
@@ -151,8 +214,16 @@ class DestinationHeader(Vertical):
         self.sync_state(self.state)
 
     def sync_state(self, state: WorkbenchHeaderState) -> None:
-        """Refresh header copy and state classes without remounting."""
+        """Refresh header copy and state classes without remounting.
+
+        A no-op once the same state has already been pushed (task-15452):
+        `Static.update` has no equality check of its own, so an ungated
+        re-push invalidates layout for three Statics per call -- and the
+        Console runs this on every printable keystroke.
+        """
         self.state = state
+        if state == self._synced_state:
+            return
         self.query_one("#workbench-header-title", Static).update(state.title)
         self.query_one("#workbench-header-subtitle", Static).update(state.subtitle)
         self.query_one("#workbench-header-status", Static).update(
@@ -161,10 +232,14 @@ class DestinationHeader(Vertical):
         self.set_class(not state.subtitle, "has-empty-subtitle")
         _sync_status_classes(self, state.status)
         _sync_density_classes(self, state.density)
+        self._synced_state = state
 
 
 class CommandStrip(Horizontal):
     """Stable strip for visible Workbench actions."""
+
+    #: Last action tuple actually pushed into the buttons (task-15452).
+    _synced_actions: Any = _UNSYNCED
 
     def __init__(
         self,
@@ -210,9 +285,18 @@ class CommandStrip(Horizontal):
             yield self._build_button(action)
 
     def sync_actions(self, actions: Iterable[WorkbenchAction]) -> None:
-        """Refresh action buttons while preserving the strip widget."""
+        """Refresh action buttons while preserving the strip widget.
+
+        A no-op once the same actions have already been pushed (task-15452).
+        `WorkbenchAction` is a frozen dataclass, so tuple equality covers
+        every attribute the button sync writes -- label, disabled, tooltip,
+        primary -- and the button IDs are derived from the same IDs, so the
+        `_button_ids_by_action_id` map is already correct too.
+        """
         actions = tuple(actions)
         self.actions = actions
+        if actions == self._synced_actions:
+            return
         actions_by_id = {action.id: action for action in actions}
         desired_button_ids = {action.id: self._button_id(action) for action in actions}
         mounted = 0
@@ -248,6 +332,7 @@ class CommandStrip(Horizontal):
         self._button_ids_by_action_id = {
             action_id: button_id for action_id, button_id in desired_button_ids.items()
         }
+        self._synced_actions = actions
         if mounted or removed:
             _record_mount_churn(
                 self,
@@ -268,6 +353,9 @@ class CommandStrip(Horizontal):
 
 class ModeStrip(Horizontal):
     """Stable strip for Workbench mode chips."""
+
+    #: Last mode tuple actually pushed into the chips (task-15452).
+    _synced_modes: Any = _UNSYNCED
 
     def __init__(
         self,
@@ -306,9 +394,16 @@ class ModeStrip(Horizontal):
             yield self._build_mode(mode)
 
     def sync_modes(self, modes: Iterable[WorkbenchMode]) -> None:
-        """Refresh mode labels without remounting unchanged mode IDs."""
+        """Refresh mode labels without remounting unchanged mode IDs.
+
+        A no-op once the same modes have already been pushed (task-15452):
+        `WorkbenchMode` is frozen, so tuple equality covers label, active
+        and status -- everything `_sync_mode_label` writes.
+        """
         modes = tuple(modes)
         self.modes = modes
+        if modes == self._synced_modes:
+            return
         modes_by_id = {mode.id: mode for mode in modes}
         mounted = 0
         removed = 0
@@ -336,6 +431,7 @@ class ModeStrip(Horizontal):
             {mode.id: index for index, mode in enumerate(modes)},
             "_workbench_mode_id",
         )
+        self._synced_modes = modes
 
         if mounted or removed:
             _record_mount_churn(
@@ -348,6 +444,10 @@ class ModeStrip(Horizontal):
 
 class RecoveryCallout(Vertical):
     """Visible recovery copy with an optional action."""
+
+    #: Last recovery state actually pushed into the children (task-15452).
+    #: `None` is a real state here, hence the sentinel default.
+    _synced_state: Any = _UNSYNCED
 
     def __init__(
         self,
@@ -388,8 +488,13 @@ class RecoveryCallout(Vertical):
         self.sync_state(self.state)
 
     def sync_state(self, state: RecoveryState | None) -> None:
-        """Refresh recovery copy, visibility, and action state."""
+        """Refresh recovery copy, visibility, and action state.
+
+        A no-op once the same state has already been pushed (task-15452).
+        """
         self.state = state
+        if state == self._synced_state:
+            return
         visible = bool(state and state.visible)
         self.set_class(not visible, "is-hidden")
         self.display = visible
@@ -409,6 +514,7 @@ class RecoveryCallout(Vertical):
         action_button.set_class(bool(action and action.primary), "is-primary")
         action_button.set_class(bool(action and action.disabled), "is-disabled")
         action_button.set_class(True, "workbench-action")
+        self._synced_state = state
 
     @on(Button.Pressed, "#workbench-recovery-action")
     def on_recovery_action_pressed(self, event: Button.Pressed) -> None:


### PR DESCRIPTION
## Summary

Task 15452 from the input-latency audit (`Docs/Design/2026-08-11-input-latency-audit.md`). The `DraftChanged` handler bypassed the state-equality guard the main sync path has, so every printable keystroke on the Console screen pushed ~12 layout-invalidating `Static.update`s + 2 `sort_children` calls (each bumping the DOM version and killing Textual's screen-wide `query_one` cache) and rebuilt provider/readiness state 7×.

- Draft path now routes through the same `_last_state` equality gate (full push incl. control bar + status chips when state moves — partial push would strand the control bar); `_sync_console_command_popup` stays outside the gate and runs on every edit
- `state == current` early-outs in the four Workbench widget sync methods; `sort_children` skipped when order already matches (exact same key function, mutation-tested)
- Per-invocation derivation memo: 7→1 provider-selection builds, 63→13 readiness-config reads
- Per idle keystroke: 12→0 widget writes, 2→0 DOM-version bumps (query cache survives); handler 6.4→3.2 ms (~95% of the ms win is the memo; the gate's payoff is the unpriced render/layout + cache churn — attribution verified by the reviewer's memo-intact revert probe)
- Behavior pinned first: the 23-test DraftChanged suite pre-exists at base, byte-identical, green on both sides; 9 new mounted-Console gate tests incl. mutation controls + 11 widget unit tests

## Verification
Independent task review: Approved, zero code defects — staleness hunt (all render inputs inside compared frozen-dataclass state), dual-path remount desync (recompose rebuilds widgets from fresh state, cannot strand), and sort-order comparison all verified; reviewer's 5 mutations each caught by the intended tests; timings reproduced independently. Pre-existing dev issues surfaced and left alone (footer-shortcut label test, mcp tooltip test, one 2/10-at-base flake in the coalescing suite) — being filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Equality-gated the Console draft-edit workbench sync and memoized per-pass derivations to reduce per-keystroke work and prevent DOM churn. Addresses TASK-15452 from the input-latency audit and keeps slash-popup filtering unchanged.

- **Performance**
  - Routed `DraftChanged` through the same equality gate via `_push_console_control_state_if_changed`; command popup sync remains outside the gate.
  - Added widget early-outs with `_UNSYNCED` for `DestinationHeader`, `ModeStrip`, `CommandStrip`, and `RecoveryCallout`.
  - Skipped no-op `sort_children` (and scheduled sorts) when order is unchanged to avoid screen DOM-version bumps and `query_one` cache eviction.
  - Introduced `_console_derivation_scope` to memoize provider selection, readiness config, and provider/model display within one sync pass.
  - Results per idle keystroke: 12→0 `Static.update`, 2→0 `sort_children`/DOM bumps; provider selection 7→1; handler ~6.4→~3.2 ms.
  - Tests: 9 mounted Console tests for the gate + 11 widget unit tests.

<sup>Written for commit 6898f54caf7d9c3c5b95841a449d3ce92e585cd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

