### PR TITLE
File Notes: add bounded conflict resolution choices

### DIFF
--- a/Docs/User_Guide/library/file-notes.md
+++ b/Docs/User_Guide/library/file-notes.md
@@ -77,9 +77,10 @@ to go, then press the relevant button.
 | **Delete** | Two-press: first press shows "Click Delete again to confirm.", second deletes ("Deleted. Restore remains available.") |
 | **Restore** | Brings back the most recently deleted file |
 | **Protect** / **Unprotect** | Toggles protection on the open file ("Protected." / "Unprotected."); every save to a protected file first stores a checkpoint of its previous contents in the local recovery database |
-| **Reload** / **Discard draft and reload** | Re-reads the open file from disk. In Conflict or Error, the destructive label is shown and the first activation opens a confirmation with **Cancel** focused; only **Discard draft and load disk** replaces the editor contents |
+| **Reload** / **Discard draft and reload** | Re-reads the open file from disk. In Error, the destructive label is shown and the first activation opens a confirmation with **Cancel** focused; only **Discard draft and load disk** replaces the editor contents |
 | **Compare** | Appears only for a Conflict and opens a read-only Base / Draft / Disk comparison without resolving the conflict or changing the editor |
-| **Save draft as copy** | Writes the complete editor draft to the typed path; only enabled while the save status is Dirty, Conflict, or Error |
+| **Resolve conflict** | Appears only for a Conflict and discloses the three bounded choices described below; none overwrites the changed disk file |
+| **Save draft as copy** | Writes the complete editor draft to the typed path; enabled while the save status is Dirty or Error. In Conflict, use **Resolve conflict** and **Save draft as new note** instead |
 | **Export exact copy** | Replaces **Save draft as copy** for a large read-only file and streams the complete current disk bytes, not the visible excerpt, to an absent typed path |
 | **Refresh** | Re-scans the folder and rebuilds the **Files** tree |
 
@@ -92,6 +93,21 @@ comparisons; oversized sides keep their exact sizes and SHA-256 identities and
 report that diff output was omitted or elided. A deleted or unreadable Disk side
 is named explicitly. Closing Compare returns to the conflict without resolving
 it or changing any side.
+
+**Resolve conflict** keeps **Compare** available and opens three explicit safe
+choices:
+
+- **Keep editing** closes the resolution choices and returns focus to
+  **Resolve conflict**. The Base, Draft, Disk, and Conflict state are unchanged.
+- **Save draft as new note** uses the path input, labeled "New note path" while
+  the choices are open. It writes the exact draft only when that destination
+  does not already exist, then opens the new note after the write succeeds.
+- **Discard draft and load disk** opens the same Cancel-first, freshness-checked
+  confirmation described below. It is the only resolution choice that can
+  replace the editor draft.
+
+There is no overwrite choice. If the proposed new-note destination already
+exists, File Notes leaves both that file and the conflict draft unchanged.
 
 **Discard draft and reload** first reads the current disk
 version and asks for confirmation. **Cancel** or **Escape** preserves the exact
@@ -232,7 +248,11 @@ not available.
    a **Search results** tree appears under the **Files** tree; pick a result
    to open that file. Activate **Load more** when a direct-path result set has
    another 100 rows. Clear the query and the tree disappears.
-4. **Stage and commit this session's edits, then push the exact commit.** Press
+4. **Resolve a disk conflict.** Use **Compare** to inspect Base, Draft, and
+   Disk. Press **Resolve conflict**, then either keep editing, save the exact
+   draft to an absent new-note path, or enter the Cancel-first discard
+   confirmation. No choice overwrites the changed disk file.
+5. **Stage and commit this session's edits, then push the exact commit.** Press
    **Session Git (N)**,
    trust the repository if asked, press **Stage all (N)**, then
    **Commit staged (N)**. Fill in **Subject**, press **Review commit**,
@@ -242,7 +262,7 @@ not available.
    **Authorize and check**, review the exact destination and parent lease, and
    finally choose **Push 1 commit**. If the result is **Uncertain**, use
    **Check remote again — no push** instead of pushing again.
-5. **Restore a deleted file.** After a delete the breadcrumb shows
+6. **Restore a deleted file.** After a delete the breadcrumb shows
    "Recently deleted: \<path\>" — press **Restore** and the file is back on
    disk and in the tree.
 
@@ -253,7 +273,7 @@ not available.
 | Up / Down (Session Git panel) | Select a row |
 | Tab (Session Git panel) | Move into the selected row's actions |
 | Enter (Session Git panel) | Run the highlighted action |
-| Esc (reload confirmation) | Cancel reload, preserve the draft and conflict, and return focus to **Discard draft and reload** |
+| Esc (reload confirmation) | Cancel reload, preserve the draft and conflict, and return focus to the action that opened the confirmation |
 | Esc (Session Git panel) | Step back safely: row list → Files; commit form → cancel; commit review → edit message; candidate/remote check → cancel; push review → Back; active push/uncertain recovery check → Files while it continues; push result → session |
 | Esc (dialogs) | Close "File Notes folder details" or **Endpoint Details**; cancel the repository-trust or destination-authorization dialog |
 

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -1958,7 +1958,10 @@ async def test_save_status_names_local_folder_and_preserved_draft(
         )
         save_copy = workspace.query_one("#file-notes-save-copy", Button)
         assert str(save_copy.label) == "Save draft as copy"
-        assert save_copy.display
+        assert not save_copy.display
+        resolve = workspace.query_one("#file-notes-resolve-conflict", Button)
+        assert resolve.display
+        assert str(resolve.label) == "Resolve conflict"
         assert workspace.query_one("#file-notes-save-status").display
 
     await workspace.shutdown()
@@ -2366,7 +2369,13 @@ async def test_conflict_reload_save_copy_and_leave_guards_preserve_draft(
         assert not await workspace.flush_pending_work()
 
         workspace.query_one("#file-notes-path", Input).value = "copy.md"
-        workspace.query_one("#file-notes-save-copy", Button).press()
+        workspace.query_one("#file-notes-resolve-conflict", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.conflict_resolution_active,
+            "conflict choices did not open",
+        )
+        workspace.query_one("#file-notes-resolution-save-new", Button).press()
         await _wait_until(
             pilot,
             lambda: workspace.current_path == "copy.md",
@@ -2650,6 +2659,267 @@ async def test_conflict_compare_rejects_a_late_editor_session(
         status = _static_text(workspace, "#file-notes-action-status")
         assert "editing session changed" in status
         assert "Draft preserved" in status
+
+    replica.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.allow_network
+@pytest.mark.parametrize("size", [(40, 20), (120, 40)])
+async def test_conflict_resolution_discloses_only_safe_choices(
+    tmp_path: Path,
+    size: tuple[int, int],
+) -> None:
+    """Conflict choices stay explicit, bounded, and non-resolving by default."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    source = root / "source.md"
+    source.write_text("base", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=size) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("source.md")
+        resolve = workspace.query_one("#file-notes-resolve-conflict", Button)
+        assert not resolve.display
+
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(editor, "retained draft")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "draft did not become dirty",
+        )
+        source.write_text("latest disk", encoding="utf-8")
+        await workspace.refresh_files()
+        assert workspace.save_state == "conflict"
+        assert resolve.display and not resolve.disabled
+        assert not workspace.query_one("#file-notes-save-copy", Button).display
+
+        resolve.focus()
+        resolve.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.conflict_resolution_active,
+            "conflict choices did not open",
+        )
+        keep = workspace.query_one("#file-notes-resolution-keep", Button)
+        save_new = workspace.query_one(
+            "#file-notes-resolution-save-new",
+            Button,
+        )
+        discard = workspace.query_one(
+            "#file-notes-resolution-discard",
+            Button,
+        )
+        choices = (keep, save_new, discard)
+        assert [str(choice.label) for choice in choices] == [
+            "Keep editing",
+            "Save draft as new note",
+            "Discard draft and load disk",
+        ]
+        assert all("overwrite" not in str(choice.label).lower() for choice in choices)
+        await _wait_until(
+            pilot,
+            lambda: keep.has_focus,
+            "resolution choices did not focus Keep editing",
+        )
+        assert _static_text(workspace, "#file-notes-resolution-copy") == (
+            "Choose a safe next step. No option overwrites the disk file."
+        )
+        assert _static_text(workspace, "#file-notes-path-label") == "New note path"
+        assert workspace.query_one("#file-notes-compare", Button).display
+        assert not workspace.query_one("#file-notes-delete", Button).display
+        for choice in choices:
+            assert choice.display and not choice.disabled
+            assert choice.render_line(0).text.strip() == str(choice.label)
+            assert choice.region.right <= workspace.region.right
+            assert choice.region.bottom <= workspace.region.bottom
+
+        keep.press()
+        await _wait_until(
+            pilot,
+            lambda: not workspace.conflict_resolution_active,
+            "Keep editing did not close the choices",
+        )
+        await _wait_until(
+            pilot,
+            lambda: resolve.has_focus,
+            "Keep editing did not return focus to Resolve conflict",
+        )
+        assert workspace.save_state == "conflict"
+        assert editor.text == "retained draft"
+        assert source.read_text(encoding="utf-8") == "latest disk"
+
+    replica.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.allow_network
+async def test_conflict_resolution_saves_draft_as_new_note_without_clobber(
+    tmp_path: Path,
+) -> None:
+    """Save draft as new note preserves source Disk and exact body style."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    source = root / "source.md"
+    source.write_bytes(b"\xef\xbb\xbf---\r\ntitle: Base\r\n---\r\nbase\r\n")
+    occupied = root / "occupied.md"
+    occupied.write_text("do not replace", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("source.md")
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(editor, "retained\ndraft")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "draft did not become dirty",
+        )
+        source.write_bytes(b"\xef\xbb\xbf---\r\ntitle: Disk\r\n---\r\nlatest\r\n")
+        disk_bytes = source.read_bytes()
+        await workspace.refresh_files()
+        workspace.query_one("#file-notes-resolve-conflict", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.conflict_resolution_active,
+            "conflict choices did not open",
+        )
+        path = workspace.query_one("#file-notes-path", Input)
+        save_new = workspace.query_one(
+            "#file-notes-resolution-save-new",
+            Button,
+        )
+
+        path.value = "occupied.md"
+        save_new.press()
+        await _wait_until(
+            pilot,
+            lambda: "already exists" in _static_text(
+                workspace,
+                "#file-notes-action-status",
+            ).lower(),
+            "existing destination did not fail closed",
+        )
+        assert occupied.read_text(encoding="utf-8") == "do not replace"
+        assert source.read_bytes() == disk_bytes
+        assert editor.text == "retained\ndraft"
+        assert workspace.save_state == "conflict"
+        assert workspace.conflict_resolution_active
+
+        path.value = "recovered.md"
+        save_new.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.current_path == "recovered.md",
+            "safe draft copy did not open as the current note",
+        )
+        assert (root / "recovered.md").read_bytes() == (
+            b"\xef\xbb\xbf---\r\ntitle: Base\r\n---\r\nretained\r\ndraft\r\n"
+        )
+        assert source.read_bytes() == disk_bytes
+        assert workspace.save_state == "saved"
+        assert not workspace.conflict_resolution_active
+        assert editor.has_focus
+
+    replica.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.allow_network
+async def test_conflict_resolution_discard_keeps_cancel_first_confirmation(
+    tmp_path: Path,
+) -> None:
+    """Discard routes through the existing revalidated, safe-default decision."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    source = root / "source.md"
+    source.write_text("base", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(80, 24)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("source.md")
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(editor, "retained draft")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "draft did not become dirty",
+        )
+        source.write_text("latest disk", encoding="utf-8")
+        await workspace.refresh_files()
+        workspace.query_one("#file-notes-resolve-conflict", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.conflict_resolution_active,
+            "conflict choices did not open",
+        )
+        discard = workspace.query_one(
+            "#file-notes-resolution-discard",
+            Button,
+        )
+        discard.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.reload_confirmation_active,
+            "discard did not open the destructive confirmation",
+        )
+        cancel = workspace.query_one("#file-notes-reload-cancel", Button)
+        assert cancel.has_focus
+        assert editor.text == "retained draft"
+        assert workspace.save_state == "conflict"
+
+        cancel.press()
+        await _wait_until(
+            pilot,
+            lambda: not workspace.reload_confirmation_active,
+            "Cancel did not close destructive confirmation",
+        )
+        await _wait_until(
+            pilot,
+            lambda: discard.has_focus,
+            "Cancel did not return focus to the resolution choice",
+        )
+        assert workspace.conflict_resolution_active
+        assert editor.text == "retained draft"
+
+        discard.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.reload_confirmation_active,
+            "second discard did not reopen confirmation",
+        )
+        workspace.query_one("#file-notes-reload-confirm", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: (
+                workspace.save_state == "saved"
+                and editor.text == "latest disk"
+            ),
+            "confirmed discard did not load the captured disk state",
+        )
+        assert not workspace.conflict_resolution_active
 
     replica.close()
 

--- a/backlog/tasks/task-15601 - Add-bounded-File-Notes-conflict-resolution-choices.md
+++ b/backlog/tasks/task-15601 - Add-bounded-File-Notes-conflict-resolution-choices.md
@@ -1,0 +1,66 @@
+---
+id: TASK-15601
+title: Add bounded File Notes conflict resolution choices
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-12 02:28'
+updated_date: '2026-08-12 02:58'
+labels:
+  - notes
+  - library
+  - ux
+  - recovery
+dependencies:
+  - TASK-15532
+references:
+  - >-
+    .impeccable/critique/2026-08-11T20-58-28Z__ok-widgets-library-library-file-notes-workspace-py.md
+documentation:
+  - backlog/decisions/029-file-notes-disk-authority.md
+  - Docs/User_Guide/library/file-notes.md
+priority: high
+type: enhancement
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Help users leave a File Notes conflict intentionally through explicit safe choices without implying that comparison itself resolves anything or exposing an overwrite path that lacks durable recovery guarantees.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Conflict state exposes one explicit resolution disclosure while routine states do not
+- [x] #2 The resolution surface names Keep editing Save draft as new note and Discard draft and load disk without exposing overwrite
+- [x] #3 Keep editing closes the surface returns focus safely and preserves Base Draft Disk and conflict state
+- [x] #4 Save draft as new note keeps the existing no-clobber path validation and exact body preservation then opens the created note only after success
+- [x] #5 Discard draft and load disk retains the distinct Cancel-first confirmation and all existing freshness revalidation
+- [x] #6 The resolution surface remains readable keyboard reachable and focus safe at 40x20 and 120x40
+- [x] #7 Focused mounted tests static checks documentation and self-review pass without changing disk authority save publication or recovery protocols
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A; conform to `backlog/decisions/029-file-notes-disk-authority.md`.
+Reason: this reorganizes existing safe-copy and confirmed-reload behaviors behind an explicit conflict-resolution disclosure and adds a no-op Keep editing choice; it adds no overwrite policy, storage contract, or mutation primitive.
+
+1. Add failing mounted regressions for conflict-only disclosure, complete choice labels, safe focus, and compact geometry.
+2. Route Keep editing to a non-resolving close path, Save draft as new note to the existing no-clobber copy flow, and Discard draft and load disk to the existing revalidated confirmation.
+3. Preserve comparison as a peer decision-support action and keep overwrite absent from code, copy, and documentation.
+4. Run focused and complete affected File Notes tests plus static, diff, and backlog checks.
+5. Record evidence, complete the task, and prepare the atomic PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added a conflict-only **Resolve conflict** disclosure with **Keep editing**, **Save draft as new note**, and **Discard draft and load disk**. **Compare** remains available and no overwrite action is exposed.
+- Reused the existing exact no-clobber copy operation for new-note recovery and the existing Cancel-first, identity- and freshness-revalidated reload confirmation for discard. Cancel now returns focus to whichever destructive action opened that confirmation.
+- Added mounted coverage for both 40x20 and 120x40 layouts, safe focus, exact body-style preservation, occupied-destination refusal, and the existing reload-confirmation path. Updated the File Notes user guide.
+- ADR required: no. The implementation conforms to `backlog/decisions/029-file-notes-disk-authority.md` and changes no disk authority, storage, autosave publication, or recovery protocol.
+- Verification: `pytest Tests/UI/test_library_file_notes_workspace.py` (86 passed); adjacent conflict/disclosure set (24 passed); Ruff on both touched Python files; `compileall`; `git diff --check`. One suite-order focus timing assertion failed once, then passed in isolation and in the clean full-module rerun.
+- Self-review found no additional actionable issue. No generalizable new testing or architecture lesson was needed.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -199,6 +199,7 @@ class _ReloadConfirmation:
     opened: OpenedFileNote
     save_state: Literal["conflict", "error"]
     disk_content_hash: str
+    opener_id: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -737,6 +738,20 @@ class LibraryFileNotesWorkspace(Vertical):
         display: none;
     }
 
+    #file-notes-resolution-copy {
+        width: 100%;
+        height: auto;
+        min-height: 1;
+        color: $warning;
+        text-style: bold;
+        text-wrap: wrap;
+    }
+
+    #file-notes-resolution-copy,
+    #file-notes-resolution-actions {
+        display: none;
+    }
+
     LibraryFileNotesWorkspace.-reload-confirming #file-notes-path-row {
         display: none;
     }
@@ -811,6 +826,18 @@ class LibraryFileNotesWorkspace(Vertical):
     LibraryFileNotesWorkspace.-stack-editor-actions
     #file-notes-maintenance-toggle {
         column-span: 2;
+    }
+
+    LibraryFileNotesWorkspace.-stack-editor-actions
+    #file-notes-resolution-actions {
+        grid-size: 1;
+        grid-columns: 1fr;
+    }
+
+    LibraryFileNotesWorkspace.-stack-editor-actions
+    #file-notes-resolution-actions Button {
+        width: 1fr;
+        padding: 0;
     }
 
     LibraryFileNotesWorkspace.-stack-editor-actions #file-notes-editor {
@@ -900,6 +927,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._save_state: SaveState = "idle"
         self._save_detail = ""
         self._reload_confirmation: _ReloadConfirmation | None = None
+        self._conflict_resolution_active = False
         self._delete_confirmation_path = ""
         self._search_generation = 0
         self._search_query = ""
@@ -1027,6 +1055,11 @@ class LibraryFileNotesWorkspace(Vertical):
         return self._reload_confirmation is not None
 
     @property
+    def conflict_resolution_active(self) -> bool:
+        """Return whether the bounded conflict choices are disclosed."""
+        return self._conflict_resolution_active
+
+    @property
     def leave_allowed(self) -> bool:
         """Return whether the retained draft can be left without a flush."""
         binding = self._session_binding
@@ -1072,6 +1105,8 @@ class LibraryFileNotesWorkspace(Vertical):
 
     def _path_field_label_copy(self) -> str:
         """Describe the action context currently represented by the path field."""
+        if self._conflict_resolution_active:
+            return "New note path"
         if self._selected_deleted_path:
             return "Restore path"
         if self._opened is not None:
@@ -1208,6 +1243,11 @@ class LibraryFileNotesWorkspace(Vertical):
                         compact=True,
                     )
                     yield Button(
+                        "Resolve conflict",
+                        id="file-notes-resolve-conflict",
+                        compact=True,
+                    )
+                    yield Button(
                         "Save draft as copy",
                         id="file-notes-save-copy",
                         compact=True,
@@ -1225,6 +1265,45 @@ class LibraryFileNotesWorkspace(Vertical):
                     yield Button("Protect", id="file-notes-protect", compact=True)
                     yield Button("Reload", id="file-notes-reload", compact=True)
                     yield Button("Refresh", id="file-notes-refresh", compact=True)
+                yield Static(
+                    (
+                        "Choose a safe next step. No option overwrites the disk "
+                        "file."
+                    ),
+                    id="file-notes-resolution-copy",
+                    markup=False,
+                )
+                with Horizontal(
+                    id="file-notes-resolution-actions",
+                    classes="file-notes-toolbar",
+                ):
+                    keep = Button(
+                        "Keep editing",
+                        id="file-notes-resolution-keep",
+                        compact=True,
+                    )
+                    keep.tooltip = "Close these choices and leave the conflict open"
+                    yield keep
+                    save_new = Button(
+                        "Save draft as new note",
+                        id="file-notes-resolution-save-new",
+                        compact=True,
+                    )
+                    save_new.tooltip = (
+                        "Write the complete draft to the New note path without "
+                        "replacing an existing file"
+                    )
+                    yield save_new
+                    discard = Button(
+                        "Discard draft and load disk",
+                        id="file-notes-resolution-discard",
+                        compact=True,
+                    )
+                    discard.tooltip = (
+                        "Open a separate confirmation before replacing the editor "
+                        "with the current disk file"
+                    )
+                    yield discard
                 yield Static(
                     (
                         self._reload_confirmation_copy()
@@ -1872,15 +1951,17 @@ class LibraryFileNotesWorkspace(Vertical):
 
     def _dismiss_reload_confirmation(self, *, focus_opener: bool) -> bool:
         """Close a pending reload decision without changing editor content."""
-        if self._reload_confirmation is None:
+        confirmation = self._reload_confirmation
+        if confirmation is None:
             return False
         self._reload_confirmation = None
         if self._active and self.is_mounted:
             self.query_one("#file-notes-reload-confirm-copy", Static).update("")
             self._update_controls()
             if focus_opener:
-                reload_button = self.query_one("#file-notes-reload", Button)
-                self.call_after_refresh(reload_button.focus)
+                opener = self.query_one(f"#{confirmation.opener_id}", Button)
+                if opener.display and not opener.disabled:
+                    self.call_after_refresh(opener.focus)
         self.post_message(self.ReloadConfirmationChanged(False))
         return True
 
@@ -3723,6 +3804,8 @@ class LibraryFileNotesWorkspace(Vertical):
     def _set_save_state(self, state: SaveState, detail: str = "") -> None:
         self._save_state = state
         self._save_detail = detail
+        if state != "conflict":
+            self._conflict_resolution_active = False
         if self._active and self.is_mounted:
             label = _SAVE_STATE_COPY[state]
             if detail:
@@ -3953,6 +4036,10 @@ class LibraryFileNotesWorkspace(Vertical):
                 "file-notes-delete",
                 "file-notes-restore",
                 "file-notes-compare",
+                "file-notes-resolve-conflict",
+                "file-notes-resolution-keep",
+                "file-notes-resolution-save-new",
+                "file-notes-resolution-discard",
                 "file-notes-protect",
                 "file-notes-reload",
                 "file-notes-save-copy",
@@ -3980,6 +4067,21 @@ class LibraryFileNotesWorkspace(Vertical):
             and structurally_available
             and self._save_state == "conflict"
         )
+        self.query_one("#file-notes-resolve-conflict", Button).disabled = not (
+            has_document
+            and structurally_available
+            and self._save_state == "conflict"
+        )
+        for selector in (
+            "resolution-keep",
+            "resolution-save-new",
+            "resolution-discard",
+        ):
+            self.query_one(f"#file-notes-{selector}", Button).disabled = not (
+                structurally_available
+                and self._save_state == "conflict"
+                and self._conflict_resolution_active
+            )
         copy_button = self.query_one("#file-notes-save-copy", Button)
         exact_export = self._opened is not None and self._opened.is_excerpt
         copy_label = "Export exact copy" if exact_export else "Save draft as copy"
@@ -4080,17 +4182,28 @@ class LibraryFileNotesWorkspace(Vertical):
     def _sync_editor_action_visibility(self) -> None:
         """Disclose only editor actions relevant to the retained state."""
         confirming_reload = self.reload_confirmation_active
+        resolving_conflict = (
+            self._conflict_resolution_active
+            and self._save_state == "conflict"
+            and self._opened is not None
+        )
         self.set_class(confirming_reload, "-reload-confirming")
+        self.set_class(resolving_conflict, "-resolving-conflict")
         has_service = self._service is not None
         has_document = self._opened is not None
         has_deleted = has_service and bool(self._selected_deleted_path)
         visibility = {
-            "file-notes-new": has_service,
+            "file-notes-new": has_service and not resolving_conflict,
             "file-notes-move": has_document,
-            "file-notes-delete": has_document,
+            "file-notes-delete": has_document and not resolving_conflict,
             "file-notes-restore": has_deleted,
             "file-notes-compare": (
                 has_document and self._save_state == "conflict"
+            ),
+            "file-notes-resolve-conflict": (
+                has_document
+                and self._save_state == "conflict"
+                and not resolving_conflict
             ),
             "file-notes-protect": has_document,
             "file-notes-reload": has_document,
@@ -4098,7 +4211,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 has_document
                 and (
                     (self._opened is not None and self._opened.is_excerpt)
-                    or self._save_state in {"dirty", "conflict", "error"}
+                    or self._save_state in {"dirty", "error"}
                 )
             ),
             "file-notes-refresh": has_service,
@@ -4112,7 +4225,9 @@ class LibraryFileNotesWorkspace(Vertical):
         maintenance_available = any(
             visibility[action_id] for action_id in maintenance_ids
         )
-        visibility["file-notes-maintenance-toggle"] = maintenance_available
+        visibility["file-notes-maintenance-toggle"] = (
+            maintenance_available and not resolving_conflict
+        )
         focused = self.app.focused
         for action_id, displayed in visibility.items():
             if action_id in maintenance_ids:
@@ -4135,8 +4250,19 @@ class LibraryFileNotesWorkspace(Vertical):
         maintenance.display = (
             maintenance_available
             and self._maintenance_expanded
+            and not resolving_conflict
             and not confirming_reload
         )
+        resolution_copy = self.query_one(
+            "#file-notes-resolution-copy",
+            Static,
+        )
+        resolution_actions = self.query_one("#file-notes-resolution-actions")
+        show_resolution = resolving_conflict and not confirming_reload
+        resolution_copy.display = show_resolution
+        resolution_actions.display = show_resolution
+        for button in resolution_actions.query(Button):
+            button.display = show_resolution
         confirmation_copy = self.query_one(
             "#file-notes-reload-confirm-copy",
             Static,
@@ -4162,6 +4288,8 @@ class LibraryFileNotesWorkspace(Vertical):
                     f"#{self._editor_action_focus_target}",
                     "#file-notes-restore",
                     "#file-notes-new",
+                    "#file-notes-resolve-conflict",
+                    "#file-notes-compare",
                     "#file-notes-maintenance-toggle",
                     "#file-notes-refresh",
                 )
@@ -4637,7 +4765,11 @@ class LibraryFileNotesWorkspace(Vertical):
         return self._apply_scan(result, deleted)
 
     def _operation_error(self, action: str, result: OperationResult) -> None:
-        detail = result.message or result.status
+        detail = (
+            "destination already exists"
+            if result.status == "exists"
+            else result.message or result.status
+        )
         self._set_action_status(f"{action} failed: {detail}")
         if self._opened is not None and result.status in {"conflict", "missing"}:
             self._set_save_state("conflict", detail)
@@ -6143,6 +6275,43 @@ class LibraryFileNotesWorkspace(Vertical):
         self._schedule_editor_action_layout()
         self.call_after_refresh(toggle.focus)
 
+    def _set_conflict_resolution(
+        self,
+        active: bool,
+        *,
+        focus_opener: bool = False,
+    ) -> None:
+        """Project the bounded conflict choices without resolving any side."""
+        self._conflict_resolution_active = bool(
+            active
+            and self._opened is not None
+            and self._save_state == "conflict"
+        )
+        self._update_controls()
+        if not self._active or not self.is_mounted:
+            return
+        if self._conflict_resolution_active:
+            keep = self.query_one("#file-notes-resolution-keep", Button)
+            self.screen.set_focus(keep)
+            self.call_after_refresh(partial(self.screen.set_focus, keep))
+        elif focus_opener:
+            opener = self.query_one("#file-notes-resolve-conflict", Button)
+            if opener.display and not opener.disabled:
+                self.screen.set_focus(opener)
+                self.call_after_refresh(partial(self.screen.set_focus, opener))
+
+    @on(Button.Pressed, "#file-notes-resolve-conflict")
+    def _open_conflict_resolution(self, event: Button.Pressed) -> None:
+        """Disclose the safe conflict choices and focus their safe default."""
+        event.stop()
+        self._set_conflict_resolution(True)
+
+    @on(Button.Pressed, "#file-notes-resolution-keep")
+    def _keep_editing_conflict(self, event: Button.Pressed) -> None:
+        """Close the choices while preserving every conflict side unchanged."""
+        event.stop()
+        self._set_conflict_resolution(False, focus_opener=True)
+
     @on(Button.Pressed, "#file-notes-delete")
     async def _delete_file(self, event: Button.Pressed) -> None:
         event.stop()
@@ -6283,6 +6452,7 @@ class LibraryFileNotesWorkspace(Vertical):
                     opened=opened,
                     save_state=state,
                     disk_content_hash=disk_snapshot.content_hash,
+                    opener_id=event.button.id or "file-notes-reload",
                 )
                 if not self._reload_confirmation_is_current(confirmation):
                     self._set_action_status(
@@ -6442,6 +6612,11 @@ class LibraryFileNotesWorkspace(Vertical):
         event.stop()
         self.cancel_reload_confirmation()
 
+    @on(Button.Pressed, "#file-notes-resolution-discard")
+    async def _discard_conflict_draft(self, event: Button.Pressed) -> None:
+        """Route the destructive choice through the existing confirmation."""
+        await self._reload_file(event)
+
     @on(Button.Pressed, "#file-notes-reload-confirm")
     async def _confirm_reload(self, event: Button.Pressed) -> None:
         """Revalidate every identity before intentionally loading disk bytes."""
@@ -6521,17 +6696,15 @@ class LibraryFileNotesWorkspace(Vertical):
             self._dismiss_reload_confirmation(focus_opener=False)
             self._apply_opened_document(reloaded)
 
-    @on(Button.Pressed, "#file-notes-save-copy")
-    async def _save_copy(self, event: Button.Pressed) -> None:
-        event.stop()
+    async def _save_editor_copy(self, action: str) -> bool:
+        """Run the shared exact, validated, no-clobber editor-copy path."""
         opened = self._opened
         service = self._service
         if service is None or opened is None:
-            return
-        action = "Export exact copy" if opened.is_excerpt else "Save draft as copy"
+            return False
         destination = self._validated_path_input(action)
         if destination is None:
-            return
+            return False
         if opened.is_excerpt:
             await self._complete_path_action(
                 action,
@@ -6550,6 +6723,31 @@ class LibraryFileNotesWorkspace(Vertical):
                 body,
                 destination,
             )
+        return (
+            self._opened is not None
+            and self._current_path == destination
+            and self._save_state == "saved"
+        )
+
+    @on(Button.Pressed, "#file-notes-save-copy")
+    async def _save_copy(self, event: Button.Pressed) -> None:
+        event.stop()
+        opened = self._opened
+        if opened is None:
+            return
+        action = "Export exact copy" if opened.is_excerpt else "Save draft as copy"
+        await self._save_editor_copy(action)
+
+    @on(Button.Pressed, "#file-notes-resolution-save-new")
+    async def _save_conflict_draft_as_new_note(
+        self,
+        event: Button.Pressed,
+    ) -> None:
+        """Save the retained draft through the existing no-clobber copy path."""
+        event.stop()
+        if await self._save_editor_copy("Save draft as new note"):
+            editor = self.query_one("#file-notes-editor", TextArea)
+            self.call_after_refresh(editor.focus)
 
     @on(Button.Pressed, "#file-notes-refresh")
     async def _refresh_pressed(self, event: Button.Pressed) -> None:


### PR DESCRIPTION
Summary: Adds a conflict-only Resolve conflict disclosure with Keep editing, Save draft as new note, and Discard draft and load disk. Compare remains available, overwrite remains absent, safe-copy reuses the no-clobber service, and discard reuses the Cancel-first freshness-revalidated reload path. Updates mounted coverage, user documentation, and TASK-15601. Verification: 86 File Notes UI tests passed; 24 adjacent conflict/disclosure tests passed; 4 post-rebase conflict-resolution tests passed; Ruff, compileall, and diff checks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a conflict-only Resolve conflict flow to File Notes with three safe choices: Keep editing, Save draft as new note, and Discard draft and load disk. Meets TASK-15601 by keeping Compare available, removing overwrite, and reusing the no-clobber copy and cancel-first reload paths.

- **New Features**
  - Show Resolve conflict only in Conflict; hide Save draft as copy in this state and relabel the path field to “New note path”.
  - Keep editing closes the choices and returns focus to Resolve conflict; Base/Draft/Disk stay unchanged.
  - Save draft as new note uses the existing no-clobber copy path, preserves exact body/encoding, opens the new note after success, and refuses occupied destinations.
  - Discard draft and load disk routes to the existing Cancel-first, freshness-checked confirmation; Cancel returns focus to the action that opened it.
  - Compare remains available during conflict; no overwrite option is exposed.
  - Focus and layout are safe at 40x20 and 120x40.
  - Updated user guide and added mounted UI tests for the new flow.

<sup>Written for commit 1fbd46ec6bca49bcfa9df7ec053ef099f0f99cca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

