### PR TITLE
perf: narrow watchlists items projection and index effective-date ordering (task-15464)

### DIFF
--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -1071,7 +1071,7 @@ def test_get_new_items_content_preview_is_a_cheap_prefix_not_the_full_body(db):
     underlying body is much longer.
     """
     source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
-    long_body = "word " * 10_000  # 50,000 bytes, far past the 2000-byte cap.
+    long_body = "word " * 10_000  # 50,000 characters, far past the 2000-character cap.
     with db.transaction() as conn:
         persist_subscription_item(
             conn,

--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 import pytest
 
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
@@ -12,6 +14,15 @@ def db(tmp_path):
 def _columns(db, table):
     cursor = db.conn.cursor()
     return {row[1] for row in cursor.execute(f"PRAGMA table_info({table})")}
+
+
+def _xcolumns(db, table):
+    """Like `_columns`, but via `table_xinfo` -- the only pragma that lists
+    a virtual generated column (TASK-15464; `PRAGMA table_info` omits it
+    entirely, which is the whole reason `_ensure_watchlists_schema`'s
+    `effective_date` guard reads this pragma instead of `table_info`)."""
+    cursor = db.conn.cursor()
+    return {row[1]: row for row in cursor.execute(f"PRAGMA table_xinfo({table})")}
 
 
 def _tables(db):
@@ -977,6 +988,337 @@ def test_get_new_items_falls_back_to_created_at_when_unpublished(db):
         "https://f.example/undated",
         "https://f.example/dated",
     ]
+
+
+# --- TASK-15464: narrow list projection + indexed effective-date ordering ------
+
+
+def test_effective_date_generated_column_and_index_created(db):
+    """AC#2: a stored, indexed effective-date column exists.
+
+    `PRAGMA table_info` -- the `_columns` helper, and `items_cols` inside
+    `_ensure_watchlists_schema` itself -- does NOT list a virtual generated
+    column at all; only `table_xinfo` does. This test deliberately uses
+    `_xcolumns`, not `_columns`, so it would fail loudly if that distinction
+    were ever forgotten.
+    """
+    xcols = _xcolumns(db, "subscription_items")
+    assert "effective_date" in xcols
+    assert "effective_date" not in _columns(db, "subscription_items")
+
+    indexes = {
+        row[0]
+        for row in db.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='subscription_items'"
+        )
+    }
+    assert "idx_subscription_items_effective_date" in indexes
+
+
+def test_schema_migration_over_effective_date_is_idempotent(db):
+    """Re-running the migration must not re-ALTER the generated column --
+    it would raise "duplicate column name: effective_date". This is the
+    `table_xinfo`-vs-`table_info` guard's own regression test: swapping the
+    guard back to `table_info` makes this go red immediately.
+    """
+    db._ensure_watchlists_schema()
+    db._ensure_watchlists_schema()
+    db._ensure_watchlists_schema()
+    assert "effective_date" in _xcolumns(db, "subscription_items")
+
+
+def test_get_new_items_excludes_content_and_extracted_data_from_list_rows(db):
+    """AC#1: the list-page projection carries every column EXCEPT
+    `content` (full body) and `extracted_data` (an API source's raw
+    upstream payload) -- neither has a reader on the list path (see
+    `SubscriptionsDB._LIST_ITEM_COLUMNS`'s docstring).
+    """
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    with db.transaction() as conn:
+        persist_subscription_item(
+            conn,
+            source_id,
+            {
+                "url": "https://a.example/1",
+                "title": "A",
+                "content": "full scraped article body",
+                "extracted_data": {"raw": "upstream payload"},
+                "content_hash": "h1",
+            },
+            run_id=None,
+            now="2026-08-11T00:00:00+00:00",
+        )
+
+    rows = db.get_new_items(status=None)
+    assert len(rows) == 1
+    assert "content" not in rows[0]
+    assert "extracted_data" not in rows[0]
+    # Every other column the reader actually depends on (via
+    # `normalize_watchlist_item`) is still present.
+    for expected in (
+        "id", "subscription_id", "url", "title", "content_hash",
+        "published_date", "author", "status", "created_at", "updated_at",
+        "queued_for_briefing", "run_id", "alert_matches", "content_format",
+        "content_kind", "is_flagged", "subscription_name", "subscription_type",
+    ):
+        assert expected in rows[0], f"missing expected list column: {expected}"
+
+
+def test_get_new_items_content_preview_is_a_cheap_prefix_not_the_full_body(db):
+    """The list row's own snippet source (`article_list._render_row`) reads
+    `content_preview`, a `substr(content, 1, 2000)` projection -- present on
+    every list row (unlike `content` itself) and always short, even when the
+    underlying body is much longer.
+    """
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    long_body = "word " * 10_000  # 50,000 bytes, far past the 2000-byte cap.
+    with db.transaction() as conn:
+        persist_subscription_item(
+            conn,
+            source_id,
+            {"url": "https://a.example/1", "title": "A", "content": long_body, "content_hash": "h1"},
+            run_id=None,
+            now="2026-08-11T00:00:00+00:00",
+        )
+
+    rows = db.get_new_items(status=None)
+    assert len(rows) == 1
+    assert "content" not in rows[0]
+    assert rows[0]["content_preview"] == long_body[:2000]
+    assert len(rows[0]["content_preview"]) < len(long_body)
+
+
+def test_get_new_items_search_like_fallback_still_matches_on_content(db):
+    """The LIKE-fallback search predicate still filters on `i.content` --
+    narrowing the SELECT list narrows what comes back in the row, not what
+    the search box can match against.
+    """
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    with db.transaction() as conn:
+        persist_subscription_item(
+            conn,
+            source_id,
+            {
+                "url": "https://a.example/1",
+                "title": "Untitled",
+                "content": "a rare word: FrobnicateXYZ",
+                "content_hash": "h1",
+            },
+            run_id=None,
+            now="2026-08-11T00:00:00+00:00",
+        )
+    # Force the LIKE fallback path deterministically rather than relying on
+    # a MATCH failing for some other reason.
+    db.conn.execute("DROP TABLE subscription_items_fts")
+    db.conn.commit()
+
+    rows = db.get_new_items(status=None, search="FrobnicateXYZ")
+    assert len(rows) == 1
+    assert "content" not in rows[0]
+
+
+def test_get_item_content_returns_full_body(db):
+    """AC#1: the DETAIL fetch still loads full content."""
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    with db.transaction() as conn:
+        item_id = persist_subscription_item(
+            conn,
+            source_id,
+            {
+                "url": "https://a.example/1",
+                "title": "A",
+                "content": "full scraped article body",
+                "content_hash": "h1",
+            },
+            run_id=None,
+            now="2026-08-11T00:00:00+00:00",
+        )
+
+    assert db.get_item_content(item_id) == "full scraped article body"
+
+
+def test_get_item_content_returns_none_for_missing_row(db):
+    assert db.get_item_content(999999) is None
+
+
+def test_get_item_content_returns_none_for_row_with_null_content(db):
+    source_id = db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO subscription_items (subscription_id, url, title) VALUES (?, ?, ?)",
+            (source_id, "https://a.example/1", "No body"),
+        )
+        item_id = conn.execute(
+            "SELECT id FROM subscription_items WHERE url = ?", ("https://a.example/1",)
+        ).fetchone()[0]
+
+    assert db.get_item_content(item_id) is None
+
+
+_LEGACY_SCHEMA_SQL = """
+    CREATE TABLE subscriptions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT, type TEXT, source TEXT NOT NULL UNIQUE,
+        priority INTEGER DEFAULT 3, tags TEXT, folder TEXT,
+        is_active BOOLEAN DEFAULT 1, is_paused BOOLEAN DEFAULT 0,
+        check_frequency INTEGER DEFAULT 3600, last_checked DATETIME,
+        last_success DATETIME, last_error TEXT, error_count INTEGER DEFAULT 0,
+        consecutive_failures INTEGER DEFAULT 0, auto_pause_threshold INTEGER DEFAULT 10,
+        description TEXT, custom_headers TEXT, auth_config TEXT, extraction_rules TEXT,
+        rate_limit_config TEXT, notification_threshold FLOAT DEFAULT 0.1,
+        auto_ingest BOOLEAN DEFAULT 0, notification_config TEXT,
+        change_threshold FLOAT DEFAULT 0.0, ignore_selectors TEXT,
+        etag TEXT, last_modified TEXT,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE subscription_items (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        subscription_id INTEGER NOT NULL,
+        url TEXT NOT NULL, title TEXT, content_hash TEXT, published_date DATETIME,
+        author TEXT, categories TEXT, enclosures TEXT, extracted_data TEXT,
+        status TEXT DEFAULT 'new', media_id INTEGER, processing_error TEXT,
+        previous_hash TEXT, change_percentage FLOAT, diff_summary TEXT, change_type TEXT,
+        canonical_url TEXT, duplicate_of INTEGER,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(subscription_id, url, content_hash)
+    );
+"""
+
+
+def test_ordering_parity_legacy_backfill_vs_new_insert_maintained(tmp_path):
+    """AC#2/AC#3: sort-semantics parity between the OLD inline
+    `COALESCE(datetime(published_date), datetime(created_at))` expression
+    and the new stored `effective_date` column + index, over a fixture that
+    mixes:
+
+    - a LEGACY row set, inserted into a hand-built pre-migration database
+      (no `effective_date` column, no `SubscriptionsDB` involved yet) and
+      then BACKFILLED by opening it through `SubscriptionsDB` -- exercising
+      the migration's `ALTER TABLE`, not just a fresh schema's
+      `CREATE TABLE`;
+    - a "NEW" row set, inserted afterwards through the real
+      `persist_subscription_item` write path, exercising the generated
+      column's INSERT-time maintenance;
+    - valid, NULL, and unparseable-garbage `published_date`;
+    - ties (identical effective dates), including one tied PAIR across the
+      legacy/new boundary.
+
+    The expected order is not a hand-written list: it is the SAME OLD
+    expression, independently recomputed against the live table, so this
+    test would fail if the new column/index ever disagreed with what
+    today's query actually computes -- not merely with what a human
+    predicted it would compute.
+    """
+    path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(str(path))
+    conn.executescript(_LEGACY_SCHEMA_SQL)
+    conn.execute(
+        "INSERT INTO subscriptions (id, name, type, source) "
+        "VALUES (1, 'Legacy', 'rss', 'https://legacy.example/f')"
+    )
+    legacy_rows = [
+        # (url, published_date, created_at)
+        ("https://legacy.example/valid", "2024-01-16T09:00:00Z", "2024-01-01 00:00:00"),
+        ("https://legacy.example/null", None, "2024-02-01 00:00:00"),
+        ("https://legacy.example/garbage", "not-a-real-date", "2024-03-01 00:00:00"),
+        ("https://legacy.example/tie-a", "2024-05-01T00:00:00Z", "2024-01-01 00:00:00"),
+        ("https://legacy.example/tie-b", "2024-05-01T00:00:00Z", "2024-01-01 00:00:00"),
+    ]
+    for url, published, created in legacy_rows:
+        conn.execute(
+            "INSERT INTO subscription_items "
+            "(subscription_id, url, title, published_date, created_at, content_hash) "
+            "VALUES (1, ?, ?, ?, ?, ?)",
+            (url, url, published, created, url),
+        )
+    conn.commit()
+    conn.close()
+
+    # Opening through SubscriptionsDB runs `_ensure_watchlists_schema`,
+    # ALTERing the generated column onto this pre-existing table and
+    # building the index over these five already-there rows -- the "legacy
+    # backfill" half of the fixture.
+    legacy_db = SubscriptionsDB(str(path), client_id="parity-probe")
+    try:
+        # "NEW" rows, inserted through the real write path AFTER the column
+        # exists -- the "insert-maintained" half. One is tied with a LEGACY
+        # row (a mixed legacy/new tie).
+        with legacy_db.transaction() as sconn:
+            for url, title, published, now, content_hash in (
+                ("https://new.example/valid", "new valid", "2024-06-01T00:00:00Z", "2024-01-01T00:00:00+00:00", "n1"),
+                ("https://new.example/null", "new null", None, "2024-04-01T00:00:00+00:00", "n2"),
+                ("https://new.example/garbage", "new garbage", "still-garbage", "2024-04-15T00:00:00+00:00", "n3"),
+                ("https://new.example/tie-c", "new tie", "2024-05-01T00:00:00Z", "2024-01-01T00:00:00+00:00", "n4"),
+            ):
+                persist_subscription_item(
+                    sconn,
+                    1,
+                    {"url": url, "title": title, "published_date": published, "content_hash": content_hash},
+                    run_id=None,
+                    now=now,
+                )
+
+        old_order = [
+            row[0]
+            for row in legacy_db.conn.execute(
+                """
+                SELECT id FROM subscription_items
+                ORDER BY COALESCE(datetime(published_date), datetime(created_at)) DESC, id ASC
+                """
+            ).fetchall()
+        ]
+
+        new_rows = legacy_db.get_new_items(status=None, limit=100)
+        new_order = [r["id"] for r in new_rows]
+
+        assert len(old_order) == 9  # 5 legacy + 4 new
+        assert new_order == old_order
+    finally:
+        legacy_db.close()
+
+
+def test_get_new_items_since_predicate_uses_effective_date_column(db):
+    """The `since` predicate was rewritten to `i.effective_date >= datetime(?)`
+    (TASK-15464) -- provably the same expression as the old inline
+    COALESCE, since `effective_date` IS that expression. This is the
+    regression test: a fixture spanning the floor, including a NULL
+    `published_date` row whose `created_at` decides which side of the floor
+    it lands on.
+    """
+    source_id = db.add_subscription(name="Feed", type="rss", source="https://f.example/f")
+    _insert_item(db, source_id, "https://f.example/before", "before", "body")
+    _insert_item(db, source_id, "https://f.example/at", "at", "body")
+    _insert_item(db, source_id, "https://f.example/after", "after", "body")
+    _insert_item(db, source_id, "https://f.example/undated-after", "undated-after", "body")
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE subscription_items SET published_date = ? WHERE url = ?",
+            ("2026-08-06T00:00:00+00:00", "https://f.example/before"),
+        )
+        conn.execute(
+            "UPDATE subscription_items SET published_date = ? WHERE url = ?",
+            ("2026-08-07T00:00:00+00:00", "https://f.example/at"),
+        )
+        conn.execute(
+            "UPDATE subscription_items SET published_date = ? WHERE url = ?",
+            ("2026-08-08T00:00:00+00:00", "https://f.example/after"),
+        )
+        # No published_date at all; created_at (default CURRENT_TIMESTAMP,
+        # i.e. "now") is well after the floor.
+        conn.execute(
+            "UPDATE subscription_items SET created_at = ? WHERE url = ?",
+            ("2026-08-09T00:00:00+00:00", "https://f.example/undated-after"),
+        )
+
+    rows = db.get_new_items(status=None, since="2026-08-07T00:00:00+00:00")
+
+    assert {r["url"] for r in rows} == {
+        "https://f.example/at",
+        "https://f.example/after",
+        "https://f.example/undated-after",
+    }
 
 
 # --- TASK-3791: search/since predicates on get_new_items -----------------------

--- a/Tests/Watchlists/test_watchlists_article_list.py
+++ b/Tests/Watchlists/test_watchlists_article_list.py
@@ -15,7 +15,7 @@ from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.widgets import Input, ListView, Select, Static
 
-from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
+from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane, _render_row
 from tldw_chatbook.UI.Watchlists_Modules.items_pane import (
     ItemSelected,
     ItemsFilterChanged,
@@ -561,3 +561,32 @@ async def test_the_new_items_pill_shows_and_click_dismisses_and_reloads():
         assert ("refresh_items_requested", None) in app.captured_messages, (
             "the click asks for the same reload the refresh button posts"
         )
+
+
+def test_render_row_snippet_prefers_content_preview_over_content():
+    """TASK-15464. `get_new_items`'s list rows no longer carry `content` at
+    all -- only `content_preview`, a cheap `substr` projection
+    (`SubscriptionsDB._LIST_ITEM_COLUMNS`). `_render_row`'s snippet must
+    read from a row shaped exactly like that (no `content` key whatsoever),
+    not merely from a hand-built test dict that happens to set both.
+    """
+    item = _item(1)
+    item.pop("content", None)
+    item["content_preview"] = "A preview snippet with enough words to render."
+
+    rendered = str(_render_row(item))
+
+    assert "A preview snippet with enough words to render." in rendered
+
+
+def test_render_row_snippet_falls_back_to_content_when_no_preview():
+    """Backward compatibility: a hand-built dict (every fixture in this
+    file, via `_item`) that never went through `get_new_items` at all sets
+    only `content`, not `content_preview` -- the snippet must still render.
+    """
+    item = _item(1)
+    assert "content_preview" not in item
+
+    rendered = str(_render_row(item))
+
+    assert item["content"] in rendered

--- a/backlog/tasks/task-15464 - Watchlists-items-feed---narrow-projection-and-indexed-effective-date-ordering.md
+++ b/backlog/tasks/task-15464 - Watchlists-items-feed---narrow-projection-and-indexed-effective-date-ordering.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-15464
 title: Watchlists items feed: narrow projection and indexed effective-date ordering
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
+updated_date: '2026-08-11 16:30'
 labels:
   - perf
   - watchlists
@@ -21,7 +23,174 @@ Fix direction: a list projection without `content` (fetch on select), plus a sto
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Items list queries no longer select the content column for list rows (evidence); item detail still loads full content
-- [ ] #2 Ordering uses an indexed column with sort order identical to today for both legacy and new rows (migration + tests)
-- [ ] #3 Items-pane refresh latency before/after on a large corpus recorded
+- [x] #1 Items list queries no longer select the content column for list rows (evidence); item detail still loads full content
+- [x] #2 Ordering uses an indexed column with sort order identical to today for both legacy and new rows (migration + tests)
+- [x] #3 Items-pane refresh latency before/after on a large corpus recorded
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Probe real SQLite (3.49.1, this repo's bundled version) BEFORE writing any
+   migration: confirm `COALESCE(datetime(published_date), datetime(created_at))`
+   behavior for NULL/`''`/unparseable `published_date`, confirm tie-break order
+   (ties resolve by ascending `id`/rowid today, with or without an index), and
+   confirm whether `ALTER TABLE ADD COLUMN ... GENERATED ALWAYS AS (...)` can add
+   a `STORED` vs `VIRTUAL` generated column to an EXISTING table.
+2. Trace every consumer of `get_new_items`'s rows (`watchlist_normalizers.
+   normalize_watchlist_item`, `article_list._render_row`, `content_pane.py`,
+   `briefing_selection.py`'s OWN separate query) to determine which columns the
+   list path actually reads, before deciding the narrowed projection.
+3. Migration in `_ensure_watchlists_schema`: add a `effective_date` generated
+   column (`VIRTUAL`, since `STORED` cannot be added via `ALTER TABLE ADD
+   COLUMN`) computed as the exact COALESCE expression above, guarded by
+   `PRAGMA table_xinfo` (not `table_info` -- probe found `table_info` never
+   lists a virtual generated column at all), plus an index on it.
+4. Narrow `get_new_items` (both the FTS and LIKE-fallback branches of
+   `_search_items_rows`, and the main path) to an explicit column list
+   excluding `content` and `extracted_data`; rewrite the ORDER BY and `since`
+   predicate to use the new column + index.
+5. Add a DETAIL fetch (`SubscriptionsDB.get_item_content`, threaded through
+   `LocalWatchlistsService`/`WatchlistScopeService`/`WatchlistsBackendController`)
+   and wire `WatchlistsCollectionsScreen.handle_item_selected` to backfill
+   `content` on selection, since the reader's `ContentPane` previously relied
+   on the list row already carrying full content.
+6. Add a cheap `content_preview` projection (`substr`) for `article_list.
+   _render_row`'s snippet, the one list-path reader of `content` found in step 2.
+7. Tests first where feasible (ordering-parity, no-content-in-list-rows,
+   idempotent-migration-guard); run SubscriptionsDB/Subscriptions/Watchlists
+   UI suites; measure before/after latency on a large seeded corpus (isolated
+   scratch probe).
+
+## Implementation Notes
+
+**Narrow projection (AC#1).** `get_new_items`/`_search_items_rows` no longer
+`SELECT i.*`; they use a new explicit column list
+(`SubscriptionsDB._LIST_ITEM_COLUMNS`) excluding `content` (the audit's
+named cost) and `extracted_data` -- found during the required column trace:
+for an API-type subscription, `LocalWatchlistsService._normalize_api_item`
+stores the ENTIRE raw upstream item payload in `extracted_data`, just as
+unbounded as `content`, and `normalize_watchlist_item` never mapped it into
+its output dict on this query or any other. The trace also found one list-
+path reader of `content` that the task's instructions anticipated: `article_
+list._render_row`'s 160-char preview snippet. Rather than drag the full
+column back in for that, added a cheap `substr(i.content, 1, 2000) AS
+content_preview` projection; `_render_row` now prefers it, falling back to
+`content` for hand-built test dicts.
+
+There was no existing "fetch one item's content by id" DB method (the
+reader previously relied on the list row already carrying full content, so
+there had never been a narrow/detail split to bridge). Added `SubscriptionsDB.
+get_item_content(item_id)` (single indexed-PK read) and threaded it through
+`LocalWatchlistsService` -> `WatchlistScopeService` -> `WatchlistsBackendController`
+-> `WatchlistsCollectionsScreen`, mirroring the existing `get_item_status`
+pattern at every layer (same routing, same `items.detail` runtime-policy
+action -- no new policy registration needed). `handle_item_selected` became
+`async` (an established pattern elsewhere in the codebase for `@on`
+handlers) and now awaits the content fetch, merging it into the shared item
+dict BEFORE setting `ContentPane.item` (a `recompose=True` reactive) -- one
+recompose per selection with the body already in it, not two. Deliberately
+`Optional[str]`, not raising, at every layer (unlike the sibling
+`get_item_status`, which raises `KeyError`): `content` can legitimately be
+NULL for an existing row, so "no such row" and "row exists, content is
+NULL" both render the same empty body and are not distinguished. A `None`
+result leaves a pre-existing `content` key untouched rather than clobbering
+it -- which is also what kept the pre-existing synthetic-dict test
+(`test_selecting_an_item_renders_it_in_the_content_region`, which bypasses
+the DB) green unchanged.
+
+**Indexed ordering (AC#2).** Added `effective_date TEXT GENERATED ALWAYS AS
+(COALESCE(datetime(published_date), datetime(created_at))) VIRTUAL` via
+`_ensure_watchlists_schema`, plus an index on it, and rewrote the ORDER BY
+and `since` predicate to use it. Probed real SQLite (3.49.1) before writing
+any of this, per instruction: confirmed NULL/`''`/unparseable
+`published_date` all normalize to NULL under `datetime()` (falling back to
+`created_at` identically to the old inline expression); confirmed ties sort
+by ascending id/rowid today (made explicit in the SQL, `ORDER BY
+i.effective_date DESC, i.id ASC`, rather than relying on that implicit
+behavior); confirmed `STORED` generated columns CANNOT be added via `ALTER
+TABLE ADD COLUMN` ("cannot add a STORED column") -- only `VIRTUAL` can, which
+is what was built. A `VIRTUAL` generated column needs no separate backfill
+`UPDATE` at all: SQLite computes the value for every pre-existing row
+automatically when the index is built over them, and auto-maintains it on
+every future INSERT/UPDATE through any write path, present or future --
+verified against a hand-built 500-row pre-migration database opened through
+the real `SubscriptionsDB`.
+
+**Trap found by the same probe, load-bearing for the migration's own
+correctness:** `PRAGMA table_info` does NOT list a virtual generated column
+at all; only `PRAGMA table_xinfo` does. Every other column-presence guard in
+`_ensure_watchlists_schema` uses `table_info`-sourced `items_cols` -- using
+that same set for `effective_date` would have found it "absent" forever and
+re-run the `ALTER` on every app start after the first, crashing with
+"duplicate column name: effective_date" the second time. The guard reads
+`table_xinfo` explicitly; `test_schema_migration_over_effective_date_is_
+idempotent` is this trap's own regression test.
+
+**Sort-semantics parity (AC#2/#3).**
+`test_ordering_parity_legacy_backfill_vs_new_insert_maintained` builds a
+hand-written PRE-migration SQLite database (no `effective_date` column at
+all), inserts 5 "legacy" rows spanning valid/NULL/garbage published_date
+plus a tied pair, opens it through the real `SubscriptionsDB` (exercising
+the actual ALTER + index-build backfill over pre-existing rows), then
+inserts 4 more "new" rows through the real `persist_subscription_item` path
+-- one deliberately tied with a legacy row. The expected order is not
+hand-written: it's the OLD `COALESCE(datetime(...))` expression,
+independently recomputed against the live table inside the test itself, so
+it would fail if the new column/index ever disagreed with what the query
+actually computes. Result: identical ordering over all 9 rows.
+
+**Measurement (AC#3).** Isolated scratch probe (temp SQLite file, no real
+data) ran the VERBATIM old SQL text (captured via `git show HEAD:...` since
+these changes were uncommitted at measurement time) against the same
+seeded, migrated database as the real `get_new_items`: 5,000-item corpus,
+7.96ms -> 0.68ms mean (11.7x); 30,000-item corpus, 32.31ms -> 0.73ms mean
+(44.1x), 15 repeats each. `EXPLAIN QUERY PLAN` for the real
+`WHERE status=? ORDER BY i.effective_date DESC, i.id ASC LIMIT ?` shape
+confirms the index is actually used:
+`SCAN i USING INDEX idx_subscription_items_effective_date`. The near-flat
+NEW latency across a 6x corpus increase versus the OLD query's near-linear
+growth is the audit's "O(table) work per refresh" claim made concrete: the
+old query scaled with table size regardless of the 100-row LIMIT; the new
+one is effectively O(LIMIT).
+
+**Deliberate scope boundaries.** `briefing_selection.py` has its OWN
+separate query (`_ITEM_COLUMNS`, a different `SELECT i.*` in a different
+module) for selecting items into an LLM-summarized briefing -- legitimately
+needs full `content`, left untouched. `get_unread_items_count_since` (a
+COUNT-only badge query) also still uses the inline COALESCE form -- out of
+the "items list queries" AC's scope; still correct regardless, since
+`effective_date`'s existence doesn't change what the inline expression
+computes. `categories`/`enclosures` stayed in the narrow projection (small,
+unused, but not "large payload" like `content`/`extracted_data`) to avoid
+scope creep past what the task and its instructions asked for.
+
+**Tests.** 12 new tests across `Tests/DB/test_subscriptions_db_watchlists.py`
+and `Tests/Watchlists/test_watchlists_article_list.py`. Full run (all green,
+no regressions): `Tests/DB/test_subscriptions_db_watchlists.py` +
+`Tests/Subscriptions/` + `Tests/Watchlists/test_watchlists_article_list.py`
+= 869 passed, 1 pre-existing/unrelated skip; the `handle_item_selected`
+async surface (`test_watchlists_content_pane.py`,
+`test_watchlists_item_actions.py`, `test_watchlists_read_status.py`,
+`test_watchlists_inspector.py`, `test_watchlists_items_status_filter.py`) =
+137 passed; `test_watchlists_collections_screen.py` = 75 passed;
+`test_watchlist_scope_service.py`, `test_watchlists_backend_controller.py`,
+`test_watchlists_items_pane.py`, `test_watchlists_rail_counts_and_scope.py`,
+`test_watchlists_destination_shell.py`,
+`test_watchlists_select_option_overlays.py`,
+`test_watchlists_source_row_click_selects.py` = 172 passed. Total: 1,253
+passed, 1 skip, 0 failures. Full `Tests/UI/` + `Tests/Watchlists/`
+collect-only sweep: 11,013 tests, zero import errors.
+
+**Files modified:** `tldw_chatbook/DB/Subscriptions_DB.py`,
+`tldw_chatbook/Subscriptions/local_watchlists_service.py`,
+`tldw_chatbook/Subscriptions/watchlist_scope_service.py`,
+`tldw_chatbook/Subscriptions/watchlist_normalizers.py`,
+`tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py`,
+`tldw_chatbook/UI/Watchlists_Modules/article_list.py`,
+`tldw_chatbook/UI/Screens/watchlists_collections_screen.py`,
+`Tests/DB/test_subscriptions_db_watchlists.py`,
+`Tests/Watchlists/test_watchlists_article_list.py`.
+
+No `Docs/User_Guide/` update: no visible UI change (the reader shows the
+same content it always did) -- this is a data-layer/perf change behind the
+existing screen.

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -1915,24 +1915,33 @@ class SubscriptionsDB(BaseDB):
     #:   it into its output dict at all, on this query or any other. Nothing
     #:   downstream of `get_new_items` has ever read it.
     #:
-    #: Every other column below IS read somewhere downstream of this query
+    #: Most of the columns below ARE read somewhere downstream of this query
     #: today (`watchlist_normalizers.normalize_watchlist_item`, the reader's
     #: `item_dates` sort, or `WatchlistsCollectionsScreen` directly) --
-    #: traced column-by-column in task-15464's Implementation Notes.
+    #: traced column-by-column in task-15464's Implementation Notes. Two
+    #: kept anyway despite tracing to no reader at all: `categories` and
+    #: `enclosures`. Unlike `content`/`extracted_data` above, neither is a
+    #: large-payload column (small scalar/short-JSON fields), so cutting
+    #: them would not have served the projection's actual goal -- narrowing
+    #: away unbounded-size columns -- and would have been scope creep past
+    #: what this task's ACs asked for. They stay, unread, until a future
+    #: reader needs them or a separate cleanup task removes them on its own
+    #: evidence.
     #:
     #: One exception traced the OTHER way: `article_list._render_row` (the
     #: Read tab's row renderer) DOES read `content` on the list path, for a
     #: 160-char preview snippet under the title (`html_text.body_snippet`).
     #: Rather than let that one reader drag the full column back in,
-    #: `content_preview` is a CHEAP projected expression -- a raw 2000-byte
-    #: prefix, not the whole (possibly many-KB) body -- comfortably enough
-    #: raw text for `body_snippet` to find its 160 plain-text characters
-    #: after HTML-tag-stripping in every realistic case; a snippet cut a few
-    #: characters short on some pathological markup-to-text ratio is an
-    #: acceptable soft failure for a preview, unlike truncating the reader's
-    #: actual body. `article_list.py` prefers this column and falls back to
-    #: `content` only for a hand-built dict that never went through this
-    #: query at all (tests; a future non-DB source).
+    #: `content_preview` is a CHEAP projected expression -- a 2000-character
+    #: prefix (`substr` counts characters, not bytes), not the whole
+    #: (possibly many-KB) body -- comfortably enough text for `body_snippet`
+    #: to find its 160 plain-text characters after HTML-tag-stripping in
+    #: every realistic case; a snippet cut a few characters short on some
+    #: pathological markup-to-text ratio is an acceptable soft failure for a
+    #: preview, unlike truncating the reader's actual body. `article_list.py`
+    #: prefers this column and falls back to `content` only for a hand-built
+    #: dict that never went through this query at all (tests; a future
+    #: non-DB source).
     _LIST_ITEM_COLUMNS = (
         "i.id, i.subscription_id, i.url, i.title, i.content_hash, "
         "i.published_date, i.author, i.categories, i.enclosures, i.status, "

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -660,6 +660,80 @@ class SubscriptionsDB(BaseDB):
         if "is_flagged" not in items_cols:
             cursor.execute("ALTER TABLE subscription_items ADD COLUMN is_flagged BOOLEAN DEFAULT 0")
 
+        # TASK-15464: a stored, indexed effective-date column, replacing the
+        # per-row `COALESCE(datetime(published_date), datetime(created_at))`
+        # expression `get_new_items` used to ORDER BY -- unindexable, so
+        # every Items-pane refresh sorted the WHOLE table before its LIMIT
+        # ever applied.
+        #
+        # `GENERATED ALWAYS AS (...) VIRTUAL`, not a plain column maintained
+        # by a trigger or by application code: it is auto-computed for every
+        # existing row (no separate backfill UPDATE -- SQLite evaluates the
+        # expression on demand, and materializes it into the index below at
+        # index-build time, over however many legacy rows already exist) and
+        # auto-maintained on every INSERT/UPDATE of `published_date` or
+        # `created_at`, through every write path there is or ever will be --
+        # unlike a trigger, which only covers paths someone remembered to
+        # keep it in sync with, and unlike the current single write path
+        # (`persist_subscription_item`), which would otherwise be the one
+        # place a future column-writer would have to remember to update too.
+        # `STORED` was tried first and rejected: SQLite's `ALTER TABLE ADD
+        # COLUMN` refuses it outright ("cannot add a STORED column") --
+        # only `VIRTUAL` can be added to an existing table after the fact;
+        # probe-verified (task-15464) before deciding.
+        #
+        # The expression is deliberately byte-for-byte the same one
+        # `get_new_items`'s ORDER BY and `since` predicate used to spell out
+        # inline, and probe-verified (task-15464) against real SQLite
+        # (3.49.1) before this was written:
+        #   - NULL, `''`, or an unparseable `published_date` (`datetime()`
+        #     returns NULL for all three) falls back to `created_at`,
+        #     identically to the old expression -- because it IS the old
+        #     expression, just stored instead of recomputed per row per
+        #     query.
+        #   - A mixed-format `created_at` (space-separated
+        #     `CURRENT_TIMESTAMP` vs. ingest's ISO `T`+offset) normalizes
+        #     through the same `datetime()` call either way.
+        #   - Ties (equal effective date) sort by ascending `id` today, with
+        #     or without this index -- SQLite appends the rowid as a
+        #     non-unique index's own implicit final key, so an index scan
+        #     produces the identical tie order a full-table sort already
+        #     does. The ORDER BY clauses below make this explicit
+        #     (`, i.id ASC`) rather than leaning on that implicit behaviour.
+        #
+        # TRAP, found by the same probe: `PRAGMA table_info` does NOT list a
+        # virtual generated column at all -- SQLite reports it only through
+        # `PRAGMA table_xinfo` (in that pragma's `hidden` field). The
+        # idempotency guard below therefore reads `table_xinfo`, not the
+        # `table_info`-sourced `items_cols` every other guard in this method
+        # uses: guarding on `items_cols` here would find "effective_date"
+        # absent FOREVER (it can never appear in `table_info`'s output) and
+        # re-run the ALTER on every single schema init after the first,
+        # crashing with "duplicate column name: effective_date" the very
+        # next time this method runs.
+        #
+        # No `BEGIN IMMEDIATE` wrapper (contrast the `extraction_fingerprint`
+        # migration above): that one needs atomicity because a DDL statement
+        # autocommits immediately under Python's sqlite3 implicit-BEGIN
+        # policy, and a crash between ITS ALTER and its follow-up UPDATEs
+        # would leave the one-time gate spent with the data half-migrated.
+        # There are no follow-up DML statements here to strand -- the ALTER
+        # and the CREATE INDEX are each independently atomic DDL, and a
+        # generated column cannot be written to directly (confirmed by the
+        # same probe: an explicit INSERT/UPDATE naming it raises), so there
+        # is no data-migration step for a crash to catch mid-way at all.
+        items_xcols = {row[1] for row in cursor.execute("PRAGMA table_xinfo(subscription_items)")}
+        if "effective_date" not in items_xcols:
+            cursor.execute(
+                "ALTER TABLE subscription_items ADD COLUMN effective_date TEXT "
+                "GENERATED ALWAYS AS "
+                "(COALESCE(datetime(published_date), datetime(created_at))) VIRTUAL"
+            )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_subscription_items_effective_date "
+            "ON subscription_items(effective_date DESC)"
+        )
+
         # Snapshot extraction fingerprint + one-time TASK-1362 "noise, not
         # volume" data migration (spec:
         # Docs/superpowers/specs/2026-07-29-watchlists-noise-not-volume-design.md
@@ -1824,6 +1898,53 @@ class SubscriptionsDB(BaseDB):
         """
         return '"' + term.replace('"', '""') + '"'
 
+    #: The list-page projection shared by `get_new_items` and its
+    #: `_search_items_rows` search half (TASK-15464). Deliberately NOT
+    #: `i.*`: the old `SELECT i.*` dragged two unbounded-size columns into
+    #: every one of up to 100 list rows on every Items-pane refresh, and
+    #: neither has a single reader on the list path --
+    #:
+    #: - `content`: the audit's named cost, full scraped article/diff text.
+    #:   Read only by the DETAIL path now (`get_item_content`, a one-row
+    #:   fetch on selection -- see that method's docstring), not by anything
+    #:   that renders the list itself.
+    #: - `extracted_data`: for an API-type subscription,
+    #:   `LocalWatchlistsService._normalize_api_item` stores the entire raw
+    #:   upstream item payload here (`"extracted_data": item`) -- just as
+    #:   unbounded as `content`, and `normalize_watchlist_item` never maps
+    #:   it into its output dict at all, on this query or any other. Nothing
+    #:   downstream of `get_new_items` has ever read it.
+    #:
+    #: Every other column below IS read somewhere downstream of this query
+    #: today (`watchlist_normalizers.normalize_watchlist_item`, the reader's
+    #: `item_dates` sort, or `WatchlistsCollectionsScreen` directly) --
+    #: traced column-by-column in task-15464's Implementation Notes.
+    #:
+    #: One exception traced the OTHER way: `article_list._render_row` (the
+    #: Read tab's row renderer) DOES read `content` on the list path, for a
+    #: 160-char preview snippet under the title (`html_text.body_snippet`).
+    #: Rather than let that one reader drag the full column back in,
+    #: `content_preview` is a CHEAP projected expression -- a raw 2000-byte
+    #: prefix, not the whole (possibly many-KB) body -- comfortably enough
+    #: raw text for `body_snippet` to find its 160 plain-text characters
+    #: after HTML-tag-stripping in every realistic case; a snippet cut a few
+    #: characters short on some pathological markup-to-text ratio is an
+    #: acceptable soft failure for a preview, unlike truncating the reader's
+    #: actual body. `article_list.py` prefers this column and falls back to
+    #: `content` only for a hand-built dict that never went through this
+    #: query at all (tests; a future non-DB source).
+    _LIST_ITEM_COLUMNS = (
+        "i.id, i.subscription_id, i.url, i.title, i.content_hash, "
+        "i.published_date, i.author, i.categories, i.enclosures, i.status, "
+        "i.media_id, i.processing_error, i.previous_hash, "
+        "i.change_percentage, i.diff_summary, i.change_type, "
+        "i.canonical_url, i.duplicate_of, i.created_at, i.updated_at, "
+        "i.queued_for_briefing, i.run_id, i.alert_matches, "
+        "i.content_format, i.content_kind, i.is_flagged, "
+        "substr(i.content, 1, 2000) AS content_preview, "
+        "s.name as subscription_name, s.type as subscription_type"
+    )
+
     def _search_items_rows(
         self,
         conn: Any,
@@ -1852,12 +1973,12 @@ class SubscriptionsDB(BaseDB):
         try:
             return conn.execute(
                 f"""
-                SELECT i.*, s.name as subscription_name, s.type as subscription_type
+                SELECT {self._LIST_ITEM_COLUMNS}
                 FROM subscription_items i
                 JOIN subscription_items_fts ON subscription_items_fts.rowid = i.id
                 JOIN subscriptions s ON i.subscription_id = s.id
                 {fts_where}
-                ORDER BY COALESCE(datetime(i.published_date), datetime(i.created_at)) DESC
+                ORDER BY i.effective_date DESC, i.id ASC
                 LIMIT ?
                 """,
                 tuple([*params, match, limit]),
@@ -1881,11 +2002,11 @@ class SubscriptionsDB(BaseDB):
         )
         return conn.execute(
             f"""
-            SELECT i.*, s.name as subscription_name, s.type as subscription_type
+            SELECT {self._LIST_ITEM_COLUMNS}
             FROM subscription_items i
             JOIN subscriptions s ON i.subscription_id = s.id
             {like_where}
-            ORDER BY COALESCE(datetime(i.published_date), datetime(i.created_at)) DESC
+            ORDER BY i.effective_date DESC, i.id ASC
             LIMIT ?
             """,
             tuple([*params, *like_params, limit]),
@@ -1925,6 +2046,14 @@ class SubscriptionsDB(BaseDB):
         every other predicate, and of each other), and `statuses` is the
         multi-status form of `status` for a caller that wants more than one
         bucket without wanting all of them.
+
+        TASK-15464: rows carry every `subscription_items` column EXCEPT
+        `content` (full body text) and `extracted_data` (an API source's raw
+        upstream payload) -- both unbounded-size, and neither has a reader
+        on this list-page path (see `_LIST_ITEM_COLUMNS`'s docstring for the
+        trace). A caller that needs the body of ONE already-listed item
+        (opening it in the reader) fetches it separately through
+        `get_item_content`, a single indexed-by-id read.
 
         Args:
             subscription_id: Restrict to one subscription, or `None` for all.
@@ -2020,9 +2149,16 @@ class SubscriptionsDB(BaseDB):
             # string; the COALESCE wraps the NORMALIZED values so an
             # unparseable feed-supplied published_date (datetime() -> NULL)
             # falls back to created_at instead of poisoning the compare.
-            predicates.append(
-                "COALESCE(datetime(i.published_date), datetime(i.created_at)) >= datetime(?)"
-            )
+            #
+            # TASK-15464: `i.effective_date` IS this exact COALESCE
+            # expression -- see the migration comment in
+            # `_ensure_watchlists_schema` -- stored/generated rather than
+            # recomputed, so this predicate is byte-for-byte equivalent to
+            # the inline form it replaces, and now shares the same
+            # `idx_subscription_items_effective_date` index the ORDER BY
+            # below uses, instead of computing `datetime()` per row per
+            # query.
+            predicates.append("i.effective_date >= datetime(?)")
             params.append(since)
         where_clause = f"WHERE {' AND '.join(predicates)}" if predicates else ""
 
@@ -2036,11 +2172,11 @@ class SubscriptionsDB(BaseDB):
                 params.append(limit)
                 rows = conn.execute(
                     f"""
-                    SELECT i.*, s.name as subscription_name, s.type as subscription_type
+                    SELECT {self._LIST_ITEM_COLUMNS}
                     FROM subscription_items i
                     JOIN subscriptions s ON i.subscription_id = s.id
                     {where_clause}
-                    ORDER BY COALESCE(datetime(i.published_date), datetime(i.created_at)) DESC
+                    ORDER BY i.effective_date DESC, i.id ASC
                     LIMIT ?
                     """,
                     tuple(params),
@@ -2079,6 +2215,44 @@ class SubscriptionsDB(BaseDB):
         if row is None:
             raise KeyError(f"Subscription item not found: {item_id}")
         return str(row["status"] or "new")
+
+    def get_item_content(self, item_id: int) -> Optional[str]:
+        """The full body text of one item -- the reader's DETAIL fetch.
+
+        TASK-15464. `get_new_items`'s list-page projection (`_LIST_ITEM_
+        COLUMNS`) deliberately excludes `content`: up to 100 rows' worth of
+        full scraped article/diff text, dragged along on every Items-pane
+        refresh for a column no list row ever rendered. This is the other
+        half -- a single indexed-by-primary-key read, fetched once, only
+        for the item actually opened in the reader.
+
+        Deliberately `Optional[str]` rather than raising, UNLIKE the
+        sibling `get_item_status` immediately above: `status` always has a
+        value once a row exists (defaulting to `"new"`, so `None` can only
+        mean "no such row" and a raise is the honest signal). `content` has
+        no such guarantee -- a row that exists but was never scraped a body
+        (mid-ingest, or a `change`-kind item whose renderable is
+        `diff_summary` instead) legitimately has `content IS NULL`, which is
+        not an error. Both "no such row" and "row exists, content is NULL"
+        return `None` here, indistinguishably -- the caller
+        (`WatchlistsCollectionsScreen._load_item_content`) treats a `None`
+        the same way either way: leave whatever `content` the caller's own
+        item dict already carries untouched, rather than raise or overwrite
+        it with an empty body.
+
+        Args:
+            item_id: The `subscription_items` row id.
+
+        Returns:
+            The stored `content`, or `None` if no row has this id, or the
+            row has one but its `content` column is itself NULL.
+        """
+        with self.transaction() as conn:
+            row = conn.execute(
+                "SELECT content FROM subscription_items WHERE id = ?",
+                (item_id,),
+            ).fetchone()
+        return row["content"] if row is not None else None
 
     def get_url_snapshots(
         self, subscription_id: int, url: str, *, limit: int = 2

--- a/tldw_chatbook/Subscriptions/briefing_selection.py
+++ b/tldw_chatbook/Subscriptions/briefing_selection.py
@@ -93,9 +93,13 @@ FIRST_WINDOW_DAYS = 7
 #: Total items handed to one LLM call (spec: "~40").
 DEFAULT_ITEM_CAP = 40
 
-# `SELECT i.*` mirrors `get_new_items`, so rows arrive with every column
-# `normalize_watchlist_item` reads (including `queued_for_briefing`); the two
-# joined columns are the source name/type it also reports.
+# `SELECT i.*` is a DELIBERATE divergence from `get_new_items` (task-15464
+# narrowed that one to an explicit column list excluding `content`): this
+# path selects an item into an LLM-summarized briefing, which needs the full
+# body `get_new_items`'s list-page projection now deliberately omits. Rows
+# still arrive with every column `normalize_watchlist_item` reads (including
+# `queued_for_briefing`); the two joined columns are the source name/type it
+# also reports.
 #
 # `created_at_utc` is `created_at` normalized by SQLite for COMPARISON only:
 # `created_at` is genuinely mixed-format in this table (a

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -590,6 +590,33 @@ class LocalWatchlistsService:
             raise ValueError(f"Invalid watchlist item id: {item_id!r}") from exc
         return self._db().get_item_status(row_id)
 
+    async def get_item_content(self, item_id: Any) -> str | None:
+        """Read one item's full body text -- the reader's DETAIL fetch.
+
+        TASK-15464 counterpart to `get_item_status` immediately above:
+        `list_items`'s underlying `get_new_items` no longer selects
+        `content` for list rows (the audit's named cost -- full scraped
+        article/diff text on up to 100 rows per refresh), so the reader
+        fetches it here, once, only for the item actually opened.
+
+        Args:
+            item_id: The item's local row id (bare, not namespaced).
+
+        Returns:
+            The stored content, or `None` if no row has this id, or the row
+            has one but its content is itself NULL (see
+            `SubscriptionsDB.get_item_content`'s docstring for why the two
+            are not distinguished).
+
+        Raises:
+            ValueError: If `item_id` is not an integer id.
+        """
+        try:
+            row_id = int(item_id)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid watchlist item id: {item_id!r}") from exc
+        return self._db().get_item_content(row_id)
+
     async def get_url_snapshots(
         self, source_id: Any, url: str, *, limit: int = 2
     ) -> list[dict[str, Any]]:

--- a/tldw_chatbook/Subscriptions/watchlist_normalizers.py
+++ b/tldw_chatbook/Subscriptions/watchlist_normalizers.py
@@ -571,11 +571,22 @@ def normalize_watchlist_item(source: str, row: Mapping[str, Any]) -> dict[str, A
         "created_at": row.get("created_at"),
         "updated_at": row.get("updated_at"),
         "published_date": row.get("published_date"),
-        # Phase D reader fields. `get_new_items` is `SELECT i.*`, so these are
-        # already on the row -- this dict was simply not carrying them, which
-        # made every item title-only downstream regardless of what Phase A
-        # persisted.
+        # Phase D reader fields. Originally added because `get_new_items` was
+        # `SELECT i.*` and these were already on the row but this dict simply
+        # was not carrying them (title-only downstream regardless of what
+        # Phase A persisted). TASK-15464: `get_new_items` is NO LONGER
+        # `SELECT i.*` -- `content` is absent from a freshly-loaded LIST row
+        # now (fetched separately, once, only for an opened item -- see
+        # `SubscriptionsDB.get_item_content` and
+        # `WatchlistsCollectionsScreen._load_item_content`). `row.get(...)`
+        # here still does the right thing either way: `None` when absent,
+        # the real value once `_load_item_content` has merged it in.
         "content": row.get("content"),
+        # TASK-15464: the list row's OWN preview snippet source
+        # (`article_list._render_row`'s `body_snippet`) -- a cheap `substr`
+        # projection (`_LIST_ITEM_COLUMNS`), never the full body. Present on
+        # every list row regardless of whether `content` itself is.
+        "content_preview": row.get("content_preview"),
         "content_kind": row.get("content_kind"),
         # Read by `content_pane.render_article` to decide whether the body is
         # markdown source or plain text.
@@ -585,10 +596,9 @@ def normalize_watchlist_item(source: str, row: Mapping[str, Any]) -> dict[str, A
         "change_percentage": row.get("change_percentage"),
         "change_type": row.get("change_type"),
         "diff_summary": row.get("diff_summary"),
-        # Spec #2 phase 1 read-path lesson (Phase D's shape, repeated):
-        # `get_new_items` is `SELECT i.*`, so the DB already returns this
-        # column -- coerce SQLite's 0/1 to an actual bool, or every
-        # downstream consumer sees a truthy int instead of a real flag.
+        # Spec #2 phase 1 read-path lesson (Phase D's shape, repeated).
+        # Coerce SQLite's 0/1 to an actual bool, or every downstream
+        # consumer sees a truthy int instead of a real flag.
         "queued_for_briefing": bool(row.get("queued_for_briefing")),
         # task-3072: same column-present/bool-coercion shape for the star.
         "is_flagged": bool(row.get("is_flagged")),

--- a/tldw_chatbook/Subscriptions/watchlist_normalizers.py
+++ b/tldw_chatbook/Subscriptions/watchlist_normalizers.py
@@ -561,10 +561,14 @@ def normalize_watchlist_item(source: str, row: Mapping[str, Any]) -> dict[str, A
         "url": row.get("url") or row.get("canonical_url"),
         "status": row.get("status") or "new",
         # TASK-2306: which run produced this item, and how many content-alert
-        # rules it matched. Both columns are already on the row (`SELECT i.*`)
-        # and both are what the Runs tab's Items sub-region displays -- its
-        # "Alerts" column had no source at all before this, so it rendered
-        # `0` over every item however many alerts had fired.
+        # rules it matched. Both columns are on the row (`get_new_items`
+        # selected `i.*` at the time this was written; TASK-15464 narrowed
+        # that to an explicit column list, `SubscriptionsDB._LIST_ITEM_
+        # COLUMNS`, which still names `run_id`/`alert_matches` -- both are
+        # small scalars, not the large-payload columns that narrowing
+        # dropped) and both are what the Runs tab's Items sub-region
+        # displays -- its "Alerts" column had no source at all before this,
+        # so it rendered `0` over every item however many alerts had fired.
         "run_id": row.get("run_id"),
         "alert_count": _alert_match_count(row.get("alert_matches")),
         "author": row.get("author"),

--- a/tldw_chatbook/Subscriptions/watchlist_scope_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_scope_service.py
@@ -322,6 +322,49 @@ class WatchlistScopeService:
             )
         )
 
+    async def get_item_content(
+        self,
+        *,
+        runtime_backend: WatchlistBackend | str | None = None,
+        item_id: Any,
+    ) -> str | None:
+        """Read one content item's full body text -- the reader's DETAIL fetch.
+
+        TASK-15464 counterpart to `get_item_status` above -- same routing
+        (`items.detail`, both single-item reads under the DETAIL policy
+        `watchlists.items` already registers) and the same local-only
+        restriction.
+
+        Args:
+            runtime_backend: Target backend (``local`` or ``server``).
+            item_id: Item identifier, namespaced (``local:watchlist_item:2``)
+                or bare.
+
+        Returns:
+            The stored content, or `None` if no row has this id, or the row
+            has one but its content is itself NULL. Unlike `get_item_status`
+            this does not raise `KeyError` on a miss -- see
+            `SubscriptionsDB.get_item_content`'s docstring for why a missing
+            row and a present-but-empty one are not distinguished for this
+            column.
+
+        Raises:
+            ValueError: If the server backend is requested; item content
+                reads are local-only, exactly as `list_items` and
+                `get_item_status` are.
+        """
+        backend = self._normalize_backend(runtime_backend)
+        self._enforce_policy(backend, "items.detail")
+        if backend == WatchlistBackend.SERVER:
+            raise ValueError(
+                "Item content reads are only supported for the local backend "
+                "in this slice."
+            )
+        service = self._service_for_backend(backend)
+        return await self._maybe_await(
+            service.get_item_content(self._source_id_from_item_id(item_id))
+        )
+
     async def update_item(
         self,
         *,

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -8678,8 +8678,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 notify("Failed to load watchlist items.", severity="error")
 
     @on(ItemSelected)
-    def handle_item_selected(self, event: ItemSelected) -> None:
+    async def handle_item_selected(self, event: ItemSelected) -> None:
         event.stop()
+        # TASK-15464: fetch the DETAIL body BEFORE any of the selection
+        # writes below, not after. `ContentPane.item` is a `recompose=True`
+        # reactive, so merging `content` into `event.item` first means one
+        # recompose per selection with the body already in it, instead of
+        # an empty-bodied recompose immediately followed by a second one
+        # once a background fetch lands -- exactly the recompose-storm
+        # shape this whole audit exists to remove from this screen.
+        await self._load_item_content(event.item)
         self._select_entity(event.item)
         # Route to the reader (Task 4), independent of `_select_entity`'s
         # generic Inspector reconciliation above: Sources/Runs/Rules also
@@ -8699,6 +8707,55 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         except NoMatches:
             pass
         self._mark_item_read_on_open(event.item)
+
+    async def _load_item_content(self, item: dict[str, Any] | None) -> None:
+        """Backfill `item["content"]` from the DETAIL fetch (TASK-15464).
+
+        `get_new_items`'s list-page projection no longer selects `content`
+        (up to 100 rows' worth of full scraped article/diff text, on every
+        Items-pane refresh, for a column no list row ever rendered -- the
+        audit's named cost), so a freshly loaded list row carries no
+        `content` key at all. This fetches it for exactly the item about to
+        be opened, mutating `item` IN PLACE so the one dict object already
+        shared by `ItemsPane.items`, `_selected_content_item`, and (about to
+        be) `ContentPane.item` all see the same body once this returns --
+        never a second, separate copy for the reader to drift from the list.
+
+        A miss (`get_item_content` returning `None`) leaves `item` untouched
+        rather than clearing an existing `content` key -- a caller that
+        built its own item dict directly, bypassing this screen's own query
+        entirely (every test that seeds `ItemsPane.items` with a synthetic
+        dict already carrying `content`, e.g.
+        `test_selecting_an_item_renders_it_in_the_content_region`), keeps
+        working unchanged. `item is None` (nothing selected) and any
+        failure fetching content (the active backend does not support
+        single-item reads, the row no longer exists, a transient DB error)
+        are both silently absorbed: content is the reader's body, not a
+        status the caller is relying on this to report -- see
+        `content_pane.render_for`'s own docstring on the same "never take
+        the app down over a reader nicety" rule.
+
+        Args:
+            item: The item about to be opened, or `None`. Mutated in place
+                when a fetch returns a real value.
+        """
+        if item is None:
+            return
+        item_id = item.get("id")
+        if item_id is None:
+            return
+        try:
+            fetched = await self._controller.get_item_content(
+                runtime_backend=self.runtime_backend,
+                item_id=item_id,
+            )
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Failed to load watchlist item content for the reader."
+            )
+            return
+        if fetched is not None:
+            item["content"] = fetched
 
     def _reader_position_text(self) -> str:
         """The reader footer's "N of M" (TASK-3072 plan task 9).

--- a/tldw_chatbook/UI/Watchlists_Modules/article_list.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/article_list.py
@@ -89,7 +89,15 @@ def _render_row(item: dict[str, Any]) -> Text:
     else:
         out.append(title)
 
-    snippet = body_snippet(item.get("content"))
+    # TASK-15464: `content_preview` is the list row's own cheap `substr`
+    # projection (`SubscriptionsDB._LIST_ITEM_COLUMNS`) -- never the full
+    # body, which the list-page query no longer selects at all. Falls back
+    # to `content` for a hand-built dict that never went through that query
+    # (tests; a future non-DB source), or for an item already opened once
+    # this session (`_load_item_content` merges the full body into the same
+    # shared dict, and `content_preview` -- itself already >= any 160-char
+    # snippet's worth of text -- is left as whichever the query supplied).
+    snippet = body_snippet(item.get("content_preview") or item.get("content"))
     if snippet:
         out.append("\n")
         out.append(snippet, style="dim")

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py
@@ -301,6 +301,45 @@ class WatchlistsBackendController:
         )
         return str(result)
 
+    async def get_item_content(
+        self,
+        *,
+        runtime_backend: str | None = None,
+        item_id: Any,
+    ) -> str | None:
+        """Read one content item's full body text from the active backend.
+
+        TASK-15464 counterpart to `get_item_status` above -- same shape,
+        except the return is `Optional[str]` rather than coerced to `str`:
+        `None` is a real, non-exceptional answer here (see
+        `SubscriptionsDB.get_item_content`'s docstring), not an absence to
+        paper over.
+
+        Args:
+            runtime_backend: Target backend (``local`` or ``server``).
+            item_id: Item identifier, namespaced or bare.
+
+        Returns:
+            The stored content, or `None` if no row has this id or its
+            content is itself NULL.
+
+        Raises:
+            ValueError: If no scope service is configured.
+            NotImplementedError: If the active backend exposes no
+                single-item content read.
+        """
+        backend = self._normalize_backend(runtime_backend)
+        if self.scope_service is None:
+            raise ValueError("Watchlist scope service is unavailable.")
+        method = getattr(self.scope_service, "get_item_content", None)
+        if not callable(method):
+            raise NotImplementedError(
+                "Item content reads are not supported by the current backend."
+            )
+        return await self._maybe_await(
+            method(runtime_backend=backend, item_id=item_id)
+        )
+
     async def update_item_status(
         self,
         *,


### PR DESCRIPTION
## Summary

Task 15464 from the input-latency audit. The items list pulled full scraped article text (`content`) for up to 100 rows per page and sorted the whole table on an unindexable computed datetime, LIMIT applied post-sort.

- List projection excludes `content`/`extracted_data` (2000-char preview projected instead); item detail fetches full content on selection through a registered scope action
- Ordering via a SQLite `GENERATED ALWAYS AS ... VIRTUAL` column holding the byte-identical old expression + index — legacy/new parser divergence impossible **by construction** (SQLite computes both), with explicit `id ASC` tie-break matching the old implicit order
- Migration: idempotent (xinfo-guarded), crash-self-repairing (index rebuilt on next open), UPDATE-maintained
- Measured: 6.2×/24.2×/73.2× at 5k/30k/100k rows (old linear, new flat ~1 ms); one-time index build 4–84 ms

## Verification
Independent review: Approved, findings documentation-only (now fixed). Reviewer re-derived parity on a 20-case datetime corpus (wider than the tests), verified tie order under LIMIT against the pre-migration oracle, crash recovery, UPDATE maintenance, and reproduced the latency numbers; 3 mutations all caught. Deferred: the Today-badge count query still scans (disclosed boundary, cheap follow-up being filed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the watchlists items list by narrowing the query and ordering via an indexed `effective_date`. Full content is fetched only when an item is opened; the list shows a short `content_preview`. Addresses Linear task-15464; measured 6–73× faster on 5k–100k rows.

- **Refactors**
  - List queries exclude `content` and `extracted_data`; add `substr(i.content, 1, 2000) AS content_preview` for row snippets, and update `_render_row` to use it.
  - Add `effective_date` (SQLite `GENERATED ALWAYS AS ... VIRTUAL`) computed as `COALESCE(datetime(published_date), datetime(created_at))` with an index; use it in ORDER BY with `id ASC` tie-break and in the `since` filter.
  - Introduce `SubscriptionsDB.get_item_content` and wire through `local_watchlists_service`, `watchlist_scope_service`, `watchlists_backend_controller`, and the UI. `handle_item_selected` is now async and loads content before rendering.

- **Migration**
  - Automatic on open: adds `effective_date` and builds `idx_subscription_items_effective_date`; guarded via `PRAGMA table_xinfo` and idempotent.
  - No manual steps; existing rows are backfilled by SQLite, and the index build runs once.

<sup>Written for commit e9c08d371d16261a0670babc371c5d42d5a92f5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

