### PR TITLE
docs(tasks): TASK-15423 root cause — Library handoff gate is all-or-nothing, not silent

### DIFF
--- a/backlog/tasks/task-15423 - Library-Open-in-Console-does-not-navigate-or-load-the-conversation.md
+++ b/backlog/tasks/task-15423 - Library-Open-in-Console-does-not-navigate-or-load-the-conversation.md
@@ -49,3 +49,46 @@ button (and the search asymmetry) misleads.
 - [ ] Activating "Open in Console" on a conversation either opens it in Console or surfaces a visible, accurate reason it cannot
 - [ ] Console's conversation search finds DB conversations that Library finds, or the two surfaces' differing scopes are made explicit in the UI
 <!-- AC:END -->
+
+## Investigation Notes (2026-08-11, follow-up session)
+
+<!-- SECTION:NOTES:BEGIN -->
+Root-caused live; the original "silently does nothing" framing was WRONG in
+one respect and right in a sharper one:
+
+- **It is not silent.** The button's handler
+  (`library_screen.py` `_open_selected_conversation_handoff`) posts a
+  warning toast on every guard; the original UAT captures (~4-5s after the
+  click) missed the transient toast. Caught live this session: "Copy or
+  link blocked Library sources into the active workspace before using them
+  in Console."
+- **The real defect candidate is the all-or-nothing gate.**
+  `build_library_workspace_depth_state` (`Workspaces/display_state.py`)
+  computes `handoff_enabled = bool(rows) and blocked_count == 0` — ONE
+  workspace-ineligible row anywhere in the visible Library disables
+  "Open in Console" for EVERY conversation, including fully eligible ones.
+  Reproduced deterministically: a Console-created conversation handed off
+  fine (navigated to Console, staged as source context, auto-sent); after
+  seeding ONE foreign-client conversation into the DB, the SAME action on
+  ANY conversation is blocked. Per-item eligibility already exists
+  (`row.active_context_eligible`), and the handoff label itself renders
+  "N eligible, M blocked" — the UI acknowledges mixed states while the
+  gate does not. The media handoff shares the same aggregate gate by
+  documented intent ("identical workspace-staging policy"), so relaxing it
+  to per-item gating is a workspace-policy decision for the owner, not a
+  unilateral fix.
+- The toast copy compounds it: a user clicking on an ELIGIBLE conversation
+  is told about "blocked Library sources" collectively, with no hint their
+  selected item is fine and some OTHER row is the blocker.
+- "Open in Console" also does not open the transcript — it stages the
+  conversation as SOURCE CONTEXT into a Console session and auto-sends a
+  "Use this conversation as source context" turn. Whether that matches the
+  label's promise is a second, smaller copy question.
+- The Console-rail search asymmetry from the original report (Console's
+  "Search conversations" found 0 for a conversation Library sees) remains
+  unverified-in-mechanism and stays open.
+
+Recommended AC revision for the implementing task, pending owner ruling:
+gate the single-item action on the SELECTED row's eligibility, keep the
+aggregate gate for bulk staging, and name the blocking row in the toast.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

Investigation-only PR closing out the fourth finding from the external-OpenAI-server UAT. No code changes — the fix is an owner-level workspace-policy decision, recorded in the task file with the evidence.

**What the UAT called "Open in Console silently does nothing" is neither silent nor a no-op.** Every guard in `_open_selected_conversation_handoff` posts a warning toast; the original captures (~5s after the click) missed the transient toast. Reproduced live with fast capture: "Copy or link blocked Library sources into the active workspace before using them in Console."

**The sharper defect**: `build_library_workspace_depth_state` computes `handoff_enabled = bool(rows) and blocked_count == 0` — ONE workspace-ineligible row anywhere in the visible Library disables the handoff for EVERY conversation. Deterministic repro: a Console-created conversation handed off fine (navigated, staged as source context); after seeding one foreign-client conversation into the DB, the same action on ANY conversation is blocked, and the toast talks about "blocked Library sources" collectively with no hint the selected item is fine.

Per-item eligibility already exists (`row.active_context_eligible`) and the handoff label itself renders "N eligible, M blocked" — the UI acknowledges mixed states while the gate does not. The media handoff shares the aggregate gate by documented intent, so relaxing to per-item gating needs an owner ruling; a recommended AC revision is in the task file. The Console-rail search asymmetry from the original report stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the root cause for TASK-15423: "Open in Console" is not silent (a transient warning toast appears); the real issue is an all-or-nothing workspace gate that blocks handoff for all items if any visible Library row is ineligible. Updates the task with evidence and a recommendation to gate single-item actions by the selected row (keep aggregate gate for bulk) and improve the toast message; no code changes.

<sup>Written for commit 846ad66cee99750ff440878b20e49256692a2a2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

