### PR TITLE
perf: skip no-op move_child in transcript reconciliation (task-15453)

### DIFF
--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -54,6 +54,30 @@ def _message_row_text(transcript: ConsoleTranscript, message_id: str) -> str:
     return str(row.renderable)
 
 
+def _spy_move_child(transcript: ConsoleTranscript) -> list[tuple[tuple, dict]]:
+    """Wrap ``transcript.move_child`` with a call-recording spy (task-15453).
+
+    Returns the list the spy appends ``(args, kwargs)`` to; still delegates
+    to the real ``Widget.move_child`` so reconciliation behaves normally.
+    """
+    calls: list[tuple[tuple, dict]] = []
+    original = transcript.move_child
+
+    def _spy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    transcript.move_child = _spy  # type: ignore[method-assign]
+    return calls
+
+
+def _rendered_message_ids(transcript: ConsoleTranscript) -> list[str]:
+    """Message ids in actual mounted DOM order (not store order)."""
+    return [
+        widget.message_id for widget in transcript.query(".console-transcript-message")
+    ]
+
+
 _BUNDLE = (
     Path(__file__).resolve().parents[2]
     / "tldw_chatbook"
@@ -2256,6 +2280,117 @@ async def test_transcript_signature_cache_survives_reorder():
     assert rendered_ids == ["m2", "m0", "m3", "m1"]
 
 
+# ---------------------------------------------------------------------------
+# TASK-15453: `_reconcile_rows` must not `move_child` a row that is already
+# in the right position. A steady-state pass (no order change) must issue
+# zero `move_child` calls; a genuine reorder must still issue >0 calls and
+# still land the correct final child order. See
+# Docs/Design/2026-08-11-input-latency-audit.md (Console section).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconcile_rows_steady_state_issues_zero_move_child_calls():
+    """A no-op refresh (same messages re-set, like the 0.2s stream tick) moves nothing."""
+    app = MutableTranscriptHarness()
+    messages = _cache_test_messages(8)
+
+    async with app.run_test(size=(100, 32)):
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_messages(messages)
+        await transcript.refresh_messages()  # first mount: nothing to move yet
+        baseline_order = _rendered_message_ids(transcript)
+
+        calls = _spy_move_child(transcript)
+        # Same objects, unchanged content/order -- exactly what the 0.2s
+        # streaming tick and a transcript click (full reconcile) do when
+        # nothing actually changed.
+        transcript.set_messages(list(messages))
+        await transcript.refresh_messages()
+
+        assert calls == [], (
+            f"steady-state reconcile issued {len(calls)} move_child call(s); "
+            "rows already in position must not be moved"
+        )
+        assert _rendered_message_ids(transcript) == baseline_order
+
+
+@pytest.mark.asyncio
+async def test_reconcile_rows_reorder_moves_widgets_and_lands_correct_order():
+    """A genuine reorder still issues move_child calls and produces correct order."""
+    app = MutableTranscriptHarness()
+    messages = _cache_test_messages(4)
+
+    async with app.run_test(size=(100, 32)):
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_messages(messages)
+        await transcript.refresh_messages()
+
+        calls = _spy_move_child(transcript)
+        reordered = [messages[2], messages[0], messages[3], messages[1]]
+        transcript.set_messages(reordered)
+        await transcript.refresh_messages()
+
+        assert len(calls) > 0, "a real reorder must still move at least one row"
+        assert _rendered_message_ids(transcript) == ["m2", "m0", "m3", "m1"]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_rows_session_switch_lands_correct_order():
+    """Switching to an entirely different message set (session switch) orders correctly."""
+    app = MutableTranscriptHarness()
+    first_session = _cache_test_messages(3)
+    second_session = [
+        ConsoleChatMessage(
+            role=ConsoleMessageRole.USER
+            if index % 2 == 0
+            else ConsoleMessageRole.ASSISTANT,
+            content=f"other session body {index}",
+            id=f"s{index}",
+        )
+        for index in range(3)
+    ]
+
+    async with app.run_test(size=(100, 32)):
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_messages(first_session)
+        await transcript.refresh_messages()
+        assert _rendered_message_ids(transcript) == ["m0", "m1", "m2"]
+
+        transcript.set_messages(second_session)
+        await transcript.refresh_messages()
+
+        assert _rendered_message_ids(transcript) == ["s0", "s1", "s2"]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_rows_branch_navigation_replaces_suffix_in_order():
+    """Branch navigation (shared prefix, swapped-in sibling suffix) orders correctly."""
+    app = MutableTranscriptHarness()
+    shared_prefix = _cache_test_messages(2)  # m0, m1
+    original_tail = [
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="q2", id="m2"),
+        ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="a2", id="m3"),
+    ]
+    sibling_tail = [
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="q2 (sibling)", id="m2b"),
+        ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="a2 (sibling)", id="m3b"),
+    ]
+
+    async with app.run_test(size=(100, 32)):
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_messages(shared_prefix + original_tail)
+        await transcript.refresh_messages()
+        assert _rendered_message_ids(transcript) == ["m0", "m1", "m2", "m3"]
+
+        # `set_active_leaf` swipe to a sibling branch: shared prefix stays,
+        # the tail past the branch point is replaced by the sibling's nodes.
+        transcript.set_messages(shared_prefix + sibling_tail)
+        await transcript.refresh_messages()
+
+        assert _rendered_message_ids(transcript) == ["m0", "m1", "m2b", "m3b"]
+
+
 @pytest.mark.asyncio
 async def test_transcript_signature_cache_survives_variant_switch():
     """Switching variants re-derives only that message and shows the variant."""
@@ -2286,6 +2421,8 @@ async def test_transcript_signature_cache_survives_variant_switch():
         assert "second answer" in _message_row_text(transcript, "m-varied")
         assert after["m-varied"] == baseline["m-varied"] + 1
         assert after["m-plain"] == baseline["m-plain"]
+        # TASK-15453: a variant switch must not disturb row position.
+        assert _rendered_message_ids(transcript) == ["m-plain", "m-varied"]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_transcript_pruning.py
+++ b/Tests/UI/test_console_transcript_pruning.py
@@ -134,6 +134,13 @@ async def test_pruning_drops_oldest_rows_over_high_watermark():
         assert mounted, "pruning must keep the newest rows"
         assert mounted[-1] == "m11"
         assert len(mounted) == 12 - len(transcript._pruned_message_ids)
+        # TASK-15453: explicit order, not just first/last presence -- the
+        # surviving rows must render in the same relative order as the
+        # (unpruned) message store.
+        expected_order = [
+            f"m{i}" for i in range(12) if f"m{i}" not in transcript._pruned_message_ids
+        ]
+        assert mounted == expected_order
         # Pruned down to (at most) the high watermark, erring on keeping rows.
         assert transcript.virtual_size.height <= 40
         # The store snapshot the widget was handed is untouched.

--- a/backlog/tasks/task-15453 - Console-transcript---skip-move_child-for-rows-already-in-position.md
+++ b/backlog/tasks/task-15453 - Console-transcript---skip-move_child-for-rows-already-in-position.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15453
 title: Console transcript: skip move_child for rows already in position
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -20,7 +21,137 @@ Fix direction: track the expected index and skip the move when the widget is alr
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A steady-state reconcile pass (no order change) issues zero move_child calls (evidence)
-- [ ] #2 Ordering still correct after prune, variant swap, and branch navigation (tests)
-- [ ] #3 Reconcile pass time on a 500+-message transcript measured before/after and recorded
+- [x] #1 A steady-state reconcile pass (no order change) issues zero move_child calls (evidence)
+- [x] #2 Ordering still correct after prune, variant swap, and branch navigation (tests)
+- [x] #3 Reconcile pass time on a 500+-message transcript measured before/after and recorded
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Pin ordering behavior first (TDD, tests must exist/extend before the fix):
+   - `Tests/UI/test_console_native_transcript.py` (TASK-259 section, next to
+     `test_transcript_signature_cache_survives_reorder`): add a
+     `move_child`-call-counting spy; add a NEW test asserting a steady-state
+     second `refresh_messages()` pass (same messages re-set, no order/content
+     change) issues ZERO `move_child` calls -- this test is expected to be
+     RED against current code (every unchanged row currently forces a move).
+     Add a companion test asserting an actual reorder (permuted message
+     list, same ids) still issues >0 `move_child` calls AND produces the
+     correct final child order.
+   - Extend `test_transcript_signature_cache_survives_variant_switch` with an
+     explicit child-order assertion (variant switch must not disturb row
+     position).
+   - `Tests/UI/test_console_transcript_pruning.py`: extend
+     `test_pruning_drops_oldest_rows_over_high_watermark` with an explicit
+     full expected-order assertion (not just first/last presence).
+   - Add a session-switch test (wholly different message id set) and a
+     branch-navigation-style test (shared prefix, replaced suffix ids) with
+     explicit final-order assertions.
+2. Fix: in `_reconcile_rows`, when a row's widget was not (re)mounted this
+   pass, compare its actual current index in `self.children` (read fresh
+   each iteration -- never a stale snapshot) against the walk's expected
+   index before calling `move_child`; skip the call when already correct.
+   Preserve the `_closing/_pruning/is_attached` abandon check and the
+   phantom-mount backstop verbatim, unmodified, in their current order.
+3. Evidence: run the new tests (RED before the fix, GREEN after) plus the
+   full console_transcript-touching UI/streaming test surface. Write an
+   isolated timing probe (500+ row transcript, steady-state reconcile pass)
+   comparing before/after wall time, record honest numbers in Implementation
+   Notes.
+
+## Implementation Notes
+
+**Approach.** `_reconcile_rows` walks the desired row list with a running
+`previous_widget`; for a row whose widget was not (re)mounted this pass, it
+unconditionally called `move_child(before=0)` / `move_child(after=
+previous_widget)` even when the widget was already exactly there. By
+induction, every row processed so far (`0..index-1`) is already at its
+correct slot in `self.children` (mounts land there directly via
+`before=0`/`after=previous_widget`; moves, when needed, restore the
+invariant) -- so row `index` is correctly positioned iff `self.children[index]
+is widget`, checked fresh every iteration (never a cached snapshot, since
+earlier mounts/removals in the same pass shift indices). `self.children`
+is Textual's `NodeList`, whose `__getitem__` is a plain O(1) list index
+(`_node_list.py:226`), so the check is cheap; `move_child` itself does two
+`list.index()` scans plus `refresh(layout=True)` plus a NodeList
+`_updates` bump that walks to the DOM root (`widget.py:1610-1677`,
+`_node_list.py:71-78`), so skipping it when the row hasn't moved is the
+entire win. The `_closing/_pruning/is_attached` abandon check and the
+phantom-mount backstop are untouched, in their original order, ahead of
+the changed block.
+
+**TDD.** Added `test_reconcile_rows_steady_state_issues_zero_move_child_calls`
+(`Tests/UI/test_console_native_transcript.py`) with a `move_child`-call
+spy; confirmed RED against the pre-fix code (17 calls for an 8-message /
+17-row steady-state pass), GREEN after the one-line guard. Added
+companion tests pinning ordering across the scenarios named in the task:
+a genuine reorder (`test_reconcile_rows_reorder_moves_widgets_and_lands_
+correct_order`, still >0 `move_child` calls + correct final order), a
+session switch (`test_reconcile_rows_session_switch_lands_correct_order`,
+disjoint id sets), and a branch-navigation-style shared-prefix/swapped-
+suffix swipe (`test_reconcile_rows_branch_navigation_replaces_suffix_in_
+order`, modelling `ConsoleChatStore.set_active_leaf`'s active-path
+recompute at the widget level, since the transcript only ever sees the
+resulting message list). Extended the existing variant-switch test with
+an explicit order assertion, and extended
+`test_pruning_drops_oldest_rows_over_high_watermark`
+(`Tests/UI/test_console_transcript_pruning.py`) from first/last presence
+to a full expected-order assertion.
+
+**Evidence (AC3, isolated probe, not committed -- scratchpad script).**
+`ConsoleTranscript` seeded with 500 messages (1002 rows, matching the
+audit's own "~2 rows/message" framing), steady-state `refresh_messages()`
+(same message objects re-set, no order/content change -- the 0.2s
+streaming-tick / transcript-click shape), 30 iterations, config-isolated
+(scratch HOME/XDG/`TLDW_CONFIG_PATH`, mirroring `Tests/conftest.py`'s
+bootstrap) and `sys.path`-pinned to this worktree (the venv's editable
+install otherwise resolves `tldw_chatbook` to a different worktree per
+the audit's "Environment note" -- confirmed hitting exactly that trap on
+the first run). "Before" was captured by temporarily reverting only the
+position-check guard (Edit-based, not git) and restoring it immediately
+after:
+
+| | mean | median | min | max |
+|---|---|---|---|---|
+| before (unconditional move_child) | 20.820 ms | 20.646 ms | 17.117 ms | 23.361 ms |
+| after (skip when already positioned) | 1.974 ms | 1.900 ms | 1.762 ms | 2.532 ms |
+
+~10.5x faster for a steady-state pass at 1002 rows; a smaller 8-row/522-row
+run showed the same shape (6.138ms -> 0.954ms, ~6.4x) with a widening gap
+as row count grows, consistent with `move_child`'s O(rows) cost per call
+being cut to zero calls in steady state.
+
+**Tests run (all targeted, cwd = this worktree, worktree's own venv;
+pass counts read from output, not inferred).** Ran the full
+console_transcript-touching UI/streaming surface named in the task
+brief, in batches:
+- `test_console_native_transcript.py` + `test_console_transcript_pruning.py`: 104 passed.
+- `test_console_transcript_markdown.py` / `_markdown_widget` / `_tail_follow` / `_selection_contract` / `_jump_pill` / `_region` / `_diff_row`: 56 passed.
+- `test_console_background_effects.py`, `test_console_citation_sources.py`, `test_console_composer_collapse.py`, `test_console_edit_resend_wiring.py`, `test_console_hands_free_wiring.py`: 153 passed, 1 failed.
+- `test_console_realtime_wiring.py`, `test_console_regenerate_feedback.py`, `test_console_setup_lock_polish.py`, `test_console_stream_scrollback.py`, `test_console_tick_gating.py`, `test_console_workbench_contract.py`, `Tests/Widgets/test_console_video_card_rows.py`, `Tests/Chat/test_change_turn_tracking.py`, `Tests/Chat/test_console_generation_card.py`, `Tests/Chat/test_tool_output_disclosure.py`: 212 passed, 1 failed.
+- `test_console_keyboard_trust.py`, `test_console_mcp_approval.py`, `test_console_message_controller.py`, `test_console_native_chat_flow.py`, `test_console_parallel_runs.py`: 416 passed, 1 xfailed.
+
+Total: **941 passed**, 2 failed, 1 xfailed -- all 3 pre-existing and
+unrelated to this change (verified, not assumed):
+- `test_console_citation_sources.py::test_zero_only_count_cache_does_not_
+  refresh_unchanged_transcript` fails at `chat_screen.py:15239`
+  (`transcript.set_presentation_context(...)` called on a
+  `SimpleNamespace` test double that never mocks that method) before
+  ever reaching `_reconcile_rows`; `git diff --stat` against dev HEAD
+  (`7cfe8df4e`) shows zero changes to either `chat_screen.py` or that
+  test file on this branch.
+- `test_console_workbench_contract.py::test_console_registers_footer_
+  workbench_shortcuts` -- matches "footer-shortcut label" on this task's
+  own known-pre-existing-dev-failures list.
+- `test_console_native_chat_flow.py::test_console_browser_selecting_
+  global_persisted_row_preserves_active_workspace` is a pre-existing
+  tracked `xfail(strict=True)` citing task-15120, unrelated to row
+  ordering/move_child.
+
+**Files changed.**
+- `tldw_chatbook/Widgets/Console/console_transcript.py` -- the
+  position-check guard in `_reconcile_rows`.
+- `Tests/UI/test_console_native_transcript.py` -- `_spy_move_child` /
+  `_rendered_message_ids` helpers; 4 new tests; 1 extended test.
+- `Tests/UI/test_console_transcript_pruning.py` -- 1 extended test
+  (explicit order assertion).

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -2506,10 +2506,23 @@ class ConsoleTranscript(VerticalScroll):
                 self._row_signatures.pop(row.key, None)
                 return
             if not row_was_mounted:
-                if previous_widget is None:
-                    self.move_child(widget, before=0)
-                else:
-                    self.move_child(widget, after=previous_widget)
+                # TASK-15453: `move_child` is several O(rows) NodeList scans
+                # plus a `refresh(layout=True)` plus a DOM-version bump --
+                # expensive to pay for a row that is already where it needs
+                # to be. Every already-processed row (0..index-1) is correct
+                # by induction (mounts above always land at the walk's
+                # current slot), so this row is in place iff it already
+                # sits at `index` in the ACTUAL child list -- read fresh
+                # every iteration (never cached) because earlier mounts in
+                # this same pass shift indices out from under a snapshot.
+                already_in_position = (
+                    index < len(self.children) and self.children[index] is widget
+                )
+                if not already_in_position:
+                    if previous_widget is None:
+                        self.move_child(widget, before=0)
+                    else:
+                        self.move_child(widget, after=previous_widget)
             previous_widget = widget
         self._paint_debug_dump("after-reconcile")
 


### PR DESCRIPTION
## Summary

Task 15453 from the input-latency audit. The transcript reconciler called `move_child` for every already-mounted row on every pass — several O(rows) NodeList scans + `refresh(layout=True)` + a DOM-version bump each — repeated on every 0.2s streaming tick and every transcript click. Order only actually changes via prune/variant/branch operations.

- One-line position guard reading `self.children` fresh each iteration (no snapshot, no cursor) — reviewer verified correctness by induction against Textual 8.2.8 move/mount semantics plus 7 adversarial mount+reorder probe passes
- Steady-state pass: 1001 → 0 move_child calls (probe: 20,020 → 0 across 20 passes at 1002 rows); reconcile pass ~20.8 → ~2.0 ms (reviewer reproduced ~9.6× independently)
- Lifecycle guards (closing/pruning abandon path, phantom-mount backstop) byte-identical; the removed unconditional layout-refresh side effect audited as not load-bearing
- Zero-moves test born red (17 calls) → green; order tests assert actual DOM sequence for prune/variant/branch/session paths

## Verification
Independent review: Approved, no Critical/Important. Three mutations (always-skip, off-by-one, stale-snapshot) — the first two caught by tests; the third analyzed order-safe (wastes moves only) with the shipped fresh-read variant strictly correct. Deferred minors recorded (full-child-sequence coverage, discriminator breadth, one pre-existing scrollback flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip no-op move_child calls during console transcript reconciliation to cut steady-state work and reduce input latency. Addresses task-15453; order is preserved and genuine reorders still move the right rows.

- **Performance**
  - In `_reconcile_rows`, skip `move_child` when `self.children[index] is widget`.
  - Keeps lifecycle guards intact; only avoids unnecessary moves.
  - Probe on ~1000 rows: move calls drop to zero; reconcile ~20.8 ms → ~2.0 ms (~10× faster).

- **Tests**
  - Added steady-state “zero moves” test and a real-reorder test (asserts correct final order).
  - Extended pruning and variant-switch tests to assert exact DOM order.
  - Added session-switch and branch-navigation tests to pin ordering.

<sup>Written for commit 57222676470e9a68e7a735e2b86946d700503570. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

