### PR TITLE
fix(tts): honest failure surfacing for Console speech — log dedup, model copy, speak-row reset (TASK-15422)

### DIFF
--- a/Tests/TTS/test_console_speak_autoplay.py
+++ b/Tests/TTS/test_console_speak_autoplay.py
@@ -214,6 +214,50 @@ async def test_console_speak_autoplay_when_no_legacy_widget_claims_message(tmp_p
     assert audio_file.read_bytes() == complete_wav
 
 
+class _FakeConsoleScreen:
+    """Stand-in for the Console screen's speak-state surface (TASK-15422)."""
+
+    def __init__(self, speaking_message_id: str | None) -> None:
+        self._console_speaking_message_id = speaking_message_id
+        self.sync_calls = 0
+
+    async def _sync_native_console_chat_ui(self) -> None:
+        """Count resyncs so the test can assert the row was repainted.
+
+        Returns:
+            None.
+        """
+        self.sync_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_error_completion_clears_console_speaking_marker() -> None:
+    """A failed generation must return the Console action row to 🔊.
+
+    The error branch reset legacy `ChatMessage` widgets only; the Console
+    transcript's action row renders from `_console_speaking_message_id`,
+    which nothing cleared on failure — so after an instant failure the row
+    kept "⏹ Stop speech" with no speech to stop (TASK-15422, observed live
+    during the TASK-15420 UAT).
+    """
+    speaking = _FakeConsoleScreen("console-msg-1")
+    other = _FakeConsoleScreen("console-msg-2")
+    fake_app = _FakeApp(widgets=())
+    fake_app.screen_stack = (other, speaking)
+    event = TTSCompleteEvent(
+        message_id="console-msg-1",
+        error="The selected TTS model is not available",
+    )
+
+    await TldwCli.handle_tts_complete_event(fake_app, event)
+
+    assert speaking._console_speaking_message_id is None
+    assert speaking.sync_calls == 1
+    # A screen speaking a DIFFERENT message keeps its own state untouched.
+    assert other._console_speaking_message_id == "console-msg-2"
+    assert other.sync_calls == 0
+
+
 @pytest.mark.asyncio
 async def test_console_speak_autoplay_skipped_when_legacy_widget_claims_message(
     tmp_path,

--- a/Tests/TTS/test_tts_unknown_model_error_copy.py
+++ b/Tests/TTS/test_tts_unknown_model_error_copy.py
@@ -1,0 +1,44 @@
+"""TASK-15422: an unroutable TTS model is a configuration problem, not luck.
+
+``UnknownLegacyModelError`` subclasses ``LookupError``, so it fell through
+``_tts_outcome_code``/``_tts_error_copy`` to the generic bucket: metric
+outcome ``generation_failed`` and the toast "Unexpected TTS generation
+failure; retry". Retrying can never fix an id the compatibility bridge does
+not route; a user who hit this (a custom model name before TASK-15420, an
+unmapped ElevenLabs profile model still today) got no hint that the model
+selection was what failed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import TTSEventHandler
+from tldw_chatbook.TTS.legacy_bridge import UnknownLegacyModelError
+
+pytestmark = pytest.mark.unit
+
+
+def test_unknown_legacy_model_error_is_a_model_configuration_outcome() -> None:
+    """The metric outcome names the model, not a generic generation failure.
+
+    Returns:
+        None.
+    """
+    error = UnknownLegacyModelError("The selected TTS model is not available")
+
+    assert TTSEventHandler._tts_outcome_code(error) == "model_invalid"
+
+
+def test_unknown_legacy_model_error_copy_points_at_the_model_selection() -> None:
+    """The toast names the model selection and where to fix it.
+
+    Returns:
+        None.
+    """
+    error = UnknownLegacyModelError("The selected TTS model is not available")
+
+    assert TTSEventHandler._tts_error_copy(error) == (
+        "The selected TTS model is not available for this provider; "
+        "check the model in STTS Settings"
+    )

--- a/Tests/test_logs_buffer_single_record_per_emission.py
+++ b/Tests/test_logs_buffer_single_record_per_emission.py
@@ -1,0 +1,73 @@
+"""TASK-15422: one log emission must appear once in the Logs screen buffer.
+
+Every Console speak failure showed TWO identical
+``TTS generation failed (outcome_code=...)`` ERROR rows in the Logs screen
+per single click, which read as two generation attempts. The generation ran
+once (the mock server received exactly one request on the success path); the
+duplication is in the logging pipeline: ``Logging_Config._setup_logging``
+installs the canonical loguru->stdlib forward
+(``_forward_loguru_to_standard``, TRACE, diagnose=False per task-2119), and
+``TldwCli._setup_buffered_logging`` then installed a SECOND loguru sink
+bridging to stdlib — so every loguru record reached the root logger's
+``PersistentLogHandler`` twice, doubling both the Logs screen rows and its
+Errors count.
+
+This test replicates the production sink layout (config forward active, then
+the app's buffered handler setup) and pins that one loguru emission produces
+exactly one buffered record.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from loguru import logger as loguru_logger
+
+pytestmark = pytest.mark.unit
+
+
+class _AppStub:
+    """Bare object for binding ``_setup_buffered_logging``."""
+
+
+def test_one_loguru_error_lands_once_in_the_logs_buffer():
+    """One ``logger.error`` -> one row in ``_log_records``, not two.
+
+    Returns:
+        None.
+    """
+    from tldw_chatbook.Logging_Config import _forward_loguru_to_standard
+    from tldw_chatbook.app import TldwCli
+
+    sinks_before = set(loguru_logger._core.handlers)
+    config_sink_id = loguru_logger.add(
+        _forward_loguru_to_standard,
+        format=(
+            "{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | "
+            "{name}:{function}:{line} - {message}"
+        ),
+        level="TRACE",
+        diagnose=False,
+        backtrace=True,
+    )
+    stub = _AppStub()
+    try:
+        TldwCli._setup_buffered_logging(stub)
+        marker = "single-record-marker-15422"
+        loguru_logger.error("TTS generation failed (outcome_code={})", marker)
+        matching = [
+            record for record in stub._log_records if marker in record[2]
+        ]
+        assert len(matching) == 1, (
+            f"one emission buffered {len(matching)} times: {matching}"
+        )
+    finally:
+        for sink_id in set(loguru_logger._core.handlers) - sinks_before:
+            try:
+                loguru_logger.remove(sink_id)
+            except ValueError:
+                pass
+        handler = getattr(stub, "_persistent_log_handler", None)
+        if handler is not None:
+            logging.getLogger().removeHandler(handler)

--- a/backlog/tasks/task-15422 - TTS-model-route-failure-surfaces-as-Unexpected-generation-failure-and-fires-twice-per-speak.md
+++ b/backlog/tasks/task-15422 - TTS-model-route-failure-surfaces-as-Unexpected-generation-failure-and-fires-twice-per-speak.md
@@ -3,7 +3,7 @@ id: TASK-15422
 title: >-
   TTS model-route failure surfaces as "Unexpected TTS generation failure" and
   fires twice per speak
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-11 12:00'
 labels:
@@ -47,7 +47,63 @@ configuration/selection problem):
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] A model/selection rejection surfaces copy that points at the TTS model configuration rather than a generic retry
-- [ ] One speak action produces exactly one generation attempt and one failure log/metric on failure
-- [ ] After a synchronous failure the message speak control returns to 🔊 promptly and deterministically
+- [x] A model/selection rejection surfaces copy that points at the TTS model configuration rather than a generic retry
+- [x] One speak action produces exactly one generation attempt and one failure log/metric on failure
+- [x] After a synchronous failure the message speak control returns to 🔊 promptly and deterministically
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Root-cause the "double fire" before assuming two generations: the mock
+   server received exactly ONE request per successful click, so the doubling
+   had to be in the logging pipeline, not dispatch.
+2. RED tests per finding; GREEN each: log duplication, error copy mapping,
+   Console speak-marker clear on failure.
+3. Live verification: dead-port TTS endpoint, one 🔊 click.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Three distinct findings, three scoped fixes (TDD red-first for each):
+
+1. **"Two failures per click" was a log-pipeline duplication, not a double
+   generation.** `Logging_Config._setup_logging` installs the canonical
+   loguru→stdlib forward (`_forward_loguru_to_standard`, TRACE,
+   diagnose=False per task-2119) on every boot path, and
+   `TldwCli._setup_buffered_logging` then installed a SECOND loguru→stdlib
+   sink — every loguru record reached the root logger's
+   `PersistentLogHandler` twice, so the Logs screen showed every
+   application log line (and counted every error) twice. Fix: the app-level
+   bridge is removed with a comment pointing at the canonical forward.
+   Test: `Tests/test_logs_buffer_single_record_per_emission.py` replicates
+   the production sink layout and pins one emission → one buffered record
+   (was 2).
+
+2. **`UnknownLegacyModelError` now maps to `model_invalid`** (already in the
+   bounded `TTSOperationCode` set) with copy "The selected TTS model is not
+   available for this provider; check the model in STTS Settings" instead of
+   falling to the generic `generation_failed` / "Unexpected TTS generation
+   failure; retry" bucket. Test:
+   `Tests/TTS/test_tts_unknown_model_error_copy.py`.
+
+3. **The stuck ⏹ was deterministic after all**: `handle_tts_complete_event`'s
+   error branch reset legacy `ChatMessage` widgets only; the Console
+   transcript renders its action row from the screen's
+   `_console_speaking_message_id`, which nothing cleared on failure. The
+   error branch now walks `screen_stack` for the screen whose marker matches
+   the failed message, clears it, and resyncs — message-id-guarded so an
+   unrelated screen's state is untouched. Test added to
+   `Tests/TTS/test_console_speak_autoplay.py` (existing `_FakeApp` idiom).
+
+Live verification (dead-port TTS endpoint, mock LLM, one 🔊 click): failure
+toast shown, the action row returned to 🔊, and the Logs screen recorded
+exactly TWO DISTINCT single rows (backend "Network request failed" +
+handler "TTS generation failed") where each was previously doubled.
+
+Adjacent observation, out of scope here: a connection failure surfaces the
+ValueError-bucket copy "TTS is not configured; open STTS Settings" (the
+backend wraps network errors in ValueError), which mislabels a reachability
+problem as a configuration one — pre-existing, noted for a future pass.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -38,6 +38,7 @@ from tldw_chatbook.TTS import (
     get_tts_service,
 )
 from tldw_chatbook.TTS.character_request_resolver import TTSVoiceRefusalDomain
+from tldw_chatbook.TTS.legacy_bridge import UnknownLegacyModelError
 from tldw_chatbook.TTS.adapter_types import (
     TTSConfigurationRevisionError,
     TTSOperationError,
@@ -2345,6 +2346,11 @@ class TTSEventHandler:
             return error.code
         if isinstance(error, _TTSResponseContractError):
             return "audio_response_invalid"
+        if isinstance(error, UnknownLegacyModelError):
+            # An id the compatibility bridge cannot route is a model
+            # configuration problem; the generic bucket's "retry" framing
+            # hid that for weeks of TASK-15420's window (TASK-15422).
+            return "model_invalid"
         if isinstance(error, ValueError):
             return "configuration_invalid"
         return "generation_failed"
@@ -2380,6 +2386,11 @@ class TTSEventHandler:
         if isinstance(error, _TTSResponseContractError):
             return (
                 "The TTS service returned invalid audio; check provider compatibility"
+            )
+        if isinstance(error, UnknownLegacyModelError):
+            return (
+                "The selected TTS model is not available for this provider; "
+                "check the model in STTS Settings"
             )
         if isinstance(error, ValueError):
             return "TTS is not configured; open STTS Settings"

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -7121,36 +7121,16 @@ class TldwCli(
             logging.getLogger().addHandler(self._persistent_log_handler)
             logger.info("Persistent logging handler set up for screen navigation")
 
-        # The app logs via loguru; the persistent handler is stdlib-only.
-        # Bridge loguru records into the stdlib root logger so the Logs
-        # screen's buffer sees the application's own logging (without this,
-        # only stdlib-logging modules ever appear there).
-        if not hasattr(self, "_loguru_bridge_installed"):
-            self._loguru_bridge_installed = True
-
-            def _loguru_to_stdlib(message) -> None:
-                record = message.record
-                logging.getLogger(record["name"]).handle(
-                    logging.LogRecord(
-                        name=record["name"],
-                        level=record["level"].no,
-                        pathname=getattr(record["file"], "path", ""),
-                        lineno=record["line"],
-                        msg=str(message).rstrip("\n"),
-                        args=(),
-                        exc_info=record["exception"],
-                        created=record["time"].timestamp(),
-                    )
-                )
-
-            try:
-                from loguru import logger as _loguru
-
-                _loguru.add(_loguru_to_stdlib, level=0, format="{message}")
-            except Exception:  # noqa: BLE001
-                logger.warning(
-                    "Failed to install loguru->stdlib bridge for Logs screen"
-                )
+        # The app logs via loguru and the persistent handler is stdlib-only,
+        # but NO bridge is installed here: `Logging_Config._setup_logging`
+        # already forwards every loguru record into stdlib logging
+        # (`_forward_loguru_to_standard`, level TRACE, diagnose=False per
+        # task-2119), and it runs before this method on every boot path —
+        # either early at process start or via `configure_application_
+        # logging` in `_setup_logging`. A second sink here made every loguru
+        # record reach the root logger twice, so the Logs screen showed each
+        # application log line — and counted each error — twice
+        # (TASK-15422).
 
         # Initialize current log widget reference
         self._current_log_widget = None
@@ -8109,6 +8089,26 @@ class TldwCli(
                             break
             except Exception as e:
                 self.loguru_logger.error(f"Error updating message UI: {e}")
+            # The Console transcript's action row renders from the screen's
+            # `_console_speaking_message_id`, not from a legacy widget — on
+            # failure it must be cleared too, or the row keeps "⏹ Stop
+            # speech" with no speech to stop (TASK-15422).
+            for screen in reversed(tuple(getattr(self, "screen_stack", ()))):
+                if (
+                    getattr(screen, "_console_speaking_message_id", None)
+                    == event.message_id
+                ):
+                    screen._console_speaking_message_id = None
+                    sync = getattr(screen, "_sync_native_console_chat_ui", None)
+                    if callable(sync):
+                        try:
+                            await sync()
+                        except Exception:
+                            self.loguru_logger.error(
+                                "Console speak-state resync failed after a "
+                                "TTS error"
+                            )
+                    break
             if event.global_override_token is not None:
                 self.run_worker(
                     self._offer_tts_global_override(event.global_override_token),


### PR DESCRIPTION
## Summary

Third PR from the external-OpenAI-server UAT (after #1512 and #1519). Three findings on how a Console speech failure presents, each with a red-first test:

1. **"Two failures per click" was a log-pipeline duplication, not a double generation.** Ground truth: the mock server received exactly one request per successful click. `Logging_Config._setup_logging` installs the canonical loguru→stdlib forward (TRACE, `diagnose=False` per task-2119) on every boot path; `_setup_buffered_logging` then added a **second** loguru→stdlib sink, so every loguru record reached the root logger's `PersistentLogHandler` twice — the Logs screen showed every application log line, and counted every error, twice. The redundant app-level bridge is removed. Test replicates the production sink layout and pins one emission → one buffered record (was 2).

2. **`UnknownLegacyModelError` maps to the bounded `model_invalid` outcome** with copy "The selected TTS model is not available for this provider; check the model in STTS Settings" — instead of the generic `generation_failed` / "Unexpected TTS generation failure; retry", which suggested retrying something that can never route.

3. **A failed generation returns the Console action row to 🔊.** The completion handler's error branch reset legacy `ChatMessage` widgets only; the Console transcript renders its row from the screen's `_console_speaking_message_id`, which nothing cleared on failure — the row kept "⏹ Stop speech" with no speech to stop (observed live during the TASK-15420 UAT). The error branch now walks `screen_stack` for the matching marker, clears it, and resyncs, message-id-guarded.

## Verification

- Live (dead-port TTS endpoint, one 🔊 click): failure toast shown, row back to 🔊, Logs screen shows two **distinct** single rows (backend "Network request failed" + handler "TTS generation failed") where each was previously doubled.
- `Tests/TTS/` + logging tests: 2,890 passed; the 4 failures + 1 error are the pre-existing set reproduced byte-identically on pristine `origin/dev`. `Tests/App/`: 109 passed. Repo-wide `--collect-only`: clean (37,866).

## Noted, out of scope

The backend wraps connection errors in `ValueError`, so a reachability failure still surfaces the not-configured copy ("TTS is not configured; open STTS Settings") — pre-existing, recorded in the task file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console speech failure UX: removes duplicate error logs, shows a precise “model not available” message, and reliably returns the action row to 🔊 after a failed generation. Addresses TASK-15422.

- **Bug Fixes**
  - Logging: removed redundant `loguru`→stdlib bridge in `tldw_chatbook/app.py` so each emission creates one buffered log record; unit test added to pin 1:1 behavior.
  - Error mapping: `UnknownLegacyModelError` now reports `model_invalid` with copy “The selected TTS model is not available for this provider; check the model in STTS Settings”; tests added.
  - UI state: on TTS error, clear `_console_speaking_message_id` and resync the Console screen so the action row returns to 🔊; test added.

<sup>Written for commit 0ccf79e0dd691151c34c08a9dba4166a49482d97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

