### PR TITLE
fix: remove dead media-viewer prompt search (task-15477)

### DIFF
--- a/Tests/UI/test_media_viewer_prompt_search_15477.py
+++ b/Tests/UI/test_media_viewer_prompt_search_15477.py
@@ -1,0 +1,164 @@
+"""TASK-15477: media-viewer prompt search was dead code raising per keystroke.
+
+`MediaViewerPanel.search_prompts` imported `get_prompts_db` from
+`DB/Prompts_DB` -- a symbol that never existed -- so every keystroke in the
+Analysis tab's "Search Prompts" box raised an ``ImportError`` that was
+silently swallowed at the bottom of the handler. The handler also called
+``self.app.call_from_thread`` from the UI thread (illegal in Textual) and,
+as designed, would have run its sqlite search inline with no debounce.
+
+Investigation (see the task's Implementation Plan) found the affordance had
+no reachable UX purpose: ``MediaViewerPanel`` is only mounted by
+``MediaWindow_v2``, which backs the standalone ``MediaScreen`` route --
+permanently aliased to Library (task-2851) with no other entry point. The
+fix removes the search/keyword/select widgets and their handlers outright
+rather than wiring them to a live DB seam that nothing could ever reach.
+The System/User Prompt ``TextArea``s and "Generate Analysis" button are
+untouched -- they don't depend on the removed widgets.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+from loguru import logger as loguru_logger
+from textual.app import App, ComposeResult
+from textual.css.query import NoMatches
+from textual.widgets import Button, TextArea
+
+from tldw_chatbook.Widgets.Media.media_viewer_panel import MediaViewerPanel
+
+# Method/handler names the pre-fix panel defined for the dead prompt-search
+# affordance. Asserted absent post-fix.
+_REMOVED_METHOD_NAMES = (
+    "search_prompts",
+    "load_prompt_details",
+    "_update_prompt_select",
+    "handle_prompt_search",
+    "handle_prompt_keyword_change",
+    "handle_prompt_selection",
+)
+
+# Widget ids the pre-fix panel composed for the dead prompt-search
+# affordance. Asserted absent post-fix.
+_REMOVED_WIDGET_IDS = (
+    "prompt-search-input",
+    "prompt-keyword-input",
+    "prompt-select",
+)
+
+# Widgets that must survive the removal: manual prompt editing and
+# "Generate Analysis" never depended on the search/select affordance
+# (`prepare_analysis_messages`/`handle_generate_analysis` only read these).
+_SURVIVING_WIDGET_IDS = (
+    "system-prompt-area",
+    "user-prompt-area",
+    "generate-analysis-btn",
+)
+
+
+class MediaViewerTestApp(App[None]):
+    def __init__(self, panel: MediaViewerPanel):
+        super().__init__()
+        self.panel = panel
+
+    def compose(self) -> ComposeResult:
+        yield self.panel
+
+
+def _media_app() -> Mock:
+    app = Mock()
+    app._media_types_for_ui = []
+    app.get_authoritative_runtime_source = Mock(return_value="local")
+    app.notify = Mock()
+    return app
+
+
+@pytest.mark.asyncio
+async def test_prompt_search_widgets_are_gone() -> None:
+    """AC1: the dead search/keyword/select widgets no longer compose.
+
+    Pre-fix, `panel.query_one("#prompt-search-input", Input)` succeeds (the
+    widget composes fine -- it's the keystroke handler that was broken), so
+    this assertion is red against the old code and green once the widgets
+    are removed.
+    """
+    panel = MediaViewerPanel(_media_app())
+    app = MediaViewerTestApp(panel)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        for widget_id in _REMOVED_WIDGET_IDS:
+            with pytest.raises(NoMatches):
+                panel.query_one(f"#{widget_id}")
+
+
+@pytest.mark.asyncio
+async def test_surviving_prompt_widgets_still_compose() -> None:
+    """Guard against over-deleting: manual prompt editing + Generate stay."""
+    panel = MediaViewerPanel(_media_app())
+    app = MediaViewerTestApp(panel)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert panel.query_one("#system-prompt-area", TextArea) is not None
+        assert panel.query_one("#user-prompt-area", TextArea) is not None
+        assert panel.query_one("#generate-analysis-btn", Button) is not None
+
+
+def test_prompt_search_methods_are_removed() -> None:
+    """AC1/AC2: the broken handler methods no longer exist on the class.
+
+    `search_prompts` was the method that imported the nonexistent
+    `get_prompts_db` symbol and illegally called `call_from_thread` from the
+    UI thread; removing it (rather than leaving a dead method around)
+    guarantees no code path can still raise per keystroke.
+    """
+    for name in _REMOVED_METHOD_NAMES:
+        assert not hasattr(MediaViewerPanel, name), (
+            f"MediaViewerPanel.{name} should have been removed with the "
+            "dead prompt-search affordance"
+        )
+
+
+def test_prompts_db_module_still_has_no_get_prompts_db() -> None:
+    """Documents the root cause: `get_prompts_db` never existed in
+    `DB/Prompts_DB`. This module is not being given that symbol -- the
+    caller was removed instead -- so this stays true after the fix too, and
+    guards against a future PR re-adding an import of a symbol that was
+    never there without re-verifying it first.
+    """
+    import tldw_chatbook.DB.Prompts_DB as prompts_db_module
+
+    assert not hasattr(prompts_db_module, "get_prompts_db")
+
+
+@pytest.mark.asyncio
+async def test_mounting_and_settling_the_panel_logs_no_prompt_search_error() -> None:
+    """AC2 log evidence: mounting the panel (which used to `on_mount` into a
+    UI where every keystroke in the now-removed search box logged
+    ``Error searching prompts: cannot import name 'get_prompts_db'``) never
+    emits that error. Pre-fix the widget existed but this assertion alone
+    wouldn't fail without a simulated keystroke; combined with
+    `test_prompt_search_widgets_are_gone` (which proves there is no longer
+    any widget to type into) and `test_prompt_search_methods_are_removed`
+    (which proves the offending method is gone), this closes the loop: no
+    code path remains that could ever produce that log line again.
+    """
+    records: list[dict] = []
+    sink_id = loguru_logger.add(lambda message: records.append(message.record), level="ERROR")
+    try:
+        panel = MediaViewerPanel(_media_app())
+        app = MediaViewerTestApp(panel)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert not any(
+        "search" in str(record.get("message", "")).lower()
+        and "prompt" in str(record.get("message", "")).lower()
+        for record in records
+    )

--- a/backlog/tasks/task-15477 - Media-viewer-prompt-search-is-dead-code-that-raises-per-keystroke.md
+++ b/backlog/tasks/task-15477 - Media-viewer-prompt-search-is-dead-code-that-raises-per-keystroke.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15477
 title: Media viewer prompt search is dead code that raises per keystroke
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - bug
@@ -20,7 +21,127 @@ Decide: wire it to the real Prompts DB seam (threaded + debounced per the task-1
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Prompt search either works against the live prompts store, off-loop and debounced, or the affordance is removed
-- [ ] #2 No exception per keystroke (log evidence)
-- [ ] #3 A regression test covers the chosen path
+- [x] #1 Prompt search either works against the live prompts store, off-loop and debounced, or the affordance is removed
+- [x] #2 No exception per keystroke (log evidence)
+- [x] #3 A regression test covers the chosen path
 <!-- AC:END -->
+
+## Implementation Plan
+
+Investigated reachability before deciding:
+
+1. `MediaViewerPanel` (`Widgets/Media/media_viewer_panel.py`) is only ever
+   constructed by `UI/MediaWindow_v2.py`, which backs the standalone
+   `MediaScreen` route (`UI/Screens/media_screen.py`).
+2. `UI/Navigation/screen_registry.py`'s `_SCREEN_ALIASES["media"] = "library"`
+   (task-2851, Library UAT 2026-08-06) permanently redirects the "media"
+   route — including any startup-config `default_screen` — to Library's own
+   media canvas instead. `app.py:1481`/`:7473-7481` confirm the same fold at
+   the shell-destination layer. There is no other call site that reaches
+   `MediaScreen`/`MediaWindow_v2`/`MediaViewerPanel` from live navigation.
+3. Library's *replacement* media viewer (`Widgets/Library/library_media_viewer.py`,
+   the one actually reachable today) never grew an equivalent
+   provider/model/prompt-search "Generate Analysis" panel -- it only has a
+   read-only analysis text + a manual edit `TextArea` (`_compose_analysis`).
+   So the broken prompt-search affordance is not a regression of a feature
+   users currently rely on; it never had a live audience post-fold.
+4. Decision: **remove the affordance**, not wire it to a DB seam. Building a
+   threaded+debounced `PromptScopeService`/`PromptsDatabase` integration
+   (the task-15476/console-picker shape) for a screen with zero reachable
+   entry points would be net-new maintenance surface for code nothing can
+   ever mount from the running app -- the opposite of long-term stability.
+   The manually-editable System Prompt / User Prompt `TextArea`s and the
+   "Generate Analysis" button stay: they don't depend on the search/select
+   widgets (confirmed via `prepare_analysis_messages`/
+   `handle_generate_analysis`, which only read the two `TextArea`s) and
+   remain the only way to drive analysis today, matching the Library
+   replacement's own "no prompt library" scope.
+5. Empirically reproduced the bug pre-fix with a throwaway pilot-mounted
+   probe: typing into `#prompt-search-input` logs
+   `ERROR ... search_prompts:1644 - Error searching prompts: cannot import
+   name 'get_prompts_db' from 'tldw_chatbook.DB.Prompts_DB'` on every
+   keystroke, swallowed, UI unaffected -- matches the audit exactly.
+6. Implementation steps:
+   - Write regression tests first (red against current code): assert the
+     panel's `compose()` no longer yields `#prompt-search-input`,
+     `#prompt-keyword-input`, `#prompt-select` (and their "Search Prompts:"/
+     "Filter by Keywords:" labels), and that `MediaViewerPanel` no longer
+     defines `search_prompts`/`load_prompt_details`/`_update_prompt_select`/
+     `handle_prompt_search`/`handle_prompt_keyword_change`/
+     `handle_prompt_selection`. Add a companion test asserting the System/
+     User Prompt `TextArea`s and Generate button are untouched (guard
+     against over-deleting).
+   - Remove those five widgets, three id-scoped `@on` handlers, and the
+     three backing methods (`search_prompts` incl. the illegal
+     `call_from_thread`, `_update_prompt_select`, `load_prompt_details`)
+     from `Widgets/Media/media_viewer_panel.py`.
+   - Confirm no CSS/`save_state`/`restore_state` reference to the removed
+     ids (checked: none found -- `.prompt-label` is a shared class still
+     used by the surviving System/User Prompt labels).
+   - Run the new tests plus the existing `media_viewer_panel`-touching
+     suites (`test_media_handoffs.py`, `test_reader_scroll_keys_1994.py`,
+     `test_media_window_v2_parity.py`, `test_markdown_hygiene_1995.py`).
+
+## Implementation Notes
+
+**Chosen resolution: removed the affordance** (not wired to a live DB
+seam). Reachability investigation (see plan) found `MediaViewerPanel` --
+the only place these widgets existed -- is exclusively mounted by
+`MediaWindow_v2`, which backs the standalone `MediaScreen` route.
+`UI/Navigation/screen_registry.py`'s `_SCREEN_ALIASES["media"] = "library"`
+(task-2851) permanently folds that route onto Library's own media canvas,
+which never grew an equivalent LLM-analysis/prompt-search panel of its own
+(`Widgets/Library/library_media_viewer.py` only has a read-only analysis
+text + manual edit `TextArea`). So the search box had no reachable
+audience: wiring it to `PromptScopeService`/`PromptsDatabase` (the
+task-15476/console-picker shape) would have added real maintenance surface
+for a screen nothing in the running app can mount. Confirmed pre-fix via a
+throwaway pilot-mounted probe that typing into `#prompt-search-input`
+logged `Error searching prompts: cannot import name 'get_prompts_db' from
+'tldw_chatbook.DB.Prompts_DB'` on every keystroke (matches the audit
+exactly) with no crash surfacing.
+
+**What changed** (`tldw_chatbook/Widgets/Media/media_viewer_panel.py`):
+removed the "Search Prompts" / "Filter by Keywords" `Input`s and the
+prompt-selection `Select` from `compose()`; removed the three backing
+methods (`search_prompts` -- the `@work(thread=True)` method with the
+nonexistent import and the illegal `self.app.call_from_thread` off a
+worker thread, `_update_prompt_select`, `load_prompt_details`); removed
+the three `@on` handlers wired to those widget ids
+(`handle_prompt_search`, `handle_prompt_keyword_change`,
+`handle_prompt_selection`). The System Prompt / User Prompt `TextArea`s
+and the "Generate Analysis" button are untouched -- `handle_generate_analysis`
+and `prepare_analysis_messages` only ever read those two `TextArea`s, never
+the removed widgets, so manual prompt entry + analysis generation keeps
+working exactly as before. No CSS or `save_state`/`restore_state` code
+referenced the removed ids (verified by grep before removing).
+
+**Tests** (`Tests/UI/test_media_viewer_prompt_search_15477.py`, new file):
+5 tests, mounting the real `MediaViewerPanel` via a Textual pilot harness
+(mirrors `test_media_handoffs.py`'s `MediaViewerTestApp` pattern). Two are
+literal red-then-green regression tests for AC1/AC2 (confirmed red against
+pre-fix code, then green after the edit):
+`test_prompt_search_widgets_are_gone` (the three removed ids raise
+`NoMatches`) and `test_prompt_search_methods_are_removed` (`hasattr`
+checks against `MediaViewerPanel` for the five removed method/handler
+names). Three supporting tests: `test_surviving_prompt_widgets_still_compose`
+(guards against over-deletion of the System/User Prompt `TextArea`s and
+Generate button), `test_prompts_db_module_still_has_no_get_prompts_db`
+(documents the root cause and guards against a future PR re-adding the
+same broken import without verifying the symbol first), and
+`test_mounting_and_settling_the_panel_logs_no_prompt_search_error` (loguru
+sink capture over a full pilot mount+settle, AC2's "log evidence" --
+combined with the other two it closes the loop that no code path can ever
+produce that log line again).
+
+**Verification**: `pytest Tests/UI/test_media_handoffs.py
+Tests/UI/test_reader_scroll_keys_1994.py
+Tests/UI/test_media_window_v2_parity.py Tests/UI/test_markdown_hygiene_1995.py
+Tests/UI/test_media_viewer_prompt_search_15477.py` -- 51 passed, 0 failed
+(the four pre-existing `media_viewer_panel`-touching suites found via
+`grep -rl media_viewer_panel Tests/`, plus the new file). `pyflakes` clean
+on both changed/added files. `ast.parse` sanity check on the edited module.
+
+**Files changed**: `tldw_chatbook/Widgets/Media/media_viewer_panel.py`
+(124 lines removed, 0 added); `Tests/UI/test_media_viewer_prompt_search_15477.py`
+(new).

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -778,25 +778,6 @@ class MediaViewerPanel(Container):
                                     value="4096",
                                 )
 
-                    # Prompt search and filtering
-                    yield Label("Search Prompts:", classes="prompt-label")
-                    yield Input(
-                        placeholder="Search for prompts...", id="prompt-search-input"
-                    )
-
-                    yield Label("Filter by Keywords:", classes="prompt-label")
-                    yield Input(
-                        placeholder="Enter keywords separated by commas...",
-                        id="prompt-keyword-input",
-                    )
-
-                    # Prompt selection dropdown
-                    yield Select(
-                        [],  # Will be populated by search results
-                        prompt="Select a prompt",
-                        id="prompt-select",
-                    )
-
                     # System prompt
                     yield Label("System Prompt:", classes="prompt-label")
                     yield TextArea(
@@ -1602,79 +1583,6 @@ class MediaViewerPanel(Container):
         except Exception as e:
             logger.error(f"Error updating models for provider {provider}: {e}")
 
-    @work(thread=True)
-    def search_prompts(self, search_term: str, keywords: str = "") -> None:
-        """Search for prompts in the database."""
-        try:
-            from ...DB.Prompts_DB import get_prompts_db
-
-            prompts_db = get_prompts_db()
-            if not prompts_db:
-                return
-
-            # Parse keywords
-            keyword_list = (
-                [k.strip() for k in keywords.split(",") if k.strip()]
-                if keywords
-                else []
-            )
-
-            # Search prompts
-            if keyword_list:
-                results = prompts_db.search_prompts_by_keyword(
-                    keyword_list, search_term
-                )
-            else:
-                results = (
-                    prompts_db.search_prompts(search_term)
-                    if search_term
-                    else prompts_db.get_all_prompts()
-                )
-
-            # Format results for Select widget
-            options = [
-                (str(p["id"]), f"{p['name']} - {p['description'][:50]}...")
-                for p in results
-            ]
-
-            # Update select widget from thread
-            self.app.call_from_thread(self._update_prompt_select, options)
-
-        except Exception as e:
-            logger.error(f"Error searching prompts: {e}")
-
-    def _update_prompt_select(self, options: List[Tuple[str, str]]) -> None:
-        """Update prompt select options from thread."""
-        try:
-            prompt_select = self.query_one("#prompt-select", Select)
-            prompt_select.set_options(options)
-        except Exception:
-            pass
-
-    def load_prompt_details(self, prompt_id: str) -> None:
-        """Load selected prompt into text areas."""
-        try:
-            from ...DB.Prompts_DB import get_prompts_db
-
-            prompts_db = get_prompts_db()
-            if not prompts_db:
-                return
-
-            # Get prompt details
-            prompt = prompts_db.get_prompt_details(int(prompt_id))
-            if not prompt:
-                return
-
-            # Update text areas
-            system_area = self.query_one("#system-prompt-area", TextArea)
-            user_area = self.query_one("#user-prompt-area", TextArea)
-
-            system_area.text = prompt.get("system_prompt", "")
-            user_area.text = prompt.get("user_prompt", "")
-
-        except Exception as e:
-            logger.error(f"Error loading prompt details: {e}")
-
     def prepare_analysis_messages(self) -> Tuple[str, str]:
         """Prepare system and user prompts with media content."""
         logger.debug("Preparing analysis messages")
@@ -1802,38 +1710,6 @@ class MediaViewerPanel(Container):
         """Handle model selection change."""
         # Just store the selection, no additional action needed
         pass
-
-    @on(Input.Changed, "#prompt-search-input")
-    def handle_prompt_search(self, event: Input.Changed) -> None:
-        """Handle prompt search input with debouncing."""
-        # Get keyword filter value
-        try:
-            keyword_input = self.query_one("#prompt-keyword-input", Input)
-            keywords = keyword_input.value
-        except Exception:
-            keywords = ""
-
-        # Trigger search
-        self.search_prompts(event.value, keywords)
-
-    @on(Input.Changed, "#prompt-keyword-input")
-    def handle_prompt_keyword_change(self, event: Input.Changed) -> None:
-        """Handle prompt keyword filter change."""
-        # Get search term
-        try:
-            search_input = self.query_one("#prompt-search-input", Input)
-            search_term = search_input.value
-        except Exception:
-            search_term = ""
-
-        # Trigger search
-        self.search_prompts(search_term, event.value)
-
-    @on(Select.Changed, "#prompt-select")
-    def handle_prompt_selection(self, event: Select.Changed) -> None:
-        """Handle prompt selection."""
-        if event.value and event.value != Select.BLANK:
-            self.load_prompt_details(event.value)
 
     @on(Button.Pressed, "#generate-analysis-btn")
     def handle_generate_analysis(self) -> None:


### PR DESCRIPTION
## Summary

Task 15477 from the input-latency audit's bug set. The media viewer panel's prompt search imported `get_prompts_db` — a symbol that has never existed — so every keystroke raised an ImportError that was silently swallowed; the feature has never worked. It also made an illegal `call_from_thread` from the UI thread.

Resolution: **removal**, not rewiring. The panel is constructed only by the standalone MediaScreen route, which `_SCREEN_ALIASES["media"] = "library"` permanently folds onto Library (reviewer independently verified no navigation path bypasses the alias resolver, and Library's live media viewer never embedded this panel). Three widgets, three handlers, three backing methods removed; System/User Prompt areas and Generate Analysis untouched.

- 5 new tests: absence pins (NoMatches for the removed ids, not-hasattr for the removed names — real regression guards) + a no-error mount log assertion; born red pre-fix
- 51 tests green across the media UI batch; Tests/UI collect sweep clean (10,615 collected)

## Verification
Independent review: Approved, zero findings — reachability argument verified end-to-end, removal completeness grepped repo-wide including CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the broken prompt search from the media viewer panel to stop per-keystroke errors. Manual prompts and Generate Analysis are unchanged and still work. Satisfies task-15477.

- **Bug Fixes**
  - Deleted the search/keyword inputs and prompt select, plus their handlers and backing methods; this removes the ImportError from nonexistent `get_prompts_db` and the illegal `call_from_thread`.
  - Verified the panel is only reachable via the standalone media route, which is aliased to Library, so no user path is affected.
  - Added 5 regression tests to assert the removed widgets/methods are gone and to check no error logs appear on mount.

<sup>Written for commit 94c997cf870a009518d9ea86ae3f4577fead7cc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

