### PR TITLE
docs(lessons): style probes are not render evidence — capture the frame

### DIFF
--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9,6 +9,35 @@ decays into folklore, and folklore is ignored. If you add one, bring the inciden
 
 ---
 
+## Style probes are not render evidence — capture the frame
+
+**TASK-15421 AC3, 2026-08-11.** The Studio exact-ID input's typed text
+vanished while focused in the live TUI. The hunt fixated on border rules for
+hours because every probe asked `styles.border` — which was empty, correctly,
+in both the live-matching harness and run_test — so the harness appeared to
+CONTRADICT the live app and the divergence got recorded as an unexplained
+live-vs-run_test cascade anomaly. There was no divergence: the reset-tier
+accessibility rule `*:focus { outline: solid }` paints the outline OVER the
+widget's outermost rendered lines (its own comment warns of this), and on a
+height-1 widget that line IS the only content line. The obscuring reproduced
+in run_test all along; no probe ever looked at a rendered frame. One
+`export_screenshot()` assertion (`assert "studio-model" in frame`) found in
+minutes what specificity analysis could not, and now pins the fix in
+`Tests/UI/test_speech_live_render_defects.py` — a file whose own docstring
+already teaches a version of this lesson ("the tests asserted the things a
+test naturally reaches for ... none of which is what was wrong").
+
+**What to do.** When the defect is "the user cannot SEE something," the
+oracle must be the rendered frame (`export_screenshot`/`export_text`, or the
+tmux capture live), not computed styles: `styles.border`, `styles.height`,
+and `region` all report the widget's own properties and are blind to
+anything painted over it — outlines, overlays, tooltips, sibling z-order.
+Before declaring a live-vs-harness divergence, confirm both sides were asked
+the SAME question at the same oracle level; here the "divergence" was one
+side being read at the style level and the other at the pixel level.
+
+---
+
 ## A fix proven at one layer can be unreachable through the product path
 
 **TASK-15420, 2026-08-11.** TASK-2260 (2026-08-04) shipped custom-endpoint

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -28,10 +28,14 @@ already teaches a version of this lesson ("the tests asserted the things a
 test naturally reaches for ... none of which is what was wrong").
 
 **What to do.** When the defect is "the user cannot SEE something," the
-oracle must be the rendered frame (`export_screenshot`/`export_text`, or the
-tmux capture live), not computed styles: `styles.border`, `styles.height`,
-and `region` all report the widget's own properties and are blind to
-anything painted over it — outlines, overlays, tooltips, sibling z-order.
+oracle must be the rendered frame, not computed styles: in run_test that
+means `app.export_screenshot()` (the SVG carries every glyph as text, so a
+plain `in` assertion works) or the compositor strips the existing UI tests
+use — NOT `App.export_text()`, which does not exist in this repo's Textual
+(8.2.7; the probe that first tried it died on AttributeError) — and live it
+means the tmux `capture-pane` text. `styles.border`, `styles.height`, and
+`region` all report the widget's own properties and are blind to anything
+painted over it — outlines, overlays, tooltips, sibling z-order.
 Before declaring a live-vs-harness divergence, confirm both sides were asked
 the SAME question at the same oracle level; here the "divergence" was one
 side being read at the style level and the other at the pixel level.


### PR DESCRIPTION
## Summary

Lessons-file entry from the TASK-15421 AC3 investigation (fix already merged in #1528), with the incident recorded per the lessons-file rule: probes that ask `styles.border`/`region` are blind to anything painted OVER a widget (outlines, overlays, tooltips), and reading one side of a live-vs-harness comparison at the style level while the other is at the pixel level manufactures a "divergence" that does not exist. When the defect is "the user cannot see something," the oracle must be the rendered frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lesson to testing-evidence docs: style probes (`styles.border`, `styles.height`, `region`) are not render evidence; for visibility bugs, capture the rendered frame via `app.export_screenshot()` in tests or tmux `capture-pane` in live.

Connects to TASK-15421 AC3 (focus outline overpainted content), anchors a screenshot assertion in `Tests/UI/test_speech_live_render_defects.py`, and removes the incorrect `export_text` reference since it doesn't exist in this repo’s `Textual` 8.2.7.

<sup>Written for commit eba2aaa977f166e706e5cfbe85867c4cee30606b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

