### PR TITLE
perf: debounce Console rail-search DB work and re-guard the workspace tray (task-15454)

### DIFF
--- a/Docs/User_Guide/console/sessions-tabs-workspaces.md
+++ b/Docs/User_Guide/console/sessions-tabs-workspaces.md
@@ -87,7 +87,7 @@ highlighted result when it is an open tab. Esc cancels.
 
 | Control | What it does |
 |---|---|
-| "Search conversations" + "Clear" | Filters the row list; "Clear" resets it |
+| "Search conversations" + "Clear" | Filters the row list, settling about a fifth of a second after you stop typing; "Clear" resets it immediately |
 | "New conversation" | Starts a fresh conversation |
 | "Starred" / "Workspaces" / "Chats" | Groups; click a header's ▸/▾ toggle to expand or collapse |
 | Conversation row | Click to open it in the Console |

--- a/Tests/UI/test_console_browser_search_echo.py
+++ b/Tests/UI/test_console_browser_search_echo.py
@@ -1,7 +1,10 @@
 """TASK-1900: the browser search input's mount echo must not exist.
 
-`ConsoleWorkspaceContextTray.sync_state` recomposes unconditionally, so every
-sync re-mounts a fresh search `Input`. Textual's `Input._watch_value` posts
+`ConsoleWorkspaceContextTray.sync_state` re-mounts a fresh search `Input` on
+every sync that changes anything -- which, while the user is typing, is every
+one of them. (It used to do so on EVERY sync; TASK-15454 narrowed it to
+changed states, which removes some echoes but not the ones this test is
+about.) Textual's `Input._watch_value` posts
 `Changed` for a constructor-set value unconditionally (the `_initial_value`
 flag only positions the cursor), and that echo travels the message pump --
 on a busy machine it lands AFTER the user typed a newer query. The screen's

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -198,12 +198,24 @@ def test_console_workspace_status_row_empty_value_uses_unavailable():
 
 
 def test_console_workspace_conversation_search_worker_uses_dedicated_group():
+    # TASK-15454 moved the `run_worker` call out of the `Input.Changed`
+    # handler and into the debounced callback the handler now arms -- the
+    # DB work in front of the timer was running once per keystroke. The
+    # contract this test pins (the search runs in its own exclusive worker
+    # group, so a newer search cancels an in-flight one) is unchanged; only
+    # the function that expresses it moved.
     source = inspect.getsource(
-        ChatScreen.on_console_workspace_conversation_search_changed
+        ChatScreen._start_console_conversation_browser_search
     )
 
     assert 'group="console-workspace-conversation-search"' in source
     assert "exclusive=True" in source
+
+    handler = inspect.getsource(
+        ChatScreen.on_console_workspace_conversation_search_changed
+    )
+    assert "_start_console_conversation_browser_search" in handler
+    assert "self.set_timer(" in handler
 
 
 def test_console_workspace_conversation_search_clear_button_stops_pending_timer():

--- a/Tests/UI/test_console_rail_search_debounce.py
+++ b/Tests/UI/test_console_rail_search_debounce.py
@@ -1,0 +1,387 @@
+"""The Console rail conversation search must do its DB work behind its debounce.
+
+TASK-15454. `#console-workspace-conversation-search`'s `Input.Changed` handler
+has had a 0.2 s debounce since it was written -- but only the persisted-row
+worker was ever behind it. In front of the timer, once per KEYSTROKE, it ran:
+
+    _invalidate_console_persisted_rows_cache()   drops the TASK-251 TTL cache
+    _native_console_browser_rows()               workspace labels + starred ids
+    _membership_console_browser_rows()           labels + starred ids +
+                                                 list_workspace_conversations
+                                                 once per workspace
+    _sync_console_workspace_context()            all of the above AGAIN, plus
+                                                 the persisted-row chain (its
+                                                 cache having just been
+                                                 dropped) and a recompose of
+                                                 up to three tray instances
+
+`_console_browser_workspace_records()` also calls `ensure_default_workspace()`,
+which can open a WRITE transaction, and Workspace_DB is DELETE-journalled --
+so a keystroke could block on another connection's lock.
+
+These tests call the handler synchronously and assert on the state of the world
+*before yielding to the event loop at all*, so nothing else can have run in
+between. Each "zero" is paired with a control that lets the debounce fire and
+requires the same counter to move -- a handler that had simply stopped
+searching would pass the first half and fail the second.
+
+Part 4 (folded in from task-15452's review) covers the composer memo: the
+draft-edit keystroke path calls `_console_composer_or_none()` twice, and it
+used to walk the whole Console DOM each time.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from textual.dom import DOMNode
+from textual.widgets import Input
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+from tldw_chatbook.Widgets.Console.console_workspace_context import (
+    ConsoleWorkspaceContextTray,
+)
+
+APP_SIZE = (160, 48)
+
+SEARCH_SELECTOR = "#console-workspace-conversation-search"
+
+
+class _KeystrokeWorkCounter:
+    """Count the DB-touching seams and tray recomposes a keystroke provokes.
+
+    The registry seams are patched on their CLASS, so an indirect call from
+    anywhere inside the screen still counts. `ConsoleWorkspaceContextTray.
+    refresh` counts the tray rebuild for all three mounted projections.
+    """
+
+    _REGISTRY_METHODS = (
+        "ensure_default_workspace",
+        "list_workspaces",
+        "list_workspace_conversations",
+    )
+
+    def __init__(self, console) -> None:
+        self._console = console
+        self._service = console.app_instance.workspace_registry_service
+        self._patched: list[tuple[type, str, object]] = []
+        self.registry_calls = 0
+        self.tray_refreshes = 0
+        self.context_syncs = 0
+
+    def __enter__(self) -> "_KeystrokeWorkCounter":
+        counter = self
+        service_type = type(self._service)
+        for name in self._REGISTRY_METHODS:
+            original = getattr(service_type, name, None)
+            if original is None:
+                continue
+
+            def make(original=original):
+                def counting(*args, **kwargs):
+                    counter.registry_calls += 1
+                    return original(*args, **kwargs)
+
+                return counting
+
+            setattr(service_type, name, make())
+            self._patched.append((service_type, name, original))
+
+        original_refresh = ConsoleWorkspaceContextTray.refresh
+
+        def counting_refresh(tray, *args, **kwargs):
+            if kwargs.get("recompose"):
+                counter.tray_refreshes += 1
+            return original_refresh(tray, *args, **kwargs)
+
+        ConsoleWorkspaceContextTray.refresh = counting_refresh
+        self._patched.append(
+            (ConsoleWorkspaceContextTray, "refresh", original_refresh)
+        )
+
+        original_sync = type(self._console)._sync_console_workspace_context
+
+        def counting_sync(screen, *args, **kwargs):
+            counter.context_syncs += 1
+            return original_sync(screen, *args, **kwargs)
+
+        type(self._console)._sync_console_workspace_context = counting_sync
+        self._patched.append(
+            (type(self._console), "_sync_console_workspace_context", original_sync)
+        )
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        for owner, name, original in reversed(self._patched):
+            setattr(owner, name, original)
+        self._patched.clear()
+
+    @property
+    def total(self) -> int:
+        return self.registry_calls + self.tray_refreshes + self.context_syncs
+
+
+def _changed_event(value: str, search_input: Input):
+    """Build the `Input.Changed` payload the handler reads."""
+    return SimpleNamespace(
+        value=value,
+        input=search_input,
+        stop=lambda: None,
+    )
+
+
+async def _mounted_rail_search(host, pilot):
+    """Return the settled Console screen and its rail search input."""
+    console = host.screen_stack[-1]
+    await _wait_for_selector(console, pilot, SEARCH_SELECTOR)
+    # Let the boot-time sync burst finish so the counters below only ever see
+    # work this test provoked.
+    for _ in range(4):
+        await pilot.pause()
+    return console, console.query_one(SEARCH_SELECTOR, Input)
+
+
+# ---------------------------------------------------------------------------
+# 1. The keystroke path itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_keystroke_does_no_db_work_and_no_tray_recompose():
+    """The synchronous part of a keystroke must touch nothing expensive."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, search_input = await _mounted_rail_search(host, pilot)
+
+        with _KeystrokeWorkCounter(console) as counter:
+            console.on_console_workspace_conversation_search_changed(
+                _changed_event("a", search_input)
+            )
+            # Deliberately NO await here: the assertions describe the state of
+            # the world at the instant the handler returned.
+            assert counter.registry_calls == 0
+            assert counter.tray_refreshes == 0
+            assert counter.context_syncs == 0
+
+        assert console._console_conversation_browser_query == "a"
+        assert console._console_conversation_browser_search_timer is not None
+
+
+@pytest.mark.asyncio
+async def test_the_debounced_pass_still_does_that_work():
+    """Control for the test above: the same counters move once the timer fires.
+
+    Without this, "zero work per keystroke" would also pass against a handler
+    that had stopped searching altogether.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, search_input = await _mounted_rail_search(host, pilot)
+
+        with _KeystrokeWorkCounter(console) as counter:
+            console.on_console_workspace_conversation_search_changed(
+                _changed_event("a", search_input)
+            )
+            await pilot.pause(0.35)
+            assert counter.context_syncs > 0
+            assert counter.registry_calls > 0
+
+
+@pytest.mark.asyncio
+async def test_a_burst_of_keystrokes_runs_the_debounced_pass_once():
+    """Six characters typed inside the debounce window search once, for "alpha6".
+
+    This is the point of the change: pre-task-15454 each of these six calls
+    ran the full derivation chain, and only the persisted-row worker was
+    spared.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, search_input = await _mounted_rail_search(host, pilot)
+
+        with _KeystrokeWorkCounter(console) as counter:
+            for text in ("a", "al", "alp", "alph", "alpha", "alpha6"):
+                console.on_console_workspace_conversation_search_changed(
+                    _changed_event(text, search_input)
+                )
+            assert counter.context_syncs == 0
+            await pilot.pause(0.35)
+            # One debounced pass; its own worker syncs again as results land.
+            # What matters is that six keystrokes did not cost six passes.
+            assert counter.context_syncs <= 3
+
+        assert console._console_conversation_browser_query == "alpha6"
+
+
+@pytest.mark.asyncio
+async def test_a_superseded_timer_never_searches_for_the_stale_query():
+    """Cancellation-token semantics survive the move behind the timer.
+
+    The debounced callback re-asserts the token/query contract that only the
+    worker used to assert, so a timer that somehow outlives its keystroke
+    cannot start a search for text the user has already replaced.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, search_input = await _mounted_rail_search(host, pilot)
+
+        console.on_console_workspace_conversation_search_changed(
+            _changed_event("stale", search_input)
+        )
+        stale_token = console._console_conversation_browser_search_token
+        console.on_console_workspace_conversation_search_changed(
+            _changed_event("fresh", search_input)
+        )
+
+        with _KeystrokeWorkCounter(console) as counter:
+            # Fire the superseded callback directly, as its stopped timer
+            # would have.
+            console._start_console_conversation_browser_search(
+                "stale", stale_token
+            )
+            assert counter.total == 0
+
+        assert console._console_conversation_browser_query == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_visible_rows_never_contradict_the_search_box_mid_debounce():
+    """The cheap in-memory re-filter keeps the rail honest inside the window.
+
+    A poll tick can sync the tray between the keystroke and the debounce. The
+    rows it would paint come from `_console_conversation_browser_rows`, so
+    those are narrowed to the new query synchronously -- with no service call
+    (asserted by the counter) because it is a pure filter over rows already in
+    memory.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, search_input = await _mounted_rail_search(host, pilot)
+
+        console.on_console_workspace_conversation_search_changed(
+            _changed_event("a", search_input)
+        )
+        await pilot.pause(0.35)
+        seeded = console._console_conversation_browser_rows
+
+        with _KeystrokeWorkCounter(console) as counter:
+            console.on_console_workspace_conversation_search_changed(
+                _changed_event("zzzz-no-such-conversation", search_input)
+            )
+            assert counter.total == 0
+
+        remaining = console._console_conversation_browser_rows
+        assert len(remaining) <= len(seeded)
+        for row in remaining:
+            assert row in seeded
+
+
+# ---------------------------------------------------------------------------
+# 2. The composer memo (task-15452 review follow-up)
+# ---------------------------------------------------------------------------
+
+
+class _ComposerQueryCounter:
+    """Count full-DOM `query()` walks for the composer selector."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self._original = DOMNode.query
+
+    def __enter__(self) -> "_ComposerQueryCounter":
+        counter = self
+        original = self._original
+
+        def counting_query(node, selector=None, *args, **kwargs):
+            if selector == "#console-native-composer":
+                counter.calls += 1
+            return original(node, selector, *args, **kwargs)
+
+        DOMNode.query = counting_query
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        DOMNode.query = self._original
+
+
+@pytest.mark.asyncio
+async def test_the_composer_lookup_is_resolved_once_then_memoized():
+    """Repeat lookups must not re-walk the largest widget tree in the app."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        console._console_composer_ref = None
+        with _ComposerQueryCounter() as counter:
+            first = console._console_composer_or_none()
+            assert counter.calls == 1
+            for _ in range(9):
+                assert console._console_composer_or_none() is first
+            assert counter.calls == 1
+
+        assert isinstance(first, ConsoleComposerBar)
+
+
+@pytest.mark.asyncio
+async def test_the_composer_memo_can_never_return_a_detached_widget():
+    """Mutation control: a removed composer must not survive in the memo.
+
+    The memo revalidates on every hit rather than relying on an invalidation
+    hook, so this holds even though nothing told it the widget went away.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        stale = console._console_composer_or_none()
+        assert stale is not None
+        assert console._console_composer_ref is stale
+
+        await stale.remove()
+        await pilot.pause()
+
+        resolved = console._console_composer_or_none()
+        assert resolved is not stale
+        assert console._console_composer_ref is not stale
+
+
+@pytest.mark.asyncio
+async def test_the_composer_memo_follows_a_recomposed_composer():
+    """After the composer is replaced, the memo resolves the NEW instance."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        original = console._console_composer_or_none()
+        assert original is not None
+        parent = original.parent
+        await original.remove()
+        replacement = ConsoleComposerBar(id="console-native-composer")
+        await parent.mount(replacement)
+        await pilot.pause()
+
+        assert console._console_composer_or_none() is replacement

--- a/Tests/UI/test_console_tick_gating.py
+++ b/Tests/UI/test_console_tick_gating.py
@@ -201,6 +201,21 @@ async def test_console_workspace_context_tray_sync_state_always_recomposes():
     errors. The guard was not implemented; this locks in the (still real)
     screen-side optimization instead (see the next test) and protects
     against a future reintroduction of the widget-level guard.
+
+    UPDATED BY TASK-15454. The claim this test pinned -- "sync_state must
+    ALWAYS recompose" -- was a proxy for the real invariant, which is "an
+    equal state is not evidence the DOM shows it". `sync_state` may now skip,
+    but ONLY on evidence: `compose()` records the (row id, row key) sequence
+    it built, and `_can_skip_recompose` compares it against the rows actually
+    mounted, on an instance the rail has already pushed to, with no recompose
+    latched. So this case -- a value-equal state pushed into a settled tray --
+    is now a proven no-op and correctly skips.
+    Every case the revert was actually about still recomposes and is pinned in
+    `Tests/UI/test_console_workspace_tray_recompose_guard.py`, including the
+    click-targeting one (rows missing from the DOM while `.state` still lists
+    them), which fails against the naive full-equality guard. Confirmed by
+    mutation while writing that file: replacing `_can_skip_recompose` with
+    `return state == self.state` reds it.
     """
     app = _build_test_app()
     host = ConsoleHarness(app)
@@ -208,6 +223,9 @@ async def test_console_workspace_context_tray_sync_state_always_recomposes():
     async with host.run_test(size=(160, 48)) as pilot:
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-workspace-context")
+        # The guard needs a settled DOM to read; let the boot sync burst end.
+        for _ in range(4):
+            await pilot.pause()
 
         tray = console.query_one(
             "#console-workspace-context", ConsoleWorkspaceContextTray
@@ -224,10 +242,19 @@ async def test_console_workspace_context_tray_sync_state_always_recomposes():
             same_value_state = replace(tray.state)
             assert same_value_state == tray.state
             tray.sync_state(same_value_state)
+            assert refresh_calls == [], (
+                "a value-equal state pushed into a tray whose mounted rows "
+                "still match what compose() built must not rebuild the tray"
+            )
+
+            # ... but the skip is evidence-based, not value-based: break the
+            # evidence and the same push must rebuild.
+            tray._composed_row_signature = (("console-workspace-conversation-0", "x"),)
+            tray.sync_state(replace(tray.state))
             assert refresh_calls == [1], (
-                "ConsoleWorkspaceContextTray.sync_state must always recompose "
-                "-- an equality guard here breaks click targeting (see "
-                "docstring)"
+                "a tray whose DOM no longer matches what compose() built must "
+                "still recompose on an equal state -- that DESYNC, not state "
+                "equality, is what the TASK-251 revert was about"
             )
 
 
@@ -464,14 +491,25 @@ async def test_console_workspace_context_fresh_tray_still_synced_mid_run():
             await pilot.pause()
             before = len(recompose_calls)
 
-            # Simulate a mid-run full-screen recompose: a FRESH tray instance
-            # with no per-widget synced marker. It must be recomposed once
-            # more despite the unchanged state (its DOM is not yet settled).
-            tray = console.query_one(
-                "#console-workspace-context", ConsoleWorkspaceContextTray
-            )
-            if hasattr(tray, "_console_workspace_context_synced"):
-                del tray._console_workspace_context_synced
+            # Simulate a mid-run full-screen recompose: FRESH tray instances
+            # with no per-widget synced marker. They must be recomposed once
+            # more despite the unchanged state (their DOM is not yet settled).
+            #
+            # TASK-15454: the marker is now cleared on ALL THREE projections,
+            # not just the Conversations one. A real full-screen recompose
+            # constructs three brand-new trays, so all three are markerless --
+            # the previous one-tray simulation only worked because the tray
+            # itself recomposed unconditionally, and each tray now checks its
+            # own marker before it may skip. The assertion below (three
+            # recomposes, the trays healing together) is unchanged.
+            for selector in (
+                "#console-session-context",
+                "#console-workspaces-context",
+                "#console-workspace-context",
+            ):
+                tray = console.query_one(selector, ConsoleWorkspaceContextTray)
+                if hasattr(tray, "_console_workspace_context_synced"):
+                    del tray._console_workspace_context_synced
 
             console._sync_console_workspace_context()
             await pilot.pause()

--- a/Tests/UI/test_console_workspace_controller.py
+++ b/Tests/UI/test_console_workspace_controller.py
@@ -94,8 +94,24 @@ async def test_search_debounce_mirrors_query_and_bumps_token_and_timer():
 
 
 @pytest.mark.asyncio
-async def test_search_debounce_empty_query_clears_state_synchronously():
-    """Clearing the search box resets workspace search state with no pending timer."""
+async def test_search_debounce_empty_query_clears_state_and_cancels_the_old_search():
+    """Emptying the search box clears the query and abandons the old search.
+
+    TASK-15454 renamed this from `..._clears_state_synchronously` and dropped
+    its "no pending timer" assertion. Backspacing to empty is a keystroke like
+    any other, and the clear it triggered ran the same full derivation chain
+    (workspace records + labels, one membership SELECT per workspace, starred
+    ids, then a 3-instance tray recompose) synchronously on the event loop --
+    so it is now debounced with the rest. The pending timer that assertion
+    forbade was really a proxy for "no stale search survives", and that is
+    asserted directly below instead: the timer that does fire carries the
+    EMPTY query, and the debounced callback re-checks the token/query before
+    doing anything, so the superseded "alpha" search can never run.
+
+    (The "Clear" button is a separate path and still clears immediately --
+    see the `console-workspace-conversation-search-clear` branch in
+    `on_button_pressed`, unchanged.)
+    """
     app = _build_test_app()
     host = ConsoleHarness(app)
 
@@ -108,12 +124,24 @@ async def test_search_debounce_empty_query_clears_state_synchronously():
         _set_workspace_search(console, "alpha")
         await pilot.pause()
         assert console._console_workspace_conversation_query == "alpha"
+        stale_token = console._console_workspace_conversation_search_token
 
         _set_workspace_search(console, "")
         await pilot.pause()
 
+        # The query mirror moves at once; only the DB work waits.
         assert console._console_workspace_conversation_query == ""
-        assert console._console_workspace_conversation_search_timer is None
+        assert console._console_conversation_browser_query == ""
+        assert console._console_workspace_conversation_search_token > stale_token
+
+        # A superseded callback cannot revive the old search.
+        console._start_console_conversation_browser_search("alpha", stale_token)
+        assert console._console_conversation_browser_query == ""
+
+        await pilot.pause(0.35)
+        assert console._console_conversation_browser_rows == ()
+        assert console._console_conversation_browser_total is None
+        assert console._console_conversation_browser_error == ""
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_workspace_tray_recompose_guard.py
+++ b/Tests/UI/test_console_workspace_tray_recompose_guard.py
@@ -44,6 +44,7 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
 )
 from tldw_chatbook.Widgets.Console.console_workspace_context import (
     ConsoleWorkspaceContextTray,
+    ConsoleWorkspaceStatusPair,
 )
 
 APP_SIZE = (160, 48)
@@ -243,6 +244,203 @@ async def test_a_tray_whose_rows_went_missing_still_heals_and_stays_clickable():
             assert console.query_one(f"#{row.id}") is row
 
 
+# ---------------------------------------------------------------------------
+# The DOM evidence must not be vacuous for the row-less projections
+# ---------------------------------------------------------------------------
+
+
+def _fixed_projection_signature_is_complete(tray) -> None:
+    """Assert every control a fixed projection MOUNTED is in its signature.
+
+    Review round 1 caught that the row half of the DOM evidence is vacuous for
+    `#console-session-context` and `#console-workspaces-context`: neither
+    builds grouped-browser rows, so their row signature is `()` and matches
+    anything, degenerating the guard toward the reverted full-equality shape.
+    The fix records their fixed controls too — and this is the tripwire that
+    keeps it honest, so that a future dynamic control added to either
+    projection cannot silently sit outside the evidence.
+
+    `ConsoleWorkspaceStatusPair` composes its own label/value Statics; that
+    subtree belongs to the pair, not to this tray's signature, so it is
+    excluded — the ONE deliberate exemption. A new composed sub-component
+    would have to be added here consciously.
+    """
+    recorded = set(tray._composed_fixed_signature or ())
+    unrecorded: list[str] = []
+    for node in tray.query("*"):
+        node_id = str(getattr(node, "id", "") or "")
+        if not node_id or node_id in recorded:
+            continue
+        owner = node
+        owned_by_pair = False
+        while owner is not None and owner is not tray:
+            if isinstance(owner, ConsoleWorkspaceStatusPair):
+                owned_by_pair = True
+                break
+            owner = owner.parent
+        if not owned_by_pair:
+            unrecorded.append(node_id)
+    assert not unrecorded, (
+        f"{tray.id}: {unrecorded} are mounted in a row-less projection but "
+        "absent from `_composed_fixed_signature`, so `_can_skip_recompose` "
+        "has no DOM evidence about them -- route them through "
+        "`_record_composed_node`"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_fixed_projections_record_every_control_they_build():
+    """Both row-less projections carry real, non-empty DOM evidence."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, _tray = await _settled_tray(host, pilot)
+
+        for selector in ("#console-session-context", "#console-workspaces-context"):
+            projection = console.query_one(selector, ConsoleWorkspaceContextTray)
+            # Vacuous row half -- this is exactly the review finding.
+            assert projection._composed_row_signature == ()
+            # ... so the fixed half must be doing the work.
+            assert projection._composed_fixed_signature, (
+                f"{selector} records no fixed controls, so its DOM evidence "
+                "is empty and the guard degenerates to full equality"
+            )
+            _fixed_projection_signature_is_complete(projection)
+
+        # The Workspaces projection's click targets specifically.
+        workspaces = console.query_one(
+            "#console-workspaces-context", ConsoleWorkspaceContextTray
+        )
+        recorded = set(workspaces._composed_fixed_signature or ())
+        assert {
+            "console-change-workspace",
+            "console-new-workspace",
+            "console-workspace-rag-scope-open",
+        } <= recorded
+
+
+@pytest.mark.asyncio
+async def test_an_unrecorded_dynamic_control_reds_the_pin_while_the_guard_skips():
+    """Mutation control: the pin is what discriminates, and it does.
+
+    Give the Sessions projection a per-row button that does NOT go through
+    `_record_composed_node` -- exactly the future change the review was
+    worried about. Two things must then be true at once, and both are
+    asserted: the guard happily skips (the hole is real, because the row half
+    of the evidence is vacuous for this projection), and the pin above reds
+    (so the hole cannot be introduced unnoticed).
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, _tray = await _settled_tray(host, pilot)
+        sessions = console.query_one(
+            "#console-session-context", ConsoleWorkspaceContextTray
+        )
+        _fixed_projection_signature_is_complete(sessions)  # clean before
+
+        original = ConsoleWorkspaceContextTray._compose_session_context
+
+        def mutated(self, *, show_selected_summary: bool):
+            yield from original(self, show_selected_summary=show_selected_summary)
+            if self.content != "session":
+                return
+            browser = self.state.conversation_browser
+            sections = browser.sections if browser is not None else ()
+            for index, section in enumerate(sections):
+                # A dynamic, data-derived click target, deliberately NOT
+                # routed through `_record_composed_node`.
+                yield Button(
+                    str(section.section_id),
+                    id=f"unrecorded-dynamic-control-{index}",
+                    classes="console-workspace-action",
+                    compact=True,
+                )
+
+        ConsoleWorkspaceContextTray._compose_session_context = mutated
+        try:
+            sessions.refresh(recompose=True)
+            for _ in range(4):
+                await pilot.pause()
+            injected = list(console.query("#console-session-context Button"))
+            assert injected, "the mutation must actually mount dynamic controls"
+
+            # (i) the hole is real -- the guard skips despite the new targets
+            assert sessions._can_skip_recompose(replace(sessions.state)) is True
+
+            # (ii) ... and the pin is what catches it
+            with pytest.raises(AssertionError) as caught:
+                _fixed_projection_signature_is_complete(sessions)
+            assert "unrecorded-dynamic-control-0" in str(caught.value)
+        finally:
+            ConsoleWorkspaceContextTray._compose_session_context = original
+            sessions.refresh(recompose=True)
+            for _ in range(3):
+                await pilot.pause()
+
+        _fixed_projection_signature_is_complete(sessions)  # clean after
+
+
+@pytest.mark.asyncio
+async def test_a_fixed_projection_whose_control_went_missing_still_heals():
+    """The row-less projections now get the same self-heal the rows do.
+
+    Prune a recorded control out of the Workspaces projection behind its back
+    and push a value-equal state: before the fixed signature existed, the
+    guard skipped (its row signature was `()` on both sides) and the control
+    stayed gone.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, _tray = await _settled_tray(host, pilot)
+        workspaces = console.query_one(
+            "#console-workspaces-context", ConsoleWorkspaceContextTray
+        )
+        assert workspaces._can_skip_recompose(replace(workspaces.state)) is True
+
+        await console.query_one("#console-change-workspace", Button).remove()
+        await pilot.pause()
+        assert not list(console.query("#console-change-workspace"))
+
+        with _RecomposeCounter() as counter:
+            workspaces.sync_state(replace(workspaces.state))
+            assert counter.calls == 1, (
+                "a row-less projection that lost a recorded control must "
+                "rebuild it even though the incoming state is value-equal"
+            )
+        for _ in range(3):
+            await pilot.pause()
+
+        assert console.query_one("#console-change-workspace", Button) is not None
+
+
+@pytest.mark.asyncio
+async def test_an_out_of_band_mount_does_not_defeat_the_guard():
+    """Extra nodes the screen mounts into a tray are not treated as drift.
+
+    The screen mounts the transitional `#console-new-workspace-conversation`
+    alias straight into the Conversations tray. Requiring exact DOM equality
+    would make that tray permanently unskippable, so the reader collects only
+    the ids compose recorded.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, tray = await _settled_tray(host, pilot)
+        assert tray._can_skip_recompose(replace(tray.state)) is True
+
+        await tray.mount(Button("Out of band", id="out-of-band-probe"))
+        await pilot.pause()
+        assert console.query_one("#out-of-band-probe", Button) is not None
+
+        assert tray._can_skip_recompose(replace(tray.state)) is True
+
+
 @pytest.mark.asyncio
 async def test_the_recorded_signature_matches_the_mounted_rows():
     """The guard's two sides must be derived from the same rows.
@@ -258,5 +456,9 @@ async def test_the_recorded_signature_matches_the_mounted_rows():
         console, tray = await _settled_tray(host, pilot)
         await _seed_rows(console, pilot)
 
-        assert tray._mounted_row_signature() == tray._composed_row_signature
+        mounted_rows, mounted_fixed = tray._mounted_signatures(
+            tray._composed_fixed_signature or ()
+        )
+        assert mounted_rows == tray._composed_row_signature
+        assert mounted_fixed == tray._composed_fixed_signature
         assert tray._can_skip_recompose(replace(tray.state)) is True

--- a/Tests/UI/test_console_workspace_tray_recompose_guard.py
+++ b/Tests/UI/test_console_workspace_tray_recompose_guard.py
@@ -1,0 +1,262 @@
+"""`ConsoleWorkspaceContextTray` must recompose on change -- and only on change.
+
+TASK-15454, re-opening a guard TASK-251 deliberately reverted.
+
+History, from the source rather than from memory: TASK-251's brief asked for
+`ConsoleRunInspector`'s `if state == self.state: return` guard here too. It was
+implemented, it broke click targeting on grouped browser rows
+(`test_console_workspace_conversation_search_selection_keeps_query_active` and
+`..._invalidates_pending_worker` both failed with "row not found"), and it was
+withdrawn before landing -- the reason is inline in `sync_state` and pinned by
+`Tests/UI/test_console_tick_gating.py`. The screen-side comment in
+`_sync_console_workspace_context` records the mechanism: a tray can hold state
+X while its DOM shows something else (a fresh instance from a full-screen
+recompose whose rows were superseded before they settled), and the
+unconditional recompose was what healed that.
+
+So the failure was never "equal states must still repaint". It was "state
+equality is not evidence about the DOM". The guard added in task-15454 supplies
+that evidence directly: `compose()` records the (row id, row key) sequence it
+builds, and the guard skips only when the rows actually mounted still match it,
+on an instance the rail has already pushed to, with no recompose latched. Row
+id + row key is the identity Console click routing dispatches on, so a match
+means every click target is where it was.
+
+Measured while writing this: applying the naive full-equality guard to today's
+dev and running the 309-test `test_console_native_chat_flow.py` plus
+`test_console_rail_sections.py` no longer reproduces the historical failure
+(only the two tick-gating pins fail). The regression that forced the revert has
+been dissolved by later work -- most likely TASK-1900's non-echoing search
+input and TASK-1191's fit-pass rework. That is a reason to re-guard, not a
+reason to guard loosely, so the DOM check below stands regardless.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from textual.widgets import Button, Input
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Widgets.Console.console_workspace_context import (
+    ConsoleWorkspaceContextTray,
+)
+
+APP_SIZE = (160, 48)
+
+TRAY_SELECTOR = "#console-workspace-context"
+SEARCH_SELECTOR = "#console-workspace-conversation-search"
+
+
+class _RecomposeCounter:
+    """Count `refresh(recompose=True)` calls on every tray instance."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self._original = ConsoleWorkspaceContextTray.refresh
+
+    def __enter__(self) -> "_RecomposeCounter":
+        counter = self
+        original = self._original
+
+        def counting_refresh(tray, *args, **kwargs):
+            if kwargs.get("recompose"):
+                counter.calls += 1
+            return original(tray, *args, **kwargs)
+
+        ConsoleWorkspaceContextTray.refresh = counting_refresh
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        ConsoleWorkspaceContextTray.refresh = self._original
+
+
+async def _settled_tray(host, pilot):
+    """Return the Console screen and its conversations tray, fully settled."""
+    console = host.screen_stack[-1]
+    await _wait_for_selector(console, pilot, TRAY_SELECTOR)
+    for _ in range(4):
+        await pilot.pause()
+    return console, console.query_one(TRAY_SELECTOR, ConsoleWorkspaceContextTray)
+
+
+async def _seed_rows(console, pilot) -> tuple:
+    """Type a query so the tray renders grouped browser rows, and return them."""
+    search = console.query_one(SEARCH_SELECTOR, Input)
+    console.on_console_workspace_conversation_search_changed(
+        type("E", (), {"value": "a", "input": search, "stop": staticmethod(lambda: None)})()
+    )
+    await pilot.pause(0.4)
+    for _ in range(3):
+        await pilot.pause()
+    return tuple(console.query(".console-workspace-conversation-row"))
+
+
+# ---------------------------------------------------------------------------
+# The guard skips a proven no-op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_proven_noop_sync_does_not_recompose():
+    """An equal state pushed into a tray whose DOM matches it changes nothing."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, tray = await _settled_tray(host, pilot)
+        assert tray._composed_row_signature is not None
+        assert getattr(tray, "_console_workspace_context_synced", False) is True
+
+        with _RecomposeCounter() as counter:
+            tray.sync_state(replace(tray.state))
+            assert counter.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# ... and recomposes for every kind of change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_structural_change_still_recomposes():
+    """A state whose row set differs must rebuild the rows (and click targets)."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, tray = await _settled_tray(host, pilot)
+        browser = tray.state.conversation_browser
+        assert browser is not None
+
+        # Drop every section: a maximal structural change.
+        changed = replace(tray.state, conversation_browser=replace(browser, sections=()))
+        with _RecomposeCounter() as counter:
+            tray.sync_state(changed)
+            assert counter.calls == 1
+        await pilot.pause()
+        assert not list(console.query(".console-workspace-conversation-row"))
+
+
+@pytest.mark.asyncio
+async def test_a_text_only_change_still_recomposes():
+    """The guard is not "structure only" -- any value change repaints.
+
+    A heading change moves no click target, but the tray renders it, so
+    skipping would leave stale text on screen. The structural signature is an
+    ADDITIONAL requirement on top of value equality, never a replacement for it.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        _console, tray = await _settled_tray(host, pilot)
+
+        with _RecomposeCounter() as counter:
+            tray.sync_state(replace(tray.state, heading="Changed heading"))
+            assert counter.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_tray_instance_always_recomposes_once():
+    """TASK-344/349's one-time healing push survives the guard.
+
+    A tray the rail has never pushed into has no evidence its DOM is settled,
+    so its first sync always rebuilds -- exactly the case
+    `test_console_workspace_context_fresh_tray_still_synced_mid_run` pins from
+    the screen side.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        _console, tray = await _settled_tray(host, pilot)
+        if hasattr(tray, "_console_workspace_context_synced"):
+            del tray._console_workspace_context_synced
+
+        with _RecomposeCounter() as counter:
+            tray.sync_state(replace(tray.state))
+            assert counter.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# The regression the revert was about: state says X, DOM says otherwise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_tray_whose_rows_went_missing_still_heals_and_stays_clickable():
+    """THE historical click-targeting case, reproduced directly.
+
+    The reverted guard's failure mode was: the tray's `.state` lists rows, the
+    DOM does not have them, an equal state arrives, the guard skips, and the
+    rows are never rebuilt -- so a click can find no row to target ("row not
+    found"). Here that desync is created deliberately (the rows are pruned
+    behind the tray's back, leaving `.state` untouched) and a value-equal state
+    is then pushed, as a poll tick would.
+
+    A full-equality guard skips and the rows stay gone. This guard reads the
+    DOM, sees the mismatch, and rebuilds -- and the assertions below require
+    the rebuilt rows to be real, addressable click targets with the same
+    identities they had before, not merely "some widgets".
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, tray = await _settled_tray(host, pilot)
+        rows_before = await _seed_rows(console, pilot)
+        assert rows_before, "fixture must render at least one grouped browser row"
+        identities_before = tuple(
+            (str(row.id), str(getattr(row, "row_key", ""))) for row in rows_before
+        )
+        pinned_state = tray.state
+
+        for row in rows_before:
+            await row.remove()
+        await pilot.pause()
+        assert not list(console.query(".console-workspace-conversation-row"))
+        # The desync the revert was about: state still claims the rows.
+        assert tray.state is pinned_state
+
+        with _RecomposeCounter() as counter:
+            tray.sync_state(replace(pinned_state))
+            assert counter.calls == 1, (
+                "a tray whose DOM has lost its rows must rebuild them even "
+                "though the incoming state is value-equal"
+            )
+        for _ in range(3):
+            await pilot.pause()
+
+        rows_after = tuple(console.query(".console-workspace-conversation-row"))
+        identities_after = tuple(
+            (str(row.id), str(getattr(row, "row_key", ""))) for row in rows_after
+        )
+        assert identities_after == identities_before
+        for row in rows_after:
+            assert isinstance(row, Button)
+            # An addressable click target: resolvable by id from the screen.
+            assert console.query_one(f"#{row.id}") is row
+
+
+@pytest.mark.asyncio
+async def test_the_recorded_signature_matches_the_mounted_rows():
+    """The guard's two sides must be derived from the same rows.
+
+    If `compose` recorded one thing and the DOM reader read another, the guard
+    would simply never skip (safe but pointless) -- or, worse, drift into
+    skipping on a mismatch it could not see. Pin the agreement.
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, tray = await _settled_tray(host, pilot)
+        await _seed_rows(console, pilot)
+
+        assert tray._mounted_row_signature() == tray._composed_row_signature
+        assert tray._can_skip_recompose(replace(tray.state)) is True

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -2868,3 +2868,41 @@ opened during it can be born stale. And treat a documented "it self-heals on ret
 as a live bug with a shortened fuse: it is one held connection away from being permanent.
 Probing the mechanism cost ~20 minutes (init/connection timeline + one retry inside the
 failing call); guessing at "sqlite locking" would have cost far more and fixed nothing.
+
+## A "we tried this and it broke X" comment is dated evidence, not a standing constraint (TASK-15454, 2026-08-11)
+
+`ConsoleWorkspaceContextTray.sync_state` carried a long, careful comment (TASK-251,
+July) explaining that the obvious `if state == self.state: return` guard had been
+implemented, had broken click targeting on grouped browser rows, and had been
+withdrawn — naming the two tests that failed. A separate test pinned the
+unconditional recompose so nobody could quietly reintroduce it. Every downstream
+comment in the file, in `chat_screen.py`, and in two test modules repeated the
+conclusion: "an equality guard here is unsafe".
+
+Re-guarding it started by reproducing that: apply the naive guard, run the two named
+tests. **Both passed.** Widening to the whole 309-test `test_console_native_chat_flow.py`
+plus `test_console_rail_sections.py` produced only the two tick-gating pins (which pin
+the unconditional recompose itself) and one failure that also fails at HEAD. The
+regression had been dissolved by later, unrelated work — most plausibly TASK-1900's
+non-echoing search input and TASK-1191's collapse of the fit-pass from three deferred
+hops to one.
+
+Two things follow, and the second matters more than the first:
+
+1. **Re-run the witness before designing around it.** Fifteen minutes of `git log -S`
+   plus two test invocations turned "this is forbidden" into "this was forbidden in
+   July, for a reason that no longer exists". Without that, the natural move is to
+   design elaborately around a constraint that is not there — or, worse, to accept the
+   comment and skip the work entirely.
+2. **A dissolved regression is not a licence to do the naive thing.** The comment's
+   *diagnosis* outlived its symptom, and it was the valuable part: state equality
+   answers "does this widget REMEMBER this state", which is a different question from
+   "is this widget SHOWING it". Those two came apart once and can come apart again.
+   The guard that shipped therefore checks the second question directly — `compose()`
+   records the row ids/keys it built; the guard compares that against the rows read
+   back out of the live DOM — and both directions are mutation-tested (`return state
+   == self.state` reds the safety tests; `return False` reds the skip tests).
+
+**What to do.** Treat every "deliberately reverted / do not reintroduce" comment as an
+experiment with a date on it. Re-run its named witnesses first; record the result in
+the task either way. Then keep the diagnosis even when the symptom is gone.

--- a/backlog/tasks/task-15454 - Console-rail-search---move-DB-work-inside-its-debounce-and-re-guard-the-workspace-tray.md
+++ b/backlog/tasks/task-15454 - Console-rail-search---move-DB-work-inside-its-debounce-and-re-guard-the-workspace-tray.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15454
 title: Console rail search: move DB work inside its debounce and re-guard the workspace tray
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -20,7 +21,129 @@ Fix direction: move everything between `:1858-1893` inside the debounced timer c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Zero SQLite queries and zero tray recompose on the keystroke path before the debounce fires (evidence)
-- [ ] #2 Tray recomposes only on structural change, with the historical click-targeting regression covered by a test
-- [ ] #3 Search results and rail behavior unchanged (existing surface green)
+- [x] #1 Zero SQLite queries and zero tray recompose on the keystroke path before the debounce fires (evidence)
+- [x] #2 Tray recomposes only on structural change, with the historical click-targeting regression covered by a test
+- [x] #3 Search results and rail behavior unchanged (existing surface green)
+- [x] #4 `_console_composer_or_none()` no longer walks the whole DOM twice per keystroke, and a cached reference can never be returned once it is detached (folded in from task-15452's review: it is 61% of the residual per-keystroke cost after 15452)
 <!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Read the handler, the tray, the reverted-guard history and the two tests the
+   revert names; reproduce the historical click-targeting regression first-hand by
+   temporarily applying the naive full-equality guard and watching those two tests
+   go red (evidence, not folklore).
+2. Keystroke path: leave only pure state bookkeeping (query, tokens, timer swap)
+   in `Input.Changed`; the TTL-cache invalidation, the row derivation and the
+   tray sync all move behind the existing 0.2 s timer. The debounced callback
+   re-checks the cancellation token/query before doing any work. Keep the
+   already-cached rows visually consistent with the newest query via the pure
+   in-memory filter (no DB) so a tick-driven sync inside the debounce window
+   cannot paint rows that contradict the search box.
+3. Tray guard: skip `refresh(recompose=True)` only when the incoming state is
+   value-equal AND the mounted DOM is provably the DOM that state produced --
+   a structural row signature (ordered row ids + row keys, the things that
+   determine click targets) recorded by `compose()` itself and compared against
+   the same signature read back out of the live DOM, plus "no recompose already
+   pending" and "mounted". Any mismatch (including the fresh-tray / superseded-
+   rows desync the revert was about) recomposes exactly as today.
+4. Memoize `_console_composer_or_none()` on a class-level attribute, revalidating
+   `is_attached`/`is_mounted`/id/parent-screen on every hit and falling back to a
+   fresh query otherwise.
+5. Tests born red where feasible: a keystroke-path no-DB/no-recompose test, tray
+   guard tests including a regression test for the historical click-targeting
+   case, and composer-memo tests including a detached-widget mutation control.
+6. Measure the per-keystroke residual before/after with an isolated probe;
+   run the rail/search/tray/workspace suites plus the task-15452 gate suites.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Three changes, all measured. Plan followed; the one deviation is recorded
+under "The revert no longer reproduces" below.
+
+**1. The keystroke path is now bookkeeping only.** `Input.Changed` keeps the
+query/token mirrors and the timer swap, and defers everything else to a new
+`ChatScreen._start_console_conversation_browser_search(query, token)` that the
+0.2 s timer arms: the TASK-251 TTL invalidation, the native/membership row
+derivation, `_sync_console_workspace_context()`, and the `run_worker` kick.
+The debounced callback re-asserts the token/query contract before it does
+anything, so a superseded timer can never search for replaced text. One
+non-bookkeeping line stays in the handler: `_filter_console_browser_rows_for_
+query` over the rows already in memory (a pure filter, no service, no DB), so
+a poll tick landing inside the debounce window cannot paint rows that
+contradict the search box. Backspacing to empty is now debounced like any
+other keystroke — it used to clear synchronously, and that clear ran the same
+full derivation chain. The "Clear" BUTTON path is untouched and still
+immediate.
+
+**2. The tray guard is evidence-based, not equality-based.**
+`ConsoleWorkspaceContextTray.compose()` now records the ordered `(row id, row
+key)` pairs it builds — published only if the generator completes — and
+`_can_skip_recompose` skips only when: the rail has pushed at least one state
+into this instance, that signature exists, no recompose is latched, the tray
+is mounted with children, the state is value-equal, AND the rows read back
+out of the LIVE DOM still match the recorded signature. Row id + row key is
+the identity Console click routing dispatches on, so a match means every
+click target is present, in place, and pointing where it did. This is the
+direct answer to the revert: the reverted guard asked "does the tray remember
+this state", which is not the same question as "is the tray showing it".
+
+**The revert no longer reproduces.** Before designing anything, the naive
+`if state == self.state: return` guard was applied to today's dev and the
+suites the revert named were run. Both witness tests
+(`..._selection_keeps_query_active`, `..._invalidates_pending_worker`) PASS,
+and across `test_console_native_chat_flow.py` (309) +
+`test_console_rail_sections.py` the only failures were the two tick-gating
+pins and one pre-existing failure. The July regression has been dissolved by
+later work (most likely TASK-1900's non-echoing search input and TASK-1191's
+fit-pass rework). That is a reason to re-guard, not to guard loosely, so the
+DOM check stands anyway — and it is mutation-tested both ways: replacing
+`_can_skip_recompose` with `return state == self.state` reds the two safety
+tests, and with `return False` reds the two skip tests.
+
+**3. `_console_composer_or_none()` is memoized** on a class-level
+`_console_composer_ref` (the `__new__()` fixture convention), revalidated on
+every hit via `is_mounted` AND `self in cached.ancestors_with_self` rather
+than invalidated from teardown hooks — so a detached node can never be
+returned even if a future teardown path forgets the memo exists.
+
+**Measured** (isolated probe, scratch HOME/XDG/TLDW_CONFIG_PATH, headless
+Pilot, 12-keystroke burst; `scratchpad/probe_15454.py`, fast M-series Mac,
+small seeded workspace set — a real workspace/conversation set scales the
+"before" column, not the "after"):
+
+| per 12-keystroke burst | before (dev 7cfe8df4e) | after |
+|---|---|---|
+| handler wall cost, per keystroke | 0.558 ms | **0.009 ms** |
+| registry calls during the burst | 252 | **0** |
+| tray recomposes during the burst | 36 | **0** |
+| workspace-context syncs during the burst | 12 | **0** |
+| registry calls, burst + settle | 293 | **62** |
+| tray recomposes, burst + settle | 42 | **3** |
+| `_console_composer_or_none()` | 1182.6 µs | **0.40 µs** |
+
+The after-settle numbers are higher than before-settle precisely because the
+work moved there; the totals are what improved.
+
+**Tests.** New: `Tests/UI/test_console_rail_search_debounce.py` (8) and
+`Tests/UI/test_console_workspace_tray_recompose_guard.py` (6). Six of the
+eight debounce tests were confirmed born-red against HEAD content; the other
+two are deliberate controls. Updated with in-test comments explaining why:
+`test_console_tick_gating.py::..._tray_sync_state_always_recomposes` (the pin
+this task was required to revisit — now asserts the evidence-based contract
+plus a desync control), `..._fresh_tray_still_synced_mid_run` (clears the
+marker on all three projections, as a real full-screen recompose does),
+`test_console_native_chat_flow.py::..._search_worker_uses_dedicated_group`
+(source inspection followed the `run_worker` into the debounced callback),
+`test_console_workspace_controller.py::..._empty_query_clears_state_*`.
+
+**Modified/added:** `tldw_chatbook/UI/Screens/chat_screen.py`,
+`tldw_chatbook/Widgets/Console/console_workspace_context.py`,
+`Docs/User_Guide/console/sessions-tabs-workspaces.md`, the four test files
+above, plus the two new ones.
+
+**Known pre-existing failures, verified at HEAD content, not caused here:**
+`test_console_rail_sections.py::test_popover_apply_returns_replaced_settings`
+and the three in `test_console_rail_width_budget.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15454 - Console-rail-search---move-DB-work-inside-its-debounce-and-re-guard-the-workspace-tray.md
+++ b/backlog/tasks/task-15454 - Console-rail-search---move-DB-work-inside-its-debounce-and-re-guard-the-workspace-tray.md
@@ -138,6 +138,33 @@ marker on all three projections, as a real full-screen recompose does),
 (source inspection followed the `run_worker` into the debounced callback),
 `test_console_workspace_controller.py::..._empty_query_clears_state_*`.
 
+**Review round 1 — DOM evidence was vacuous for the row-less projections.**
+The DOM-evidence clause only compared grouped-browser rows, and
+`#console-session-context` / `#console-workspaces-context` build none — their
+row signature was `()` on both sides and matched anything, so for those two
+trays the guard degenerated toward the reverted full-equality shape. Closed
+both ways the review offered: `compose` now also records the ordered ids of
+the FIXED controls those projections build (`_record_composed_node`, a
+one-expression wrapper at each site) and the guard requires that half to match
+too; and a pin test asserts every id-carrying node mounted in either
+projection appears in that signature, with `ConsoleWorkspaceStatusPair`'s own
+subtree as the single deliberate exemption. The pin discriminates: a mutation
+that adds a dynamic per-row Button to the Sessions projection without
+recording it reds the pin **while `_can_skip_recompose` still returns True** —
+both facts asserted in the same test, so the pin is demonstrably what catches
+the hole. Two further tests cover the new half: a pruned Switch button now
+forces a heal (it did not before), and an out-of-band mount (the screen's
+`#console-new-workspace-conversation` alias, which lands directly in the
+Conversations tray) is deliberately NOT treated as drift — requiring exact DOM
+equality would make that tray permanently unskippable.
+
+**Why the User Guide "Verified against" stamp was not bumped.** The page's
+conversation-browser table row was updated to state the new debounce, but the
+stamp (`dev @ ff435772c — 2026-07-31`) was left alone on purpose: bumping it
+asserts the WHOLE page was re-verified against a running app, and only this one
+behaviour was. Claiming otherwise would make the stamp worthless for the next
+reader.
+
 **Modified/added:** `tldw_chatbook/UI/Screens/chat_screen.py`,
 `tldw_chatbook/Widgets/Console/console_workspace_context.py`,
 `Docs/User_Guide/console/sessions-tabs-workspaces.md`, the four test files

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -10004,6 +10004,35 @@ class ChatScreen(BaseAppScreen):
         rows: Iterable[ConsoleConversationBrowserInputRow],
         query: str,
     ) -> tuple[ConsoleConversationBrowserInputRow, ...]:
+        """Return the rows matching ``query``; pure, no service or DB access.
+
+        Called from two places with different jobs. The debounced pass filters
+        freshly derived rows. The keystroke handler filters the rows already
+        on screen, which is the only work it does beyond bookkeeping
+        (TASK-15454) -- and that carries a documented tradeoff worth stating
+        where the filter lives:
+
+        **An empty query returns the rows unchanged**, so backspacing the
+        search box to empty leaves the PRIOR result set visible for up to the
+        0.2 s debounce, until ``_start_console_conversation_browser_search``
+        clears it. (Every non-empty query narrows instead, so the visible rows
+        never contradict the search box; only the emptied box does, and only
+        by showing more than it should.) Clicking a row in that window was
+        checked and is safe: ``on_button_pressed`` carries the row's own
+        ``conversation_id``/``row_key`` on the button, and when
+        ``_find_console_browser_row`` no longer finds the row in freshly built
+        state it falls back to that id and resumes the conversation anyway --
+        so a stale row still opens the conversation it names, it does not dead-
+        click. The "Clear" BUTTON does not go through this window at all; it
+        clears immediately.
+
+        Args:
+            rows: Rows to filter.
+            query: Raw search text; blank means "no filtering".
+
+        Returns:
+            The matching rows, in input order.
+        """
         normalized_query = str(query or "").strip().lower()
         row_tuple = tuple(rows)
         if not normalized_query:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1854,7 +1854,26 @@ class ChatScreen(BaseAppScreen):
     def on_console_workspace_conversation_search_changed(
         self, event: Input.Changed
     ) -> None:
-        """Debounce grouped conversation-browser search in the Console rail."""
+        """Debounce grouped conversation-browser search in the Console rail.
+
+        TASK-15454: everything this handler does is now either a pure
+        attribute write or an in-memory filter over rows already held in
+        the screen. The DB work the 0.2s timer was supposed to be
+        debouncing -- the persisted-rows TTL invalidation, the
+        workspace-record/label reads (``ensure_default_workspace`` can open
+        a WRITE transaction), one ``list_workspace_conversations`` SELECT
+        per workspace, the starred-id SELECTs, and the workspace-context
+        tray sync that repeats all of it plus a 3-instance recompose --
+        used to run in front of the timer, so it ran once per KEYSTROKE and
+        the debounce only ever spared the persisted-row worker. It now runs
+        in ``_start_console_conversation_browser_search``, behind the timer.
+
+        The one non-bookkeeping line left here is the in-memory re-filter of
+        the rows the rail is already showing: it touches no service and no
+        DB, and it keeps a tick-driven sync landing inside the debounce
+        window from painting rows that contradict the search box. It can
+        only narrow the visible set; the debounced pass refills it.
+        """
         event.stop()
         event_input = getattr(event, "input", None)
         if getattr(event_input, "disabled", False):
@@ -1862,10 +1881,6 @@ class ChatScreen(BaseAppScreen):
         next_query = str(event.value or "")
         if next_query == self._console_conversation_browser_query:
             return
-        # TASK-251: invalidate before kicking the refresh -- a same-text
-        # re-search within the TTL window (e.g. clear then retype) must not
-        # be served a stale persisted-rows cache entry.
-        self._invalidate_console_persisted_rows_cache()
         self._console_conversation_browser_query = next_query
         self._console_workspace_conversation_query = (
             self._console_conversation_browser_query
@@ -1882,6 +1897,57 @@ class ChatScreen(BaseAppScreen):
         if self._console_workspace_conversation_search_timer is not None:
             self._console_workspace_conversation_search_timer.stop()
             self._console_workspace_conversation_search_timer = None
+        self._console_conversation_browser_rows = (
+            self._filter_console_browser_rows_for_query(
+                self._console_conversation_browser_rows,
+                query,
+            )
+        )
+        self._console_conversation_browser_search_timer = self.set_timer(
+            0.2,
+            partial(
+                self._start_console_conversation_browser_search,
+                query,
+                token,
+            ),
+        )
+        self._console_workspace_conversation_search_timer = (
+            self._console_conversation_browser_search_timer
+        )
+
+    def _start_console_conversation_browser_search(
+        self,
+        query: str,
+        token: int,
+    ) -> None:
+        """Run the debounced half of a rail conversation-search keystroke.
+
+        TASK-15454: the deferred body of
+        ``on_console_workspace_conversation_search_changed``. Everything
+        here was previously executed synchronously, per keystroke, in front
+        of the timer that schedules this.
+
+        The token/query re-check is belt-and-braces -- a superseded timer is
+        already stopped by the next keystroke -- but this callback now opens
+        transactions, so it re-asserts the same cancellation contract
+        ``_refresh_console_conversation_browser_search`` asserts before its
+        own work.
+
+        Args:
+            query: Search text captured when the timer was armed.
+            token: Search token captured when the timer was armed.
+
+        Returns:
+            None.
+        """
+        if token != self._console_conversation_browser_search_token:
+            return
+        if query != self._console_conversation_browser_query:
+            return
+        # TASK-251: invalidate before kicking the refresh -- a same-text
+        # re-search within the TTL window (e.g. clear then retype) must not
+        # be served a stale persisted-rows cache entry.
+        self._invalidate_console_persisted_rows_cache()
         if not query.strip():
             self._console_conversation_browser_rows = ()
             self._console_conversation_browser_total = None
@@ -1901,19 +1967,13 @@ class ChatScreen(BaseAppScreen):
         self._console_conversation_browser_total = None
         self._console_conversation_browser_error = ""
         self._sync_console_workspace_context()
-        self._console_conversation_browser_search_timer = self.set_timer(
-            0.2,
-            lambda: self.run_worker(
-                self._refresh_console_conversation_browser_search(
-                    query,
-                    token,
-                ),
-                group="console-workspace-conversation-search",
-                exclusive=True,
+        self.run_worker(
+            self._refresh_console_conversation_browser_search(
+                query,
+                token,
             ),
-        )
-        self._console_workspace_conversation_search_timer = (
-            self._console_conversation_browser_search_timer
+            group="console-workspace-conversation-search",
+            exclusive=True,
         )
 
     @on(Select.Changed, "#compact-api-provider")
@@ -5252,10 +5312,43 @@ class ChatScreen(BaseAppScreen):
                 )
         return selection
 
+    #: Memoized ``#console-native-composer`` node, or None when nothing has
+    #: been resolved (or the last resolved node went away). A CLASS attribute
+    #: default because the hand-built ``ChatScreen.__new__()`` test fixtures
+    #: never run ``__init__``. Never read directly -- always through
+    #: ``_console_composer_or_none``, which revalidates before returning it.
+    _console_composer_ref: ConsoleComposerBar | None = None
+
     def _console_composer_or_none(self) -> ConsoleComposerBar | None:
-        """Return the native Console composer when it is mounted."""
+        """Return the native Console composer when it is mounted.
+
+        TASK-15454 (folded in from task-15452's review): this used to run an
+        uncached ``self.query()`` -- a full walk of the largest widget tree
+        in the app -- and the draft-edit keystroke path alone calls it twice,
+        which measured as the majority of that path's residual cost. The
+        resolved node is memoized instead.
+
+        A stale reference must be impossible, so the memo is revalidated on
+        every hit rather than invalidated from teardown hooks: the cached
+        widget is returned only while it is still mounted AND still reachable
+        from this screen. A recompose that replaces the composer detaches the
+        old node (``_parent`` cleared by the prune) and clears its mounted
+        flag, so both halves fail closed and the next call re-queries. The
+        memo therefore cannot outlive the widget it names even if some future
+        teardown path forgets about it entirely.
+        """
+        cached = self._console_composer_ref
+        if cached is not None:
+            try:
+                still_live = cached.is_mounted and self in cached.ancestors_with_self
+            except Exception:  # pragma: no cover - defensive, see above
+                still_live = False
+            if still_live:
+                return cached
+            self._console_composer_ref = None
         composers = list(self.query("#console-native-composer"))
         if composers and isinstance(composers[0], ConsoleComposerBar):
+            self._console_composer_ref = composers[0]
             return composers[0]
         return None
 
@@ -11486,16 +11579,26 @@ class ChatScreen(BaseAppScreen):
             # construction time, so comparing against it here stays safe
             # across recomposes too.
             state_changed = state != workspace_context.state
-            # TASK-344/349: the tray recomposes unconditionally in its own
-            # sync_state (a widget-level equality guard is forbidden -- it
-            # breaks grouped-browser click targeting, see
-            # test_console_workspace_context_tray_sync_state_always_recomposes).
-            # That unconditional recompose ALSO self-heals a real DOM/state
+            # TASK-344/349: the tray used to recompose unconditionally in its
+            # own sync_state (a plain widget-level equality guard is still
+            # forbidden -- it breaks grouped-browser click targeting). That
+            # unconditional recompose ALSO self-healed a real DOM/state
             # desync: a full-screen recompose constructs a fresh tray whose
             # `.state` is set but whose rows can be superseded before they
             # settle, so `.state` says X while the DOM shows nothing -- the
             # next tick's recompose repaints it. So an equality guard is
-            # unsafe in general. It IS safe on the ~5x/second run tick: the
+            # unsafe in general.
+            #
+            # TASK-15454 replaced the unconditional recompose with an
+            # evidence-based one (`ConsoleWorkspaceContextTray.
+            # _can_skip_recompose`): the tray now skips only when the rows
+            # actually mounted still match the ones its last completed
+            # `compose` built, on an instance the rail has already pushed to.
+            # That subsumes the self-heal above rather than removing it -- a
+            # desynced or fresh tray fails the check and recomposes. The
+            # screen-side skip here is kept as-is: it is a cheaper, earlier
+            # exit on exactly the tick it was written for, and the two agree.
+            # It IS safe on the ~5x/second run tick: the
             # workspace state is unchanged and recomposing the browser that
             # often tore it visibly down mid-run (the list vanished / showed
             # a half-composed frame and displaced clicks).

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -484,6 +484,16 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
     _composed_row_signature: tuple[tuple[str, str], ...] | None = None
     #: Live collector for the compose pass currently running, or None.
     _composing_row_signature: list[tuple[str, str]] | None = None
+    #: Ordered ids of the FIXED (non-row) controls the last completed
+    #: `compose()` built. The Sessions and Workspaces projections build no
+    #: rows at all, so the row signature above is empty for them and proves
+    #: nothing -- this is what carries their DOM evidence (task-15454 review
+    #: round 1). Populated through `_record_composed_node`; the pin in
+    #: `Tests/UI/test_console_workspace_tray_recompose_guard.py` reds if a
+    #: control is ever added to those two projections without recording it.
+    _composed_fixed_signature: tuple[str, ...] | None = None
+    #: Live collector for the compose pass currently running, or None.
+    _composing_fixed_signature: list[str] | None = None
 
     class Relabeled(Message):
         """Posted after a width-driven relabel recompose.
@@ -596,7 +606,7 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         there left the grouped-browser rows unbuilt and the click targets
         with them.
 
-        So all five of these must hold before a recompose is skipped:
+        So all six of these must hold before a recompose is skipped:
 
         1. The rail has pushed at least one state into THIS instance
            (``_console_workspace_context_synced``, set by
@@ -609,13 +619,29 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         3. No recompose is already latched (``_recompose_required``): the
            DOM is about to change, so it is not evidence of anything.
         4. The tray is mounted and has children at all.
-        5. The state is value-equal AND the rows currently in the DOM match,
-           in order, the rows ``compose`` recorded building. Row id + row key
-           is exactly the identity Console click routing dispatches on
-           (`on_button_pressed` matches the id prefix, then reads `row_key`/
-           `conversation_id` off the button), so a signature match means
-           every click target is present, in place, and pointing at the same
-           conversation it did before.
+        5. The state is value-equal.
+        6. The DOM still matches what ``compose`` recorded building, on BOTH
+           halves:
+           - the grouped-browser rows, in order, by (row id, row key). That
+             pair is exactly the identity Console click routing dispatches on
+             (`on_button_pressed` matches the id prefix, then reads `row_key`/
+             `conversation_id` off the button), so a match means every dynamic
+             click target is present, in place, and pointing at the same
+             conversation it did before;
+           - the FIXED controls, in order, by id. Without this half the
+             evidence would be vacuous for the Sessions and Workspaces
+             projections, which build no rows: their row signature is empty
+             and would trivially match anything, degenerating the guard back
+             toward the reverted full-equality shape (task-15454 review round
+             1). Now the Workspaces projection proves its Switch / New / RAG
+             Scope buttons and their rows are still mounted, and the Sessions
+             projection proves its status pair and summary line are.
+
+        Nodes mounted into the tray from OUTSIDE ``compose`` are ignored
+        rather than treated as drift: the screen mounts the transitional
+        ``#console-new-workspace-conversation`` alias directly into the
+        Conversations tray, and requiring exact DOM equality would make that
+        tray permanently unskippable.
 
         Args:
             state: The incoming display state.
@@ -625,8 +651,9 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         """
         if not getattr(self, "_console_workspace_context_synced", False):
             return False
-        composed = self._composed_row_signature
-        if composed is None:
+        composed_rows = self._composed_row_signature
+        composed_fixed = self._composed_fixed_signature
+        if composed_rows is None or composed_fixed is None:
             return False
         if getattr(self, "_recompose_required", False):
             return False
@@ -634,22 +661,58 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
             return False
         if state != self.state:
             return False
-        return self._mounted_row_signature() == composed
+        mounted_rows, mounted_fixed = self._mounted_signatures(composed_fixed)
+        return mounted_rows == composed_rows and mounted_fixed == composed_fixed
 
-    def _mounted_row_signature(self) -> tuple[tuple[str, str], ...]:
-        """Return the (row id, row key) pairs actually mounted, in DOM order.
+    def _mounted_signatures(
+        self,
+        expected_fixed_ids: tuple[str, ...],
+    ) -> tuple[tuple[tuple[str, str], ...], tuple[str, ...]]:
+        """Read both DOM signatures out of the live tree in one walk.
 
         Read from the live DOM rather than from state, so it can contradict
         what the tray believes -- which is the whole point (see
         ``_can_skip_recompose``).
 
+        Args:
+            expected_fixed_ids: The fixed-control ids ``compose`` recorded.
+                Only these are collected, so an out-of-band mount elsewhere
+                in the tray never registers as drift.
+
         Returns:
-            One pair per mounted grouped-browser row button.
+            ``(row signature, fixed-id signature)``, each in DOM order.
         """
-        return tuple(
-            (str(row.id or ""), str(getattr(row, "row_key", "") or ""))
-            for row in self.query(".console-workspace-conversation-row")
-        )
+        wanted = set(expected_fixed_ids)
+        rows: list[tuple[str, str]] = []
+        fixed: list[str] = []
+        for node in self.query("*"):
+            node_id = str(getattr(node, "id", "") or "")
+            if node.has_class("console-workspace-conversation-row"):
+                rows.append((node_id, str(getattr(node, "row_key", "") or "")))
+            elif node_id in wanted:
+                fixed.append(node_id)
+        return tuple(rows), tuple(fixed)
+
+    def _record_composed_node(self, widget: Any) -> Any:
+        """Record one fixed (non-row) control built by the running compose pass.
+
+        Returns ``widget`` so a call site stays a single expression
+        (``yield self._record_composed_node(Button(...))``). A no-op outside
+        a compose pass, and for a widget with no id.
+
+        Args:
+            widget: The freshly built control.
+
+        Returns:
+            ``widget``, unchanged.
+        """
+        collector = self._composing_fixed_signature
+        if collector is None:
+            return widget
+        widget_id = str(getattr(widget, "id", "") or "")
+        if widget_id:
+            collector.append(widget_id)
+        return widget
 
     def _nearest_scroll_parent(self) -> Any | None:
         """Return the nearest ancestor that owns vertical scrolling.
@@ -1062,14 +1125,19 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         # a pass abandoned part-way (Textual closing the generator) leaves it
         # None, which forbids skipping.
         collected: list[tuple[str, str]] = []
+        collected_fixed: list[str] = []
         self._composing_row_signature = collected
+        self._composing_fixed_signature = collected_fixed
         self._composed_row_signature = None
+        self._composed_fixed_signature = None
         try:
             if self.show_heading:
-                yield self._static(
-                    self.state.heading,
-                    id="console-workspace-context-title",
-                    classes="destination-section",
+                yield self._record_composed_node(
+                    self._static(
+                        self.state.heading,
+                        id="console-workspace-context-title",
+                        classes="destination-section",
+                    )
                 )
 
             if self.content in {"all", "workspace"}:
@@ -1089,23 +1157,41 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
                 )
         finally:
             self._composing_row_signature = None
+            self._composing_fixed_signature = None
         self._composed_row_signature = tuple(collected)
+        self._composed_fixed_signature = tuple(collected_fixed)
 
     def _compose_workspace_context(self) -> ComposeResult:
-        """Render active workspace identity and workspace-scoped actions."""
+        """Render active workspace identity and workspace-scoped actions.
+
+        TASK-15454 review round 1: every id-carrying control built here goes
+        through ``_record_composed_node``, because this projection
+        (``#console-workspaces-context``) builds no grouped-browser rows and
+        would otherwise contribute NO DOM evidence to ``_can_skip_recompose``.
+        Anything added here must be recorded too -- pinned by
+        ``test_the_fixed_projections_record_every_control_they_build``, which
+        reds on an unrecorded control rather than letting the guard quietly
+        lose its evidence. (``ConsoleWorkspaceStatusPair`` composes its own
+        label/value Statics; that subtree is its business, not this
+        signature's.)
+        """
 
         workspace_value = self.state.workspace_name or self._workspace_selector_label()
-        yield ConsoleWorkspaceStatusPair(
-            "Workspace",
-            workspace_value,
-            label_id="console-active-workspace-label",
-            value_id="console-active-workspace-value",
-            id="console-active-workspace",
+        yield self._record_composed_node(
+            ConsoleWorkspaceStatusPair(
+                "Workspace",
+                workspace_value,
+                label_id="console-active-workspace-label",
+                value_id="console-active-workspace-value",
+                id="console-active-workspace",
+            )
         )
 
-        with Horizontal(
-            id="console-workspace-action-row",
-            classes="console-workspace-action-row",
+        with self._record_composed_node(
+            Horizontal(
+                id="console-workspace-action-row",
+                classes="console-workspace-action-row",
+            )
         ):
             switch_button = Button(
                 "Switch",
@@ -1127,13 +1213,15 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
                 and self.state.change_workspace_recovery
             ):
                 switch_button.tooltip = self.state.change_workspace_recovery
-            yield switch_button
-            yield Button(
-                "New",
-                id="console-new-workspace",
-                classes="console-workspace-action",
-                compact=True,
-                disabled=not self.state.new_workspace_enabled,
+            yield self._record_composed_node(switch_button)
+            yield self._record_composed_node(
+                Button(
+                    "New",
+                    id="console-new-workspace",
+                    classes="console-workspace-action",
+                    compact=True,
+                    disabled=not self.state.new_workspace_enabled,
+                )
             )
 
         # task-13: workspace-level RAG retrieval scope entry point.
@@ -1153,9 +1241,11 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         # button's clickable region extended past the rail body -- real
         # clicks (and `pilot.click`) landed on the rail backdrop instead
         # of the button.
-        with Horizontal(
-            id="console-workspace-rag-scope-row",
-            classes="console-workspace-action-row",
+        with self._record_composed_node(
+            Horizontal(
+                id="console-workspace-rag-scope-row",
+                classes="console-workspace-action-row",
+            )
         ):
             scope_button = Button(
                 "RAG Scope",
@@ -1165,23 +1255,27 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
                 disabled=not self.state.rag_scope_enabled,
             )
             scope_button.tooltip = "Narrow RAG retrieval to items in this workspace"
-            yield scope_button
+            yield self._record_composed_node(scope_button)
 
         if (
             not self.state.change_workspace_enabled
             and self.state.change_workspace_recovery
         ):
-            yield self._static(
-                self.state.change_workspace_recovery,
-                id="console-change-workspace-recovery",
-                classes="console-workspace-recovery",
+            yield self._record_composed_node(
+                self._static(
+                    self.state.change_workspace_recovery,
+                    id="console-change-workspace-recovery",
+                    classes="console-workspace-recovery",
+                )
             )
 
         if self.state.recovery_copy:
-            yield self._static(
-                self.state.recovery_copy,
-                id="console-workspace-recovery",
-                classes="console-workspace-recovery",
+            yield self._record_composed_node(
+                self._static(
+                    self.state.recovery_copy,
+                    id="console-workspace-recovery",
+                    classes="console-workspace-recovery",
+                )
             )
 
     def _compose_session_context(
@@ -1189,7 +1283,14 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         *,
         show_selected_summary: bool,
     ) -> ComposeResult:
-        """Render the active session identity without workspace controls."""
+        """Render the active session identity without workspace controls.
+
+        TASK-15454 review round 1: like ``_compose_workspace_context``, this
+        projection (``#console-session-context``) builds no grouped-browser
+        rows, so every id-carrying control it builds is recorded through
+        ``_record_composed_node`` to give ``_can_skip_recompose`` real DOM
+        evidence. See that method's docstring for the pin that enforces it.
+        """
 
         # RAG-45: this pair renders the active CONVERSATION's identity, not a
         # RAG retrieval scope. The raw durable id remains available on hover.
@@ -1203,20 +1304,22 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         )
         if self.state.scope_detail:
             scope_pair.tooltip = f"Conversation id: {self.state.scope_detail}"
-        yield scope_pair
+        yield self._record_composed_node(scope_pair)
 
         if show_selected_summary:
             browser = self.state.conversation_browser
             selected_summary = (
                 browser.selected_summary if browser is not None else ""
             )
-            yield self._static(
-                selected_summary or "No active session.",
-                id="console-workspace-selected-conversation",
-                classes=(
-                    "console-workspace-selected-conversation "
-                    "console-session-selected-conversation"
-                ),
+            yield self._record_composed_node(
+                self._static(
+                    selected_summary or "No active session.",
+                    id="console-workspace-selected-conversation",
+                    classes=(
+                        "console-workspace-selected-conversation "
+                        "console-session-selected-conversation"
+                    ),
+                )
             )
 
     def _compose_conversation_browser(

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -37,9 +37,11 @@ from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 class ConsoleBrowserSearchInput(Input):
     """Search input whose initial value never echoes as a user edit.
 
-    TASK-1900. `ConsoleWorkspaceContextTray.sync_state` recomposes
-    unconditionally (see its own docstring for why an equality guard is
-    unsafe), so every sync re-mounts a fresh search input. Textual's
+    TASK-1900. `ConsoleWorkspaceContextTray.sync_state` re-mounts a fresh
+    search input on every sync that actually changes anything -- which, while
+    the user is typing, is every one of them (TASK-15454 narrowed the tray's
+    recompose to changed states, so a no-op sync no longer replaces this
+    widget; a real search still does). Textual's
     `Input._watch_value` posts `Changed` for a constructor-set value
     unconditionally -- its `_initial_value` flag only positions the cursor --
     and that echo travels the message pump, so on a busy machine it lands
@@ -474,6 +476,15 @@ class ConsoleWorkspaceStatusPair(Horizontal):
 class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
     """Render workspace selection, conversation scope, and recovery copy."""
 
+    #: (row id, row key) pairs for the grouped-browser rows the last COMPLETED
+    #: `compose()` built, or None when `compose` has not finished for this
+    #: instance (never started, or abandoned part-way). Only
+    #: `_can_skip_recompose` reads it; None means "no proof, recompose".
+    #: Class attribute so an instance that never composed still answers None.
+    _composed_row_signature: tuple[tuple[str, str], ...] | None = None
+    #: Live collector for the compose pass currently running, or None.
+    _composing_row_signature: list[tuple[str, str]] | None = None
+
     class Relabeled(Message):
         """Posted after a width-driven relabel recompose.
 
@@ -551,12 +562,19 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         # + resume flows) -- skipping `refresh(recompose=True)` also skips
         # rebuilding the row children, and this widget's own scroll/fit-pass
         # (`_schedule_recomposed_content_fit`) alone does not settle correct
-        # on-screen regions for the (unrebuilt) existing children. Tried
-        # narrowing the guard to skip only the recompose while still always
-        # scheduling the fit-pass -- still broke the same two tests -- so
-        # this keeps the original unconditional recompose. The screen-side
-        # skip in `_sync_console_workspace_context` (the `call_after_refresh`
-        # legacy-alias kick) still applies and is safe/tested.
+        # on-screen regions for the (unrebuilt) existing children.
+        #
+        # TASK-15454 re-guards this, NARROWLY. The lesson from the revert is
+        # that state equality alone is not evidence the DOM shows that
+        # state: the tray can hold state X while its children say something
+        # else, and the unconditional recompose was what healed that. So
+        # `_can_skip_recompose` skips only when the mounted DOM is *proved*
+        # to be the DOM this state produced -- see its docstring. Every case
+        # the revert was about (fresh instance, unsettled/emptied children,
+        # a recompose already latched) fails that proof and recomposes
+        # exactly as before.
+        if self._can_skip_recompose(state):
+            return
         self.state = state
         self.styles.min_height = 0
         scroll_parent = self._nearest_scroll_parent()
@@ -565,6 +583,73 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         self.refresh(recompose=True)
         if self.is_mounted:
             self._schedule_recomposed_content_fit(restore_scroll_y=restore_scroll_y)
+
+    def _can_skip_recompose(self, state: ConsoleWorkspaceContextState) -> bool:
+        """Return True only when the mounted DOM already IS ``state``'s DOM.
+
+        TASK-15454. This is deliberately not the value-equality guard the
+        siblings use. The reverted TASK-251 guard failed because
+        ``state == self.state`` answers "does the tray remember this state",
+        not "is the tray *showing* it" -- and those two came apart (a fresh
+        tray from a full-screen recompose, or one whose rows were superseded
+        before they settled, remembers rows it is not displaying). Skipping
+        there left the grouped-browser rows unbuilt and the click targets
+        with them.
+
+        So all five of these must hold before a recompose is skipped:
+
+        1. The rail has pushed at least one state into THIS instance
+           (``_console_workspace_context_synced``, set by
+           ``ConsoleLeftRail.sync_workspace_context`` after each push, and
+           dying with the widget). This is the same per-instance marker the
+           screen-side skip already uses, and it is what preserves the
+           TASK-344/349 one-time healing push for a fresh instance.
+        2. ``compose`` has run to completion for this instance, so there is
+           a recorded signature of the rows it built.
+        3. No recompose is already latched (``_recompose_required``): the
+           DOM is about to change, so it is not evidence of anything.
+        4. The tray is mounted and has children at all.
+        5. The state is value-equal AND the rows currently in the DOM match,
+           in order, the rows ``compose`` recorded building. Row id + row key
+           is exactly the identity Console click routing dispatches on
+           (`on_button_pressed` matches the id prefix, then reads `row_key`/
+           `conversation_id` off the button), so a signature match means
+           every click target is present, in place, and pointing at the same
+           conversation it did before.
+
+        Args:
+            state: The incoming display state.
+
+        Returns:
+            True when recomposing would rebuild an identical DOM.
+        """
+        if not getattr(self, "_console_workspace_context_synced", False):
+            return False
+        composed = self._composed_row_signature
+        if composed is None:
+            return False
+        if getattr(self, "_recompose_required", False):
+            return False
+        if not self.is_mounted or not self.children:
+            return False
+        if state != self.state:
+            return False
+        return self._mounted_row_signature() == composed
+
+    def _mounted_row_signature(self) -> tuple[tuple[str, str], ...]:
+        """Return the (row id, row key) pairs actually mounted, in DOM order.
+
+        Read from the live DOM rather than from state, so it can contradict
+        what the tray believes -- which is the whole point (see
+        ``_can_skip_recompose``).
+
+        Returns:
+            One pair per mounted grouped-browser row button.
+        """
+        return tuple(
+            (str(row.id or ""), str(getattr(row, "row_key", "") or ""))
+            for row in self.query(".console-workspace-conversation-row")
+        )
 
     def _nearest_scroll_parent(self) -> Any | None:
         """Return the nearest ancestor that owns vertical scrolling.
@@ -970,28 +1055,41 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         return max(_CONVERSATION_BROWSER_EMPTY_COPY_HEIGHT, height)
 
     def compose(self) -> ComposeResult:
-        if self.show_heading:
-            yield self._static(
-                self.state.heading,
-                id="console-workspace-context-title",
-                classes="destination-section",
-            )
+        # TASK-15454: record the row signature of THIS pass so
+        # `_can_skip_recompose` can later check the mounted DOM against what
+        # was actually built, not against what `self.state` claims. The
+        # signature is published only after the generator runs to the end --
+        # a pass abandoned part-way (Textual closing the generator) leaves it
+        # None, which forbids skipping.
+        collected: list[tuple[str, str]] = []
+        self._composing_row_signature = collected
+        self._composed_row_signature = None
+        try:
+            if self.show_heading:
+                yield self._static(
+                    self.state.heading,
+                    id="console-workspace-context-title",
+                    classes="destination-section",
+                )
 
-        if self.content in {"all", "workspace"}:
-            yield from self._compose_workspace_context()
+            if self.content in {"all", "workspace"}:
+                yield from self._compose_workspace_context()
 
-        if self.content in {"all", "session"}:
-            yield from self._compose_session_context(
-                show_selected_summary=self.content == "session"
-            )
+            if self.content in {"all", "session"}:
+                yield from self._compose_session_context(
+                    show_selected_summary=self.content == "session"
+                )
 
-        browser = self.state.conversation_browser
-        if self.content in {"all", "conversations"} and browser is not None:
-            yield from self._compose_conversation_browser(
-                browser,
-                show_heading=self.content == "all",
-                show_selected_summary=self.content == "all",
-            )
+            browser = self.state.conversation_browser
+            if self.content in {"all", "conversations"} and browser is not None:
+                yield from self._compose_conversation_browser(
+                    browser,
+                    show_heading=self.content == "all",
+                    show_selected_summary=self.content == "all",
+                )
+        finally:
+            self._composing_row_signature = None
+        self._composed_row_signature = tuple(collected)
 
     def _compose_workspace_context(self) -> ComposeResult:
         """Render active workspace identity and workspace-scoped actions."""
@@ -1434,6 +1532,12 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
                 name_line_count=len(name_lines),
             )
             row_button.row_key = row.row_key
+            # TASK-15454: this pair is the row's click identity; `compose`
+            # publishes the collected sequence once it finishes.
+            if self._composing_row_signature is not None:
+                self._composing_row_signature.append(
+                    (str(row_button.id or ""), str(row.row_key or ""))
+                )
             row_button.native_session_id = row.native_session_id
             row_button.scope_type = row.scope_type
             row_button.workspace_id = row.workspace_id


### PR DESCRIPTION
## Summary

Task 15454 from the input-latency audit + the folded-in composer-lookup follow-up from task-15452's review.

- Rail conversation search: 6-10 sync SQLite queries + a 3-tray recompose ran per keystroke BEFORE the 0.2s debounce — all moved inside it; the keystroke path is now attribute writes + one pure in-memory filter (handler 0.558 → 0.009 ms)
- Workspace tray re-guarded with DOM-evidence (ordered live row ids + recorded fixed-control ids), not state equality — the July full-equality guard's click-targeting regression class is structurally covered, including a heal test for pruned controls and a discriminating pin that reds if a future dynamic control bypasses the recorder; notable: the original July regression NO LONGER REPRODUCES on today's dev (dissolved upstream) — the guard keeps the diagnosis anyway, lesson recorded
- `_console_composer_or_none` memoized with per-access revalidation (1182.6 → 0.40 µs, was 61% of the residual keystroke cost); stale-ref impossible (parent-chain revalidation fails closed)
- Deliberate, documented behavior change: backspace-to-empty is debounced like any edit (~200 ms); Clear button still instant; click fallback verified safe

## Verification
Independent review (Approved; both-direction mutation tests on the guard; submit-vs-debounce race verified nonexistent; pre-existing failures reproduced at BASE in a throwaway worktree) + scoped re-review of the fix round (both findings fully addressed; recorder exception-safety verified line-for-line against the row collector). 4 pre-existing rail-suite failures surfaced and being filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves all Console rail conversation search DB work behind the 200 ms debounce and adds a DOM‑evidence guard to the workspace tray, eliminating per‑keystroke queries/recomposes and keeping click targets correct. Also memoizes the native composer lookup and documents the debounce in the user guide. (TASK‑15454)

- **Refactors**
  - Rail search: the `Input.Changed` handler now only mirrors state and applies an in‑memory filter; `_start_console_conversation_browser_search` runs TTL invalidation, row derivation, `_sync_console_workspace_context`, and `run_worker` with token recheck; backspacing to empty is debounced; “Clear” stays instant.
  - Tray guard: `ConsoleWorkspaceContextTray.sync_state` skips only when state is equal and the mounted DOM matches the last `compose` (ordered row id/row key and fixed control ids); fresh/desynced trays still recompose; out‑of‑band mounts are ignored; fixed‑projection controls are recorded via `_record_composed_node`.
  - Composer: `_console_composer_or_none` is memoized with per‑access validation to avoid stale refs and repeated full‑DOM walks.

- **Bug Fixes**
  - Prevents superseded searches from running by re‑checking token/query in the debounced callback.
  - Restores and protects click targeting in the tray by rebuilding when DOM and state diverge; adds focused tests for historical regression cases.

<sup>Written for commit f98ca299e9ce5793e7c00592abfc87cc9d2b481d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

