### PR TITLE
perf: indexed dictionary attachments and threaded backend for Personas (task-15469)

### DIFF
--- a/Tests/Character_Chat/test_dictionary_attachment_index.py
+++ b/Tests/Character_Chat/test_dictionary_attachment_index.py
@@ -1,0 +1,635 @@
+"""The trigger-maintained conversation<->dictionary attachment index (task-15469).
+
+`list_dictionary_conversations` used to answer "which conversations use this
+dictionary?" with `metadata LIKE '%active_dictionaries%'` -- a full scan of
+`conversations` plus a JSON parse of every match -- on the event loop, on every
+dictionary row click. It is now an indexed lookup over two derived tables
+maintained by SQLite triggers (ChaChaNotes V34->V35).
+
+The bar for that swap is EQUALITY, not "close enough": these tests pin the new
+implementation against a byte-for-byte re-implementation of the old scan over a
+corpus of metadata shapes that includes everything the old code tolerated
+(malformed JSON, non-list values, non-dict documents, string/float/bool/null
+ids, duplicate keys, escaped keys) -- for EVERY dictionary id, including ids no
+conversation references.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.Character_Chat.local_chat_dictionary_service import (
+    LocalChatDictionaryService,
+    statistics_from_record,
+)
+from tldw_chatbook.Character_Chat.chat_dictionary_scope_service import (
+    ChatDictionaryScopeService,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def dictionary_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "chat_dictionaries.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+# --- the corpus -------------------------------------------------------------
+# Every shape the old scan could meet. `title` doubles as the label so a
+# failure names the offending shape.
+METADATA_CORPUS: list[tuple[str, str | None]] = [
+    ("plain-ints", '{"active_dictionaries": [1, 2]}'),
+    ("single-int", '{"active_dictionaries": [11]}'),
+    ("empty-list", '{"active_dictionaries": []}'),
+    ("null-value", '{"active_dictionaries": null}'),
+    ("non-list-value", '{"active_dictionaries": 5}'),
+    ("string-id", '{"active_dictionaries": ["3"]}'),
+    ("padded-string-id", '{"active_dictionaries": [" 3 "]}'),
+    ("underscore-string-id", '{"active_dictionaries": ["1_0"]}'),
+    ("float-id", '{"active_dictionaries": [3.9]}'),
+    ("bool-ids", '{"active_dictionaries": [true, false]}'),
+    ("null-element", '{"active_dictionaries": [null]}'),
+    ("object-element", '{"active_dictionaries": [{"a": 1}]}'),
+    ("array-element", '{"active_dictionaries": [[1]]}'),
+    ("mixed-elements", '{"active_dictionaries": [null, {"z": 1}, 4]}'),
+    ("duplicate-ids", '{"active_dictionaries": [2, 2, 3]}'),
+    ("duplicate-key", '{"active_dictionaries":[1],"active_dictionaries":[2]}'),
+    ("escaped-key", '{"\\u0061ctive_dictionaries": [7]}'),
+    ("huge-int", '{"active_dictionaries": [99999999999999999999]}'),
+    ("negative-id", '{"active_dictionaries": [-3]}'),
+    ("nan-literal", '{"active_dictionaries": [1], "x": NaN}'),
+    ("marker-in-prose", '{"note": "see active_dictionaries", "x": 1}'),
+    ("marker-twice", '{"active_dictionaries": [6], "n": "active_dictionaries"}'),
+    ("truncated-json", '{"active_dictionaries": [1]'),
+    ("single-quotes", "{'active_dictionaries': [1]}"),
+    ("bare-scalar", "5"),
+    ("bare-string-marker", '"active_dictionaries"'),
+    ("top-level-array", "[1, 2]"),
+    ("no-marker", '{"title": "hi"}'),
+    ("empty-string", ""),
+    ("null-metadata", None),
+    ("sibling-keys", '{"rag_scope": {"a": 1}, "active_dictionaries": [1, 9]}'),
+]
+
+#: ids to sweep: every id any corpus row could plausibly resolve to, plus ids
+#: nothing references (the 1-vs-11 substring trap lives in this range too).
+SWEEP_IDS = [0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 99]
+
+
+def _reference_used_by(db: CharactersRAGDB, dictionary_id: int) -> list[dict[str, Any]]:
+    """The pre-task-15469 implementation, verbatim, as the parity oracle."""
+    did = int(dictionary_id)
+    conn = db.get_connection()
+    rows = conn.execute(
+        "SELECT id, title, metadata FROM conversations "
+        "WHERE deleted = 0 AND metadata LIKE '%active_dictionaries%'"
+    ).fetchall()
+    conversations: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            is_member = did in LocalChatDictionaryService._active_dictionaries(
+                {"metadata": row["metadata"]}
+            )
+        except Exception:
+            continue
+        if is_member:
+            conversations.append(
+                {
+                    "conversation_id": str(row["id"]),
+                    "title": str(row["title"] or ""),
+                }
+            )
+    return conversations
+
+
+def _seed_corpus(db: CharactersRAGDB) -> dict[str, str]:
+    """One conversation per corpus row; returns {label: conversation_id}."""
+    ids: dict[str, str] = {}
+    for label, metadata in METADATA_CORPUS:
+        conversation_id = db.add_conversation({"title": label})
+        record = db.get_conversation_by_id(conversation_id)
+        db.update_conversation(
+            conversation_id,
+            {"metadata": metadata},
+            expected_version=record["version"],
+        )
+        ids[label] = conversation_id
+    return ids
+
+
+class TestParityWithTheOldScan:
+    def test_every_dictionary_id_matches_the_old_scan(self, dictionary_db):
+        service = LocalChatDictionaryService(dictionary_db)
+        _seed_corpus(dictionary_db)
+
+        for dictionary_id in SWEEP_IDS:
+            indexed = service.list_dictionary_conversations(dictionary_id)
+            assert indexed["source"] == "local"
+            assert indexed["conversations"] == _reference_used_by(
+                dictionary_db, dictionary_id
+            ), f"used-by diverged for dictionary id {dictionary_id}"
+
+    def test_corpus_actually_exercises_both_branches(self, dictionary_db):
+        """Guard the guard: a corpus that resolves everything proves nothing."""
+        _seed_corpus(dictionary_db)
+        conn = dictionary_db.get_connection()
+        resolved = conn.execute(
+            "SELECT count(*) FROM conversation_dictionary_attachments"
+        ).fetchone()[0]
+        unresolved = conn.execute(
+            "SELECT count(*) FROM conversation_dictionary_unresolved"
+        ).fetchone()[0]
+        assert resolved > 0
+        assert unresolved > 0
+
+    def test_python_verdict_beats_the_index_for_a_duplicate_key(self, dictionary_db):
+        """A duplicated JSON key resolves last-wins in Python, first-wins in
+        SQLite. The row is therefore marked unresolved and Python decides -- so
+        the conversation belongs to dictionary 2, NOT to the indexed 1."""
+        service = LocalChatDictionaryService(dictionary_db)
+        conversation_id = dictionary_db.add_conversation({"title": "dup"})
+        record = dictionary_db.get_conversation_by_id(conversation_id)
+        dictionary_db.update_conversation(
+            conversation_id,
+            {"metadata": '{"active_dictionaries":[1],"active_dictionaries":[2]}'},
+            expected_version=record["version"],
+        )
+        conn = dictionary_db.get_connection()
+        assert [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT dictionary_id FROM conversation_dictionary_attachments "
+                "WHERE conversation_id = ?",
+                (conversation_id,),
+            )
+        ] == [(1,)]
+
+        assert service.list_dictionary_conversations(1)["conversations"] == []
+        assert [
+            row["conversation_id"]
+            for row in service.list_dictionary_conversations(2)["conversations"]
+        ] == [conversation_id]
+
+    def test_result_order_matches_the_old_scan_order(self, dictionary_db):
+        service = LocalChatDictionaryService(dictionary_db)
+        attached = []
+        for index in range(6):
+            conversation_id = dictionary_db.add_conversation({"title": f"c{index}"})
+            service.attach_to_conversation(4, conversation_id)
+            attached.append(conversation_id)
+        # An unresolved row in the middle must not reorder the rest.
+        middle = attached[3]
+        record = dictionary_db.get_conversation_by_id(middle)
+        dictionary_db.update_conversation(
+            middle,
+            {"metadata": '{"active_dictionaries": ["4"]}'},
+            expected_version=record["version"],
+        )
+        result = [
+            row["conversation_id"]
+            for row in service.list_dictionary_conversations(4)["conversations"]
+        ]
+        assert result == attached
+        assert result == [
+            row["conversation_id"] for row in _reference_used_by(dictionary_db, 4)
+        ]
+
+    def test_soft_deleted_conversations_stay_out(self, dictionary_db):
+        service = LocalChatDictionaryService(dictionary_db)
+        kept = dictionary_db.add_conversation({"title": "kept"})
+        removed = dictionary_db.add_conversation({"title": "removed"})
+        service.attach_to_conversation(1, kept)
+        service.attach_to_conversation(1, removed)
+        record = dictionary_db.get_conversation_by_id(removed)
+        dictionary_db.soft_delete_conversation(
+            removed, expected_version=record["version"]
+        )
+
+        assert [
+            row["conversation_id"]
+            for row in service.list_dictionary_conversations(1)["conversations"]
+        ] == [kept]
+        assert service.list_dictionary_conversations(1)[
+            "conversations"
+        ] == _reference_used_by(dictionary_db, 1)
+
+
+class TestIndexMaintenance:
+    def test_attach_and_detach_keep_the_index_in_step(self, dictionary_db):
+        service = LocalChatDictionaryService(dictionary_db)
+        conversation_id = dictionary_db.add_conversation({"title": "chat"})
+        conn = dictionary_db.get_connection()
+
+        service.attach_to_conversation(3, conversation_id)
+        assert [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT dictionary_id FROM conversation_dictionary_attachments "
+                "WHERE conversation_id = ?",
+                (conversation_id,),
+            )
+        ] == [(3,)]
+
+        service.detach_from_conversation(3, conversation_id)
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM conversation_dictionary_attachments "
+                "WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()[0]
+            == 0
+        )
+
+    def test_a_foreign_metadata_writer_keeps_the_index_correct(self, dictionary_db):
+        """The point of maintaining the index with TRIGGERS rather than at
+        attach/detach time: `chat_persistence_service`, `rag_scope` and any
+        other `update_conversation` caller rewrite the whole metadata blob."""
+        service = LocalChatDictionaryService(dictionary_db)
+        conversation_id = dictionary_db.add_conversation({"title": "chat"})
+        service.attach_to_conversation(5, conversation_id)
+
+        record = dictionary_db.get_conversation_by_id(conversation_id)
+        metadata = json.loads(record["metadata"])
+        metadata["rag_scope"] = {"mode": "collections"}
+        metadata["active_dictionaries"] = [5, 8]
+        dictionary_db.update_conversation(
+            conversation_id,
+            {"metadata": json.dumps(metadata)},
+            expected_version=record["version"],
+        )
+
+        assert [
+            row["conversation_id"]
+            for row in service.list_dictionary_conversations(8)["conversations"]
+        ] == [conversation_id]
+
+        record = dictionary_db.get_conversation_by_id(conversation_id)
+        dictionary_db.update_conversation(
+            conversation_id,
+            {"metadata": json.dumps({"rag_scope": {"mode": "collections"}})},
+            expected_version=record["version"],
+        )
+        assert service.list_dictionary_conversations(5)["conversations"] == []
+        assert service.list_dictionary_conversations(8)["conversations"] == []
+
+    def test_hard_delete_clears_index_rows(self, dictionary_db):
+        service = LocalChatDictionaryService(dictionary_db)
+        conversation_id = dictionary_db.add_conversation({"title": "chat"})
+        service.attach_to_conversation(2, conversation_id)
+        conn = dictionary_db.get_connection()
+        conn.execute("DELETE FROM conversations WHERE id = ?", (conversation_id,))
+
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM conversation_dictionary_attachments"
+            ).fetchone()[0]
+            == 0
+        )
+
+    def test_malformed_metadata_never_breaks_the_write(self, dictionary_db):
+        """The triggers call json_each/json_type, which RAISE on malformed
+        JSON; a raising trigger would fail the conversation write itself."""
+        conversation_id = dictionary_db.add_conversation({"title": "chat"})
+        for metadata in (
+            '{"active_dictionaries": [1]',
+            "active_dictionaries not json",
+            '{"active_dictionaries": "  "}',
+            "5",
+        ):
+            record = dictionary_db.get_conversation_by_id(conversation_id)
+            dictionary_db.update_conversation(
+                conversation_id,
+                {"metadata": metadata},
+                expected_version=record["version"],
+            )
+            assert (
+                dictionary_db.get_conversation_by_id(conversation_id)["metadata"]
+                == metadata
+            )
+
+
+class TestNoFullScan:
+    def test_used_by_query_plan_never_scans_conversations(self, dictionary_db):
+        """`conversations` must only ever be probed by primary key.
+
+        The alias in the query is `conversation`, so this asserts on that
+        prefix -- matching on the literal table name would pass vacuously.
+        Both joins are CROSS JOINs precisely because the planner otherwise
+        chose `SCAN conversation` as the unresolved branch's outer loop.
+        """
+        _seed_corpus(dictionary_db)
+        conn = dictionary_db.get_connection()
+        steps = [
+            str(row[3])
+            for row in conn.execute(
+                "EXPLAIN QUERY PLAN " + LocalChatDictionaryService._USED_BY_SQL, (1,)
+            ).fetchall()
+        ]
+        plan = "\n".join(steps)
+        assert steps, "EXPLAIN QUERY PLAN returned nothing"
+        assert not any(step.startswith("SCAN conversation") for step in steps), plan
+        assert (
+            "SEARCH conversation USING INDEX sqlite_autoindex_conversations_1" in plan
+        ), plan
+        assert "idx_conversation_dictionary_attachments_dictionary" in plan, plan
+
+    def test_selection_issues_at_most_two_statements(self, dictionary_db):
+        """The DB work behind one dictionary row click: the record load and the
+        attachment lookup. Statistics are derived from the loaded record and
+        the versions baseline is seeded from it, so neither re-reads the row."""
+        service = LocalChatDictionaryService(dictionary_db)
+        created = service.create_dictionary({"name": "Meds"})
+        conversation_id = dictionary_db.add_conversation({"title": "chat"})
+        service.attach_to_conversation(created["id"], conversation_id)
+
+        statements: list[str] = []
+        conn = dictionary_db.get_connection()
+        conn.set_trace_callback(statements.append)
+        try:
+            # Exactly what PersonasScreen._select_dictionary does.
+            record = service.get_dictionary(created["id"])
+            stats = statistics_from_record(record, dictionary_id=created["id"])
+            service.list_versions(created["id"], record=record)
+            used_by = service.list_dictionary_conversations(created["id"])
+        finally:
+            conn.set_trace_callback(None)
+
+        # `SELECT 1` is the connection liveness ping (task-261), not query work.
+        queries = [
+            statement
+            for statement in statements
+            if statement.strip().upper().startswith("SELECT")
+            and statement.strip() != "SELECT 1"
+        ]
+        # Exactly two, and both identified -- an empty trace would satisfy
+        # "at most two" while proving nothing.
+        assert len(queries) == 2, queries
+        assert "FROM chat_dictionaries" in queries[0]
+        assert "conversation_dictionary_attachments" in queries[1]
+        assert stats["entry_count"] == 0
+        assert [row["conversation_id"] for row in used_by["conversations"]] == [
+            conversation_id
+        ]
+
+
+class TestStatisticsParity:
+    def test_derived_statistics_equal_the_service_payload(self, dictionary_db):
+        service = LocalChatDictionaryService(dictionary_db)
+        created = service.create_dictionary(
+            {
+                "name": "Meds",
+                "entries": [
+                    {"pattern": "BP", "replacement": "blood pressure"},
+                    {"pattern": "HR", "replacement": "heart rate"},
+                ],
+            }
+        )
+        disabled = service.create_dictionary({"name": "Off", "is_active": False})
+
+        for dictionary_id in (created["id"], disabled["id"]):
+            record = service.get_dictionary(dictionary_id)
+            assert statistics_from_record(
+                record, dictionary_id=dictionary_id
+            ) == service.get_statistics(dictionary_id)
+
+    def test_seeded_versions_baseline_matches_the_loaded_one(self, dictionary_db):
+        """`list_versions(record=...)` skips a reload -- the baseline snapshot
+        it writes must be the one the reload would have produced."""
+        service = LocalChatDictionaryService(dictionary_db)
+        created = service.create_dictionary(
+            {"name": "Meds", "entries": [{"pattern": "BP", "replacement": "bp"}]}
+        )
+        service._history = {}  # drop the create-time history
+        seeded = service.list_versions(
+            created["id"], record=service.get_dictionary(created["id"])
+        )
+
+        other = LocalChatDictionaryService(dictionary_db)
+        other._history = {}
+        loaded = other.list_versions(created["id"])
+
+        def _without_timestamp(versions):
+            return [
+                {key: value for key, value in version.items() if key != "created_at"}
+                for version in versions
+            ]
+
+        assert _without_timestamp(seeded["versions"]) == _without_timestamp(
+            loaded["versions"]
+        )
+        assert (
+            service._history_bucket(created["id"])["versions"][0]["snapshot"]
+            == other._history_bucket(created["id"])["versions"][0]["snapshot"]
+        )
+
+    def test_derived_statistics_accept_the_raw_record_shape(self, dictionary_db):
+        """`get_statistics` reads a raw `load_chat_dictionary` record (entries
+        are ChatDictionary objects); the screen passes the normalized one."""
+        from tldw_chatbook.Character_Chat import Chat_Dictionary_Lib as cdl
+
+        service = LocalChatDictionaryService(dictionary_db)
+        created = service.create_dictionary(
+            {"name": "Meds", "entries": [{"pattern": "BP", "replacement": "bp"}]}
+        )
+        raw = cdl.load_chat_dictionary(dictionary_db, created["id"])
+        normalized = service.get_dictionary(created["id"])
+        assert statistics_from_record(raw) == statistics_from_record(normalized)
+
+
+class TestUsedByCountsForListing:
+    def test_include_usage_counts_match_the_old_scan(self, dictionary_db):
+        service = LocalChatDictionaryService(dictionary_db)
+        first = service.create_dictionary({"name": "One"})
+        second = service.create_dictionary({"name": "Two"})
+        _seed_corpus(dictionary_db)
+        chat = dictionary_db.add_conversation({"title": "chat"})
+        service.attach_to_conversation(first["id"], chat)
+
+        listed = service.list_dictionaries(include_usage=True)
+        usage = {
+            record["id"]: record["usage"]["conversation_count"]
+            for record in listed["dictionaries"]
+        }
+        assert usage[first["id"]] == len(_reference_used_by(dictionary_db, first["id"]))
+        assert usage[second["id"]] == len(
+            _reference_used_by(dictionary_db, second["id"])
+        )
+
+
+class _ThreadRecordingBackend:
+    """Local-service-shaped double that records the thread it ran on."""
+
+    def __init__(self, *, is_memory_db: bool):
+        self.db = type("_DB", (), {"is_memory_db": is_memory_db})()
+        self.thread_ident: int | None = None
+
+    def get_dictionary(self, dictionary_id: int) -> dict[str, Any]:
+        self.thread_ident = threading.get_ident()
+        return {"id": int(dictionary_id), "source": "local"}
+
+    def list_dictionary_conversations(self, dictionary_id: int) -> dict[str, Any]:
+        self.thread_ident = threading.get_ident()
+        return {"conversations": [], "source": "local"}
+
+    def add_entry(self, dictionary_id: int, request_data: Any) -> dict[str, Any]:
+        self.thread_ident = threading.get_ident()
+        return {"source": "local"}
+
+    def reorder_entries(self, dictionary_id: int, request_data: Any) -> dict[str, Any]:
+        self.thread_ident = threading.get_ident()
+        return {"source": "local"}
+
+    def list_versions(self, dictionary_id: int, **kwargs: Any) -> dict[str, Any]:
+        self.thread_ident = threading.get_ident()
+        return {"versions": [], "source": "local"}
+
+
+@pytest.mark.asyncio
+class TestBackendRunsOffTheEventLoop:
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda scope: scope.get_dictionary(1, mode="local"),
+            lambda scope: scope.list_dictionary_conversations(1, mode="local"),
+            lambda scope: scope.add_entry(1, {}, mode="local"),
+            lambda scope: scope.reorder_entries(1, {}, mode="local"),
+            lambda scope: scope.list_versions(1, mode="local"),
+        ],
+    )
+    async def test_file_backed_local_calls_run_on_a_worker_thread(self, call):
+        backend = _ThreadRecordingBackend(is_memory_db=False)
+        scope = ChatDictionaryScopeService(
+            local_service=backend, server_service=None, policy_enforcer=None
+        )
+        await call(scope)
+        assert backend.thread_ident is not None
+        assert backend.thread_ident != threading.get_ident()
+
+    async def test_memory_backed_local_calls_stay_on_the_loop_thread(self):
+        """A `:memory:` sqlite DB is visible only to the thread that created
+        it, so threading the call would hand a worker an empty database."""
+        backend = _ThreadRecordingBackend(is_memory_db=True)
+        scope = ChatDictionaryScopeService(
+            local_service=backend, server_service=None, policy_enforcer=None
+        )
+        await scope.get_dictionary(1, mode="local")
+        assert backend.thread_ident == threading.get_ident()
+
+    async def test_an_unidentifiable_backend_stays_on_the_loop_thread(self):
+        """Positive confirmation: a double with no `.db` is NOT threaded."""
+
+        class _Bare:
+            thread_ident: int | None = None
+
+            def get_dictionary(self, dictionary_id: int) -> dict[str, Any]:
+                self.thread_ident = threading.get_ident()
+                return {"id": dictionary_id}
+
+        backend = _Bare()
+        scope = ChatDictionaryScopeService(
+            local_service=backend, server_service=None, policy_enforcer=None
+        )
+        await scope.get_dictionary(1, mode="local")
+        assert backend.thread_ident == threading.get_ident()
+
+    async def test_real_service_used_by_runs_off_the_loop(self, dictionary_db):
+        service = LocalChatDictionaryService(dictionary_db)
+        created = service.create_dictionary({"name": "Meds"})
+        conversation_id = dictionary_db.add_conversation({"title": "chat"})
+        service.attach_to_conversation(created["id"], conversation_id)
+        scope = ChatDictionaryScopeService(
+            local_service=service, server_service=None, policy_enforcer=None
+        )
+        seen: dict[str, int] = {}
+        original = service.list_dictionary_conversations
+
+        def _record(dictionary_id: int):
+            seen["thread"] = threading.get_ident()
+            return original(dictionary_id)
+
+        service.list_dictionary_conversations = _record  # type: ignore[assignment]
+        result = await scope.list_dictionary_conversations(created["id"], mode="local")
+        assert seen["thread"] != threading.get_ident()
+        assert [row["conversation_id"] for row in result["conversations"]] == [
+            conversation_id
+        ]
+
+
+class TestMigrationBackfill:
+    def test_v34_database_backfills_existing_attachments(self, tmp_path):
+        """Rewind a live DB to V34 (drop the derived tables/triggers, reset the
+        version), then reopen it: the real V34->V35 runner must rebuild the
+        index from metadata that was written while no trigger existed."""
+        db_path = tmp_path / "rewind.db"
+        db = CharactersRAGDB(db_path, "test-client")
+        service = LocalChatDictionaryService(db)
+        created = service.create_dictionary({"name": "Meds"})
+        attached = db.add_conversation({"title": "attached"})
+        service.attach_to_conversation(created["id"], attached)
+        loose = db.add_conversation({"title": "loose"})
+        record = db.get_conversation_by_id(loose)
+        db.update_conversation(
+            loose,
+            {"metadata": '{"active_dictionaries": ["7"]}'},
+            expected_version=record["version"],
+        )
+        db.close_connection()
+
+        raw = sqlite3.connect(db_path)
+        raw.executescript(
+            """
+            DROP TRIGGER IF EXISTS conversation_dictionary_index_ai;
+            DROP TRIGGER IF EXISTS conversation_dictionary_index_au;
+            DROP TRIGGER IF EXISTS conversation_dictionary_index_ad;
+            DROP TABLE IF EXISTS conversation_dictionary_attachments;
+            DROP TABLE IF EXISTS conversation_dictionary_unresolved;
+            UPDATE db_schema_version SET version = 34
+             WHERE schema_name = 'rag_char_chat_schema';
+            """
+        )
+        raw.commit()
+        raw.close()
+
+        migrated = CharactersRAGDB(db_path, "test-client")
+        try:
+            conn = migrated.get_connection()
+            assert (
+                conn.execute(
+                    "SELECT version FROM db_schema_version WHERE schema_name = ?",
+                    ("rag_char_chat_schema",),
+                ).fetchone()["version"]
+                == 35
+            )
+            assert [
+                tuple(row)
+                for row in conn.execute(
+                    "SELECT conversation_id, dictionary_id "
+                    "FROM conversation_dictionary_attachments"
+                )
+            ] == [(attached, created["id"])]
+            assert [
+                tuple(row)
+                for row in conn.execute(
+                    "SELECT conversation_id FROM conversation_dictionary_unresolved"
+                )
+            ] == [(loose,)]
+
+            rebuilt = LocalChatDictionaryService(migrated)
+            assert [
+                row["conversation_id"]
+                for row in rebuilt.list_dictionary_conversations(created["id"])[
+                    "conversations"
+                ]
+            ] == [attached]
+            assert [
+                row["conversation_id"]
+                for row in rebuilt.list_dictionary_conversations(7)["conversations"]
+            ] == [loose]
+        finally:
+            migrated.close_connection()

--- a/Tests/Character_Chat/test_dictionary_attachment_index.py
+++ b/Tests/Character_Chat/test_dictionary_attachment_index.py
@@ -278,6 +278,62 @@ class TestIndexMaintenance:
         assert service.list_dictionary_conversations(5)["conversations"] == []
         assert service.list_dictionary_conversations(8)["conversations"] == []
 
+    @pytest.mark.parametrize("foreign_keys", [True, False])
+    def test_conversation_id_change_leaves_no_stale_rows(
+        self, dictionary_db, foreign_keys
+    ):
+        """The FK's ON UPDATE CASCADE runs BEFORE the AFTER UPDATE trigger.
+
+        A conversation id change renames the index rows to NEW.id first, so a
+        trigger deleting only `WHERE conversation_id = OLD.id` matched nothing
+        and the OLD dictionary ids survived under the NEW id -- this exact
+        UPDATE (id AND metadata, [1, 2] -> [3]) used to leave 1, 2 AND 3
+        indexed. Parametrized over `PRAGMA foreign_keys` because the two modes
+        fail in opposite directions: with cascade the stale rows follow the new
+        id, without it they linger under the old one.
+        """
+        service = LocalChatDictionaryService(dictionary_db)
+        conversation_id = dictionary_db.add_conversation({"title": "chat"})
+        record = dictionary_db.get_conversation_by_id(conversation_id)
+        dictionary_db.update_conversation(
+            conversation_id,
+            {"metadata": json.dumps({"active_dictionaries": [1, 2]})},
+            expected_version=record["version"],
+        )
+        conn = dictionary_db.get_connection()
+        if not foreign_keys:
+            conn.execute("PRAGMA foreign_keys = OFF")
+        try:
+            conn.execute(
+                "UPDATE conversations SET id = ?, metadata = ? WHERE id = ?",
+                (
+                    "renamed-conversation",
+                    json.dumps({"active_dictionaries": [3]}),
+                    conversation_id,
+                ),
+            )
+        finally:
+            conn.execute("PRAGMA foreign_keys = ON")
+
+        assert [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT conversation_id, dictionary_id "
+                "FROM conversation_dictionary_attachments"
+            )
+        ] == [("renamed-conversation", 3)]
+        assert service.list_dictionary_conversations(1)["conversations"] == []
+        assert service.list_dictionary_conversations(2)["conversations"] == []
+        assert [
+            row["conversation_id"]
+            for row in service.list_dictionary_conversations(3)["conversations"]
+        ] == ["renamed-conversation"]
+        # ...and the answer still matches the old scan for every id involved.
+        for dictionary_id in (1, 2, 3):
+            assert service.list_dictionary_conversations(dictionary_id)[
+                "conversations"
+            ] == _reference_used_by(dictionary_db, dictionary_id)
+
     def test_hard_delete_clears_index_rows(self, dictionary_db):
         service = LocalChatDictionaryService(dictionary_db)
         conversation_id = dictionary_db.add_conversation({"title": "chat"})
@@ -559,6 +615,89 @@ class TestBackendRunsOffTheEventLoop:
         assert [row["conversation_id"] for row in result["conversations"]] == [
             conversation_id
         ]
+
+
+class TestHistoryStoreConcurrency:
+    """The version-history sidecar is now reachable from worker threads.
+
+    Before task-15469 every call into this service was serialized by the event
+    loop; threading the scope service means `_record_history`'s
+    mutate-bucket-then-rewrite-`<sidecar>.tmp`-then-replace can run twice at
+    once, which can publish a half-written file and lose appends.
+    """
+
+    def test_concurrent_history_writes_keep_the_sidecar_whole(
+        self, dictionary_db, tmp_path
+    ):
+        """Mutation-checked: with the lock replaced by a no-op this fails
+        3 runs out of 3 with `FileNotFoundError` -- one writer's `replace()`
+        moves the shared `.tmp` file out from under another's."""
+        store = tmp_path / "history.json"
+        service = LocalChatDictionaryService(dictionary_db, history_store_path=store)
+        records = [
+            service.create_dictionary({"name": f"Dictionary {index}"})
+            for index in range(4)
+        ]
+        errors: list[BaseException] = []
+        barrier = threading.Barrier(len(records) * 2)
+
+        def _write(record: dict, revision: int) -> None:
+            try:
+                barrier.wait(timeout=10)
+                service._record_history(
+                    record["id"], "update", {**record, "version": revision}
+                )
+            except BaseException as exc:  # noqa: BLE001 - reported below
+                errors.append(exc)
+
+        def _read(record: dict) -> None:
+            try:
+                barrier.wait(timeout=10)
+                for _ in range(10):
+                    service.list_versions(record["id"])
+                    service.list_activity(record["id"])
+            except BaseException as exc:  # noqa: BLE001 - reported below
+                errors.append(exc)
+
+        threads = []
+        for revision, record in enumerate(records, start=2):
+            threads.append(threading.Thread(target=_write, args=(record, revision)))
+            threads.append(threading.Thread(target=_read, args=(record,)))
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+
+        assert not [thread for thread in threads if thread.is_alive()], "deadlock"
+        assert errors == []
+        # The file on disk is whole, and no write was lost.
+        persisted = json.loads(store.read_text(encoding="utf-8"))["dictionaries"]
+        for revision, record in enumerate(records, start=2):
+            revisions = {
+                int(version["revision"])
+                for version in persisted[str(record["id"])]["versions"]
+            }
+            assert revision in revisions, (record["id"], revisions)
+        assert not store.with_suffix(store.suffix + ".tmp").exists()
+
+    def test_nested_history_lock_does_not_deadlock(self, dictionary_db, tmp_path):
+        """`list_versions` -> `_ensure_history_baseline` -> `_record_history`
+        re-enters the lock; a non-reentrant Lock would hang here forever."""
+        service = LocalChatDictionaryService(
+            dictionary_db, history_store_path=tmp_path / "history.json"
+        )
+        created = service.create_dictionary({"name": "Meds"})
+        service._history = {}  # force the baseline-seeding path
+
+        done: list[dict] = []
+        worker = threading.Thread(
+            target=lambda: done.append(service.list_versions(created["id"]))
+        )
+        worker.start()
+        worker.join(timeout=15)
+
+        assert not worker.is_alive(), "nested history lock deadlocked"
+        assert done and done[0]["versions"]
 
 
 class TestMigrationBackfill:

--- a/Tests/DB/test_chachanotes_console_context_memory_migration.py
+++ b/Tests/DB/test_chachanotes_console_context_memory_migration.py
@@ -94,7 +94,7 @@ def test_fresh_database_reaches_current_with_local_tables(tmp_path) -> None:
     )
     table_names = {str(row[0]) for row in rows}
 
-    assert _version(db) == 34
+    assert _version(db) == 35  # bumped by TASK-15469
     assert EXPECTED_TABLES <= table_names
 
     sync_triggers = (
@@ -130,7 +130,7 @@ def test_migration_preserves_valid_legacy_summary_as_inactive_memory(
         .fetchone()
     )
 
-    assert _version(db) == 34
+    assert _version(db) == 35  # bumped by TASK-15469
     assert row is not None
     assert row["conversation_id"] == conversation_id
     assert row["boundary_message_id"] == boundary_id
@@ -154,7 +154,7 @@ def test_v33_policy_migrates_with_inherited_text_representation(
     db = CharactersRAGDB(path, client_id="v34-open")
     result = ConsoleContextRepository(db).load_policy(conversation_id)
 
-    assert _version(db) == 34
+    assert _version(db) == 35  # bumped by TASK-15469
     assert result.error is None
     assert result.overrides.custom_budget_tokens == 12_000
     assert result.overrides.compaction_mode is ContextCompactionMode.AUTOMATIC

--- a/Tests/UI/test_personas_dictionaries.py
+++ b/Tests/UI/test_personas_dictionaries.py
@@ -2193,6 +2193,41 @@ class TestDictionaryStatsTab:
             assert "Priority: 0..5" in body
             assert "tokens" in body  # approximate token total line
 
+    async def test_selection_loads_the_record_once_and_derives_stats(
+        self, mock_app_instance, stub_characters, fake_dict_service
+    ):
+        """task-15469: selecting a dictionary used to load the SAME row twice
+        (once for the detail, once inside `get_statistics`). The stats payload
+        is now derived from the record already in hand, so a selection is one
+        record load and no statistics call -- while the Stats tab still renders
+        the same numbers."""
+        loads: list[int] = []
+        statistics_calls: list[int] = []
+        original_get = fake_dict_service.get_dictionary
+        original_stats = fake_dict_service.get_statistics
+
+        async def _counted_get(dictionary_id: int, mode: str = "local"):
+            loads.append(int(dictionary_id))
+            return await original_get(dictionary_id, mode=mode)
+
+        async def _counted_stats(dictionary_id: int, mode: str = "local"):
+            statistics_calls.append(int(dictionary_id))
+            return await original_stats(dictionary_id, mode=mode)
+
+        fake_dict_service.get_dictionary = _counted_get
+        fake_dict_service.get_statistics = _counted_stats
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(200, 60)) as pilot:
+            screen = await _enter_dictionaries(pilot)
+            await self._select_first(pilot, screen)
+            body = str(screen.query_one("#personas-dict-stats-body", Static).renderable)
+
+        assert loads == [1]
+        assert statistics_calls == []
+        assert "Entries: 2" in body
+        assert "Dictionary enabled: yes" in body
+
     async def test_stats_refreshed_after_settings_save(
         self, mock_app_instance, stub_characters, fake_dict_service
     ):

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -3097,3 +3097,41 @@ navigation leaves the control outside the viewport, handle descendant focus
 at the narrow owning component and call `scroll_visible(animate=False,
 force=True, immediate=True)` on the exact control. Do not infer reachability
 from focus state or a nonzero layout region alone.
+
+## An "indexed" query can still scan the table the index exists to avoid — and the plan assertion can miss it (TASK-15469, 2026-08-11)
+
+TASK-15469 replaced a `metadata LIKE '%active_dictionaries%'` full scan of
+`conversations` with a lookup over a trigger-maintained index table. The new query
+joined the index table to `conversations`, and the test asserted
+`"SCAN conversations" not in plan`. It passed. It proved nothing:
+
+* The query aliases the table (`conversations AS conversation`), and
+  `EXPLAIN QUERY PLAN` prints the **alias**, so the plan said `SCAN conversation` —
+  which the assertion's literal `"SCAN conversations"` never matches. The test would
+  have passed with a plan made entirely of full scans.
+* And there really was one. SQLite's planner chose `conversations` as the outer loop
+  of the second branch (`SCAN conversation` + a covering-index probe per row): a full
+  scan of the very table the index was built to stop reading. Only the FIRST branch
+  used the new index; nothing in the assertion covered the second.
+
+It surfaced from a **timing** arm, not from the plan test: on a 10,000-conversation
+DB, "used-by for a dictionary attached to nothing" measured 2.07 ms when it should
+have been unmeasurable. `CROSS JOIN` (which pins the left table as the outer loop and
+disables that particular join reordering) took the same arm to 0.00 ms and the whole
+click's DB work from 7.8 ms to 0.54 ms. The plan test now asserts on the alias prefix,
+asserts `conversations` is reached only by `SEARCH ... USING INDEX
+sqlite_autoindex_conversations_1`, and asserts the plan is non-empty.
+
+One more planner subtlety worth knowing: this project never runs `ANALYZE`, so the
+planner works from default row-count estimates and reliably prefers the index. Running
+`ANALYZE` on a small dev database flips it back to `SCAN` on the tiny index table —
+so a plan captured on a hand-seeded 50-row fixture with `ANALYZE` is not the plan
+production runs.
+
+**What to do.** When the claim is "no full-table scan", (1) grep the plan for the
+identifier the query actually uses — the alias, not the table name — and assert
+positively on what SHOULD happen (`SEARCH ... USING INDEX <name>`), not only
+negatively on what should not; (2) assert the plan is non-empty, or an empty result
+satisfies every "not in" assertion; (3) check EVERY branch of a compound query; and
+(4) keep one timing arm whose expected value is ~zero (a lookup with no hits) — a
+scan cannot hide from that, and it is what caught this one.

--- a/backlog/tasks/task-15469 - Personas-dictionaries---indexed-attachment-lookup-and-a-threaded-backend.md
+++ b/backlog/tasks/task-15469 - Personas-dictionaries---indexed-attachment-lookup-and-a-threaded-backend.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15469
 title: Personas dictionaries: indexed attachment lookup and a threaded backend
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-11 12:05'
 labels:
@@ -20,7 +20,159 @@ Fix direction: thread the local backend in the scope service; replace the LIKE s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A dictionary row click issues no full-table scan (query-plan or timing evidence) and at most 2 queries, none on the event loop
-- [ ] #2 Statistics and attachment lists return identical values (tests)
-- [ ] #3 Click latency before/after with a 1,000+-conversation DB recorded
+- [x] #1 A dictionary row click issues no full-table scan (query-plan or timing evidence) and at most 2 queries, none on the event loop
+- [x] #2 Statistics and attachment lists return identical values (tests)
+- [x] #3 Click latency before/after with a 1,000+-conversation DB recorded
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+**Mechanism choice (investigated first, as required).** Who writes
+`conversations.metadata`? `LocalChatDictionaryService._write_active_dictionaries`
+is the only writer of the `active_dictionaries` KEY, but the metadata BLOB is
+read-modify-written wholesale by several unrelated paths
+(`Chat/chat_persistence_service.py` roleplay context + pinned prefill,
+`Chat/rag_scope.py` scope storage, `DB.update_conversation` from anywhere,
+sync apply, tests). Option (a) — a JSON1 expression index — cannot work at all
+here: `active_dictionaries` is a JSON *array*, and an expression index over
+`json_extract(metadata,'$.active_dictionaries')` indexes the array's text, which
+answers no membership query. So option (b), an attachment table. But maintaining
+it "at attach/detach time" in Python would silently rot the moment any of those
+other blob writers changes the key, so it is maintained by SQLite TRIGGERS on
+`conversations` (INSERT/UPDATE/DELETE) — every writer, including raw SQL and
+sync apply, keeps it correct — plus a backfill in the migration. Same shape as
+the existing FTS5 external-content triggers.
+
+**Exact parity, by construction.** SQL cannot reproduce Python's `int()`
+coercion for every element shape (probe evidence: `"1_0"`→10, `"٣"`→3,
+`1e300`→a 300-digit int, `NaN` literal parses in Python but not in SQLite,
+duplicate JSON keys resolve last-wins in Python and first-wins in SQLite). So
+the index resolves ONLY elements that are unambiguous JSON integers
+(`json_each.type='integer' AND typeof(value)='integer'`); every other shape that
+could still coerce in Python marks the conversation in a second, tiny
+`conversation_dictionary_unresolved` table whose rows are verified in Python
+with the unchanged `_active_dictionaries()` predicate. Element types that can
+never coerce (`null`/`object`/`array`) are skipped, matching Python. The trigger
+carries today's `metadata LIKE '%active_dictionaries%'` prefilter verbatim so
+the new path inherits the old path's blind spots (e.g. a `a`-escaped key)
+rather than "fixing" them into a behaviour change.
+
+1. Migration V34→V35: `conversation_dictionary_attachments(conversation_id,
+   dictionary_id)` + `idx_..._dictionary`, `conversation_dictionary_unresolved
+   (conversation_id)`, three triggers, backfill from existing metadata. Local-only
+   (no sync columns, no sync triggers). Bump `_CURRENT_SCHEMA_VERSION` to 35, add
+   the runner + `migration_steps` entry, register both tables in
+   `DB/sql_validation.py`'s `VALID_TABLES['chachanotes']`.
+2. `list_dictionary_conversations`: one indexed query (resolved ∪ unresolved,
+   ordered by `conversations.rowid` = today's scan order), unresolved rows
+   verified in Python; unresolved verdict always wins over the index.
+3. Single load per selection: `statistics_from_record()` (pure) derives the
+   `get_statistics` payload from the already-loaded record; `_select_dictionary`
+   and the two other record-in-hand call sites use it. `list_versions` accepts the
+   preloaded record so `_ensure_history_baseline` stops re-loading it.
+4. Threaded backend: `ChatDictionaryScopeService` runs local-mode sync backend
+   calls via `asyncio.to_thread` behind a POSITIVE-confirmation predicate (thread
+   only when `service.db.is_memory_db is False`); covers select, attachments and
+   the entry add/update/delete/reorder handlers, which all route through it.
+5. Evidence: parity test over a malformed-metadata fixture corpus, EXPLAIN QUERY
+   PLAN assertion (no `SCAN conversations`), a per-click statement counter
+   (≤2), an off-loop thread-identity test, and a 1k-conversation latency probe.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The used-by scan is gone, the double load is gone, and the local backend runs off
+the event loop. ChaChaNotes schema **V34 -> V35**.
+
+**Schema (V34->V35, `chachanotes_v34_to_v35_conversation_dictionary_attachments.sql`).**
+Two derived, local-only tables — `conversation_dictionary_attachments
+(conversation_id, dictionary_id)` with an index on `dictionary_id`, and
+`conversation_dictionary_unresolved(conversation_id)` — maintained by three
+triggers on `conversations` (insert/update/delete) plus a backfill. No sync
+columns, no sync_log triggers: this is derived state over `conversations.metadata`,
+which is itself synced. The migration header carries the full rationale; the
+short version:
+
+* **Triggers, not attach/detach-time maintenance.** Only
+  `_write_active_dictionaries` writes the KEY, but the metadata BLOB is
+  read-modify-written by `chat_persistence_service`, `rag_scope`, any
+  `update_conversation` caller and sync apply. An index maintained in Python at
+  attach time would rot the first time one of those wrote it. A trigger cannot be
+  bypassed.
+* **A JSON1 expression index (option (a)) cannot answer this query at all** —
+  `active_dictionaries` is an array, so an index over
+  `json_extract(metadata,'$.active_dictionaries')` indexes the array's text, which
+  answers no membership question.
+* **Two tables, because SQL cannot reproduce Python's `int()` for every element
+  shape** (probed, not assumed: `"1_0"`->10, `"٣"`->3, `1e300`->an exact 300-digit
+  int, a `NaN` literal parses in Python but is invalid JSON to SQLite, a duplicated
+  key is last-wins in Python and first-wins in `json_each`). The index resolves only
+  unambiguous JSON integers; every other shape marks the row unresolved and the
+  service decides it with the unchanged `_active_dictionaries()` predicate, whose
+  verdict overrides the index. Shapes that can never coerce (`null`/`object`/`array`)
+  are skipped, matching Python. In an app-written database the unresolved table is
+  empty.
+* Every `json_*` call in the triggers reads `CASE WHEN json_valid(x) THEN x ELSE
+  '{}' END` — `json_each`/`json_type` raise on malformed JSON and a raising trigger
+  would fail the conversation write itself. The old query's
+  `metadata LIKE '%active_dictionaries%'` prefilter is carried over verbatim so the
+  index inherits its blind spots rather than "fixing" them into a behaviour change.
+* The pre-existing dead `conversation_dictionaries` junction table is unusable here:
+  `conversation_id INTEGER` against a TEXT UUID PK, and an FK to `chat_dictionaries`
+  that would fail the write for a stale dictionary id.
+
+**Query.** `list_dictionary_conversations` is one statement over both branches,
+ordered by `conversations.rowid` (the old scan's order). Both joins are **CROSS
+JOINs**: without them SQLite chose `conversations` as the unresolved branch's outer
+loop — i.e. still a full scan (see the lesson added to
+`lessons-testing-evidence.md`; it cost 2.07 ms/click at 10k conversations and the
+first plan assertion missed it because `EXPLAIN QUERY PLAN` prints the ALIAS).
+
+**One load per selection.** `statistics_from_record()` (new, pure) derives the
+`get_statistics` payload from the record already in hand; `_select_dictionary`,
+`_refresh_dictionary_statistics` and `_reload_selected_dictionary_entries` use it.
+`list_versions(record=...)` seeds a missing history baseline from the same record
+instead of re-loading. `get_statistics` itself is unchanged in behaviour (it now
+calls the shared helper).
+
+**Threading.** `ChatDictionaryScopeService._call_backend` runs local-mode sync
+backend calls via `asyncio.to_thread` behind a POSITIVE-confirmation predicate
+(`service.db.is_memory_db is False`) — stricter than task-283's, which threads what
+it cannot identify; the doubles behind this seam have no `.db`. This covers
+selection, attachments, versions/activity and the entry add/update/delete/reorder
+handlers, which all route through the scope service.
+
+**Measured** (isolated probe, `add_conversation` + metadata writes, medians of 25):
+
+| conversations | click DB work BEFORE | AFTER | used-by BEFORE | AFTER | used-by, 0 hits, BEFORE | AFTER |
+|---|---|---|---|---|---|---|
+| 1,500 | 1.11 ms | 0.12 ms | 0.99 ms | 0.07 ms | 0.98 ms | 0.00 ms |
+| 10,000 | 7.80 ms | 0.54 ms | 7.74 ms | 0.48 ms | 7.69 ms | 0.00 ms |
+
+BEFORE re-runs the old scan + the old double/triple load against the SAME database.
+The old path is O(conversations); the new one is O(matches). Write cost of the
+triggers, same probe shape: a metadata-changing `update_conversation` goes 0.097 ->
+0.145 ms median; `add_conversation` is unchanged (its metadata has no marker).
+
+**Files.** `DB/migrations/chachanotes_v34_to_v35_conversation_dictionary_attachments.sql`
+(new), `DB/ChaChaNotes_DB.py` (version 35 + runner + step), `DB/sql_validation.py`
+(both tables allowlisted), `Character_Chat/local_chat_dictionary_service.py`,
+`Character_Chat/chat_dictionary_scope_service.py`, `UI/Screens/personas_screen.py`,
+`Tests/Character_Chat/test_dictionary_attachment_index.py` (new, 24 tests),
+`Tests/UI/test_personas_dictionaries.py` (+1), `Tests/DB/
+test_chachanotes_console_context_memory_migration.py` (3 current-version
+assertions 34 -> 35), `backlog/docs/lessons-testing-evidence.md`.
+
+**Tests.** New file 24 passed; `Tests/Character_Chat/` 568 passed;
+`Tests/UI/test_personas_dictionaries.py` 79 passed; `Tests/DB/` +
+`Tests/ChaChaNotesDB/` 1046 passed / 34 failed — byte-identical to the pre-change
+baseline (the V33->V34 `duplicate column name: compaction_representation` bug and
+its stale hardcoded-version assertions; not touched). `Tests/UI/
+test_console_dictionary_send_integration.py`'s 2 failures were confirmed
+pre-existing by running that file against a pristine copy of the base commit.
+Not fixed here: `Tests/DB/test_sql_validation.py::test_no_missing_tables` stays red
+on the three `console_*` tables a previous migration never allowlisted — the two
+tables added here ARE allowlisted, so that failure is unchanged, not worsened.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15469 - Personas-dictionaries---indexed-attachment-lookup-and-a-threaded-backend.md
+++ b/backlog/tasks/task-15469 - Personas-dictionaries---indexed-attachment-lookup-and-a-threaded-backend.md
@@ -144,6 +144,24 @@ it cannot identify; the doubles behind this seam have no `.db`. This covers
 selection, attachments, versions/activity and the entry add/update/delete/reorder
 handlers, which all route through the scope service.
 
+**Review bundle (two follow-up fixes, second commit).**
+1. The AU trigger cleared only `OLD.id`, but the FK's `ON UPDATE CASCADE` has already
+   renamed the index rows to `NEW.id` by the time an AFTER UPDATE trigger fires — so a
+   conversation id change left the OLD dictionary ids indexed under the NEW id
+   (reproduced: one UPDATE changing id and metadata `[1,2]`→`[3]` left 1, 2 AND 3).
+   Both DELETEs now clear `IN (OLD.id, NEW.id)`, which is also what keeps this correct
+   on a connection running without `PRAGMA foreign_keys = ON`. The migration file was
+   amended in place (it has never merged, so no second migration). Test is
+   parametrized over both FK modes and both arms are mutation-checked: `IN (OLD.id)`
+   reds only the FK-on arm, `IN (NEW.id)` reds only the FK-off arm.
+2. Threading made the version-history sidecar reachable from worker threads, where two
+   `_record_history` calls raced on the single `<sidecar>.tmp` write+replace. Closed
+   with a `threading.RLock` around every mutate+persist and every read snapshot
+   (RLock because `_ensure_history_baseline` nests `_record_history`; no deadlock is
+   possible because no caller holds an open DB transaction while taking it). Mutation-
+   checked: with the lock stubbed out the new concurrency test fails 3 runs of 3 with
+   `FileNotFoundError`.
+
 **Measured** (isolated probe, `add_conversation` + metadata writes, medians of 25):
 
 | conversations | click DB work BEFORE | AFTER | used-by BEFORE | AFTER | used-by, 0 hits, BEFORE | AFTER |
@@ -160,16 +178,17 @@ triggers, same probe shape: a metadata-changing `update_conversation` goes 0.097
 (new), `DB/ChaChaNotes_DB.py` (version 35 + runner + step), `DB/sql_validation.py`
 (both tables allowlisted), `Character_Chat/local_chat_dictionary_service.py`,
 `Character_Chat/chat_dictionary_scope_service.py`, `UI/Screens/personas_screen.py`,
-`Tests/Character_Chat/test_dictionary_attachment_index.py` (new, 24 tests),
+`Tests/Character_Chat/test_dictionary_attachment_index.py` (new, 28 tests),
 `Tests/UI/test_personas_dictionaries.py` (+1), `Tests/DB/
 test_chachanotes_console_context_memory_migration.py` (3 current-version
 assertions 34 -> 35), `backlog/docs/lessons-testing-evidence.md`.
 
-**Tests.** New file 24 passed; `Tests/Character_Chat/` 568 passed;
-`Tests/UI/test_personas_dictionaries.py` 79 passed; `Tests/DB/` +
-`Tests/ChaChaNotesDB/` 1046 passed / 34 failed — byte-identical to the pre-change
-baseline (the V33->V34 `duplicate column name: compaction_representation` bug and
-its stale hardcoded-version assertions; not touched). `Tests/UI/
+**Tests** (after the review bundle). New file 28 passed;
+`Tests/Character_Chat/` 573 passed; `Tests/UI/test_personas_dictionaries.py` +
+`test_console_dictionaries_screen.py` 88 passed; `Tests/DB/` +
+`Tests/ChaChaNotesDB/` 1046 passed / 1 skipped / 34 failed — byte-identical to the
+pre-change baseline (the V33->V34 `duplicate column name: compaction_representation`
+bug and its stale hardcoded-version assertions; not touched). `Tests/UI/
 test_console_dictionary_send_integration.py`'s 2 failures were confirmed
 pre-existing by running that file against a pristine copy of the base commit.
 Not fixed here: `Tests/DB/test_sql_validation.py::test_no_missing_tables` stays red

--- a/tldw_chatbook/Character_Chat/chat_dictionary_scope_service.py
+++ b/tldw_chatbook/Character_Chat/chat_dictionary_scope_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from typing import Any
 
@@ -64,6 +65,44 @@ class ChatDictionaryScopeService:
         if inspect.isawaitable(value):
             return await value
         return value
+
+    @staticmethod
+    def _is_file_backed_local(service: Any) -> bool:
+        """True only when ``service``'s sqlite DB is POSITIVELY file-backed.
+
+        Threading a backend call is safe only for a file-backed, thread-local
+        sqlite connection: a ``:memory:`` ChaChaNotes DB is visible solely to
+        the thread that created and migrated it, so handing the call to a
+        worker thread would give it a separate, empty, unmigrated database.
+
+        This is deliberately a POSITIVE confirmation -- unlike task-283's
+        `_is_memory_backed`, which threads whatever it cannot identify. The
+        backends behind this seam include test doubles and the server service,
+        none of which expose a `.db`; running an unknown shape on the event
+        loop is at worst slow, while threading an unknown shape can be wrong.
+
+        Args:
+            service: The backend to inspect.
+
+        Returns:
+            True when ``service.db.is_memory_db`` exists and is exactly False.
+        """
+        return getattr(getattr(service, "db", None), "is_memory_db", None) is False
+
+    async def _call_backend(self, backend: Any, method: Any, *args: Any, **kwargs: Any):
+        """Await ``method``, running a threadable local sync call off the loop.
+
+        Every local chat-dictionary method is plain synchronous sqlite work
+        (record loads, entry mutations, attach/detach, the used-by lookup).
+        Called straight from an ``@on`` handler that would block the event
+        loop for the whole query (task-15469; task-283's shape). Server-mode
+        methods are real coroutines and are simply awaited.
+        """
+        if not inspect.iscoroutinefunction(method) and self._is_file_backed_local(
+            backend
+        ):
+            return await asyncio.to_thread(lambda: method(*args, **kwargs))
+        return await self._maybe_await(method(*args, **kwargs))
 
     def _enforce_policy(self, action_id: str) -> None:
         if self.policy_enforcer is None:
@@ -140,7 +179,7 @@ class ChatDictionaryScopeService:
             raise ValueError(
                 f"Chat dictionary backend does not provide {method_name}()."
             )
-        return await self._maybe_await(method(*args, **kwargs))
+        return await self._call_backend(backend, method, *args, **kwargs)
 
     def _raise_local_activity_unsupported(self) -> None:
         raise ValueError(_LOCAL_UNSUPPORTED_CAPABILITIES[0]["user_message"])
@@ -316,7 +355,9 @@ class ChatDictionaryScopeService:
             getattr(backend, "list_activity", None)
         ):
             self._raise_local_activity_unsupported()
-        return await self._maybe_await(backend.list_activity(dictionary_id, **kwargs))
+        return await self._call_backend(
+            backend, backend.list_activity, dictionary_id, **kwargs
+        )
 
     async def list_versions(
         self, dictionary_id: int, mode: str = "local", **kwargs: Any
@@ -328,7 +369,9 @@ class ChatDictionaryScopeService:
             getattr(backend, "list_versions", None)
         ):
             self._raise_local_versions_unsupported()
-        return await self._maybe_await(backend.list_versions(dictionary_id, **kwargs))
+        return await self._call_backend(
+            backend, backend.list_versions, dictionary_id, **kwargs
+        )
 
     async def get_version(
         self, dictionary_id: int, revision: int, mode: str = "local"
@@ -340,7 +383,9 @@ class ChatDictionaryScopeService:
             getattr(backend, "get_version", None)
         ):
             self._raise_local_versions_unsupported()
-        return await self._maybe_await(backend.get_version(dictionary_id, revision))
+        return await self._call_backend(
+            backend, backend.get_version, dictionary_id, revision
+        )
 
     async def revert_version(
         self, dictionary_id: int, revision: int, mode: str = "local"
@@ -352,7 +397,9 @@ class ChatDictionaryScopeService:
             getattr(backend, "revert_version", None)
         ):
             self._raise_local_versions_unsupported()
-        return await self._maybe_await(backend.revert_version(dictionary_id, revision))
+        return await self._call_backend(
+            backend, backend.revert_version, dictionary_id, revision
+        )
 
     async def get_statistics(self, dictionary_id: int, mode: str = "local") -> Any:
         normalized_mode = self._normalize_mode(mode)

--- a/tldw_chatbook/Character_Chat/local_chat_dictionary_service.py
+++ b/tldw_chatbook/Character_Chat/local_chat_dictionary_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
@@ -175,6 +176,21 @@ class LocalChatDictionaryService:
             if history_store_path is not None
             else None
         )
+        # The in-memory history and its JSON sidecar are shared mutable state,
+        # and since task-15469 the scope service runs these methods on
+        # `asyncio.to_thread` workers -- they are no longer serialized by the
+        # event loop. Two threads recording history would interleave appends to
+        # the same bucket list AND race on the single `<sidecar>.tmp` write +
+        # replace, which can publish a half-written file. Every mutate+persist
+        # and every read snapshot is taken under this lock.
+        #
+        # RLock, not Lock: `_ensure_history_baseline` holds it across
+        # `_record_history`. Held across `get_dictionary()`'s DB read in that
+        # one path, which cannot deadlock -- no caller holds an open DB
+        # transaction while acquiring this lock (every `_record_history` call
+        # site runs after its DB write has committed), so there is no lock
+        # ordering cycle to close.
+        self._history_lock = threading.RLock()
         self._history: dict[str, dict[str, list[dict[str, Any]]]] = {}
         self._load_history()
 
@@ -193,30 +209,42 @@ class LocalChatDictionaryService:
         try:
             payload = json.loads(self.history_store_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
-            self._history = {}
+            with self._history_lock:
+                self._history = {}
             return
         dictionaries = (
             payload.get("dictionaries", payload) if isinstance(payload, dict) else {}
         )
-        if not isinstance(dictionaries, dict):
+        with self._history_lock:
+            if not isinstance(dictionaries, dict):
+                self._history = {}
+                return
             self._history = {}
-            return
-        self._history = {}
-        for dictionary_id, bucket in dictionaries.items():
-            if not isinstance(bucket, dict):
-                continue
-            activity = bucket.get("activity", [])
-            versions = bucket.get("versions", [])
-            self._history[str(dictionary_id)] = {
-                "activity": [dict(item) for item in activity if isinstance(item, dict)]
-                if isinstance(activity, list)
-                else [],
-                "versions": [dict(item) for item in versions if isinstance(item, dict)]
-                if isinstance(versions, list)
-                else [],
-            }
+            for dictionary_id, bucket in dictionaries.items():
+                if not isinstance(bucket, dict):
+                    continue
+                activity = bucket.get("activity", [])
+                versions = bucket.get("versions", [])
+                self._history[str(dictionary_id)] = {
+                    "activity": [
+                        dict(item) for item in activity if isinstance(item, dict)
+                    ]
+                    if isinstance(activity, list)
+                    else [],
+                    "versions": [
+                        dict(item) for item in versions if isinstance(item, dict)
+                    ]
+                    if isinstance(versions, list)
+                    else [],
+                }
 
     def _persist_history(self) -> None:
+        """Rewrite the history sidecar. Callers must hold ``_history_lock``.
+
+        The temp path is a single fixed name, so two unserialized writers would
+        interleave their `write_text` + `replace` and could publish a
+        half-written file.
+        """
         if self.history_store_path is None:
             return
         self.history_store_path.parent.mkdir(parents=True, exist_ok=True)
@@ -232,6 +260,11 @@ class LocalChatDictionaryService:
         temp_path.replace(self.history_store_path)
 
     def _history_bucket(self, dictionary_id: int) -> dict[str, list[dict[str, Any]]]:
+        """Return (creating if needed) one dictionary's history bucket.
+
+        Callers must hold ``_history_lock`` -- both the create-if-missing and
+        every use of the returned lists are shared mutable state.
+        """
         key = str(int(dictionary_id))
         if key not in self._history:
             self._history[key] = {"activity": [], "versions": []}
@@ -259,41 +292,42 @@ class LocalChatDictionaryService:
         self, dictionary_id: int, action: str, record: Mapping[str, Any]
     ) -> None:
         snapshot = self._dictionary_snapshot(record)
-        bucket = self._history_bucket(dictionary_id)
-        now = self._now()
-        revision = int(snapshot.get("version", 1) or 1)
-        bucket["activity"].append(
-            {
-                "id": f"local:chat_dictionary_activity:{int(dictionary_id)}:{len(bucket['activity']) + 1}",
+        with self._history_lock:
+            bucket = self._history_bucket(dictionary_id)
+            now = self._now()
+            revision = int(snapshot.get("version", 1) or 1)
+            bucket["activity"].append(
+                {
+                    "id": f"local:chat_dictionary_activity:{int(dictionary_id)}:{len(bucket['activity']) + 1}",
+                    "dictionary_id": int(dictionary_id),
+                    "action": action,
+                    "revision": revision,
+                    "created_at": now,
+                    "source": "local",
+                }
+            )
+            existing_index = next(
+                (
+                    index
+                    for index, item in enumerate(bucket["versions"])
+                    if int(item.get("revision", -1)) == revision
+                ),
+                None,
+            )
+            version_record = {
                 "dictionary_id": int(dictionary_id),
-                "action": action,
                 "revision": revision,
+                "action": action,
+                "name": snapshot.get("name"),
                 "created_at": now,
+                "snapshot": snapshot,
                 "source": "local",
             }
-        )
-        existing_index = next(
-            (
-                index
-                for index, item in enumerate(bucket["versions"])
-                if int(item.get("revision", -1)) == revision
-            ),
-            None,
-        )
-        version_record = {
-            "dictionary_id": int(dictionary_id),
-            "revision": revision,
-            "action": action,
-            "name": snapshot.get("name"),
-            "created_at": now,
-            "snapshot": snapshot,
-            "source": "local",
-        }
-        if existing_index is None:
-            bucket["versions"].append(version_record)
-        else:
-            bucket["versions"][existing_index] = version_record
-        self._persist_history()
+            if existing_index is None:
+                bucket["versions"].append(version_record)
+            else:
+                bucket["versions"][existing_index] = version_record
+            self._persist_history()
 
     def _ensure_history_baseline(
         self, dictionary_id: int, record: Mapping[str, Any] | None = None
@@ -307,13 +341,14 @@ class LocalChatDictionaryService:
                 (task-15469); it is used only when a baseline is actually
                 missing.
         """
-        bucket = self._history_bucket(dictionary_id)
-        if bucket["versions"]:
-            return
-        if record is None:
-            record = self.get_dictionary(int(dictionary_id))
-        if record is not None:
-            self._record_history(int(dictionary_id), "baseline", record)
+        with self._history_lock:
+            bucket = self._history_bucket(dictionary_id)
+            if bucket["versions"]:
+                return
+            if record is None:
+                record = self.get_dictionary(int(dictionary_id))
+            if record is not None:
+                self._record_history(int(dictionary_id), "baseline", record)
 
     def _normalize_dictionary(
         self, record: dict[str, Any] | None
@@ -726,8 +761,12 @@ class LocalChatDictionaryService:
         self, dictionary_id: int, *, limit: int = 20, offset: int = 0
     ) -> dict[str, Any]:
         self._ensure_history_baseline(int(dictionary_id))
-        bucket = self._history_bucket(int(dictionary_id))
-        activity = list(reversed(bucket["activity"]))
+        with self._history_lock:
+            # Snapshot under the lock: a concurrent `_record_history` appends
+            # to this very list.
+            activity = list(
+                reversed(self._history_bucket(int(dictionary_id))["activity"])
+            )
         page = activity[offset : offset + limit]
         return {
             "dictionary_id": int(dictionary_id),
@@ -757,12 +796,14 @@ class LocalChatDictionaryService:
                 without a second full load (task-15469).
         """
         self._ensure_history_baseline(int(dictionary_id), record)
-        bucket = self._history_bucket(int(dictionary_id))
-        versions = sorted(
-            bucket["versions"],
-            key=lambda item: int(item.get("revision", 0)),
-            reverse=True,
-        )
+        with self._history_lock:
+            # Snapshot under the lock: a concurrent `_record_history` appends
+            # to (or replaces an item in) this very list.
+            versions = sorted(
+                list(self._history_bucket(int(dictionary_id))["versions"]),
+                key=lambda item: int(item.get("revision", 0)),
+                reverse=True,
+            )
         summaries = [
             {key: value for key, value in version.items() if key != "snapshot"}
             for version in versions
@@ -779,10 +820,10 @@ class LocalChatDictionaryService:
 
     def get_version(self, dictionary_id: int, revision: int) -> dict[str, Any]:
         self._ensure_history_baseline(int(dictionary_id))
-        bucket = self._history_bucket(int(dictionary_id))
-        for version in bucket["versions"]:
-            if int(version.get("revision", -1)) == int(revision):
-                return dict(version)
+        with self._history_lock:
+            for version in list(self._history_bucket(int(dictionary_id))["versions"]):
+                if int(version.get("revision", -1)) == int(revision):
+                    return dict(version)
         raise ValueError(
             f"local_chat_dictionary_version_not_found:{dictionary_id}:{revision}"
         )

--- a/tldw_chatbook/Character_Chat/local_chat_dictionary_service.py
+++ b/tldw_chatbook/Character_Chat/local_chat_dictionary_service.py
@@ -121,6 +121,40 @@ def _parse_markdown_entries(content: str) -> list[cdl.ChatDictionary]:
     return entries
 
 
+def statistics_from_record(
+    record: Mapping[str, Any], *, dictionary_id: int | None = None
+) -> dict[str, Any]:
+    """Derive the ``get_statistics`` payload from an already-loaded record.
+
+    Byte-for-byte the payload
+    :meth:`LocalChatDictionaryService.get_statistics` returns, computed
+    without a second full load of the same row. Accepts either a raw
+    ``load_chat_dictionary`` record (entries are ``ChatDictionary`` objects)
+    or a normalized service record (entries are dicts) -- only the entry
+    COUNT and the enabled flag are read, and both shapes agree on those.
+    An explicit ``entry_count`` wins over ``len(entries)`` for the same reason
+    it does in ``_normalize_dictionary``: a list ROW carries the cheap SQL
+    count without materializing entries.
+
+    Args:
+        record: The loaded dictionary record.
+        dictionary_id: The id to report. Defaults to the record's own ``id``.
+
+    Returns:
+        ``{"dictionary_id", "entry_count", "enabled", "source": "local"}``.
+    """
+    resolved_id = int(record["id"] if dictionary_id is None else dictionary_id)
+    entry_count = record.get("entry_count")
+    return {
+        "dictionary_id": resolved_id,
+        "entry_count": int(entry_count)
+        if entry_count is not None
+        else len(record.get("entries") or []),
+        "enabled": bool(record.get("enabled")),
+        "source": "local",
+    }
+
+
 def _entries_payload(entries: list[Any]) -> list[dict[str, Any]]:
     payloads: list[dict[str, Any]] = []
     for entry in entries:
@@ -261,11 +295,23 @@ class LocalChatDictionaryService:
             bucket["versions"][existing_index] = version_record
         self._persist_history()
 
-    def _ensure_history_baseline(self, dictionary_id: int) -> None:
+    def _ensure_history_baseline(
+        self, dictionary_id: int, record: Mapping[str, Any] | None = None
+    ) -> None:
+        """Seed the version history with a baseline snapshot if it has none.
+
+        Args:
+            dictionary_id: The dictionary to seed.
+            record: An already-loaded record for it, when the caller has one.
+                Passing it avoids a redundant full load of the same row
+                (task-15469); it is used only when a baseline is actually
+                missing.
+        """
         bucket = self._history_bucket(dictionary_id)
         if bucket["versions"]:
             return
-        record = self.get_dictionary(int(dictionary_id))
+        if record is None:
+            record = self.get_dictionary(int(dictionary_id))
         if record is not None:
             self._record_history(int(dictionary_id), "baseline", record)
 
@@ -693,9 +739,24 @@ class LocalChatDictionaryService:
         }
 
     def list_versions(
-        self, dictionary_id: int, *, limit: int = 20, offset: int = 0
+        self,
+        dictionary_id: int,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+        record: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
-        self._ensure_history_baseline(int(dictionary_id))
+        """List version summaries, newest first.
+
+        Args:
+            dictionary_id: The dictionary whose history to page.
+            limit: Page size.
+            offset: Page offset.
+            record: An already-loaded record for this dictionary, when the
+                caller has one. Used only to seed a missing history baseline
+                without a second full load (task-15469).
+        """
+        self._ensure_history_baseline(int(dictionary_id), record)
         bucket = self._history_bucket(int(dictionary_id))
         versions = sorted(
             bucket["versions"],
@@ -758,13 +819,15 @@ class LocalChatDictionaryService:
         return record
 
     def get_statistics(self, dictionary_id: int) -> dict[str, Any]:
+        """Load the dictionary and summarize it.
+
+        Callers that already hold the record (the Personas selection path, and
+        every save/revert refresh) should use :func:`statistics_from_record`
+        instead -- it returns this exact payload without a second full load of
+        the same row (task-15469).
+        """
         record = self._load_required_dictionary(int(dictionary_id))
-        return {
-            "dictionary_id": int(dictionary_id),
-            "entry_count": len(record.get("entries") or []),
-            "enabled": bool(record.get("enabled")),
-            "source": "local",
-        }
+        return statistics_from_record(record, dictionary_id=int(dictionary_id))
 
     def _load_conversation_or_raise(self, conversation_id: str) -> dict[str, Any]:
         record = self._require_db().get_conversation_by_id(str(conversation_id))
@@ -865,8 +928,58 @@ class LocalChatDictionaryService:
             "source": "local",
         }
 
+    #: One indexed lookup for "which conversations use this dictionary?".
+    #: Replaces a leading-wildcard ``metadata LIKE '%active_dictionaries%'``
+    #: full scan of ``conversations`` (task-15469). Two branches, one
+    #: statement: rows the trigger-maintained index resolved for this
+    #: dictionary, and rows whose metadata shape the index could not resolve
+    #: (see the V34->V35 migration header) -- the latter carry ``metadata`` so
+    #: the byte-for-byte Python predicate can decide them. ``rowid`` is
+    #: selected so the result keeps the old scan's ordering (``conversations``
+    #: table order); ``metadata`` is NULL on the resolved branch so a big JSON
+    #: blob is never pulled for a row that does not need parsing.
+    #:
+    #: Both joins are CROSS JOINs, which is what makes this an indexed lookup
+    #: rather than a scan wearing a join's clothes: SQLite's planner otherwise
+    #: picks `conversations` as the outer loop of the second branch (measured:
+    #: `SCAN conversation` + a covering-index probe per row -- a full scan of
+    #: the very table this index exists to avoid reading). CROSS JOIN pins the
+    #: derived table as the outer loop; the index tables drive, `conversations`
+    #: is only probed by primary key.
+    _USED_BY_SQL = """
+        SELECT conversation.rowid AS conversation_rowid,
+               conversation.id    AS conversation_id,
+               conversation.title AS title,
+               NULL               AS metadata,
+               0                  AS needs_python_check
+          FROM conversation_dictionary_attachments AS attachment
+          CROSS JOIN conversations AS conversation
+            ON conversation.id = attachment.conversation_id
+         WHERE attachment.dictionary_id = ?
+           AND conversation.deleted = 0
+        UNION ALL
+        SELECT conversation.rowid,
+               conversation.id,
+               conversation.title,
+               conversation.metadata,
+               1
+          FROM conversation_dictionary_unresolved AS unresolved
+          CROSS JOIN conversations AS conversation
+            ON conversation.id = unresolved.conversation_id
+         WHERE conversation.deleted = 0
+         ORDER BY conversation_rowid
+    """
+
     def list_dictionary_conversations(self, dictionary_id: int) -> dict[str, Any]:
         """Reverse used-by: conversations whose active_dictionaries include this id.
+
+        Answered from the trigger-maintained attachment index rather than a
+        full scan of ``conversations``. Rows the index could not resolve
+        (exotic metadata shapes; see the V34->V35 migration) are decided here
+        by the unchanged :meth:`_active_dictionaries` predicate, and that
+        verdict overrides the index for those conversations -- the two can
+        legitimately disagree (a duplicated JSON key resolves last-wins in
+        Python, first-wins in SQLite), and Python is the definition.
 
         Args:
             dictionary_id: The dictionary to find attachments for.
@@ -876,25 +989,36 @@ class LocalChatDictionaryService:
         """
         did = int(dictionary_id)
         conn = self._require_db().get_connection()
-        # LIKE prefilter shrinks the scan; exact int membership below avoids the
-        # id-1-matches-11 substring trap. metadata is a column on conversations.
-        rows = conn.execute(
-            "SELECT id, title, metadata FROM conversations "
-            "WHERE deleted = 0 AND metadata LIKE '%active_dictionaries%'"
-        ).fetchall()
+        rows = conn.execute(self._USED_BY_SQL, (did,)).fetchall()
+        unresolved_ids = {
+            str(row["conversation_id"]) for row in rows if row["needs_python_check"]
+        }
         conversations: list[dict[str, Any]] = []
+        seen: set[str] = set()
         for row in rows:
-            try:
-                is_member = did in self._active_dictionaries(
-                    {"metadata": row["metadata"]}
-                )
-            except Exception:
-                # One pathological row's metadata must never break the whole scan.
+            conversation_id = str(row["conversation_id"])
+            if conversation_id in seen:
                 continue
+            if row["needs_python_check"]:
+                try:
+                    is_member = did in self._active_dictionaries(
+                        {"metadata": row["metadata"]}
+                    )
+                except Exception:
+                    # One pathological row's metadata must never break used-by
+                    # for every other conversation.
+                    continue
+            elif conversation_id in unresolved_ids:
+                # The unresolved branch owns this conversation's verdict; its
+                # row decides it (and is reached by this same loop).
+                continue
+            else:
+                is_member = True
             if is_member:
+                seen.add(conversation_id)
                 conversations.append(
                     {
-                        "conversation_id": str(row["id"]),
+                        "conversation_id": conversation_id,
                         "title": str(row["title"] or ""),
                     }
                 )
@@ -1050,4 +1174,4 @@ class LocalChatDictionaryService:
         return cdl.summarize_active_dictionaries(self._require_db(), conv_id, char_data)
 
 
-__all__ = ["LocalChatDictionaryService"]
+__all__ = ["LocalChatDictionaryService", "statistics_from_record"]

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -163,7 +163,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
 
-    _CURRENT_SCHEMA_VERSION = 34  # Deterministic visual-compaction representation policy (TASK-14914).
+    _CURRENT_SCHEMA_VERSION = 35  # Conversation<->dictionary attachment index (TASK-15469).
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
     _DEFAULT_CONVERSATION_STATE = "in-progress"
@@ -4832,6 +4832,54 @@ UPDATE db_schema_version
                 f"Migration from V33 to V34 failed for '{self._SCHEMA_NAME}': {exc}"
             ) from exc
 
+    def _migrate_from_v34_to_v35(self, conn: sqlite3.Connection) -> None:
+        """Add the derived conversation<->dictionary attachment index.
+
+        Replaces the ``metadata LIKE '%active_dictionaries%'`` full scan behind
+        "which conversations use this dictionary?" with two trigger-maintained
+        tables plus a backfill (TASK-15469). Local-only derived state: no sync
+        columns and no sync_log triggers -- see the migration file's header for
+        the full rationale, including why the index resolves only unambiguous
+        JSON integers and defers every other shape to the Python predicate.
+        """
+        if self._get_db_version(conn) != 34:
+            raise SchemaError(
+                f"[{self._SCHEMA_NAME} V34→V35] Migration requires schema version 34"
+            )
+        migration_path = (
+            Path(__file__).parent
+            / "migrations"
+            / "chachanotes_v34_to_v35_conversation_dictionary_attachments.sql"
+        )
+        try:
+            with self.transaction() as cursor:
+                pending = ""
+                for line in migration_path.read_text(encoding="utf-8").splitlines(
+                    keepends=True
+                ):
+                    pending += line
+                    if sqlite3.complete_statement(pending):
+                        cursor.execute(pending)
+                        pending = ""
+                if pending.strip():
+                    raise SchemaError(
+                        "Conversation dictionary attachment migration contains "
+                        "incomplete SQL"
+                    )
+                row = cursor.execute(
+                    "SELECT version FROM db_schema_version WHERE schema_name = ?",
+                    (self._SCHEMA_NAME,),
+                ).fetchone()
+                if row is None or row["version"] != 35:
+                    raise SchemaError(
+                        "Conversation dictionary attachment schema version "
+                        "verification failed"
+                    )
+        except (OSError, sqlite3.Error, CharactersRAGDBError, SchemaError) as exc:
+            raise SchemaError(
+                f"Migration from V34 to V35 failed for '{self._SCHEMA_NAME}': {exc}"
+            ) from exc
+
     def _migrate_from_v18_to_v19(self, conn: sqlite3.Connection):
         """
         Migrates the database schema from version 18 to version 19.
@@ -4996,6 +5044,7 @@ UPDATE db_schema_version
                     31: self._migrate_from_v31_to_v32,
                     32: self._migrate_from_v32_to_v33,
                     33: self._migrate_from_v33_to_v34,
+                    34: self._migrate_from_v34_to_v35,
                 }
 
                 if current_db_version == 0:

--- a/tldw_chatbook/DB/migrations/chachanotes_v34_to_v35_conversation_dictionary_attachments.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v34_to_v35_conversation_dictionary_attachments.sql
@@ -1,0 +1,204 @@
+-- Migration: ChaChaNotes V34 to V35 conversation<->dictionary attachment index
+-- (task-15469).
+--
+-- WHY. "Which conversations use this dictionary?" was answered by
+-- `SELECT id, title, metadata FROM conversations
+--    WHERE deleted = 0 AND metadata LIKE '%active_dictionaries%'`
+-- -- a leading-wildcard LIKE, i.e. a full scan of `conversations` plus a JSON
+-- parse of every match, on the event loop, on every dictionary row click in
+-- Personas (and once per dictionary in `list_dictionaries(include_usage=True)`).
+-- These two tables are a derived INDEX over `conversations.metadata` that turns
+-- that scan into an indexed lookup.
+--
+-- WHY TRIGGERS, not maintenance at attach/detach time. The
+-- `metadata.active_dictionaries` KEY is only written by
+-- `LocalChatDictionaryService._write_active_dictionaries`, but the metadata
+-- BLOB is read-modify-written wholesale by several unrelated paths
+-- (`Chat/chat_persistence_service.py`, `Chat/rag_scope.py`, any
+-- `CharactersRAGDB.update_conversation` caller, sync apply, tests). An index
+-- maintained only at attach/detach time would silently rot the first time one
+-- of those wrote a metadata blob carrying a different `active_dictionaries`
+-- value. Triggers see every writer, including raw SQL, so the index cannot
+-- disagree with the column it indexes.
+--
+-- WHY TWO TABLES. SQLite cannot reproduce Python's `int()` coercion for every
+-- JSON element shape: `"1_0"` -> 10 (PEP 515), `"٣"` -> 3, `1e300` -> an
+-- exact 300-digit int, a `NaN` literal parses in Python but is invalid JSON to
+-- SQLite, and a duplicated JSON key resolves last-wins in Python but first-wins
+-- in `json_each`. So `conversation_dictionary_attachments` indexes ONLY
+-- unambiguous JSON integers (`json_each.type = 'integer'` AND the value's SQLite
+-- storage class is also `integer`, which excludes an int too large for int64).
+-- Every other element shape that could still coerce to an int in Python
+-- (`real`/`text`/`true`/`false`), a metadata blob holding the marker substring
+-- more than once (possible duplicate key), and metadata SQLite cannot parse at
+-- all, mark the conversation in `conversation_dictionary_unresolved`; the
+-- service re-checks exactly those rows in Python with its unchanged
+-- `_active_dictionaries()` predicate, and the unresolved verdict always wins
+-- over the index. Element types that can NEVER coerce in Python (`null`,
+-- `object`, `array`) are skipped, matching Python. In a database written only
+-- by this application the unresolved table stays empty.
+--
+-- The `metadata LIKE '%active_dictionaries%'` prefilter is carried over from
+-- the scan VERBATIM, on purpose: the index must reproduce the old query's
+-- results exactly, including its blind spots (a `"active_dictionaries"`
+-- escaped key is invisible to that LIKE, so it must stay invisible here too).
+--
+-- EVERY `json_*` call below reads
+-- `CASE WHEN json_valid(x) THEN x ELSE '{}' END`, never the raw column:
+-- `json_each`/`json_type` RAISE "malformed JSON" on invalid input, and a
+-- raising trigger would fail the conversation write itself. SQLite does not
+-- guarantee that a `json_valid(...)` term in the same WHERE clause is
+-- evaluated first, so the guard is structural rather than positional.
+--
+-- WHY NOT the pre-existing `conversation_dictionaries` junction table (V4
+-- schema, `ChaChaNotes_DB._FULL_SCHEMA_SQL_V4`): it is dead -- no Python code
+-- reads or writes it -- and unusable here. Its `conversation_id` is INTEGER
+-- while `conversations.id` is a TEXT UUID, and its `dictionary_id` carries a
+-- real FK to `chat_dictionaries(id)`, so a metadata blob naming a since-deleted
+-- (or never-existent) dictionary id would fail the FK and take the whole
+-- conversation write down with it. A derived index must accept whatever the
+-- column it indexes actually contains.
+--
+-- Deliberately NO sync columns (`client_id`/`version`/`deleted`) and no
+-- sync_log triggers: this is derived local state, rebuildable at any time from
+-- `conversations.metadata`, which IS synced. Syncing the derivation as well
+-- would be redundant and could contradict the column it derives from. Soft
+-- deletion is not tracked here either -- readers join `conversations` and
+-- filter `deleted = 0`, exactly as the scan did.
+
+CREATE TABLE IF NOT EXISTS conversation_dictionary_attachments(
+  conversation_id TEXT    NOT NULL REFERENCES conversations(id)
+                            ON DELETE CASCADE ON UPDATE CASCADE,
+  dictionary_id   INTEGER NOT NULL,
+  PRIMARY KEY (conversation_id, dictionary_id)
+);
+CREATE INDEX IF NOT EXISTS idx_conversation_dictionary_attachments_dictionary
+  ON conversation_dictionary_attachments(dictionary_id);
+
+CREATE TABLE IF NOT EXISTS conversation_dictionary_unresolved(
+  conversation_id TEXT PRIMARY KEY REFERENCES conversations(id)
+                        ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+DROP TRIGGER IF EXISTS conversation_dictionary_index_ai;
+DROP TRIGGER IF EXISTS conversation_dictionary_index_au;
+DROP TRIGGER IF EXISTS conversation_dictionary_index_ad;
+
+CREATE TRIGGER conversation_dictionary_index_ai
+AFTER INSERT ON conversations
+WHEN NEW.metadata LIKE '%active_dictionaries%'
+BEGIN
+  INSERT OR IGNORE INTO conversation_dictionary_attachments(conversation_id, dictionary_id)
+  SELECT NEW.id, CAST(element.value AS INTEGER)
+    FROM json_each(
+           CASE WHEN json_valid(NEW.metadata) THEN NEW.metadata ELSE '{}' END,
+           '$.active_dictionaries'
+         ) AS element
+   WHERE json_type(CASE WHEN json_valid(NEW.metadata) THEN NEW.metadata ELSE '{}' END) = 'object'
+     AND json_type(CASE WHEN json_valid(NEW.metadata) THEN NEW.metadata ELSE '{}' END,
+                   '$.active_dictionaries') = 'array'
+     AND element.type = 'integer'
+     AND typeof(element.value) = 'integer';
+
+  INSERT OR IGNORE INTO conversation_dictionary_unresolved(conversation_id)
+  SELECT NEW.id
+   WHERE json_valid(NEW.metadata) = 0
+      OR (length(NEW.metadata) - length(replace(NEW.metadata, 'active_dictionaries', ''))) / 19 <> 1
+      OR EXISTS (
+           SELECT 1
+             FROM json_each(
+                    CASE WHEN json_valid(NEW.metadata) THEN NEW.metadata ELSE '{}' END,
+                    '$.active_dictionaries'
+                  ) AS element
+            WHERE json_type(CASE WHEN json_valid(NEW.metadata) THEN NEW.metadata ELSE '{}' END,
+                            '$.active_dictionaries') = 'array'
+              AND element.type NOT IN ('null', 'object', 'array')
+              AND NOT (element.type = 'integer' AND typeof(element.value) = 'integer')
+         );
+END;
+
+CREATE TRIGGER conversation_dictionary_index_au
+AFTER UPDATE ON conversations
+WHEN NEW.metadata IS NOT OLD.metadata OR NEW.id <> OLD.id
+BEGIN
+  DELETE FROM conversation_dictionary_attachments WHERE conversation_id = OLD.id;
+  DELETE FROM conversation_dictionary_unresolved  WHERE conversation_id = OLD.id;
+
+  INSERT OR IGNORE INTO conversation_dictionary_attachments(conversation_id, dictionary_id)
+  SELECT NEW.id, CAST(element.value AS INTEGER)
+    FROM json_each(
+           CASE WHEN json_valid(NEW.metadata) THEN NEW.metadata ELSE '{}' END,
+           '$.active_dictionaries'
+         ) AS element
+   WHERE NEW.metadata LIKE '%active_dictionaries%'
+     AND json_type(CASE WHEN json_valid(NEW.metadata) THEN NEW.metadata ELSE '{}' END) = 'object'
+     AND json_type(CASE WHEN json_valid(NEW.metadata) THEN NEW.metadata ELSE '{}' END,
+                   '$.active_dictionaries') = 'array'
+     AND element.type = 'integer'
+     AND typeof(element.value) = 'integer';
+
+  INSERT OR IGNORE INTO conversation_dictionary_unresolved(conversation_id)
+  SELECT NEW.id
+   WHERE NEW.metadata LIKE '%active_dictionaries%'
+     AND (json_valid(NEW.metadata) = 0
+      OR (length(NEW.metadata) - length(replace(NEW.metadata, 'active_dictionaries', ''))) / 19 <> 1
+      OR EXISTS (
+           SELECT 1
+             FROM json_each(
+                    CASE WHEN json_valid(NEW.metadata) THEN NEW.metadata ELSE '{}' END,
+                    '$.active_dictionaries'
+                  ) AS element
+            WHERE json_type(CASE WHEN json_valid(NEW.metadata) THEN NEW.metadata ELSE '{}' END,
+                            '$.active_dictionaries') = 'array'
+              AND element.type NOT IN ('null', 'object', 'array')
+              AND NOT (element.type = 'integer' AND typeof(element.value) = 'integer')
+         ));
+END;
+
+/* The FKs above declare ON DELETE CASCADE and this pool always runs with
+   `PRAGMA foreign_keys = ON` (see `_get_thread_connection`), so this trigger is
+   belt-and-braces for any connection that ever runs without it -- deleting
+   already-cascaded rows is a no-op. */
+CREATE TRIGGER conversation_dictionary_index_ad
+AFTER DELETE ON conversations BEGIN
+  DELETE FROM conversation_dictionary_attachments WHERE conversation_id = OLD.id;
+  DELETE FROM conversation_dictionary_unresolved  WHERE conversation_id = OLD.id;
+END;
+
+/* Backfill: the same predicates, applied to every pre-existing row. */
+INSERT OR IGNORE INTO conversation_dictionary_attachments(conversation_id, dictionary_id)
+SELECT conversation.id, CAST(element.value AS INTEGER)
+  FROM conversations AS conversation
+  JOIN json_each(
+         CASE WHEN json_valid(conversation.metadata) THEN conversation.metadata ELSE '{}' END,
+         '$.active_dictionaries'
+       ) AS element
+ WHERE conversation.metadata LIKE '%active_dictionaries%'
+   AND json_type(CASE WHEN json_valid(conversation.metadata) THEN conversation.metadata ELSE '{}' END) = 'object'
+   AND json_type(CASE WHEN json_valid(conversation.metadata) THEN conversation.metadata ELSE '{}' END,
+                 '$.active_dictionaries') = 'array'
+   AND element.type = 'integer'
+   AND typeof(element.value) = 'integer';
+
+INSERT OR IGNORE INTO conversation_dictionary_unresolved(conversation_id)
+SELECT conversation.id
+  FROM conversations AS conversation
+ WHERE conversation.metadata LIKE '%active_dictionaries%'
+   AND (json_valid(conversation.metadata) = 0
+    OR (length(conversation.metadata) - length(replace(conversation.metadata, 'active_dictionaries', ''))) / 19 <> 1
+    OR EXISTS (
+         SELECT 1
+           FROM json_each(
+                  CASE WHEN json_valid(conversation.metadata) THEN conversation.metadata ELSE '{}' END,
+                  '$.active_dictionaries'
+                ) AS element
+          WHERE json_type(CASE WHEN json_valid(conversation.metadata) THEN conversation.metadata ELSE '{}' END,
+                          '$.active_dictionaries') = 'array'
+            AND element.type NOT IN ('null', 'object', 'array')
+            AND NOT (element.type = 'integer' AND typeof(element.value) = 'integer')
+       ));
+
+UPDATE db_schema_version
+   SET version = 35
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version = 34;

--- a/tldw_chatbook/DB/migrations/chachanotes_v34_to_v35_conversation_dictionary_attachments.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v34_to_v35_conversation_dictionary_attachments.sql
@@ -117,12 +117,22 @@ BEGIN
          );
 END;
 
+/* The DELETEs clear BOTH ids, not just OLD.id, because the FK's ON UPDATE
+   CASCADE has already run by the time an AFTER UPDATE trigger fires: a
+   conversation id change renames these rows to NEW.id first, so a
+   `WHERE conversation_id = OLD.id` delete matches nothing and the row's OLD
+   dictionary ids survive under the NEW id (reproduced: an UPDATE changing id
+   AND metadata from [1,2] to [3] left 1, 2 AND 3 indexed). Clearing both ids
+   is also what keeps this correct on a connection running WITHOUT
+   `PRAGMA foreign_keys = ON`, where no cascade renames anything. */
 CREATE TRIGGER conversation_dictionary_index_au
 AFTER UPDATE ON conversations
 WHEN NEW.metadata IS NOT OLD.metadata OR NEW.id <> OLD.id
 BEGIN
-  DELETE FROM conversation_dictionary_attachments WHERE conversation_id = OLD.id;
-  DELETE FROM conversation_dictionary_unresolved  WHERE conversation_id = OLD.id;
+  DELETE FROM conversation_dictionary_attachments
+   WHERE conversation_id IN (OLD.id, NEW.id);
+  DELETE FROM conversation_dictionary_unresolved
+   WHERE conversation_id IN (OLD.id, NEW.id);
 
   INSERT OR IGNORE INTO conversation_dictionary_attachments(conversation_id, dictionary_id)
   SELECT NEW.id, CAST(element.value AS INTEGER)

--- a/tldw_chatbook/DB/sql_validation.py
+++ b/tldw_chatbook/DB/sql_validation.py
@@ -41,6 +41,8 @@ VALID_TABLES = {
         "chat_dictionaries",
         "collection_keywords",
         "conversation_dictionaries",
+        "conversation_dictionary_attachments",
+        "conversation_dictionary_unresolved",
         "conversation_keywords",
         "conversation_local_marks",
         "conversation_world_books",

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -36,6 +36,7 @@ from ...Character_Chat.expression_generation import (
     EXPRESSION_PROMPT_STATES,
     compose_expression_prompt,
 )
+from ...Character_Chat.local_chat_dictionary_service import statistics_from_record
 from ...Character_Chat.persona_list_paging import page_persona_profiles
 from ...Character_Chat.world_book_import import normalize_world_book_import
 from ...Character_Chat.world_book_manager import CHARACTER_WORLD_BOOKS_KEY
@@ -3711,14 +3712,10 @@ class PersonasScreen(BaseAppScreen):
         )
         detail = self.query_one(PersonasDictionaryDetailWidget)
         detail.load_dictionary(record)
-        stats = None
-        try:
-            stats = await service.get_statistics(int(entity_id), mode="local")
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Could not load dictionary {entity_id} statistics."
-            )
-        detail.load_statistics(stats, list(record.get("entries") or []))
+        detail.load_statistics(
+            self._dictionary_statistics(record, entity_id),
+            list(record.get("entries") or []),
+        )
         self._show_center("#personas-dictionary-detail")
         library = self.query_one(PersonasLibraryPane)
         library.mark_active_row("dictionary", entity_id)
@@ -3733,8 +3730,26 @@ class PersonasScreen(BaseAppScreen):
         self._sync_inspector_console_actions()
         self._update_title()
         self._update_purpose_line()
-        await self._refresh_dictionary_versions()
+        await self._refresh_dictionary_versions(record=record)
         await self._refresh_dictionary_attachments()
+
+    @staticmethod
+    def _dictionary_statistics(record: dict, entity_id: str | int) -> dict | None:
+        """The Stats-tab payload, derived from the record already in hand.
+
+        Selecting a dictionary used to load the same row TWICE -- once for the
+        detail and once inside ``get_statistics`` -- so the second load is
+        derived here instead (task-15469). Never raises: a malformed record
+        degrades to ``None``, which the widget renders as "service stats
+        unavailable", exactly as a failed ``get_statistics`` call did.
+        """
+        try:
+            return statistics_from_record(record, dictionary_id=int(entity_id))
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"Could not derive dictionary {entity_id} statistics."
+            )
+            return None
 
     @staticmethod
     def _load_lore_book_and_entries(
@@ -3834,15 +3849,9 @@ class PersonasScreen(BaseAppScreen):
         service = self._dictionary_scope_service()
         if service is None or not entity_id:
             return
-        stats = None
-        try:
-            stats = await service.get_statistics(int(entity_id), mode="local")
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Could not refresh dictionary statistics."
-            )
         self.query_one(PersonasDictionaryDetailWidget).load_statistics(
-            stats, list(record.get("entries") or [])
+            self._dictionary_statistics(record, entity_id),
+            list(record.get("entries") or []),
         )
 
     @on(DictionarySettingsEdited)
@@ -4042,21 +4051,23 @@ class PersonasScreen(BaseAppScreen):
             int(raw_version) if raw_version is not None else None
         )
         detail.update_entries(list(record.get("entries") or []))
-        stats = None
-        try:
-            stats = await service.get_statistics(int(entity_id), mode="local")
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Could not load dictionary {entity_id} statistics."
-            )
-        detail.load_statistics(stats, list(record.get("entries") or []))
+        detail.load_statistics(
+            self._dictionary_statistics(record, entity_id),
+            list(record.get("entries") or []),
+        )
         await self._render_dictionary_rows(query=self.state.search_query)
         self.query_one(PersonasLibraryPane).mark_active_row("dictionary", entity_id)
-        await self._refresh_dictionary_versions()
+        await self._refresh_dictionary_versions(record=record)
         return True
 
-    async def _refresh_dictionary_versions(self) -> None:
-        """Feed the Versions tab for the selected dictionary (best-effort)."""
+    async def _refresh_dictionary_versions(self, *, record: dict | None = None) -> None:
+        """Feed the Versions tab for the selected dictionary (best-effort).
+
+        Args:
+            record: The record the caller just loaded, when it has one. It
+                seeds a missing history baseline so the service does not load
+                the same row again (task-15469).
+        """
         entity_id = self.state.selected_entity_id
         service = self._dictionary_scope_service()
         if (
@@ -4066,8 +4077,11 @@ class PersonasScreen(BaseAppScreen):
         ):
             return
         detail = self.query_one(PersonasDictionaryDetailWidget)
+        kwargs = {} if record is None else {"record": record}
         try:
-            response = await service.list_versions(int(entity_id), mode="local")
+            response = await service.list_versions(
+                int(entity_id), mode="local", **kwargs
+            )
         except Exception:
             logger.opt(exception=True).warning(
                 f"Could not list dictionary {entity_id} versions."


### PR DESCRIPTION
## Summary

Task 15469 from the input-latency audit. Clicking one dictionary row ran 4+ sync queries on the event loop including a leading-wildcard `LIKE '%active_dictionaries%'` full scan of the conversations table with JSON parsing of matches; the record loaded twice per click; `include_usage` listing was N+1.

- **ChaChaNotes V35**: attachment index table + triggers, with backfill parity proven against the old scan as oracle (implementer's 31-shape corpus + reviewer's 20 additional adversarial shapes — byte-identical including order); the reviewer REHEARSED THE MIGRATION ON A SNAPSHOT OF THE REAL USER DB (V32→35 clean in 18 ms, integrity ok) and established the standing V33→V34 baseline failure is fixture-shaped, not a user-data hazard
- Click DB work 7.80 → 0.54 ms at 10k conversations (reviewer reproduced 3.1 → 0.007 ms on its own corpus); ≤2 queries per selection, single record load, plan pinned by an alias-proof EXPLAIN assertion (mutation-protected — the original assertion could never fail because SQLite prints the alias; caught by a ~zero-expected timing arm, lesson banked)
- Local backend threaded (positive-confirmation shape) incl. entry add/update/delete/reorder; history store now RLock-guarded (new thread reachability; no-deadlock argument verified by call-chain read)
- AU trigger id-change edge fixed (`IN (OLD.id, NEW.id)` — CASCADE runs before AFTER-trigger; both PRAGMA arms mutation-tested)

## Verification
Independent opus review (Approved; migration rehearsed on real-DB snapshot; version-gate chain proven non-cascading) + scoped re-review (3/3 ADDRESSED; trigger mutation re-verified; lock sweep clean; 28+88 counts reproduced). Documented residuals: escaped+plain-key hairline (unreachable from any writer), unresolved-branch full-reparse (zero rows in app-written DBs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Personas “used by” scan with a trigger‑backed attachment index and moved local backend calls off the event loop. Selection work drops from ~7.8 ms to ~0.54 ms at 10k conversations with ≤2 queries. Addresses TASK-15469.

- **New Features**
  - Trigger‑maintained index: `conversation_dictionary_attachments` + `conversation_dictionary_unresolved`. One UNION ALL query with CROSS JOINs; unresolved rows are decided in Python. Matches the old scan exactly.
  - Local backend runs on worker threads via `asyncio.to_thread` when the DB is file‑backed; keeps the UI responsive.
  - One load per selection: stats derived from the loaded record (`statistics_from_record`); `list_versions(record=...)` seeds history without reloading.
  - History sidecar writes protected by an RLock to prevent races.
  - Plan/assertions ensure only PK probes (no conversation scans). Measured: used‑by 7.74→0.48 ms; used‑by with 0 hits 7.69→0.00 ms; selection DB work 7.80→0.54 ms (10k).

- **Migration**
  - ChaChaNotes V34→V35 adds the index tables and insert/update/delete triggers with backfill; id‑change cleanup deletes by `IN (OLD.id, NEW.id)` to avoid stale rows (FK ON/OFF). No manual steps.

<sup>Written for commit 01a0d217cde812228d788f2510d34c60aceb9db3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

