### PR TITLE
perf: cache cost-chip token estimates across Console sync ticks (task-15451)

### DIFF
--- a/Tests/Chat/test_console_cost_estimate_cache.py
+++ b/Tests/Chat/test_console_cost_estimate_cache.py
@@ -1,0 +1,214 @@
+"""``TokenEstimateCache`` + ``build_cost_snapshot(estimate_cache=...)`` (task-15451).
+
+The cache exists so the Console cost chip stops re-tokenizing an unchanged
+transcript on every sync tick. Its whole safety argument is that a HIT is
+verified against the estimate's full signature -- ``(model, provider, role,
+content)`` -- so the cache key can only affect the hit rate, never the answer.
+These tests pin both halves: the misses that must still happen (edited row,
+model switch, key collision), and the hits that must (unchanged rows, and a
+rebuilt-but-equal string such as the staged-evidence pseudo-row).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tldw_chatbook.Chat import console_cost_tracker as tracker
+from tldw_chatbook.Chat.console_cost_tracker import (
+    TokenEstimateCache,
+    build_cost_snapshot,
+    token_estimate_signature,
+)
+
+PROVIDER = "anthropic"
+MODEL = "claude-sonnet-4-6"
+
+
+def _msg(message_id, content, role="user"):
+    return SimpleNamespace(id=message_id, content=content, usage=None, role=role)
+
+
+def _transcript(rows=6):
+    return [
+        _msg(f"m{index}", f"row {index}: " + ("lorem ipsum dolor sit amet. " * 20))
+        for index in range(rows)
+    ]
+
+
+@pytest.fixture()
+def estimator_spy(monkeypatch):
+    spy = Mock(wraps=tracker._estimate_tokens_locally)
+    monkeypatch.setattr(tracker, "_estimate_tokens_locally", spy)
+    return spy
+
+
+def _snapshot(messages, cache, model=MODEL):
+    return build_cost_snapshot(
+        messages, provider=PROVIDER, model=model, estimate_cache=cache
+    )
+
+
+# --- the cache must not change the answer ----------------------------------
+
+
+def test_cached_and_uncached_snapshots_agree():
+    messages = _transcript()
+
+    uncached = build_cost_snapshot(messages, provider=PROVIDER, model=MODEL)
+    cached = _snapshot(messages, TokenEstimateCache())
+
+    assert cached == uncached
+
+
+def test_default_call_still_estimates_every_row(estimator_spy):
+    """No cache passed -> byte-identical to the pre-task behavior."""
+    messages = _transcript(rows=4)
+
+    build_cost_snapshot(messages, provider=PROVIDER, model=MODEL)
+    build_cost_snapshot(messages, provider=PROVIDER, model=MODEL)
+
+    assert estimator_spy.call_count == 8
+
+
+# --- the hits ---------------------------------------------------------------
+
+
+def test_repeat_pass_over_unchanged_rows_estimates_nothing(estimator_spy):
+    messages = _transcript()
+    cache = TokenEstimateCache()
+
+    first = _snapshot(messages, cache)
+    assert estimator_spy.call_count == len(messages)
+
+    second = _snapshot(messages, cache)
+
+    assert estimator_spy.call_count == len(messages)
+    assert second == first
+
+
+def test_a_fresh_snapshot_of_the_same_rows_still_hits(estimator_spy):
+    """The store hands back new dataclass copies every pass
+    (``messages_for_session`` -> ``dataclasses.replace``), so a hit must not
+    depend on the ROW objects being the same objects."""
+    messages = _transcript()
+    cache = TokenEstimateCache()
+    _snapshot(messages, cache)
+    baseline = estimator_spy.call_count
+
+    copies = [_msg(row.id, row.content, row.role) for row in messages]
+    _snapshot(copies, cache)
+
+    assert estimator_spy.call_count == baseline
+
+
+def test_equal_but_rebuilt_content_still_hits(estimator_spy):
+    """The staged-evidence pseudo-row is joined afresh on every pass, so its
+    content is an equal-but-distinct string object each time."""
+    cache = TokenEstimateCache()
+    text = "corpus text " * 500
+
+    _snapshot([_msg("staged", text)], cache)
+    baseline = estimator_spy.call_count
+    assert baseline == 1
+
+    rebuilt = "".join(["corpus text "] * 500)
+    assert rebuilt is not text and rebuilt == text
+    _snapshot([_msg("staged", rebuilt)], cache)
+
+    assert estimator_spy.call_count == baseline
+
+
+# --- the misses that must still happen --------------------------------------
+
+
+def test_edited_row_is_re_estimated_and_repriced(estimator_spy):
+    messages = _transcript()
+    cache = TokenEstimateCache()
+    before = _snapshot(messages, cache)
+    baseline = estimator_spy.call_count
+
+    messages[2] = _msg(messages[2].id, "short")
+    after = _snapshot(messages, cache)
+
+    assert estimator_spy.call_count == baseline + 1
+    assert after.total_tokens < before.total_tokens
+
+
+def test_model_change_re_estimates_every_row(estimator_spy):
+    messages = _transcript()
+    cache = TokenEstimateCache()
+    _snapshot(messages, cache)
+    baseline = estimator_spy.call_count
+
+    _snapshot(messages, cache, model="gpt-4")
+
+    assert estimator_spy.call_count == baseline + len(messages)
+
+
+def test_role_change_re_estimates_the_row(estimator_spy):
+    """Role is part of what the estimator counts (chat-format framing), and
+    it also decides input vs output pricing, so it must be part of the hit
+    test rather than assumed constant per message id."""
+    cache = TokenEstimateCache()
+    _snapshot([_msg("m0", "text " * 50, role="user")], cache)
+    baseline = estimator_spy.call_count
+
+    _snapshot([_msg("m0", "text " * 50, role="assistant")], cache)
+
+    assert estimator_spy.call_count == baseline + 1
+
+
+def test_colliding_keys_cannot_serve_a_wrong_estimate():
+    """Correctness must not rest on key uniqueness: two different rows
+    forced onto ONE key must each get their own answer."""
+    cache = TokenEstimateCache()
+    short = token_estimate_signature((("user", "hi"),), MODEL, PROVIDER)
+    long = token_estimate_signature((("user", "hi " * 500),), MODEL, PROVIDER)
+
+    short_tokens = cache.estimate(
+        "same-key", short, lambda: tracker._estimate_row_tokens("user", "hi", MODEL, PROVIDER)
+    )
+    long_tokens = cache.estimate(
+        "same-key",
+        long,
+        lambda: tracker._estimate_row_tokens("user", "hi " * 500, MODEL, PROVIDER),
+    )
+    short_again = cache.estimate(
+        "same-key", short, lambda: tracker._estimate_row_tokens("user", "hi", MODEL, PROVIDER)
+    )
+
+    assert long_tokens > short_tokens
+    assert short_again == short_tokens
+
+
+# --- bounded memory ---------------------------------------------------------
+
+
+def test_cache_is_bounded_and_evicts_least_recently_used():
+    cache = TokenEstimateCache(max_entries=2)
+    signature = token_estimate_signature((("user", "hi"),), MODEL, PROVIDER)
+
+    for key in ("a", "b"):
+        cache.estimate(key, signature, lambda: 1)
+    cache.estimate("a", signature, lambda: 1)  # refreshes "a", so "b" is oldest
+    cache.estimate("c", signature, lambda: 1)
+
+    assert len(cache) == 2
+    # Probing mutates recency, so check the two survivors one at a time:
+    # "a" (refreshed) is still there, "b" (least recently used) is gone.
+    misses: list[str] = []
+    cache.estimate("a", signature, lambda: misses.append("a") or 1)
+    assert misses == []
+    cache.estimate("b", signature, lambda: misses.append("b") or 1)
+    assert misses == ["b"]
+
+
+def test_clear_drops_every_entry():
+    cache = TokenEstimateCache()
+    _snapshot(_transcript(rows=3), cache)
+    assert len(cache) == 3
+
+    cache.clear()
+
+    assert len(cache) == 0

--- a/Tests/UI/test_console_cost_chip_estimate_cache.py
+++ b/Tests/UI/test_console_cost_chip_estimate_cache.py
@@ -1,0 +1,249 @@
+"""Screen-level tests: the cost chip must not re-tokenize a frozen transcript.
+
+task-15451. ``_sync_console_cost_chip`` runs on the 0.2 s tick for the whole
+duration of any active run (plus every control-bar sync pass and the 10 s TTL
+timer), and its equality guard gates only the REPAINT -- the state build itself
+ran unconditionally, re-running ``_estimate_tokens_locally`` over every
+usage-less row every single time. With tiktoken absent from base deps
+(task-2526) that estimator is a per-character Python loop, so this was
+O(transcript chars) on the event loop, five times a second.
+
+These tests count estimator calls rather than timing anything: a second
+IDENTICAL build must tokenize nothing, and a build after a one-row edit must
+tokenize exactly that one row. The chip's SEMANTICS (mid-stream freeze, staged
+evidence, ``~`` prefix, TTL states, fingerprint gating) are pinned unchanged by
+Tests/UI/test_console_cost_chip_screen.py, which this file deliberately does
+not modify.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from Tests.UI.test_console_cost_chip_screen import (
+    WARM_USAGE,
+    _AnthropicCostGateway,
+    _configure_anthropic_ready_console,
+    _mount_and_send_warm_reply,
+)
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+
+from tldw_chatbook.Chat import console_cost_tracker as cost_tracker_module
+from tldw_chatbook.Chat.citation_evidence_models import (
+    EvidenceBundle,
+    EvidenceReference,
+)
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
+from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+
+_TRANSCRIPT_ROWS = 12
+_ROW_TEXT = "the quick brown fox jumps over the lazy dog. " * 40
+
+
+def _seed_usageless_transcript(console) -> tuple[object, str]:
+    """Append rows with real text and no ``ProviderUsage`` -- the estimated
+    rows that ``build_cost_snapshot`` prices with the local estimator."""
+    store = console._ensure_console_chat_store()
+    session_id = store.active_session_id
+    for index in range(_TRANSCRIPT_ROWS):
+        store.append_message(
+            session_id,
+            role=(
+                ConsoleMessageRole.USER
+                if index % 2 == 0
+                else ConsoleMessageRole.ASSISTANT
+            ),
+            content=f"row {index}: {_ROW_TEXT}",
+            persist=False,
+        )
+    return store, session_id
+
+
+def _spy_on_estimator(monkeypatch) -> Mock:
+    spy = Mock(wraps=cost_tracker_module._estimate_tokens_locally)
+    monkeypatch.setattr(cost_tracker_module, "_estimate_tokens_locally", spy)
+    return spy
+
+
+@pytest.mark.asyncio
+async def test_second_identical_tick_does_not_retokenize_the_transcript(monkeypatch):
+    """The headline defect: two identical ticks, two full re-tokenizations."""
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-cost-chip")
+        _seed_usageless_transcript(console)
+
+        spy = _spy_on_estimator(monkeypatch)
+
+        first = console._build_console_cost_state()
+        first_calls = spy.call_count
+        assert first_calls == _TRANSCRIPT_ROWS, (
+            "test setup: every seeded row must be an estimated row"
+        )
+
+        second = console._build_console_cost_state()
+
+        assert spy.call_count == first_calls, (
+            "the cost chip re-tokenized an unchanged transcript on the next "
+            f"tick ({spy.call_count - first_calls} extra estimator calls)"
+        )
+        assert second == first
+
+
+@pytest.mark.asyncio
+async def test_editing_one_row_retokenizes_only_that_row(monkeypatch):
+    """O(changed), not O(transcript): one edited row costs one estimate."""
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-cost-chip")
+        store, session_id = _seed_usageless_transcript(console)
+
+        console._build_console_cost_state()
+        spy = _spy_on_estimator(monkeypatch)
+
+        target = store.messages_for_session(session_id)[3]
+        store.update_message_content(target.id, "a different, much shorter row")
+        state = console._build_console_cost_state()
+
+        assert spy.call_count == 1, (
+            "editing one row re-tokenized "
+            f"{spy.call_count} rows -- the other rows are unchanged"
+        )
+        assert state is not None
+
+
+@pytest.mark.asyncio
+async def test_edited_row_is_repriced_not_served_stale(monkeypatch):
+    """The other half of the guarantee: a cached row must never outlive its
+    content. Shrinking one row's text has to move the reported total."""
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-cost-chip")
+        store, session_id = _seed_usageless_transcript(console)
+
+        before = console._build_console_cost_state()
+        target = store.messages_for_session(session_id)[3]
+        store.update_message_content(target.id, "tiny")
+        after = console._build_console_cost_state()
+
+        assert before is not None and after is not None
+        assert after.tooltip != before.tooltip
+        # And restoring the original text restores the original reading.
+        store.update_message_content(target.id, target.content)
+        restored = console._build_console_cost_state()
+        assert restored is not None
+        assert restored.tooltip == before.tooltip
+
+
+@pytest.mark.asyncio
+async def test_staged_evidence_row_is_not_retokenized_every_tick(monkeypatch):
+    """The staged-evidence pseudo-row is rebuilt as a NEW string on every
+    pass (``console_prompted_evidence_text`` joins the snippets each call),
+    so it only caches if identity is not the test for a hit."""
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-cost-chip")
+
+        reference = EvidenceReference(
+            evidence_id="S1",
+            source_id="media-1",
+            source_type="media",
+            title="Big corpus",
+            snippet="corpus text " * 20_000,
+            authority_label="local",
+            status="available",
+            source_owner="local",
+        )
+        bundle = EvidenceBundle(
+            bundle_id="bundle-big",
+            query="question",
+            source="Library Search/RAG",
+            references=(reference,),
+        )
+        # Spy BEFORE staging: staging itself drives a sync pass, so the
+        # pseudo-row's one legitimate estimate may be spent there.
+        spy = _spy_on_estimator(monkeypatch)
+        console._stage_console_library_rag_launch(
+            ConsoleLiveWorkLaunch.from_values(
+                source="Library Search/RAG",
+                title="Library Search/RAG retrieval",
+                payload={"query": "question", "evidence_bundle": bundle.to_payload()},
+                status="staged",
+            )
+        )
+        await pilot.pause()
+
+        first = console._build_console_cost_state()
+        settled_calls = spy.call_count
+        assert settled_calls >= 1, "test setup: staged text must price as a row"
+        assert first is not None and first.label.startswith("~")
+
+        second = console._build_console_cost_state()
+
+        assert spy.call_count == settled_calls, (
+            "the staged-evidence pseudo-row was re-tokenized on the next tick"
+        )
+        assert second == first
+
+
+@pytest.mark.asyncio
+async def test_projected_delta_estimate_is_not_recomputed_every_tick():
+    """The WARM+break_reason projection estimates the WHOLE transcript in one
+    call, and (unlike the fingerprint) is recomputed on every build -- so an
+    alerting session paid it 5x/s for the life of the alert."""
+    gateway = _AnthropicCostGateway(WARM_USAGE, reply="warm reply")
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        store, session_id = await _mount_and_send_warm_reply(console, pilot)
+
+        user_message = next(
+            message
+            for message in store.messages_for_session(session_id)
+            if message.role is ConsoleMessageRole.USER
+        )
+        store.update_message_content(user_message.id, "EDITED EARLIER HISTORY")
+
+        spy = Mock(wraps=chat_screen_module._estimate_tokens_locally)
+        original = chat_screen_module._estimate_tokens_locally
+        chat_screen_module._estimate_tokens_locally = spy
+        try:
+            alert_state = console._build_console_cost_state()
+            assert alert_state is not None and alert_state.alert is True
+            assert spy.call_count == 1, "test setup: the projection must run once"
+
+            repeat_state = console._build_console_cost_state()
+
+            assert spy.call_count == 1, (
+                "the projected cache-break delta re-tokenized the whole "
+                "transcript on an unchanged tick"
+            )
+            assert repeat_state == alert_state
+        finally:
+            chat_screen_module._estimate_tokens_locally = original

--- a/backlog/tasks/task-15451 - Console-cost-chip-must-stop-re-tokenizing-the-transcript-on-every-sync-tick.md
+++ b/backlog/tasks/task-15451 - Console-cost-chip-must-stop-re-tokenizing-the-transcript-on-every-sync-tick.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-15451
 title: Console cost chip must stop re-tokenizing the transcript on every sync tick
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-11 12:05'
-updated_date: '2026-08-11 22:36'
+updated_date: '2026-08-11 22:37'
 labels:
   - perf
   - console

--- a/backlog/tasks/task-15451 - Console-cost-chip-must-stop-re-tokenizing-the-transcript-on-every-sync-tick.md
+++ b/backlog/tasks/task-15451 - Console-cost-chip-must-stop-re-tokenizing-the-transcript-on-every-sync-tick.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-15451
 title: Console cost chip must stop re-tokenizing the transcript on every sync tick
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
+updated_date: '2026-08-11 22:36'
 labels:
   - perf
   - console
@@ -20,7 +22,59 @@ Fix direction: cache per-message token estimates keyed by message identity + con
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Cost state build does no repeated tokenization of unchanged rows across ticks (unit or probe evidence on a long transcript)
-- [ ] #2 The existing cost-chip test surface passes unchanged (mid-stream freeze, staged evidence, ~ prefix, TTL states)
-- [ ] #3 0.2 s tick cost measured before/after on a transcript with substantial usage-less text, and recorded in the task
+- [x] #1 Cost state build does no repeated tokenization of unchanged rows across ticks (unit or probe evidence on a long transcript)
+- [x] #2 The existing cost-chip test surface passes unchanged (mid-stream freeze, staged evidence, ~ prefix, TTL states)
+- [x] #3 0.2 s tick cost measured before/after on a transcript with substantial usage-less text, and recorded in the task
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Baseline: run the whole cost-chip test surface green FIRST (Tests/UI/test_console_cost_chip_screen.py, Tests/Chat/test_console_cost_tracker.py, Tests/UI/test_console_cost_modal.py, Tests/Chat/test_console_status_chips_cost.py) and keep it unmodified.
+
+2. Shape decision -- per-row memo, NOT a revision-gated snapshot. Rejecting the payload-revision gate on evidence: `ConsoleChatStore.set_message_usage` (console_chat_store.py:3214) never calls `_bump_payload_revision` -- usage is not payload-affecting -- so in the documented late-attach ordering (Stop path: terminal mark first, usage attach after) a revision-gated snapshot would keep showing the ESTIMATED total after the real priced usage landed. Also fleet_tokens, provider/model and the staged-evidence pseudo-row all change with no revision movement. A memo keyed on the estimator's own inputs cannot go stale by construction.
+
+3. Add `TranscriptTokenEstimateCache` to Chat/console_cost_tracker.py: a keyed memo whose every HIT is verified by comparing the cached (role, content) rows against the live ones (identity fast path, then ==). Correctness therefore does not depend on the key choice -- the key only determines hit rate. Entries hold the store's own string objects (dataclasses.replace shares the reference), so a hit retains no extra memory; the cache is pruned to the keys seen in each pass so it can never outgrow the transcript.
+
+4. Thread it through as an OPTIONAL keyword: `build_cost_snapshot(..., estimate_cache=None)` defaults to today's uncached behavior byte-for-byte (existing tracker tests untouched). ChatScreen owns one instance via a CLASS-level attribute default (`__new__()` fixtures never run `__init__`), passes it per build, and routes the WARM+break_reason `projected_delta_usd` whole-transcript estimate through the same cache -- still calling the module-global `_estimate_tokens_locally` name on a miss so the existing estimator spy test still intercepts.
+
+5. TDD: new test counts `_estimate_tokens_locally` calls across two identical builds on a long transcript -- fails on the current shape (N calls per tick, every tick), passes when the second tick makes zero. Plus tests for: content edit re-estimates only the edited row; model switch invalidates; staged-evidence pseudo-row (rebuilt as a NEW string each pass) still hits.
+
+6. Measure before/after with an isolated probe (scratch HOME/XDG/TLDW_CONFIG_PATH): per-tick cost of the cost-state build on a transcript with substantial usage-less text. Record honest attribution in the task.
+
+7. Re-run the full cost-chip surface unmodified + ruff; self-review the diff; notes + Done; commit task file with code.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Made the Console cost-chip state build O(changed) instead of O(transcript chars) by memoizing the per-row local token estimates across sync ticks. The chip's semantics are untouched: the existing cost-chip test surface (65 tests across Tests/UI/test_console_cost_chip_screen.py, Tests/Chat/test_console_cost_tracker.py, Tests/UI/test_console_cost_modal.py, Tests/Chat/test_console_status_chips_cost.py) passes UNMODIFIED.
+
+## Approach
+
+`TokenEstimateCache` (new, Chat/console_cost_tracker.py) is a verified memo, not an invalidated cache: every HIT is checked against the estimate's full signature -- `(model, provider, ((role, content), ...))` -- before it is served. So the cache KEY only affects the hit rate, never the answer; there is no invalidation protocol that a future mutation site could forget to call. Tuple comparison short-circuits on per-element identity, so the ordinary case (the store hands back the same `str` objects pass after pass, since `messages_for_session` -> `dataclasses.replace` shares the reference) costs pointer compares, and a rebuilt-but-equal string (the staged-evidence pseudo-row, joined afresh every pass) costs one C-level memcmp. Bounded by an LRU cap (4096 entries) so it can never grow without limit; entries hold the caller's own strings, so a live entry costs a tuple rather than a copy.
+
+`build_cost_snapshot` takes it as an OPTIONAL `estimate_cache=None` keyword -- omitted, it estimates every row on every call exactly as before, so every other caller and the whole existing tracker test surface is byte-identical. `ChatScreen` owns one instance (class-level attribute default, since `__new__()` fixtures never run `__init__`) and passes it from `_build_console_cost_state`; the WARM+break_reason `projected_delta_usd` whole-transcript estimate goes through the same memo under its own per-session key, still calling chat_screen's module-global `_estimate_tokens_locally` on a miss so the existing estimator-spy test keeps intercepting it.
+
+## Why not gate the rebuild on payload_revision
+
+Considered and rejected on evidence, and the reason is now a comment at the call site: usage is not payload-affecting, so `ConsoleChatStore.set_message_usage` never calls `_bump_payload_revision`. A real priced usage landing on an already-terminal row (the documented Stop-path ordering, where the terminal mark precedes the attach) would leave a revision-gated snapshot showing the ESTIMATED total until some unrelated edit moved the counter. Provider/model, fleet tokens and the staged-evidence pseudo-row also all change with no revision movement. Deviation from the plan: the plan said prune-to-last-pass; an LRU cap replaced it because the projection entry (written after the snapshot pass) would have been evicted by the next pass's prune, defeating its own caching. The plan's working name `TranscriptTokenEstimateCache` shortened to `TokenEstimateCache`.
+
+## Measured (AC#3)
+
+Isolated probe on the real mounted screen (pytest-hermetic config), 40 rows / 99,310 chars of usage-less text, anthropic/claude-sonnet-4-6, tiktoken absent so the estimator is the per-character chars-floor loop. Median of 20 `_build_console_cost_state()` calls:
+
+| | per tick | at the 0.2 s tick |
+|---|---|---|
+| before (cache cold each call) | 27.39 ms | 137.0 ms/s |
+| after (warm) | 0.36 ms | 1.8 ms/s |
+
+~76x on this transcript; the residual 0.36 ms is dominated by everything OTHER than tokenization (`messages_for_session` alone is 0.08 ms). Honest scope: this removes the REPEAT cost only -- the first tick after any change still pays the estimate for the changed rows, and `build_cost_snapshot` with no cache passed is unchanged at 27.0 ms. The audit's estimate for this size was 50-100 ms/tick; measured here it is 27 ms, so the win is real but the starting figure was smaller than the audit projected on this hardware. tiktoken (task-2526) and the modelling gaps (task-2525) remain open and untouched.
+
+## Files
+
+- `tldw_chatbook/Chat/console_cost_tracker.py` -- `TokenEstimateCache`, `token_estimate_signature`, `_estimate_row_tokens`, `build_cost_snapshot(estimate_cache=...)`
+- `tldw_chatbook/UI/Screens/chat_screen.py` -- per-screen cache + both estimate sites in `_build_console_cost_state`
+- `Tests/Chat/test_console_cost_estimate_cache.py` (new, 11 tests) -- hits, misses (edited row, model switch, role switch, forced key collision), LRU bound, cached==uncached totals
+- `Tests/UI/test_console_cost_chip_estimate_cache.py` (new, 5 tests) -- screen-level estimator call counts across identical ticks, one-row edit, staged evidence, the projection; plus an anti-staleness control that was green before AND after
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_cost_tracker.py
+++ b/tldw_chatbook/Chat/console_cost_tracker.py
@@ -26,9 +26,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Mapping, Optional, Sequence
+from functools import partial
+from typing import Any, Callable, Mapping, Optional, Sequence
 
 from loguru import logger
 
@@ -51,6 +53,133 @@ class ConsoleCacheState(str, Enum):
     NONE = "none"
     WARM = "warm"
     EXPIRED = "expired"
+
+
+#
+#######################################################################################################################
+#
+# Token-estimate memo (task-15451)
+#
+
+
+#: Entry ceiling for :class:`TokenEstimateCache`. Generous on purpose: past
+#: this size a single pass over a longer transcript would evict its own
+#: earlier rows and degrade to the uncached cost (never to a WRONG cost), so
+#: the cap is set well above any realistic Console transcript rather than
+#: tuned for memory. Entries hold the caller's OWN row strings -- the store
+#: already owns those objects -- so a live entry costs a tuple, not a copy.
+TOKEN_ESTIMATE_CACHE_MAX_ENTRIES = 4096
+
+
+class TokenEstimateCache:
+    """Verified memo for local token estimates over transcript rows (task-15451).
+
+    ``_estimate_tokens_locally`` is a per-character Python loop whenever no
+    tokenizer is installed (tiktoken is not a base dependency -- task-2526),
+    so re-estimating an unchanged transcript on every Console sync tick cost
+    O(transcript chars) on the event loop five times a second. This memo
+    makes a repeat pass O(rows).
+
+    Correctness does not depend on the KEY. Every hit is verified against
+    the full signature of the estimate -- ``(model, provider, rows)``, where
+    ``rows`` is a tuple of ``(role, content)`` pairs -- so a key that
+    collides, or is reused by a row whose text changed, misses and
+    recomputes. The key only determines the hit RATE. That is why this can
+    be reasoned about locally: there is no invalidation protocol to get
+    wrong, and no way for a stale estimate to be served.
+
+    Tuple comparison short-circuits on identity per element, so the common
+    case (the store hands back the same ``str`` objects pass after pass --
+    ``dataclasses.replace`` shares the reference) costs pointer compares;
+    a rebuilt-but-equal string (the staged-evidence pseudo-row, joined
+    afresh every pass) costs one C-level ``memcmp``.
+
+    Not thread-safe: it is owned by, and only ever touched from, the UI
+    thread that builds the chip state.
+    """
+
+    def __init__(self, *, max_entries: int = TOKEN_ESTIMATE_CACHE_MAX_ENTRIES) -> None:
+        self._entries: "OrderedDict[Any, tuple[tuple[Any, ...], int]]" = OrderedDict()
+        self._max_entries = max(1, int(max_entries))
+
+    def estimate(
+        self,
+        key: Any,
+        signature: tuple[Any, ...],
+        compute: Callable[[], int],
+    ) -> int:
+        """Return the memoized estimate for ``signature``, computing on a miss.
+
+        Args:
+            key: Cache slot. Any hashable; a message id for a transcript row.
+                Collisions only cost a recompute, never a wrong answer.
+            signature: Everything the estimate depends on -- by convention
+                ``(model, provider, rows)`` built by
+                :func:`token_estimate_signature`. Compared for equality
+                before any hit is served.
+            compute: Called on a miss. Deliberately a callback rather than a
+                hard-wired estimator call so each call site keeps its own
+                estimator reference (and stays interceptable by its own
+                tests).
+
+        Returns:
+            The estimated token count for ``signature``.
+        """
+        entry = self._entries.get(key)
+        if entry is not None and entry[0] == signature:
+            self._entries.move_to_end(key)
+            return entry[1]
+        value = compute()
+        self._entries[key] = (signature, value)
+        self._entries.move_to_end(key)
+        while len(self._entries) > self._max_entries:
+            self._entries.popitem(last=False)
+        return value
+
+    def clear(self) -> None:
+        """Drop every entry (nothing depends on this for correctness)."""
+        self._entries.clear()
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+def token_estimate_signature(
+    rows: Sequence[tuple[Any, Any]],
+    model: str,
+    provider: str,
+) -> tuple[Any, ...]:
+    """Build a :class:`TokenEstimateCache` signature for ``rows``.
+
+    Args:
+        rows: ``(role, content)`` pairs exactly as they will be handed to
+            the estimator.
+        model: Model name the estimate is for (selects the tokenizer).
+        provider: Normalized provider key (selects the chars-floor ratio).
+
+    Returns:
+        A comparison tuple. Only equality is ever taken on it, never a
+        hash, so row content that is unhashable still compares correctly.
+    """
+    return (model, provider, tuple(rows))
+
+
+def _estimate_row_tokens(role: Any, content: Any, model: str, provider: str) -> int:
+    """Estimate one transcript row's tokens.
+
+    The single call shared by :func:`build_cost_snapshot`'s cached and
+    uncached paths, so the two can never drift apart.
+    """
+    return _estimate_tokens_locally(
+        [{"role": role, "content": content}], model, provider
+    )
+
+
+#
+#######################################################################################################################
+#
+# Enums / dataclasses (continued)
+#
 
 
 @dataclass(frozen=True)
@@ -450,6 +579,7 @@ def build_cost_snapshot(
     provider: str,
     model: Optional[str],
     fleet_tokens: int = 0,
+    estimate_cache: Optional[TokenEstimateCache] = None,
 ) -> ConsoleCostSnapshot:
     """Sum dollar/token totals across a Console session's transcript rows.
 
@@ -493,6 +623,14 @@ def build_cost_snapshot(
             but never dollars). Defaults to 0, byte-identical to this
             function's pre-Task-5 behavior for every caller that doesn't
             pass it.
+        estimate_cache: task-15451 -- optional :class:`TokenEstimateCache`
+            memoizing the per-row local estimates, so a caller polling this
+            on a timer (the Console cost chip, 5x/s while a run is active)
+            stops re-tokenizing rows whose text has not changed. Every hit
+            is verified against the row's own ``(model, provider, role,
+            content)``, so passing one can only change how LONG this takes,
+            never what it returns. ``None`` (the default) estimates every
+            row on every call, exactly as before.
 
     Returns:
         A :class:`ConsoleCostSnapshot`. Never raises -- an unexpected
@@ -507,7 +645,7 @@ def build_cost_snapshot(
         total_tokens = 0
         row_count = 0
 
-        for message in messages:
+        for index, message in enumerate(messages):
             usage = getattr(message, "usage", None)
 
             if isinstance(usage, ProviderUsage):
@@ -525,9 +663,26 @@ def build_cost_snapshot(
                 continue
             role = getattr(message, "role", "") or ""
 
-            estimated_tokens = _estimate_tokens_locally(
-                [{"role": role, "content": content}], model or "", provider_key
-            )
+            if estimate_cache is None:
+                estimated_tokens = _estimate_row_tokens(
+                    role, content, model or "", provider_key
+                )
+            else:
+                # Cache slot: the row's own id when it has one. The staged-
+                # evidence pseudo-row (`console_prompted_evidence_text`) has
+                # none, so it falls back to its position -- stable across
+                # passes, and wrong only in the harmless direction: a hit is
+                # still verified against the row's text before it is served.
+                row_id = getattr(message, "id", None)
+                estimated_tokens = estimate_cache.estimate(
+                    row_id if isinstance(row_id, str) and row_id else ("#row", index),
+                    token_estimate_signature(
+                        ((role, content),), model or "", provider_key
+                    ),
+                    partial(
+                        _estimate_row_tokens, role, content, model or "", provider_key
+                    ),
+                )
             total_tokens += estimated_tokens
             row_count += 1
             has_estimated = True

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -104,11 +104,13 @@ from ...Chat.console_cost_tracker import (
     ConsoleCacheState,
     ConsoleCostRowTotals,
     ConsoleCostState,
+    TokenEstimateCache,
     build_cost_rows,
     build_cost_rows_totals,
     build_cost_snapshot,
     build_cost_state,
     fingerprint_break_reason,
+    token_estimate_signature,
 )
 from ...Chat.message_metadata import MessageMetadata
 from ...Chat.provider_usage import ProviderUsage, as_seconds
@@ -3527,6 +3529,28 @@ class ChatScreen(BaseAppScreen):
     #: no pass is open. A CLASS attribute default because the hand-built
     #: `ChatScreen.__new__()` test fixtures never run `__init__`.
     _console_derivation_memo: dict[Any, Any] | None = None
+
+    #: Cross-tick memo for the cost chip's per-row token estimates
+    #: (task-15451), lazily created by `_console_cost_estimate_cache_or_new`.
+    #: Unlike `_console_derivation_memo` this deliberately OUTLIVES a single
+    #: pass -- the whole point is that the 0.2s tick stops re-tokenizing rows
+    #: it already estimated on the previous tick. Also a CLASS attribute
+    #: default, for the same `__new__()`-fixture reason.
+    _console_cost_estimate_cache: TokenEstimateCache | None = None
+
+    def _console_cost_estimate_cache_or_new(self) -> TokenEstimateCache:
+        """Return this screen's token-estimate memo, creating it on first use.
+
+        Held per screen rather than per session: entries are keyed by message
+        id and every hit is re-verified against the row's own text, so the
+        two sessions of a switched-between pair share the cache safely (see
+        :class:`TokenEstimateCache`).
+        """
+        cache = self._console_cost_estimate_cache
+        if cache is None:
+            cache = TokenEstimateCache()
+            self._console_cost_estimate_cache = cache
+        return cache
 
     @contextmanager
     def _console_derivation_scope(self):
@@ -8357,11 +8381,30 @@ class ChatScreen(BaseAppScreen):
             # the rail can never disagree about a conversation's fleet
             # spend.
             fleet_tokens = self._agent._console_agent_fleet_token_total()
+            # task-15451: this method runs on the 0.2s tick for the whole
+            # duration of a run (plus every control-bar sync pass and the
+            # 10s TTL timer), and the equality guard in
+            # `_sync_console_cost_chip` gates only the REPAINT -- the build
+            # itself always ran. Without the memo below every usage-less row
+            # (all user/system rows, legacy assistant rows, the staged
+            # evidence pseudo-row) was re-tokenized by a per-character
+            # Python loop 5x/s: ~28ms/tick on a 99KB transcript, measured.
+            # The memo re-verifies each row's own text before serving a hit,
+            # so it can change how long this takes but not what it returns.
+            #
+            # Gating the whole snapshot on `store.payload_revision` instead
+            # was considered and rejected: usage is not payload-affecting, so
+            # `ConsoleChatStore.set_message_usage` never bumps that counter --
+            # a real priced usage landing on an ALREADY-terminal row (the
+            # documented Stop-path ordering) would leave the chip showing the
+            # estimated total until some unrelated edit moved the revision.
+            estimate_cache = self._console_cost_estimate_cache_or_new()
             snapshot = build_cost_snapshot(
                 snapshot_messages,
                 provider=provider,
                 model=model,
                 fleet_tokens=fleet_tokens,
+                estimate_cache=estimate_cache,
             )
 
             controller = self._console_chat_controller
@@ -8433,15 +8476,37 @@ class ChatScreen(BaseAppScreen):
                     # (fingerprint recompute -- and so `break_reason` /
                     # `alert` -- is frozen during the run, but this
                     # projection is computed fresh every call).
-                    dict_messages = [
-                        {
-                            "role": str(getattr(message.role, "value", message.role)),
-                            "content": message.content,
-                        }
+                    #
+                    # task-15451: gated, but not cheap -- an alerting
+                    # session pays a WHOLE-transcript estimate on every tick
+                    # for as long as the alert stands. Same memo, same
+                    # guarantee: the hit is verified against every row's
+                    # (role, content) before it is served.
+                    projection_rows = tuple(
+                        (
+                            str(getattr(message.role, "value", message.role)),
+                            message.content,
+                        )
                         for message in snapshot_messages
-                    ]
-                    estimated_tokens = _estimate_tokens_locally(
-                        dict_messages, model or "", provider_key
+                    )
+
+                    def _estimate_projection() -> int:
+                        return _estimate_tokens_locally(
+                            [
+                                {"role": role, "content": content}
+                                for role, content in projection_rows
+                            ],
+                            model or "",
+                            provider_key,
+                        )
+
+                    projection_cache = self._console_cost_estimate_cache_or_new()
+                    estimated_tokens = projection_cache.estimate(
+                        ("#cost-projection", session_id),
+                        token_estimate_signature(
+                            projection_rows, model or "", provider_key
+                        ),
+                        _estimate_projection,
                     )
                     rate_delta = (
                         pricing.cache_write_per_mtok - pricing.cache_read_per_mtok


### PR DESCRIPTION
## Summary

Task 15451 from the input-latency audit. The Console cost chip rebuilt its state unconditionally on every sync pass — including the 0.2s tick running for the whole duration of any active run — re-running the per-character token estimator over every usage-less transcript row each time (tiktoken is not in base deps, so the slow fallback is the norm).

- Signature-verified per-message estimate memo (key = message id; every hit verified against `(model, provider, (role, content))` — the July length-signature trap is structurally impossible; a wrong-total is unreachable by construction, not discipline)
- Staged-evidence pseudo-row and the WARM-projection branch route through the same memo; cached-vs-uncached totals pinned equal
- LRU 4096 bound: degrade-to-recompute, never wrong
- Measured: 27.4 ms → 0.36 ms per tick on a 40-row/99 KB transcript (137 → 1.8 ms/s during streaming); honest attribution — only the repeat cost is removed
- 16 new tests (4 born red, mutation-verified); the pre-existing 65-test cost surface is byte-identical and green

## Verification
Independent review: Approved, no Critical/Important. Reviewer reproduced the baseline measurement in its own isolated probe, mutation-injected the staleness bug (6 tests caught it incl. a money-visible tooltip assertion), and verified the revision-gate alternative was correctly REJECTED (usage attach does not bump payload revision — that design would show estimated totals after real priced usage landed). Deferred minors recorded: production-dead `clear()` (bounded-count, unbounded-size retention until eviction), pseudo-row key hit-rate. One NEW pre-existing dev failure found and being filed separately (console shell chip swap TypeError).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches per-message token estimates for the Console cost chip to stop re-tokenizing unchanged transcripts on every sync tick. Addresses Linear TASK-15451 and cuts per-tick build time from ~27.4 ms to ~0.36 ms on a 40-row/99 KB transcript while keeping totals identical.

- New Features
  - Added `TokenEstimateCache` (LRU 4096) with signature-verified hits `(model, provider, (role, content))`; wrong totals are structurally impossible.
  - `build_cost_snapshot(..., estimate_cache=None)` now accepts an optional cache; default remains uncached and byte-identical.
  - `ChatScreen` uses a per-screen cache and routes the WARM projection through it; staged-evidence pseudo-row also hits.
  - Tests: added focused unit/UI coverage; existing cost-chip tests remain unchanged and green.

- Performance
  - Repeat passes do zero re-tokenization; only edited rows re-estimate (O(changed)).
  - Measured improvement: 27.4 ms → 0.36 ms per tick (~76x), 137 → 1.8 ms/s at the 0.2 s tick.
  - Reduces event-loop load when `tiktoken` isn’t installed; `_estimate_tokens_locally` runs only on cache miss.

<sup>Written for commit 8f7c0208914493faf7377cf3dbb917f597dc9dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

