### PR TITLE
perf: throttle fence-interior re-highlighting during Console streaming (task-15456)

### DIFF
--- a/Tests/UI/test_console_transcript_fence_throttle.py
+++ b/Tests/UI/test_console_transcript_fence_throttle.py
@@ -286,6 +286,139 @@ async def test_final_render_after_fence_close_matches_unthrottled_render(monkeyp
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_status", ["complete", "stopped", "failed"])
+async def test_stream_ending_mid_open_fence_flushes_buffered_tail(
+    monkeypatch, terminal_status: str
+):
+    """AC#2 regression (fix round 1): a stream that ends while its fence is
+    STILL OPEN must not strand buffered content.
+
+    Reproduces the exact production path a code reviewer caught the first
+    version of this task missing: the transcript reconciler calls
+    ``sync_message`` on a status-only change (status is part of the row
+    signature), which is exactly what "user presses Stop mid-code-block" or
+    a length-limit cutoff looks like -- the message body stops growing and
+    the NEXT (and only remaining) call carries the SAME body text with a
+    new terminal status. `sync_message`'s "body unchanged" fast path used
+    to return before ever looking at the pending fence buffer, permanently
+    stranding whatever was deferred. This drives the body deep enough into
+    an open fence that the throttle is guaranteed to be holding a
+    non-empty buffer (the fake clock never advances far enough to cross
+    the deadline on its own), then flips status with NO further body
+    change -- the one shape that previously lost content.
+    """
+    clock = _FakeClock()
+    monkeypatch.setattr(console_transcript_module, "monotonic", clock)
+
+    final_body = (
+        "Cutting off mid-block:\n\n"
+        "```python\n"
+        "def add(a, b):\n"
+        "    return a + b\n\n"
+        "for i in range(3):\n"
+        "    print(add(i, i))\n"
+    )  # deliberately never closed -- fence is still open when streaming ends
+
+    app_a = MarkdownHarness()
+    async with app_a.run_test() as pilot_a:
+        transcript_a = app_a.query_one(ConsoleTranscript)
+        streamed = ""
+        transcript_a.set_messages([_assistant(streamed)])
+        await transcript_a.refresh_messages()
+        await pilot_a.pause()
+
+        chunk_size = 5
+        for start in range(0, len(final_body), chunk_size):
+            streamed = final_body[: start + chunk_size]
+            transcript_a.set_messages([_assistant(streamed)])
+            await transcript_a.refresh_messages()
+            await pilot_a.pause()
+            # Advance well under the 1.0s deadline so nothing flushes on
+            # its own -- only the terminal-status transition below can be
+            # responsible for delivering the tail.
+            clock.advance(0.05)
+
+        row_a = transcript_a.query_one("#console-message-a1", ConsoleMarkdownMessage)
+        # Sanity: the throttle really is holding something back at this
+        # point, and the widget's own source really is behind the logical
+        # body -- otherwise this test would pass for the wrong reason.
+        assert row_a._pending_fence_delta != ""
+        markdown_a = row_a.query_one(Markdown)
+        assert markdown_a.source != streamed
+
+        # Same body text, terminal status, no further growth -- the exact
+        # shape that used to hit the early return and strand the buffer.
+        transcript_a.set_messages([_assistant(streamed, status=terminal_status)])
+        await transcript_a.refresh_messages()
+        await pilot_a.pause()
+
+        assert row_a._pending_fence_delta == ""
+        assert markdown_a.source == final_body
+        fences_a = list(markdown_a.query(MarkdownFence))
+        assert len(fences_a) == 1
+
+    # Reference: render the identical final (still-open-fence) content
+    # directly, never streamed/throttled at all.
+    app_b = MarkdownHarness()
+    async with app_b.run_test() as pilot_b:
+        transcript_b = app_b.query_one(ConsoleTranscript)
+        transcript_b.set_messages(
+            [_assistant(final_body, status=terminal_status, id="a1")]
+        )
+        await transcript_b.refresh_messages()
+        await pilot_b.pause()
+
+        row_b = transcript_b.query_one("#console-message-a1", ConsoleMarkdownMessage)
+        markdown_b = row_b.query_one(Markdown)
+        assert markdown_b.source == final_body
+        fences_b = list(markdown_b.query(MarkdownFence))
+        assert len(fences_b) == 1
+
+    assert fences_a[0].code == fences_b[0].code
+    assert fences_a[0].lexer == fences_b[0].lexer
+    assert fences_a[0]._highlighted_code.plain == fences_b[0]._highlighted_code.plain
+    assert list(fences_a[0]._highlighted_code.spans) == list(
+        fences_b[0]._highlighted_code.spans
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_status", ["complete", "stopped", "failed"])
+async def test_status_only_change_with_no_pending_buffer_is_a_no_op(
+    monkeypatch, terminal_status: str
+):
+    """Companion to the regression above: when there is nothing buffered,
+    a status-only change must stay a true no-op (no spurious append)."""
+    clock = _FakeClock()
+    monkeypatch.setattr(console_transcript_module, "monotonic", clock)
+
+    app = MarkdownHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        body = "plain prose, no fence"
+        transcript.set_messages([_assistant(body)])
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        row = transcript.query_one("#console-message-a1", ConsoleMarkdownMessage)
+        markdown = row.query_one(Markdown)
+        append_calls = []
+        original_append = markdown.append
+        monkeypatch.setattr(
+            markdown,
+            "append",
+            lambda text: append_calls.append(text) or original_append(text),
+        )
+
+        assert row._pending_fence_delta == ""
+        transcript.set_messages([_assistant(body, status=terminal_status)])
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        assert append_calls == []
+
+
 # ---------------------------------------------------------------------------
 # AC#3: multi-block prose streaming is untouched.
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_console_transcript_fence_throttle.py
+++ b/Tests/UI/test_console_transcript_fence_throttle.py
@@ -1,0 +1,336 @@
+"""TASK-15456: Console streaming defers syntax highlighting for open fences.
+
+Textual's ``Markdown.append()`` re-parses only from the last completed
+top-level block (textual/widgets/_markdown.py:1445-1509); while a code fence
+is open, every append re-parses the whole fence-so-far and ``MarkdownFence``
+re-runs Pygments over it synchronously on the event loop
+(textual/widgets/_markdown.py:895-901) -- on every 0.2s streaming sync tick.
+
+These tests cover:
+- The conservative fence-parity detector in isolation (pure function).
+- That a long, still-open fence defers ``MarkdownFence.highlight()`` work to
+  a bounded number of calls, not one per tick.
+- That the final rendered message (post fence-close / stream-end) is
+  byte-identical to an unthrottled render of the same content.
+- That plain multi-block prose streaming is untouched: still exactly one
+  ``Markdown.append()`` per delta, no batching introduced.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Markdown
+from textual.widgets._markdown import MarkdownFence
+
+import tldw_chatbook.Widgets.Console.console_transcript as console_transcript_module
+from tldw_chatbook.Chat.console_chat_models import ConsoleChatMessage, ConsoleMessageRole
+from tldw_chatbook.Widgets.Console.console_transcript import (
+    ConsoleMarkdownMessage,
+    ConsoleTranscript,
+    _console_markdown_body_ends_in_open_fence,
+)
+
+
+class MarkdownHarness(App):
+    CSS = "ConsoleTranscript { height: 40; }"
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleTranscript(id="console-native-transcript")
+
+
+def _assistant(content: str, status: str = "streaming", **kwargs) -> ConsoleChatMessage:
+    return ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT,
+        content=content,
+        status=status,
+        id=kwargs.pop("id", "a1"),
+        **kwargs,
+    )
+
+
+class _FakeClock:
+    """A controllable stand-in for ``time.monotonic`` so tests don't depend
+    on real wall-clock timing (flaky under CI load)."""
+
+    def __init__(self, start: float = 1_000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+# ---------------------------------------------------------------------------
+# The detector, in isolation.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        ("", False),
+        ("just prose, no fences at all", False),
+        ("some `inline code` and more prose", False),
+        ("```python\nprint(1)\n", True),  # opened, never closed
+        ("```python\nprint(1)\n```\n", False),  # closed
+        ("```python\nprint(1)\n```\nmore prose after", False),
+        ("text\n\n```\ncode\n", True),
+        ("~~~\ncode\n", True),  # tilde fence, open
+        ("~~~\ncode\n~~~\n", False),  # tilde fence, closed
+        ("````\ncode with ``` inside\n````\n", False),  # longer run closes
+        ("````\ncode with ``` inside\n", True),  # longer run, still open
+        ("  ```python\ncode\n  ```\n", False),  # <=3 leading spaces is valid
+        ("    ```python\ncode\n", False),  # 4-space indent: not a fence line
+        ("```one```\n", False),  # backticks with content after -- no close
+    ],
+)
+def test_fence_detector_matches_expected_state(body: str, expected: bool) -> None:
+    assert _console_markdown_body_ends_in_open_fence(body) is expected
+
+
+def test_fence_detector_stays_closed_when_info_string_has_a_backtick() -> None:
+    # CommonMark: a backtick-fence info string can't itself contain a
+    # backtick, so this line can't validly open one. Conservative: treat as
+    # ordinary text rather than guessing.
+    body = "```so `me` info\nstill just text\n"
+    assert _console_markdown_body_ends_in_open_fence(body) is False
+
+
+def test_fence_detector_requires_matching_or_longer_run_to_close() -> None:
+    # Opened with 4 backticks; a 3-backtick line inside can't close it.
+    body = "````python\n```\nmore code\n"
+    assert _console_markdown_body_ends_in_open_fence(body) is True
+    # A 4-backtick (or longer) line does close it.
+    assert (
+        _console_markdown_body_ends_in_open_fence("````python\n```\nmore code\n````\n")
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Evidence: highlight work during a long open-fence stream is bounded.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_long_open_fence_stream_defers_highlight_work(monkeypatch):
+    """AC#1 evidence: streaming a long single code fence no longer
+    re-highlights the full fence every tick.
+
+    Without the throttle, each of the 30 simulated ticks below calls
+    ``Markdown.append()`` while the body still ends inside the open fence,
+    and every such call constructs a fresh ``MarkdownFence`` (re-running
+    Pygments over the whole fence-so-far) -- counted here via
+    ``MarkdownFence.__init__`` invocations, which fire exactly once per
+    fence (re)parse regardless of anything else touching the DOM. (An
+    earlier version of this test counted ``MarkdownFence.highlight()``
+    calls directly and was contaminated by an unrelated source: Textual's
+    ``Stylesheet.apply`` calls ``notify_style_update()`` -- which also
+    calls ``highlight()`` -- on every node in a CSS-reapplied subtree,
+    which this test's per-tick header/class updates trigger regardless of
+    whether the fence content changed. Counting reconstructions instead of
+    raw highlight calls isolates the mechanism this task actually changes.)
+    This test fails (would be "born red") against that shape: 30 ticks
+    would produce 30 reconstructions, violating the bound asserted below.
+    """
+    clock = _FakeClock()
+    monkeypatch.setattr(console_transcript_module, "monotonic", clock)
+
+    highlight_calls: list[int] = []
+    original_init = MarkdownFence.__init__
+
+    def counting_init(self, markdown, token, code):
+        highlight_calls.append(len(code))
+        return original_init(self, markdown, token, code)
+
+    monkeypatch.setattr(MarkdownFence, "__init__", counting_init)
+
+    app = MarkdownHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        body = "```python\n"
+        transcript.set_messages([_assistant(body)])
+        await transcript.refresh_messages()
+        await pilot.pause()
+        highlight_calls.clear()  # ignore the initial full-parse mount
+
+        TICKS = 30
+        for i in range(TICKS):
+            body += f"x_{i} = {i}\n"
+            transcript.set_messages([_assistant(body)])
+            await transcript.refresh_messages()
+            await pilot.pause()
+            clock.advance(0.2)  # matches the real 0.2s transcript sync tick
+
+        # Bounded: nowhere near one highlight call per tick. The throttle's
+        # deadline is 1.0s at a simulated 0.2s cadence, so ~5 ticks land
+        # between flushes -- generous headroom below TICKS either way.
+        assert 0 < len(highlight_calls) < TICKS // 2, highlight_calls
+
+        # Close the fence; the closing delta must flush immediately
+        # (fence-close is a "not deferrable" transition), independent of
+        # the deadline.
+        calls_before_close = len(highlight_calls)
+        body += "```\n"
+        transcript.set_messages([_assistant(body, status="complete")])
+        await transcript.refresh_messages()
+        await pilot.pause()
+        assert len(highlight_calls) == calls_before_close + 1
+
+        row = transcript.query_one("#console-message-a1", ConsoleMarkdownMessage)
+        markdown = row.query_one(Markdown)
+        assert markdown.source == body
+
+
+@pytest.mark.asyncio
+async def test_no_open_fence_never_defers(monkeypatch):
+    """A message that never opens a fence must never accumulate a pending
+    buffer -- the deferral path is scoped exactly to open-fence streaming."""
+    clock = _FakeClock()
+    monkeypatch.setattr(console_transcript_module, "monotonic", clock)
+
+    app = MarkdownHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        body = "intro "
+        transcript.set_messages([_assistant(body)])
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        for i in range(10):
+            body += f"word{i} "
+            transcript.set_messages([_assistant(body)])
+            await transcript.refresh_messages()
+            await pilot.pause()
+            # No wall-clock advance: if this content were mistakenly treated
+            # as fence-interior, the whole 1.0s deadline would still be
+            # unexpired and everything would wrongly stay buffered.
+
+        row = transcript.query_one("#console-message-a1", ConsoleMarkdownMessage)
+        assert row._pending_fence_delta == ""
+        assert row._fence_defer_deadline is None
+        markdown = row.query_one(Markdown)
+        assert markdown.source == body
+
+
+# ---------------------------------------------------------------------------
+# AC#2: final rendered output identical to an unthrottled render.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_final_render_after_fence_close_matches_unthrottled_render(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(console_transcript_module, "monotonic", clock)
+
+    final_body = (
+        "Here is an example:\n\n"
+        "```python\n"
+        "def add(a, b):\n"
+        "    return a + b\n\n"
+        "for i in range(5):\n"
+        "    print(add(i, i))\n"
+        "```\n\n"
+        "That's the whole snippet."
+    )
+
+    # Path A: stream it in incrementally, character-by-character-ish chunks,
+    # advancing the fake clock so several deadline flushes fire mid-fence.
+    app_a = MarkdownHarness()
+    async with app_a.run_test() as pilot_a:
+        transcript_a = app_a.query_one(ConsoleTranscript)
+        streamed = ""
+        transcript_a.set_messages([_assistant(streamed)])
+        await transcript_a.refresh_messages()
+        await pilot_a.pause()
+        chunk_size = 7
+        for start in range(0, len(final_body), chunk_size):
+            streamed = final_body[: start + chunk_size]
+            transcript_a.set_messages([_assistant(streamed)])
+            await transcript_a.refresh_messages()
+            await pilot_a.pause()
+            clock.advance(0.2)
+        # Final chunk plus stream completion.
+        transcript_a.set_messages([_assistant(final_body, status="complete")])
+        await transcript_a.refresh_messages()
+        await pilot_a.pause()
+
+        row_a = transcript_a.query_one("#console-message-a1", ConsoleMarkdownMessage)
+        markdown_a = row_a.query_one(Markdown)
+        assert markdown_a.source == final_body
+        fences_a = list(markdown_a.query(MarkdownFence))
+        assert len(fences_a) == 1
+
+    # Path B: render the identical final content directly, never streamed.
+    app_b = MarkdownHarness()
+    async with app_b.run_test() as pilot_b:
+        transcript_b = app_b.query_one(ConsoleTranscript)
+        transcript_b.set_messages([_assistant(final_body, status="complete", id="a1")])
+        await transcript_b.refresh_messages()
+        await pilot_b.pause()
+
+        row_b = transcript_b.query_one("#console-message-a1", ConsoleMarkdownMessage)
+        markdown_b = row_b.query_one(Markdown)
+        assert markdown_b.source == final_body
+        fences_b = list(markdown_b.query(MarkdownFence))
+        assert len(fences_b) == 1
+
+    # Same source, same code captured per fence, and identical highlighted
+    # output (same code + language + theme -> deterministic Pygments output).
+    assert fences_a[0].code == fences_b[0].code
+    assert fences_a[0].lexer == fences_b[0].lexer
+    assert fences_a[0]._highlighted_code.plain == fences_b[0]._highlighted_code.plain
+    assert list(fences_a[0]._highlighted_code.spans) == list(
+        fences_b[0]._highlighted_code.spans
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC#3: multi-block prose streaming is untouched.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_block_prose_streaming_appends_every_delta(monkeypatch):
+    """No fence anywhere in the stream: every tick's delta is still applied
+    immediately via exactly one ``Markdown.append()`` call, same as before
+    this task -- batching is scoped to open-fence bodies only."""
+    clock = _FakeClock()
+    monkeypatch.setattr(console_transcript_module, "monotonic", clock)
+
+    app = MarkdownHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        body = "# Heading\n\n"
+        transcript.set_messages([_assistant(body)])
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        row = transcript.query_one("#console-message-a1", ConsoleMarkdownMessage)
+        markdown = row.query_one(Markdown)
+        append_calls = []
+        original_append = markdown.append
+        monkeypatch.setattr(
+            markdown,
+            "append",
+            lambda text: append_calls.append(text) or original_append(text),
+        )
+
+        paragraphs = [
+            "First paragraph grows one word at a time. ",
+            "\n\nSecond paragraph, a fresh block. ",
+            "\n\n- item one\n- item two\n",
+        ]
+        for paragraph in paragraphs:
+            for word in paragraph.split(" "):
+                body += word + " "
+                transcript.set_messages([_assistant(body)])
+                await transcript.refresh_messages()
+                await pilot.pause()
+                # No clock advance -- if prose were mistakenly throttled by
+                # the fence deadline, a 0-advance run would defer everything
+                # into one call instead of one-per-delta.
+
+        expected_ticks = sum(len(p.split(" ")) for p in paragraphs)
+        assert len(append_calls) == expected_ticks

--- a/backlog/tasks/task-15456 - Console-streaming---defer-syntax-highlighting-for-open-fences.md
+++ b/backlog/tasks/task-15456 - Console-streaming---defer-syntax-highlighting-for-open-fences.md
@@ -147,3 +147,65 @@ Python fence at simulated 0.2s cadence with real wall-clock timing:
 TASK-` and silently wrote a stray, empty `backlog/tasks/task-task- - .md`
 instead of touching this file. Deleted the stray file; this file was hand-edited
 directly per that lesson's guidance.
+
+### Fix round 1 (code review, not approved on first pass)
+
+**Critical, reviewer-reproduced against the real classes.** `sync_message`'s
+pre-existing early return (`if new_body == self._body_text: return`) fired
+*before* the new pending-fence buffer was ever consulted. The throttle broke
+the old invariant that `_body_text` mirrors what had actually been handed to
+the Markdown widget: `_body_text` now advances immediately in the growth
+branch even when the corresponding `markdown.append()` call is deferred. The
+reconciler calls `sync_message` on a status-only row-signature change (status
+is part of that signature), so a routine "Stop mid-code-block" or a
+length-limit cutoff -- unchanged body text, new terminal status -- hit the
+early return and the buffered fence-interior tail was **never flushed**,
+permanently, even though the true message content in the store was always
+complete and correct. A rendering-only bug, but a real, live one.
+
+**Fix.** `sync_message`'s unchanged-body fast path now flushes
+`_pending_fence_delta` whenever it is non-empty AND the message's status is
+no longer `"streaming"`, before returning. Extracted the actual
+`markdown.append()` + state-clear into a single shared
+`_flush_pending_fence_delta` helper, called from both that fast path and
+`_append_or_defer_body_delta`'s existing deadline/status-driven flush, so
+there is exactly one implementation of "hand the widget the complete
+buffered text" to keep correct. Audited every other terminal/flush path:
+the non-append-edit branch (`markdown.update(new_body)`) already discards
+the buffer correctly (the whole widget content is replaced wholesale, so
+the stale pending text is superseded, not lost); a pruned/unmounted row
+carries no data-loss risk either, because `_build_row_widget` always
+constructs a *fresh* `ConsoleMarkdownMessage` from the live message content
+on remount (`compose()` does a full parse, never depends on any prior
+widget's pending buffer).
+
+**Detector comment updated** (per review) to state the corrected
+consequence precisely: since the terminal flush no longer consults the
+fence detector at all, a false "open" verdict in an untracked
+blockquote/list context is now purely a delayed-highlight risk, never a
+drop risk. Also documented the detector's known O(body length) per-tick
+cost (it rescans the full accumulated body, not just the delta, on every
+call that needs a decision) as an accepted, non-Pygments-level cost.
+
+**New tests**, both parametrized over all three terminal statuses
+(`complete`, `stopped`, `failed`):
+- `test_stream_ending_mid_open_fence_flushes_buffered_tail` -- streams into
+  a fence that is *never closed*, holds the throttle's buffer non-empty by
+  advancing the fake clock well under the defer deadline, then flips status
+  with the body text unchanged (the exact shape that escaped review).
+  Verified this test fails red against the pre-fix early return (manually
+  reverted the fix, reran, confirmed `AssertionError` on all three
+  parametrizations with the stranded fence text in the diff, then restored
+  the fix) before trusting it as a real regression test. Also compares the
+  final `MarkdownFence` against an unthrottled reference render of the same
+  still-open-fence content (byte-identical `.code`/`.lexer`/highlighted
+  output).
+- `test_status_only_change_with_no_pending_buffer_is_a_no_op` -- companion
+  negative case: a status-only change with nothing buffered must not
+  trigger a spurious `markdown.append()`.
+
+**Re-verification.** `Tests/UI/test_console_transcript_fence_throttle.py`
+(26 tests, up from 20) plus the same
+console_transcript/tail-follow/markdown/pruning/region/selection/diff/jump-pill
+suites as round 1: **90 passed**, no regressions. `ruff check` on both
+touched files: clean.

--- a/backlog/tasks/task-15456 - Console-streaming---defer-syntax-highlighting-for-open-fences.md
+++ b/backlog/tasks/task-15456 - Console-streaming---defer-syntax-highlighting-for-open-fences.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15456
 title: Console streaming: defer syntax highlighting for open fences
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -20,7 +21,129 @@ Fix direction: throttle fence-interior appends (e.g. plain-text tail while the f
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Streaming a long single code fence no longer re-highlights the full fence every tick (evidence)
-- [ ] #2 Final rendered message identical to today's output at stream end (test)
-- [ ] #3 No behavior change for multi-block prose streaming
+- [x] #1 Streaming a long single code fence no longer re-highlights the full fence every tick (evidence)
+- [x] #2 Final rendered message identical to today's output at stream end (test)
+- [x] #3 No behavior change for multi-block prose streaming
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Locate the append seam: `ConsoleMarkdownMessage.sync_message` in
+   `Widgets/Console/console_transcript.py`, which prefix-diffs the assistant
+   body and calls `Markdown.append(delta)` on pure growth.
+2. Add a conservative, cheap fence-parity detector
+   (`_console_markdown_body_ends_in_open_fence`): scans lines for CommonMark
+   fence delimiters (<=3 leading spaces, backtick/tilde run >=3, matching
+   char + run length to close), returning True only when confident the body
+   ends inside an open fence. False negatives/positives both degrade safely
+   (never drop or reorder content -- only affect timing of a flush).
+3. In `sync_message`'s growth branch, route the delta through a new
+   `_append_or_defer_body_delta` helper: while `message.status == "streaming"`
+   AND the body currently ends in an open fence AND a wall-clock deadline
+   (`_FENCE_APPEND_DEFER_SECONDS`, monotonic-based) hasn't elapsed, buffer the
+   delta instead of calling `markdown.append()`. Otherwise flush the full
+   buffered+new delta in one `markdown.append()` call and reset the deadline.
+   Non-append edits (variant switch/`update()`) and any non-streaming status
+   always flush immediately, guaranteeing correct final content.
+4. Tests (new file, existing suites untouched):
+   - Unit tests for the fence detector against CommonMark edge cases
+     (open/closed, tilde vs backtick, mismatched run length, indented,
+     inline code, ambiguous info-string-with-backtick).
+   - Evidence test: simulate a long streamed fence with a fake monotonic
+     clock: assert `MarkdownFence` reconstructions are bounded, not 1:1 with
+     ticks (contrasted against the disabled-throttle shape, which the probe
+     shows is 1:1).
+   - Byte-identical final render test: streamed-with-throttle vs direct
+     unthrottled render of the same final content produce the same
+     `Markdown.source` and the same `MarkdownFence` highlighted output.
+   - Multi-block prose regression test: no fence anywhere -> still exactly
+     one `Markdown.append()` per delta (AC#3, unthrottled).
+5. Run the new tests plus the existing console_transcript/streaming/
+   tail-follow suites unmodified; measure per-tick append cost before/after
+   with an isolated probe; update the task file and commit.
+
+## Implementation Notes
+
+**Approach.** The append seam is `ConsoleMarkdownMessage.sync_message`
+(`Widgets/Console/console_transcript.py`), which prefix-diffs the assistant
+body against `self._body_text` and calls `Markdown.append(delta)` on pure
+growth. Added a conservative fence-parity scanner,
+`_console_markdown_body_ends_in_open_fence`, that tracks CommonMark
+fence-delimiter parity line-by-line (<=3-space indent, backtick/tilde run
+>=3, closing run length >= opening, no info string on the closing line;
+backtick info strings containing a backtick are treated as ambiguous and
+never open a fence). It intentionally does not track blockquote/list
+indentation contexts -- misjudging those only costs either a missed
+optimization or a delayed flush, never dropped/reordered content, because
+every code path that consumes it still ends with a full, correct
+`markdown.append()`/`markdown.update()` of the true accumulated text.
+
+New helper `_append_or_defer_body_delta` on `ConsoleMarkdownMessage`: while
+`message.status == "streaming"` AND the body ends inside an open fence AND a
+monotonic deadline (`_FENCE_APPEND_DEFER_SECONDS = 1.0`) hasn't elapsed, the
+delta is buffered (`self._pending_fence_delta`) instead of calling
+`markdown.append()`. The deadline is wall-clock (not a tick counter) so a
+slow/stalled model doesn't stretch staleness indefinitely just because fewer
+sync ticks landed while it paused. Any of: fence closing, `status` leaving
+`"streaming"`, or the deadline elapsing forces an immediate flush of the
+*complete* buffered text in one `markdown.append()` call -- append order and
+final content are unaffected, only the number of
+`Markdown.append`/`MarkdownFence`-reconstruction (Pygments) passes changes.
+A non-append edit (variant switch, retry, DB-resume rebind) discards any
+pending buffer and falls back to the existing full `markdown.update()`.
+
+**Evidence (AC#1).** `MarkdownFence.__init__` runs `highlight()` (Pygments)
+over the whole fence-so-far every time it's reconstructed, which happens once
+per relevant `Markdown.append()`/`.update()` call -- this is the exact
+mechanism the audit names. Counting `MarkdownFence.__init__` invocations
+(not `.highlight()` directly -- see the note in
+`test_long_open_fence_stream_defers_highlight_work`, where an earlier version
+counting `.highlight()` was contaminated by Textual's unrelated
+`Stylesheet.apply` -> `notify_style_update()` path, which also calls
+`highlight()` on every node in a CSS-reapplied subtree) over a simulated
+30-tick, 0.2s-cadence open-fence stream: **5 reconstructions with the
+throttle active vs 30 with it disabled** (verified directly, not just via the
+test's looser bound). A test asserting the bound would fail against the
+disabled-throttle shape (30 > 15), satisfying "born red."
+
+**Final-render evidence (AC#2).** A new test streams a fence-containing
+message in in small chunks through the throttled path (with several
+deadline-forced mid-fence flushes) and compares the final mounted
+`MarkdownFence` against one built by a single unthrottled render of the
+identical final text: same `.source`, same `.code`/`.lexer`, and
+identical `._highlighted_code` (plain text and spans) -- i.e. Pygments ran
+over the exact same final content either way.
+
+**AC#3 (untouched prose).** The throttle only ever activates when the
+detector confirms an open fence; a `no-fence` regression test asserts
+exactly one `Markdown.append()` per delta across 10 streamed word-by-word
+prose growths (matching the pre-existing, unmodified
+`test_streaming_appends_without_reparse`/`test_streaming_append_activates_flavor_when_marker_closes`
+in `Tests/UI/test_console_transcript_markdown_widget.py`, both still green).
+
+**Performance probe (isolated, not committed).** A standalone script
+(`t15456_probe.py`, scratchpad) streamed a 120-tick / ~360-line synthetic
+Python fence at simulated 0.2s cadence with real wall-clock timing:
+- Isolated `MarkdownFence.__init__` (highlight) cost: BEFORE 121 calls /
+  5057.9ms total vs AFTER 21 calls / 998.1ms total -- **5.07x speedup**,
+  call count 121 -> 21 (matches the ~5x predicted by the O(ticks x size)
+  vs O(ticks/N x size) math for a 1.0s/0.2s = 5-tick defer window).
+- Full `refresh_messages()+pilot.pause()` tick cost only improved **1.23x**
+  (273.9ms -> 223.1ms mean/tick) -- reported honestly alongside the 5.07x
+  number because it's dominated by per-frame Textual costs (DOM
+  reconciliation, compositing an already-large mounted widget) this task
+  does not touch, not by the highlighting work itself.
+
+**Files modified:**
+- `tldw_chatbook/Widgets/Console/console_transcript.py` -- fence detector,
+  throttle constant, `ConsoleMarkdownMessage` state fields, and
+  `_append_or_defer_body_delta`.
+- `Tests/UI/test_console_transcript_fence_throttle.py` (new) -- detector unit
+  tests, bounded-highlight evidence test, byte-identical final-render test,
+  no-fence regression test.
+
+**Backlog CLI note.** `backlog task edit 15456 ...` hit the documented
+5-digit-id bug (`lessons-backlog-hygiene.md`): it printed `Updated task
+TASK-` and silently wrote a stray, empty `backlog/tasks/task-task- - .md`
+instead of touching this file. Deleted the stray file; this file was hand-edited
+directly per that lesson's guidance.

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -790,7 +790,21 @@ def _console_markdown_body_ends_in_open_fence(body: str) -> bool:
     would say "open" only skips an optimization opportunity (falls back to
     the unthrottled append, today's behavior). Neither ever drops or
     reorders content -- the throttle that consumes this always applies the
-    complete accumulated text on flush.
+    complete accumulated text on flush, and (fix round 1, TASK-15456) every
+    path that can end a message's active streaming --
+    ``_append_or_defer_body_delta`` seeing a non-"streaming" status, AND
+    ``sync_message``'s no-new-body-text fast path -- flushes any buffered
+    text unconditionally, without consulting this function at all. So a
+    false "open" verdict here is now purely a *delayed-highlight* risk, not
+    a drop risk, regardless of how this scan is wrong.
+
+    Known cost: this rescans the *entire* ``body`` on every call that needs
+    a decision (``_append_or_defer_body_delta`` passes ``self._body_text``,
+    not just the new delta), so it is O(body length) per streamed tick, not
+    O(delta). For a single assistant reply that stays well under a few
+    hundred KB (the normal case) this is negligible next to the Pygments
+    cost it exists to avoid, but it is a real, unbounded-with-message-size
+    cost worth knowing about, not a free check.
     """
     fence_char: str | None = None
     fence_len = 0
@@ -1053,6 +1067,19 @@ class ConsoleMarkdownMessage(Vertical):
         footer.display = footer_content is not None
         new_body = _assistant_markdown_body(message, presentation)
         if new_body == self._body_text:
+            # TASK-15456 fix round 1: a status-only change (Stop, a
+            # length-cutoff, a failure -- all routine mid-open-fence exits
+            # from "streaming") reaches this fast path with an UNCHANGED
+            # body, because the reconciler calls sync_message whenever the
+            # row signature changes and status is part of that signature.
+            # `self._body_text` already mirrors the true full content (it
+            # advances immediately in the growth branch below, even when
+            # the corresponding widget append was deferred) -- so this is
+            # the only place a still-buffered fence-interior tail can ever
+            # reach the widget once the message stops growing. Returning
+            # here without checking would strand that text permanently.
+            if self._pending_fence_delta and message.status != "streaming":
+                self._flush_pending_fence_delta(markdown)
             return
         if new_body.startswith(self._body_text):
             delta = new_body[len(self._body_text) :]
@@ -1061,11 +1088,30 @@ class ConsoleMarkdownMessage(Vertical):
         else:
             # Non-append edit (variant switch, retry, DB-resume rebind): the
             # prior diff base no longer applies, so any deferred fence
-            # buffer is void too -- the full update below supersedes it.
+            # buffer is void too -- markdown.update(new_body) below replaces
+            # the widget's content wholesale, so the (now-irrelevant, would
+            # have been superseded anyway) pending text is safe to discard
+            # rather than flush.
             self._pending_fence_delta = ""
             self._fence_defer_deadline = None
             markdown.update(new_body)
             self._body_text = new_body
+
+    def _flush_pending_fence_delta(self, markdown: Markdown) -> None:
+        """Hand any buffered fence-interior text to the widget and clear state.
+
+        The single place that actually calls ``Markdown.append()`` for
+        deferred text, used both by a deadline/status-driven flush inside
+        ``_append_or_defer_body_delta`` and by ``sync_message``'s terminal-
+        status fast path above -- so there is exactly one flush
+        implementation for the "hand over the complete buffered text"
+        invariant to hold against.
+        """
+        pending = self._pending_fence_delta
+        self._pending_fence_delta = ""
+        self._fence_defer_deadline = None
+        if pending:
+            markdown.append(pending)
 
     def _append_or_defer_body_delta(
         self, markdown: Markdown, delta: str, message: ConsoleChatMessage
@@ -1082,9 +1128,12 @@ class ConsoleMarkdownMessage(Vertical):
         both the buffered memory and the visible staleness window. Every
         branch below still ends by handing the widget the *complete*
         buffered text -- append-order and final content are unaffected, only
-        the number of Markdown/Pygments passes changes.
+        the number of Markdown/Pygments passes changes. A buffer started
+        here can also be flushed later from ``sync_message``'s terminal-
+        status fast path (see ``_flush_pending_fence_delta``) if the message
+        stops growing before this function runs again.
         """
-        pending = self._pending_fence_delta + delta
+        self._pending_fence_delta += delta
         now = monotonic()
         deadline_due = (
             self._fence_defer_deadline is not None and now >= self._fence_defer_deadline
@@ -1094,13 +1143,10 @@ class ConsoleMarkdownMessage(Vertical):
             and not deadline_due
             and _console_markdown_body_ends_in_open_fence(self._body_text)
         ):
-            self._pending_fence_delta = pending
             if self._fence_defer_deadline is None:
                 self._fence_defer_deadline = now + _FENCE_APPEND_DEFER_SECONDS
             return
-        self._pending_fence_delta = ""
-        self._fence_defer_deadline = None
-        markdown.append(pending)
+        self._flush_pending_fence_delta(markdown)
 
     @on(Markdown.LinkClicked)
     def _open_link(self, event: Markdown.LinkClicked) -> None:

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -753,6 +753,81 @@ def _assistant_markdown_body(
     return message.content
 
 
+#: TASK-15456. A line that -- with <=3 leading spaces, per CommonMark's fence
+#: indentation rule -- opens or closes a fenced code block: a run of 3+
+#: backticks or tildes, optionally followed by trailing content (an info
+#: string on an opening line; nothing but whitespace on a closing line).
+_FENCE_DELIMITER_LINE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
+
+
+def _console_markdown_body_ends_in_open_fence(body: str) -> bool:
+    """Return True only when ``body`` is confidently known to end inside an
+    open (unclosed) top-level Markdown code fence.
+
+    Deliberately conservative: this tracks fence-delimiter parity line by
+    line rather than running a real Markdown parse, so it can be called on
+    every streamed delta without itself becoming the cost it exists to
+    avoid. It mirrors just the CommonMark rules that matter for staying
+    confident:
+
+    - An opening line is <=3 leading spaces of ```` ``` ```` / ``~~~`` (3+
+      repeats), optionally followed by an info string. A backtick-fenced
+      info string may not itself contain a backtick (CommonMark); a line
+      like ``` ```some`code` ``` therefore never opens a fence here --
+      ambiguous stays "not open", the safe direction (see below).
+    - A closing line is <=3 leading spaces of the SAME delimiter character,
+      a run length >= the opening run, followed by nothing but trailing
+      whitespace.
+    - Anything else while a fence is open just stays inside it, regardless
+      of what it contains (mismatched-delimiter or shorter-run lines can't
+      close a real fence either).
+
+    This does not track blockquote/list-item indentation contexts, so a
+    fence nested inside one can be mis-scored. That is safe in both
+    directions for the caller (a streaming-append throttle): scoring "open"
+    when a real parse would say "closed" only delays a flush (content is
+    still applied in full, just later); scoring "closed" when a real parse
+    would say "open" only skips an optimization opportunity (falls back to
+    the unthrottled append, today's behavior). Neither ever drops or
+    reorders content -- the throttle that consumes this always applies the
+    complete accumulated text on flush.
+    """
+    fence_char: str | None = None
+    fence_len = 0
+    for line in body.split("\n"):
+        match = _FENCE_DELIMITER_LINE_RE.match(line)
+        if not match:
+            continue
+        run, rest = match.groups()
+        char = run[0]
+        if fence_char is None:
+            if char == "`" and "`" in rest:
+                # Not a valid opening fence line (backtick info strings
+                # can't contain backticks) -- ordinary text, ignore it.
+                continue
+            fence_char = char
+            fence_len = len(run)
+            continue
+        if char == fence_char and len(run) >= fence_len and not rest.strip():
+            fence_char = None
+            fence_len = 0
+    return fence_char is not None
+
+
+#: TASK-15456. While an assistant reply is streaming inside an open code
+#: fence, batch appends for up to this many seconds before flushing to the
+#: Markdown widget instead of calling ``Markdown.append()`` (and therefore
+#: re-running Pygments over the whole fence-so-far, textual/widgets/
+#: _markdown.py:895-901) on every 0.2s sync tick. A wall-clock deadline
+#: (rather than a tick counter) keeps the bound meaningful even if a slow
+#: model pauses mid-fence between chunks: it depends only on how long
+#: content has sat unflushed, not on how many sync ticks happened to land
+#: while it did. Total Pygments work across a stream scales down by
+#: roughly (this many seconds / 0.2s sync interval) -- see the task's
+#: Implementation Notes for the derivation.
+_FENCE_APPEND_DEFER_SECONDS = 1.0
+
+
 def _assistant_markdown_header(
     message: ConsoleChatMessage,
     presentation: ConsoleMessagePresentation | None = None,
@@ -915,6 +990,11 @@ class ConsoleMarkdownMessage(Vertical):
         super().__init__(id=f"console-message-{message.id}", classes=classes)
         self._message = message
         self._body_text = _assistant_markdown_body(message, self._presentation)
+        # TASK-15456: text appended to ``self._body_text`` above but not yet
+        # handed to the Markdown widget (deferred while streaming inside an
+        # open fence), plus the monotonic deadline by which it must flush.
+        self._pending_fence_delta = ""
+        self._fence_defer_deadline: float | None = None
 
     def compose(self) -> ComposeResult:
         yield Static(
@@ -975,10 +1055,52 @@ class ConsoleMarkdownMessage(Vertical):
         if new_body == self._body_text:
             return
         if new_body.startswith(self._body_text):
-            markdown.append(new_body[len(self._body_text) :])
+            delta = new_body[len(self._body_text) :]
+            self._body_text = new_body
+            self._append_or_defer_body_delta(markdown, delta, message)
         else:
+            # Non-append edit (variant switch, retry, DB-resume rebind): the
+            # prior diff base no longer applies, so any deferred fence
+            # buffer is void too -- the full update below supersedes it.
+            self._pending_fence_delta = ""
+            self._fence_defer_deadline = None
             markdown.update(new_body)
-        self._body_text = new_body
+            self._body_text = new_body
+
+    def _append_or_defer_body_delta(
+        self, markdown: Markdown, delta: str, message: ConsoleChatMessage
+    ) -> None:
+        """Apply a streamed body delta, throttling fence-interior Pygments work.
+
+        TASK-15456: ``Markdown.append()`` is cheap for ordinary prose growth
+        (Textual only re-parses from the last completed top-level block), so
+        that path is untouched -- this only changes behavior while the body
+        currently ends inside an open code fence during active streaming,
+        where every ``append()`` re-runs Pygments over the whole
+        fence-so-far. In that state, deltas are buffered instead of applied
+        immediately, for up to ``_FENCE_APPEND_DEFER_SECONDS``, bounding
+        both the buffered memory and the visible staleness window. Every
+        branch below still ends by handing the widget the *complete*
+        buffered text -- append-order and final content are unaffected, only
+        the number of Markdown/Pygments passes changes.
+        """
+        pending = self._pending_fence_delta + delta
+        now = monotonic()
+        deadline_due = (
+            self._fence_defer_deadline is not None and now >= self._fence_defer_deadline
+        )
+        if (
+            message.status == "streaming"
+            and not deadline_due
+            and _console_markdown_body_ends_in_open_fence(self._body_text)
+        ):
+            self._pending_fence_delta = pending
+            if self._fence_defer_deadline is None:
+                self._fence_defer_deadline = now + _FENCE_APPEND_DEFER_SECONDS
+            return
+        self._pending_fence_delta = ""
+        self._fence_defer_deadline = None
+        markdown.append(pending)
 
     @on(Markdown.LinkClicked)
     def _open_link(self, event: Markdown.LinkClicked) -> None:


### PR DESCRIPTION
## Summary

Task 15456 from the input-latency audit. Textual's `Markdown.append` only advances past completed blocks, so a reply that is one long code fence re-ran Pygments over the entire fence-so-far every 0.2s tick, on the event loop.

- Conservative whole-body fence detector (re-evaluated per call — split-across-delta markers cannot cause transient false positives by construction; CommonMark edge cases parametrized: tilde fences, 4-backtick runs, info strings, indentation)
- Fence-interior deltas batch and flush on a slower cadence; fence close / stream end renders byte-identical to unthrottled (identity tests)
- 5.07× less highlight work over a 120-tick fence stream (121 → 21 fence reconstructions); full-tick wall time 1.23× — honestly attributed (unrelated per-frame costs dominate)
- **Review caught a real Critical before merge:** a stream ending mid-open-fence (Stop, error, length cutoff) permanently dropped the buffered tail — the pre-existing unchanged-body early-return fired before the pending buffer was consulted. Fixed: terminal-status flush on every stream-ending path, with per-terminal-status identity tests born red against the reverted bug.

## Verification
Independent review (Not-approved round: Critical reproduced against production classes; detector verified sound; prose path byte-identical) + scoped re-review (ADDRESSED: control-flow traced across same-pass flips, double flips, deadline interplay, prune/unmount; red/green revert re-proof; 26+90 counts reproduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttles syntax highlighting for open Markdown code fences during Console streaming to cut repeated work without changing the final output. Addresses task 15456 and reduces `MarkdownFence` reconstructions ~5x while keeping prose streaming behavior the same.

- **New Features**
  - Buffers open‑fence deltas during `streaming`; flushes on fence close, a 1s deadline, or when status leaves `streaming`.
  - Adds a conservative fence detector (backtick/tilde, run length) so the throttle only applies inside open fences.
  - Prose stays unbatched: still one `Markdown.append()` per delta.
  - 120‑tick stream: 121→21 `MarkdownFence` reconstructions (~5.07× less highlight work).

- **Bug Fixes**
  - Flushes any buffered fence text when a stream ends mid‑open‑fence to prevent dropped content.

<sup>Written for commit 22c8555cb82944c1f4404b2559ff423f4d53d178. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

