### PR TITLE
perf: run the notes import loop off the event loop (task-15468)

### DIFF
--- a/Tests/Event_Handlers/test_note_ingest_import_offload.py
+++ b/Tests/Event_Handlers/test_note_ingest_import_offload.py
@@ -1,0 +1,312 @@
+# Tests/Event_Handlers/test_note_ingest_import_offload.py
+"""TASK-15468 evidence: the "Import Selected Notes Now" loop must run off
+the event loop.
+
+Before this task, `import_worker_notes()` (the per-file parse / per-note
+`notes_service.add_note` / template JSON I/O loop inside
+`handle_ingest_notes_import_now_button_pressed`) was declared `async def`
+but contained no internal `await`, so calling it with a bare `await` ran
+the *entire* O(files x notes) loop inline, in one uninterruptible step, on
+the main event loop -- freezing all UI input for the duration of a large
+import (see Docs/Design/2026-08-11-input-latency-audit.md). The fix wraps
+the now-plain-sync `import_worker_notes` in `asyncio.to_thread(...)`.
+
+This file adds three tests on top of (not replacing) the pre-existing
+`test_note_ingest_events.py` suite, which is left green and unmodified:
+
+1. An "evidence-seam" test: the per-file parse and per-note `add_note`
+   calls must happen on a different thread than the one that invoked the
+   button handler.
+2. A mechanism A/B test: a concurrent `await asyncio.sleep(0)` loop must
+   get many scheduling turns while a (Mock-timed) large import runs, and
+   almost none if the dispatch is reverted to the pre-fix on-loop shape.
+3. An honest before/after probe against a *real* `CharactersRAGDB` /
+   `NotesInteropService` and a few hundred real generated notes, reporting
+   genuine wall-clock and event-loop-tick numbers for both shapes. This
+   runs under pytest (not a bare script) specifically so it inherits the
+   repo's config/data isolation from `Tests/conftest.py` -- see
+   `backlog/docs/lessons-live-verification.md`, "Importing the test
+   harness outside pytest is NOT config-isolated", for why a standalone
+   script poking real `tldw_chatbook` DB/config code is unsafe here.
+"""
+
+import asyncio
+import json
+import threading
+import time
+from pathlib import Path
+from typing import List, Tuple
+from unittest.mock import Mock
+
+import pytest
+from textual.css.query import QueryError
+from textual.widgets import Button, Collapsible, RadioButton, TextArea
+
+from tldw_chatbook.Event_Handlers import note_ingest_events
+from tldw_chatbook.Event_Handlers.note_ingest_events import (
+    handle_ingest_notes_import_now_button_pressed,
+)
+
+
+def _write_note_files(tmp_path: Path, note_count: int, files: int) -> List[Path]:
+    """Write `note_count` notes spread round-robin across `files` JSON files.
+
+    Each file is a JSON array of note objects -- `JSONImporter.parse_file`
+    (tldw_chatbook/Utils/note_importers.py) turns each array entry into its
+    own note, so this exercises both the per-file parse loop and the
+    per-note `add_note` loop the audit flagged.
+    """
+    buckets: List[List[dict]] = [[] for _ in range(files)]
+    for i in range(note_count):
+        buckets[i % files].append(
+            {"title": f"Note {i}", "content": f"Body for generated note {i}. " * 5}
+        )
+    paths = []
+    for idx, bucket in enumerate(buckets):
+        path = tmp_path / f"notes_{idx}.json"
+        path.write_text(json.dumps(bucket), encoding="utf-8")
+        paths.append(path)
+    return paths
+
+
+def _make_mock_app(note_files: List[Path]) -> Mock:
+    app = Mock()
+    app.selected_note_files_for_import = list(note_files)
+    app.notes_user_id = "user-1"
+    app.notes_service = Mock()
+    app.notes_service.add_note = Mock(return_value="note-id-1")
+    app.notify = Mock()
+    app.call_later = Mock()
+    app.screen = Mock()
+
+    widgets = {
+        "#import-as-templates-radio": Mock(spec=RadioButton, value=False),
+        "#ingest-notes-import-status-area": Mock(spec=TextArea, text=""),
+        "#chat-notes-collapsible": Mock(spec=Collapsible),
+    }
+
+    def query_one_side_effect(selector, widget_type=None):
+        try:
+            return widgets[selector]
+        except KeyError:
+            raise QueryError(f"{selector} not found")
+
+    app.query_one = Mock(side_effect=query_one_side_effect)
+
+    captured_worker = {}
+
+    def run_worker_side_effect(worker_callable, **kwargs):
+        captured_worker["callable"] = worker_callable
+        return Mock()
+
+    app.run_worker = Mock(side_effect=run_worker_side_effect)
+    app._captured_worker = captured_worker
+    return app
+
+
+async def _dispatch_and_get_worker(app: Mock):
+    await handle_ingest_notes_import_now_button_pressed(
+        app, Button.Pressed(Mock(spec=Button))
+    )
+    return app._captured_worker["callable"]
+
+
+# --- 1. Evidence-seam: parse + add_note run off the main/event-loop thread ---
+
+
+@pytest.mark.asyncio
+async def test_import_worker_runs_parse_and_add_note_off_the_main_thread(
+    tmp_path, monkeypatch
+):
+    note_files = _write_note_files(tmp_path, note_count=6, files=2)
+    app = _make_mock_app(note_files)
+
+    main_thread_ident = threading.get_ident()
+    add_note_threads: List[int] = []
+    parse_threads: List[int] = []
+
+    def add_note_side_effect(**kwargs):
+        add_note_threads.append(threading.get_ident())
+        return "note-id"
+
+    app.notes_service.add_note = Mock(side_effect=add_note_side_effect)
+
+    original_parse = note_ingest_events._parse_single_note_file_for_preview
+
+    def spy_parse(*args, **kwargs):
+        parse_threads.append(threading.get_ident())
+        return original_parse(*args, **kwargs)
+
+    monkeypatch.setattr(
+        note_ingest_events, "_parse_single_note_file_for_preview", spy_parse
+    )
+
+    worker_callable = await _dispatch_and_get_worker(app)
+    await worker_callable()
+
+    assert add_note_threads, "add_note was never called"
+    assert parse_threads, "the per-file parse was never called"
+    assert main_thread_ident not in add_note_threads, (
+        f"add_note ran on the event-loop thread ({main_thread_ident}) -- "
+        "the import loop is still blocking the UI (task-15468 regression)"
+    )
+    assert main_thread_ident not in parse_threads, (
+        f"note parsing ran on the event-loop thread ({main_thread_ident}) -- "
+        "the import loop is still blocking the UI (task-15468 regression)"
+    )
+    # The whole batch is handed to the executor in ONE `asyncio.to_thread`
+    # call (not one hop per note), so every call lands on the same thread.
+    assert len(set(add_note_threads) | set(parse_threads)) == 1
+
+
+# --- 2. Mechanism A/B: the event loop keeps ticking while the import runs ---
+
+
+@pytest.mark.asyncio
+async def test_import_worker_keeps_event_loop_responsive_during_large_import(
+    tmp_path, monkeypatch
+):
+    """TASK-15468 AC1. A/B against the SAME production dispatch function
+    (`_run_note_import_worker_and_dispatch`, captured via the `run_worker`
+    call), with only the thread-dispatch primitive swapped for an inline
+    stand-in that reproduces the pre-fix on-loop shape for the "before" arm.
+    """
+    note_count = 40
+    per_note_cost = 0.004  # seconds; stands in for a real synchronous DB commit
+    note_files = _write_note_files(tmp_path, note_count=note_count, files=4)
+
+    def make_app() -> Mock:
+        app = _make_mock_app(note_files)
+
+        def slow_add_note(**kwargs):
+            time.sleep(per_note_cost)
+            return "note-id"
+
+        app.notes_service.add_note = Mock(side_effect=slow_add_note)
+        return app
+
+    async def run_and_count_ticks(app: Mock) -> int:
+        worker_callable = await _dispatch_and_get_worker(app)
+        import_task = asyncio.ensure_future(worker_callable())
+        ticks = 0
+        while not import_task.done():
+            await asyncio.sleep(0)
+            ticks += 1
+        await import_task  # propagate any exception; avoid "never retrieved"
+        return ticks
+
+    # "after" -- real production path (asyncio.to_thread offload).
+    after_ticks = await run_and_count_ticks(make_app())
+    assert after_ticks >= 20, (
+        f"expected the event loop to get many scheduling turns while a "
+        f"{note_count}-note import ran off-thread; only got {after_ticks} -- "
+        "asyncio.to_thread offload does not appear to be working"
+    )
+
+    # "before" -- same production code, `asyncio.to_thread` swapped for an
+    # inline stand-in that reproduces the pre-TASK-15468 on-loop shape.
+    async def _inline_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(note_ingest_events.asyncio, "to_thread", _inline_to_thread)
+    before_ticks = await run_and_count_ticks(make_app())
+    assert before_ticks <= 2, (
+        f"expected the pre-fix (on-loop) shape to starve the event loop of "
+        f"scheduling turns for the whole import; got {before_ticks} ticks -- "
+        "the A/B baseline is not reproducing the original bug"
+    )
+
+    assert after_ticks > before_ticks * 10
+
+
+# --- 3. Honest before/after probe: a real DB, a few hundred real notes ---
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_note_import_probe_hundreds_of_real_notes_before_after(
+    tmp_path, monkeypatch
+):
+    """TASK-15468 AC1/AC3 honest probe -- real `CharactersRAGDB` /
+    `NotesInteropService`, no artificial per-note delay. Reports genuine
+    wall-clock and event-loop-tick numbers for both dispatch shapes; run
+    with `-s` to see the printed line.
+    """
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+    from tldw_chatbook.Notes.Notes_Library import NotesInteropService
+
+    note_count = 300
+    file_count = 30
+    note_files = _write_note_files(tmp_path, note_count=note_count, files=file_count)
+
+    db_path = tmp_path / "chachanotes_probe.db"
+    real_db = CharactersRAGDB(db_path, "probe_client")
+    notes_service = NotesInteropService(
+        base_db_directory=tmp_path,
+        api_client_id="probe_client",
+        global_db_to_use=real_db,
+    )
+
+    def make_app() -> Mock:
+        app = _make_mock_app(note_files)
+        app.notes_service = notes_service
+        app.notes_user_id = "probe-user"
+        return app
+
+    async def run_and_measure(app: Mock) -> Tuple[float, int]:
+        worker_callable = await _dispatch_and_get_worker(app)
+        start = time.monotonic()
+        import_task = asyncio.ensure_future(worker_callable())
+        ticks = 0
+        while not import_task.done():
+            await asyncio.sleep(0)
+            ticks += 1
+        results = await import_task
+        elapsed = time.monotonic() - start
+        successes = sum(1 for r in results if r.get("status") == "success")
+        assert successes == note_count, (
+            f"expected all {note_count} generated notes to import "
+            f"successfully, got {successes}"
+        )
+        return elapsed, ticks
+
+    # "after" -- real production path (asyncio.to_thread offload).
+    after_elapsed, after_ticks = await run_and_measure(make_app())
+
+    # "before" -- same production code, `asyncio.to_thread` swapped for an
+    # inline stand-in that reproduces the pre-TASK-15468 on-loop shape.
+    async def _inline_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(note_ingest_events.asyncio, "to_thread", _inline_to_thread)
+    before_elapsed, before_ticks = await run_and_measure(make_app())
+
+    print(
+        f"\n[TASK-15468 probe] {note_count} real notes / {file_count} files, "
+        f"real ChaChaNotes DB (WAL, synchronous=NORMAL):\n"
+        f"  before (on-loop):  wall={before_elapsed * 1000:.1f}ms  "
+        f"loop_ticks_during_import={before_ticks}\n"
+        f"  after  (threaded): wall={after_elapsed * 1000:.1f}ms  "
+        f"loop_ticks_during_import={after_ticks}\n"
+    )
+
+    # AC1: the event loop must get meaningfully more scheduling turns once
+    # the import is off-thread, proving real input would be processed
+    # during a real several-hundred-note import.
+    assert before_ticks <= 2, (
+        f"before-arm baseline did not reproduce a blocked loop: "
+        f"{before_ticks} ticks (expected <= 2)"
+    )
+    assert after_ticks > before_ticks, (
+        f"threaded import did not free the event loop more than the "
+        f"on-loop shape: before={before_ticks} ticks, after={after_ticks} ticks"
+    )
+
+    # AC3: wall time must not be materially regressed by the thread hop --
+    # a single whole-batch `asyncio.to_thread` dispatch adds microseconds of
+    # overhead; this is a generous ceiling against a gross regression, not a
+    # tight benchmark assertion.
+    assert after_elapsed < max(before_elapsed * 3, before_elapsed + 0.25), (
+        f"import wall time regressed materially: before={before_elapsed:.3f}s, "
+        f"after={after_elapsed:.3f}s"
+    )

--- a/Tests/Event_Handlers/test_note_ingest_import_offload.py
+++ b/Tests/Event_Handlers/test_note_ingest_import_offload.py
@@ -11,7 +11,7 @@ the main event loop -- freezing all UI input for the duration of a large
 import (see Docs/Design/2026-08-11-input-latency-audit.md). The fix wraps
 the now-plain-sync `import_worker_notes` in `asyncio.to_thread(...)`.
 
-This file adds three tests on top of (not replacing) the pre-existing
+This file adds five tests on top of (not replacing) the pre-existing
 `test_note_ingest_events.py` suite, which is left green and unmodified:
 
 1. An "evidence-seam" test: the per-file parse and per-note `add_note`
@@ -28,6 +28,23 @@ This file adds three tests on top of (not replacing) the pre-existing
    `backlog/docs/lessons-live-verification.md`, "Importing the test
    harness outside pytest is NOT config-isolated", for why a standalone
    script poking real `tldw_chatbook` DB/config code is unsafe here.
+
+Fix-round-1 (review, 2026-08-11) -- two side effects of AC1 itself (moving
+the loop off the event loop makes the app responsive DURING an import,
+which makes both of the below newly reachable in a way they weren't when
+the whole app was frozen for the duration):
+
+4. SHARED-LIST RACE: `app.selected_note_files_for_import` is a plain list
+   the main thread can mutate mid-import (e.g. "Clear Selection"). The
+   loop now iterates a snapshot taken before dispatch; this test mutates
+   the live list from the loop side mid-import and asserts the import
+   still completes over the original selection.
+5. QUIT-DURING-IMPORT: cancelling the wrapping coroutine used to leave the
+   background thread running the whole batch unattended (a `threading`
+   worker cannot be forcibly interrupted). A cooperative `cancel_event`,
+   checked between notes/files, now stops it at the next boundary; this
+   test cancels mid-import and asserts the loop stops early with no false
+   "N imported" success accounting.
 """
 
 import asyncio
@@ -309,4 +326,147 @@ async def test_note_import_probe_hundreds_of_real_notes_before_after(
     assert after_elapsed < max(before_elapsed * 3, before_elapsed + 0.25), (
         f"import wall time regressed materially: before={before_elapsed:.3f}s, "
         f"after={after_elapsed:.3f}s"
+    )
+
+
+# --- 4. Fix-round-1: shared-list race (review finding, 2026-08-11) ---
+
+
+@pytest.mark.asyncio
+async def test_import_worker_completes_over_snapshot_when_list_mutated_mid_import(
+    tmp_path,
+):
+    """TASK-15468 fix-round-1: `app.selected_note_files_for_import` is a
+    plain list the main thread can mutate while the import runs on its
+    worker thread -- "Clear Selection" is a plausible mid-import click. If
+    the loop iterated the live list, a mid-import `.clear()` would silently
+    truncate it (incomplete import, no error). It must instead iterate a
+    snapshot taken before dispatch, so a later mutation of the live list
+    cannot affect an in-flight import.
+
+    Mutates the list from inside `add_note`'s side effect -- i.e. from the
+    loop side, on the worker thread, mid-batch -- to simulate the timing of
+    a concurrent main-thread click without needing a real race.
+    """
+    note_files = _write_note_files(tmp_path, note_count=6, files=3)
+    app = _make_mock_app(note_files)
+
+    call_count = {"n": 0}
+
+    def add_note_side_effect(**kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Simulate "Clear Selection" landing on the main thread while
+            # this (worker-thread) loop is mid-import.
+            app.selected_note_files_for_import.clear()
+        return f"note-id-{call_count['n']}"
+
+    app.notes_service.add_note = Mock(side_effect=add_note_side_effect)
+
+    worker_callable = await _dispatch_and_get_worker(app)
+    results = await worker_callable()
+
+    assert app.selected_note_files_for_import == [], (
+        "the mid-import mutation itself did not take effect -- test setup "
+        "is broken"
+    )
+    successes = [r for r in results if r.get("status") == "success"]
+    assert len(successes) == 6, (
+        f"expected all 6 originally-selected notes to import despite "
+        f"selected_note_files_for_import being cleared mid-import; got "
+        f"{len(successes)} successes -- the loop is reading the live list "
+        "instead of a snapshot (task-15468 shared-list-race regression)"
+    )
+
+
+# --- 5. Fix-round-1: quit-during-import cancellation (review finding, 2026-08-11) ---
+
+
+@pytest.mark.asyncio
+async def test_import_cancellation_stops_at_a_note_boundary_with_honest_accounting(
+    tmp_path,
+):
+    """TASK-15468 fix-round-1: cancelling the wrapping coroutine (e.g. app
+    shutdown cancelling outstanding workers) must not leave the background
+    thread running the rest of the batch unattended. The cooperative
+    `cancel_event` must make it stop at the next note boundary, with no
+    crash, and it must not report a false "N imported" success summary for
+    a batch that never finished.
+
+    A per-note delay is used so the (otherwise much faster) worker thread
+    doesn't race straight through the whole batch before the event loop
+    gets a chance to actually deliver the cancellation -- this is purely a
+    test-determinism aid; the mechanism under test (the cooperative
+    `cancel_event` check) is real production code.
+    """
+    note_count = 40
+    per_note_delay = 0.01  # seconds
+    cancel_at = 5  # request cancellation while committing the 5th note
+    note_files = _write_note_files(tmp_path, note_count=note_count, files=4)
+    app = _make_mock_app(note_files)
+
+    loop = asyncio.get_running_loop()
+    call_count = {"n": 0}
+    task_holder: dict = {}
+
+    def add_note_side_effect(**kwargs):
+        call_count["n"] += 1
+        n = call_count["n"]
+        if n == cancel_at:
+            # Request cancellation the way app shutdown would -- from
+            # outside the worker thread, thread-safely, on the loop that
+            # owns the Task.
+            loop.call_soon_threadsafe(task_holder["task"].cancel)
+        time.sleep(per_note_delay)
+        return f"note-id-{n}"
+
+    app.notes_service.add_note = Mock(side_effect=add_note_side_effect)
+
+    worker_callable = await _dispatch_and_get_worker(app)
+    import_task = asyncio.ensure_future(worker_callable())
+    task_holder["task"] = import_task
+
+    with pytest.raises(asyncio.CancelledError):
+        await import_task
+
+    # The background thread is not forcibly killable -- `import_task`
+    # being cancelled/done only means the *coroutine* gave up on it; the
+    # thread itself keeps running until `import_worker_notes` next checks
+    # `cancel_event` and returns. Poll a bounded window until the call
+    # count stops growing (the thread has actually stopped), rather than
+    # asserting immediately.
+    stable_count = None
+    for _ in range(50):  # up to ~1s
+        await asyncio.sleep(0.02)
+        if call_count["n"] == stable_count:
+            break
+        stable_count = call_count["n"]
+    else:
+        pytest.fail(
+            f"add_note call count never stabilized (still at "
+            f"{call_count['n']} after the polling window) -- the "
+            "background thread does not appear to have stopped"
+        )
+
+    final_count = call_count["n"]
+    assert cancel_at <= final_count <= cancel_at + 15, (
+        f"expected the import to stop within a small number of notes after "
+        f"cancellation was requested at note {cancel_at}; add_note was "
+        f"called {final_count} times total"
+    )
+    assert final_count < note_count, (
+        f"add_note was called {final_count}/{note_count} times -- the "
+        "cancelled import ran to completion instead of stopping at a "
+        "boundary (task-15468 quit-during-import regression)"
+    )
+
+    # Honest accounting: a cancelled import must never report the false
+    # "N imported" success summary `on_import_success_notes` produces --
+    # that summary is for a batch that actually finished.
+    notify_messages = [
+        str(c.args[0]) for c in app.notify.call_args_list if c.args
+    ]
+    assert not any("import finished" in msg.lower() for msg in notify_messages), (
+        f"a cancelled import fired the completed-import notification "
+        f"anyway: {notify_messages}"
     )

--- a/backlog/tasks/task-15468 - Notes-ingest---run-the-import-loop-off-the-event-loop.md
+++ b/backlog/tasks/task-15468 - Notes-ingest---run-the-import-loop-off-the-event-loop.md
@@ -71,8 +71,10 @@ Fix direction: `thread=True` worker with `call_from_thread` for the UI updates (
 
 ## Implementation Notes
 
-**Approach.** Two-line functional change in
-`Event_Handlers/note_ingest_events.py`: `import_worker_notes` (the nested
+**Approach (initial implementation; see "Fix round 1" below for two
+review-driven additions to this same function).** Two-line functional
+change in `Event_Handlers/note_ingest_events.py`: `import_worker_notes`
+(the nested
 per-file/per-note loop inside
 `handle_ingest_notes_import_now_button_pressed`) lost its `async` keyword
 (it had no internal `await`s, so this changes nothing about its body), and
@@ -137,7 +139,7 @@ plain sync file I/O, also thread-safe.
    import regardless of duration, while the threaded shape gives it
    thousands, and wall time is not regressed (here, noise-level faster).
 
-**Test run:** `Tests/Event_Handlers/test_note_ingest_events.py` +
+**Test run (initial):** `Tests/Event_Handlers/test_note_ingest_events.py` +
 `test_note_ingest_import_offload.py` + `Tests/Notes/test_notes_library_unit.py`
 + `test_notes_adapter.py` + `test_notes_integration.py` +
 `test_notes_scope_service_library_canvas.py` + `test_sync_engine.py` +
@@ -146,6 +148,92 @@ plain sync file I/O, also thread-safe.
 tilde-path environment skip). `ruff check` on both changed/added files:
 clean.
 
+## Fix round 1 (review, 2026-08-11)
+
+Code review flagged two Important findings against the initial
+implementation above -- both are side effects of AC1 itself: moving the
+loop off the event loop means the UI (and app shutdown) can now genuinely
+run *concurrently* with an in-flight import, which is exactly what makes
+both of the below newly reachable in a way they structurally could not be
+while the whole app was frozen for the import's duration. Undisclosed in
+the original Implementation Notes above; recorded here as required.
+
+**1. SHARED-LIST RACE.** `import_worker_notes` iterated
+`app.selected_note_files_for_import` -- a plain, mutable list -- LIVE, on
+the worker thread, while the main thread keeps handling clicks (including
+"Clear Selection", `handle_ingest_notes_clear_files_button_pressed`, which
+calls `.clear()` on that exact list). A mid-import click would silently
+truncate the loop: an incomplete import with no error, no different from
+a successful complete one in the UI. Fix: `note_files_snapshot =
+list(app.selected_note_files_for_import)` is taken synchronously on the
+event loop, before the thread hop (the handler has no `await` between
+that point and `run_worker(...)`, so there is no race window on the
+snapshot itself). Both loops (templates and notes) now iterate
+`note_files_snapshot`, never the live list.
+
+**2. QUIT-DURING-IMPORT SEMANTICS.** An `asyncio.Future` in PENDING state
+(what `asyncio.to_thread` awaits) cancels *immediately* when the awaiting
+Task is cancelled -- but the underlying executor thread is NOT
+interruptible and keeps running `import_worker_notes` to completion
+regardless, since a running thread cannot be forced to stop. Left
+unaddressed, cancelling the import (app shutdown cancelling outstanding
+`file_operations`-group workers) would leave that thread running the rest
+of a potentially-hundreds-of-notes batch completely unattended, and
+`ThreadPoolExecutor.shutdown(wait=True)` (part of Python's own
+interpreter-exit sequence) would then block process shutdown on it, with
+no indication to the user, for as long as that remaining work takes. Fix:
+a `threading.Event` (`cancel_event`), created alongside the snapshot.
+`_run_note_import_worker_and_dispatch` now has an
+`except asyncio.CancelledError: cancel_event.set(); raise` clause around
+the `await asyncio.to_thread(...)` call. Both loops check
+`cancel_event.is_set()` at the top of each per-file AND per-note
+iteration, `break`-ing out at the next boundary rather than continuing.
+Honest residual, documented in a code comment at the `cancel_event`
+declaration: the note/template *currently* being committed when
+cancellation is requested still finishes -- there is no way to interrupt a
+single `add_note` call or a single file parse mid-flight, only between
+them. The (destination) `asyncio.to_thread` future's *result* is silently
+discarded once cancelled (asyncio drops it if the destination is already
+CANCELLED when the underlying `concurrent.futures.Future` completes), so
+a cancelled run never calls `on_import_success_notes` and therefore never
+reports a false "N imported" summary for a batch that didn't finish --
+that absence of a false-positive summary IS the "accounting reflects the
+partial import truthfully" requirement; the only durable record of a
+cancelled run is the `add_note` calls that actually committed before the
+stop, which the fix bounds to a small, deterministic window past the
+cancellation point rather than unboundedly close to a full complete run.
+
+**New evidence (same file), two more tests (5 total in the file now):**
+4. `test_import_worker_completes_over_snapshot_when_list_mutated_mid_import`
+   -- mutates (`.clear()`s) `app.selected_note_files_for_import` from
+   inside `add_note`'s side effect (i.e. from the loop side, mid-batch, to
+   simulate the timing of a concurrent main-thread click without needing a
+   real race) and asserts all 6 originally-selected notes still import
+   successfully.
+5. `test_import_cancellation_stops_at_a_note_boundary_with_honest_accounting`
+   -- schedules `import_task.cancel()` via `loop.call_soon_threadsafe`
+   (the thread-safe way app shutdown would reach across from a different
+   thread) from inside the 5th `add_note` call of a 40-note import (a
+   small per-note delay keeps the worker thread from racing through the
+   whole batch before the event loop gets a turn to actually deliver the
+   cancellation -- a test-determinism aid only; the mechanism under test,
+   `cancel_event`, is real production code), awaits the task expecting
+   `asyncio.CancelledError`, polls until the (still-running,
+   not-forcibly-killable) background thread's call count stabilizes, and
+   asserts it stopped within a small bounded window past the cancellation
+   point (not at the full 40) and that no "import finished" notification
+   ever fired.
+
+**Test run (after fix round 1):** same command set as above --
+`test_note_ingest_events.py` + `test_note_ingest_import_offload.py` (now 5
+tests) + the four Notes suites + `test_note_tool_user_id.py`: **116
+passed**. Full `Tests/Event_Handlers/`: **52 passed, 1 skipped**
+(pre-existing, unrelated). The two new timing-sensitive tests were run 5x
+back-to-back in isolation with no flakes. `ruff check` on both
+changed/added files: clean.
+
 **Files changed:** `tldw_chatbook/Event_Handlers/note_ingest_events.py`
-(2-line functional change + comments); added
-`Tests/Event_Handlers/test_note_ingest_import_offload.py`.
+(the original `asyncio.to_thread` dispatch change, plus the snapshot list
+and `cancel_event` mechanisms from this round -- no longer a 2-line diff,
+see the file for the full change); `Tests/Event_Handlers/
+test_note_ingest_import_offload.py` (5 tests total, 2 added this round).

--- a/backlog/tasks/task-15468 - Notes-ingest---run-the-import-loop-off-the-event-loop.md
+++ b/backlog/tasks/task-15468 - Notes-ingest---run-the-import-loop-off-the-event-loop.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15468
 title: Notes ingest: run the import loop off the event loop
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -20,7 +21,131 @@ Fix direction: `thread=True` worker with `call_from_thread` for the UI updates (
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The UI processes input while a large import runs (evidence: interaction during an N-hundred-note import)
-- [ ] #2 Import results, preview, template handling, and per-note failure accounting unchanged (tests)
-- [ ] #3 Import wall-time not materially regressed (before/after)
+- [x] #1 The UI processes input while a large import runs (evidence: interaction during an N-hundred-note import)
+- [x] #2 Import results, preview, template handling, and per-note failure accounting unchanged (tests)
+- [x] #3 Import wall-time not materially regressed (before/after)
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Read `Event_Handlers/note_ingest_events.py:306-656` end to end; confirm
+   `import_worker_notes()` (the per-file/per-note loop, `:344-518`) contains
+   no internal `await`s despite being declared `async def` -- it's pure sync
+   work (file parse, `notes_service.add_note`, template JSON I/O) executed
+   inline on the caller's coroutine, which today is the main event loop
+   (per the `_run_note_import_worker_and_dispatch` comment at `:630-641`).
+2. Confirm `NotesInteropService._get_db`/`CharactersRAGDB` are safe to call
+   from a non-main thread (`threading.Lock`-guarded instance cache +
+   per-thread `threading.local` SQLite connections) so moving the loop to a
+   worker thread doesn't need new locking.
+3. Minimal-diff fix: drop `async` from `import_worker_notes` (make it a
+   plain sync function -- it has no awaits to lose), and in
+   `_run_note_import_worker_and_dispatch` replace
+   `results = await import_worker_notes()` with
+   `results = await asyncio.to_thread(import_worker_notes)`. This keeps
+   `_run_note_import_worker_and_dispatch` itself `async def` and its
+   `on_import_success_notes`/`on_import_failure_notes` calls unchanged and
+   still on the main thread (asyncio.to_thread resumes the awaiting
+   coroutine on the same event-loop thread once the executor thread
+   finishes) -- no `call_from_thread` marshaling needed, and the existing
+   `run_worker(..., group="file_operations")` call and its cancellation
+   semantics are untouched. `asyncio.to_thread` is an established pattern
+   elsewhere in this codebase (e.g. `app.py`, `ccp_character_handler.py`).
+4. Add an "evidence-seam" test: patch `add_note`/the parse call to record
+   `threading.current_thread()` and assert it differs from the thread that
+   invoked the button handler.
+5. Add a responsiveness test: run the import (with an artificially slowed
+   sync `add_note`, e.g. `time.sleep`) as a background asyncio task and
+   assert a concurrent lightweight loop keeps ticking (`await
+   asyncio.sleep(0)`) with low latency while the import is in flight --
+   demonstrating the event loop is not blocked (AC1).
+6. Write an isolated before/after probe script (scratchpad, not committed)
+   that calls `import_worker_notes()` directly (old, on-loop shape) vs
+   `await asyncio.to_thread(import_worker_notes)` (new shape) against a
+   few hundred generated note files + a real `NotesInteropService`/
+   `CharactersRAGDB`, measuring max event-loop tick gap and total wall
+   time for both arms -- honest before/after numbers for AC1/AC3.
+7. Run the existing note-ingest + notes-service suites (baseline already
+   green at 86 passed pre-change) plus the new tests; confirm nothing
+   regresses.
+
+## Implementation Notes
+
+**Approach.** Two-line functional change in
+`Event_Handlers/note_ingest_events.py`: `import_worker_notes` (the nested
+per-file/per-note loop inside
+`handle_ingest_notes_import_now_button_pressed`) lost its `async` keyword
+(it had no internal `await`s, so this changes nothing about its body), and
+`_run_note_import_worker_and_dispatch` now calls it via `results = await
+asyncio.to_thread(import_worker_notes)` instead of `results = await
+import_worker_notes()`. `asyncio.to_thread` hands the whole batch to the
+default executor as a single call (not one hop per note) and, critically,
+resumes the awaiting coroutine back on the *same* event-loop thread once
+the executor thread finishes -- so `on_import_success_notes`/
+`on_import_failure_notes` (both UI-touching: `query_one`, `notify`,
+`call_later`) stay exactly where they were, called directly, no
+`call_from_thread` marshaling needed. `run_worker(..., group="file_operations")`
+is untouched, so cancellation/group semantics are unchanged. This is an
+established pattern elsewhere in the codebase (`app.py`,
+`ccp_character_handler.py`, `stts_profile_library.py`, etc).
+
+**Why this shape over `thread=True` + `call_from_thread`:** it's the
+smaller diff, and it keeps `_run_note_import_worker_and_dispatch` itself
+`async def`, which is exactly the shape the pre-existing
+`test_note_ingest_events.py` suite's `await worker_callable()` pattern
+already assumes -- so that suite needed **zero** changes and stayed green
+throughout (confirmed: 86 passed before AND after, byte-identical file).
+
+**Thread-safety check (not just assumed):** `NotesInteropService._get_db`
+caches one `CharactersRAGDB` per user_id behind a `threading.Lock`, and
+`CharactersRAGDB` itself opens one SQLite connection per thread via
+`threading.local` (`check_same_thread=False`) -- so calling
+`notes_service.add_note` from a worker thread needs no new locking.
+`note_importer_registry.parse_file` and the template JSON read/write are
+plain sync file I/O, also thread-safe.
+
+**Evidence (new file, does not touch the existing test file):**
+`Tests/Event_Handlers/test_note_ingest_import_offload.py`, three tests:
+1. `test_import_worker_runs_parse_and_add_note_off_the_main_thread` --
+   evidence-seam: patches `add_note` and `_parse_single_note_file_for_preview`
+   to record `threading.get_ident()`, asserts neither call lands on the
+   thread that invoked the button handler.
+2. `test_import_worker_keeps_event_loop_responsive_during_large_import` --
+   A/B against the *production* dispatch function, with `asyncio.to_thread`
+   swapped for an inline stand-in (`async def _inline: return fn(*a,**kw)`)
+   to reproduce the pre-fix on-loop shape for the "before" arm. Counts how
+   many `await asyncio.sleep(0)` scheduling turns a concurrent loop gets
+   while a Mock-timed 40-note import runs: after >= 20 ticks, before <= 2.
+3. `test_note_import_probe_hundreds_of_real_notes_before_after` -- the
+   task's "isolated probe importing a few hundred generated notes": a
+   *real* `CharactersRAGDB`/`NotesInteropService` (no per-note delay
+   injected), 300 real generated notes across 30 files, same A/B swap.
+   Written as a pytest test (not a bare script) specifically so it
+   inherits `Tests/conftest.py`'s config/data isolation --
+   `backlog/docs/lessons-live-verification.md` documents a prior incident
+   where a bare-script probe touched the real user config/data dir; this
+   task's own investigation nearly repeated it (a `python -c "import
+   note_ingest_events"` sanity check, run without isolation, was later
+   found to have only *read* `~/.config/tldw_cli/config.toml`, confirmed
+   via mtime -- no write occurred, but it was a needless risk that a
+   pytest-based probe avoids by construction). Honest measured numbers
+   from one local run (fast M-series Mac, real WAL+`synchronous=NORMAL`
+   DB per task-15465's fix, no artificial delay):
+   `before (on-loop): wall=91.4ms ticks=1` vs.
+   `after (threaded): wall=72.4ms ticks=4181` -- i.e. the on-loop shape
+   gives a concurrent scheduling loop exactly one turn for the whole
+   import regardless of duration, while the threaded shape gives it
+   thousands, and wall time is not regressed (here, noise-level faster).
+
+**Test run:** `Tests/Event_Handlers/test_note_ingest_events.py` +
+`test_note_ingest_import_offload.py` + `Tests/Notes/test_notes_library_unit.py`
++ `test_notes_adapter.py` + `test_notes_integration.py` +
+`test_notes_scope_service_library_canvas.py` + `test_sync_engine.py` +
+`Tests/Tools/test_note_tool_user_id.py`: **114 passed**. Full
+`Tests/Event_Handlers/`: **50 passed, 1 skipped** (pre-existing, unrelated
+tilde-path environment skip). `ruff check` on both changed/added files:
+clean.
+
+**Files changed:** `tldw_chatbook/Event_Handlers/note_ingest_events.py`
+(2-line functional change + comments); added
+`Tests/Event_Handlers/test_note_ingest_import_offload.py`.

--- a/tldw_chatbook/Event_Handlers/note_ingest_events.py
+++ b/tldw_chatbook/Event_Handlers/note_ingest_events.py
@@ -5,6 +5,7 @@
 # Imports
 import asyncio
 import json
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, List, Any, Dict
 
@@ -342,6 +343,34 @@ async def handle_ingest_notes_import_now_button_pressed(
 
     user_id = app.notes_user_id
 
+    # TASK-15468 fix-round-1 (SHARED-LIST RACE): once the loop runs on a
+    # worker thread, the main thread keeps handling clicks concurrently --
+    # including "Clear Selection", which does
+    # `app.selected_note_files_for_import.clear()`. Iterating the live list
+    # from the thread would let a mid-import click silently truncate the
+    # loop (incomplete import, no error). Snapshot it once here, on the
+    # event loop, synchronously and before the thread hop (this whole
+    # handler runs without an intervening `await` up to `run_worker(...)`
+    # below, so there is no race window on the snapshot itself), and have
+    # the loop iterate ONLY the snapshot -- never the live, mutable list.
+    note_files_snapshot: List[Path] = list(app.selected_note_files_for_import)
+
+    # TASK-15468 fix-round-1 (QUIT-DURING-IMPORT): cooperative cancellation.
+    # `asyncio.to_thread`'s awaited future is cancelled promptly when this
+    # coroutine's Task is cancelled (e.g. app shutdown cancels outstanding
+    # workers), but the background thread itself is NOT interruptible -- it
+    # keeps running `import_worker_notes` to completion regardless of the
+    # coroutine giving up on it, which can block process shutdown on the
+    # executor for as long as the whole batch takes (up to ~300s on a
+    # large import), with no indication to the user. This Event lets the
+    # thread notice a cancellation request and stop at the next note/file
+    # boundary instead of finishing the rest of the batch unattended.
+    # Honest residual: the note/template *currently* being committed when
+    # cancellation is requested still finishes -- there is no way to
+    # interrupt a single `add_note` call or a single file parse mid-flight,
+    # only between them.
+    cancel_event = threading.Event()
+
     def import_worker_notes():
         """Per-file/per-note import loop.
 
@@ -356,6 +385,13 @@ async def handle_ingest_notes_import_now_button_pressed(
         UI input for the duration of a large import (see
         Docs/Design/2026-08-11-input-latency-audit.md). It is now dispatched
         via ``asyncio.to_thread`` instead, which needs a plain sync callable.
+
+        TASK-15468 fix-round-1: iterates `note_files_snapshot` (a copy taken
+        on the event loop before dispatch), never the live
+        `app.selected_note_files_for_import`, and checks `cancel_event`
+        between files and between notes so a cancelled import (app
+        shutdown) stops at the next boundary instead of running the whole
+        batch unattended.
         """
         results = []
 
@@ -380,12 +416,21 @@ async def handle_ingest_notes_import_now_button_pressed(
                 except Exception as e:
                     logger.error(f"Error loading existing templates: {e}")
 
-            # Process each file
-            for file_path in app.selected_note_files_for_import:
+            # Process each file (TASK-15468: snapshot, not the live list)
+            for file_path in note_files_snapshot:
+                if cancel_event.is_set():
+                    logger.info(
+                        "Template import cancelled; stopping at file boundary."
+                    )
+                    break
                 notes_in_file = _parse_single_note_file_for_preview(
                     file_path, app, import_as_template=True
                 )
+                file_cancelled = False
                 for note_data in notes_in_file:
+                    if cancel_event.is_set():
+                        file_cancelled = True
+                        break
                     if (
                         "error" in note_data
                         or not note_data.get("title")
@@ -452,8 +497,14 @@ async def handle_ingest_notes_import_now_button_pressed(
                                 "message": f"Error: {type(e).__name__}",
                             }
                         )
+                if file_cancelled:
+                    logger.info(
+                        "Template import cancelled; stopping at note boundary."
+                    )
+                    break
 
-            # Save all templates
+            # Save all templates parsed so far (honest partial progress if
+            # cancelled -- see cancel_event above).
             if any(r["status"] == "success" for r in results):
                 try:
                     output = {"templates": templates}
@@ -471,10 +522,21 @@ async def handle_ingest_notes_import_now_button_pressed(
                             r["message"] = f"Template imported but failed to save: {e}"
 
         else:
-            # Import as notes (existing logic)
-            for file_path in app.selected_note_files_for_import:
+            # Import as notes (existing logic). TASK-15468: snapshot, not
+            # the live list; checked for cancellation between files and
+            # between notes.
+            for file_path in note_files_snapshot:
+                if cancel_event.is_set():
+                    logger.info(
+                        "Note import cancelled; stopping at file boundary."
+                    )
+                    break
                 notes_in_file = _parse_single_note_file_for_preview(file_path, app)
+                file_cancelled = False
                 for note_data in notes_in_file:
+                    if cancel_event.is_set():
+                        file_cancelled = True
+                        break
                     if (
                         "error" in note_data
                         or not note_data.get("title")
@@ -530,6 +592,9 @@ async def handle_ingest_notes_import_now_button_pressed(
                                 "message": f"Unexpected error: {type(e).__name__}",
                             }
                         )
+                if file_cancelled:
+                    logger.info("Note import cancelled; stopping at note boundary.")
+                    break
         return results
 
     def on_import_success_notes(results: List[Dict[str, Any]]):
@@ -663,8 +728,24 @@ async def handle_ingest_notes_import_now_button_pressed(
         # that changed to fix the import-freezes-the-app symptom; everything
         # else in this function (ordering, exception handling, callback
         # dispatch) is unchanged from before.
+        #
+        # TASK-15468 fix-round-1 (QUIT-DURING-IMPORT): an `asyncio.Future`
+        # in PENDING state (which is what `asyncio.to_thread` awaits)
+        # cancels immediately when this coroutine's Task is cancelled --
+        # even though the underlying executor thread keeps running
+        # `import_worker_notes` regardless, since a running thread cannot
+        # be forcibly interrupted. Catching `CancelledError` here and
+        # setting `cancel_event` lets that still-running thread notice the
+        # cancellation and return early (see `import_worker_notes`'s
+        # per-file/per-note checks), bounding how long it keeps running
+        # unattended -- and therefore how long process shutdown can block
+        # waiting on the executor -- to "until the next note/file
+        # boundary" instead of "the rest of the batch".
         try:
             results = await asyncio.to_thread(import_worker_notes)
+        except asyncio.CancelledError:
+            cancel_event.set()
+            raise
         except Exception as e:
             on_import_failure_notes(e)
             raise

--- a/tldw_chatbook/Event_Handlers/note_ingest_events.py
+++ b/tldw_chatbook/Event_Handlers/note_ingest_events.py
@@ -3,6 +3,7 @@
 # Note ingestion event handlers and related functions
 #
 # Imports
+import asyncio
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, List, Any, Dict
@@ -341,7 +342,21 @@ async def handle_ingest_notes_import_now_button_pressed(
 
     user_id = app.notes_user_id
 
-    async def import_worker_notes():
+    def import_worker_notes():
+        """Per-file/per-note import loop.
+
+        TASK-15468: plain ``def`` (not ``async def``) on purpose -- this body
+        is entirely synchronous (sync file parse, sync
+        ``notes_service.add_note`` DB transaction, sync template JSON I/O)
+        and contains no ``await``. It used to be declared ``async def`` and
+        called with a bare ``await`` from
+        ``_run_note_import_worker_and_dispatch``, which -- with no internal
+        await points -- ran the *entire* O(files x notes) loop inline, in one
+        shot, on the caller's coroutine (the main event loop), blocking all
+        UI input for the duration of a large import (see
+        Docs/Design/2026-08-11-input-latency-audit.md). It is now dispatched
+        via ``asyncio.to_thread`` instead, which needs a plain sync callable.
+        """
         results = []
 
         if import_as_templates:
@@ -635,12 +650,21 @@ async def handle_ingest_notes_import_now_button_pressed(
         # "file_operations" group this worker runs in) ever invoked them,
         # so the post-import status-area summary, the chat-notes sidebar
         # refresh, and (now) the Library notes-canvas refresh never actually
-        # fired. Since this worker is a plain coroutine (no `thread=True`),
-        # it runs on the main event loop, so calling these UI-touching
-        # callbacks directly here -- rather than relying on that dead
-        # dispatch path -- is safe.
+        # fired. Calling these UI-touching callbacks directly here -- rather
+        # than relying on that dead dispatch path -- is safe because
+        # `await asyncio.to_thread(...)` below always resumes this coroutine
+        # back on the *same* event-loop thread it started on once the worker
+        # thread finishes (TASK-15468), so by the time execution reaches
+        # this point we are back on the main/UI thread regardless of where
+        # `import_worker_notes` itself ran.
+        #
+        # TASK-15468: `import_worker_notes` moved off the event loop via
+        # `asyncio.to_thread` -- see its docstring. This is the only line
+        # that changed to fix the import-freezes-the-app symptom; everything
+        # else in this function (ordering, exception handling, callback
+        # dispatch) is unchanged from before.
         try:
-            results = await import_worker_notes()
+            results = await asyncio.to_thread(import_worker_notes)
         except Exception as e:
             on_import_failure_notes(e)
             raise


### PR DESCRIPTION
## Summary

Task 15468 from the input-latency audit. The notes import worker's own comment admitted it ran on the main event loop — O(files × notes) sync parses and per-note DB transactions, serially: a guaranteed multi-second full-app freeze on large imports.

- Import body moved off-loop via `asyncio.to_thread` (one batch dispatch, not per-note hops); UI callbacks resume on the loop; per-note error accounting and ordering structurally preserved (loop body untouched, only its execution context moved)
- **Two newly-reachable-by-the-fix bugs closed in-review:** the threaded loop now iterates a pre-dispatch snapshot (a mid-import "Clear Selection" no longer silently truncates the import), and a per-import cooperative cancellation Event stops the batch at the next note boundary on quit/cancel (previously the background thread would run the full batch and could hold process shutdown up to 300 s) — honest residual documented: mid-note work is not interruptible
- 300-note probe: loop stays responsive during import; wall-time not regressed (72 vs 91 ms baseline ceiling)

## Verification
Independent review (Approved; thread-safety of the DB layer independently confirmed; evidence tests mutation-verified) + scoped re-review of the fix round (both Important findings verified addressed; 116 targeted + 52 Event_Handlers reproduced exactly; timing-sensitive tests 6/6 across re-runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the notes import off the main event loop using `asyncio.to_thread` so the UI stays responsive during large imports. Also fixes two concurrency bugs found by the change. Meets TASK-15468 ACs: UI responsive during import and no wall‑time regression in a 300‑note probe.

- **Refactors**
  - Offload the entire import loop via `asyncio.to_thread`; UI updates continue on the loop.
  - Preserve ordering and per‑note error accounting; DB access remains thread‑safe.

- **Bug Fixes**
  - Iterate a snapshot of `selected_note_files_for_import` to prevent mid‑import list mutations from truncating work.
  - Add cooperative cancellation with a `threading.Event`; stop at the next note/file boundary and avoid false “import finished” notifications.

<sup>Written for commit fb0c237563de58ee44a93ef1b96dc189603dab37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

