### PR TITLE
perf: lazy BLOB logging and image-free character list projections (task-15474)

### DIFF
--- a/Tests/ChaChaNotesDB/test_chachanotes_db.py
+++ b/Tests/ChaChaNotesDB/test_chachanotes_db.py
@@ -377,6 +377,33 @@ class TestCharacterCards:
         }
         assert added_card_names == {card_data1["name"], card_data2["name"]}
 
+    def test_list_character_cards_excludes_image_by_default(
+        self, db_instance: CharactersRAGDB
+    ):
+        """task-15474: list/picker reads must not fetch the `image` BLOB
+        column by default -- it drags up to `limit` raw images through
+        SQLite/Python for callers that only render name/description rows."""
+        image_bytes = b"\x89PNG\r\n\x1a\n" + b"fake-png-bytes" * 100
+        card_id = db_instance.add_character_card(
+            {"name": "Imaged Default List", "image": image_bytes}
+        )
+        cards = db_instance.list_character_cards(limit=100)
+        assert cards
+        for card in cards:
+            assert "image" not in card
+        assert any(c["id"] == card_id for c in cards)
+
+    def test_list_character_cards_include_image_true_round_trips(
+        self, db_instance: CharactersRAGDB
+    ):
+        image_bytes = b"\x89PNG\r\n\x1a\n" + b"fake-png-bytes" * 100
+        card_id = db_instance.add_character_card(
+            {"name": "Imaged Include List", "image": image_bytes}
+        )
+        cards = db_instance.list_character_cards(limit=100, include_image=True)
+        card = next(c for c in cards if c["id"] == card_id)
+        assert card["image"] == image_bytes
+
     def test_update_character_card(
         self, db_instance: CharactersRAGDB, sample_card: dict
     ):

--- a/Tests/DB/test_character_cards_paging.py
+++ b/Tests/DB/test_character_cards_paging.py
@@ -150,3 +150,93 @@ def test_lib_wrapper_shapes_rows(db):
     }
     assert count_character_page(db) == len(get_character_page_for_ui(db, limit=1000, offset=0))
     assert "x" in list_character_tags(db)
+
+
+# --- task-15474: image-free list/picker projections -----------------------
+#
+# `character_cards.image` is a BLOB (sometimes multi-MB). `list_character_
+# cards_page` backs the Library character list and personas paging, neither
+# of which renders avatars -- so by default it must not even fetch the
+# `image` column. `include_image=True` is the opt-in escape hatch for a
+# caller that genuinely needs it.
+
+_SAMPLE_IMAGE = b"\x89PNG\r\n\x1a\n" + b"fake-png-bytes" * 100
+
+
+def test_page_excludes_image_column_by_default_no_search(db):
+    _add(db, "Imaged", [])
+    char_id = db.add_character_card({"name": "Imaged2", "image": _SAMPLE_IMAGE})
+    rows = db.list_character_cards_page(limit=100, offset=0)
+    assert rows  # sanity: rows were actually returned
+    for row in rows:
+        assert "image" not in row
+    # Confirm the row for the image-carrying card is really in the result
+    # set (i.e. the projection excluded the column, not the row).
+    assert any(r["id"] == char_id for r in rows)
+
+
+def test_page_excludes_image_column_by_default_when_searching(db):
+    db.add_character_card({"name": "Dragon Imaged", "image": _SAMPLE_IMAGE})
+    rows = db.list_character_cards_page(
+        limit=100, offset=0, search_term='"Dragon"*'
+    )
+    assert rows
+    for row in rows:
+        assert "image" not in row
+
+
+def test_page_include_image_true_returns_image_bytes(db):
+    char_id = db.add_character_card({"name": "Imaged3", "image": _SAMPLE_IMAGE})
+    rows = db.list_character_cards_page(limit=100, offset=0, include_image=True)
+    row = next(r for r in rows if r["id"] == char_id)
+    assert row["image"] == _SAMPLE_IMAGE
+
+
+def test_page_include_image_true_returns_image_bytes_when_searching(db):
+    char_id = db.add_character_card({"name": "Dragon Imaged2", "image": _SAMPLE_IMAGE})
+    rows = db.list_character_cards_page(
+        limit=100, offset=0, search_term='"Dragon"*', include_image=True
+    )
+    row = next(r for r in rows if r["id"] == char_id)
+    assert row["image"] == _SAMPLE_IMAGE
+
+
+def test_page_image_free_projection_does_not_regress_other_fields(db):
+    """The column-list projection must still surface every non-image field
+    a consumer relies on (task-15474 must not silently drop e.g. tags)."""
+    char_id = db.add_character_card(
+        {
+            "name": "Full Fields",
+            "description": "desc",
+            "personality": "kind",
+            "scenario": "a scene",
+            "system_prompt": "sp",
+            "post_history_instructions": "phi",
+            "first_message": "hi",
+            "message_example": "ex",
+            "creator_notes": "notes",
+            "alternate_greetings": ["g1", "g2"],
+            "tags": ["x", "y"],
+            "creator": "me",
+            "character_version": "1.0",
+            "extensions": {"a": 1},
+        }
+    )
+    row = next(
+        r for r in db.list_character_cards_page(limit=100, offset=0) if r["id"] == char_id
+    )
+    assert row["description"] == "desc"
+    assert row["personality"] == "kind"
+    assert row["scenario"] == "a scene"
+    assert row["system_prompt"] == "sp"
+    assert row["post_history_instructions"] == "phi"
+    assert row["first_message"] == "hi"
+    assert row["message_example"] == "ex"
+    assert row["creator_notes"] == "notes"
+    assert row["alternate_greetings"] == ["g1", "g2"]
+    assert row["tags"] == ["x", "y"]
+    assert row["creator"] == "me"
+    assert row["character_version"] == "1.0"
+    assert row["extensions"] == {"a": 1}
+    assert "created_at" in row and "last_modified" in row
+    assert "deleted" in row and "client_id" in row and "version" in row

--- a/Tests/DB/test_client_media_debug_logging.py
+++ b/Tests/DB/test_client_media_debug_logging.py
@@ -1,0 +1,132 @@
+# test_client_media_debug_logging.py
+# Description: RED-first-turned-green regression coverage for task-15474
+# (lazy debug logging in Client_Media_DB_v2.py).
+"""
+task-15474 audit finding: `Client_Media_DB_v2.py` already had the lazy
+`logger.opt(lazy=True)` + `preview_params` pattern in its shared
+`execute_query` (task-246), but three call sites in `search_media_db` and
+one in `get_all_document_versions` built their own eager
+`logging.debug(f"... {params}")`/`logging.info(f"... {params}")` lines on
+every call, ahead of / in addition to `execute_query`'s own (already-lazy)
+logging. None of these particular sites carry a raw image/document BLOB
+today (media content bytes are never passed as a bound *search* filter
+param), but they were still unconditional `str(...)` builds of a
+params-like collection on every call regardless of log level -- exactly
+what this module's own `execute_query` precedent (and `DB/sql_logging.py`)
+exists to avoid, and the shape a future caller could turn into a real BLOB
+cost.
+
+Two kinds of evidence, matching the two things worth proving:
+
+1. Behavioral sanity (`TestConvertedSitesStillLogUnderDebug`): with a DEBUG
+   sink explicitly attached, the converted lines still fire, so the
+   conversion didn't silently delete the log line.
+2. Structural regression coverage (`TestNoEagerFStringParamsRemain`): the
+   method source no longer contains the old eager
+   `f"...: {params}"`-style literal, and does route the same params through
+   `preview_params`. This is the durable, environment-independent form of
+   "no eager params stringification remains" -- loguru's own default sink
+   (level DEBUG, active for the whole pytest session unless a test removes
+   it) makes a call-counting/"never invoked without an explicit sink" style
+   test unreliable here: that ambient sink means `opt(lazy=True)` lambdas
+   legitimately DO run in this process even when a test adds no sink of its
+   own, so the meaningful, stable assertion is over the source shape, not
+   over invocation counts. BLOB-safety itself (bytes never repr()'d/str()'d
+   by `preview_params`) is covered directly by `test_sql_debug_logging.py`,
+   including for the one call site in this codebase that genuinely carries
+   an image BLOB (`ChaChaNotes_DB.update_character_card`).
+"""
+
+import inspect
+import sys
+
+import pytest
+from loguru import logger
+
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = MediaDatabase(db_path=tmp_path / "media.db", client_id="test-client")
+    yield database
+    database.close_connection()
+
+
+def _seed_one_media_item(db: MediaDatabase) -> int:
+    media_id, _uuid, _msg = db.add_media_with_keywords(
+        title="Task 15474 Fixture",
+        media_type="article",
+        content="Content mentioning fifteen thousand four hundred seventy four.",
+        keywords=["task15474"],
+    )
+    assert media_id is not None
+    return media_id
+
+
+class TestConvertedSitesStillLogUnderDebug:
+    """Sanity check: the lazy conversion didn't silently delete these lines."""
+
+    def test_search_media_db_log_lines_fire_under_debug(self, db, capsys):
+        _seed_one_media_item(db)
+        sink_id = logger.add(sys.stderr, level="DEBUG")
+        try:
+            results, total = db.search_media_db(search_query="fifteen thousand")
+        finally:
+            logger.remove(sink_id)
+        assert total >= 1
+        captured = capsys.readouterr().err
+        assert "Search Count Params" in captured
+        assert "Search Results Params" in captured
+        assert "Search using FTS with query parts" in captured
+        assert "Search using LIKE with patterns" in captured
+
+    def test_get_all_document_versions_log_line_fires_under_debug(self, db, capsys):
+        media_id = _seed_one_media_item(db)
+        sink_id = logger.add(sys.stderr, level="DEBUG")
+        try:
+            db.get_all_document_versions(media_id)
+        finally:
+            logger.remove(sink_id)
+        captured = capsys.readouterr().err
+        assert "Executing get_all_document_versions query" in captured
+
+
+class TestNoEagerFStringParamsRemain:
+    """Structural regression coverage: the old eager `f"...: {params}"`
+    literals are gone, and the same values now go through `preview_params`.
+
+    Reads live source via `inspect.getsource` rather than re-grepping the
+    file on disk, so this test breaks (not silently passes) if a refactor
+    moves the code without preserving the guarantee.
+    """
+
+    def test_search_media_db_no_eager_params_fstrings(self):
+        source = inspect.getsource(MediaDatabase.search_media_db)
+        for eager_literal in (
+            '{params}")',
+            "{params})",
+            "{paginated_params}",
+            "{fts_query_parts}",
+            "{like_params}",
+        ):
+            assert eager_literal not in source, (
+                f"Eager params f-string literal {eager_literal!r} reintroduced "
+                "into search_media_db -- route it through preview_params "
+                "under logger.opt(lazy=True) instead (task-15474)."
+            )
+        assert source.count("preview_params(") >= 3, (
+            "Expected preview_params() to cover the count/results/LIKE "
+            "params sites in search_media_db."
+        )
+        assert "logger.opt(lazy=True)" in source
+
+    def test_get_all_document_versions_no_eager_params_fstring(self):
+        source = inspect.getsource(MediaDatabase.get_all_document_versions)
+        assert "{params}" not in source, (
+            "Eager params f-string literal reintroduced into "
+            "get_all_document_versions -- route it through preview_params "
+            "under logger.opt(lazy=True) instead (task-15474)."
+        )
+        assert "preview_params(params)" in source
+        assert "logger.opt(lazy=True)" in source

--- a/Tests/DB/test_sql_debug_logging.py
+++ b/Tests/DB/test_sql_debug_logging.py
@@ -114,6 +114,70 @@ class TestNoStringifyAtDefaultLevel:
         assert "Executing SQL" in captured.err
 
 
+class TestCharacterCardUpdateNoEagerBlobLogging:
+    """task-15474: ``update_character_card``'s debug log used to build an
+    eager ``f"Params: {final_params}"`` string on every call. ``image`` is in
+    ``updatable_direct_fields``, so a character-card save with an embedded
+    avatar built a multi-MB repr on every single update regardless of log
+    level -- exactly the cost ``DB/sql_logging.py`` (and this file's own
+    ``execute_query`` coverage above) exists to eliminate.
+    """
+
+    def test_image_blob_not_stringified_at_default_log_level(self, db):
+        blob = _make_blob_param(size=2_000_000)
+        char_id = db.add_character_card({"name": "Blob Carrier"})
+        assert CountingBytes.repr_calls == 0  # sanity: add didn't touch it
+
+        result = db.update_character_card(char_id, {"image": blob}, expected_version=1)
+        assert result is True
+        assert CountingBytes.repr_calls == 0
+
+    def test_image_blob_not_stringified_even_with_debug_sink_attached(self, db, capsys):
+        blob = _make_blob_param(size=2_000_000)
+        char_id = db.add_character_card({"name": "Blob Carrier 2"})
+        sink_id = logger.add(sys.stderr, level="DEBUG")
+        try:
+            result = db.update_character_card(
+                char_id, {"image": blob}, expected_version=1
+            )
+        finally:
+            logger.remove(sink_id)
+        assert result is True
+        assert CountingBytes.repr_calls == 0
+
+    def test_update_debug_log_line_is_actually_emitted_when_enabled(self, db, capsys):
+        """Sanity check the lazy conversion didn't silently delete the log
+        line -- it must still fire (with a length-only preview) at DEBUG."""
+        char_id = db.add_character_card({"name": "Blob Carrier 3"})
+        sink_id = logger.add(sys.stderr, level="DEBUG")
+        try:
+            db.update_character_card(
+                char_id, {"image": b"x" * 1024}, expected_version=1
+            )
+        finally:
+            logger.remove(sink_id)
+        captured = capsys.readouterr()
+        assert "Executing SINGLE character update query" in captured.err
+        assert "<1024 bytes>" in captured.err
+
+    def test_no_eager_params_fstring_remains_in_source(self):
+        """Structural regression coverage (task-15474): reads live source via
+        ``inspect.getsource`` so a refactor that reintroduces
+        ``f"Params: {final_params}"`` fails this test even if it moves the
+        code -- durable, environment-independent evidence alongside the
+        functional BLOB-safety tests above."""
+        import inspect
+
+        source = inspect.getsource(CharactersRAGDB.update_character_card)
+        assert '{final_params}")' not in source, (
+            "Eager params f-string literal reintroduced into "
+            "update_character_card -- route it through preview_params "
+            "under logger.opt(lazy=True) instead (task-15474)."
+        )
+        assert "preview_params(final_params)" in source
+        assert "logger.opt(lazy=True)" in source
+
+
 def test_add_message_debug_log_redacts_sensitive_insert_params(db):
     conversation_id = db.add_conversation(
         {

--- a/backlog/tasks/task-15474 - DB-sundries---lazy-BLOB-logging-and-image-free-list-projections.md
+++ b/backlog/tasks/task-15474 - DB-sundries---lazy-BLOB-logging-and-image-free-list-projections.md
@@ -134,7 +134,7 @@ consumer: `Chat_Functions.load_characters` base64-encodes `image` into
 `image_base64` for a test-covered (if currently UI-dead) compatibility
 helper -- updated to pass `include_image=True`.
 
-Tests added: `Tests/DB/test_character_cards_paging.py` gained six tests
+Tests added: `Tests/DB/test_character_cards_paging.py` gained five tests
 (image excluded by default in both the plain-browse and FTS-search branches,
 `include_image=True` round-trips the exact bytes in both branches, and a
 "no other field regressed" check covering every non-image column).

--- a/backlog/tasks/task-15474 - DB-sundries---lazy-BLOB-logging-and-image-free-list-projections.md
+++ b/backlog/tasks/task-15474 - DB-sundries---lazy-BLOB-logging-and-image-free-list-projections.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15474
 title: DB sundries: lazy BLOB logging and image-free list projections
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -20,6 +21,157 @@ Fix direction: `logger.opt(lazy=True)` + `preview_params` for all four sites; ex
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 No eager params stringification remains in ChaChaNotes or Client_Media execute paths (grep + unit evidence)
-- [ ] #2 Character list/picker paths fetch no image column (evidence); card save/list behavior unchanged (tests)
+- [x] #1 No eager params stringification remains in ChaChaNotes or Client_Media execute paths (grep + unit evidence)
+- [x] #2 Character list/picker paths fetch no image column (evidence); card save/list behavior unchanged (tests)
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Lazy logging: convert `ChaChaNotes_DB.py`'s `update_character_card` query+params debug
+   lines (current line ~5920-5923; `final_params` carries `image`, a BLOB) to
+   `logger.opt(lazy=True)` + `preview_params`, matching the established pattern at
+   `:3021-3028`. Sweep `ChaChaNotes_DB.py` for any other eager params-interpolating
+   log line (grep for `param`/`value` near `.debug(f"`/`.info(f"`/etc.) -- audit shows
+   this is the only remaining site in this file.
+2. Convert `Client_Media_DB_v2.py`'s three eager "Params:" sites (in the media search
+   function, ~2192/2253, and `get_all_document_versions`, ~5827) to the same lazy
+   pattern -- this file already has the `logger.opt(lazy=True)` + `preview_params`
+   precedent at its own `execute_query` (~:823-826). Sweep for the smaller
+   query-part/LIKE-pattern debug/info lines in the same search function
+   (~2075/2076/2136) and convert those too for consistency (list-not-BLOB risk, but
+   still eager stringification of params-shaped data).
+3. Write a unit test per file asserting a sentinel bytes-like/repr-raising param
+   passed through the execute path is never rendered when the effective log level is
+   above DEBUG (and IS rendered, length-only, when DEBUG is admitted) -- proving
+   laziness and BLOB-safety, not just presence of `opt(lazy=True)` in the source.
+4. Image-free list projections: add an explicit column list for `character_cards`
+   excluding `image` (mirroring the CREATE TABLE column order minus `image`), and a
+   small helper to render it with/without a table alias. Add `include_image: bool =
+   False` (keyword-only) to `list_character_cards` and `list_character_cards_page`;
+   default excludes `image`, opt-in flag restores `SELECT *`/`cc.*` for the one
+   caller that legitimately needs it.
+5. Classify every caller of both functions (9 call sites found across
+   Tools_Settings_Window, Evals evals_state/card_picker, watchlists_collections_screen,
+   chat_screen, ChatbookCreationWizard, Chat_Functions x2, MCP/tools, Character_Chat
+   local_character_persona_service + Character_Chat_Lib x2) -- update the one genuine
+   image consumer (`Chat_Functions.load_characters`, base64-encodes `image` for a
+   test-covered compatibility helper) to pass `include_image=True`; leave the rest on
+   the new image-free default.
+6. Tests: a test asserting the list/picker query text and/or returned row keys never
+   include `image` by default, and a round-trip test that `include_image=True` still
+   returns the BLOB unchanged. Run existing character/picker/evals-state suites green.
+7. Measure `list_character_cards_page` before/after on a seeded scratch DB (few
+   hundred cards, ~100KB images) -- isolated scratch probe, not the live app.
+
+## Implementation Notes
+
+**Lazy logging (AC #1).** Converted the one true BLOB-risk site --
+`ChaChaNotes_DB.update_character_card`'s combined
+`"Executing SINGLE character update query" | Params: {final_params}"` debug
+line (`final_params` carries `image` on every card save) -- to
+`logger.opt(lazy=True)` + `preview_params`, matching the file's own
+`:3014-3028` precedent. Swept `Client_Media_DB_v2.py` and converted six more
+eager sites: three explicitly named in the brief (`search_media_db`'s count
+and results Params lines, `get_all_document_versions`'s Params line) plus
+three lower-risk stragglers found during the sweep (`search_media_db`'s
+FTS-query-parts/combined-FTS-query/LIKE-patterns debug/info lines) -- none of
+these six carry a raw BLOB today (media content bytes are never a bound
+*search filter* param), but they were still unconditional `str(...)` builds
+on every call. Reviewed and left alone: `execute_many`'s debug/error lines
+(log only `len(params_list)` or the exception text, never the params
+collection) and the module's pre-existing `execute_query` lazy guard
+(already correct, task-246). Grep evidence: no `f"..{...param..}"` literal
+remains in either file outside the two reviewed-clean `execute_many` lines.
+Tests: `Tests/DB/test_sql_debug_logging.py` gained a
+`TestCharacterCardUpdateNoEagerBlobLogging` class (a `CountingBytes` sentinel
+proves `update_character_card` never reprs a 2MB image blob, with and
+without a DEBUG sink attached, plus a source-inspection regression check).
+New `Tests/DB/test_client_media_debug_logging.py` proves the six converted
+`Client_Media_DB_v2.py` sites still fire under an explicit DEBUG sink and
+contain no eager `f"...{params}"` literal in source -- call-counting on
+`preview_params` was tried first but rejected: this test process has an
+ambient loguru default sink (level DEBUG) live for the whole pytest session,
+so "not called without a sink" isn't a meaningful invariant here; BLOB-safety
+itself is already proven directly by the `CountingBytes` tests.
+
+**Image-free list projections (AC #2).** Added `_CHARACTER_CARD_LIST_COLUMNS`
+(the `character_cards` CREATE TABLE column list minus `image`) and a
+`_character_card_select_columns(include_image, alias)` helper to
+`ChaChaNotes_DB.py`. Both `list_character_cards` and
+`list_character_cards_page` gained a keyword-only `include_image: bool =
+False`; default now projects the explicit image-free column list, opt-in
+restores `SELECT *`/`cc.*`. Hit and fixed a real SQLite quirk along the way:
+`list_character_cards_page`'s search branch joins `character_cards_fts`
+(which also has a `name` column) against `character_cards cc`; the old code
+relied on `cc.*` wildcard expansion being exempt from SQLite's ORDER BY
+ambiguity check, and swapping in an explicit `cc.name` column list broke
+that exemption ("ambiguous column name: name"), caught immediately by the
+existing `test_search_composes_with_tag_and_sort` test going red. Fixed by
+parameterizing `_CHARACTER_SORT_CLAUSES` with an `{a}` alias placeholder
+(`cc.` when searching, `""` otherwise) filled in by `_resolve_sort_clause`.
+
+Checked every caller of both functions (9 production call sites):
+`Tools_Settings_Window._export_characters_worker` (JSON backup dump --
+already crashes on `json.dumps()` for any image-bearing card today since raw
+`bytes` isn't JSON-serializable and nothing base64-encodes it first; the new
+default silently drops the already-broken field instead of crashing --
+improvement, not a regression, and out of scope to fully fix here),
+`Evals/evals_state.character_cards` (bench-editor picker, id/name only),
+`watchlists_collections_screen._load_character_options` (briefing preset
+Select, `(name, id)` tuples), `chat_screen._console_character_picker_options`
+(id/name/description, matches the task's own claim),
+`ChatbookCreationWizard` (content-node title/subtitle),
+`Chat_Functions.get_character_names` (names only; also dead code -- zero
+production callers), `MCP/tools.list_available_characters`
+(id/name/description/message_count), `Character_Chat_Lib.
+get_character_list_for_ui`/`get_character_page_for_ui` (id/name[/description/
+tags], the task's own "personas paging" reference) and
+`local_character_persona_service.list_characters` (a generic passthrough
+with zero production UI callers -- personas' own local-mode paging goes
+through `get_character_page_for_ui` instead; only exercised by its own unit
+tests, none of which touch `image`). Exactly one caller is a genuine image
+consumer: `Chat_Functions.load_characters` base64-encodes `image` into
+`image_base64` for a test-covered (if currently UI-dead) compatibility
+helper -- updated to pass `include_image=True`.
+
+Tests added: `Tests/DB/test_character_cards_paging.py` gained six tests
+(image excluded by default in both the plain-browse and FTS-search branches,
+`include_image=True` round-trips the exact bytes in both branches, and a
+"no other field regressed" check covering every non-image column).
+`Tests/ChaChaNotesDB/test_chachanotes_db.py` gained two tests for
+`list_character_cards` (default excludes `image`, `include_image=True`
+round-trips it).
+
+**Performance (isolated scratch probe, not the live app).** 400 character
+cards seeded with 100KB images in a scratch `CharactersRAGDB`;
+`list_character_cards_page(limit=100)` timed 15x each for `include_image=True`
+(reproduces the exact pre-task query shape) vs the new default, back to back
+in the same process against the same DB. Two runs: 63.95ms -> 2.67ms mean
+(23.97x) and 41.90ms -> 2.82ms mean (14.88x) -- consistent order-of-magnitude
+win, as expected for skipping ~10MB of BLOB deserialization per 100-row page.
+
+**Test runs (READ pass counts).** `Tests/DB/` full: 861 passed, 32 failed
+(pre-existing ChaChaNotes V33->V34 migration suite, confirmed unrelated --
+same file/line-independent schema-migration failures called out as
+known-pre-existing in the task brief). `Tests/Media_DB/`: 100 passed, 6
+skipped (unrelated sync-server integration tests). `Tests/Character_Chat/`:
+545 passed. Combined caller-suite run (`test_chat_functions`,
+`test_evals_card_picker`, `test_ccp_handlers`,
+`test_watchlists_briefing_presets_ui`, `test_chatbook_integration`,
+`test_library_export_roundtrip`, `test_character_cards_paging`,
+`test_chachanotes_db`, `Character_Chat/`, `Media_DB/`): 881 passed, 1 known
+pre-existing failure, 6 skipped. `Tests/UI/test_tools_settings_window.py` +
+`test_settings_tools_section.py`: 74 passed. One order-dependent flake was
+observed in a large ad hoc 9-file combo (`test_uat_first_time_character_chat`
+failing only under randomized test order); confirmed unrelated to this
+change -- passes in isolation, in every smaller combo tried, and with
+`-p no:randomly`. `Tests/MCP/test_builtin_tool_imports.py` has 4 pre-existing
+errors unrelated to this task (network-blocked HuggingFace embedding-model
+download in the sandboxed test environment, from `MCPTools.__init__`'s RAG
+service construction -- nothing to do with character list/logging code).
+
+**Files modified:** `tldw_chatbook/DB/ChaChaNotes_DB.py`,
+`tldw_chatbook/DB/Client_Media_DB_v2.py`, `tldw_chatbook/Chat/Chat_Functions.py`,
+`Tests/DB/test_sql_debug_logging.py`, `Tests/DB/test_character_cards_paging.py`,
+`Tests/ChaChaNotesDB/test_chachanotes_db.py`. **Files added:**
+`Tests/DB/test_client_media_debug_logging.py`.

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -2900,9 +2900,12 @@ def load_characters(db: CharactersRAGDB) -> Dict[str, Dict[str, Any]]:
     start_time = time.time()
     characters_map: Dict[str, Dict[str, Any]] = {}
     try:
-        # list_character_cards returns List[Dict[str, Any]]
+        # list_character_cards returns List[Dict[str, Any]]. This function
+        # base64-encodes each card's `image` below, so it needs the BLOB --
+        # unlike every other list_character_cards caller (task-15474), which
+        # defaults to an image-free projection.
         all_cards_list = db.list_character_cards(
-            limit=10000
+            limit=10000, include_image=True
         )  # Assuming not too many cards for now
 
         for card_dict in all_cards_list:

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -5182,13 +5182,76 @@ UPDATE db_schema_version
 
     _CHARACTER_CARD_JSON_FIELDS = ["alternate_greetings", "tags", "extensions"]
 
+    # task-15474: explicit column projection for list/picker reads, excluding
+    # `image` (a BLOB, sometimes multi-MB). Mirrors the `character_cards`
+    # CREATE TABLE column order (schema section near the top of this file)
+    # minus `image` -- if a future migration adds a character_cards column,
+    # add it here too, or list/picker rows will silently omit it (detail
+    # fetches like `get_character_card_by_id` still `SELECT *` and are
+    # unaffected). See `_character_card_select_columns`.
+    _CHARACTER_CARD_LIST_COLUMNS: Tuple[str, ...] = (
+        "id",
+        "name",
+        "description",
+        "personality",
+        "scenario",
+        "system_prompt",
+        "post_history_instructions",
+        "first_message",
+        "message_example",
+        "creator_notes",
+        "alternate_greetings",
+        "tags",
+        "creator",
+        "character_version",
+        "extensions",
+        "created_at",
+        "last_modified",
+        "deleted",
+        "client_id",
+        "version",
+    )
+
+    @classmethod
+    def _character_card_select_columns(
+        cls, *, include_image: bool, alias: str = ""
+    ) -> str:
+        """Render a `character_cards` SELECT column list.
+
+        Args:
+            include_image: If True, select every column (`*`/`<alias>.*`),
+                including the `image` BLOB. If False (the default for
+                list/picker reads), select the explicit image-free column
+                list.
+            alias: Optional table alias (e.g. "cc") to prefix each column
+                (or the `*`) with, for queries that join against
+                `character_cards`.
+
+        Returns:
+            A column-list string suitable for interpolation into a SELECT
+            clause.
+        """
+        if include_image:
+            return f"{alias}.*" if alias else "*"
+        prefix = f"{alias}." if alias else ""
+        return ", ".join(f"{prefix}{col}" for col in cls._CHARACTER_CARD_LIST_COLUMNS)
+
     # P3a: whitelist of UI sort keys → exact ORDER BY clauses. The ONLY dynamic
     # SQL fragment; search_term/tag are always bound parameters. "relevance"
     # is valid only in the search (FTS) branch.
+    #
+    # `{a}` is filled in with a `cc.` alias prefix (search branch) or "" (plain
+    # browse) by `_resolve_sort_clause`. This is required, not cosmetic
+    # (task-15474): `character_cards_fts` also has a `name` column, so once
+    # the search branch's SELECT stops being the `cc.*` wildcard (the
+    # image-free column-list projection lists `cc.<col>` explicitly), SQLite
+    # resolves a bare `ORDER BY name` against *both* joined tables and raises
+    # "ambiguous column name: name" -- `cc.*` wildcard expansion is exempt
+    # from that ambiguity check, but an explicit `cc.name` column list is not.
     _CHARACTER_SORT_CLAUSES = {
-        "name_asc": "ORDER BY name COLLATE NOCASE ASC",
-        "modified_desc": "ORDER BY last_modified DESC, name COLLATE NOCASE ASC",
-        "created_desc": "ORDER BY created_at DESC, name COLLATE NOCASE ASC",
+        "name_asc": "ORDER BY {a}name COLLATE NOCASE ASC",
+        "modified_desc": "ORDER BY {a}last_modified DESC, {a}name COLLATE NOCASE ASC",
+        "created_desc": "ORDER BY {a}created_at DESC, {a}name COLLATE NOCASE ASC",
         "relevance": "ORDER BY rank",
     }
 
@@ -5610,7 +5673,7 @@ UPDATE db_schema_version
             raise
 
     def list_character_cards(
-        self, limit: int = 100, offset: int = 0
+        self, limit: int = 100, offset: int = 0, *, include_image: bool = False
     ) -> List[Dict[str, Any]]:
         """
         Lists character cards, ordered by name.
@@ -5621,16 +5684,25 @@ UPDATE db_schema_version
         Args:
             limit: The maximum number of cards to return. Defaults to 100.
             offset: The number of cards to skip before starting to return. Defaults to 0.
+            include_image: If True, include the `image` BLOB column. Defaults
+                to False -- most callers of this method are list/picker
+                surfaces (name/description dropdowns, exports, ID lookups)
+                that never touch `image`; dragging up to `limit` raw BLOBs
+                through SQLite/Python on every call is wasted work for them
+                (task-15474). Callers that genuinely need the image (e.g. a
+                bulk export that re-embeds it) should pass `include_image=True`.
 
         Returns:
             A list of dictionaries, each representing a character card.
-            The list may be empty if no cards are found.
+            The list may be empty if no cards are found. When `include_image`
+            is False, returned dicts have no `image` key.
 
         Raises:
             CharactersRAGDBError: For database errors during listing.
         """
         start_time = time.time()
-        query = "SELECT * FROM character_cards WHERE deleted = 0 ORDER BY name LIMIT ? OFFSET ?"
+        columns = self._character_card_select_columns(include_image=include_image)
+        query = f"SELECT {columns} FROM character_cards WHERE deleted = 0 ORDER BY name LIMIT ? OFFSET ?"
         try:
             cursor = self.execute_query(query, (limit, offset))
             rows = cursor.fetchall()
@@ -5684,7 +5756,10 @@ UPDATE db_schema_version
         clause = self._CHARACTER_SORT_CLAUSES.get(order_by)
         if clause is None or (order_by == "relevance" and not searching):
             clause = self._CHARACTER_SORT_CLAUSES["name_asc"]
-        return clause
+        # See the `{a}` note on _CHARACTER_SORT_CLAUSES: only the search
+        # branch joins in a second table with overlapping column names, so
+        # only it needs the `cc.` qualifier.
+        return clause.format(a="cc." if searching else "")
 
     def list_character_cards_page(
         self,
@@ -5694,6 +5769,7 @@ UPDATE db_schema_version
         order_by: str = "name_asc",
         search_term: str | None = None,
         tag: str | None = None,
+        include_image: bool = False,
     ) -> List[Dict[str, Any]]:
         """Paged, sortable, tag- and search-filterable character list.
 
@@ -5705,10 +5781,16 @@ UPDATE db_schema_version
             search_term: FTS5 MATCH query (already prefix-wrapped by the caller,
                 e.g. ``'"dragon"*'``) or None for a browse query.
             tag: Exact tag membership filter, or None.
+            include_image: If True, include the `image` BLOB column. Defaults
+                to False -- this is the Library/personas paging backend and
+                every current caller renders name/description/tags rows, not
+                avatars (task-15474). Pass True for a caller that genuinely
+                needs the image on a page of results.
 
         Returns:
             Deserialized character-card dicts for the page. Never raises on
-            NULL/invalid tags (json_each is json-valid-guarded).
+            NULL/invalid tags (json_each is json-valid-guarded). When
+            `include_image` is False, returned dicts have no `image` key.
         """
         searching = bool(search_term)
         sort_clause = self._resolve_sort_clause(order_by, searching=searching)
@@ -5716,14 +5798,18 @@ UPDATE db_schema_version
         where = ["cc.deleted = 0"] if searching else ["deleted = 0"]
         alias = "cc" if searching else "character_cards"
         if searching:
+            columns = self._character_card_select_columns(
+                include_image=include_image, alias="cc"
+            )
             head = (
-                "SELECT cc.* FROM character_cards_fts fts "
+                f"SELECT {columns} FROM character_cards_fts fts "
                 "JOIN character_cards cc ON fts.rowid = cc.id"
             )
             where.insert(0, "fts.character_cards_fts MATCH ?")
             params.append(search_term)
         else:
-            head = "SELECT * FROM character_cards"
+            columns = self._character_card_select_columns(include_image=include_image)
+            head = f"SELECT {columns} FROM character_cards"
         if tag is not None:
             where.append(
                 f"EXISTS (SELECT 1 FROM {self._TAGS_JSON_EACH.format(t=alias)} WHERE value = ?)"
@@ -5917,10 +6003,17 @@ UPDATE db_schema_version
                 where_params = [character_id, expected_version]
                 final_params = tuple(params_for_set_clause + where_params)
 
-                logger.debug(
-                    f"Executing SINGLE character update query: {final_update_query}"
+                # Lazy + BLOB-safe: `image` is in updatable_direct_fields, so
+                # final_params can carry a multi-MB raw BLOB on every single
+                # character-card save. Match the module's opt(lazy=True) +
+                # preview_params pattern (see :3014-3028 and DB/sql_logging.py)
+                # so nothing is built unless a sink actually admits DEBUG, and
+                # even then the BLOB is summarized by length only.
+                logger.opt(lazy=True).debug(
+                    "Executing SINGLE character update query: {} | Params: {}",
+                    lambda: final_update_query,
+                    lambda: preview_params(final_params),
                 )
-                logger.debug(f"Params: {final_params}")
 
                 cursor = conn.execute(final_update_query, final_params)
                 logger.debug(f"Character Update executed, rowcount: {cursor.rowcount}")

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -2072,8 +2072,17 @@ class MediaDatabase:
 
                 # Combine all FTS query parts with OR
                 combined_fts_query = " OR ".join(fts_query_parts)
-                logging.debug(f"Combined FTS query: '{combined_fts_query}'")
-                logging.info(f"Search using FTS with query parts: {fts_query_parts}")
+                # Lazy (task-15474 sweep): route through loguru's opt(lazy=True)
+                # + preview_params, matching this module's execute_query
+                # precedent (~:823-826), so the query-part list is never
+                # stringified unless a sink admits the level.
+                logger.opt(lazy=True).debug(
+                    "Combined FTS query: '{}'", lambda: combined_fts_query
+                )
+                logger.opt(lazy=True).info(
+                    "Search using FTS with query parts: {}",
+                    lambda: preview_params(fts_query_parts),
+                )
 
                 # Add a single MATCH condition
                 conditions.append("fts.media_fts MATCH ?")
@@ -2133,7 +2142,10 @@ class MediaDatabase:
 
             # Add LIKE conditions to the main conditions list
             if like_conditions:
-                logging.info(f"Search using LIKE with patterns: {like_params}")
+                logger.opt(lazy=True).info(
+                    "Search using LIKE with patterns: {}",
+                    lambda: preview_params(like_params),
+                )
                 conditions.append(f"({' OR '.join(like_conditions)})")
                 params.extend(like_params)
 
@@ -2188,8 +2200,16 @@ class MediaDatabase:
             count_sql = (
                 f"SELECT {count_select} {base_from} {join_clause} {where_clause}"
             )
-            logging.debug(f"Search Count SQL ({self.db_path_str}): {count_sql}")
-            logging.debug(f"Search Count Params: {params}")
+            # Lazy (task-15474): count/results params are not BLOB-carrying
+            # today, but route through the same opt(lazy=True) +
+            # preview_params guard as this module's execute_query (~:823-826)
+            # so a future caller can't silently reintroduce an eager repr.
+            logger.opt(lazy=True).debug(
+                "Search Count SQL ({}): {}", lambda: self.db_path_str, lambda: count_sql
+            )
+            logger.opt(lazy=True).debug(
+                "Search Count Params: {}", lambda: preview_params(params)
+            )
 
             try:
                 count_cursor = self.execute_query(count_sql, tuple(params))
@@ -2249,8 +2269,15 @@ class MediaDatabase:
                 # Results Query
                 results_sql = f"{final_select_stmt} {base_from} {join_clause} {where_clause} {order_by_clause_str} LIMIT ? OFFSET ?"
                 paginated_params = tuple(params + [results_per_page, offset])
-                logging.debug(f"Search Results SQL ({self.db_path_str}): {results_sql}")
-                logging.debug(f"Search Results Params: {paginated_params}")
+                logger.opt(lazy=True).debug(
+                    "Search Results SQL ({}): {}",
+                    lambda: self.db_path_str,
+                    lambda: results_sql,
+                )
+                logger.opt(lazy=True).debug(
+                    "Search Results Params: {}",
+                    lambda: preview_params(paginated_params),
+                )
 
                 try:
                     results_cursor = self.execute_query(results_sql, paginated_params)
@@ -5823,8 +5850,12 @@ class MediaDatabase:
             """
 
             # --- Execution ---
-            logging.debug(
-                f"Executing get_all_document_versions query | Params: {params}"
+            # Lazy (task-15474): `params` here is only media_id/limit/offset,
+            # not BLOB-carrying, but route through the shared guard so an
+            # eager repr can't creep back in if this ever grows a params entry.
+            logger.opt(lazy=True).debug(
+                "Executing get_all_document_versions query | Params: {}",
+                lambda: preview_params(params),
             )
             # Use self.execute_query
             cursor = self.execute_query(final_query, tuple(params))


### PR DESCRIPTION
## Summary

Task 15474 from the input-latency audit — two DB sundries:

1. **Lazy BLOB logging.** `update_character_card` built a multi-MB `repr()` of the raw image BLOB on every save regardless of log level (plain f-string at the one site the July lazy-logging sweep missed); three smaller eager stragglers in Client_Media. All converted to the module's own `opt(lazy=True)` + `preview_params` pattern, with unit tests whose sentinel BLOB reddens on any re-eagerization (mutation-verified by the reviewer).
2. **Image-free list projections.** `list_character_cards(_page)` selected `*`, dragging image BLOBs into 500-row name pickers. Explicit projection minus `image` (exact schema match, verified), `include_image=False` default safe for all callers including MCP tools; detail fetches keep full rows. Measured 15–24× on a 400-card/100 KB-image page.

## Verification
Independent review: Approved. Caller sweep independently re-derived (11 sites, all classified safe — every consumer uses `.get()`, every avatar/portrait path routes through untouched detail fetches); logging sweep mutation-tested; the disclosed latent bug (character JSON export crashes on image-bearing cards) confirmed genuinely pre-existing and untouched — being filed separately. 545 Character_Chat + 861 DB + caller suites green (reviewer-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes SQL debug logging lazy and removes image BLOBs from character list queries by default. This prevents multi‑MB string builds and speeds 100‑row pages by ~15–24x (Task 15474).

- **Performance**
  - Converted `update_character_card` to `logger.opt(lazy=True)` with `preview_params`, avoiding BLOB reprs; cleaned up eager param logs in `Client_Media_DB_v2.search_media_db` and `get_all_document_versions`.
  - `list_character_cards` and `list_character_cards_page` now project an image-free column list by default; pass `include_image=True` to opt in. Fixed search ORDER BY to qualify columns when joining FTS.

- **Migration**
  - If a caller needs `image`, call `list_character_cards(..., include_image=True)` or `list_character_cards_page(..., include_image=True)`. Updated `Chat_Functions.load_characters` accordingly.

<sup>Written for commit 8ba77b9573e122559cd22af1b2d088c03a5746ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

