### PR TITLE
feat(notes): compare File Notes conflict sides [TASK-15532]

### DIFF
--- a/Docs/User_Guide/library/file-notes.md
+++ b/Docs/User_Guide/library/file-notes.md
@@ -78,13 +78,22 @@ to go, then press the relevant button.
 | **Restore** | Brings back the most recently deleted file |
 | **Protect** / **Unprotect** | Toggles protection on the open file ("Protected." / "Unprotected."); every save to a protected file first stores a checkpoint of its previous contents in the local recovery database |
 | **Reload** / **Discard draft and reload** | Re-reads the open file from disk. In Conflict or Error, the destructive label is shown and the first activation opens a confirmation with **Cancel** focused; only **Discard draft and load disk** replaces the editor contents |
+| **Compare** | Appears only for a Conflict and opens a read-only Base / Draft / Disk comparison without resolving the conflict or changing the editor |
 | **Save draft as copy** | Writes the complete editor draft to the typed path; only enabled while the save status is Dirty, Conflict, or Error |
 | **Export exact copy** | Replaces **Save draft as copy** for a large read-only file and streams the complete current disk bytes, not the visible excerpt, to an absent typed path |
 | **Refresh** | Re-scans the folder and rebuilds the **Files** tree |
 
 Saving is automatic: edit and the status walks Dirty → Saving → Saved. If the
 file changes on disk underneath you, the status shows Conflict and keeps the
-draft in the editor. **Discard draft and reload** first reads the current disk
+draft in the editor. **Compare** identifies Base (the body loaded into the
+editor or last saved), Draft (the current editor body), and Disk (the latest
+readable file body). It shows bounded Base-to-Draft and Base-to-Disk unified
+comparisons; oversized sides keep their exact sizes and SHA-256 identities and
+report that diff output was omitted or elided. A deleted or unreadable Disk side
+is named explicitly. Closing Compare returns to the conflict without resolving
+it or changing any side.
+
+**Discard draft and reload** first reads the current disk
 version and asks for confirmation. **Cancel** or **Escape** preserves the exact
 draft and conflict; confirming rechecks the root, file, editing session, and
 disk version before it replaces the draft. If any of those changed, reload

--- a/Tests/Notes/test_file_notes_conflict_compare.py
+++ b/Tests/Notes/test_file_notes_conflict_compare.py
@@ -1,0 +1,65 @@
+"""Pure tests for bounded File Notes conflict comparisons."""
+
+from __future__ import annotations
+
+from tldw_chatbook.Notes.file_notes_conflict_compare import (
+    CONFLICT_DIFF_MAX_OUTPUT_CHARS,
+    ConflictSide,
+    build_conflict_comparison,
+)
+
+
+def test_comparison_labels_base_draft_and_disk_changes() -> None:
+    comparison = build_conflict_comparison(
+        ConflictSide.from_text("Base", "one\ntwo\n"),
+        ConflictSide.from_text("Draft", "one\ndraft\n"),
+        ConflictSide.from_text("Disk", "one\ndisk\n"),
+    )
+
+    assert comparison.output_elided is False
+    assert "Base → Draft" in comparison.diff_text
+    assert "--- Base" in comparison.diff_text
+    assert "+++ Draft" in comparison.diff_text
+    assert "-two" in comparison.diff_text
+    assert "+draft" in comparison.diff_text
+    assert "Base → Disk" in comparison.diff_text
+    assert "+disk" in comparison.diff_text
+    assert [side.label for side in comparison.sides] == ["Base", "Draft", "Disk"]
+    assert all(len(side.sha256) == 64 for side in comparison.sides)
+
+
+def test_comparison_reports_missing_disk_without_inventing_content() -> None:
+    comparison = build_conflict_comparison(
+        ConflictSide.from_text("Base", "base"),
+        ConflictSide.from_text("Draft", "draft"),
+        ConflictSide.absent("Disk"),
+    )
+
+    assert comparison.sides[2].state == "absent"
+    assert comparison.sides[2].summary == "Disk · absent"
+    assert "Base → Disk" in comparison.diff_text
+    assert "Disk is absent; no textual diff is available." in comparison.diff_text
+
+
+def test_comparison_bounds_oversized_input_and_output() -> None:
+    oversized = "line\n" * 10_001
+    input_elided = build_conflict_comparison(
+        ConflictSide.from_text("Base", oversized),
+        ConflictSide.from_text("Draft", oversized + "draft\n"),
+        ConflictSide.from_text("Disk", oversized + "disk\n"),
+    )
+    assert input_elided.output_elided is True
+    assert "Diff omitted because one or more sides exceed" in input_elided.diff_text
+    assert "SHA-256" in input_elided.summary_text
+
+    base = "".join(f"before-{index}\n" for index in range(7_000))
+    draft = "".join(f"draft-{index}\n" for index in range(7_000))
+    disk = "".join(f"disk-{index}\n" for index in range(7_000))
+    output_elided = build_conflict_comparison(
+        ConflictSide.from_text("Base", base),
+        ConflictSide.from_text("Draft", draft),
+        ConflictSide.from_text("Disk", disk),
+    )
+    assert output_elided.output_elided is True
+    assert len(output_elided.diff_text) <= CONFLICT_DIFF_MAX_OUTPUT_CHARS
+    assert "comparison output elided" in output_elided.diff_text

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -44,6 +44,7 @@ from tldw_chatbook.Notes.file_notes_service import (  # noqa: E402
 )
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen  # noqa: E402
 from tldw_chatbook.Widgets.Library.library_file_notes_workspace import (  # noqa: E402
+    FileNotesConflictCompareDialog,
     LibraryFileNotesWorkspace,
 )
 from tldw_chatbook.Widgets.Library.library_file_notes_git_panel import (  # noqa: E402
@@ -2442,6 +2443,214 @@ async def test_conflict_reload_save_copy_and_leave_guards_preserve_draft(
         )
         assert workspace.save_state == "error"
         assert editor.text == "surviving error draft"
+    replica.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.allow_network
+@pytest.mark.parametrize("size", [(40, 20), (120, 40)])
+async def test_conflict_compare_preserves_draft_and_returns_focus(
+    tmp_path: Path,
+    size: tuple[int, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compare labels all sides without resolving or mutating the conflict."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    source = root / "source.md"
+    source.write_text("base line\nshared\n", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+    ui_thread = threading.get_ident()
+    comparison_threads: list[int] = []
+    original_builder = workspace_module.build_conflict_comparison
+
+    def observed_builder(*args):
+        comparison_threads.append(threading.get_ident())
+        return original_builder(*args)
+
+    monkeypatch.setattr(
+        workspace_module,
+        "build_conflict_comparison",
+        observed_builder,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=size) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("source.md")
+        compare = workspace.query_one("#file-notes-compare", Button)
+        assert not compare.display
+
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(editor, "draft line\nshared\n")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "draft did not become dirty",
+        )
+        source.write_text("disk line\nshared\n", encoding="utf-8")
+        await workspace.refresh_files()
+        assert workspace.save_state == "conflict"
+        assert compare.display and not compare.disabled
+
+        compare.focus()
+        compare.press()
+        await _wait_until(
+            pilot,
+            lambda: isinstance(pilot.app.screen, FileNotesConflictCompareDialog),
+            "conflict comparison did not open",
+        )
+        dialog = pilot.app.screen
+        assert isinstance(dialog, FileNotesConflictCompareDialog)
+        assert comparison_threads
+        assert all(thread_id != ui_thread for thread_id in comparison_threads)
+        assert dialog.query_one("#file-notes-conflict-dialog").region.right <= size[0]
+        assert dialog.query_one("#file-notes-conflict-dialog").region.bottom <= size[1]
+        summary = dialog.query_one("#file-notes-conflict-summary", TextArea).text
+        diff = dialog.query_one("#file-notes-conflict-diff", TextArea).text
+        assert "Base · editor baseline" in summary
+        assert "Draft · current editor" in summary
+        assert "Disk · latest readable snapshot" in summary
+        assert "Base → Draft" in diff
+        assert "+draft line" in diff
+        assert "Base → Disk" in diff
+        assert "+disk line" in diff
+        assert workspace.save_state == "conflict"
+        assert editor.text == "draft line\nshared\n"
+        assert source.read_text(encoding="utf-8") == "disk line\nshared\n"
+
+        await pilot.press("escape")
+        await _wait_until(
+            pilot,
+            lambda: pilot.app.screen is pilot.app.screen_stack[0],
+            "conflict comparison did not close",
+        )
+        await _wait_until(
+            pilot,
+            lambda: compare.has_focus,
+            "focus did not return to Compare",
+        )
+        assert workspace.save_state == "conflict"
+        assert editor.text == "draft line\nshared\n"
+
+    replica.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.allow_network
+async def test_conflict_compare_represents_deleted_disk(
+    tmp_path: Path,
+) -> None:
+    """A deleted disk side remains explicit while the editor draft stays live."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    source = root / "source.md"
+    source.write_text("base", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(80, 24)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("source.md")
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(editor, "retained draft")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "draft did not become dirty",
+        )
+        source.unlink()
+        await workspace.refresh_files()
+        assert workspace.save_state == "conflict"
+
+        workspace.query_one("#file-notes-compare", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: isinstance(pilot.app.screen, FileNotesConflictCompareDialog),
+            "deleted-side comparison did not open",
+        )
+        dialog = pilot.app.screen
+        assert isinstance(dialog, FileNotesConflictCompareDialog)
+        summary = dialog.query_one("#file-notes-conflict-summary", TextArea).text
+        diff = dialog.query_one("#file-notes-conflict-diff", TextArea).text
+        assert "Disk · absent" in summary
+        assert "Disk is absent; no textual diff is available." in diff
+        assert editor.text == "retained draft"
+        assert workspace.save_state == "conflict"
+
+    replica.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.allow_network
+async def test_conflict_compare_rejects_a_late_editor_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disk read finishing for a stale editor cannot publish comparison."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    source = root / "source.md"
+    source.write_text("base", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(80, 24)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("source.md")
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(editor, "retained draft")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "draft did not become dirty",
+        )
+        source.write_text("disk", encoding="utf-8")
+        await workspace.refresh_files()
+        assert workspace.save_state == "conflict"
+        service = workspace._service
+        assert service is not None
+        original_open = service.open_file
+        read_started = threading.Event()
+        release_read = threading.Event()
+
+        def delayed_open(relative_path: str):
+            read_started.set()
+            assert release_read.wait(2)
+            return original_open(relative_path)
+
+        monkeypatch.setattr(service, "open_file", delayed_open)
+        compare = workspace.query_one("#file-notes-compare", Button)
+        comparison_task = asyncio.create_task(
+            workspace._compare_conflict(Button.Pressed(compare))
+        )
+        assert await asyncio.to_thread(read_started.wait, 2)
+        workspace._session_key = "replacement-session"
+        release_read.set()
+        await comparison_task
+
+        assert not isinstance(pilot.app.screen, FileNotesConflictCompareDialog)
+        assert workspace.save_state == "conflict"
+        assert editor.text == "retained draft"
+        status = _static_text(workspace, "#file-notes-action-status")
+        assert "editing session changed" in status
+        assert "Draft preserved" in status
+
     replica.close()
 
 

--- a/backlog/tasks/task-15532 - Add-bounded-Base-Draft-and-Disk-conflict-comparison.md
+++ b/backlog/tasks/task-15532 - Add-bounded-Base-Draft-and-Disk-conflict-comparison.md
@@ -1,0 +1,66 @@
+---
+id: TASK-15532
+title: Add bounded Base Draft and Disk conflict comparison
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-12 01:31'
+updated_date: '2026-08-12 01:48'
+labels:
+  - notes
+  - library
+  - ux
+  - recovery
+dependencies: []
+references:
+  - .impeccable/critique/2026-08-11T20-58-28Z__ok-widgets-library-library-file-notes-workspace-py.md
+documentation:
+  - backlog/decisions/029-file-notes-disk-authority.md
+  - Docs/User_Guide/library/file-notes.md
+priority: high
+type: enhancement
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let File Notes users inspect the exact editor baseline, retained draft, and latest readable disk version before choosing a recovery action, without resolving or discarding the conflict.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Conflict state exposes Compare while routine states do not
+- [x] #2 Compare captures the current Base Draft and Disk identities without changing the editor or resolving the conflict
+- [x] #3 The comparison computes bounded diff output off the UI thread and labels Base to Draft and Base to Disk changes
+- [x] #4 Missing or unreadable disk state is represented explicitly and oversized comparison output reports elision with exact side hashes and sizes
+- [x] #5 Escape and Close return focus to Compare while preserving the draft conflict and existing destructive reload confirmation
+- [x] #6 Focused mounted tests static checks and documentation pass without changing disk authority save or recovery protocols
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A; conform to `backlog/decisions/029-file-notes-disk-authority.md`.
+Reason: this adds bounded, read-only decision support around the existing hash-checked conflict state. It does not change disk authority, mutation publication, recovery ownership, or resolution policy.
+
+1. Capture an immutable Base, Draft, and latest Disk snapshot under the current root, file, and editor-session identities.
+2. Build bounded Base-to-Draft and Base-to-Disk unified comparisons off the UI thread, with explicit absent/unreadable and elided-content metadata.
+3. Add a keyboard-readable comparison modal and conflict-only Compare action with deterministic close-to-opener focus.
+4. Add focused unit and mounted regressions for exact side identity, stale-session refusal, missing disk, bounds, focus return, and non-resolution.
+5. Update the File Notes guide, run focused/static/diff checks, self-review, and close the task only after every criterion is evidenced.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a conflict-only Compare action and a keyboard-readable modal that names Base, Draft, and Disk before users choose recovery. Base is the retained editor baseline, Draft is the exact current editor body, and Disk is freshly read or represented as absent/unreadable. The modal shows bounded Base-to-Draft and Base-to-Disk unified comparisons plus exact UTF-8 sizes and SHA-256 identities, and reports input/output elision explicitly.
+
+Comparison computation runs off the UI thread. Exact root, binding, file-object, editor-session, conflict-state, and draft identities are checked before and after computation, so stale results fail closed without replacing the draft. Escape and Close dismiss the modal, return focus to Compare, and leave the existing conflict and destructive-reload confirmation unchanged.
+
+Updated the File Notes guide and added pure/mounted coverage for labels, hashes, diff bounds, deleted Disk, stale-session refusal, 40×20/120×40 geometry, focus return, non-resolution, and worker-thread execution. Evidence: focused comparison matrix 7 passed; adjacent conflict/action/focus matrix 21 passed; complete affected File Notes module plus pure comparison tests 85 passed. Targeted Ruff, new-file format check, Python compilation, `git diff --check`, duplicate-task sweep, and self-review passed. Existing warnings were limited to the documented pydub deprecation, Windows SQLite privacy posture, and pytest-asyncio loop-scope notice.
+
+ADR required: no. This conforms to ADR-029 and changes no disk authority, save publication, replica ownership, recovery protocol, or resolution policy. No new lessons entry was warranted.
+
+Modified: `tldw_chatbook/Notes/file_notes_conflict_compare.py`, `tldw_chatbook/Widgets/Library/library_file_notes_workspace.py`, `Tests/Notes/test_file_notes_conflict_compare.py`, `Tests/UI/test_library_file_notes_workspace.py`, and `Docs/User_Guide/library/file-notes.md`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Notes/file_notes_conflict_compare.py
+++ b/tldw_chatbook/Notes/file_notes_conflict_compare.py
@@ -1,0 +1,203 @@
+"""Bounded, presentation-neutral File Notes conflict comparison."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from difflib import unified_diff
+from hashlib import sha256
+from typing import Literal
+
+CONFLICT_DIFF_MAX_INPUT_CHARS = 200_000
+CONFLICT_DIFF_MAX_INPUT_LINES = 10_000
+CONFLICT_DIFF_MAX_OUTPUT_CHARS = 120_000
+CONFLICT_DIFF_MAX_OUTPUT_LINES = 2_000
+
+_SIDE_ROLES = {
+    "Base": "editor baseline",
+    "Draft": "current editor",
+    "Disk": "latest readable snapshot",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ConflictSide:
+    """One immutable side of a File Notes conflict."""
+
+    label: Literal["Base", "Draft", "Disk"]
+    state: Literal["readable", "absent", "unreadable"]
+    text: str | None
+    character_count: int
+    byte_count: int
+    line_count: int
+    sha256: str
+    detail: str = ""
+
+    @classmethod
+    def from_text(
+        cls,
+        label: Literal["Base", "Draft", "Disk"],
+        text: str,
+    ) -> ConflictSide:
+        """Create one exact readable body identity.
+
+        Args:
+            label: Stable conflict-side name.
+            text: Exact editor-body text captured for the side.
+
+        Returns:
+            An immutable side with exact size and SHA-256 metadata.
+        """
+        encoded = text.encode("utf-8")
+        return cls(
+            label=label,
+            state="readable",
+            text=text,
+            character_count=len(text),
+            byte_count=len(encoded),
+            line_count=len(text.splitlines()),
+            sha256=sha256(encoded).hexdigest(),
+        )
+
+    @classmethod
+    def absent(cls, label: Literal["Disk"] = "Disk") -> ConflictSide:
+        """Represent an explicitly absent disk side.
+
+        Args:
+            label: Stable disk-side name.
+
+        Returns:
+            An immutable absent side.
+        """
+        return cls(label, "absent", None, 0, 0, 0, "")
+
+    @classmethod
+    def unreadable(
+        cls,
+        detail: str,
+        label: Literal["Disk"] = "Disk",
+    ) -> ConflictSide:
+        """Represent a disk side that could not be read.
+
+        Args:
+            detail: Bounded user-facing read failure detail.
+            label: Stable disk-side name.
+
+        Returns:
+            An immutable unreadable side.
+        """
+        return cls(label, "unreadable", None, 0, 0, 0, "", detail[:500])
+
+    @property
+    def summary(self) -> str:
+        """Return a complete literal identity line for this side."""
+        if self.state == "absent":
+            return f"{self.label} · absent"
+        if self.state == "unreadable":
+            suffix = f": {self.detail}" if self.detail else ""
+            return f"{self.label} · unreadable{suffix}"
+        role = _SIDE_ROLES[self.label]
+        return (
+            f"{self.label} · {role} · {self.character_count:,} chars · "
+            f"{self.byte_count:,} UTF-8 bytes · {self.line_count:,} lines · "
+            f"SHA-256 {self.sha256}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ConflictComparison:
+    """Bounded display payload for all three conflict sides."""
+
+    sides: tuple[ConflictSide, ConflictSide, ConflictSide]
+    summary_text: str
+    diff_text: str
+    output_elided: bool
+
+
+def _input_exceeds_diff_budget(side: ConflictSide) -> bool:
+    return side.state == "readable" and (
+        side.character_count > CONFLICT_DIFF_MAX_INPUT_CHARS
+        or side.line_count > CONFLICT_DIFF_MAX_INPUT_LINES
+    )
+
+
+def _diff_section(base: ConflictSide, target: ConflictSide) -> list[str]:
+    heading = f"{base.label} → {target.label}"
+    if target.state == "absent":
+        return [heading, f"{target.label} is absent; no textual diff is available."]
+    if target.state == "unreadable":
+        return [
+            heading,
+            f"{target.label} is unreadable; no textual diff is available.",
+        ]
+    assert base.text is not None
+    assert target.text is not None
+    lines = list(
+        unified_diff(
+            base.text.splitlines(),
+            target.text.splitlines(),
+            fromfile=base.label,
+            tofile=target.label,
+            lineterm="",
+        )
+    )
+    if not lines:
+        lines = ["No body changes."]
+    return [heading, *lines]
+
+
+def _bounded_output(lines: list[str]) -> tuple[str, bool]:
+    retained: list[str] = []
+    retained_chars = 0
+    elided = False
+    marker = "… comparison output elided at the bounded display limit."
+    for line in lines:
+        addition = len(line) + (1 if retained else 0)
+        if (
+            len(retained) >= CONFLICT_DIFF_MAX_OUTPUT_LINES
+            or retained_chars + addition + len(marker) + 1
+            > CONFLICT_DIFF_MAX_OUTPUT_CHARS
+        ):
+            elided = True
+            break
+        retained.append(line)
+        retained_chars += addition
+    if elided:
+        retained.append(marker)
+    return "\n".join(retained), elided
+
+
+def build_conflict_comparison(
+    base: ConflictSide,
+    draft: ConflictSide,
+    disk: ConflictSide,
+) -> ConflictComparison:
+    """Build two bounded unified comparisons around the editor baseline.
+
+    Args:
+        base: Body loaded into the editor or last saved successfully.
+        draft: Exact body currently retained in the editor.
+        disk: Latest readable disk body, or an explicit unavailable state.
+
+    Returns:
+        Summary and bounded Base-to-Draft/Base-to-Disk diff output.
+    """
+    sides = (base, draft, disk)
+    summary_text = "\n".join(side.summary for side in sides)
+    if any(_input_exceeds_diff_budget(side) for side in sides):
+        diff_text = (
+            "Base → Draft\nBase → Disk\n\n"
+            "Diff omitted because one or more sides exceed the bounded "
+            f"comparison input limit ({CONFLICT_DIFF_MAX_INPUT_CHARS:,} "
+            f"characters or {CONFLICT_DIFF_MAX_INPUT_LINES:,} lines per side). "
+            "Use the exact sizes and SHA-256 identities above before choosing a "
+            "recovery action."
+        )
+        return ConflictComparison(sides, summary_text, diff_text, True)
+
+    lines = [
+        *_diff_section(base, draft),
+        "",
+        *_diff_section(base, disk),
+    ]
+    diff_text, output_elided = _bounded_output(lines)
+    return ConflictComparison(sides, summary_text, diff_text, output_elided)

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -45,6 +45,11 @@ from tldw_chatbook.Notes.file_notes_git_service import (
     RetainedPushOperation,
     coalesce_session_changes,
 )
+from tldw_chatbook.Notes.file_notes_conflict_compare import (
+    ConflictComparison,
+    ConflictSide,
+    build_conflict_comparison,
+)
 from tldw_chatbook.Notes.file_notes_git_commit import (
     CommitOutcome,
     CommitRecoveryProjection,
@@ -194,6 +199,18 @@ class _ReloadConfirmation:
     opened: OpenedFileNote
     save_state: Literal["conflict", "error"]
     disk_content_hash: str
+
+
+@dataclass(frozen=True, slots=True)
+class _ConflictCompareRequest:
+    """Exact editor identity captured before reading the latest disk side."""
+
+    service: FileNotesService
+    binding: SessionBinding
+    root_generation: int
+    session_key: str
+    opened: OpenedFileNote
+    draft: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -405,6 +422,129 @@ class FileNotesRootDetailsDialog(ModalScreen[None]):
         self.query_one("#file-notes-root-details-text", TextArea).focus()
 
     @on(Button.Pressed, "#file-notes-root-details-close")
+    def _close(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+
+class FileNotesConflictCompareDialog(ModalScreen[None]):
+    """Show one immutable, bounded Base/Draft/Disk comparison."""
+
+    BINDINGS = [("escape", "dismiss", "Close")]
+
+    DEFAULT_CSS = """
+    FileNotesConflictCompareDialog {
+        align: center middle;
+    }
+
+    #file-notes-conflict-dialog {
+        width: 110;
+        max-width: 95%;
+        height: 90%;
+        min-height: 16;
+        max-height: 95%;
+        border: round $warning;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #file-notes-conflict-title {
+        height: 1;
+        color: $warning;
+        text-style: bold;
+    }
+
+    #file-notes-conflict-path,
+    #file-notes-conflict-help {
+        height: auto;
+        min-height: 1;
+        color: $text-muted;
+    }
+
+    #file-notes-conflict-summary {
+        height: 7;
+        min-height: 4;
+        margin-top: 1;
+    }
+
+    #file-notes-conflict-diff {
+        height: 1fr;
+        min-height: 4;
+        margin-top: 1;
+    }
+
+    #file-notes-conflict-close {
+        width: auto;
+        height: 1;
+        min-height: 1;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(
+        self,
+        relative_path: str,
+        comparison: ConflictComparison,
+    ) -> None:
+        """Initialize an immutable conflict comparison.
+
+        Args:
+            relative_path: Literal note path owning the conflict.
+            comparison: Precomputed bounded comparison payload.
+        """
+        super().__init__(id="file-notes-conflict-dialog-screen")
+        self._relative_path = relative_path
+        self._comparison = comparison
+
+    def compose(self) -> ComposeResult:
+        """Compose labeled read-only side identities and diffs.
+
+        Returns:
+            The widgets that make up the comparison dialog.
+        """
+        with Vertical(id="file-notes-conflict-dialog"):
+            yield Static(
+                "Compare conflict",
+                id="file-notes-conflict-title",
+                markup=False,
+            )
+            yield Static(
+                self._relative_path,
+                id="file-notes-conflict-path",
+                markup=False,
+            )
+            yield Static(
+                (
+                    "Base is the editor baseline. Draft is the current editor. "
+                    "Disk is the latest captured file state. Comparing does not "
+                    "resolve the conflict."
+                ),
+                id="file-notes-conflict-help",
+                markup=False,
+            )
+            summary = TextArea(
+                self._comparison.summary_text,
+                id="file-notes-conflict-summary",
+                read_only=True,
+                soft_wrap=True,
+            )
+            summary.tooltip = "Base, Draft, and Disk identities"
+            yield summary
+            diff = TextArea(
+                self._comparison.diff_text,
+                id="file-notes-conflict-diff",
+                read_only=True,
+                soft_wrap=False,
+            )
+            diff.tooltip = "Base to Draft and Base to Disk unified comparisons"
+            yield diff
+            yield Button("Close", id="file-notes-conflict-close", compact=True)
+
+    def on_mount(self) -> None:
+        """Focus the comparison output for immediate keyboard reading."""
+        self.query_one("#file-notes-conflict-diff", TextArea).focus()
+
+    @on(Button.Pressed, "#file-notes-conflict-close")
     def _close(self, event: Button.Pressed) -> None:
         event.stop()
         self.dismiss(None)
@@ -1062,6 +1202,11 @@ class LibraryFileNotesWorkspace(Vertical):
                     yield Button("New", id="file-notes-new", compact=True)
                     yield Button("Delete", id="file-notes-delete", compact=True)
                     yield Button("Restore", id="file-notes-restore", compact=True)
+                    yield Button(
+                        "Compare",
+                        id="file-notes-compare",
+                        compact=True,
+                    )
                     yield Button(
                         "Save draft as copy",
                         id="file-notes-save-copy",
@@ -3807,6 +3952,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 "file-notes-move",
                 "file-notes-delete",
                 "file-notes-restore",
+                "file-notes-compare",
                 "file-notes-protect",
                 "file-notes-reload",
                 "file-notes-save-copy",
@@ -3828,6 +3974,11 @@ class LibraryFileNotesWorkspace(Vertical):
             )
         self.query_one("#file-notes-protect", Button).disabled = not (
             has_document and structurally_available
+        )
+        self.query_one("#file-notes-compare", Button).disabled = not (
+            has_document
+            and structurally_available
+            and self._save_state == "conflict"
         )
         copy_button = self.query_one("#file-notes-save-copy", Button)
         exact_export = self._opened is not None and self._opened.is_excerpt
@@ -3938,6 +4089,9 @@ class LibraryFileNotesWorkspace(Vertical):
             "file-notes-move": has_document,
             "file-notes-delete": has_document,
             "file-notes-restore": has_deleted,
+            "file-notes-compare": (
+                has_document and self._save_state == "conflict"
+            ),
             "file-notes-protect": has_document,
             "file-notes-reload": has_document,
             "file-notes-save-copy": (
@@ -6162,6 +6316,125 @@ class LibraryFileNotesWorkspace(Vertical):
             ):
                 return
             self._apply_opened_document(reloaded)
+
+    def _conflict_compare_request_is_current(
+        self,
+        request: _ConflictCompareRequest,
+    ) -> bool:
+        """Validate the exact editor identity before publishing comparison."""
+        if (
+            not self._active
+            or not self.is_mounted
+            or self._service is not request.service
+            or self._root_generation != request.root_generation
+            or self._session_binding != request.binding
+            or self._session_owner.current_binding() != request.binding
+            or self._opened is not request.opened
+            or self._current_path != request.opened.relative_path
+            or self._session_key != request.session_key
+            or self._save_state != "conflict"
+        ):
+            return False
+        return self.query_one("#file-notes-editor", TextArea).text == request.draft
+
+    @staticmethod
+    def _build_conflict_comparison(
+        opened: OpenedFileNote,
+        draft: str,
+        disk: OpenedFileNote | None,
+        disk_error: str = "",
+    ) -> ConflictComparison:
+        """Build the immutable comparison away from the UI loop.
+
+        Args:
+            opened: Exact editor baseline retained by the current session.
+            draft: Exact current editor body.
+            disk: Latest readable disk snapshot, when present.
+            disk_error: Bounded read failure detail when disk is unreadable.
+
+        Returns:
+            A bounded display payload for the comparison modal.
+        """
+        disk_side = (
+            ConflictSide.from_text("Disk", disk.body)
+            if disk is not None
+            else (
+                ConflictSide.unreadable(disk_error)
+                if disk_error
+                else ConflictSide.absent()
+            )
+        )
+        return build_conflict_comparison(
+            ConflictSide.from_text("Base", opened.body),
+            ConflictSide.from_text("Draft", draft),
+            disk_side,
+        )
+
+    @on(Button.Pressed, "#file-notes-compare")
+    async def _compare_conflict(self, event: Button.Pressed) -> None:
+        """Capture and show Base, Draft, and latest Disk without resolving."""
+        event.stop()
+        opened = self._opened
+        service = self._service
+        binding = self._session_binding
+        if (
+            opened is None
+            or service is None
+            or binding is None
+            or self._save_state != "conflict"
+        ):
+            return
+        request = _ConflictCompareRequest(
+            service=service,
+            binding=binding,
+            root_generation=self._root_generation,
+            session_key=self._session_key,
+            opened=opened,
+            draft=self.query_one("#file-notes-editor", TextArea).text,
+        )
+        disk: OpenedFileNote | None = None
+        disk_error = ""
+        try:
+            disk = await asyncio.to_thread(
+                service.open_file,
+                opened.relative_path,
+            )
+        except FileNotFoundError:
+            pass
+        except (OSError, ValueError) as error:
+            disk_error = str(error)
+        if not self._conflict_compare_request_is_current(request):
+            self._set_action_status(
+                "Compare stopped: the active root, file, draft, or editing "
+                "session changed. Draft preserved; open Compare again."
+            )
+            return
+        comparison = await asyncio.to_thread(
+            self._build_conflict_comparison,
+            opened,
+            request.draft,
+            disk,
+            disk_error,
+        )
+        if not self._conflict_compare_request_is_current(request):
+            self._set_action_status(
+                "Compare stopped: the active root, file, draft, or editing "
+                "session changed. Draft preserved; open Compare again."
+            )
+            return
+        opener = event.button
+
+        def restore_opener(_: None = None) -> None:
+            if opener.is_mounted and opener.display and not opener.disabled:
+                opener.focus()
+
+        await self.app.push_screen(
+            FileNotesConflictCompareDialog(
+                opened.relative_path,
+                comparison,
+            ),
+            callback=restore_opener,
+        )
 
     @on(Button.Pressed, "#file-notes-reload-cancel")
     def _cancel_reload(self, event: Button.Pressed) -> None:


### PR DESCRIPTION
## Summary
- add a conflict-only Compare action for immutable Base, Draft, and latest Disk identities
- compute bounded Base-to-Draft and Base-to-Disk unified comparisons off the UI thread, with explicit absent/unreadable and elision states
- preserve the draft, conflict, destructive-reload guard, and focus across close at 40x20 and 120x40

## Verification
- 85 passed: complete File Notes workspace module plus pure comparison tests
- 21 passed: adjacent conflict, reload, action-disclosure, focus, and compact-layout matrix
- 7 passed after rebase: focused comparison matrix
- Ruff, new-module format check, compileall, and diff checks passed

## Architecture
ADR required: no. Conforms to ADR-029; no disk authority, save publication, replica ownership, recovery protocol, or resolution policy changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a conflict-only Compare for File Notes that shows a read-only Base/Draft/Disk diff without resolving the conflict or changing the editor. Comparison is computed off the UI thread with bounded output and explicit absent/unreadable disk states. Implements TASK-15532.

- **New Features**
  - Added Compare button (visible only in Conflict) and `FileNotesConflictCompareDialog` modal with Base → Draft and Base → Disk unified diffs.
  - Bounded input/output with elision markers; shows exact UTF-8 sizes and SHA-256 for each side; labels missing/unreadable Disk explicitly.
  - Comparison runs off the UI thread; validates root/file/session/draft before and after; stale results are dropped with a status message.
  - Close/Escape returns focus to Compare; draft and conflict remain intact; destructive reload guard unchanged.
  - Updated `Docs/User_Guide/library/file-notes.md`; added pure and UI tests for labels, bounds, deleted Disk, stale-session refusal, focus return, and small/large layouts.

<sup>Written for commit 07a6cb3e1d27ed133fba4ab065fd42c86394c1d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

