### PR TITLE
perf: thread local media reading-service calls off the event loop (task-15467)

### DIFF
--- a/Tests/Media/test_media_reading_scope_service_off_loop.py
+++ b/Tests/Media/test_media_reading_scope_service_off_loop.py
@@ -1,0 +1,474 @@
+"""task-15467: thread local media-reading service calls off the event loop.
+
+Evidence for the audit finding in `Docs/Design/2026-08-11-input-latency-audit.md`
+("Blocking I/O in click paths. Media hub: `run_worker(coroutine)` != a thread;
+every search/filter/item click runs sync SQLite on the loop
+(`MediaWindow_v2.py:2387/:1188`)"): `MediaReadingScopeService` routed every
+LOCAL-mode call straight through `_maybe_await` to a plain synchronous
+`LocalMediaReadingService` method. `run_worker(coroutine)` does not leave the
+event loop, so those sync sqlite calls ran inline on the loop whenever a
+search/filter/pagination/item-click worker fired.
+
+Two kinds of evidence, mirroring task-283's `Tests/Chat/test_search_off_loop.py`
+and task-15463's `Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py`:
+
+  * Thread-affinity doubles: a file-backed local service's leaf call records
+    `threading.get_ident()` and must NOT match the caller/event-loop thread;
+    a `:memory:`-backed local service (and every server-mode call, sync or
+    async) must stay on the caller thread -- threading a `:memory:` DB would
+    hand a worker thread an empty, unmigrated database (the task-283 hazard).
+
+  * A real `MediaDatabase` + `sqlite3.Connection.set_trace_callback` bound to
+    the calling (event-loop) thread's own connection: since `MediaDatabase`
+    keeps thread-local connections, any statement this callback observes is
+    by construction a statement that ran on the calling thread -- no timing,
+    no sampling, no flake. Covers the exact two audited call chains: a
+    search/browse call, and the full item-click detail chain (detail +
+    reading progress + highlights + document versions).
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+from tldw_chatbook.Media.local_media_reading_service import LocalMediaReadingService
+from tldw_chatbook.Media.media_reading_scope_service import MediaReadingScopeService
+
+
+# ---------------------------------------------------------------------------
+# Thread-affinity doubles
+# ---------------------------------------------------------------------------
+
+
+class _RecordingLocalService:
+    """Plain-sync local service double recording the thread each leaf ran on."""
+
+    def __init__(self, *, is_memory_db: bool):
+        self.media_db = SimpleNamespace(is_memory_db=is_memory_db)
+        self.thread_idents: dict[str, list[int]] = {}
+        self.calls: list[tuple[str, Any]] = []
+
+    def _record(self, name: str, *args: Any) -> None:
+        self.thread_idents.setdefault(name, []).append(threading.get_ident())
+        self.calls.append((name, args))
+
+    def search_media(self, *, query=None, limit=20, offset=0, **kwargs):
+        self._record("search_media", query)
+        return {"items": [], "total": 0, "offset": offset, "limit": limit}
+
+    def get_media_detail(self, media_id):
+        self._record("get_media_detail", media_id)
+        return {"id": media_id, "title": "Detail", "type": "article"}
+
+    def get_reading_progress(self, media_id):
+        self._record("get_reading_progress", media_id)
+        return {"media_id": media_id, "current_page": 1, "total_pages": 5}
+
+    def list_reading_highlights(self, item_id):
+        self._record("list_reading_highlights", item_id)
+        return []
+
+    def list_document_versions(self, media_id, include_deleted=False):
+        self._record("list_document_versions", media_id)
+        return []
+
+    def delete_media(self, media_id):
+        self._record("delete_media", media_id)
+        return True
+
+    def undelete_media(self, media_id):
+        self._record("undelete_media", media_id)
+        return True
+
+    def create_reading_highlight(self, item_id, **kwargs):
+        self._record("create_reading_highlight", item_id)
+        return {"id": 5, "item_id": item_id, "quote": kwargs.get("quote", "")}
+
+    def update_reading_highlight(self, highlight_id, **changes):
+        self._record("update_reading_highlight", highlight_id)
+        return {"id": highlight_id, "item_id": 1, "quote": "q"}
+
+    def delete_reading_highlight(self, highlight_id):
+        self._record("delete_reading_highlight", highlight_id)
+        return True
+
+    def save_analysis_version(
+        self, media_id, *, content, analysis_content, prompt=None
+    ):
+        self._record("save_analysis_version", media_id)
+        return {"media_id": media_id}
+
+    def overwrite_analysis_version(
+        self, media_id, *, content, analysis_content, prompt=None
+    ):
+        self._record("overwrite_analysis_version", media_id)
+        return {"media_id": media_id}
+
+    def delete_analysis_version(self, version_uuid):
+        self._record("delete_analysis_version", version_uuid)
+        return True
+
+    def save_to_read_it_later(self, media_id):
+        self._record("save_to_read_it_later", media_id)
+        return True
+
+    def remove_from_read_it_later(self, media_id):
+        self._record("remove_from_read_it_later", media_id)
+        return True
+
+    def update_media_metadata(self, media_id, **metadata):
+        self._record("update_media_metadata", media_id)
+        return {"id": media_id, **metadata}
+
+
+class _RecordingServerService:
+    """Async server double -- server mode must never thread."""
+
+    def __init__(self):
+        self.thread_idents: dict[str, list[int]] = {}
+
+    def _record(self, name: str) -> None:
+        self.thread_idents.setdefault(name, []).append(threading.get_ident())
+
+    async def search_media(self, *, query=None, limit=20, offset=0, **kwargs):
+        self._record("search_media")
+        return {"items": [], "total": 0, "offset": offset, "limit": limit}
+
+    async def get_media_detail(self, media_id):
+        self._record("get_media_detail")
+        return {"id": media_id, "title": "Detail"}
+
+    async def get_reading_progress(self, media_id):
+        self._record("get_reading_progress")
+        return None
+
+
+def _scope(*, is_memory_db: bool) -> tuple[MediaReadingScopeService, _RecordingLocalService]:
+    local = _RecordingLocalService(is_memory_db=is_memory_db)
+    scope = MediaReadingScopeService(local_service=local, server_service=None)
+    return scope, local
+
+
+# Each case: (label, coroutine factory taking the scope service, expected leaf
+# call names that must have run -- usually one, two for get_media_detail
+# which also fetches reading progress inline).
+LOCAL_LEAF_CASES: list[tuple[str, Any, list[str]]] = [
+    (
+        "search_media",
+        lambda s: s.search_media(mode="local", query="q"),
+        ["search_media"],
+    ),
+    (
+        "list_read_it_later",
+        lambda s: s.list_read_it_later(mode="local", query="q"),
+        ["search_media"],
+    ),
+    (
+        "get_media_detail",
+        lambda s: s.get_media_detail(mode="local", media_id=1),
+        ["get_media_detail", "get_reading_progress"],
+    ),
+    (
+        "get_reading_progress",
+        lambda s: s.get_reading_progress(mode="local", media_id=1),
+        ["get_reading_progress"],
+    ),
+    (
+        "list_reading_highlights",
+        lambda s: s.list_reading_highlights(mode="local", media_id=1),
+        ["list_reading_highlights"],
+    ),
+    (
+        "list_document_versions",
+        lambda s: s.list_document_versions(mode="local", media_id=1),
+        ["list_document_versions"],
+    ),
+    (
+        "delete_media",
+        lambda s: s.delete_media(mode="local", media_id=1),
+        ["delete_media"],
+    ),
+    (
+        "undelete_media",
+        lambda s: s.undelete_media(mode="local", media_id=1),
+        ["undelete_media"],
+    ),
+    (
+        "create_reading_highlight",
+        lambda s: s.create_reading_highlight(mode="local", media_id=1, quote="hi"),
+        ["create_reading_highlight"],
+    ),
+    (
+        "update_reading_highlight",
+        lambda s: s.update_reading_highlight(
+            mode="local", highlight_id=5, quote="hi"
+        ),
+        ["update_reading_highlight"],
+    ),
+    (
+        "delete_reading_highlight",
+        lambda s: s.delete_reading_highlight(mode="local", highlight_id=5),
+        ["delete_reading_highlight"],
+    ),
+    (
+        "save_analysis_version",
+        lambda s: s.save_analysis_version(
+            mode="local", media_id=1, content="c", analysis_content="a"
+        ),
+        ["save_analysis_version"],
+    ),
+    (
+        "overwrite_analysis_version",
+        lambda s: s.overwrite_analysis_version(
+            mode="local", media_id=1, content="c", analysis_content="a"
+        ),
+        ["overwrite_analysis_version"],
+    ),
+    (
+        "delete_analysis_version",
+        lambda s: s.delete_analysis_version(mode="local", version_uuid="v1"),
+        ["delete_analysis_version"],
+    ),
+    (
+        "save_to_read_it_later",
+        lambda s: s.save_to_read_it_later(mode="local", media_id=1),
+        ["save_to_read_it_later"],
+    ),
+    (
+        "remove_from_read_it_later",
+        lambda s: s.remove_from_read_it_later(mode="local", media_id=1),
+        ["remove_from_read_it_later"],
+    ),
+    (
+        "update_media_metadata",
+        lambda s: s.update_media_metadata(mode="local", media_id=1, title="t"),
+        ["update_media_metadata"],
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("label,call,leaves", LOCAL_LEAF_CASES, ids=[c[0] for c in LOCAL_LEAF_CASES])
+async def test_local_leaf_threads_off_the_calling_thread_when_file_backed(
+    label, call, leaves
+):
+    scope, local = _scope(is_memory_db=False)
+    caller_thread = threading.get_ident()
+
+    await call(scope)
+
+    for leaf in leaves:
+        idents = local.thread_idents.get(leaf)
+        assert idents, f"{label}: leaf {leaf!r} was never called"
+        assert all(ident != caller_thread for ident in idents), (
+            f"{label}: leaf {leaf!r} ran on the calling (event-loop) thread "
+            f"instead of a worker thread"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("label,call,leaves", LOCAL_LEAF_CASES, ids=[c[0] for c in LOCAL_LEAF_CASES])
+async def test_local_leaf_stays_inline_when_memory_backed(label, call, leaves):
+    scope, local = _scope(is_memory_db=True)
+    caller_thread = threading.get_ident()
+
+    await call(scope)
+
+    for leaf in leaves:
+        idents = local.thread_idents.get(leaf)
+        assert idents, f"{label}: leaf {leaf!r} was never called"
+        assert all(ident == caller_thread for ident in idents), (
+            f"{label}: leaf {leaf!r} ran off the calling thread for a "
+            f":memory:-backed DB -- this would hand a worker thread an "
+            f"empty, unmigrated database"
+        )
+
+
+@pytest.mark.asyncio
+async def test_local_leaf_threads_an_unrecognized_local_double_with_no_media_db():
+    """Positive-confirmation predicate (task-283 lesson): a local service the
+    seam cannot positively confirm as memory-backed still threads -- there is
+    no negative branch that silently keeps an unrecognized shape inline.
+    """
+
+    class _BareLocalDouble:
+        def __init__(self):
+            self.thread_idents: list[int] = []
+
+        def search_media(self, *, query=None, limit=20, offset=0, **kwargs):
+            self.thread_idents.append(threading.get_ident())
+            return {"items": [], "total": 0}
+
+    local = _BareLocalDouble()
+    scope = MediaReadingScopeService(local_service=local, server_service=None)
+    caller_thread = threading.get_ident()
+
+    await scope.search_media(mode="local", query="q")
+
+    assert local.thread_idents
+    assert local.thread_idents[0] != caller_thread
+
+
+@pytest.mark.asyncio
+async def test_server_mode_never_threads_even_for_a_sync_double():
+    """The threading gate is mode == LOCAL, not merely "is this sync?" --
+    mirrors ChatConversationScopeService's server-mode carve-out.
+    """
+
+    class _SyncServerDouble:
+        def __init__(self):
+            self.thread_idents: list[int] = []
+
+        def search_media(self, *, query=None, limit=20, offset=0, **kwargs):
+            self.thread_idents.append(threading.get_ident())
+            return {"items": [], "total": 0}
+
+    server = _SyncServerDouble()
+    scope = MediaReadingScopeService(local_service=None, server_service=server)
+    caller_thread = threading.get_ident()
+
+    await scope.search_media(mode="server", query="q")
+
+    assert server.thread_idents == [caller_thread]
+
+
+@pytest.mark.asyncio
+async def test_server_mode_async_double_runs_inline_as_before():
+    server = _RecordingServerService()
+    scope = MediaReadingScopeService(local_service=None, server_service=server)
+    caller_thread = threading.get_ident()
+
+    await scope.get_media_detail(mode="server", media_id=41)
+
+    assert server.thread_idents["get_media_detail"] == [caller_thread]
+
+
+# ---------------------------------------------------------------------------
+# Real MediaDatabase + sqlite trace callback: the "15463 evidence-suite
+# pattern" -- no sampling, no timing, no flake.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def real_local_scope(tmp_path):
+    db = MediaDatabase(str(tmp_path / "media_off_loop.db"), client_id="off_loop_test")
+    media_id, _, _ = db.add_media_with_keywords(
+        title="Offloop Fixture",
+        content="Body text for the offloop probe.",
+        media_type="article",
+        keywords=[],
+    )
+    local_service = LocalMediaReadingService(db)
+    scope = MediaReadingScopeService(local_service=local_service, server_service=None)
+    try:
+        yield scope, db, media_id
+    finally:
+        db.close_connection()
+
+
+@pytest.mark.asyncio
+async def test_search_media_runs_no_sqlite_on_the_event_loop(real_local_scope):
+    """AC#1: the search/browse/pagination/keyword-filter leaf.
+
+    `db.get_connection()` returns the connection belonging to THIS thread --
+    the thread the event loop runs on. `MediaDatabase` connections are
+    thread-local, so any statement this callback sees is, by construction, a
+    statement that ran on the event-loop thread; the worker's own
+    thread-local connection is invisible to it.
+    """
+    scope, db, media_id = real_local_scope
+    loop_statements: list[str] = []
+    db.get_connection().set_trace_callback(loop_statements.append)
+    try:
+        result = await scope.search_media(mode="local", query="Offloop")
+    finally:
+        db.get_connection().set_trace_callback(None)
+
+    assert not loop_statements, (
+        "media search ran SQL on the event-loop thread: "
+        f"{loop_statements[:5]}"
+    )
+    assert result["total"] == 1
+    assert result["items"][0]["title"] == "Offloop Fixture"
+
+
+@pytest.mark.asyncio
+async def test_item_click_detail_chain_runs_no_sqlite_on_the_event_loop(
+    real_local_scope,
+):
+    """AC#1: the item-click chain -- detail (which internally also fetches
+    reading progress) and document versions -- the sequential queries the
+    audit named at `MediaWindow_v2.py:1188-1191`.
+
+    ``list_reading_highlights`` is deliberately NOT exercised here against
+    the real ``LocalMediaReadingService``: the scope service's local branch
+    calls ``service.list_reading_highlights(...)``, but
+    ``LocalMediaReadingService`` only implements ``list_highlights`` (no
+    ``reading_`` prefix) -- a pre-existing production gap (every local-mode
+    item click already hits `AttributeError` there today, caught by
+    `MediaWindow_v2._load_media_item_detail`'s broad `except Exception` and
+    presented as zero highlights) that predates and is unrelated to this
+    task's event-loop fix; see `test_local_leaf_threads_off_the_calling_
+    thread_when_file_backed[list_reading_highlights]` above for proof that
+    threading is correctly applied to that leaf whenever it exists.
+    """
+    scope, db, media_id = real_local_scope
+    loop_statements: list[str] = []
+    db.get_connection().set_trace_callback(loop_statements.append)
+    try:
+        detail = await scope.get_media_detail(mode="local", media_id=media_id)
+        versions = await scope.list_document_versions(
+            mode="local", media_id=media_id
+        )
+    finally:
+        db.get_connection().set_trace_callback(None)
+
+    assert not loop_statements, (
+        "the item-click detail chain ran SQL on the event-loop thread: "
+        f"{loop_statements[:5]}"
+    )
+    # Never vacuous: the chain really did fetch real data, including the
+    # reading-progress leaf `get_media_detail` fetches internally, and the
+    # document version `add_media_with_keywords` creates automatically.
+    assert detail["title"] == "Offloop Fixture"
+    assert "reading_progress" in detail
+    assert len(versions) == 1
+    assert versions[0]["media_id"] == media_id
+
+
+@pytest.mark.asyncio
+async def test_memory_backed_real_db_stays_on_the_calling_thread(tmp_path):
+    """A `:memory:` MediaDatabase must NOT be threaded -- it is only visible
+    to the thread that created it (the task-283 hazard). This positively
+    proves the opposite of the two tests above for the one case where
+    staying inline is correct.
+    """
+    db = MediaDatabase(":memory:", client_id="off_loop_memory_test")
+    try:
+        media_id, _, _ = db.add_media_with_keywords(
+            title="Memory Fixture",
+            content="Body",
+            media_type="article",
+            keywords=[],
+        )
+        local_service = LocalMediaReadingService(db)
+        scope = MediaReadingScopeService(
+            local_service=local_service, server_service=None
+        )
+        caller_thread = threading.get_ident()
+
+        detail = await scope.get_media_detail(mode="local", media_id=media_id)
+
+        assert detail["title"] == "Memory Fixture"
+        # A threaded call against a :memory: DB would hit a fresh, empty
+        # connection and raise/return nothing -- getting the real row back
+        # at all is itself evidence the call stayed on this thread, and the
+        # thread-affinity parametrized test above pins the mechanism.
+        assert threading.get_ident() == caller_thread
+    finally:
+        db.close_connection()

--- a/backlog/tasks/task-15467 - Media-hub---take-local-reading-service-calls-off-the-event-loop.md
+++ b/backlog/tasks/task-15467 - Media-hub---take-local-reading-service-calls-off-the-event-loop.md
@@ -113,16 +113,26 @@ fast -- not worth the risk for this task's scope.
 
 **Pre-existing bugs found, NOT fixed (out of scope, flagged per the
 task-283 convention):**
-- `LocalMediaReadingService` never implemented `list_reading_highlights` --
-  only `list_highlights` (no `reading_` prefix; the Library screen's own,
-  separate call sites use the correct name and work fine). Every local-mode
-  item click already hit `AttributeError` there before this change, caught
-  by `_load_media_item_detail`'s broad `except Exception` and presented as
-  zero highlights. Confirmed with a real `LocalMediaReadingService` in a
-  probe; `_call_local_leaf`'s `getattr(service, method_name)` raises the
-  identical `AttributeError` at the identical point, so this task changes
-  nothing about that gap -- it was already broken, still is, unrelated to
-  the event loop.
+- `LocalMediaReadingService` never implemented the `reading_`-prefixed
+  highlight CRUD the scope service calls in local mode -- all **four**
+  methods are affected, not just the one first spotted: `list_reading_
+  highlights`, `create_reading_highlight`, `update_reading_highlight`, and
+  `delete_reading_highlight` all `AttributeError` against a real local
+  service, because `LocalMediaReadingService` only implements the
+  unprefixed `list_highlights`/`create_highlight`/`update_highlight`/
+  `delete_highlight` (the Library screen's own, separate call sites use
+  those correct, unprefixed names and work fine). Every local-mode item
+  click already hit `AttributeError` loading highlights before this change
+  (caught by `_load_media_item_detail`'s broad `except Exception`,
+  presented as zero highlights), and every local-mode highlight
+  create/update/delete action already hit the identical `AttributeError`
+  too. Confirmed all four directly against a real `LocalMediaReadingService`
+  instance (`getattr(service, "create_reading_highlight")` etc. all raise).
+  `_call_local_leaf`'s `getattr(service, method_name)` raises the identical
+  `AttributeError` at the identical point, before any threading decision is
+  made, so this task changes nothing about the surface, thread, or timing of
+  that failure for any of the four -- it was already broken, still is,
+  unrelated to the event loop.
 - `MediaWindow_v2.py:1685` (`handle_analysis_request`'s `perform_analysis`,
   dispatched via `run_worker(coroutine)`) has its own, separate direct
   `self.app_instance.media_db.get_media_by_id(...)` call, bypassing the
@@ -151,10 +161,22 @@ thread-affinity test and the trace-callback test failed with the exact
 statements/thread-identity evidence in the assertion message, then restored
 and re-confirmed green.
 
-**AC#2 (existing tests green, unmodified first).** `Tests/Media/test_media_
-reading_scope_service.py` (73), `Tests/Media/test_local_media_reading_
-service.py` (100), `Tests/UI/test_media_window_v2_parity.py` (78) all green
-before any code change and still green after -- these tests mostly use
+**AC#2 (existing tests green, unmodified first).** CORRECTION (review round,
+2026-08-11): the counts originally recorded here were wrong -- each file was
+run individually with `pytest <file> -q` and its own "N passed" line read
+directly, replacing an earlier accounting error where two files run together
+in one command had their combined count misattributed to a single file.
+Verified individually: `Tests/Media/test_media_reading_scope_service.py`
+(**73**), `Tests/Media/test_local_media_reading_service.py` (**69**, not
+100), `Tests/UI/test_media_window_v2_parity.py` (**31**, not 78) --
+**173 pre-existing tests**, all green before any code change and still green
+after. Adding the new `Tests/Media/test_media_reading_scope_service_off_
+loop.py` (**40**, new -- not a pre-existing-regression check) brings the
+combined targeted total to **213** when all four files are run together
+(`pytest Tests/Media/test_media_reading_scope_service.py Tests/Media/test_
+local_media_reading_service.py Tests/UI/test_media_window_v2_parity.py
+Tests/Media/test_media_reading_scope_service_off_loop.py -q`), not the 291
+previously claimed. These tests mostly use
 `Mock`/`AsyncMock` scope services with `runtime_backend="server"` (never
 threaded) or `FakeLocalMediaService` doubles with no `media_db` attribute
 (now threaded, but the tests only assert on the returned value / recorded

--- a/backlog/tasks/task-15467 - Media-hub---take-local-reading-service-calls-off-the-event-loop.md
+++ b/backlog/tasks/task-15467 - Media-hub---take-local-reading-service-calls-off-the-event-loop.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15467
 title: Media hub: take local reading-service calls off the event loop
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -20,7 +21,196 @@ Fix direction: thread the local mode in the scope service, mirroring `ChatConver
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 No synchronous DB work runs on the event loop for media search, browse, pagination, or item click (evidence)
-- [ ] #2 Results, pagination, undelete, and detail loads identical (existing tests green)
-- [ ] #3 Item-click latency before/after on a large media DB recorded
+- [x] #1 No synchronous DB work runs on the event loop for media search, browse, pagination, or item click (evidence)
+- [x] #2 Results, pagination, undelete, and detail loads identical (existing tests green)
+- [x] #3 Item-click latency before/after on a large media DB recorded
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Read the template (`Chat/chat_conversation_scope_service.py`, task-283): a
+   positive-confirmation predicate -- `mode == LOCAL and not
+   iscoroutinefunction(fn) and not is_memory_backed(service)` -- gates
+   `asyncio.to_thread`; everything else (server mode, an already-async
+   method, or a positively-confirmed `:memory:` DB) keeps running inline via
+   the existing `_maybe_await`.
+2. Sweep `Media/media_reading_scope_service.py` for every LOCAL-mode leaf
+   call `UI/MediaWindow_v2.py` (the Media hub) actually invokes, and
+   classify each as sync-passthrough (thread it) vs. already-async /
+   server-only (leave untouched). Add one shared async helper
+   (`_call_local_leaf`) implementing the predicate once, keyed on
+   `service.media_db.is_memory_db` (the local attribute name; the chat
+   template uses `.db`), and re-point every classified call through it.
+3. For the item-click chain (`get_media_detail` + nested reading-progress +
+   highlights + document-versions), decide thread-individually vs. batch
+   into one `to_thread` hop; record the decision and why.
+4. Write evidence: thread-affinity tests (file-backed threads off-loop,
+   `:memory:`-backed and server-mode stay inline) for every converted leaf,
+   plus a real-`MediaDatabase` + `sqlite3.Connection.set_trace_callback`
+   test (the task-15463 evidence pattern) proving zero SQL statements
+   execute on the calling/event-loop thread for the search leaf and the
+   item-click chain. Mutation-test at least one guard by reverting it and
+   confirming the test fails.
+5. Run the existing Media suites unmodified first (must be green before
+   touching anything), then the new evidence suite.
+6. Record an honest before/after item-click latency measurement against a
+   large (6,000-row) local media DB in an isolated scratch HOME.
+
+## Implementation Notes
+
+**Approach.** Added `MediaReadingScopeService._is_memory_backed` (mirrors
+`ChatConversationScopeService._is_memory_backed`, keyed on `service.media_db`
+-- the local service's actual attribute name, not `.db`) and
+`_call_local_leaf(mode, service, method_name, *args, **kwargs)`, the shared
+positive-confirmation gate: `fn = getattr(service, method_name)` (so a
+service shape that lacks the method still raises the identical
+`AttributeError` it always did, at the same point, before any threading
+decision is made -- see the highlights caveat below), then thread via
+`asyncio.to_thread` only when `mode == LOCAL and not
+iscoroutinefunction(fn) and not is_memory_backed(service)`; otherwise fall
+through to the pre-existing `_maybe_await(fn(*args, **kwargs))`. Every other
+existing behavior (policy enforcement, normalization, error handling) is
+untouched -- only the leaf DB call itself moved.
+
+**Sweep result (every LOCAL-mode leaf `MediaWindow_v2.py` actually calls,
+now threaded):** `search_media` (search/browse/pagination/keyword-filter,
+and its page-correction retry, which reuses the same method), `list_read_it_
+later` (the read-it-later browse subview -- same underlying
+`local_service.search_media` leaf), `get_media_detail` (item click; also
+threads its own internal nested `get_reading_progress` call),
+`get_reading_progress` (standalone), `list_reading_highlights`,
+`list_document_versions`, `delete_media`, `undelete_media`,
+`create_reading_highlight`, `update_reading_highlight`,
+`delete_reading_highlight`, `save_analysis_version`,
+`overwrite_analysis_version`, `delete_analysis_version`,
+`save_to_read_it_later`, `remove_from_read_it_later`,
+`update_media_metadata` (the leaf `update_media_metadata_latest`'s
+last-write-wins lock ultimately calls). Server mode and every other scope-
+service method (ingest/process operations, saved searches, note links,
+digest schedules, `list_unified_items`/`get_unified_item` and the
+`list_backing_media_*`/`get_backing_media_item` family the Library screen
+uses) were left untouched: they are either already async, server-only, or
+-- for the Library-only family -- not reachable from the Media hub at all
+(Library screen already threads its own scope-service calls at the caller
+level via `_run_library_service_call(..., isolate_in_worker=True)`, an
+independent, coarser-grained mechanism; the 3 methods it shares with the
+Media hub, `save_analysis_version`/`save_to_read_it_later`/`remove_from_
+read_it_later`, now get a harmless extra thread-hop when Library calls them
+-- functionally identical, one more context switch).
+
+**Item-click batching decision.** Threaded individually (detail, then
+highlights, then document-versions -- each its own `to_thread` hop) rather
+than bundling into one combined leaf call. Reasons: (1) it preserves the
+existing per-stage `_detail_presentation_is_current` staleness re-check
+between each `await`, so a selection change mid-load still bails without
+doing the remaining work, exactly as before; (2) each hop is a single
+indexed-PK sqlite read (confirmed cheap by the latency probe below, <1ms
+each), so the extra ~0.1-0.3ms per hop is imperceptible next to the
+compounding effects the audit measured elsewhere (CSS reparse, screen
+switch); (3) a bundled call would need a brand-new scope-service method and
+its own test surface for a case where the underlying queries are already
+fast -- not worth the risk for this task's scope.
+
+**Pre-existing bugs found, NOT fixed (out of scope, flagged per the
+task-283 convention):**
+- `LocalMediaReadingService` never implemented `list_reading_highlights` --
+  only `list_highlights` (no `reading_` prefix; the Library screen's own,
+  separate call sites use the correct name and work fine). Every local-mode
+  item click already hit `AttributeError` there before this change, caught
+  by `_load_media_item_detail`'s broad `except Exception` and presented as
+  zero highlights. Confirmed with a real `LocalMediaReadingService` in a
+  probe; `_call_local_leaf`'s `getattr(service, method_name)` raises the
+  identical `AttributeError` at the identical point, so this task changes
+  nothing about that gap -- it was already broken, still is, unrelated to
+  the event loop.
+- `MediaWindow_v2.py:1685` (`handle_analysis_request`'s `perform_analysis`,
+  dispatched via `run_worker(coroutine)`) has its own, separate direct
+  `self.app_instance.media_db.get_media_by_id(...)` call, bypassing the
+  scope service entirely -- a rare fallback branch (only when the event's
+  own record is empty), structurally the same "run_worker(coroutine) != a
+  thread" bug the audit named, but not one of the two audited sites and not
+  on the search/browse/item-click/undelete AC's path. Left unthreaded; flag
+  for a follow-up if it turns out to matter in practice.
+
+**Evidence (AC#1).** New `Tests/Media/test_media_reading_scope_service_off_
+loop.py` (40 tests): a parametrized thread-affinity double covering all 17
+converted call sites, run twice -- file-backed (must NOT run on the caller
+thread) and `:memory:`-backed (must stay on the caller thread, the
+task-283 hazard); a test proving an unrecognized local double with no
+`media_db` still threads (positive-confirmation predicate, no negative
+branch); a test proving server mode never threads even for a sync double
+(the gate is `mode == LOCAL`, not merely "is this sync?"); and two real-
+`MediaDatabase` + `sqlite3.Connection.set_trace_callback` tests (the
+task-15463 evidence pattern) asserting zero SQL statements land on the
+calling/event-loop thread's own connection for the search leaf and for the
+item-click chain (`get_media_detail` + its internal reading-progress fetch,
+plus `list_document_versions`; `list_reading_highlights` deliberately
+excluded from this real-DB test per the pre-existing-bug note above).
+Mutation-tested by reverting the `search_media` conversion by hand: both the
+thread-affinity test and the trace-callback test failed with the exact
+statements/thread-identity evidence in the assertion message, then restored
+and re-confirmed green.
+
+**AC#2 (existing tests green, unmodified first).** `Tests/Media/test_media_
+reading_scope_service.py` (73), `Tests/Media/test_local_media_reading_
+service.py` (100), `Tests/UI/test_media_window_v2_parity.py` (78) all green
+before any code change and still green after -- these tests mostly use
+`Mock`/`AsyncMock` scope services with `runtime_backend="server"` (never
+threaded) or `FakeLocalMediaService` doubles with no `media_db` attribute
+(now threaded, but the tests only assert on the returned value / recorded
+call args, which `await asyncio.to_thread(...)` preserves exactly since the
+`await` blocks until the thread finishes). One real-DB test in the existing
+suite (`test_scope_service_local_detail_carries_saved_state_from_local_
+service`) already used a `:memory:` `Database` + real
+`LocalMediaReadingService` and stayed green, confirming the memory-backed
+guard degrades correctly for that pre-existing case too. Also ran the wider
+consumer surface (`Tests/Library/`, `Tests/RuntimePolicy/test_unsupported_
+capabilities.py`, `Tests/MCP/test_library_tools.py`,
+`Tests/ProductionApp/test_media_state_ownership.py`,
+`Tests/ProductionApp/test_service_composition_lifecycle.py`,
+`Tests/UI/test_home_screen.py`): identical failure SET before and after (13
+failed / 15 errors in the two `ProductionApp` files, confirmed pre-existing
+by swapping in the pre-change file and re-running the identical command --
+same 13 + 15 test names both times; root cause looks environmental, a
+blocked real network-egress attempt plus a screen-routing timeout, unrelated
+to this change). Everything else in that sweep (1789 in `Tests/Library/`
+alone) passed both before and after.
+
+**AC#3 (latency probe, isolated scratch HOME).** Script at
+`/private/tmp/.../scratchpad/t15467_latency_probe.py` (session-scoped
+scratch, not committed): `HOME`/`XDG_CONFIG_HOME`/`XDG_DATA_HOME`/
+`TLDW_CONFIG_PATH` all pointed at a fresh `tempfile.mkdtemp()` before any
+`tldw_chatbook` import (never touches the real profile). Built a 6,000-row
+local media DB (~2.4 KB article body each, distinct per row -- the DB
+dedups by content, not just title, which the first probe attempt found the
+hard way) and measured both raw wall time and event-loop starvation (a 1ms
+heartbeat coroutine racing the DB call; missed ticks == time the loop
+couldn't run anything else) for the search leaf and the item-click chain,
+8 repeats each:
+
+| leaf | wall(ms) median | heartbeat ticks median |
+|---|---|---|
+| search, BEFORE (inline) | 1059 | 0 |
+| search, AFTER (threaded) | 982 | 831 |
+| item-click chain, BEFORE (inline) | 0.10 | 0 |
+| item-click chain, AFTER (threaded) | 0.39 | 0 |
+
+Honest reading: search on this dataset is genuinely slow (~1s) because the
+FTS fallback's `LIKE '%query%'` clause over the `content` column can't use
+an index and full-scans ~14 MB of text -- that is exactly the shape a real,
+sizeable local library search hits, and the AFTER row proves the loop stays
+almost perfectly live throughout (831 ticks at 1ms cadence over a ~980ms
+call) where BEFORE it is completely frozen for the full second. The
+item-click chain is fast regardless on this dataset (indexed
+primary-key/foreign-key reads) -- both numbers are sub-millisecond, so no
+starvation is visible at this scale either way, and AFTER is measurably
+*slower* in raw wall time by the ~0.1-0.3ms/hop `asyncio.to_thread` context-
+switch cost noted in the batching decision above. Not fixed by batching (see
+that decision); the win from threading the item-click chain is correctness
+under slower disks/hardware (the audit's 3-5x constrained-hardware
+multiplier) and consistency with search, not a measured latency win on this
+fast local SSD with a small per-item DB.
+
+**Files changed:** `tldw_chatbook/Media/media_reading_scope_service.py`
+(the helper + 17 converted call sites). New test file:
+`Tests/Media/test_media_reading_scope_service_off_loop.py` (40 tests).

--- a/tldw_chatbook/Media/media_reading_scope_service.py
+++ b/tldw_chatbook/Media/media_reading_scope_service.py
@@ -121,6 +121,61 @@ class MediaReadingScopeService:
             return await value
         return value
 
+    @staticmethod
+    def _is_memory_backed(service: Any) -> bool:
+        """True when a local service's backing DB is a per-connection ``:memory:`` store.
+
+        Mirrors ``ChatConversationScopeService._is_memory_backed`` (task-283):
+        thread-local (file-backed) sqlite connections are safe to run via
+        ``asyncio.to_thread``; a ``:memory:`` ``MediaDatabase`` is only
+        visible to the thread that created/migrated it, so threading it
+        would hand the worker an empty, unmigrated database. Degrades to
+        False (i.e. eligible to thread) when the service shape doesn't
+        expose ``.media_db`` -- the server service, for one, has no local
+        sqlite connection at all, and an unrecognized local test double is
+        harmless to hand a thread hop (see ``_call_local_leaf``).
+        """
+        db = getattr(service, "media_db", None)
+        return bool(getattr(db, "is_memory_db", False))
+
+    async def _call_local_leaf(
+        self,
+        mode: "MediaReadingBackend",
+        service: Any,
+        method_name: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Call one backend leaf, threading a confirmed local sync call (task-15467).
+
+        ``run_worker(coroutine)`` does NOT leave the event loop, so every
+        local-mode call that previously went straight through
+        ``_maybe_await`` to a plain synchronous ``LocalMediaReadingService``
+        method (``search_media``, ``get_media_detail``,
+        ``get_reading_progress``, highlight/version CRUD, ...) ran its sync
+        sqlite work inline on the loop whenever ``run_worker`` fired it.
+
+        POSITIVE-confirmation predicate (task-283 lesson, mirrored from
+        ``ChatConversationScopeService``): a call only threads once it is
+        confirmed local, confirmed not-a-coroutine-function, and confirmed
+        not memory-backed. There is no negative branch that inlines an
+        *unrecognized* local shape -- an unfamiliar local service or test
+        double still threads (a thread hop around an ordinary callable is
+        harmless); the one thing that must never thread is a per-connection
+        ``:memory:`` DB, which only degrades OUT of threading when
+        positively confirmed via ``_is_memory_backed``. Server mode and any
+        already-async method are untouched -- they always take the
+        ``_maybe_await`` branch, exactly as before this change.
+        """
+        fn = getattr(service, method_name)
+        if (
+            mode == MediaReadingBackend.LOCAL
+            and not inspect.iscoroutinefunction(fn)
+            and not self._is_memory_backed(service)
+        ):
+            return await asyncio.to_thread(fn, *args, **kwargs)
+        return await self._maybe_await(fn(*args, **kwargs))
+
     def _enforce_policy(self, action_id: str) -> None:
         if self.policy_enforcer is None:
             return
@@ -650,8 +705,14 @@ class MediaReadingScopeService:
         if id_allowlist is not None:
             filters = dict(filters)
             filters["media_ids_filter"] = list(id_allowlist)
-        payload = await self._maybe_await(
-            service.search_media(query=query, limit=limit, offset=offset, **filters)
+        payload = await self._call_local_leaf(
+            normalized_mode,
+            service,
+            "search_media",
+            query=query,
+            limit=limit,
+            offset=offset,
+            **filters,
         )
         raw_items = (
             list(payload.get("items", []))
@@ -683,13 +744,15 @@ class MediaReadingScopeService:
         normalized_mode = self._normalize_mode(mode)
         self._enforce_policy(self._reading_action_id(normalized_mode, "detail"))
         service = self._service_for_mode(normalized_mode)
-        detail = await self._maybe_await(service.get_media_detail(media_id))
+        detail = await self._call_local_leaf(
+            normalized_mode, service, "get_media_detail", media_id
+        )
         normalized = self._normalize_media_record(normalized_mode, detail)
 
         backing_media_id = normalized.get("backing_media_id")
         if backing_media_id not in (None, ""):
-            progress = await self._maybe_await(
-                service.get_reading_progress(backing_media_id)
+            progress = await self._call_local_leaf(
+                normalized_mode, service, "get_reading_progress", backing_media_id
             )
             normalized["reading_progress"] = normalize_reading_progress(
                 progress,
@@ -1229,19 +1292,23 @@ class MediaReadingScopeService:
             raise ValueError(str(capability["reason"]))
         self._enforce_policy(self._reading_list_action_id(normalized_mode, "list"))
         service = self._service_for_mode(normalized_mode)
-        payload = await self._maybe_await(
-            service.search_media(
+        if normalized_mode == MediaReadingBackend.LOCAL:
+            payload = await self._call_local_leaf(
+                normalized_mode,
+                service,
+                "search_media",
                 query=query,
                 limit=limit,
                 offset=offset,
                 read_it_later_only=True,
                 **filters,
             )
-            if normalized_mode == MediaReadingBackend.LOCAL
-            else service.search_media(
-                query=query, limit=limit, offset=offset, status=["saved"], **filters
+        else:
+            payload = await self._maybe_await(
+                service.search_media(
+                    query=query, limit=limit, offset=offset, status=["saved"], **filters
+                )
             )
-        )
         raw_items = list(payload.get("items", []))
         items = [
             self._normalize_media_record(normalized_mode, item) for item in raw_items
@@ -1263,7 +1330,9 @@ class MediaReadingScopeService:
         self._enforce_policy(self._reading_list_action_id(normalized_mode, "create"))
         service = self._service_for_mode(normalized_mode)
         if normalized_mode == MediaReadingBackend.LOCAL:
-            return await self._maybe_await(service.save_to_read_it_later(media_id))
+            return await self._call_local_leaf(
+                normalized_mode, service, "save_to_read_it_later", media_id
+            )
         return await self._maybe_await(
             service.update_media_metadata(media_id, status="saved")
         )
@@ -1278,7 +1347,9 @@ class MediaReadingScopeService:
         self._enforce_policy(self._reading_list_action_id(normalized_mode, "delete"))
         service = self._service_for_mode(normalized_mode)
         if normalized_mode == MediaReadingBackend.LOCAL:
-            return await self._maybe_await(service.remove_from_read_it_later(media_id))
+            return await self._call_local_leaf(
+                normalized_mode, service, "remove_from_read_it_later", media_id
+            )
         return await self._maybe_await(
             service.update_media_metadata(media_id, status="archived")
         )
@@ -2442,8 +2513,8 @@ class MediaReadingScopeService:
         normalized_mode = self._normalize_mode(mode)
         self._enforce_policy(self._reading_action_id(normalized_mode, "update"))
         service = self._service_for_mode(normalized_mode)
-        return await self._maybe_await(
-            service.update_media_metadata(media_id, **metadata)
+        return await self._call_local_leaf(
+            normalized_mode, service, "update_media_metadata", media_id, **metadata
         )
 
     def update_media_metadata_latest(
@@ -2500,7 +2571,9 @@ class MediaReadingScopeService:
         normalized_mode = self._normalize_mode(mode)
         self._enforce_policy(self._reading_action_id(normalized_mode, "delete"))
         service = self._service_for_mode(normalized_mode)
-        return await self._maybe_await(service.delete_media(media_id))
+        return await self._call_local_leaf(
+            normalized_mode, service, "delete_media", media_id
+        )
 
     async def bulk_update_reading_items(
         self,
@@ -2537,7 +2610,9 @@ class MediaReadingScopeService:
         normalized_mode = self._normalize_mode(mode)
         self._enforce_policy(self._reading_action_id(normalized_mode, "update"))
         service = self._service_for_mode(normalized_mode)
-        return await self._maybe_await(service.undelete_media(media_id))
+        return await self._call_local_leaf(
+            normalized_mode, service, "undelete_media", media_id
+        )
 
     async def get_reading_progress(
         self,
@@ -2554,8 +2629,8 @@ class MediaReadingScopeService:
         backing_media_id = self._resolve_backing_media_id(
             record=record, media_id=media_id
         )
-        progress = await self._maybe_await(
-            service.get_reading_progress(backing_media_id)
+        progress = await self._call_local_leaf(
+            normalized_mode, service, "get_reading_progress", backing_media_id
         )
         return normalize_reading_progress(
             progress,
@@ -2644,8 +2719,12 @@ class MediaReadingScopeService:
             }.items()
             if value is not None
         }
-        highlight = await self._maybe_await(
-            service.create_reading_highlight(resolved_item_id, **payload)
+        highlight = await self._call_local_leaf(
+            normalized_mode,
+            service,
+            "create_reading_highlight",
+            resolved_item_id,
+            **payload,
         )
         return normalize_reading_highlight(highlight, backend=normalized_mode.value)
 
@@ -2666,8 +2745,8 @@ class MediaReadingScopeService:
             item_id=item_id,
             media_id=media_id,
         )
-        highlights = await self._maybe_await(
-            service.list_reading_highlights(resolved_item_id)
+        highlights = await self._call_local_leaf(
+            normalized_mode, service, "list_reading_highlights", resolved_item_id
         )
         return [
             normalize_reading_highlight(highlight, backend=normalized_mode.value)
@@ -2686,11 +2765,12 @@ class MediaReadingScopeService:
             self._reading_highlight_action_id(normalized_mode, "update")
         )
         service = self._service_for_mode(normalized_mode)
-        highlight = await self._maybe_await(
-            service.update_reading_highlight(
-                highlight_id,
-                **{key: value for key, value in changes.items() if value is not None},
-            )
+        highlight = await self._call_local_leaf(
+            normalized_mode,
+            service,
+            "update_reading_highlight",
+            highlight_id,
+            **{key: value for key, value in changes.items() if value is not None},
         )
         return normalize_reading_highlight(highlight, backend=normalized_mode.value)
 
@@ -2705,7 +2785,9 @@ class MediaReadingScopeService:
             self._reading_highlight_action_id(normalized_mode, "delete")
         )
         service = self._service_for_mode(normalized_mode)
-        return await self._maybe_await(service.delete_reading_highlight(highlight_id))
+        return await self._call_local_leaf(
+            normalized_mode, service, "delete_reading_highlight", highlight_id
+        )
 
     async def create_highlight(
         self,
@@ -3251,8 +3333,12 @@ class MediaReadingScopeService:
         normalized_mode = self._normalize_mode(mode)
         self._enforce_policy(self._reading_action_id(normalized_mode, "detail"))
         service = self._service_for_mode(normalized_mode)
-        return await self._maybe_await(
-            service.list_document_versions(media_id, include_deleted=include_deleted)
+        return await self._call_local_leaf(
+            normalized_mode,
+            service,
+            "list_document_versions",
+            media_id,
+            include_deleted=include_deleted,
         )
 
     async def get_analysis_version(
@@ -3290,13 +3376,14 @@ class MediaReadingScopeService:
         normalized_mode = self._normalize_mode(mode)
         self._enforce_policy(self._reading_action_id(normalized_mode, "update"))
         service = self._service_for_mode(normalized_mode)
-        return await self._maybe_await(
-            service.save_analysis_version(
-                media_id,
-                content=content,
-                analysis_content=analysis_content,
-                prompt=prompt,
-            )
+        return await self._call_local_leaf(
+            normalized_mode,
+            service,
+            "save_analysis_version",
+            media_id,
+            content=content,
+            analysis_content=analysis_content,
+            prompt=prompt,
         )
 
     async def overwrite_analysis_version(
@@ -3311,13 +3398,14 @@ class MediaReadingScopeService:
         normalized_mode = self._normalize_mode(mode)
         self._enforce_policy(self._reading_action_id(normalized_mode, "update"))
         service = self._service_for_mode(normalized_mode)
-        return await self._maybe_await(
-            service.overwrite_analysis_version(
-                media_id,
-                content=content,
-                analysis_content=analysis_content,
-                prompt=prompt,
-            )
+        return await self._call_local_leaf(
+            normalized_mode,
+            service,
+            "overwrite_analysis_version",
+            media_id,
+            content=content,
+            analysis_content=analysis_content,
+            prompt=prompt,
         )
 
     async def delete_analysis_version(
@@ -3331,7 +3419,9 @@ class MediaReadingScopeService:
         normalized_mode = self._normalize_mode(mode)
         self._enforce_policy(self._reading_action_id(normalized_mode, "delete"))
         service = self._service_for_mode(normalized_mode)
-        return await self._maybe_await(service.delete_analysis_version(version_uuid))
+        return await self._call_local_leaf(
+            normalized_mode, service, "delete_analysis_version", version_uuid
+        )
 
     @staticmethod
     def _raise_local_advanced_version_unsupported() -> None:


### PR DESCRIPTION
## Summary

Task 15467 from the input-latency audit. Every media search, keyword filter, pagination, subview change, undelete, and list-item click ran sync SQLite on the event loop inside `run_worker(coroutine)` — which never leaves the loop; item clicks stacked 3-4 sequential queries.

- Local mode threaded in `media_reading_scope_service` (task-283 template: positive-confirmation predicate — only a positively-confirmed :memory: DB stays inline; unknown shapes thread), all 17 UI-facing passthroughs classified and covered
- No new race class: the pre-existing generation guards (`_detail_presentation_is_current` / `_search_presentation_is_current` + exclusive worker) already handle out-of-order completion — reviewer verified structurally
- One deliberately-left unthreaded bypass (rare analysis-request fallback, only reachable when three richer sources all miss) — disclosed and reviewer-verified rare
- 40 new off-loop evidence tests (mutation-verified by both implementer and reviewer: re-inlining a leaf reds the SQL-on-loop assertions with real evidence)

## Verification
Independent review: Approved. Sweep re-derived; ProductionApp failure set byte-identical at base (reviewer swapped base file in/out to prove it); evidence tests mutation-checked. The review caught inflated test counts in the notes (claimed 291, actual 213, zero failures either way) — corrected before merge, per the repo's evidence-accuracy rule; the pre-existing highlights naming-mismatch disclosure was widened to all four CRUD methods (being filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads all local media local-mode calls off the event loop to eliminate blocking SQLite in search, pagination, and item-click paths, improving UI responsiveness. Implements task-15467 with a guarded thread hop and evidence tests; server-mode behavior is unchanged.

- **Refactors**
  - Added `MediaReadingScopeService._call_local_leaf` with a positive-confirmation gate: `mode == LOCAL`, function is sync, and service is not `:memory:`-backed via `service.media_db.is_memory_db`; uses `asyncio.to_thread`, otherwise falls back to `_maybe_await`.
  - Applied to 17 LOCAL leaves, including `search_media`, `list_read_it_later`, `get_media_detail` (+`get_reading_progress`), `get_reading_progress`, reading-highlight CRUD, `list_document_versions`, `delete_media`/`undelete_media`, analysis-version ops, read-it-later ops, and `update_media_metadata`.
  - Kept item-click steps threaded per-leaf to preserve staleness guards; server-mode and already-async paths remain inline.
  - Evidence: 40 new tests (thread-affinity and real `sqlite3` trace-callback) prove zero SQL on the event loop for search and item-click; existing suites remain green. Known pre-existing gaps left unchanged: `reading_*` highlight methods missing in `LocalMediaReadingService`, and a rare analysis fallback that bypasses the scope.

<sup>Written for commit 209e21f39f06693fa781d123c7067e0d3b8e3c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

