### PR TITLE
perf: non-blocking Ollama probe and change-gated nav overflow tick (task-15473)

### DIFF
--- a/Tests/UI/test_llm_screen_ollama_probe_nonblocking.py
+++ b/Tests/UI/test_llm_screen_ollama_probe_nonblocking.py
@@ -1,0 +1,203 @@
+"""Non-blocking Ollama probe (task-15473).
+
+`_probe_local_server` (`UI/Screens/llm_screen.py`) used to be a blocking
+`socket.create_connection(..., timeout=0.25)`, called directly from the
+Models screen's periodic status timer (`LLMManagementWindow._update_
+ollama_api_state`, driven by `set_interval(3.0, ...)` and also run once,
+unconditionally, right after mount). ECONNREFUSED resolved instantly, but a
+genuinely unresponsive ("blackholed") port -- the firewalled/container
+setups the audit called out -- froze the WHOLE event loop for up to the
+full 250ms per tick, since a synchronous socket call on the loop thread
+blocks every other task in the process, not just this one.
+
+This file pins two things against REAL sockets, no mocking of asyncio
+itself:
+  1. The async replacement (`asyncio.wait_for(asyncio.open_connection(...),
+     timeout=0.25)`) preserves the exact up/refused/timeout semantics.
+  2. The event loop stays responsive while the probe is in flight against a
+     genuinely unresponsive address -- the actual bug this fixes.
+
+`test_llm_screen_ollama_ux_unchanged.py` (companion file) covers AC#1's
+other half: that the Models screen's button-gating UX is unchanged by the
+async conversion, with the probe itself patched out (no network needed
+there).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+import time
+
+import pytest
+
+from tldw_chatbook.UI.Screens.llm_screen import _probe_local_server
+
+# Every test in this file opens a real socket (or deliberately tries to
+# reach an unresponsive one) -- opt out of the autouse network-egress guard
+# for the whole module (Tests/conftest.py, task-15111).
+pytestmark = pytest.mark.allow_network
+
+#: A private, non-routed ("black hole") address: nothing answers the SYN and
+#: nothing sends back an ICMP unreachable either, so a connect attempt hangs
+#: for the full OS-level timeout instead of failing fast. Verified in this
+#: sandbox (no route configured) to hang for the requested duration rather
+#: than raise "network unreachable" immediately -- the same failure mode the
+#: audit measured for a firewalled/container Ollama setup. The task's own
+#: evidence note acknowledges a true blackhole is hard to simulate portably;
+#: this address is the standard, widely-used stand-in for it and the tests
+#: below tolerate an environment where it instead fails fast (see the
+#: timing assertions).
+_BLACKHOLE_HOST = "10.255.255.1"
+_BLACKHOLE_PORT = 11434
+
+
+def _real_listener() -> tuple[socket.socket, int]:
+    """A real TCP listener on an ephemeral loopback port."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    return server, server.getsockname()[1]
+
+
+def _closed_port() -> int:
+    """A port nothing is listening on -- connecting refuses immediately."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    port = server.getsockname()[1]
+    server.close()
+    return port
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_up_against_a_real_listener() -> None:
+    """Up = connectable, same as the old blocking probe."""
+    server, port = _real_listener()
+    accepted: list[socket.socket] = []
+
+    def _accept() -> None:
+        try:
+            conn, _addr = server.accept()
+            accepted.append(conn)
+        except OSError:
+            pass
+
+    thread = threading.Thread(target=_accept, daemon=True)
+    thread.start()
+    try:
+        result = await _probe_local_server("127.0.0.1", port)
+    finally:
+        thread.join(timeout=2)
+        for conn in accepted:
+            conn.close()
+        server.close()
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_down_on_a_refused_connection() -> None:
+    """Down = refused, same as the old blocking probe (instant either way)."""
+    port = _closed_port()
+    result = await _probe_local_server("127.0.0.1", port)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_probe_caps_at_the_configured_timeout_against_an_unresponsive_address() -> None:
+    """Down = timeout, capped at the same 0.25s the blocking probe used.
+
+    Best-effort against a real network condition (see `_BLACKHOLE_HOST`'s
+    docstring): the behavioural assertion (`result is False`) holds whether
+    the environment hangs or fails fast; the timing assertion only checks
+    an upper bound generous enough to tolerate either.
+    """
+    start = time.monotonic()
+    result = await _probe_local_server(_BLACKHOLE_HOST, _BLACKHOLE_PORT)
+    elapsed = time.monotonic() - start
+
+    assert result is False
+    assert elapsed < 2.0, (
+        f"probe should cap near 0.25s even against an unresponsive address, "
+        f"took {elapsed:.3f}s"
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_never_calls_the_blocking_socket_primitives(monkeypatch) -> None:
+    """Structural guard: the async probe must never fall back to a
+    synchronous connect -- that is the exact regression this task fixes.
+    """
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError(
+            "the async probe must never call the blocking "
+            "socket.create_connection"
+        )
+
+    monkeypatch.setattr(socket, "create_connection", _forbidden)
+
+    server, port = _real_listener()
+    accepted: list[socket.socket] = []
+
+    def _accept() -> None:
+        try:
+            conn, _addr = server.accept()
+            accepted.append(conn)
+        except OSError:
+            pass
+
+    thread = threading.Thread(target=_accept, daemon=True)
+    thread.start()
+    try:
+        up = await _probe_local_server("127.0.0.1", port)
+    finally:
+        thread.join(timeout=2)
+        for conn in accepted:
+            conn.close()
+        server.close()
+    assert up is True
+
+    down = await _probe_local_server("127.0.0.1", _closed_port())
+    assert down is False
+
+
+@pytest.mark.asyncio
+async def test_event_loop_stays_responsive_during_an_unresponsive_probe() -> None:
+    """The actual bug: a heartbeat task must keep ticking while the probe
+    awaits a genuinely unresponsive connect.
+
+    A synchronous equivalent run on the loop thread starves everything else
+    for the whole wait -- measured directly (see the module docstring and
+    the task's audit) at ~1 heartbeat tick in the same ~0.25s window versus
+    dozens for the async version. This test only asserts the async side,
+    since production no longer contains the blocking code path to compare
+    against live.
+    """
+    heartbeats = 0
+    stop = asyncio.Event()
+
+    async def _heartbeat() -> None:
+        nonlocal heartbeats
+        while not stop.is_set():
+            heartbeats += 1
+            await asyncio.sleep(0.005)
+
+    hb_task = asyncio.create_task(_heartbeat())
+    try:
+        result = await _probe_local_server(_BLACKHOLE_HOST, _BLACKHOLE_PORT)
+    finally:
+        stop.set()
+        await hb_task
+
+    assert result is False
+    # A loop frozen by a blocking call would land at ~1 (the tick already
+    # in flight when the block started); a healthy async wait comfortably
+    # clears double digits over a ~0.25s window at a 5ms heartbeat period.
+    assert heartbeats >= 10, (
+        f"event loop looks starved during the probe: only {heartbeats} "
+        "heartbeat ticks landed"
+    )

--- a/Tests/UI/test_llm_screen_ollama_ux_unchanged.py
+++ b/Tests/UI/test_llm_screen_ollama_ux_unchanged.py
@@ -17,7 +17,10 @@ real-socket up/refused/timeout behavior and loop responsiveness).
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
+from textual.screen import Screen
 from textual.widgets import Button
 
 from tldw_chatbook.config import get_cli_setting as _real_get_cli_setting
@@ -54,13 +57,21 @@ def _deterministic_models_mount(monkeypatch):
     monkeypatch.setattr("tldw_chatbook.app.get_cli_setting", fake_get_cli_setting)
 
 
-async def _mount_models_with_probe_result(monkeypatch, pilot_app, *, available: bool):
+async def _mount_models_with_probe_result(monkeypatch, pilot, *, available: bool):
     """Mount the Models screen with the Ollama probe patched to a fixed
-    result and return its `LLMManagementWindow`.
+    result and return its `LLMManagementWindow`, fully settled.
 
     Patches the module attribute `_probe_local_server` resolves via its
     local import in `_ollama_api_available` -- no real socket is ever
     opened.
+
+    Two `pilot.pause()` calls, not one: matches
+    `test_llm_screen_lab_adoption.py`'s established convention for this
+    exact mount (`LLMManagementWindow.on_mount` defers the five heavy
+    views and the post-mount steps via `call_after_refresh`, which is
+    itself async work -- under load a single pause intermittently landed
+    before that chain fully drained, observed directly as a `NoMatches`
+    on `#llm-view-ollama` in a looped rerun of this file).
     """
 
     async def fake_probe(host: str = "127.0.0.1", port: int = 11434) -> bool:
@@ -68,8 +79,10 @@ async def _mount_models_with_probe_result(monkeypatch, pilot_app, *, available: 
 
     monkeypatch.setattr(llm_screen_module, "_probe_local_server", fake_probe)
 
-    screen = LLMScreen(pilot_app)
-    await pilot_app.push_screen(screen)
+    screen = LLMScreen(pilot.app)
+    await pilot.app.push_screen(screen)
+    await pilot.pause()
+    await pilot.pause()
     return screen.query_one(LLMManagementWindow)
 
 
@@ -86,8 +99,7 @@ def _gated_buttons(window: LLMManagementWindow) -> list[Button]:
 async def test_ollama_controls_disabled_when_probe_reports_down(monkeypatch):
     app = _build_test_app()
     async with app.run_test(size=(120, 40)) as pilot:
-        window = await _mount_models_with_probe_result(monkeypatch, app, available=False)
-        await pilot.pause()
+        window = await _mount_models_with_probe_result(monkeypatch, pilot, available=False)
 
         gated = _gated_buttons(window)
         assert gated, "test premise: at least one gated Ollama button exists"
@@ -108,8 +120,7 @@ async def test_ollama_controls_disabled_when_probe_reports_down(monkeypatch):
 async def test_ollama_controls_enabled_when_probe_reports_up(monkeypatch):
     app = _build_test_app()
     async with app.run_test(size=(120, 40)) as pilot:
-        window = await _mount_models_with_probe_result(monkeypatch, app, available=True)
-        await pilot.pause()
+        window = await _mount_models_with_probe_result(monkeypatch, pilot, available=True)
 
         gated = _gated_buttons(window)
         assert gated, "test premise: at least one gated Ollama button exists"
@@ -128,8 +139,7 @@ async def test_ollama_controls_flip_when_availability_changes_between_ticks(monk
     """
     app = _build_test_app()
     async with app.run_test(size=(120, 40)) as pilot:
-        window = await _mount_models_with_probe_result(monkeypatch, app, available=False)
-        await pilot.pause()
+        window = await _mount_models_with_probe_result(monkeypatch, pilot, available=False)
         assert all(button.disabled for button in _gated_buttons(window))
 
         async def fake_probe_up(host: str = "127.0.0.1", port: int = 11434) -> bool:
@@ -141,4 +151,84 @@ async def test_ollama_controls_flip_when_availability_changes_between_ticks(monk
 
         assert not any(button.disabled for button in _gated_buttons(window)), (
             "the gate should flip to enabled on the very next probe result"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_screen_switch_mid_probe_leaves_buttons_untouched(monkeypatch):
+    """Review finding on task-15473: converting the probe to `async` opened
+    a race the old synchronous version could not have. `_update_ollama_api_
+    state` only checked `is_attached`/`screen.is_active` BEFORE the (now
+    awaited, up to ~0.25s) probe call -- a widget whose screen goes inactive
+    WHILE the probe is in flight (the realistic case: the user navigates
+    away from Models before a slow probe resolves) used to still get its
+    buttons mutated once the probe resolved, since nothing re-checked after
+    the `await`. The fix repeats the same guard immediately after it.
+
+    Sentinel: capture every gated button's exact `(disabled, tooltip)` while
+    available=True (all enabled), then run a SECOND `_update_ollama_api_
+    state` call whose probe is held open by an `asyncio.Event` and resolves
+    to `available=False` -- a result that, if applied, would flip every
+    gated button to disabled with a different tooltip, a change trivially
+    distinguishable from "untouched". `screen.is_active` is flipped to
+    `False` the realistic way -- pushing a new screen on top of Models,
+    confirmed to leave the window fully mounted (`is_attached` stays
+    `True`, its buttons remain query-able) -- deliberately NOT via
+    `widget.remove()`: that was tried first and found to be a vacuous
+    mutation target, since removing the window also tears down its
+    descendants, so `view.query(Button)` returns zero buttons and the
+    loop body never runs regardless of whether the guard exists. Pushing a
+    screen on top is the scenario the guard's `screen.is_active` half
+    actually exists for, and it keeps the buttons real and mutable so the
+    guard's absence is observable.
+    """
+    app = _build_test_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        window = await _mount_models_with_probe_result(monkeypatch, pilot, available=True)
+        gated = _gated_buttons(window)
+        assert gated, "test premise: at least one gated Ollama button exists"
+        assert not any(button.disabled for button in gated), (
+            "test premise: buttons start enabled (available=True)"
+        )
+        baseline = [(button.disabled, button.tooltip) for button in gated]
+
+        probe_started = asyncio.Event()
+        release_probe = asyncio.Event()
+
+        async def gated_probe_reporting_down(
+            host: str = "127.0.0.1", port: int = 11434
+        ) -> bool:
+            probe_started.set()
+            await release_probe.wait()
+            return False  # a result that WOULD flip every gated button
+
+        monkeypatch.setattr(
+            llm_screen_module, "_probe_local_server", gated_probe_reporting_down
+        )
+
+        task = asyncio.create_task(window._update_ollama_api_state())
+        await asyncio.wait_for(probe_started.wait(), timeout=2)
+
+        # Navigate away while the coroutine is suspended inside the probe --
+        # the window stays mounted (`is_attached` True), only its screen
+        # stops being the active one.
+        await pilot.app.push_screen(Screen())
+        await pilot.pause()
+        assert window.is_attached, "test premise: the window stays mounted"
+        assert not window.screen.is_active, (
+            "test premise: Models' screen is no longer active"
+        )
+        assert len(list(window.query_one("#llm-view-ollama").query(Button))) == len(
+            gated
+        ) + len(_UNGATED_BUTTON_IDS), (
+            "test premise: the buttons are still real, mutable widgets"
+        )
+
+        release_probe.set()
+        await asyncio.wait_for(task, timeout=2)
+
+        after = [(button.disabled, button.tooltip) for button in gated]
+        assert after == baseline, (
+            "a probe that resolves after the screen went inactive must not "
+            f"mutate its buttons: before={baseline} after={after}"
         )

--- a/Tests/UI/test_llm_screen_ollama_ux_unchanged.py
+++ b/Tests/UI/test_llm_screen_ollama_ux_unchanged.py
@@ -1,0 +1,144 @@
+"""Models' Ollama button gating survives the async probe conversion
+(task-15473 AC#1: "Models availability UX unchanged").
+
+`LLMManagementWindow._update_ollama_api_state`/`_ollama_api_available` were
+converted from plain sync methods to coroutines so the probe they call
+(`_probe_local_server`) can `await` a non-blocking connect instead of
+freezing the event loop. This file pins the OBSERVABLE end-to-end behavior
+that conversion must not change: with the service down, every dependent
+Ollama button is disabled with the "requires a running service" tooltip;
+with it up, none of them are.
+
+`_probe_local_server` is patched to a fixed async result here -- no real
+socket is opened, so this file needs no `allow_network` opt-in (unlike
+`test_llm_screen_ollama_probe_nonblocking.py`, which pins the probe's own
+real-socket up/refused/timeout behavior and loop responsiveness).
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button
+
+from tldw_chatbook.config import get_cli_setting as _real_get_cli_setting
+from tldw_chatbook.UI.LLM_Management_Window import LLMManagementWindow
+from tldw_chatbook.UI.Screens import llm_screen as llm_screen_module
+from tldw_chatbook.UI.Screens.llm_screen import LLMScreen
+from Tests.UI.app_factory import _build_test_app
+
+#: Buttons `_update_ollama_api_state` deliberately never gates (they must
+#: stay usable regardless of service availability -- starting the service,
+#: or fixing the configured executable path, are exactly what an unavailable
+#: state needs).
+_UNGATED_BUTTON_IDS = {
+    "ollama-start-service-button",
+    "ollama-stop-service-button",
+    "ollama-browse-exec-button",
+}
+
+_DOWN_TOOLTIP = "Requires a running Ollama service — start it above."
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_models_mount(monkeypatch):
+    """Same rationale as ``test_llm_screen_lab_adoption.py``'s identically
+    named fixture: neutralize the splash race so the Models screen mounts
+    deterministically.
+    """
+
+    def fake_get_cli_setting(section, key=None, default=None):
+        if section == "splash_screen" and key == "enabled":
+            return False
+        return _real_get_cli_setting(section, key, default)
+
+    monkeypatch.setattr("tldw_chatbook.app.get_cli_setting", fake_get_cli_setting)
+
+
+async def _mount_models_with_probe_result(monkeypatch, pilot_app, *, available: bool):
+    """Mount the Models screen with the Ollama probe patched to a fixed
+    result and return its `LLMManagementWindow`.
+
+    Patches the module attribute `_probe_local_server` resolves via its
+    local import in `_ollama_api_available` -- no real socket is ever
+    opened.
+    """
+
+    async def fake_probe(host: str = "127.0.0.1", port: int = 11434) -> bool:
+        return available
+
+    monkeypatch.setattr(llm_screen_module, "_probe_local_server", fake_probe)
+
+    screen = LLMScreen(pilot_app)
+    await pilot_app.push_screen(screen)
+    return screen.query_one(LLMManagementWindow)
+
+
+def _gated_buttons(window: LLMManagementWindow) -> list[Button]:
+    view = window.query_one("#llm-view-ollama")
+    return [
+        button
+        for button in view.query(Button)
+        if button.id and button.id not in _UNGATED_BUTTON_IDS
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ollama_controls_disabled_when_probe_reports_down(monkeypatch):
+    app = _build_test_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        window = await _mount_models_with_probe_result(monkeypatch, app, available=False)
+        await pilot.pause()
+
+        gated = _gated_buttons(window)
+        assert gated, "test premise: at least one gated Ollama button exists"
+        assert all(button.disabled for button in gated), (
+            "every gated Ollama button should be disabled while the "
+            "service is unavailable"
+        )
+        assert all(button.tooltip == _DOWN_TOOLTIP for button in gated)
+
+        # "Start Ollama Service" is excluded from the availability gate (a
+        # user must be able to start the service from an unavailable
+        # state) and starts enabled at compose time.
+        start_button = window.query_one("#ollama-start-service-button", Button)
+        assert not start_button.disabled
+
+
+@pytest.mark.asyncio
+async def test_ollama_controls_enabled_when_probe_reports_up(monkeypatch):
+    app = _build_test_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        window = await _mount_models_with_probe_result(monkeypatch, app, available=True)
+        await pilot.pause()
+
+        gated = _gated_buttons(window)
+        assert gated, "test premise: at least one gated Ollama button exists"
+        assert not any(button.disabled for button in gated), (
+            "no gated Ollama button should be disabled while the service "
+            "is available"
+        )
+
+
+@pytest.mark.asyncio
+async def test_ollama_controls_flip_when_availability_changes_between_ticks(monkeypatch):
+    """The same coroutine drives both the one-shot post-mount check and
+    the periodic `set_interval(3.0, ...)` tick -- exercise both directly
+    rather than waiting a real 3s for the timer, and prove the gate is not
+    stuck from whichever result the FIRST call happened to see.
+    """
+    app = _build_test_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        window = await _mount_models_with_probe_result(monkeypatch, app, available=False)
+        await pilot.pause()
+        assert all(button.disabled for button in _gated_buttons(window))
+
+        async def fake_probe_up(host: str = "127.0.0.1", port: int = 11434) -> bool:
+            return True
+
+        monkeypatch.setattr(llm_screen_module, "_probe_local_server", fake_probe_up)
+        await window._update_ollama_api_state()
+        await pilot.pause()
+
+        assert not any(button.disabled for button in _gated_buttons(window)), (
+            "the gate should flip to enabled on the very next probe result"
+        )

--- a/Tests/UI/test_nav_overflow_tick_gating.py
+++ b/Tests/UI/test_nav_overflow_tick_gating.py
@@ -1,0 +1,130 @@
+"""Change-gated nav overflow tick (task-15473).
+
+`MainNavigationBar._update_overflow_hints` is the callback for the nav
+bar's periodic 0.5s `set_interval` (and the first post-mount pass, and
+`on_resize`'s deferred call). Before this task it ran its full pipeline --
+hint toggle, `_refresh_overflow_hint_visibility`'s reclaimable-space math,
+and scheduling `_recenter_strip` (which itself chains into
+`_ghost_clipped_buttons`) -- unconditionally on every one of those
+triggers, forever, on every screen, even when nothing about the strip had
+moved since the previous pass.
+
+This file pins two things:
+  1. A no-op tick (nothing scrolled, resized, or changed) does none of that
+     work -- the counting seam this task's fix is required to satisfy
+     (born red against the pre-fix implementation; see the test's
+     docstring for the mutation-test result).
+  2. The gate does not falsely skip when the strip's CONTENT changes (a
+     destination added to the strip) even though nothing here scrolled or
+     resized -- the scenario the task explicitly calls out as needing its
+     own coverage, distinct from the resize/scroll cases the existing
+     `test_master_shell_navigation.py`/`test_chrome_ux_fixes.py` suites
+     already pin.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal
+
+from tldw_chatbook.UI.Navigation.main_navigation import (
+    MainNavigationBar,
+    NavigationButton,
+)
+
+
+class _NavHarness(App[None]):
+    def __init__(self, active: str = "logs"):
+        super().__init__()
+        self.active = active
+
+    def compose(self) -> ComposeResult:
+        yield MainNavigationBar(active=self.active)
+
+
+@pytest.mark.asyncio
+async def test_a_settled_no_op_tick_does_no_measurement_or_toggle_work() -> None:
+    """Once the strip has settled, a later tick with nothing changed must
+    not call `_refresh_overflow_hint_visibility` (and, by extension, must
+    not toggle a hint or schedule a recenter/ghost pass -- that method is
+    the one thing every branch of the gated pipeline funnels through).
+
+    Mutation-tested: reverting `_update_overflow_hints` to call the
+    pipeline unconditionally (removing the signature gate) turns this red
+    -- the interval fires at least once more inside the second 0.6s
+    window and the counter goes non-zero.
+    """
+    # 80 cols with "logs" active reliably overflows (see
+    # test_chrome_ux_fixes.py's identical premise) -- the settled state
+    # this test cares about is the STEADY state after that overflow is
+    # already resolved, not the transient first pass.
+    app = _NavHarness(active="logs")
+    async with app.run_test(size=(80, 24)) as pilot:
+        # Let the mount-time settle passes (call_after_refresh, the 0.05s
+        # and 0.25s one-shot hint timers, and several interval ticks) run
+        # and stabilize the signature. Directly measured: at 80 cols the
+        # strip's own region width still moves for 2-3 ticks after mount
+        # (showing the overflow hint reclaims/costs width, which itself
+        # only settles a pass later) -- a shorter wait here would install
+        # the spy while the strip was still genuinely converging and see
+        # a real, expected change, not a regression.
+        for _ in range(6):
+            await pilot.pause(0.3)
+
+        nav = app.query_one(MainNavigationBar)
+        strip = app.query_one("#nav-destination-strip", Horizontal)
+        assert strip.max_scroll_x >= 0  # test premise: strip is measurable
+        assert nav._overflow_signature is not None, (
+            "test premise: the strip has produced at least one settled "
+            "signature by now"
+        )
+
+        spy = MagicMock(wraps=nav._refresh_overflow_hint_visibility)
+        nav._refresh_overflow_hint_visibility = spy
+
+        # At least one more full interval period, with nothing scrolled,
+        # resized, or mounted in the meantime.
+        await pilot.pause(0.6)
+
+        assert spy.call_count == 0, (
+            f"a no-op tick should skip all downstream work, but "
+            f"_refresh_overflow_hint_visibility was called {spy.call_count} "
+            "time(s)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_tick_after_a_destination_is_added_still_does_the_work() -> None:
+    """The gate must not falsely skip when the strip's CONTENT changes --
+    a new destination button mounted into the strip -- even though nothing
+    scrolled or resized. Proves the signature is keyed on the button set,
+    not only on scroll/width.
+    """
+    app = _NavHarness(active="home")
+    async with app.run_test(size=(200, 24)) as pilot:
+        await pilot.pause(0.6)
+
+        nav = app.query_one(MainNavigationBar)
+        strip = app.query_one("#nav-destination-strip", Horizontal)
+
+        spy = MagicMock(wraps=nav._refresh_overflow_hint_visibility)
+        nav._refresh_overflow_hint_visibility = spy
+
+        # Simulate a new destination joining the strip at runtime.
+        extra = NavigationButton(
+            "Extra",
+            id="nav-overflow-tick-gating-test-extra",
+            classes="nav-button",
+            target_route="chat",
+        )
+        await strip.mount(extra)
+
+        await pilot.pause(0.6)
+
+        assert spy.call_count >= 1, (
+            "a tick after the button set changed should still run the "
+            "overflow-hint pipeline, not skip it as a no-op"
+        )

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9,6 +9,38 @@ decays into folklore, and folklore is ignored. If you add one, bring the inciden
 
 ---
 
+## A "slow-accept listener" does not delay TCP connect() — it delays accept()
+
+**TASK-15473, 2026-08-11.** Writing an evidence test that the event loop stays
+responsive during a non-blocking socket probe, the task's own brief suggested "a
+slow-accept listener" as the portable way to simulate an unresponsive server. Timed
+directly before writing the test: a real `socket.listen()`ing server that never calls
+`accept()` still let a client's `socket.create_connection()` complete in ~7ms. TCP's
+three-way handshake completes at the OS kernel level as soon as a connection is
+queued in the listen backlog — independent of whether the application ever calls
+`accept()`. A "slow-accept" listener therefore cannot be used to create connect-side
+delay; it only delays whatever happens *after* the client tries to read/write, which
+this probe (connect-then-immediately-close, no data exchange) never does.
+
+What actually produced a real, mutation-verified delay: connecting to a private,
+non-routed address (`10.255.255.1`) that neither answers the SYN nor sends back an
+ICMP unreachable — a genuine kernel-level "black hole" — measured to hang for the
+full requested timeout in this sandbox (no immediate "network unreachable"). The
+resulting test caught a real regression: reverting the probe to a blocking
+`socket.create_connection` call inside the coroutine dropped a 5ms-period heartbeat
+task from ~44 ticks to 0 during the same ~0.25s window.
+
+**What to do.** Before trusting "slow accept" (or similar accept-side framing) to
+simulate a connect-side timeout in a test, time it directly — a bound-and-listening
+socket with a deliberately delayed `accept()` will not slow down a bare `connect()`
+on any common OS. For a genuine connect-timeout test, either use a real black-hole
+address (accepting the environment-dependence, verify empirically first) or
+mutation-test whatever mechanism you do use against the blocking equivalent it's
+supposed to replace — the ~44-vs-0 heartbeat contrast is what proved this test was
+not vacuous.
+
+---
+
 ## Style probes are not render evidence — capture the frame
 
 **TASK-15421 AC3, 2026-08-11.** The Studio exact-ID input's typed text

--- a/backlog/tasks/task-15473 - Timer-gating---non-blocking-Ollama-probe-and-change-gated-nav-overflow-tick.md
+++ b/backlog/tasks/task-15473 - Timer-gating---non-blocking-Ollama-probe-and-change-gated-nav-overflow-tick.md
@@ -147,3 +147,49 @@ task's scope. Worth a follow-up task to either mark the affected tests
 **Files added:** `Tests/UI/test_llm_screen_ollama_probe_nonblocking.py`,
 `Tests/UI/test_llm_screen_ollama_ux_unchanged.py`,
 `Tests/UI/test_nav_overflow_tick_gating.py`.
+
+## Review fix (post-approval minor)
+
+Reviewer flagged a real race the async conversion introduced:
+`_update_ollama_api_state` checked `is_attached`/`screen.is_active` only BEFORE the
+now-awaited (up to ~0.25s) probe call; the old synchronous version was atomic
+end-to-end, so a widget that detached or whose screen went inactive WHILE the probe
+was in flight used to still get its buttons mutated once the probe resolved, since
+nothing re-checked after the `await`. Fixed by repeating the identical guard
+immediately after `available = await self._ollama_api_available()`, before touching
+any button.
+
+Added `test_a_screen_switch_mid_probe_leaves_buttons_untouched` in
+`Tests/UI/test_llm_screen_ollama_ux_unchanged.py`: holds the probe open on an
+`asyncio.Event`, pushes a new screen on top of Models (so `screen.is_active` goes
+`False` while the window stays fully mounted), releases the probe with a result that
+WOULD flip every gated button, and asserts every button's `(disabled, tooltip)` is
+byte-identical to its pre-probe baseline. Mutation-tested (removed the new guard,
+confirmed red; restored, confirmed green).
+
+One trap hit while writing this test, worth recording since it nearly produced a
+vacuous pass: the first version simulated the race with `await window.remove()`
+(genuinely flips `is_attached` to `False`) instead of a screen push. That mutation-
+tested as a FALSE PASS -- removing the window also tears down its descendants, so
+`view.query(Button)` returns zero buttons post-removal and the loop body never runs
+regardless of whether the guard exists, i.e. the test would have passed even with
+the guard deleted. Switched to pushing a new screen on top (confirmed: `is_attached`
+stays `True`, buttons remain real and query-able, only `screen.is_active` flips) --
+that version killed the mutant. Lesson candidate for
+`backlog/docs/lessons-testing-evidence.md` if this pattern recurs: a widget-removal
+race test can silently test nothing if removal also empties the exact query the
+code under test uses.
+
+Also hit and fixed independently: this file's mount helper used a single
+`pilot.pause()` (unlike `test_llm_screen_lab_adoption.py`'s established two-pause
+convention for this same deferred mount), which surfaced as a genuine low-rate
+flake (`NoMatches` on `#llm-view-ollama`) reproduced in a 30-run loop at roughly
+1-in-15. Fixed by matching the two-`pilot.pause()` convention inside the shared
+`_mount_models_with_probe_result` helper; reran 20/20 clean afterward.
+
+Reviewer's second minor accepted as residual, not fixed: the refused-connection
+path's promptness (`_probe_local_server` returning `False` quickly on ECONNREFUSED)
+is logically OS-immediate but has no test asserting an upper time bound --
+`test_probe_reports_down_on_a_refused_connection` in
+`Tests/UI/test_llm_screen_ollama_probe_nonblocking.py` asserts the boolean outcome
+only. Left as-is per reviewer guidance.

--- a/backlog/tasks/task-15473 - Timer-gating---non-blocking-Ollama-probe-and-change-gated-nav-overflow-tick.md
+++ b/backlog/tasks/task-15473 - Timer-gating---non-blocking-Ollama-probe-and-change-gated-nav-overflow-tick.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15473
 title: Timer gating: non-blocking Ollama probe and change-gated nav overflow tick
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-11 12:05'
 labels:
@@ -19,6 +19,131 @@ Fix direction: probe via `asyncio.open_connection` (same 0.25 s cap) or a thread
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 No blocking connect ever runs on the event loop (evidence); Models availability UX unchanged
-- [ ] #2 The nav tick performs no measurement/ghost work when nothing changed (evidence); hints still correct after resize, overflow, and scroll (tests)
+- [x] #1 No blocking connect ever runs on the event loop (evidence); Models availability UX unchanged
+- [x] #2 The nav tick performs no measurement/ghost work when nothing changed (evidence); hints still correct after resize, overflow, and scroll (tests)
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Ollama probe (`UI/Screens/llm_screen.py`'s `_probe_local_server`): convert to an
+   `async def` using `asyncio.wait_for(asyncio.open_connection(host, port), timeout=0.25)`,
+   catching `(OSError, asyncio.TimeoutError)` -> down, success -> up (close the writer).
+   Same semantics, same 0.25s cap. Its one caller, `LLMManagementWindow._ollama_api_available`
+   (`UI/LLM_Management_Window.py:613`), becomes async and awaits it; its one caller,
+   `_update_ollama_api_state` (`:622`), becomes async too. `_update_ollama_api_state` is
+   driven from two places: `set_interval(3.0, ...)` in `on_mount` (Textual timers natively
+   support async callbacks via `invoke()`, no change needed there) and a synchronous
+   `step()` loop in `_finish_deferred_mount` (`:541-551`) -- that loop gets an
+   `inspect.isawaitable(result)` check so it can `await` whichever steps are coroutines
+   without disturbing the per-step try/except isolation or ordering.
+2. Nav overflow tick (`UI/Navigation/main_navigation.py`): add
+   `self._overflow_signature: tuple | None = None` in `__init__`. In
+   `_update_overflow_hints`, after the existing early-return guards, compute a cheap
+   signature `(scroll_x, strip.region.width, strip.virtual_size.width, button ids tuple)`
+   from data already being queried; compare to the stored signature and return early
+   (no hint toggle, no `_refresh_overflow_hint_visibility`, no `_recenter_strip`
+   scheduling) when unchanged, else store it and run the existing pipeline. First call
+   after mount always runs (`None` never equals a real tuple). Keep the 0.5s timer
+   (stability preference) rather than switching to event-driven.
+3. Tests: (a) a counting-seam test proving a repeated no-op tick calls zero downstream
+   work (patch `_refresh_overflow_hint_visibility`, assert uncalled on the second,
+   unchanged tick); (b) a "content changed" test (mount an extra button into the strip)
+   proving the gate does not falsely skip; (c) confirm existing resize/scroll/overflow
+   coverage in `test_master_shell_navigation.py`/`test_chrome_ux_fixes.py` still passes
+   unmodified; (d) Ollama probe up/refused/timeout parity tests against a real localhost
+   listener/closed port (`@pytest.mark.allow_network`, no mocking of asyncio itself);
+   (e) a loop-responsiveness test: run the real probe against a genuinely unresponsive
+   address (10.255.255.1, a private/non-routed "black hole" -- verified in this sandbox to
+   hang for the full timeout rather than fail fast) concurrently with a fast heartbeat
+   task, asserting many heartbeat ticks land during the probe's ~0.25s wait (a blocking
+   equivalent measurably starves the heartbeat to ~1 tick in the same window).
+4. Run nav bar suites + LLM screen suites + new tests; compare failure sets against the
+   pre-change baseline (already captured: `Tests/UI/test_llm_screen_lab_adoption.py` has
+   20 pre-existing teardown-only network-guard errors unrelated to blocking, and the nav
+   suites are clean) to confirm no regressions.
+
+## Implementation Notes
+
+Both halves implemented as planned; no deviations.
+
+**Ollama probe.** `_probe_local_server` (`UI/Screens/llm_screen.py`) is now
+`async def`, using `await asyncio.wait_for(asyncio.open_connection(host, port),
+timeout=0.25)` in place of the blocking `socket.create_connection(..., timeout=0.25)`.
+Same up/refused/timeout semantics, same 0.25s cap. Its sole caller,
+`LLMManagementWindow._ollama_api_available` (`UI/LLM_Management_Window.py`), and
+*its* sole caller, `_update_ollama_api_state`, are now coroutines too. `set_interval`
+needed no change (Textual's `Timer._tick` already awaits a coroutine callback via
+`invoke()`); the synchronous `step()` loop in `_finish_deferred_mount` gained an
+`inspect.isawaitable(result): await result` branch so the one now-async step is
+awaited without disturbing the other two sync steps' independent try/except
+isolation. A repo-wide grep confirmed both functions have exactly one caller each --
+nothing else needed converting.
+
+**Nav overflow tick.** `MainNavigationBar._update_overflow_hints` now computes a
+signature `(scroll_x, strip.region.width, strip.virtual_size.width, tuple(button
+ids))` from data it already queries, and returns before any hint toggle /
+`_refresh_overflow_hint_visibility` / `_recenter_strip` scheduling when the
+signature matches the stored one from the last full pass (`self._overflow_signature`,
+seeded `None` so the first pass after mount always runs). Kept the 0.5s timer
+(stability preference, per instructions) rather than moving to resize/scroll events.
+
+**Evidence.** Mutation-tested every guard by temporarily breaking it and confirming
+the corresponding test goes red, then restored:
+- Reverting the probe to the old blocking `socket.create_connection` turned red both
+  `test_probe_never_calls_the_blocking_socket_primitives` and
+  `test_event_loop_stays_responsive_during_an_unresponsive_probe` (heartbeat count
+  0 vs >=10 required) -- the async version measured dozens of heartbeat ticks during
+  a real ~0.25s wait against `10.255.255.1` (a non-routed "black hole" address,
+  empirically verified in this sandbox to hang for the full timeout rather than fail
+  fast) where the blocking equivalent measured zero.
+- Inverting the availability gate's boolean in `_update_ollama_api_state` turned red
+  all three tests in `test_llm_screen_ollama_ux_unchanged.py`.
+- Disabling the nav signature gate (`if False and signature == ...`) turned red
+  `test_a_settled_no_op_tick_does_no_measurement_or_toggle_work` (the "born red"
+  counting-seam test).
+- Dropping the button-ids component from the nav signature turned red
+  `test_a_tick_after_a_destination_is_added_still_does_the_work` (the nav-content-
+  change case the task called out as needing its own coverage).
+
+**New test files:**
+- `Tests/UI/test_llm_screen_ollama_probe_nonblocking.py` -- probe up/refused/timeout
+  parity against real sockets (a real listener, a closed port, and the black-hole
+  address), a structural guard that the blocking primitive is never called, and the
+  loop-responsiveness heartbeat test. Marked `allow_network` (module-level
+  `pytestmark`) per `Tests/conftest.py`'s autouse network-egress guard (task-15111).
+- `Tests/UI/test_llm_screen_ollama_ux_unchanged.py` -- end-to-end button-gating
+  behavior (disabled + tooltip when down, enabled when up, flips on the next tick)
+  with the probe patched to a fixed result -- no real socket, no network marker
+  needed.
+- `Tests/UI/test_nav_overflow_tick_gating.py` -- the no-op-tick counting seam and the
+  content-change case.
+
+**Existing coverage re-verified unmodified:** `Tests/UI/test_master_shell_navigation.py`
+(the interval/resize/restore-active focus-stranding tests already cover scroll and
+resize), `Tests/UI/test_chrome_ux_fixes.py` (overflow-indicator correctness at
+several widths), `Tests/UI/test_settings_nav_active_scroll.py`. All pass unchanged
+after the gate.
+
+**Pre-existing gap found, not fixed (out of scope).**
+`Tests/UI/test_llm_screen_lab_adoption.py` has 20 tests that ERROR at teardown --
+`AssertionError: test attempted network egress (blocked): socket.create_connection ->
+127.0.0.1:11434` -- because mounting `LLMScreen`/`LLMManagementWindow` runs
+`_finish_deferred_mount`'s post-mount step list unconditionally, which reaches the
+real Ollama probe with nothing marking the test `allow_network`. Confirmed
+pre-existing on a clean worktree (identical `58 passed, 20 errors` before and after
+this task's change) and NOT introduced or fixed by converting the probe to async --
+`asyncio.open_connection` routes through the same guarded `socket.connect_ex`, so
+network egress is denied identically either way. One test's own docstring even
+claims "mounting Models reaches no network at all" (task-887), which is no longer
+true. A similar, larger-surface version likely also affects
+`Tests/ProductionApp/test_llm_destination_actions.py` (same mount path, no
+`allow_network` marker found there either) -- not verified in depth, out of this
+task's scope. Worth a follow-up task to either mark the affected tests
+`allow_network` or patch `_probe_local_server` in their shared fixture.
+
+**Files modified:** `tldw_chatbook/UI/Screens/llm_screen.py`,
+`tldw_chatbook/UI/LLM_Management_Window.py`,
+`tldw_chatbook/UI/Navigation/main_navigation.py`.
+**Files added:** `Tests/UI/test_llm_screen_ollama_probe_nonblocking.py`,
+`Tests/UI/test_llm_screen_ollama_ux_unchanged.py`,
+`Tests/UI/test_nav_overflow_tick_gating.py`.

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -543,10 +543,16 @@ class LLMManagementWindow(Container):
             # Autofill the Ollama executable when it's discoverable (UX-078).
             self._autofill_ollama_path,
             # Keep the Ollama API controls gated on a live service (UX-091).
+            # task-15473: this step is now a coroutine function (it awaits
+            # the non-blocking Ollama probe) -- the others are still plain
+            # sync methods, so each result is awaited only if awaitable,
+            # preserving the per-step try/except isolation and ordering.
             self._update_ollama_api_state,
         ):
             try:
-                step()
+                result = step()
+                if inspect.isawaitable(result):
+                    await result
             except Exception:
                 logger.exception(f"Post-mount step failed: {step.__name__}")
         self.post_message(self.DeferredViewsMounted())
@@ -610,16 +616,16 @@ class LLMManagementWindow(Container):
             )
         )
 
-    def _ollama_api_available(self) -> bool:
+    async def _ollama_api_available(self) -> bool:
         """True when an Ollama service answers (app-launched or external)."""
         proc = getattr(self.app_instance, "ollama_server_process", None)
         if proc is not None and proc.poll() is None:
             return True
         from .Screens.llm_screen import _probe_local_server
 
-        return _probe_local_server()
+        return await _probe_local_server()
 
-    def _update_ollama_api_state(self) -> None:
+    async def _update_ollama_api_state(self) -> None:
         """Disable API controls when no Ollama service is running.
 
         The banner already says "requires running service"; without gating,
@@ -638,7 +644,7 @@ class LLMManagementWindow(Container):
             view = self.query_one("#llm-view-ollama")
         except Exception:  # noqa: BLE001 - view not mounted
             return
-        available = self._ollama_api_available()
+        available = await self._ollama_api_available()
         for button in view.query(Button):
             if not button.id or button.id in excluded:
                 continue

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -645,6 +645,15 @@ class LLMManagementWindow(Container):
         except Exception:  # noqa: BLE001 - view not mounted
             return
         available = await self._ollama_api_available()
+        # task-15473 review: the probe above can take up to ~0.25s (it now
+        # awaits instead of blocking), during which this widget can detach
+        # or its screen can go inactive -- the old synchronous version was
+        # atomic end-to-end, so the pre-await guard above was sufficient;
+        # the async version needs the identical check repeated here before
+        # touching any button, or a detach mid-probe mutates widgets that
+        # are no longer the active screen's.
+        if not self.is_attached or not self.screen.is_active:
+            return
         for button in view.query(Button):
             if not button.id or button.id in excluded:
                 continue

--- a/tldw_chatbook/UI/Navigation/main_navigation.py
+++ b/tldw_chatbook/UI/Navigation/main_navigation.py
@@ -335,6 +335,14 @@ class MainNavigationBar(Container):
         # consumed as that automatic landing, never recorded as deliberate.
         self._settle_after_next_focus = False
         self._deliberate_focus_id: str | None = None
+        # task-15473: cheap fingerprint of everything `_update_overflow_hints`'
+        # downstream work (hint toggles, `_recenter_strip` scheduling, the
+        # ghost-check it chains into) depends on -- when the periodic 0.5s
+        # tick recomputes the same signature it stored last pass, nothing
+        # has moved and the whole pipeline is skipped. `None` never equals a
+        # real signature tuple, so the very first pass after mount always
+        # runs in full.
+        self._overflow_signature: tuple[object, ...] | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the navigation bar from master-shell destination metadata."""
@@ -443,7 +451,25 @@ class MainNavigationBar(Container):
         self._mount_settled = True
 
     def _update_overflow_hints(self) -> None:
-        """Toggle the ‹ indicator from real scroll state."""
+        """Toggle the ‹ indicator from real scroll state.
+
+        task-15473: gated behind a cheap signature of everything the
+        downstream work actually depends on -- scroll position, the
+        strip's rendered and virtual (content) widths, and the set of
+        button ids currently in the strip. This is the callback for the
+        periodic 0.5s interval (`on_mount`), the first post-mount pass,
+        and `on_resize`'s deferred call; before this it ran the full
+        measure/toggle/recenter/ghost pipeline unconditionally on every
+        one of those triggers, forever, on every screen (verified: a
+        no-op tick used to still call `_refresh_overflow_hint_visibility`
+        and schedule `_recenter_strip` every 0.5s with nothing having
+        moved). When the signature is unchanged since the last full pass,
+        every one of those is skipped -- geometry that has not moved
+        cannot need a different hint state or scroll position, so this
+        is behavior-neutral, not merely "probably fine": any scroll, any
+        resize, and any button being added or removed changes the
+        signature and forces a full pass on the very next tick.
+        """
         # Skip while the screen/tab is inactive so hidden tabs burn no CPU.
         if not self.is_attached or not self.screen.is_active:
             return
@@ -456,6 +482,15 @@ class MainNavigationBar(Container):
             scroll_x = strip.scroll_x
         except Exception:
             return
+        signature = (
+            scroll_x,
+            strip.region.width,
+            strip.virtual_size.width,
+            tuple(child.id for child in strip.children),
+        )
+        if signature == self._overflow_signature:
+            return
+        self._overflow_signature = signature
         # Left hint tracks position (more destinations hidden on the left);
         # the right affordance's visibility is width-driven, re-evaluated by
         # `_refresh_overflow_hint_visibility` (NV-01 reclaimable-space math).
@@ -464,9 +499,10 @@ class MainNavigationBar(Container):
         # Layout settles asynchronously (hint toggles change the strip's
         # width, fonts finish, etc.), so keep the active destination (or,
         # while it differs, the keyboard-focused button -- see
-        # `_recenter_strip`, review rounds 2-3) pinned every tick instead
-        # of only when a hint changed state — the call is idempotent and
-        # cheap.
+        # `_recenter_strip`, review rounds 2-3) pinned every time the
+        # signature above moves — the call is idempotent and cheap, and
+        # the signature already changing here is what used to be covered
+        # by calling it unconditionally every tick.
         self.call_after_refresh(self._recenter_strip)
 
     def on_resize(self) -> None:

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -87,15 +87,36 @@ LAB_SERVER_POLL_SECONDS = 2.0
 _SERVER_PROCESS_ATTRS = LAB_SERVER_SOURCES
 
 
-def _probe_local_server(host: str = "127.0.0.1", port: int = 11434) -> bool:
-    """Cheap TCP probe for an externally-started Ollama server."""
-    import socket
+async def _probe_local_server(host: str = "127.0.0.1", port: int = 11434) -> bool:
+    """Cheap TCP probe for an externally-started Ollama server.
 
+    task-15473: this used to be a blocking `socket.create_connection(...,
+    timeout=0.25)`, called directly from the Models screen's periodic
+    status timer -- instant on ECONNREFUSED, but a genuinely blackholed
+    port (firewalled/container setups) froze the WHOLE event loop for up
+    to the full 250ms, once per tick, since a synchronous socket call on
+    the loop thread blocks every other task in the process, not just this
+    one. `asyncio.open_connection` under the same 0.25s `wait_for` cap
+    keeps the exact semantics (up = connectable, down = refused or
+    timeout, same interval) but the wait yields the loop instead of
+    freezing it -- verified live (mutation-tested against the old
+    blocking implementation): a concurrent heartbeat task ticks dozens
+    of times during the wait against a real unresponsive address, versus
+    zero for the old blocking call in the same window (see
+    ``Tests/UI/test_llm_screen_ollama_probe_nonblocking.py``).
+    """
     try:
-        with socket.create_connection((host, port), timeout=0.25):
-            return True
-    except OSError:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port), timeout=0.25
+        )
+    except (OSError, asyncio.TimeoutError):
         return False
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except OSError:
+        pass
+    return True
 
 
 class LLMScreen(LabScreen):


### PR DESCRIPTION
## Summary

Task 15473 from the input-latency audit — two steady-state loop-stealers:

1. **Ollama probe**: the Models screen's 3s status timer ended in a blocking `socket.create_connection` on the event loop (up to 250ms frozen per probe when the port blackholes). Now `asyncio.open_connection` under the same 0.25s cap — evidence test: a heartbeat task ticks 44× during a real 0.25s probe wait vs 0 with the old blocking call. Post-await attach/active re-check closes the detached-widget mutation window the async conversion opened (mutation-tested; the first version of that test was itself caught false-passing and rewritten).
2. **Nav overflow tick**: the 0.5s bar timer re-measured overflow hints + scheduled two callbacks every tick forever. Now signature-gated (scroll_x, strip width, virtual width, button ids) — no-op ticks do zero measurement/toggle work; hints still correct after resize/overflow/scroll (signature completeness verified against the bar's actual render inputs: labels are construction-time-fixed, active-tab is per-instance).

Bonus: a pre-existing ~1-in-15 mount-helper flake fixed to the two-pause convention (20/20 clean); a testing lesson banked (a slow-accept listener cannot delay TCP connect — the kernel backlog completes the handshake; the brief's own suggested technique, disproved empirically).

## Verification
Independent review (Approved; both halves mutation-verified by the reviewer; probe parity incl. clean socket close under -W always; cancellation traced through Textual timer teardown). Accepted residual recorded: refused-path promptness is OS-immediate by logic, not time-bounded by a test. Known-unrelated: the 20 pre-existing network-guard teardown errors (byte-identical at base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Models screen’s Ollama status probe non‑blocking and gate the nav bar’s overflow tick by change to cut UI stalls and needless work. Addresses TASK-15473 by removing blocking connects on the event loop and skipping nav work when nothing changed.

- **Refactors**
  - `UI/Screens/llm_screen.py`: `_probe_local_server` is now async using `asyncio.open_connection` under a 0.25s cap; same up/refused/timeout behavior.
  - `tldw_chatbook/UI/LLM_Management_Window.py`: `_ollama_api_available` and `_update_ollama_api_state` are async; `_finish_deferred_mount` now awaits steps when awaitable.
  - `tldw_chatbook/UI/Navigation/main_navigation.py`: change-gated `MainNavigationBar._update_overflow_hints` via `(scroll_x, strip width, virtual width, button ids)` to skip measurement/toggle/recenter on no‑op ticks (timer retained).
  - Bug fix: re-check `is_attached`/`screen.is_active` after awaiting the probe to avoid post-navigation button mutations.
  - Tests: added coverage for probe semantics and loop responsiveness, unchanged Models UX, and nav tick gating (`Tests/UI/test_llm_screen_ollama_probe_nonblocking.py`, `Tests/UI/test_llm_screen_ollama_ux_unchanged.py`, `Tests/UI/test_nav_overflow_tick_gating.py`).

<sup>Written for commit 17a1ff42bd8bbc5c1f8a6ca227e14be17a88e25e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

