### PR TITLE
fix: autocommit + documented nesting semantics for Workspace_DB held connection (task-15480)

### DIFF
--- a/Tests/DB/test_held_connections.py
+++ b/Tests/DB/test_held_connections.py
@@ -39,10 +39,12 @@ import pytest
 
 from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
 from tldw_chatbook.DB.RAG_Indexing_DB import RAGIndexingDB
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.Library.library_collections_service import (
     LocalLibraryCollectionsService,
 )
 from tldw_chatbook.Notifications.client_notifications_db import ClientNotificationsDB
+from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
 
 
 def _count_opens(db) -> list[sqlite3.Connection]:
@@ -603,4 +605,118 @@ class TestNotificationSettingsAreWrittenAtomically:
         assert settings["enabled"] is False
         assert settings["toast_enabled"] is False
         assert settings["category_preferences"] == {"watchlist": {"enabled": False}}
+        db.close()
+
+
+# === 5. WorkspaceDB (task-15480): autocommit + guarded nesting ===
+
+
+def _insert_workspace_record(conn: sqlite3.Connection, workspace_id: str, name: str) -> None:
+    """Bare INSERT against ``workspace_records``, bypassing ``transaction()``.
+
+    No production call site does this today (task-15480's audit found every
+    ``Workspaces/registry_service.py`` write already goes through
+    ``db.transaction()``, and ``Workspace_DB``'s own ``connection()`` sites
+    -- ``_initialize_schema``'s ``executescript`` and ``get_schema_version``
+    -- are a self-committing script and a pure read, respectively). This
+    helper exists to pin the connection property itself, so a FUTURE bare
+    write through ``connection()`` cannot silently reintroduce the
+    task-3012 failure mode.
+    """
+    conn.execute(
+        """
+        INSERT INTO workspace_records (
+            workspace_id, name, description, authority, sync_status,
+            active, archived, created_at, updated_at
+        ) VALUES (?, ?, '', 'local-only', 'not-configured', 0, 0, ?, ?)
+        """,
+        (workspace_id, name, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"),
+    )
+
+
+@pytest.mark.unit
+class TestWorkspaceDBAutocommitAndNesting:
+    """WorkspaceDB (task-3011) predates the task-3012 fix that
+    ``Library_Collections_DB``/``AgentRunsDB`` already carry:
+    ``isolation_level=None`` on the held connection, and a nesting-safe
+    ``transaction()``.
+    """
+
+    def test_isolation_level_is_none(self, tmp_path):
+        db = WorkspaceDB(tmp_path / "workspace.db")
+        assert db._held_connection().isolation_level is None
+        db.close()
+
+    def test_bare_dml_through_connection_survives_closing_the_held_connection(
+        self, tmp_path
+    ):
+        """The exact task-3012 failure: bare DML rolled back on close.
+
+        Under sqlite3's default isolation mode a held connection would
+        auto-BEGIN on the INSERT and never commit it, so closing the
+        connection would silently discard the row.
+        """
+        path = tmp_path / "workspace.db"
+        db = WorkspaceDB(path)
+        with db.connection() as conn:
+            _insert_workspace_record(conn, "bare-dml", "Bare DML")
+        db.close()
+
+        reopened = WorkspaceDB(path)
+        with reopened.connection() as conn:
+            row = conn.execute(
+                "SELECT name FROM workspace_records WHERE workspace_id = ?",
+                ("bare-dml",),
+            ).fetchone()
+        assert row is not None and row["name"] == "Bare DML"
+        reopened.close()
+
+    def test_explicit_begin_still_works_after_bare_dml(self, tmp_path):
+        """A write transaction right after bare DML must not raise.
+
+        Without ``isolation_level=None`` the bare DML above leaves an
+        implicit transaction open on the held connection, and the explicit
+        ``BEGIN`` in ``transaction()`` fails with "cannot start a
+        transaction within a transaction".
+        """
+        db = WorkspaceDB(tmp_path / "workspace.db")
+        with db.connection() as conn:  # bare DML
+            _insert_workspace_record(conn, "bare-dml", "Bare DML")
+
+        service = LocalWorkspaceRegistryService(db)
+        created = service.create_workspace(workspace_id="ws-1", name="One")
+
+        assert created.workspace_id == "ws-1"
+        # Both the bare DML (now durable under isolation_level=None) and the
+        # explicit-transaction write it was followed by must be present.
+        assert {record.workspace_id for record in service.list_workspaces()} == {
+            "bare-dml",
+            "ws-1",
+        }
+        db.close()
+
+    def test_nesting_a_transaction_raises_and_the_outer_block_rolls_back(
+        self, tmp_path
+    ):
+        """One connection per thread means one transaction at a time.
+
+        Pre-port each caller opened its own connection, so nesting silently
+        "worked". It now raises -- and the outer block must still roll
+        back cleanly rather than strand an open transaction on the held
+        connection.
+        """
+        db = WorkspaceDB(tmp_path / "workspace.db")
+        service = LocalWorkspaceRegistryService(db)
+        before = {record.workspace_id for record in service.list_workspaces()}
+
+        with pytest.raises(sqlite3.OperationalError, match="within a transaction"):
+            with db.transaction() as conn:
+                _insert_workspace_record(conn, "outer", "Outer")
+                with db.transaction():
+                    pass
+
+        assert db._held_connection().in_transaction is False
+        assert {
+            record.workspace_id for record in service.list_workspaces()
+        } == before
         db.close()

--- a/backlog/tasks/task-15480 - Workspace_DB-held-connection-needs-isolation_level=None-and-a-guarded-BEGIN.md
+++ b/backlog/tasks/task-15480 - Workspace_DB-held-connection-needs-isolation_level=None-and-a-guarded-BEGIN.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15480
 title: Workspace_DB held connection needs isolation_level=None and a guarded BEGIN
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - bug
@@ -20,7 +21,174 @@ Evidence and method: Docs/Design/2026-08-11-input-latency-audit.md (audit of dev
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Workspace_DB holds its connection with isolation_level=None; the bare-DML call-site audit is recorded in the notes
-- [ ] #2 transaction() is safe when a transaction is already open (test)
-- [ ] #3 The stale workspace_file_roots comment is corrected; existing Workspace surfaces green
+- [x] #1 Workspace_DB holds its connection with isolation_level=None; the bare-DML call-site audit is recorded in the notes
+- [x] #2 transaction() is safe when a transaction is already open (test)
+- [x] #3 The stale workspace_file_roots comment is corrected; existing Workspace surfaces green
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read the task-3012 rationale in `DB/AgentRuns_DB.py:73-95` and the fresh
+   task-15466 precedent in `DB/Library_Collections_DB.py` (its
+   `_get_connection` autocommit comment and its `transaction()`/
+   `read_transaction()` nesting-docstring wording) as the two templates to
+   mirror.
+2. Audit every call site that reaches `WorkspaceDB.connection()` or
+   `.transaction()` (`Workspaces/registry_service.py`, plus
+   `Workspace_DB.py`'s own `_initialize_schema`/`get_schema_version`) and
+   classify each as read / DML-inside-`transaction()` / bare DML through
+   `connection()`. Record the result before writing any fix.
+3. TDD: add Workspace_DB cases to `Tests/DB/test_held_connections.py`
+   (isolation_level is None; bare DML through `connection()` survives
+   closing the held connection; an explicit `BEGIN` still works right
+   after bare DML; nesting `transaction()` raises
+   `sqlite3.OperationalError` and the outer block still rolls back
+   cleanly) and confirm the autocommit-dependent ones are RED against
+   current `dev`.
+4. Add `conn.isolation_level = None` to `WorkspaceDB._get_connection`,
+   with a comment mirroring the AgentRuns/Library_Collections rationale
+   and citing this task's audit result.
+5. Add the nesting paragraph to `transaction()`'s docstring, worded like
+   `Library_Collections_DB.transaction()`'s.
+6. Fix the stale "fresh connection per operation" comment at
+   `Tools/workspace_file_roots.py:43-45`.
+7. Confirm the new tests are GREEN, then run the existing Workspace_DB
+   suite (`Tests/Workspaces/`, `Tests/Tools/test_*workspace_file_roots*`)
+   and the wider Workspace UI/Agents/Notes consumer suites for
+   regressions, plus the pragma-pairing regression test
+   (`Tests/DB/test_pragma_settings.py`, which already parametrizes
+   `WorkspaceDB` into `_HELD_CONNECTION_DBS`).
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Call-site audit (AC#1)** — every reachable `WorkspaceDB.connection()` /
+`.transaction()` use, by grep + manual read of `Workspaces/registry_service.py`
+and `DB/Workspace_DB.py`:
+
+- `Workspace_DB.py:114` (`_initialize_schema`'s `connection()` block): DDL +
+  an explicit `conn.commit()` inside the block, self-committing under
+  either isolation mode. Its v2-migration writes run inside
+  `self.transaction()` (`:253`), not here.
+- `Workspace_DB.py:272` (`get_schema_version`): pure read.
+- `Workspaces/registry_service.py`: 11 `connection()` call sites, ALL pure
+  `SELECT`s (`list_workspaces`, `get_workspace`, membership lookups,
+  runtime-binding lookups, change-review/rag-scope reads, the default-
+  workspace legacy-binding check). Every write (`create_workspace`,
+  `rename_workspace`, archive/unarchive, `set_active_workspace`, membership
+  insert, runtime-binding upsert/delete, change-review toggle, rag-scope
+  upsert/delete, default-workspace reseed) goes through `self.db.transaction()`.
+  One `transaction()` call (`:576`) wraps a pure `SELECT` — wasteful but not
+  a correctness issue.
+
+**Conclusion: no bare DML through `connection()` exists in production
+today.** This confirms the task description's "latent, not live" framing —
+the fix closes a correctness fuse for the next contributor rather than
+fixing an active data-loss bug. Two new tests
+(`test_bare_dml_through_connection_survives_closing_the_held_connection`,
+`test_explicit_begin_still_works_after_bare_dml`) exercise the scenario
+synthetically (direct `INSERT` through `db.connection()`, mirroring how
+`Tests/DB/test_held_connections.py` already pins the same property for
+`RAGIndexingDB`) since there is no real call site to exercise it through.
+
+**Fix (AC#1, AC#2)** — `WorkspaceDB._get_connection` now sets
+`conn.isolation_level = None` (mirrors `AgentRuns_DB`/`Library_Collections_DB`,
+with a comment citing the audit above). `transaction()`'s existing
+try/except-rollback-reraise shape (unchanged) already made a nested
+`transaction()` call raise `sqlite3.OperationalError: cannot start a
+transaction within a transaction` with the outer block rolling back
+cleanly — the TDD run confirmed this specific test was already green pre-fix,
+so AC#2 only needed the nesting-docstring paragraph (worded like
+`Library_Collections_DB.transaction()`'s) and a pinning test, not a
+behavior change. Went with the "loud raise, clean outer rollback" shape
+(the `Library_Collections_DB`/`AgentRuns_DB` precedent) rather than the
+`in_transaction`-guard shape (`Research_DB`/`Writing_DB`) since that is
+what the two freshest (task-15466) ports already established and what
+`WorkspaceDB.transaction()`'s existing try/except already provides for
+free. Family split (per review round 1): the held-connection DBs
+(`WorkspaceDB`, `Library_Collections_DB`, `AgentRunsDB`) all bare-`BEGIN`-
+and-raise on nesting — no in-transaction guard, nesting is a bug the
+caller must not do, and it fails loudly; `Research_DB`/`Writing_DB` are
+the older per-call-connection family and instead JOIN an already-open
+transaction via an `in_transaction` check. This task did not add a code
+guard to `WorkspaceDB.transaction()` — it documents and pins the
+already-correct raise-and-rollback behavior the held-connection family
+shares.
+
+**TDD verification**: added the four new tests first and ran them against
+pre-fix `Workspace_DB.py` — `test_isolation_level_is_none`,
+`test_bare_dml_through_connection_survives_closing_the_held_connection`,
+and `test_explicit_begin_still_works_after_bare_dml` were RED (isolation_level
+was `''` not `None`; the bare-DML row was lost on close; the immediate
+follow-up write raised `OperationalError`); `test_nesting_a_transaction_raises_and_the_outer_block_rolls_back`
+was already GREEN pre-fix, as expected. All four are GREEN after the fix.
+
+**AC#3**: corrected the stale "`WorkspaceDB` opens a fresh `sqlite3`
+connection per operation" claim in
+`Tools/workspace_file_roots.py:43-47`'s `_default_registry_factory`
+docstring to describe the actual task-3011 per-thread held-connection
+shape. Review round 1 confirmed two more stale comments of the same
+"fresh connection per call" claim and asked for both to be folded in
+rather than deferred: `Chat/console_chat_controller.py:639` (a memoization
+rationale comment — reworded to "a repeat query against `WorkspaceDB`'s
+held, per-thread connection -- task-3011") and
+`UI/Console_Modules/workspace.py:1132` (the `:memory:`-guard rationale in
+`_read_console_workspace_scope` — reworded to explain the guard's actual
+current reason: a per-thread held connection would hand each new thread
+its own empty, table-less `:memory:` database, since `WorkspaceDB` — unlike
+`ClientNotificationsDB` — has no cross-thread `:memory:`-sharing branch).
+All three fixed comments now describe the real task-3011 held-connection
+shape.
+
+**Review round 1 (4 Minors, all fixed, mechanical)**:
+1. The `TestWorkspaceDBAutocommitAndNesting` class insertion had silently
+   dropped the pre-existing `db.close()` teardown from
+   `TestNotificationSettingsAreWrittenAtomically.test_multi_key_update_uses_one_transaction`
+   (an artifact of inserting the new section between it and the next
+   class) and left a duplicated `db.close()` at the end of the new nesting
+   test. Restored the missing teardown call, deleted the duplicate.
+2. Corrected two more stale "`WorkspaceDB` opens a fresh/brand-new
+   connection per call" comments the reviewer found, same family as the
+   `workspace_file_roots.py` one this task already fixed:
+   `Chat/console_chat_controller.py:639` and
+   `UI/Console_Modules/workspace.py:1132` (details above, replacing the
+   earlier "left untouched, follow-up task" note — both are now fixed in
+   this task per reviewer instruction).
+3. Fixed the "13 `connection()` call sites in `registry_service.py`" count
+   above to the correct 11 (13 was double-counting `Workspace_DB.py`'s own
+   2 sites, which are listed separately in the bullet above it).
+4. The commit subject overstated the fix as "guarded BEGIN" — there is no
+   `in_transaction` guard; nesting deliberately raises. Amended locally
+   (unpushed) to `fix: autocommit + documented nesting semantics for
+   Workspace_DB held connection (task-15480)`, and the family-split
+   sentence above records the reviewer's point that held-connection DBs
+   raise on nesting while the older per-call DBs join.
+
+**Testing**: `Tests/DB/test_held_connections.py` (32 passed, including the
+4 new/extended Workspace_DB cases and the round-1 teardown fix),
+`Tests/DB/test_pragma_settings.py` + `Tests/Workspaces/` +
+`Tests/Tools/test_file_tools_workspace_roots.py` +
+`Tests/Tools/test_workspace_file_roots.py` (294 passed — `WorkspaceDB` was
+already present in `_HELD_CONNECTION_DBS`, no change needed there),
+`Tests/Chat/test_console_chat_controller.py` (172 passed — covers the
+round-1 comment fix in that file), and the wider Workspace UI/Agents/Notes
+consumer suites (`Tests/UI/test_console_workspace_*`,
+`test_settings_workspaces_category.py`, `test_post_release_workspaces_library_depth.py`,
+`Tests/Agents/test_builtin_provider_workspace_binding.py`,
+`test_run_log_workspace_isolation.py`, `Tests/Notes/test_server_notes_workspace_service.py`,
+150 passed — covers the round-1 comment fix in `UI/Console_Modules/workspace.py`).
+`Tests/DB/` full-directory run showed the pre-existing dev baseline
+failures (32, all ChaChaNotes V33/V34 migration + `test_sql_validation.py`
+schema-drift tests) — unrelated to this change, matches the documented
+known-baseline note.
+
+**Files touched**: `tldw_chatbook/DB/Workspace_DB.py` (autocommit fix +
+transaction nesting docstring), `tldw_chatbook/Tools/workspace_file_roots.py`
+(stale comment fix), `tldw_chatbook/Chat/console_chat_controller.py` +
+`tldw_chatbook/UI/Console_Modules/workspace.py` (round-1: two more stale
+"fresh connection per call" comments), `Tests/DB/test_held_connections.py`
+(new `TestWorkspaceDBAutocommitAndNesting` class, 4 tests, a shared
+`_insert_workspace_record` helper, and the round-1 teardown fix).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -635,8 +635,9 @@ def build_tool_review_hook(
         # Minor (round 1 review): memoize `allowed_file_roots` across every
         # builtin file-tool row THIS batch checks -- `workspace_id` is fixed
         # for the whole call, so a turn with several read_file/write_file
-        # rows would otherwise re-hit the workspace registry (a fresh
-        # sqlite3 connection per `WorkspaceDB` operation) once per row.
+        # rows would otherwise re-hit the workspace registry (a repeat query
+        # against `WorkspaceDB`'s held, per-thread connection -- task-3011)
+        # once per row.
         # Fresh dict per `review_tool_calls` call -- never reused across
         # turns, so a folder binding added/removed between turns is still
         # picked up on the very next call.

--- a/tldw_chatbook/DB/Workspace_DB.py
+++ b/tldw_chatbook/DB/Workspace_DB.py
@@ -46,6 +46,21 @@ class WorkspaceDB(BaseDB):
         # query-heavy path (task-15465). Unconditional: synchronous is
         # per-connection, so every held connection needs it re-applied.
         conn.execute("PRAGMA synchronous = NORMAL")
+        # task-3012 (missed at task-3011 port time; fixed at task-15480): a
+        # held (long-lived) connection needs true autocommit. Python's
+        # default isolation mode auto-BEGINs on any DML, and an implicit
+        # transaction accumulated outside `transaction()` makes the explicit
+        # `BEGIN` there fail with "cannot start a transaction within a
+        # transaction" -- and silently ROLLS BACK bare DML on close (masked
+        # pre-task-3011 by per-call connections, which committed
+        # explicitly). Audited (task-15480): every `connection()` call site
+        # in `Workspaces/registry_service.py` is read-only -- every write
+        # there already goes through `transaction()` -- and this class's own
+        # `connection()` sites (`_initialize_schema`'s `executescript`,
+        # `get_schema_version`'s read) self-commit or don't write at all.
+        # Latent today, not live; this closes the correctness fuse before
+        # any future bare-DML call site can trip it.
+        conn.isolation_level = None
         return conn
 
     def _held_connection(self) -> sqlite3.Connection:
@@ -85,7 +100,20 @@ class WorkspaceDB(BaseDB):
 
     @contextmanager
     def transaction(self) -> Iterator[sqlite3.Connection]:
-        """Run a write transaction on the held connection; roll back on failure."""
+        """Run a write transaction on the held connection; roll back on failure.
+
+        Nesting: this issues an explicit BEGIN on the ONE connection this
+        thread holds, so nesting a second `transaction()` call inside the
+        first raises `sqlite3.OperationalError: cannot start a transaction
+        within a transaction`. Pre-port each block had its own connection
+        and nesting silently "worked"; the outer block still rolls back
+        cleanly here, because the failure propagates through its `except`
+        before reaching the caller.
+
+        Raises:
+            Exception: Re-raised after rolling back, on any error inside
+                the `with` block. On clean exit the transaction commits.
+        """
 
         conn = self._held_connection()
         conn.execute("BEGIN")

--- a/tldw_chatbook/Tools/workspace_file_roots.py
+++ b/tldw_chatbook/Tools/workspace_file_roots.py
@@ -40,10 +40,11 @@ def _default_registry_factory():
     instance without touching the database again.
 
     Thread safety: the cached ``LocalWorkspaceRegistryService`` instance is
-    shared across threads/calls, but ``WorkspaceDB`` opens a fresh
-    ``sqlite3`` connection per operation (see ``WorkspaceDB.connection`` /
-    ``WorkspaceDB.transaction``) rather than holding one open, so sharing
-    the service object does not share any live connection state and is
+    shared across threads/calls. ``WorkspaceDB`` (task-3011) holds one
+    ``sqlite3`` connection per THREAD rather than opening a fresh one per
+    operation -- see ``WorkspaceDB.connection`` / ``WorkspaceDB.transaction``
+    -- so sharing the service object shares no connection ACROSS threads
+    (each thread gets and keeps its own), which is exactly what makes it
     safe under concurrent tool calls.
 
     Returns:

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -1129,10 +1129,12 @@ class ConsoleWorkspaceController:
 
         Mirrors ``_read_console_retrieval_scope``'s in-memory-DB guard
         (task-13): ``LocalWorkspaceRegistryService.db`` is never actually
-        ``:memory:``-backed in production (``WorkspaceDB`` opens a brand-new
-        connection per call, incompatible with SQLite's ``:memory:``
-        semantics beyond a single call), but the guard is applied anyway
-        for the same defensive discipline the conversation-scope read uses.
+        ``:memory:``-backed in production (``WorkspaceDB`` (task-3011) holds
+        one connection per THREAD rather than sharing a single connection
+        for ``:memory:``, so each new thread touching it would open its own
+        empty, table-less ``:memory:`` database -- broken beyond a single
+        thread), but the guard is applied anyway for the same defensive
+        discipline the conversation-scope read uses.
         """
         db = getattr(registry_service, "db", None)
         if getattr(db, "is_memory_db", False):


### PR DESCRIPTION
## Summary

Task 15480 from the input-latency audit — the latent silent-rollback fuse. Workspace_DB's task-3011 held-connection port predated the task-3012 lesson: without `isolation_level=None`, sqlite3 auto-BEGINs on bare DML and close() silently rolls back.

- `isolation_level=None` on the held connection, AgentRuns-style rationale in place
- Mandatory call-site audit recorded and independently re-derived by the reviewer: 11 `connection()` sites in the registry service, zero live bare DML — the fuse was latent, exactly as scoped
- Nesting semantics documented and pinned by test (held-connection family raises; the older per-call family joins — family split now recorded)
- 4 new TDD tests (red-first independently mutation-verified: reverting the fix reddens exactly the 3 tests that should redden); 32/32 held-connection, 46/46 pragma, 248 Workspace/Tools, 172 controller, 150 consumer tests green
- Three stale "fresh connection per call" comments corrected (workspace_file_roots, console_chat_controller, Console workspace module)

## Verification
Independent review (Approved; audit re-derived; mutation-verified) + scoped re-review of the fix round (4/4 resolved, 32/32 reproduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets `isolation_level=None` on the `WorkspaceDB` held connection to enable true autocommit and prevent silent rollbacks, and documents the nesting behavior of `transaction()`. Addresses Linear task-15480 by aligning `WorkspaceDB` with the held-connection semantics used in `AgentRunsDB` and `Library_Collections_DB`.

- **Bug Fixes**
  - Enabled autocommit on the held `sqlite3` connection to avoid implicit transactions and close-time rollbacks; audited registry writes already use `transaction()`.
  - Documented that nested `transaction()` calls raise and the outer block rolls back; added tests for autocommit, bare DML durability, and nesting behavior.
  - Corrected stale “fresh connection per call” comments in `tldw_chatbook/Tools/workspace_file_roots.py`, `tldw_chatbook/Chat/console_chat_controller.py`, and `tldw_chatbook/UI/Console_Modules/workspace.py`.

<sup>Written for commit 5062c1b57243bec8659b99144d0690d04426301c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

