### PR TITLE
feat(console): window long transcript mounts [TASK-15455]

### DIFF
--- a/Tests/UI/test_console_transcript_windowing.py
+++ b/Tests/UI/test_console_transcript_windowing.py
@@ -1,0 +1,219 @@
+"""TASK-15455: tail-first Console transcript mounting and lazy scrollback.
+
+The store-facing message list remains complete.  Only a contiguous tail window
+is mounted initially; reaching its upper boundary prepends an earlier chunk and
+keeps the same message under the reader.  Reconciliation uses Textual's batch
+DOM APIs so a long resume does not pay one awaited mount/remove per row.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+
+
+class WindowHarness(App):
+    """Compact transcript host with deterministic pruning and Markdown settings."""
+
+    CSS = "ConsoleTranscript { height: 24; width: 100; }"
+
+    def __init__(self, *, low: int = 12_000, high: int = 0) -> None:
+        super().__init__()
+        self.app_config = {
+            "chat_defaults": {
+                "assistant_markdown": False,
+                "prune_low_watermark": low,
+                "prune_high_watermark": high,
+            }
+        }
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleTranscript(id="console-native-transcript")
+
+
+def _messages(count: int, *, prefix: str = "m") -> list[ConsoleChatMessage]:
+    return [
+        ConsoleChatMessage(
+            id=f"{prefix}{index}",
+            role=(
+                ConsoleMessageRole.USER
+                if index % 2 == 0
+                else ConsoleMessageRole.ASSISTANT
+            ),
+            content="\n".join(f"message {index} line {line}" for line in range(4)),
+        )
+        for index in range(count)
+    ]
+
+
+def _mounted_message_ids(transcript: ConsoleTranscript) -> list[str]:
+    return [
+        row.message_id for row in transcript.query(".console-transcript-message")
+    ]
+
+
+async def _wait_for(pilot, predicate, *, attempts: int = 80) -> bool:
+    for _ in range(attempts):
+        await pilot.pause()
+        if predicate():
+            return True
+    return False
+
+
+def _top_visible_message_id(transcript: ConsoleTranscript) -> str | None:
+    viewport_top = transcript.content_region.y
+    viewport_bottom = viewport_top + transcript.content_region.height
+    for row in transcript.query(".console-transcript-message"):
+        if row.region.y + row.region.height > viewport_top and row.region.y < viewport_bottom:
+            return row.message_id
+    return None
+
+
+@pytest.mark.asyncio
+async def test_long_resume_mounts_only_a_contiguous_tail_window() -> None:
+    app = WindowHarness()
+    history = _messages(500)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        mounted = _mounted_message_ids(transcript)
+
+        assert 0 < len(mounted) < len(history) // 2
+        assert mounted == [message.id for message in history[-len(mounted) :]]
+        assert transcript._pruned_message_ids == {
+            message.id for message in history[: -len(mounted)]
+        }
+        assert transcript._messages == history
+
+
+@pytest.mark.asyncio
+async def test_long_session_swap_batches_row_mounts_and_removals(monkeypatch) -> None:
+    app = WindowHarness()
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(180, prefix="old-"))
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        mount_batch_sizes: list[int] = []
+        remove_batch_sizes: list[int] = []
+        original_mount = transcript.mount
+        original_remove_children = transcript.remove_children
+
+        def recording_mount(*widgets, **kwargs):
+            mount_batch_sizes.append(len(widgets))
+            return original_mount(*widgets, **kwargs)
+
+        def recording_remove_children(widgets="*"):
+            materialized = list(widgets) if not isinstance(widgets, str) else widgets
+            if isinstance(materialized, list):
+                remove_batch_sizes.append(len(materialized))
+            return original_remove_children(materialized)
+
+        monkeypatch.setattr(transcript, "mount", recording_mount)
+        monkeypatch.setattr(transcript, "remove_children", recording_remove_children)
+
+        transcript.set_messages(_messages(180, prefix="new-"))
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        assert mount_batch_sizes and max(mount_batch_sizes) > 1
+        assert remove_batch_sizes and max(remove_batch_sizes) > 1
+        assert len(mount_batch_sizes) <= 2
+        assert len(remove_batch_sizes) == 1
+
+
+@pytest.mark.asyncio
+async def test_scroll_boundary_hydrates_earlier_rows_and_preserves_reader_state() -> None:
+    app = WindowHarness()
+    history = _messages(180)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        hidden_before = len(transcript._pruned_message_ids)
+        mounted_before = _mounted_message_ids(transcript)
+        top_before = mounted_before[0]
+        selected = mounted_before[2]
+        transcript.select_message(selected)
+        await transcript.refresh_messages()
+        transcript.release_anchor()
+        transcript.scroll_to(y=0, animate=False)
+        await pilot.pause()
+
+        assert await _wait_for(
+            pilot,
+            lambda: len(transcript._pruned_message_ids) < hidden_before,
+        ), "reaching the scrollback boundary did not hydrate an earlier chunk"
+        assert await _wait_for(
+            pilot,
+            lambda: _top_visible_message_id(transcript) == top_before,
+        ), "prepending scrollback moved the reader to different content"
+        assert transcript.selected_message_id == selected
+        assert not transcript._is_following_tail()
+        assert _mounted_message_ids(transcript)[-1] == history[-1].id
+
+        # A sibling swipe replaces the selected native id at the same tree
+        # position.  The pending handoff must stay mounted even when that row is
+        # the first row of the current lazy window.
+        visible_ids = _mounted_message_ids(transcript)
+        boundary_id = visible_ids[0]
+        boundary_index = next(
+            index for index, message in enumerate(history) if message.id == boundary_id
+        )
+        sibling = replace(history[boundary_index], id="branch-sibling")
+        branched = list(history)
+        branched[boundary_index] = sibling
+        transcript.pending_selection_id = sibling.id
+        transcript.set_messages(branched)
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        assert transcript.selected_message_id == sibling.id
+        assert sibling.id in _mounted_message_ids(transcript)
+
+
+@pytest.mark.asyncio
+async def test_hydration_still_obeys_mounted_height_watermarks() -> None:
+    app = WindowHarness(low=45, high=0)
+    history = _messages(180)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await pilot.pause()
+        hidden_before_hydration = len(transcript._pruned_message_ids)
+        transcript.release_anchor()
+        await transcript._hydrate_scrollback()
+        assert await _wait_for(
+            pilot,
+            lambda: len(transcript._pruned_message_ids) < hidden_before_hydration,
+        ), "the watermark check never observed a genuinely hydrated chunk"
+        hidden_after_hydration = len(transcript._pruned_message_ids)
+
+        app.app_config["chat_defaults"]["prune_high_watermark"] = 70
+        await transcript.refresh_messages()
+        assert await _wait_for(
+            pilot, lambda: transcript.virtual_size.height <= 70
+        ), "hydrated rows escaped the configured height watermark"
+
+        assert transcript._messages == history
+        assert len(transcript._pruned_message_ids) > hidden_after_hydration
+        assert len(_mounted_message_ids(transcript)) < len(history)

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -42,6 +42,24 @@ side being read at the style level and the other at the pixel level.
 
 ---
 
+## Preserve the visible set across a reorder, not its former first row
+
+**TASK-15455, 2026-08-11.** Console transcript windowing initially preserved a
+lazy window across refreshes by finding the first previously visible message id
+that still existed in the new ordered list. That was correct for append-only
+streaming and session-local deletes, but wrong for branch/path reorder: moving a
+later visible message ahead of that chosen id put it into the newly computed
+hidden prefix. The focused windowing tests were all green. The pre-existing
+signature-cache reorder contract caught the missing mounted row.
+
+**What to do.** When a windowed projection accepts a reordered full list,
+preserve the minimum new index of every surviving previously visible item (plus
+any explicit selection handoff), not the new index of one former boundary item.
+Include an order-sensitive DOM assertion in the reachable regression set; cache
+counts alone prove reuse, not that every reused row stayed visible.
+
+---
+
 ## A fix proven at one layer can be unreachable through the product path
 
 **TASK-15420, 2026-08-11.** TASK-2260 (2026-08-04) shipped custom-endpoint

--- a/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
+++ b/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15455
 title: Console transcript: windowed mount for long-conversation load
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - codex
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -20,7 +21,33 @@ Fix direction: mount a tail-first window (bottom N lines) and hydrate scrollback
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Loading a 500+-message conversation mounts only the visible tail window initially (evidence + session-switch latency before/after)
-- [ ] #2 Scrollback hydrates on demand without breaking anchor/tail-follow, selection, or branch navigation (tests)
-- [ ] #3 Prune watermarks still bound total mounted height
+- [x] #1 Loading a 500+-message conversation mounts only the visible tail window initially (evidence + session-switch latency before/after)
+- [x] #2 Scrollback hydrates on demand without breaking anchor/tail-follow, selection, or branch navigation (tests)
+- [x] #3 Prune watermarks still bound total mounted height
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Characterize the existing transcript refresh, pruning, selection, branch-navigation, and viewport-follow contracts with focused tests and latency instrumentation.
+2. Add a bounded tail-first projection and batched transcript reconciliation in `UI/Console_Modules/`, preserving the transcript widget's public API and current region ownership.
+3. Hydrate earlier messages when the viewport reaches the scrollback boundary while restoring the reading anchor and retaining selection and branch behavior.
+4. Verify the 500+ message resume path, hydration behavior, and mounted-height watermarks with focused automated tests and before/after timing evidence.
+5. Run affected Console suites, static analysis, and a self-review; document implementation notes and complete the acceptance criteria only when the evidence supports them.
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: This is an internal performance refinement of the existing Console transcript-region and message-store contracts; it does not change persistence, ownership, security, or a cross-module service interface.
+
+## Implementation Notes
+
+- Added a viewport-scaled, turn-aligned tail projection before row signatures or Markdown widgets are built. The complete history remains in the transcript model for export, persistence, selection, and branch operations.
+- Added coalesced scrollback hydration for upward scrolling, wheel-at-boundary, and Page Up. Prepended rows compensate the scroll offset by their measured virtual height, preserving the reader's visible message and detached follow state.
+- Reconciliation now removes stale direct children and mounts contiguous missing runs through Textual's batch DOM APIs. The existing reorder contract remains intact.
+- Kept the implementation in the existing `ConsoleTranscript` leaf rather than adding a new `UI/Console_Modules/` controller: the window is internal view state of the actual scroll container, and moving it outward would split the established pruning, selection, row-signature, and reconciliation invariants. No screen-size ratchet growth was introduced.
+- Identical 500-message Markdown session-swap probe at 100x30: merged baseline `19.8457s`, 500 mounted messages; windowed implementation `0.2411s`, 22 mounted messages and 478 lazily retained messages. This is an 82x speedup and 98.8% lower elapsed time on the test host.
+- Verification: 4 focused windowing tests, 17 combined windowing/pruning/tail-follow contracts, and 127 broader native-transcript/Markdown/selection/diff/jump/region test bodies passed; two mutation checks killed removal of initial windowing and hydration; Ruff, `py_compile`, and `git diff --check` passed. The repository pytest wrapper cannot bootstrap asyncio on this Windows host because its process-wide network guard intercepts Python's loopback `socketpair`; the same test bodies were therefore executed directly in isolated Textual harnesses.
+- Added the reorder/window lesson to `backlog/docs/lessons-testing-evidence.md` after the broader regression pass caught a boundary-preservation defect that focused tests missed.
+- Modified: `tldw_chatbook/Widgets/Console/console_transcript.py`, `Tests/UI/test_console_transcript_windowing.py`, this task, and the testing-evidence lessons document.
+- ADR required: no. The existing Console transcript-region and leaf-widget ownership remain unchanged.

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -11,7 +11,7 @@ from typing import Any, Iterable, Literal, Mapping
 from loguru import logger
 from PIL import Image as PILImage
 from rich_pixels import Pixels
-from textual import on
+from textual import events, on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.content import Content, Span
@@ -73,6 +73,12 @@ CONSOLE_GENERATING_PLACEHOLDER = "Generating…"
 #: (``UI/Chat_Modules/chat_log_pruning.py`` on feat/toad-ui-improvements).
 DEFAULT_PRUNE_HIGH_WATERMARK = 20000
 DEFAULT_PRUNE_LOW_WATERMARK = 12000
+#: TASK-15455: long resumes render only a buffered tail before Markdown is
+#: parsed.  The effective budget also scales with the mounted viewport; these
+#: floors keep a useful scroll buffer when layout has not settled yet.
+DEFAULT_INITIAL_WINDOW_LINES = 144
+DEFAULT_SCROLLBACK_CHUNK_LINES = 96
+SCROLLBACK_HYDRATION_THRESHOLD = 2
 #: task-2154.16 (FB-01): a failed assistant row with no partial content used
 #: to render as the bare token ``[failed]``. It now shows this placeholder
 #: (dimmed) with the state carried by a separate dim status line. Same copy
@@ -1645,6 +1651,11 @@ class ConsoleTranscript(VerticalScroll):
         #: and the reconciliation stale-key path owns their removal.
         self._pruned_message_ids: set[str] = set()
         self._prune_check_scheduled = False
+        #: TASK-15455: scrollback hydration is coalesced separately from the
+        #: existing height-prune pass.  Both mutate the same contiguous hidden
+        #: prefix, but only hydration removes ids from it.
+        self._scrollback_hydration_scheduled = False
+        self._hydrating_scrollback = False
 
     def on_mount(self) -> None:
         """Engage tail-follow: stay scrolled to the newest content.
@@ -1772,6 +1783,169 @@ class ConsoleTranscript(VerticalScroll):
         # than waiting for the next 0.2s sync tick.
         self.sync_jump_indicator(self._last_run_status)
 
+    @on(events.MouseScrollUp)
+    def _hydrate_scrollback_on_boundary_wheel(
+        self, _event: events.MouseScrollUp
+    ) -> None:
+        """Notice an upward wheel gesture that cannot change ``scroll_y``."""
+        if self.scroll_y <= SCROLLBACK_HYDRATION_THRESHOLD:
+            self._schedule_scrollback_hydration()
+
+    def action_page_up(self) -> None:
+        """Page upward and hydrate when the current window is already at y=0."""
+        at_boundary = self.scroll_y <= SCROLLBACK_HYDRATION_THRESHOLD
+        super().action_page_up()
+        if at_boundary:
+            self._schedule_scrollback_hydration()
+
+    def watch_scroll_y(self, old_value: float, new_value: float) -> None:
+        """Hydrate the previous window when a detached reader reaches the top."""
+        super().watch_scroll_y(old_value, new_value)
+        if (
+            new_value <= old_value
+            and new_value <= SCROLLBACK_HYDRATION_THRESHOLD
+        ):
+            self._schedule_scrollback_hydration()
+
+    def _window_viewport_height(self) -> int:
+        """Return a stable viewport height for line-budget calculations."""
+        return max(1, int(self.size.height or 24))
+
+    def _initial_window_line_budget(self) -> int:
+        """Return the tail-first render budget in estimated terminal lines."""
+        return max(
+            DEFAULT_INITIAL_WINDOW_LINES,
+            self._window_viewport_height() * 6,
+        )
+
+    def _scrollback_chunk_line_budget(self) -> int:
+        """Return the amount of earlier history prepended per boundary request."""
+        return max(
+            DEFAULT_SCROLLBACK_CHUNK_LINES,
+            self._window_viewport_height() * 4,
+        )
+
+    def _estimated_message_lines(self, message: ConsoleChatMessage) -> int:
+        """Cheaply estimate a message's rendered height without parsing Markdown."""
+        content = (
+            message.variants.current.content
+            if message.variants is not None
+            else message.content
+        )
+        content_width = max(20, int(self.size.width or 80) - 4)
+        wrapped_lines = 0
+        for line in content.splitlines() or ("",):
+            wrapped_lines += max(1, (len(line) + content_width - 1) // content_width)
+        # One separator and one speaker/status line are the stable minimum
+        # around every message body.  Rich/Textual may wrap differently, so
+        # watermarks remain the authoritative post-layout bound.
+        return wrapped_lines + 2
+
+    def _turn_aligned_start(self, messages: list[ConsoleChatMessage], start: int) -> int:
+        """Move a window boundary back to the nearest user turn."""
+        start = max(0, min(start, len(messages)))
+        while start > 0 and (
+            start >= len(messages)
+            or messages[start].role != ConsoleMessageRole.USER
+        ):
+            start -= 1
+        return start
+
+    def _tail_window_start(
+        self,
+        messages: list[ConsoleChatMessage],
+        *,
+        end: int | None = None,
+        line_budget: int,
+    ) -> int:
+        """Return the earliest message in a bounded tail slice."""
+        end = len(messages) if end is None else max(0, min(end, len(messages)))
+        if end == 0:
+            return 0
+        used = 0
+        start = end
+        while start > 0 and used < line_budget:
+            start -= 1
+            used += self._estimated_message_lines(messages[start])
+        return self._turn_aligned_start(messages, start)
+
+    def _first_visible_message_index(self) -> int:
+        """Return the contiguous window start in the complete message list."""
+        for index, message in enumerate(self._messages):
+            if message.id not in self._pruned_message_ids:
+                return index
+        return len(self._messages)
+
+    def _set_hidden_prefix(self, start: int) -> None:
+        """Replace the view-only hidden set with one contiguous prefix."""
+        start = max(0, min(start, len(self._messages)))
+        self._pruned_message_ids = {
+            message.id for message in self._messages[:start]
+        }
+
+    def _schedule_scrollback_hydration(self) -> None:
+        """Coalesce one lazy prepend after explicit detached upward scrolling."""
+        if (
+            self._scrollback_hydration_scheduled
+            or self._hydrating_scrollback
+            or not self.is_mounted
+            or self._is_following_tail()
+            or self._first_visible_message_index() <= 0
+        ):
+            return
+        self._scrollback_hydration_scheduled = True
+        self.call_later(self._hydrate_scrollback)
+
+    async def _hydrate_scrollback(self) -> None:
+        """Prepend one earlier chunk while keeping the current content fixed."""
+        self._scrollback_hydration_scheduled = False
+        if (
+            self._hydrating_scrollback
+            or not self.is_mounted
+            or self._is_following_tail()
+        ):
+            return
+        current_start = self._first_visible_message_index()
+        if current_start <= 0:
+            return
+        next_start = self._tail_window_start(
+            self._messages,
+            end=current_start,
+            line_budget=self._scrollback_chunk_line_budget(),
+        )
+        if next_start >= current_start:
+            next_start = current_start - 1
+
+        previous_height = self.virtual_size.height
+        previous_scroll_y = float(self.scroll_y)
+        self._hydrating_scrollback = True
+        self._set_hidden_prefix(next_start)
+        try:
+            async with self._refresh_lock:
+                await self._reconcile_rows(self._transcript_rows())
+        except Exception:
+            self._hydrating_scrollback = False
+            raise
+
+        def _restore_reader() -> None:
+            try:
+                if not self.is_mounted:
+                    return
+                added_height = max(0, self.virtual_size.height - previous_height)
+                # Use Textual's internal switch only to avoid treating this
+                # compensating scroll as a fresh user gesture.  The public
+                # scroll_to() always calls release_anchor() first.
+                self._scroll_to(
+                    y=previous_scroll_y + added_height,
+                    animate=False,
+                    release_anchor=False,
+                )
+                self._schedule_prune_check()
+            finally:
+                self._hydrating_scrollback = False
+
+        self.call_after_refresh(_restore_reader)
+
     def set_presentation_context(
         self,
         context: ConsolePresentationContext,
@@ -1808,6 +1982,11 @@ class ConsoleTranscript(VerticalScroll):
                 cache entries for messages no longer present are pruned here
                 (delete correctness for the TASK-259 per-message cache).
         """
+        previous_visible_ids = [
+            message.id
+            for message in self._messages
+            if message.id not in self._pruned_message_ids
+        ]
         self._messages = list(messages)
         message_ids = {message.id for message in self._messages}
         # Expansion is per message id, so ids that left the transcript (a
@@ -1815,9 +1994,26 @@ class ConsoleTranscript(VerticalScroll):
         # set grows for the life of the widget and a recycled id would come
         # back already expanded.
         self._expanded_tool_output_ids &= message_ids
-        # TASK-1365: same lifecycle for the prune window -- a session switch
-        # re-renders from scratch, and a deleted message must not linger here.
-        self._pruned_message_ids &= message_ids
+        # TASK-15455: preserve the current contiguous window across streaming
+        # updates by anchoring it to the first still-present visible id.  A
+        # disjoint session switch has no such id and starts from a bounded tail
+        # before any Markdown signature/widget is built.
+        index_by_id = {
+            message.id: index for index, message in enumerate(self._messages)
+        }
+        preserved_indices = [
+            index_by_id[message_id]
+            for message_id in previous_visible_ids
+            if message_id in index_by_id
+        ]
+        preserved_start = min(preserved_indices) if preserved_indices else None
+        if preserved_start is None:
+            window_start = self._tail_window_start(
+                self._messages,
+                line_budget=self._initial_window_line_budget(),
+            )
+        else:
+            window_start = preserved_start
         new_user_send = any(
             message.id not in self._seen_message_ids
             and message.role == ConsoleMessageRole.USER
@@ -1849,7 +2045,17 @@ class ConsoleTranscript(VerticalScroll):
             and self.pending_selection_id in message_ids
         ):
             self.selected_message_id = self.pending_selection_id
+            pending_index = index_by_id[self.pending_selection_id]
+            if pending_index < window_start:
+                # Branch sibling handoff: the replacement id may sit exactly
+                # where the old window boundary id disappeared.  Keep the new
+                # selected row in the window rather than mounting a disjoint
+                # orphan or clearing a valid selection.
+                window_start = self._turn_aligned_start(
+                    self._messages, pending_index
+                )
             self.pending_selection_id = None
+        self._set_hidden_prefix(window_start)
         if self.selected_message_id not in message_ids:
             self.selected_message_id = None
         for stale_id in [
@@ -2167,8 +2373,19 @@ class ConsoleTranscript(VerticalScroll):
 
     def select_message(self, message_id: str) -> None:
         """Select one message and show its contextual action row."""
-        if message_id not in {message.id for message in self._messages}:
+        index_by_id = {
+            message.id: index for index, message in enumerate(self._messages)
+        }
+        if message_id not in index_by_id:
             return
+        selected_index = index_by_id[message_id]
+        if selected_index < self._first_visible_message_index():
+            # Keep the public pre-windowing contract: callers may select any
+            # message in the complete transcript model.  Reveal the contiguous
+            # prefix through that turn before mounting its action row.
+            self._set_hidden_prefix(
+                self._turn_aligned_start(self._messages, selected_index)
+            )
         self.selected_message_id = message_id
         if self.is_mounted:
             self.call_later(self.refresh_messages)
@@ -2621,76 +2838,100 @@ class ConsoleTranscript(VerticalScroll):
         desired_keys = [row.key for row in rows]
         desired_key_set = set(desired_keys)
 
+        removals: list[Widget] = []
         for stale_key in [
             key for key in self._row_widgets if key not in desired_key_set
         ]:
-            stale_widget = self._row_widgets.pop(stale_key)
+            removals.append(self._row_widgets.pop(stale_key))
             self._row_signatures.pop(stale_key, None)
             self._row_build_counts.pop(stale_key, None)
-            await stale_widget.remove()
 
-        previous_widget: Widget | None = None
-        for index, row in enumerate(rows):
+        replacements: dict[str, Widget] = {}
+        for row in rows:
+            widget = self._row_widgets.get(row.key)
+            if widget is None or self._row_signatures.get(row.key) == row.signature:
+                continue
+            updated_widget = self._update_row_widget(widget, row)
+            if updated_widget is widget:
+                self._row_signatures[row.key] = row.signature
+                continue
+            removals.append(widget)
+            replacements[row.key] = updated_widget
+            self._row_widgets.pop(row.key, None)
+            self._row_signatures.pop(row.key, None)
+
+        # Textual's remove_children() prunes all supplied direct children in
+        # one DOM operation.  A session swap therefore has one await instead
+        # of two awaits per message (rule + body).
+        if removals:
+            await self.remove_children(removals)
+
+        pending_widgets: list[Widget] = []
+        pending_rows: list[_TranscriptRow] = []
+
+        async def _mount_pending(*, before: Widget | None) -> bool:
+            """Mount one contiguous missing run and validate attachment."""
+            if not pending_widgets:
+                return True
             if self._closing or self._pruning or not self.is_attached:
-                # This instance is being removed (a parent recompose/session
-                # surface swap can prune the transcript between this loop's
-                # awaits). Widget.mount() silently no-ops while pruning, so
-                # continuing would record detached widgets in the row maps
-                # and then crash in move_child. The replacement instance
-                # composes fresh state; abandon this pass.
+                for pending_row in pending_rows:
+                    self._row_widgets.pop(pending_row.key, None)
+                    self._row_signatures.pop(pending_row.key, None)
+                return False
+            if before is None:
+                await self.mount(*pending_widgets)
+            else:
+                await self.mount(*pending_widgets, before=before)
+            if any(widget.parent is not self for widget in pending_widgets):
+                for pending_row in pending_rows:
+                    self._row_widgets.pop(pending_row.key, None)
+                    self._row_signatures.pop(pending_row.key, None)
+                return False
+            pending_widgets.clear()
+            pending_rows.clear()
+            return True
+
+        for row in rows:
+            if self._closing or self._pruning or not self.is_attached:
                 return
             widget = self._row_widgets.get(row.key)
-            row_was_mounted = False
+            if widget is not None:
+                if not await _mount_pending(before=widget):
+                    return
+                continue
+            widget = replacements.pop(row.key, None)
             if widget is None:
                 widget = self._build_row_widget(row, track=True)
-                if previous_widget is None:
-                    await self.mount(widget, before=0 if self.children else None)
-                else:
-                    await self.mount(widget, after=previous_widget)
-                row_was_mounted = True
-                self._row_widgets[row.key] = widget
-                self._row_signatures[row.key] = row.signature
-            elif self._row_signatures.get(row.key) != row.signature:
-                updated_widget = self._update_row_widget(widget, row)
-                if updated_widget is widget:
-                    self._row_signatures[row.key] = row.signature
-                else:
-                    await widget.remove()
-                    widget = updated_widget
-                    if previous_widget is None:
-                        await self.mount(widget, before=0 if self.children else None)
-                    else:
-                        await self.mount(widget, after=previous_widget)
-                    row_was_mounted = True
-                    self._row_widgets[row.key] = widget
-                    self._row_signatures[row.key] = row.signature
+            self._row_widgets[row.key] = widget
+            self._row_signatures[row.key] = row.signature
+            pending_widgets.append(widget)
+            pending_rows.append(row)
 
-            if row_was_mounted and widget.parent is not self:
-                # Version-proof backstop for the pruning check above:
-                # mount() completed without attaching (it no-ops while the
-                # container is being removed). Drop the phantom map entries
-                # and abandon the pass instead of poisoning later moves.
-                self._row_widgets.pop(row.key, None)
-                self._row_signatures.pop(row.key, None)
-                return
-            if not row_was_mounted:
-                # TASK-15453: `move_child` is several O(rows) NodeList scans
-                # plus a `refresh(layout=True)` plus a DOM-version bump --
-                # expensive to pay for a row that is already where it needs
-                # to be. Every already-processed row (0..index-1) is correct
-                # by induction (mounts above always land at the walk's
-                # current slot), so this row is in place iff it already
-                # sits at `index` in the ACTUAL child list -- read fresh
-                # every iteration (never cached) because earlier mounts in
-                # this same pass shift indices out from under a snapshot.
-                already_in_position = (
-                    index < len(self.children) and self.children[index] is widget
+        if pending_widgets:
+            try:
+                pill = self.query_one(
+                    "#console-transcript-jump-pill", ConsoleTranscriptJumpPill
                 )
-                if not already_in_position:
-                    if previous_widget is None:
-                        self.move_child(widget, before=0)
-                    else:
-                        self.move_child(widget, after=previous_widget)
+            except NoMatches:
+                pill = None
+            if not await _mount_pending(before=pill):
+                return
+        # Preserve the reorder contract for branch changes after the batched
+        # mount/remove work above. TASK-15453 established that move_child is
+        # costly, so only move rows that are not already at their target index.
+        # Read children fresh on every iteration because an earlier move can
+        # shift the remaining indices.
+        previous_widget: Widget | None = None
+        for index, row in enumerate(rows):
+            widget = self._row_widgets[row.key]
+            already_in_position = (
+                index < len(self.children) and self.children[index] is widget
+            )
+            if not already_in_position:
+                if previous_widget is None:
+                    self.move_child(widget, before=0)
+                else:
+                    self.move_child(widget, after=previous_widget)
             previous_widget = widget
         self._paint_debug_dump("after-reconcile")
 


### PR DESCRIPTION
## Summary

- Render long Console transcripts using a tail-first bounded window
- Lazily hydrate older messages while preserving scroll position
- Preserve follow mode, selection, and branch behavior
- Batch message mounting and removal to reduce UI churn

## Performance

A 500-message Markdown-heavy session switch improved from 19.85s with
500 mounted messages to 0.24s with 22 mounted messages—approximately
82× faster and 98.8% lower latency.

## Verification

- 4 focused transcript-windowing tests passed
- 17 combined windowing, pruning, and tail tests passed
- 127 broader test bodies passed
- Mutation checks passed
- Ruff, py_compile, and git diff validation passed

The standard Windows pytest wrapper remains affected by the repository
network guard intercepting asyncio's internal loopback socket pair.
Tests were therefore executed through isolated Textual harnesses.

ADR required: no — this implements bounded UI rendering without changing
storage, schemas, or cross-module ownership.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Windowed the Console transcript to mount only a bounded tail on load and hydrate older messages on demand, cutting session-switch latency dramatically. Satisfies TASK-15455; a 500-message, markdown-heavy session dropped from 19.85s to 0.24s (~82× faster) by mounting ~22 rows instead of 500.

- New Features
  - Tail-first bounded window on initial render with viewport-scaled, user-turn-aligned slice; full history stays in the model; prune watermarks still cap mounted height.
  - Lazy scrollback hydration when reaching the top, on boundary wheel, and on Page Up; coalesced and restores scroll to keep the same message under the reader; preserves follow mode and selection; branch navigation supported; selecting an off-window message reveals its turn-aligned prefix.
  - Batched row removal and mount via Textual DOM APIs (`remove_children`, contiguous mounts) to reduce awaits and churn; minimal `move_child` only when needed.

- Bug Fixes
  - Reorder and branch sibling handoff now preserve the whole visible set (not just the former first row), preventing the selected or boundary row from being hidden after a reorder.

<sup>Written for commit 84baf56895750430fdd525621a34647a80ca5fa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

