### PR TITLE
perf: in-place Watchlists pane filtering instead of per-keystroke recompose (task-15460)

### DIFF
--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -1333,15 +1333,22 @@ async def test_space_in_items_search_input_still_types():
 
 @pytest.mark.asyncio
 async def test_typing_in_sources_search_survives_the_recompose():
-    """Typing in the sources search box keeps focus and value across recomposes.
+    """Typing in the sources search box keeps focus and value, end to end.
 
     task-3071: the SourcesPane sibling of the items-search bug pinned above.
-    `SourcesPane.search_query` is likewise `reactive(..., recompose=True)`,
-    so every keystroke rebuilt the pane and destroyed the focused input --
-    and its `recompose()` only re-homed CREATE-FORM focus, so the box was
-    lost (and with Textual's default `select_on_focus=True`, any
-    programmatic refocus would have selected-all, replacing the half-typed
-    query on the next keystroke).
+    `SourcesPane.search_query` was then `reactive(..., recompose=True)`, so
+    every keystroke rebuilt the pane and destroyed the focused input -- and
+    its `recompose()` only re-homed CREATE-FORM focus, so the box was lost
+    (and with Textual's default `select_on_focus=True`, any programmatic
+    refocus would have selected-all, replacing the half-typed query on the
+    next keystroke).
+
+    task-15460 removed that teardown entirely -- the filters are plain
+    reactives that re-populate the table in place -- so the property this
+    asserts now holds because nothing takes the focus rather than because
+    `recompose()` gives it back. The assertions are unchanged on purpose:
+    they are the user-facing outcome, and they must keep holding through
+    whichever mechanism is underneath.
     """
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
@@ -1359,9 +1366,11 @@ async def test_typing_in_sources_search_survives_the_recompose():
         await pilot.press("k", "r", "e", "b", "s")
         await pilot.pause(0.2)
 
-        # Re-query: each keystroke recomposes the pane, so the input that
-        # was focused at the start was destroyed; this is the live
-        # replacement.
+        # Re-query rather than reusing the reference: before task-15460
+        # every keystroke recomposed the pane and destroyed the input that
+        # was focused at the start, so only a fresh query saw the live one.
+        # Nothing replaces it today, but reading the DOM is what makes this
+        # test agnostic about that.
         search = pane.query_one("#sources-search-input", Input)
         assert search.value == "krebs"
         assert search.has_focus, "typing must not lose the sources search box"

--- a/Tests/Watchlists/test_watchlists_pane_filter_in_place.py
+++ b/Tests/Watchlists/test_watchlists_pane_filter_in_place.py
@@ -1,0 +1,577 @@
+"""Watchlists panes filter in place, without a per-keystroke teardown (task-15460).
+
+Two halves, deliberately kept in one file because the second only means
+anything on top of the first:
+
+* **Characterisation.** What the three filtering panes RENDER for a given
+  query/filter, asserted off the live widgets (ListView rows and day headers,
+  `DataTable` rows) rather than off the pure `_filtered_*` helpers. These
+  pass before and after the change -- they are the contract the perf work is
+  not allowed to move.
+* **Evidence.** Per keystroke: zero pane recomposes, the search `Input` is
+  the same widget object throughout, and the caret stays exactly where the
+  user put it (mid-string included). Before the change all three fail: every
+  character rebuilt the pane and a `recompose()` override re-focused the
+  fresh input with the caret slammed to the end of the value.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from rich.style import Style
+from textual.app import App, ComposeResult
+from textual.widgets import Button, DataTable, Input, ListView, Static
+
+from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
+from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+from tldw_chatbook.UI.Watchlists_Modules.sources_pane import SourcesPane
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# Fixtures / harnesses
+# --------------------------------------------------------------------------
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _item(
+    item_id: int,
+    *,
+    title: str | None = None,
+    status: str = "new",
+    published_offset_hours: float = 1.0,
+    **extra: Any,
+) -> dict[str, Any]:
+    published = _now() - timedelta(hours=published_offset_hours)
+    return {
+        "id": f"local:watchlist_item:{item_id}",
+        "item_id": item_id,
+        "title": title or f"Article {item_id}",
+        "source_name": "Feed",
+        "status": status,
+        "published_date": published.isoformat(),
+        "created_at": published.isoformat(),
+        "content": f"Body of article {item_id}.",
+        "queued_for_briefing": False,
+        "is_flagged": False,
+        **extra,
+    }
+
+
+def _source(
+    source_id: int,
+    *,
+    name: str,
+    source_type: str = "rss",
+    status: str = "ok",
+    active: bool = True,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": f"source-{source_id}",
+        "name": name,
+        "source_type": source_type,
+        "status": status,
+        "last_scraped": "2026-08-01",
+        "active": active,
+        "tags": tags or [],
+    }
+
+
+class _ArticleHarness(App):
+    def compose(self) -> ComposeResult:
+        yield ArticleListPane()
+
+
+class _ItemsHarness(App):
+    def compose(self) -> ComposeResult:
+        yield ItemsPane()
+
+
+class _SourcesHarness(App):
+    def compose(self) -> ComposeResult:
+        yield SourcesPane()
+
+
+def _visible_rows(pane: ArticleListPane) -> list[str]:
+    """Article rows the user can actually see, in painted order.
+
+    Written so it reads the same truth before and after task-15460: rows the
+    filter excludes are *absent* from the ListView before it and *hidden*
+    (`display=False`, `disabled=True`) after it, and both forms are excluded
+    here -- as is the whole ListView, which the pre-change `compose()` did
+    not yield at all when nothing matched.
+    """
+    return [
+        str(node.query_one(Static).renderable)
+        for node in _list_nodes(pane)
+        if node.display and not node.disabled
+    ]
+
+
+def _visible_headers(pane: ArticleListPane) -> list[str]:
+    return [
+        str(node.query_one(Static).renderable)
+        for node in _list_nodes(pane)
+        if node.display and node.disabled
+    ]
+
+
+def _list_nodes(pane: ArticleListPane) -> list:
+    tables = pane.query("#items-table")
+    if not tables:
+        return []
+    return list(tables.first(ListView).children)
+
+
+def _empty_state_text(pane: ArticleListPane) -> str | None:
+    """The empty-state copy the user can read, or None when there is none.
+
+    Absent (pre-change: `compose()` yields it only when nothing matched) and
+    hidden (post-change: mounted once, `display` toggled) both read as None.
+    """
+    nodes = pane.query("#items-empty-state")
+    if not nodes:
+        return None
+    node = nodes.first(Static)
+    return str(node.renderable) if node.display else None
+
+
+def _table_column(table: DataTable, column: int = 0) -> list[str]:
+    return [
+        str(table.get_row_at(index)[column]) for index in range(table.row_count)
+    ]
+
+
+class _RecomposeCounter:
+    """Counts this widget's own recomposes by wrapping the bound coroutine.
+
+    `refresh(recompose=True)` schedules `Widget._check_recompose`, which
+    calls `self.recompose()` -- so an instance attribute is the exact seam a
+    teardown has to pass through, whichever reactive triggered it.
+    """
+
+    def __init__(self, widget) -> None:
+        self.count = 0
+        self._widget = widget
+        original = widget.recompose
+
+        async def counting_recompose() -> None:
+            self.count += 1
+            await original()
+
+        widget.recompose = counting_recompose  # type: ignore[method-assign]
+
+
+# --------------------------------------------------------------------------
+# Characterisation: ArticleListPane
+# --------------------------------------------------------------------------
+
+
+async def test_article_search_query_renders_only_matching_rows():
+    app = _ArticleHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [
+            _item(1, title="Krebs on security", published_offset_hours=1),
+            _item(2, title="ArXiv digest", published_offset_hours=2),
+            _item(3, title="Krebs follow-up", published_offset_hours=3),
+        ]
+        await pilot.pause()
+        assert len(_visible_rows(pane)) == 3, "precondition"
+
+        pane.search_query = "krebs"
+        await pilot.pause()
+
+        rendered = _visible_rows(pane)
+        assert len(rendered) == 2
+        assert "Krebs on security" in rendered[0]
+        assert "Krebs follow-up" in rendered[1]
+        assert [item["item_id"] for item in pane.displayed_items()] == [1, 3]
+
+
+async def test_article_search_hides_a_day_header_whose_whole_group_is_filtered_out():
+    """A rebuild would not paint a header with nothing under it, so neither
+    may an in-place filter."""
+    app = _ArticleHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [
+            _item(1, title="Today match", published_offset_hours=1),
+            _item(2, title="Yesterday other", published_offset_hours=26),
+        ]
+        await pilot.pause()
+        assert _visible_headers(pane) == ["Today", "Yesterday"], "precondition"
+
+        pane.search_query = "match"
+        await pilot.pause()
+
+        assert _visible_headers(pane) == ["Today"]
+        assert len(_visible_rows(pane)) == 1
+
+
+async def test_article_status_filter_renders_unread_only_and_pins_the_open_item():
+    app = _ArticleHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        items = [
+            _item(1, status="new", published_offset_hours=1),
+            _item(2, status="reviewed", published_offset_hours=2),
+        ]
+        pane.items = items
+        await pilot.pause()
+
+        pane.status_filter = "unread"
+        await pilot.pause()
+        assert len(_visible_rows(pane)) == 1
+        assert "Article 1" in _visible_rows(pane)[0]
+
+        # Mark-read-on-open mutates the shared dict; the open item must stay.
+        items[0]["status"] = "reviewed"
+        pane.selected_item = items[0]
+        await pilot.pause()
+        assert [item["item_id"] for item in pane.displayed_items()] == [1]
+        assert len(_visible_rows(pane)) == 1
+
+
+async def test_article_all_filter_renders_reader_statuses_only():
+    app = _ArticleHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [
+            _item(1, status="new", published_offset_hours=1),
+            _item(2, status="reviewed", published_offset_hours=2),
+            _item(3, status="ingested", published_offset_hours=3),
+            _item(4, status="ignored", published_offset_hours=4),
+            _item(5, status="error", published_offset_hours=5),
+        ]
+        await pilot.pause()
+        pane.status_filter = "all"
+        await pilot.pause()
+
+        rendered = _visible_rows(pane)
+        assert len(rendered) == 3
+        assert [item["item_id"] for item in pane.displayed_items()] == [1, 2, 3]
+
+
+async def test_article_empty_state_explains_which_emptiness_it_is():
+    app = _ArticleHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1, status="reviewed")]
+        await pilot.pause()
+
+        pane.status_filter = "unread"
+        await pilot.pause()
+        assert "caught up" in (_empty_state_text(pane) or "")
+        assert _visible_rows(pane) == []
+
+        pane.status_filter = "all"
+        pane.search_query = "nothing matches this"
+        await pilot.pause()
+        assert "No matching items" in (_empty_state_text(pane) or "")
+
+        pane.search_query = ""
+        await pilot.pause()
+        assert len(_visible_rows(pane)) == 1
+        assert _empty_state_text(pane) is None
+
+
+async def test_article_reload_replaces_the_rows_with_the_new_page():
+    """The debounced DB reload path: new data still repaints the list."""
+    app = _ArticleHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1, title="First page")]
+        await pilot.pause()
+        assert "First page" in _visible_rows(pane)[0]
+
+        pane.items = [
+            _item(7, title="Second page A", published_offset_hours=1),
+            _item(8, title="Second page B", published_offset_hours=2),
+        ]
+        await pilot.pause()
+
+        rendered = _visible_rows(pane)
+        assert len(rendered) == 2
+        assert "Second page A" in rendered[0]
+        assert "Second page B" in rendered[1]
+        assert [item["item_id"] for item in pane.displayed_items()] == [7, 8]
+
+
+async def test_article_reload_respects_the_active_search_query():
+    app = _ArticleHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.search_query = "keeper"
+        pane.items = [
+            _item(1, title="keeper one", published_offset_hours=1),
+            _item(2, title="dropped", published_offset_hours=2),
+        ]
+        await pilot.pause()
+
+        rendered = _visible_rows(pane)
+        assert len(rendered) == 1
+        assert "keeper one" in rendered[0]
+
+
+# --------------------------------------------------------------------------
+# Characterisation: ItemsPane / SourcesPane (DataTable panes)
+# --------------------------------------------------------------------------
+
+
+async def test_items_pane_search_and_status_filters_render_the_same_rows():
+    app = _ItemsHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ItemsPane)
+        pane.items = [
+            _item(1, title="Krebs on security", status="new"),
+            _item(2, title="ArXiv digest", status="reviewed"),
+            _item(3, title="Krebs follow-up", status="reviewed"),
+        ]
+        await pilot.pause()
+        table = pane.query_one("#items-table", DataTable)
+        assert table.row_count == 3, "precondition"
+
+        pane.search_query = "krebs"
+        await pilot.pause()
+        assert _table_column(pane.query_one("#items-table", DataTable)) == [
+            "Krebs on security",
+            "Krebs follow-up",
+        ]
+
+        pane.status_filter = "reviewed"
+        await pilot.pause()
+        assert _table_column(pane.query_one("#items-table", DataTable)) == [
+            "Krebs follow-up"
+        ]
+
+        pane.search_query = ""
+        await pilot.pause()
+        assert _table_column(pane.query_one("#items-table", DataTable)) == [
+            "ArXiv digest",
+            "Krebs follow-up",
+        ]
+
+
+async def test_sources_pane_filters_render_the_same_rows():
+    app = _SourcesHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(SourcesPane)
+        pane.sources = [
+            _source(1, name="AI News RSS", tags=["tech", "ai"]),
+            _source(2, name="Tech Atom Feed", source_type="atom", status="error",
+                    active=False, tags=["tech"]),
+            _source(3, name="Playlist Watch", source_type="playlist", tags=["video"]),
+        ]
+        await pilot.pause()
+        assert pane.query_one("#sources-table", DataTable).row_count == 3
+
+        pane.search_query = "ai"
+        await pilot.pause()
+        assert _table_column(pane.query_one("#sources-table", DataTable)) == [
+            "AI News RSS"
+        ]
+
+        pane.search_query = ""
+        pane.source_type_filter = "atom"
+        await pilot.pause()
+        assert _table_column(pane.query_one("#sources-table", DataTable)) == [
+            "Tech Atom Feed"
+        ]
+
+        pane.source_type_filter = "all"
+        pane.status_filter = "error"
+        await pilot.pause()
+        assert _table_column(pane.query_one("#sources-table", DataTable)) == [
+            "Tech Atom Feed"
+        ]
+
+        pane.status_filter = "all"
+        pane.active_filter = "inactive"
+        await pilot.pause()
+        assert _table_column(pane.query_one("#sources-table", DataTable)) == [
+            "Tech Atom Feed"
+        ]
+
+        pane.active_filter = "all"
+        pane.tags_filter = "video"
+        await pilot.pause()
+        assert _table_column(pane.query_one("#sources-table", DataTable)) == [
+            "Playlist Watch"
+        ]
+
+
+async def test_sources_pane_selection_highlight_survives_a_filter_change():
+    """The selected row must still paint as selected after an in-place
+    re-populate -- `compose()` used to be the only thing that drew it."""
+    app = _SourcesHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(SourcesPane)
+        pane.sources = [
+            _source(1, name="AI News RSS"),
+            _source(2, name="Tech Atom Feed", source_type="atom"),
+        ]
+        await pilot.pause()
+        pane.select_source_by_id("source-1")
+        await pilot.pause()
+
+        pane.search_query = "news"
+        await pilot.pause()
+
+        table = pane.query_one("#sources-table", DataTable)
+        assert table.row_count == 1
+        raw_style = table.get_cell("source-1", list(table.columns.keys())[0]).style
+        style = Style.parse(raw_style) if isinstance(raw_style, str) else raw_style
+        assert style.reverse, (
+            "the selected row lost its highlight when the filter re-populated"
+        )
+
+
+# --------------------------------------------------------------------------
+# Evidence: no teardown per keystroke, focus and caret intact
+# --------------------------------------------------------------------------
+
+
+async def test_typing_in_the_article_search_never_recomposes_the_pane():
+    app = _ArticleHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(index, title=f"Article {index}") for index in range(20)]
+        await pilot.pause()
+
+        search = pane.query_one("#items-search-input", Input)
+        search.focus()
+        await pilot.pause()
+        counter = _RecomposeCounter(pane)
+
+        await pilot.press("k", "r", "e", "b", "s")
+        await pilot.pause()
+
+        assert counter.count == 0, (
+            f"typing 5 characters tore the pane down {counter.count} times"
+        )
+        assert pane.query_one("#items-search-input", Input) is search, (
+            "the search box was destroyed and replaced while typing"
+        )
+
+
+async def test_the_article_search_box_keeps_focus_and_caret_while_typing():
+    app = _ArticleHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(index, title=f"Article {index}") for index in range(20)]
+        await pilot.pause()
+
+        search = pane.query_one("#items-search-input", Input)
+        search.focus()
+        await pilot.pause()
+
+        await pilot.press("a", "r", "t")
+        await pilot.pause()
+        assert app.screen.focused is search
+        assert search.value == "art"
+        assert search.cursor_position == 3
+
+        # Editing mid-string is where a teardown+refocus is at its worst: the
+        # restore hack always put the caret at the END of the value.
+        search.cursor_position = 1
+        await pilot.press("x")
+        await pilot.pause()
+
+        assert app.screen.focused is search, "focus left the search box mid-word"
+        assert search.value == "axrt"
+        assert search.cursor_position == 2, (
+            "the caret jumped -- the input was rebuilt under the user"
+        )
+
+
+async def test_typing_in_the_sources_search_never_recomposes_the_pane():
+    app = _SourcesHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(SourcesPane)
+        pane.sources = [_source(index, name=f"Source {index}") for index in range(20)]
+        await pilot.pause()
+
+        search = pane.query_one("#sources-search-input", Input)
+        search.focus()
+        await pilot.pause()
+        counter = _RecomposeCounter(pane)
+
+        await pilot.press("s", "o", "u", "r")
+        await pilot.pause()
+
+        assert counter.count == 0, (
+            f"typing 4 characters tore the pane down {counter.count} times"
+        )
+        assert pane.query_one("#sources-search-input", Input) is search
+        assert app.screen.focused is search
+        assert search.cursor_position == 4
+
+
+async def test_typing_in_the_sources_tag_filter_never_recomposes_the_pane():
+    app = _SourcesHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(SourcesPane)
+        pane.sources = [_source(index, name=f"Source {index}") for index in range(20)]
+        await pilot.pause()
+        pane.query_one("#sources-filter-toggle", Button).press()
+        await pilot.pause()
+
+        tags = pane.query_one("#sources-tags-filter", Input)
+        tags.focus()
+        await pilot.pause()
+        counter = _RecomposeCounter(pane)
+
+        await pilot.press("t", "e", "c", "h")
+        await pilot.pause()
+
+        assert counter.count == 0
+        assert pane.query_one("#sources-tags-filter", Input) is tags
+        assert app.screen.focused is tags
+        assert tags.cursor_position == 4
+
+
+async def test_typing_in_the_items_pane_search_never_recomposes_the_pane():
+    app = _ItemsHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ItemsPane)
+        pane.items = [_item(index, title=f"Article {index}") for index in range(20)]
+        await pilot.pause()
+
+        search = pane.query_one("#items-search-input", Input)
+        search.focus()
+        await pilot.pause()
+        counter = _RecomposeCounter(pane)
+
+        await pilot.press("a", "r", "t")
+        await pilot.pause()
+
+        assert counter.count == 0
+        assert pane.query_one("#items-search-input", Input) is search
+        assert app.screen.focused is search
+        assert search.cursor_position == 3
+
+
+async def test_changing_the_article_status_filter_never_recomposes_the_pane():
+    """The Select siblings shared the search box's blast radius."""
+    app = _ArticleHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(index, title=f"Article {index}") for index in range(20)]
+        await pilot.pause()
+        counter = _RecomposeCounter(pane)
+
+        pane.status_filter = "unread"
+        await pilot.pause()
+        pane.status_filter = "all"
+        await pilot.pause()
+
+        assert counter.count == 0

--- a/Tests/Watchlists/test_watchlists_pane_filter_in_place.py
+++ b/Tests/Watchlists/test_watchlists_pane_filter_in_place.py
@@ -306,6 +306,67 @@ async def test_article_reload_replaces_the_rows_with_the_new_page():
         assert [item["item_id"] for item in pane.displayed_items()] == [7, 8]
 
 
+async def test_a_filter_change_during_a_row_rebuild_lands_on_the_new_filter():
+    """The reload/keystroke interleave, made deterministic.
+
+    `_rebuild_rows` awaits `clear()` and `extend()`, and a filter assignment
+    from another message pump (the screen re-seeding `search_query`, a
+    selection write) runs its synchronous watcher inside that gap -- against
+    a half-swapped list, with the rebuild then mounting rows built from the
+    PRE-change filter. Without the post-await re-check, `displayed_items()`
+    (which `j`/`k` walk) describes the new filter while the painted rows
+    still show the old one.
+
+    The gap is forced open here by wrapping the ListView's own `clear()` in
+    an awaitable that assigns `search_query` after the removal completes --
+    the same instant a real cross-pump assignment would land in.
+    """
+    app = _ArticleHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [_item(1, title="First page")]
+        await pilot.pause()
+
+        list_view = pane.query_one("#items-table", ListView)
+        original_clear = list_view.clear
+        fired = False
+
+        def clear_then_change_the_filter():
+            nonlocal fired
+            removal = original_clear()
+
+            async def _clear_and_type():
+                await removal
+                nonlocal fired
+                if not fired:
+                    fired = True
+                    pane.search_query = "keeper"
+
+            return _clear_and_type()
+
+        list_view.clear = clear_then_change_the_filter
+
+        # The reload the screen's debounce would fire, carrying a page the
+        # new query only partly matches.
+        pane.items = [
+            _item(7, title="keeper one", published_offset_hours=1),
+            _item(8, title="dropped", published_offset_hours=2),
+        ]
+        await pilot.pause()
+        await pilot.pause()
+
+        assert fired, "the test did not actually open the gap it is pinning"
+        rendered = _visible_rows(pane)
+        assert len(rendered) == 1, (
+            f"painted rows disagree with the new filter: {rendered}"
+        )
+        assert "keeper one" in rendered[0]
+        assert [item["item_id"] for item in pane.displayed_items()] == [7], (
+            "displayed_items() -- the j/k authority -- must agree with what "
+            "is painted"
+        )
+
+
 async def test_article_reload_respects_the_active_search_query():
     app = _ArticleHarness()
     async with app.run_test(size=(120, 40)) as pilot:

--- a/backlog/tasks/task-15460 - Watchlists---replace-per-keystroke-pane-teardowns-with-in-place-updates.md
+++ b/backlog/tasks/task-15460 - Watchlists---replace-per-keystroke-pane-teardowns-with-in-place-updates.md
@@ -113,4 +113,39 @@ mid-string edit).
 Modified: `tldw_chatbook/UI/Watchlists_Modules/article_list.py`,
 `items_pane.py`, `sources_pane.py`. Added:
 `Tests/Watchlists/test_watchlists_pane_filter_in_place.py`.
+
+### Review follow-up (Important, closed before merge)
+
+`_rebuild_rows` captured `_filtered_items()` synchronously and then yielded
+twice (`clear()`, `extend()`). A filter assignment arriving from another
+message pump inside that gap -- the screen re-seeding `search_query`, a
+selection write -- ran its synchronous watcher against a half-swapped list,
+leaving `_rendered_items` (the `j`/`k` authority `displayed_items()` returns)
+describing the NEW filter while the rows the rebuild then mounted still
+carried the old one. Self-healing on the next event, but real and unpinned.
+
+Closed by re-reading the filter state after the awaits (`_filter_state()` --
+both filters plus the open-item pin, since a moved selection also changes
+which row survives) and re-running `_apply_row_visibility()` once if it
+moved. One pass converges and cannot oscillate: that method awaits nothing,
+so nothing can interleave inside it, and it derives the painted rows and
+`_rendered_items` from a single read of the current filter; a change landing
+after it returns is an ordinary filter change arriving through its own
+watcher.
+
+Pinned by
+`test_a_filter_change_during_a_row_rebuild_lands_on_the_new_filter`, which
+forces the gap open deterministically by wrapping the ListView's own
+`clear()` in an awaitable that assigns `search_query` after the removal
+completes, then asserts painted rows == `displayed_items()` == the new
+filter's result. Mutation-verified: with the post-await re-check disabled the
+test fails with both rows painted (`assert 2 == 1`) against a
+`displayed_items()` of one -- exactly the divergence described.
+
+Also corrected a stale docstring/comment in
+`Tests/Watchlists/test_watchlists_collections_screen.py::
+test_typing_in_sources_search_survives_the_recompose`, which described the
+pre-15460 per-keystroke recompose as current behaviour. The test's
+assertions are unchanged -- they are the user-facing outcome and must hold
+through whichever mechanism is underneath.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15460 - Watchlists---replace-per-keystroke-pane-teardowns-with-in-place-updates.md
+++ b/backlog/tasks/task-15460 - Watchlists---replace-per-keystroke-pane-teardowns-with-in-place-updates.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15460
 title: Watchlists: replace per-keystroke pane teardowns with in-place updates
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -20,7 +21,96 @@ Fix direction: plain reactives + in-place row repaint (surgical helpers already 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Typing in Watchlists search/filter boxes causes no pane recompose (evidence)
-- [ ] #2 Filtering results identical, including the debounced DB reload path (tests)
-- [ ] #3 Focus stays in the input while typing (regression test replacing the re-focus override)
+- [x] #1 Typing in Watchlists search/filter boxes causes no pane recompose (evidence)
+- [x] #2 Filtering results identical, including the debounced DB reload path (tests)
+- [x] #3 Focus stays in the input while typing (regression test replacing the re-focus override)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. PIN FIRST: characterisation tests for the current filtering behaviour of all
+   three panes (typed query -> visible rows; status/type/active filters; tags
+   filter; the open-item pin), asserting RENDERED results, green before any
+   production change.
+2. Born-red evidence tests: count pane recomposes per keystroke (expect 0), and
+   assert the search `Input` widget identity + caret position survive a burst of
+   keystrokes.
+3. `ArticleListPane`: `items`/`search_query`/`status_filter`/`runtime_backend`
+   become plain reactives. Rows for the whole item page are mounted once per
+   data arrival (`watch_items` -> in-place ListView rebuild, toolbar untouched);
+   filtering is a pure display/disabled toggle over the mounted rows plus the
+   day headers. Delete the `recompose()` re-focus override -- with the toolbar
+   never destroyed there is nothing to re-focus.
+4. `ItemsPane`/`SourcesPane`: filter reactives become plain; a `DataTable`
+   holds data rows, not widgets, so filtering re-populates the table in place
+   (`clear()` + `add_row`) with zero widget mounts and no toolbar teardown.
+   `SourcesPane.recompose()` keeps its create-form focus logic (still driven by
+   `show_create_form`/`create_draft_source_type`).
+5. Latency probe on a seeded 100-article pane, before vs after, isolated HOME.
+6. Run the Watchlists UI suites + the panes' own suites; read pass counts.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The three filtering panes no longer tear themselves down per keystroke.
+
+**`ArticleListPane`** (the pane actually mounted in the Read section) now has
+no `recompose=True` reactive at all. `_build_rows` mounts one `_ArticleRow`
+for every item on the loaded page -- not just the ones the filter admits --
+so filtering is a `display`/`disabled` toggle over rows that already exist
+(`_apply_row_visibility`), including hiding a day header once its whole group
+is hidden. `disabled` deliberately tracks `display`: ListView's cursor
+movement skips disabled children and knows nothing about `display`, so a
+hidden-but-enabled row would silently take the cursor and `j`/`k`. The
+data-arrival path (`watch_items`) rebuilds the ListView's children in place,
+touching nothing in the toolbar -- which matters because the screen's reload
+is debounced 0.3 s behind the last keystroke and used to destroy the search
+box the user was still typing into. With nothing destroying the input, the
+`recompose()`/`_restore_search_focus` pair (TASK-3071) was deleted rather
+than kept: the caret now stays where the user put it instead of being
+restored to the end of the value. The empty state and the ListView are both
+always mounted with `display` toggled, so "nothing matches" is not itself a
+teardown.
+
+**`ItemsPane`/`SourcesPane`** are `DataTable` panes, and a `DataTable`'s rows
+are data rather than widgets -- so their filters became plain reactives that
+re-populate the table in place (`_refresh_table_rows` -> `_populate_table`,
+shared with `compose()`), which constructs no widget and leaves the toolbar,
+an open create form, the focused `Input` and its caret alone. Their `items`/
+`sources` reactives keep `recompose=True` (a data arrival, never triggered by
+typing in `SourcesPane`, whose search is client-side only), and
+`SourcesPane.recompose()` keeps its create-form focus logic, which is still
+driven by `show_create_form`/`create_draft_source_type`. `runtime_backend`
+was `recompose=True` on both panes while being read by neither `compose()` --
+a free rebuild, now plain.
+
+Measured on a seeded 100-article pane, isolated HOME, same probe before and
+after (mean of 8 keystrokes, `pilot.press` + settle):
+
+| | before | after |
+|---|---|---|
+| ms/keystroke | 312.7 | 142 |
+| pane recomposes | 1.00/key | 0 |
+| `_ArticleRow` constructions | 100/key | 0 |
+| search `Input` replaced | every key | never |
+
+The harness floor (same probe, 0 articles, after) is 122.5 ms, so the pane's
+own per-keystroke work went from ~190 ms to ~20 ms. A narrowing query
+(`"article 1"`, 100 -> 11 rows) measures 147-157 ms, also with zero
+recomposes and zero row constructions. The no-op guard in `set_row_visible`
+is load-bearing for that: a `display` write is a styles mutation and a
+refresh even when the value is unchanged, and it runs once per row per
+character.
+
+Tests: `Tests/Watchlists/test_watchlists_pane_filter_in_place.py` -- ten
+characterisation tests asserting RENDERED rows (they passed before the change
+and still do) plus six evidence tests that were red before it (recompose
+count per keystroke, `Input` identity, focus, and caret position including a
+mid-string edit).
+
+Modified: `tldw_chatbook/UI/Watchlists_Modules/article_list.py`,
+`items_pane.py`, `sources_pane.py`. Added:
+`Tests/Watchlists/test_watchlists_pane_filter_in_place.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Watchlists_Modules/article_list.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/article_list.py
@@ -404,6 +404,21 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
         _set_header_visible(header, header_has_visible)
         return rows
 
+    def _filter_state(self) -> tuple[str, str, str | None]:
+        """Everything `_filtered_items()` reads, as one comparable value.
+
+        The open-item pin is part of it, not just the two filters: a
+        selection that moves decides which row survives a filter that would
+        otherwise drop it.
+        """
+        selected = self.selected_item
+        selected_id = (
+            str(selected["id"])
+            if isinstance(selected, dict) and selected.get("id") is not None
+            else None
+        )
+        return (self.status_filter, self.search_query, selected_id)
+
     async def _rebuild_rows(self) -> None:
         """Replace the ListView's children after a data arrival.
 
@@ -411,6 +426,20 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
         ListView's own children: the toolbar -- and with it the search
         `Input` the user may still be typing into, since the screen's reload
         is debounced 0.3 s behind the last keystroke -- is never touched.
+
+        `clear()`/`extend()` both yield, and a filter assignment arriving
+        from ANOTHER message pump (the screen re-seeding `search_query`, a
+        selection write) runs its synchronous watcher inside that gap:
+        `_apply_row_visibility` would walk a half-swapped list and leave
+        `_rendered_items` -- the `j`/`k` navigation authority -- describing
+        the new filter while the rows this method then mounts still carry
+        the old one. So the filter state is re-read after the awaits and the
+        visibility pass re-run once if it moved. Once is enough and cannot
+        oscillate: `_apply_row_visibility` awaits nothing, so nothing can
+        interleave inside it, and it derives both the painted rows and
+        `_rendered_items` from a single read of the current filter. A change
+        landing after it returns is an ordinary filter change and arrives
+        through its own watcher.
         """
         try:
             list_view = self.query_one("#items-table", _ArticleListView)
@@ -419,11 +448,15 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
             # only just constructed, and `compose()` will build these rows.
             return
         rows = self._build_rows()
+        filter_state = self._filter_state()
         await list_view.clear()
         if not self.is_running or not list_view.is_attached:
             return
         if rows:
             await list_view.extend(rows)
+        if self._filter_state() != filter_state:
+            self._apply_row_visibility()
+            return
         self._update_empty_state()
 
     def _apply_row_visibility(self) -> None:

--- a/tldw_chatbook/UI/Watchlists_Modules/article_list.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/article_list.py
@@ -11,10 +11,19 @@ Everything `ItemsPane` taught the hard way carries over, deliberately:
 `displayed_items()` / `select_and_reveal()`, the `_rendered_items`
 rendered-sequence authority, open-item pinning in the filter, the
 `ItemsFilterChanged` mirror, in-place single-row repaints (a recompose
-destroys the live list and drops focus), the search box's
-`select_on_focus=False` + recompose focus restore (TASK-3071), and the
-pane-bound `space` binding. The screen-facing API and message set are
-unchanged on purpose -- the construction-site swap is one line.
+destroys the live list and drops focus), and the pane-bound `space`
+binding. The screen-facing API and message set are unchanged on purpose --
+the construction-site swap is one line.
+
+task-15460 finished the job the single-row repaints started: this pane no
+longer recomposes AT ALL. Rows are built once per data arrival
+(`watch_items` -> `_rebuild_rows`, which touches only the ListView's own
+children), and filtering -- the search box and the Unread/All Select -- is a
+display toggle over those already-mounted rows (`_apply_row_visibility`).
+The toolbar, and with it the search `Input`, is therefore never destroyed,
+so the TASK-3071 focus-restore override could go: focus and caret survive
+typing because nothing takes them away, not because something puts them
+back.
 
 Remote text is APPENDED to a `Text`, never parsed (the
 `content_pane.render_article` rule): a markup-shaped title renders as those
@@ -118,20 +127,54 @@ class _DayHeader(ListItem):
 
 
 class _ArticleRow(ListItem):
-    """One displayed item. `item_id_key` is the row's stable identity for
-    selection and in-place repaints (the pane's `update_item_*_cell` API).
+    """One item of the loaded page. `item_id_key` is the row's stable
+    identity for selection, filtering and in-place repaints (the pane's
+    `update_item_*_cell` API).
 
     `display_overrides` accumulates the transient writes of every repaint so
     far: a status repaint followed by a queued repaint must show BOTH, the
     way ItemsPane's independent cells did, without either one writing back
-    to the shared item dict (see `_repaint_row`). Recomposes rebuild rows
-    from the dicts, which is precisely when the reload has made them fresh.
+    to the shared item dict (see `_repaint_row`). Row rebuilds re-render from
+    the dicts, which is precisely when the reload has made them fresh.
+
+    task-15460: a row exists for every item on the loaded page, whether the
+    current filter shows it or not, and `visible` decides which. `disabled`
+    tracks `display` deliberately -- ListView's cursor movement skips
+    disabled children and knows nothing about `display`, so a hidden row
+    that stayed enabled would silently take the cursor (and `j`/`k`) while
+    being invisible.
     """
 
-    def __init__(self, item: dict[str, Any]) -> None:
+    def __init__(self, item: dict[str, Any], *, visible: bool = True) -> None:
         self.item_id_key = str(item.get("id") or "")
         self.display_overrides: dict[str, Any] = {}
         super().__init__(Static(_render_row(item), classes="article-row"))
+        self.set_row_visible(visible)
+
+    def set_row_visible(self, visible: bool) -> None:
+        """Show or hide this row (see the class docstring on `disabled`).
+
+        No-ops when the row is already in the requested state. That guard is
+        what makes a keystroke that changes nothing (typing further into a
+        term every row still matches) cost nothing: a bare `display` write
+        is a styles mutation and a refresh even when the value is identical,
+        and this runs once per row of the loaded page per character typed.
+        """
+        if self.display is visible and self.disabled is not visible:
+            return
+        self.display = visible
+        self.disabled = not visible
+
+
+def _set_header_visible(header: "_DayHeader | None", visible: bool) -> None:
+    """Show a day header only while it still has a row under it.
+
+    Same no-op guard as `_ArticleRow.set_row_visible`, and skipped entirely
+    for the `None` that stands for "no header opened yet".
+    """
+    if header is None or header.display is visible:
+        return
+    header.display = visible
 
 
 class _ArticleListView(ListView):
@@ -190,11 +233,23 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
     ]
     _READER_STATUSES = frozenset({"new", "reviewed", "ingested"})
 
-    items = reactive[list[dict[str, Any]]]([], recompose=True)
+    #: task-15460: every one of these is a PLAIN reactive. `search_query`
+    #: and `status_filter` were `recompose=True`, so a keystroke in the
+    #: search box tore down and rebuilt the whole pane -- ~220 widgets for
+    #: one character, measured at ~310 ms per keystroke on a 100-article
+    #: page (Docs/Design/2026-08-11-input-latency-audit.md). They now toggle
+    #: the visibility of rows that are already mounted
+    #: (`_apply_row_visibility`). `items` is the data-arrival path and
+    #: rebuilds the ListView's children in place (`_rebuild_rows`) rather
+    #: than recomposing the toolbar along with them -- that is what keeps
+    #: the debounced reload from destroying the search box the user is
+    #: still typing into 0.3 s later. `runtime_backend` is read by nothing
+    #: in `compose()` at all; it was rebuilding the pane for free.
+    items = reactive[list[dict[str, Any]]]([])
     selected_item = reactive[dict[str, Any] | None](None)
-    status_filter = reactive("all", recompose=True)
-    search_query = reactive("", recompose=True)
-    runtime_backend = reactive("local", recompose=True)
+    status_filter = reactive("all")
+    search_query = reactive("")
+    runtime_backend = reactive("local")
     #: The pill's text ("" hides it). Screen-pushed after a refresh-all --
     #: the pane holds no counts of its own. Plain reactive, NOT
     #: `recompose=True`: flipping it must update one Static in place, never
@@ -241,12 +296,19 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
         self._rendered_items: list[dict[str, Any]] = []
 
     def compose(self):
-        """Build the toolbar and the grouped rows, once per recompose.
+        """Build the toolbar and the grouped rows, once per pane instance.
 
         Rows are sorted by effective date descending IN PYTHON over the
-        displayed set (the SQL COALESCE picks the page; mixed stored tz
+        loaded page (the SQL COALESCE picks the page; mixed stored tz
         shapes make it only approximate -- see `get_new_items`), with a
         `_DayHeader` inserted wherever the bucket changes.
+
+        task-15460: this now runs ONCE -- the pane has no `recompose=True`
+        reactive left. `_build_rows` seeds the same visibility
+        `_apply_row_visibility` maintains afterwards, so a pane built with a
+        filter already seeded (the screen's `_build_detail_pane` does
+        exactly that on every workbench rebuild) paints filtered on its
+        first frame rather than flashing the unfiltered page.
         """
         with Horizontal(id="items-toolbar", classes="destination-filter-strip"):
             yield Button(
@@ -259,11 +321,12 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
                 placeholder="Search items...",
                 id="items-search-input",
                 value=self.search_query,
-                # `select_on_focus=False` is load-bearing (TASK-3071): this
-                # pane recomposes on every keystroke and recompose restores
-                # focus to the fresh input; with Textual's default the
-                # refocus would select-all and the next keystroke would
-                # REPLACE the query. See `ItemsPane.compose`'s full note.
+                # TASK-3071 introduced this because a recompose re-focused a
+                # freshly built input and Textual's default would select-all,
+                # so the next keystroke REPLACED the query. task-15460 removed
+                # that teardown entirely, but the property stays on its own
+                # merits: clicking back into a half-typed search must put the
+                # caret where you clicked, not arm the whole term for deletion.
                 select_on_focus=False,
                 compact=True,
             )
@@ -288,29 +351,128 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
             pill.display = bool(self.new_items_note)
             yield pill
 
-        filtered = self._filtered_items()
-        self._rendered_items = filtered
-        if not filtered:
-            yield Static(self._empty_text(), id="items-empty-state")
-        else:
-            rows: list[ListItem] = []
-            last_bucket: str | None = None
-            for item in filtered:
-                bucket = day_bucket(effective_date(item))
-                if bucket != last_bucket:
-                    rows.append(_DayHeader(bucket))
-                    last_bucket = bucket
-                rows.append(_ArticleRow(item))
-            # `initial_index=None`: no opening row-0 highlight announcement
-            # for a rebuilt list to fire -- the rebuilt-table highlight is
-            # exactly what `ItemsPane`'s focus gate existed to filter.
-            yield _ArticleListView(*rows, id="items-table", initial_index=None)
+        rows = self._build_rows()
+        # Both the empty state and the list are always mounted, their
+        # `display` decided by whether anything survived the filter: the
+        # empty state used to be composed INSTEAD of the ListView, which
+        # made "nothing matches this search" a full teardown of the list --
+        # and then another one on the next keypress that matched again.
+        empty_state = Static(self._empty_text(), id="items-empty-state")
+        empty_state.display = not self._rendered_items
+        yield empty_state
+        # `initial_index=None`: no opening row-0 highlight announcement for
+        # a rebuilt list to fire -- the rebuilt-table highlight is exactly
+        # what `ItemsPane`'s focus gate existed to filter.
+        yield _ArticleListView(*rows, id="items-table", initial_index=None)
         yield Static(
             f"{self._UNREAD_DOT} unread · {self._STAR_GLYPH} starred · "
             f"{self._QUEUED_GLYPH} queued for briefing",
             id="items-queued-legend",
             classes="watchlists-hint-line",
         )
+
+    def _build_rows(self) -> list[ListItem]:
+        """Rows and day headers for the whole loaded page, pre-filtered.
+
+        One `_ArticleRow` per item on the page -- not per item the filter
+        currently admits -- because that is what makes filtering a display
+        toggle instead of a rebuild. Headers are computed over the same full
+        sequence, so a bucket's header always precedes every row in it, and
+        a header whose rows are all hidden is hidden with them.
+
+        Sets `_rendered_items` as a side effect (`compose()` and
+        `_rebuild_rows` both need it seeded before the rows are mounted).
+        """
+        filtered = self._filtered_items()
+        self._rendered_items = filtered
+        visible_keys = {str(item.get("id") or "") for item in filtered}
+        rows: list[ListItem] = []
+        last_bucket: str | None = None
+        header: _DayHeader | None = None
+        header_has_visible = False
+        for item in sorted(self.items, key=_sort_key, reverse=True):
+            bucket = day_bucket(effective_date(item))
+            if bucket != last_bucket:
+                _set_header_visible(header, header_has_visible)
+                header = _DayHeader(bucket)
+                header_has_visible = False
+                rows.append(header)
+                last_bucket = bucket
+            visible = str(item.get("id") or "") in visible_keys
+            header_has_visible = header_has_visible or visible
+            rows.append(_ArticleRow(item, visible=visible))
+        _set_header_visible(header, header_has_visible)
+        return rows
+
+    async def _rebuild_rows(self) -> None:
+        """Replace the ListView's children after a data arrival.
+
+        The reload path (`watch_items`). Deliberately scoped to the
+        ListView's own children: the toolbar -- and with it the search
+        `Input` the user may still be typing into, since the screen's reload
+        is debounced 0.3 s behind the last keystroke -- is never touched.
+        """
+        try:
+            list_view = self.query_one("#items-table", _ArticleListView)
+        except NoMatches:
+            # Not mounted yet: the screen seeds `items` on a pane it has
+            # only just constructed, and `compose()` will build these rows.
+            return
+        rows = self._build_rows()
+        await list_view.clear()
+        if not self.is_running or not list_view.is_attached:
+            return
+        if rows:
+            await list_view.extend(rows)
+        self._update_empty_state()
+
+    def _apply_row_visibility(self) -> None:
+        """Re-run the filter over the mounted rows, showing/hiding in place.
+
+        The whole point of task-15460: a keystroke moves `display` on rows
+        that already exist rather than destroying and rebuilding them. The
+        rendered sequence is `_filtered_items()` exactly as before -- rows
+        are built for every item on the page, so every filtered item has
+        one -- and the DOM walk only decides what is on screen, including
+        which day headers still have a row under them.
+        """
+        filtered = self._filtered_items()
+        self._rendered_items = filtered
+        visible_keys = {str(item.get("id") or "") for item in filtered}
+        try:
+            list_view = self.query_one("#items-table", _ArticleListView)
+        except NoMatches:
+            return
+        header: _DayHeader | None = None
+        header_has_visible = False
+        for node in list_view.children:
+            if isinstance(node, _DayHeader):
+                _set_header_visible(header, header_has_visible)
+                header = node
+                header_has_visible = False
+            elif isinstance(node, _ArticleRow):
+                visible = node.item_id_key in visible_keys
+                node.set_row_visible(visible)
+                header_has_visible = header_has_visible or visible
+        _set_header_visible(header, header_has_visible)
+        # The cursor must not be left parked on a row that just went away:
+        # `ListView.index` is a position, and a hidden row still occupies
+        # one. `None` is the same "nothing highlighted" state a fresh list
+        # opens in (`initial_index=None`).
+        index = list_view.index
+        if index is not None and 0 <= index < len(list_view.children):
+            if not list_view.children[index].display:
+                list_view.index = None
+        self._update_empty_state()
+
+    def _update_empty_state(self) -> None:
+        """Show the right emptiness message, or none at all."""
+        try:
+            empty_state = self.query_one("#items-empty-state", Static)
+        except NoMatches:
+            return
+        empty_state.update(self._empty_text())
+        empty_state.display = not self._rendered_items
 
     def _empty_text(self) -> str:
         """What the list says when there is nothing to show."""
@@ -370,38 +532,28 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
             self.status_filter = str(event.value or "all")
         event.stop()
 
+    async def watch_items(self, items: list[dict[str, Any]]) -> None:
+        """Repaint the list for a newly loaded page, in place.
+
+        Args:
+            items: The page the screen's (debounced) reload produced.
+        """
+        await self._rebuild_rows()
+
     def watch_status_filter(self, status_filter: str) -> None:
+        self._apply_row_visibility()
         self._post_filter_changed()
 
     def watch_search_query(self, search_query: str) -> None:
+        self._apply_row_visibility()
         self._post_filter_changed()
 
-    async def recompose(self) -> None:
-        """Preserve search-box focus across the recompose typing triggers.
-
-        Verbatim port of `ItemsPane.recompose` (TASK-3071's shape): capture
-        WHO was focused before the teardown, restore it to the fresh input
-        after the `await`, and leave any other focus exactly as Textual
-        leaves it. `self.screen.focused`, never `self.app.focused` -- see
-        the original's `ScreenStackError` note.
-        """
-        try:
-            focused = self.screen.focused if self.is_mounted else None
-        except Exception:
-            focused = None
-        refocus_search = focused is not None and focused.id == "items-search-input"
-        await super().recompose()
-        if refocus_search and self.is_running:
-            self.call_after_refresh(self._restore_search_focus)
-
-    def _restore_search_focus(self) -> None:
-        """Focus the freshly recomposed search input, caret at end of query."""
-        try:
-            search = self.query_one("#items-search-input", Input)
-        except NoMatches:
-            return
-        search.focus()
-        search.cursor_position = len(search.value)
+    # task-15460 deleted the `recompose()`/`_restore_search_focus` pair that
+    # used to live here (TASK-3071's shape, ported from `ItemsPane`): it
+    # existed only to put focus back into a search box the per-keystroke
+    # recompose had just destroyed, caret slammed to the end of the value.
+    # Nothing destroys it now, so there is nothing to restore -- and the
+    # caret stays where the user actually left it, mid-word included.
 
     def _post_filter_changed(self) -> None:
         """Mirror the filter state to the screen so a rebuild can restore it.
@@ -570,7 +722,16 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
         except NoMatches:
             return
         for index, node in enumerate(list_view.children):
-            if isinstance(node, _ArticleRow) and node.item_id_key == item_id:
+            # `node.display`: a row the current filter hides is still a
+            # child (task-15460), and moving the cursor onto one would
+            # scroll to a widget the user cannot see. The screen only ever
+            # reveals items from `displayed_items()`, so this is a guard,
+            # not a code path with a caller.
+            if (
+                isinstance(node, _ArticleRow)
+                and node.item_id_key == item_id
+                and node.display
+            ):
                 list_view.index = index
                 break
 

--- a/tldw_chatbook/UI/Watchlists_Modules/items_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/items_pane.py
@@ -75,9 +75,18 @@ class ItemsPane(RecomposeCaptureGuard, Vertical):
 
     items = reactive[list[dict[str, Any]]]([], recompose=True)
     selected_item = reactive[dict[str, Any] | None](None)
-    status_filter = reactive("all", recompose=True)
-    search_query = reactive("", recompose=True)
-    runtime_backend = reactive("local", recompose=True)
+    #: task-15460: plain reactives, all three. The two filters were
+    #: `recompose=True`, so every character typed into the search box tore
+    #: this pane down and rebuilt it -- toolbar, table and all -- which
+    #: `recompose()` below then had to paper over by re-focusing the
+    #: destroyed input. A `DataTable`'s rows
+    #: are data, not widgets, so re-populating it (`_refresh_table_rows`)
+    #: costs no widget construction at all and leaves the toolbar, the
+    #: focused `Input` and its caret untouched. `runtime_backend` is read by
+    #: nothing in `compose()`; it was rebuilding the pane for free.
+    status_filter = reactive("all")
+    search_query = reactive("")
+    runtime_backend = reactive("local")
 
     # Task 5 fix round 1 (Minor): "Reviewed" -> "Read". The underlying value
     # is still the "reviewed" status (no schema change -- see
@@ -184,10 +193,10 @@ class ItemsPane(RecomposeCaptureGuard, Vertical):
                 placeholder="Search items...",
                 id="items-search-input",
                 value=self.search_query,
-                # `select_on_focus=False` is load-bearing, not taste. This
-                # pane recomposes on every keystroke (`search_query` is
-                # `reactive(..., recompose=True)`) and `recompose()` restores
-                # focus to the fresh input; with Textual's default
+                # `select_on_focus=False` is load-bearing, not taste. A
+                # rebuild of this pane (an `items` reload; before
+                # task-15460, every keystroke) makes `recompose()` restore
+                # focus to the fresh input, and with Textual's default
                 # `select_on_focus=True` that programmatic focus selects ALL
                 # the text, so the next keystroke REPLACES the query instead
                 # of appending to it ("f", space, "o" ended as "o"). A
@@ -217,6 +226,31 @@ class ItemsPane(RecomposeCaptureGuard, Vertical):
         self._column_keys = table.add_columns(
             "Title", "Source", "Status", "Published", "Queued"
         )
+        self._populate_table(table)
+        yield table
+        # TASK-2313, AC#6: the Queued column was a bare glyph or a blank
+        # cell with no discoverable meaning anywhere on screen -- UAT. A
+        # persistent legend, matching Sources' rail-count legend
+        # (TASK-2304) for the identical reason: a per-row suffix would
+        # cost width on every row, one caption line costs it once.
+        yield Static(
+            f"{self._QUEUED_GLYPH} = queued for the next briefing "
+            "(toggle from the Inspector).",
+            id="items-queued-legend",
+            classes="watchlists-hint-line",
+        )
+
+    def _populate_table(self, table: DataTable) -> None:
+        """Add one row per filtered item, and record what was rendered.
+
+        Shared by `compose()` (the initial paint and any `items` reload) and
+        `_refresh_table_rows` (a filter change), so the two can never drift
+        into painting a row differently.
+
+        Args:
+            table: The items table, already carrying its columns and empty
+                of rows.
+        """
         filtered = self._filtered_items()
         self._rendered_items = filtered
         for item in filtered:
@@ -241,18 +275,25 @@ class ItemsPane(RecomposeCaptureGuard, Vertical):
                 self._QUEUED_GLYPH if item.get("queued_for_briefing") else "",
                 key=str(item.get("id") or id(item)),
             )
-        yield table
-        # TASK-2313, AC#6: the Queued column was a bare glyph or a blank
-        # cell with no discoverable meaning anywhere on screen -- UAT. A
-        # persistent legend, matching Sources' rail-count legend
-        # (TASK-2304) for the identical reason: a per-row suffix would
-        # cost width on every row, one caption line costs it once.
-        yield Static(
-            f"{self._QUEUED_GLYPH} = queued for the next briefing "
-            "(toggle from the Inspector).",
-            id="items-queued-legend",
-            classes="watchlists-hint-line",
-        )
+
+    def _refresh_table_rows(self) -> None:
+        """Re-populate the table for a filter change, without a recompose.
+
+        task-15460. `DataTable` rows are data rather than widgets, so
+        clearing and re-adding them mounts and destroys nothing: the
+        toolbar, the focused search `Input` and its caret all survive, which
+        is exactly what the per-keystroke recompose could not manage.
+        `clear()` keeps the columns, so `_column_keys` stays valid for the
+        single-cell repaints below.
+        """
+        try:
+            table = self.query_one("#items-table", DataTable)
+        except NoMatches:
+            # Seeded before mount by `_build_detail_pane`; `compose()` will
+            # apply the filter when it builds the table.
+            return
+        table.clear()
+        self._populate_table(table)
 
     def _filtered_items(self) -> list[dict[str, Any]]:
         """Apply the status filter and search query, pinning the open item.
@@ -303,30 +344,39 @@ class ItemsPane(RecomposeCaptureGuard, Vertical):
         event.stop()
 
     def watch_status_filter(self, status_filter: str) -> None:
+        self._refresh_table_rows()
         self._post_filter_changed()
 
     def watch_search_query(self, search_query: str) -> None:
+        self._refresh_table_rows()
         self._post_filter_changed()
 
     async def recompose(self) -> None:
-        """Preserve search-box focus across the recompose that typing triggers.
+        """Preserve search-box focus across a rebuild of this pane.
 
-        `search_query` is `reactive(..., recompose=True)`, so EVERY keystroke
-        in `#items-search-input` tears the whole pane down and rebuilds it --
-        and the focused input goes with it (`Widget.recompose()` removes all
-        children; Textual has no focus preservation). The user-visible
-        symptom was that only the first character of a search ever landed in
-        the box: the rest fell through to the table, where they fired the
-        reader verb keys. Textual schedules the teardown via
-        `call_next(_check_recompose)`, so a `call_after_refresh` from the
-        watcher can fire BEFORE the rebuild and refocus a doomed widget --
-        the only ordering-proof place to restore focus is here, after the
-        teardown's `await` completes. Capture WHO was focused before the
-        teardown (not a "was typing" flag: with two fast keystrokes the
-        second recompose would already have consumed a one-shot flag and
-        dropped focus again), and restore it to the fresh input afterwards.
-        Any focus other than the search box is left exactly as Textual
-        leaves it, so programmatic rebuilds never steal focus.
+        task-15460 narrowed what this covers. Typing no longer rebuilds
+        anything (`search_query`/`status_filter` are plain reactives that
+        re-populate the table in place), so the only recompose left is the
+        `items` data arrival -- which can still land while the search box is
+        focused, because the screen's reload is debounced 0.3 s behind the
+        last keystroke. The mechanism below is unchanged and still earns its
+        place for exactly that case.
+
+        The original defect, kept here because it is what the shape defends
+        against: `Widget.recompose()` removes all children and Textual has
+        no focus preservation, so the focused input went with them and only
+        the first character of a search ever landed in the box -- the rest
+        fell through to the table, where they fired the reader verb keys.
+        Textual schedules the teardown via `call_next(_check_recompose)`, so
+        a `call_after_refresh` from a watcher can fire BEFORE the rebuild
+        and refocus a doomed widget; the only ordering-proof place to
+        restore focus is here, after the teardown's `await` completes.
+        Capture WHO was focused before the teardown (not a "was typing"
+        flag: with two fast keystrokes the second recompose would already
+        have consumed a one-shot flag and dropped focus again), and restore
+        it to the fresh input afterwards. Any focus other than the search
+        box is left exactly as Textual leaves it, so programmatic rebuilds
+        never steal focus.
 
         `self.screen.focused`, NOT `self.app.focused`: `App.focused` goes
         through `App.screen`, which RAISES `ScreenStackError` while the app

--- a/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
@@ -128,11 +128,21 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
     #: reason `selected_source` above is not), so `watch_busy_source_ids`
     #: repaints the one button that can show it, surgically.
     busy_source_ids = reactive[frozenset[str]](frozenset())
-    search_query = reactive("", recompose=True)
-    source_type_filter = reactive("all", recompose=True)
-    status_filter = reactive("all", recompose=True)
-    active_filter = reactive("all", recompose=True)
-    tags_filter = reactive("", recompose=True)
+    #: task-15460: the five filters are PLAIN reactives. All five were
+    #: `recompose=True`, so a single character typed into the search box (or
+    #: the tags box) tore down and rebuilt this entire pane -- toolbar, the
+    #: eight-control create form if it happened to be open, and the table --
+    #: and `recompose()` then had to put focus back into the input it had
+    #: just destroyed. A `DataTable`'s rows are data, not widgets, so
+    #: re-populating it (`_refresh_table_rows`) mounts nothing and leaves
+    #: the focused `Input`, its caret and any open form exactly where they
+    #: were. The create-form reactives below stay `recompose=True`: those
+    #: genuinely change WHICH CONTROLS EXIST.
+    search_query = reactive("")
+    source_type_filter = reactive("all")
+    status_filter = reactive("all")
+    active_filter = reactive("all")
+    tags_filter = reactive("")
     show_create_form = reactive(False, recompose=True)
     show_filter_editor = reactive(False, recompose=True)
     # Seed values for the create form's free-text inputs. No `recompose=True`:
@@ -329,7 +339,10 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
                     # `select_on_focus=True` makes the programmatic refocus
                     # after a recompose select ALL text, so the user's next
                     # keystroke REPLACES the half-typed query instead of
-                    # appending to it.
+                    # appending to it. Typing no longer causes that
+                    # recompose (task-15460), but opening the create form
+                    # still does, and a click back into the box must land
+                    # the caret rather than arm the term for deletion.
                     select_on_focus=False,
                     compact=True,
                 )
@@ -549,9 +562,6 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
                     yield Button("Create", id="sources-create-submit", variant="success")
                     yield Button("Cancel", id="sources-create-cancel", variant="default")
 
-        selected_key = (
-            str(self.selected_source.get("id")) if self.selected_source else None
-        )
         table = DataTable(id="sources-table")
         # TASK-2313, AC#2: "checked"/"Check now" is the vocabulary this
         # screen uses everywhere else for the same fetch action (the
@@ -559,19 +569,51 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         # checked on its normal schedule."); this column was the one
         # holdout still saying "scraped".
         table.add_columns("Name", "Type", "Status", "Last checked", "Active")
-        filtered = self._filtered_sources()
-        for source in filtered:
+        self._populate_table(table)
+        yield table
+
+    def _populate_table(self, table: DataTable) -> None:
+        """Add one row per filtered source, painting the selected one.
+
+        Shared by `compose()` and `_refresh_table_rows` so the initial paint
+        and a filter change can never draw the same row differently.
+
+        Args:
+            table: The sources table, already carrying its columns and empty
+                of rows.
+        """
+        selected_key = (
+            str(self.selected_source.get("id")) if self.selected_source else None
+        )
+        for source in self._filtered_sources():
             row_key = str(source.get("id") or id(source))
             table.add_row(
                 *self._source_row_cells(source, row_key == selected_key),
                 key=row_key,
             )
-        # `compose()` just painted the highlight fresh from `selected_source`
-        # itself, so this is authoritative going forward -- see
+        # The rows were just painted fresh from `selected_source` itself, so
+        # this is authoritative going forward -- see
         # `_update_selection_highlight`'s docstring for why a later,
-        # non-recomposing selection change needs to know what to revert.
+        # non-rebuilding selection change needs to know what to revert.
         self._highlighted_source_key = selected_key
-        yield table
+
+    def _refresh_table_rows(self) -> None:
+        """Re-populate the table for a filter change, without a recompose.
+
+        task-15460. `DataTable` rows are data rather than widgets, so
+        clearing and re-adding them destroys no widget: the toolbar, an open
+        create form, the focused `Input` and its caret all survive a
+        keystroke that changes what the table shows. `clear()` keeps the
+        columns, which `_update_selection_highlight` reads back.
+        """
+        try:
+            table = self.query_one("#sources-table", DataTable)
+        except NoMatches:
+            # Seeded before mount by `_build_detail_pane`; `compose()` will
+            # apply the filter when it builds the table.
+            return
+        table.clear()
+        self._populate_table(table)
 
     @classmethod
     def _type_takes_ignore_selectors(cls, source_type: Any) -> bool:
@@ -789,6 +831,24 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
             results.append(source)
         return results
 
+    # task-15460: one watcher per filter, all doing the same in-place
+    # re-populate. Written out rather than shared through a `watch` alias so
+    # each reactive's name still appears where a reader looks for it.
+    def watch_search_query(self, search_query: str) -> None:
+        self._refresh_table_rows()
+
+    def watch_source_type_filter(self, source_type_filter: str) -> None:
+        self._refresh_table_rows()
+
+    def watch_status_filter(self, status_filter: str) -> None:
+        self._refresh_table_rows()
+
+    def watch_active_filter(self, active_filter: str) -> None:
+        self._refresh_table_rows()
+
+    def watch_tags_filter(self, tags_filter: str) -> None:
+        self._refresh_table_rows()
+
     def on_input_changed(self, event: Input.Changed) -> None:
         if event.input.id == "sources-search-input":
             self.search_query = event.value
@@ -932,13 +992,17 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
 
         task-3071 adds a third case ahead of these, checked first: the
         search box (`#sources-search-input`) held focus when the teardown
-        started. `search_query` is `reactive(..., recompose=True)`, so
-        every keystroke in it rebuilds this pane, which used to destroy
+        started. It used to be that `search_query` was `reactive(...,
+        recompose=True)`, so every keystroke rebuilt this pane and destroyed
         the focused input mid-word -- only the first character of a search
         ever landed (the exact bug `ItemsPane.recompose` fixed in
-        task-2513). Search focus is restored to the fresh input and the
-        create-form path below is skipped for that rebuild, so a still-
-        armed `_pending_create_focus` cannot yank the caret out of the box.
+        task-2513). task-15460 removed that trigger (the filters are plain
+        reactives now), but the case remains live for every OTHER rebuild
+        that can land while the search box is focused -- a `sources` reload,
+        a region collapse, the create form opening. Search focus is restored
+        to the fresh input and the create-form path below is skipped for
+        that rebuild, so a still-armed `_pending_create_focus` cannot yank
+        the caret out of the box.
 
         Two create-form cases are handled, and only these two — focus is
         never taken from anywhere outside this pane's own create form or
@@ -979,10 +1043,11 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         #     `_focused_create_field_id()` is `None` and
         #     `_pending_create_focus` (armed to field 0 by
         #     `watch_show_create_form`) still supplies the target.
-        # task-3071: the search box is this pane's OTHER focusable the
-        # recompose destroys (`search_query` is `reactive(...,
-        # recompose=True)`, so every keystroke rebuilds the pane) --
-        # capture it alongside the create-form cases. `self.screen.focused`,
+        # task-3071: the search box is this pane's OTHER focusable a
+        # recompose destroys -- no longer once per keystroke (task-15460),
+        # but still on every rebuild that can land while the user is typing
+        # -- so capture it alongside the create-form cases.
+        # `self.screen.focused`,
         # NOT `self.app.focused`, for the same ScreenStackError reason
         # `ItemsPane.recompose` documents.
         try:


### PR DESCRIPTION
## Summary

Task 15460 from the input-latency audit. Typing in Watchlists search/filter boxes tore down and rebuilt ~220 widgets per character (recompose=True reactives on the article list, items pane, and sources pane; a recompose() override existed solely to re-focus the destroyed search box).

- Per-keystroke reactives converted to plain; filtering applies in place (row visibility + day-header toggles proven parity-safe by the shared stable sort); the debounced DB reload path unchanged
- Focus AND caret position survive keystrokes (pinned mid-string, which the old end-of-value refocus hack could never satisfy); the refocus hack deleted
- Measured: 312.7 → 142 ms per keystroke on a 100-article pane; 1 → 0 recomposes; 100 → 0 row constructions
- Review's race finding closed: a filter change landing inside the rebuild's await gaps now reconciles post-await via a state-tuple re-check (oscillation impossible by construction — the visibility pass contains no awaits); deterministic race test born red without the guard

## Verification
Independent review (Approved; recompose-elimination mutation-proven; day-header parity traced by hand; reload-seeding order verified) + scoped re-review (ADDRESSED; guard mutation re-verified independently; 42+121 counts reproduced). Deferred note recorded: a compound items+filter change in the identical gap remains self-correcting-but-unpinned — follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced per-keystroke recomposes in Watchlists with in-place filtering. Typing in search/filters no longer rebuilds panes, preserves focus and caret, and reduces keystroke latency from ~312.7 ms to ~142 ms on a 100-article pane (task-15460).

- **Refactors**
  - ArticleListPane: made filters plain reactives; build one row per item and toggle row `display` + `disabled`; hide day headers when a group has no visible rows.
  - Reload now rebuilds only ListView children; removed the recompose focus hack; empty state toggles without tearing down the list.
  - ItemsPane/SourcesPane: re-populate `DataTable` rows in place; keep create-form recomposes; `runtime_backend` is plain.

- **Bug Fixes**
  - Fixed race where a filter change during row rebuild caused mismatch by re-checking filter state post-await and reapplying visibility once.
  - Prevented focus/caret loss and input replacement while typing; selection highlight survives filter changes.
  - Added targeted tests covering rendered results, zero recomposes per keystroke, stable input identity/caret; updated a stale docstring.

<sup>Written for commit 46d453786b78ebc2604e735664d58701595c36e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

