### PR TITLE
fix(tts): connection failures surface reachability copy, not "not configured" (TASK-15530)

### DIFF
--- a/Tests/TTS/test_tts_connection_error_copy.py
+++ b/Tests/TTS/test_tts_connection_error_copy.py
@@ -78,8 +78,11 @@ async def test_openai_backend_raises_the_typed_error_on_connection_failure(
     backend = OpenAITTSBackend(
         {"OPENAI_BASE_URL": "http://127.0.0.1:1/v1/audio/speech"}
     )
+    # The constructor builds a real AsyncClient; close it before swapping in
+    # the stub so the test leaks no client.
+    await backend.client.aclose()
 
-    class _FailingStream:
+    class FailingStream:
         def __init__(self, *args, **kwargs):
             pass
 
@@ -89,9 +92,13 @@ async def test_openai_backend_raises_the_typed_error_on_connection_failure(
         async def __aexit__(self, *exc):
             return False
 
-    monkeypatch.setattr(
-        backend, "client", type("C", (), {"stream": _FailingStream})()
-    )
+    class StubClient:
+        stream = FailingStream
+
+        async def aclose(self) -> None:
+            """Keep ``backend.close()`` safe after the swap."""
+
+    monkeypatch.setattr(backend, "client", StubClient())
 
     request = OpenAISpeechRequest(
         model="mock-model", input="hi", voice="mock-voice",
@@ -100,3 +107,4 @@ async def test_openai_backend_raises_the_typed_error_on_connection_failure(
     with pytest.raises(TTSBackendConnectionError):
         async for _chunk in backend.generate_speech_stream(request):
             pass
+    await backend.close()

--- a/Tests/TTS/test_tts_connection_error_copy.py
+++ b/Tests/TTS/test_tts_connection_error_copy.py
@@ -1,0 +1,102 @@
+"""TASK-15530: a connection failure is not a configuration failure.
+
+The dead-port live check in TASK-15422 surfaced "TTS is not configured;
+open STTS Settings" for a *reachability* failure against a fully
+configured endpoint: `OpenAITTSBackend` wraps `httpx.RequestError` in a
+plain `ValueError`, and the events layer buckets every `ValueError` as
+configuration-invalid. The typed error stays a `ValueError` subclass so
+every existing backend-stream consumer that catches `ValueError`
+(audiobook, media reading, briefings) is unaffected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import TTSEventHandler
+from tldw_chatbook.TTS.base_backends import TTSBackendConnectionError
+
+pytestmark = pytest.mark.unit
+
+
+def test_connection_error_is_a_value_error_for_existing_consumers() -> None:
+    """The backend failure contract ("failures are ValueError") holds.
+
+    Returns:
+        None.
+    """
+    assert issubclass(TTSBackendConnectionError, ValueError)
+
+
+def test_connection_error_maps_to_connection_unavailable_outcome() -> None:
+    """The metric outcome names reachability, not configuration.
+
+    Returns:
+        None.
+    """
+    error = TTSBackendConnectionError(
+        "Unable to connect to TTS service. Please check your internet connection."
+    )
+
+    assert TTSEventHandler._tts_outcome_code(error) == "connection_unavailable"
+
+
+def test_connection_error_copy_points_at_the_server_not_the_config() -> None:
+    """The toast names the server and Base URL as the thing to check.
+
+    Returns:
+        None.
+    """
+    error = TTSBackendConnectionError(
+        "Unable to connect to TTS service. Please check your internet connection."
+    )
+
+    assert TTSEventHandler._tts_error_copy(error) == (
+        "Unable to reach the TTS server; check that it is running and "
+        "the Base URL in STTS Settings"
+    )
+
+
+@pytest.mark.asyncio
+async def test_openai_backend_raises_the_typed_error_on_connection_failure(
+    monkeypatch,
+) -> None:
+    """The openai backend's network branch raises the typed error.
+
+    Args:
+        monkeypatch: Used to stub the HTTP client seam with a connect
+            failure.
+
+    Returns:
+        None.
+    """
+    import httpx
+
+    from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
+    from tldw_chatbook.TTS.backends.openai import OpenAITTSBackend
+
+    backend = OpenAITTSBackend(
+        {"OPENAI_BASE_URL": "http://127.0.0.1:1/v1/audio/speech"}
+    )
+
+    class _FailingStream:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            raise httpx.ConnectError("connection refused")
+
+        async def __aexit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(
+        backend, "client", type("C", (), {"stream": _FailingStream})()
+    )
+
+    request = OpenAISpeechRequest(
+        model="mock-model", input="hi", voice="mock-voice",
+        response_format="wav", speed=1.0,
+    )
+    with pytest.raises(TTSBackendConnectionError):
+        async for _chunk in backend.generate_speech_stream(request):
+            pass

--- a/backlog/tasks/task-15530 - TTS-connection-failures-surface-not-configured-copy.md
+++ b/backlog/tasks/task-15530 - TTS-connection-failures-surface-not-configured-copy.md
@@ -1,0 +1,75 @@
+---
+id: TASK-15530
+title: >-
+  TTS connection failures surface "not configured" copy instead of a
+  connection outcome
+status: Done
+assignee: []
+created_date: '2026-08-11 16:20'
+labels:
+  - tts
+  - speech
+  - ux
+  - uat
+priority: medium
+dependencies:
+  - TASK-15422
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Observed during the TASK-15422 live verification (dead-port custom Base URL,
+Console 🔊): the failure toast read **"TTS is not configured; open STTS
+Settings"** and the metric outcome was `configuration_invalid` — for a
+*reachability* failure against a fully configured endpoint. Mechanism:
+`OpenAITTSBackend.generate_speech_stream` wraps `httpx.RequestError` in a
+plain `ValueError("Unable to connect to TTS service...")`, and
+`tts_events`' `_tts_outcome_code`/`_tts_error_copy` bucket every
+`ValueError` as configuration-invalid. A user whose server is simply down
+(or whose port is wrong) is told their configuration is missing, which
+points them away from the actual fix.
+
+The bounded `TTSOperationCode` set already has `connection_unavailable`.
+The backends' shared contract is "failures are ValueError" (consumers in
+audiobook, media reading, and briefings catch ValueError), so the typed
+error must remain a ValueError subclass to keep every existing consumer
+working unchanged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] A connection failure to the TTS endpoint surfaces copy about reaching the server (naming the Base URL as the thing to check), not "not configured"
+- [x] The metric outcome for a connection failure is `connection_unavailable`, not `configuration_invalid`
+- [x] Existing consumers that catch `ValueError` from backend streams are unaffected
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: typed-error contract (ValueError subclass), outcome mapping, copy
+   mapping, and a backend test pinning the network branch raises the type.
+2. GREEN: `TTSBackendConnectionError(ValueError)` in `base_backends.py`;
+   openai backend's `httpx.RequestError` branch raises it; `tts_events`
+   maps it to `connection_unavailable` + reachability copy BEFORE the
+   ValueError bucket it subclasses.
+3. Live dead-port verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`TTSBackendConnectionError(ValueError)` added to `TTS/base_backends.py` —
+a ValueError subclass on purpose, so every existing backend-stream
+consumer catching ValueError (audiobook, media reading, briefings) is
+unchanged; pinned by an explicit subclass test. The openai backend's
+`httpx.RequestError` branch raises it (same message); `tts_events` maps
+it to the bounded `connection_unavailable` outcome with copy "Unable to
+reach the TTS server; check that it is running and the Base URL in STTS
+Settings", ordered before the generic ValueError bucket. Scope is the
+openai backend (the custom-endpoint provider this arc is about); other
+API backends keep their existing wrapping. Live-verified dead-port: the
+toast now names reachability and the Base URL instead of "not
+configured". 122 neighboring consumer tests green.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -37,6 +37,7 @@ from tldw_chatbook.TTS import (
     TTSRequestedSelectionSnapshot,
     get_tts_service,
 )
+from tldw_chatbook.TTS.base_backends import TTSBackendConnectionError
 from tldw_chatbook.TTS.character_request_resolver import TTSVoiceRefusalDomain
 from tldw_chatbook.TTS.legacy_bridge import UnknownLegacyModelError
 from tldw_chatbook.TTS.adapter_types import (
@@ -2351,6 +2352,10 @@ class TTSEventHandler:
             # configuration problem; the generic bucket's "retry" framing
             # hid that for weeks of TASK-15420's window (TASK-15422).
             return "model_invalid"
+        if isinstance(error, TTSBackendConnectionError):
+            # Reachability, not configuration — this must precede the
+            # generic ValueError bucket it subclasses (TASK-15530).
+            return "connection_unavailable"
         if isinstance(error, ValueError):
             return "configuration_invalid"
         return "generation_failed"
@@ -2391,6 +2396,11 @@ class TTSEventHandler:
             return (
                 "The selected TTS model is not available for this provider; "
                 "check the model in STTS Settings"
+            )
+        if isinstance(error, TTSBackendConnectionError):
+            return (
+                "Unable to reach the TTS server; check that it is running "
+                "and the Base URL in STTS Settings"
             )
         if isinstance(error, ValueError):
             return "TTS is not configured; open STTS Settings"

--- a/tldw_chatbook/TTS/backends/openai.py
+++ b/tldw_chatbook/TTS/backends/openai.py
@@ -11,7 +11,10 @@ from loguru import logger
 
 # Local imports
 from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
-from tldw_chatbook.TTS.base_backends import APITTSBackend
+from tldw_chatbook.TTS.base_backends import (
+    APITTSBackend,
+    TTSBackendConnectionError,
+)
 from tldw_chatbook.config import get_cli_setting
 
 #######################################################################################################################
@@ -321,7 +324,7 @@ class OpenAITTSBackend(APITTSBackend):
         except httpx.RequestError:
             # Log without exposing connection details
             logger.error("OpenAITTSBackend: Network request failed")
-            raise ValueError(
+            raise TTSBackendConnectionError(
                 "Unable to connect to TTS service. Please check your internet connection."
             )
 

--- a/tldw_chatbook/TTS/base_backends.py
+++ b/tldw_chatbook/TTS/base_backends.py
@@ -100,6 +100,17 @@ class TTSBackendBase(ABC):
                 logger.warning(f"Progress callback error: {e}")
 
 
+class TTSBackendConnectionError(ValueError):
+    """Raised when a TTS backend cannot reach its endpoint.
+
+    A ``ValueError`` subclass on purpose: the backend failure contract is
+    "failures are ValueError" and consumers across audiobook, media
+    reading, and briefings catch exactly that — the subclass lets the
+    events layer distinguish reachability from configuration
+    (TASK-15530) without changing any existing consumer.
+    """
+
+
 class APITTSBackend(TTSBackendBase):
     """Base class for API-based TTS backends (OpenAI, ElevenLabs, etc.)"""
 


### PR DESCRIPTION
## Summary

Residue from the TASK-15422 live verification: a dead-port TTS endpoint surfaced **"TTS is not configured; open STTS Settings"** (outcome `configuration_invalid`) for a pure reachability failure. The openai backend wraps `httpx.RequestError` in a plain `ValueError`, and the events layer buckets every `ValueError` as configuration-invalid.

`TTSBackendConnectionError(ValueError)` is added to `base_backends` — a `ValueError` subclass on purpose so every existing backend-stream consumer (audiobook, media reading, briefings) is unchanged, pinned by an explicit subclass test. The openai network branch raises it; `tts_events` maps it (ordered before the `ValueError` bucket it subclasses) to the bounded `connection_unavailable` outcome with copy "Unable to reach the TTS server; check that it is running and the Base URL in STTS Settings".

## Verification

TDD red-first (4 new tests: subclass contract, outcome, copy, backend network-branch type). Live dead-port check shows the new toast. 122 neighboring consumer tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TTS connection failures so they show a reachability message and outcome instead of "not configured". Addresses TASK-15530 and keeps existing consumers unchanged.

- **Bug Fixes**
  - Added `TTSBackendConnectionError` (subclass of `ValueError`) to represent network reachability failures.
  - OpenAI backend now raises this error on `httpx.RequestError`.
  - Mapped to outcome code `connection_unavailable` with copy: "Unable to reach the TTS server; check that it is running and the Base URL in STTS Settings".
  - Preserved the `ValueError` contract so audiobook, media reading, and briefings continue to work; tests updated to close the constructed client to avoid leaks.

<sup>Written for commit 6b90369d606cbb747f454def24654a52eeebcb03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

