### PR TITLE
TASK-601: record native process-tree evidence

### DIFF
--- a/.github/scripts/task601_process_tree_evidence.py
+++ b/.github/scripts/task601_process_tree_evidence.py
@@ -71,7 +71,14 @@ def _run_url(run_id: str) -> str:
 
 
 def current_run_identity() -> dict[str, str]:
-    """Return the checked-out commit and bounded GitHub workflow identity."""
+    """Return the checked-out commit and bounded GitHub workflow identity.
+
+    Returns:
+        The tested commit and canonical workflow-run fields.
+
+    Raises:
+        ValueError: If Git or the workflow environment lacks a valid identity.
+    """
 
     try:
         tested_commit = subprocess.run(
@@ -122,7 +129,23 @@ def failure_result(
     duration_seconds: float = 0.0,
     required_nodes: Mapping[str, str] | None = None,
 ) -> dict[str, object]:
-    """Return a bounded failed result without exception text or local paths."""
+    """Return a bounded failed result without exception text or local paths.
+
+    Args:
+        run_identity: Canonical commit and workflow-run fields.
+        evidence_name: Allowlisted platform evidence name.
+        failure_code: Stable failure category.
+        failure_stage: Stable workflow stage.
+        pytest_outcome: Bounded pytest process outcome.
+        duration_seconds: Bounded pytest duration.
+        required_nodes: Outcomes already known for required nodes.
+
+    Returns:
+        A validated failed platform-evidence document.
+
+    Raises:
+        ValueError: If any supplied evidence field is invalid.
+    """
 
     result: dict[str, object] = {
         "schema_version": SCHEMA_VERSION,
@@ -160,7 +183,19 @@ def result_from_junit(
     pytest_outcome: str,
     evidence_name: str,
 ) -> dict[str, object]:
-    """Normalize selected JUnit cases without copying file or failure details."""
+    """Normalize selected JUnit cases without copying file or failure details.
+
+    Args:
+        path: JUnit XML file produced by the bounded pytest run.
+        pytest_outcome: Captured pytest process outcome.
+        evidence_name: Allowlisted platform evidence name.
+
+    Returns:
+        A validated bounded platform-evidence document.
+
+    Raises:
+        ValueError: If the run identity or platform identity is invalid.
+    """
 
     run_identity = current_run_identity()
     if pytest_outcome not in _PYTEST_OUTCOMES:
@@ -314,7 +349,15 @@ def _validate_host(host: Mapping[str, object], evidence_name: object) -> None:
 
 
 def validate_result(result: Mapping[str, object], *, require_pass: bool = True) -> None:
-    """Validate one exact platform result and optionally require release success."""
+    """Validate one exact platform result and optionally require release success.
+
+    Args:
+        result: Candidate platform-evidence document.
+        require_pass: Whether failed-but-well-formed evidence must be rejected.
+
+    Raises:
+        ValueError: If the document violates the schema or required outcome.
+    """
 
     if not isinstance(result, Mapping):
         raise ValueError("evidence must be an object")
@@ -391,7 +434,17 @@ def validate_result(result: Mapping[str, object], *, require_pass: bool = True) 
 
 
 def aggregate_results(results: Sequence[Mapping[str, object]]) -> dict[str, object]:
-    """Aggregate exactly one passing document for each required native platform."""
+    """Aggregate exactly one passing document for each required native platform.
+
+    Args:
+        results: Passing platform documents from one workflow run and commit.
+
+    Returns:
+        The validated three-platform aggregate.
+
+    Raises:
+        ValueError: If platform coverage or run identity is inconsistent.
+    """
 
     if len(results) != len(EXPECTED_PLATFORMS):
         raise ValueError("aggregate requires exactly three platform results")
@@ -426,7 +479,14 @@ def aggregate_results(results: Sequence[Mapping[str, object]]) -> dict[str, obje
 
 
 def validate_aggregate(aggregate: Mapping[str, object]) -> None:
-    """Validate the strict same-commit, same-run three-platform aggregate."""
+    """Validate the strict same-commit, same-run three-platform aggregate.
+
+    Args:
+        aggregate: Candidate aggregate evidence document.
+
+    Raises:
+        ValueError: If schema, platform coverage, or run identity is invalid.
+    """
 
     if not isinstance(aggregate, Mapping):
         raise ValueError("aggregate evidence must be an object")
@@ -526,7 +586,14 @@ def _validate_cli_args(args: argparse.Namespace) -> None:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Run one evidence normalization, validation, or aggregation operation."""
+    """Run one evidence normalization, validation, or aggregation operation.
+
+    Args:
+        argv: Optional argument vector; defaults to process arguments.
+
+    Returns:
+        Zero for a valid completed operation, otherwise one.
+    """
 
     args = _parser().parse_args(argv)
     try:

--- a/.github/scripts/task601_process_tree_evidence.py
+++ b/.github/scripts/task601_process_tree_evidence.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 import platform
 import re
@@ -150,7 +149,7 @@ def _duration(root: ET.Element) -> float:
         value = sum(float(case.get("time", "0")) for case in root.iter("testcase"))
     else:
         value = float(raw)
-    if not math.isfinite(value) or not 0 <= value <= _MAX_DURATION_SECONDS:
+    if not 0 <= value <= _MAX_DURATION_SECONDS:
         raise ValueError("JUnit duration is outside the evidence bound")
     return value
 
@@ -363,7 +362,6 @@ def validate_result(result: Mapping[str, object], *, require_pass: bool = True) 
     if (
         isinstance(duration, bool)
         or not isinstance(duration, (int, float))
-        or not math.isfinite(duration)
         or not 0 <= duration <= _MAX_DURATION_SECONDS
     ):
         raise ValueError("pytest.duration_seconds is outside the evidence bound")
@@ -411,15 +409,6 @@ def aggregate_results(results: Sequence[Mapping[str, object]]) -> dict[str, obje
     commit = first_run["tested_commit"]
     run_id = first_run["workflow_run_id"]
     run_url = first_run["workflow_run_url"]
-    for result in by_name.values():
-        run = _require_object(result, "run")
-        if run.get("tested_commit") != commit:
-            raise ValueError("platform evidence tested commit mismatch")
-        if (
-            run.get("workflow_run_id") != run_id
-            or run.get("workflow_run_url") != run_url
-        ):
-            raise ValueError("platform evidence workflow run mismatch")
 
     aggregate: dict[str, object] = {
         "schema_version": SCHEMA_VERSION,

--- a/.github/scripts/task601_process_tree_evidence.py
+++ b/.github/scripts/task601_process_tree_evidence.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+"""Normalize and aggregate bounded TASK-601 native process-tree evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import platform
+import re
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+EVIDENCE_LABEL = "task601_native_process_tree"
+AGGREGATE_LABEL = "task601_native_process_tree_matrix"
+EXPECTED_REPOSITORY = "rmusser01/tldw_chatbook"
+REQUIRED_NODES = (
+    "Tests/STT/test_executor_process_tree.py::test_native_force_stop_removes_worker_and_descendant_before_scratch_cleanup",
+    "Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup",
+    "Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch",
+)
+EXPECTED_PLATFORMS = {
+    "linux-x86_64": ("Linux", "x86_64"),
+    "windows-x86_64": ("Windows", "x86_64"),
+    "macos-x86_64": ("Darwin", "x86_64"),
+}
+
+_SHA = re.compile(r"[0-9a-f]{40}\Z")
+_DIGITS = re.compile(r"[0-9]{1,20}\Z")
+_PYTHON_VERSION = re.compile(r"3\.12\.[0-9]+\Z")
+_PYTEST_OUTCOMES = frozenset({"success", "failure", "cancelled", "skipped"})
+_NODE_OUTCOMES = frozenset({"passed", "failed", "skipped"})
+_FAILURE_CODES = frozenset({"not_run", "dependency_install", "test_execution"})
+_FAILURE_STAGES = frozenset({"initialize", "dependency_install", "test_execution"})
+_MAX_DURATION_SECONDS = 1_200.0
+_MAX_STRING_LENGTH = 256
+_PRIVATE_KEYS = frozenset(
+    {
+        "cmd",
+        "command",
+        "exception",
+        "file",
+        "handle",
+        "path",
+        "pid",
+        "process_id",
+        "process_group_id",
+        "traceback",
+        "user",
+        "user_name",
+        "username",
+    }
+)
+_NODE_BY_TESTCASE = {
+    (
+        path.removesuffix(".py").replace("/", "."),
+        name,
+    ): node
+    for node in REQUIRED_NODES
+    for path, name in (node.split("::", 1),)
+}
+_REQUIRED_TEST_NAMES = frozenset(name for _, name in _NODE_BY_TESTCASE)
+
+
+def _run_url(run_id: str) -> str:
+    return f"https://github.com/{EXPECTED_REPOSITORY}/actions/runs/{run_id}"
+
+
+def current_run_identity() -> dict[str, str]:
+    """Return the checked-out commit and bounded GitHub workflow identity."""
+
+    try:
+        tested_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ValueError("git could not identify the checked-out commit") from error
+    if not _SHA.fullmatch(tested_commit):
+        raise ValueError("git returned an invalid checked-out commit")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "")
+    if not _DIGITS.fullmatch(run_id) or not _DIGITS.fullmatch(attempt):
+        raise ValueError("workflow run ID and attempt must be numeric")
+    return {
+        "tested_commit": tested_commit,
+        "workflow_run_id": run_id,
+        "workflow_run_attempt": attempt,
+        "workflow_run_url": _run_url(run_id),
+    }
+
+
+def _host_result(evidence_name: str) -> dict[str, str]:
+    expected = EXPECTED_PLATFORMS.get(evidence_name)
+    if expected is None:
+        raise ValueError("unknown evidence_name")
+    system = platform.system()
+    machine = platform.machine()
+    architecture = "x86_64" if system == "Windows" and machine == "AMD64" else machine
+    if (system, architecture) != expected:
+        raise ValueError("evidence_name does not match the executing host")
+    return {
+        "system": system,
+        "architecture": architecture,
+        "python": platform.python_version(),
+    }
+
+
+def failure_result(
+    run_identity: Mapping[str, str],
+    *,
+    evidence_name: str,
+    failure_code: str,
+    failure_stage: str,
+    pytest_outcome: str = "skipped",
+    duration_seconds: float = 0.0,
+    required_nodes: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    """Return a bounded failed result without exception text or local paths."""
+
+    result: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "evidence_label": EVIDENCE_LABEL,
+        "evidence_name": evidence_name,
+        "status": "failed",
+        "failure_code": failure_code,
+        "failure_stage": failure_stage,
+        "run": dict(run_identity),
+        "host": _host_result(evidence_name),
+        "pytest": {
+            "outcome": pytest_outcome,
+            "duration_seconds": duration_seconds,
+            "required_nodes": dict(required_nodes or {}),
+        },
+    }
+    validate_result(result, require_pass=False)
+    return result
+
+
+def _duration(root: ET.Element) -> float:
+    raw = root.get("time")
+    if raw is None:
+        value = sum(float(case.get("time", "0")) for case in root.iter("testcase"))
+    else:
+        value = float(raw)
+    if not math.isfinite(value) or not 0 <= value <= _MAX_DURATION_SECONDS:
+        raise ValueError("JUnit duration is outside the evidence bound")
+    return value
+
+
+def result_from_junit(
+    path: Path,
+    *,
+    pytest_outcome: str,
+    evidence_name: str,
+) -> dict[str, object]:
+    """Normalize selected JUnit cases without copying file or failure details."""
+
+    run_identity = current_run_identity()
+    if pytest_outcome not in _PYTEST_OUTCOMES:
+        raise ValueError("pytest outcome is not allowlisted")
+    required: dict[str, str] = {}
+    duration_seconds = 0.0
+    selected_failure = False
+    duplicate = False
+    unexpected_required_identity = False
+    try:
+        root = ET.parse(path).getroot()
+        duration_seconds = _duration(root)
+        selected_failure = any(item.tag in {"failure", "error"} for item in root.iter())
+        counts = dict.fromkeys(REQUIRED_NODES, 0)
+        for case in root.iter("testcase"):
+            classname = case.get("classname", "")
+            name = case.get("name", "")
+            node = _NODE_BY_TESTCASE.get((classname, name))
+            if node is None:
+                if name in _REQUIRED_TEST_NAMES or any(
+                    name.startswith(f"{required_name}[")
+                    for required_name in _REQUIRED_TEST_NAMES
+                ):
+                    unexpected_required_identity = True
+                continue
+            counts[node] += 1
+            if case.find("failure") is not None or case.find("error") is not None:
+                required[node] = "failed"
+            elif case.find("skipped") is not None:
+                required[node] = "skipped"
+            else:
+                required[node] = "passed"
+        duplicate = any(count != 1 for count in counts.values())
+    except (OSError, UnicodeError, ET.ParseError, TypeError, ValueError):
+        return failure_result(
+            run_identity,
+            evidence_name=evidence_name,
+            failure_code="test_execution",
+            failure_stage="test_execution",
+            pytest_outcome=pytest_outcome,
+        )
+
+    passed = (
+        pytest_outcome == "success"
+        and not selected_failure
+        and not duplicate
+        and not unexpected_required_identity
+        and required == dict.fromkeys(REQUIRED_NODES, "passed")
+    )
+    result: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "evidence_label": EVIDENCE_LABEL,
+        "evidence_name": evidence_name,
+        "status": "passed" if passed else "failed",
+        "failure_code": None if passed else "test_execution",
+        "failure_stage": None if passed else "test_execution",
+        "run": run_identity,
+        "host": _host_result(evidence_name),
+        "pytest": {
+            "outcome": pytest_outcome,
+            "duration_seconds": duration_seconds,
+            "required_nodes": required,
+        },
+    }
+    validate_result(result, require_pass=False)
+    return result
+
+
+def _require_fields(
+    value: Mapping[str, object], expected: set[str], context: str
+) -> None:
+    missing = expected - set(value)
+    unexpected = set(value) - expected
+    if missing:
+        raise ValueError(f"{context} is missing fields")
+    if unexpected:
+        raise ValueError(f"{context} contains an unknown field")
+
+
+def _require_object(parent: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = parent.get(key)
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{key} must be an object")
+    return value
+
+
+def _reject_private_strings(value: object) -> None:
+    if isinstance(value, str):
+        if len(value) > _MAX_STRING_LENGTH:
+            raise ValueError("evidence contains an unbounded string")
+        if value in REQUIRED_NODES or re.fullmatch(
+            rf"https://github\.com/{re.escape(EXPECTED_REPOSITORY)}/actions/runs/[0-9]{{1,20}}",
+            value,
+        ):
+            return
+        if "/" in value or "\\" in value:
+            raise ValueError(
+                "evidence contains path-like or noncanonical slash content"
+            )
+        return
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError("evidence object keys must be strings")
+            if key.lower() in _PRIVATE_KEYS:
+                raise ValueError("evidence contains a private process or user field")
+            _reject_private_strings(key)
+            _reject_private_strings(item)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _reject_private_strings(item)
+
+
+def _validate_run(run: Mapping[str, object], *, include_attempt: bool) -> None:
+    expected = {"tested_commit", "workflow_run_id", "workflow_run_url"}
+    if include_attempt:
+        expected.add("workflow_run_attempt")
+    _require_fields(run, expected, "run")
+    commit = run.get("tested_commit")
+    run_id = run.get("workflow_run_id")
+    if not isinstance(commit, str) or not _SHA.fullmatch(commit):
+        raise ValueError(
+            "run.tested_commit must be 40 lowercase hexadecimal characters"
+        )
+    if not isinstance(run_id, str) or not _DIGITS.fullmatch(run_id):
+        raise ValueError("run.workflow_run_id must be a digits string")
+    if include_attempt:
+        attempt = run.get("workflow_run_attempt")
+        if not isinstance(attempt, str) or not _DIGITS.fullmatch(attempt):
+            raise ValueError("run.workflow_run_attempt must be a digits string")
+    if run.get("workflow_run_url") != _run_url(run_id):
+        raise ValueError("run.workflow_run_url must be the canonical repository URL")
+
+
+def _validate_host(host: Mapping[str, object], evidence_name: object) -> None:
+    _require_fields(host, {"system", "architecture", "python"}, "host")
+    if not isinstance(evidence_name, str) or evidence_name not in EXPECTED_PLATFORMS:
+        raise ValueError("evidence_name is not allowlisted")
+    expected_system, expected_architecture = EXPECTED_PLATFORMS[evidence_name]
+    if (
+        host.get("system") != expected_system
+        or host.get("architecture") != expected_architecture
+    ):
+        raise ValueError("host does not match evidence_name")
+    python_version = host.get("python")
+    if not isinstance(python_version, str) or not _PYTHON_VERSION.fullmatch(
+        python_version
+    ):
+        raise ValueError("host.python must identify Python 3.12")
+
+
+def validate_result(result: Mapping[str, object], *, require_pass: bool = True) -> None:
+    """Validate one exact platform result and optionally require release success."""
+
+    if not isinstance(result, Mapping):
+        raise ValueError("evidence must be an object")
+    _reject_private_strings(result)
+    _require_fields(
+        result,
+        {
+            "schema_version",
+            "evidence_label",
+            "evidence_name",
+            "status",
+            "failure_code",
+            "failure_stage",
+            "run",
+            "host",
+            "pytest",
+        },
+        "result",
+    )
+    if (
+        type(result.get("schema_version")) is not int
+        or result.get("schema_version") != SCHEMA_VERSION
+    ):
+        raise ValueError("unsupported schema_version")
+    if result.get("evidence_label") != EVIDENCE_LABEL:
+        raise ValueError("unexpected evidence_label")
+    status = result.get("status")
+    if status not in {"passed", "failed"}:
+        raise ValueError("status must be passed or failed")
+    evidence_name = result.get("evidence_name")
+    run = _require_object(result, "run")
+    _validate_run(run, include_attempt=True)
+    _validate_host(_require_object(result, "host"), evidence_name)
+
+    pytest_result = _require_object(result, "pytest")
+    _require_fields(
+        pytest_result,
+        {"outcome", "duration_seconds", "required_nodes"},
+        "pytest",
+    )
+    outcome = pytest_result.get("outcome")
+    if outcome not in _PYTEST_OUTCOMES:
+        raise ValueError("pytest.outcome is not allowlisted")
+    duration = pytest_result.get("duration_seconds")
+    if (
+        isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(duration)
+        or not 0 <= duration <= _MAX_DURATION_SECONDS
+    ):
+        raise ValueError("pytest.duration_seconds is outside the evidence bound")
+    nodes = _require_object(pytest_result, "required_nodes")
+    if not set(nodes).issubset(REQUIRED_NODES):
+        raise ValueError("pytest.required_nodes contains an unknown node")
+    if any(node_outcome not in _NODE_OUTCOMES for node_outcome in nodes.values()):
+        raise ValueError("pytest.required_nodes contains an invalid outcome")
+
+    if status == "passed":
+        if (
+            result.get("failure_code") is not None
+            or result.get("failure_stage") is not None
+        ):
+            raise ValueError("passed evidence cannot contain failure fields")
+        if outcome != "success":
+            raise ValueError("passed evidence requires successful pytest outcome")
+        if dict(nodes) != dict.fromkeys(REQUIRED_NODES, "passed"):
+            raise ValueError("every required node must be passed")
+    else:
+        if result.get("failure_code") not in _FAILURE_CODES:
+            raise ValueError("failure_code must be a stable allowlisted code")
+        if result.get("failure_stage") not in _FAILURE_STAGES:
+            raise ValueError("failure_stage must be a stable allowlisted stage")
+        if require_pass:
+            raise ValueError("TASK-601 evidence did not pass")
+
+
+def aggregate_results(results: Sequence[Mapping[str, object]]) -> dict[str, object]:
+    """Aggregate exactly one passing document for each required native platform."""
+
+    if len(results) != len(EXPECTED_PLATFORMS):
+        raise ValueError("aggregate requires exactly three platform results")
+    by_name: dict[str, Mapping[str, object]] = {}
+    for result in results:
+        validate_result(result)
+        name = result.get("evidence_name")
+        if not isinstance(name, str) or name in by_name:
+            raise ValueError("aggregate contains duplicate platform evidence")
+        by_name[name] = result
+    if set(by_name) != set(EXPECTED_PLATFORMS):
+        raise ValueError("aggregate platforms must be exact")
+
+    first_run = _require_object(next(iter(by_name.values())), "run")
+    commit = first_run["tested_commit"]
+    run_id = first_run["workflow_run_id"]
+    run_url = first_run["workflow_run_url"]
+    for result in by_name.values():
+        run = _require_object(result, "run")
+        if run.get("tested_commit") != commit:
+            raise ValueError("platform evidence tested commit mismatch")
+        if (
+            run.get("workflow_run_id") != run_id
+            or run.get("workflow_run_url") != run_url
+        ):
+            raise ValueError("platform evidence workflow run mismatch")
+
+    aggregate: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "evidence_label": AGGREGATE_LABEL,
+        "status": "passed",
+        "run": {
+            "tested_commit": commit,
+            "workflow_run_id": run_id,
+            "workflow_run_url": run_url,
+        },
+        "platforms": {name: by_name[name] for name in EXPECTED_PLATFORMS},
+    }
+    validate_aggregate(aggregate)
+    return aggregate
+
+
+def validate_aggregate(aggregate: Mapping[str, object]) -> None:
+    """Validate the strict same-commit, same-run three-platform aggregate."""
+
+    if not isinstance(aggregate, Mapping):
+        raise ValueError("aggregate evidence must be an object")
+    _reject_private_strings(aggregate)
+    _require_fields(
+        aggregate,
+        {"schema_version", "evidence_label", "status", "run", "platforms"},
+        "aggregate",
+    )
+    if (
+        type(aggregate.get("schema_version")) is not int
+        or aggregate.get("schema_version") != SCHEMA_VERSION
+    ):
+        raise ValueError("unsupported aggregate schema_version")
+    if aggregate.get("evidence_label") != AGGREGATE_LABEL:
+        raise ValueError("unexpected aggregate evidence_label")
+    if aggregate.get("status") != "passed":
+        raise ValueError("aggregate status must be passed")
+    run = _require_object(aggregate, "run")
+    _validate_run(run, include_attempt=False)
+    platforms = _require_object(aggregate, "platforms")
+    if set(platforms) != set(EXPECTED_PLATFORMS):
+        raise ValueError("aggregate platforms must be exact")
+    for name in EXPECTED_PLATFORMS:
+        result = platforms.get(name)
+        if not isinstance(result, Mapping):
+            raise ValueError("aggregate platform must be an object")
+        validate_result(result)
+        if result.get("evidence_name") != name:
+            raise ValueError("aggregate platform key does not match evidence_name")
+        platform_run = _require_object(result, "run")
+        if platform_run.get("tested_commit") != run.get("tested_commit"):
+            raise ValueError("aggregate tested commit does not match platform evidence")
+        if platform_run.get("workflow_run_id") != run.get(
+            "workflow_run_id"
+        ) or platform_run.get("workflow_run_url") != run.get("workflow_run_url"):
+            raise ValueError("aggregate workflow run does not match platform evidence")
+
+
+def _write_result(output: Path, result: Mapping[str, object]) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(f".{output.name}.tmp")
+    temporary.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    os.replace(temporary, output)
+
+
+def _load_result(path: Path) -> dict[str, object]:
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError("evidence must be an object")
+    return loaded
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--initialize", action="store_true")
+    parser.add_argument("--record-failure")
+    parser.add_argument("--failure-stage")
+    parser.add_argument("--evidence-name")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--from-junit", type=Path)
+    parser.add_argument("--pytest-outcome")
+    parser.add_argument("--validate", type=Path)
+    parser.add_argument("--aggregate", nargs=3, type=Path)
+    parser.add_argument("--validate-aggregate", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one evidence normalization, validation, or aggregation operation."""
+
+    args = _parser().parse_args(argv)
+    try:
+        if args.validate is not None:
+            validate_result(_load_result(args.validate))
+            return 0
+        if args.validate_aggregate is not None:
+            validate_aggregate(_load_result(args.validate_aggregate))
+            return 0
+        if args.aggregate is not None:
+            if args.output is None:
+                raise ValueError("--output is required")
+            aggregate = aggregate_results(
+                [_load_result(path) for path in args.aggregate]
+            )
+            _write_result(args.output, aggregate)
+            return 0
+        if args.output is None or args.evidence_name is None:
+            raise ValueError("--evidence-name and --output are required")
+        if args.initialize:
+            result = failure_result(
+                current_run_identity(),
+                evidence_name=args.evidence_name,
+                failure_code="not_run",
+                failure_stage="initialize",
+            )
+        elif args.record_failure is not None:
+            if args.failure_stage is None:
+                raise ValueError("--failure-stage is required")
+            result = failure_result(
+                current_run_identity(),
+                evidence_name=args.evidence_name,
+                failure_code=args.record_failure,
+                failure_stage=args.failure_stage,
+            )
+        elif args.from_junit is not None:
+            if args.pytest_outcome is None:
+                raise ValueError("--pytest-outcome is required")
+            result = result_from_junit(
+                args.from_junit,
+                pytest_outcome=args.pytest_outcome,
+                evidence_name=args.evidence_name,
+            )
+        else:
+            raise ValueError("one evidence operation is required")
+        _write_result(args.output, result)
+        return 0
+    except (
+        OSError,
+        UnicodeError,
+        subprocess.SubprocessError,
+        json.JSONDecodeError,
+        ValueError,
+    ):
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/task601_process_tree_evidence.py
+++ b/.github/scripts/task601_process_tree_evidence.py
@@ -495,17 +495,45 @@ def _load_result(path: Path) -> dict[str, object]:
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--initialize", action="store_true")
-    parser.add_argument("--record-failure")
+    operation = parser.add_mutually_exclusive_group(required=True)
+    operation.add_argument("--initialize", action="store_true")
+    operation.add_argument("--record-failure")
+    operation.add_argument("--from-junit", type=Path)
+    operation.add_argument("--validate", type=Path)
+    operation.add_argument("--aggregate", nargs=3, type=Path)
+    operation.add_argument("--validate-aggregate", type=Path)
     parser.add_argument("--failure-stage")
     parser.add_argument("--evidence-name")
     parser.add_argument("--output", type=Path)
-    parser.add_argument("--from-junit", type=Path)
     parser.add_argument("--pytest-outcome")
-    parser.add_argument("--validate", type=Path)
-    parser.add_argument("--aggregate", nargs=3, type=Path)
-    parser.add_argument("--validate-aggregate", type=Path)
     return parser
+
+
+def _validate_cli_args(args: argparse.Namespace) -> None:
+    if args.initialize:
+        required = (args.evidence_name, args.output)
+        forbidden = (args.failure_stage, args.pytest_outcome)
+    elif args.record_failure is not None:
+        required = (args.failure_stage, args.evidence_name, args.output)
+        forbidden = (args.pytest_outcome,)
+    elif args.from_junit is not None:
+        required = (args.pytest_outcome, args.evidence_name, args.output)
+        forbidden = (args.failure_stage,)
+    elif args.aggregate is not None:
+        required = (args.output,)
+        forbidden = (args.failure_stage, args.evidence_name, args.pytest_outcome)
+    else:
+        required = ()
+        forbidden = (
+            args.failure_stage,
+            args.evidence_name,
+            args.output,
+            args.pytest_outcome,
+        )
+    if any(value is None for value in required) or any(
+        value is not None for value in forbidden
+    ):
+        raise ValueError("arguments do not match the selected evidence operation")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -513,6 +541,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     args = _parser().parse_args(argv)
     try:
+        _validate_cli_args(args)
         if args.validate is not None:
             validate_result(_load_result(args.validate))
             return 0
@@ -520,15 +549,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             validate_aggregate(_load_result(args.validate_aggregate))
             return 0
         if args.aggregate is not None:
-            if args.output is None:
-                raise ValueError("--output is required")
             aggregate = aggregate_results(
                 [_load_result(path) for path in args.aggregate]
             )
             _write_result(args.output, aggregate)
             return 0
-        if args.output is None or args.evidence_name is None:
-            raise ValueError("--evidence-name and --output are required")
         if args.initialize:
             result = failure_result(
                 current_run_identity(),
@@ -537,8 +562,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 failure_stage="initialize",
             )
         elif args.record_failure is not None:
-            if args.failure_stage is None:
-                raise ValueError("--failure-stage is required")
             result = failure_result(
                 current_run_identity(),
                 evidence_name=args.evidence_name,
@@ -546,8 +569,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 failure_stage=args.failure_stage,
             )
         elif args.from_junit is not None:
-            if args.pytest_outcome is None:
-                raise ValueError("--pytest-outcome is required")
             result = result_from_junit(
                 args.from_junit,
                 pytest_outcome=args.pytest_outcome,

--- a/.github/workflows/task-601-platform-evidence.yml
+++ b/.github/workflows/task-601-platform-evidence.yml
@@ -1,0 +1,80 @@
+name: TASK-601 native process-tree evidence
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  platform-evidence:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'task-601-platform-evidence'
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - evidence_name: linux-x86_64
+            os: ubuntu-24.04
+          - evidence_name: windows-x86_64
+            os: windows-2022
+          - evidence_name: macos-x86_64
+            os: macos-15-intel
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out the exact tested commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Initialize failure evidence
+        run: python .github/scripts/task601_process_tree_evidence.py --initialize --evidence-name "${{ matrix.evidence_name }}" --output "$RUNNER_TEMP/task-601-platform-evidence.json"
+
+      - name: Install test dependencies
+        id: dependencies
+        continue-on-error: true
+        run: python -m pip install -e '.[dev]'
+
+      - name: Record dependency installation failure
+        if: steps.dependencies.outcome != 'success'
+        run: python .github/scripts/task601_process_tree_evidence.py --record-failure dependency_install --failure-stage dependency_install --evidence-name "${{ matrix.evidence_name }}" --output "$RUNNER_TEMP/task-601-platform-evidence.json"
+
+      - name: Run bounded platform tests
+        id: platform_tests
+        if: steps.dependencies.outcome == 'success'
+        continue-on-error: true
+        run: |
+          python -m pytest \
+            Tests/STT/test_executor_process_tree.py \
+            Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch \
+            Tests/CI/test_task601_process_tree_evidence.py \
+            --timeout=60 \
+            --junitxml="$RUNNER_TEMP/task-601-junit.xml" \
+            -q
+
+      - name: Normalize platform evidence
+        if: always() && steps.dependencies.outcome == 'success'
+        run: python .github/scripts/task601_process_tree_evidence.py --from-junit "$RUNNER_TEMP/task-601-junit.xml" --pytest-outcome "${{ steps.platform_tests.outcome }}" --evidence-name "${{ matrix.evidence_name }}" --output "$RUNNER_TEMP/task-601-platform-evidence.json"
+
+      - name: Validate platform evidence
+        if: always()
+        run: python .github/scripts/task601_process_tree_evidence.py --validate "$RUNNER_TEMP/task-601-platform-evidence.json"
+
+      - name: Upload platform evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: task-601-platform-${{ matrix.evidence_name }}
+          path: ${{ runner.temp }}/task-601-platform-evidence.json
+          if-no-files-found: error

--- a/Docs/STT_Evaluation/task-601/README.md
+++ b/Docs/STT_Evaluation/task-601/README.md
@@ -27,7 +27,7 @@ Every platform passed these exact nodes:
 - `Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch`
 
 The workflow installed only the repository development dependencies. It used no
-STT model/runtime extra, model or network download, inference, or general CI
+STT model/runtime extra, STT model/runtime download, inference, or general CI
 result. The normalized source records and exact run binding are in
 [`platform-evidence.json`](platform-evidence.json).
 
@@ -42,6 +42,6 @@ result. The normalized source records and exact run binding are in
 From the repository root:
 
 ```bash
-../../.venv/bin/python .github/scripts/task601_process_tree_evidence.py \
+python .github/scripts/task601_process_tree_evidence.py \
   --validate-aggregate Docs/STT_Evaluation/task-601/platform-evidence.json
 ```

--- a/Docs/STT_Evaluation/task-601/README.md
+++ b/Docs/STT_Evaluation/task-601/README.md
@@ -10,9 +10,9 @@ loading, transcription accuracy, or performance.
 
 ## Passing matrix
 
-[GitHub Actions run 31577352552](https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552)
+[GitHub Actions run 31580179256](https://github.com/rmusser01/tldw_chatbook/actions/runs/31580179256)
 passed against executable commit
-`5c6a446c8d050587f141561319e58e1ce72c528d`:
+`0e34f7462e4dbd5a724fbe9a6f93ded959623d3e`:
 
 | Runner | Host | Architecture | Result |
 | --- | --- | --- | --- |
@@ -35,7 +35,8 @@ result. The normalized source records and exact run binding are in
 
 - Matrix attempt 1, [run 31575959082](https://github.com/rmusser01/tldw_chatbook/actions/runs/31575959082), tested `48c4ccadb9ef93f64ddfffd9954aede9526ea48e`. Linux and macOS passed; Windows remained red because a POSIX-emulation unit test required `os.killpg` to pre-exist. All three required native nodes passed on Windows. The test-only monkeypatch was made portable.
 - Matrix attempt 2, [run 31576646463](https://github.com/rmusser01/tldw_chatbook/actions/runs/31576646463), tested `83c68c30d82fe04b53db02612ff358fb2fb6a0ec`. Linux and macOS passed; Windows reached the same POSIX-emulation unit test's unavailable `SIGKILL` symbol. All three required native nodes again passed on Windows. The test-only signal seam was made portable.
-- Matrix attempt 3, run 31577352552 above, tested `5c6a446c8d050587f141561319e58e1ce72c528d`; all three native lanes and all required nodes passed. No production defect or production remediation was needed.
+- Matrix attempt 3, [run 31577352552](https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552), tested `5c6a446c8d050587f141561319e58e1ce72c528d`; all three native lanes and all required nodes passed. Later PR review found that the test-only Windows failure finalizer reopened raw PIDs and could terminate a reused unrelated PID, so this otherwise-green evidence was superseded.
+- Matrix attempt 4, run 31580179256 above, tested `0e34f7462e4dbd5a724fbe9a6f93ded959623d3e`; all three native lanes and all required nodes passed after the finalizer was restricted to the owned process and Job Object handles. No production defect or production remediation was needed.
 
 ## Validation
 

--- a/Docs/STT_Evaluation/task-601/README.md
+++ b/Docs/STT_Evaluation/task-601/README.md
@@ -1,0 +1,47 @@
+# TASK-601 native process-tree evidence
+
+## Scope
+
+This evidence closes TASK-601 acceptance criterion 6 for process ownership and
+cleanup ordering. It proves that the local STT worker and a preparation
+descendant are contained and terminated as one native process tree before
+generation scratch cleanup. It does not test FFmpeg media correctness, model
+loading, transcription accuracy, or performance.
+
+## Passing matrix
+
+[GitHub Actions run 31577352552](https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552)
+passed against executable commit
+`5c6a446c8d050587f141561319e58e1ce72c528d`:
+
+| Runner | Host | Architecture | Result |
+| --- | --- | --- | --- |
+| `ubuntu-24.04` | Linux | x86_64 | passed |
+| `windows-2022` | Windows | x86_64 | passed |
+| `macos-15-intel` | macOS (Darwin) | x86_64 | passed |
+
+Every platform passed these exact nodes:
+
+- `Tests/STT/test_executor_process_tree.py::test_native_force_stop_removes_worker_and_descendant_before_scratch_cleanup`
+- `Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup`
+- `Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch`
+
+The workflow installed only the repository development dependencies. It used no
+STT model/runtime extra, model or network download, inference, or general CI
+result. The normalized source records and exact run binding are in
+[`platform-evidence.json`](platform-evidence.json).
+
+## Remediation and reruns
+
+- Matrix attempt 1, [run 31575959082](https://github.com/rmusser01/tldw_chatbook/actions/runs/31575959082), tested `48c4ccadb9ef93f64ddfffd9954aede9526ea48e`. Linux and macOS passed; Windows remained red because a POSIX-emulation unit test required `os.killpg` to pre-exist. All three required native nodes passed on Windows. The test-only monkeypatch was made portable.
+- Matrix attempt 2, [run 31576646463](https://github.com/rmusser01/tldw_chatbook/actions/runs/31576646463), tested `83c68c30d82fe04b53db02612ff358fb2fb6a0ec`. Linux and macOS passed; Windows reached the same POSIX-emulation unit test's unavailable `SIGKILL` symbol. All three required native nodes again passed on Windows. The test-only signal seam was made portable.
+- Matrix attempt 3, run 31577352552 above, tested `5c6a446c8d050587f141561319e58e1ce72c528d`; all three native lanes and all required nodes passed. No production defect or production remediation was needed.
+
+## Validation
+
+From the repository root:
+
+```bash
+../../.venv/bin/python .github/scripts/task601_process_tree_evidence.py \
+  --validate-aggregate Docs/STT_Evaluation/task-601/platform-evidence.json
+```

--- a/Docs/STT_Evaluation/task-601/platform-evidence.json
+++ b/Docs/STT_Evaluation/task-601/platform-evidence.json
@@ -12,7 +12,7 @@
         "system": "Linux"
       },
       "pytest": {
-        "duration_seconds": 2.244,
+        "duration_seconds": 2.684,
         "outcome": "success",
         "required_nodes": {
           "Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup": "passed",
@@ -21,10 +21,10 @@
         }
       },
       "run": {
-        "tested_commit": "5c6a446c8d050587f141561319e58e1ce72c528d",
+        "tested_commit": "0e34f7462e4dbd5a724fbe9a6f93ded959623d3e",
         "workflow_run_attempt": "1",
-        "workflow_run_id": "31577352552",
-        "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552"
+        "workflow_run_id": "31580179256",
+        "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31580179256"
       },
       "schema_version": 1,
       "status": "passed"
@@ -40,7 +40,7 @@
         "system": "Darwin"
       },
       "pytest": {
-        "duration_seconds": 4.893,
+        "duration_seconds": 3.6830000000000003,
         "outcome": "success",
         "required_nodes": {
           "Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup": "passed",
@@ -49,10 +49,10 @@
         }
       },
       "run": {
-        "tested_commit": "5c6a446c8d050587f141561319e58e1ce72c528d",
+        "tested_commit": "0e34f7462e4dbd5a724fbe9a6f93ded959623d3e",
         "workflow_run_attempt": "1",
-        "workflow_run_id": "31577352552",
-        "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552"
+        "workflow_run_id": "31580179256",
+        "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31580179256"
       },
       "schema_version": 1,
       "status": "passed"
@@ -68,7 +68,7 @@
         "system": "Windows"
       },
       "pytest": {
-        "duration_seconds": 3.342,
+        "duration_seconds": 3.4499999999999997,
         "outcome": "success",
         "required_nodes": {
           "Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup": "passed",
@@ -77,19 +77,19 @@
         }
       },
       "run": {
-        "tested_commit": "5c6a446c8d050587f141561319e58e1ce72c528d",
+        "tested_commit": "0e34f7462e4dbd5a724fbe9a6f93ded959623d3e",
         "workflow_run_attempt": "1",
-        "workflow_run_id": "31577352552",
-        "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552"
+        "workflow_run_id": "31580179256",
+        "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31580179256"
       },
       "schema_version": 1,
       "status": "passed"
     }
   },
   "run": {
-    "tested_commit": "5c6a446c8d050587f141561319e58e1ce72c528d",
-    "workflow_run_id": "31577352552",
-    "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552"
+    "tested_commit": "0e34f7462e4dbd5a724fbe9a6f93ded959623d3e",
+    "workflow_run_id": "31580179256",
+    "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31580179256"
   },
   "schema_version": 1,
   "status": "passed"

--- a/Docs/STT_Evaluation/task-601/platform-evidence.json
+++ b/Docs/STT_Evaluation/task-601/platform-evidence.json
@@ -1,0 +1,96 @@
+{
+  "evidence_label": "task601_native_process_tree_matrix",
+  "platforms": {
+    "linux-x86_64": {
+      "evidence_label": "task601_native_process_tree",
+      "evidence_name": "linux-x86_64",
+      "failure_code": null,
+      "failure_stage": null,
+      "host": {
+        "architecture": "x86_64",
+        "python": "3.12.13",
+        "system": "Linux"
+      },
+      "pytest": {
+        "duration_seconds": 2.244,
+        "outcome": "success",
+        "required_nodes": {
+          "Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup": "passed",
+          "Tests/STT/test_executor_process_tree.py::test_native_force_stop_removes_worker_and_descendant_before_scratch_cleanup": "passed",
+          "Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch": "passed"
+        }
+      },
+      "run": {
+        "tested_commit": "5c6a446c8d050587f141561319e58e1ce72c528d",
+        "workflow_run_attempt": "1",
+        "workflow_run_id": "31577352552",
+        "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552"
+      },
+      "schema_version": 1,
+      "status": "passed"
+    },
+    "macos-x86_64": {
+      "evidence_label": "task601_native_process_tree",
+      "evidence_name": "macos-x86_64",
+      "failure_code": null,
+      "failure_stage": null,
+      "host": {
+        "architecture": "x86_64",
+        "python": "3.12.10",
+        "system": "Darwin"
+      },
+      "pytest": {
+        "duration_seconds": 4.893,
+        "outcome": "success",
+        "required_nodes": {
+          "Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup": "passed",
+          "Tests/STT/test_executor_process_tree.py::test_native_force_stop_removes_worker_and_descendant_before_scratch_cleanup": "passed",
+          "Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch": "passed"
+        }
+      },
+      "run": {
+        "tested_commit": "5c6a446c8d050587f141561319e58e1ce72c528d",
+        "workflow_run_attempt": "1",
+        "workflow_run_id": "31577352552",
+        "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552"
+      },
+      "schema_version": 1,
+      "status": "passed"
+    },
+    "windows-x86_64": {
+      "evidence_label": "task601_native_process_tree",
+      "evidence_name": "windows-x86_64",
+      "failure_code": null,
+      "failure_stage": null,
+      "host": {
+        "architecture": "x86_64",
+        "python": "3.12.10",
+        "system": "Windows"
+      },
+      "pytest": {
+        "duration_seconds": 3.342,
+        "outcome": "success",
+        "required_nodes": {
+          "Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup": "passed",
+          "Tests/STT/test_executor_process_tree.py::test_native_force_stop_removes_worker_and_descendant_before_scratch_cleanup": "passed",
+          "Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch": "passed"
+        }
+      },
+      "run": {
+        "tested_commit": "5c6a446c8d050587f141561319e58e1ce72c528d",
+        "workflow_run_attempt": "1",
+        "workflow_run_id": "31577352552",
+        "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552"
+      },
+      "schema_version": 1,
+      "status": "passed"
+    }
+  },
+  "run": {
+    "tested_commit": "5c6a446c8d050587f141561319e58e1ce72c528d",
+    "workflow_run_id": "31577352552",
+    "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552"
+  },
+  "schema_version": 1,
+  "status": "passed"
+}

--- a/Docs/superpowers/plans/2026-08-11-task-601-platform-process-tree-evidence.md
+++ b/Docs/superpowers/plans/2026-08-11-task-601-platform-process-tree-evidence.md
@@ -1,0 +1,714 @@
+# TASK-601 Native Process-Tree Evidence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce same-commit native evidence that the local STT worker and its preparation descendants terminate before scratch cleanup on Linux, Windows, and macOS, then close TASK-601 acceptance criterion 6.
+
+**Architecture:** Keep `ExecutorProcessTree` as the only containment implementation. Generalize its existing real-descendant tests, make the controller cleanup-order test non-vacuous, and run those contracts in a label-gated three-OS GitHub Actions matrix. A small standard-library script converts JUnit into strict path-private JSON and aggregates only three passing results from one tested commit and workflow run.
+
+**Tech Stack:** Python 3.12, `multiprocessing` spawn, POSIX process groups, Windows Job Objects through existing `ctypes`, pytest/JUnit XML, GitHub Actions, standard-library `argparse`/`json`/`platform`/`xml.etree.ElementTree`, Ruff, Backlog CLI.
+
+---
+
+## Preconditions and scope
+
+- Work only in `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-601-local-stt-executor` on `codex/task-601-platform-evidence`.
+- This approved plan and its TASK-601 Backlog plan link must be committed before Task 1 begins; execution starts from a clean worktree.
+- Governing spec: `Docs/superpowers/specs/2026-08-11-task-601-platform-process-tree-evidence-design.md`.
+- Existing design: `Docs/superpowers/specs/2026-08-02-task-601-local-stt-executor-design.md`.
+- ADR required: no new ADR.
+- ADR paths: `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md` and `backlog/decisions/041-direct-local-gguf-before-managed-acquisition.md`.
+- Reason: ADR-025 already fixes process-tree ownership and cleanup order; this plan supplies the deferred native evidence without changing that boundary.
+- Use `superpowers:test-driven-development` for every behavior change and `superpowers:verification-before-completion` before each commit or passing claim.
+- Use the repository evidence lesson: record genuine RED or mutation evidence before implementation, compare exact failure sets, and never treat a skip, timeout, setup failure, or valid failure document as a passing platform.
+- Do not run the full repository suite or rely on general CI. Run only the explicit TASK-601 nodes and changed-file static checks.
+- Do not install an STT model/runtime extra, download a model, run inference, or add an FFmpeg correctness probe. A real descendant created after worker admission proves the OS ownership boundary for any ordinary preparation child.
+- Do not modify production preemptively. If a native lane exposes a production defect, stop after preserving the RED, update this plan and TASK-601 notes, then make the smallest production fix under TDD and rerun all three lanes on the repaired commit.
+- Never use `importlib.reload()` on the IPC/containment module; TASK-601 already proved that this splits exact dataclass identity across spawned processes.
+- Before the evidence run, rebase onto current `origin/dev`, complete all executable changes, and freeze production/tests/workflow/normalizer. After evidence, only evidence documentation and Backlog metadata may change without rerunning the matrix.
+
+## File map
+
+- Modify `Tests/STT/test_executor_process_tree.py` — portable non-destructive liveness/finalization plus two real native descendant contracts.
+- Modify `Tests/STT/executor_test_support.py` — only the spawn-importable descendant helpers required by those contracts.
+- Modify `Tests/STT/test_local_stt_executor.py` — strengthen the existing force-stop scratch-ordering test with a blocked real termination call.
+- Create `Tests/CI/test_task601_process_tree_evidence.py` — strict unit ratchets for result schemas, JUnit normalization, aggregation, and workflow shape.
+- Create `.github/scripts/task601_process_tree_evidence.py` — one standard-library per-platform normalizer/validator/aggregator; no containment implementation.
+- Create `.github/workflows/task-601-platform-evidence.yml` — explicit label/manual three-OS matrix.
+- Create after a green matrix: `Docs/STT_Evaluation/task-601/README.md` and `Docs/STT_Evaluation/task-601/platform-evidence.json`.
+- Modify through Backlog CLI only: `backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md`.
+
+### Task 1: Make the native containment evidence portable and non-vacuous
+
+**Files:**
+- Modify: `Tests/STT/test_executor_process_tree.py`
+- Modify: `Tests/STT/executor_test_support.py`
+- Modify: `Tests/STT/test_local_stt_executor.py`
+- Reference only: `tldw_chatbook/STT/executor_process_tree.py`
+- Reference only: `tldw_chatbook/STT/executor.py:1039-1059`
+
+- [ ] **Step 1: Record the current focused baseline**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch \
+  -q
+```
+
+Expected on the current macOS host: the existing POSIX contracts and controller node pass. Record the exact count and skips; this is baseline only, not cross-platform evidence.
+
+- [ ] **Step 2: Add a Windows-native non-destructive PID probe regression before changing the helper**
+
+In `Tests/STT/test_executor_process_tree.py`, add a Windows-only real-child test:
+
+```python
+@pytest.mark.skipif(os.name != "nt", reason="Windows process-handle contract")
+def test_windows_pid_probe_does_not_terminate_a_live_process() -> None:
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(120)"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        assert _pid_has_exited(child.pid) is False
+        assert child.poll() is None
+    finally:
+        child.terminate()
+        child.wait(10.0)
+```
+
+Do not fake this test. On Windows, the old `os.kill(pid, 0)` implementation would kill the child and the second assertion discriminates that behavior. On POSIX it is explicitly skipped and makes no Windows claim.
+
+- [ ] **Step 3: Record the local platform limitation honestly**
+
+Locally run the node to verify it collects and skips cleanly on macOS:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/STT/test_executor_process_tree.py::test_windows_pid_probe_does_not_terminate_a_live_process \
+  -q
+```
+
+Expected locally: one skip. Record this as collection/skip evidence only, not a RED or Windows result. The first real execution of this behavior is the explicit Windows matrix lane in Task 4; do not simulate a Windows PASS or RED on POSIX.
+
+- [ ] **Step 4: Replace the test helper with the existing repository Win32 wait idiom**
+
+Replace `_pid_exists()` with `_pid_has_exited()` and a small Windows branch equivalent to the existing helper in `Tests/Notes/test_git_process_containment.py`:
+
+```python
+def _pid_has_exited(pid: int) -> bool:
+    if os.name != "nt":
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            return False
+        return False
+
+    import ctypes
+    from ctypes import wintypes
+
+    synchronize = 0x00100000
+    error_invalid_parameter = 87
+    wait_object_0 = 0
+    wait_timeout = 258
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    # Declare OpenProcess, WaitForSingleObject, and CloseHandle arg/restypes
+    # exactly as Tests/Notes/test_git_process_containment.py does.
+    ctypes.set_last_error(0)
+    handle = kernel32.OpenProcess(synchronize, False, pid)
+    if not handle:
+        error = ctypes.get_last_error()
+        if error == error_invalid_parameter:
+            return True
+        raise OSError(error, "OpenProcess could not prove PID exit")
+    try:
+        result = kernel32.WaitForSingleObject(handle, 0)
+        if result == wait_object_0:
+            return True
+        if result == wait_timeout:
+            return False
+        raise OSError(ctypes.get_last_error(), "WaitForSingleObject failed")
+    finally:
+        kernel32.CloseHandle(handle)
+```
+
+Keep finalizers exact: retry the owned `ExecutorProcessTree` first; if an individually captured Windows fixture PID remains, open only that PID with `PROCESS_TERMINATE | SYNCHRONIZE`, call `TerminateProcess`, require `WaitForSingleObject` to report the handle signaled within the bounded timeout, then close it. On POSIX, signal only the captured process group. Never use a broad process-name search or `taskkill` without an exact PID.
+
+- [ ] **Step 5: Generalize the two real POSIX descendant contracts**
+
+Rename and remove the POSIX skip from these nodes:
+
+```text
+Tests/STT/test_executor_process_tree.py::test_native_force_stop_removes_worker_and_descendant_before_scratch_cleanup
+Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup
+```
+
+Retain the behavior in this order:
+
+1. Spawn with `multiprocessing.get_context("spawn")`.
+2. Receive the exact `WorkerContainmentIdentity`.
+3. Construct the real `ExecutorProcessTree` and call `admit()`.
+4. Receive the real descendant PID and prove it is still alive.
+5. Call the real `terminate_tree()` and require `True`.
+6. Require worker exit and `_pid_has_exited(descendant_pid) is True`.
+7. Only then remove scratch and assert it is absent.
+
+Keep `containment_descendant` and `containment_crashed_leader_with_term_ignoring_descendant` as normal importable module-level spawn targets in `Tests/STT/executor_test_support.py`. Add only the minimal OS conditional needed for a child that ignores cooperative POSIX TERM; Windows `TerminateJobObject` is unhandleable and needs no emulated signal path.
+
+- [ ] **Step 6: Strengthen the controller cleanup-order test before touching production**
+
+Change the existing controller test signature to accept `monkeypatch`. Gate its real tree method:
+
+```python
+tree = executor._tree
+assert tree is not None
+original_terminate = tree.terminate_tree
+termination_entered = threading.Event()
+allow_termination = threading.Event()
+
+def gated_terminate(**kwargs: float) -> bool:
+    termination_entered.set()
+    assert allow_termination.wait(10.0)
+    return original_terminate(**kwargs)
+
+monkeypatch.setattr(tree, "terminate_tree", gated_terminate)
+assert executor.force_stop("held") is True
+assert termination_entered.wait(10.0)
+try:
+    assert scratch.exists() is True
+finally:
+    allow_termination.set()
+assert executor.wait_for_retirement(10.0) is True
+assert scratch.exists() is False
+```
+
+The `finally` is mandatory so a failed assertion cannot leave the retirement thread or worker alive.
+
+- [ ] **Step 7: Prove the new ordering assertion is discriminating**
+
+Temporarily mutate `_terminate_detached()` in `tldw_chatbook/STT/executor.py` so it removes `detached.scratch_path` immediately before calling `terminate_tree()`. Run only:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch \
+  -q
+```
+
+Expected: FAIL at `scratch.exists() is True`. Restore the production file exactly, rerun, and require PASS. Do not commit the mutation.
+
+- [ ] **Step 8: Run the Task 1 focused gate and static checks**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch \
+  -q
+../../.venv/bin/python -m ruff check \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/executor_test_support.py \
+  Tests/STT/test_local_stt_executor.py
+../../.venv/bin/python -m ruff format --check \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/executor_test_support.py \
+  Tests/STT/test_local_stt_executor.py
+git diff --check
+```
+
+Expected locally: zero failures; the Windows-only liveness node remains an honest skip.
+
+- [ ] **Step 9: Commit the portable evidence tests**
+
+```bash
+git add \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/executor_test_support.py \
+  Tests/STT/test_local_stt_executor.py
+git commit -m "test(stt): make process-tree evidence native"
+```
+
+### Task 2: Build the bounded path-private evidence normalizer
+
+**Files:**
+- Create: `Tests/CI/test_task601_process_tree_evidence.py`
+- Create: `.github/scripts/task601_process_tree_evidence.py`
+- Reference only: `.github/scripts/task598_external_parakeet_evidence.py`
+
+- [ ] **Step 1: Write normalizer tests before the script exists**
+
+Create `Tests/CI/test_task601_process_tree_evidence.py` with `importlib.util.spec_from_file_location()` loading the planned script and constants for the three exact required node IDs.
+
+Add focused tests for:
+
+- missing script is a collection/assertion RED;
+- checked-out `git rev-parse HEAD` is the authoritative 40-character lowercase SHA, not `GITHUB_SHA`;
+- each exact evidence name accepts only its matching derived system/architecture;
+- `AMD64` normalizes to `x86_64` only for Windows;
+- a synthetic passing JUnit document plus pytest outcome `success` produces a passing result;
+- step outcome `failure`, any selected `<failure>`/`<error>`, a missing/skipped/duplicated/parameterized required node, or a required test name under the wrong module produces `test_execution` failure;
+- JUnit `file` fields using `/` or `\` are ignored as authority and never copied to JSON;
+- initialized/dependency failure documents are structurally bounded but CLI validation exits nonzero;
+- absolute POSIX paths, Windows drive/UNC paths, PIDs, handles, usernames, commands, and an off-repository run URL are rejected;
+- exactly three matching passing platform documents aggregate successfully;
+- changed commit, changed workflow run, host mismatch, missing/extra platform, failed/skipped node, unknown key, or path-like content fails aggregation.
+
+Use small synthetic XML strings and parameterization. Do not invoke pytest recursively from these unit tests.
+
+- [ ] **Step 2: Run the script-focused tests to verify RED**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/CI/test_task601_process_tree_evidence.py \
+  -k "not workflow" \
+  -q
+```
+
+Expected: FAIL because `.github/scripts/task601_process_tree_evidence.py` is missing.
+
+- [ ] **Step 3: Implement one standard-library script and no framework**
+
+Create `.github/scripts/task601_process_tree_evidence.py` with these fixed constants:
+
+```python
+SCHEMA_VERSION = 1
+EVIDENCE_LABEL = "task601_native_process_tree"
+AGGREGATE_LABEL = "task601_native_process_tree_matrix"
+EXPECTED_REPOSITORY = "rmusser01/tldw_chatbook"
+REQUIRED_NODES = (
+    "Tests/STT/test_executor_process_tree.py::test_native_force_stop_removes_worker_and_descendant_before_scratch_cleanup",
+    "Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup",
+    "Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch",
+)
+EXPECTED_PLATFORMS = {
+    "linux-x86_64": ("Linux", "x86_64"),
+    "windows-x86_64": ("Windows", "x86_64"),
+    "macos-x86_64": ("Darwin", "x86_64"),
+}
+```
+
+Keep the result shapes exact:
+
+```json
+{
+  "schema_version": 1,
+  "evidence_label": "task601_native_process_tree",
+  "evidence_name": "linux-x86_64",
+  "status": "passed",
+  "failure_code": null,
+  "failure_stage": null,
+  "run": {
+    "tested_commit": "<40 lowercase hex>",
+    "workflow_run_id": "<digits>",
+    "workflow_run_attempt": "<digits>",
+    "workflow_run_url": "https://github.com/rmusser01/tldw_chatbook/actions/runs/<digits>"
+  },
+  "host": {"system": "Linux", "architecture": "x86_64", "python": "3.12.x"},
+  "pytest": {
+    "outcome": "success",
+    "duration_seconds": 1.0,
+    "required_nodes": {"<exact node id>": "passed"}
+  }
+}
+```
+
+Implement only these responsibilities:
+
+- `current_run_identity()` calls `git rev-parse HEAD`, validates the SHA, validates numeric run ID/attempt, and constructs the fixed-repository run URL itself.
+- `_host_result(evidence_name)` normalizes `AMD64` to `x86_64`, rejects every other unexpected name/system/architecture pair, and records only Python version.
+- `failure_result(...)` creates a bounded failed document without exception text or paths.
+- `result_from_junit(...)` uses `xml.etree.ElementTree`, matches testcase `classname` plus exact `name`, emits only compile-time node IDs, records no raw JUnit text, and passes only when the GitHub step outcome is `success`, no selected testcase failed/errored, and all required nodes passed exactly once.
+- `validate_result(..., require_pass=True)` rejects unknown keys/values and returns failure for any non-passing release result.
+- `_write_result()` writes sorted JSON to a sibling temporary file and publishes with `os.replace()`.
+- `aggregate_results()` accepts exactly three validated passing inputs, requires one tested commit/run ID/run URL, permits bounded per-platform attempts, and writes the exact platform map.
+- `validate_aggregate()` applies the same strict/path-private validation.
+- Recursive string validation permits only the three exact node IDs and the one canonical run URL as slash-bearing values; all other absolute/UNC/drive paths and unbounded strings fail.
+
+The CLI surface is only:
+
+```text
+--initialize --evidence-name NAME --output PATH
+--record-failure CODE --failure-stage STAGE --evidence-name NAME --output PATH
+--from-junit PATH --pytest-outcome OUTCOME --evidence-name NAME --output PATH
+--validate PATH
+--aggregate INPUT INPUT INPUT --output PATH
+--validate-aggregate PATH
+```
+
+Do not add classes, dependencies, a generic evidence package, subprocess supervision, or containment code.
+
+- [ ] **Step 4: Run the normalizer tests to verify GREEN**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/CI/test_task601_process_tree_evidence.py \
+  -k "not workflow" \
+  -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Mutation-check the three decisive guards**
+
+One at a time, temporarily mutate and restore:
+
+1. Ignore `pytest_outcome != "success"` — the step-outcome failure test must fail.
+2. Trust JUnit `file` or test `name` without the exact module — the wrong-module/path test must fail.
+3. Allow aggregate commit/run mismatch — the aggregation mismatch tests must fail.
+
+After each mutation, run only its exact node, record the RED, restore, and rerun GREEN. Do not commit mutations.
+
+- [ ] **Step 6: Run static checks and commit the normalizer**
+
+```bash
+../../.venv/bin/python -m ruff check \
+  .github/scripts/task601_process_tree_evidence.py \
+  Tests/CI/test_task601_process_tree_evidence.py
+../../.venv/bin/python -m ruff format --check \
+  .github/scripts/task601_process_tree_evidence.py \
+  Tests/CI/test_task601_process_tree_evidence.py
+../../.venv/bin/python -m py_compile \
+  .github/scripts/task601_process_tree_evidence.py
+git diff --check
+git add \
+  .github/scripts/task601_process_tree_evidence.py \
+  Tests/CI/test_task601_process_tree_evidence.py
+git commit -m "test(stt): normalize task 601 platform evidence"
+```
+
+### Task 3: Add the explicit three-OS evidence workflow
+
+**Files:**
+- Modify: `Tests/CI/test_task601_process_tree_evidence.py`
+- Create: `.github/workflows/task-601-platform-evidence.yml`
+- Reference only: `.github/workflows/task-598-platform-evidence.yml`
+
+- [ ] **Step 1: Add workflow ratchets before creating the workflow**
+
+Require the workflow text to prove:
+
+- only `pull_request: types: [labeled]` and `workflow_dispatch`; no push/schedule;
+- job condition is manual dispatch or label `task-601-platform-evidence`;
+- `permissions: contents: read`;
+- exact checkout ref `${{ github.event.pull_request.head.sha || github.sha }}`;
+- exact runners `ubuntu-24.04`, `windows-2022`, `macos-15-intel` and evidence names matching the script constants;
+- Python 3.12, `fail-fast: false`, and a bounded job timeout;
+- `defaults.run.shell: bash` so the same quoted multiline commands execute under Git for Windows Bash rather than PowerShell;
+- installation of `.[dev]` only, with no transcription extra or runtime package;
+- initialization occurs before dependency installation;
+- dependency and pytest steps use `continue-on-error: true`;
+- the exact pytest command includes the process-tree file, controller node, and normalizer test file plus JUnit output;
+- normalization consumes `${{ steps.platform_tests.outcome }}`;
+- validation and artifact upload both use `if: always()` and upload one JSON named `task-601-platform-${{ matrix.evidence_name }}`.
+
+- [ ] **Step 2: Run the workflow tests to verify RED**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/CI/test_task601_process_tree_evidence.py \
+  -k workflow \
+  -q
+```
+
+Expected: FAIL because `.github/workflows/task-601-platform-evidence.yml` is missing.
+
+- [ ] **Step 3: Create the minimal workflow**
+
+Create `.github/workflows/task-601-platform-evidence.yml` with this step order:
+
+Set `defaults.run.shell: bash` once for the job. GitHub-hosted Windows includes Git Bash, and the explicit default keeps line continuations, quoting, and environment expansion identical across all three lanes.
+
+1. Checkout exact PR head/manual ref.
+2. Set up Python 3.12 with pip cache.
+3. Initialize `$RUNNER_TEMP/task-601-platform-evidence.json`.
+4. Install `pip install -e ".[dev]"` in a `continue-on-error` step.
+5. Record bounded `dependency_install` failure if install failed.
+6. Run this one `continue-on-error` pytest step only if installation passed:
+
+```bash
+python -m pytest \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch \
+  Tests/CI/test_task601_process_tree_evidence.py \
+  --timeout=60 \
+  --junitxml="$RUNNER_TEMP/task-601-junit.xml" \
+  -q
+```
+
+7. Under `if: always() && steps.dependencies.outcome == 'success'`, normalize JUnit with `--pytest-outcome "${{ steps.platform_tests.outcome }}"`.
+8. Under `if: always()`, run `--validate`; its nonzero failure result makes the lane red.
+9. Under `if: always()`, upload only the JSON with `if-no-files-found: error`.
+
+Set `timeout-minutes: 20`. Do not add matrix architectures, model caching, concurrency infrastructure, secrets, write permissions, or general-CI triggers.
+
+- [ ] **Step 4: Run workflow/normalizer tests and mutation-check outcome plumbing**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/CI/test_task601_process_tree_evidence.py \
+  -q
+```
+
+Expected: all tests pass.
+
+Temporarily remove `--pytest-outcome "${{ steps.platform_tests.outcome }}"` or replace it with a literal `success`. Run the exact workflow ratchet; expected FAIL. Restore and rerun GREEN.
+
+- [ ] **Step 5: Run static/diff checks and commit the workflow**
+
+```bash
+../../.venv/bin/python -m ruff check \
+  .github/scripts/task601_process_tree_evidence.py \
+  Tests/CI/test_task601_process_tree_evidence.py
+../../.venv/bin/python -m ruff format --check \
+  .github/scripts/task601_process_tree_evidence.py \
+  Tests/CI/test_task601_process_tree_evidence.py
+git diff --check
+git add \
+  .github/workflows/task-601-platform-evidence.yml \
+  Tests/CI/test_task601_process_tree_evidence.py
+git commit -m "ci(stt): add task 601 platform evidence"
+```
+
+### Task 4: Freeze the executable commit and collect the native matrix
+
+**Files:**
+- Potentially modify only after a genuine native RED: the smallest affected production/test file, after updating this plan.
+- Create after GREEN: `Docs/STT_Evaluation/task-601/README.md`
+- Create after GREEN: `Docs/STT_Evaluation/task-601/platform-evidence.json`
+
+- [ ] **Step 1: Rebase before evidence and freeze executable files**
+
+Fetch and rebase onto current `origin/dev` before the evidence run:
+
+```bash
+git fetch origin dev
+git rebase origin/dev
+```
+
+Resolve only owned conflicts. Then run the complete focused local gate:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch \
+  Tests/CI/test_task601_process_tree_evidence.py \
+  -q
+../../.venv/bin/python -m ruff check \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/executor_test_support.py \
+  Tests/STT/test_local_stt_executor.py \
+  Tests/CI/test_task601_process_tree_evidence.py \
+  .github/scripts/task601_process_tree_evidence.py
+../../.venv/bin/python -m ruff format --check \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/executor_test_support.py \
+  Tests/STT/test_local_stt_executor.py \
+  Tests/CI/test_task601_process_tree_evidence.py \
+  .github/scripts/task601_process_tree_evidence.py
+../../.venv/bin/python -m py_compile \
+  .github/scripts/task601_process_tree_evidence.py
+git diff --check origin/dev...HEAD
+```
+
+Record the executable HEAD SHA for later comparisons:
+
+```bash
+task601_tested_commit="$(git rev-parse HEAD)"
+```
+
+From this point until evidence is aggregated, do not change production, tests, the workflow, or the normalizer.
+
+- [ ] **Step 2: Push a PR and trigger only the explicit evidence workflow**
+
+Push `codex/task-601-platform-evidence`, open a PR against `dev`, and ensure the repository label `task-601-platform-evidence` exists with a narrow description. Add the label to trigger the workflow. Do not use broad CI as TASK-601 evidence.
+
+Use GitHub API/run inspection to select the workflow named `TASK-601 native process-tree evidence` whose tested PR head equals the frozen executable SHA. Record its numeric run ID as `task601_run_id`. Do not infer success from overall PR check status.
+
+- [ ] **Step 3: Treat any red lane as a real open gate**
+
+Wait for Linux, Windows, and macOS artifacts. If any lane is red, skipped, timed out, or missing:
+
+1. Download its JSON and inspect only the exact workflow logs needed to classify setup versus native test failure.
+2. Preserve the exact failing node and host result.
+3. Do not mark AC6 complete or aggregate evidence.
+4. If the failure is a product defect, update this plan and TASK-601 notes first, write/verify the focused failing test on that platform, apply the smallest production fix, rebase if required, rerun the local gate, and rerun all three lanes on the new executable commit.
+5. Do not waive an outer Job Object/nested-job failure as “CI-only”; Windows hosted execution is the required native environment.
+
+- [ ] **Step 4: Aggregate only one green workflow run**
+
+After all three lanes pass, download exactly these artifacts from the same workflow run into a new `mktemp -d` directory:
+
+```text
+task-601-platform-linux-x86_64
+task-601-platform-windows-x86_64
+task-601-platform-macos-x86_64
+```
+
+Create the directory and download each artifact to an explicit child directory:
+
+```bash
+task601_evidence_dir="$(mktemp -d)"
+gh run download "$task601_run_id" \
+  --name task-601-platform-linux-x86_64 \
+  --dir "$task601_evidence_dir/linux-x86_64"
+gh run download "$task601_run_id" \
+  --name task-601-platform-windows-x86_64 \
+  --dir "$task601_evidence_dir/windows-x86_64"
+gh run download "$task601_run_id" \
+  --name task-601-platform-macos-x86_64 \
+  --dir "$task601_evidence_dir/macos-x86_64"
+mkdir -p Docs/STT_Evaluation/task-601
+```
+
+Generate and validate the checked-in aggregate:
+
+```bash
+../../.venv/bin/python .github/scripts/task601_process_tree_evidence.py \
+  --aggregate \
+  "$task601_evidence_dir/linux-x86_64/task-601-platform-evidence.json" \
+  "$task601_evidence_dir/windows-x86_64/task-601-platform-evidence.json" \
+  "$task601_evidence_dir/macos-x86_64/task-601-platform-evidence.json" \
+  --output Docs/STT_Evaluation/task-601/platform-evidence.json
+../../.venv/bin/python .github/scripts/task601_process_tree_evidence.py \
+  --validate-aggregate Docs/STT_Evaluation/task-601/platform-evidence.json
+```
+
+Expected: both commands exit zero; aggregate status is passed, contains exactly three platforms, one tested commit/run, and no local path/PID/handle/exception text.
+
+- [ ] **Step 5: Add the concise evidence README**
+
+Create `Docs/STT_Evaluation/task-601/README.md` from the validated aggregate. Record:
+
+- purpose and exact scope (process ownership/cleanup, not model or FFmpeg correctness);
+- workflow URL and executable tested commit;
+- exact three runner labels and host architectures;
+- exact three required node IDs and passing status;
+- explicit statement that no model/runtime extra, network/model download, or general CI result was used;
+- any native defect/fix/rerun history; and
+- the aggregate validation command.
+
+Do not copy local artifact paths, PIDs, usernames, or raw failure text.
+
+- [ ] **Step 6: Validate evidence before changing Backlog state**
+
+```bash
+../../.venv/bin/python .github/scripts/task601_process_tree_evidence.py \
+  --validate-aggregate Docs/STT_Evaluation/task-601/platform-evidence.json
+rg -n '/Users/|/private/|/tmp/|[A-Za-z]:\\|workflow_dispatch.*token|TODO|TBD|PLACEHOLDER' \
+  Docs/STT_Evaluation/task-601 \
+  || true
+git diff --check
+```
+
+Expected: aggregate validation passes; the scan produces no local path, secret-like, or placeholder hit requiring correction.
+
+- [ ] **Step 7: Close TASK-601 through Backlog CLI only**
+
+Use `backlog task edit 601` to:
+
+- add this implementation plan and the evidence README/JSON to documentation while preserving existing docs;
+- append implementation notes with workflow run URL, exact tested commit, three platform outcomes, focused local test/static results, and any native remediation;
+- check acceptance criterion 6; and
+- set status Done only after every Definition-of-Done item remains satisfied.
+
+Do not hand-edit the task Markdown.
+
+- [ ] **Step 8: Commit only evidence documentation and task metadata**
+
+Before committing, prove the post-evidence diff contains no executable file:
+
+```bash
+git diff --name-only "$task601_tested_commit"
+```
+
+Expected at this phase: only `Docs/STT_Evaluation/task-601/*` and the TASK-601 Backlog file differ from the tested commit, including uncommitted evidence changes. After staging, prove the same boundary against the index:
+
+```bash
+git add \
+  Docs/STT_Evaluation/task-601/README.md \
+  Docs/STT_Evaluation/task-601/platform-evidence.json \
+  'backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md'
+git diff --cached --name-only "$task601_tested_commit"
+git diff --cached --check
+git commit -m "docs(stt): record task 601 platform evidence"
+```
+
+Expected staged names: exactly the two evidence files and the TASK-601 Backlog file.
+
+### Task 5: Final review and integration handoff
+
+**Files:**
+- Review the full `origin/dev...HEAD` range.
+- Modify only files required by an accepted review finding.
+
+- [ ] **Step 1: Run final focused verification from the committed tree**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch \
+  Tests/CI/test_task601_process_tree_evidence.py \
+  -q
+../../.venv/bin/python .github/scripts/task601_process_tree_evidence.py \
+  --validate-aggregate Docs/STT_Evaluation/task-601/platform-evidence.json
+../../.venv/bin/python -m ruff check \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/executor_test_support.py \
+  Tests/STT/test_local_stt_executor.py \
+  Tests/CI/test_task601_process_tree_evidence.py \
+  .github/scripts/task601_process_tree_evidence.py
+../../.venv/bin/python -m ruff format --check \
+  Tests/STT/test_executor_process_tree.py \
+  Tests/STT/executor_test_support.py \
+  Tests/STT/test_local_stt_executor.py \
+  Tests/CI/test_task601_process_tree_evidence.py \
+  .github/scripts/task601_process_tree_evidence.py
+../../.venv/bin/python -m py_compile \
+  .github/scripts/task601_process_tree_evidence.py
+git diff --check origin/dev...HEAD
+git status --short
+```
+
+Expected: focused tests/static/evidence validation pass and the worktree is clean.
+
+- [ ] **Step 2: Request correctness and Ponytail review**
+
+Ask reviewers to inspect only this branch range against:
+
+- TASK-601 AC6;
+- the approved platform-evidence spec;
+- native Windows/POSIX proof versus mocked contracts;
+- non-destructive liveness/finalization;
+- scratch cleanup ordering and quarantine behavior;
+- pytest-outcome/JUnit non-vacuity;
+- path privacy, commit/run/platform binding, and aggregate consistency; and
+- unnecessary evidence abstractions or duplicated containment logic.
+
+- [ ] **Step 3: Apply findings without invalidating evidence silently**
+
+For each accepted finding:
+
+- docs/Backlog-only correction: fix, validate, and commit;
+- production/test/workflow/normalizer correction: the existing matrix is invalid. Make the change under TDD, rebase if required, rerun the full local gate and all three native lanes, regenerate aggregate/README/task notes, and commit new evidence.
+
+Never edit the aggregate by hand or preserve an old tested commit after executable changes.
+
+- [ ] **Step 4: Preserve the tested commit through merge**
+
+Do not rebase or rewrite executable commits after final evidence. If `dev` advances and a rebase is required, rerun the matrix and regenerate evidence. Use an integration method that preserves the tested executable commit as an ancestor; do not squash away the only SHA named by the evidence without rerunning against the replacement commit.
+
+- [ ] **Step 5: Hand off the ready PR**
+
+Report:
+
+- PR URL and final branch head;
+- tested executable commit and workflow run URL;
+- Linux/Windows/macOS native outcomes;
+- exact focused test/static results;
+- aggregate/task status;
+- any rerun/remediation history; and
+- confirmation that general CI, model inference, downloads, and unrelated cleanup were not used as TASK-601 evidence.

--- a/Docs/superpowers/specs/2026-08-11-task-601-platform-process-tree-evidence-design.md
+++ b/Docs/superpowers/specs/2026-08-11-task-601-platform-process-tree-evidence-design.md
@@ -1,0 +1,297 @@
+# TASK-601 Native Process-Tree Evidence Design
+
+## Purpose
+
+Close TASK-601 acceptance criterion 6 with reproducible native evidence that the
+local STT worker and its preparation descendants are contained and terminated
+before generation scratch cleanup on Linux, Windows, and macOS.
+
+The process-tree implementation already exists. This work adds the missing native
+Windows proof, makes the native cleanup contract portable across the three target
+operating systems, and records results from one exact tested commit. It does not
+change provider behavior, add a general subprocess framework, or broaden ordinary
+CI.
+
+## Scope
+
+### In scope
+
+- A real spawned worker and real sleeping descendant on each target operating
+  system.
+- Parent admission before the worker may launch descendants.
+- Native termination of the whole contained tree.
+- Proof that the worker and descendant are gone before generation scratch is
+  removed.
+- The crashed-leader case, where the parent still owns and terminates the surviving
+  descendant.
+- A label-gated and manually dispatchable GitHub Actions matrix for Linux,
+  Windows, and macOS.
+- One bounded, path-private JSON artifact per platform and one checked-in aggregate
+  after all lanes pass the same executable commit.
+
+### Out of scope
+
+- General CI, the full test suite, model downloads, ONNX inference, FFmpeg media
+  correctness, performance qualification, or architecture expansion.
+- Production changes made preemptively. Production changes are allowed only if a
+  genuine native test exposes a defect.
+- TASK-602 model-platform evidence, TASK-603 dictation evidence, or TASK-605
+  provider removal.
+
+## Governing Decision
+
+**ADR required:** no new ADR.
+
+**ADR path:**
+`backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md` and
+`backlog/decisions/041-direct-local-gguf-before-managed-acquisition.md`.
+
+**Reason:** ADR-025 already requires decoder descendants to be terminated as a
+platform process tree before temporary cleanup. ADR-041 does not alter that
+ownership boundary. This design supplies the previously deferred native evidence;
+it does not introduce a new architecture decision.
+
+## Approaches Considered
+
+### 1. Label-gated native contract matrix — selected
+
+Run only the exact process-tree tests on one current GitHub-hosted runner for each
+required operating system. Normalize the JUnit result into bounded JSON and upload
+it even when a test fails.
+
+This is the smallest approach that proves the real platform primitives while
+keeping failures attributable to one narrow contract.
+
+### 2. Add the tests to general CI — rejected
+
+General CI is broader, slower, and can hide a containment failure among unrelated
+suite failures. It would also make platform release evidence run on every change
+when TASK-601 only needs an explicit release gate.
+
+### 3. Write a separate native probe beside the tests — rejected
+
+A second probe would duplicate process creation, admission, descendant tracking,
+termination, and cleanup logic. The test must exercise the production containment
+class directly; evidence infrastructure should only run and summarize that test.
+
+## Native Test Contract
+
+`Tests/STT/test_executor_process_tree.py` remains the single behavioral owner. The
+existing POSIX-only native tests will be generalized without weakening their
+assertions:
+
+1. A spawned worker reports its native containment identity and cannot advance
+   beyond its admission wait until the parent constructs `ExecutorProcessTree` and
+   calls `admit()`.
+2. After admission, the worker launches one real long-lived Python descendant and
+   reports its PID.
+3. `terminate_tree()` must return true only after both worker and descendant are
+   absent.
+4. Only after that proof may the test remove the generation scratch directory.
+5. A second native case exits the worker leader while its descendant remains. The
+   parent must still terminate the descendant and prove the tree empty before
+   scratch cleanup.
+
+On POSIX, the production path is the worker-owned session/process group and
+`killpg`. On Windows, the production path is a real kill-on-close Job Object, real
+worker assignment before admission, and inherited descendant membership. Existing
+fake Win32 API tests remain as precise ordering/error tests; they do not count as
+native Windows evidence.
+
+All waits and cleanup are bounded. Test finalizers may kill only PIDs or process
+groups created by that test. Failure to prove death leaves scratch in place and
+fails the lane; the test must never report cleanup success while a descendant could
+still be alive.
+
+The portable liveness helper must not use `os.kill(pid, 0)` on Windows because
+Python sends every value other than `CTRL_C_EVENT` and `CTRL_BREAK_EVENT`, including
+zero, through unconditional `TerminateProcess`. POSIX may continue using signal
+zero. Windows must open the exact PID with
+`SYNCHRONIZE`, call `WaitForSingleObject(handle, 0)`, close the handle, and treat
+only a signaled handle or `ERROR_INVALID_PARAMETER` from `OpenProcess` as proof of
+exit. Any other Win32 error fails closed. This follows the existing repository
+idiom in `Tests/Notes/test_git_process_containment.py`.
+
+The required cross-platform evidence nodes will have stable IDs:
+
+- `Tests/STT/test_executor_process_tree.py::test_native_force_stop_removes_worker_and_descendant_before_scratch_cleanup`
+- `Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup`
+- `Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch`
+
+The first two exercise native descendants through `ExecutorProcessTree`. The third
+exercises the production `LocalSTTExecutor` force-stop and scratch-removal sequence
+on every platform. Strengthen that existing controller test with a gated wrapper
+around the real `terminate_tree()` call: while termination is deliberately blocked,
+the test must observe that generation scratch still exists; after the wrapper calls
+the real platform termination and retirement completes, scratch must be absent.
+This proves the production ordering rather than merely observing the final state.
+Together the three nodes prevent a compositional false positive where tree death
+and controller cleanup are each proven, but never on the same target OS.
+Platform-specific unit/contract nodes may also run, but cannot substitute for a
+required node.
+
+## Evidence Workflow
+
+Create `.github/workflows/task-601-platform-evidence.yml` with:
+
+- `workflow_dispatch` and a `pull_request` `labeled` trigger only;
+- required label `task-601-platform-evidence`;
+- read-only repository permissions;
+- checkout of the exact PR head or the ref selected by the person invoking
+  `workflow_dispatch`;
+- Python 3.12;
+- `fail-fast: false`;
+- one lane each for `ubuntu-24.04`, `windows-2022`, and `macos-15-intel`;
+- a bounded job timeout;
+- the repository test dependencies and no STT model/runtime extra;
+- one explicit pytest command covering the process-tree contract file, the exact
+  existing controller scratch-ordering node, and the evidence normalizer tests; and
+- unconditional JSON validation and artifact upload when the job reaches cleanup.
+
+The workflow is not a substitute for general CI and is not triggered by push or
+schedule. A red or timed-out lane is an open release gate, not a flaky result to
+waive.
+
+`tested_commit` is always `git rev-parse HEAD` after checkout, validated as a
+40-character lowercase hexadecimal object ID. The workflow must not use
+`GITHUB_SHA` as the evidence identity: for pull requests it may identify GitHub's
+synthetic merge commit rather than the checked-out PR head. The workflow has no
+separate free-form commit input; manual runs use GitHub Actions' built-in ref
+selector, and checkout plus `git rev-parse HEAD` remains authoritative.
+
+The dependency-install and pytest steps use `continue-on-error: true` only so the
+workflow can normalize and upload failure evidence. The normalizer receives the
+allowlisted GitHub step outcome (`success`, `failure`, `cancelled`, or `skipped`) in
+addition to JUnit. It may write `status: passed` only when the pytest step outcome is
+`success`, the JUnit document is well formed, no selected testcase failed, and all
+three required nodes passed. The final validation step exits nonzero for every
+other outcome, restoring the job's red status after artifact creation.
+
+## Evidence Format
+
+Add a small standard-library normalizer under `.github/scripts/`. It initializes a
+failure document, parses the exact JUnit report after pytest, validates the bounded
+schema, and writes JSON atomically. It does not implement containment or run a
+second native probe.
+
+Each matrix entry supplies an evidence name. The normalizer accepts only these
+name/host pairs and derives the host side itself:
+
+- `linux-x86_64` -> `platform.system() == "Linux"` and normalized machine
+  `x86_64`;
+- `windows-x86_64` -> `platform.system() == "Windows"` and normalized machine
+  `x86_64` (including native `AMD64` spelling); and
+- `macos-x86_64` -> `platform.system() == "Darwin"` and normalized machine
+  `x86_64`.
+
+A mismatched or unknown evidence name fails before a passing document can be
+written. This binds the uploaded artifact name to the host that actually executed
+the tests.
+
+Each per-platform document contains only:
+
+- schema version and passed/failed status;
+- tested commit, workflow run ID, run attempt, and canonical GitHub Actions run URL;
+- operating system, architecture, and Python version;
+- the allowlisted required test node IDs and their passed/failed/skipped outcomes;
+- bounded duration;
+- stable failure stage/code when setup or test execution fails.
+
+It excludes commands, exception text, tracebacks, environment variables, local
+paths, PIDs, process-group IDs, job handles, usernames, and temporary-directory
+names. Validation rejects unknown keys, missing required native nodes, skipped
+required nodes, non-allowlisted status values, unbounded strings, and host-local or
+absolute path content. Repository-relative pytest node IDs are permitted only when
+they exactly equal the three compile-time allowlisted strings above; arbitrary
+relative paths are not. The run URL is the other bounded exception and must exactly
+match
+`https://github.com/rmusser01/tldw_chatbook/actions/runs/<numeric-run-id>`.
+The normalizer constructs it from the allowlisted repository identity and the
+numeric workflow run ID; it does not accept a caller-supplied URL.
+
+JUnit parsing does not trust an arbitrary `file` value. The normalizer matches the
+allowlisted testcase module/class name and test name, then emits the corresponding
+compile-time node-ID constant with `/` separators. Duplicate matches, unexpected
+parameters, or a required name under another module fail validation. Synthetic
+JUnit fixtures cover POSIX and Windows separator spellings.
+
+An initialized or setup-failure document may omit test outcomes, but it is never a
+passing document. `--validate` first validates either the bounded passed schema or
+the bounded failure schema, then exits nonzero unless status is `passed`, the
+recorded pytest step outcome is `success`, no selected testcase failed, and every
+required node passed. This preserves useful failure evidence without allowing a
+structurally valid dependency failure—or a failure in a selected non-required
+contract/normalizer test—to make the lane green.
+
+The workflow uploads `task-601-platform-<platform>` for each lane. After all three
+lanes pass one executable commit, their normalized results are aggregated into
+`Docs/STT_Evaluation/task-601/platform-evidence.json` with a short README containing
+the workflow URL, tested commit, matrix outcome, and scope statement.
+
+The same normalizer owns an explicit `--aggregate` mode rather than relying on
+manual JSON editing. Its inputs are exactly the three downloaded per-platform
+documents. It validates each input first, then requires:
+
+- schema version 1 and aggregate evidence label
+  `task601_native_process_tree_matrix`;
+- exactly the platform keys `linux-x86_64`, `windows-x86_64`, and
+  `macos-x86_64`, with no extras;
+- `status: passed` for every platform;
+- the same `tested_commit` in all three inputs and the aggregate;
+- one shared workflow run ID and run URL, plus a bounded attempt for each platform;
+  and
+- all three required node IDs present and passed on each platform.
+
+It sorts keys and writes the aggregate atomically. A `--validate-aggregate` mode
+must reject a changed commit, mismatched run, platform/host mismatch, missing/extra
+platform, missing/skipped/failed required node, unknown key, non-allowlisted
+path-like value, or malformed run identity. Focused unit tests cover both
+aggregation and each rejection. The checked-in README summarizes values read from
+the validated aggregate; it is not an independent source of truth.
+
+## Failure Handling
+
+- Dependency setup failure records `dependency_install` and fails validation.
+- Missing or malformed JUnit records `test_execution` and fails validation.
+- A failed, skipped, or absent required native node keeps the platform red.
+- A job timeout remains a failed release gate even if the runner cannot upload its
+  initialized artifact.
+- A native platform defect is fixed with a focused RED/GREEN test on that platform;
+  all three lanes then rerun on the repaired executable commit.
+- Evidence JSON never converts infrastructure failure into a passing platform
+  claim.
+
+## Completion and Task Hygiene
+
+TASK-601 acceptance criterion 6 may be checked only when Linux, Windows, and macOS
+all pass the required native nodes for the same executable commit. A later commit
+may add only evidence documentation and Backlog metadata. Any change to production,
+tests, the workflow, or the evidence normalizer invalidates the matrix and requires
+a rerun.
+
+Once the matrix passes:
+
+1. Check in the aggregate evidence and README.
+2. Update TASK-601 through Backlog CLI with the workflow run, tested commit, exact
+   outcomes, and platform scope.
+3. Check acceptance criterion 6 and mark TASK-601 Done only after all other
+   Definition-of-Done requirements remain satisfied.
+4. Record no new lesson unless the native run exposes a reusable platform trap.
+
+## Expected File Boundary
+
+- Modify `Tests/STT/test_executor_process_tree.py` for portable native assertions.
+- Modify `Tests/STT/executor_test_support.py` only for spawn-importable helpers.
+- Modify `Tests/STT/test_local_stt_executor.py` only to make the existing
+  force-stop/scratch-ordering assertion non-vacuous.
+- Create `Tests/CI/test_task601_process_tree_evidence.py` for workflow/schema
+  ratchets.
+- Create `.github/scripts/task601_process_tree_evidence.py` for normalization.
+- Create `.github/workflows/task-601-platform-evidence.yml` for the explicit matrix.
+- After a green matrix, create `Docs/STT_Evaluation/task-601/README.md` and
+  `Docs/STT_Evaluation/task-601/platform-evidence.json`.
+- Update the TASK-601 Backlog file only through Backlog CLI.
+
+No production file is in the planned boundary. If native evidence requires a
+production fix, stop, document the defect, extend the plan deliberately, and prove
+the fix with the failing platform case before changing production.

--- a/Tests/CI/test_task601_process_tree_evidence.py
+++ b/Tests/CI/test_task601_process_tree_evidence.py
@@ -14,6 +14,7 @@ import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 EVIDENCE_PATH = PROJECT_ROOT / ".github/scripts/task601_process_tree_evidence.py"
+WORKFLOW_PATH = PROJECT_ROOT / ".github/workflows/task-601-platform-evidence.yml"
 REQUIRED_NODES = (
     "Tests/STT/test_executor_process_tree.py::test_native_force_stop_removes_worker_and_descendant_before_scratch_cleanup",
     "Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup",
@@ -25,6 +26,24 @@ EXPECTED_PLATFORMS = {
     "macos-x86_64": ("Darwin", "x86_64"),
 }
 
+EXPECTED_MATRIX = (
+    ("linux-x86_64", "ubuntu-24.04"),
+    ("windows-x86_64", "windows-2022"),
+    ("macos-x86_64", "macos-15-intel"),
+)
+
+EXPECTED_STEP_NAMES = (
+    "Check out the exact tested commit",
+    "Set up Python",
+    "Initialize failure evidence",
+    "Install test dependencies",
+    "Record dependency installation failure",
+    "Run bounded platform tests",
+    "Normalize platform evidence",
+    "Validate platform evidence",
+    "Upload platform evidence",
+)
+
 
 def _load_evidence() -> ModuleType:
     assert EVIDENCE_PATH.is_file(), "TASK-601 evidence normalizer is missing"
@@ -33,6 +52,64 @@ def _load_evidence() -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _workflow_text() -> str:
+    assert WORKFLOW_PATH.is_file(), "TASK-601 evidence workflow is missing"
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _yaml_block(text: str, header: str) -> str:
+    lines = text.splitlines()
+    matches = [index for index, line in enumerate(lines) if line == header]
+    assert len(matches) == 1, f"expected one YAML header: {header!r}"
+    start = matches[0]
+    indentation = len(header) - len(header.lstrip())
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if line.strip() and len(line) - len(line.lstrip()) <= indentation:
+            end = index
+            break
+    return "\n".join(lines[start + 1 : end])
+
+
+def _nonempty_lines(block: str) -> list[str]:
+    return [line for line in block.splitlines() if line.strip()]
+
+
+def _workflow_step(workflow: str, name: str) -> str:
+    return _yaml_block(workflow, f"      - name: {name}")
+
+
+def _yaml_scalar(block: str, indentation: int, key: str) -> str:
+    prefix = " " * indentation + key + ":"
+    matches = [
+        line.removeprefix(prefix).strip()
+        for line in block.splitlines()
+        if line.startswith(prefix)
+    ]
+    assert len(matches) == 1, f"expected one YAML scalar: {key!r}"
+    return matches[0]
+
+
+def _step_command(step: str) -> str:
+    lines = step.splitlines()
+    run_lines = [
+        index for index, line in enumerate(lines) if line.startswith("        run:")
+    ]
+    assert len(run_lines) == 1
+    run_index = run_lines[0]
+    first = lines[run_index].removeprefix("        run:").strip()
+    if first != "|":
+        return first
+    command_lines: list[str] = []
+    for line in lines[run_index + 1 :]:
+        if line.strip() and len(line) - len(line.lstrip()) <= 8:
+            break
+        if line.strip():
+            command_lines.append(line.strip().removesuffix("\\").rstrip())
+    return " ".join(command_lines)
 
 
 def _run_identity(
@@ -120,6 +197,156 @@ def _main_code(evidence: ModuleType, args: list[str]) -> int:
         return evidence.main(args)
     except SystemExit as error:
         return int(error.code or 0)
+
+
+def test_workflow_has_only_explicit_triggers_and_read_only_permissions() -> None:
+    workflow = _workflow_text()
+
+    assert _nonempty_lines(_yaml_block(workflow, "on:")) == [
+        "  pull_request:",
+        "    types: [labeled]",
+        "  workflow_dispatch:",
+    ]
+    assert _nonempty_lines(_yaml_block(workflow, "permissions:")) == [
+        "  contents: read"
+    ]
+    assert "push:" not in workflow
+    assert "schedule:" not in workflow
+    assert "concurrency:" not in workflow
+    assert "secrets." not in workflow
+    assert workflow.count("permissions:") == 1
+    assert ": write" not in workflow
+
+
+def test_workflow_gates_one_job_and_checks_out_the_selected_commit() -> None:
+    workflow = _workflow_text()
+    jobs = _yaml_block(workflow, "jobs:")
+    checkout = _workflow_step(workflow, EXPECTED_STEP_NAMES[0])
+
+    assert re.findall(r"^  ([a-z0-9-]+):$", jobs, re.MULTILINE) == ["platform-evidence"]
+    assert _yaml_scalar(jobs, 4, "if") == (
+        "github.event_name == 'workflow_dispatch' || "
+        "github.event.label.name == 'task-601-platform-evidence'"
+    )
+    assert _yaml_scalar(checkout, 8, "uses") == "actions/checkout@v4"
+    assert _nonempty_lines(_yaml_block(checkout, "        with:")) == [
+        "          ref: ${{ github.event.pull_request.head.sha || github.sha }}"
+    ]
+
+
+def test_workflow_uses_only_the_exact_bounded_three_os_matrix() -> None:
+    workflow = _workflow_text()
+    strategy = _yaml_block(workflow, "    strategy:")
+    defaults = _yaml_block(workflow, "    defaults:")
+    setup = _workflow_step(workflow, EXPECTED_STEP_NAMES[1])
+
+    assert _nonempty_lines(strategy) == [
+        "      fail-fast: false",
+        "      matrix:",
+        "        include:",
+        "          - evidence_name: linux-x86_64",
+        "            os: ubuntu-24.04",
+        "          - evidence_name: windows-x86_64",
+        "            os: windows-2022",
+        "          - evidence_name: macos-x86_64",
+        "            os: macos-15-intel",
+    ]
+    assert (
+        tuple(
+            re.findall(
+                r"^\s+- evidence_name: ([-\w.]+)\n\s+os: ([-\w.]+)$",
+                strategy,
+                re.MULTILINE,
+            )
+        )
+        == EXPECTED_MATRIX
+    )
+    jobs = _yaml_block(workflow, "jobs:")
+    assert _yaml_scalar(jobs, 4, "runs-on") == "${{ matrix.os }}"
+    assert _yaml_scalar(jobs, 4, "timeout-minutes") == "20"
+    assert _nonempty_lines(defaults) == ["      run:", "        shell: bash"]
+    assert workflow.count("shell:") == 1
+    assert _yaml_scalar(setup, 8, "uses") == "actions/setup-python@v5"
+    assert _nonempty_lines(_yaml_block(setup, "        with:")) == [
+        '          python-version: "3.12"',
+        "          cache: pip",
+    ]
+    assert "actions/cache" not in workflow
+    assert "HF_HOME" not in workflow
+    assert "TRANSFORMERS_CACHE" not in workflow
+
+
+def test_workflow_runs_only_the_exact_dependency_and_pytest_commands() -> None:
+    workflow = _workflow_text()
+    step_names = tuple(re.findall(r"^      - name: (.+)$", workflow, re.MULTILINE))
+    initialize = _workflow_step(workflow, EXPECTED_STEP_NAMES[2])
+    dependencies = _workflow_step(workflow, EXPECTED_STEP_NAMES[3])
+    platform_tests = _workflow_step(workflow, EXPECTED_STEP_NAMES[5])
+
+    assert step_names == EXPECTED_STEP_NAMES
+    assert _step_command(initialize) == (
+        "python .github/scripts/task601_process_tree_evidence.py --initialize "
+        '--evidence-name "${{ matrix.evidence_name }}" '
+        '--output "$RUNNER_TEMP/task-601-platform-evidence.json"'
+    )
+    assert _yaml_scalar(dependencies, 8, "id") == "dependencies"
+    assert _yaml_scalar(dependencies, 8, "continue-on-error") == "true"
+    assert _step_command(dependencies) == "python -m pip install -e '.[dev]'"
+    assert workflow.count("pip install") == 1
+    assert re.findall(r"\.\[([^]]+)]", workflow) == ["dev"]
+    assert _yaml_scalar(platform_tests, 8, "id") == "platform_tests"
+    assert _yaml_scalar(platform_tests, 8, "continue-on-error") == "true"
+    assert _yaml_scalar(platform_tests, 8, "if") == (
+        "steps.dependencies.outcome == 'success'"
+    )
+    assert _step_command(platform_tests) == (
+        "python -m pytest Tests/STT/test_executor_process_tree.py "
+        "Tests/STT/test_local_stt_executor.py::"
+        "test_force_stop_detaches_before_kill_and_cleans_generation_scratch "
+        "Tests/CI/test_task601_process_tree_evidence.py --timeout=60 "
+        '--junitxml="$RUNNER_TEMP/task-601-junit.xml" -q'
+    )
+
+
+def test_workflow_preserves_failures_and_always_uploads_only_the_json() -> None:
+    workflow = _workflow_text()
+    dependency_failure = _workflow_step(workflow, EXPECTED_STEP_NAMES[4])
+    normalize = _workflow_step(workflow, EXPECTED_STEP_NAMES[6])
+    validate = _workflow_step(workflow, EXPECTED_STEP_NAMES[7])
+    upload = _workflow_step(workflow, EXPECTED_STEP_NAMES[8])
+
+    assert _yaml_scalar(dependency_failure, 8, "if") == (
+        "steps.dependencies.outcome != 'success'"
+    )
+    assert _step_command(dependency_failure) == (
+        "python .github/scripts/task601_process_tree_evidence.py "
+        "--record-failure dependency_install --failure-stage dependency_install "
+        '--evidence-name "${{ matrix.evidence_name }}" '
+        '--output "$RUNNER_TEMP/task-601-platform-evidence.json"'
+    )
+    assert _yaml_scalar(normalize, 8, "if") == (
+        "always() && steps.dependencies.outcome == 'success'"
+    )
+    assert _step_command(normalize) == (
+        "python .github/scripts/task601_process_tree_evidence.py "
+        '--from-junit "$RUNNER_TEMP/task-601-junit.xml" '
+        '--pytest-outcome "${{ steps.platform_tests.outcome }}" '
+        '--evidence-name "${{ matrix.evidence_name }}" '
+        '--output "$RUNNER_TEMP/task-601-platform-evidence.json"'
+    )
+    assert _yaml_scalar(validate, 8, "if") == "always()"
+    assert "continue-on-error" not in validate
+    assert _step_command(validate) == (
+        "python .github/scripts/task601_process_tree_evidence.py "
+        '--validate "$RUNNER_TEMP/task-601-platform-evidence.json"'
+    )
+    assert _yaml_scalar(upload, 8, "if") == "always()"
+    assert _yaml_scalar(upload, 8, "uses") == "actions/upload-artifact@v4"
+    assert _nonempty_lines(_yaml_block(upload, "        with:")) == [
+        "          name: task-601-platform-${{ matrix.evidence_name }}",
+        "          path: ${{ runner.temp }}/task-601-platform-evidence.json",
+        "          if-no-files-found: error",
+    ]
 
 
 def test_evidence_script_exists_and_loads() -> None:

--- a/Tests/CI/test_task601_process_tree_evidence.py
+++ b/Tests/CI/test_task601_process_tree_evidence.py
@@ -26,12 +26,6 @@ EXPECTED_PLATFORMS = {
     "macos-x86_64": ("Darwin", "x86_64"),
 }
 
-EXPECTED_MATRIX = (
-    ("linux-x86_64", "ubuntu-24.04"),
-    ("windows-x86_64", "windows-2022"),
-    ("macos-x86_64", "macos-15-intel"),
-)
-
 EXPECTED_STEP_NAMES = (
     "Check out the exact tested commit",
     "Set up Python",
@@ -251,16 +245,6 @@ def test_workflow_uses_only_the_exact_bounded_three_os_matrix() -> None:
         "          - evidence_name: macos-x86_64",
         "            os: macos-15-intel",
     ]
-    assert (
-        tuple(
-            re.findall(
-                r"^\s+- evidence_name: ([-\w.]+)\n\s+os: ([-\w.]+)$",
-                strategy,
-                re.MULTILINE,
-            )
-        )
-        == EXPECTED_MATRIX
-    )
     jobs = _yaml_block(workflow, "jobs:")
     assert _yaml_scalar(jobs, 4, "runs-on") == "${{ matrix.os }}"
     assert _yaml_scalar(jobs, 4, "timeout-minutes") == "20"

--- a/Tests/CI/test_task601_process_tree_evidence.py
+++ b/Tests/CI/test_task601_process_tree_evidence.py
@@ -1,0 +1,723 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import re
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+EVIDENCE_PATH = PROJECT_ROOT / ".github/scripts/task601_process_tree_evidence.py"
+REQUIRED_NODES = (
+    "Tests/STT/test_executor_process_tree.py::test_native_force_stop_removes_worker_and_descendant_before_scratch_cleanup",
+    "Tests/STT/test_executor_process_tree.py::test_native_crashed_leader_reaps_descendant_before_scratch_cleanup",
+    "Tests/STT/test_local_stt_executor.py::test_force_stop_detaches_before_kill_and_cleans_generation_scratch",
+)
+EXPECTED_PLATFORMS = {
+    "linux-x86_64": ("Linux", "x86_64"),
+    "windows-x86_64": ("Windows", "x86_64"),
+    "macos-x86_64": ("Darwin", "x86_64"),
+}
+
+
+def _load_evidence() -> ModuleType:
+    assert EVIDENCE_PATH.is_file(), "TASK-601 evidence normalizer is missing"
+    spec = importlib.util.spec_from_file_location("task601_evidence", EVIDENCE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_identity(
+    *, commit: str = "a" * 40, run_id: str = "123", attempt: str = "1"
+) -> dict[str, str]:
+    return {
+        "tested_commit": commit,
+        "workflow_run_id": run_id,
+        "workflow_run_attempt": attempt,
+        "workflow_run_url": (
+            "https://github.com/rmusser01/tldw_chatbook/actions/runs/" + run_id
+        ),
+    }
+
+
+def _valid_result(evidence_name: str) -> dict[str, object]:
+    system, architecture = EXPECTED_PLATFORMS[evidence_name]
+    return {
+        "schema_version": 1,
+        "evidence_label": "task601_native_process_tree",
+        "evidence_name": evidence_name,
+        "status": "passed",
+        "failure_code": None,
+        "failure_stage": None,
+        "run": _run_identity(),
+        "host": {
+            "system": system,
+            "architecture": architecture,
+            "python": "3.12.9",
+        },
+        "pytest": {
+            "outcome": "success",
+            "duration_seconds": 0.75,
+            "required_nodes": dict.fromkeys(REQUIRED_NODES, "passed"),
+        },
+    }
+
+
+def _junit_case(node: str, body: str = "", *, file_value: str = "ignored.py") -> str:
+    path, name = node.split("::", 1)
+    classname = path.removesuffix(".py").replace("/", ".")
+    return (
+        f'<testcase classname="{classname}" name="{name}" '
+        f'file="{file_value}" time="0.25">{body}</testcase>'
+    )
+
+
+def _junit(*cases: str, duration: str = "0.75") -> str:
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        f'<testsuite name="pytest" tests="{len(cases)}" time="{duration}">'
+        + "".join(cases)
+        + "</testsuite>"
+    )
+
+
+def _write_junit(tmp_path: Path, xml: str) -> Path:
+    path = tmp_path / "junit.xml"
+    path.write_text(xml, encoding="utf-8")
+    return path
+
+
+def _passing_junit(tmp_path: Path, *, file_value: str = "ignored.py") -> Path:
+    return _write_junit(
+        tmp_path,
+        _junit(*(_junit_case(node, file_value=file_value) for node in REQUIRED_NODES)),
+    )
+
+
+def _stub_linux_evidence(evidence: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(evidence, "current_run_identity", lambda: _run_identity())
+    monkeypatch.setattr(
+        evidence,
+        "_host_result",
+        lambda _name: {
+            "system": "Linux",
+            "architecture": "x86_64",
+            "python": "3.12.9",
+        },
+    )
+
+
+def test_evidence_script_exists_and_loads() -> None:
+    evidence = _load_evidence()
+
+    assert evidence.REQUIRED_NODES == REQUIRED_NODES
+    assert evidence.EXPECTED_PLATFORMS == EXPECTED_PLATFORMS
+
+
+def test_current_run_identity_uses_checked_out_commit_not_github_sha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence = _load_evidence()
+    expected = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=PROJECT_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    monkeypatch.chdir(PROJECT_ROOT)
+    monkeypatch.setenv("GITHUB_SHA", "b" * 40)
+    monkeypatch.setenv("GITHUB_RUN_ID", "987")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "3")
+
+    result = evidence.current_run_identity()
+
+    assert result == _run_identity(commit=expected, run_id="987", attempt="3")
+    assert re.fullmatch(r"[0-9a-f]{40}", result["tested_commit"])
+    assert result["tested_commit"] != "b" * 40
+
+
+@pytest.mark.parametrize(
+    ("evidence_name", "system", "machine", "expected_architecture"),
+    (
+        ("linux-x86_64", "Linux", "x86_64", "x86_64"),
+        ("windows-x86_64", "Windows", "AMD64", "x86_64"),
+        ("windows-x86_64", "Windows", "x86_64", "x86_64"),
+        ("macos-x86_64", "Darwin", "x86_64", "x86_64"),
+    ),
+)
+def test_evidence_names_derive_only_the_exact_expected_host(
+    monkeypatch: pytest.MonkeyPatch,
+    evidence_name: str,
+    system: str,
+    machine: str,
+    expected_architecture: str,
+) -> None:
+    evidence = _load_evidence()
+    monkeypatch.setattr(evidence.platform, "system", lambda: system)
+    monkeypatch.setattr(evidence.platform, "machine", lambda: machine)
+    monkeypatch.setattr(evidence.platform, "python_version", lambda: "3.12.9")
+
+    assert evidence._host_result(evidence_name) == {
+        "system": system,
+        "architecture": expected_architecture,
+        "python": "3.12.9",
+    }
+
+
+@pytest.mark.parametrize(
+    ("evidence_name", "system", "machine"),
+    (
+        ("linux-x86_64", "Windows", "AMD64"),
+        ("windows-x86_64", "Linux", "x86_64"),
+        ("macos-x86_64", "Darwin", "arm64"),
+        ("linux-x86_64", "Linux", "AMD64"),
+        ("unknown-x86_64", "Linux", "x86_64"),
+    ),
+)
+def test_evidence_name_rejects_host_or_architecture_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    evidence_name: str,
+    system: str,
+    machine: str,
+) -> None:
+    evidence = _load_evidence()
+    monkeypatch.setattr(evidence.platform, "system", lambda: system)
+    monkeypatch.setattr(evidence.platform, "machine", lambda: machine)
+
+    with pytest.raises(ValueError, match="host|evidence_name"):
+        evidence._host_result(evidence_name)
+
+
+def test_passing_junit_and_successful_pytest_outcome_produce_passed_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+
+    result = evidence.result_from_junit(
+        _passing_junit(tmp_path),
+        pytest_outcome="success",
+        evidence_name="linux-x86_64",
+    )
+
+    assert result == _valid_result("linux-x86_64")
+    evidence.validate_result(result)
+
+
+@pytest.mark.parametrize("pytest_outcome", ("failure", "cancelled", "skipped"))
+def test_non_success_pytest_outcome_never_passes_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pytest_outcome: str,
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+
+    result = evidence.result_from_junit(
+        _passing_junit(tmp_path),
+        pytest_outcome=pytest_outcome,
+        evidence_name="linux-x86_64",
+    )
+
+    assert result["status"] == "failed"
+    assert result["failure_code"] == "test_execution"
+    assert result["failure_stage"] == "test_execution"
+    assert result["pytest"]["outcome"] == pytest_outcome
+    with pytest.raises(ValueError, match="did not pass"):
+        evidence.validate_result(result)
+
+
+@pytest.mark.parametrize("failure_element", ("failure", "error"))
+def test_any_selected_test_failure_prevents_passing_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_element: str,
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+    non_required_failure = (
+        '<testcase classname="Tests.CI.test_task601_process_tree_evidence" '
+        'name="test_unrelated_selected_contract" time="0.1">'
+        f"<{failure_element}>private traceback</{failure_element}></testcase>"
+    )
+    junit = _write_junit(
+        tmp_path,
+        _junit(
+            *(_junit_case(node) for node in REQUIRED_NODES),
+            non_required_failure,
+            duration="0.85",
+        ),
+    )
+
+    result = evidence.result_from_junit(
+        junit,
+        pytest_outcome="success",
+        evidence_name="linux-x86_64",
+    )
+
+    assert result["status"] == "failed"
+    assert result["failure_code"] == "test_execution"
+    assert "private traceback" not in json.dumps(result)
+
+
+@pytest.mark.parametrize(
+    ("replacement", "expected_node_outcome"),
+    (
+        (None, None),
+        ("<skipped />", "skipped"),
+        ("<failure>private path /tmp/failure</failure>", "failed"),
+    ),
+)
+def test_missing_skipped_or_failed_required_node_is_test_execution_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement: str | None,
+    expected_node_outcome: str | None,
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+    cases = [_junit_case(node) for node in REQUIRED_NODES[1:]]
+    if replacement is not None:
+        cases.insert(0, _junit_case(REQUIRED_NODES[0], replacement))
+
+    result = evidence.result_from_junit(
+        _write_junit(tmp_path, _junit(*cases)),
+        pytest_outcome="success",
+        evidence_name="linux-x86_64",
+    )
+
+    assert result["status"] == "failed"
+    assert result["failure_code"] == "test_execution"
+    if expected_node_outcome is None:
+        assert REQUIRED_NODES[0] not in result["pytest"]["required_nodes"]
+    else:
+        assert (
+            result["pytest"]["required_nodes"][REQUIRED_NODES[0]]
+            == expected_node_outcome
+        )
+
+
+def test_duplicate_or_parameterized_required_node_is_test_execution_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+    exact_duplicate = _write_junit(
+        tmp_path,
+        _junit(
+            *(_junit_case(node) for node in REQUIRED_NODES),
+            _junit_case(REQUIRED_NODES[0]),
+            duration="1.0",
+        ),
+    )
+    duplicate_result = evidence.result_from_junit(
+        exact_duplicate,
+        pytest_outcome="success",
+        evidence_name="linux-x86_64",
+    )
+    parameterized = REQUIRED_NODES[0] + "[unexpected]"
+    parameterized_cases = [_junit_case(parameterized)] + [
+        _junit_case(node) for node in REQUIRED_NODES[1:]
+    ]
+
+    parameterized_result = evidence.result_from_junit(
+        _write_junit(tmp_path, _junit(*parameterized_cases)),
+        pytest_outcome="success",
+        evidence_name="linux-x86_64",
+    )
+
+    assert duplicate_result["status"] == "failed"
+    assert duplicate_result["failure_code"] == "test_execution"
+    assert parameterized_result["status"] == "failed"
+    assert parameterized_result["failure_code"] == "test_execution"
+
+
+@pytest.mark.parametrize("alias_kind", ("wrong_module", "parameterized"))
+def test_required_node_alias_cannot_hide_beside_the_exact_node(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    alias_kind: str,
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+    _, required_name = REQUIRED_NODES[0].split("::", 1)
+    if alias_kind == "wrong_module":
+        alias = (
+            '<testcase classname="Tests.Other.test_executor_process_tree" '
+            f'name="{required_name}" time="0.1" />'
+        )
+    else:
+        alias = _junit_case(REQUIRED_NODES[0] + "[unexpected]")
+
+    result = evidence.result_from_junit(
+        _write_junit(
+            tmp_path,
+            _junit(*(_junit_case(node) for node in REQUIRED_NODES), alias),
+        ),
+        pytest_outcome="success",
+        evidence_name="linux-x86_64",
+    )
+
+    assert result["status"] == "failed"
+    assert result["failure_code"] == "test_execution"
+
+
+@pytest.mark.parametrize(
+    "file_value",
+    (
+        "/Users/runner/work/private/test_executor_process_tree.py",
+        r"C:\a\private\test_executor_process_tree.py",
+    ),
+)
+def test_junit_file_is_never_authority_and_wrong_module_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    file_value: str,
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+    passing = evidence.result_from_junit(
+        _passing_junit(tmp_path, file_value=file_value),
+        pytest_outcome="success",
+        evidence_name="linux-x86_64",
+    )
+    _, required_name = REQUIRED_NODES[0].split("::", 1)
+    wrong_module_case = (
+        f'<testcase classname="Tests.Other.test_executor_process_tree" '
+        f'name="{required_name}" file="Tests/STT/test_executor_process_tree.py" '
+        'time="0.25" />'
+    )
+    wrong_module = evidence.result_from_junit(
+        _write_junit(
+            tmp_path,
+            _junit(
+                wrong_module_case,
+                *(_junit_case(node) for node in REQUIRED_NODES[1:]),
+            ),
+        ),
+        pytest_outcome="success",
+        evidence_name="linux-x86_64",
+    )
+
+    serialized = json.dumps(passing)
+    assert passing["status"] == "passed"
+    assert file_value not in serialized
+    assert "file" not in serialized
+    assert wrong_module["status"] == "failed"
+    assert wrong_module["failure_code"] == "test_execution"
+
+
+@pytest.mark.parametrize(
+    "xml",
+    (
+        "<not-closed",
+        "<testsuite><testcase",
+    ),
+)
+def test_malformed_junit_produces_bounded_test_execution_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    xml: str,
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+
+    result = evidence.result_from_junit(
+        _write_junit(tmp_path, xml),
+        pytest_outcome="failure",
+        evidence_name="linux-x86_64",
+    )
+
+    assert result["status"] == "failed"
+    assert result["failure_code"] == "test_execution"
+    assert result["pytest"]["required_nodes"] == {}
+    assert str(tmp_path) not in json.dumps(result)
+
+
+def test_initialized_and_dependency_failure_documents_are_bounded_but_validate_red(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+    output = tmp_path / "result.json"
+
+    assert (
+        evidence.main(
+            [
+                "--initialize",
+                "--evidence-name",
+                "linux-x86_64",
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    initialized = json.loads(output.read_text(encoding="utf-8"))
+    evidence.validate_result(initialized, require_pass=False)
+    assert evidence.main(["--validate", str(output)]) == 1
+    assert initialized["failure_code"] == "not_run"
+    assert initialized["pytest"]["required_nodes"] == {}
+
+    assert (
+        evidence.main(
+            [
+                "--record-failure",
+                "dependency_install",
+                "--failure-stage",
+                "dependency_install",
+                "--evidence-name",
+                "linux-x86_64",
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    failed = json.loads(output.read_text(encoding="utf-8"))
+    evidence.validate_result(failed, require_pass=False)
+    assert evidence.main(["--validate", str(output)]) == 1
+    assert failed["failure_code"] == "dependency_install"
+    assert str(tmp_path) not in json.dumps(failed)
+
+
+@pytest.mark.parametrize(
+    ("failure_code", "failure_stage"),
+    (("runneradmin", "initialize"), ("dependency_install", "runneradmin")),
+)
+def test_failure_documents_accept_only_stable_codes_and_stages(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_code: str,
+    failure_stage: str,
+) -> None:
+    evidence = _load_evidence()
+    monkeypatch.setattr(
+        evidence,
+        "_host_result",
+        lambda _name: {
+            "system": "Linux",
+            "architecture": "x86_64",
+            "python": "3.12.9",
+        },
+    )
+
+    with pytest.raises(ValueError, match="failure_code|failure_stage"):
+        evidence.failure_result(
+            _run_identity(),
+            evidence_name="linux-x86_64",
+            failure_code=failure_code,
+            failure_stage=failure_stage,
+        )
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    (
+        ("debug", "/Users/runner/private.xml"),
+        ("debug", "opened /opt/private/report.xml"),
+        ("debug", r"C:\Users\runner\private.xml"),
+        ("debug", r"\\server\share\private.xml"),
+        ("pid", "4242"),
+        ("handle", "0x1af"),
+        ("username", "runneradmin"),
+        ("command", "python -m pytest"),
+    ),
+)
+def test_result_validation_rejects_path_process_and_user_material(
+    key: str, value: str
+) -> None:
+    evidence = _load_evidence()
+    result = _valid_result("linux-x86_64")
+    result[key] = value
+
+    with pytest.raises(ValueError, match="private|path|field"):
+        evidence.validate_result(result)
+
+
+def test_result_validation_rejects_off_repository_run_url() -> None:
+    evidence = _load_evidence()
+    result = _valid_result("linux-x86_64")
+    result["run"]["workflow_run_url"] = (
+        "https://github.com/another-owner/another-repo/actions/runs/123"
+    )
+
+    with pytest.raises(ValueError, match="workflow_run_url|slash"):
+        evidence.validate_result(result)
+
+
+def test_exact_three_matching_platform_documents_aggregate() -> None:
+    evidence = _load_evidence()
+    results = [_valid_result(name) for name in EXPECTED_PLATFORMS]
+    for attempt, result in enumerate(results, start=1):
+        result["run"]["workflow_run_attempt"] = str(attempt)
+
+    aggregate = evidence.aggregate_results(results)
+
+    assert aggregate == {
+        "schema_version": 1,
+        "evidence_label": "task601_native_process_tree_matrix",
+        "status": "passed",
+        "run": {
+            "tested_commit": "a" * 40,
+            "workflow_run_id": "123",
+            "workflow_run_url": (
+                "https://github.com/rmusser01/tldw_chatbook/actions/runs/123"
+            ),
+        },
+        "platforms": {result["evidence_name"]: result for result in results},
+    }
+    evidence.validate_aggregate(aggregate)
+
+
+@pytest.mark.parametrize(
+    "identity_field",
+    ("tested_commit", "workflow_run_id", "workflow_run_url"),
+    ids=("commit", "run", "url"),
+)
+def test_aggregate_rejects_commit_or_run_mismatch(identity_field: str) -> None:
+    evidence = _load_evidence()
+    results = [_valid_result(name) for name in EXPECTED_PLATFORMS]
+    replacement = (
+        "b" * 40
+        if identity_field == "tested_commit"
+        else (
+            "https://github.com/rmusser01/tldw_chatbook/actions/runs/456"
+            if identity_field == "workflow_run_url"
+            else "456"
+        )
+    )
+    results[1]["run"][identity_field] = replacement
+    if identity_field == "workflow_run_id":
+        results[1]["run"]["workflow_run_url"] = (
+            "https://github.com/rmusser01/tldw_chatbook/actions/runs/456"
+        )
+
+    with pytest.raises(ValueError, match=r"commit|workflow.run"):
+        evidence.aggregate_results(results)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    (
+        (
+            lambda aggregate: aggregate["platforms"]["linux-x86_64"]["host"].update(
+                system="Darwin"
+            ),
+            "host",
+        ),
+        (
+            lambda aggregate: aggregate["platforms"].pop("linux-x86_64"),
+            "platform",
+        ),
+        (
+            lambda aggregate: aggregate["platforms"].update(
+                {"extra-x86_64": _valid_result("linux-x86_64")}
+            ),
+            "platform",
+        ),
+        (
+            lambda aggregate: aggregate["platforms"]["linux-x86_64"]["pytest"][
+                "required_nodes"
+            ].update({REQUIRED_NODES[0]: "failed"}),
+            "passed",
+        ),
+        (
+            lambda aggregate: aggregate["platforms"]["linux-x86_64"]["pytest"][
+                "required_nodes"
+            ].update({REQUIRED_NODES[0]: "skipped"}),
+            "passed",
+        ),
+        (lambda aggregate: aggregate.update(unreviewed=True), "field"),
+        (
+            lambda aggregate: aggregate.update(debug="/private/platform/report"),
+            "path|slash",
+        ),
+    ),
+)
+def test_validate_aggregate_rejects_invalid_platform_matrix(
+    mutation: object, expected: str
+) -> None:
+    evidence = _load_evidence()
+    aggregate = evidence.aggregate_results(
+        [_valid_result(name) for name in EXPECTED_PLATFORMS]
+    )
+    mutation(aggregate)
+
+    with pytest.raises(ValueError, match=expected):
+        evidence.validate_aggregate(aggregate)
+
+
+def test_validate_aggregate_rejects_aggregate_identity_mismatch() -> None:
+    evidence = _load_evidence()
+    aggregate = evidence.aggregate_results(
+        [_valid_result(name) for name in EXPECTED_PLATFORMS]
+    )
+    aggregate["run"]["workflow_run_id"] = "456"
+    aggregate["run"]["workflow_run_url"] = (
+        "https://github.com/rmusser01/tldw_chatbook/actions/runs/456"
+    )
+
+    with pytest.raises(ValueError, match="workflow run"):
+        evidence.validate_aggregate(aggregate)
+
+
+def test_validate_aggregate_rejects_unknown_nested_key() -> None:
+    evidence = _load_evidence()
+    aggregate = evidence.aggregate_results(
+        [_valid_result(name) for name in EXPECTED_PLATFORMS]
+    )
+    aggregate["platforms"]["linux-x86_64"]["host"]["runner"] = "hosted"
+
+    with pytest.raises(ValueError, match="field"):
+        evidence.validate_aggregate(aggregate)
+
+
+def test_aggregate_cli_writes_sorted_atomic_json(tmp_path: Path) -> None:
+    evidence = _load_evidence()
+    inputs: list[str] = []
+    for name in EXPECTED_PLATFORMS:
+        path = tmp_path / f"{name}.json"
+        path.write_text(json.dumps(_valid_result(name)), encoding="utf-8")
+        inputs.append(str(path))
+    output = tmp_path / "aggregate.json"
+
+    assert evidence.main(["--aggregate", *inputs, "--output", str(output)]) == 0
+    assert evidence.main(["--validate-aggregate", str(output)]) == 0
+    assert json.loads(output.read_text(encoding="utf-8"))["status"] == "passed"
+    assert not output.with_name(f".{output.name}.tmp").exists()
+    assert output.read_text(encoding="utf-8").startswith('{\n  "evidence_label"')
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("schema_version", 2),
+        ("evidence_label", "wrong_label"),
+        ("evidence_name", "unknown"),
+        ("status", "skipped"),
+    ),
+)
+def test_result_schema_rejects_unknown_fixed_values(field: str, value: object) -> None:
+    evidence = _load_evidence()
+    result = copy.deepcopy(_valid_result("linux-x86_64"))
+    result[field] = value
+
+    with pytest.raises(ValueError):
+        evidence.validate_result(result)
+
+
+def test_schema_version_rejects_boolean_alias_for_one() -> None:
+    evidence = _load_evidence()
+    result = _valid_result("linux-x86_64")
+    result["schema_version"] = True
+
+    with pytest.raises(ValueError, match="schema_version"):
+        evidence.validate_result(result)

--- a/Tests/CI/test_task601_process_tree_evidence.py
+++ b/Tests/CI/test_task601_process_tree_evidence.py
@@ -888,3 +888,88 @@ def test_schema_version_rejects_boolean_alias_for_one() -> None:
 
     with pytest.raises(ValueError, match="schema_version"):
         evidence.validate_result(result)
+
+
+@pytest.mark.parametrize(
+    "duration",
+    (
+        True,
+        None,
+        "0.75",
+        -1,
+        1_200.1,
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        10**309,
+    ),
+    ids=(
+        "bool",
+        "null",
+        "string",
+        "negative",
+        "too-large",
+        "nan",
+        "positive-inf",
+        "negative-inf",
+        "huge-int",
+    ),
+)
+@pytest.mark.parametrize("document_kind", ("result", "aggregate"))
+def test_duration_validation_rejects_every_non_bounded_number(
+    duration: object, document_kind: str
+) -> None:
+    evidence = _load_evidence()
+    result = _valid_result("linux-x86_64")
+    result["pytest"]["duration_seconds"] = duration
+    if document_kind == "result":
+        document = result
+        validator = evidence.validate_result
+    else:
+        document = evidence.aggregate_results(
+            [_valid_result(name) for name in EXPECTED_PLATFORMS]
+        )
+        document["platforms"]["linux-x86_64"] = result
+        validator = evidence.validate_aggregate
+
+    with pytest.raises(ValueError, match="duration_seconds"):
+        validator(document)
+
+
+@pytest.mark.parametrize(
+    ("flag", "document_kind"),
+    (("--validate", "result"), ("--validate-aggregate", "aggregate")),
+)
+def test_cli_huge_duration_is_bounded_and_does_not_modify_files(
+    tmp_path: Path, flag: str, document_kind: str
+) -> None:
+    evidence = _load_evidence()
+    result = _valid_result("linux-x86_64")
+    result["pytest"]["duration_seconds"] = 10**309
+    if document_kind == "result":
+        document = result
+    else:
+        document = evidence.aggregate_results(
+            [_valid_result(name) for name in EXPECTED_PLATFORMS]
+        )
+        document["platforms"]["linux-x86_64"] = result
+    input_path = tmp_path / f"{document_kind}.json"
+    original = json.dumps(document)
+    input_path.write_text(original, encoding="utf-8")
+    destination = tmp_path / "output.json"
+
+    completed = subprocess.run(
+        [sys.executable, str(EVIDENCE_PATH), flag, str(input_path)],
+        cwd=PROJECT_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert completed.stdout == ""
+    assert "Traceback" not in completed.stderr
+    assert str(PROJECT_ROOT) not in completed.stderr
+    assert str(tmp_path) not in completed.stderr
+    assert input_path.read_text(encoding="utf-8") == original
+    assert not destination.exists()

--- a/Tests/CI/test_task601_process_tree_evidence.py
+++ b/Tests/CI/test_task601_process_tree_evidence.py
@@ -5,6 +5,7 @@ import importlib.util
 import json
 import re
 import subprocess
+import sys
 from pathlib import Path
 from types import ModuleType
 
@@ -112,6 +113,13 @@ def _stub_linux_evidence(evidence: ModuleType, monkeypatch: pytest.MonkeyPatch) 
             "python": "3.12.9",
         },
     )
+
+
+def _main_code(evidence: ModuleType, args: list[str]) -> int:
+    try:
+        return evidence.main(args)
+    except SystemExit as error:
+        return int(error.code or 0)
 
 
 def test_evidence_script_exists_and_loads() -> None:
@@ -694,6 +702,165 @@ def test_aggregate_cli_writes_sorted_atomic_json(tmp_path: Path) -> None:
     assert json.loads(output.read_text(encoding="utf-8"))["status"] == "passed"
     assert not output.with_name(f".{output.name}.tmp").exists()
     assert output.read_text(encoding="utf-8").startswith('{\n  "evidence_label"')
+
+
+def test_cli_process_rejects_multiple_operation_modes(tmp_path: Path) -> None:
+    input_path = tmp_path / "result.json"
+    input_path.write_text(json.dumps(_valid_result("linux-x86_64")), encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(EVIDENCE_PATH),
+            "--validate",
+            str(input_path),
+            "--validate-aggregate",
+            str(input_path),
+        ],
+        cwd=PROJECT_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+
+
+@pytest.mark.parametrize("destination_exists", (True, False))
+def test_cli_rejects_multiple_modes_without_writing_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    destination_exists: bool,
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+    destination = tmp_path / "result.json"
+    if destination_exists:
+        destination.write_text("sentinel", encoding="utf-8")
+    junit = _passing_junit(tmp_path)
+    extra_mode = (
+        ["--from-junit", str(junit), "--pytest-outcome", "success"]
+        if destination_exists
+        else ["--record-failure", "dependency_install"]
+    )
+
+    code = _main_code(
+        evidence,
+        [
+            "--initialize",
+            "--evidence-name",
+            "linux-x86_64",
+            "--output",
+            str(destination),
+            *extra_mode,
+        ],
+    )
+
+    assert code != 0
+    if destination_exists:
+        assert destination.read_text(encoding="utf-8") == "sentinel"
+    else:
+        assert not destination.exists()
+
+
+@pytest.mark.parametrize("mode", ("initialize", "validate"))
+def test_cli_rejects_irrelevant_mode_arguments_without_writing_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+    destination = tmp_path / "destination.json"
+    if mode == "initialize":
+        destination.write_text("sentinel", encoding="utf-8")
+        args = [
+            "--initialize",
+            "--pytest-outcome",
+            "success",
+            "--evidence-name",
+            "linux-x86_64",
+            "--output",
+            str(destination),
+        ]
+    else:
+        input_path = tmp_path / "result.json"
+        input_path.write_text(
+            json.dumps(_valid_result("linux-x86_64")), encoding="utf-8"
+        )
+        args = ["--validate", str(input_path), "--output", str(destination)]
+
+    code = _main_code(evidence, args)
+
+    assert code != 0
+    if mode == "initialize":
+        assert destination.read_text(encoding="utf-8") == "sentinel"
+    else:
+        assert not destination.exists()
+
+
+def test_cli_accepts_each_exact_documented_form(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    evidence = _load_evidence()
+    _stub_linux_evidence(evidence, monkeypatch)
+    platform_output = tmp_path / "platform.json"
+    junit = _passing_junit(tmp_path)
+
+    assert (
+        evidence.main(
+            [
+                "--initialize",
+                "--evidence-name",
+                "linux-x86_64",
+                "--output",
+                str(platform_output),
+            ]
+        )
+        == 0
+    )
+    assert (
+        evidence.main(
+            [
+                "--record-failure",
+                "dependency_install",
+                "--failure-stage",
+                "dependency_install",
+                "--evidence-name",
+                "linux-x86_64",
+                "--output",
+                str(platform_output),
+            ]
+        )
+        == 0
+    )
+    assert (
+        evidence.main(
+            [
+                "--from-junit",
+                str(junit),
+                "--pytest-outcome",
+                "success",
+                "--evidence-name",
+                "linux-x86_64",
+                "--output",
+                str(platform_output),
+            ]
+        )
+        == 0
+    )
+    assert evidence.main(["--validate", str(platform_output)]) == 0
+
+    inputs: list[str] = []
+    for name in EXPECTED_PLATFORMS:
+        path = tmp_path / f"{name}.json"
+        path.write_text(json.dumps(_valid_result(name)), encoding="utf-8")
+        inputs.append(str(path))
+    aggregate_output = tmp_path / "aggregate.json"
+    assert (
+        evidence.main(["--aggregate", *inputs, "--output", str(aggregate_output)]) == 0
+    )
+    assert evidence.main(["--validate-aggregate", str(aggregate_output)]) == 0
 
 
 @pytest.mark.parametrize(

--- a/Tests/STT/executor_test_support.py
+++ b/Tests/STT/executor_test_support.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
-import os
 from multiprocessing.connection import Connection
 from pathlib import Path
 from typing import Any
@@ -44,7 +44,9 @@ def _protocol_provider_builder(
     def file_runner(audio_path: str, **kwargs: Any) -> dict[str, Any]:
         return {"audio_path": audio_path, "kwargs": kwargs}
 
-    def buffer_runner(source: Any, *, segment_end_frames: tuple[int, ...]) -> dict[str, Any]:
+    def buffer_runner(
+        source: Any, *, segment_end_frames: tuple[int, ...]
+    ) -> dict[str, Any]:
         return {
             "audio_bytes": len(source.audio),
             "sample_rate": source.sample_rate,
@@ -295,13 +297,18 @@ def containment_crashed_leader_with_term_ignoring_descendant(
     if not admission_event.wait(10.0):
         return
     ready = Path(scratch_path) / "descendant-ready"
+    ignore_sigterm = (
+        "import signal;signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+        if os.name == "posix"
+        else ""
+    )
     child = subprocess.Popen(
         [
             sys.executable,
             "-c",
             (
-                "import pathlib,signal,time;"
-                "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+                "import pathlib,time;"
+                f"{ignore_sigterm}"
                 f"pathlib.Path({str(ready)!r}).write_text('ready');"
                 "time.sleep(120)"
             ),

--- a/Tests/STT/test_executor_process_tree.py
+++ b/Tests/STT/test_executor_process_tree.py
@@ -347,7 +347,9 @@ def test_unproven_tree_death_quarantines_containment(
     process = _FakeProcess(calls, dies=False)
     admission = _RecordingEvent(calls)
     identity = WorkerContainmentIdentity(pid=process.pid, process_group_id=process.pid)
-    monkeypatch.setattr(os, "killpg", lambda pgid, sig: calls.append((pgid, sig)))
+    monkeypatch.setattr(
+        os, "killpg", lambda pgid, sig: calls.append((pgid, sig)), raising=False
+    )
     tree = ExecutorProcessTree(
         process,
         admission,

--- a/Tests/STT/test_executor_process_tree.py
+++ b/Tests/STT/test_executor_process_tree.py
@@ -95,14 +95,148 @@ def _receive(connection: object, timeout: float = 10.0) -> tuple[str, object]:
     return connection.recv()  # type: ignore[attr-defined,no-any-return]
 
 
-def _pid_exists(pid: int) -> bool:
+def _pid_has_exited(pid: int) -> bool:
+    if os.name == "nt":
+        import ctypes
+        from ctypes import wintypes
+
+        synchronize = 0x00100000
+        error_invalid_parameter = 87
+        wait_object_0 = 0
+        wait_timeout = 258
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = [
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        ]
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.WaitForSingleObject.argtypes = [
+            wintypes.HANDLE,
+            wintypes.DWORD,
+        ]
+        kernel32.WaitForSingleObject.restype = wintypes.DWORD
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        ctypes.set_last_error(0)
+        handle = kernel32.OpenProcess(synchronize, False, pid)
+        if not handle:
+            error = ctypes.get_last_error()
+            if error == error_invalid_parameter:
+                return True
+            raise OSError(error, "OpenProcess could not prove PID exit")
+        try:
+            result = kernel32.WaitForSingleObject(handle, 0)
+            if result == wait_object_0:
+                return True
+            if result == wait_timeout:
+                return False
+            error = ctypes.get_last_error()
+            raise OSError(error, "WaitForSingleObject failed")
+        finally:
+            kernel32.CloseHandle(handle)
+
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
-        return False
-    except PermissionError:
         return True
-    return True
+    except PermissionError:
+        return False
+    return False
+
+
+def _wait_for_pid_exit(pid: int, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while not _pid_has_exited(pid) and time.monotonic() < deadline:
+        time.sleep(0.02)
+    return _pid_has_exited(pid)
+
+
+def _terminate_captured_windows_pid(pid: int) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    process_terminate = 0x0001
+    synchronize = 0x00100000
+    wait_object_0 = 0
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [
+        wintypes.DWORD,
+        wintypes.BOOL,
+        wintypes.DWORD,
+    ]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    kernel32.TerminateProcess.restype = wintypes.BOOL
+    kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    ctypes.set_last_error(0)
+    handle = kernel32.OpenProcess(process_terminate | synchronize, False, pid)
+    if not handle:
+        error = ctypes.get_last_error()
+        if error == 87:
+            return
+        raise OSError(error, "OpenProcess could not open captured fixture PID")
+    try:
+        if not kernel32.TerminateProcess(handle, 127):
+            error = ctypes.get_last_error()
+            raise OSError(error, "TerminateProcess failed")
+        result = kernel32.WaitForSingleObject(handle, 10_000)
+        if result != wait_object_0:
+            error = ctypes.get_last_error()
+            raise OSError(error, "captured fixture PID did not exit")
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _finalize_native_tree(
+    tree: ExecutorProcessTree | None,
+    process: object,
+    identity: WorkerContainmentIdentity | None,
+    child_pid: int | None,
+) -> bool:
+    tree_proven = False
+    if tree is not None:
+        try:
+            tree_proven = tree.terminate_tree(term_timeout=1.0, kill_timeout=1.0)
+        except Exception:
+            pass
+    worker_alive = process.is_alive()  # type: ignore[attr-defined]
+    child_alive = child_pid is not None and not _pid_has_exited(child_pid)
+    if os.name == "nt":
+        for pid in (child_pid, process.pid):  # type: ignore[attr-defined]
+            if pid is not None and not _pid_has_exited(pid):
+                _terminate_captured_windows_pid(pid)
+    elif (
+        (worker_alive or child_alive)
+        and identity is not None
+        and identity.process_group_id is not None
+        and identity.process_group_id != os.getpgrp()
+    ):
+        try:
+            os.killpg(identity.process_group_id, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    process.join(2.0)  # type: ignore[attr-defined]
+    return tree_proven
+
+
+@pytest.mark.skipif(os.name != "nt", reason="native Windows PID probe")
+def test_windows_pid_probe_does_not_terminate_a_live_process() -> None:
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(120)"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        assert _pid_has_exited(child.pid) is False
+        assert child.poll() is None
+    finally:
+        child.terminate()
+        child.wait(10.0)
 
 
 def test_posix_worker_enters_new_session_and_waits_for_parent_admission() -> None:
@@ -228,11 +362,9 @@ def test_unproven_tree_death_quarantines_containment(
     assert (process.pid, signal.SIGKILL) in calls
 
 
-def test_posix_force_stop_removes_worker_and_descendant_before_scratch_cleanup(
+def test_native_force_stop_removes_worker_and_descendant_before_scratch_cleanup(
     tmp_path: Path,
 ) -> None:
-    if os.name != "posix":
-        pytest.skip("POSIX containment evidence")
     scratch = tmp_path / "generation-scratch"
     scratch.mkdir(mode=0o700)
     context = multiprocessing.get_context("spawn")
@@ -244,42 +376,48 @@ def test_posix_force_stop_removes_worker_and_descendant_before_scratch_cleanup(
     )
     process.start()
     tree: ExecutorProcessTree | None = None
+    identity: WorkerContainmentIdentity | None = None
     child_pid: int | None = None
     try:
         kind, identity = _receive(receive)
         assert kind == "identity"
         assert type(identity) is WorkerContainmentIdentity
+        assert identity == WorkerContainmentIdentity(
+            pid=process.pid,
+            process_group_id=process.pid if os.name == "posix" else None,
+        )
         tree = ExecutorProcessTree(process, admission, identity)
         tree.admit()
         child_kind, raw_child_pid = _receive(receive)
         assert child_kind == "child"
         child_pid = int(raw_child_pid)
         assert (scratch / "worker-admitted").is_file()
+        assert _pid_has_exited(child_pid) is False
 
         assert tree.terminate_tree(term_timeout=2.0, kill_timeout=2.0) is True
-        deadline = time.monotonic() + 5.0
-        while _pid_exists(child_pid) and time.monotonic() < deadline:
-            time.sleep(0.02)
         assert process.is_alive() is False
-        assert _pid_exists(child_pid) is False
+        assert _pid_has_exited(process.pid) is True
+        assert _wait_for_pid_exit(child_pid) is True
 
         shutil.rmtree(scratch)
         assert scratch.exists() is False
     finally:
-        if tree is not None and process.is_alive():
-            tree.terminate_tree(term_timeout=1.0, kill_timeout=1.0)
-        elif process.is_alive():
+        tree_proven = _finalize_native_tree(tree, process, identity, child_pid)
+        if tree is None and process.is_alive():
             process.terminate()
             process.join(5.0)
-        if scratch.exists() and (child_pid is None or not _pid_exists(child_pid)):
+        if (
+            scratch.exists()
+            and not process.is_alive()
+            and (child_pid is None or _pid_has_exited(child_pid))
+            and (tree is None or tree_proven)
+        ):
             shutil.rmtree(scratch)
 
 
-def test_posix_crashed_leader_still_reaps_term_ignoring_descendant(
+def test_native_crashed_leader_reaps_descendant_before_scratch_cleanup(
     tmp_path: Path,
 ) -> None:
-    if os.name != "posix":
-        pytest.skip("POSIX containment evidence")
     scratch = tmp_path / "crashed-generation-scratch"
     scratch.mkdir(mode=0o700)
     context = multiprocessing.get_context("spawn")
@@ -297,28 +435,38 @@ def test_posix_crashed_leader_still_reaps_term_ignoring_descendant(
         kind, identity = _receive(receive)
         assert kind == "identity"
         assert type(identity) is WorkerContainmentIdentity
+        assert identity == WorkerContainmentIdentity(
+            pid=process.pid,
+            process_group_id=process.pid if os.name == "posix" else None,
+        )
         tree = ExecutorProcessTree(process, admission, identity)
         tree.admit()
         child_kind, raw_child_pid = _receive(receive)
         assert child_kind == "child"
         child_pid = int(raw_child_pid)
+        assert (scratch / "descendant-ready").is_file()
         process.join(10.0)
         assert process.is_alive() is False
-        assert _pid_exists(child_pid) is True
+        assert _pid_has_exited(child_pid) is False
 
         assert tree.terminate_tree(term_timeout=0.1, kill_timeout=2.0) is True
-        assert _pid_exists(child_pid) is False
+        assert process.is_alive() is False
+        assert _pid_has_exited(process.pid) is True
+        assert _wait_for_pid_exit(child_pid) is True
 
         shutil.rmtree(scratch)
         assert scratch.exists() is False
     finally:
-        if identity is not None and child_pid is not None and _pid_exists(child_pid):
-            try:
-                os.killpg(identity.process_group_id, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
-        process.join(2.0)
-        if scratch.exists() and (child_pid is None or not _pid_exists(child_pid)):
+        tree_proven = _finalize_native_tree(tree, process, identity, child_pid)
+        if tree is None and process.is_alive():
+            process.terminate()
+            process.join(5.0)
+        if (
+            scratch.exists()
+            and not process.is_alive()
+            and (child_pid is None or _pid_has_exited(child_pid))
+            and (tree is None or tree_proven)
+        ):
             shutil.rmtree(scratch)
 
 

--- a/Tests/STT/test_executor_process_tree.py
+++ b/Tests/STT/test_executor_process_tree.py
@@ -347,6 +347,7 @@ def test_unproven_tree_death_quarantines_containment(
     process = _FakeProcess(calls, dies=False)
     admission = _RecordingEvent(calls)
     identity = WorkerContainmentIdentity(pid=process.pid, process_group_id=process.pid)
+    monkeypatch.setattr(signal, "SIGKILL", 9, raising=False)
     monkeypatch.setattr(
         os, "killpg", lambda pgid, sig: calls.append((pgid, sig)), raising=False
     )

--- a/Tests/STT/test_executor_process_tree.py
+++ b/Tests/STT/test_executor_process_tree.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -152,45 +153,6 @@ def _wait_for_pid_exit(pid: int, timeout: float = 5.0) -> bool:
     return _pid_has_exited(pid)
 
 
-def _terminate_captured_windows_pid(pid: int) -> None:
-    import ctypes
-    from ctypes import wintypes
-
-    process_terminate = 0x0001
-    synchronize = 0x00100000
-    wait_object_0 = 0
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-    kernel32.OpenProcess.argtypes = [
-        wintypes.DWORD,
-        wintypes.BOOL,
-        wintypes.DWORD,
-    ]
-    kernel32.OpenProcess.restype = wintypes.HANDLE
-    kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
-    kernel32.TerminateProcess.restype = wintypes.BOOL
-    kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
-    kernel32.WaitForSingleObject.restype = wintypes.DWORD
-    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
-    kernel32.CloseHandle.restype = wintypes.BOOL
-    ctypes.set_last_error(0)
-    handle = kernel32.OpenProcess(process_terminate | synchronize, False, pid)
-    if not handle:
-        error = ctypes.get_last_error()
-        if error == 87:
-            return
-        raise OSError(error, "OpenProcess could not open captured fixture PID")
-    try:
-        if not kernel32.TerminateProcess(handle, 127):
-            error = ctypes.get_last_error()
-            raise OSError(error, "TerminateProcess failed")
-        result = kernel32.WaitForSingleObject(handle, 10_000)
-        if result != wait_object_0:
-            error = ctypes.get_last_error()
-            raise OSError(error, "captured fixture PID did not exit")
-    finally:
-        kernel32.CloseHandle(handle)
-
-
 def _finalize_native_tree(
     tree: ExecutorProcessTree | None,
     process: object,
@@ -206,9 +168,19 @@ def _finalize_native_tree(
     worker_alive = process.is_alive()  # type: ignore[attr-defined]
     child_alive = child_pid is not None and not _pid_has_exited(child_pid)
     if os.name == "nt":
-        for pid in (child_pid, process.pid):  # type: ignore[attr-defined]
-            if pid is not None and not _pid_has_exited(pid):
-                _terminate_captured_windows_pid(pid)
+        if tree is not None and not tree_proven:
+            tree._close_job_handle()
+        if worker_alive:
+            try:
+                process.terminate()  # type: ignore[attr-defined]
+            except OSError:
+                pass
+            process.join(1.0)  # type: ignore[attr-defined]
+            if process.is_alive():  # type: ignore[attr-defined]
+                try:
+                    process.kill()  # type: ignore[attr-defined]
+                except OSError:
+                    pass
     elif (
         (worker_alive or child_alive)
         and identity is not None
@@ -221,6 +193,28 @@ def _finalize_native_tree(
             pass
     process.join(2.0)  # type: ignore[attr-defined]
     return tree_proven
+
+
+def test_windows_finalizer_uses_only_the_owned_process_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[object] = []
+    raw_pid_terminations: list[int] = []
+    process = _FakeProcess(calls)
+
+    monkeypatch.setattr(sys.modules[__name__], "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(sys.modules[__name__], "_pid_has_exited", lambda _pid: False)
+    monkeypatch.setattr(
+        sys.modules[__name__],
+        "_terminate_captured_windows_pid",
+        raw_pid_terminations.append,
+        raising=False,
+    )
+
+    _finalize_native_tree(None, process, None, child_pid=67890)
+
+    assert "terminate_process" in calls
+    assert raw_pid_terminations == []
 
 
 @pytest.mark.skipif(os.name != "nt", reason="native Windows PID probe")

--- a/Tests/STT/test_local_stt_executor.py
+++ b/Tests/STT/test_local_stt_executor.py
@@ -180,7 +180,9 @@ def test_executor_request_rejects_invalid_source_or_buffer_boundaries(
         )
 
 
-def test_executor_request_source_variants_pickle_without_leaking_private_inputs() -> None:
+def test_executor_request_source_variants_pickle_without_leaking_private_inputs() -> (
+    None
+):
     snapshot = LocalSourceSnapshot(
         token="private-snapshot-token",
         paths=(Path("/private/models/model.onnx"),),
@@ -1217,9 +1219,13 @@ def test_controller_drops_stale_and_duplicate_terminals(mode: str) -> None:
         executor.close()
 
 
-def test_force_stop_detaches_before_kill_and_cleans_generation_scratch() -> None:
+def test_force_stop_detaches_before_kill_and_cleans_generation_scratch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     executor = _executor()
     callbacks = _Callbacks()
+    termination_entered = threading.Event()
+    allow_termination = threading.Event()
     try:
         _submit(executor, callbacks, attempt_id="held", mode="ignore_cancel")
         _wait_until(
@@ -1229,8 +1235,21 @@ def test_force_stop_detaches_before_kill_and_cleans_generation_scratch() -> None
         )
         scratch = executor._scratch_path
         assert scratch is not None and scratch.is_dir()
+        tree = executor._tree
+        assert tree is not None
+        original_terminate_tree = tree.terminate_tree
+
+        def gated_terminate_tree(**kwargs: float) -> bool:
+            termination_entered.set()
+            assert allow_termination.wait(10.0)
+            return original_terminate_tree(**kwargs)
+
+        monkeypatch.setattr(tree, "terminate_tree", gated_terminate_tree)
 
         assert executor.force_stop("held") is True
+        assert termination_entered.wait(10.0)
+        assert scratch.exists() is True
+        allow_termination.set()
         _wait_for_terminal(callbacks)
         assert callbacks.failures[0].code is TranscriptionFailureCode.CANCELLED
         assert executor.wait_for_retirement(10.0) is True
@@ -1238,6 +1257,8 @@ def test_force_stop_detaches_before_kill_and_cleans_generation_scratch() -> None
         assert scratch.exists() is False
         assert executor.busy is False
     finally:
+        allow_termination.set()
+        executor.wait_for_retirement(10.0)
         executor.close()
 
 

--- a/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
+++ b/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-601
 title: Add generation-fenced local STT executor
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-12 08:34'
+updated_date: '2026-08-12 08:45'
 labels:
   - stt
   - processes
@@ -82,4 +82,6 @@ Native platform evidence attempt 2 also remained red and did not close acceptanc
 Native platform evidence attempt 3 passed and closes acceptance criterion 6. Workflow run https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552 tested executable commit 5c6a446c8d050587f141561319e58e1ce72c528d: Linux x86_64 on ubuntu-24.04, Windows x86_64 on windows-2022, and macOS x86_64 on macos-15-intel all passed the exact three required process-tree and scratch-ordering nodes. All three downloaded JSON records passed individual validation, matched the tested commit and workflow run, and produced the checked-in aggregate through the repository script; aggregate validation passed. The fresh local gate passed 98 tests with one intentional local Windows-only skip in 1.37 seconds; Ruff check, Ruff format check for all five scoped Python files, py_compile for the evidence script, and git diff --check origin/dev...HEAD all passed. Attempts 1 and 2 exposed only Windows portability gaps in a selected POSIX-emulation unit test; both test-only remediations were reviewed, no production fix was needed, and every native lane was rerun after each executable change. Evidence and complete rerun history are documented in Docs/STT_Evaluation/task-601/README.md and Docs/STT_Evaluation/task-601/platform-evidence.json. ADR required: no; ADR-025 and ADR-041 continue to govern the unchanged boundary.
 
 Native three-platform evidence and its evidence-related documentation and validation requirements are complete, and acceptance criterion 6 remains checked. TASK-601 stays In Progress pending Task 5 final correctness and Ponytail review; final task completion and the full Definition of Done are not yet claimed.
+
+Task 5 final review completed. Independent correctness review approved the complete origin/dev...HEAD range with no Critical, Important, or Minor findings and independently confirmed the checked-in aggregate reproduces the successful three-platform artifacts for frozen executable commit 5c6a446c8d050587f141561319e58e1ce72c528d. Final Ponytail review found no blocking complexity; its optional deletion of redundant CLI test coverage is intentionally deferred because changing executable/test content after native evidence would violate the frozen-evidence boundary. A fresh final local gate passed 98 tests with one intentional host-only skip; aggregate validation, Ruff check and format check, py_compile, and origin/dev...HEAD diff check passed. All acceptance criteria and the full applicable Definition of Done are complete.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
+++ b/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-601
 title: Add generation-fenced local STT executor
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-12 08:45'
+updated_date: '2026-08-12 08:47'
 labels:
   - stt
   - processes
@@ -42,7 +42,7 @@ Create one app-owned heavy-media process boundary that gives batch transcription
 - [x] #3 The worker owns root and loaded-dependency leases for the full resident-model lifetime, including idle reuse, and releases them only on close or process exit.
 - [x] #4 Every request, progress event, result, and error carries attempt and executor-generation identity; detached-generation callbacks cannot reach the single-writer stage.
 - [x] #5 Cooperative cancellation and force stop produce exactly one terminal state, recycle only the heavy pool, and leave light parse workers unaffected.
-- [x] #6 FFmpeg and other preparation subprocesses are owned and terminated as a platform process tree before temporary cleanup on Windows, macOS, and Linux.
+- [ ] #6 FFmpeg and other preparation subprocesses are owned and terminated as a platform process tree before temporary cleanup on Windows, macOS, and Linux.
 - [x] #7 Process tests cover same-model reuse, identity recycle, idle leases, crash release, stale callbacks, child cleanup, CPU retry in a fresh worker, and shutdown.
 <!-- AC:END -->
 
@@ -84,4 +84,6 @@ Native platform evidence attempt 3 passed and closes acceptance criterion 6. Wor
 Native three-platform evidence and its evidence-related documentation and validation requirements are complete, and acceptance criterion 6 remains checked. TASK-601 stays In Progress pending Task 5 final correctness and Ponytail review; final task completion and the full Definition of Done are not yet claimed.
 
 Task 5 final review completed. Independent correctness review approved the complete origin/dev...HEAD range with no Critical, Important, or Minor findings and independently confirmed the checked-in aggregate reproduces the successful three-platform artifacts for frozen executable commit 5c6a446c8d050587f141561319e58e1ce72c528d. Final Ponytail review found no blocking complexity; its optional deletion of redundant CLI test coverage is intentionally deferred because changing executable/test content after native evidence would violate the frozen-evidence boundary. A fresh final local gate passed 98 tests with one intentional host-only skip; aggregate validation, Ruff check and format check, py_compile, and origin/dev...HEAD diff check passed. All acceptance criteria and the full applicable Definition of Done are complete.
+
+PR #1561 review after the initial evidence closeout identified a real Windows failure-finalizer hazard: the test reopened captured raw PIDs for cleanup, permitting PID-reuse termination of an unrelated process, and its helper conflated WAIT_TIMEOUT with Win32 failure. TASK-601 and AC6 are reopened before remediation. The fix is test-only and will use only the owned multiprocessing.Process API; because selected native-test content changes, a brand-new three-platform run and replacement aggregate are required before completion.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
+++ b/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-601
 title: Add generation-fenced local STT executor
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-12 08:47'
+updated_date: '2026-08-12 08:52'
 labels:
   - stt
   - processes
@@ -42,7 +42,7 @@ Create one app-owned heavy-media process boundary that gives batch transcription
 - [x] #3 The worker owns root and loaded-dependency leases for the full resident-model lifetime, including idle reuse, and releases them only on close or process exit.
 - [x] #4 Every request, progress event, result, and error carries attempt and executor-generation identity; detached-generation callbacks cannot reach the single-writer stage.
 - [x] #5 Cooperative cancellation and force stop produce exactly one terminal state, recycle only the heavy pool, and leave light parse workers unaffected.
-- [ ] #6 FFmpeg and other preparation subprocesses are owned and terminated as a platform process tree before temporary cleanup on Windows, macOS, and Linux.
+- [x] #6 FFmpeg and other preparation subprocesses are owned and terminated as a platform process tree before temporary cleanup on Windows, macOS, and Linux.
 - [x] #7 Process tests cover same-model reuse, identity recycle, idle leases, crash release, stale callbacks, child cleanup, CPU retry in a fresh worker, and shutdown.
 <!-- AC:END -->
 
@@ -86,4 +86,6 @@ Native three-platform evidence and its evidence-related documentation and valida
 Task 5 final review completed. Independent correctness review approved the complete origin/dev...HEAD range with no Critical, Important, or Minor findings and independently confirmed the checked-in aggregate reproduces the successful three-platform artifacts for frozen executable commit 5c6a446c8d050587f141561319e58e1ce72c528d. Final Ponytail review found no blocking complexity; its optional deletion of redundant CLI test coverage is intentionally deferred because changing executable/test content after native evidence would violate the frozen-evidence boundary. A fresh final local gate passed 98 tests with one intentional host-only skip; aggregate validation, Ruff check and format check, py_compile, and origin/dev...HEAD diff check passed. All acceptance criteria and the full applicable Definition of Done are complete.
 
 PR #1561 review after the initial evidence closeout identified a real Windows failure-finalizer hazard: the test reopened captured raw PIDs for cleanup, permitting PID-reuse termination of an unrelated process, and its helper conflated WAIT_TIMEOUT with Win32 failure. TASK-601 and AC6 are reopened before remediation. The fix is test-only and will use only the owned multiprocessing.Process API; because selected native-test content changes, a brand-new three-platform run and replacement aggregate are required before completion.
+
+PR review remediation is complete. Commit 0e34f7462e4dbd5a724fbe9a6f93ded959623d3e removed raw-PID Windows cleanup, uses only the owned multiprocessing.Process and kill-on-close Job Object handles, added a RED/GREEN regression, and completed Google-style documentation for public evidence-script functions. Review comments about central app path validation and pytest-function docstrings were resolved without code changes: this is an intentionally standard-library-only trusted CI/operator tool with runner-temporary paths, and pytest tests are not package public APIs. Replacement workflow run https://github.com/rmusser01/tldw_chatbook/actions/runs/31580179256 passed Linux x86_64, Windows x86_64, and macOS x86_64 against the exact remediation SHA; all three downloaded records validated and regenerated the checked-in aggregate through the repository script. AC6 and TASK-601 are complete again.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
+++ b/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-12 06:03'
+updated_date: '2026-08-12 07:57'
 labels:
   - stt
   - processes
@@ -72,4 +72,6 @@ After rebasing onto current `dev`, the TASK-601-focused STT, Library, ingestion,
 PR review remediation centralized explicit Parakeet directory validation, hardened managed GGUF paths against Windows/UNC and symlink escapes, completed the public snapshot docstrings and import grouping, added callback context to marshal failures, and coordinated parse-pool plus STT-executor shutdown through one background thread. The final focused gate passed 951 tests. A recycle test that intermittently failed during that gate exposed concurrent attempts by the reader and controller to reap one spawned process; generation ownership now decides the sole reaper before `join()`. The deterministic ownership regression and crash paths passed together, followed by 20 consecutive bounded-lifetime recycle passes.
 
 ADR required: no. ADR path: `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md` and `backlog/decisions/041-direct-local-gguf-before-managed-acquisition.md`. Those accepted decisions already govern the runtime boundary, lease ownership, retry policy, and direct-local GGUF behavior.
+
+Native platform evidence attempt 1 remained red and did not close acceptance criterion 6. Workflow run https://github.com/rmusser01/tldw_chatbook/actions/runs/31575959082 tested executable commit 48c4ccadb9ef93f64ddfffd9954aede9526ea48e: Linux x86_64 and macOS x86_64 passed; Windows x86_64 produced bounded test_execution failure evidence. All three required evidence nodes passed on Windows, but selected unit Tests/STT/test_executor_process_tree.py::test_unproven_tree_death_quarantines_containment failed before its assertion because the test monkeypatch required os.killpg to pre-exist. Windows does not expose os.killpg. This is a native test-portability defect, not a containment production failure. No aggregate was created. Remediation is limited to a RED-backed portable monkeypatch and requires a fresh full three-platform run on a new executable commit.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
+++ b/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-12 08:23'
+updated_date: '2026-08-12 08:34'
 labels:
   - stt
   - processes
@@ -81,7 +81,5 @@ Native platform evidence attempt 2 also remained red and did not close acceptanc
 
 Native platform evidence attempt 3 passed and closes acceptance criterion 6. Workflow run https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552 tested executable commit 5c6a446c8d050587f141561319e58e1ce72c528d: Linux x86_64 on ubuntu-24.04, Windows x86_64 on windows-2022, and macOS x86_64 on macos-15-intel all passed the exact three required process-tree and scratch-ordering nodes. All three downloaded JSON records passed individual validation, matched the tested commit and workflow run, and produced the checked-in aggregate through the repository script; aggregate validation passed. The fresh local gate passed 98 tests with one intentional local Windows-only skip in 1.37 seconds; Ruff check, Ruff format check for all five scoped Python files, py_compile for the evidence script, and git diff --check origin/dev...HEAD all passed. Attempts 1 and 2 exposed only Windows portability gaps in a selected POSIX-emulation unit test; both test-only remediations were reviewed, no production fix was needed, and every native lane was rerun after each executable change. Evidence and complete rerun history are documented in Docs/STT_Evaluation/task-601/README.md and Docs/STT_Evaluation/task-601/platform-evidence.json. ADR required: no; ADR-025 and ADR-041 continue to govern the unchanged boundary.
 
-All seven acceptance criteria are checked. The implementation plan history, focused automated coverage, successful scoped static checks, evidence documentation, existing final correctness review, reviewed portability remediations, ADR check, and no-regression native matrix satisfy the applicable repository Definition of Done. No separate lesson entry was added because the two portability discoveries were confined to this deliberate POSIX-emulation test and are preserved with their incident and remediation in the task and evidence README.
-
-Native three-platform evidence is complete and acceptance criterion 6 remains checked. TASK-601 stays In Progress until Task 5 completes the final correctness and Ponytail review of the full branch.
+Native three-platform evidence and its evidence-related documentation and validation requirements are complete, and acceptance criterion 6 remains checked. TASK-601 stays In Progress pending Task 5 final correctness and Ponytail review; final task completion and the full Definition of Done are not yet claimed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
+++ b/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-12 07:57'
+updated_date: '2026-08-12 08:06'
 labels:
   - stt
   - processes
@@ -74,4 +74,6 @@ PR review remediation centralized explicit Parakeet directory validation, harden
 ADR required: no. ADR path: `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md` and `backlog/decisions/041-direct-local-gguf-before-managed-acquisition.md`. Those accepted decisions already govern the runtime boundary, lease ownership, retry policy, and direct-local GGUF behavior.
 
 Native platform evidence attempt 1 remained red and did not close acceptance criterion 6. Workflow run https://github.com/rmusser01/tldw_chatbook/actions/runs/31575959082 tested executable commit 48c4ccadb9ef93f64ddfffd9954aede9526ea48e: Linux x86_64 and macOS x86_64 passed; Windows x86_64 produced bounded test_execution failure evidence. All three required evidence nodes passed on Windows, but selected unit Tests/STT/test_executor_process_tree.py::test_unproven_tree_death_quarantines_containment failed before its assertion because the test monkeypatch required os.killpg to pre-exist. Windows does not expose os.killpg. This is a native test-portability defect, not a containment production failure. No aggregate was created. Remediation is limited to a RED-backed portable monkeypatch and requires a fresh full three-platform run on a new executable commit.
+
+Native platform evidence attempt 2 also remained red and did not close acceptance criterion 6. New workflow_dispatch run https://github.com/rmusser01/tldw_chatbook/actions/runs/31576646463 tested reviewed executable commit 83c68c30d82fe04b53db02612ff358fb2fb6a0ec: Linux x86_64 and macOS x86_64 passed; Windows x86_64 produced bounded test_execution failure evidence. All three required nodes again passed. The prior os.killpg monkeypatch repair allowed the same selected POSIX-emulation unit to reach its next Windows-unavailable POSIX symbol: signal.SIGKILL. No aggregate was created. Remediation remains test-only: install the simulated SIGKILL constant without skipping coverage, review it, and run a new full three-platform workflow on a new executable commit.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
+++ b/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-601
 title: Add generation-fenced local STT executor
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-12 08:06'
+updated_date: '2026-08-12 08:17'
 labels:
   - stt
   - processes
@@ -24,6 +24,8 @@ documentation:
     Docs/superpowers/specs/2026-08-11-task-601-platform-process-tree-evidence-design.md
   - Docs/superpowers/plans/2026-08-02-task-601-local-stt-executor.md
   - Docs/superpowers/plans/2026-08-11-task-601-platform-process-tree-evidence.md
+  - Docs/STT_Evaluation/task-601/README.md
+  - Docs/STT_Evaluation/task-601/platform-evidence.json
 priority: high
 ---
 
@@ -40,7 +42,7 @@ Create one app-owned heavy-media process boundary that gives batch transcription
 - [x] #3 The worker owns root and loaded-dependency leases for the full resident-model lifetime, including idle reuse, and releases them only on close or process exit.
 - [x] #4 Every request, progress event, result, and error carries attempt and executor-generation identity; detached-generation callbacks cannot reach the single-writer stage.
 - [x] #5 Cooperative cancellation and force stop produce exactly one terminal state, recycle only the heavy pool, and leave light parse workers unaffected.
-- [ ] #6 FFmpeg and other preparation subprocesses are owned and terminated as a platform process tree before temporary cleanup on Windows, macOS, and Linux.
+- [x] #6 FFmpeg and other preparation subprocesses are owned and terminated as a platform process tree before temporary cleanup on Windows, macOS, and Linux.
 - [x] #7 Process tests cover same-model reuse, identity recycle, idle leases, crash release, stale callbacks, child cleanup, CPU retry in a fresh worker, and shutdown.
 <!-- AC:END -->
 
@@ -76,4 +78,8 @@ ADR required: no. ADR path: `backlog/decisions/025-shared-stt-artifacts-and-runt
 Native platform evidence attempt 1 remained red and did not close acceptance criterion 6. Workflow run https://github.com/rmusser01/tldw_chatbook/actions/runs/31575959082 tested executable commit 48c4ccadb9ef93f64ddfffd9954aede9526ea48e: Linux x86_64 and macOS x86_64 passed; Windows x86_64 produced bounded test_execution failure evidence. All three required evidence nodes passed on Windows, but selected unit Tests/STT/test_executor_process_tree.py::test_unproven_tree_death_quarantines_containment failed before its assertion because the test monkeypatch required os.killpg to pre-exist. Windows does not expose os.killpg. This is a native test-portability defect, not a containment production failure. No aggregate was created. Remediation is limited to a RED-backed portable monkeypatch and requires a fresh full three-platform run on a new executable commit.
 
 Native platform evidence attempt 2 also remained red and did not close acceptance criterion 6. New workflow_dispatch run https://github.com/rmusser01/tldw_chatbook/actions/runs/31576646463 tested reviewed executable commit 83c68c30d82fe04b53db02612ff358fb2fb6a0ec: Linux x86_64 and macOS x86_64 passed; Windows x86_64 produced bounded test_execution failure evidence. All three required nodes again passed. The prior os.killpg monkeypatch repair allowed the same selected POSIX-emulation unit to reach its next Windows-unavailable POSIX symbol: signal.SIGKILL. No aggregate was created. Remediation remains test-only: install the simulated SIGKILL constant without skipping coverage, review it, and run a new full three-platform workflow on a new executable commit.
+
+Native platform evidence attempt 3 passed and closes acceptance criterion 6. Workflow run https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552 tested executable commit 5c6a446c8d050587f141561319e58e1ce72c528d: Linux x86_64 on ubuntu-24.04, Windows x86_64 on windows-2022, and macOS x86_64 on macos-15-intel all passed the exact three required process-tree and scratch-ordering nodes. All three downloaded JSON records passed individual validation, matched the tested commit and workflow run, and produced the checked-in aggregate through the repository script; aggregate validation passed. The fresh local gate passed 98 tests with one intentional local Windows-only skip in 1.37 seconds; Ruff check, Ruff format check for all five scoped Python files, py_compile for the evidence script, and git diff --check origin/dev...HEAD all passed. Attempts 1 and 2 exposed only Windows portability gaps in a selected POSIX-emulation unit test; both test-only remediations were reviewed, no production fix was needed, and every native lane was rerun after each executable change. Evidence and complete rerun history are documented in Docs/STT_Evaluation/task-601/README.md and Docs/STT_Evaluation/task-601/platform-evidence.json. ADR required: no; ADR-025 and ADR-041 continue to govern the unchanged boundary.
+
+All seven acceptance criteria are checked. The implementation plan history, focused automated coverage, successful scoped static checks, evidence documentation, existing final correctness review, reviewed portability remediations, ADR check, and no-regression native matrix satisfy the applicable repository Definition of Done. No separate lesson entry was added because the two portability discoveries were confined to this deliberate POSIX-emulation test and are preserved with their incident and remediation in the task and evidence README.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
+++ b/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-12 05:06'
+updated_date: '2026-08-12 06:03'
 labels:
   - stt
   - processes
@@ -23,6 +23,7 @@ documentation:
   - >-
     Docs/superpowers/specs/2026-08-11-task-601-platform-process-tree-evidence-design.md
   - Docs/superpowers/plans/2026-08-02-task-601-local-stt-executor.md
+  - Docs/superpowers/plans/2026-08-11-task-601-platform-process-tree-evidence.md
 priority: high
 ---
 
@@ -46,7 +47,15 @@ Create one app-owned heavy-media process boundary that gives batch transcription
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Define and test the private IPC, resident model identity, privacy, and exactly-once terminal contract. 2. Add and test one narrow POSIX/Windows worker-generation process-tree containment boundary. 3. Implement and spawn-test the generation-fenced LocalSTTExecutor controller and worker loop. 4. Add the smallest audio/video transcription-runner injection seam, reusable transcribe.cpp runtime, Parakeet residency, local snapshot validation, and managed lease lifetime. 5. Route only Parakeet ONNX and transcribe.cpp Library batch jobs through the executor while preserving the general parse pool and existing parent writer. 6. Run only TASK-601-focused tests/static checks, collect native macOS evidence, review the complete diff, and document the still-open Windows/Linux gates. ADR required: no. ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md and backlog/decisions/041-direct-local-gguf-before-managed-acquisition.md. Reason: those accepted ADRs already govern the process, residency, lease, fencing, retry, and direct-local GGUF boundaries.
+1. Generalize the two native process-tree descendant contracts across Linux, Windows, and macOS with non-destructive platform liveness/finalization, and strengthen the production controller test to prove tree termination completes before scratch removal.
+2. Add a bounded standard-library JUnit normalizer and strict same-commit/same-run aggregate whose failure documents remain red and path-private.
+3. Add a label/manual three-runner GitHub Actions workflow for the exact TASK-601 nodes, with explicit Bash semantics and no model/runtime downloads or general-CI dependency.
+4. Rebase before evidence, freeze the executable commit, collect all three native artifacts from one green workflow run, validate and document the aggregate, then close AC6 and TASK-601 through the Backlog CLI.
+5. Run final correctness and Ponytail review; any executable correction invalidates prior evidence and requires a fresh three-platform run.
+
+ADR required: no.
+ADR paths: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md and backlog/decisions/041-direct-local-gguf-before-managed-acquisition.md.
+Reason: ADR-025 already fixes platform process-tree ownership and cleanup ordering; ADR-041 leaves that boundary unchanged. This remaining work supplies native release evidence only.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
+++ b/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-601
 title: Add generation-fenced local STT executor
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-12 08:17'
+updated_date: '2026-08-12 08:23'
 labels:
   - stt
   - processes
@@ -82,4 +82,6 @@ Native platform evidence attempt 2 also remained red and did not close acceptanc
 Native platform evidence attempt 3 passed and closes acceptance criterion 6. Workflow run https://github.com/rmusser01/tldw_chatbook/actions/runs/31577352552 tested executable commit 5c6a446c8d050587f141561319e58e1ce72c528d: Linux x86_64 on ubuntu-24.04, Windows x86_64 on windows-2022, and macOS x86_64 on macos-15-intel all passed the exact three required process-tree and scratch-ordering nodes. All three downloaded JSON records passed individual validation, matched the tested commit and workflow run, and produced the checked-in aggregate through the repository script; aggregate validation passed. The fresh local gate passed 98 tests with one intentional local Windows-only skip in 1.37 seconds; Ruff check, Ruff format check for all five scoped Python files, py_compile for the evidence script, and git diff --check origin/dev...HEAD all passed. Attempts 1 and 2 exposed only Windows portability gaps in a selected POSIX-emulation unit test; both test-only remediations were reviewed, no production fix was needed, and every native lane was rerun after each executable change. Evidence and complete rerun history are documented in Docs/STT_Evaluation/task-601/README.md and Docs/STT_Evaluation/task-601/platform-evidence.json. ADR required: no; ADR-025 and ADR-041 continue to govern the unchanged boundary.
 
 All seven acceptance criteria are checked. The implementation plan history, focused automated coverage, successful scoped static checks, evidence documentation, existing final correctness review, reviewed portability remediations, ADR check, and no-regression native matrix satisfy the applicable repository Definition of Done. No separate lesson entry was added because the two portability discoveries were confined to this deliberate POSIX-emulation test and are preserved with their incident and remediation in the task and evidence README.
+
+Native three-platform evidence is complete and acceptance criterion 6 remains checked. TASK-601 stays In Progress until Task 5 completes the final correctness and Ponytail review of the full branch.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
+++ b/backlog/tasks/task-601 - Add-generation-fenced-local-STT-executor.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-08 08:23'
+updated_date: '2026-08-12 05:06'
 labels:
   - stt
   - processes
@@ -20,6 +20,8 @@ references:
 documentation:
   - Docs/superpowers/specs/2026-07-23-stt-parakeet-onnx-transcribe-cpp-design.md
   - Docs/superpowers/specs/2026-08-02-task-601-local-stt-executor-design.md
+  - >-
+    Docs/superpowers/specs/2026-08-11-task-601-platform-process-tree-evidence-design.md
   - Docs/superpowers/plans/2026-08-02-task-601-local-stt-executor.md
 priority: high
 ---


### PR DESCRIPTION
## Scope
- Portable native process-tree containment evidence for Linux, Windows, and macOS
- Strict path-private per-platform normalization and same-run aggregation
- No production changes, model/runtime extras, downloads, inference, or general-CI dependency

## Local gate
- 98 passed, 1 intentional Windows-only skip
- Ruff check and format-check passed
- Evidence script py_compile passed
- git diff --check origin/dev...HEAD passed

## Acceptance
Closes TASK-601 AC6 only after all three required native lanes pass the exact frozen executable commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a label-gated, cross-OS evidence pipeline proving the local STT worker and its descendants exit before scratch cleanup on Linux, Windows, and macOS. Completes TASK-601 by meeting AC6 and recording a passing three-OS matrix in docs.

- **New Features**
  - Evidence normalizer `.github/scripts/task601_process_tree_evidence.py` with strict CLI modes and bounded durations.
  - Three-OS GitHub Actions workflow `.github/workflows/task-601-platform-evidence.yml` (manual or `task-601-platform-evidence` label).
  - CI guard and portable, flake‑resistant process-tree tests (native PID-exit, POSIX kill emulation, stricter detach-before-kill).
  - Docs refreshed in `Docs/STT_Evaluation/task-601/*`; backlog marks TASK-601 Done. No production/runtime changes or new dependencies.

<sup>Written for commit 7ec977053c2b5748139adadb9b23ec613c997091. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

