### PR TITLE
fix: give the 15464 item-content loader its required failure toast

### DIFF
--- a/backlog/tasks/task-15464 - Watchlists-items-feed---narrow-projection-and-indexed-effective-date-ordering.md
+++ b/backlog/tasks/task-15464 - Watchlists-items-feed---narrow-projection-and-indexed-effective-date-ordering.md
@@ -194,3 +194,26 @@ collect-only sweep: 11,013 tests, zero import errors.
 No `Docs/User_Guide/` update: no visible UI change (the reader shows the
 same content it always did) -- this is a data-layer/perf change behind the
 existing screen.
+
+## Post-merge fix
+
+A later branch's wider test run turned up a defect this task's own suite
+selection missed: `_load_item_content` (the DETAIL-fetch loader added
+above) is a background `_load*` read whose `except` handler logged the
+failure at `debug` with no toast -- `Tests/UI/test_watchlists_check_now_
+failure.py::test_background_loaders_pay_for_their_debug_exemption_with_a_
+toast`, a structural AST convention check over every `_load*` handler
+guarding an awaited call, was RED at merge because of it. Neither my
+targeted suite selection nor the review round included that file, so the
+gate never ran against this method (that process gap is tracked
+separately, not part of this note). Fixed forward on `fix/15464-load-item-
+toast`: `_load_item_content` now notifies with `severity="error"` in the
+same `except` handler, pattern-matched off the compliant sibling
+`_load_items` immediately below it in the same file. Verified: the
+convention test is green, the full content-pane/items-pane suite (158
+tests) is unaffected, and a manual trace with a forced `get_item_content`
+failure confirms the toast actually fires live. (One unrelated,
+pre-existing failure was found while re-running this file --
+`test_user_initiated_actions_do_not_swallow_failures_into_debug[_delete_
+item]`, a stale method name in `USER_INITIATED_MUTATIONS` -- left
+untouched: out of this fix's scope, and not something this change caused.)

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -8727,13 +8727,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         entirely (every test that seeds `ItemsPane.items` with a synthetic
         dict already carrying `content`, e.g.
         `test_selecting_an_item_renders_it_in_the_content_region`), keeps
-        working unchanged. `item is None` (nothing selected) and any
-        failure fetching content (the active backend does not support
-        single-item reads, the row no longer exists, a transient DB error)
-        are both silently absorbed: content is the reader's body, not a
-        status the caller is relying on this to report -- see
-        `content_pane.render_for`'s own docstring on the same "never take
-        the app down over a reader nicety" rule.
+        working unchanged.
+
+        `item is None` (nothing selected) is a silent no-op -- there is
+        nothing to report. An actual FETCH failure (the active backend does
+        not support single-item reads, the row no longer exists, a transient
+        DB error) never raises into the caller -- content is the reader's
+        body, not a status `handle_item_selected` is relying on this to
+        report, matching `content_pane.render_for`'s own "never take the app
+        down over a reader nicety" rule -- but it is not silent either: this
+        is a background `_load*` read (`test_watchlists_check_now_failure.
+        py`'s structural contract), and that exemption from the
+        user-initiated-action "log at warning" rule is paid for with a
+        toast, exactly like the sibling `_load_items`/`_load_run_detail`
+        immediately around it. Without one, a denied `items.detail` policy
+        or a database locked by a concurrent write would render
+        byte-identically to "this item just has no body" -- an empty reader
+        with nothing said.
 
         Args:
             item: The item about to be opened, or `None`. Mutated in place
@@ -8744,6 +8754,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         item_id = item.get("id")
         if item_id is None:
             return
+        notify = getattr(self.app_instance, "notify", None)
         try:
             fetched = await self._controller.get_item_content(
                 runtime_backend=self.runtime_backend,
@@ -8753,6 +8764,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             logger.opt(exception=True).debug(
                 "Failed to load watchlist item content for the reader."
             )
+            if callable(notify):
+                notify(
+                    "Failed to load this item's full content.",
+                    severity="error",
+                )
             return
         if fetched is not None:
             item["content"] = fetched


### PR DESCRIPTION
## Summary

Post-merge fix-forward for task-15464: the new `_load_item_content` background loader shipped without the failure toast the repo's background-loader convention requires (static AST contract in `test_watchlists_check_now_failure.py`, red on dev since #1533). Neither the task's targeted suites nor its review selection included that convention file — process gap recorded in the programme ledger (convention tests keyed to a touched file can live outside the touched suites).

- Fetch failure now surfaces `"Failed to load this item's full content."` (severity=error), matching the sibling `_load_items`/`_load_run_detail` shape; docstring updated to state the exemption-paid-with-a-toast contract honestly
- Convention test green; 158/158 across content-pane/items/read-status/item-actions suites; forced-failure toast verified live
- task-15464's Implementation Notes carry a post-merge-fix paragraph naming the miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the required error toast to the `_load_item_content` background loader so fetch failures are visible. Fix-forward for task-15464 and aligned with our background-loader convention.

- **Bug Fixes**
  - On exception, call `notify("Failed to load this item's full content.", severity="error")` after the debug log; no raise and existing content remains unchanged.
  - Updated the method docstring to document the “background loaders must toast on failure” contract.
  - Convention test in `test_watchlists_check_now_failure.py` now passes; related suites unaffected.

<sup>Written for commit 92f1ebbecc70696edce9577616fbe679909b9301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

