### PR TITLE
perf: tail-first windowed mount for Console transcript loads (task-15455)

### DIFF
--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -158,7 +158,12 @@ older turns load in as you reach them; the jump-to-latest pill (or a new send)
 takes you back to the tail. Nothing is deleted: exports, `/rewind`, and the
 context sent to the model always use the full history. Very long sessions
 still stop growing the view at the height watermarks, so the oldest turns can
-drop out of the scrollback. Tune it under `[chat_defaults]` in
+drop out of the scrollback — where that leaves a hole in what you are reading,
+the transcript marks it with a dim "⋯ N earlier messages not shown" line rather
+than joining two unrelated turns silently. While you are sitting in loaded
+scrollback the view stops trimming itself, so a long reply streaming in
+meanwhile can push it past the height limit; it trims again as soon as you
+return to the latest message. Tune it under `[chat_defaults]` in
 `config.toml` — `transcript_window_messages` (set it to `0` to mount
 everything at load, as before), `transcript_window_lines`,
 `transcript_hydrate_messages`, and the `prune_*_watermark` pair.

--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -149,6 +149,20 @@ composer-level strip below shows once setup completes.
 | **Approvals** | Pending approvals; press Enter or Space on it to jump to the approval card. |
 | **Scope** | Appears when retrieval is narrowed ("Scope: N"); Enter or Space opens the scope picker. |
 
+### Long conversations
+
+Opening or switching to a long conversation shows the most recent stretch of
+it first, rather than mounting the whole history up front — a 500-message
+session opens in about a second instead of tens of seconds. Scroll up and the
+older turns load in as you reach them; the jump-to-latest pill (or a new send)
+takes you back to the tail. Nothing is deleted: exports, `/rewind`, and the
+context sent to the model always use the full history. Very long sessions
+still stop growing the view at the height watermarks, so the oldest turns can
+drop out of the scrollback. Tune it under `[chat_defaults]` in
+`config.toml` — `transcript_window_messages` (set it to `0` to mount
+everything at load, as before), `transcript_window_lines`,
+`transcript_hydrate_messages`, and the `prune_*_watermark` pair.
+
 ### Composer
 
 Editing keys, send/stream/stop, attachments, and Mic dictation live in
@@ -273,4 +287,6 @@ outranks that provider's environment variable. Verified against
 42b28089f — 2026-08-06 (task-2852: live check on a fresh profile — a
 Library Search/RAG handoff staged while locked now shows a receipt line
 on the Get started card, and the same handoff on a configured Console
-still lands on the unchanged staged-evidence strip).*
+still lands on the unchanged staged-evidence strip). "Long conversations"
+verified against 9d2b3147e — 2026-08-11 (task-15455: shipped tests plus an
+isolated 500-message load probe; not re-checked live).*

--- a/Tests/UI/test_console_transcript_windowed_mount.py
+++ b/Tests/UI/test_console_transcript_windowed_mount.py
@@ -391,7 +391,7 @@ def test_window_settings_defaults_and_kill_switch():
 
 
 @pytest.mark.asyncio
-async def test_load_mounts_only_the_tail_window(): 
+async def test_load_mounts_only_the_tail_window():
     """AC#1: a 500-message load mounts the newest window, not the history."""
     app = WindowHarness()
     async with app.run_test() as pilot:

--- a/Tests/UI/test_console_transcript_windowed_mount.py
+++ b/Tests/UI/test_console_transcript_windowed_mount.py
@@ -1,0 +1,282 @@
+"""TASK-15455: tail-first windowed mount + scrollback hydration.
+
+Session resume used to mount EVERY persisted row (one awaited ``mount()`` per
+row, one Textual Markdown widget per assistant message) before the height
+watermarks could trim anything. The transcript now mounts only the newest
+window on a fresh load and hydrates older messages when the reader scrolls
+back.
+
+The first half of this module is the PIN section: invariants that existed
+before windowing and must survive it, exercised on a history large enough
+(60+ messages) that the window path is actually in play — the pre-existing
+suites top out at 30 messages, so none of them would have noticed.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+    ConsoleVariantSet,
+)
+from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+
+
+class WindowHarness(App):
+    """Small viewport so a handful of messages overflow it."""
+
+    CSS = "ConsoleTranscript { height: 10; }"
+
+    def __init__(
+        self,
+        *,
+        low: int = 12000,
+        high: int = 20000,
+        window_messages: int | None = None,
+        window_lines: int | None = None,
+        hydrate_messages: int | None = None,
+    ) -> None:
+        super().__init__()
+        chat_defaults: dict[str, object] = {
+            "prune_high_watermark": high,
+            "prune_low_watermark": low,
+        }
+        if window_messages is not None:
+            chat_defaults["transcript_window_messages"] = window_messages
+        if window_lines is not None:
+            chat_defaults["transcript_window_lines"] = window_lines
+        if hydrate_messages is not None:
+            chat_defaults["transcript_hydrate_messages"] = hydrate_messages
+        self.app_config = {"chat_defaults": chat_defaults}
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleTranscript(id="console-native-transcript")
+
+
+def _msg(
+    i: int | str,
+    role: ConsoleMessageRole = ConsoleMessageRole.ASSISTANT,
+    *,
+    status: str = "completed",
+    lines: int = 4,
+) -> ConsoleChatMessage:
+    return ConsoleChatMessage(
+        role=role,
+        content="\n".join(f"line {i}.{j}" for j in range(lines)),
+        id=f"m{i}",
+        status=status,
+    )
+
+
+def _messages(n: int, *, lines: int = 4) -> list[ConsoleChatMessage]:
+    return [
+        _msg(
+            i,
+            ConsoleMessageRole.USER if i % 2 == 0 else ConsoleMessageRole.ASSISTANT,
+            lines=lines,
+        )
+        for i in range(n)
+    ]
+
+
+def _mounted_message_ids(transcript: ConsoleTranscript) -> list[str]:
+    # Class query, not a type query: assistant rows may render as
+    # ConsoleMarkdownMessage (TASK-1990) while other roles stay plain.
+    return [
+        widget.message_id for widget in transcript.query(".console-transcript-message")
+    ]
+
+
+async def _wait_for(pilot, predicate, *, attempts: int = 50) -> bool:
+    for _ in range(attempts):
+        await pilot.pause()
+        if predicate():
+            return True
+    return False
+
+
+async def _settle(pilot, *, times: int = 8) -> None:
+    for _ in range(times):
+        await pilot.pause()
+
+
+# ---------------------------------------------------------------------------
+# PIN section — behavior that predates windowing and must survive it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pin_large_history_load_leaves_reader_at_the_tail():
+    """A 60-message load lands anchored at the newest content."""
+    app = WindowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        assert transcript._is_following_tail(), "load must keep tail-follow engaged"
+        assert transcript.max_scroll_y > 0, "fixture must overflow the viewport"
+        assert transcript.scroll_y == transcript.max_scroll_y
+        mounted = _mounted_message_ids(transcript)
+        assert mounted, "the newest rows must be mounted"
+        assert mounted[-1] == "m59", "the newest message must be the last row"
+
+
+@pytest.mark.asyncio
+async def test_pin_selection_and_action_row_on_a_mounted_row():
+    """Clicking/selecting a mounted row shows its contextual action row."""
+    app = WindowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        target = _mounted_message_ids(transcript)[-2]
+        transcript.select_message(target)
+        assert await _wait_for(
+            pilot,
+            lambda: bool(transcript.query(".console-transcript-action-row")),
+        ), "selecting a mounted row must mount its action row"
+        assert transcript.selected_message_id == target
+        assert target in _mounted_message_ids(transcript)
+
+
+@pytest.mark.asyncio
+async def test_pin_prune_watermarks_bound_mounted_height():
+    """The height watermarks still bound the mounted transcript."""
+    app = WindowHarness(low=25, high=40)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        assert transcript.virtual_size.height <= 40, (
+            "mounted height must settle at or under the high watermark"
+        )
+        assert transcript._is_following_tail()
+        assert len(transcript._messages) == 60, "the store snapshot is untouched"
+
+
+@pytest.mark.asyncio
+async def test_pin_branch_swap_keeps_shared_prefix_rows():
+    """A branch/variant swap replaces the suffix without rebuilding the prefix."""
+    app = WindowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(60)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        kept_key = f"message:{history[-3].id}"
+        builds_before = transcript.row_build_counts().get(kept_key)
+        assert builds_before is not None, "the pinned row must be mounted"
+
+        swapped = list(history[:-1]) + [
+            _msg("branch-b", ConsoleMessageRole.ASSISTANT)
+        ]
+        transcript.set_messages(swapped)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        mounted = _mounted_message_ids(transcript)
+        assert mounted[-1] == "mbranch-b", "the swapped-in branch tail must mount"
+        assert history[-1].id not in mounted, "the replaced tail must be gone"
+        assert transcript.row_build_counts().get(kept_key) == builds_before, (
+            "a branch swap must not rebuild the shared prefix rows"
+        )
+
+
+@pytest.mark.asyncio
+async def test_pin_variant_navigation_on_a_mounted_row():
+    """`>`/`<` variant navigation still swaps the rendered variant."""
+    app = WindowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(60)
+        history[-1] = ConsoleChatMessage(
+            role=ConsoleMessageRole.ASSISTANT,
+            content="variant one",
+            id="mvariants",
+            variants=ConsoleVariantSet.from_contents(
+                turn_id="turn-variants",
+                contents=["variant one", "variant two"],
+                selected_index=0,
+            ),
+        )
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        transcript.select_next_variant("mvariants")
+        await _settle(pilot)
+        assert "variant two" in transcript.to_plain_text(width=60)
+
+
+@pytest.mark.asyncio
+async def test_pin_session_switch_replaces_every_row():
+    """Switching sessions drops the old rows and renders the new tail."""
+    app = WindowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        other = [
+            _msg(f"other{i}", ConsoleMessageRole.ASSISTANT) for i in range(60)
+        ]
+        transcript.set_messages(other)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        mounted = _mounted_message_ids(transcript)
+        assert mounted, "the new session must render rows"
+        assert all(message_id.startswith("mother") for message_id in mounted), (
+            "no row from the previous session may survive a switch"
+        )
+        assert mounted[-1] == "mother59"
+        assert transcript._is_following_tail()
+
+
+@pytest.mark.asyncio
+async def test_pin_jump_pill_and_jump_to_latest_after_scrolling_up():
+    """Detaching shows the pill; jump_to_latest re-anchors and hides it."""
+    app = WindowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        transcript.release_anchor()
+        transcript.scroll_to(y=0, animate=False)
+        await _settle(pilot)
+        transcript.sync_jump_indicator("streaming")
+        pill = transcript.query_one("#console-transcript-jump-pill")
+        assert pill.display is True, "a detached reader mid-run sees the pill"
+
+        transcript.jump_to_latest()
+        await _settle(pilot)
+        assert pill.display is False
+        assert transcript._is_following_tail()
+        assert transcript.scroll_y == transcript.max_scroll_y
+
+
+@pytest.mark.asyncio
+async def test_pin_exports_render_full_history_regardless_of_mounting():
+    """`to_plain_text` renders every message, mounted or not."""
+    app = WindowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        plain = transcript.to_plain_text(width=40)
+        assert "line 0.0" in plain
+        assert "line 59.3" in plain

--- a/Tests/UI/test_console_transcript_windowed_mount.py
+++ b/Tests/UI/test_console_transcript_windowed_mount.py
@@ -280,3 +280,69 @@ async def test_pin_exports_render_full_history_regardless_of_mounting():
         plain = transcript.to_plain_text(width=40)
         assert "line 0.0" in plain
         assert "line 59.3" in plain
+
+
+# ---------------------------------------------------------------------------
+# Batched DOM churn (reconciler).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_rows_mount_in_one_batched_call():
+    """Contiguous new rows are mounted with a single `mount()` call."""
+    app = WindowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        calls: list[int] = []
+        original_mount = transcript.mount
+
+        def _counting_mount(*widgets, **kwargs):
+            calls.append(len(widgets))
+            return original_mount(*widgets, **kwargs)
+
+        transcript.mount = _counting_mount  # type: ignore[method-assign]
+        transcript.set_messages(_messages(20))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        transcript.mount = original_mount  # type: ignore[method-assign]
+
+        mounted_rows = sum(calls)
+        assert mounted_rows > 20, "the load must mount at least one row per message"
+        assert len(calls) <= 2, (
+            "a fresh load must mount its rows in one batch "
+            f"(saw {len(calls)} mount calls for {mounted_rows} rows)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_removed_rows_are_pruned_in_one_batched_call():
+    """A session switch removes the old rows with one `remove_children()`."""
+    app = WindowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(20))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        removals: list[int] = []
+        original_remove_children = transcript.remove_children
+
+        def _counting_remove_children(selector="*"):
+            widgets = list(selector) if not isinstance(selector, str) else []
+            removals.append(len(widgets))
+            return original_remove_children(widgets or selector)
+
+        transcript.remove_children = _counting_remove_children  # type: ignore[method-assign]
+        transcript.set_messages(
+            [_msg(f"other{i}", ConsoleMessageRole.ASSISTANT) for i in range(4)]
+        )
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        transcript.remove_children = original_remove_children  # type: ignore[method-assign]
+
+        assert removals, "the switch must remove the previous session's rows"
+        assert len(removals) == 1, (
+            f"stale rows must be removed in one batch (saw {len(removals)} calls)"
+        )
+        assert removals[0] > 20, "every stale row belongs to that one batch"
+        assert _mounted_message_ids(transcript) == [f"mother{i}" for i in range(4)]

--- a/Tests/UI/test_console_transcript_windowed_mount.py
+++ b/Tests/UI/test_console_transcript_windowed_mount.py
@@ -20,7 +20,13 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleMessageRole,
     ConsoleVariantSet,
 )
-from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+from tldw_chatbook.Widgets.Console.console_transcript import (
+    DEFAULT_TRANSCRIPT_HYDRATE_MESSAGES,
+    DEFAULT_TRANSCRIPT_WINDOW_LINES,
+    DEFAULT_TRANSCRIPT_WINDOW_MESSAGES,
+    ConsoleTranscript,
+    get_console_transcript_window,
+)
 
 
 class WindowHarness(App):
@@ -346,3 +352,502 @@ async def test_removed_rows_are_pruned_in_one_batched_call():
         )
         assert removals[0] > 20, "every stale row belongs to that one batch"
         assert _mounted_message_ids(transcript) == [f"mother{i}" for i in range(4)]
+
+
+# ---------------------------------------------------------------------------
+# Tail-first window + scroll-back hydration.
+# ---------------------------------------------------------------------------
+
+
+def test_window_settings_defaults_and_kill_switch():
+    """Config resolution mirrors the watermark helper, including the escape."""
+    assert get_console_transcript_window(None) == (
+        DEFAULT_TRANSCRIPT_WINDOW_MESSAGES,
+        DEFAULT_TRANSCRIPT_WINDOW_LINES,
+        DEFAULT_TRANSCRIPT_HYDRATE_MESSAGES,
+    )
+    assert get_console_transcript_window({"chat_defaults": "nope"}) == (
+        DEFAULT_TRANSCRIPT_WINDOW_MESSAGES,
+        DEFAULT_TRANSCRIPT_WINDOW_LINES,
+        DEFAULT_TRANSCRIPT_HYDRATE_MESSAGES,
+    )
+    assert get_console_transcript_window(
+        {"chat_defaults": {"transcript_window_messages": "x"}}
+    ) == (
+        DEFAULT_TRANSCRIPT_WINDOW_MESSAGES,
+        DEFAULT_TRANSCRIPT_WINDOW_LINES,
+        DEFAULT_TRANSCRIPT_HYDRATE_MESSAGES,
+    )
+    # The kill switch is preserved verbatim; the other two are floored at 1.
+    assert get_console_transcript_window(
+        {
+            "chat_defaults": {
+                "transcript_window_messages": 0,
+                "transcript_window_lines": 0,
+                "transcript_hydrate_messages": -5,
+            }
+        }
+    ) == (0, 1, 1)
+
+
+@pytest.mark.asyncio
+async def test_load_mounts_only_the_tail_window(): 
+    """AC#1: a 500-message load mounts the newest window, not the history."""
+    app = WindowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(500))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        mounted = _mounted_message_ids(transcript)
+        assert len(mounted) <= DEFAULT_TRANSCRIPT_WINDOW_MESSAGES, (
+            f"the load window must bound mounted rows (mounted {len(mounted)})"
+        )
+        assert mounted[-1] == "m499", "the newest message must be mounted"
+        assert mounted == [f"m{i}" for i in range(500 - len(mounted), 500)], (
+            "the window must be the contiguous newest suffix, in order"
+        )
+        assert len(transcript._messages) == 500, "the store snapshot is untouched"
+        assert transcript._is_following_tail()
+
+
+@pytest.mark.asyncio
+async def test_window_lines_budget_caps_long_messages():
+    """A few very long messages hit the line budget before the message cap."""
+    app = WindowHarness(window_messages=40, window_lines=60)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60, lines=20))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        mounted = _mounted_message_ids(transcript)
+        assert 3 <= len(mounted) <= 5, (
+            f"~23 estimated rows per message must cap the window (got {len(mounted)})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_mounts_every_row():
+    """`transcript_window_messages = 0` restores the pre-task behavior."""
+    app = WindowHarness(window_messages=0)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(120))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        assert transcript.unhydrated_message_ids() == frozenset()
+        assert len(_mounted_message_ids(transcript)) == 120
+
+
+@pytest.mark.asyncio
+async def test_scrolling_to_the_top_hydrates_older_messages_in_order():
+    """AC#2: scroll-back mounts the next older chunk, in transcript order."""
+    app = WindowHarness(window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        mounted_before = _mounted_message_ids(transcript)
+        assert mounted_before == [f"m{i}" for i in range(50, 60)]
+
+        transcript.release_anchor()
+        transcript.scroll_to(y=0, animate=False)
+        assert await _wait_for(
+            pilot,
+            lambda: len(_mounted_message_ids(transcript)) > len(mounted_before),
+        ), "scrolling to the top never hydrated older messages"
+
+        mounted_after = _mounted_message_ids(transcript)
+        assert mounted_after[-1] == "m59", "the tail must stay mounted"
+        assert mounted_after == [
+            f"m{i}" for i in range(60 - len(mounted_after), 60)
+        ], "hydrated rows must extend the window as an ordered suffix"
+        assert set(mounted_before) <= set(mounted_after)
+        # Rows, not just ids: the DOM order matches the message order.
+        assert [
+            widget.message_id
+            for widget in transcript.query(".console-transcript-message")
+        ] == mounted_after
+
+
+@pytest.mark.asyncio
+async def test_hydration_keeps_the_reader_on_the_same_content():
+    """Rows added ABOVE the reader shift the offset, not the content."""
+    app = WindowHarness(window_messages=12, hydrate_messages=6)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        mounted_before = _mounted_message_ids(transcript)
+        assert mounted_before == [f"m{i}" for i in range(48, 60)], (
+            "the window must be in play for this test to mean anything"
+        )
+        height_before = transcript.virtual_size.height
+
+        def _top_visible_message_id() -> str | None:
+            region = transcript.content_region
+            viewport_top = region.y
+            viewport_bottom = region.y + region.height
+            for widget in transcript.query(".console-transcript-message"):
+                row = widget.region
+                if row.y + row.height > viewport_top and row.y < viewport_bottom:
+                    return widget.message_id
+            return None
+
+        # Park at the very top: the row at the viewport top is then the oldest
+        # mounted one, so the expected post-hydration answer is known WITHOUT
+        # having to catch the pre-hydration frame.
+        transcript.release_anchor()
+        transcript.scroll_to(y=0, animate=False)
+        assert await _wait_for(
+            pilot, lambda: len(_mounted_message_ids(transcript)) > 12
+        ), "hydration never fired"
+        await _settle(pilot)
+
+        assert not transcript._is_following_tail(), (
+            "hydration must not re-attach a detached reader"
+        )
+        assert _top_visible_message_id() == mounted_before[0], (
+            "hydration must keep the same row at the viewport top"
+        )
+        added = transcript.virtual_size.height - height_before
+        assert added > 0
+        assert transcript.scroll_y == added, (
+            "the offset must shift by exactly the height mounted above the reader"
+        )
+
+
+@pytest.mark.asyncio
+async def test_window_shorter_than_the_viewport_fills_until_scrollable():
+    """A window that cannot scroll would strand history: fill it instead."""
+    app = WindowHarness(window_messages=3, hydrate_messages=3)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60, lines=1))
+        await transcript.refresh_messages()
+        await _settle(pilot, times=20)
+
+        assert transcript.max_scroll_y > 0, (
+            "the transcript must end up scrollable so older rows are reachable"
+        )
+        mounted = _mounted_message_ids(transcript)
+        assert len(mounted) > 3, "the 3-message window must have filled"
+        assert transcript.unhydrated_message_ids(), (
+            "the fill must stop once scrollable, not mount the whole history"
+        )
+        assert mounted == [f"m{i}" for i in range(60 - len(mounted), 60)]
+        assert transcript._is_following_tail(), "the fill must not detach the reader"
+        assert transcript.scroll_y == transcript.max_scroll_y
+
+
+@pytest.mark.asyncio
+async def test_selecting_an_unhydrated_message_hydrates_it_first():
+    """A jump target outside the window is hydrated before it is selected."""
+    app = WindowHarness(window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        target = "m20"
+        assert target in transcript.unhydrated_message_ids()
+        assert target not in _mounted_message_ids(transcript)
+
+        transcript.select_message(target)
+        assert await _wait_for(
+            pilot, lambda: target in _mounted_message_ids(transcript)
+        ), "the jump target was never hydrated"
+        assert transcript.selected_message_id == target
+        assert target not in transcript.unhydrated_message_ids()
+        mounted = _mounted_message_ids(transcript)
+        assert mounted == [f"m{i}" for i in range(20, 60)], (
+            "hydrating a target must mount it and everything after it"
+        )
+        assert await _wait_for(
+            pilot, lambda: bool(transcript.query(".console-transcript-action-row"))
+        ), "the hydrated target must show its action row"
+
+
+@pytest.mark.asyncio
+async def test_keyboard_selection_never_lands_on_an_unhydrated_row():
+    """`k` from the oldest mounted row stays inside the mounted window."""
+    app = WindowHarness(window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        oldest_mounted = _mounted_message_ids(transcript)[0]
+        assert oldest_mounted != "m0", "older history must be windowed out"
+        assert transcript.unhydrated_message_ids()
+        transcript.select_message(oldest_mounted)
+        await _settle(pilot)
+        transcript.action_select_previous()
+        await _settle(pilot)
+
+        assert transcript.selected_message_id == oldest_mounted, (
+            "selection must clamp at the oldest MOUNTED row"
+        )
+        assert transcript.selected_message_id not in transcript.unhydrated_message_ids()
+
+
+@pytest.mark.asyncio
+async def test_hydration_stops_at_the_low_watermark():
+    """AC#3: hydration refuses to run once the mounted height reaches the mark."""
+    app = WindowHarness(low=60, high=80, window_messages=6, hydrate_messages=2)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        transcript.release_anchor()
+        for _ in range(30):
+            transcript.scroll_to(y=0, animate=False)
+            await pilot.pause()
+        await _settle(pilot)
+
+        assert transcript.unhydrated_message_ids(), (
+            "hydration must stop while history remains, not mount everything"
+        )
+        assert transcript.virtual_size.height <= 80, (
+            "hydration must not push the transcript past the high watermark"
+        )
+
+
+async def _hydrated_over_the_high_mark(pilot, app) -> ConsoleTranscript:
+    """Load windowed, hydrate scrollback, then arm watermarks it exceeds.
+
+    Pruning starts disabled (``high = 0``) so the window and the hydration are
+    observable first; arming the marks afterwards is the pruning suite's own
+    idiom for putting a mounted transcript over the line deterministically.
+    """
+    transcript = app.query_one(ConsoleTranscript)
+    transcript.set_messages(_messages(40))
+    await transcript.refresh_messages()
+    await _settle(pilot)
+    assert len(_mounted_message_ids(transcript)) == 10, "the window must be in play"
+
+    # Hydrate without selecting: a selected message is protected from the
+    # watermark walk on its own (TASK-1365), which would mask what this
+    # fixture is here to exercise.
+    assert transcript.ensure_message_hydrated("m15")
+    assert await _wait_for(pilot, lambda: "m15" in _mounted_message_ids(transcript)), (
+        "the scrollback the reader asked for was never hydrated"
+    )
+    # Detach WITHOUT parking at the top, so arming the marks below is the only
+    # thing that changes -- no extra hydration in between.
+    transcript.release_anchor()
+    transcript.scroll_to(y=transcript.max_scroll_y / 2, animate=False)
+    await _settle(pilot)
+    assert transcript.virtual_size.height > 40, "the fixture must exceed the marks"
+
+    app.app_config["chat_defaults"]["prune_high_watermark"] = 40
+    app.app_config["chat_defaults"]["prune_low_watermark"] = 25
+    await transcript.refresh_messages()
+    await _settle(pilot)
+    return transcript
+
+
+@pytest.mark.asyncio
+async def test_pruning_does_not_take_back_hydrated_scrollback_while_detached():
+    """Hydrated rows survive the watermark walk while the reader reads them."""
+    app = WindowHarness(low=25, high=0, window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = await _hydrated_over_the_high_mark(pilot, app)
+
+        mounted = _mounted_message_ids(transcript)
+        assert "m15" in mounted, (
+            "the watermark walk must not delete hydrated scrollback under a "
+            "detached reader"
+        )
+        assert mounted == [f"m{i}" for i in range(15, 40)]
+        assert not transcript._pruned_message_ids
+
+        # AC#3: the bound is restored the moment the reader follows the tail
+        # again -- protection is scoped to the detached reader, not permanent.
+        transcript.jump_to_latest()
+        assert await _wait_for(
+            pilot, lambda: transcript.virtual_size.height <= 40, attempts=60
+        ), (
+            "returning to the tail must let the watermarks trim the hydrated "
+            f"head (height {transcript.virtual_size.height})"
+        )
+        assert transcript._pruned_message_ids, "the trim must be recorded"
+        assert _mounted_message_ids(transcript)[-1] == "m39"
+
+
+@pytest.mark.asyncio
+async def test_hydrate_prune_cannot_oscillate():
+    """The invariant: no message is hydrated, pruned, and hydrated again.
+
+    The reader is pinned at the top for many frames with the transcript over
+    the high watermark -- the only state in which hydration and pruning could
+    chase each other. Oscillation shows up either as an id leaving the mounted
+    set after it arrived, or as a mounted set that never settles.
+    """
+    app = WindowHarness(low=25, high=0, window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = await _hydrated_over_the_high_mark(pilot, app)
+
+        seen: set[str] = set(_mounted_message_ids(transcript))
+        samples: list[tuple[str, ...]] = []
+        for _ in range(40):
+            transcript.scroll_to(y=0, animate=False)
+            await pilot.pause()
+            mounted = tuple(_mounted_message_ids(transcript))
+            samples.append(mounted)
+            dropped = seen - set(mounted)
+            assert not dropped, (
+                f"mounted rows must never be taken back while scrolled up: {dropped}"
+            )
+            seen |= set(mounted)
+
+        assert transcript.virtual_size.height > 40, (
+            "the fixture must stay over the high mark -- the state where "
+            "pruning could undo a hydration"
+        )
+        assert samples[-5:] == [samples[-1]] * 5, (
+            "the mounted set must reach a fixed point, not keep churning"
+        )
+        assert transcript.unhydrated_message_ids(), (
+            "hydration must stay refused above the low mark, not creep forward"
+        )
+
+
+@pytest.mark.asyncio
+async def test_session_switch_reestablishes_the_window():
+    """Hydrated scrollback does not follow the reader into another session."""
+    app = WindowHarness(window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        transcript.select_message("m10")
+        assert await _wait_for(
+            pilot, lambda: "m10" in _mounted_message_ids(transcript)
+        )
+
+        other = [_msg(f"other{i}", ConsoleMessageRole.ASSISTANT) for i in range(60)]
+        transcript.set_messages(other)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        mounted = _mounted_message_ids(transcript)
+        assert len(mounted) <= 10, "the new session gets a fresh tail window"
+        assert mounted[-1] == "mother59"
+        assert transcript.unhydrated_message_ids() == frozenset(
+            f"mother{i}" for i in range(60 - len(mounted))
+        )
+
+
+@pytest.mark.asyncio
+async def test_streaming_ticks_do_not_reestablish_the_window():
+    """An overlapping ingest (the 0.2s tick, a send) keeps hydrated scrollback."""
+    app = WindowHarness(window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(60)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        transcript.select_message("m30")
+        assert await _wait_for(
+            pilot, lambda: "m30" in _mounted_message_ids(transcript)
+        )
+        hydrated = set(_mounted_message_ids(transcript))
+
+        # The streaming tick re-sets the same list; then a send appends.
+        transcript.set_messages(list(history))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        assert set(_mounted_message_ids(transcript)) >= hydrated
+
+        transcript.note_follow_intent()
+        transcript.set_messages(history + [_msg(60, ConsoleMessageRole.USER)])
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        mounted = set(_mounted_message_ids(transcript))
+        assert hydrated <= mounted, "a send must not re-window the reader's scrollback"
+        assert "m60" in mounted
+        assert transcript.unhydrated_message_ids() == frozenset(
+            f"m{i}" for i in range(30)
+        ), "the untouched head of the window must stay windowed out"
+
+
+@pytest.mark.asyncio
+async def test_hydration_step_is_sized_to_the_watermark_headroom():
+    """A hydration step must not hand the watermark walk the rows it mounted.
+
+    Measured before the step budget existed: a 3-message window under a 20/40
+    configuration hydrated its full 10-message chunk, crossed the high mark,
+    and had 9 of those 10 messages pruned one tick later — mount work spent to
+    produce rows that were immediately (and permanently) discarded.
+    """
+    app = WindowHarness(low=20, high=40, window_messages=3, hydrate_messages=10)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot, times=20)
+
+        assert transcript._pruned_message_ids == set(), (
+            "hydration must stay inside the watermark headroom instead of "
+            "mounting rows the prune walk then throws away"
+        )
+        mounted = _mounted_message_ids(transcript)
+        assert 3 <= len(mounted) <= 5, f"expected a minimal step, mounted {mounted}"
+        assert transcript.virtual_size.height <= 40
+
+
+@pytest.mark.asyncio
+async def test_jump_to_latest_releases_protection_without_a_scroll_change():
+    """The jump pill must reclaim scrollback even when it moves nothing.
+
+    A reader detached at the very bottom (release without scrolling) gives
+    `scroll_end` nothing to do, so the scroll watcher never fires — the jump
+    itself has to drop the protection latch or the watermarks stay blocked for
+    the rest of the session.
+    """
+    app = WindowHarness(low=25, high=0, window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(40))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        assert transcript.ensure_message_hydrated("m15")
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        transcript.release_anchor()  # detached, still parked at the bottom
+        await _settle(pilot)
+        scroll_at_bottom = transcript.scroll_y
+
+        app.app_config["chat_defaults"]["prune_high_watermark"] = 40
+        app.app_config["chat_defaults"]["prune_low_watermark"] = 25
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        assert transcript.virtual_size.height > 40, "protection must hold here"
+
+        transcript.jump_to_latest()
+        assert transcript.scroll_y == scroll_at_bottom, (
+            "this test only means something while the jump moves nothing"
+        )
+        assert await _wait_for(
+            pilot, lambda: transcript.virtual_size.height <= 40, attempts=60
+        ), (
+            "the jump must release protection so the watermarks can trim "
+            f"(height {transcript.virtual_size.height})"
+        )

--- a/Tests/UI/test_console_transcript_windowed_mount.py
+++ b/Tests/UI/test_console_transcript_windowed_mount.py
@@ -851,3 +851,27 @@ async def test_jump_to_latest_releases_protection_without_a_scroll_change():
             "the jump must release protection so the watermarks can trim "
             f"(height {transcript.virtual_size.height})"
         )
+
+
+@pytest.mark.asyncio
+async def test_pending_swipe_selection_outside_the_window_is_hydrated():
+    """A handoff selection (task-501) must land on a row, not a filtered id."""
+    app = WindowHarness(window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(60)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        assert "m12" in transcript.unhydrated_message_ids()
+
+        transcript.pending_selection_id = "m12"
+        transcript.set_messages(list(history))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        assert transcript.selected_message_id == "m12"
+        assert "m12" in _mounted_message_ids(transcript)
+        assert transcript.query(".console-transcript-action-row"), (
+            "the handed-off selection must show its action row"
+        )

--- a/Tests/UI/test_console_transcript_windowed_mount.py
+++ b/Tests/UI/test_console_transcript_windowed_mount.py
@@ -14,6 +14,7 @@ suites top out at 30 messages, so none of them would have noticed.
 
 import pytest
 from textual.app import App, ComposeResult
+from textual.widgets import Static
 
 from tldw_chatbook.Chat.console_chat_models import (
     ConsoleChatMessage,
@@ -92,6 +93,22 @@ def _mounted_message_ids(transcript: ConsoleTranscript) -> list[str]:
     return [
         widget.message_id for widget in transcript.query(".console-transcript-message")
     ]
+
+
+def _mounted_row_body(transcript: ConsoleTranscript, message_id: str) -> str | None:
+    """Return the body text of a MOUNTED message row, or None when it has none.
+
+    Deliberately not `to_plain_text`, which renders the store snapshot whether
+    or not a row is mounted.
+    """
+    for widget in transcript.query(".console-transcript-message"):
+        if widget.message_id != message_id:
+            continue
+        body = getattr(widget, "_body_text", None)
+        if body is not None:
+            return str(body).strip()
+        return str(widget.renderable)
+    return None
 
 
 async def _wait_for(pilot, predicate, *, attempts: int = 50) -> bool:
@@ -218,9 +235,13 @@ async def test_pin_variant_navigation_on_a_mounted_row():
         await transcript.refresh_messages()
         await _settle(pilot)
 
+        # Read the MOUNTED row, not `to_plain_text`: that renders `_messages`
+        # whether or not a row exists, so it would pass with nothing mounted at
+        # all (proven blind in review).
+        assert _mounted_row_body(transcript, "mvariants") == "variant one"
         transcript.select_next_variant("mvariants")
         await _settle(pilot)
-        assert "variant two" in transcript.to_plain_text(width=60)
+        assert _mounted_row_body(transcript, "mvariants") == "variant two"
 
 
 @pytest.mark.asyncio
@@ -410,6 +431,10 @@ async def test_load_mounts_only_the_tail_window():
         )
         assert len(transcript._messages) == 500, "the store snapshot is untouched"
         assert transcript._is_following_tail()
+        # The mount-sensitive reader used by the variant pin: no row, no body
+        # (`to_plain_text` would happily return the content of all 500).
+        assert _mounted_row_body(transcript, "m0") is None
+        assert "line 0.0" in transcript.to_plain_text(width=40)
 
 
 @pytest.mark.asyncio
@@ -636,6 +661,15 @@ async def _hydrated_over_the_high_mark(pilot, app) -> ConsoleTranscript:
     await _settle(pilot)
     assert len(_mounted_message_ids(transcript)) == 10, "the window must be in play"
 
+    # Detach FIRST: protection is only latched for a reader who is away from
+    # the tail (a tail-position jump has nothing to protect against, and its
+    # release could never fire). Park mid-transcript, not at the top, so
+    # arming the marks below is the only thing that changes afterwards -- no
+    # extra hydration in between.
+    transcript.release_anchor()
+    transcript.scroll_to(y=transcript.max_scroll_y / 2, animate=False)
+    await _settle(pilot)
+
     # Hydrate without selecting: a selected message is protected from the
     # watermark walk on its own (TASK-1365), which would mask what this
     # fixture is here to exercise.
@@ -643,10 +677,7 @@ async def _hydrated_over_the_high_mark(pilot, app) -> ConsoleTranscript:
     assert await _wait_for(pilot, lambda: "m15" in _mounted_message_ids(transcript)), (
         "the scrollback the reader asked for was never hydrated"
     )
-    # Detach WITHOUT parking at the top, so arming the marks below is the only
-    # thing that changes -- no extra hydration in between.
-    transcript.release_anchor()
-    transcript.scroll_to(y=transcript.max_scroll_y / 2, animate=False)
+    assert transcript._scrollback_protected is True
     await _settle(pilot)
     assert transcript.virtual_size.height > 40, "the fixture must exceed the marks"
 
@@ -816,10 +847,16 @@ async def test_hydration_step_is_sized_to_the_watermark_headroom():
 async def test_jump_to_latest_releases_protection_without_a_scroll_change():
     """The jump pill must reclaim scrollback even when it moves nothing.
 
-    A reader detached at the very bottom (release without scrolling) gives
-    `scroll_end` nothing to do, so the scroll watcher never fires — the jump
-    itself has to drop the protection latch or the watermarks stay blocked for
-    the rest of the session.
+    When the jump changes `scroll_y`, the scroll watcher notices the re-engaged
+    anchor and releases the latch — but a jump that moves nothing (the reader is
+    already at the bottom, or the transcript is too short to scroll) fires no
+    watcher, and then only `jump_to_latest`'s own release keeps the watermarks
+    from staying blocked for the rest of the session.
+
+    The latch is set directly here: releasing the anchor while parked at the
+    bottom does not survive in Textual (the next `scroll_y` write re-attaches
+    via `_check_anchor`), so the physical route into "latched AND already at the
+    bottom" cannot be staged in a harness — the state itself can.
     """
     app = WindowHarness(low=25, high=0, window_messages=10, hydrate_messages=5)
     async with app.run_test() as pilot:
@@ -831,8 +868,7 @@ async def test_jump_to_latest_releases_protection_without_a_scroll_change():
         assert transcript.ensure_message_hydrated("m15")
         await transcript.refresh_messages()
         await _settle(pilot)
-        transcript.release_anchor()  # detached, still parked at the bottom
-        await _settle(pilot)
+        transcript._scrollback_protected = True  # as a detached hydration leaves it
         scroll_at_bottom = transcript.scroll_y
 
         app.app_config["chat_defaults"]["prune_high_watermark"] = 40
@@ -842,6 +878,9 @@ async def test_jump_to_latest_releases_protection_without_a_scroll_change():
         assert transcript.virtual_size.height > 40, "protection must hold here"
 
         transcript.jump_to_latest()
+        assert transcript._scrollback_protected is False, (
+            "the jump itself must drop the latch"
+        )
         assert transcript.scroll_y == scroll_at_bottom, (
             "this test only means something while the jump moves nothing"
         )
@@ -875,3 +914,176 @@ async def test_pending_swipe_selection_outside_the_window_is_hydrated():
         assert transcript.query(".console-transcript-action-row"), (
             "the handed-off selection must show its action row"
         )
+
+
+# ---------------------------------------------------------------------------
+# Review round 1 fixes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tail_position_jump_leaves_pruning_live():
+    """A jump made from the tail must not latch scrollback protection.
+
+    The latch is released when the reader RETURNS to the tail; latching while
+    they are already there arms a protection nothing can release, and the
+    watermark walk stays blocked through idle (review: mounted height 158
+    against a high mark of 40).
+    """
+    app = WindowHarness(low=25, high=0, window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(40))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        assert transcript._is_following_tail(), "this test jumps from the tail"
+
+        # Hydrate a jump target from the tail position, WITHOUT selecting it:
+        # a selected message is protected by the watermark walk on its own
+        # (TASK-1365), which would hide whether the latch was armed.
+        assert transcript.ensure_message_hydrated("m15")
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        assert "m15" in _mounted_message_ids(transcript)
+        assert transcript._scrollback_protected is False, (
+            "a tail-position jump must not latch protection"
+        )
+
+        app.app_config["chat_defaults"]["prune_high_watermark"] = 40
+        app.app_config["chat_defaults"]["prune_low_watermark"] = 25
+        await transcript.refresh_messages()
+        assert await _wait_for(
+            pilot, lambda: transcript.virtual_size.height <= 40, attempts=60
+        ), (
+            "pruning must stay live after a tail-position jump "
+            f"(height {transcript.virtual_size.height})"
+        )
+        assert transcript._pruned_message_ids, "the trim must be recorded"
+
+        # The same holds through `select_message`, the production entry point.
+        transcript.select_message("m28")
+        await _settle(pilot)
+        assert transcript._scrollback_protected is False
+
+
+def _mounted_row_ids_in_dom_order(transcript: ConsoleTranscript) -> list[str]:
+    """Message ids and gap markers in child order, as the reader sees them."""
+    ordered: list[str] = []
+    for widget in transcript.children:
+        if widget.has_class("console-transcript-gap"):
+            ordered.append("<gap>")
+        elif widget.has_class("console-transcript-message"):
+            ordered.append(widget.message_id)
+    return ordered
+
+
+@pytest.mark.asyncio
+async def test_jump_into_pruned_out_history_marks_the_seam():
+    """Discontiguous mounted history renders a gap marker, not a silent join."""
+    app = WindowHarness(low=25, high=0, window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(40))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        # Prune the middle away: arm the marks while following the tail.
+        app.app_config["chat_defaults"]["prune_high_watermark"] = 40
+        app.app_config["chat_defaults"]["prune_low_watermark"] = 25
+        await transcript.refresh_messages()
+        assert await _wait_for(pilot, lambda: bool(transcript._pruned_message_ids)), (
+            "pruning never fired"
+        )
+        pruned = set(transcript._pruned_message_ids)
+        assert _mounted_row_ids_in_dom_order(transcript).count("<gap>") == 0, (
+            "a pruned HEAD is not a hole -- no marker belongs there"
+        )
+
+        # Now jump above the pruned stretch.
+        target = "m2"
+        assert target in transcript.unhydrated_message_ids()
+        transcript.select_message(target)
+        assert await _wait_for(
+            pilot, lambda: target in _mounted_message_ids(transcript)
+        ), "the jump target was never hydrated"
+        await _settle(pilot)
+
+        ordered = _mounted_row_ids_in_dom_order(transcript)
+        assert ordered.count("<gap>") == 1, (
+            f"exactly one seam expected between the two stretches: {ordered}"
+        )
+        gap_index = ordered.index("<gap>")
+        above = ordered[:gap_index]
+        below = ordered[gap_index + 1 :]
+        assert above and below, f"the seam must sit BETWEEN stretches: {ordered}"
+        assert not (set(above) & pruned) and not (set(below) & pruned)
+        # Order is still the message order across the seam.
+        mounted = [row for row in ordered if row != "<gap>"]
+        assert mounted == sorted(mounted, key=lambda mid: int(mid[1:]))
+        # And the marker names the hole.
+        gap_widget = transcript.query_one(".console-transcript-gap", Static)
+        rendered = str(gap_widget.renderable)
+        assert "not shown" in rendered
+        assert str(len(pruned)) in rendered
+
+
+@pytest.mark.asyncio
+async def test_rewind_into_the_windowed_out_head_never_paints_a_rowless_frame():
+    """A truncation to a prefix inside the window re-windows on the survivors.
+
+    Measured before the fix: a 60-message session windowed to 40 and rewound to
+    16 rendered NO rows for a frame, then recovered only a hydration step's
+    worth.
+    """
+    app = WindowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(60)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        assert len(_mounted_message_ids(transcript)) == 40
+
+        transcript.set_messages(history[:16])
+        await transcript.refresh_messages()
+        assert _mounted_message_ids(transcript) == [f"m{i}" for i in range(16)], (
+            "the frame right after the rewind must already render the survivors"
+        )
+        await _settle(pilot)
+        assert _mounted_message_ids(transcript) == [f"m{i}" for i in range(16)]
+        assert transcript.unhydrated_message_ids() == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_restored_reading_state_hydrates_its_selected_message():
+    """`restore_reading_state` assigns the id directly — it must mount it first.
+
+    Inert whenever the selection is already mounted; the case that matters is a
+    state captured before a re-window (a session switch between capture and
+    restore), where the id would otherwise name a message with no row.
+    """
+    from tldw_chatbook.UI.Console_Modules.transcript import (
+        ConsoleTranscriptRegion,
+        _ConsoleTranscriptReadingState,
+    )
+
+    app = WindowHarness(window_messages=10, hydrate_messages=5)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(60))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        assert "m12" in transcript.unhydrated_message_ids()
+
+        region = ConsoleTranscriptRegion.__new__(ConsoleTranscriptRegion)
+        region._transcript_or_none = lambda: transcript  # type: ignore[method-assign]
+        ConsoleTranscriptRegion.restore_reading_state(
+            region,
+            _ConsoleTranscriptReadingState(
+                anchored=True, scroll_y=0.0, selected_message_id="m12"
+            ),
+        )
+        assert await _wait_for(
+            pilot, lambda: "m12" in _mounted_message_ids(transcript)
+        ), "the restored selection was never hydrated"
+        assert transcript.selected_message_id == "m12"

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -942,7 +942,22 @@ actually works: add the override to a `CSS_PATH`-bundled source file (`_navigati
 tcss` here), in the SAME tier as the rule being overridden, where ordinary
 specificity resolves it without needing `!important` at all.
 
-**What to do (all five instances).** Never trust a bare-`App`-no-`CSS_PATH` test's
+**Sixth instance (2026-08-11, task-15455, height physics this time).** The Console
+transcript's height watermarks and the new hydration budget are pure geometry
+arithmetic, so staging "one message big enough to cross the high mark" needed a tall
+row. Under the transcript suites' own harnesses (bare `App`, CSS just
+`ConsoleTranscript { height: 10; }` — the shape used by
+`test_console_transcript_pruning.py` and `_tail_follow.py` since task-1365) a
+**150-line message rendered as a 1-row widget**: `.console-transcript-message {
+height: auto; }` lives in the bundle, and without it the row `Vertical` collapses.
+Measured directly — `outer_size` `Size(width=78, height=1)` for a 150-line body. Every
+watermark test in those files is therefore exercising ~3.4 rows per message regardless
+of content, which is fine for "does pruning fire" but silently useless for "how tall is
+this message". The fix used here was to keep the emergent-physics assertions off exact
+heights (arm the watermarks after seeding, the pruning suite's own idiom) rather than
+to invent tall rows a bare harness cannot produce.
+
+**What to do (all six instances).** Never trust a bare-`App`-no-`CSS_PATH` test's
 color/opacity or geometry as proof of live behavior — it can miss a rule entirely
 (instances 1-4) or miss a PRIORITY inversion where `CSS_PATH` beats `DEFAULT_CSS`
 regardless of `!important` (instance 5). Before shipping any "hide via CSS" trick
@@ -2939,3 +2954,35 @@ Two things follow, and the second matters more than the first:
 **What to do.** Treat every "deliberately reverted / do not reintroduce" comment as an
 experiment with a date on it. Re-run its named witnesses first; record the result in
 the task either way. Then keep the diagnosis even when the symptom is gone.
+
+---
+
+## `anchor()` does not re-attach the anchor — a sampled tail-follow predicate makes the follow-up no-op (2026-08-11)
+
+**Incident.** task-15455 protects hydrated Console scrollback from the height-watermark
+walk while the reader is reading it, and releases that protection when they return to
+the tail. The first implementation sampled the state: `_compute_prunable_prefix`
+protected the hydrated ids `if not self._is_following_tail()`, and `jump_to_latest()`
+scheduled a prune check right after `anchor()`. The test asserting the reclaim failed
+with the transcript still 132 rows over a 40-row high mark, `_is_following_tail()`
+reading `True` by the time the assertion ran, and no prune ever recorded.
+
+**Mechanism.** Textual's `Widget.anchor()` only sets `_anchored = True` and calls
+`scroll_end()`. It never clears `_anchor_released`; that flag is cleared exclusively by
+`_check_anchor()`, which runs from `watch_scroll_y` and only when `scroll_y >=
+max_scroll_y` — i.e. one or more frames later, after the scroll actually lands. So a
+callback scheduled by the jump (`call_after_refresh`) can run in the window where the
+widget still reads as detached, take the "protect" branch, find the whole head
+protected, and return having done nothing. Nothing re-schedules it, so the reclaim is
+lost for the rest of the session. A second, narrower path fails the same way for a
+different reason: a reader detached while already parked at the bottom gives
+`scroll_end()` nothing to do, so `watch_scroll_y` never fires at all.
+
+**What to do.** For "this state ends when the user does X", latch the state explicitly
+and clear it in X's handler; do not re-derive it from a widget predicate that settles
+asynchronously. Here: a `_scrollback_protected` boolean set at hydration time and
+cleared by `jump_to_latest()`, by the send/anchor path in `set_messages`, and by
+`watch_scroll_y` once follow is genuinely re-engaged — each clear also scheduling the
+check that consumes it. And when a mechanism has more than one entry point, mutation-
+test each one separately: removing the `jump_to_latest` clear left the whole suite
+green until a test was added for the no-scroll-change case specifically.

--- a/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
+++ b/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
@@ -135,6 +135,36 @@ mutations of the new mechanisms killed by a targeted test; transcript surface
 Chat-side console suites 119 passed; config/decomposition 204 passed with the
 known pre-existing `test_console_left_rail_sections_use_available_space`.
 
+**Review round 1 (approved with two Importants).** Four fixes and two doc
+items landed on top:
+- The protection latch was armed unconditionally by `ensure_message_hydrated`,
+  including for a jump made FROM the tail — where its documented release
+  ("the reader returns to the tail") can never fire, so the walk stayed blocked
+  through idle (reviewer measured height 158 against a high mark of 40). It now
+  latches only when the reader is away from the tail; a tail-position jump still
+  keeps its target row through the pre-existing selection protection.
+- "Mounted rows stay one contiguous suffix" was FALSE after a prune: a jump into
+  windowed-out history mounts a stretch separated from the tail by the pruned
+  hole, and the two rendered adjacent with no seam. `_transcript_rows` now emits
+  a dim, non-interactive "⋯ N earlier messages not shown" row at an INTERIOR
+  hole only (a windowed-out head is not a hole), and the comment states the real
+  invariant: mounted messages form at most two contiguous stretches, and every
+  consumer walks child order, not contiguity. No CSS-bundle change — the marker
+  dims through Content markup, like the summary banner, which also ships without
+  a rule.
+- Pin #5 asserted through `to_plain_text`, which renders the store snapshot
+  whether or not a row is mounted (proven blind: it returns message 0 of 500
+  while nothing but the tail window is mounted). It now reads the mounted row's
+  body, and one windowing test pins that the reader really is mount-sensitive.
+- `restore_reading_state` assigned `selected_message_id` directly, bypassing
+  hydration; it now ensures the target is mounted first (inert today).
+- `/rewind` shape (truncation to a shared PREFIX) could land entirely inside the
+  windowed-out head: measured one ROWLESS frame, then recovery to only a
+  hydration step's worth of rows instead of a full window. `set_messages` now
+  re-windows on the survivors when an ingest would leave nothing mounted.
+- Guide: added the caveat that trimming is suspended while you sit in scrollback
+  and resumes on return, plus the gap-marker line.
+
 **Suites (read counts).** New window suite 27 passed; transcript surface (13 suites)
 269 passed + 1 pre-existing failure; Chat-side console suites 119 passed;
 native_transcript + native_chat_flow 404 passed / 1 xfailed; parallel_runs +

--- a/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
+++ b/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15455
 title: Console transcript: windowed mount for long-conversation load
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -24,3 +25,43 @@ Fix direction: mount a tail-first window (bottom N lines) and hydrate scrollback
 - [ ] #2 Scrollback hydrates on demand without breaking anchor/tail-follow, selection, or branch navigation (tests)
 - [ ] #3 Prune watermarks still bound total mounted height
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. **Pin first (no production change).** New pin suite covering the invariants
+   windowing could break on a LARGE history (60+ messages, which the existing
+   suites never exercise — their biggest fixture is 30): anchor sits at the
+   bottom after load, tail message is mounted, selection + action row on an old
+   row, prune watermarks bound the height, branch/variant swap and session
+   switch reconcile, jump pill + `jump_to_latest`. Run green BEFORE touching
+   production code; commit as its own slice.
+2. **Batch the reconciler's DOM churn** (no visible behavior change): contiguous
+   newly-built rows mount in ONE `mount(*widgets, after=...)` call; stale rows
+   are removed with one `remove_children([...])`. Keeps the task-15453
+   already-in-position induction intact.
+3. **Tail-first window.** `set_messages` detects a fresh load (first ingest or
+   an id-set disjoint from the last one = session switch) and marks all but the
+   newest N messages "unhydrated"; `_transcript_rows` filters them exactly like
+   the task-1365 prune window. N derives from a message cap AND an estimated
+   line budget (`[chat_defaults] transcript_window_messages` /
+   `transcript_window_lines`, `<= 0` disables = kill switch).
+4. **Hydration on scroll-up.** `watch_scroll_y` schedules a coalesced check;
+   near the top (or when the window is too short to scroll) the next chunk of
+   older messages hydrates, restoring the reader's offset by the measured added
+   height (mirrors the prune path's `_restore_scroll`).
+   **Anti-oscillation, structural:** hydration is refused unless the virtual
+   height is BELOW the low watermark, and pruning only ever fires ABOVE the high
+   watermark leaving the remainder strictly above the low watermark — so a prune
+   can never re-enable hydration, and no hydrate→prune→hydrate cycle exists for
+   ANY watermark configuration. Second, independent guard: ids hydrated on
+   demand are protected from pruning while the reader is detached from the tail,
+   so scrollback never vanishes under the reader; protection lifts the moment
+   they follow the tail again, which is what keeps AC#3 true.
+5. **Jump/selection into unhydrated history**: `ensure_message_hydrated()`
+   hydrates the target's window before selection/focus so programmatic jumps
+   land on a mounted row.
+6. **Evidence**: isolated 500-message session-load probe (windowed vs kill
+   switch, same build), mounted-row-count bound test, hydration order tests, the
+   oscillation-impossibility test, all pinned suites green unmodified.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
+++ b/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15455
 title: Console transcript: windowed mount for long-conversation load
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-11 12:05'
@@ -134,6 +134,13 @@ mutations of the new mechanisms killed by a targeted test; transcript surface
 (`test_console_citation_sources` stub lacking `set_presentation_context`);
 Chat-side console suites 119 passed; config/decomposition 204 passed with the
 known pre-existing `test_console_left_rail_sections_use_available_space`.
+
+**Suites (read counts).** New window suite 27 passed; transcript surface (13 suites)
+269 passed + 1 pre-existing failure; Chat-side console suites 119 passed;
+native_transcript + native_chat_flow 404 passed / 1 xfailed; parallel_runs +
+composer_collapse + realtime_wiring 141 passed (one non-reproducible collapse flake on
+the first run — that fixture seeds 24 messages, below the window, so this branch is
+inert in it); config/decomposition 204 passed + 1 pre-existing failure; ruff clean.
 
 **Files:** `tldw_chatbook/Widgets/Console/console_transcript.py`,
 `tldw_chatbook/config.py`, `Docs/User_Guide/console.md`,

--- a/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
+++ b/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
@@ -21,9 +21,9 @@ Fix direction: mount a tail-first window (bottom N lines) and hydrate scrollback
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Loading a 500+-message conversation mounts only the visible tail window initially (evidence + session-switch latency before/after)
-- [ ] #2 Scrollback hydrates on demand without breaking anchor/tail-follow, selection, or branch navigation (tests)
-- [ ] #3 Prune watermarks still bound total mounted height
+- [x] #1 Loading a 500+-message conversation mounts only the visible tail window initially (evidence + session-switch latency before/after)
+- [x] #2 Scrollback hydrates on demand without breaking anchor/tail-follow, selection, or branch navigation (tests)
+- [x] #3 Prune watermarks still bound total mounted height
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -65,3 +65,77 @@ Fix direction: mount a tail-first window (bottom N lines) and hydrate scrollback
    switch, same build), mounted-row-count bound test, hydration order tests, the
    oscillation-impossibility test, all pinned suites green unmodified.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+A conversation LOAD now mounts a tail-first window instead of the whole
+persisted tree, and older messages hydrate as the reader scrolls back. Four
+commits, pins first.
+
+**Pins first (6517267c).** The pre-existing transcript suites top out at 30
+messages, so none of them could have noticed a 40-message window. Eight pins
+were written and run green against unmodified dev code on a 60-message load
+(anchor lands at the tail, selection mounts the action row, watermarks bound
+the height, branch swap keeps the shared prefix rows, variant navigation,
+session switch, jump pill + `jump_to_latest`, exports render full history).
+All eight still pass unmodified.
+
+**Batching (dce47985).** The reconciler now mounts contiguous new rows with
+one `mount(*widgets, after=…)` and removes stale rows with one
+`remove_children([...])`. Textual inserts a multi-widget mount in argument
+order, so child order is unchanged; the batch is flushed before any decision
+that reads the real child list, which keeps the task-15453 already-in-position
+induction exactly as it was.
+
+**Windowing + hydration (9d2b3147).** `set_messages` (re)establishes the
+window when the ingest is a load — the first one, or one whose ids are
+disjoint from the last (a session switch); a tick/send/branch swap shares ids
+and keeps whatever the reader hydrated. Window size = message cap AND an
+estimated line budget (`[chat_defaults] transcript_window_messages` /
+`transcript_window_lines`, `<= 0` disables). Unhydrated ids are filtered in
+`_transcript_rows` exactly like the task-1365 prune window, but reversibly:
+`watch_scroll_y` schedules a coalesced check that hydrates the next step when
+the reader is within a viewport of the top (or the window is too short to
+scroll), restoring their offset by the measured height added above them.
+
+**Anti-oscillation is structural, and three things had to be true, not one.**
+(1) Hydration is refused at/above the LOW watermark while pruning only fires
+above the HIGH one and always leaves the remainder above the low one — so a
+prune can never restore a hydratable state. (2) Each step is sized against the
+headroom under the low mark: *measured during development*, without this a
+3-message window under a 20/40 config mounted its full 10-message chunk,
+crossed the high mark, and had 9 of those 10 pruned away one tick later —
+wasted mounts, and permanently unreachable history. (3) Rows the reader
+hydrated are protected from the walk by an explicit `_scrollback_protected`
+latch that drops when they return to the tail. The latch replaced a sampled
+`_is_following_tail()` check after that version silently failed: `anchor()`
+does not clear Textual's `_anchor_released`, so the prune check scheduled by
+`jump_to_latest` ran while the widget still read as detached and skipped the
+reclaim entirely.
+
+Jump targets outside the window hydrate from the target forward
+(`ensure_message_hydrated`, wired into `select_message` and the task-501
+swipe handoff), keeping mounted rows one contiguous suffix. Keyboard
+selection walks the mounted window only.
+
+**Trade-off, deliberate:** while the latch holds (reader parked in hydrated
+scrollback), the watermark walk cannot trim, so a marathon run streaming into
+a transcript the reader has left behind can grow past the high mark until they
+return to the tail. Pruning content out from under a reader mid-read is worse.
+
+**Evidence.** Isolated 500-message load probe (bare transcript, 120x40,
+production-like row CSS, medians of 3): per-row mounts of every row (dev
+behavior, emulated) 47.2 s / 1002 rows / 5502 widgets → batched only 14.1 s →
+windowed + batched 2.1 s / 82 rows / 442 widgets. The ratio is the finding;
+absolute numbers are harness-specific. Tests: 27 in the new suite, each of ten
+mutations of the new mechanisms killed by a targeted test; transcript surface
+(13 suites) 269 passed with one pre-existing failure
+(`test_console_citation_sources` stub lacking `set_presentation_context`);
+Chat-side console suites 119 passed; config/decomposition 204 passed with the
+known pre-existing `test_console_left_rail_sections_use_available_space`.
+
+**Files:** `tldw_chatbook/Widgets/Console/console_transcript.py`,
+`tldw_chatbook/config.py`, `Docs/User_Guide/console.md`,
+`Tests/UI/test_console_transcript_windowed_mount.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Console_Modules/transcript.py
+++ b/tldw_chatbook/UI/Console_Modules/transcript.py
@@ -227,6 +227,12 @@ class ConsoleTranscriptRegion(Vertical):
         transcript = self._transcript_or_none()
         if transcript is None:
             return
+        if state.selected_message_id is not None:
+            # TASK-15455: assigning the id directly bypasses `select_message`,
+            # so a selection captured before a re-window (a session switch
+            # between capture and restore) could name a message with no
+            # mounted row. Inert whenever the id is already mounted.
+            transcript.ensure_message_hydrated(state.selected_message_id)
         transcript.selected_message_id = state.selected_message_id
         if state.anchored:
             transcript.anchor()

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -2621,15 +2621,70 @@ class ConsoleTranscript(VerticalScroll):
         desired_keys = [row.key for row in rows]
         desired_key_set = set(desired_keys)
 
+        stale_widgets: list[Widget] = []
         for stale_key in [
             key for key in self._row_widgets if key not in desired_key_set
         ]:
-            stale_widget = self._row_widgets.pop(stale_key)
+            stale_widgets.append(self._row_widgets.pop(stale_key))
             self._row_signatures.pop(stale_key, None)
             self._row_build_counts.pop(stale_key, None)
-            await stale_widget.remove()
+        if stale_widgets:
+            # TASK-15455: one batched removal instead of one awaited
+            # `remove()` per row -- a session switch or a prune drops hundreds
+            # of rows at once, and each individual removal is its own DOM
+            # walk + await. `remove_children` prunes the whole set in one
+            # pass. Widgets that are not (or no longer) our children take the
+            # per-widget path they always did.
+            own_rows = [widget for widget in stale_widgets if widget.parent is self]
+            if own_rows:
+                await self.remove_children(own_rows)
+            for stale_widget in stale_widgets:
+                if stale_widget.parent is not None:
+                    await stale_widget.remove()
 
         previous_widget: Widget | None = None
+        # TASK-15455: contiguous freshly built rows are accumulated here and
+        # mounted in ONE `mount(*widgets, after=...)` call. Textual inserts a
+        # multi-widget mount in argument order, so the resulting child order
+        # is identical to mounting them one at a time -- only the number of
+        # DOM/layout passes changes. The batch is flushed before any decision
+        # that reads the real child list (the in-position check below).
+        pending_widgets: list[Widget] = []
+        pending_keys: list[str] = []
+        pending_signatures: list[tuple] = []
+        pending_after: Widget | None = None
+
+        async def _flush_pending_mounts() -> bool:
+            """Mount the accumulated new rows; False means abandon the pass."""
+            nonlocal previous_widget
+            if not pending_widgets:
+                return True
+            widgets = list(pending_widgets)
+            keys = list(pending_keys)
+            signatures = list(pending_signatures)
+            pending_widgets.clear()
+            pending_keys.clear()
+            pending_signatures.clear()
+            if pending_after is None:
+                await self.mount(*widgets, before=0 if self.children else None)
+            else:
+                await self.mount(*widgets, after=pending_after)
+            for key, widget, signature in zip(keys, widgets, signatures):
+                if widget.parent is not self:
+                    # Version-proof backstop for the pruning check in the
+                    # walk: mount() completed without attaching (it no-ops
+                    # while the container is being removed). Drop the phantom
+                    # map entries for this batch and abandon the pass instead
+                    # of poisoning later moves.
+                    for pending_key in keys:
+                        self._row_widgets.pop(pending_key, None)
+                        self._row_signatures.pop(pending_key, None)
+                    return False
+                self._row_widgets[key] = widget
+                self._row_signatures[key] = signature
+            previous_widget = widgets[-1]
+            return True
+
         for index, row in enumerate(rows):
             if self._closing or self._pruning or not self.is_attached:
                 # This instance is being removed (a parent recompose/session
@@ -2643,14 +2698,17 @@ class ConsoleTranscript(VerticalScroll):
             row_was_mounted = False
             if widget is None:
                 widget = self._build_row_widget(row, track=True)
-                if previous_widget is None:
-                    await self.mount(widget, before=0 if self.children else None)
-                else:
-                    await self.mount(widget, after=previous_widget)
-                row_was_mounted = True
-                self._row_widgets[row.key] = widget
-                self._row_signatures[row.key] = row.signature
-            elif self._row_signatures.get(row.key) != row.signature:
+                if not pending_widgets:
+                    pending_after = previous_widget
+                pending_widgets.append(widget)
+                pending_keys.append(row.key)
+                pending_signatures.append(row.signature)
+                continue
+            # An already-mounted row: every row above it must be in the DOM
+            # before its position can be judged, so flush first.
+            if not await _flush_pending_mounts():
+                return
+            if self._row_signatures.get(row.key) != row.signature:
                 updated_widget = self._update_row_widget(widget, row)
                 if updated_widget is widget:
                     self._row_signatures[row.key] = row.signature
@@ -2692,6 +2750,10 @@ class ConsoleTranscript(VerticalScroll):
                     else:
                         self.move_child(widget, after=previous_widget)
             previous_widget = widget
+        if self._closing or self._pruning or not self.is_attached:
+            return
+        if not await _flush_pending_mounts():
+            return
         self._paint_debug_dump("after-reconcile")
 
     def _build_row_widget(self, row: _TranscriptRow, *, track: bool) -> Widget:

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -73,6 +73,27 @@ CONSOLE_GENERATING_PLACEHOLDER = "Generating…"
 #: (``UI/Chat_Modules/chat_log_pruning.py`` on feat/toad-ui-improvements).
 DEFAULT_PRUNE_HIGH_WATERMARK = 20000
 DEFAULT_PRUNE_LOW_WATERMARK = 12000
+#: TASK-15455: tail-first mount window for a conversation LOAD (session resume
+#: or a session switch). The watermarks above bound a transcript that GROWS;
+#: they can only act after the rows are mounted and laid out, so a resumed
+#: 500-message session used to pay a full mount plus a full-history Markdown
+#: parse before anything was trimmed. A load now mounts at most this many of
+#: the newest messages, further capped by an estimated line budget, and
+#: hydrates older messages when the reader scrolls back.
+#: 40 messages is roughly a dozen turns of scrollback -- comfortably more than
+#: any terminal shows at once, and above every fixture in the transcript
+#: suites, so the window only engages on histories those never reach.
+DEFAULT_TRANSCRIPT_WINDOW_MESSAGES = 40
+#: Estimated rendered rows (body lines + per-row chrome) allowed in the initial
+#: window. A handful of very long messages hit this before the message cap.
+DEFAULT_TRANSCRIPT_WINDOW_LINES = 600
+#: Messages hydrated per scroll-back step.
+DEFAULT_TRANSCRIPT_HYDRATE_MESSAGES = 20
+#: The window never shrinks below this many messages, however long they are --
+#: a single mounted row would make the transcript look truncated.
+MIN_TRANSCRIPT_WINDOW_MESSAGES = 3
+#: Per-message row chrome (rule + speaker label) folded into the line estimate.
+_MESSAGE_ROW_CHROME_LINES = 2
 #: task-2154.16 (FB-01): a failed assistant row with no partial content used
 #: to render as the bare token ``[failed]``. It now shows this placeholder
 #: (dimmed) with the state carried by a separate dim status line. Same copy
@@ -162,6 +183,57 @@ def get_console_prune_watermarks(
     if low > high:
         low = high
     return low, high
+
+
+def get_console_transcript_window(
+    app_config: Mapping[str, object] | None,
+) -> tuple[int, int, int]:
+    """Resolve the tail-first mount window settings from config.
+
+    Reads ``[chat_defaults] transcript_window_messages`` /
+    ``transcript_window_lines`` / ``transcript_hydrate_messages``, falling back
+    to the ``DEFAULT_TRANSCRIPT_*`` constants when missing or invalid. A
+    ``window_messages <= 0`` disables windowing entirely (the kill switch:
+    every message mounts at load, exactly as before TASK-15455).
+
+    Args:
+        app_config: The loaded application config dict (``app.app_config``).
+
+    Returns:
+        Tuple of ``(window_messages, window_lines, hydrate_messages)``.
+    """
+    chat_defaults = (app_config or {}).get("chat_defaults", {})
+    if not isinstance(chat_defaults, Mapping):
+        chat_defaults = {}
+    window_messages = _coerce_prune_int(
+        chat_defaults.get("transcript_window_messages"),
+        DEFAULT_TRANSCRIPT_WINDOW_MESSAGES,
+    )
+    window_lines = _coerce_prune_int(
+        chat_defaults.get("transcript_window_lines"), DEFAULT_TRANSCRIPT_WINDOW_LINES
+    )
+    hydrate_messages = _coerce_prune_int(
+        chat_defaults.get("transcript_hydrate_messages"),
+        DEFAULT_TRANSCRIPT_HYDRATE_MESSAGES,
+    )
+    return window_messages, max(1, window_lines), max(1, hydrate_messages)
+
+
+def _estimated_message_lines(message: ConsoleChatMessage) -> int:
+    """Estimate a message's rendered height in terminal rows.
+
+    Deliberately cheap and approximate (raw newlines plus fixed row chrome, no
+    wrapping): it only sizes the INITIAL mount window, and the real bound on
+    mounted height stays the measured height watermarks.
+
+    Args:
+        message: The message about to be sized.
+
+    Returns:
+        Estimated rows the message's row group occupies.
+    """
+    content = getattr(message, "content", "") or ""
+    return content.count("\n") + 1 + _MESSAGE_ROW_CHROME_LINES
 
 
 def _message_role_label(message: ConsoleChatMessage) -> str:
@@ -1645,6 +1717,24 @@ class ConsoleTranscript(VerticalScroll):
         #: and the reconciliation stale-key path owns their removal.
         self._pruned_message_ids: set[str] = set()
         self._prune_check_scheduled = False
+        #: TASK-15455: tail-first mount window. Ids of the OLDEST messages a
+        #: conversation load deliberately did not mount; ``_transcript_rows``
+        #: filters them exactly like the prune window above. Unlike pruning
+        #: these come back: scrolling near the top hydrates the next chunk.
+        self._unhydrated_message_ids: set[str] = set()
+        #: Ids hydrated back into the view since the window was established.
+        #: They are protected from the watermark walk while
+        #: ``_scrollback_protected`` holds, so scrollback never vanishes
+        #: mid-read.
+        self._hydrated_message_ids: set[str] = set()
+        #: True from the moment scrollback is hydrated until the reader is back
+        #: at the tail (jump pill, a send, or simply scrolling to the bottom).
+        #: An explicit latch rather than a sampled "is following the tail?":
+        #: the anchor re-engages asynchronously, so a check scheduled by the
+        #: jump can otherwise run while the widget still reads as detached and
+        #: skip the reclaim entirely.
+        self._scrollback_protected = False
+        self._hydration_check_scheduled = False
 
     def on_mount(self) -> None:
         """Engage tail-follow: stay scrolled to the newest content.
@@ -1658,6 +1748,9 @@ class ConsoleTranscript(VerticalScroll):
         # TASK-1365: a transcript composed with a preloaded (resumed) history
         # can already exceed the watermarks before any refresh_messages call.
         self._schedule_prune_check()
+        # TASK-15455: the same compose path can have applied a mount window;
+        # a window shorter than the viewport must fill until it can scroll.
+        self._schedule_hydration_check()
 
     def compose(self) -> ComposeResult:
         self._row_widgets.clear()
@@ -1746,6 +1839,10 @@ class ConsoleTranscript(VerticalScroll):
         except NoMatches:
             pass
         self._jump_pill_state = (False, "")
+        # TASK-15455: hydrated scrollback is protected from the watermark walk
+        # only while the reader is reading it; jumping back to the tail is
+        # exactly when that protection lifts, so drop it and run the check.
+        self._release_scrollback_protection()
 
     def note_follow_intent(self) -> None:
         """Record a programmatic jump-to-tail intent (send/resume/switch).
@@ -1818,6 +1915,17 @@ class ConsoleTranscript(VerticalScroll):
         # TASK-1365: same lifecycle for the prune window -- a session switch
         # re-renders from scratch, and a deleted message must not linger here.
         self._pruned_message_ids &= message_ids
+        # TASK-15455: (re)establish the tail-first mount window on a LOAD --
+        # the first ingest, or one whose ids are disjoint from the last (a
+        # session switch). An ingest that shares ids is the 0.2s sync tick, a
+        # send, or a branch swap: those extend the current view and must keep
+        # whatever the reader has already hydrated.
+        self._unhydrated_message_ids &= message_ids
+        self._hydrated_message_ids &= message_ids
+        if not self._seen_message_ids or not (message_ids & self._seen_message_ids):
+            self._hydrated_message_ids.clear()
+            self._scrollback_protected = False
+            self._unhydrated_message_ids = self._initial_unhydrated_ids()
         new_user_send = any(
             message.id not in self._seen_message_ids
             and message.role == ConsoleMessageRole.USER
@@ -1839,6 +1947,9 @@ class ConsoleTranscript(VerticalScroll):
             # anchor late, and it must not yank a reader who has already
             # scrolled back.
             self.anchor()
+            # TASK-15455: the send takes the reader out of any scrollback they
+            # hydrated, so the watermarks own those rows again.
+            self._release_scrollback_protection()
         self._seen_message_ids = message_ids
         # task-501: apply a swipe-handoff selection once its id is actually in
         # the ingested set (see ``pending_selection_id``); checked BEFORE the
@@ -1959,6 +2070,7 @@ class ConsoleTranscript(VerticalScroll):
         async with self._refresh_lock:
             await self._reconcile_rows(self._transcript_rows())
         self._schedule_prune_check()
+        self._schedule_hydration_check()
 
     def _schedule_prune_check(self) -> None:
         """Run one watermark pruning check after the pending refresh settles.
@@ -1979,6 +2091,224 @@ class ConsoleTranscript(VerticalScroll):
         except NoActiveAppError:
             app_config = None
         return get_console_prune_watermarks(app_config)
+
+    def _window_settings(self) -> tuple[int, int, int]:
+        """Return ``(window_messages, window_lines, hydrate_messages)``."""
+        try:
+            app_config = getattr(self.app, "app_config", None)
+        except NoActiveAppError:
+            app_config = None
+        return get_console_transcript_window(app_config)
+
+    def _initial_unhydrated_ids(self) -> set[str]:
+        """Return the ids a fresh load leaves unmounted (the tail-first window).
+
+        Walks backwards from the newest message, keeping messages until either
+        the message cap or the estimated line budget is reached (never fewer
+        than :data:`MIN_TRANSCRIPT_WINDOW_MESSAGES`). Everything older is
+        reported as unhydrated.
+
+        Returns:
+            Ids of the oldest messages to leave unmounted; empty when the whole
+            history fits the window or windowing is disabled.
+        """
+        window_messages, window_lines, _hydrate = self._window_settings()
+        total = len(self._messages)
+        if window_messages <= 0 or total <= window_messages:
+            return set()
+        kept = 0
+        lines = 0
+        for message in reversed(self._messages):
+            if kept >= window_messages:
+                break
+            if kept >= MIN_TRANSCRIPT_WINDOW_MESSAGES and lines >= window_lines:
+                break
+            lines += _estimated_message_lines(message)
+            kept += 1
+        if kept >= total:
+            return set()
+        logger.debug(
+            f"Console transcript load window: mounting the newest {kept} of "
+            f"{total} messages (~{lines} estimated rows)"
+        )
+        return {message.id for message in self._messages[: total - kept]}
+
+    def watch_scroll_y(self, old_value: float, new_value: float) -> None:
+        """Hydrate older scrollback as the reader approaches the top.
+
+        Every scroll path (wheel, keyboard, scrollbar drag, programmatic)
+        lands here, so this is the single trigger for scroll-back hydration.
+        Costs one attribute read on the common path: transcripts with nothing
+        windowed out return immediately.
+        """
+        super().watch_scroll_y(old_value, new_value)
+        if getattr(self, "_scrollback_protected", False) and self._is_following_tail():
+            # Back at the tail: the reader has left the scrollback they
+            # hydrated, so the watermark walk may reclaim it again (see
+            # `_compute_prunable_prefix`).
+            self._release_scrollback_protection()
+        if not getattr(self, "_unhydrated_message_ids", None):
+            return
+        if new_value <= max(1, self.container_size.height):
+            self._schedule_hydration_check()
+
+    def _release_scrollback_protection(self) -> None:
+        """Let the watermarks reclaim hydrated scrollback again.
+
+        Called when the reader returns to the tail by any route (the jump
+        pill, a send, or scrolling to the bottom). No-op when nothing is
+        protected, so the common scroll path costs one boolean read.
+        """
+        if not self._scrollback_protected:
+            return
+        self._scrollback_protected = False
+        self._schedule_prune_check()
+
+    def _schedule_hydration_check(self) -> None:
+        """Queue one coalesced scroll-back hydration check after the refresh."""
+        if self._hydration_check_scheduled or not self.is_mounted:
+            return
+        if not self._unhydrated_message_ids:
+            return
+        self._hydration_check_scheduled = True
+        self.call_after_refresh(self._run_hydration_check)
+
+    async def _run_hydration_check(self) -> None:
+        """Mount the next chunk of older messages when the reader needs it.
+
+        Two conditions gate hydration, and together they make a
+        hydrate → prune → hydrate oscillation impossible for ANY watermark
+        configuration:
+
+        1. The mounted height must be strictly BELOW the low watermark. The
+           watermark walk only fires above the HIGH mark and always stops
+           while the remainder is still above the LOW mark, so a prune can
+           never put the transcript back into a hydratable state.
+        2. The reader must be within one viewport of the top -- or the window
+           must be too short to scroll at all, which is the same request
+           ("there is more above and I cannot reach it").
+
+        Each step is additionally sized against the room left under the low
+        watermark, so a hydration chunk does not vault the transcript over the
+        HIGH mark and hand the watermark walk the rows it just mounted.
+
+        A second, independent guard lives in ``_compute_prunable_prefix``:
+        hydrated ids are protected from pruning while the reader is detached,
+        so an oversized chunk that overshoots the high watermark is never
+        yanked back out from under them.
+        """
+        self._hydration_check_scheduled = False
+        if not self.is_mounted or self._closing or self._pruning:
+            return
+        if not self._unhydrated_message_ids:
+            return
+        low_mark, high_mark = self._prune_watermarks()
+        total_height = self.virtual_size.height
+        if high_mark > 0 and total_height >= low_mark:
+            return
+        if self.scroll_y > max(1, self.container_size.height):
+            return
+        _window, _lines, chunk = self._window_settings()
+        pending = [
+            message
+            for message in self._messages
+            if message.id in self._unhydrated_message_ids
+        ]
+        if not pending:
+            self._unhydrated_message_ids.clear()
+            return
+        # Size the step against the room left under the low watermark, using
+        # the same estimator as the initial window. Without this a fixed-size
+        # chunk can vault a small transcript clean over the HIGH mark, and the
+        # watermark walk then throws the freshly hydrated rows away (measured:
+        # a 3-message window hydrating 10 messages under a 20/40 config mounted
+        # 10 rows and pruned 9 of them one tick later). One message is always
+        # taken so scroll-back never stalls silently.
+        budget = max(0, low_mark - total_height) if high_mark > 0 else None
+        hydrate_ids: list[str] = []
+        estimated = 0
+        for message in reversed(pending):
+            if len(hydrate_ids) >= chunk:
+                break
+            lines = _estimated_message_lines(message)
+            if budget is not None and hydrate_ids and estimated + lines > budget:
+                break
+            estimated += lines
+            hydrate_ids.append(message.id)
+        hydrate_ids.reverse()
+        following = self._is_following_tail()
+        anchor_y = self.scroll_y
+        self._unhydrated_message_ids.difference_update(hydrate_ids)
+        self._hydrated_message_ids.update(hydrate_ids)
+        if not following:
+            # Reader-driven scroll-back: hold it until they return to the tail.
+            # A fill while following the tail is not scrollback the reader is
+            # reading, so it stays reclaimable by the watermarks.
+            self._scrollback_protected = True
+        logger.debug(
+            f"Hydrating {len(hydrate_ids)} older Console transcript message(s) "
+            f"({len(self._unhydrated_message_ids)} still windowed out)"
+        )
+        async with self._refresh_lock:
+            await self._reconcile_rows(self._transcript_rows())
+
+        def _restore_scroll() -> None:
+            if not self.is_mounted:
+                return
+            if following:
+                self.anchor()
+                self.scroll_end(animate=False)
+            else:
+                # Keep the same content in view: the hydrated rows were added
+                # ABOVE the reader, so shift down by the height actually added
+                # (measured, not estimated) -- the mirror image of pruning.
+                added = self.virtual_size.height - total_height
+                self.scroll_to(y=max(0.0, anchor_y + added), animate=False)
+            # One chunk may not be enough (a short window under a tall
+            # viewport, or tiny messages); re-arm. Bounded by the gates above
+            # and by the unhydrated set emptying.
+            self._schedule_hydration_check()
+
+        self.call_after_refresh(_restore_scroll)
+        self._schedule_prune_check()
+
+    def ensure_message_hydrated(self, message_id: str) -> bool:
+        """Mount a windowed-out message (and everything after it) on demand.
+
+        Jump targets -- a citation, a search hit, a programmatic selection --
+        can name a message the tail-first window never mounted. Hydrating from
+        that message forward keeps the mounted rows one contiguous suffix of
+        the history, which is what pruning and reconciliation both assume.
+
+        Args:
+            message_id: Identifier of the message that must have a row.
+
+        Returns:
+            True when rows were hydrated (a refresh is scheduled), False when
+            the message was already mounted or is not in this transcript.
+        """
+        if message_id not in self._unhydrated_message_ids:
+            return False
+        ordered = [
+            message.id
+            for message in self._messages
+            if message.id in self._unhydrated_message_ids
+        ]
+        try:
+            index = ordered.index(message_id)
+        except ValueError:  # pragma: no cover - membership was just checked
+            return False
+        hydrate_ids = ordered[index:]
+        self._unhydrated_message_ids.difference_update(hydrate_ids)
+        self._hydrated_message_ids.update(hydrate_ids)
+        self._scrollback_protected = True
+        if self.is_mounted:
+            self.call_later(self.refresh_messages)
+        return True
+
+    def unhydrated_message_ids(self) -> frozenset[str]:
+        """Return the ids currently outside the tail-first mount window."""
+        return frozenset(self._unhydrated_message_ids)
 
     def _assistant_markdown_enabled(self) -> bool:
         """Return the ``[chat_defaults] assistant_markdown`` toggle (TASK-1990)."""
@@ -2073,6 +2403,14 @@ class ConsoleTranscript(VerticalScroll):
         }
         if self.selected_message_id is not None:
             protected_ids.add(self.selected_message_id)
+        if self._scrollback_protected:
+            # TASK-15455: scrollback the reader deliberately hydrated is what
+            # they are looking at; the walk must not delete it from under
+            # them (and an oversized hydration step that overshot the high
+            # mark must not be undone, which would restart the cycle).
+            # The latch drops the moment they return to the tail, so the
+            # watermarks still bound the steady state.
+            protected_ids |= self._hydrated_message_ids
 
         prune_ids: list[str] = []
         prune_height = 0
@@ -2169,6 +2507,10 @@ class ConsoleTranscript(VerticalScroll):
         """Select one message and show its contextual action row."""
         if message_id not in {message.id for message in self._messages}:
             return
+        # TASK-15455: a jump target (citation, search hit, programmatic focus)
+        # can name a message the tail-first window has not mounted; hydrate it
+        # first so the selection lands on a real row with its action row.
+        self.ensure_message_hydrated(message_id)
         self.selected_message_id = message_id
         if self.is_mounted:
             self.call_later(self.refresh_messages)
@@ -2418,17 +2760,19 @@ class ConsoleTranscript(VerticalScroll):
         )
 
     def _visible_messages(self) -> list[ConsoleChatMessage]:
-        """Return the messages with rendered rows (excludes the pruned window).
+        """Return the messages with rendered rows (excludes unmounted windows).
 
-        Keyboard selection walks this list so j/k never lands on a pruned
-        (row-less) message; the store-facing ``_messages`` keeps full history.
+        Keyboard selection walks this list so j/k never lands on a pruned or
+        not-yet-hydrated (row-less) message; the store-facing ``_messages``
+        keeps full history.
         """
-        if not self._pruned_message_ids:
+        if not self._pruned_message_ids and not self._unhydrated_message_ids:
             return self._messages
         return [
             message
             for message in self._messages
             if message.id not in self._pruned_message_ids
+            and message.id not in self._unhydrated_message_ids
         ]
 
     def _notify_selection_changed(self) -> None:
@@ -2445,6 +2789,11 @@ class ConsoleTranscript(VerticalScroll):
             if message.id in self._pruned_message_ids:
                 # TASK-1365: pruned by the height watermarks; the store keeps
                 # the message, the view window drops every row derived from it.
+                continue
+            if message.id in self._unhydrated_message_ids:
+                # TASK-15455: older than the tail-first load window. Same
+                # view-only contract as pruning above, except this one is
+                # reversible -- scrolling back hydrates these ids again.
                 continue
             message = self._with_expanded_tool_output(message)
             selected = message.id == self.selected_message_id

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -1959,6 +1959,10 @@ class ConsoleTranscript(VerticalScroll):
             self.pending_selection_id is not None
             and self.pending_selection_id in message_ids
         ):
+            # TASK-15455: a handoff can name a message outside the mount
+            # window (a swipe carried across a session switch); a selection
+            # with no row would show no action row at all.
+            self.ensure_message_hydrated(self.pending_selection_id)
             self.selected_message_id = self.pending_selection_id
             self.pending_selection_id = None
         if self.selected_message_id not in message_ids:
@@ -2193,9 +2197,10 @@ class ConsoleTranscript(VerticalScroll):
         HIGH mark and hand the watermark walk the rows it just mounted.
 
         A second, independent guard lives in ``_compute_prunable_prefix``:
-        hydrated ids are protected from pruning while the reader is detached,
-        so an oversized chunk that overshoots the high watermark is never
-        yanked back out from under them.
+        hydrated ids are protected from pruning while the
+        ``_scrollback_protected`` latch holds (set here for a reader-driven
+        step, dropped when they return to the tail), so an oversized step that
+        overshoots the high watermark is never yanked back out from under them.
         """
         self._hydration_check_scheduled = False
         if not self.is_mounted or self._closing or self._pruning:

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -219,6 +219,21 @@ def get_console_transcript_window(
     return window_messages, max(1, window_lines), max(1, hydrate_messages)
 
 
+def _gap_notice(skipped: int) -> Content:
+    """Return the one-line marker shown where mounted history is discontiguous.
+
+    Args:
+        skipped: How many messages sit in the hole.
+
+    Returns:
+        Dim single-line content naming the gap.
+    """
+    label = "message" if skipped == 1 else "messages"
+    return Content.assemble(
+        (f"⋯ {skipped} earlier {label} not shown (still in this conversation)", "dim")
+    )
+
+
 def _estimated_message_lines(message: ConsoleChatMessage) -> int:
     """Estimate a message's rendered height in terminal rows.
 
@@ -1637,6 +1652,7 @@ class ConsoleTranscript(VerticalScroll):
             "console-transcript-empty-state",
             "console-transcript-rule",
             "console-transcript-summary-banner",
+            "console-transcript-gap",
             "console-transcript-citation-sources",
             # Textual scrollbars carry the generic system-widget class; ignore them
             # defensively if a scrollbar click ever bubbles up to the transcript.
@@ -1922,7 +1938,21 @@ class ConsoleTranscript(VerticalScroll):
         # whatever the reader has already hydrated.
         self._unhydrated_message_ids &= message_ids
         self._hydrated_message_ids &= message_ids
-        if not self._seen_message_ids or not (message_ids & self._seen_message_ids):
+        mounted_ids = (
+            message_ids - self._unhydrated_message_ids - self._pruned_message_ids
+        )
+        if (
+            not self._seen_message_ids
+            or not (message_ids & self._seen_message_ids)
+            # TASK-15455 (review): a `/rewind` -- or any truncation to a shared
+            # PREFIX -- can land entirely inside the windowed-out head, leaving
+            # a transcript that HAS messages and renders none. Measured: a
+            # 60-message session windowed to 40, rewound to 16, painted one
+            # rowless frame and then recovered only a hydration step's worth of
+            # rows. Re-window on the survivors instead of waiting for the
+            # scroll-back path to notice.
+            or (message_ids and not mounted_ids and self._unhydrated_message_ids)
+        ):
             self._hydrated_message_ids.clear()
             self._scrollback_protected = False
             self._unhydrated_message_ids = self._initial_unhydrated_ids()
@@ -2281,9 +2311,16 @@ class ConsoleTranscript(VerticalScroll):
         """Mount a windowed-out message (and everything after it) on demand.
 
         Jump targets -- a citation, a search hit, a programmatic selection --
-        can name a message the tail-first window never mounted. Hydrating from
-        that message forward keeps the mounted rows one contiguous suffix of
-        the history, which is what pruning and reconciliation both assume.
+        can name a message the tail-first window never mounted. Hydration always
+        runs from that message forward, never as an isolated row.
+
+        The true invariant (the earlier "one contiguous suffix" comment was
+        wrong): mounted messages form AT MOST TWO contiguous stretches of the
+        history -- the hydrated jump target's stretch and the tail -- separated
+        by whatever the watermark walk pruned in between, and
+        ``_transcript_rows`` marks that seam with a gap row. Nothing downstream
+        needs contiguity: the reconciler and ``_compute_prunable_prefix`` both
+        walk CHILD ORDER, which stays the message order either way.
 
         Args:
             message_id: Identifier of the message that must have a row.
@@ -2306,7 +2343,15 @@ class ConsoleTranscript(VerticalScroll):
         hydrate_ids = ordered[index:]
         self._unhydrated_message_ids.difference_update(hydrate_ids)
         self._hydrated_message_ids.update(hydrate_ids)
-        self._scrollback_protected = True
+        if not self._is_following_tail():
+            # Latch ONLY for a reader who is away from the tail. Latching while
+            # following would arm a protection whose documented release ("the
+            # reader returns to the tail") can never fire -- they are already
+            # there -- so the watermark walk would stay blocked through idle
+            # (review: mounted height 158 against a high mark of 40). A
+            # tail-position jump still keeps its target row: the selected
+            # message is protected by `_compute_prunable_prefix` on its own.
+            self._scrollback_protected = True
         if self.is_mounted:
             self.call_later(self.refresh_messages)
         return True
@@ -2790,18 +2835,40 @@ class ConsoleTranscript(VerticalScroll):
 
     def _transcript_rows(self) -> list[_TranscriptRow]:
         rows: list[_TranscriptRow] = []
+        # TASK-15455: messages skipped since the last rendered one. A skipped
+        # run BEFORE the first rendered message is the ordinary head omission
+        # (older history sits above; scrolling up hydrates it). A skipped run
+        # BETWEEN two rendered messages is a hole -- a jump into windowed-out
+        # history lands above rows the watermark walk already pruned -- and
+        # without a marker the transcript renders two unrelated turns adjacent
+        # with no seam, which silently lies about the conversation.
+        skipped_since_rendered = 0
+        rendered_any = False
         for message in self._messages:
             if message.id in self._pruned_message_ids:
                 # TASK-1365: pruned by the height watermarks; the store keeps
                 # the message, the view window drops every row derived from it.
+                skipped_since_rendered += 1
                 continue
             if message.id in self._unhydrated_message_ids:
                 # TASK-15455: older than the tail-first load window. Same
                 # view-only contract as pruning above, except this one is
                 # reversible -- scrolling back hydrates these ids again.
+                skipped_since_rendered += 1
                 continue
             message = self._with_expanded_tool_output(message)
             selected = message.id == self.selected_message_id
+            if rendered_any and skipped_since_rendered:
+                rows.append(
+                    _TranscriptRow(
+                        key=f"gap:{message.id}",
+                        kind="gap",
+                        signature=("gap", message.id, skipped_since_rendered),
+                        renderable=_gap_notice(skipped_since_rendered),
+                    )
+                )
+            skipped_since_rendered = 0
+            rendered_any = True
             rows.append(
                 _TranscriptRow(
                     key=f"rule:{message.id}",
@@ -3126,6 +3193,15 @@ class ConsoleTranscript(VerticalScroll):
             return Static(
                 row.renderable,
                 classes="console-transcript-summary-banner",
+            )
+        if row.kind == "gap":
+            # TASK-15455: non-interactive seam between two discontiguous
+            # stretches of mounted history. Dim via Content markup rather than
+            # a stylesheet rule, matching the summary banner (which likewise
+            # ships without one) -- no CSS bundle change needed.
+            return Static(
+                row.renderable,
+                classes="console-transcript-gap",
             )
         if row.kind == "empty":
             assert row.card_state is not None

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3256,6 +3256,16 @@ strip_thinking_tags = true
 prune_high_watermark = 20000
 prune_low_watermark = 12000
 
+# Console transcript load window: resuming or switching to a conversation
+# mounts only the newest transcript_window_messages messages (further capped
+# by transcript_window_lines estimated rows), and hydrates
+# transcript_hydrate_messages older messages at a time as you scroll back.
+# The watermarks above still bound the total. Set
+# transcript_window_messages <= 0 to mount the whole history at load.
+transcript_window_messages = 40
+transcript_window_lines = 600
+transcript_hydrate_messages = 20
+
 # Render assistant replies as full markdown (code blocks, tables, lists,
 # links) in the Console transcript. Set false to restore the lightweight
 # span renderer, which keeps roleplay speech/action flavor colors.


### PR DESCRIPTION
## Summary

Task 15455 from the input-latency audit — the most structural Console change. Session resume mounted every persisted row via individual awaited `mount()` calls with full-history markdown parse before pruning could apply.

- Tail-first window (40 messages/600 est. rows, configurable under `[chat_defaults]` with a kill switch) + on-demand scrollback hydration; batched mounts/removals
- **Load probe at 500 messages: 47.2 s → 2.1 s** (reviewer reproduced the machine-independent shape: 1002 → 82 rows, 5502 → 442 widgets; same-build windowed-vs-kill-switch ≈ 13×)
- Pins-first: 8 behavioral invariants green on unmodified dev before any change; 31-test window suite with 14 kill-tested mutations
- Anti-oscillation is structural (hydration refuses at/above the low mark; pruning refuses to cross it — the gates cannot both open for any watermark pair)
- Review round: latch now arms only away from the tail (pruning stays live at tail position); interior prune gaps render an honest `⋯ N earlier messages not shown` seam (keyed row, prunes atomically with its group, click-protected); /rewind into the windowed-out head re-windows on survivors instead of painting a rowless frame; Guide documents the scrollback prune-suspension caveat

## Verification
Independent opus review (Approved; residual rulings measured — 200-message stream parked in scrollback recovers fully on return; jump-flow coverage = the only two call sites that exist) + scoped re-review (APPROVE; gap-seam mechanism traced through reconciler/prune-group/click paths; fixture adaptations verified strengthening; both suites reproduced 31 + 121). One narrow non-blocking follow-up recorded for filing: `restore_reading_state` reads the tail-follow latch against the pre-restore anchor (masked today by selection protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load long Console conversations faster by mounting a tail-first window and hydrating older messages on scroll. A 500‑message resume drops from ~47.2s to ~2.1s in the probe, without losing any history. Satisfies task-15455 ACs #1–#3.

- New Features
  - Windowed load: mount newest messages by count and line budget; tune under `[chat_defaults]` (`transcript_window_messages`, `transcript_window_lines`, `transcript_hydrate_messages`; set `transcript_window_messages` to `0` to disable).
  - Scrollback hydration on demand, sized to watermark headroom; protected while away from the tail and released on return; session switches re‑establish the window; exports and model context still use full history.
  - Clear seam for interior gaps: renders "⋯ N earlier messages not shown" between stretches.
  - Batched row mounts/removals to cut DOM churn; 500‑message load probe: 47.2s → 2.1s, 1002 → 82 rows, 5502 → 442 widgets.

- Bug Fixes
  - Selecting or jumping to an unmounted message hydrates it first; keyboard nav never lands on an unmounted row.
  - Tail-position jumps no longer arm scrollback protection; pruning remains active.
  - `/rewind` into a windowed-out head re-windows on survivors; no blank frame.
  - `restore_reading_state` hydrates its selected message before applying selection.

<sup>Written for commit 73b7e87c170e82d18b97884e3747d876e3e1b467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

