### PR TITLE
Improve Library navigation and File Notes delete safety

### DIFF
--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -42,6 +42,10 @@ pages:
 - **Header line** — reads **Library | Local**, or **Library | Server:
   \<label\>** when a server runtime is configured.
 - **Left rail**, top to bottom:
+  - a **Navigation** heading with **Collapse** at the opposite edge. Collapse
+    hides the rail without changing the selected destination, search query,
+    section disclosures, or canvas. The slim **Nav** handle expands it again;
+    it is keyboard-focusable and remains part of the **F6** pane cycle;
   - the **Import…** button ("Add files, links, and transcripts to
     your Library.");
   - the **Search Library…** box — submitting it lands on the
@@ -105,6 +109,8 @@ on-screen. Escape (or the **Database** link) returns to the notes list — see
 
 | Control | What it does |
 |---|---|
+| **Collapse** | Hides the wide navigation rail in place and gives the canvas the reclaimed width. The choice lasts for the current Library screen session. |
+| **Nav** | Expands a manually collapsed rail and returns focus to **Search Library…**. On compact terminals, Library's existing one-pane routing takes precedence and the manual collapse returns when the terminal is wide again. |
 | **Import…** | Opens the Import media canvas — see [Import & export](library/import-and-export.md). |
 | **Search Library…** | Type a query and press Enter: lands on the Search / RAG canvas and runs it (empty submit just opens the canvas) — see [Search & RAG](library/search-and-rag.md). |
 | **▾** / **▸** (section headers) | Open or collapse that rail section. |

--- a/Docs/User_Guide/library/file-notes.md
+++ b/Docs/User_Guide/library/file-notes.md
@@ -22,7 +22,8 @@ Open [Library](../library.md) (**Ctrl+3**), pick **Notes** in the rail's
 Browse section, then use the source strip at the top of the canvas: it reads
 **Database** | **Files**. Click **Files** — while the workspace loads you'll
 briefly see "Opening File Notes…". At 120 columns and wider, the rail stays
-visible and the workspace fills the canvas pane next to it. On compact
+beside the workspace unless you press **Collapse** in its **Navigation**
+heading; use the slim **Nav** handle to expand it again. On compact
 terminals, Library shows the File Notes canvas as the single visible stage so
 its controls remain on-screen; **Escape** or **Database** returns to Database
 Notes. Either switch first saves any unsaved edits on the side you're leaving.
@@ -46,9 +47,10 @@ Notes. Either switch first saves any unsaved edits on the side you're leaving.
   one; "Recently deleted: \<path\>" right after a delete), a save-status
   label (Idle / Dirty / Saving / Saved / Conflict / Error, sometimes with a
   detail after a dash), a path input with placeholder "relative/path.md",
-  two toolbars (**New Delete Restore Save draft as copy More file actions**
-  and the disclosed secondary actions), the text editor itself, and an action-status
-  line where results like "Deleted. Restore remains available." appear.
+  two toolbars (a primary row beginning with **New** and ending with
+  **Delete**, plus the disclosed secondary actions), the text editor itself,
+  and an action-status line where results like "Deleted. Restore remains
+  available." appear.
 - **Session Git panel** — pressing **Session Git (N)** swaps the whole
   workspace for the staging, commit, and guarded-push panel described below;
   from the row list, **Esc** or **Back to navigator** returns to the files.
@@ -69,6 +71,10 @@ Notes. Either switch first saves any unsaved edits on the side you're leaving.
 The path input ("relative/path.md") is the target for **New**, **Move**, and
 **Save draft as copy** or **Export exact copy**: type where you want the file
 to go, then press the relevant button.
+
+On a wide editor, **New** stays at the far left and **Delete** is separated
+from the routine actions at the far right. On a compact editor, **Delete** is
+the final full-width row. Its two-activation confirmation is unchanged.
 
 | Control | What it does |
 |---|---|

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -4237,7 +4237,12 @@ async def test_file_notes_delete_is_last_and_spatially_separated_from_new(
     tmp_path: Path,
     size: tuple[int, int],
 ) -> None:
-    """Delete stays last in keyboard order and away from routine actions."""
+    """Verify Delete stays last in keyboard order and away from routine actions.
+
+    Args:
+        tmp_path: Temporary directory used as the File Notes root.
+        size: Terminal width and height used to exercise the responsive layout.
+    """
     root = tmp_path / "notes"
     root.mkdir()
     (root / "safety.md").write_text("keep me\n", encoding="utf-8")

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -4230,6 +4230,56 @@ async def test_file_notes_discloses_actions_by_editor_state_and_redirects_focus(
     replica.close()
 
 
+@pytest.mark.parametrize("size", ((120, 40), (40, 20)))
+@pytest.mark.asyncio
+@pytest.mark.allow_network
+async def test_file_notes_delete_is_last_and_spatially_separated_from_new(
+    tmp_path: Path,
+    size: tuple[int, int],
+) -> None:
+    """Delete stays last in keyboard order and away from routine actions."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "safety.md").write_text("keep me\n", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=replica,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=size) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("safety.md")
+        await pilot.pause()
+        await pilot.pause()
+
+        toolbar = workspace.query_one("#file-notes-file-actions")
+        new = workspace.query_one("#file-notes-new", Button)
+        delete = workspace.query_one("#file-notes-delete", Button)
+        spacer = workspace.query_one("#file-notes-delete-spacer", Static)
+        button_ids = [button.id for button in toolbar.query(Button)]
+
+        assert button_ids[0] == "file-notes-new"
+        assert button_ids[-1] == "file-notes-delete"
+        assert new.display and delete.display
+        assert new.render_line(0).text.strip() == "New"
+        assert delete.render_line(0).text.strip() == "Delete"
+        if size[0] == 120:
+            assert not workspace.has_class("-stack-editor-actions")
+            assert spacer.display
+            assert delete.region.x > new.region.right
+            assert delete.region.right == toolbar.content_region.right
+        else:
+            assert workspace.has_class("-stack-editor-actions")
+            assert not spacer.display
+            assert delete.region.y > new.region.y
+            assert delete.region.width == toolbar.content_region.width
+
+    replica.close()
+
+
 @pytest.mark.asyncio
 async def test_disabled_file_notes_actions_carry_marker_and_visible_recovery(
     tmp_path: Path,

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -20077,6 +20077,93 @@ async def test_library_note_wide_deep_link_back_clears_future_compact_intent() -
 
 
 @pytest.mark.asyncio
+@pytest.mark.allow_network
+async def test_library_navigation_rail_collapses_in_place_and_survives_breakpoints() -> (
+    None
+):
+    """The wide rail yields canvas space without losing its mounted state."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await pilot.pause()
+
+        rail = screen.query_one("#library-rail", LibraryRail)
+        canvas = screen.query_one("#library-canvas")
+        handle = screen.query_one("#library-rail-handle")
+        collapse = screen.query_one("#library-rail-collapse", Button)
+        search = screen.query_one("#library-search-input", Input)
+        details_body = screen.query_one("#library-rail-section-body-details")
+        selected = screen.query_one(
+            f"#{LIBRARY_RAIL_ROW_PREFIX}{LIBRARY_ROW_BROWSE_CONVERSATIONS}",
+            Button,
+        )
+        search.value = "retained query"
+        assert not details_body.display
+        initial_canvas_width = canvas.region.width
+
+        collapse.focus()
+        collapse.press()
+        await _wait_for_condition(
+            pilot,
+            lambda: handle.display and not rail.display,
+            message="Library rail did not collapse to its handle",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: canvas.region.width > initial_canvas_width,
+            message="Library canvas did not receive the collapsed rail width",
+        )
+        assert screen.focused is screen.query_one("#library-rail-open", Button)
+        assert canvas.region.width > initial_canvas_width
+        assert screen.query_one("#library-rail", LibraryRail) is rail
+        assert search.value == "retained query"
+        assert selected.has_class("library-rail-row-selected")
+        assert screen.query_one("#library-rail-section-body-details") is details_body
+        assert not details_body.display
+
+        canvas_action = screen.query_one("#library-conversation-row-0", Button)
+        canvas_action.focus()
+        screen.action_focus_next_workbench_pane()
+        await pilot.pause()
+        assert screen.focused is screen.query_one("#library-rail-open", Button)
+
+        screen.query_one("#library-rail-open", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: rail.display and not handle.display,
+            message="Library rail did not expand from its handle",
+        )
+        assert screen.focused is search
+        assert search.value == "retained query"
+        assert selected.has_class("library-rail-row-selected")
+        assert not details_body.display
+
+        collapse.press()
+        await _wait_for_condition(
+            pilot,
+            lambda: handle.display and not rail.display,
+            message="Library rail did not re-collapse",
+        )
+        await pilot.resize_terminal(60, 20)
+        await _wait_for_library_notes_compact(screen, pilot, True)
+        assert rail.display
+        assert not handle.display
+        assert not collapse.display
+
+        await pilot.resize_terminal(170, 48)
+        await _wait_for_library_notes_compact(screen, pilot, False)
+        assert not rail.display
+        assert handle.display
+        assert canvas.display
+
+
+@pytest.mark.asyncio
 async def test_library_note_compact_stage_drills_in_and_back_without_losing_origin() -> (
     None
 ):

--- a/backlog/tasks/task-15602 - Separate-File-Notes-Delete-from-primary-creation-actions.md
+++ b/backlog/tasks/task-15602 - Separate-File-Notes-Delete-from-primary-creation-actions.md
@@ -1,0 +1,53 @@
+---
+id: TASK-15602
+title: Separate File Notes Delete from primary creation actions
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-12 03:21'
+labels: []
+dependencies:
+  - TASK-15601
+documentation:
+  - Docs/User_Guide/library/file-notes.md
+priority: high
+type: enhancement
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reduce accidental File Notes deletion by separating Delete spatially and sequentially from New and the routine editor actions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 New remains the first File Notes editor action and Delete becomes the final action in DOM and keyboard order
+- [x] #2 In a wide editor toolbar Delete is anchored at the far-right edge with flexible separation from routine actions
+- [x] #3 In the compact action layout Delete occupies its own final full-width row rather than sitting beside New or another routine action and every action label remains fully readable at 40 columns
+- [x] #4 Delete retains its existing two-activation confirmation copy focus behavior stale-state checks and recovery behavior
+- [x] #5 Mounted 40x20 and 120x40 tests verify rendered placement keyboard order and unchanged confirmation behavior and focused static checks pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: this is a local action-layout and tab-order safety improvement that changes no mutation, confirmation, recovery, or authority protocol.
+
+1. Add mounted layout assertions that fail against the adjacent New/Delete ordering.
+2. Move Delete to the final DOM position and use a flexible separator on wide layouts plus an isolated final row on compact layouts; use a single compact column at 40 columns so long recovery labels remain readable.
+3. Re-run the existing destructive confirmation tests and rendered compact/wide checks.
+4. Update the File Notes guide and record closeout evidence.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Moved Delete to the final toolbar and keyboard position, using a flexible wide-layout separator and an isolated final compact row. At 40 columns the compact toolbar now uses one column so recovery labels remain complete. The existing two-activation delete, stale-state, and restore flow was left unchanged and verified through the real service test.
+
+- Updated the File Notes workspace, mounted layout coverage, and File Notes guide.
+- Verified 40x20 and 120x40 rendered labels, geometry, and DOM order; the real create/move/delete/restore flow; and adjacent action-disclosure layouts.
+- Ruff passes for the focused File Notes implementation and tests; `git diff --check` passes.
+- ADR required: no. No storage, authority, confirmation, or recovery contract changed.

--- a/backlog/tasks/task-15603 - Make-the-Library-navigation-rail-collapsible.md
+++ b/backlog/tasks/task-15603 - Make-the-Library-navigation-rail-collapsible.md
@@ -1,0 +1,53 @@
+---
+id: TASK-15603
+title: Make the Library navigation rail collapsible
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-12 03:21'
+labels: []
+dependencies: []
+documentation:
+  - Docs/User_Guide/library.md
+  - backlog/decisions/011-chatbook-workbench-ui-system.md
+priority: high
+type: enhancement
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let users reclaim Library canvas width by collapsing the left navigation rail without losing its route, query, disclosure, focus, or canvas state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 Wide Library layouts expose an explicit Collapse control in the navigation rail and replace the collapsed rail with a focusable Expand navigation handle
+- [x] #2 Collapse and expand update the existing mounted shell in place so route selection search text section disclosure state and the active canvas survive unchanged
+- [x] #3 Collapsing moves focus to the Expand navigation handle expanding moves focus into rail search and F6 includes whichever rail surface is currently visible
+- [x] #4 The existing compact Notes single-stage router remains authoritative below its breakpoint and a manual wide-layout collapse is restored when the terminal returns wide
+- [x] #5 The canvas receives the released width no new shortcut or footer hint is introduced and mounted wide compact resize and keyboard tests plus static checks pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A; conform to `backlog/decisions/011-chatbook-workbench-ui-system.md`.
+Reason: this reuses the established destination rail handle and keeps collapse state only in the mounted Library screen session; it adds no persisted setting, route contract, or keybinding.
+
+1. Add a production Library shell test for collapse, state retention, focus, F6, canvas expansion, and compact breakpoint behavior.
+2. Add an explicit rail heading Collapse control and the shared collapsed-rail handle.
+3. Apply visibility in place through the existing Library shell stage synchronizer, with compact Notes routing taking precedence.
+4. Update the Library guide and run focused Library shell and File Notes regressions plus static checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Added a restrained Navigation heading with Collapse and a three-column-wide, keyboard-focusable Nav handle built on the existing destination-rail handle. Collapse updates mounted visibility instead of recomposing the shell, so the route, query, disclosures, selection, and canvas survive; compact Notes routing remains authoritative and restores the manual collapse after returning wide.
+
+- Updated the Library rail, screen integration, widget exports, mounted shell coverage, and Library guide.
+- Verified canvas width reclamation, focus handoff, F6 cycling, state retention, compact breakpoint precedence, wide restoration, rail scrolling, and recompose behavior.
+- Focused Ruff passes with the repository's pre-existing `E721` and unused-import diagnostics excluded in the two large legacy files; `git diff --check` passes.
+- ADR required: no. The implementation conforms to `backlog/decisions/011-chatbook-workbench-ui-system.md` and adds no persisted setting or keybinding.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -312,6 +312,7 @@ from ...Widgets.Library import (
     LibraryMediaTrashCanvas,
     LibraryMediaViewer,
     LibraryNotesCanvas,
+    LibraryNavigationRailHandle,
     LibraryPromptsListCanvas,
     LibraryRail,
     LibrarySearchRagPanel,
@@ -1659,8 +1660,12 @@ class LibraryScreen(BaseAppScreen):
     #: action, which exists only on the landing.
     _WORKBENCH_FOCUS_TARGETS = (
         WorkbenchPaneTarget(
+            "library-rail-handle",
+            ("library-rail-open",),
+        ),
+        WorkbenchPaneTarget(
             "library-rail",
-            ("library-search-input",),
+            ("library-search-input", "library-rail-collapse"),
         ),
         WorkbenchPaneTarget(
             "library-canvas",
@@ -2903,6 +2908,7 @@ class LibraryScreen(BaseAppScreen):
         # explicit presentation input now so compact/wide utility grouping is
         # testable without coupling the canvas to terminal geometry.
         self._library_notes_compact: bool = False
+        self._library_rail_collapsed: bool = False
         self._library_notes_stage: Literal["rail", "notes"] = "rail"
         self._library_notes_explicit_stage_intent = False
         self._library_notes_pending_focus_identity: LibraryNotesFocusIdentity | None = (
@@ -4110,6 +4116,7 @@ class LibraryScreen(BaseAppScreen):
             return
         try:
             shell = self.query_one("#library-shell-grid", Widget)
+            rail_handle = self.query_one("#library-rail-handle", Widget)
             rail = self.query_one("#library-rail", Widget)
             canvas = self.query_one("#library-canvas", Widget)
         except (NoMatches, QueryError):
@@ -4130,12 +4137,26 @@ class LibraryScreen(BaseAppScreen):
         single_stage = (
             self._library_notes_compact and self._library_notes_compact_stage_applies()
         )
-        rail_display = not single_stage or self._library_notes_stage == "rail"
+        manually_collapsed = (
+            self._library_rail_collapsed and not self._library_notes_compact
+        )
+        rail_display = (
+            not single_stage or self._library_notes_stage == "rail"
+        ) and not manually_collapsed
         canvas_display = not single_stage or self._library_notes_stage == "notes"
+        handle_display = manually_collapsed
+        if rail_handle.display != handle_display:
+            rail_handle.display = handle_display
         if rail.display != rail_display:
             rail.display = rail_display
         if canvas.display != canvas_display:
             canvas.display = canvas_display
+        try:
+            collapse = rail.query_one("#library-rail-collapse", Button)
+        except (NoMatches, QueryError):
+            pass
+        else:
+            collapse.display = not self._library_notes_compact
 
     def _transition_library_notes_presentation(
         self,
@@ -7685,6 +7706,12 @@ class LibraryScreen(BaseAppScreen):
             self._library_notes_compact and self._library_notes_compact_stage_applies()
         )
         with shell_grid:
+            rail_handle = LibraryNavigationRailHandle(id="library-rail-handle")
+            rail_handle.styles.height = "100%"
+            rail_handle.display = (
+                self._library_rail_collapsed and not self._library_notes_compact
+            )
+            yield rail_handle
             rail = LibraryRail(
                 shell,
                 preferences,
@@ -7696,7 +7723,12 @@ class LibraryScreen(BaseAppScreen):
                 classes="destination-workbench-pane",
             )
             rail.styles.height = "100%"
-            rail.display = not single_notes_stage or self._library_notes_stage == "rail"
+            rail.display = (
+                (not single_notes_stage or self._library_notes_stage == "rail")
+                and not (
+                    self._library_rail_collapsed and not self._library_notes_compact
+                )
+            )
             yield rail
             canvas_host = Vertical(
                 id="library-canvas", classes="destination-workbench-pane"
@@ -11848,6 +11880,32 @@ class LibraryScreen(BaseAppScreen):
             save_setting_to_cli_config("library.rail_state", "sections", serialized)
         except Exception:
             pass
+
+    def _set_library_rail_collapsed(self, collapsed: bool) -> None:
+        """Toggle wide Library navigation in place without rebuilding state."""
+        self._library_rail_collapsed = collapsed
+        self._apply_library_notes_stage_visibility()
+        if not self.is_mounted or self._library_notes_compact:
+            return
+        selector = "#library-rail-open" if collapsed else "#library-search-input"
+        try:
+            target = self.query_one(selector)
+        except (NoMatches, QueryError):
+            return
+        self.set_focus(target, scroll_visible=False)
+        self.call_after_refresh(target.focus)
+
+    @on(Button.Pressed, "#library-rail-collapse")
+    def _collapse_library_rail(self, event: Button.Pressed) -> None:
+        """Collapse the wide navigation rail to its keyboard-reachable handle."""
+        event.stop()
+        self._set_library_rail_collapsed(True)
+
+    @on(Button.Pressed, "#library-rail-open")
+    def _expand_library_rail(self, event: Button.Pressed) -> None:
+        """Expand Library navigation and return focus to its search field."""
+        event.stop()
+        self._set_library_rail_collapsed(False)
 
     @on(Button.Pressed, "#library-ingest-top-button")
     async def _on_library_ingest_top_button(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Library/__init__.py
+++ b/tldw_chatbook/Widgets/Library/__init__.py
@@ -13,7 +13,12 @@ from .library_media_trash_canvas import LibraryMediaTrashCanvas
 from .library_media_viewer import LibraryMediaViewer
 from .library_notes_canvas import LibraryNotesCanvas
 from .library_prompts_canvas import LibraryPromptsListCanvas
-from .library_rail import LIBRARY_RAIL_ROW_PREFIX, LibraryRail, library_dim_label_text
+from .library_rail import (
+    LIBRARY_RAIL_ROW_PREFIX,
+    LibraryNavigationRailHandle,
+    LibraryRail,
+    library_dim_label_text,
+)
 from .library_search_rag_panel import (
     LibrarySearchRagPanel,
     library_rag_answer_children,
@@ -67,6 +72,7 @@ __all__ = [
     "LibraryMediaTrashCanvas",
     "LibraryMediaViewer",
     "LibraryNotesCanvas",
+    "LibraryNavigationRailHandle",
     "LibraryPromptsListCanvas",
     "LibraryRail",
     "LibrarySearchRagPanel",

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -814,9 +814,20 @@ class LibraryFileNotesWorkspace(Vertical):
         padding: 0;
     }
 
+    #file-notes-delete-spacer {
+        width: 1fr;
+        height: 1;
+        min-height: 1;
+    }
+
     LibraryFileNotesWorkspace.-stack-editor-actions
-    #file-notes-delete.-confirm-delete {
+    #file-notes-delete-spacer {
+        display: none;
+    }
+
+    LibraryFileNotesWorkspace.-stack-editor-actions #file-notes-delete {
         column-span: 2;
+        width: 1fr;
     }
 
     LibraryFileNotesWorkspace.-stack-editor-actions #file-notes-save-copy {
@@ -826,6 +837,18 @@ class LibraryFileNotesWorkspace(Vertical):
     LibraryFileNotesWorkspace.-stack-editor-actions
     #file-notes-maintenance-toggle {
         column-span: 2;
+    }
+
+    LibraryFileNotesWorkspace.-single-editor-actions .file-notes-toolbar {
+        grid-size: 1;
+        grid-columns: 1fr;
+    }
+
+    LibraryFileNotesWorkspace.-single-editor-actions #file-notes-delete,
+    LibraryFileNotesWorkspace.-single-editor-actions #file-notes-save-copy,
+    LibraryFileNotesWorkspace.-single-editor-actions
+    #file-notes-maintenance-toggle {
+        column-span: 1;
     }
 
     LibraryFileNotesWorkspace.-stack-editor-actions
@@ -1235,7 +1258,6 @@ class LibraryFileNotesWorkspace(Vertical):
                     classes="file-notes-toolbar",
                 ):
                     yield Button("New", id="file-notes-new", compact=True)
-                    yield Button("Delete", id="file-notes-delete", compact=True)
                     yield Button("Restore", id="file-notes-restore", compact=True)
                     yield Button(
                         "Compare",
@@ -1257,6 +1279,8 @@ class LibraryFileNotesWorkspace(Vertical):
                         id="file-notes-maintenance-toggle",
                         compact=True,
                     )
+                    yield Static("", id="file-notes-delete-spacer")
+                    yield Button("Delete", id="file-notes-delete", compact=True)
                 with Horizontal(
                     id="file-notes-maintenance-actions",
                     classes="file-notes-toolbar",
@@ -1980,7 +2004,8 @@ class LibraryFileNotesWorkspace(Vertical):
         available_width = pane.content_region.width
         if available_width <= 0:
             return
-        needs_stack = any(
+        single_column = available_width <= 40
+        needs_stack = single_column or any(
             toolbar.display
             and sum(
                 cell_len(str(button.label)) + 4
@@ -1991,6 +2016,11 @@ class LibraryFileNotesWorkspace(Vertical):
             for toolbar in pane.query(".file-notes-toolbar")
         )
         self.set_class(needs_stack, "-stack-editor-actions")
+        self.set_class(single_column, "-single-editor-actions")
+        delete = self.query_one("#file-notes-delete", Button)
+        self.query_one("#file-notes-delete-spacer", Static).display = (
+            delete.display and not needs_stack
+        )
 
     def _rebuild_tree(self) -> None:
         if not self._active or not self.is_mounted:
@@ -4237,6 +4267,10 @@ class LibraryFileNotesWorkspace(Vertical):
             if button is focused and not displayed:
                 self._editor_action_focus_target = action_id
             button.display = displayed
+        self.query_one("#file-notes-delete-spacer", Static).display = (
+            visibility["file-notes-delete"]
+            and not self.has_class("-stack-editor-actions")
+        )
 
         maintenance_toggle = self.query_one(
             "#file-notes-maintenance-toggle", Button

--- a/tldw_chatbook/Widgets/Library/library_rail.py
+++ b/tldw_chatbook/Widgets/Library/library_rail.py
@@ -8,7 +8,7 @@ from typing import Any
 from rich.markup import escape as escape_markup
 from rich.text import Text
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.events import Focus, Key, MouseDown, Resize
 from textual.widget import Widget
 from textual.widgets import Button, Input, Static
@@ -19,7 +19,10 @@ from tldw_chatbook.Library.library_shell_state import (
     LibraryRailSectionState,
     LibraryShellState,
 )
-from tldw_chatbook.Widgets.destination_rail import DestinationRailSectionHeader
+from tldw_chatbook.Widgets.destination_rail import (
+    DestinationRailHandle,
+    DestinationRailSectionHeader,
+)
 from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 
 LIBRARY_RAIL_ROW_PREFIX = "library-row-"
@@ -247,6 +250,41 @@ class LibraryRailRowButton(Button):
         )
 
 
+class LibraryNavigationRailHandle(DestinationRailHandle):
+    """Compact, focusable handle for reopening Library navigation."""
+
+    WIDTH = 3
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(
+            label="Nav",
+            button_id="library-rail-open",
+            badge_id="library-rail-handle-badge",
+            side="left",
+            open_tooltip="Expand Library navigation",
+            **kwargs,
+        )
+        self.add_class("console-rail-handle-vertical")
+        self.styles.width = self.WIDTH
+        self.styles.min_width = self.WIDTH
+        self.styles.max_width = self.WIDTH
+
+    def compose(self) -> ComposeResult:
+        for child in super().compose():
+            if isinstance(child, Button):
+                child.add_class("console-rail-handle-button-vertical")
+                child.styles.width = 1
+                child.styles.max_width = 1
+                child.styles.height = "1fr"
+                child.styles.clear_rule("min_height")
+                child.styles.clear_rule("max_height")
+                child.styles.line_pad = 0
+            yield child
+
+    def _display_label(self) -> str:
+        return "N\na\nv"
+
+
 class LibraryRail(RecomposeCaptureGuard, Vertical):
     """Render the Library shell rail: search, source sections, and Details.
 
@@ -459,6 +497,26 @@ class LibraryRail(RecomposeCaptureGuard, Vertical):
             ComposeResult with the search box, one header + body per section,
             and the Details header + body.
         """
+        heading_row = Horizontal(id="library-rail-heading")
+        heading_row.styles.height = 1
+        heading_row.styles.min_height = 1
+        with heading_row:
+            heading = Static("Navigation", id="library-rail-heading-label")
+            heading.styles.height = 1
+            heading.styles.width = "1fr"
+            yield heading
+            collapse = Button(
+                "Collapse",
+                id="library-rail-collapse",
+                compact=True,
+            )
+            collapse.tooltip = "Collapse Library navigation"
+            collapse.styles.width = "auto"
+            collapse.styles.height = 1
+            collapse.styles.min_height = 1
+            collapse.styles.padding = (0, 1)
+            collapse.styles.border = ("none", "transparent")
+            yield collapse
         if self.top_action_factory is not None:
             yield from self.top_action_factory()
         yield LibraryRailSearchInput(

--- a/tldw_chatbook/Widgets/Library/library_rail.py
+++ b/tldw_chatbook/Widgets/Library/library_rail.py
@@ -270,6 +270,11 @@ class LibraryNavigationRailHandle(DestinationRailHandle):
         self.styles.max_width = self.WIDTH
 
     def compose(self) -> ComposeResult:
+        """Render the narrow vertical button used to expand Library navigation.
+
+        Returns:
+            ComposeResult yielding the configured navigation button.
+        """
         for child in super().compose():
             if isinstance(child, Button):
                 child.add_class("console-rail-handle-button-vertical")


### PR DESCRIPTION
## Summary

- move File Notes Delete to the final DOM and keyboard position, separated from New at the far right on wide layouts
- use a readable single-column action stack at 40 columns, with Delete isolated as the final full-width action
- add an in-place Library navigation Collapse control and a focusable Nav expansion handle
- preserve the selected route, search query, disclosure state, active canvas, F6 behavior, and compact Notes routing
- document the interactions and close TASK-15602 and TASK-15603

## Validation

- `pytest Tests/UI/test_library_file_notes_workspace.py::test_file_notes_delete_is_last_and_spatially_separated_from_new Tests/UI/test_library_shell.py::test_library_navigation_rail_collapses_in_place_and_survives_breakpoints -q` (3 passed)
- focused adjacent File Notes and Library shell tests (14 additional cases passed)
- Ruff on affected files (existing legacy `E721` and `F401` baseline excluded where applicable)
- `git diff --check origin/dev...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Library navigation rail collapsible and isolate File Notes Delete to reduce accidental deletes. Preserves route, search, disclosures, canvas width, and focus behavior; satisfies TASK-15602 and TASK-15603.

- **New Features**
  - Library rail: added “Collapse” in the Navigation heading and a keyboard-focusable “Nav” handle to re-open it. Expanding/collapsing keeps selection, search text, section disclosures, and the active canvas. The canvas gains the freed width. F6 cycles through the visible rail or handle. Compact Notes routing still takes precedence and restores manual collapse when the terminal is wide again.
  - File Notes: moved Delete to the final DOM and keyboard position. On wide editors, Delete is anchored at the far right with a flexible spacer; on compact editors, it’s the last full-width row. At 40 columns, actions use a single readable column. Two-press confirmation and restore behavior are unchanged.

<sup>Written for commit ffcbc3cd0f407f6fd804d364b1585c3ee00cc811. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

