### PR TITLE
fix: make character voice add/remove actually refresh the table (task-15479)

### DIFF
--- a/Tests/Widgets/test_character_voice_widget.py
+++ b/Tests/Widgets/test_character_voice_widget.py
@@ -1,0 +1,133 @@
+# test_character_voice_widget.py
+# Description: Regression coverage for CharacterVoiceWidget's add/remove table refresh (task-15479)
+"""
+task-15479: ``_add_character_manually`` and ``_remove_selected_character`` used
+``self.characters = self.characters`` to force the ``characters`` reactive
+(``reactive([], recompose=True)``) to re-run its watcher and refresh the
+character ``DataTable``. Assigning the same list object back to itself is a
+no-op as far as Textual's reactive system is concerned -- it compares equal
+to the previous value (same identity) and the reactive has no
+``always_update=True``, so ``watch_characters`` never fires and the table
+never reflects the add/remove that already happened on the underlying list.
+
+These tests exercise the two button-handler code paths directly and assert
+on the mounted ``DataTable``'s actual row content, so they are red against
+the pre-fix code (table stays stale) and green once the refresh is forced
+via ``mutate_reactive``.
+
+Each test resets ``widget.characters`` to a fresh ``[]`` before mutating it.
+This is *not* incidental: ``characters = reactive([])``'s default is a bare
+list literal, which Textual's ``Reactive._initialize_reactive`` shares as
+the *same object* across every ``CharacterVoiceWidget`` instance that never
+explicitly reassigns it (the classic mutable-default-argument trap, applied
+to a reactive default) -- a pre-existing bug independent of task-15479,
+discovered here because it made these tests order-dependent within one
+pytest session (an earlier test's ``.append()`` onto the shared default
+leaked into a later test's row count). Assigning a fresh list breaks the
+aliasing for that instance going forward. Out of scope for task-15479's
+self-assignment-trigger fix; worth filing separately.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable
+
+from tldw_chatbook.TTS.audiobook_generator import Character
+from tldw_chatbook.Widgets.TTS.character_voice_widget import CharacterVoiceWidget
+
+
+class _CharacterVoiceWidgetTestApp(App[None]):
+    """Minimal host app mounting a single CharacterVoiceWidget."""
+
+    def compose(self) -> ComposeResult:
+        yield CharacterVoiceWidget(provider="openai", id="character-voice-widget")
+
+
+def _table(pilot) -> DataTable:
+    return pilot.app.query_one("#character-table", DataTable)
+
+
+def _widget(pilot) -> CharacterVoiceWidget:
+    return pilot.app.query_one("#character-voice-widget", CharacterVoiceWidget)
+
+
+@pytest.mark.asyncio
+async def test_add_character_manually_refreshes_table() -> None:
+    """Adding a character via the button handler must show up in the table.
+
+    Regression for the dead self-assignment at (pre-fix) line 455: before the
+    fix, ``self.characters`` gains the new ``Character`` object but
+    ``watch_characters`` never runs, so ``table.row_count`` stays 0.
+
+    The table is re-queried fresh after each mutation rather than cached in
+    a local variable: a stale reference can keep reporting whatever row
+    count it had before being replaced/removed, which would let this test
+    pass for the wrong reason instead of reflecting what is actually live
+    in the DOM.
+    """
+    app = _CharacterVoiceWidgetTestApp()
+    async with app.run_test() as pilot:
+        widget = _widget(pilot)
+        widget.characters = []  # isolate from the shared-default reactive (see module docstring)
+        await pilot.pause()
+        assert _table(pilot).row_count == 0
+
+        widget._add_character_manually()
+        await pilot.pause()
+
+        table = _table(pilot)
+        assert table.row_count == 1
+        assert len(widget.characters) == 1
+        added_name = widget.characters[0].name
+        row = table.get_row_at(0)
+        assert row[0] == added_name
+
+
+@pytest.mark.asyncio
+async def test_add_character_manually_twice_refreshes_table_each_time() -> None:
+    """A second add must also be reflected -- guards against a fix that only
+    happens to work once (e.g. relying on incidental identity changes)."""
+    app = _CharacterVoiceWidgetTestApp()
+    async with app.run_test() as pilot:
+        widget = _widget(pilot)
+        widget.characters = []  # isolate from the shared-default reactive (see module docstring)
+        await pilot.pause()
+
+        widget._add_character_manually()
+        await pilot.pause()
+        widget._add_character_manually()
+        await pilot.pause()
+
+        assert _table(pilot).row_count == 2
+        assert len(widget.characters) == 2
+
+
+@pytest.mark.asyncio
+async def test_remove_selected_character_refreshes_table() -> None:
+    """Removing the selected character via the button handler must clear its
+    row from the table.
+
+    Regression for the dead self-assignment at (pre-fix) line 465: before the
+    fix, ``self.characters`` loses the popped ``Character`` object but
+    ``watch_characters`` never runs, so the table keeps showing the stale row.
+    """
+    app = _CharacterVoiceWidgetTestApp()
+    async with app.run_test() as pilot:
+        widget = _widget(pilot)
+
+        # Seed via a fresh-list assignment (a real reactive change, not the
+        # buggy self-assignment) so this test isolates the remove path only.
+        widget.characters = [Character(name="Seeded", voice="narrator")]
+        await pilot.pause()
+        assert _table(pilot).row_count == 1
+
+        widget.selected_character_index = 0
+        await pilot.pause()
+
+        widget._remove_selected_character()
+        await pilot.pause()
+
+        assert _table(pilot).row_count == 0
+        assert widget.characters == []

--- a/backlog/tasks/task-15479 - Character-voice-widget---reactive-self-assignment-can-never-fire.md
+++ b/backlog/tasks/task-15479 - Character-voice-widget---reactive-self-assignment-can-never-fire.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15479
 title: Character voice widget: reactive self-assignment can never fire
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - bug
@@ -20,6 +21,38 @@ Fix direction: `mutate_reactive`, assign a new list, or `always_update=True`; ad
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Adding and removing a character updates the table (test)
-- [ ] #2 No other self-assignment reactive triggers remain (grep evidence in notes)
+- [x] #1 Adding and removing a character updates the table (test)
+- [x] #2 No other self-assignment reactive triggers remain (grep evidence in notes)
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Read `Widgets/TTS/character_voice_widget.py` in full to confirm both cited sites (`_add_character_manually`, `_remove_selected_character`) and check for a third instance nearby (`_reset_all_voices`).
+2. TDD: write tests mounting `CharacterVoiceWidget` in a minimal `App`, calling the add/remove handlers, asserting the `#character-table` `DataTable`'s live row count/content — confirm red on unmodified code.
+3. Fix the triggering bug using the codebase's established `mutate_reactive` idiom (grepped precedent in `settings_screen.py` / `speech_catalog_mixin.py`), applied at all matching call sites in this file.
+4. Repo-wide grep for the exact `self\.(\w+) = self\.\1` shape (refined to bare self-assignment only, excluding `self.x = self.x.method()`/slicing/swap-idiom false positives) and classify every hit.
+5. Re-run tests; investigate any surprising failures rather than papering over them (this surfaced two extra pre-existing issues, handled below).
+6. Update backlog task and write the report.
+
+## Implementation Notes
+
+**Fixed** (`tldw_chatbook/Widgets/TTS/character_voice_widget.py`): both cited self-assignment sites (`_add_character_manually` line ~469, `_remove_selected_character` line ~486) now call `self.mutate_reactive(CharacterVoiceWidget.characters)` instead of `self.characters = self.characters`. This is the codebase's existing idiom for forcing a mutable reactive's watcher to run (precedent: `UI/Screens/settings_screen.py:_refresh_settings_workspaces_pane`, `UI/Speech/speech_catalog_mixin.py`), and matches Textual's own documented use of `mutate_reactive`.
+
+**TDD evidence**: `Tests/Widgets/test_character_voice_widget.py` (new) mounts the widget in a minimal `App`, calls the private add/remove handlers, and asserts on the live, freshly-queried `#character-table` `DataTable`. All 3 tests were confirmed red against the unmodified widget (`assert table.row_count == 1` failed with `0`, etc.) before the fix, and green after.
+
+**Second bug found via TDD, fixed in the same commit (in scope — same file, directly entangled with the trigger fix)**: `characters = reactive([], recompose=True)`. `compose()` never reads `self.characters` — the `DataTable` is built empty (columns only) and populated *imperatively* by `_refresh_character_table()`, called from `watch_characters`. `recompose=True` was a silent no-op only because the self-assignment bug meant the reactive never actually fired. Once fixed to fire (via `mutate_reactive`), `recompose=True` tore down and rebuilt the whole widget subtree on every add/remove: the freshly-added row was there for one instant, then discarded when the recompose swapped in a brand-new (columns-only, zero-row) `DataTable`, with nothing to repopulate it afterward. Confirmed live with a throwaway repro script: after settling, a **fresh** query of `#character-table` reported `row_count == 0` even though `widget.characters` correctly held the added item. Removed `recompose=True` (the other 3 reactives on this widget — `selected_character_index`, `voice_assignments`, `provider` — already have no such flag, and none of them are read from `compose()` either, so this makes `characters` consistent with its siblings). This was necessary for AC #1 to be genuinely true (not just true for a stale/orphaned test reference) — see comment block above the reactive declaration for the full reasoning, and the docstring of the new test file.
+
+**AC #2 grep sweep**: exact-shape regex for a bare self-assignment reactive trigger, `^\s*self\.([A-Za-z_]\w*)\s*=\s*self\.\1\s*(#.*)?$` (anchored at both ends so `self.x = self.x.method()`, slicing `self.x = self.x[:-10]`, and the `a, self._b = self._b, None` swap idiom are correctly excluded as **not** the dead-trigger shape):
+```
+grep -rnP '^\s*self\.([A-Za-z_][A-Za-z0-9_]*)\s*=\s*self\.\1\s*(#.*)?$' --include='*.py' tldw_chatbook/
+```
+Before the fix: exactly 3 hits, all 3 in this file (`characters` ×2, `voice_assignments` ×1). After the fix: **0 hits repo-wide**. A broader, unanchored version of the same regex (allowing anything after the repeated name, e.g. `self.x = self.x.toggle(...)`) turned up ~50 more matches across the tree (`lab_frame.py`, `video_player_screen.py`, `dictation.py`, `code_audit_tool.py`, `mindmap_model.py`, `Embeddings_Lib.py`, `reply_sentence_sequencer.py`, `console_voice_input.py`, `swarmui_client.py`, `evaluation_state.py`, `streaming_sink.py`, `transcription_service.py`, `dictation_service_lazy.py`, `directory_navigation.py`, `world_info_processor.py`, `chatterbox_isolated.py`, `TTS/utils/performance.py`, `status_widget.py`, `file_list_item_enhanced.py`, `enhanced_file_picker.py`, `detailed_progress.py`, `console_prompts_modal.py`) — every one of these was manually inspected and classified as **not** the dead-trigger shape: each RHS calls a method, slices, concatenates, or is a swap-tuple-unpack (`old, self._x = self._x, None`), all of which produce a genuinely new object rather than the identical one, so they legitimately change the reactive/attribute's value (or are plain, non-`reactive()` attributes with no watcher to fail to trigger in the first place). None were touched.
+
+**Also fixed the identical one-line pattern found in the same file** (`_reset_all_voices`, `self.voice_assignments = self.voice_assignments`) → `self.mutate_reactive(CharacterVoiceWidget.voice_assignments)`. Note for the record: `voice_assignments` has no `watch_voice_assignments` method anywhere in the class, so this line was already a pure no-op before *and* after the fix in terms of observable behavior (the explicit `_refresh_character_table()` / `_update_assignment_summary()` calls immediately below are what actually keep `_reset_all_voices`'s UI in sync). Fixed anyway for consistency with the identical pattern and to keep the reactive honest if a watcher is ever added later — this did not require a new test since there is currently no watcher-driven behavior it could regress.
+
+**Found but explicitly out of scope, flagging for a follow-up task**: `characters = reactive([])`'s default value is a bare list literal. Textual's `Reactive._initialize_reactive` uses `default_or_callable() if callable(...) else default_or_callable` — since `[]` is not callable, the *exact same list object* is installed as `_reactive_characters` on every `CharacterVoiceWidget` instance that hasn't explicitly reassigned it yet (the classic mutable-default-argument trap, applied to a Textual reactive default). This is independent of the self-assignment trigger bug and was **not** introduced by this fix (the aliasing existed before, under the old `recompose=True` declaration too) — it was only discovered because it made the new tests order-dependent within one pytest session (an earlier test's `.append()` leaked into a later test's row count via the shared default). Production impact: any two `CharacterVoiceWidget` instances that both start from the un-set default and never reassign `characters` to a fresh list would share and cross-mutate the same underlying list. Not fixed here (outside this task's AC boundary); the new tests work around it defensively by assigning `widget.characters = []` (a fresh list) before use, which is documented in the test file's module docstring.
+
+**Files modified**: `tldw_chatbook/Widgets/TTS/character_voice_widget.py` (reactive declaration + 3 call sites).
+**Files added**: `Tests/Widgets/test_character_voice_widget.py` (3 tests: add refreshes table, two adds each refresh, remove refreshes table).
+
+**Tests run**: `Tests/Widgets/test_character_voice_widget.py` (3/3 passed, confirmed red pre-fix), `Tests/UI/test_stts_profile_library.py` (73/73 passed — the only other test file referencing `character_voice_widget`, via an import-isolation stub, unaffected), `Tests/Widgets/` full directory (376/377 passed; the 1 failure, `test_library_collections_panel.py::test_library_collections_panel_empty_state_renders_message_once`, is unrelated to this widget/change — reproduces in isolation on unmodified files, pre-existing on `dev`), `Tests/TTS/test_tts_profile_capabilities.py` (40/43 passed; the 3 failures are the standing pre-existing Protocol-`isinstance` failures called out in the environment brief, untouched by this change).

--- a/tldw_chatbook/Widgets/TTS/character_voice_widget.py
+++ b/tldw_chatbook/Widgets/TTS/character_voice_widget.py
@@ -125,7 +125,22 @@ class CharacterVoiceWidget(RecomposeCaptureGuard, Widget):
     """
 
     # Reactive properties
-    characters = reactive([], recompose=True)
+    #
+    # `characters` intentionally has NO `recompose=True`: `compose()` below
+    # never reads `self.characters` (the table is built empty, with only
+    # its columns, and populated imperatively by `_refresh_character_table`,
+    # called from `watch_characters`). A `recompose=True` here was
+    # previously a silent no-op only because the same-object self-assignment
+    # bug (task-15479) meant the reactive never actually fired; once fixed
+    # to fire correctly (e.g. via `mutate_reactive`), `recompose=True` would
+    # tear down and rebuild the whole widget subtree -- discarding the rows
+    # `_refresh_character_table` just added (nothing repopulates them after
+    # a recompose) and any in-progress UI state (selected voice, sample
+    # text, Collapsible expand state) -- on every single add/remove.
+    # Confirmed live: with `recompose=True` restored, a fresh
+    # `#character-table` query after settling reports `row_count == 0` even
+    # though `self.characters` holds the added item.
+    characters = reactive([])
     selected_character_index = reactive(-1)
     voice_assignments = reactive({})
     provider = reactive("openai")
@@ -452,7 +467,13 @@ class CharacterVoiceWidget(RecomposeCaptureGuard, Widget):
             description="Manually added character",
         )
         self.characters.append(new_character)
-        self.characters = self.characters  # Trigger reactive update
+        # `characters` holds a mutable list; assigning it back to itself
+        # (the previous approach) compares equal by identity and never
+        # fires `watch_characters`, so the table would silently go stale
+        # (task-15479). `mutate_reactive` is the idiom this codebase already
+        # uses for forcing a mutated-in-place reactive to re-run its watcher
+        # (see settings_screen.py's `_refresh_settings_workspaces_pane`).
+        self.mutate_reactive(CharacterVoiceWidget.characters)
 
     def _remove_selected_character(self) -> None:
         """Remove the selected character"""
@@ -462,7 +483,9 @@ class CharacterVoiceWidget(RecomposeCaptureGuard, Widget):
             if character.name in self.voice_assignments:
                 del self.voice_assignments[character.name]
 
-            self.characters = self.characters  # Trigger reactive update
+            # Same dead-self-assignment bug as `_add_character_manually`
+            # above (task-15479): force the watcher via `mutate_reactive`.
+            self.mutate_reactive(CharacterVoiceWidget.characters)
             self.selected_character_index = min(
                 self.selected_character_index, len(self.characters) - 1
             )
@@ -471,7 +494,14 @@ class CharacterVoiceWidget(RecomposeCaptureGuard, Widget):
     def _reset_all_voices(self) -> None:
         """Reset all voice assignments to narrator"""
         self.voice_assignments.clear()
-        self.voice_assignments = self.voice_assignments  # Trigger reactive
+        # Same dead-self-assignment shape as `characters` above (task-15479
+        # AC #2 grep sweep). No `watch_voice_assignments` exists today, so
+        # this was a pure no-op either way; `mutate_reactive` is the correct
+        # idiom regardless, and keeps this reactive honest if a watcher is
+        # ever added later. The explicit `_refresh_character_table()` /
+        # `_update_assignment_summary()` calls right below are what actually
+        # keep the UI in sync today.
+        self.mutate_reactive(CharacterVoiceWidget.voice_assignments)
         self._refresh_character_table()
         self._update_assignment_summary()
         self.app.notify("All voices reset to narrator", severity="information")


### PR DESCRIPTION
## Summary

Task 15479 from the input-latency audit's bug set. `self.characters = self.characters` can never fire a Textual reactive (same-object equality, no `always_update`), so add/remove-character never refreshed the table.

- Trigger fixed via `mutate_reactive` (the codebase's established idiom) — and TDD surfaced an entangled second bug: the reactive carried `recompose=True` while `compose()` never reads it (rows are imperative), so a genuinely-firing trigger would have BLANKED the table; dropped, consistent with the widget's other reactives
- 3 born-red tests (reviewer re-verified red under the reverted fix); repo-wide sweep for the dead self-assignment shape: zero anchored hits remain, all ~45 broader-shape hits classified safe (spot-checked by the reviewer)
- Found in passing, pre-existing, deferred for filing: non-callable reactive defaults (`[]`/`{}`) are shared by identity across widget instances

## Verification
Independent review: Approved, no findings — mutation-tested, sweep re-derived, all counts reproduced exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the character voice table not updating after add/remove. We now trigger the `characters` reactive via `mutate_reactive` and removed a wrong `recompose=True` that was clearing the table (TASK-15479).

- **Bug Fixes**
  - `_add_character_manually` and `_remove_selected_character` call `self.mutate_reactive(CharacterVoiceWidget.characters)` so `watch_characters` runs and the `DataTable` refreshes.
  - Removed `recompose=True` from `characters`; `compose()` doesn’t use it and it was rebuilding the widget and dropping rows/state.
  - Replaced `self.voice_assignments = self.voice_assignments` with `mutate_reactive` for consistency (no behavior change today).
  - Added 3 regression tests for add/remove refresh; repo sweep confirmed no other dead self-assignment triggers remain.

<sup>Written for commit 4aed854e311082047dd9aed9096b223af54ee407. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

