### PR TITLE
Add QwenCloud dual API provider support

### DIFF
--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -187,8 +187,11 @@ through the shared cached catalog. Configure its durable **API mode** in
 pins the selected mode and endpoint for every model turn, so changing Settings
 mid-run cannot switch its continuation to another API.
 
-- `responses` is the default. It re-sends the required history, asks for
-  `store=false`, and does not use a response ID or provider conversation ID.
+- `responses` is the default. It re-sends the required history, does not send
+  `previous_response_id` or a provider conversation ID, and does not rely on
+  provider-managed session state. It requests `store=false` where the
+  compatible endpoint honors it; Chatbook makes no claim about provider
+  operational retention or caching.
 - `chat_completions` disables preserved-thinking replay because Chatbook does
   not retain private reasoning content.
 - Existing Chatbook function tools work through the same approval, execution,
@@ -209,9 +212,9 @@ TLDW_LIVE_QWENCLOUD=1 .venv/bin/python -m pytest -q \
 ```
 
 The test runs both API modes in isolated temporary config and data profiles,
-checks identifying text plus one calculator continuation, and does not print
-the key, prompt, or response. Override the defaults only when your account
-requires it with `TLDW_LIVE_QWENCLOUD_MODEL` or
+checks identifying text plus a marker derived from one calculator result, and
+does not print the key, prompt, or response. Override the defaults only when
+your account requires it with `TLDW_LIVE_QWENCLOUD_MODEL` or
 `TLDW_LIVE_QWENCLOUD_API_BASE_URL`.
 
 ### Leaving Console during a run

--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -178,6 +178,42 @@ button, the Model section's **Configure** button in the left rail, or the
 For a faster switch, **Alt+M** opens the quick **Model** popover —
 provider, model, and temperature without the full modal.
 
+#### QwenCloud in Console
+
+QwenCloud behaves like the other hosted providers: select it once, use the
+normal streaming Console and native function tools, and discover models
+through the shared cached catalog. Configure its durable **API mode** in
+**F9 ▸ Providers & Models**; it is not a per-session Console override. A run
+pins the selected mode and endpoint for every model turn, so changing Settings
+mid-run cannot switch its continuation to another API.
+
+- `responses` is the default. It re-sends the required history, asks for
+  `store=false`, and does not use a response ID or provider conversation ID.
+- `chat_completions` disables preserved-thinking replay because Chatbook does
+  not retain private reasoning content.
+- Existing Chatbook function tools work through the same approval, execution,
+  cancellation, budget, and continuation path in both modes. QwenCloud-hosted
+  built-in tools are not exposed.
+- The default model is `qwen3.8-max`. Model/mode availability still depends on
+  your QwenCloud account; use model discovery or the provider's recovery error
+  instead of assuming compatibility from the model name.
+- Token usage can be shown even when pricing is unavailable. **Pricing
+  unknown** means no verified rate is configured, not zero cost.
+
+Optional live verification makes paid requests and is never part of the
+default suite. With `DASHSCOPE_API_KEY` already exported, explicitly opt in:
+
+```bash
+TLDW_LIVE_QWENCLOUD=1 .venv/bin/python -m pytest -q \
+  Tests/Chat/test_live_qwencloud_api.py
+```
+
+The test runs both API modes in isolated temporary config and data profiles,
+checks identifying text plus one calculator continuation, and does not print
+the key, prompt, or response. Override the defaults only when your account
+requires it with `TLDW_LIVE_QWENCLOUD_MODEL` or
+`TLDW_LIVE_QWENCLOUD_API_BASE_URL`.
+
 ### Leaving Console during a run
 
 Agent runs are screen-scoped: navigating to any other screen cancels every

--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -148,6 +148,51 @@ reports "reachable", "reachable (N models)", or a named failure ("timeout",
 "connection refused", "HTTP \<status\>"). A successful **Save** deliberately
 clears the previous verdict — run **Test Provider** again afterwards.
 
+#### QwenCloud
+
+Choose **QwenCloud** to reveal its provider-scoped **API mode** field. The two
+saved values are exactly `responses` and `chat_completions`; **Responses** is
+the default when the setting is absent. The embedded model and endpoint are
+`qwen3.8-max` and
+`https://dashscope-intl.aliyuncs.com/compatible-mode/v1`. Set
+`DASHSCOPE_API_KEY`, or save a local key in this page. If your account provides
+a workspace-specific regional compatible-mode endpoint, replace the shared
+international (Singapore) base with that regional base. A compatible custom
+HTTP(S) base is also allowed; QwenCloud never borrows another provider's URL
+or credential.
+
+The mode changes only QwenCloud's external wire protocol:
+
+| Mode | Behavior and parameter limits |
+|---|---|
+| **Responses** (`responses`, default) | Re-sends canonical history on every turn, requests `store=false`, and never uses `previous_response_id`, conversation IDs, or a server-side session cache. Supported generation fields are temperature, top-p, maximum output, and the documented reasoning-effort values. Maximum output must be at least 16. Seed, penalties, response format, stop, `n`, log probabilities, verbosity, and reasoning summary are intentionally omitted. |
+| **Chat Completions** (`chat_completions`) | Sends `preserve_thinking=false` because Chatbook does not store private `reasoning_content` for exact replay. It supports temperature, top-p/top-k, maximum completion tokens, seed, presence penalty, stop, text/JSON-object response format, `n`, log probabilities, and reasoning effort. Tool requests require `n=1`; min-p, frequency penalty, logit bias, user identifiers, reasoning summary, verbosity, Anthropic thinking fields, and prompt-caching fields are intentionally omitted. |
+
+These lists are fail-closed: generic settings outside the selected mode's
+allowlist are not forwarded. A model can still reject a supported mode or
+parameter; Chatbook does not infer compatibility from its name.
+
+Existing Chatbook function tools use the ordinary Console agent runtime in
+both modes, including structured continuation. QwenCloud-hosted built-in tool
+types (such as hosted search or code execution) are excluded. **Discover
+models** and startup refresh use the same disk TTL cache, configured fallback,
+50-model selector cap, and full searchable catalog as other cloud providers;
+an empty or failed refresh does not erase the configured/cached fallback.
+
+Usage is still counted when the API returns it. If Chatbook has no verified
+price for the selected QwenCloud model, the Console says **pricing unknown**;
+it does not invent a dollar amount or treat unknown pricing as free.
+
+Recovery is fail-closed:
+
+- If **API mode** is invalid, sending and saving stay blocked. Open the field,
+  choose **Responses** or **Chat Completions**, then save.
+- If `api_settings.qwencloud` is not a TOML table, this page reports that the
+  provider settings are invalid and cannot repair the table in place. Open
+  **Advanced Config**, replace the malformed value with an
+  `[api_settings.qwencloud]` table, set a valid `api_mode`, then **Validate Raw
+  TOML**, **Save Raw TOML**, and **Reload Config** under Diagnostics.
+
 ### Core — Speech & TTS
 
 Application-wide speech and text-to-speech defaults — which TTS provider

--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -165,12 +165,17 @@ The mode changes only QwenCloud's external wire protocol:
 
 | Mode | Behavior and parameter limits |
 |---|---|
-| **Responses** (`responses`, default) | Re-sends canonical history on every turn, requests `store=false`, and never uses `previous_response_id`, conversation IDs, or a server-side session cache. Supported generation fields are temperature, top-p, maximum output, and the documented reasoning-effort values. Maximum output must be at least 16. Seed, penalties, response format, stop, `n`, log probabilities, verbosity, and reasoning summary are intentionally omitted. |
+| **Responses** (`responses`, default) | Re-sends canonical history on every turn; it does not send `previous_response_id` or conversation IDs and does not rely on provider-managed session state. It requests `store=false` where the compatible endpoint honors it, without making a claim about provider operational retention or caching. Supported generation fields are temperature, top-p, maximum output, and reasoning effort `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Maximum output must be at least 16. Seed, penalties, response format, stop, `n`, log probabilities, verbosity, and reasoning summary are intentionally omitted. |
 | **Chat Completions** (`chat_completions`) | Sends `preserve_thinking=false` because Chatbook does not store private `reasoning_content` for exact replay. It supports temperature, top-p/top-k, maximum completion tokens, seed, presence penalty, stop, text/JSON-object response format, `n`, log probabilities, and reasoning effort. Tool requests require `n=1`; min-p, frequency penalty, logit bias, user identifiers, reasoning summary, verbosity, Anthropic thinking fields, and prompt-caching fields are intentionally omitted. |
 
 These lists are fail-closed: generic settings outside the selected mode's
 allowlist are not forwarded. A model can still reject a supported mode or
 parameter; Chatbook does not infer compatibility from its name.
+
+For existing function tools in either mode, `tool_choice` may be unset,
+`auto`, or `none`. Chatbook rejects `required`, a forced function/name, and
+object-shaped choices before network I/O even if an upstream API supports
+additional choices.
 
 Existing Chatbook function tools use the ordinary Console agent runtime in
 both modes, including structured continuation. QwenCloud-hosted built-in tool

--- a/Docs/superpowers/plans/2026-08-11-qwencloud-dual-api-provider-implementation.md
+++ b/Docs/superpowers/plans/2026-08-11-qwencloud-dual-api-provider-implementation.md
@@ -1,0 +1,636 @@
+# QwenCloud Dual-API Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add QwenCloud as an ordinary hosted API provider with a pinned `api_mode` setting that defaults to Responses, supports Chat Completions as an alternative, and carries existing Chatbook function tools through both modes.
+
+**Architecture:** Register one `qwencloud` provider behind the existing dispatcher and Console gateway. Keep all mode-specific endpoint, payload, tool-history, response, and SSE translation inside a dedicated adapter; the shared runtime receives only normalized OpenAI-shaped text/tool/usage events. Pin the validated mode and effective base URL in `ConsoleProviderResolution`, then prove the unchanged native-tool runtime can execute and continue multiple calls in both modes.
+
+**Tech Stack:** Python 3.11+, `requests`/`urllib3` transport, Textual 8.x Settings UI, pytest/pytest-asyncio, existing Chatbook provider dispatcher, Console gateway, native-agent runtime, and model-catalog service.
+
+---
+
+## Design Sources And ADR Check
+
+- Approved design: `Docs/superpowers/specs/2026-08-02-qwencloud-dual-api-provider-design.md`
+- Existing decision: `backlog/decisions/045-qwencloud-dual-api-provider-boundary.md`
+- Related decisions: ADR-006, ADR-012, ADR-020, and ADR-026.
+- Backlog source of truth: `backlog/tasks/task-3771 - Add-QwenCloud-dual-API-provider-support.md`
+- Official provider references: `https://www.qwencloud.com/skills.md` and `https://www.qwencloud.com/models/qwen3.8-max#api-reference`
+
+ADR required: yes
+
+ADR path: `backlog/decisions/045-qwencloud-dual-api-provider-boundary.md`
+
+Reason: This feature changes a provider/runtime boundary and wire contract. ADR-045 already records the approved one-provider/two-mode decision, the pinned handoff, and adapter ownership, so no new ADR is needed.
+
+## Scope Guardrails
+
+- Implement existing Chatbook function tools only. QwenCloud built-in tools remain a separate feature.
+- Do not add a second provider identity for Chat Completions.
+- Do not add Responses server-side state (`previous_response_id`, `conversation`) and always send `store=false`.
+- Do not add QwenCloud pricing without a verified official price source; the existing unknown-pricing path must continue to show token counts.
+- Do not change legacy Settings surfaces. The only UI change belongs in `tldw_chatbook/UI/Screens/settings_screen.py`.
+- Do not add a database schema or migration.
+- Do not make paid calls in the default test suite. Optional live verification is explicitly gated.
+
+## Baseline Evidence
+
+Run from `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/qwencloud-provider` with `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python`.
+
+Frozen baseline commit: `97a75fb8b` (`origin/dev` when this plan was written).
+
+- Provider/runtime/catalog baseline: 272 passed. Two first-run errors were only the managed sandbox blocking localhost socket binds; the identical command passed outside that restriction.
+- Canonical Settings baseline: 323 passed, 4 failed on untouched `origin/dev`:
+  - `test_settings_ownership_records_cover_categories_and_runtime_boundaries`
+  - `test_settings_console_behavior_saves_display_name_exactly`
+  - `test_settings_provider_category_saves_provider_defaults_without_sampling`
+  - `test_settings_provider_switch_does_not_save_stale_endpoint`
+- During implementation, compare any failure from an identical command against this baseline. A baseline failure is not evidence that a new QwenCloud test passed; every new test must first be shown red for the intended missing behavior and then green after the smallest implementation.
+- Do not mark TASK-3771 Done if the feature adds a failure beyond the recorded baseline. If `origin/dev` moves, rerun both baseline and feature arms at the same base commit.
+
+Reproduce the 272-pass baseline with:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_provider_gateway.py Tests/Agents/test_native_tools.py Tests/Chat/test_provider_readiness.py Tests/Chat/test_console_provider_endpoints.py Tests/Chat/test_console_provider_support.py Tests/LLM_Provider_Catalog/test_model_catalog_settings.py Tests/LLM_Provider_Catalog/test_model_discovery_provider_identity.py Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py Tests/test_config_model_catalog_defaults.py
+```
+
+Reproduce the Settings baseline with:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_configuration_hub.py Tests/UI/test_settings_save_commit_models.py
+```
+
+## TDD And Commit Discipline
+
+- For every behavior below: add one focused test, run it and inspect the expected failure, implement only enough production code to satisfy it, rerun the focused test, then run the task's regression set.
+- Use verbatim QwenCloud JSON/SSE fixtures. Network fakes may intercept I/O but must not replace production function signatures or the real dispatcher/gateway/native-runtime boundaries.
+- Place a mutation guard around request inputs and assert they are unchanged after translation.
+- Keep sensitive request bodies, message/tool content, keys, and raw provider error bodies out of logs.
+- Commit after each task only when its focused tests pass. Suggested commit messages are included; do not commit a red intermediate state.
+
+### Task 1: Establish provider configuration, identity, readiness, and endpoint contracts
+
+**Files:**
+
+- Modify: `tldw_chatbook/config.py`
+- Modify: `tldw_chatbook/Chat/provider_catalog.py`
+- Modify: `tldw_chatbook/Chat/console_provider_support.py`
+- Modify: `tldw_chatbook/Chat/provider_readiness.py`
+- Modify: `tldw_chatbook/Chat/console_provider_endpoints.py`
+- Modify: `Tests/test_config_model_catalog_defaults.py`
+- Modify: `Tests/Chat/test_console_provider_support.py`
+- Modify: `Tests/Chat/test_provider_readiness.py`
+- Modify: `Tests/Chat/test_console_provider_endpoints.py`
+- Create: `Tests/Chat/test_qwencloud_provider_contract.py`
+
+- [ ] **Cycle 1A — defaults red:** add `test_qwencloud_embedded_config_defaults` asserting `[providers].QwenCloud == ["qwen3.8-max"]`, `[api_settings.qwencloud].api_mode == "responses"`, `api_key_env_var == "DASHSCOPE_API_KEY"`, and the international compatible-mode base URL and retry/stream defaults from the design.
+- [ ] Run the one new node:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_qwencloud_provider_contract.py::test_qwencloud_embedded_config_defaults
+  ```
+
+  Expected: fail because QwenCloud is absent from embedded config.
+
+- [ ] Implement only the `[providers]` and `[api_settings.qwencloud]` defaults in `CONFIG_TOML_CONTENT` plus `QwenCloud` in `_cloud_provider_keys`; rerun the node and expect pass.
+- [ ] **Cycle 1B — identity red:** add `test_qwencloud_uses_one_supported_console_identity` and extend the existing provider inventory assertions for display label `QwenCloud`, normalized readiness/execution key `qwencloud`, and ordinary Console sendability.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_qwencloud_provider_contract.py::test_qwencloud_uses_one_supported_console_identity Tests/Chat/test_console_provider_support.py
+  ```
+
+  Expected: fail because the catalog/support inventory has no QwenCloud identity.
+
+- [ ] Add `"qwencloud": "QwenCloud"` to the shared provider display-name catalog and only the minimum support inventory needed for the derived Console catalog; rerun and expect pass.
+- [ ] **Cycle 1C — readiness red:** add `test_qwencloud_readiness_uses_modern_config_before_its_env` and `test_qwencloud_readiness_never_borrows_another_provider`. Cover credential requirement, default `DASHSCOPE_API_KEY`, configured env-name override, modern-config-over-environment precedence, and isolation from OpenAI/DeepSeek/Custom OpenAI keys.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_qwencloud_provider_contract.py::test_qwencloud_readiness_uses_modern_config_before_its_env Tests/Chat/test_qwencloud_provider_contract.py::test_qwencloud_readiness_never_borrows_another_provider
+  ```
+
+  Expected: fail because readiness does not require or resolve QwenCloud credentials.
+
+- [ ] Add `qwencloud` to `PROVIDERS_REQUIRING_API_KEY_KEYS` and map it to `DASHSCOPE_API_KEY` in `_DEFAULT_API_KEY_ENV_VAR_ALIASES`. Keep precedence in the shared readiness/config boundary and add no legacy bridge unless one already exists (none exists at plan time); rerun and expect pass.
+- [ ] **Cycle 1D — endpoint registration red:** add `test_qwencloud_builtin_endpoint_is_international_compatible_base`, asserting the absent-config effective endpoint is `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` and QwenCloud is treated as an endpoint-using hosted provider.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_qwencloud_provider_contract.py::test_qwencloud_builtin_endpoint_is_international_compatible_base`, expect failure, then add the built-in endpoint/URL-provider registration and rerun green. Full path validation and pasted endpoint normalization deliberately land in Task 2's single pure normalizer, not in this registry step.
+- [ ] Run regression tests:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_provider_support.py Tests/Chat/test_provider_readiness.py Tests/Chat/test_console_provider_endpoints.py Tests/test_config_model_catalog_defaults.py Tests/Chat/test_qwencloud_provider_contract.py
+  ```
+
+  Expected: pass with no OpenAI/DeepSeek/Custom OpenAI behavior changes.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/config.py tldw_chatbook/Chat/provider_catalog.py tldw_chatbook/Chat/console_provider_support.py tldw_chatbook/Chat/provider_readiness.py tldw_chatbook/Chat/console_provider_endpoints.py Tests/test_config_model_catalog_defaults.py Tests/Chat/test_console_provider_support.py Tests/Chat/test_provider_readiness.py Tests/Chat/test_console_provider_endpoints.py Tests/Chat/test_qwencloud_provider_contract.py
+  git commit -m "feat(qwencloud): add provider configuration and readiness"
+  ```
+
+### Task 2: Build fail-closed mode, request, history, and function-tool translation
+
+**Files:**
+
+- Create: `tldw_chatbook/LLM_Calls/qwencloud.py`
+- Create: `Tests/LLM_Calls/test_qwencloud.py`
+
+- [ ] Create these concrete pure interfaces before transport:
+
+  ```python
+  QwenCloudAPIMode = Literal["responses", "chat_completions"]
+
+  def normalize_qwencloud_api_mode(
+      api_mode: str | None,
+      *,
+      provider_settings: Mapping[str, Any] | None = None,
+  ) -> QwenCloudAPIMode: ...
+
+  def normalize_qwencloud_base_url(api_base_url: str | None) -> str: ...
+
+  def resolve_qwencloud_api_key(
+      explicit_api_key: str | None,
+      *,
+      provider_settings: Mapping[str, Any] | None = None,
+      environ: Mapping[str, str] | None = None,
+  ) -> str: ...
+
+  def build_qwencloud_payload(
+      *,
+      api_mode: QwenCloudAPIMode,
+      model: str,
+      system_message: str | None,
+      messages_payload: Sequence[Mapping[str, Any]],
+      streaming: bool,
+      tools: Sequence[Mapping[str, Any]] | None = None,
+      tool_choice: str | None = None,
+      **sampling: Any,
+  ) -> dict[str, Any]: ...
+  ```
+
+  `build_qwencloud_payload` accepts only the dispatcher parameters explicitly mapped in Task 3; it must not forward arbitrary `sampling` keys. The loose annotation above reflects the existing dispatch surface, while the implementation selects named allowed fields one by one.
+
+- [ ] **Cycle 2A — resolution helpers red:** add `test_api_mode_config_then_default_and_exact_values`, `test_base_url_normalizes_base_and_pasted_endpoints`, `test_base_url_rejects_unsafe_or_malformed_values`, and `test_api_key_precedence_is_provider_isolated`.
+- [ ] Positive base cases must normalize all three to the same base: `/compatible-mode/v1`, `/compatible-mode/v1/responses`, and `/compatible-mode/v1/chat/completions` (with whitespace/trailing slash). Remove exactly one recognized terminal request suffix. Reject `/models`, embedded credentials, query/fragment, non-HTTP(S), missing host, double/unknown terminal paths, and malformed paths before a network trap is touched.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py::test_api_mode_config_then_default_and_exact_values Tests/LLM_Calls/test_qwencloud.py::test_base_url_normalizes_base_and_pasted_endpoints Tests/LLM_Calls/test_qwencloud.py::test_base_url_rejects_unsafe_or_malformed_values Tests/LLM_Calls/test_qwencloud.py::test_api_key_precedence_is_provider_isolated
+  ```
+
+  Expected: collection/import failure because the helpers do not exist.
+
+- [ ] Implement constants and the three small resolution helpers. Mode aliases/unknowns raise `ChatConfigurationError`; endpoint/key errors use existing typed configuration/auth errors without including raw secrets. Rerun the four nodes and expect pass.
+- [ ] **Cycle 2B — Responses request red:** add `test_responses_payload_has_exact_allowlist_and_stateless_invariants`, `test_responses_system_message_maps_to_instructions`, and `test_responses_reasoning_effort_enum_is_exact`. Cover the exact Responses allowlist:
+
+  ```text
+  model,input,instructions,stream,store,temperature,top_p,max_output_tokens,tools,tool_choice,reasoning
+  ```
+
+  Assert `store` is exactly `false`, stateful IDs are absent, `max_tokens` maps to `max_output_tokens` with minimum 16, `system_message` maps to `instructions`, equal duplicate leading system text is de-duplicated, a conflicting leading system instruction fails, and reasoning accepts exactly `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` under `reasoning={"effort": ...}`.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py::test_responses_payload_has_exact_allowlist_and_stateless_invariants Tests/LLM_Calls/test_qwencloud.py::test_responses_system_message_maps_to_instructions Tests/LLM_Calls/test_qwencloud.py::test_responses_reasoning_effort_enum_is_exact
+  ```
+
+  Expected: assertion failures from the absent Responses builder. Implement only the Responses scalar/system mapping and exact allowlist; rerun green.
+- [ ] **Cycle 2C — Chat request red:** add `test_chat_payload_has_exact_allowlist_and_thinking_invariant` for the exact Chat Completions allowlist:
+
+  ```text
+  model,messages,stream,temperature,top_p,top_k,max_completion_tokens,seed,presence_penalty,stop,response_format,n,logprobs,top_logprobs,tools,tool_choice,reasoning_effort,preserve_thinking,stream_options
+  ```
+
+  Assert `preserve_thinking` is always `false`, streaming sets `stream_options.include_usage=true`, tool requests force `n=1`, and only `text`/`json_object` response formats pass. Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py::test_chat_payload_has_exact_allowlist_and_thinking_invariant` red, implement the Chat scalar mapping, then rerun green.
+- [ ] **Cycle 2D — tool schema red:** add `test_function_tools_translate_by_mode` and `test_invalid_or_builtin_tools_fail_before_network`. Chat keeps the nested OpenAI function schema; Responses flattens it. Require `type="function"`, non-empty unique names, and object-shaped `parameters`; accept absent/`auto`/`none` tool choice; reject forced choices, duplicate/empty names, non-object parameters, and QwenCloud built-in tool types.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py::test_function_tools_translate_by_mode Tests/LLM_Calls/test_qwencloud.py::test_invalid_or_builtin_tools_fail_before_network` red, implement `_validate_and_translate_qwencloud_tools(...)`, wire it into the builder, and rerun green.
+- [ ] **Cycle 2E — message/history red:** add `test_message_content_translation_is_role_safe_and_immutable`, `test_responses_assistant_text_is_id_free_easy_input_message`, `test_responses_pairs_out_of_order_results_by_call_id`, and `test_responses_rejects_unpairable_tool_batches_before_network`.
+- [ ] Cover ordinary string text, text-array collapse, mixed user `input_text`/`input_image`, user-only images, supported roles, role/content type rejection, non-user image rejection, unknown part rejection, empty assistant content with tool calls, and deep input immutability.
+- [ ] Assert prior assistant text is exactly `{"role":"assistant","content":[{"type":"output_text","text":"..."}]}` with no `id`, `status`, or top-level `type`.
+- [ ] Use assistant text plus calls A/B followed by result rows B/A as the positive Responses fixture. Pair by `call_id` and emit assistant text, call A/output A, call B/output B. Keep missing, duplicate, orphaned, extra, reused, and cross-batch results as negative fixtures. Never synthesize a user message.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py::test_message_content_translation_is_role_safe_and_immutable Tests/LLM_Calls/test_qwencloud.py::test_responses_assistant_text_is_id_free_easy_input_message Tests/LLM_Calls/test_qwencloud.py::test_responses_pairs_out_of_order_results_by_call_id Tests/LLM_Calls/test_qwencloud.py::test_responses_rejects_unpairable_tool_batches_before_network` red, implement one validated canonical-history pass plus two mode renderers, then rerun green.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py
+  ```
+
+  Expected: pass.
+
+- [ ] Run mutation/parameter regressions together with representative dispatcher tests:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py Tests/Chat/test_chat_unit_mocked_APIs.py -k "qwencloud or openai or deepseek"
+  ```
+
+  Expected: QwenCloud tests pass and existing representative providers do not regress.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/LLM_Calls/qwencloud.py Tests/LLM_Calls/test_qwencloud.py
+  git commit -m "feat(qwencloud): translate dual API requests and tools"
+  ```
+
+### Task 3: Add non-streaming transport, normalization, retries, dispatcher registration, and safe errors
+
+**Files:**
+
+- Modify: `tldw_chatbook/LLM_Calls/qwencloud.py`
+- Modify: `tldw_chatbook/Chat/Chat_Functions.py`
+- Modify: `Tests/LLM_Calls/test_qwencloud.py`
+- Modify: `Tests/Chat/test_chat_unit_mocked_APIs.py`
+- Modify: `Tests/Chat/test_sensitive_llm_logging.py`
+- Modify: `Tests/Chat/test_qwencloud_provider_contract.py`
+
+- [ ] Add these concrete adapter/dispatcher seams:
+
+  ```python
+  def normalize_qwencloud_response(
+      payload: Mapping[str, Any], *, api_mode: QwenCloudAPIMode
+  ) -> dict[str, Any]: ...
+
+  def chat_with_qwencloud(
+      input_data: list[dict[str, Any]],
+      model: str | None = None,
+      api_key: str | None = None,
+      system_message: str | None = None,
+      temp: float | None = None,
+      streaming: bool | None = False,
+      topp: float | None = None,
+      topk: int | None = None,
+      max_tokens: int | None = None,
+      seed: int | None = None,
+      stop: str | list[str] | None = None,
+      logprobs: bool | None = None,
+      top_logprobs: int | None = None,
+      presence_penalty: float | None = None,
+      response_format: dict[str, str] | None = None,
+      n: int | None = None,
+      tools: list[dict[str, Any]] | None = None,
+      tool_choice: str | dict[str, Any] | None = None,
+      reasoning_effort: str | None = None,
+      api_base_url: str | None = None,
+      api_mode: str | None = None,
+  ) -> dict[str, Any] | Iterator[dict[str, Any]]: ...
+  ```
+
+  This matches the existing provider-handler convention: `PROVIDER_PARAM_MAP` renames generic `messages_payload` to `input_data`. It deliberately omits generic fields excluded by the approved allowlists. Transport `timeout`, `retries`, and `retry_delay` resolve inside the adapter from `[api_settings.qwencloud]`; this plan does **not** add those three to the shared dispatcher signature.
+
+- [ ] **Cycle 3A — dispatcher red:** add `test_chat_api_call_forwards_qwencloud_mode_base_and_tools` and `test_qwencloud_is_sensitive_auxiliary_audited`. Change the public dispatcher contract to `chat_api_call(..., api_mode: str | None = None)`; update its docstring, let `_CHAT_API_GENERIC_PARAMS` derive the new name from the signature, register `API_CALL_HANDLERS["qwencloud"]`, and define `PROVIDER_PARAM_MAP["qwencloud"]` with the exact supported generic fields including `api_mode`, `api_base_url`, tools, sampling, model, key, messages, and streaming.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_qwencloud_provider_contract.py::test_chat_api_call_forwards_qwencloud_mode_base_and_tools Tests/Chat/test_qwencloud_provider_contract.py::test_qwencloud_is_sensitive_auxiliary_audited
+  ```
+
+  Expected: fail because the handler/signature/map/audit membership is absent. Add only that neutral plumbing and rerun green. Assert a representative OpenAI/DeepSeek call receives no `api_mode` kwarg.
+- [ ] **Cycle 3B — transport/config red:** add `test_nonstream_transport_uses_exact_mode_url_headers_and_timeout` and `test_direct_adapter_loads_only_qwencloud_config_when_arguments_are_none`. Parameterize Responses/Chat and assert exact POST suffix, bearer header, JSON content type, config-resolved timeout, and Task 2 payload. The direct test calls `chat_with_qwencloud(input_data=[...], api_mode=None, api_base_url=None, api_key=None)` against an intercepted transport and proves it loads `[api_settings.qwencloud]` mode/base/key with the same precedence, defaulting behavior, and provider isolation as the pure helpers.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py::test_nonstream_transport_uses_exact_mode_url_headers_and_timeout Tests/LLM_Calls/test_qwencloud.py::test_direct_adapter_loads_only_qwencloud_config_when_arguments_are_none` red, implement adapter config loading plus session/request construction and endpoint suffix append, then rerun green. The intercepted request must never contain another provider's base or key.
+- [ ] **Cycle 3C — normalization red:** add `test_nonstream_normalizes_text_tools_finish_and_usage` and `test_nonstream_rejects_empty_success_and_malformed_shapes`. Cover text-only, tool-only, mixed text/tool, multi-call, refusal/failure, incomplete calls, empty 2xx, and malformed envelopes. Normalize both modes to `choices[0].message`, standard `tool_calls`, `finish_reason`, and top-level usage; preserve Responses `input_tokens`, `output_tokens`, and `total_tokens`.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py::test_nonstream_normalizes_text_tools_finish_and_usage Tests/LLM_Calls/test_qwencloud.py::test_nonstream_rejects_empty_success_and_malformed_shapes` red, implement `normalize_qwencloud_response`, then rerun green. A 2xx with neither usable text nor complete tools must raise `ChatProviderError`, never become an empty successful answer.
+- [ ] **Cycle 3D — retry/error red:** add `test_retry_policy_counts_status_connection_and_timeout_attempts`, `test_sensitive_request_forces_zero_retries`, `test_nontransient_4xx_and_mode_model_mismatch_are_not_retried`, and `test_qwencloud_errors_and_logs_redact_private_values`.
+- [ ] Use a local scripted server plus patched connection/timeout exceptions. `retries` means additional attempts, negative values clamp to zero, and `llm_retry_count()` can force zero in sensitive context. Retry POST for 429/500/502/503/504, connection-establishment failures, and timeouts; honor integer/date `Retry-After`; use exponential `retry_delay`; attempt every other 4xx once.
+- [ ] For a fixture representing model/mode incompatibility, assert one attempt and an actionable typed recovery message that recommends a compatible model or switching `api_mode`; do not expose the raw provider body. Assert authorization, messages, tools, arguments, results, and raw bodies never enter logs or sensitive-mode wrapped exceptions.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py::test_retry_policy_counts_status_connection_and_timeout_attempts Tests/LLM_Calls/test_qwencloud.py::test_sensitive_request_forces_zero_retries Tests/LLM_Calls/test_qwencloud.py::test_nontransient_4xx_and_mode_model_mismatch_are_not_retried Tests/LLM_Calls/test_qwencloud.py::test_qwencloud_errors_and_logs_redact_private_values` red, implement the `HTTPAdapter`/`Retry` policy plus typed safe errors, then rerun green.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py Tests/Chat/test_chat_unit_mocked_APIs.py -k "qwencloud or dispatch"
+  ```
+
+  Expected: pass.
+
+- [ ] Run privacy and registration regressions:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_sensitive_llm_logging.py Tests/Chat/test_qwencloud_provider_contract.py
+  ```
+
+  Expected: pass; no QwenCloud secrets or payload fragments appear in captured logs.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/LLM_Calls/qwencloud.py tldw_chatbook/Chat/Chat_Functions.py Tests/LLM_Calls/test_qwencloud.py Tests/Chat/test_chat_unit_mocked_APIs.py Tests/Chat/test_sensitive_llm_logging.py Tests/Chat/test_qwencloud_provider_contract.py
+  git commit -m "feat(qwencloud): add transport dispatcher and retries"
+  ```
+
+### Task 4: Implement record-aware streaming and deterministic resource closure
+
+**Files:**
+
+- Create: `tldw_chatbook/LLM_Calls/qwencloud_streaming.py`
+- Modify: `tldw_chatbook/LLM_Calls/qwencloud.py`
+- Create: `Tests/LLM_Calls/test_qwencloud_streaming.py`
+
+- [ ] Implement toward these concrete interfaces:
+
+  ```python
+  def iter_sse_data_records(chunks: Iterable[bytes]) -> Iterator[str]: ...
+
+  class QwenResponsesStreamTranslator:
+      def feed(self, event: Mapping[str, Any]) -> tuple[dict[str, Any], ...]: ...
+      def finish(self) -> tuple[dict[str, Any], ...]: ...
+
+  class QwenCloudStream(Iterator[dict[str, Any]]):
+      def __init__(self, *, response: requests.Response, session: requests.Session,
+                   api_mode: QwenCloudAPIMode) -> None: ...
+      def __next__(self) -> dict[str, Any]: ...
+      def close(self) -> None: ...
+  ```
+
+  `iter_sse_data_records` owns incremental UTF-8/newline/blank-record framing; the translator owns Responses event state; `QwenCloudStream.close()` is idempotent and owns response/session closure.
+
+- [ ] **Cycle 4A — framing red:** add `test_sse_records_survive_adversarial_byte_boundaries` and `test_sse_comments_and_multiline_data_frame_without_decoding`. Use verbatim bytes split inside UTF-8 code points, `data:` lines, and CRLF boundaries. Collect multiline data through the blank terminator and ignore comments/heartbeats. This layer returns record strings and deliberately does not parse JSON.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud_streaming.py::test_sse_records_survive_adversarial_byte_boundaries Tests/LLM_Calls/test_qwencloud_streaming.py::test_sse_comments_and_multiline_data_frame_without_decoding` red, implement only `iter_sse_data_records`, and rerun green.
+- [ ] **Cycle 4B — text/state red:** add `test_responses_text_delta_done_recovery_is_exactly_once`, `test_responses_sequence_duplicate_conflict_and_decrease`, and `test_responses_terminal_usage_finish_and_empty_delta`. Cover output/content part added, text delta/done, content/output item done, completed, exact duplicate replay, conflicting/decreasing sequence, distinct output indexes, post-terminal events, failed/incomplete status, malformed/missing terminal, nested usage, and terminal `delta.content == ""`.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud_streaming.py::test_responses_text_delta_done_recovery_is_exactly_once Tests/LLM_Calls/test_qwencloud_streaming.py::test_responses_sequence_duplicate_conflict_and_decrease Tests/LLM_Calls/test_qwencloud_streaming.py::test_responses_terminal_usage_finish_and_empty_delta` red, implement text/sequence/terminal state in `QwenResponsesStreamTranslator`, and rerun green.
+- [ ] **Cycle 4C — function-call red:** add `test_responses_function_call_fragments_recover_without_duplication` and `test_responses_partial_or_mismatched_call_never_surfaces`. Item-added establishes index/call ID/name; deltas emit standard indexed `delta.tool_calls`; done/output-item/completed validates or recovers arguments once. Invalid JSON, incomplete identity, or mismatched terminal arguments raise before a complete call reaches the accumulator.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud_streaming.py::test_responses_function_call_fragments_recover_without_duplication Tests/LLM_Calls/test_qwencloud_streaming.py::test_responses_partial_or_mismatched_call_never_surfaces` red, add function-call state to the translator, and rerun green.
+- [ ] **Cycle 4D — wrapper/lifecycle/decoding red:** add `test_chat_stream_preserves_openai_deltas_and_usage`, `test_stream_retries_only_before_first_consumed_byte`, `test_stream_close_is_idempotent_and_closes_response_and_session`, and `test_stream_malformed_json_and_error_event_are_typed_closed_and_not_retried`. Cover `[DONE]`, Chat text/tool fragments, finish/usage, pre-consumption status retry, no retry after any response byte/event, normal exhaustion, error, and caller `.close()`. Malformed JSON and provider `error` events are decoded in `QwenCloudStream`, raise typed `ChatProviderError(provider="qwencloud")`, close resources, and never retry because bytes were consumed.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud_streaming.py::test_chat_stream_preserves_openai_deltas_and_usage Tests/LLM_Calls/test_qwencloud_streaming.py::test_stream_retries_only_before_first_consumed_byte Tests/LLM_Calls/test_qwencloud_streaming.py::test_stream_close_is_idempotent_and_closes_response_and_session Tests/LLM_Calls/test_qwencloud_streaming.py::test_stream_malformed_json_and_error_event_are_typed_closed_and_not_retried` red, implement record decoding plus `QwenCloudStream` and return it from `chat_with_qwencloud`, then rerun green. Its `finally` path closes response/session exactly once; it never yields a partial complete call.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud_streaming.py Tests/LLM_Calls/test_qwencloud.py
+  ```
+
+  Expected: pass.
+
+- [ ] Run a mutation check by temporarily changing one fixture sequence number/done value and confirm the relevant test fails, then restore the fixture and rerun green.
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/LLM_Calls/qwencloud.py tldw_chatbook/LLM_Calls/qwencloud_streaming.py Tests/LLM_Calls/test_qwencloud.py Tests/LLM_Calls/test_qwencloud_streaming.py
+  git commit -m "feat(qwencloud): parse and normalize streaming events"
+  ```
+
+### Task 5: Pin QwenCloud mode/base in Console and fix gateway cancellation/usage handoff
+
+**Files:**
+
+- Modify: `tldw_chatbook/Chat/console_provider_gateway.py`
+- Modify: `Tests/Chat/test_console_provider_gateway.py`
+- Modify: `Tests/Chat/test_qwencloud_provider_contract.py`
+
+- [ ] Extend the frozen handoff exactly as follows:
+
+  ```python
+  @dataclass(frozen=True)
+  class ConsoleProviderResolution:
+      # existing fields unchanged
+      api_mode: str | None = None
+  ```
+
+  `resolve_for_send` calls Task 2's pure `normalize_qwencloud_api_mode` and `normalize_qwencloud_base_url` only for execution key `qwencloud`. `_chat_api_kwargs_from_prepared`, `_chat_api_kwargs`, and `_auxiliary_chat_api_kwargs` add `api_mode` plus the pinned `api_base_url` only for QwenCloud. No shared caller selects a wire endpoint.
+
+- [ ] **Cycle 5A — pinned resolution red:** add `test_qwencloud_resolution_pins_normalized_mode_and_base`, `test_qwencloud_resolution_rejects_invalid_mode_before_dispatch`, and `test_non_qwen_resolutions_omit_api_mode`. Include base, pasted `/responses`, and pasted `/chat/completions` selection values; all must pin the normalized base.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_provider_gateway.py::test_qwencloud_resolution_pins_normalized_mode_and_base Tests/Chat/test_console_provider_gateway.py::test_qwencloud_resolution_rejects_invalid_mode_before_dispatch Tests/Chat/test_console_provider_gateway.py::test_non_qwen_resolutions_omit_api_mode` red, add the optional field and Qwen-only `resolve_for_send` validation/recovery copy, then rerun green. Invalid mode/endpoint recovery names QwenCloud and the setting but never a key.
+- [ ] **Cycle 5B — handoff red:** add `test_all_qwencloud_kwargs_paths_forward_pinned_mode_and_base` and `test_qwencloud_run_ignores_midrun_config_mutation`. Resolve Responses/base A, mutate config to Chat/base B, then make two turns plus an auxiliary completion with the original resolution; every call must remain Responses/base A. Representative OpenAI, DeepSeek, and Anthropic kwargs remain unchanged and omit `api_mode`.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_provider_gateway.py::test_all_qwencloud_kwargs_paths_forward_pinned_mode_and_base Tests/Chat/test_console_provider_gateway.py::test_qwencloud_run_ignores_midrun_config_mutation` red, add the three Qwen-only kwargs branches, and rerun green.
+- [ ] **Cycle 5C — usage red:** add `test_qwencloud_responses_terminal_usage_reaches_console_signals_without_copy` and `test_qwencloud_total_tokens_reaches_agent_usage_counter`. Feed a normalized terminal chunk through the existing gateway and usage consumers; assert input/output details reach `ProviderUsage`, total reaches `AgentService._usage_total_tokens`, and no fallback content is emitted.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_provider_gateway.py::test_qwencloud_responses_terminal_usage_reaches_console_signals_without_copy Tests/Chat/test_console_provider_gateway.py::test_qwencloud_total_tokens_reaches_agent_usage_counter` red, make only the smallest gateway normalization adjustment if Task 4's standard terminal chunk is not already sufficient, and rerun green.
+- [ ] **Cycle 5D — cancellation red:** add `test_gateway_cancellation_closes_qwencloud_iterator` and `test_tee_tool_calls_closes_underlying_iterator_once`. Cover async consumer cancellation, normal exhaustion, and provider exception.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_provider_gateway.py::test_gateway_cancellation_closes_qwencloud_iterator Tests/Chat/test_console_provider_gateway.py::test_tee_tool_calls_closes_underlying_iterator_once` red, retain the response/iterator in `_stream_generic_chat` and close it in `finally`, and make `_tee_tool_calls` forward `.close()` idempotently. Rerun green.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_qwencloud_provider_contract.py -k "qwencloud or chat_api_kwargs or tee_tool_calls or cancel or usage"
+  ```
+
+  Expected: pass.
+
+- [ ] Run the complete gateway regression suite outside the managed sandbox if its localhost fixtures cannot bind:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_provider_gateway.py
+  ```
+
+  Expected: pass.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/Chat/console_provider_gateway.py Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_qwencloud_provider_contract.py
+  git commit -m "feat(qwencloud): pin Console mode and close streams"
+  ```
+
+### Task 6: Prove native function-tool continuation in both modes, then enable the provider
+
+**Files:**
+
+- Modify: `tldw_chatbook/Agents/native_tools.py`
+- Modify: `Tests/Agents/test_native_tools.py`
+- Modify: `Tests/Chat/test_console_agent_bridge.py`
+- Create: `Tests/Chat/test_qwencloud_native_tools.py`
+
+- [ ] Use the real direction and current class names:
+
+  ```text
+  ConsoleAgentBridge.run_reply
+    -> AgentService / agent_runtime
+    -> _StreamingModelAdapter.chat_call
+    -> ConsoleProviderGateway.stream_chat
+    -> chat_api_call
+    -> chat_with_qwencloud
+    -> scripted local HTTP boundary
+  ```
+
+  There is no `GatewayChatAdapter`. Do not introduce one. The bridge may be invoked through `ConsoleAgentBridge.run_reply`; narrower cases may instantiate the existing private `_StreamingModelAdapter` exactly as current bridge tests do.
+
+- [ ] **Cycle 6A — native eligibility red:** add `test_native_provider_contract_requires_qwencloud_dispatch_and_history` to the shared invariant. Assert tools forward, normalized `message.tool_calls` return, and canonical continuation is accepted. Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Agents/test_native_tools.py::test_native_provider_contract_requires_qwencloud_dispatch_and_history` and expect failure while `qwencloud` is absent from `NATIVE_TOOLS_PROVIDERS`; do not add membership yet.
+- [ ] **Cycle 6B — exact joined continuation red:** add `test_console_agent_bridge_runs_qwencloud_two_call_continuation` parameterized over both modes. Invoke `ConsoleAgentBridge.run_reply` with the existing catalog/executor and a scripted local HTTP server. First turn emits calls A/B, the real runtime executes them, second request contains exact canonical continuation/no synthetic user row, and final turn returns a unique text sentinel.
+- [ ] For Cycles 6B/6C only, the test fixture must temporarily monkeypatch `tldw_chatbook.Agents.native_tools.NATIVE_TOOLS_PROVIDERS` to include `qwencloud`. This bypasses only the capability gate so the proof can exercise the unchanged runtime before permanent eligibility; it must not patch `provider_supports_native_tools`, `AgentService`, `_StreamingModelAdapter`, the gateway, dispatcher, adapter, or HTTP boundary.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_qwencloud_native_tools.py::test_console_agent_bridge_runs_qwencloud_two_call_continuation
+  ```
+
+  Expected: fail at the first missing integration contract. Make only seam-compatible fixes in the adapter/gateway, never in `agent_runtime`, until both parameters pass. Responses must emit call A/output A, call B/output B even if runtime result rows are B/A; Chat must preserve the assistant batch plus exact tool IDs and `preserve_thinking=false`.
+- [ ] **Cycle 6C — errors/cancellation/budget red:** add `test_qwencloud_tool_error_continues_structurally`, `test_qwencloud_partial_call_cancellation_never_executes`, and `test_qwencloud_responses_usage_enforces_agent_budget`, each parameterized where applicable. Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_qwencloud_native_tools.py::test_qwencloud_tool_error_continues_structurally Tests/Chat/test_qwencloud_native_tools.py::test_qwencloud_partial_call_cancellation_never_executes Tests/Chat/test_qwencloud_native_tools.py::test_qwencloud_responses_usage_enforces_agent_budget` red, then fix only adapter/gateway normalization or closure. Assert structured tool error continuation, cancelled state, closed iterator/response, zero partial executions, no unpaired output, and existing token-budget stop.
+- [ ] **Cycle 6D — enable provider:** when Cycles 6B/6C are green under only that temporary capability fixture, add `qwencloud` to `NATIVE_TOOLS_PROVIDERS`, remove the monkeypatch fixture from Cycles 6B/6C, and rerun Cycles 6A/6B/6C unpatched. All must pass through permanent production eligibility. This membership change is the last production change in the task.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_qwencloud_native_tools.py Tests/Chat/test_console_agent_bridge.py Tests/Agents/test_native_tools.py
+  ```
+
+  Expected: pass in both API modes.
+
+- [ ] Run the native/gateway regression set:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Agents/test_native_tools.py Tests/Agents/test_agent_service.py Tests/Agents/test_agent_runtime.py Tests/Chat/test_console_provider_gateway.py
+  ```
+
+  If exact Agent test filenames differ, use `rg --files Tests/Agents | sort` to select the existing AgentService/runtime suites; do not silently omit them. Expected: pass outside any known baseline failures.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/Agents/native_tools.py Tests/Agents/test_native_tools.py Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_qwencloud_native_tools.py
+  git commit -m "feat(qwencloud): enable native function tools in both modes"
+  ```
+
+### Task 7: Add the canonical Settings `api_mode` control with provider-isolated drafts
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py`
+- Modify: `Tests/UI/test_settings_configuration_hub.py`
+- Modify: `Tests/UI/test_settings_save_commit_models.py`
+- Create: `Tests/UI/test_settings_qwencloud_api_mode.py`
+
+- [ ] Keep the existing single category-level `SettingsDraft`; do not invent a second draft object. Add a namespaced key helper such as `_provider_api_mode_draft_key(provider) -> "provider_api_mode:<normalized-provider>"` and store its original/value in the Providers & Models draft. Add `_provider_api_mode_value(provider)` to read the namespaced draft first, then that provider's saved config, then `responses` only for QwenCloud.
+- [ ] On selector change, stage `provider_api_mode:qwencloud`. On provider switch, snapshot the current Qwen widget first and let `_clear_provider_auxiliary_draft_keys()` clear its existing endpoint/credential/profile keys while deliberately retaining every `provider_api_mode:*` namespace. The newly selected provider's widget loads through `_provider_api_mode_value`.
+- [ ] Saving QwenCloud validates/writes `api_settings.qwencloud.api_mode` and removes only `provider_api_mode:qwencloud` from `values` and `originals` after success. Saving another provider neither writes nor clears that namespaced Qwen draft; if the existing save path rebuilds/pops the category draft, preserve and restore the namespace around that operation. Category Revert clears the namespace with the rest of the category draft and reloads saved Qwen mode. Provider test/readiness overlays the selected Qwen namespaced value without persisting it.
+- [ ] **Cycle 7A — render/load red:** add `test_qwencloud_api_mode_selector_visibility_options_and_default` and `test_qwencloud_api_mode_loads_saved_chat_completions`. Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_qwencloud_api_mode.py::test_qwencloud_api_mode_selector_visibility_options_and_default Tests/UI/test_settings_qwencloud_api_mode.py::test_qwencloud_api_mode_loads_saved_chat_completions` red, add `Select(..., id="settings-provider-api-mode")` to the canonical provider detail form plus loaded/display values, and rerun green. The selector exists and is enabled only for normalized QwenCloud identity.
+- [ ] **Cycle 7B — draft isolation red:** add `test_qwencloud_api_mode_draft_survives_provider_switch` and `test_saving_other_provider_never_mutates_qwencloud_mode`. Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_qwencloud_api_mode.py::test_qwencloud_api_mode_draft_survives_provider_switch Tests/UI/test_settings_qwencloud_api_mode.py::test_saving_other_provider_never_mutates_qwencloud_mode` red, implement the namespaced `SettingsDraft` key and switch/save preservation rules above, then rerun green. Saving QwenCloud writes only its provider table plus already-owned category fields.
+- [ ] **Cycle 7C — validation/save/revert red:** add `test_qwencloud_api_mode_save_and_revert_exact_values` and `test_invalid_persisted_qwencloud_mode_blocks_save_and_send`. Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_qwencloud_api_mode.py::test_qwencloud_api_mode_save_and_revert_exact_values Tests/UI/test_settings_qwencloud_api_mode.py::test_invalid_persisted_qwencloud_mode_blocks_save_and_send` red, wire Task 2 validation into the existing category validation/save/revert flow, and rerun green.
+- [ ] **Cycle 7D — ownership/help red:** add `test_qwencloud_api_mode_field_guide_describes_mode_contract`. Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_qwencloud_api_mode.py::test_qwencloud_api_mode_field_guide_describes_mode_contract` red. Update the provider category ownership record with `api_settings.<provider>.api_mode` and explain Responses stateless `store=false`, Chat thinking replay disabled, existing function tools supported, and QwenCloud built-ins excluded; rerun green.
+- [ ] Do not touch `UI/Tools_Settings_Window.py` or `Widgets/enhanced_settings_sidebar.py` in any cycle.
+- [ ] Run the new focused suite:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_qwencloud_api_mode.py
+  ```
+
+  Expected: pass.
+
+- [ ] Run Settings save-model regressions:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_save_commit_models.py Tests/UI/test_settings_configuration_hub.py -k "provider or ownership or qwencloud"
+  ```
+
+  Expected: all new QwenCloud cases pass. Compare any of the four recorded baseline failures with the identical baseline command; do not count them as feature failures unless behavior changed.
+
+- [ ] Run the complete canonical Settings files, record the result, and confirm there are no failures beyond the four baseline names:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_configuration_hub.py Tests/UI/test_settings_save_commit_models.py Tests/UI/test_settings_qwencloud_api_mode.py
+  ```
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/UI/Screens/settings_screen.py Tests/UI/test_settings_configuration_hub.py Tests/UI/test_settings_save_commit_models.py Tests/UI/test_settings_qwencloud_api_mode.py
+  git commit -m "feat(settings): add QwenCloud API mode selector"
+  ```
+
+### Task 8: Join QwenCloud to the existing cached model-catalog pipeline
+
+**Files:**
+
+- Modify: `tldw_chatbook/LLM_Provider_Catalog/model_catalog_settings.py`
+- Modify: `tldw_chatbook/LLM_Provider_Catalog/model_discovery_provider_identity.py`
+- Modify: `tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py`
+- Modify: `Tests/LLM_Provider_Catalog/test_model_catalog_settings.py`
+- Modify: `Tests/LLM_Provider_Catalog/test_model_discovery_provider_identity.py`
+- Modify: `Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py`
+- Modify: `Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py`
+- Modify: `Tests/Provider/test_provider_model_resolution.py`
+- Modify: `Tests/UI/test_provider_model_resolution.py`
+
+- [ ] **Cycle 8A — identity red:** add `test_qwencloud_is_seventh_auto_refresh_cloud_provider` and `test_qwencloud_model_discovery_identity_uses_qwencloud`. Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Provider_Catalog/test_model_catalog_settings.py::test_qwencloud_is_seventh_auto_refresh_cloud_provider Tests/LLM_Provider_Catalog/test_model_discovery_provider_identity.py::test_qwencloud_model_discovery_identity_uses_qwencloud` red, add QwenCloud to `AUTO_REFRESH_PROVIDER_LIST_KEYS`, `_MODEL_DISCOVERY_PROVIDER_HANDLER_KEYS`, and `_BASE_URL_INFERABLE_PROVIDER_KEYS`, then rerun green.
+- [ ] **Cycle 8B — URL/credential seams red:** add `test_qwencloud_models_url_normalizes_base_and_both_request_endpoints` to the pure discovery module and `test_qwencloud_discovery_uses_only_its_modern_or_environment_key` to `test_local_llm_provider_catalog_service.py`. The URL test asserts `/compatible-mode/v1`, `/compatible-mode/v1/responses`, and `/compatible-mode/v1/chat/completions` all become exactly `/compatible-mode/v1/models`. The service test supplies conflicting Qwen modern/env and other-provider keys, invokes the real service resolution, and asserts the discovery client receives only the correctly prioritized QwenCloud key.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py::test_qwencloud_models_url_normalizes_base_and_both_request_endpoints` red. Update `_models_path_for_endpoint_path()` and explicit-compatible-path recognition so the Qwen-compatible base and `/responses` suffix are recognized alongside `/chat/completions`; preserve existing hosts and strip query/fragment through the existing safe URL builder. Rerun green.
+- [ ] Run `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py::test_qwencloud_discovery_uses_only_its_modern_or_environment_key` red. Wire QwenCloud through the service's existing `_resolve_api_key`/readiness ownership without moving credential policy into URL construction; rerun green.
+- [ ] **Cycle 8C — cache/consumer red:** add `test_qwencloud_catalog_normalization_cache_fallback_and_write_through`, `test_qwencloud_discovered_models_use_capped_selector_merge`, and `test_qwencloud_full_catalog_remains_searchable_in_model_popover`. Prove the 50-model selector cap and full Alt+M/search catalog use the ordinary shared merge. Include malformed/empty discovery and configured/cached fallback.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py::test_qwencloud_catalog_normalization_cache_fallback_and_write_through
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Provider/test_provider_model_resolution.py::test_qwencloud_discovered_models_use_capped_selector_merge
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_provider_model_resolution.py::test_qwencloud_full_catalog_remains_searchable_in_model_popover
+  ```
+
+  Expected: fail before QwenCloud flows through shared resolution. Add only standard registry/fixture handling; do not create a Qwen-specific cache, selector, refresh worker, or source. Rerun green.
+- [ ] Run:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Provider_Catalog/test_model_catalog_settings.py Tests/LLM_Provider_Catalog/test_model_discovery_provider_identity.py Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py Tests/Provider/test_provider_model_resolution.py Tests/UI/test_provider_model_resolution.py Tests/test_config_model_catalog_defaults.py
+  ```
+
+  Expected: pass.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/LLM_Provider_Catalog/model_catalog_settings.py tldw_chatbook/LLM_Provider_Catalog/model_discovery_provider_identity.py tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py Tests/LLM_Provider_Catalog/test_model_catalog_settings.py Tests/LLM_Provider_Catalog/test_model_discovery_provider_identity.py Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py Tests/Provider/test_provider_model_resolution.py Tests/UI/test_provider_model_resolution.py
+  git commit -m "feat(qwencloud): add cached model discovery"
+  ```
+
+### Task 9: Document, optionally verify live, and complete repository evidence
+
+**Files:**
+
+- Modify: `Docs/superpowers/specs/2026-08-02-qwencloud-dual-api-provider-design.md` only if implementation evidence requires a factual clarification
+- Modify: `README.md`
+- Modify: `Docs/User_Guide/settings.md`
+- Modify: `Docs/User_Guide/console.md`
+- Create: `Tests/Chat/test_live_qwencloud_api.py`
+- Modify: `backlog/tasks/task-3771 - Add-QwenCloud-dual-API-provider-support.md`
+- Modify: `backlog/docs/lessons-testing-evidence.md` or `backlog/docs/lessons-live-verification.md` only if this implementation produced a genuinely reusable incident-backed lesson
+
+- [ ] Add provider documentation covering `DASHSCOPE_API_KEY`, the international default and regional endpoint guidance, model default, both exact `api_mode` values and default, stateless Responses/`store=false`, Chat reasoning replay safety, parameter limits, existing function-tool support, built-in-tool exclusion, model discovery, and unknown-pricing behavior.
+- [ ] Add a default-skipped live smoke test requiring both `TLDW_LIVE_QWENCLOUD=1` and `DASHSCOPE_API_KEY`. Parameterize both modes, ask the model to reproduce a harmless unique sentinel such as `QWENCLOUD_LIVE_TEXT_<random>` and assert that identifying content, then run one harmless existing function tool whose result contains a second unique sentinel and assert that result influences the final answer. Isolate config/data directories so the test never reads or writes the user's real config.
+- [ ] Prove the live test is collected but skipped by default:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_live_qwencloud_api.py
+  ```
+
+  Expected: skipped unless the explicit gate and key are present.
+
+- [ ] If the user explicitly authorizes paid live verification and the gate/key are available, run with isolated temporary configuration. The test itself must identify the harmless sentinels rather than merely observe no exception; implementation notes record only pass/fail shape and usage, never private prompt/response content or keys. Otherwise document that live verification was not run; do not treat that as an automated-test failure.
+- [ ] Run formatting/static checks scoped to changed Python files using the repository's configured tools. At minimum:
+
+  ```bash
+  git diff --check
+  git diff --name-only -z --diff-filter=ACM 97a75fb8b -- '*.py' | xargs -0 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check
+  git diff --name-only -z --diff-filter=ACM 97a75fb8b -- '*.py' | xargs -0 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m mypy tldw_chatbook/LLM_Calls/qwencloud.py tldw_chatbook/LLM_Calls/qwencloud_streaming.py
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m compileall -q tldw_chatbook/LLM_Calls/qwencloud.py tldw_chatbook/LLM_Calls/qwencloud_streaming.py
+  ```
+
+- [ ] Run the complete QwenCloud and touched-surface regression suite:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_qwencloud.py Tests/LLM_Calls/test_qwencloud_streaming.py Tests/Chat/test_qwencloud_provider_contract.py Tests/Chat/test_qwencloud_native_tools.py Tests/Chat/test_live_qwencloud_api.py Tests/Chat/test_chat_unit_mocked_APIs.py Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_console_agent_bridge.py Tests/Agents/test_native_tools.py Tests/Chat/test_provider_readiness.py Tests/Chat/test_console_provider_endpoints.py Tests/Chat/test_console_provider_support.py Tests/Chat/test_sensitive_llm_logging.py Tests/LLM_Provider_Catalog/test_model_catalog_settings.py Tests/LLM_Provider_Catalog/test_model_discovery_provider_identity.py Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py Tests/Provider/test_provider_model_resolution.py Tests/UI/test_provider_model_resolution.py Tests/test_config_model_catalog_defaults.py Tests/UI/test_settings_configuration_hub.py Tests/UI/test_settings_save_commit_models.py Tests/UI/test_settings_qwencloud_api_mode.py
+  ```
+
+  Expected: all non-live tests pass and live tests skip by default. Run outside the managed sandbox if localhost fixtures need to bind.
+
+- [ ] Run the whole repository suite with the absolute venv interpreter:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q
+  ```
+
+  Compare any failure with an identical clean-base command. Resolve every QwenCloud/touched-surface regression before closeout; record unrelated baseline failures precisely rather than claiming a blanket pass.
+
+- [ ] Self-review the diff against every acceptance criterion and ADR-045. Confirm no built-in QwenCloud tools, no stateful Responses fields, no legacy Settings changes, no unverified pricing, no secret-bearing logs, and no partial tool execution on cancellation.
+- [ ] Update TASK-3771 only after evidence is complete: check every acceptance criterion, add concise Implementation Notes with test evidence and the ADR-045 link, document deviations/baseline failures, and set status Done with the Backlog CLI. If any criterion is incomplete, leave the task In Progress.
+- [ ] Commit final documentation/task evidence:
+
+  ```bash
+  git add README.md Docs/User_Guide/settings.md Docs/User_Guide/console.md Docs/superpowers/specs/2026-08-02-qwencloud-dual-api-provider-design.md Docs/superpowers/plans/2026-08-11-qwencloud-dual-api-provider-implementation.md backlog/decisions/045-qwencloud-dual-api-provider-boundary.md "backlog/tasks/task-3771 - Add-QwenCloud-dual-API-provider-support.md" Tests/Chat/test_live_qwencloud_api.py
+  git commit -m "docs(qwencloud): document setup and verification"
+  ```
+
+## Final Acceptance Checklist
+
+- [ ] One `qwencloud` provider behaves like the existing hosted providers across dispatcher, readiness, Console, Settings, errors, usage, and model discovery.
+- [ ] `api_mode` is explicit, validated, defaults to `responses`, and remains pinned with the base URL throughout a run.
+- [ ] Streaming and non-streaming text/tool/finish/usage work in Responses and Chat Completions.
+- [ ] Existing function tools complete multiple-call continuation through the real runtime in both modes; QwenCloud built-ins remain unsupported.
+- [ ] Responses history is stateless and exactly paired/adjacent; Chat history cannot replay thinking.
+- [ ] Streaming is record-aware, de-duplicated, safely terminal, non-retrying after consumption, and closeable on cancellation.
+- [ ] Canonical Settings persistence is provider-isolated and model discovery uses the shared cached catalog.
+- [ ] Automated tests are green beyond documented identical-base failures, sensitive logging is clean, optional live calls remain gated, ADR-045 is linked, and TASK-3771 hygiene is complete.

--- a/Docs/superpowers/specs/2026-08-02-qwencloud-dual-api-provider-design.md
+++ b/Docs/superpowers/specs/2026-08-02-qwencloud-dual-api-provider-design.md
@@ -1,8 +1,8 @@
 # QwenCloud Dual-API Provider Design
 
 Date: 2026-08-02
-Revised: 2026-08-07
-Status: Architecture approved; pending final document review
+Revised: 2026-08-11
+Status: Approved for implementation
 Backlog task: [TASK-3771](../../../backlog/tasks/task-3771%20-%20Add-QwenCloud-dual-API-provider-support.md)
 Architecture decision: [ADR-045](../../../backlog/decisions/045-qwencloud-dual-api-provider-boundary.md)
 
@@ -34,11 +34,33 @@ provider identity or a Qwen-specific Console/tool runtime.
   name.
 - Some Qwen text-only models reject array-shaped content even when it contains
   only text. Pure text arrays must be collapsed before submission.
+- Responses function results must immediately follow their corresponding
+  `function_call` input item. Chatbook's batched assistant-call/tool-result
+  history therefore needs a pairing mapper rather than a flat shape rewrite.
+- QwenCloud Responses streams function arguments through
+  `response.function_call_arguments.delta` / `.done`; terminal
+  `response.completed` carries usage. Chat Completions streams omit usage
+  unless `stream_options.include_usage` is enabled.
+- `qwen3.8-max` enables preserved thinking by default in Chat Completions and
+  requires historical `reasoning_content` when that behavior is enabled.
+  Chatbook does not retain private reasoning content, so the adapter must
+  explicitly disable preserved-thinking replay.
+- QwenCloud's shared Singapore domain remains functional, while Alibaba now
+  recommends workspace-specific regional domains for production traffic.
+  The endpoint must remain user-configurable.
+- QwenCloud's current OpenAI Responses and Chat Completions references both use
+  `qwen3.8-max` with the shared
+  `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` base. That pair is
+  therefore the embedded default; runtime model discovery and actionable
+  provider errors still own later catalog/entitlement changes.
 
 Primary references:
 
 - [QwenCloud skills index](https://www.qwencloud.com/skills.md)
 - [Qwen3.8-Max API reference](https://www.qwencloud.com/models/qwen3.8-max#api-reference)
+- [QwenCloud OpenAI Chat reference](https://docs.qwencloud.com/api-reference/chat/openai-chat)
+- [QwenCloud OpenAI Responses reference](https://docs.qwencloud.com/api-reference/chat/openai-responses)
+- [QwenCloud streaming guide](https://docs.qwencloud.com/developer-guides/text-generation/streaming)
 - [Qwen through Chat Completions](https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-chat-completions)
 - [Qwen through Responses](https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-responses)
 
@@ -72,8 +94,11 @@ Primary references:
 - Do not restore the retired legacy Chat/CCP streaming pipeline. ADR-026 makes
   native Console the live interactive chat surface; CCP remains a conversation
   management/display surface.
-- Do not use `previous_response_id` or persist QwenCloud server-side response
-  state.
+- Do not use or persist `previous_response_id`, a QwenCloud conversation ID,
+  or other server-side continuation state. Responses requests ask the service
+  not to store a reusable response when the compatible endpoint honors
+  `store=false`; Chatbook does not claim to control provider operational
+  retention.
 - Do not change the conversation database schema or add durable tool metadata.
 - Do not infer model/API compatibility from model-name patterns.
 - Do not make paid requests in the default automated test suite.
@@ -122,19 +147,33 @@ streaming = true
 default `responses`. Surrounding whitespace and case are normalized before
 validation. Aliases and unknown values are rejected before a request.
 
+For Console sends, the resolved value is copied into an explicit optional
+`api_mode` field on `ConsoleProviderResolution`. `_chat_api_kwargs()` forwards
+that pinned value and the pinned QwenCloud base URL to `chat_api_call()`, whose
+signature and `PROVIDER_PARAM_MAP["qwencloud"]` forward them to the adapter.
+Non-Qwen providers receive no `api_mode` argument. Direct/non-Console callers
+may pass a mode explicitly; when they omit it, `chat_with_qwencloud()` resolves
+the same config/default chain and validates before network I/O.
+
 This is a durable provider setting, not a Console session override. A Console
 run resolves the selected provider/model/settings once through the existing
 `ConsoleProviderResolution`; every model turn in that run therefore uses the
-same QwenCloud mode. Credentials remain resolved by the established provider
-credential boundary and are not copied into persisted run state.
+same QwenCloud mode and base URL even if Settings changes mid-run. Credentials
+remain resolved by the established provider credential boundary and are not
+copied into persisted run state.
 
 Credential precedence:
 
 1. Explicit key supplied by a trusted caller.
-2. Environment variable named by `api_key_env_var`.
-3. `DASHSCOPE_API_KEY`.
-4. Existing config-backed credential fallback, if enabled by the shared
-   credential policy.
+2. Explicit modern `api_settings.qwencloud.api_key` configuration.
+3. Environment variable named by `api_key_env_var`, which defaults to
+   `DASHSCOPE_API_KEY`.
+4. A legacy `[API]` QwenCloud key only if the shared config bridge defines one.
+
+This intentionally follows the repository's current readiness/spend policy:
+modern Settings configuration outranks the environment. The adapter does not
+implement an independent credential lookup when Console already supplied the
+pinned readiness key.
 
 QwenCloud must never fall back to OpenAI, DeepSeek, or Custom OpenAI endpoint
 or credential settings.
@@ -195,6 +234,11 @@ The QwenCloud adapter owns only:
 - response and stream-event normalization;
 - QwenCloud error classification and safe retry behavior.
 
+The shared provider-resolution and dispatch seams gain only the neutral data
+plumbing needed to carry QwenCloud's pinned `api_mode` and base URL. They do
+not inspect that mode to choose endpoints, map messages, parse events, or
+execute/continue tools.
+
 The existing systems retain their current ownership:
 
 - Console resolves provider/model/settings and owns streaming/cancellation.
@@ -216,10 +260,13 @@ The configured value is a base API URL. Resolution:
 3. Append `/responses` for Responses mode or `/chat/completions` for Chat
    Completions mode.
 
-Arbitrary HTTP(S) compatible bases are retained for Token Plan or future
-compatible endpoints. Readiness rejects missing schemes, non-HTTP(S) URLs,
-embedded credentials, and malformed endpoint paths. Model discovery uses
-`GET {normalized_base}/models`.
+Arbitrary HTTP(S) compatible bases are retained for workspace-specific
+regional domains, Token Plan, or future compatible endpoints. The shared
+Singapore URL is the zero-configuration default because it remains functional;
+Settings documentation recommends a workspace-specific regional base when the
+account provides one. Readiness rejects missing schemes, non-HTTP(S) URLs,
+embedded credentials, query/fragment endpoint configuration, and malformed
+endpoint paths. Model discovery uses `GET {normalized_base}/models`.
 
 ## Canonical Message Contract
 
@@ -246,16 +293,33 @@ Chat Completions mapping:
 
 Responses mapping:
 
-- Convert ordinary messages to Responses input messages/items.
+- Map the separately supplied leading `system_message` to Responses
+  `instructions`; reject a second conflicting leading system instruction.
+- Convert ordinary user messages to Responses input messages. Convert prior
+  assistant text to the ID-free EasyInputMessage form
+  `{"role":"assistant","content":[{"type":"output_text","text":"..."}]}`.
+  It deliberately omits Responses transport `id`, `status`, and top-level
+  `type`; the mapper must not fabricate a `ResponseOutputMessage` from
+  Chatbook's chat-shaped history.
 - Keep simple text input string-shaped; convert mixed user text/image content
   to `input_text` and `input_image` parts.
-- Convert prior assistant tool calls to `function_call` items.
-- Convert paired tool results to `function_call_output` items using
-  `tool_call_id` as `call_id`.
-- Reject orphaned tool results before network I/O.
+- Treat each canonical assistant `tool_calls` message and its following
+  `role="tool"` rows as one batch. Validate non-empty, unique call IDs and an
+  exact one-result-per-call match. In canonical call order, emit each
+  `function_call` immediately followed by its matching
+  `function_call_output`, using `tool_call_id` as `call_id`. This deliberate
+  within-batch pairing satisfies QwenCloud's adjacency rule even though the
+  internal history stores all calls before all results.
+- If assistant text coexists with the call batch, emit its assistant
+  output-message item before the paired call/output items.
+- Reject missing, duplicate, orphaned, or cross-batch tool results before
+  network I/O. The mapper never mutates or repairs canonical history.
 
-Responses requests are stateless: each continuation sends the necessary
-canonical history. `previous_response_id` is not used.
+Responses requests are stateless from Chatbook's perspective: each
+continuation sends the necessary canonical history. `previous_response_id`
+and QwenCloud conversation IDs are not used, and the request includes
+`store=false` where supported. Provider-side operational retention remains
+governed by QwenCloud's service policy.
 
 ## Existing Function Tools
 
@@ -277,8 +341,11 @@ function fields into the documented Responses function-tool shape.
 
 Validation requires a non-empty name, object-shaped parameters, unique names,
 and `type="function"`. QwenCloud built-in tool types are rejected locally.
-Absent `tool_choice`, `auto`, and `none` are supported; other values require
-separate compatibility work.
+Absent `tool_choice`, `auto`, and `none` are supported by this first slice;
+forced/required choices require separate compatibility work even when the
+external API documents them. The adapter and native runtime accept multiple
+calls in one provider result, but the adapter does not promise that every
+model/mode will generate a parallel batch.
 
 For Responses output, `function_call.call_id` becomes the canonical OpenAI
 tool-call `id`. The output item's separate transport `id` is never used to
@@ -301,15 +368,34 @@ accepts the assistant/tool continuation history produced by `agent_runtime`.
 The adapter constructs payloads from explicit allowlists and never forwards a
 generic kwargs dictionary wholesale.
 
-Responses mode forwards only documented, supported values such as `model`,
-translated `input`, `stream`, `temperature`, `top_p`, function `tools`, and
-supported `tool_choice`. Reasoning effort is forwarded only when QwenCloud
-documents it for this API. Unsupported generic max-token, seed, penalty,
-response-format, verbosity, reasoning-summary, and stop fields are omitted.
+The complete Responses request-key allowlist for this slice is:
+`model`, `input`, `instructions`, `stream`, `store`, `temperature`, `top_p`,
+`max_output_tokens`, `tools`, `tool_choice`, and `reasoning`. `input`,
+`instructions`, tools, and reasoning are translated structures rather than
+generic passthrough values. Chatbook's maximum-output setting maps to
+`max_output_tokens` and must be at least 16 before network I/O. Generic
+reasoning effort maps to `reasoning={"effort": ...}` only for `none`,
+`minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. The adapter-owned
+request invariant `store=false` is sent; `previous_response_id`,
+`conversation`, and session-cache enablement are never sent. Seed, penalties,
+response format, verbosity, reasoning summary, stop, `n`, logprobs, and every
+unknown generic kwarg are omitted.
 
-Chat Completions mode forwards only documented chat parameters. Chatbook's
-maximum output setting maps to `max_completion_tokens` where the endpoint
-supports it. Function tools retain the nested chat shape.
+The complete Chat Completions request-key allowlist for this slice is:
+`model`, `messages`, `stream`, `temperature`, `top_p`, `top_k`,
+`max_completion_tokens`, `seed`, `presence_penalty`, `stop`, `response_format`,
+`n`, `logprobs`, `top_logprobs`, `tools`, `tool_choice`, `reasoning_effort`,
+`preserve_thinking`, and `stream_options`. Function tools retain the nested
+chat shape. `response_format` accepts only the existing `text` and
+`json_object` variants; `n` must be 1 when tools are present. Maximum output
+maps to `max_completion_tokens`. Streaming requests set
+`stream_options={"include_usage": true}` so the standard cost/usage path
+receives the terminal usage chunk. The adapter explicitly sends
+`preserve_thinking=false`: Chatbook intentionally does not store or replay
+`reasoning_content`, and `qwen3.8-max` otherwise defaults preserved thinking
+on and requires exact historical reasoning replay. `min_p`, frequency penalty,
+logit bias, user identifier, reasoning summary, verbosity, Anthropic thinking
+fields, prompt caching, and unknown generic kwargs are omitted.
 
 Settings must explain intentional omissions without suggesting that every
 Qwen model supports both modes.
@@ -326,30 +412,64 @@ existing providers:
       "message": {
         "content": "...",
         "tool_calls": []
-      }
+      },
+      "finish_reason": "stop"
     }
-  ]
+  ],
+  "usage": {}
 }
 ```
 
 Text and tool calls may coexist and neither is discarded. Responses
 `function_call.call_id` becomes the normalized call ID; arguments remain the
-JSON string expected by the existing accumulator/parser.
+JSON string expected by the existing accumulator/parser. Responses usage keeps
+its documented `input_tokens`, `output_tokens`, and `total_tokens` fields (plus
+supported detail mappings). `ProviderUsage.from_provider_payload()` consumes
+the first two/detail fields for the cost ticker, while
+`AgentService._usage_total_tokens()` consumes `total_tokens` for run-budget
+enforcement. Normalized `finish_reason` is `tool_calls` when calls are present,
+`stop` for a completed text result, and `length` for usable partial text
+stopped by `max_output_tokens`. Failed/cancelled terminals and incomplete tool
+calls are typed provider errors.
 
 Streaming Chat Completions preserves normal OpenAI `choices[0].delta`
 fragments. It does not add a second adapter-level complete-call buffer.
 
 Streaming Responses uses a stateful wire translator because typed Responses
-events are not chat deltas. It tracks each output item and emits standard
-`delta.content` and `delta.tool_calls` fragments with stable numeric indexes.
-The existing Console accumulator remains the one owner that merges names,
-IDs, and interleaved argument fragments into complete calls.
+events are not chat deltas. The adapter owns SSE record framing: it ignores
+comment/heartbeat fields, collects `data:` fields until the record boundary,
+parses one JSON event, and never exposes raw Qwen SSE control lines to the
+Console gateway. It tracks `sequence_number`, `output_index`, and item/call
+identity, then emits standard `delta.content` and `delta.tool_calls` mappings
+with stable numeric indexes. The existing Console accumulator remains the one
+owner that merges names, IDs, and interleaved argument fragments into complete
+calls.
 
-The translator must distinguish argument delta events from terminal events so
-a final full-arguments value is not appended after its deltas. Duplicate or
-replayed completion events cannot emit a call twice. A terminal response with
-an incomplete call identity or arguments raises a malformed-provider-response
-error.
+`response.output_item.added` establishes function call identity/name,
+`response.function_call_arguments.delta` emits argument fragments, and
+`response.function_call_arguments.done`, `response.output_item.done`, and
+`response.completed` validate or recover the final full value without
+re-appending already emitted arguments. Exact duplicate sequence events are
+ignored; a conflicting duplicate or decreasing sequence is malformed. A
+terminal response with an incomplete call identity, mismatched reconstructed
+arguments, or invalid JSON arguments raises a malformed-provider-response
+error before the executor sees a call. `response.completed` contributes the
+terminal normalized finish reason and hoists `response.usage` to the top-level
+normalized `usage` mapping expected by `ConsoleProviderStreamSignals`. Its
+normalized terminal chunk includes a standard empty-string `delta.content` so
+the current gateway records usage/finish metadata without misclassifying a
+usage-only mapping as unsupported visible content. Terminal call data is used
+for validation/recovery only and is never emitted again after equivalent
+deltas.
+
+For visible text, every `response.output_text.delta` emits exactly one
+standard `choices[0].delta.content` fragment, keyed by output/item/content
+index. `response.output_text.done`, `response.content_part.done`,
+`response.output_item.done`, and `response.completed` validate the accumulated
+text against the terminal full value. If no text delta was emitted for that
+part, the first terminal full value recovers it once; otherwise terminal values
+are validation-only and never append the full text a second time. A conflicting
+terminal text value is a malformed provider response.
 
 Provider error events raise the project's typed `ChatProviderError` with the
 provider label `qwencloud`; they are never emitted as a successful content
@@ -372,9 +492,11 @@ tool timeouts, model-turn/step/wall/token budgets, cycle detection, result
 truncation, and run logging remain existing runtime behavior. No Qwen-specific
 round cap or session ledger is introduced.
 
-Conversation persistence is unchanged. QwenCloud transport objects and
-`previous_response_id` are not persisted, and credentials never enter the
-conversation or run-log payload.
+Conversation persistence is unchanged. QwenCloud transport objects,
+reasoning items/content, `previous_response_id`, and conversation IDs are not
+persisted, and credentials never enter the conversation or run-log payload.
+Responses asks for `store=false` where supported, but Chatbook documents no
+guarantee about provider operational logs or retention.
 
 ## Readiness And Settings UX
 
@@ -425,6 +547,12 @@ compatibility matrix.
   copy.
 - Rate limits, transient server errors, connection-establishment failures,
   and timeouts use the existing bounded provider retry configuration.
+- `retries` means additional attempts after the initial request, is clamped to
+  a non-negative integer, and passes through `llm_retry_count()` so the shared
+  sensitive-request policy can force it to zero. Retryable statuses are 429,
+  500, 502, 503, and 504 for POST, with `retry_delay` as the exponential
+  backoff factor and provider `Retry-After` honored. Other `4xx` responses are
+  attempted once.
 - Streaming requests are never replayed after the first response byte/event.
 - A successful HTTP status with no usable text or tool calls is a malformed
   provider response, not an empty successful answer.
@@ -445,12 +573,25 @@ Provider-parity tests:
 
 Adapter tests for both modes:
 
-- exact URL, headers, timeout/retry settings, and parameter allowlists;
+- exact URL, headers, timeout/retry settings/counts (including sensitive mode),
+  and the complete request-key allowlists;
 - text-array collapse and supported image conversion without input mutation;
 - function schema and assistant/tool-history translation;
+- pinned `api_mode`/base propagation through `ConsoleProviderResolution`,
+  `_chat_api_kwargs()`, `chat_api_call()`, and the adapter, including a config
+  mutation after resolution that cannot switch a running agent turn;
 - text-only, tool-only, and mixed text/tool results;
-- multiple and interleaved calls with exact `call_id` round-trip;
-- Responses delta/done de-duplication;
+- multiple and interleaved calls with exact `call_id` round-trip and immediate
+  Responses call/output adjacency; missing, duplicate, and orphaned results
+  fail locally;
+- Responses SSE record framing, sequence replay/conflict handling,
+  text/tool delta/done recovery and de-duplication, completion status, finish
+  reasons, and terminal usage without visible fallback copy;
+- Responses `total_tokens` reaches native-agent budget enforcement while its
+  detailed input/output usage reaches the Console cost ticker;
+- Responses `store=false`/state exclusions and max-output mapping;
+- Chat `preserve_thinking=false`, streaming usage opt-in, and
+  max-completion mapping;
 - typed errors, malformed terminals, retry counts, and no retry after stream
   consumption;
 - secret-redaction checks.
@@ -464,7 +605,9 @@ Joined consumer tests:
   tool validation/execution error, and cancellation before a partial call can
   execute;
 - assert the second request contains the exact assistant/tool continuation and
-  does not create a synthetic user message.
+  does not create a synthetic user message;
+- assert cancellation closes the provider iterator/response and never exposes
+  a partial call to execution.
 
 Settings/model-catalog tests cover selector visibility, defaulting,
 persistence isolation, validation, help copy, `/models` normalization, cache
@@ -488,10 +631,12 @@ identifying response content rather than merely asserting no exception.
 
 ## Documentation And Delivery
 
-Provider documentation records setup, credential variable, international base
-URL, both `api_mode` values and default, parameter limitations, existing
-function-tool support, built-in-tool exclusion, configurable compatible bases,
-and optional live-test instructions.
+Provider documentation records setup, credential variable, the functional
+shared Singapore default plus workspace-specific regional override guidance,
+both `api_mode` values and default, state/storage limitations, reasoning replay
+behavior, parameter limitations, existing function-tool support,
+built-in-tool exclusion, configurable compatible bases, and optional live-test
+instructions.
 
 No schema migration is required. Configuration remains TOML-backed.
 

--- a/README.md
+++ b/README.md
@@ -651,8 +651,11 @@ api_mode = "responses" # or "chat_completions"
 model = "qwen3.8-max"
 ```
 
-`responses` is the default API mode. It sends stateless history with
-`store=false`; Chatbook does not use QwenCloud response or conversation IDs.
+`responses` is the default API mode. It re-sends the required history, does
+not send `previous_response_id` or QwenCloud conversation IDs, and does not
+rely on provider-managed session state. It requests `store=false` where the
+compatible endpoint honors it; this is not a claim about QwenCloud's
+operational retention or caching.
 `chat_completions` is also supported and explicitly disables preserved
 thinking because Chatbook does not retain private reasoning for replay.
 Existing Chatbook function tools work in both modes; QwenCloud-hosted built-in

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ The screen shell is organized around a **master shell** of primary destinations 
 > **Migration note:** legacy tabs — `Chat` (now Console), `Notes`, `Media`, `Ingest`, `Search`, `Coding`, `Characters/Prompts` (now Personas), `Subscriptions` (now Watchlists), and `Chatbooks` (now under Artifacts) — still resolve as routes/aliases, but are no longer separate primary destinations. `Coding` in particular is now a thin compatibility stub; agentic programming happens in the Console.
 
 ### LLM Support
-- **Commercial LLM APIs**: OpenAI, Anthropic, Cohere, DeepSeek, Google, Groq, Mistral, OpenRouter, HuggingFace
+- **Commercial LLM APIs**: OpenAI, Anthropic, Cohere, DeepSeek, Google, Groq, Mistral, OpenRouter, QwenCloud, HuggingFace
 - **Local LLM APIs**: Llama.cpp, Ollama, Kobold.cpp, vLLM, Aphrodite, MLX-LM, ONNX Runtime, Custom OpenAI-compatible endpoints
 - **Streaming responses** with real-time display
 - **Full conversation management**: Save, load, edit, fork conversations
@@ -632,7 +632,35 @@ API keys can also be set via environment variables:
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
 - `COHERE_API_KEY`
+- `DASHSCOPE_API_KEY` (QwenCloud)
 - etc.
+
+### QwenCloud
+
+QwenCloud is a first-class Console provider with `qwen3.8-max` as the embedded
+default model. Its default compatible base is the functional international
+(Singapore) endpoint, while accounts that provide a workspace-specific
+regional endpoint should save that base under **Settings ▸ Providers &
+Models** instead:
+
+```toml
+[api_settings.qwencloud]
+api_key_env_var = "DASHSCOPE_API_KEY"
+api_base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+api_mode = "responses" # or "chat_completions"
+model = "qwen3.8-max"
+```
+
+`responses` is the default API mode. It sends stateless history with
+`store=false`; Chatbook does not use QwenCloud response or conversation IDs.
+`chat_completions` is also supported and explicitly disables preserved
+thinking because Chatbook does not retain private reasoning for replay.
+Existing Chatbook function tools work in both modes; QwenCloud-hosted built-in
+tools are not supported by this feature. Model discovery uses the shared
+cached catalog, and model/mode compatibility is reported by the service rather
+than guessed from a model name. See [Settings](Docs/User_Guide/settings.md#qwencloud)
+and [Console](Docs/User_Guide/console.md#qwencloud-in-console) for parameter,
+endpoint, recovery, and optional live-test details.
 
 ### Database Files
 Located at `~/.local/share/tldw_cli/`:

--- a/Tests/Agents/test_native_tools.py
+++ b/Tests/Agents/test_native_tools.py
@@ -11,6 +11,10 @@ from tldw_chatbook.Agents.native_tools import (
     schemas_to_openai_tools,
 )
 from tldw_chatbook.Chat.Chat_Functions import PROVIDER_PARAM_MAP
+from tldw_chatbook.LLM_Calls.qwencloud import (
+    build_qwencloud_payload,
+    normalize_qwencloud_response,
+)
 
 
 def test_capability_set_membership():
@@ -31,6 +35,105 @@ def test_every_native_provider_forwards_tools_in_param_map():
         mapping = PROVIDER_PARAM_MAP.get(provider)
         assert mapping is not None, provider
         assert mapping.get("tools") == "tools", provider
+
+
+def test_native_provider_contract_requires_qwencloud_dispatch_and_history():
+    """QwenCloud may be native only after all three seam invariants hold."""
+    assert "qwencloud" in NATIVE_TOOLS_PROVIDERS
+    assert PROVIDER_PARAM_MAP["qwencloud"]["tools"] == "tools"
+
+    normalized = normalize_qwencloud_response(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "function_call",
+                    "status": "completed",
+                    "call_id": "call_A",
+                    "name": "calculator",
+                    "arguments": '{"expression":"6*7"}',
+                },
+                {
+                    "type": "function_call",
+                    "status": "completed",
+                    "call_id": "call_B",
+                    "name": "calculator",
+                    "arguments": '{"expression":"8*8"}',
+                },
+            ],
+        },
+        api_mode="responses",
+    )
+    assert normalized["choices"][0]["message"]["tool_calls"] == [
+        {
+            "id": "call_A",
+            "type": "function",
+            "function": {
+                "name": "calculator",
+                "arguments": '{"expression":"6*7"}',
+            },
+        },
+        {
+            "id": "call_B",
+            "type": "function",
+            "function": {
+                "name": "calculator",
+                "arguments": '{"expression":"8*8"}',
+            },
+        },
+    ]
+
+    continuation = [
+        {"role": "user", "content": "Calculate it."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": normalized["choices"][0]["message"]["tool_calls"],
+        },
+        # Canonical runtime history is accepted even when result rows arrive
+        # out of call order; Responses must restore call/output adjacency.
+        {"role": "tool", "tool_call_id": "call_B", "content": "64"},
+        {"role": "tool", "tool_call_id": "call_A", "content": "42"},
+    ]
+    responses_payload = build_qwencloud_payload(
+        api_mode="responses",
+        model="qwen3.8-max",
+        system_message=None,
+        messages_payload=continuation,
+        streaming=False,
+    )
+    assert responses_payload["input"][-4:] == [
+        {
+            "type": "function_call",
+            "call_id": "call_A",
+            "name": "calculator",
+            "arguments": '{"expression":"6*7"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_A",
+            "output": "42",
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_B",
+            "name": "calculator",
+            "arguments": '{"expression":"8*8"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_B",
+            "output": "64",
+        },
+    ]
+    chat_payload = build_qwencloud_payload(
+        api_mode="chat_completions",
+        model="qwen3.8-max",
+        system_message=None,
+        messages_payload=continuation,
+        streaming=False,
+    )
+    assert chat_payload["messages"] == continuation
 
 
 def test_schemas_to_openai_tools_shape_and_empty_parameters_default():

--- a/Tests/Chat/test_chat_unit_mocked_APIs.py
+++ b/Tests/Chat/test_chat_unit_mocked_APIs.py
@@ -310,7 +310,7 @@ class TestMockedChatAPIs:
 class TestMockedChatUnit:
     """Unit tests with mocked external services to verify error handling"""
 
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_local_service_connection_handling(self, mock_post):
         """Test handling of local service connection errors"""
         # Mock connection refused error

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -1257,6 +1257,55 @@ def test_openai_usage_handoff_preserves_chat_completion_cache_details():
             "cache_creation_input_tokens": 1.5,
             "output_tokens": 3,
         },
+        {
+            "input_tokens": 9,
+            "input_token_details": {"cached_tokens": 0, "audio_tokens": True},
+            "output_tokens": 3,
+            "total_tokens": 12,
+        },
+        {
+            "input_tokens": 9,
+            "input_token_details": {
+                "cached_tokens": 2,
+                "cached_tokens_details": [],
+            },
+            "output_tokens": 3,
+            "total_tokens": 12,
+        },
+        {
+            "input_tokens": 9,
+            "input_tokens_details": {"cached_tokens": 2},
+            "output_tokens": 3,
+            "output_tokens_details": {"accepted_prediction_tokens": "1"},
+            "total_tokens": 12,
+        },
+        {
+            "input_tokens": 9,
+            "input_token_details": {"text_tokens": 9.5},
+            "output_tokens": 3,
+            "total_tokens": 12,
+        },
+        {
+            "input_tokens": 9,
+            "output_tokens": 3,
+            "output_token_details": {"image_tokens": -1},
+            "total_tokens": 12,
+        },
+        {
+            "input_tokens": 9,
+            "input_token_details": {
+                "cached_tokens": 2,
+                "cached_tokens_details": {"audio_tokens": "1"},
+            },
+            "output_tokens": 3,
+            "total_tokens": 12,
+        },
+        {
+            "input_tokens": 9,
+            "output_tokens": 3,
+            "output_tokens_details": {"rejected_prediction_tokens": False},
+            "total_tokens": 12,
+        },
     ],
     ids=(
         "bool",
@@ -1268,6 +1317,13 @@ def test_openai_usage_handoff_preserves_chat_completion_cache_details():
         "nested-float",
         "malformed-details-shape",
         "anthropic-cache-fields",
+        "boolean-audio",
+        "malformed-cached-details-shape",
+        "numeric-string-accepted-prediction",
+        "fractional-singular-text",
+        "negative-singular-image",
+        "malformed-nested-cached-count",
+        "boolean-rejected-prediction",
     ),
 )
 def test_malformed_streamed_usage_uses_agent_estimator_instead_of_coercion(
@@ -1337,9 +1393,47 @@ def test_exact_zero_streamed_usage_counts_remain_authoritative(
 ):
     usage = {
         "input_tokens": 0,
-        "input_tokens_details": {"cached_tokens": 0},
+        "input_tokens_details": {
+            "cached_tokens": 0,
+            "audio_tokens": 0,
+            "text_tokens": 0,
+            "image_tokens": 0,
+            "cached_tokens_details": {
+                "audio_tokens": 0,
+                "text_tokens": 0,
+                "image_tokens": 0,
+                "vendor_metadata": "preserved",
+            },
+        },
+        "input_token_details": {
+            "cached_tokens": 0,
+            "audio_tokens": 0,
+            "text_tokens": 0,
+            "image_tokens": 0,
+            "cached_tokens_details": {
+                "audio_tokens": 0,
+                "text_tokens": 0,
+                "image_tokens": 0,
+            },
+        },
         "output_tokens": 3,
-        "output_tokens_details": {"reasoning_tokens": 0},
+        "output_tokens_details": {
+            "reasoning_tokens": 0,
+            "audio_tokens": 0,
+            "text_tokens": 0,
+            "image_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0,
+            "vendor_metadata": "preserved",
+        },
+        "output_token_details": {
+            "reasoning_tokens": 0,
+            "audio_tokens": 0,
+            "text_tokens": 0,
+            "image_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0,
+        },
         "total_tokens": 3,
     }
 

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -1120,9 +1120,82 @@ def test_anthropic_split_usage_reaches_agent_budget_with_cache_buckets(
         {},
         {"tokens": 12},
         {"prompt_tokens": "not-a-number", "completion_tokens": -5},
+        {
+            "input_tokens": 0,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens": 0,
+            "output_tokens_details": {"reasoning_tokens": 0},
+            "total_tokens": 0,
+        },
     ],
 )
 def test_provider_usage_handoff_omits_absent_or_nonpositive_payloads(payload):
+    assert (
+        _openai_usage_from_provider_call(
+            payload,
+            provider="openai",
+            model="gpt-4.1",
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "count_key",
+    [
+        "prompt_tokens",
+        "input_tokens",
+        "completion_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+    ],
+)
+def test_budget_usage_handoff_rejects_each_malformed_top_level_count(count_key):
+    payload = {
+        "prompt_tokens": 1,
+        "input_tokens": 1,
+        "completion_tokens": 1,
+        "output_tokens": 1,
+        "total_tokens": 2,
+        count_key: "1",
+    }
+
+    assert (
+        _openai_usage_from_provider_call(
+            payload,
+            provider="openai",
+            model="gpt-4.1",
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("details_key", "details"),
+    [
+        ("prompt_tokens_details", None),
+        ("input_tokens_details", []),
+        ("input_token_details", {"cached_tokens": "1"}),
+        ("completion_tokens_details", {"cached_tokens": False}),
+        ("output_tokens_details", {"reasoning_tokens": 1.5}),
+        ("output_token_details", {"reasoning_tokens": -1}),
+    ],
+)
+def test_budget_usage_handoff_rejects_each_malformed_details_shape_or_count(
+    details_key,
+    details,
+):
+    payload = {
+        "prompt_tokens": 1,
+        "input_tokens": 1,
+        "completion_tokens": 1,
+        "output_tokens": 1,
+        "total_tokens": 2,
+        details_key: details,
+    }
+
     assert (
         _openai_usage_from_provider_call(
             payload,
@@ -1149,6 +1222,169 @@ def test_openai_usage_handoff_preserves_chat_completion_cache_details():
         "completion_tokens": 20,
         "total_tokens": 120,
     }
+
+
+@pytest.mark.parametrize(
+    "usage",
+    [
+        {"input_tokens": True, "output_tokens": 3, "total_tokens": 4},
+        {"input_tokens": "9", "output_tokens": 3, "total_tokens": 12},
+        {"input_tokens": 9.5, "output_tokens": 3, "total_tokens": 12},
+        {"input_tokens": -1, "output_tokens": 3, "total_tokens": 2},
+        {"input_tokens": 9, "output_tokens": 3, "total_tokens": "12"},
+        {
+            "input_tokens": 9,
+            "input_tokens_details": {"cached_tokens": False},
+            "output_tokens": 3,
+            "total_tokens": 12,
+        },
+        {
+            "input_tokens": 9,
+            "input_tokens_details": {"cached_tokens": 2},
+            "output_tokens": 3,
+            "output_tokens_details": {"reasoning_tokens": 1.5},
+            "total_tokens": 12,
+        },
+        {
+            "input_tokens": 9,
+            "input_tokens_details": [],
+            "output_tokens": 3,
+            "total_tokens": 12,
+        },
+        {
+            "input_tokens": 9,
+            "cache_read_input_tokens": "2",
+            "cache_creation_input_tokens": 1.5,
+            "output_tokens": 3,
+        },
+    ],
+    ids=(
+        "bool",
+        "numeric-string",
+        "fractional-float",
+        "negative",
+        "malformed-total",
+        "nested-bool",
+        "nested-float",
+        "malformed-details-shape",
+        "anthropic-cache-fields",
+    ),
+)
+def test_malformed_streamed_usage_uses_agent_estimator_instead_of_coercion(
+    tmp_path,
+    monkeypatch,
+    usage,
+):
+    estimator_calls: list[str] = []
+
+    def count_messages(*_args, **_kwargs):
+        estimator_calls.append("messages")
+        return 40
+
+    def count_text(*_args, **_kwargs):
+        estimator_calls.append("text")
+        return 2
+
+    monkeypatch.setattr(agent_service, "count_tokens_messages", count_messages)
+    monkeypatch.setattr(agent_service, "estimate_tokens", count_text)
+
+    def chat_api_call(**_kwargs):
+        return iter(
+            (
+                {"choices": [{"delta": {"content": "answer"}}]},
+                {
+                    "choices": [{"delta": {"content": ""}, "finish_reason": "stop"}],
+                    "usage": usage,
+                },
+            )
+        )
+
+    gateway = ConsoleProviderGateway(chat_api_call_fn=chat_api_call)
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway)
+    signals = ConsoleProviderStreamSignals()
+    resolution = ConsoleProviderResolution(
+        provider="OpenAI",
+        base_url="https://api.openai.com/v1",
+        model="gpt-4.1",
+        ready=True,
+        readiness_key="openai",
+        execution_key="openai",
+        api_key="openai-test-key",
+        streaming=True,
+    )
+
+    outcome = _run(
+        bridge,
+        store,
+        session,
+        aid,
+        resolution=resolution,
+        model="gpt-4.1",
+        provider_stream_signals=signals,
+    )
+
+    assert outcome.status == "done"
+    assert outcome.total_tokens == 42
+    assert estimator_calls == ["messages", "text"]
+    # The raw aggregate remains tolerant/unchanged for persistence and cost
+    # consumers; only the AgentService budget handoff fails closed.
+    assert signals.usage_payloads() == [usage]
+
+
+def test_exact_zero_streamed_usage_counts_remain_authoritative(
+    tmp_path,
+    monkeypatch,
+):
+    usage = {
+        "input_tokens": 0,
+        "input_tokens_details": {"cached_tokens": 0},
+        "output_tokens": 3,
+        "output_tokens_details": {"reasoning_tokens": 0},
+        "total_tokens": 3,
+    }
+
+    def fail_estimator(*_args, **_kwargs):
+        raise AssertionError("valid exact-integer usage must remain authoritative")
+
+    monkeypatch.setattr(agent_service, "count_tokens_messages", fail_estimator)
+    monkeypatch.setattr(agent_service, "estimate_tokens", fail_estimator)
+
+    def chat_api_call(**_kwargs):
+        return iter(
+            (
+                {"choices": [{"delta": {"content": "answer"}}]},
+                {
+                    "choices": [{"delta": {"content": ""}, "finish_reason": "stop"}],
+                    "usage": usage,
+                },
+            )
+        )
+
+    gateway = ConsoleProviderGateway(chat_api_call_fn=chat_api_call)
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway)
+    resolution = ConsoleProviderResolution(
+        provider="QwenCloud",
+        base_url="https://workspace.example.test/compatible-mode/v1",
+        model="qwen3.8-max",
+        ready=True,
+        readiness_key="qwencloud",
+        execution_key="qwencloud",
+        api_key="qwen-test-key",
+        streaming=True,
+        api_mode="responses",
+    )
+
+    outcome = _run(
+        bridge,
+        store,
+        session,
+        aid,
+        resolution=resolution,
+        model="qwen3.8-max",
+    )
+
+    assert outcome.status == "done"
+    assert outcome.total_tokens == 3
 
 
 def test_concurrent_subagent_adapter_calls_keep_terminal_usage_call_scoped(tmp_path):

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -15,6 +15,7 @@ from tldw_chatbook.Chat.console_agent_bridge import (
     FIND_LOAD_DISCOVERY_HINT,
     ConsoleAgentBridge,
     SubAgentSummary,
+    _StreamingModelAdapter,
     compose_agent_system_prompt,
     format_agent_step_marker,
     format_todo_marker,
@@ -33,6 +34,8 @@ from tldw_chatbook.Chat.console_chat_models import (
 )
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_provider_gateway import (
+    ConsoleProviderGateway,
+    ConsoleProviderResolution,
     ConsoleProviderStreamSignals,
     ProviderToolCalls,
 )
@@ -439,7 +442,10 @@ def test_run_reply_threads_session_workspace_id_end_to_end(tmp_path, monkeypatch
     # provider is built once at bridge-construction time, before any
     # session exists, so it is out of scope for a per-session binding.
     outcome = _run(
-        bridge, store, session, assistant.id,
+        bridge,
+        store,
+        session,
+        assistant.id,
         builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
     )
     assert outcome.status == "done"
@@ -467,9 +473,7 @@ def test_run_reply_refuses_write_file_in_an_ephemeral_session_end_to_end(
         config_module,
         "get_cli_setting",
         lambda section, key=None, default=None: (
-            True
-            if section == "tools" and key == "write_file_enabled"
-            else default
+            True if section == "tools" and key == "write_file_enabled" else default
         ),
     )
 
@@ -496,7 +500,10 @@ def test_run_reply_refuses_write_file_in_an_ephemeral_session_end_to_end(
         agent_runs_db=db, store=store, provider_gateway=_ChunkGateway(scripts)
     )
     outcome = _run(
-        bridge, store, session, assistant.id,
+        bridge,
+        store,
+        session,
+        assistant.id,
         builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
     )
     assert outcome.status == "done"
@@ -515,9 +522,7 @@ def test_run_reply_refuses_write_file_in_an_ephemeral_session_end_to_end(
     db2 = AgentRunsDB(tmp_path / "runs2.db", client_id="t")
     store2 = ConsoleChatStore()
     normal_session = store2.create_session()
-    store2.append_message(
-        normal_session.id, role=ConsoleMessageRole.USER, content="hi"
-    )
+    store2.append_message(normal_session.id, role=ConsoleMessageRole.USER, content="hi")
     normal_assistant = store2.append_message(
         normal_session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     )
@@ -529,7 +534,10 @@ def test_run_reply_refuses_write_file_in_an_ephemeral_session_end_to_end(
         agent_runs_db=db2, store=store2, provider_gateway=_ChunkGateway(scripts2)
     )
     outcome2 = _run(
-        bridge2, store2, normal_session, normal_assistant.id,
+        bridge2,
+        store2,
+        normal_session,
+        normal_assistant.id,
         builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
     )
     assert outcome2.status == "done"
@@ -734,13 +742,9 @@ def test_a_concurrent_child_runs_alongside_the_parent_on_its_own_loop(tmp_path):
     assistant = store.append_message(
         session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     )
-    bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=gateway
-    )
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
 
-    outcome = _run(
-        bridge, store, session, assistant.id, conversation_id="conv-overlap"
-    )
+    outcome = _run(bridge, store, session, assistant.id, conversation_id="conv-overlap")
 
     assert outcome.status == "done"
     assert outcome.final_text == "parent final"
@@ -965,6 +969,173 @@ def test_provider_stream_signal_is_never_reset_by_bridge(tmp_path):
     assert gateway.signals_seen == [signals]
     assert gateway.signal_states_seen == [True]
     assert signals.synthetic_fallback_emitted is True
+
+
+def test_qwencloud_terminal_usage_reaches_agent_native_budget_without_fallback(
+    tmp_path,
+):
+    usage = {
+        "input_tokens": 9,
+        "input_tokens_details": {"cached_tokens": 2},
+        "output_tokens": 3,
+        "output_tokens_details": {"reasoning_tokens": 1},
+        "total_tokens": 12,
+    }
+
+    def chat_api_call(**_kwargs):
+        return iter(
+            (
+                {"choices": [{"delta": {"content": "answer"}}]},
+                {
+                    "choices": [{"delta": {"content": ""}, "finish_reason": "stop"}],
+                    "usage": usage,
+                },
+            )
+        )
+
+    gateway = ConsoleProviderGateway(chat_api_call_fn=chat_api_call)
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway)
+    signals = ConsoleProviderStreamSignals()
+    resolution = ConsoleProviderResolution(
+        provider="QwenCloud",
+        base_url="https://workspace.example.test/compatible-mode/v1",
+        model="qwen3.8-max",
+        ready=True,
+        readiness_key="qwencloud",
+        execution_key="qwencloud",
+        api_key="qwen-test-key",
+        streaming=True,
+        api_mode="responses",
+    )
+
+    outcome = _run(
+        bridge,
+        store,
+        session,
+        aid,
+        resolution=resolution,
+        model="qwen3.8-max",
+        provider_stream_signals=signals,
+    )
+
+    assert outcome.status == "done"
+    assert outcome.final_text == "answer"
+    assert outcome.total_tokens == 12
+    assert store.get_message(aid).content == "answer"
+    assert signals.synthetic_fallback_emitted is False
+    assert signals.usage_payloads() == [usage]
+
+
+def test_concurrent_subagent_adapter_calls_keep_terminal_usage_call_scoped(tmp_path):
+    terminal_seen = threading.Barrier(3)
+    release_terminal = threading.Event()
+    usage_by_prompt = {"alpha": 12, "beta": 34}
+
+    def chat_api_call(**kwargs):
+        prompt = kwargs["messages_payload"][-1]["content"]
+        total = usage_by_prompt[prompt]
+
+        def stream():
+            yield {"choices": [{"delta": {"content": prompt}}]}
+            yield {
+                "choices": [{"delta": {"content": ""}, "finish_reason": "stop"}],
+                "usage": {
+                    "input_tokens": total - 3,
+                    "input_tokens_details": {"cached_tokens": total // 6},
+                    "output_tokens": 3,
+                    "output_tokens_details": {"reasoning_tokens": 1},
+                    "total_tokens": total,
+                },
+            }
+            terminal_seen.wait(timeout=5)
+            release_terminal.wait(timeout=5)
+
+        return stream()
+
+    gateway = ConsoleProviderGateway(chat_api_call_fn=chat_api_call)
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    assistant = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+    )
+    signals = ConsoleProviderStreamSignals()
+    resolution = ConsoleProviderResolution(
+        provider="QwenCloud",
+        base_url="https://workspace.example.test/compatible-mode/v1",
+        model="qwen3.8-max",
+        ready=True,
+        readiness_key="qwencloud",
+        execution_key="qwencloud",
+        api_key="qwen-test-key",
+        streaming=True,
+        api_mode="responses",
+    )
+    loop = asyncio.new_event_loop()
+    loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+    loop_thread.start()
+    adapter = _StreamingModelAdapter(
+        store=store,
+        provider_gateway=gateway,
+        resolution=resolution,
+        assistant_message_id=assistant.id,
+        should_cancel=lambda: False,
+        loop=loop,
+        provider_stream_signals=signals,
+    )
+    responses: dict[str, dict] = {}
+    errors: list[BaseException] = []
+
+    def call(prompt: str) -> None:
+        try:
+            responses[prompt] = adapter.chat_call(
+                messages_payload=[
+                    {"role": "system", "content": SUBAGENT_PROMPT_PREFIX},
+                    {"role": "user", "content": prompt},
+                ]
+            )
+        except BaseException as exc:  # noqa: BLE001 - asserted below
+            errors.append(exc)
+
+    callers = [
+        threading.Thread(target=call, args=(prompt,)) for prompt in usage_by_prompt
+    ]
+    try:
+        for caller in callers:
+            caller.start()
+        terminal_seen.wait(timeout=5)
+        assert sorted(
+            payload["total_tokens"] for payload in signals.usage_payloads()
+        ) == [12, 34]
+        release_terminal.set()
+        for caller in callers:
+            caller.join(timeout=5)
+    finally:
+        release_terminal.set()
+        for caller in callers:
+            caller.join(timeout=5)
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=2)
+        loop.close()
+
+    assert errors == []
+    assert all(not caller.is_alive() for caller in callers)
+    assert {
+        prompt: response["usage"]["total_tokens"]
+        for prompt, response in responses.items()
+    } == usage_by_prompt
+    assert responses["alpha"]["usage"] == {
+        "prompt_tokens": 9,
+        "prompt_tokens_details": {"cached_tokens": 2},
+        "completion_tokens": 3,
+        "completion_tokens_details": {"reasoning_tokens": 1},
+        "total_tokens": 12,
+    }
+    assert sorted(payload["total_tokens"] for payload in signals.usage_payloads()) == [
+        12,
+        34,
+    ]
 
 
 def test_provider_stream_signal_omission_preserves_legacy_gateway_signature(tmp_path):
@@ -1274,19 +1445,22 @@ def test_step_truncation_cuts_on_newline_and_tab_boundaries():
     text = "### Heading\n\nsome body text that keeps going well past the limit here"
     out = _truncate_step_text(text, limit=15)
     assert out.split("\u2026", 1)[0] == "### Heading"  # cut at the newline, not "so"
+
+
 def test_format_todo_marker_renders_statuses_and_active_form():
     text = format_todo_marker(
         [
             {"content": "write tests", "status": "completed"},
-            {"content": "implement", "status": "in_progress", "activeForm": "implementing"},
+            {
+                "content": "implement",
+                "status": "in_progress",
+                "activeForm": "implementing",
+            },
             {"content": "commit", "status": "pending"},
         ]
     )
     assert text == (
-        "☰ Todos (1 in progress):\n"
-        "  [x] write tests\n"
-        "  [~] implementing\n"
-        "  [ ] commit"
+        "☰ Todos (1 in progress):\n  [x] write tests\n  [~] implementing\n  [ ] commit"
     )
 
 
@@ -1315,7 +1489,8 @@ def test_append_todo_marker_appends_tool_message_to_store(tmp_path):
         session.id, [{"content": "ship it", "status": "in_progress"}]
     )
     tool_messages = [
-        m for m in store.messages_for_session(session.id)
+        m
+        for m in store.messages_for_session(session.id)
         if m.role is ConsoleMessageRole.TOOL
     ]
     assert [m.content for m in tool_messages] == [
@@ -1990,8 +2165,9 @@ def test_run_reply_wires_one_skill_file_bindings_to_both_service_and_runner(
         skills_service=skills_service,
     )
 
-    with patch.object(_BridgeSkillRunner, "__init__", spy_runner_init), patch.object(
-        AgentService, "__init__", spy_service_init
+    with (
+        patch.object(_BridgeSkillRunner, "__init__", spy_runner_init),
+        patch.object(AgentService, "__init__", spy_service_init),
     ):
         outcome = _run(
             bridge, store, session, assistant.id, conversation_id="conv-bindings"
@@ -2037,8 +2213,9 @@ def test_run_reply_seeds_turn_bindings_into_shared_object(tmp_path):
         skills_service=skills_service,
     )
 
-    with patch.object(_BridgeSkillRunner, "__init__", spy_runner_init), patch.object(
-        AgentService, "__init__", spy_service_init
+    with (
+        patch.object(_BridgeSkillRunner, "__init__", spy_runner_init),
+        patch.object(AgentService, "__init__", spy_service_init),
     ):
         outcome = _run(
             bridge,
@@ -2241,7 +2418,9 @@ def test_compose_run_registry_excludes_skill_named_like_a_runtime_tool():
             },
         ],
     }
-    registry, allowed_tools, builtin_names, _local_names = _compose_run_registry_and_allowed(context)
+    registry, allowed_tools, builtin_names, _local_names = (
+        _compose_run_registry_and_allowed(context)
+    )
     assert LOAD_TOOLS_NAME not in allowed_tools[len(builtin_names) :]
     catalog_entries = [(entry.name, entry.source) for entry in registry.list_catalog()]
     assert (LOAD_TOOLS_NAME, "skill") not in catalog_entries
@@ -2252,8 +2431,8 @@ def test_compose_run_registry_excludes_skill_named_like_a_runtime_tool():
 
 def test_compose_run_registry_and_allowed_includes_mcp_entries_when_eligible():
     mcp_provider = _FakeMCPProvider([("mcp__srv_a__search", "Search the web")])
-    registry, allowed_tools, _builtin_names, _local_names = _compose_run_registry_and_allowed(
-        {}, mcp_provider=mcp_provider
+    registry, allowed_tools, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed({}, mcp_provider=mcp_provider)
     )
     assert "mcp__srv_a__search" in allowed_tools
     catalog_entries = [(e.name, e.source) for e in registry.list_catalog()]
@@ -2266,7 +2445,9 @@ def test_compose_run_registry_and_allowed_includes_mcp_entries_when_eligible():
 def test_compose_run_registry_and_allowed_absent_mcp_provider_is_unchanged():
     """`mcp_provider=None` (the default) must not add anything -- the
     pre-P5-T6 no-MCP behavior stays byte-identical."""
-    registry, allowed_tools, _builtin_names, _local_names = _compose_run_registry_and_allowed({})
+    registry, allowed_tools, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed({})
+    )
     assert allowed_tools == ("calculator", "get_current_datetime", SPAWN_TOOL_NAME)
     assert len(registry.list_catalog()) == 2
 
@@ -2290,8 +2471,8 @@ def test_compose_run_registry_and_allowed_threads_builtin_gate_into_the_provider
     else a decision the caller's review hook stamped on that gate would
     never be visible to `invoke()`."""
     gate = _FakeBuiltinGateForRegistry(refuse=True)
-    registry, _allowed_tools, _builtin_names, _local_names = _compose_run_registry_and_allowed(
-        {}, builtin_gate=gate
+    registry, _allowed_tools, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed({}, builtin_gate=gate)
     )
     result = registry.invoke_by_name("calculator", {"expression": "6*7"})
     assert result.ok is False
@@ -2302,7 +2483,9 @@ def test_compose_run_registry_and_allowed_threads_builtin_gate_into_the_provider
 def test_compose_run_registry_and_allowed_no_builtin_gate_is_unchanged():
     """`builtin_gate=None` (the default) must not alter the pre-task-545
     no-skills/no-MCP behavior -- the provider builds its own lazy gate."""
-    registry, allowed_tools, _builtin_names, _local_names = _compose_run_registry_and_allowed({})
+    registry, allowed_tools, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed({})
+    )
     assert allowed_tools == ("calculator", "get_current_datetime", SPAWN_TOOL_NAME)
     result = registry.invoke_by_name("calculator", {"expression": "6*7"})
     assert result.ok is True
@@ -2325,10 +2508,12 @@ def test_compose_run_registry_and_allowed_threads_workspace_id_into_the_provider
     """task-6 (settings-workspaces-folder-roots spec Sec3): `workspace_id=`
     must reach the freshly-built `BuiltinToolProvider` so its `invoke()`
     binds the run's workspace around every tool call."""
-    registry, _allowed_tools, _builtin_names, _local_names = _compose_run_registry_and_allowed(
-        {},
-        builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
-        workspace_id="ws-compose",
+    registry, _allowed_tools, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed(
+            {},
+            builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
+            workspace_id="ws-compose",
+        )
     )
     # registry._providers[0] is the BuiltinToolProvider this call just built
     # (see _compose_run_registry_and_allowed's own body) -- poke a probe
@@ -2343,8 +2528,10 @@ def test_compose_run_registry_and_allowed_threads_workspace_id_into_the_provider
 def test_compose_run_registry_and_allowed_no_workspace_id_is_unchanged():
     """`workspace_id=None` (the default) must not alter the pre-task-6
     behavior -- the provider leaves the run workspace unbound."""
-    registry, _allowed_tools, _builtin_names, _local_names = _compose_run_registry_and_allowed(
-        {}, builtin_gate=_FakeBuiltinGateForRegistry(refuse=False)
+    registry, _allowed_tools, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed(
+            {}, builtin_gate=_FakeBuiltinGateForRegistry(refuse=False)
+        )
     )
     registry._providers[0]._tools["probe_workspace"] = _WorkspaceProbeTool()
     result = registry.invoke_by_name("probe_workspace", {})
@@ -2372,10 +2559,12 @@ def test_compose_run_registry_and_allowed_threads_ephemeral_into_the_provider():
     `BuiltinToolProvider` so its `invoke()` refuses the write-shaped
     built-ins for a temporary session. Mirrors ``..._threads_workspace_id_
     into_the_provider`` exactly."""
-    registry, _allowed_tools, _builtin_names, _local_names = _compose_run_registry_and_allowed(
-        {},
-        builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
-        ephemeral=True,
+    registry, _allowed_tools, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed(
+            {},
+            builtin_gate=_FakeBuiltinGateForRegistry(refuse=False),
+            ephemeral=True,
+        )
     )
     registry._providers[0]._tools["write_file"] = _StubWriteFileTool()
     result = registry.invoke_by_name("write_file", {})
@@ -2386,8 +2575,10 @@ def test_compose_run_registry_and_allowed_threads_ephemeral_into_the_provider():
 def test_compose_run_registry_and_allowed_no_ephemeral_is_unchanged():
     """`ephemeral=False` (the default) must not alter pre-F4 behavior --
     the provider dispatches the tool normally."""
-    registry, _allowed_tools, _builtin_names, _local_names = _compose_run_registry_and_allowed(
-        {}, builtin_gate=_FakeBuiltinGateForRegistry(refuse=False)
+    registry, _allowed_tools, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed(
+            {}, builtin_gate=_FakeBuiltinGateForRegistry(refuse=False)
+        )
     )
     registry._providers[0]._tools["write_file"] = _StubWriteFileTool()
     result = registry.invoke_by_name("write_file", {})
@@ -2637,8 +2828,8 @@ def test_compose_run_registry_and_allowed_excludes_mcp_name_colliding_with_built
     mcp_provider = _FakeMCPProvider(
         [("calculator", "shadowing MCP tool"), ("mcp__srv_a__search", "Search")]
     )
-    registry, allowed_tools, _builtin_names, _local_names = _compose_run_registry_and_allowed(
-        {}, mcp_provider=mcp_provider
+    registry, allowed_tools, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed({}, mcp_provider=mcp_provider)
     )
     assert allowed_tools.count("calculator") == 1
     assert "mcp__srv_a__search" in allowed_tools
@@ -2652,8 +2843,8 @@ def test_compose_run_registry_and_allowed_excludes_mcp_name_colliding_with_runti
     tool named like one of the loop's own in-loop runtime handlers must
     never become a distinct, MCP-routable catalog entry."""
     mcp_provider = _FakeMCPProvider([(LOAD_TOOLS_NAME, "shadowing MCP tool")])
-    registry, allowed_tools, builtin_names, _local_names = _compose_run_registry_and_allowed(
-        {}, mcp_provider=mcp_provider
+    registry, allowed_tools, builtin_names, _local_names = (
+        _compose_run_registry_and_allowed({}, mcp_provider=mcp_provider)
     )
     assert LOAD_TOOLS_NAME not in allowed_tools[len(builtin_names) :]
     catalog_entries = [(e.name, e.source) for e in registry.list_catalog()]
@@ -2676,8 +2867,8 @@ def test_compose_run_registry_and_allowed_excludes_mcp_name_colliding_with_skill
     mcp_provider = _FakeMCPProvider(
         [("code-review", "shadowing MCP tool"), ("mcp__srv_a__search", "Search")]
     )
-    registry, allowed_tools, _builtin_names, _local_names = _compose_run_registry_and_allowed(
-        context, mcp_provider=mcp_provider
+    registry, allowed_tools, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed(context, mcp_provider=mcp_provider)
     )
     assert allowed_tools.count("code-review") == 1
     catalog_entries = [(e.name, e.source) for e in registry.list_catalog()]
@@ -2690,8 +2881,8 @@ def test_compose_run_registry_and_allowed_all_mcp_names_colliding_skips_registra
     """When every MCP entry collides, the provider is not registered at
     all -- no dangling catalog entries the model could never reach."""
     mcp_provider = _FakeMCPProvider([("calculator", "shadowing MCP tool")])
-    registry, allowed_tools, _builtin_names, _local_names = _compose_run_registry_and_allowed(
-        {}, mcp_provider=mcp_provider
+    registry, allowed_tools, _builtin_names, _local_names = (
+        _compose_run_registry_and_allowed({}, mcp_provider=mcp_provider)
     )
     assert allowed_tools == ("calculator", "get_current_datetime", SPAWN_TOOL_NAME)
     catalog_entries = [(e.name, e.source) for e in registry.list_catalog()]
@@ -2900,9 +3091,11 @@ def test_run_reply_still_wires_stamp_scope_for_the_inline_kill_switch_path(
     harmful, not merely unnecessary.
     """
     monkeypatch.setattr(
-        agent_service, "_setting", lambda key, default: (
+        agent_service,
+        "_setting",
+        lambda key, default: (
             1 if key == agent_service.MAX_LIVE_SUBAGENTS_KEY else default
-        )
+        ),
     )
     scripts = [
         [_fence("spawn_subagent", {"task": "compute 1+1"})],  # primary turn 1
@@ -3016,9 +3209,7 @@ def test_run_reply_keeps_the_parents_mcp_verdict_across_a_concurrent_child(tmp_p
     assistant = store.append_message(
         session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     )
-    bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=gateway
-    )
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
 
     def release_then_settle():
         # The parent is about to cash in its verdict. Let the child finish
@@ -3370,7 +3561,9 @@ def _install_skills_service():
     def enforce_install_remote():
         return None
 
-    async def import_skill_file(*a, **k):  # not used (install_skill_from_url is patched)
+    async def import_skill_file(
+        *a, **k
+    ):  # not used (install_skill_from_url is patched)
         return {"name": "unused"}
 
     svc.enforce_install_remote = enforce_install_remote
@@ -3385,7 +3578,11 @@ def test_install_skill_confirm_allow_installs(tmp_path, monkeypatch):
 
     async def fake_install(url, *, scope_service, **kw):
         installed.append(url)
-        return {"name": "demo", "trust_status": "quarantined_added", "trust_blocked": True}
+        return {
+            "name": "demo",
+            "trust_status": "quarantined_added",
+            "trust_blocked": True,
+        }
 
     monkeypatch.setattr(srf, "install_skill_from_url", fake_install)
 
@@ -3397,23 +3594,33 @@ def test_install_skill_confirm_allow_installs(tmp_path, monkeypatch):
     store = ConsoleChatStore()
     session = store.ensure_session()
     store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
-    assistant = store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
     bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=_ChunkGateway(scripts),
+        agent_runs_db=db,
+        store=store,
+        provider_gateway=_ChunkGateway(scripts),
         skills_service=_install_skills_service(),
     )
     confirmed = []
 
     outcome = _run(
-        bridge, store, session, assistant.id,
+        bridge,
+        store,
+        session,
+        assistant.id,
         conversation_id="conv-install",
         request_skill_install_confirm=lambda url: confirmed.append(url) or True,
     )
     assert outcome.status == "done"
     assert confirmed == ["https://github.com/o/r"]
     assert installed == ["https://github.com/o/r"]
-    tool_msgs = [m.content for m in store.messages_for_session(session.id)
-                 if m.role == ConsoleMessageRole.TOOL]
+    tool_msgs = [
+        m.content
+        for m in store.messages_for_session(session.id)
+        if m.role == ConsoleMessageRole.TOOL
+    ]
     assert any("demo" in c and "pending" in c.lower() for c in tool_msgs)
 
 
@@ -3433,19 +3640,29 @@ def test_install_skill_confirm_deny_does_not_install(tmp_path, monkeypatch):
     store = ConsoleChatStore()
     session = store.ensure_session()
     store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
-    assistant = store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
     bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=_ChunkGateway(scripts),
+        agent_runs_db=db,
+        store=store,
+        provider_gateway=_ChunkGateway(scripts),
         skills_service=_install_skills_service(),
     )
     outcome = _run(
-        bridge, store, session, assistant.id,
+        bridge,
+        store,
+        session,
+        assistant.id,
         conversation_id="conv-deny",
         request_skill_install_confirm=lambda url: False,
     )
     assert outcome.status == "done"
-    tool_msgs = [m.content for m in store.messages_for_session(session.id)
-                 if m.role == ConsoleMessageRole.TOOL]
+    tool_msgs = [
+        m.content
+        for m in store.messages_for_session(session.id)
+        if m.role == ConsoleMessageRole.TOOL
+    ]
     assert any("declined" in c.lower() for c in tool_msgs)
 
 
@@ -3460,13 +3677,21 @@ def test_install_skill_malformed_url_never_prompts(tmp_path):
     store = ConsoleChatStore()
     session = store.ensure_session()
     store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
-    assistant = store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
     bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=_ChunkGateway(scripts),
+        agent_runs_db=db,
+        store=store,
+        provider_gateway=_ChunkGateway(scripts),
         skills_service=_install_skills_service(),
     )
     outcome = _run(
-        bridge, store, session, assistant.id, conversation_id="conv-bad",
+        bridge,
+        store,
+        session,
+        assistant.id,
+        conversation_id="conv-bad",
         request_skill_install_confirm=lambda url: prompted.append(url) or True,
     )
     assert outcome.status == "done"
@@ -3489,18 +3714,29 @@ def test_install_skill_collision_error_survives_turn(tmp_path, monkeypatch):
     store = ConsoleChatStore()
     session = store.ensure_session()
     store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
-    assistant = store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
     bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=_ChunkGateway(scripts),
+        agent_runs_db=db,
+        store=store,
+        provider_gateway=_ChunkGateway(scripts),
         skills_service=_install_skills_service(),
     )
     outcome = _run(
-        bridge, store, session, assistant.id, conversation_id="conv-exists",
+        bridge,
+        store,
+        session,
+        assistant.id,
+        conversation_id="conv-exists",
         request_skill_install_confirm=lambda url: True,
     )
     assert outcome.status == "done"  # turn survives the bare ValueError
-    tool_msgs = [m.content for m in store.messages_for_session(session.id)
-                 if m.role == ConsoleMessageRole.TOOL]
+    tool_msgs = [
+        m.content
+        for m in store.messages_for_session(session.id)
+        if m.role == ConsoleMessageRole.TOOL
+    ]
     assert any("local_skill_exists" in c for c in tool_msgs)
 
 
@@ -3520,18 +3756,29 @@ def test_install_skill_absent_without_confirm_callback(tmp_path):
     store = ConsoleChatStore()
     session = store.ensure_session()
     store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
-    assistant = store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
     bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=_ChunkGateway(scripts),
+        agent_runs_db=db,
+        store=store,
+        provider_gateway=_ChunkGateway(scripts),
         skills_service=_install_skills_service(),
     )
     outcome = _run(
-        bridge, store, session, assistant.id, conversation_id="conv-no-confirm",
+        bridge,
+        store,
+        session,
+        assistant.id,
+        conversation_id="conv-no-confirm",
         # request_skill_install_confirm intentionally omitted.
     )
     assert outcome.status == "done"
-    tool_msgs = [m.content for m in store.messages_for_session(session.id)
-                 if m.role == ConsoleMessageRole.TOOL]
+    tool_msgs = [
+        m.content
+        for m in store.messages_for_session(session.id)
+        if m.role == ConsoleMessageRole.TOOL
+    ]
     assert any("Tool not permitted: install_skill" in c for c in tool_msgs)
     assert not any("declined" in c.lower() for c in tool_msgs)
 
@@ -3609,9 +3856,7 @@ def test_combine_state_scopes_restores_both_when_the_nested_run_raises():
     assert exited == ["builtin", "mcp"]
 
 
-def test_resumed_markers_carry_the_same_full_output_as_live_ones(
-    tmp_path, monkeypatch
-):
+def test_resumed_markers_carry_the_same_full_output_as_live_ones(tmp_path, monkeypatch):
     """TASK-1860 AC#5: resume is a second door, and it has been missed before.
 
     `resume_marker_messages` re-derives markers from AgentRunsDB and builds
@@ -3660,10 +3905,7 @@ def test_resumed_markers_carry_the_same_full_output_as_live_ones(
     assert [m.content for m in resumed] == [m.content for m in live]
     assert [m.tool_output_full for m in resumed] == [
         m.tool_output_full for m in live
-    ], (
-        "a resumed marker exposes a different amount of its result than the "
-        "live one did"
-    )
+    ], "a resumed marker exposes a different amount of its result than the live one did"
 
 
 # -- task-1337: Library/RAG provider registration order and inheritance --
@@ -3849,7 +4091,9 @@ class _FleetTwoChildGateway:
     is paused.
     """
 
-    def __init__(self, parent_script, child_result, gate: threading.Event, needed: int = 2):
+    def __init__(
+        self, parent_script, child_result, gate: threading.Event, needed: int = 2
+    ):
         self._parent = list(parent_script)
         self._child_result = list(child_result)
         self._gate = gate
@@ -3941,9 +4185,7 @@ def test_fleet_snapshot_reflects_two_live_handles_in_flight_then_empty_after_run
     assistant = store.append_message(
         session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     )
-    bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=gateway
-    )
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
 
     result: dict = {}
 
@@ -4138,9 +4380,7 @@ def test_cancel_subagent_delegates_to_the_published_services_live_handle(
     assistant = store.append_message(
         session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     )
-    bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=gateway
-    )
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
 
     result: dict = {}
 
@@ -4152,9 +4392,7 @@ def test_cancel_subagent_delegates_to_the_published_services_live_handle(
     runner = threading.Thread(target=do_run, name="test-bridge-cancel-subagent-run")
     runner.start()
     try:
-        assert gateway.entered_event.wait(5), (
-            "the child never reached its gated turn"
-        )
+        assert gateway.entered_event.wait(5), "the child never reached its gated turn"
         live = bridge.fleet_snapshot("conv-cancel")
         assert len(live) == 1
         handle_id = live[0].handle_id
@@ -4318,9 +4556,7 @@ def test_live_snapshot_two_concurrent_subagents_get_distinct_run_ids_that_dont_c
     assistant = store.append_message(
         session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     )
-    bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=gateway
-    )
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
 
     result: dict = {}
 

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -16,6 +16,7 @@ from tldw_chatbook.Chat.console_agent_bridge import (
     ConsoleAgentBridge,
     SubAgentSummary,
     _StreamingModelAdapter,
+    _openai_usage_from_provider_call,
     compose_agent_system_prompt,
     format_agent_step_marker,
     format_todo_marker,
@@ -1024,6 +1025,130 @@ def test_qwencloud_terminal_usage_reaches_agent_native_budget_without_fallback(
     assert store.get_message(aid).content == "answer"
     assert signals.synthetic_fallback_emitted is False
     assert signals.usage_payloads() == [usage]
+
+
+@pytest.mark.parametrize(
+    ("cache_creation_input_tokens", "expected_total"),
+    [(0, 10_954), (111, 11_065)],
+    ids=("cache-read", "cache-read-and-creation"),
+)
+def test_anthropic_split_usage_reaches_agent_budget_with_cache_buckets(
+    tmp_path,
+    monkeypatch,
+    cache_creation_input_tokens,
+    expected_total,
+):
+    estimator_calls: list[str] = []
+    captured_usage: list[dict] = []
+
+    def fail_estimator(*_args, **_kwargs):
+        estimator_calls.append("called")
+        raise AssertionError("provider usage must bypass the local estimator")
+
+    monkeypatch.setattr(agent_service, "count_tokens_messages", fail_estimator)
+    monkeypatch.setattr(agent_service, "estimate_tokens", fail_estimator)
+    real_usage_total_tokens = agent_service._usage_total_tokens
+
+    def capture_usage(response):
+        captured_usage.append(response["usage"])
+        return real_usage_total_tokens(response)
+
+    monkeypatch.setattr(agent_service, "_usage_total_tokens", capture_usage)
+    input_usage = {
+        "input_tokens": 3_571,
+        "cache_read_input_tokens": 6_656,
+        "cache_creation_input_tokens": cache_creation_input_tokens,
+    }
+    output_usage = {"output_tokens": 727}
+
+    def chat_api_call(**_kwargs):
+        return iter(
+            (
+                {"choices": [], "usage": input_usage},
+                {"choices": [{"delta": {"content": "answer"}}]},
+                {
+                    "choices": [{"delta": {"content": ""}, "finish_reason": "stop"}],
+                    "usage": output_usage,
+                },
+            )
+        )
+
+    gateway = ConsoleProviderGateway(chat_api_call_fn=chat_api_call)
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway)
+    signals = ConsoleProviderStreamSignals()
+    resolution = ConsoleProviderResolution(
+        provider="Anthropic",
+        base_url="",
+        model="claude-sonnet-4-6",
+        ready=True,
+        readiness_key="anthropic",
+        execution_key="anthropic",
+        api_key="anthropic-test-key",
+        streaming=True,
+    )
+
+    outcome = _run(
+        bridge,
+        store,
+        session,
+        aid,
+        resolution=resolution,
+        model="claude-sonnet-4-6",
+        provider_stream_signals=signals,
+    )
+
+    assert outcome.status == "done"
+    assert outcome.final_text == "answer"
+    assert outcome.total_tokens == expected_total
+    assert estimator_calls == []
+    assert captured_usage == [
+        {
+            "prompt_tokens": 3_571 + 6_656 + cache_creation_input_tokens,
+            "prompt_tokens_details": {"cached_tokens": 6_656},
+            "completion_tokens": 727,
+            "total_tokens": expected_total,
+        }
+    ]
+    assert signals.synthetic_fallback_emitted is False
+    assert signals.usage_payloads() == [{**input_usage, **output_usage}]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        {},
+        {"tokens": 12},
+        {"prompt_tokens": "not-a-number", "completion_tokens": -5},
+    ],
+)
+def test_provider_usage_handoff_omits_absent_or_nonpositive_payloads(payload):
+    assert (
+        _openai_usage_from_provider_call(
+            payload,
+            provider="openai",
+            model="gpt-4.1",
+        )
+        is None
+    )
+
+
+def test_openai_usage_handoff_preserves_chat_completion_cache_details():
+    assert _openai_usage_from_provider_call(
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "total_tokens": 120,
+            "prompt_tokens_details": {"cached_tokens": 80},
+        },
+        provider="openai",
+        model="gpt-4.1",
+    ) == {
+        "prompt_tokens": 100,
+        "prompt_tokens_details": {"cached_tokens": 80},
+        "completion_tokens": 20,
+        "total_tokens": 120,
+    }
 
 
 def test_concurrent_subagent_adapter_calls_keep_terminal_usage_call_scoped(tmp_path):

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -961,6 +961,56 @@ async def test_qwencloud_resolution_rejects_invalid_mode_before_dispatch(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "configured_base_url",
+    [42, False, [], {}, "", "   ", None],
+    ids=("integer", "boolean", "list", "mapping", "empty", "whitespace", "none"),
+)
+async def test_qwencloud_resolution_rejects_present_malformed_saved_base_before_network_or_dispatch(
+    configured_base_url: object,
+) -> None:
+    requests: list[httpx.Request] = []
+    dispatches: list[dict[str, object]] = []
+
+    async def network_trap(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"data": [{"id": "unexpected-model"}]})
+
+    def dispatch_trap(**kwargs: object) -> object:
+        dispatches.append(dict(kwargs))
+        return {"choices": [{"message": {"content": "unexpected"}}]}
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(network_trap)) as client:
+        gateway = ConsoleProviderGateway(
+            http_client=client,
+            config_provider=lambda: {
+                "api_settings": {
+                    "qwencloud": {
+                        "api_key": "QWENCLOUD-KEY-CANARY",
+                        "api_mode": "responses",
+                        "api_base_url": configured_base_url,
+                        "model": "PAYLOAD-MODEL-CANARY",
+                    }
+                }
+            },
+            environ={},
+            chat_api_call_fn=dispatch_trap,
+        )
+
+        resolved = await gateway.resolve_for_send(
+            ConsoleProviderSelection(provider="QwenCloud")
+        )
+
+    assert resolved.ready is False
+    assert "QwenCloud" in resolved.visible_copy
+    assert "API base URL" in resolved.visible_copy
+    assert "QWENCLOUD-KEY-CANARY" not in resolved.visible_copy
+    assert "PAYLOAD-MODEL-CANARY" not in resolved.visible_copy
+    assert requests == []
+    assert dispatches == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("provider", "model", "settings"),
     [
         ("openai", "gpt-4.1", {"api_key": "openai-key"}),
@@ -3791,6 +3841,155 @@ async def test_qwencloud_responses_terminal_usage_reaches_console_signals_withou
     assert normalized.uncached_input == 7
     assert normalized.cache_read == 2
     assert normalized.output == 3
+
+
+class _FirstNextBlockingCloseTrackingIterator:
+    def __init__(self) -> None:
+        self.next_entered = threading.Event()
+        self.released = threading.Event()
+        self.closed = threading.Event()
+        self._state_lock = threading.Lock()
+        self.next_calls = 0
+        self.close_calls = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        with self._state_lock:
+            self.next_calls += 1
+        self.next_entered.set()
+        self.released.wait(timeout=5)
+        raise StopIteration
+
+    def close(self) -> None:
+        with self._state_lock:
+            self.close_calls += 1
+        self.closed.set()
+        self.released.set()
+
+
+@pytest.mark.asyncio
+async def test_gateway_cancellation_before_qwencloud_iterator_retention_closes_without_iteration() -> (
+    None
+):
+    provider_call_entered = threading.Event()
+    allow_provider_return = threading.Event()
+    provider_iterator = _FirstNextBlockingCloseTrackingIterator()
+
+    def delayed_chat_api_call(**_kwargs):
+        provider_call_entered.set()
+        allow_provider_return.wait(timeout=5)
+        return provider_iterator
+
+    gateway = ConsoleProviderGateway(chat_api_call_fn=delayed_chat_api_call)
+    resolution = ConsoleProviderResolution(
+        provider="QwenCloud",
+        base_url="https://workspace.example.test/compatible-mode/v1",
+        model="qwen3.8-max",
+        ready=True,
+        readiness_key="qwencloud",
+        execution_key="qwencloud",
+        api_key="qwen-test-key",
+        streaming=True,
+        api_mode="responses",
+    )
+    stream = gateway.stream_chat(
+        resolution,
+        [{"role": "user", "content": "hi"}],
+    )
+    pending = asyncio.create_task(anext(stream))
+
+    try:
+        assert await asyncio.to_thread(provider_call_entered.wait, 1)
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+
+        allow_provider_return.set()
+        for _ in range(100):
+            if (
+                provider_iterator.closed.is_set()
+                or provider_iterator.next_entered.is_set()
+            ):
+                break
+            await asyncio.sleep(0.01)
+
+        assert provider_iterator.next_calls == 0
+        assert provider_iterator.closed.is_set()
+        assert provider_iterator.close_calls == 1
+        await stream.aclose()
+        assert provider_iterator.close_calls == 1
+    finally:
+        allow_provider_return.set()
+        if provider_iterator.next_entered.is_set():
+            provider_iterator.released.set()
+        if not pending.done():
+            pending.cancel()
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_gateway_cancellation_after_retention_before_normalization_does_not_iterate(
+    monkeypatch,
+) -> None:
+    normalization_entered = threading.Event()
+    allow_normalization = threading.Event()
+    provider_iterator = _FirstNextBlockingCloseTrackingIterator()
+    gateway = ConsoleProviderGateway(
+        chat_api_call_fn=lambda **_kwargs: provider_iterator
+    )
+    original_normalize = gateway.normalize_provider_response
+
+    def paused_normalize(response, *, suppress_fallback_copy=False, signals=None):
+        normalization_entered.set()
+        allow_normalization.wait(timeout=5)
+        return original_normalize(
+            response,
+            suppress_fallback_copy=suppress_fallback_copy,
+            signals=signals,
+        )
+
+    monkeypatch.setattr(gateway, "normalize_provider_response", paused_normalize)
+    resolution = ConsoleProviderResolution(
+        provider="QwenCloud",
+        base_url="https://workspace.example.test/compatible-mode/v1",
+        model="qwen3.8-max",
+        ready=True,
+        readiness_key="qwencloud",
+        execution_key="qwencloud",
+        api_key="qwen-test-key",
+        streaming=True,
+        api_mode="responses",
+    )
+    stream = gateway.stream_chat(
+        resolution,
+        [{"role": "user", "content": "hi"}],
+    )
+    pending = asyncio.create_task(anext(stream))
+
+    try:
+        assert await asyncio.to_thread(normalization_entered.wait, 1)
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+        assert provider_iterator.closed.wait(timeout=1)
+        assert provider_iterator.close_calls == 1
+
+        allow_normalization.set()
+        for _ in range(20):
+            if provider_iterator.next_entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert provider_iterator.next_calls == 0
+        await stream.aclose()
+        assert provider_iterator.close_calls == 1
+    finally:
+        allow_normalization.set()
+        provider_iterator.released.set()
+        if not pending.done():
+            pending.cancel()
+        await stream.aclose()
 
 
 class _BlockingCloseTrackingIterator:

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -864,6 +864,277 @@ async def test_resolve_for_send_reads_config_provider_at_resolution_time() -> No
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "selected_base_url",
+    [
+        "https://workspace.example.test/compatible-mode/v1",
+        "https://workspace.example.test/compatible-mode/v1/responses",
+        "https://workspace.example.test/compatible-mode/v1/chat/completions/",
+    ],
+)
+async def test_qwencloud_resolution_pins_normalized_mode_and_base(
+    selected_base_url: str,
+) -> None:
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {
+            "api_settings": {
+                "qwencloud": {
+                    "api_key": "qwen-test-key",
+                    "api_mode": "  ReSpOnSeS  ",
+                    "api_base_url": (
+                        "https://workspace.example.test/compatible-mode/v1"
+                    ),
+                    "model": "qwen3.8-max",
+                }
+            }
+        },
+        environ={},
+    )
+
+    resolved = await gateway.resolve_for_send(
+        ConsoleProviderSelection(
+            provider="QwenCloud",
+            base_url=selected_base_url,
+        )
+    )
+
+    assert resolved.ready is True
+    assert resolved.execution_key == "qwencloud"
+    assert resolved.api_mode == "responses"
+    assert resolved.base_url == "https://workspace.example.test/compatible-mode/v1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("settings", "setting_copy"),
+    [
+        (
+            {
+                "api_mode": "response",
+                "api_base_url": ("https://workspace.example.test/compatible-mode/v1"),
+            },
+            "API mode",
+        ),
+        (
+            {
+                "api_mode": "responses",
+                "api_base_url": (
+                    "https://workspace.example.test/compatible-mode/v1?token="
+                    "ENDPOINT-PAYLOAD-CANARY"
+                ),
+            },
+            "API base URL",
+        ),
+    ],
+)
+async def test_qwencloud_resolution_rejects_invalid_mode_before_dispatch(
+    settings: dict[str, str],
+    setting_copy: str,
+) -> None:
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {
+            "api_settings": {
+                "qwencloud": {
+                    **settings,
+                    "api_key": "QWENCLOUD-KEY-CANARY",
+                    "model": "PAYLOAD-MODEL-CANARY",
+                }
+            }
+        },
+        environ={},
+        chat_api_call_fn=lambda **_kwargs: pytest.fail(
+            "invalid QwenCloud settings must fail before dispatch"
+        ),
+    )
+
+    resolved = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider="QwenCloud")
+    )
+
+    assert resolved.ready is False
+    assert "QwenCloud" in resolved.visible_copy
+    assert setting_copy in resolved.visible_copy
+    assert "QWENCLOUD-KEY-CANARY" not in resolved.visible_copy
+    assert "PAYLOAD-MODEL-CANARY" not in resolved.visible_copy
+    assert "ENDPOINT-PAYLOAD-CANARY" not in resolved.visible_copy
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "model", "settings"),
+    [
+        ("openai", "gpt-4.1", {"api_key": "openai-key"}),
+        ("deepseek", "deepseek-chat", {"api_key": "deepseek-key"}),
+        ("anthropic", "claude-sonnet-4-6", {"api_key": "anthropic-key"}),
+    ],
+)
+async def test_non_qwen_resolutions_omit_api_mode(
+    provider: str,
+    model: str,
+    settings: dict[str, str],
+) -> None:
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {
+            "api_settings": {provider: {**settings, "model": model}}
+        },
+        environ={},
+    )
+
+    resolved = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider=provider)
+    )
+
+    assert resolved.ready is True
+    assert resolved.api_mode is None
+
+
+@pytest.mark.asyncio
+async def test_all_qwencloud_kwargs_paths_forward_pinned_mode_and_base() -> None:
+    pinned_base = "https://workspace-a.example.test/compatible-mode/v1"
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {
+            "api_settings": {
+                "qwencloud": {
+                    "api_key": "qwen-test-key",
+                    "api_mode": "responses",
+                    "api_base_url": f"{pinned_base}/responses",
+                    "model": "qwen3.8-max",
+                }
+            }
+        },
+        environ={},
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider="QwenCloud")
+    )
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Hello."},
+    ]
+    prepared = gateway.prepare_chat_request(resolution, messages)
+    auxiliary = AuxiliaryCompletionRequest(
+        resolution=resolution,
+        messages=tuple(messages),
+        response_format=None,
+        max_output_tokens=64,
+    )
+
+    kwargs_paths = (
+        gateway._chat_api_kwargs_from_prepared(resolution, prepared),
+        gateway._chat_api_kwargs(resolution, messages),
+        gateway._auxiliary_chat_api_kwargs(auxiliary, resolution),
+    )
+
+    for kwargs in kwargs_paths:
+        assert kwargs["api_mode"] == "responses"
+        assert kwargs["api_base_url"] == pinned_base
+
+    for provider, base_url in (
+        ("openai", "https://api.openai.com/v1"),
+        ("deepseek", "https://api.deepseek.com"),
+        ("anthropic", "https://api.anthropic.com/v1"),
+    ):
+        other = dataclasses.replace(
+            resolution,
+            provider=provider,
+            readiness_key=provider,
+            execution_key=provider,
+            base_url=base_url,
+            api_mode=None,
+        )
+        other_prepared = gateway.prepare_chat_request(other, messages)
+        other_auxiliary = AuxiliaryCompletionRequest(
+            resolution=other,
+            messages=tuple(messages),
+            response_format=None,
+            max_output_tokens=64,
+        )
+        primary_kwargs = gateway._chat_api_kwargs(other, messages)
+        prepared_kwargs = gateway._chat_api_kwargs_from_prepared(
+            other,
+            other_prepared,
+        )
+        auxiliary_kwargs = gateway._auxiliary_chat_api_kwargs(
+            other_auxiliary,
+            other,
+        )
+
+        assert "api_mode" not in primary_kwargs
+        assert "api_mode" not in prepared_kwargs
+        assert "api_mode" not in auxiliary_kwargs
+        if provider == "anthropic":
+            assert primary_kwargs["api_base_url"] == base_url
+            assert prepared_kwargs["api_base_url"] == base_url
+        else:
+            assert "api_base_url" not in primary_kwargs
+            assert "api_base_url" not in prepared_kwargs
+        assert auxiliary_kwargs["api_base_url"] == base_url
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_run_ignores_midrun_config_mutation() -> None:
+    base_a = "https://workspace-a.example.test/compatible-mode/v1"
+    config: dict[str, object] = {
+        "api_settings": {
+            "qwencloud": {
+                "api_key": "qwen-test-key",
+                "api_mode": "responses",
+                "api_base_url": base_a,
+                "model": "qwen3.8-max",
+            }
+        }
+    }
+    calls: list[dict[str, object]] = []
+
+    def fake_chat_api_call(**kwargs: object) -> dict[str, object]:
+        calls.append(dict(kwargs))
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: config,
+        environ={},
+        chat_api_call_fn=fake_chat_api_call,
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider="QwenCloud", streaming=False)
+    )
+    config["api_settings"] = {
+        "qwencloud": {
+            "api_key": "mutated-key",
+            "api_mode": "chat_completions",
+            "api_base_url": (
+                "https://workspace-b.example.test/compatible-mode/v1/chat/completions"
+            ),
+            "model": "mutated-model",
+        }
+    }
+
+    for content in ("turn one", "turn two"):
+        assert [
+            chunk
+            async for chunk in gateway.stream_chat(
+                resolution,
+                [{"role": "user", "content": content}],
+            )
+        ] == ["ok"]
+
+    auxiliary = AuxiliaryCompletionRequest(
+        resolution=resolution,
+        messages=({"role": "user", "content": "auxiliary"},),
+        response_format=None,
+        max_output_tokens=64,
+    )
+    assert (await gateway.complete_auxiliary(auxiliary)).text == "ok"
+
+    assert len(calls) == 3
+    for call in calls:
+        assert call["api_mode"] == "responses"
+        assert call["api_base_url"] == base_a
+        assert call["api_key"] == "qwen-test-key"
+        assert call["model"] == "qwen3.8-max"
+
+
+@pytest.mark.asyncio
 async def test_llamacpp_stream_chat_yields_content_chunks():
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/v1/chat/completions"
@@ -2380,9 +2651,9 @@ def test_concurrent_live_loops_never_close_each_others_client():
 
     assert errors == [], f"unexpected errors from worker threads: {errors!r}"
     assert "a" in obtained and "b" in obtained, "both loops must obtain a client"
-    assert (
-        obtained["a"] is not obtained["b"]
-    ), "two live loops must never share the same owned http client"
+    assert obtained["a"] is not obtained["b"], (
+        "two live loops must never share the same owned http client"
+    )
     assert obtained["a"].is_closed is False, (
         "loop A's client was closed while loop B was concurrently alive and "
         "touching the shared gateway -- a live loop must never close "
@@ -2776,6 +3047,94 @@ def test_tool_call_accumulator_preserves_extra_fragment_keys() -> None:
     assert call["google_thought_signature"] == ""
     assert "arbitrary_extra" not in call
     assert "none_extra" not in call
+
+
+class _CloseTrackingIterator:
+    def __init__(
+        self,
+        items: list[object],
+        *,
+        failure: BaseException | None = None,
+        close_failure: Exception | None = None,
+    ) -> None:
+        self._items = iter(items)
+        self._failure = failure
+        self._close_failure = close_failure
+        self.close_calls = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            return next(self._items)
+        except StopIteration:
+            if self._failure is not None:
+                failure, self._failure = self._failure, None
+                raise failure
+            raise
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self._close_failure is not None:
+            raise self._close_failure
+
+
+def test_tee_tool_calls_closes_underlying_iterator_once() -> None:
+    payload = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    exhausted = _CloseTrackingIterator([payload])
+    exhausted_accumulator = gateway_module._ToolCallAccumulator()
+    exhausted_tee = gateway_module._tee_tool_calls(
+        exhausted,
+        exhausted_accumulator,
+    )
+    assert list(exhausted_tee) == [payload]
+    assert exhausted_accumulator.calls()[0]["id"] == "call-1"
+    assert exhausted.close_calls == 1
+    exhausted_tee.close()
+    assert exhausted.close_calls == 1
+
+    provider_failure = RuntimeError("provider-primary-error")
+    failed = _CloseTrackingIterator(
+        [],
+        failure=provider_failure,
+        close_failure=RuntimeError("close-secondary-error"),
+    )
+    failed_tee = gateway_module._tee_tool_calls(
+        failed,
+        gateway_module._ToolCallAccumulator(),
+    )
+    with pytest.raises(RuntimeError, match="provider-primary-error"):
+        next(failed_tee)
+    assert failed.close_calls == 1
+    failed_tee.close()
+    assert failed.close_calls == 1
+
+    caller_closed = _CloseTrackingIterator([payload, payload])
+    caller_closed_tee = gateway_module._tee_tool_calls(
+        caller_closed,
+        gateway_module._ToolCallAccumulator(),
+    )
+    assert next(caller_closed_tee) == payload
+    caller_closed_tee.close()
+    caller_closed_tee.close()
+    assert caller_closed.close_calls == 1
 
 
 @pytest.mark.asyncio
@@ -3371,6 +3730,164 @@ async def test_non_streaming_mapping_response_records_usage() -> None:
     ]
     assert chunks == ["hello"]
     assert signals.usage_payloads() == [{"prompt_tokens": 10, "completion_tokens": 2}]
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_responses_terminal_usage_reaches_console_signals_without_copy() -> (
+    None
+):
+    usage = {
+        "input_tokens": 9,
+        "input_tokens_details": {"cached_tokens": 2},
+        "output_tokens": 3,
+        "output_tokens_details": {"reasoning_tokens": 1},
+        "total_tokens": 12,
+    }
+    terminal = {
+        "choices": [{"delta": {"content": ""}, "finish_reason": "stop"}],
+        "usage": usage,
+    }
+
+    def fake_chat_api_call(**_kwargs):
+        return iter(
+            (
+                {"choices": [{"delta": {"content": "answer"}}]},
+                terminal,
+            )
+        )
+
+    gateway = ConsoleProviderGateway(chat_api_call_fn=fake_chat_api_call)
+    resolution = ConsoleProviderResolution(
+        provider="QwenCloud",
+        base_url="https://workspace.example.test/compatible-mode/v1",
+        model="qwen3.8-max",
+        ready=True,
+        readiness_key="qwencloud",
+        execution_key="qwencloud",
+        api_key="qwen-test-key",
+        streaming=True,
+        api_mode="responses",
+    )
+    signals = ConsoleProviderStreamSignals()
+
+    chunks = [
+        chunk
+        async for chunk in gateway.stream_chat(
+            resolution,
+            [{"role": "user", "content": "hi"}],
+            signals=signals,
+        )
+    ]
+
+    assert chunks == ["answer"]
+    assert signals.synthetic_fallback_emitted is False
+    assert signals.usage_payloads() == [usage]
+    normalized = ProviderUsage.from_provider_payload(
+        signals.usage_payloads()[0],
+        provider="qwencloud",
+        model="qwen3.8-max",
+    )
+    assert normalized is not None
+    assert normalized.uncached_input == 7
+    assert normalized.cache_read == 2
+    assert normalized.output == 3
+
+
+class _BlockingCloseTrackingIterator:
+    def __init__(self) -> None:
+        self._first = True
+        self.blocked = threading.Event()
+        self.released = threading.Event()
+        self.closed = threading.Event()
+        self._close_lock = threading.Lock()
+        self.close_calls = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._first:
+            self._first = False
+            return {"choices": [{"delta": {"content": "partial"}}]}
+        self.blocked.set()
+        self.released.wait(timeout=5)
+        raise StopIteration
+
+    def close(self) -> None:
+        with self._close_lock:
+            self.close_calls += 1
+        self.closed.set()
+        self.released.set()
+
+
+@pytest.mark.asyncio
+async def test_gateway_cancellation_closes_qwencloud_iterator() -> None:
+    provider_iterator = _BlockingCloseTrackingIterator()
+    gateway = ConsoleProviderGateway(
+        chat_api_call_fn=lambda **_kwargs: provider_iterator
+    )
+    resolution = ConsoleProviderResolution(
+        provider="QwenCloud",
+        base_url="https://workspace.example.test/compatible-mode/v1",
+        model="qwen3.8-max",
+        ready=True,
+        readiness_key="qwencloud",
+        execution_key="qwencloud",
+        api_key="qwen-test-key",
+        streaming=True,
+        api_mode="responses",
+    )
+    stream = gateway.stream_chat(
+        resolution,
+        [{"role": "user", "content": "hi"}],
+    )
+
+    pending: asyncio.Task[object] | None = None
+    try:
+        assert await anext(stream) == "partial"
+        for _ in range(100):
+            if provider_iterator.blocked.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert provider_iterator.blocked.is_set()
+
+        pending = asyncio.create_task(anext(stream))
+        await asyncio.sleep(0)
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+
+        for _ in range(100):
+            if provider_iterator.closed.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert provider_iterator.closed.is_set()
+        assert provider_iterator.close_calls == 1
+
+        await stream.aclose()
+        assert provider_iterator.close_calls == 1
+    finally:
+        if pending is not None and not pending.done():
+            pending.cancel()
+        provider_iterator.released.set()
+        await stream.aclose()
+
+
+def test_qwencloud_total_tokens_reaches_agent_usage_counter() -> None:
+    from tldw_chatbook.Agents.agent_service import _usage_total_tokens
+
+    terminal = {
+        "choices": [{"delta": {"content": ""}, "finish_reason": "stop"}],
+        "usage": {
+            "input_tokens": 9,
+            "input_tokens_details": {"cached_tokens": 2},
+            "output_tokens": 3,
+            "output_tokens_details": {"reasoning_tokens": 1},
+            "total_tokens": 12,
+        },
+    }
+
+    assert _usage_total_tokens(terminal) == 12
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -1,6 +1,7 @@
 import asyncio
 import builtins
 import dataclasses
+from copy import deepcopy
 import http.server
 import json
 import threading
@@ -935,6 +936,84 @@ async def test_qwencloud_resolution_prefers_canonical_fields_and_alias_fallbacks
     assert resolved.api_mode == "chat_completions"
     assert resolved.model == "qwen-alias-model"
     assert resolved.base_url == "https://alias.example.test/compatible-mode/v1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("canonical_first", [False, True])
+async def test_qwencloud_resolution_blocks_malformed_canonical_table_without_alias_leakage(
+    canonical_first: bool,
+) -> None:
+    alias = {
+        "api_key": "ALIAS-SECRET-CANARY",
+        "model": "ALIAS-MODEL-CANARY",
+    }
+    entries = (
+        [("qwencloud", []), ("QwenCloud", alias)]
+        if canonical_first
+        else [("QwenCloud", alias), ("qwencloud", [])]
+    )
+    source = {"api_settings": dict(entries)}
+    original = deepcopy(source)
+    gateway = ConsoleProviderGateway(config_provider=lambda: source, environ={})
+
+    resolved = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider="QwenCloud")
+    )
+
+    assert source == original
+    assert resolved.ready is False
+    assert "provider settings" in resolved.visible_copy.lower()
+    assert "api_settings.qwencloud" in resolved.visible_copy
+    assert "ALIAS-SECRET-CANARY" not in resolved.visible_copy
+    assert "ALIAS-MODEL-CANARY" not in resolved.visible_copy
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("canonical_first", [False, True])
+async def test_qwencloud_resolution_ignores_malformed_alias_when_canonical_is_valid(
+    canonical_first: bool,
+) -> None:
+    canonical = {
+        "api_key": "canonical-key",
+        "api_mode": "responses",
+        "api_base_url": "https://canonical.example.test/compatible-mode/v1",
+        "model": "canonical-model",
+    }
+    entries = (
+        [("qwencloud", canonical), ("QwenCloud", [])]
+        if canonical_first
+        else [("QwenCloud", []), ("qwencloud", canonical)]
+    )
+    source = {"api_settings": dict(entries)}
+    original = deepcopy(source)
+    gateway = ConsoleProviderGateway(config_provider=lambda: source, environ={})
+
+    resolved = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider="QwenCloud")
+    )
+
+    assert source == original
+    assert resolved.ready is True
+    assert resolved.api_key == "canonical-key"
+    assert resolved.model == "canonical-model"
+    assert resolved.base_url == "https://canonical.example.test/compatible-mode/v1"
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_resolution_blocks_alias_only_malformed_table():
+    source = {"api_settings": {"QwenCloud": ["SECRET-CANARY"]}}
+    original = deepcopy(source)
+    gateway = ConsoleProviderGateway(config_provider=lambda: source, environ={})
+
+    resolved = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider="QwenCloud")
+    )
+
+    assert source == original
+    assert resolved.ready is False
+    assert "provider settings" in resolved.visible_copy.lower()
+    assert "api_settings.qwencloud" in resolved.visible_copy
+    assert "SECRET-CANARY" not in resolved.visible_copy
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -3177,6 +3177,18 @@ class _CloseableMapping(dict):
             raise self.close_failure
 
 
+class _BlockingAccumulator:
+    def __init__(self) -> None:
+        self.feed_entered = threading.Event()
+        self.release_feed = threading.Event()
+        self.payloads: list[object] = []
+
+    def feed_payload(self, payload: object) -> None:
+        self.feed_entered.set()
+        self.release_feed.wait(timeout=5)
+        self.payloads.append(payload)
+
+
 def test_tee_tool_calls_explicit_close_stops_future_iteration() -> None:
     underlying = _CloseTrackingIterator([{"content": "late"}])
     accumulator = _RecordingAccumulator()
@@ -3214,6 +3226,92 @@ def test_tee_tool_calls_discards_item_returned_after_concurrent_close() -> None:
     assert len(outcomes) == 1 and isinstance(outcomes[0], StopIteration)
     assert underlying.close_calls == 1
     assert accumulator.payloads == []
+
+
+def test_tee_tool_calls_close_is_prompt_while_accumulator_feed_is_blocked() -> None:
+    payload = {"choices": [{"delta": {"content": "late"}}]}
+    underlying = _CloseTrackingIterator([payload])
+    accumulator = _BlockingAccumulator()
+    tee = gateway_module._tee_tool_calls(underlying, accumulator)
+    outcomes: list[object] = []
+    close_finished = threading.Event()
+
+    def consume() -> None:
+        try:
+            outcomes.append(next(tee))
+        except BaseException as exc:  # noqa: BLE001 - asserted below
+            outcomes.append(exc)
+
+    def close() -> None:
+        tee.close()
+        close_finished.set()
+
+    consumer = threading.Thread(target=consume)
+    closer = threading.Thread(target=close)
+    consumer.start()
+    assert accumulator.feed_entered.wait(timeout=1)
+    closer.start()
+    try:
+        assert close_finished.wait(timeout=0.5)
+        assert underlying.close_calls == 1
+    finally:
+        accumulator.release_feed.set()
+        consumer.join(timeout=1)
+        closer.join(timeout=1)
+
+    assert not consumer.is_alive()
+    assert not closer.is_alive()
+    assert len(outcomes) == 1 and isinstance(outcomes[0], StopIteration)
+    # The feed was already running when close sealed the tee, so it may finish
+    # its own work; the sealed item must still never be returned.
+    assert accumulator.payloads == [payload]
+    tee.close()
+    assert underlying.close_calls == 1
+
+
+@pytest.mark.parametrize("close_stage", ["decode", "feed"])
+def test_tee_tool_calls_reentrant_close_does_not_deadlock(
+    close_stage,
+    monkeypatch,
+) -> None:
+    payload = {"choices": [{"delta": {"content": "late"}}]}
+    underlying = _CloseTrackingIterator([payload])
+    accumulator = _RecordingAccumulator()
+    tee_holder: dict[str, object] = {}
+
+    if close_stage == "decode":
+
+        def close_during_decode(item):
+            tee_holder["tee"].close()
+            return item
+
+        monkeypatch.setattr(gateway_module, "_decode_stream_item", close_during_decode)
+    else:
+
+        def close_during_feed(item):
+            tee_holder["tee"].close()
+            accumulator.payloads.append(item)
+
+        accumulator.feed_payload = close_during_feed
+
+    tee = gateway_module._tee_tool_calls(underlying, accumulator)
+    tee_holder["tee"] = tee
+    outcomes: list[object] = []
+
+    def consume() -> None:
+        try:
+            outcomes.append(next(tee))
+        except BaseException as exc:  # noqa: BLE001 - asserted below
+            outcomes.append(exc)
+
+    consumer = threading.Thread(target=consume, daemon=True)
+    consumer.start()
+    consumer.join(timeout=0.5)
+
+    assert not consumer.is_alive()
+    assert len(outcomes) == 1 and isinstance(outcomes[0], StopIteration)
+    assert underlying.close_calls == 1
+    assert accumulator.payloads == ([] if close_stage == "decode" else [payload])
 
 
 @pytest.mark.parametrize("failure_stage", ["decode", "feed"])

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -905,6 +905,39 @@ async def test_qwencloud_resolution_pins_normalized_mode_and_base(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("canonical_first", [False, True])
+async def test_qwencloud_resolution_prefers_canonical_fields_and_alias_fallbacks(
+    canonical_first: bool,
+) -> None:
+    alias = {
+        "api_key": "alias-key",
+        "api_mode": "responses",
+        "api_base_url": "https://alias.example.test/compatible-mode/v1",
+        "model": "qwen-alias-model",
+    }
+    canonical = {"api_mode": "chat_completions"}
+    entries = (
+        [("qwencloud", canonical), ("QwenCloud", alias)]
+        if canonical_first
+        else [("QwenCloud", alias), ("qwencloud", canonical)]
+    )
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {"api_settings": dict(entries)},
+        environ={},
+    )
+
+    resolved = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider="QwenCloud")
+    )
+
+    assert resolved.ready is True
+    assert resolved.api_key == "alias-key"
+    assert resolved.api_mode == "chat_completions"
+    assert resolved.model == "qwen-alias-model"
+    assert resolved.base_url == "https://alias.example.test/compatible-mode/v1"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("settings", "setting_copy"),
     [

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -1549,6 +1549,7 @@ def test_stream_signal_privacy_has_one_private_event_and_a_public_usage_payload(
         "_synthetic_fallback",
         "usage_payload",
         "completed_usage_payloads",
+        "_active_usage_payloads",
         "_usage_lock",
     ]
     assert isinstance(signals._synthetic_fallback, threading.Event)
@@ -1556,6 +1557,7 @@ def test_stream_signal_privacy_has_one_private_event_and_a_public_usage_payload(
         "_synthetic_fallback",
         "usage_payload",
         "completed_usage_payloads",
+        "_active_usage_payloads",
         "_usage_lock",
     )
     assert not hasattr(signals, "__dict__")
@@ -3105,7 +3107,7 @@ class _CloseTrackingIterator:
         items: list[object],
         *,
         failure: BaseException | None = None,
-        close_failure: Exception | None = None,
+        close_failure: BaseException | None = None,
     ) -> None:
         self._items = iter(items)
         self._failure = failure
@@ -3128,6 +3130,153 @@ class _CloseTrackingIterator:
         self.close_calls += 1
         if self._close_failure is not None:
             raise self._close_failure
+
+
+class _RecordingAccumulator:
+    def __init__(self, failure: BaseException | None = None) -> None:
+        self.failure = failure
+        self.payloads: list[object] = []
+
+    def feed_payload(self, payload: object) -> None:
+        if self.failure is not None:
+            raise self.failure
+        self.payloads.append(payload)
+
+
+class _BlockingLateIterator:
+    def __init__(self, item: object) -> None:
+        self.item = item
+        self.next_entered = threading.Event()
+        self.release_next = threading.Event()
+        self.next_calls = 0
+        self.close_calls = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self.next_calls += 1
+        self.next_entered.set()
+        self.release_next.wait(timeout=5)
+        return self.item
+
+    def close(self) -> None:
+        self.close_calls += 1
+        self.release_next.set()
+
+
+class _CloseableMapping(dict):
+    def __init__(self, *args, close_failure: BaseException | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.close_calls = 0
+        self.close_failure = close_failure
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self.close_failure is not None:
+            raise self.close_failure
+
+
+def test_tee_tool_calls_explicit_close_stops_future_iteration() -> None:
+    underlying = _CloseTrackingIterator([{"content": "late"}])
+    accumulator = _RecordingAccumulator()
+    tee = gateway_module._tee_tool_calls(underlying, accumulator)
+
+    tee.close()
+
+    with pytest.raises(StopIteration):
+        next(tee)
+    assert underlying.close_calls == 1
+    assert accumulator.payloads == []
+
+
+def test_tee_tool_calls_discards_item_returned_after_concurrent_close() -> None:
+    payload = {"choices": [{"delta": {"content": "late"}}]}
+    underlying = _BlockingLateIterator(payload)
+    accumulator = _RecordingAccumulator()
+    tee = gateway_module._tee_tool_calls(underlying, accumulator)
+    outcomes: list[object] = []
+
+    def consume() -> None:
+        try:
+            outcomes.append(next(tee))
+        except BaseException as exc:  # noqa: BLE001 - asserted below
+            outcomes.append(exc)
+
+    consumer = threading.Thread(target=consume)
+    consumer.start()
+    assert underlying.next_entered.wait(timeout=1)
+
+    tee.close()
+    consumer.join(timeout=1)
+
+    assert not consumer.is_alive()
+    assert len(outcomes) == 1 and isinstance(outcomes[0], StopIteration)
+    assert underlying.close_calls == 1
+    assert accumulator.payloads == []
+
+
+@pytest.mark.parametrize("failure_stage", ["decode", "feed"])
+def test_tee_tool_calls_closes_once_on_decode_or_accumulator_failure(
+    failure_stage: str,
+    monkeypatch,
+) -> None:
+    underlying = _CloseTrackingIterator([{"content": "chunk"}])
+    accumulator = _RecordingAccumulator(
+        ValueError("feed-primary") if failure_stage == "feed" else None
+    )
+    if failure_stage == "decode":
+
+        def fail_decode(_item):
+            raise ValueError("decode-primary")
+
+        monkeypatch.setattr(gateway_module, "_decode_stream_item", fail_decode)
+    tee = gateway_module._tee_tool_calls(underlying, accumulator)
+
+    with pytest.raises(ValueError, match=f"{failure_stage}-primary"):
+        next(tee)
+    assert underlying.close_calls == 1
+    tee.close()
+    assert underlying.close_calls == 1
+
+
+def test_tee_tool_calls_closes_mapping_when_accumulator_fails() -> None:
+    response = _CloseableMapping(
+        {"choices": []},
+        close_failure=KeyboardInterrupt("close-secondary"),
+    )
+    accumulator = _RecordingAccumulator(ValueError("feed-primary"))
+
+    caught: BaseException | None = None
+    try:
+        gateway_module._tee_tool_calls(response, accumulator)
+    except BaseException as exc:  # noqa: BLE001 - primary identity asserted below
+        caught = exc
+
+    assert isinstance(caught, ValueError)
+    assert str(caught) == "feed-primary"
+    assert response.close_calls == 1
+
+
+def test_tee_tool_calls_provider_error_survives_keyboard_interrupt_from_close() -> None:
+    provider_error = ValueError("provider-primary")
+    underlying = _CloseTrackingIterator(
+        [],
+        failure=provider_error,
+        close_failure=KeyboardInterrupt("close-secondary"),
+    )
+    tee = gateway_module._tee_tool_calls(underlying, _RecordingAccumulator())
+
+    caught: BaseException | None = None
+    try:
+        next(tee)
+    except BaseException as exc:  # noqa: BLE001 - primary identity asserted below
+        caught = exc
+
+    assert caught is provider_error
+    assert underlying.close_calls == 1
+    tee.close()
+    assert underlying.close_calls == 1
 
 
 def test_tee_tool_calls_closes_underlying_iterator_once() -> None:
@@ -4070,23 +4219,6 @@ async def test_gateway_cancellation_closes_qwencloud_iterator() -> None:
             pending.cancel()
         provider_iterator.released.set()
         await stream.aclose()
-
-
-def test_qwencloud_total_tokens_reaches_agent_usage_counter() -> None:
-    from tldw_chatbook.Agents.agent_service import _usage_total_tokens
-
-    terminal = {
-        "choices": [{"delta": {"content": ""}, "finish_reason": "stop"}],
-        "usage": {
-            "input_tokens": 9,
-            "input_tokens_details": {"cached_tokens": 2},
-            "output_tokens": 3,
-            "output_tokens_details": {"reasoning_tokens": 1},
-            "total_tokens": 12,
-        },
-    }
-
-    assert _usage_total_tokens(terminal) == 12
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_provider_support.py
+++ b/Tests/Chat/test_console_provider_support.py
@@ -121,6 +121,7 @@ def test_supported_console_provider_catalog_describes_handler_identities() -> No
             "local_vllm",
             "mlx_lm",
             "local_mlx_lm",
+            "qwencloud",
         }
     )
     by_readiness_key = {entry.readiness_key: entry for entry in catalog}
@@ -133,12 +134,15 @@ def test_supported_console_provider_catalog_describes_handler_identities() -> No
         "local_mlx_lm",
         "local_vllm",
         "openai",
+        "qwencloud",
     }
     assert by_readiness_key["custom"].execution_key == "custom-openai-api"
     assert by_readiness_key["custom_2"].execution_key == "custom-openai-api-2"
     assert by_readiness_key["llama_cpp"].requires_api_key is False
     assert by_readiness_key["openai"].requires_api_key is True
     assert by_readiness_key["openai"].display_name == "OpenAI"
+    assert by_readiness_key["qwencloud"].execution_key == "qwencloud"
+    assert by_readiness_key["qwencloud"].display_name == "QwenCloud"
 
 
 def test_all_chat_api_call_handlers_resolve_to_supported_console_identity() -> None:

--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -292,6 +292,14 @@ def test_provider_options_include_console_sendable_handlers_missing_from_model_r
     assert "mistralai" in option_values
 
 
+def test_qwencloud_is_a_first_class_normalized_console_provider_option() -> None:
+    options = build_console_provider_options({"QwenCloud": ["qwen3.8-max"]})
+    options_by_value = {option.value: option for option in options}
+
+    assert options_by_value["qwencloud"].label == "qwencloud"
+    assert "qwencloud" in CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS
+
+
 def test_provider_options_label_configured_unsupported_providers_as_wip() -> None:
     options = build_console_provider_options({"local_onnx": ["manual-model"]})
     options_by_value = {option.value: option for option in options}

--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -139,6 +139,81 @@ def test_qwencloud_default_settings_use_canonical_fields_with_alias_fallbacks() 
     assert settings.base_url == "https://alias.example.test/compatible-mode/v1"
 
 
+def test_qwencloud_public_builders_fail_closed_for_malformed_canonical_settings() -> (
+    None
+):
+    config = {
+        "chat_defaults": {"model": "safe-default"},
+        "api_settings": {
+            "qwencloud": ["not", "a", "table"],
+            "QwenCloud": {
+                "model": "alias-canary-model",
+                "api_key": "alias-canary-key",
+            },
+        },
+    }
+
+    defaults = build_default_console_session_settings(config, provider="QwenCloud")
+    errors = validate_console_session_settings(defaults, app_config=config)
+    readiness = build_console_settings_readiness(
+        defaults,
+        app_config=config,
+        environ={},
+    )
+
+    assert defaults.model == "safe-default"
+    assert errors == []
+    assert readiness.label == "Not ready"
+    assert "Invalid provider settings" in readiness.detail
+    assert "alias-canary" not in readiness.detail
+
+
+def test_qwencloud_public_builders_fail_closed_for_malformed_alias_only() -> None:
+    config = {
+        "chat_defaults": {"model": "safe-default"},
+        "api_settings": {"QwenCloud": "not-a-table"},
+    }
+
+    defaults = build_default_console_session_settings(config, provider="qwencloud")
+    errors = validate_console_session_settings(defaults, app_config=config)
+    readiness = build_console_settings_readiness(
+        defaults,
+        app_config=config,
+        environ={},
+    )
+
+    assert defaults.model == "safe-default"
+    assert errors == []
+    assert readiness.label == "Not ready"
+    assert "Invalid provider settings" in readiness.detail
+
+
+def test_qwencloud_public_builders_ignore_malformed_alias_when_exact_is_valid() -> None:
+    config = {
+        "api_settings": {
+            "QwenCloud": ["not", "a", "table"],
+            "qwencloud": {
+                "model": "canonical-model",
+                "api_base_url": "https://canonical.example.test/v1",
+                "api_key_env_var": "QWENCLOUD_TEST_API_KEY",
+            },
+        }
+    }
+
+    defaults = build_default_console_session_settings(config, provider="QwenCloud")
+    errors = validate_console_session_settings(defaults, app_config=config)
+    readiness = build_console_settings_readiness(
+        defaults,
+        app_config=config,
+        environ={"QWENCLOUD_TEST_API_KEY": "available"},
+    )
+
+    assert defaults.model == "canonical-model"
+    assert defaults.base_url == "https://canonical.example.test/v1"
+    assert errors == []
+    assert readiness.label == "Ready"
+
+
 def test_console_session_settings_system_prompt_defaults_to_none() -> None:
     """Native Console session settings carry no system prompt by default."""
     settings = ConsoleSessionSettings(provider="llama_cpp")

--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -121,6 +121,24 @@ def test_default_settings_prefers_chat_defaults_and_provider_config() -> None:
     assert settings.max_tokens == 2048
 
 
+def test_qwencloud_default_settings_use_canonical_fields_with_alias_fallbacks() -> None:
+    settings = build_default_console_session_settings(
+        {
+            "api_settings": {
+                "QwenCloud": {
+                    "model": "alias-model",
+                    "api_base_url": ("https://alias.example.test/compatible-mode/v1"),
+                },
+                "qwencloud": {"model": "canonical-model"},
+            }
+        },
+        provider="QwenCloud",
+    )
+
+    assert settings.model == "canonical-model"
+    assert settings.base_url == "https://alias.example.test/compatible-mode/v1"
+
+
 def test_console_session_settings_system_prompt_defaults_to_none() -> None:
     """Native Console session settings carry no system prompt by default."""
     settings = ConsoleSessionSettings(provider="llama_cpp")

--- a/Tests/Chat/test_live_qwencloud_api.py
+++ b/Tests/Chat/test_live_qwencloud_api.py
@@ -1,0 +1,208 @@
+"""Opt-in live QwenCloud text and native-tool verification.
+
+The paid checks run in a subprocess whose profile paths are isolated before
+any Chatbook module is imported. They require both ``TLDW_LIVE_QWENCLOUD=1``
+and ``DASHSCOPE_API_KEY`` and are skipped by default.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import os
+from pathlib import Path
+import subprocess
+import sys
+from textwrap import dedent
+
+import pytest
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.optional, pytest.mark.slow]
+
+
+def _live_enabled(environ: Mapping[str, str]) -> bool:
+    return environ.get("TLDW_LIVE_QWENCLOUD", "").strip() == "1" and bool(
+        environ.get("DASHSCOPE_API_KEY", "").strip()
+    )
+
+
+_LIVE_CHILD = dedent(
+    r"""
+    from __future__ import annotations
+
+    import json
+    import os
+    from pathlib import Path
+    import secrets
+
+    config_path = Path(os.environ["TLDW_CONFIG_PATH"])
+    data_dir = Path(os.environ["TLDW_LIVE_QWENCLOUD_DATA_DIR"])
+    config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    data_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    base_url = os.environ.get(
+        "TLDW_LIVE_QWENCLOUD_API_BASE_URL",
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    ).strip() or "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    model = (
+        os.environ.get("TLDW_LIVE_QWENCLOUD_MODEL", "qwen3.8-max").strip()
+        or "qwen3.8-max"
+    )
+    api_mode = os.environ["TLDW_LIVE_QWENCLOUD_API_MODE"]
+    config_path.write_text(
+        "\n".join(
+            (
+                "[general]",
+                'users_name = "qwencloud-live-test"',
+                "",
+                "[paths]",
+                f"data_dir = {json.dumps(str(data_dir))}",
+                "",
+                "[api_settings.qwencloud]",
+                'api_key_env_var = "DASHSCOPE_API_KEY"',
+                f"api_base_url = {json.dumps(base_url)}",
+                f"api_mode = {json.dumps(api_mode)}",
+                f"model = {json.dumps(model)}",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    config_path.chmod(0o600)
+
+    from loguru import logger
+
+    logger.remove()
+
+    from tldw_chatbook.Agents.agent_models import STEP_TOOL_CALL, STEP_TOOL_RESULT
+    from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+    from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+    from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+    from tldw_chatbook.Chat.console_provider_gateway import (
+        ConsoleProviderGateway,
+        ConsoleProviderResolution,
+    )
+    from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+    text_sentinel = f"QWENCLOUD_LIVE_TEXT_{secrets.token_hex(8).upper()}"
+    left = 10**12 + secrets.randbelow(10**11)
+    right = 10**12 + secrets.randbelow(10**11)
+    expected = left + right
+    tool_sentinel = f"QWENCLOUD_LIVE_TOOL_{expected}"
+    expression = f"{left} + {right}"
+    system_prompt = (
+        "You are running a harmless API contract probe. Call the calculator "
+        f"tool exactly once with expression {expression!r}. After its result, "
+        f"reply with both exact markers {text_sentinel!r} and {tool_sentinel!r}."
+    )
+    user_prompt = "Run the requested contract probe now."
+
+    db = AgentRunsDB(data_dir / f"agent-runs-{api_mode}.db", client_id="qwen-live")
+    try:
+        store = ConsoleChatStore()
+        session = store.ensure_session()
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content=user_prompt,
+        )
+        assistant = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+        )
+        bridge = ConsoleAgentBridge(
+            agent_runs_db=db,
+            store=store,
+            provider_gateway=ConsoleProviderGateway(),
+        )
+        resolution = ConsoleProviderResolution(
+            provider="QwenCloud",
+            base_url=base_url,
+            model=model,
+            ready=True,
+            readiness_key="qwencloud",
+            execution_key="qwencloud",
+            api_key=os.environ["DASHSCOPE_API_KEY"],
+            streaming=True,
+            api_mode=api_mode,
+        )
+        _run_id, outcome = bridge.run_reply(
+            conversation_id=f"qwencloud-live-{api_mode}",
+            session_id=session.id,
+            resolution=resolution,
+            assistant_message_id=assistant.id,
+            model=model,
+            session_system_prompt=system_prompt,
+            agent_messages=[{"role": "user", "content": user_prompt}],
+            should_cancel=lambda: False,
+        )
+
+        if outcome.status != "done":
+            raise SystemExit("QwenCloud live run did not complete.")
+        if text_sentinel not in outcome.final_text:
+            raise SystemExit("QwenCloud live text marker was not returned.")
+        if tool_sentinel not in outcome.final_text:
+            raise SystemExit("QwenCloud live tool marker did not affect the answer.")
+        tool_calls = [
+            step
+            for step in outcome.steps
+            if step.kind == STEP_TOOL_CALL and step.tool_name == "calculator"
+        ]
+        tool_results = [
+            step
+            for step in outcome.steps
+            if step.kind == STEP_TOOL_RESULT and step.tool_name == "calculator"
+        ]
+        if len(tool_calls) != 1 or len(tool_results) != 1:
+            raise SystemExit("QwenCloud did not execute exactly one calculator call.")
+        if str(expected) not in tool_results[0].result:
+            raise SystemExit("QwenCloud calculator result marker was not recorded.")
+    finally:
+        db.close()
+    """
+)
+
+
+@pytest.mark.parametrize("api_mode", ["responses", "chat_completions"])
+@pytest.mark.allow_network
+@pytest.mark.skipif(
+    not _live_enabled(os.environ),
+    reason="Set TLDW_LIVE_QWENCLOUD=1 and DASHSCOPE_API_KEY to run paid live checks.",
+)
+def test_live_qwencloud_text_and_native_tool(
+    tmp_path: Path,
+    api_mode: str,
+) -> None:
+    """Require identifying text and a real calculator continuation in each mode."""
+    profile = tmp_path / api_mode
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(profile / "home"),
+            "XDG_CONFIG_HOME": str(profile / "xdg-config"),
+            "XDG_DATA_HOME": str(profile / "xdg-data"),
+            "TLDW_CONFIG_PATH": str(profile / "config" / "config.toml"),
+            "TLDW_LIVE_QWENCLOUD_DATA_DIR": str(profile / "data"),
+            "TLDW_LIVE_QWENCLOUD_API_MODE": api_mode,
+        }
+    )
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", _LIVE_CHILD],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=360,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            f"Live QwenCloud {api_mode} verification timed out without exposing "
+            "request or response content."
+        )
+    if completed.returncode != 0:
+        pytest.fail(
+            f"Live QwenCloud {api_mode} verification failed without exposing "
+            "request or response content."
+        )

--- a/Tests/Chat/test_live_qwencloud_api.py
+++ b/Tests/Chat/test_live_qwencloud_api.py
@@ -7,23 +7,252 @@ and ``DASHSCOPE_API_KEY`` and are skipped by default.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
+import json
 import os
 from pathlib import Path
 import subprocess
 import sys
 from textwrap import dedent
+from types import SimpleNamespace
 
 import pytest
 
 
-pytestmark = [pytest.mark.integration, pytest.mark.optional, pytest.mark.slow]
+_TOOL_MARKER_PREFIX = "QWENCLOUD_LIVE_TOOL_RESULT_"
+_TOOL_MARKER_SUFFIX = "_END"
 
 
 def _live_enabled(environ: Mapping[str, str]) -> bool:
     return environ.get("TLDW_LIVE_QWENCLOUD", "").strip() == "1" and bool(
         environ.get("DASHSCOPE_API_KEY", "").strip()
     )
+
+
+def _live_subprocess_environment(
+    profile: Path,
+    api_mode: str,
+    environ: Mapping[str, str],
+) -> dict[str, str]:
+    """Return an isolated environment for one paid live subprocess."""
+    env = dict(environ)
+    env.update(
+        {
+            "HOME": str(profile / "home"),
+            "XDG_CONFIG_HOME": str(profile / "xdg-config"),
+            "XDG_DATA_HOME": str(profile / "xdg-data"),
+            "TLDW_CONFIG_PATH": str(profile / "config" / "config.toml"),
+            "TLDW_LIVE_QWENCLOUD_DATA_DIR": str(profile / "data"),
+            "TLDW_LIVE_QWENCLOUD_API_MODE": api_mode,
+        }
+    )
+    return env
+
+
+@pytest.mark.parametrize(
+    ("environ", "expected"),
+    [
+        ({}, False),
+        ({"TLDW_LIVE_QWENCLOUD": "1"}, False),
+        ({"DASHSCOPE_API_KEY": "test-key"}, False),
+        (
+            {"TLDW_LIVE_QWENCLOUD": "1", "DASHSCOPE_API_KEY": "test-key"},
+            True,
+        ),
+    ],
+)
+def test_live_gate_requires_explicit_opt_in_and_key(
+    environ: Mapping[str, str],
+    expected: bool,
+) -> None:
+    assert _live_enabled(environ) is expected
+
+
+def test_live_subprocess_profile_is_isolated_before_chatbook_imports() -> None:
+    profile = Path("/tmp/qwencloud-live-structural-test")
+    env = _live_subprocess_environment(
+        profile,
+        "responses",
+        {"DASHSCOPE_API_KEY": "test-key"},
+    )
+
+    assert env["HOME"] == str(profile / "home")
+    assert env["XDG_CONFIG_HOME"] == str(profile / "xdg-config")
+    assert env["XDG_DATA_HOME"] == str(profile / "xdg-data")
+    assert env["TLDW_CONFIG_PATH"] == str(profile / "config" / "config.toml")
+    assert env["TLDW_LIVE_QWENCLOUD_DATA_DIR"] == str(profile / "data")
+    assert env["TLDW_LIVE_QWENCLOUD_API_MODE"] == "responses"
+    assert _LIVE_CHILD.index("config_path.write_text") < _LIVE_CHILD.index(
+        "from tldw_chatbook"
+    )
+    assert _LIVE_CHILD.index("config_path.chmod") < _LIVE_CHILD.index(
+        "from tldw_chatbook"
+    )
+
+
+def _build_probe_contract(
+    left: int,
+    right: int,
+    text_sentinel: str,
+) -> tuple[str, str, str]:
+    """Build a prompt whose derived tool marker is unavailable before execution."""
+    expression = f"{left} + {right}"
+    system_prompt = (
+        "You are running a harmless API contract probe. Call the calculator "
+        f"tool exactly once with expression {expression!r}. Only after the tool "
+        f"returns, reply with text marker {text_sentinel!r}, fixed prefix "
+        f"{_TOOL_MARKER_PREFIX!r}, the exact integer result copied as plain ASCII "
+        f"digits without commas or a decimal point, then suffix {_TOOL_MARKER_SUFFIX!r}."
+    )
+    user_prompt = "Run the requested contract probe now."
+    return system_prompt, user_prompt, expression
+
+
+def _validate_probe_observation(
+    *,
+    status: str,
+    final_text: str,
+    steps: Sequence[object],
+    text_sentinel: str,
+    system_prompt: str,
+    user_prompt: str,
+    expression: str,
+    left: int,
+    right: int,
+) -> None:
+    """Validate identifying output without exposing request or response content."""
+    expected = left + right
+    tool_marker = f"{_TOOL_MARKER_PREFIX}{expected}{_TOOL_MARKER_SUFFIX}"
+    if tool_marker in system_prompt or tool_marker in user_prompt:
+        raise ValueError(
+            "Derived calculator marker was disclosed before tool execution."
+        )
+    if status != "done":
+        raise ValueError("QwenCloud live run did not complete.")
+    tool_calls = [
+        step
+        for step in steps
+        if getattr(step, "kind", "") == "tool_call"
+        and getattr(step, "tool_name", "") == "calculator"
+    ]
+    tool_results = [
+        step
+        for step in steps
+        if getattr(step, "kind", "") == "tool_result"
+        and getattr(step, "tool_name", "") == "calculator"
+    ]
+    if len(tool_calls) != 1 or len(tool_results) != 1:
+        raise ValueError("QwenCloud did not execute exactly one calculator call.")
+    if getattr(tool_calls[0], "args", None) != {"expression": expression}:
+        raise ValueError(
+            "QwenCloud calculator call did not use the requested expression."
+        )
+    try:
+        result_payload = json.loads(str(getattr(tool_results[0], "result", "")))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "QwenCloud calculator result was not structured JSON."
+        ) from exc
+    observed = (
+        result_payload.get("result") if isinstance(result_payload, Mapping) else None
+    )
+    if (
+        isinstance(observed, bool)
+        or not isinstance(observed, int)
+        or observed != expected
+    ):
+        raise ValueError("QwenCloud calculator result did not match the derived value.")
+    if text_sentinel not in final_text:
+        raise ValueError("QwenCloud live text marker was not returned.")
+    if tool_marker not in final_text:
+        raise ValueError("QwenCloud live tool marker did not affect the answer.")
+
+
+def test_live_probe_contract_does_not_disclose_derived_tool_marker() -> None:
+    left = 1_000_000_003
+    right = 2_000_000_033
+    system_prompt, user_prompt, _expression = _build_probe_contract(
+        left,
+        right,
+        "QWENCLOUD_LIVE_TEXT_TEST",
+    )
+    tool_marker = f"{_TOOL_MARKER_PREFIX}{left + right}{_TOOL_MARKER_SUFFIX}"
+
+    assert tool_marker not in system_prompt
+    assert tool_marker not in user_prompt
+    assert "{tool_sentinel!r}" not in _LIVE_CHILD
+
+
+def test_live_probe_validation_rejects_mutated_calculator_result() -> None:
+    text_sentinel = "QWENCLOUD_LIVE_TEXT_TEST"
+    left = 1_000_000_003
+    right = 2_000_000_033
+    expected = left + right
+    tool_marker = f"{_TOOL_MARKER_PREFIX}{expected}{_TOOL_MARKER_SUFFIX}"
+    system_prompt, user_prompt, expression = _build_probe_contract(
+        left,
+        right,
+        text_sentinel,
+    )
+    good_steps = [
+        SimpleNamespace(
+            kind="tool_call",
+            tool_name="calculator",
+            args={"expression": expression},
+            result="",
+        ),
+        SimpleNamespace(
+            kind="tool_result",
+            tool_name="calculator",
+            args=None,
+            result=json.dumps(
+                {
+                    "expression": expression,
+                    "result": expected,
+                    "result_type": "int",
+                }
+            ),
+        ),
+    ]
+    _validate_probe_observation(
+        status="done",
+        final_text=f"{text_sentinel} {tool_marker}",
+        steps=good_steps,
+        text_sentinel=text_sentinel,
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        expression=expression,
+        left=left,
+        right=right,
+    )
+
+    mutated_steps = [
+        good_steps[0],
+        SimpleNamespace(
+            kind="tool_result",
+            tool_name="calculator",
+            args=None,
+            result=json.dumps(
+                {
+                    "expression": expression,
+                    "result": expected + 1,
+                    "result_type": "int",
+                }
+            ),
+        ),
+    ]
+    with pytest.raises(ValueError, match="calculator result"):
+        _validate_probe_observation(
+            status="done",
+            final_text=f"{text_sentinel} {tool_marker}",
+            steps=mutated_steps,
+            text_sentinel=text_sentinel,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            expression=expression,
+            left=left,
+            right=right,
+        )
 
 
 _LIVE_CHILD = dedent(
@@ -73,7 +302,10 @@ _LIVE_CHILD = dedent(
 
     logger.remove()
 
-    from tldw_chatbook.Agents.agent_models import STEP_TOOL_CALL, STEP_TOOL_RESULT
+    from Tests.Chat.test_live_qwencloud_api import (
+        _build_probe_contract,
+        _validate_probe_observation,
+    )
     from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
     from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
     from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
@@ -86,15 +318,9 @@ _LIVE_CHILD = dedent(
     text_sentinel = f"QWENCLOUD_LIVE_TEXT_{secrets.token_hex(8).upper()}"
     left = 10**12 + secrets.randbelow(10**11)
     right = 10**12 + secrets.randbelow(10**11)
-    expected = left + right
-    tool_sentinel = f"QWENCLOUD_LIVE_TOOL_{expected}"
-    expression = f"{left} + {right}"
-    system_prompt = (
-        "You are running a harmless API contract probe. Call the calculator "
-        f"tool exactly once with expression {expression!r}. After its result, "
-        f"reply with both exact markers {text_sentinel!r} and {tool_sentinel!r}."
+    system_prompt, user_prompt, expression = _build_probe_contract(
+        left, right, text_sentinel
     )
-    user_prompt = "Run the requested contract probe now."
 
     db = AgentRunsDB(data_dir / f"agent-runs-{api_mode}.db", client_id="qwen-live")
     try:
@@ -137,26 +363,17 @@ _LIVE_CHILD = dedent(
             should_cancel=lambda: False,
         )
 
-        if outcome.status != "done":
-            raise SystemExit("QwenCloud live run did not complete.")
-        if text_sentinel not in outcome.final_text:
-            raise SystemExit("QwenCloud live text marker was not returned.")
-        if tool_sentinel not in outcome.final_text:
-            raise SystemExit("QwenCloud live tool marker did not affect the answer.")
-        tool_calls = [
-            step
-            for step in outcome.steps
-            if step.kind == STEP_TOOL_CALL and step.tool_name == "calculator"
-        ]
-        tool_results = [
-            step
-            for step in outcome.steps
-            if step.kind == STEP_TOOL_RESULT and step.tool_name == "calculator"
-        ]
-        if len(tool_calls) != 1 or len(tool_results) != 1:
-            raise SystemExit("QwenCloud did not execute exactly one calculator call.")
-        if str(expected) not in tool_results[0].result:
-            raise SystemExit("QwenCloud calculator result marker was not recorded.")
+        _validate_probe_observation(
+            status=outcome.status,
+            final_text=outcome.final_text,
+            steps=outcome.steps,
+            text_sentinel=text_sentinel,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            expression=expression,
+            left=left,
+            right=right,
+        )
     finally:
         db.close()
     """
@@ -165,6 +382,9 @@ _LIVE_CHILD = dedent(
 
 @pytest.mark.parametrize("api_mode", ["responses", "chat_completions"])
 @pytest.mark.allow_network
+@pytest.mark.integration
+@pytest.mark.optional
+@pytest.mark.slow
 @pytest.mark.skipif(
     not _live_enabled(os.environ),
     reason="Set TLDW_LIVE_QWENCLOUD=1 and DASHSCOPE_API_KEY to run paid live checks.",
@@ -175,17 +395,7 @@ def test_live_qwencloud_text_and_native_tool(
 ) -> None:
     """Require identifying text and a real calculator continuation in each mode."""
     profile = tmp_path / api_mode
-    env = os.environ.copy()
-    env.update(
-        {
-            "HOME": str(profile / "home"),
-            "XDG_CONFIG_HOME": str(profile / "xdg-config"),
-            "XDG_DATA_HOME": str(profile / "xdg-data"),
-            "TLDW_CONFIG_PATH": str(profile / "config" / "config.toml"),
-            "TLDW_LIVE_QWENCLOUD_DATA_DIR": str(profile / "data"),
-            "TLDW_LIVE_QWENCLOUD_API_MODE": api_mode,
-        }
-    )
+    env = _live_subprocess_environment(profile, api_mode, os.environ)
     try:
         completed = subprocess.run(
             [sys.executable, "-c", _LIVE_CHILD],

--- a/Tests/Chat/test_provider_readiness.py
+++ b/Tests/Chat/test_provider_readiness.py
@@ -2,6 +2,7 @@
 
 import os
 from contextlib import contextmanager
+from copy import deepcopy
 
 import pytest
 
@@ -195,6 +196,81 @@ def test_qwencloud_readiness_uses_alias_fields_missing_from_canonical(
     assert readiness.ready is True
     assert readiness.api_key == "environment-secret"
     assert readiness.api_key_source == "env:QWEN_ALIAS_API_KEY"
+
+
+@pytest.mark.parametrize("canonical_first", [False, True])
+def test_qwencloud_malformed_canonical_table_fails_closed_without_alias_leakage(
+    canonical_first,
+):
+    alias = {"api_key": "alias-secret-canary", "api_mode": "responses"}
+    entries = (
+        [("qwencloud", []), ("QwenCloud", alias)]
+        if canonical_first
+        else [("QwenCloud", alias), ("qwencloud", [])]
+    )
+    source = {"api_settings": dict(entries)}
+    original = deepcopy(source)
+
+    with pytest.raises(ValueError) as exc_info:
+        config_mod.provider_settings_for_key(source["api_settings"], "qwencloud")
+
+    readiness = get_provider_readiness("QwenCloud", source, environ={})
+
+    assert source == original
+    assert "alias-secret-canary" not in str(exc_info.value)
+    assert readiness.ready is False
+    assert readiness.api_key is None
+    assert readiness.api_key_source is None
+    assert readiness.reason == "Invalid provider settings"
+    assert "api_settings.qwencloud" in readiness.user_message
+    assert "alias-secret-canary" not in readiness.user_message
+
+
+@pytest.mark.parametrize("canonical_first", [False, True])
+def test_qwencloud_valid_canonical_table_ignores_malformed_alias(
+    canonical_first,
+):
+    canonical = {"api_key": "canonical-secret", "api_mode": "responses"}
+    entries = (
+        [("qwencloud", canonical), ("QwenCloud", [])]
+        if canonical_first
+        else [("QwenCloud", []), ("qwencloud", canonical)]
+    )
+    source = {"api_settings": dict(entries)}
+    original = deepcopy(source)
+
+    settings = config_mod.provider_settings_for_key(source["api_settings"], "qwencloud")
+    readiness = get_provider_readiness("QwenCloud", source, environ={})
+
+    assert source == original
+    assert settings == canonical
+    assert readiness.ready is True
+    assert readiness.api_key == "canonical-secret"
+    assert readiness.api_key_source == "config:api_settings.qwencloud.api_key"
+
+
+def test_qwencloud_alias_only_malformed_table_fails_closed():
+    source = {
+        "api_settings": {
+            "QwenCloud": ["secret-canary"],
+            " QWENCLOUD ": {"api_key": "later-alias-secret-canary"},
+        }
+    }
+    original = deepcopy(source)
+
+    with pytest.raises(ValueError) as exc_info:
+        config_mod.provider_settings_for_key(source["api_settings"], "qwencloud")
+
+    readiness = get_provider_readiness("QwenCloud", source, environ={})
+
+    assert source == original
+    assert "secret-canary" not in str(exc_info.value)
+    assert "later-alias-secret-canary" not in str(exc_info.value)
+    assert readiness.ready is False
+    assert readiness.api_key is None
+    assert readiness.reason == "Invalid provider settings"
+    assert "api_settings.qwencloud" in readiness.user_message
+    assert "later-alias-secret-canary" not in readiness.user_message
 
 
 def test_qwencloud_multiple_aliases_keep_first_match_as_fallback():

--- a/Tests/Chat/test_provider_readiness.py
+++ b/Tests/Chat/test_provider_readiness.py
@@ -148,6 +148,88 @@ def test_provider_settings_lookup_uses_normalized_config_key():
     assert readiness.api_key_source == "config:api_settings.custom_2.api_key"
 
 
+@pytest.mark.parametrize("canonical_first", [False, True])
+def test_qwencloud_readiness_prefers_canonical_fields_over_normalized_alias(
+    canonical_first,
+):
+    alias = {
+        "api_key": "alias-secret",
+        "api_key_env_var": "QWEN_ALIAS_API_KEY",
+    }
+    canonical = {"api_key": "canonical-secret"}
+    entries = (
+        [("qwencloud", canonical), ("QwenCloud", alias)]
+        if canonical_first
+        else [("QwenCloud", alias), ("qwencloud", canonical)]
+    )
+
+    readiness = get_provider_readiness(
+        "QwenCloud",
+        {"api_settings": dict(entries)},
+        environ={"QWEN_ALIAS_API_KEY": "environment-secret"},
+    )
+
+    assert readiness.ready is True
+    assert readiness.api_key == "canonical-secret"
+    assert readiness.api_key_source == "config:api_settings.qwencloud.api_key"
+
+
+@pytest.mark.parametrize("canonical_first", [False, True])
+def test_qwencloud_readiness_uses_alias_fields_missing_from_canonical(
+    canonical_first,
+):
+    alias = {"api_key_env_var": "QWEN_ALIAS_API_KEY"}
+    canonical = {"api_mode": "chat_completions"}
+    entries = (
+        [("qwencloud", canonical), ("QwenCloud", alias)]
+        if canonical_first
+        else [("QwenCloud", alias), ("qwencloud", canonical)]
+    )
+
+    readiness = get_provider_readiness(
+        "QwenCloud",
+        {"api_settings": dict(entries)},
+        environ={"QWEN_ALIAS_API_KEY": "environment-secret"},
+    )
+
+    assert readiness.ready is True
+    assert readiness.api_key == "environment-secret"
+    assert readiness.api_key_source == "env:QWEN_ALIAS_API_KEY"
+
+
+def test_qwencloud_multiple_aliases_keep_first_match_as_fallback():
+    readiness = get_provider_readiness(
+        "QwenCloud",
+        {
+            "api_settings": {
+                "QwenCloud": {},
+                "QWENCLOUD": {"api_key_env_var": "SECOND_ALIAS_API_KEY"},
+                "qwencloud": {"api_mode": "responses"},
+            }
+        },
+        environ={"SECOND_ALIAS_API_KEY": "must-not-win"},
+    )
+
+    assert readiness.ready is False
+    assert readiness.env_var == "DASHSCOPE_API_KEY"
+
+
+def test_non_qwen_provider_lookup_keeps_first_normalized_match():
+    readiness = get_provider_readiness(
+        "OpenAI",
+        {
+            "api_settings": {
+                "OpenAI": {"api_key": "first-match-key"},
+                "openai": {"api_key": "canonical-key"},
+            }
+        },
+        environ={},
+    )
+
+    assert readiness.ready is True
+    assert readiness.api_key == "first-match-key"
+
+
 def test_keyless_local_provider_is_ready_without_api_key():
     readiness = get_provider_readiness(
         "Ollama",

--- a/Tests/Chat/test_qwencloud_native_tools.py
+++ b/Tests/Chat/test_qwencloud_native_tools.py
@@ -1,0 +1,628 @@
+"""Joined QwenCloud native-tool tests through the real Console path."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import threading
+from typing import Any, Iterator
+
+import pytest
+
+from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_provider_gateway import (
+    ConsoleProviderGateway,
+    ConsoleProviderResolution,
+)
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+
+_FINAL_SENTINEL = "QWENCLOUD-NATIVE-FINAL-SENTINEL"
+
+
+def _sse(events: list[dict[str, Any]]) -> bytes:
+    return (
+        b"".join(
+            b"data: " + json.dumps(event, separators=(",", ":")).encode() + b"\n\n"
+            for event in events
+        )
+        + b"data: [DONE]\n\n"
+    )
+
+
+def _responses_tool_turn(
+    calls: list[tuple[str, str, str]] | None = None,
+    *,
+    usage: dict[str, int] | None = None,
+) -> bytes:
+    calls = calls or [
+        ("fc_A", "call_A", '{"expression":"6*7"}'),
+        ("fc_B", "call_B", '{"expression":"8*8"}'),
+    ]
+    events: list[dict[str, Any]] = []
+    sequence = 0
+    output: list[dict[str, Any]] = []
+    for output_index, (item_id, call_id, arguments) in enumerate(calls):
+        item = {
+            "id": item_id,
+            "type": "function_call",
+            "status": "completed",
+            "call_id": call_id,
+            "name": "calculator",
+            "arguments": arguments,
+        }
+        events.extend(
+            [
+                {
+                    "type": "response.output_item.added",
+                    "sequence_number": sequence,
+                    "output_index": output_index,
+                    "item": {**item, "status": "in_progress", "arguments": ""},
+                },
+                {
+                    "type": "response.function_call_arguments.delta",
+                    "sequence_number": sequence + 1,
+                    "output_index": output_index,
+                    "item_id": item_id,
+                    "delta": arguments,
+                },
+                {
+                    "type": "response.function_call_arguments.done",
+                    "sequence_number": sequence + 2,
+                    "output_index": output_index,
+                    "item_id": item_id,
+                    "arguments": arguments,
+                },
+            ]
+        )
+        sequence += 3
+        output.append(item)
+    events.append(
+        {
+            "type": "response.completed",
+            "sequence_number": sequence,
+            "response": {
+                "id": "resp_tools",
+                "object": "response",
+                "status": "completed",
+                "output": output,
+                "usage": usage
+                or {"input_tokens": 20, "output_tokens": 10, "total_tokens": 30},
+            },
+        }
+    )
+    return _sse(events)
+
+
+def _responses_final_turn(text: str = _FINAL_SENTINEL) -> bytes:
+    item = {
+        "id": "msg_final",
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": text, "annotations": []}],
+    }
+    return _sse(
+        [
+            {
+                "type": "response.output_item.added",
+                "sequence_number": 0,
+                "output_index": 0,
+                "item": {**item, "status": "in_progress", "content": []},
+            },
+            {
+                "type": "response.content_part.added",
+                "sequence_number": 1,
+                "output_index": 0,
+                "item_id": "msg_final",
+                "content_index": 0,
+                "part": {"type": "output_text", "text": "", "annotations": []},
+            },
+            {
+                "type": "response.output_text.delta",
+                "sequence_number": 2,
+                "output_index": 0,
+                "item_id": "msg_final",
+                "content_index": 0,
+                "delta": text,
+                "logprobs": [],
+            },
+            {
+                "type": "response.output_text.done",
+                "sequence_number": 3,
+                "output_index": 0,
+                "item_id": "msg_final",
+                "content_index": 0,
+                "text": text,
+                "logprobs": [],
+            },
+            {
+                "type": "response.completed",
+                "sequence_number": 4,
+                "response": {
+                    "id": "resp_final",
+                    "object": "response",
+                    "status": "completed",
+                    "output": [item],
+                    "usage": {
+                        "input_tokens": 30,
+                        "output_tokens": 5,
+                        "total_tokens": 35,
+                    },
+                },
+            },
+        ]
+    )
+
+
+def _chat_tool_turn(
+    calls: list[tuple[str, str]] | None = None,
+    *,
+    usage: dict[str, int] | None = None,
+) -> bytes:
+    calls = calls or [
+        ("call_A", '{"expression":"6*7"}'),
+        ("call_B", '{"expression":"8*8"}'),
+    ]
+    return _sse(
+        [
+            {
+                "id": "chatcmpl_tools",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "tool_calls": [
+                                {
+                                    "index": index,
+                                    "id": call_id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": "calculator",
+                                        "arguments": arguments,
+                                    },
+                                }
+                                for index, (call_id, arguments) in enumerate(calls)
+                            ],
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl_tools",
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+            },
+            {
+                "id": "chatcmpl_tools",
+                "choices": [],
+                "usage": usage
+                or {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 10,
+                    "total_tokens": 30,
+                },
+            },
+        ]
+    )
+
+
+def _chat_final_turn(text: str = _FINAL_SENTINEL) -> bytes:
+    return _sse(
+        [
+            {
+                "id": "chatcmpl_final",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": text},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl_final",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 30,
+                    "completion_tokens": 5,
+                    "total_tokens": 35,
+                },
+            },
+        ]
+    )
+
+
+class _JoinedQwenServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self,
+        bodies: list[bytes],
+        *,
+        on_request: Any = None,
+    ) -> None:
+        super().__init__(("127.0.0.1", 0), _JoinedQwenHandler)
+        self.bodies = list(bodies)
+        self.requests: list[dict[str, Any]] = []
+        self.on_request = on_request
+        self._lock = threading.Lock()
+
+    def handle_request_payload(self, path: str, payload: dict[str, Any]) -> bytes:
+        with self._lock:
+            self.requests.append({"path": path, "payload": payload})
+            if self.on_request is not None:
+                self.on_request(len(self.requests))
+            assert self.bodies, "provider script exhausted"
+            return self.bodies.pop(0)
+
+
+class _JoinedQwenHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length))
+        server = self.server
+        assert isinstance(server, _JoinedQwenServer)
+        body = server.handle_request_payload(self.path, payload)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+        self.wfile.flush()
+        self.close_connection = True
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+@contextmanager
+def _joined_qwen_server(
+    bodies: list[bytes],
+    *,
+    on_request: Any = None,
+) -> Iterator[_JoinedQwenServer]:
+    server = _JoinedQwenServer(bodies, on_request=on_request)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _resolution(server: _JoinedQwenServer, api_mode: str) -> ConsoleProviderResolution:
+    address = server.server_address
+    assert isinstance(address, tuple)
+    host, port = address[0], address[1]
+    assert isinstance(host, str)
+    assert isinstance(port, int)
+    return ConsoleProviderResolution(
+        provider="QwenCloud",
+        base_url=f"http://{host}:{port}/compatible-mode/v1",
+        model="qwen3.8-max",
+        ready=True,
+        readiness_key="qwencloud",
+        execution_key="qwencloud",
+        api_key="test-qwen-key",
+        streaming=True,
+        api_mode=api_mode,
+    )
+
+
+def _run_joined_reply(
+    tmp_path: Any,
+    server: _JoinedQwenServer,
+    api_mode: str,
+    *,
+    should_cancel: Any = lambda: False,
+) -> tuple[Any, ConsoleChatStore]:
+    db = AgentRunsDB(tmp_path / f"{api_mode}.db", client_id="qwen-native")
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="Calculate two expressions.",
+    )
+    assistant = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+    )
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db,
+        store=store,
+        provider_gateway=ConsoleProviderGateway(),
+    )
+    _run_id, outcome = bridge.run_reply(
+        conversation_id="qwen-conversation",
+        session_id=session.id,
+        resolution=_resolution(server, api_mode),
+        assistant_message_id=assistant.id,
+        model="qwen3.8-max",
+        session_system_prompt="",
+        agent_messages=[{"role": "user", "content": "Calculate two expressions."}],
+        should_cancel=should_cancel,
+    )
+    return outcome, store
+
+
+@pytest.mark.parametrize("api_mode", ["responses", "chat_completions"])
+@pytest.mark.allow_network
+def test_console_agent_bridge_runs_qwencloud_two_call_continuation(
+    tmp_path: Any,
+    api_mode: str,
+) -> None:
+    bodies = (
+        [_responses_tool_turn(), _responses_final_turn()]
+        if api_mode == "responses"
+        else [_chat_tool_turn(), _chat_final_turn()]
+    )
+    with _joined_qwen_server(bodies) as server:
+        outcome, store = _run_joined_reply(tmp_path, server, api_mode)
+
+    assert outcome.status == "done"
+    assert outcome.final_text == _FINAL_SENTINEL
+    assistant_rows = [
+        message
+        for session in store.sessions()
+        for message in store.messages_for_session(session.id)
+        if message.role is ConsoleMessageRole.ASSISTANT
+    ]
+    assert assistant_rows[-1].content == _FINAL_SENTINEL
+    assert len(server.requests) == 2
+
+    first = server.requests[0]
+    second = server.requests[1]
+    assert first["path"] == (
+        "/compatible-mode/v1/responses"
+        if api_mode == "responses"
+        else "/compatible-mode/v1/chat/completions"
+    )
+    assert len(first["payload"]["tools"]) >= 2
+
+    if api_mode == "responses":
+        continuation = second["payload"]["input"]
+        assert continuation[-4:] == [
+            {
+                "type": "function_call",
+                "call_id": "call_A",
+                "name": "calculator",
+                "arguments": '{"expression":"6*7"}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_A",
+                "output": '{"expression": "6*7", "result": 42, "result_type": "int"}',
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_B",
+                "name": "calculator",
+                "arguments": '{"expression":"8*8"}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_B",
+                "output": '{"expression": "8*8", "result": 64, "result_type": "int"}',
+            },
+        ]
+        assert [item for item in continuation if item.get("role") == "user"] == [
+            {"role": "user", "content": "Calculate two expressions."}
+        ]
+        assert second["payload"]["store"] is False
+    else:
+        continuation = second["payload"]["messages"]
+        assistant = next(row for row in continuation if row.get("role") == "assistant")
+        assert [call["id"] for call in assistant["tool_calls"]] == [
+            "call_A",
+            "call_B",
+        ]
+        tool_rows = [row for row in continuation if row.get("role") == "tool"]
+        assert [row["tool_call_id"] for row in tool_rows] == ["call_A", "call_B"]
+        assert [row for row in continuation if row.get("role") == "user"] == [
+            {"role": "user", "content": "Calculate two expressions."}
+        ]
+        assert second["payload"]["preserve_thinking"] is False
+
+
+@pytest.mark.parametrize("api_mode", ["responses", "chat_completions"])
+@pytest.mark.allow_network
+def test_qwencloud_tool_error_continues_structurally(
+    tmp_path: Any,
+    api_mode: str,
+) -> None:
+    invalid_arguments = '{"expression":"1/0"}'
+    first = (
+        _responses_tool_turn([("fc_error", "call_error", invalid_arguments)])
+        if api_mode == "responses"
+        else _chat_tool_turn([("call_error", invalid_arguments)])
+    )
+    with _joined_qwen_server(
+        [first, _responses_final_turn("ERROR-RECOVERED")]
+        if api_mode == "responses"
+        else [first, _chat_final_turn("ERROR-RECOVERED")]
+    ) as server:
+        outcome, _store = _run_joined_reply(tmp_path, server, api_mode)
+
+    assert outcome.status == "done"
+    assert outcome.final_text == "ERROR-RECOVERED"
+    assert len(server.requests) == 2
+    second = server.requests[1]["payload"]
+    if api_mode == "responses":
+        output = second["input"][-1]
+        assert output["type"] == "function_call_output"
+        assert output["call_id"] == "call_error"
+        assert output["output"].startswith("ERROR: ")
+        assert "zero" in output["output"].lower()
+        assert [row for row in second["input"] if row.get("role") == "user"] == [
+            {"role": "user", "content": "Calculate two expressions."}
+        ]
+    else:
+        output = second["messages"][-1]
+        assert output["role"] == "tool"
+        assert output["tool_call_id"] == "call_error"
+        assert output["content"].startswith("ERROR: ")
+        assert "zero" in output["content"].lower()
+        assert second["preserve_thinking"] is False
+
+
+def _responses_partial_call_then_text() -> bytes:
+    return _sse(
+        [
+            {
+                "type": "response.output_item.added",
+                "sequence_number": 0,
+                "output_index": 0,
+                "item": {
+                    "id": "fc_partial",
+                    "type": "function_call",
+                    "status": "in_progress",
+                    "call_id": "call_partial",
+                    "name": "calculator",
+                    "arguments": "",
+                },
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "sequence_number": 1,
+                "output_index": 0,
+                "item_id": "fc_partial",
+                "delta": '{"expression":',
+            },
+            {
+                "type": "response.output_item.added",
+                "sequence_number": 2,
+                "output_index": 1,
+                "item": {
+                    "id": "msg_cancel",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                },
+            },
+            {
+                "type": "response.content_part.added",
+                "sequence_number": 3,
+                "output_index": 1,
+                "item_id": "msg_cancel",
+                "content_index": 0,
+                "part": {"type": "output_text", "text": "", "annotations": []},
+            },
+            {
+                "type": "response.output_text.delta",
+                "sequence_number": 4,
+                "output_index": 1,
+                "item_id": "msg_cancel",
+                "content_index": 0,
+                "delta": "cancel-checkpoint",
+                "logprobs": [],
+            },
+        ]
+    )
+
+
+def _chat_partial_call_then_text() -> bytes:
+    return _sse(
+        [
+            {
+                "id": "chatcmpl_partial",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "cancel-checkpoint",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_partial",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "calculator",
+                                        "arguments": '{"expression":',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        ]
+    )
+
+
+@pytest.mark.parametrize("api_mode", ["responses", "chat_completions"])
+@pytest.mark.allow_network
+def test_qwencloud_partial_call_cancellation_never_executes(
+    tmp_path: Any,
+    api_mode: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.Tools.tool_executor import CalculatorTool
+
+    executions: list[str] = []
+    real_execute = CalculatorTool.execute
+
+    async def recording_execute(self: CalculatorTool, expression: str) -> dict:
+        executions.append(expression)
+        return await real_execute(self, expression)
+
+    monkeypatch.setattr(CalculatorTool, "execute", recording_execute)
+    cancelled = threading.Event()
+    body = (
+        _responses_partial_call_then_text()
+        if api_mode == "responses"
+        else _chat_partial_call_then_text()
+    )
+
+    with _joined_qwen_server(
+        [body],
+        on_request=lambda request_count: cancelled.set(),
+    ) as server:
+        outcome, _store = _run_joined_reply(
+            tmp_path,
+            server,
+            api_mode,
+            should_cancel=cancelled.is_set,
+        )
+
+    assert outcome.status == "cancelled"
+    assert len(server.requests) == 1
+    assert executions == []
+    assert not any(step.kind == "tool_result" for step in outcome.steps)
+
+
+@pytest.mark.allow_network
+def test_qwencloud_responses_usage_enforces_agent_budget(
+    tmp_path: Any,
+) -> None:
+    usage = {
+        "input_tokens": 1_000_000,
+        "output_tokens": 1,
+        "total_tokens": 1_000_001,
+    }
+    body = _responses_tool_turn(
+        [("fc_budget", "call_budget", '{"expression":"2+2"}')],
+        usage=usage,
+    )
+    with _joined_qwen_server([body]) as server:
+        outcome, _store = _run_joined_reply(tmp_path, server, "responses")
+
+    assert outcome.status == "stuck"
+    assert outcome.total_tokens == 1_000_001
+    assert len(server.requests) == 1
+    assert outcome.steps[-1].kind == "error"
+    assert outcome.steps[-1].summary == "token budget exhausted"

--- a/Tests/Chat/test_qwencloud_native_tools.py
+++ b/Tests/Chat/test_qwencloud_native_tools.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from contextlib import contextmanager
+from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import threading
-from typing import Any, Iterator
+from typing import Any, Callable, Iterator
 
 import pytest
+import requests
 
 from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
@@ -23,14 +26,12 @@ from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 _FINAL_SENTINEL = "QWENCLOUD-NATIVE-FINAL-SENTINEL"
 
 
-def _sse(events: list[dict[str, Any]]) -> bytes:
-    return (
-        b"".join(
-            b"data: " + json.dumps(event, separators=(",", ":")).encode() + b"\n\n"
-            for event in events
-        )
-        + b"data: [DONE]\n\n"
+def _sse(events: list[dict[str, Any]], *, done: bool = True) -> bytes:
+    wire = b"".join(
+        b"data: " + json.dumps(event, separators=(",", ":")).encode() + b"\n\n"
+        for event in events
     )
+    return wire + (b"data: [DONE]\n\n" if done else b"")
 
 
 def _responses_tool_turn(
@@ -237,27 +238,59 @@ def _chat_final_turn(text: str = _FINAL_SENTINEL) -> bytes:
     )
 
 
+@dataclass(frozen=True)
+class _StalledSSE:
+    """One non-terminal chunk that remains live until the client closes."""
+
+    prefix: bytes
+    client_close_started: threading.Event
+
+
+@dataclass(frozen=True)
+class _ValidationFailure:
+    message: str
+
+
+_RequestValidator = Callable[[str, dict[str, Any]], None]
+_ScriptedBody = bytes | _StalledSSE
+
+
 class _JoinedQwenServer(ThreadingHTTPServer):
     daemon_threads = True
 
     def __init__(
         self,
-        bodies: list[bytes],
+        bodies: Sequence[_ScriptedBody],
         *,
-        on_request: Any = None,
+        validators: list[_RequestValidator] | None = None,
+        on_request: Callable[[int], None] | None = None,
     ) -> None:
         super().__init__(("127.0.0.1", 0), _JoinedQwenHandler)
         self.bodies = list(bodies)
+        self.validators = list(validators or [])
         self.requests: list[dict[str, Any]] = []
+        self.validation_errors: list[str] = []
         self.on_request = on_request
+        self.stall_started = threading.Event()
+        self.stall_timed_out = threading.Event()
         self._lock = threading.Lock()
 
-    def handle_request_payload(self, path: str, payload: dict[str, Any]) -> bytes:
+    def handle_request_payload(
+        self, path: str, payload: dict[str, Any]
+    ) -> _ScriptedBody | _ValidationFailure:
         with self._lock:
             self.requests.append({"path": path, "payload": payload})
             if self.on_request is not None:
                 self.on_request(len(self.requests))
             assert self.bodies, "provider script exhausted"
+            if self.validators:
+                try:
+                    self.validators[0](path, payload)
+                except AssertionError as exc:
+                    message = str(exc) or "scripted request validation failed"
+                    self.validation_errors.append(message)
+                    return _ValidationFailure(message)
+                self.validators.pop(0)
             return self.bodies.pop(0)
 
 
@@ -269,7 +302,40 @@ class _JoinedQwenHandler(BaseHTTPRequestHandler):
         payload = json.loads(self.rfile.read(length))
         server = self.server
         assert isinstance(server, _JoinedQwenServer)
-        body = server.handle_request_payload(self.path, payload)
+        action = server.handle_request_payload(self.path, payload)
+        if isinstance(action, _ValidationFailure):
+            body = json.dumps({"error": {"message": action.message}}).encode()
+            self.send_response(422)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(body)
+            self.wfile.flush()
+            self.close_connection = True
+            return
+        if isinstance(action, _StalledSSE):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Transfer-Encoding", "chunked")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            chunk = action.prefix
+            self.wfile.write(f"{len(chunk):X}\r\n".encode())
+            self.wfile.write(chunk)
+            self.wfile.write(b"\r\n")
+            self.wfile.flush()
+            server.stall_started.set()
+            if not action.client_close_started.wait(timeout=2):
+                server.stall_timed_out.set()
+            try:
+                self.wfile.write(b"0\r\n\r\n")
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            self.close_connection = True
+            return
+        body = action
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")
         self.send_header("Content-Length", str(len(body)))
@@ -285,11 +351,16 @@ class _JoinedQwenHandler(BaseHTTPRequestHandler):
 
 @contextmanager
 def _joined_qwen_server(
-    bodies: list[bytes],
+    bodies: Sequence[_ScriptedBody],
     *,
-    on_request: Any = None,
+    validators: list[_RequestValidator] | None = None,
+    on_request: Callable[[int], None] | None = None,
 ) -> Iterator[_JoinedQwenServer]:
-    server = _JoinedQwenServer(bodies, on_request=on_request)
+    server = _JoinedQwenServer(
+        bodies,
+        validators=validators,
+        on_request=on_request,
+    )
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -325,6 +396,7 @@ def _run_joined_reply(
     api_mode: str,
     *,
     should_cancel: Any = lambda: False,
+    agent_messages: list[dict[str, Any]] | None = None,
 ) -> tuple[Any, ConsoleChatStore]:
     db = AgentRunsDB(tmp_path / f"{api_mode}.db", client_id="qwen-native")
     store = ConsoleChatStore()
@@ -351,10 +423,125 @@ def _run_joined_reply(
         assistant_message_id=assistant.id,
         model="qwen3.8-max",
         session_system_prompt="",
-        agent_messages=[{"role": "user", "content": "Calculate two expressions."}],
+        agent_messages=(
+            agent_messages
+            if agent_messages is not None
+            else [{"role": "user", "content": "Calculate two expressions."}]
+        ),
         should_cancel=should_cancel,
     )
     return outcome, store
+
+
+def _canonical_tool_calls() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "call_A",
+            "type": "function",
+            "function": {
+                "name": "calculator",
+                "arguments": '{"expression":"6*7"}',
+            },
+        },
+        {
+            "id": "call_B",
+            "type": "function",
+            "function": {
+                "name": "calculator",
+                "arguments": '{"expression":"8*8"}',
+            },
+        },
+    ]
+
+
+def _assert_common_request(api_mode: str, path: str, payload: dict[str, Any]) -> None:
+    expected_path = (
+        "/compatible-mode/v1/responses"
+        if api_mode == "responses"
+        else "/compatible-mode/v1/chat/completions"
+    )
+    assert path == expected_path
+    assert payload["stream"] is True
+    assert any(
+        tool.get("name") == "calculator"
+        or tool.get("function", {}).get("name") == "calculator"
+        for tool in payload["tools"]
+    )
+
+
+def _initial_request_validator(api_mode: str) -> _RequestValidator:
+    def validate(path: str, payload: dict[str, Any]) -> None:
+        _assert_common_request(api_mode, path, payload)
+        if api_mode == "responses":
+            assert payload["input"] == [
+                {"role": "user", "content": "Calculate two expressions."}
+            ]
+            assert payload["store"] is False
+        else:
+            assert payload["messages"][0]["role"] == "system"
+            assert payload["messages"][1:] == [
+                {"role": "user", "content": "Calculate two expressions."}
+            ]
+            assert payload["preserve_thinking"] is False
+
+    return validate
+
+
+def _continuation_request_validator(
+    api_mode: str,
+    *,
+    result_a: str,
+    result_b: str,
+) -> _RequestValidator:
+    calls = _canonical_tool_calls()
+
+    def validate(path: str, payload: dict[str, Any]) -> None:
+        _assert_common_request(api_mode, path, payload)
+        if api_mode == "responses":
+            assert payload["input"] == [
+                {"role": "user", "content": "Calculate two expressions."},
+                {
+                    "type": "function_call",
+                    "call_id": "call_A",
+                    "name": "calculator",
+                    "arguments": '{"expression":"6*7"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_A",
+                    "output": result_a,
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_B",
+                    "name": "calculator",
+                    "arguments": '{"expression":"8*8"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_B",
+                    "output": result_b,
+                },
+            ]
+            return
+        assert payload["messages"][0]["role"] == "system"
+        assert payload["messages"][1:] == [
+            {"role": "user", "content": "Calculate two expressions."},
+            {"role": "assistant", "content": "", "tool_calls": calls},
+            {
+                "role": "tool",
+                "tool_call_id": "call_A",
+                "content": result_a,
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_B",
+                "content": result_b,
+            },
+        ]
+        assert payload["preserve_thinking"] is False
+
+    return validate
 
 
 @pytest.mark.parametrize("api_mode", ["responses", "chat_completions"])
@@ -363,12 +550,24 @@ def test_console_agent_bridge_runs_qwencloud_two_call_continuation(
     tmp_path: Any,
     api_mode: str,
 ) -> None:
+    result_a = '{"expression": "6*7", "result": 42, "result_type": "int"}'
+    result_b = '{"expression": "8*8", "result": 64, "result_type": "int"}'
     bodies = (
         [_responses_tool_turn(), _responses_final_turn()]
         if api_mode == "responses"
         else [_chat_tool_turn(), _chat_final_turn()]
     )
-    with _joined_qwen_server(bodies) as server:
+    with _joined_qwen_server(
+        bodies,
+        validators=[
+            _initial_request_validator(api_mode),
+            _continuation_request_validator(
+                api_mode,
+                result_a=result_a,
+                result_b=result_b,
+            ),
+        ],
+    ) as server:
         outcome, store = _run_joined_reply(tmp_path, server, api_mode)
 
     assert outcome.status == "done"
@@ -381,6 +580,8 @@ def test_console_agent_bridge_runs_qwencloud_two_call_continuation(
     ]
     assert assistant_rows[-1].content == _FINAL_SENTINEL
     assert len(server.requests) == 2
+    assert server.validation_errors == []
+    assert server.validators == []
 
     first = server.requests[0]
     second = server.requests[1]
@@ -403,7 +604,7 @@ def test_console_agent_bridge_runs_qwencloud_two_call_continuation(
             {
                 "type": "function_call_output",
                 "call_id": "call_A",
-                "output": '{"expression": "6*7", "result": 42, "result_type": "int"}',
+                "output": result_a,
             },
             {
                 "type": "function_call",
@@ -414,7 +615,7 @@ def test_console_agent_bridge_runs_qwencloud_two_call_continuation(
             {
                 "type": "function_call_output",
                 "call_id": "call_B",
-                "output": '{"expression": "8*8", "result": 64, "result_type": "int"}',
+                "output": result_b,
             },
         ]
         assert [item for item in continuation if item.get("role") == "user"] == [
@@ -423,17 +624,59 @@ def test_console_agent_bridge_runs_qwencloud_two_call_continuation(
         assert second["payload"]["store"] is False
     else:
         continuation = second["payload"]["messages"]
-        assistant = next(row for row in continuation if row.get("role") == "assistant")
-        assert [call["id"] for call in assistant["tool_calls"]] == [
-            "call_A",
-            "call_B",
-        ]
-        tool_rows = [row for row in continuation if row.get("role") == "tool"]
-        assert [row["tool_call_id"] for row in tool_rows] == ["call_A", "call_B"]
-        assert [row for row in continuation if row.get("role") == "user"] == [
-            {"role": "user", "content": "Calculate two expressions."}
+        assert continuation[0]["role"] == "system"
+        assert continuation[1:] == [
+            {"role": "user", "content": "Calculate two expressions."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": _canonical_tool_calls(),
+            },
+            {"role": "tool", "tool_call_id": "call_A", "content": result_a},
+            {"role": "tool", "tool_call_id": "call_B", "content": result_b},
         ]
         assert second["payload"]["preserve_thinking"] is False
+
+
+@pytest.mark.allow_network
+def test_qwencloud_responses_joined_runtime_history_pairs_out_of_order_results(
+    tmp_path: Any,
+) -> None:
+    """Runtime-shaped B/A result rows become adjacent A/A then B/B on wire."""
+    result_a = "runtime result A"
+    result_b = "runtime result B"
+    runtime_history: list[dict[str, Any]] = [
+        {"role": "user", "content": "Calculate two expressions."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": _canonical_tool_calls(),
+        },
+        {"role": "tool", "tool_call_id": "call_B", "content": result_b},
+        {"role": "tool", "tool_call_id": "call_A", "content": result_a},
+    ]
+    with _joined_qwen_server(
+        [_responses_final_turn("REORDERED-HISTORY-ACCEPTED")],
+        validators=[
+            _continuation_request_validator(
+                "responses",
+                result_a=result_a,
+                result_b=result_b,
+            )
+        ],
+    ) as server:
+        outcome, _store = _run_joined_reply(
+            tmp_path,
+            server,
+            "responses",
+            agent_messages=runtime_history,
+        )
+
+    assert outcome.status == "done"
+    assert outcome.final_text == "REORDERED-HISTORY-ACCEPTED"
+    assert len(server.requests) == 1
+    assert server.validation_errors == []
+    assert server.validators == []
 
 
 @pytest.mark.parametrize("api_mode", ["responses", "chat_completions"])
@@ -529,7 +772,8 @@ def _responses_partial_call_then_text() -> bytes:
                 "delta": "cancel-checkpoint",
                 "logprobs": [],
             },
-        ]
+        ],
+        done=False,
     )
 
 
@@ -560,7 +804,8 @@ def _chat_partial_call_then_text() -> bytes:
                     }
                 ],
             }
-        ]
+        ],
+        done=False,
     )
 
 
@@ -587,11 +832,28 @@ def test_qwencloud_partial_call_cancellation_never_executes(
         if api_mode == "responses"
         else _chat_partial_call_then_text()
     )
+    close_calls: list[int] = []
+    client_close_started = threading.Event()
+    real_response_close = requests.Response.close
 
     with _joined_qwen_server(
-        [body],
-        on_request=lambda request_count: cancelled.set(),
+        [_StalledSSE(body, client_close_started)],
+        on_request=lambda _request_count: cancelled.set(),
     ) as server:
+        address = server.server_address
+        assert isinstance(address, tuple)
+        host, port = address[0], address[1]
+        assert isinstance(host, str)
+        assert isinstance(port, int)
+        request_prefix = f"http://{host}:{port}/compatible-mode/v1/"
+
+        def recording_response_close(response: requests.Response) -> None:
+            if str(response.url).startswith(request_prefix):
+                close_calls.append(id(response))
+                client_close_started.set()
+            real_response_close(response)
+
+        monkeypatch.setattr(requests.Response, "close", recording_response_close)
         outcome, _store = _run_joined_reply(
             tmp_path,
             server,
@@ -601,8 +863,21 @@ def test_qwencloud_partial_call_cancellation_never_executes(
 
     assert outcome.status == "cancelled"
     assert len(server.requests) == 1
+    assert server.stall_started.is_set()
+    assert not server.stall_timed_out.is_set()
+    assert len(close_calls) == 1
     assert executions == []
-    assert not any(step.kind == "tool_result" for step in outcome.steps)
+    assert not any(step.kind in {"tool_call", "tool_result"} for step in outcome.steps)
+    request_payload = server.requests[0]["payload"]
+    if api_mode == "responses":
+        assert not any(
+            item.get("type") == "function_call_output"
+            for item in request_payload["input"]
+        )
+    else:
+        assert not any(
+            item.get("role") == "tool" for item in request_payload["messages"]
+        )
 
 
 @pytest.mark.allow_network

--- a/Tests/Chat/test_qwencloud_native_tools.py
+++ b/Tests/Chat/test_qwencloud_native_tools.py
@@ -24,6 +24,13 @@ from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
 
 _FINAL_SENTINEL = "QWENCLOUD-NATIVE-FINAL-SENTINEL"
+_CANCEL_CHECKPOINT = "cancel-checkpoint"
+# StreamGate keeps a fence-sized suffix; extra visible text lets the complete
+# checkpoint reach the real store before the still-open response is cancelled.
+_CANCEL_STREAM_TEXT = f"{_CANCEL_CHECKPOINT}-visible-stream-padding"
+# Exceed requests' 8 KiB read size with valid SSE comments while withholding
+# the terminal HTTP chunk, ensuring parser consumption precedes client closure.
+_STREAM_HOLD_PADDING = b": hold-open\n\n" * 1024
 
 
 def _sse(events: list[dict[str, Any]], *, done: bool = True) -> bytes:
@@ -263,14 +270,12 @@ class _JoinedQwenServer(ThreadingHTTPServer):
         bodies: Sequence[_ScriptedBody],
         *,
         validators: list[_RequestValidator] | None = None,
-        on_request: Callable[[int], None] | None = None,
     ) -> None:
         super().__init__(("127.0.0.1", 0), _JoinedQwenHandler)
         self.bodies = list(bodies)
         self.validators = list(validators or [])
         self.requests: list[dict[str, Any]] = []
         self.validation_errors: list[str] = []
-        self.on_request = on_request
         self.stall_started = threading.Event()
         self.stall_timed_out = threading.Event()
         self._lock = threading.Lock()
@@ -280,8 +285,6 @@ class _JoinedQwenServer(ThreadingHTTPServer):
     ) -> _ScriptedBody | _ValidationFailure:
         with self._lock:
             self.requests.append({"path": path, "payload": payload})
-            if self.on_request is not None:
-                self.on_request(len(self.requests))
             assert self.bodies, "provider script exhausted"
             if self.validators:
                 try:
@@ -354,12 +357,10 @@ def _joined_qwen_server(
     bodies: Sequence[_ScriptedBody],
     *,
     validators: list[_RequestValidator] | None = None,
-    on_request: Callable[[int], None] | None = None,
 ) -> Iterator[_JoinedQwenServer]:
     server = _JoinedQwenServer(
         bodies,
         validators=validators,
-        on_request=on_request,
     )
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -769,7 +770,7 @@ def _responses_partial_call_then_text() -> bytes:
                 "output_index": 1,
                 "item_id": "msg_cancel",
                 "content_index": 0,
-                "delta": "cancel-checkpoint",
+                "delta": _CANCEL_STREAM_TEXT,
                 "logprobs": [],
             },
         ],
@@ -787,7 +788,7 @@ def _chat_partial_call_then_text() -> bytes:
                         "index": 0,
                         "delta": {
                             "role": "assistant",
-                            "content": "cancel-checkpoint",
+                            "content": _CANCEL_STREAM_TEXT,
                             "tool_calls": [
                                 {
                                     "index": 0,
@@ -809,6 +810,70 @@ def _chat_partial_call_then_text() -> bytes:
     )
 
 
+def _assert_partial_call_precedes_checkpoint(api_mode: str, body: bytes) -> str:
+    """Validate the cancellation fixture cannot degrade to ordinary text."""
+    events = [
+        json.loads(record.removeprefix(b"data: "))
+        for record in body.split(b"\n\n")
+        if record.startswith(b"data: {")
+    ]
+    if api_mode == "responses":
+        partial_item_indexes = [
+            index
+            for index, event in enumerate(events)
+            if event.get("type") == "response.output_item.added"
+            and event.get("item", {}).get("type") == "function_call"
+            and event.get("item", {}).get("status") == "in_progress"
+        ]
+        partial_delta_indexes = [
+            index
+            for index, event in enumerate(events)
+            if event.get("type") == "response.function_call_arguments.delta"
+            and event.get("delta") == '{"expression":'
+        ]
+        checkpoint_indexes = [
+            index
+            for index, event in enumerate(events)
+            if event.get("type") == "response.output_text.delta"
+            and event.get("delta") == _CANCEL_STREAM_TEXT
+        ]
+        assert partial_item_indexes
+        assert partial_delta_indexes
+        assert checkpoint_indexes
+        assert partial_item_indexes[0] < checkpoint_indexes[0]
+        assert partial_delta_indexes[0] < checkpoint_indexes[0]
+        return "response.function_call_arguments.delta"
+
+    checkpoint_events = []
+    for event in events:
+        choices = event.get("choices")
+        if not isinstance(choices, list) or not choices:
+            continue
+        if choices[0].get("delta", {}).get("content") == _CANCEL_STREAM_TEXT:
+            checkpoint_events.append(event)
+    assert checkpoint_events
+    tool_calls = checkpoint_events[0]["choices"][0]["delta"].get("tool_calls")
+    assert isinstance(tool_calls, list) and len(tool_calls) == 1
+    assert tool_calls[0]["function"] == {
+        "name": "calculator",
+        "arguments": '{"expression":',
+    }
+    return "chat.delta.tool_calls"
+
+
+@pytest.mark.parametrize("api_mode", ["responses", "chat_completions"])
+def test_partial_call_cancellation_fixture_rejects_text_only_mutation(
+    api_mode: str,
+) -> None:
+    text_only = (
+        _responses_final_turn(_CANCEL_STREAM_TEXT)
+        if api_mode == "responses"
+        else _chat_final_turn(_CANCEL_STREAM_TEXT)
+    )
+    with pytest.raises(AssertionError):
+        _assert_partial_call_precedes_checkpoint(api_mode, text_only)
+
+
 @pytest.mark.parametrize("api_mode", ["responses", "chat_completions"])
 @pytest.mark.allow_network
 def test_qwencloud_partial_call_cancellation_never_executes(
@@ -827,18 +892,36 @@ def test_qwencloud_partial_call_cancellation_never_executes(
 
     monkeypatch.setattr(CalculatorTool, "execute", recording_execute)
     cancelled = threading.Event()
+    checkpoint_observed = threading.Event()
     body = (
         _responses_partial_call_then_text()
         if api_mode == "responses"
         else _chat_partial_call_then_text()
     )
+    partial_event = _assert_partial_call_precedes_checkpoint(api_mode, body)
     close_calls: list[int] = []
     client_close_started = threading.Event()
     real_response_close = requests.Response.close
+    real_append_stream_chunk = ConsoleChatStore.append_stream_chunk
+
+    def recording_stream_chunk(
+        store: ConsoleChatStore, message_id: str, chunk: str
+    ) -> Any:
+        message = real_append_stream_chunk(store, message_id, chunk)
+        if _CANCEL_CHECKPOINT in chunk:
+            checkpoint_observed.set()
+            cancelled.set()
+        return message
+
+    monkeypatch.setattr(
+        ConsoleChatStore,
+        "append_stream_chunk",
+        recording_stream_chunk,
+    )
+    assert not cancelled.is_set()
 
     with _joined_qwen_server(
-        [_StalledSSE(body, client_close_started)],
-        on_request=lambda _request_count: cancelled.set(),
+        [_StalledSSE(body + _STREAM_HOLD_PADDING, client_close_started)]
     ) as server:
         address = server.server_address
         assert isinstance(address, tuple)
@@ -862,6 +945,12 @@ def test_qwencloud_partial_call_cancellation_never_executes(
         )
 
     assert outcome.status == "cancelled"
+    assert checkpoint_observed.is_set()
+    assert partial_event == (
+        "response.function_call_arguments.delta"
+        if api_mode == "responses"
+        else "chat.delta.tool_calls"
+    )
     assert len(server.requests) == 1
     assert server.stall_started.is_set()
     assert not server.stall_timed_out.is_set()

--- a/Tests/Chat/test_qwencloud_provider_contract.py
+++ b/Tests/Chat/test_qwencloud_provider_contract.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import tomllib
 
+import pytest
+
+import tldw_chatbook.Chat.Chat_Functions as chat_functions
+
 from tldw_chatbook.Chat.console_provider_support import (
     ConsoleProviderIdentity,
     resolve_console_provider_identity,
@@ -25,9 +29,7 @@ def test_qwencloud_embedded_config_defaults() -> None:
     assert config["api_settings"]["qwencloud"] == {
         "api_mode": "responses",
         "api_key_env_var": "DASHSCOPE_API_KEY",
-        "api_base_url": (
-            "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
-        ),
+        "api_base_url": ("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
         "model": "qwen3.8-max",
         "timeout": 120,
         "retries": 3,
@@ -82,11 +84,7 @@ def test_qwencloud_readiness_uses_modern_config_before_its_env() -> None:
 
     configured_env = get_provider_readiness(
         "QwenCloud",
-        {
-            "api_settings": {
-                "qwencloud": {"api_key_env_var": "QWENCLOUD_OVERRIDE_KEY"}
-            }
-        },
+        {"api_settings": {"qwencloud": {"api_key_env_var": "QWENCLOUD_OVERRIDE_KEY"}}},
         environ={
             "QWENCLOUD_OVERRIDE_KEY": "configured-env-key",
             "DASHSCOPE_API_KEY": "default-env-key",
@@ -138,3 +136,122 @@ def test_qwencloud_builtin_endpoint_is_international_compatible_base() -> None:
         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
     )
     assert provider_uses_endpoint("qwencloud", {}) is True
+
+
+def test_chat_api_call_forwards_qwencloud_mode_base_and_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def qwencloud_handler(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    qwencloud_handler.__name__ = "qwencloud_handler"
+    monkeypatch.setitem(
+        chat_functions.API_CALL_HANDLERS, "qwencloud", qwencloud_handler
+    )
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Look up a value.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    chat_functions.chat_api_call(
+        api_endpoint="QwenCloud",
+        messages_payload=[{"role": "user", "content": "hello"}],
+        api_key="qwen-key",
+        temp=0.2,
+        system_message="Be concise.",
+        streaming=False,
+        model="qwen3.8-max",
+        topk=20,
+        topp=0.8,
+        logprobs=True,
+        top_logprobs=2,
+        presence_penalty=0.1,
+        frequency_penalty=0.4,
+        tools=tools,
+        tool_choice="auto",
+        max_tokens=128,
+        seed=7,
+        stop=["END"],
+        response_format={"type": "json_object"},
+        n=1,
+        reasoning_effort="medium",
+        api_base_url="https://qwen.example/compatible-mode/v1",
+        api_mode="chat_completions",
+    )
+
+    assert captured == {
+        "input_data": [{"role": "user", "content": "hello"}],
+        "model": "qwen3.8-max",
+        "api_key": "qwen-key",
+        "system_message": "Be concise.",
+        "temp": 0.2,
+        "streaming": False,
+        "topp": 0.8,
+        "topk": 20,
+        "max_tokens": 128,
+        "seed": 7,
+        "stop": ["END"],
+        "logprobs": True,
+        "top_logprobs": 2,
+        "presence_penalty": 0.1,
+        "response_format": {"type": "json_object"},
+        "n": 1,
+        "tools": tools,
+        "tool_choice": "auto",
+        "reasoning_effort": "medium",
+        "api_base_url": "https://qwen.example/compatible-mode/v1",
+        "api_mode": "chat_completions",
+    }
+    assert "frequency_penalty" not in captured
+    assert set(chat_functions.PROVIDER_PARAM_MAP["qwencloud"]) == {
+        "messages_payload",
+        "model",
+        "api_key",
+        "system_message",
+        "temp",
+        "streaming",
+        "topp",
+        "topk",
+        "max_tokens",
+        "seed",
+        "stop",
+        "logprobs",
+        "top_logprobs",
+        "presence_penalty",
+        "response_format",
+        "n",
+        "tools",
+        "tool_choice",
+        "reasoning_effort",
+        "api_base_url",
+        "api_mode",
+    }
+
+    for endpoint in ("openai", "deepseek"):
+        other: dict[str, object] = {}
+
+        def representative_handler(**kwargs: object) -> dict[str, object]:
+            other.update(kwargs)
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+        representative_handler.__name__ = f"{endpoint}_handler"
+        monkeypatch.setitem(
+            chat_functions.API_CALL_HANDLERS, endpoint, representative_handler
+        )
+        chat_functions.chat_api_call(
+            api_endpoint=endpoint,
+            messages_payload=[{"role": "user", "content": "hello"}],
+            model="representative-model",
+            streaming=False,
+            api_mode="responses",
+        )
+        assert "api_mode" not in other

--- a/Tests/Chat/test_qwencloud_provider_contract.py
+++ b/Tests/Chat/test_qwencloud_provider_contract.py
@@ -255,3 +255,8 @@ def test_chat_api_call_forwards_qwencloud_mode_base_and_tools(
             api_mode="responses",
         )
         assert "api_mode" not in other
+
+
+def test_qwencloud_is_sensitive_auxiliary_audited() -> None:
+    assert "qwencloud" in chat_functions.API_CALL_HANDLERS
+    assert "qwencloud" in chat_functions.SENSITIVE_AUXILIARY_AUDITED_ENDPOINTS

--- a/Tests/Chat/test_qwencloud_provider_contract.py
+++ b/Tests/Chat/test_qwencloud_provider_contract.py
@@ -1,0 +1,140 @@
+"""Cross-boundary registration contracts for the QwenCloud provider."""
+
+from __future__ import annotations
+
+import tomllib
+
+from tldw_chatbook.Chat.console_provider_support import (
+    ConsoleProviderIdentity,
+    resolve_console_provider_identity,
+    supported_console_provider_catalog,
+)
+from tldw_chatbook.Chat.console_provider_endpoints import (
+    effective_provider_endpoint,
+    provider_uses_endpoint,
+)
+from tldw_chatbook.Chat.provider_catalog import provider_display_name
+from tldw_chatbook.Chat.provider_readiness import get_provider_readiness
+from tldw_chatbook.config import API_MODELS_BY_PROVIDER, CONFIG_TOML_CONTENT
+
+
+def test_qwencloud_embedded_config_defaults() -> None:
+    config = tomllib.loads(CONFIG_TOML_CONTENT)
+
+    assert config["providers"]["QwenCloud"] == ["qwen3.8-max"]
+    assert config["api_settings"]["qwencloud"] == {
+        "api_mode": "responses",
+        "api_key_env_var": "DASHSCOPE_API_KEY",
+        "api_base_url": (
+            "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+        ),
+        "model": "qwen3.8-max",
+        "timeout": 120,
+        "retries": 3,
+        "retry_delay": 1,
+        "streaming": True,
+    }
+    assert API_MODELS_BY_PROVIDER["QwenCloud"] == ["qwen3.8-max"]
+
+
+def test_qwencloud_uses_one_supported_console_identity() -> None:
+    handler_keys = {"qwencloud"}
+
+    assert provider_display_name("qwencloud") == "QwenCloud"
+    assert resolve_console_provider_identity(
+        "QwenCloud",
+        handler_keys=handler_keys,
+    ) == ConsoleProviderIdentity(
+        display_key="qwencloud",
+        readiness_key="qwencloud",
+        execution_key="qwencloud",
+        is_supported=True,
+    )
+
+    catalog = supported_console_provider_catalog(handler_keys=handler_keys)
+    assert len(catalog) == 1
+    assert catalog[0].readiness_key == "qwencloud"
+    assert catalog[0].execution_key == "qwencloud"
+    assert catalog[0].display_name == "QwenCloud"
+
+
+def test_qwencloud_readiness_uses_modern_config_before_its_env() -> None:
+    modern = get_provider_readiness(
+        "QwenCloud",
+        {
+            "api_settings": {
+                "qwencloud": {
+                    "api_key": "modern-qwencloud-key",
+                    "api_key_env_var": "QWENCLOUD_OVERRIDE_KEY",
+                }
+            }
+        },
+        environ={
+            "QWENCLOUD_OVERRIDE_KEY": "configured-env-key",
+            "DASHSCOPE_API_KEY": "default-env-key",
+        },
+    )
+
+    assert modern.requires_api_key is True
+    assert modern.ready is True
+    assert modern.api_key == "modern-qwencloud-key"
+    assert modern.api_key_source == "config:api_settings.qwencloud.api_key"
+
+    configured_env = get_provider_readiness(
+        "QwenCloud",
+        {
+            "api_settings": {
+                "qwencloud": {"api_key_env_var": "QWENCLOUD_OVERRIDE_KEY"}
+            }
+        },
+        environ={
+            "QWENCLOUD_OVERRIDE_KEY": "configured-env-key",
+            "DASHSCOPE_API_KEY": "default-env-key",
+        },
+    )
+    assert configured_env.api_key == "configured-env-key"
+    assert configured_env.api_key_source == "env:QWENCLOUD_OVERRIDE_KEY"
+
+    default_env = get_provider_readiness(
+        "QwenCloud",
+        {"api_settings": {"qwencloud": {"model": "qwen3.8-max"}}},
+        environ={"DASHSCOPE_API_KEY": "default-env-key"},
+    )
+    assert default_env.api_key == "default-env-key"
+    assert default_env.api_key_source == "env:DASHSCOPE_API_KEY"
+    assert default_env.env_var == "DASHSCOPE_API_KEY"
+
+
+def test_qwencloud_readiness_never_borrows_another_provider() -> None:
+    readiness = get_provider_readiness(
+        "QwenCloud",
+        {
+            "api_settings": {
+                "qwencloud": {"model": "qwen3.8-max"},
+                "openai": {"api_key": "openai-config-key"},
+                "deepseek": {"api_key": "deepseek-config-key"},
+                "custom": {"api_key": "custom-openai-config-key"},
+            }
+        },
+        environ={
+            "OPENAI_API_KEY": "openai-env-key",
+            "DEEPSEEK_API_KEY": "deepseek-env-key",
+            "CUSTOM_API_KEY": "custom-openai-env-key",
+        },
+    )
+
+    assert readiness.requires_api_key is True
+    assert readiness.ready is False
+    assert readiness.api_key is None
+    assert readiness.env_var == "DASHSCOPE_API_KEY"
+    assert readiness.reason == "Missing API key"
+    assert readiness.recovery == (
+        "Set DASHSCOPE_API_KEY or add api_key under [api_settings.qwencloud]."
+    )
+
+
+def test_qwencloud_builtin_endpoint_is_international_compatible_base() -> None:
+    assert effective_provider_endpoint("qwencloud", None, {}) == (
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    )
+    assert provider_uses_endpoint("qwencloud", {}) is True

--- a/Tests/Chat/test_sensitive_llm_logging.py
+++ b/Tests/Chat/test_sensitive_llm_logging.py
@@ -317,6 +317,11 @@ def test_sensitive_audit_registry_covers_every_registered_chat_handler() -> None
     )
 
 
+def test_qwencloud_is_sensitive_auxiliary_audited() -> None:
+    assert "qwencloud" in chat_functions.API_CALL_HANDLERS
+    assert "qwencloud" in SENSITIVE_AUXILIARY_AUDITED_ENDPOINTS
+
+
 def test_registered_chat_handlers_accept_pinned_endpoint_override() -> None:
     missing = {
         endpoint
@@ -1268,6 +1273,7 @@ def _plant_sentinel_openai_config(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.parametrize("sensitive", [False, True])
+@pytest.mark.allow_network
 def test_sentinel_api_key_never_reaches_diagnose_false_sink_on_request_exception(
     monkeypatch: pytest.MonkeyPatch,
     sensitive: bool,
@@ -1305,6 +1311,7 @@ def test_sentinel_api_key_never_reaches_diagnose_false_sink_on_request_exception
     assert SENTINEL_API_KEY not in rendered
 
 
+@pytest.mark.allow_network
 def test_sentinel_api_key_leaks_via_diagnose_true_sink_confirming_mechanism_is_real(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1478,9 +1485,7 @@ def test_fresh_process_incident_shape_leaks_only_without_package_import(
 
     project_root = Path(__file__).resolve().parents[2]
     child_env = {
-        key: value
-        for key, value in os.environ.items()
-        if not key.startswith("LOGURU_")
+        key: value for key, value in os.environ.items() if not key.startswith("LOGURU_")
     }
     child_env["LEAK_SENTINEL"] = SENTINEL_API_KEY
     child_env["PYTHONPATH"] = str(project_root) + (
@@ -1546,9 +1551,7 @@ def test_package_import_preserves_host_configured_loguru_sinks(
 
     project_root = Path(__file__).resolve().parents[2]
     child_env = {
-        key: value
-        for key, value in os.environ.items()
-        if not key.startswith("LOGURU_")
+        key: value for key, value in os.environ.items() if not key.startswith("LOGURU_")
     }
     child_env["PYTHONPATH"] = str(project_root) + (
         os.pathsep + child_env["PYTHONPATH"] if child_env.get("PYTHONPATH") else ""

--- a/Tests/Chat/test_sensitive_llm_logging.py
+++ b/Tests/Chat/test_sensitive_llm_logging.py
@@ -317,11 +317,6 @@ def test_sensitive_audit_registry_covers_every_registered_chat_handler() -> None
     )
 
 
-def test_qwencloud_is_sensitive_auxiliary_audited() -> None:
-    assert "qwencloud" in chat_functions.API_CALL_HANDLERS
-    assert "qwencloud" in SENSITIVE_AUXILIARY_AUDITED_ENDPOINTS
-
-
 def test_registered_chat_handlers_accept_pinned_endpoint_override() -> None:
     missing = {
         endpoint

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -2261,6 +2261,143 @@ def test_direct_adapter_canonical_qwencloud_config_overrides_alias_in_any_order(
     assert "canonical-key-canary" not in "".join(logs)
 
 
+@pytest.mark.parametrize("canonical_first", [False, True])
+def test_direct_adapter_rejects_malformed_canonical_table_without_alias_leakage(
+    monkeypatch: pytest.MonkeyPatch,
+    canonical_first: bool,
+) -> None:
+    alias = {
+        "api_key": "ALIAS-SECRET-CANARY",
+        "api_mode": "responses",
+        "model": "ALIAS-MODEL-CANARY",
+    }
+    entries = (
+        [("qwencloud", []), ("QwenCloud", alias)]
+        if canonical_first
+        else [("QwenCloud", alias), ("qwencloud", [])]
+    )
+    source = {"api_settings": dict(entries)}
+    original = deepcopy(source)
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(values=source),
+    )
+    monkeypatch.setattr(
+        qwencloud.requests,
+        "Session",
+        lambda: pytest.fail("malformed Qwen config must fail before network"),
+    )
+
+    with _captured_qwencloud_logs() as logs:
+        with pytest.raises(ChatConfigurationError):
+            chat_with_qwencloud(
+                input_data=[{"role": "user", "content": "hello"}],
+                model=None,
+                api_key=None,
+                streaming=False,
+                api_base_url=None,
+                api_mode=None,
+            )
+
+    assert source == original
+    assert "ALIAS-SECRET-CANARY" not in "".join(logs)
+    assert "ALIAS-MODEL-CANARY" not in "".join(logs)
+
+
+def test_direct_adapter_rejects_alias_only_malformed_table_before_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = {"api_settings": {"QwenCloud": ["SECRET-CANARY"]}}
+    original = deepcopy(source)
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(values=source),
+    )
+    monkeypatch.setattr(
+        qwencloud.requests,
+        "Session",
+        lambda: pytest.fail("malformed Qwen config must fail before network"),
+    )
+
+    with _captured_qwencloud_logs() as logs:
+        with pytest.raises(ChatConfigurationError):
+            chat_with_qwencloud(
+                input_data=[{"role": "user", "content": "hello"}],
+                model="explicit-model",
+                api_key="explicit-key",
+                streaming=False,
+                api_base_url="https://explicit.example.test/v1",
+                api_mode="responses",
+            )
+
+    assert source == original
+    assert "SECRET-CANARY" not in "".join(logs)
+
+
+@pytest.mark.parametrize("canonical_first", [False, True])
+def test_direct_adapter_ignores_malformed_alias_when_canonical_is_valid(
+    monkeypatch: pytest.MonkeyPatch,
+    canonical_first: bool,
+) -> None:
+    response = _TransportResponse(
+        {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+    )
+    session = _RecordingSession(response)
+    monkeypatch.setattr(
+        qwencloud,
+        "requests",
+        SimpleNamespace(Session=lambda: session),
+    )
+    canonical = {
+        "api_key": "canonical-key",
+        "api_mode": "chat_completions",
+        "api_base_url": "https://canonical.example.test/v1",
+        "model": "canonical-model",
+        "timeout": 17,
+        "retries": 0,
+    }
+    entries = (
+        [("qwencloud", canonical), ("QwenCloud", ["SECRET-CANARY"])]
+        if canonical_first
+        else [("QwenCloud", ["SECRET-CANARY"]), ("qwencloud", canonical)]
+    )
+    source = {"api_settings": dict(entries)}
+    original = deepcopy(source)
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(values=source),
+    )
+
+    with _captured_qwencloud_logs() as logs:
+        chat_with_qwencloud(
+            input_data=[{"role": "user", "content": "hello"}],
+            model=None,
+            api_key=None,
+            streaming=False,
+            api_base_url=None,
+            api_mode=None,
+        )
+
+    assert source == original
+    assert session.posts[0]["url"] == (
+        "https://canonical.example.test/v1/chat/completions"
+    )
+    assert session.posts[0]["headers"]["Authorization"] == "Bearer canonical-key"
+    assert session.posts[0]["json"]["model"] == "canonical-model"
+    assert session.posts[0]["timeout"] == 17.0
+    assert "SECRET-CANARY" not in "".join(logs)
+
+
 @pytest.mark.parametrize(
     "api_settings",
     (

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -10,7 +10,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import socket
 import threading
 from types import SimpleNamespace
-from typing import Any, Iterator
+from typing import Any, Iterator, Never
 
 import pytest
 import requests
@@ -97,6 +97,9 @@ _SCRIPTED_SUCCESS_BODY = (
     b'"finish_reason":"stop"}]}'
 )
 _STALLED_ERROR_CANARY = b"RAW-STALLED-400-CANARY"
+_TRUNCATED_BODY_CANARY = b'RAW-TRUNCATED-BODY-CANARY{"choices":['
+_INVALID_JSON_CANARY = b"RAW-INVALID-JSON-CANARY"
+_INVALID_GZIP_CANARY = b"RAW-CONTENT-DECODING-CANARY"
 _ScriptedAction = str | tuple[int, dict[str, str]]
 
 
@@ -111,6 +114,37 @@ class _ScriptedQwenHandler(BaseHTTPRequestHandler):
         server = self.server
         assert isinstance(server, _ScriptedQwenServer)
         action = server.next_action()
+        if action == "truncated":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(_TRUNCATED_BODY_CANARY) + 100))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(_TRUNCATED_BODY_CANARY)
+            self.wfile.flush()
+            self.close_connection = True
+            return
+        if action == "invalid_json":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(_INVALID_JSON_CANARY)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(_INVALID_JSON_CANARY)
+            self.wfile.flush()
+            self.close_connection = True
+            return
+        if action == "invalid_gzip":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Encoding", "gzip")
+            self.send_header("Content-Length", str(len(_INVALID_GZIP_CANARY)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(_INVALID_GZIP_CANARY)
+            self.wfile.flush()
+            self.close_connection = True
+            return
         if action == "stall_400":
             self.send_response(400)
             self.send_header("Content-Type", "application/json")
@@ -424,6 +458,37 @@ def test_api_key_precedence_is_provider_isolated() -> None:
         )
     assert exc_info.value.provider == "qwencloud"
     assert "do-not-use" not in str(exc_info.value)
+
+
+def test_api_key_resolution_strips_and_skips_repository_placeholders() -> None:
+    assert resolve_qwencloud_api_key("  explicit-key  ", environ={}) == "explicit-key"
+    assert (
+        resolve_qwencloud_api_key(
+            " YOUR_KEY ",
+            provider_settings={"api_key": "  modern-key  "},
+            environ={"DASHSCOPE_API_KEY": "env-key"},
+        )
+        == "modern-key"
+    )
+    assert (
+        resolve_qwencloud_api_key(
+            "<API_KEY_HERE>",
+            provider_settings={
+                "api_key": " your-api-key ",
+                "api_key_env_var": "QWEN_KEY",
+            },
+            environ={"QWEN_KEY": "  env-key  "},
+        )
+        == "env-key"
+    )
+
+    with pytest.raises(ChatConfigurationError) as exc_info:
+        resolve_qwencloud_api_key(
+            "YOUR_KEY",
+            provider_settings={"api_key": " <API_KEY_HERE> "},
+            environ={"DASHSCOPE_API_KEY": " your_key "},
+        )
+    assert exc_info.value.provider == "qwencloud"
 
 
 def test_resolution_helpers_reject_invalid_mapping_shapes() -> None:
@@ -1600,6 +1665,123 @@ def test_nonstream_rejects_empty_success_and_malformed_shapes() -> None:
         assert "private" not in str(exc_info.value)
 
 
+@pytest.mark.parametrize(
+    ("content", "tool_calls", "raw_finish_reason", "expected_finish_reason"),
+    (
+        pytest.param("answer", None, "stop", "stop", id="text-stop"),
+        pytest.param("partial", None, "length", "length", id="text-length"),
+        pytest.param(
+            "I will check.",
+            [
+                {
+                    "id": "call_chat",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+            "tool_calls",
+            "tool_calls",
+            id="mixed-tool-calls",
+        ),
+    ),
+)
+def test_chat_finish_reason_accepts_only_consistent_terminal_states(
+    content: str,
+    tool_calls: list[dict[str, Any]] | None,
+    raw_finish_reason: str,
+    expected_finish_reason: str,
+) -> None:
+    message: dict[str, Any] = {"role": "assistant", "content": content}
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
+
+    normalized = qwencloud.normalize_qwencloud_response(
+        {"choices": [{"message": message, "finish_reason": raw_finish_reason}]},
+        api_mode="chat_completions",
+    )
+
+    assert normalized["choices"][0]["finish_reason"] == expected_finish_reason
+
+
+@pytest.mark.parametrize(
+    ("message", "choice_fields"),
+    (
+        pytest.param(
+            {"role": "assistant", "content": "private"},
+            {"finish_reason": "content_filter"},
+            id="content-filter",
+        ),
+        pytest.param(
+            {"role": "assistant", "content": "private"},
+            {"finish_reason": "future-value"},
+            id="unknown",
+        ),
+        pytest.param(
+            {"role": "assistant", "content": "private"},
+            {},
+            id="missing",
+        ),
+        pytest.param(
+            {"role": "assistant", "content": "private"},
+            {"finish_reason": ""},
+            id="empty",
+        ),
+        pytest.param(
+            {"role": "assistant", "content": "private"},
+            {"finish_reason": "   "},
+            id="blank",
+        ),
+        pytest.param(
+            {"role": "assistant", "content": "private"},
+            {"finish_reason": "tool_calls"},
+            id="tool-reason-without-calls",
+        ),
+        pytest.param(
+            {
+                "role": "assistant",
+                "content": "private",
+                "tool_calls": [
+                    {
+                        "id": "call_chat",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"finish_reason": "stop"},
+            id="calls-with-stop",
+        ),
+        pytest.param(
+            {
+                "role": "assistant",
+                "content": "private",
+                "tool_calls": [
+                    {
+                        "id": "call_chat",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"finish_reason": "length"},
+            id="calls-with-length",
+        ),
+    ),
+)
+def test_chat_finish_reason_rejects_unknown_or_contradictory_states(
+    message: dict[str, Any],
+    choice_fields: dict[str, Any],
+) -> None:
+    with pytest.raises(ChatProviderError) as exc_info:
+        qwencloud.normalize_qwencloud_response(
+            {"choices": [{"message": message, **choice_fields}]},
+            api_mode="chat_completions",
+        )
+
+    assert exc_info.value.provider == "qwencloud"
+    assert "private" not in str(exc_info.value)
+
+
 def test_responses_requires_call_id_not_transport_id() -> None:
     for call_id_fields in ({}, {"call_id": "  "}):
         with pytest.raises(ChatProviderError) as exc_info:
@@ -1785,6 +1967,136 @@ def test_direct_adapter_loads_only_qwencloud_config_when_arguments_are_none(
         assert canary not in serialized
 
 
+@pytest.mark.parametrize(
+    "api_settings",
+    (
+        {"qwencloud": []},
+        {
+            "qwencloud": {
+                "api_key": "key",
+                "api_base_url": 17,
+                "retries": 0,
+            }
+        },
+    ),
+    ids=("non-mapping-provider-table", "non-string-configured-base"),
+)
+def test_direct_adapter_rejects_malformed_provider_config_before_network(
+    monkeypatch: pytest.MonkeyPatch,
+    api_settings: dict[str, Any],
+) -> None:
+    def unexpected_session() -> Never:
+        raise AssertionError("network must not be initialized")
+
+    monkeypatch.setattr(qwencloud.requests, "Session", unexpected_session)
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(values={"api_settings": api_settings}),
+    )
+
+    with pytest.raises(ChatConfigurationError) as exc_info:
+        chat_with_qwencloud(
+            input_data=[{"role": "user", "content": "hello"}],
+            model="qwen3.8-max",
+            api_key="key",
+            streaming=False,
+            api_base_url=None,
+            api_mode="chat_completions",
+        )
+    assert exc_info.value.provider == "qwencloud"
+
+
+def test_direct_adapter_uses_stripped_lower_key_and_explicit_base_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _TransportResponse(
+        {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+    )
+    session = _RecordingSession(response)
+    monkeypatch.setattr(
+        qwencloud,
+        "requests",
+        SimpleNamespace(Session=lambda: session),
+    )
+    monkeypatch.setenv("QWEN_KEY", "  env-fallback-key  ")
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    "qwencloud": {
+                        "api_key": " YOUR_KEY ",
+                        "api_key_env_var": "QWEN_KEY",
+                        "api_base_url": 17,
+                        "timeout": 3,
+                        "retries": 0,
+                        "retry_delay": 0,
+                    }
+                }
+            }
+        ),
+    )
+
+    chat_with_qwencloud(
+        input_data=[{"role": "user", "content": "hello"}],
+        model="qwen3.8-max",
+        api_key=" <API_KEY_HERE> ",
+        streaming=False,
+        api_base_url="https://explicit.example/v1",
+        api_mode="chat_completions",
+    )
+
+    assert len(session.posts) == 1
+    assert session.posts[0]["url"] == ("https://explicit.example/v1/chat/completions")
+    assert session.posts[0]["headers"]["Authorization"] == ("Bearer env-fallback-key")
+
+
+def test_direct_adapter_rejects_unresolved_placeholders_before_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_session() -> Never:
+        raise AssertionError("network must not be initialized")
+
+    monkeypatch.setattr(qwencloud.requests, "Session", unexpected_session)
+    monkeypatch.setenv("DASHSCOPE_API_KEY", " your_key ")
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    "qwencloud": {
+                        "api_key": " YOUR_KEY ",
+                        "timeout": 3,
+                        "retries": 0,
+                        "retry_delay": 0,
+                    }
+                }
+            }
+        ),
+    )
+
+    with pytest.raises(ChatConfigurationError) as exc_info:
+        chat_with_qwencloud(
+            input_data=[{"role": "user", "content": "hello"}],
+            model="qwen3.8-max",
+            api_key=" <API_KEY_HERE> ",
+            streaming=False,
+            api_base_url="https://explicit.example/v1",
+            api_mode="chat_completions",
+        )
+    assert exc_info.value.provider == "qwencloud"
+
+
 @pytest.mark.allow_network
 def test_retry_policy_counts_status_connection_and_timeout_attempts(
     monkeypatch: pytest.MonkeyPatch,
@@ -1917,6 +2229,45 @@ def test_retry_policy_honors_retry_after_and_exponential_delay(
 
 
 @pytest.mark.allow_network
+@pytest.mark.parametrize("status_code", (429, 503))
+def test_invalid_retry_after_uses_exponential_fallback_without_disclosure(
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr("time.sleep", lambda delay: sleeps.append(delay))
+    post_urls, returned_responses, closed_response_ids = (
+        _track_real_transport_resources(monkeypatch)
+    )
+    closed_session_ids = _track_real_session_closes(monkeypatch)
+    _configure_qwencloud_transport(monkeypatch, retries=2, retry_delay=0.25)
+
+    retry_after_canary = "RAW-RETRY-AFTER-CANARY"
+    with (
+        _captured_qwencloud_logs() as logs,
+        _scripted_qwen_server(
+            [
+                (503, {}),
+                (status_code, {"Retry-After": retry_after_canary}),
+                "success",
+            ]
+        ) as (api_base_url, server),
+    ):
+        result = _call_scripted_qwencloud(api_base_url)
+
+    assert result["choices"][0]["message"]["content"] == "ok"
+    assert len(server.attempts) == 3
+    assert len(post_urls) == 3
+    assert len(returned_responses) == 3
+    assert all(id(response) in closed_response_ids for response in returned_responses)
+    assert len(closed_session_ids) == 1
+    assert sleeps == [pytest.approx(0.5)]
+    rendered = "\n".join(logs)
+    assert retry_after_canary not in rendered
+    assert "InvalidHeader" not in rendered
+
+
+@pytest.mark.allow_network
 def test_retry_policy_uses_one_global_budget_across_mixed_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1936,6 +2287,69 @@ def test_retry_policy_uses_one_global_budget_across_mixed_failures(
     assert len(post_urls) == 3
     assert len(returned_responses) == 3
     assert all(id(response) in closed_response_ids for response in returned_responses)
+
+
+@pytest.mark.allow_network
+def test_truncated_body_retries_once_and_closes_each_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post_urls, returned_responses, closed_response_ids = (
+        _track_real_transport_resources(monkeypatch)
+    )
+    closed_session_ids = _track_real_session_closes(monkeypatch)
+    _configure_qwencloud_transport(monkeypatch, retries=1)
+
+    with (
+        _captured_qwencloud_logs() as logs,
+        _scripted_qwen_server(["truncated", "success"]) as (api_base_url, server),
+    ):
+        result = _call_scripted_qwencloud(api_base_url)
+
+    assert result["choices"][0]["message"]["content"] == "ok"
+    assert len(server.attempts) == 2
+    assert len(post_urls) == 2
+    assert len(returned_responses) == 2
+    assert all(id(response) in closed_response_ids for response in returned_responses)
+    assert len(closed_session_ids) == 1
+    assert _TRUNCATED_BODY_CANARY.decode() not in "\n".join(logs)
+
+
+@pytest.mark.allow_network
+@pytest.mark.parametrize(
+    ("action", "canary"),
+    (
+        pytest.param("invalid_json", _INVALID_JSON_CANARY, id="invalid-json"),
+        pytest.param("invalid_gzip", _INVALID_GZIP_CANARY, id="invalid-content"),
+    ),
+)
+def test_malformed_success_body_is_typed_redacted_and_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+    action: str,
+    canary: bytes,
+) -> None:
+    post_urls, returned_responses, closed_response_ids = (
+        _track_real_transport_resources(monkeypatch)
+    )
+    closed_session_ids = _track_real_session_closes(monkeypatch)
+    _configure_qwencloud_transport(monkeypatch, retries=3)
+
+    with (
+        _captured_qwencloud_logs() as logs,
+        _scripted_qwen_server([action, "success"]) as (api_base_url, server),
+        pytest.raises(ChatProviderError) as exc_info,
+    ):
+        _call_scripted_qwencloud(api_base_url)
+
+    assert len(server.attempts) == 1
+    assert len(post_urls) == 1
+    assert len(returned_responses) == 1
+    assert id(returned_responses[0]) in closed_response_ids
+    assert len(closed_session_ids) == 1
+    assert exc_info.value.provider == "qwencloud"
+    rendered = "\n".join(logs) + "\n" + str(exc_info.value)
+    assert "malformed" in rendered.lower()
+    assert "network request failed" not in rendered.lower()
+    assert canary.decode() not in rendered
 
 
 def test_nontransient_4xx_and_mode_model_mismatch_are_not_retried(

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -1,0 +1,759 @@
+"""Pure request-translation contracts for the QwenCloud adapter."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from tldw_chatbook.Chat.Chat_Deps import ChatBadRequestError, ChatConfigurationError
+from tldw_chatbook.LLM_Calls.qwencloud import (
+    build_qwencloud_payload,
+    normalize_qwencloud_api_mode,
+    normalize_qwencloud_base_url,
+    resolve_qwencloud_api_key,
+)
+
+
+def test_api_mode_config_then_default_and_exact_values() -> None:
+    assert normalize_qwencloud_api_mode(None) == "responses"
+    assert (
+        normalize_qwencloud_api_mode(
+            None, provider_settings={"api_mode": " CHAT_COMPLETIONS "}
+        )
+        == "chat_completions"
+    )
+    assert (
+        normalize_qwencloud_api_mode(
+            " Responses ", provider_settings={"api_mode": "chat_completions"}
+        )
+        == "responses"
+    )
+
+    for rejected in ("response", "chat", "chat-completions", "unknown", ""):
+        with pytest.raises(ChatConfigurationError) as exc_info:
+            normalize_qwencloud_api_mode(rejected)
+        assert exc_info.value.provider == "qwencloud"
+
+
+def test_base_url_normalizes_base_and_pasted_endpoints() -> None:
+    expected = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    assert normalize_qwencloud_base_url(None) == expected
+    assert normalize_qwencloud_base_url(f"  {expected}///  ") == expected
+    assert normalize_qwencloud_base_url(f"{expected}/responses") == expected
+    assert normalize_qwencloud_base_url(f"{expected}/chat/completions/") == expected
+    assert (
+        normalize_qwencloud_base_url("http://gateway.internal:8080/team/qwen/v1/")
+        == "http://gateway.internal:8080/team/qwen/v1"
+    )
+
+
+def test_base_url_rejects_unsafe_or_malformed_values() -> None:
+    rejected = (
+        "dashscope.example/v1",
+        "ftp://dashscope.example/v1",
+        "https:///v1",
+        "https://user:secret@dashscope.example/v1",
+        "https://dashscope.example/v1?tenant=a",
+        "https://dashscope.example/v1#fragment",
+        "https://dashscope.example/v1?",
+        "https://dashscope.example/v1#",
+        "https://dashscope.example/v1/models",
+        "https://dashscope.example/v1/responses/responses",
+        "https://dashscope.example/v1/chat/completions/chat/completions",
+        "https://dashscope.example/v1/responses/extra",
+        "https://dashscope.example/v1/chat/completions/extra",
+        "https://dashscope.example//compatible-mode/v1",
+        "https://bad host.example/v1",
+        "https://dashscope.example:/v1",
+        "https://dashscope.example\n.evil/v1",
+        "https://dashscope.example/%zz",
+        "   ",
+    )
+    for value in rejected:
+        with pytest.raises(ChatConfigurationError) as exc_info:
+            normalize_qwencloud_base_url(value)
+        assert exc_info.value.provider == "qwencloud"
+        assert "secret" not in str(exc_info.value)
+
+
+def test_api_key_precedence_is_provider_isolated() -> None:
+    environ = {
+        "DASHSCOPE_API_KEY": "default-env-key",
+        "QWEN_KEY": "selected-env-key",
+        "OPENAI_API_KEY": "other-provider-key",
+    }
+    settings = {
+        "api_key": "modern-key",
+        "api_key_env_var": "QWEN_KEY",
+        "openai_api_key": "other-provider-setting",
+    }
+
+    assert (
+        resolve_qwencloud_api_key(
+            "trusted-key", provider_settings=settings, environ=environ
+        )
+        == "trusted-key"
+    )
+    assert (
+        resolve_qwencloud_api_key(None, provider_settings=settings, environ=environ)
+        == "modern-key"
+    )
+    assert (
+        resolve_qwencloud_api_key(
+            None,
+            provider_settings={"api_key_env_var": "QWEN_KEY"},
+            environ=environ,
+        )
+        == "selected-env-key"
+    )
+    assert resolve_qwencloud_api_key(None, environ=environ) == "default-env-key"
+
+    with pytest.raises(ChatConfigurationError) as exc_info:
+        resolve_qwencloud_api_key(
+            None,
+            provider_settings={"openai_api_key": "do-not-use"},
+            environ={"OPENAI_API_KEY": "do-not-use"},
+        )
+    assert exc_info.value.provider == "qwencloud"
+    assert "do-not-use" not in str(exc_info.value)
+
+
+def test_responses_payload_has_exact_allowlist_and_stateless_invariants() -> None:
+    payload = build_qwencloud_payload(
+        api_mode="responses",
+        model="qwen3.8-max",
+        system_message="Be concise.",
+        messages_payload=[{"role": "user", "content": "Hello"}],
+        streaming=True,
+        temp=0.2,
+        topp=0.8,
+        topk=20,
+        max_tokens=128,
+        seed=7,
+        presence_penalty=0.3,
+        stop=["END"],
+        response_format={"type": "json_object"},
+        n=2,
+        logprobs=True,
+        top_logprobs=3,
+    )
+
+    assert payload == {
+        "model": "qwen3.8-max",
+        "input": [{"role": "user", "content": "Hello"}],
+        "instructions": "Be concise.",
+        "stream": True,
+        "store": False,
+        "temperature": 0.2,
+        "top_p": 0.8,
+        "max_output_tokens": 128,
+    }
+    assert "previous_response_id" not in payload
+    assert "conversation" not in payload
+
+    with pytest.raises(ChatBadRequestError) as exc_info:
+        build_qwencloud_payload(
+            api_mode="responses",
+            model="qwen3.8-max",
+            system_message=None,
+            messages_payload=[{"role": "user", "content": "Hello"}],
+            streaming=False,
+            max_tokens=15,
+        )
+    assert exc_info.value.provider == "qwencloud"
+
+    with pytest.raises(ChatBadRequestError) as exc_info:
+        build_qwencloud_payload(
+            api_mode="responses",
+            model="qwen3.8-max",
+            system_message=None,
+            messages_payload=[{"role": "user", "content": "Hello"}],
+            streaming=False,
+            max_tokens="128",  # type: ignore[arg-type]
+        )
+    assert exc_info.value.provider == "qwencloud"
+
+
+def test_responses_system_message_maps_to_instructions() -> None:
+    kwargs = {
+        "api_mode": "responses",
+        "model": "qwen3.8-max",
+        "streaming": False,
+    }
+
+    from_leading_row = build_qwencloud_payload(
+        **kwargs,
+        system_message=None,
+        messages_payload=[
+            {"role": "system", "content": "Be precise."},
+            {"role": "user", "content": "Hello"},
+        ],
+    )
+    assert from_leading_row["instructions"] == "Be precise."
+    assert from_leading_row["input"] == [{"role": "user", "content": "Hello"}]
+
+    duplicate = build_qwencloud_payload(
+        **kwargs,
+        system_message="Be precise.",
+        messages_payload=[
+            {"role": "system", "content": "Be precise."},
+            {"role": "user", "content": "Hello"},
+        ],
+    )
+    assert duplicate["instructions"] == "Be precise."
+    assert duplicate["input"] == [{"role": "user", "content": "Hello"}]
+
+    with pytest.raises(ChatBadRequestError):
+        build_qwencloud_payload(
+            **kwargs,
+            system_message="Be concise.",
+            messages_payload=[
+                {"role": "system", "content": "Be expansive."},
+                {"role": "user", "content": "Hello"},
+            ],
+        )
+    with pytest.raises(ChatBadRequestError):
+        build_qwencloud_payload(
+            **kwargs,
+            system_message=None,
+            messages_payload=[
+                {"role": "user", "content": "Hello"},
+                {"role": "system", "content": "Too late."},
+            ],
+        )
+
+
+def test_responses_reasoning_effort_enum_is_exact() -> None:
+    base = {
+        "api_mode": "responses",
+        "model": "qwen3.8-max",
+        "system_message": None,
+        "messages_payload": [{"role": "user", "content": "Hello"}],
+        "streaming": False,
+    }
+    for effort in ("none", "minimal", "low", "medium", "high", "xhigh", "max"):
+        payload = build_qwencloud_payload(**base, reasoning_effort=effort)
+        assert payload["reasoning"] == {"effort": effort}
+
+    for rejected in ("", "LOW", "ultra", "maximum"):
+        with pytest.raises(ChatBadRequestError) as exc_info:
+            build_qwencloud_payload(**base, reasoning_effort=rejected)
+        assert exc_info.value.provider == "qwencloud"
+    with pytest.raises(ChatBadRequestError) as exc_info:
+        build_qwencloud_payload(**base, reasoning_effort=[])  # type: ignore[arg-type]
+    assert exc_info.value.provider == "qwencloud"
+
+
+def test_chat_payload_has_exact_allowlist_and_thinking_invariant() -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Look something up.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    payload = build_qwencloud_payload(
+        api_mode="chat_completions",
+        model="qwen3.8-max",
+        system_message="Be precise.",
+        messages_payload=[{"role": "user", "content": "Hello"}],
+        streaming=True,
+        tools=tools,
+        tool_choice="auto",
+        temp=0.2,
+        topp=0.8,
+        topk=20,
+        max_tokens=128,
+        seed=7,
+        presence_penalty=0.3,
+        stop=["END"],
+        response_format={"type": "json_object"},
+        n=1,
+        logprobs=True,
+        top_logprobs=3,
+        reasoning_effort="high",
+    )
+    assert payload == {
+        "model": "qwen3.8-max",
+        "messages": [
+            {"role": "system", "content": "Be precise."},
+            {"role": "user", "content": "Hello"},
+        ],
+        "stream": True,
+        "temperature": 0.2,
+        "top_p": 0.8,
+        "top_k": 20,
+        "max_completion_tokens": 128,
+        "seed": 7,
+        "presence_penalty": 0.3,
+        "stop": ["END"],
+        "response_format": {"type": "json_object"},
+        "n": 1,
+        "logprobs": True,
+        "top_logprobs": 3,
+        "tools": tools,
+        "tool_choice": "auto",
+        "reasoning_effort": "high",
+        "preserve_thinking": False,
+        "stream_options": {"include_usage": True},
+    }
+
+    nonstream = build_qwencloud_payload(
+        api_mode="chat_completions",
+        model="qwen3.8-max",
+        system_message=None,
+        messages_payload=[{"role": "user", "content": "Hello"}],
+        streaming=False,
+        response_format={"type": "text"},
+        n=2,
+    )
+    assert nonstream["n"] == 2
+    assert nonstream["preserve_thinking"] is False
+    assert "stream_options" not in nonstream
+
+    with pytest.raises(ChatBadRequestError):
+        build_qwencloud_payload(
+            api_mode="chat_completions",
+            model="qwen3.8-max",
+            system_message=None,
+            messages_payload=[{"role": "user", "content": "Hello"}],
+            streaming=False,
+            tools=tools,
+            n=2,
+        )
+    for rejected_format in (
+        {"type": "json_schema"},
+        {"type": "text", "extra": "not-allowed"},
+    ):
+        with pytest.raises(ChatBadRequestError):
+            build_qwencloud_payload(
+                api_mode="chat_completions",
+                model="qwen3.8-max",
+                system_message=None,
+                messages_payload=[{"role": "user", "content": "Hello"}],
+                streaming=False,
+                response_format=rejected_format,
+            )
+
+
+def test_function_tools_translate_by_mode() -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Look something up.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    ]
+    original = deepcopy(tools)
+    common = {
+        "model": "qwen3.8-max",
+        "system_message": None,
+        "messages_payload": [{"role": "user", "content": "Hello"}],
+        "streaming": False,
+        "tools": tools,
+        "tool_choice": "auto",
+    }
+
+    chat_payload = build_qwencloud_payload(api_mode="chat_completions", **common)
+    assert chat_payload["tools"] == tools
+    assert chat_payload["tool_choice"] == "auto"
+    assert chat_payload["n"] == 1
+
+    responses_payload = build_qwencloud_payload(api_mode="responses", **common)
+    assert responses_payload["tools"] == [
+        {
+            "type": "function",
+            "name": "lookup",
+            "description": "Look something up.",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        }
+    ]
+    assert responses_payload["tool_choice"] == "auto"
+    assert tools == original
+    assert chat_payload["tools"] is not tools
+    assert (
+        responses_payload["tools"][0]["parameters"]
+        is not tools[0]["function"]["parameters"]
+    )
+
+    for mode in ("responses", "chat_completions"):
+        for accepted_choice in (None, "auto", "none"):
+            payload = build_qwencloud_payload(
+                api_mode=mode, **{**common, "tool_choice": accepted_choice}
+            )
+            if accepted_choice is None:
+                assert "tool_choice" not in payload
+            else:
+                assert payload["tool_choice"] == accepted_choice
+
+
+def test_invalid_or_builtin_tools_fail_before_network() -> None:
+    base = {
+        "model": "qwen3.8-max",
+        "system_message": None,
+        "messages_payload": [{"role": "user", "content": "Hello"}],
+        "streaming": False,
+    }
+    valid_function = {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "description": "Look something up.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    rejected_tool_sets = (
+        [{"type": "web_search"}],
+        [{"type": "function", "function": {"name": "", "parameters": {}}}],
+        [{"type": "function", "function": {"name": "   ", "parameters": {}}}],
+        [
+            valid_function,
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "parameters": {"type": "object"},
+                },
+            },
+        ],
+        [
+            {
+                "type": "function",
+                "function": {"name": "lookup", "parameters": []},
+            }
+        ],
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "parameters": {"type": "array"},
+                },
+            }
+        ],
+        [
+            {
+                "type": "function",
+                "function": {
+                    "type": "web_search",
+                    "name": "lookup",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    )
+    for mode in ("responses", "chat_completions"):
+        for rejected_tools in rejected_tool_sets:
+            with pytest.raises(ChatBadRequestError) as exc_info:
+                build_qwencloud_payload(
+                    api_mode=mode,
+                    **base,
+                    tools=rejected_tools,  # type: ignore[arg-type]
+                )
+            assert exc_info.value.provider == "qwencloud"
+
+        for rejected_choice in ("required", "lookup", {"type": "function"}):
+            with pytest.raises(ChatBadRequestError):
+                build_qwencloud_payload(
+                    api_mode=mode,
+                    **base,
+                    tools=[valid_function],
+                    tool_choice=rejected_choice,
+                )
+
+
+def test_message_content_translation_is_role_safe_and_immutable() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Hello "},
+                {"type": "text", "text": "world"},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is shown?"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,AAAA",
+                        "detail": "auto",
+                    },
+                },
+            ],
+        },
+    ]
+    original = deepcopy(messages)
+    common = {
+        "model": "qwen3.8-max",
+        "system_message": None,
+        "messages_payload": messages,
+        "streaming": False,
+    }
+
+    chat = build_qwencloud_payload(api_mode="chat_completions", **common)
+    assert chat["messages"] == [
+        {"role": "user", "content": "Hello world"},
+        original[1],
+    ]
+    responses = build_qwencloud_payload(api_mode="responses", **common)
+    assert responses["input"] == [
+        {"role": "user", "content": "Hello world"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "What is shown?"},
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,AAAA",
+                },
+            ],
+        },
+    ]
+    assert messages == original
+    assert chat["messages"][1]["content"] is not messages[1]["content"]
+
+    empty_assistant_batch = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_empty",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_empty", "content": "ok"},
+    ]
+    empty_chat = build_qwencloud_payload(
+        api_mode="chat_completions",
+        model="qwen3.8-max",
+        system_message=None,
+        messages_payload=empty_assistant_batch,
+        streaming=False,
+    )
+    assert empty_chat["messages"][0]["content"] == ""
+    empty_responses = build_qwencloud_payload(
+        api_mode="responses",
+        model="qwen3.8-max",
+        system_message=None,
+        messages_payload=empty_assistant_batch,
+        streaming=False,
+    )
+    assert empty_responses["input"] == [
+        {
+            "type": "function_call",
+            "call_id": "call_empty",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_empty",
+            "output": "ok",
+        },
+    ]
+
+    rejected_messages = (
+        [{"role": "assistant", "content": [original[1]["content"][1]]}],
+        [{"role": "user", "content": [{"type": "audio", "audio": "x"}]}],
+        [{"role": "user", "content": [{"type": "video", "video": "x"}]}],
+        [{"role": "user", "content": [{"type": "file", "file": "x"}]}],
+        [{"role": "user", "content": [{"type": "unknown", "value": "x"}]}],
+        [{"role": "critic", "content": "No"}],
+        [{"role": 42, "content": "No"}],
+        [{"role": "user", "content": 42}],
+        [{"role": "user", "content": [{"type": "text", "text": 42}]}],
+        [{"role": "user", "content": [{"type": "image_url", "image_url": {}}]}],
+        [
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "Too late"},
+        ],
+    )
+    for mode in ("responses", "chat_completions"):
+        for rejected in rejected_messages:
+            with pytest.raises(ChatBadRequestError) as exc_info:
+                build_qwencloud_payload(
+                    api_mode=mode,
+                    model="qwen3.8-max",
+                    system_message=None,
+                    messages_payload=rejected,  # type: ignore[arg-type]
+                    streaming=False,
+                )
+            assert exc_info.value.provider == "qwencloud"
+
+
+def test_responses_assistant_text_is_id_free_easy_input_message() -> None:
+    payload = build_qwencloud_payload(
+        api_mode="responses",
+        model="qwen3.8-max",
+        system_message=None,
+        messages_payload=[
+            {"role": "user", "content": "Question"},
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Prior answer"}],
+            },
+        ],
+        streaming=False,
+    )
+    assistant_item = payload["input"][1]
+    assert assistant_item == {
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "Prior answer"}],
+    }
+    assert set(assistant_item) == {"role", "content"}
+    assert "id" not in assistant_item
+    assert "status" not in assistant_item
+    assert "type" not in assistant_item
+
+
+def test_responses_pairs_out_of_order_results_by_call_id() -> None:
+    messages = [
+        {"role": "user", "content": "Compare both."},
+        {
+            "role": "assistant",
+            "content": "I'll check.",
+            "tool_calls": [
+                {
+                    "id": "call_A",
+                    "type": "function",
+                    "function": {
+                        "name": "first_tool",
+                        "arguments": '{"value": 1}',
+                    },
+                },
+                {
+                    "id": "call_B",
+                    "type": "function",
+                    "function": {
+                        "name": "second_tool",
+                        "arguments": '{"value": 2}',
+                    },
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_B", "content": "result B"},
+        {"role": "tool", "tool_call_id": "call_A", "content": "result A"},
+    ]
+    original = deepcopy(messages)
+
+    payload = build_qwencloud_payload(
+        api_mode="responses",
+        model="qwen3.8-max",
+        system_message=None,
+        messages_payload=messages,
+        streaming=False,
+    )
+    assert payload["input"] == [
+        {"role": "user", "content": "Compare both."},
+        {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "I'll check."}],
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_A",
+            "name": "first_tool",
+            "arguments": '{"value": 1}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_A",
+            "output": "result A",
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_B",
+            "name": "second_tool",
+            "arguments": '{"value": 2}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_B",
+            "output": "result B",
+        },
+    ]
+    assert messages == original
+
+    chat = build_qwencloud_payload(
+        api_mode="chat_completions",
+        model="qwen3.8-max",
+        system_message=None,
+        messages_payload=messages,
+        streaming=False,
+    )
+    assert chat["messages"] == original
+
+
+def test_responses_rejects_unpairable_tool_batches_before_network() -> None:
+    def call(
+        call_id: object = "call_A", name: object = "lookup", arguments: object = "{}"
+    ) -> dict:
+        return {
+            "id": call_id,
+            "type": "function",
+            "function": {"name": name, "arguments": arguments},
+        }
+
+    def assistant(*calls: dict, content: object = "") -> dict:
+        return {"role": "assistant", "content": content, "tool_calls": list(calls)}
+
+    def result(call_id: object = "call_A", content: object = "ok") -> dict:
+        return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+    rejected_histories = (
+        [assistant(call())],
+        [assistant(call()), result(), result()],
+        [result()],
+        [assistant(call()), result("call_extra")],
+        [assistant(call(), call()), result()],
+        [assistant(call("")), result("")],
+        [assistant(call(name="")), result()],
+        [assistant(call(arguments="{")), result()],
+        [assistant(call(arguments=42)), result()],
+        [assistant(call(arguments="[]")), result()],
+        [assistant(call()), result(content={"not": "a string"})],
+        [assistant(call()), {"role": "tool", "content": "missing id"}],
+        [
+            assistant(call("call_A")),
+            result("call_A"),
+            assistant(call("call_A")),
+            result("call_A"),
+        ],
+        [
+            assistant(call("call_A")),
+            assistant(call("call_B")),
+            result("call_A"),
+            result("call_B"),
+        ],
+    )
+    for history in rejected_histories:
+        with pytest.raises(ChatBadRequestError) as exc_info:
+            build_qwencloud_payload(
+                api_mode="responses",
+                model="qwen3.8-max",
+                system_message=None,
+                messages_payload=history,
+                streaming=False,
+            )
+        assert exc_info.value.provider == "qwencloud"

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -420,6 +420,82 @@ def test_base_url_rejects_malformed_authorities() -> None:
         assert exc_info.value.provider == "qwencloud"
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://dashscope.example/api%2fv2",
+        "https://dashscope.example/api%252Fv2",
+        "https://dashscope.example/api%5Cv2",
+        "https://dashscope.example/api/v2/%2e/responses",
+        "https://dashscope.example/api/v2/%2E%2e/responses",
+        "https://dashscope.example/api/v2/%252e%252e/responses",
+        "https://dashscope.example/api/v2/res%70onses",
+        "https://dashscope.example/api/v2/RES%70ONSES",
+        "https://dashscope.example/api/v2/chat/%63ompletions",
+        "https://dashscope.example/api/v2/mod%65ls",
+        "https://dashscope.example/api/v2/res%2570onses",
+        "https://dashscope.example/api/v2/chat/%2563ompletions",
+        "https://dashscope.example/api/v2/mod%2565ls",
+        "https://dashscope.example/api/v2/res%252570onses",
+    ],
+)
+def test_base_url_rejects_encoded_endpoint_structure(value: str) -> None:
+    with pytest.raises(ChatConfigurationError) as exc_info:
+        normalize_qwencloud_base_url(value)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert value not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("https://dashscope.example", "https://dashscope.example"),
+        (
+            "https://dashscope.example/api/RESPONSES",
+            "https://dashscope.example/api/RESPONSES",
+        ),
+        (
+            "https://dashscope.example/tenant-responses/api/v2",
+            "https://dashscope.example/tenant-responses/api/v2",
+        ),
+        (
+            "https://dashscope.example/completion-gateway/api/v2",
+            "https://dashscope.example/completion-gateway/api/v2",
+        ),
+        (
+            "https://dashscope.example/api/v2/responses-extra",
+            "https://dashscope.example/api/v2/responses-extra",
+        ),
+        (
+            "https://dashscope.example/api/v2/chat/completions-extra",
+            "https://dashscope.example/api/v2/chat/completions-extra",
+        ),
+        (
+            "https://dashscope.example/api/v2/myresponses",
+            "https://dashscope.example/api/v2/myresponses",
+        ),
+        (
+            "https://dashscope.example/tenant%20alpha/api/v2",
+            "https://dashscope.example/tenant%20alpha/api/v2",
+        ),
+        (
+            "https://dashscope.example/tenant%2520alpha/api/v2",
+            "https://dashscope.example/tenant%2520alpha/api/v2",
+        ),
+        (
+            "https://dashscope.example/mod%65ls/api/v2",
+            "https://dashscope.example/mod%65ls/api/v2",
+        ),
+    ],
+)
+def test_base_url_preserves_valid_arbitrary_prefix_contract(
+    value: str,
+    expected: str,
+) -> None:
+    assert normalize_qwencloud_base_url(value) == expected
+
+
 def test_api_key_precedence_is_provider_isolated() -> None:
     environ = {
         "DASHSCOPE_API_KEY": "default-env-key",

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -2,22 +2,19 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import socket
+import threading
 from types import SimpleNamespace
 from typing import Any, Iterator
 
 import pytest
 import requests
 from loguru import logger
-from urllib3.exceptions import (
-    ConnectTimeoutError,
-    MaxRetryError,
-    ReadTimeoutError,
-)
-from urllib3.util import Retry
 
 from tldw_chatbook.Chat.Chat_Deps import (
     ChatAuthenticationError,
@@ -95,13 +92,161 @@ class _RecordingSession:
         self.closed = True
 
 
-class _RetryResponse:
-    def __init__(self, status: int, *, headers: dict[str, str] | None = None) -> None:
-        self.status = status
-        self.headers = headers or {}
+_SCRIPTED_SUCCESS_BODY = (
+    b'{"choices":[{"message":{"role":"assistant","content":"ok"},'
+    b'"finish_reason":"stop"}]}'
+)
+_ScriptedAction = str | tuple[int, dict[str, str]]
 
-    def get_redirect_location(self) -> None:
-        return None
+
+class _ScriptedQwenHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        if content_length:
+            self.rfile.read(content_length)
+
+        server = self.server
+        assert isinstance(server, _ScriptedQwenServer)
+        action = server.next_action()
+        if action == "stall":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(_SCRIPTED_SUCCESS_BODY)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.flush()
+            server.release_stalls.wait(timeout=1)
+            self.close_connection = True
+            return
+
+        if action == "success":
+            status_code = 200
+            headers: dict[str, str] = {}
+            body = _SCRIPTED_SUCCESS_BODY
+        else:
+            status_code, headers = action
+            body = b'{"error":{"message":"scripted provider failure"}}'
+
+        self.send_response(status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        for name, value in headers.items():
+            self.send_header(name, value)
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+            self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        self.close_connection = True
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+class _ScriptedQwenServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, actions: list[_ScriptedAction]) -> None:
+        super().__init__(("127.0.0.1", 0), _ScriptedQwenHandler)
+        self.actions = actions
+        self.attempts: list[_ScriptedAction] = []
+        self.release_stalls = threading.Event()
+        self._attempt_lock = threading.Lock()
+
+    def next_action(self) -> _ScriptedAction:
+        with self._attempt_lock:
+            attempt_index = len(self.attempts)
+            action = (
+                self.actions[attempt_index]
+                if attempt_index < len(self.actions)
+                else (599, {})
+            )
+            self.attempts.append(action)
+            return action
+
+
+@contextmanager
+def _scripted_qwen_server(
+    actions: list[_ScriptedAction],
+) -> Iterator[tuple[str, _ScriptedQwenServer]]:
+    server = _ScriptedQwenServer(actions)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}/compatible-mode/v1", server
+    finally:
+        server.release_stalls.set()
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=2)
+
+
+def _configure_qwencloud_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    retries: int,
+    retry_delay: float = 0,
+    timeout: float = 0.05,
+) -> None:
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    "qwencloud": {
+                        "timeout": timeout,
+                        "retries": retries,
+                        "retry_delay": retry_delay,
+                    }
+                }
+            }
+        ),
+    )
+
+
+def _track_real_transport_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[str], list[requests.Response], set[int]]:
+    post_urls: list[str] = []
+    returned_responses: list[requests.Response] = []
+    closed_response_ids: set[int] = set()
+    real_post = requests.Session.post
+    real_close = requests.Response.close
+
+    def recording_post(
+        session: requests.Session, url: str, **kwargs: Any
+    ) -> requests.Response:
+        post_urls.append(url)
+        response = real_post(session, url, **kwargs)
+        returned_responses.append(response)
+        return response
+
+    def recording_close(response: requests.Response) -> None:
+        closed_response_ids.add(id(response))
+        real_close(response)
+
+    monkeypatch.setattr(requests.Session, "post", recording_post)
+    monkeypatch.setattr(requests.Response, "close", recording_close)
+    return post_urls, returned_responses, closed_response_ids
+
+
+def _call_scripted_qwencloud(api_base_url: str) -> dict[str, Any]:
+    result = chat_with_qwencloud(
+        input_data=[{"role": "user", "content": "hello"}],
+        model="qwen3.8-max",
+        api_key="key",
+        streaming=False,
+        api_base_url=api_base_url,
+        api_mode="chat_completions",
+    )
+    assert isinstance(result, dict)
+    return result
 
 
 @contextmanager
@@ -1429,6 +1574,29 @@ def test_nonstream_rejects_empty_success_and_malformed_shapes() -> None:
         assert "private" not in str(exc_info.value)
 
 
+def test_responses_requires_call_id_not_transport_id() -> None:
+    for call_id_fields in ({}, {"call_id": "  "}):
+        with pytest.raises(ChatProviderError) as exc_info:
+            qwencloud.normalize_qwencloud_response(
+                {
+                    "status": "completed",
+                    "output": [
+                        {
+                            "id": "fc_transport_only",
+                            "type": "function_call",
+                            "status": "completed",
+                            "name": "lookup",
+                            "arguments": "{}",
+                            **call_id_fields,
+                        }
+                    ],
+                },
+                api_mode="responses",
+            )
+        assert exc_info.value.provider == "qwencloud"
+        assert "incomplete function call" in str(exc_info.value).lower()
+
+
 @pytest.mark.parametrize(
     ("api_mode", "suffix", "response_payload"),
     (
@@ -1591,142 +1759,157 @@ def test_direct_adapter_loads_only_qwencloud_config_when_arguments_are_none(
         assert canary not in serialized
 
 
-def _mounted_retry_policy(
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    retries: object,
-    retry_delay: object,
-    sensitive: bool = False,
-) -> Retry:
-    response = _TransportResponse(
-        {
-            "choices": [
-                {
-                    "message": {"role": "assistant", "content": "ok"},
-                    "finish_reason": "stop",
-                }
-            ]
-        }
-    )
-    session = _RecordingSession(response)
-    monkeypatch.setattr(
-        qwencloud,
-        "requests",
-        SimpleNamespace(Session=lambda: session),
-    )
-    monkeypatch.setattr(
-        qwencloud,
-        "get_runtime_config_snapshot",
-        lambda: SimpleNamespace(
-            values={
-                "api_settings": {
-                    "qwencloud": {
-                        "timeout": 3,
-                        "retries": retries,
-                        "retry_delay": retry_delay,
-                    }
-                }
-            }
-        ),
-    )
-
-    request_context = sensitive_llm_request() if sensitive else nullcontext()
-    with request_context:
-        chat_with_qwencloud(
-            input_data=[{"role": "user", "content": "hello"}],
-            model="qwen3.8-max",
-            api_key="key",
-            streaming=False,
-            api_base_url="https://qwen.example/v1",
-            api_mode="chat_completions",
-        )
-
-    assert {prefix for prefix, _adapter in session.mounts} == {"http://", "https://"}
-    retry_policies = {
-        id(adapter.max_retries): adapter.max_retries
-        for _prefix, adapter in session.mounts
-    }
-    assert len(retry_policies) == 1
-    return next(iter(retry_policies.values()))
-
-
-def _attempts_until_exhausted(
-    retry: Retry,
-    *,
-    response: _RetryResponse | None = None,
-    error: Exception | None = None,
-) -> int:
-    attempts = 1
-    current = retry
-    while True:
-        try:
-            current = current.increment(
-                method="POST",
-                url="https://qwen.example/v1/chat/completions",
-                response=response,
-                error=error,
-            )
-        except MaxRetryError:
-            return attempts
-        attempts += 1
-
-
+@pytest.mark.allow_network
 def test_retry_policy_counts_status_connection_and_timeout_attempts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    retry = _mounted_retry_policy(monkeypatch, retries=2, retry_delay=0.25)
-
-    assert retry.total == 2
-    assert retry.allowed_methods == frozenset({"POST"})
-    assert retry.status_forcelist == frozenset({429, 500, 502, 503, 504})
-    assert retry.respect_retry_after_header is True
-    assert _attempts_until_exhausted(retry, response=_RetryResponse(503)) == 3
-    assert (
-        _attempts_until_exhausted(
-            retry, error=ConnectTimeoutError(None, "connection canary")
-        )
-        == 3
+    post_urls, returned_responses, closed_response_ids = (
+        _track_real_transport_resources(monkeypatch)
     )
-    assert (
-        _attempts_until_exhausted(
-            retry, error=ReadTimeoutError(None, None, "timeout canary")
-        )
-        == 3
-    )
+    _configure_qwencloud_transport(monkeypatch, retries=2)
 
-    integer_retry_after = retry.get_retry_after(
-        _RetryResponse(429, headers={"Retry-After": "4"})  # type: ignore[arg-type]
-    )
-    assert integer_retry_after == 4
-    date_header = format_datetime(datetime.now(timezone.utc) + timedelta(seconds=5))
-    date_retry_after = retry.get_retry_after(
-        _RetryResponse(429, headers={"Retry-After": date_header})  # type: ignore[arg-type]
-    )
-    assert date_retry_after is not None
-    assert 3 <= date_retry_after <= 6
+    post_start = len(post_urls)
+    response_start = len(returned_responses)
+    with _scripted_qwen_server(["stall", "stall", "success"]) as (
+        api_base_url,
+        timeout_server,
+    ):
+        result = _call_scripted_qwencloud(api_base_url)
+    timeout_responses = returned_responses[response_start:]
+    assert result["choices"][0]["message"]["content"] == "ok"
+    assert len(timeout_server.attempts) == 3
+    assert len(post_urls[post_start:]) == 3
+    assert len(timeout_responses) == 3
+    assert all(id(response) in closed_response_ids for response in timeout_responses)
 
-    after_one = retry.increment(
-        method="POST",
-        url="https://qwen.example/v1/chat/completions",
-        error=ConnectTimeoutError(None, "first"),
-    )
-    after_two = after_one.increment(
-        method="POST",
-        url="https://qwen.example/v1/chat/completions",
-        error=ConnectTimeoutError(None, "second"),
-    )
-    assert after_two.get_backoff_time() == pytest.approx(0.5)
+    post_start = len(post_urls)
+    response_start = len(returned_responses)
+    with _scripted_qwen_server([(503, {}), (503, {}), "success"]) as (
+        api_base_url,
+        status_server,
+    ):
+        result = _call_scripted_qwencloud(api_base_url)
+    status_responses = returned_responses[response_start:]
+    assert result["choices"][0]["message"]["content"] == "ok"
+    assert len(status_server.attempts) == 3
+    assert len(post_urls[post_start:]) == 3
+    assert len(status_responses) == 3
+    assert all(id(response) in closed_response_ids for response in status_responses)
 
-    negative = _mounted_retry_policy(monkeypatch, retries=-9, retry_delay=1)
-    assert negative.total == 0
+    guarded_connect = socket.socket.connect
+    connection_attempts = 0
+    post_start = len(post_urls)
+    response_start = len(returned_responses)
+    with _scripted_qwen_server(["success"]) as (api_base_url, connection_server):
+        target_port = connection_server.server_address[1]
+
+        def flaky_connect(
+            client_socket: socket.socket, address: tuple[str, int]
+        ) -> None:
+            nonlocal connection_attempts
+            if address[1] == target_port:
+                connection_attempts += 1
+                if connection_attempts < 3:
+                    raise ConnectionRefusedError("scripted connection failure")
+            guarded_connect(client_socket, address)
+
+        monkeypatch.setattr(socket.socket, "connect", flaky_connect)
+        result = _call_scripted_qwencloud(api_base_url)
+    connection_responses = returned_responses[response_start:]
+    assert result["choices"][0]["message"]["content"] == "ok"
+    assert connection_attempts == 3
+    assert len(connection_server.attempts) == 1
+    assert len(post_urls[post_start:]) == 3
+    assert len(connection_responses) == 1
+    assert id(connection_responses[0]) in closed_response_ids
+
+    _configure_qwencloud_transport(monkeypatch, retries=-9)
+    post_start = len(post_urls)
+    with _scripted_qwen_server([(503, {}), "success"]) as (
+        api_base_url,
+        negative_server,
+    ):
+        with pytest.raises(ChatProviderError):
+            _call_scripted_qwencloud(api_base_url)
+    assert len(negative_server.attempts) == 1
+    assert len(post_urls[post_start:]) == 1
 
 
+@pytest.mark.allow_network
 def test_sensitive_request_forces_zero_retries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    retry = _mounted_retry_policy(monkeypatch, retries=7, retry_delay=1, sensitive=True)
-    assert retry.total == 0
-    assert _attempts_until_exhausted(retry, response=_RetryResponse(503)) == 1
+    _configure_qwencloud_transport(monkeypatch, retries=7)
+    with (
+        _scripted_qwen_server([(503, {}), "success"]) as (
+            api_base_url,
+            server,
+        ),
+        sensitive_llm_request(),
+        pytest.raises(ChatProviderError),
+    ):
+        _call_scripted_qwencloud(api_base_url)
+    assert len(server.attempts) == 1
+
+
+@pytest.mark.allow_network
+def test_retry_policy_honors_retry_after_and_exponential_delay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr("time.sleep", lambda delay: sleeps.append(delay))
+
+    _configure_qwencloud_transport(monkeypatch, retries=1)
+    with _scripted_qwen_server([(429, {"Retry-After": "4"}), "success"]) as (
+        api_base_url,
+        integer_server,
+    ):
+        _call_scripted_qwencloud(api_base_url)
+    assert len(integer_server.attempts) == 2
+    assert sleeps == [4]
+
+    sleeps.clear()
+    date_header = format_datetime(datetime.now(timezone.utc) + timedelta(seconds=5))
+    with _scripted_qwen_server([(503, {"Retry-After": date_header}), "success"]) as (
+        api_base_url,
+        date_server,
+    ):
+        _call_scripted_qwencloud(api_base_url)
+    assert len(date_server.attempts) == 2
+    assert len(sleeps) == 1
+    assert 3 <= sleeps[0] <= 6
+
+    sleeps.clear()
+    _configure_qwencloud_transport(monkeypatch, retries=2, retry_delay=0.25)
+    with _scripted_qwen_server([(503, {}), (503, {}), "success"]) as (
+        api_base_url,
+        backoff_server,
+    ):
+        _call_scripted_qwencloud(api_base_url)
+    assert len(backoff_server.attempts) == 3
+    assert sleeps == [pytest.approx(0.5)]
+
+
+@pytest.mark.allow_network
+def test_retry_policy_uses_one_global_budget_across_mixed_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post_urls, returned_responses, closed_response_ids = (
+        _track_real_transport_resources(monkeypatch)
+    )
+    _configure_qwencloud_transport(monkeypatch, retries=2)
+
+    with _scripted_qwen_server([(503, {}), "stall", (503, {}), "success"]) as (
+        api_base_url,
+        server,
+    ):
+        with pytest.raises(ChatProviderError):
+            _call_scripted_qwencloud(api_base_url)
+
+    assert len(server.attempts) == 3
+    assert len(post_urls) == 3
+    assert len(returned_responses) == 3
+    assert all(id(response) in closed_response_ids for response in returned_responses)
 
 
 def test_nontransient_4xx_and_mode_model_mismatch_are_not_retried(

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -96,6 +96,7 @@ _SCRIPTED_SUCCESS_BODY = (
     b'{"choices":[{"message":{"role":"assistant","content":"ok"},'
     b'"finish_reason":"stop"}]}'
 )
+_STALLED_ERROR_CANARY = b"RAW-STALLED-400-CANARY"
 _ScriptedAction = str | tuple[int, dict[str, str]]
 
 
@@ -110,6 +111,17 @@ class _ScriptedQwenHandler(BaseHTTPRequestHandler):
         server = self.server
         assert isinstance(server, _ScriptedQwenServer)
         action = server.next_action()
+        if action == "stall_400":
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(_STALLED_ERROR_CANARY) + 100))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(_STALLED_ERROR_CANARY)
+            self.wfile.flush()
+            server.release_stalls.wait(timeout=1)
+            self.close_connection = True
+            return
         if action == "stall":
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
@@ -234,6 +246,20 @@ def _track_real_transport_resources(
     monkeypatch.setattr(requests.Session, "post", recording_post)
     monkeypatch.setattr(requests.Response, "close", recording_close)
     return post_urls, returned_responses, closed_response_ids
+
+
+def _track_real_session_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> set[int]:
+    closed_session_ids: set[int] = set()
+    real_close = requests.Session.close
+
+    def recording_close(session: requests.Session) -> None:
+        closed_session_ids.add(id(session))
+        real_close(session)
+
+    monkeypatch.setattr(requests.Session, "close", recording_close)
+    return closed_session_ids
 
 
 def _call_scripted_qwencloud(api_base_url: str) -> dict[str, Any]:
@@ -1976,6 +2002,36 @@ def test_nontransient_4xx_and_mode_model_mismatch_are_not_retried(
             assert "compatible model" in recovery
             assert "api_mode" in recovery
             assert "RAW-MISMATCH-CANARY" not in recovery
+
+
+@pytest.mark.allow_network
+def test_stalled_nonretryable_400_is_typed_redacted_and_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post_urls, returned_responses, closed_response_ids = (
+        _track_real_transport_resources(monkeypatch)
+    )
+    closed_session_ids = _track_real_session_closes(monkeypatch)
+    _configure_qwencloud_transport(monkeypatch, retries=3)
+
+    with (
+        _captured_qwencloud_logs() as logs,
+        _scripted_qwen_server(["stall_400", "success"]) as (api_base_url, server),
+        pytest.raises(ChatBadRequestError) as exc_info,
+    ):
+        _call_scripted_qwencloud(api_base_url)
+
+    assert len(server.attempts) == 1
+    assert len(post_urls) == 1
+    assert len(returned_responses) == 1
+    assert id(returned_responses[0]) in closed_response_ids
+    assert len(closed_session_ids) == 1
+    assert exc_info.value.provider == "qwencloud"
+
+    rendered = "\n".join(logs) + "\n" + str(exc_info.value)
+    assert _STALLED_ERROR_CANARY.decode() not in rendered
+    assert "ConnectionError" not in rendered
+    assert "HTTPConnectionPool" not in rendered
 
 
 def test_qwencloud_errors_and_logs_redact_private_values(

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -43,12 +43,14 @@ class _TransportResponse:
         text: str = "",
         headers: dict[str, str] | None = None,
         chunks: list[bytes] | None = None,
+        close_error: Exception | None = None,
     ) -> None:
         self._payload = payload
         self.status_code = status_code
         self.text = text
         self.headers = headers or {}
         self.chunks = chunks or []
+        self.close_error = close_error
         self.closed = False
         self.close_calls = 0
 
@@ -62,6 +64,8 @@ class _TransportResponse:
     def close(self) -> None:
         self.close_calls += 1
         self.closed = True
+        if self.close_error is not None:
+            raise self.close_error
 
     def iter_content(self, chunk_size: int) -> Iterator[bytes]:
         assert chunk_size > 0
@@ -74,12 +78,15 @@ class _RecordingSession:
         response: _TransportResponse,
         *,
         error: requests.exceptions.RequestException | None = None,
+        close_error: Exception | None = None,
     ) -> None:
         self.response = response
         self.error = error
+        self.close_error = close_error
         self.mounts: list[tuple[str, object]] = []
         self.posts: list[dict[str, Any]] = []
         self.closed = False
+        self.close_calls = 0
 
     def __enter__(self) -> _RecordingSession:
         return self
@@ -97,7 +104,10 @@ class _RecordingSession:
         return self.response
 
     def close(self) -> None:
+        self.close_calls += 1
         self.closed = True
+        if self.close_error is not None:
+            raise self.close_error
 
 
 _SCRIPTED_SUCCESS_BODY = (
@@ -1894,14 +1904,85 @@ def test_nonstream_transport_uses_exact_mode_url_headers_and_timeout(
     assert response.closed is True
 
 
+@pytest.mark.parametrize("path", ("success", "provider-error"))
+def test_nonstream_cleanup_failures_never_mask_result_or_provider_error(
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+) -> None:
+    payload = (
+        {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+        if path == "success"
+        else {"choices": []}
+    )
+    response = _TransportResponse(
+        payload,
+        close_error=RuntimeError("RAW-RESPONSE-CLOSE-CANARY"),
+    )
+    session = _RecordingSession(
+        response,
+        close_error=RuntimeError("RAW-SESSION-CLOSE-CANARY"),
+    )
+    monkeypatch.setattr(qwencloud, "requests", SimpleNamespace(Session=lambda: session))
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    "qwencloud": {"timeout": 3, "retries": 0, "retry_delay": 0}
+                }
+            }
+        ),
+    )
+
+    with _captured_qwencloud_logs() as logs:
+        if path == "success":
+            result = chat_with_qwencloud(
+                input_data=[{"role": "user", "content": "hello"}],
+                model="qwen3.8-max",
+                api_key="key",
+                streaming=False,
+                api_base_url="https://qwen.example/v1",
+                api_mode="chat_completions",
+            )
+            assert result["choices"][0]["message"]["content"] == "ok"
+            disclosure = "".join(logs)
+        else:
+            with pytest.raises(ChatProviderError) as exc_info:
+                chat_with_qwencloud(
+                    input_data=[{"role": "user", "content": "hello"}],
+                    model="qwen3.8-max",
+                    api_key="key",
+                    streaming=False,
+                    api_base_url="https://qwen.example/v1",
+                    api_mode="chat_completions",
+                )
+            assert exc_info.value.provider == "qwencloud"
+            assert exc_info.value.__cause__ is None
+            assert exc_info.value.__context__ is None
+            disclosure = str(exc_info.value) + "".join(logs)
+
+    assert "RAW-RESPONSE-CLOSE-CANARY" not in disclosure
+    assert "RAW-SESSION-CLOSE-CANARY" not in disclosure
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
 def test_streaming_transport_transfers_response_and_session_ownership(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     response = _TransportResponse(
         {},
         chunks=[
-            b'data: {"choices":[{"delta":{"content":"owned"},'
-            b'"finish_reason":null}]}\n\n',
+            b'data: {"choices":[{"index":0,"delta":{"content":"owned"},'
+            b'"finish_reason":"stop"}]}\n\n',
             b"data: [DONE]\n\n",
         ],
     )

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -429,6 +429,58 @@ def test_chat_payload_has_exact_allowlist_and_thinking_invariant() -> None:
             )
 
 
+@pytest.mark.parametrize(
+    "api_mode",
+    ("responses", "chat_completions"),
+    ids=("responses", "chat-completions"),
+)
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    (
+        pytest.param("model", "", id="model-empty"),
+        pytest.param("model", "   ", id="model-blank"),
+        pytest.param("model", 7, id="model-non-string"),
+        pytest.param("streaming", "no", id="streaming-non-bool"),
+        pytest.param("temp", "hot", id="temperature-non-numeric"),
+        pytest.param("temp", True, id="temperature-bool"),
+        pytest.param("temp", float("nan"), id="temperature-nan"),
+        pytest.param("topp", float("inf"), id="top-p-infinity"),
+        pytest.param("topk", 1.5, id="top-k-non-int"),
+        pytest.param("max_tokens", False, id="max-tokens-bool"),
+        pytest.param("seed", "seven", id="seed-non-int"),
+        pytest.param("presence_penalty", "high", id="presence-penalty-non-numeric"),
+        pytest.param(
+            "presence_penalty",
+            float("-inf"),
+            id="presence-penalty-negative-infinity",
+        ),
+        pytest.param("stop", 7, id="stop-non-sequence"),
+        pytest.param("stop", ["END", 7], id="stop-non-string-member"),
+        pytest.param("n", True, id="n-bool"),
+        pytest.param("logprobs", "yes", id="logprobs-non-bool"),
+        pytest.param("top_logprobs", False, id="top-logprobs-bool"),
+        pytest.param("reasoning_effort", [], id="reasoning-effort-non-string"),
+    ),
+)
+def test_scalar_boundaries_reject_invalid_shapes_in_both_modes(
+    api_mode: str,
+    field: str,
+    invalid_value: object,
+) -> None:
+    kwargs: dict[str, object] = {
+        "api_mode": api_mode,
+        "model": "qwen3.8-max",
+        "system_message": None,
+        "messages_payload": [{"role": "user", "content": "Hello"}],
+        "streaming": False,
+    }
+    kwargs[field] = invalid_value
+
+    with pytest.raises(ChatBadRequestError) as exc_info:
+        build_qwencloud_payload(**kwargs)  # type: ignore[arg-type]
+    assert exc_info.value.provider == "qwencloud"
+
+
 def test_chat_stop_sequence_is_deep_copied() -> None:
     stop = ["END", "DONE"]
     payload = build_qwencloud_payload(
@@ -508,27 +560,62 @@ def test_function_tools_translate_by_mode() -> None:
                 assert payload["tool_choice"] == accepted_choice
 
 
-def test_invalid_or_builtin_tools_fail_before_network() -> None:
-    base = {
-        "model": "qwen3.8-max",
-        "system_message": None,
-        "messages_payload": [{"role": "user", "content": "Hello"}],
-        "streaming": False,
-    }
-    valid_function = {
-        "type": "function",
-        "function": {
-            "name": "lookup",
-            "description": "Look something up.",
-            "parameters": {"type": "object", "properties": {}},
-        },
-    }
-    rejected_tool_sets = (
+@pytest.mark.parametrize(
+    "api_mode",
+    ("responses", "chat_completions"),
+    ids=("responses", "chat-completions"),
+)
+def test_function_tools_reject_private_top_level_metadata_without_disclosure(
+    api_mode: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    canary = "SECRET-QWENCLOUD-TOOL-CANARY"
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            "private_metadata": {"token": canary},
+        }
+    ]
+
+    with pytest.raises(ChatBadRequestError) as exc_info:
+        build_qwencloud_payload(
+            api_mode=api_mode,  # type: ignore[arg-type]
+            model="qwen3.8-max",
+            system_message=None,
+            messages_payload=[{"role": "user", "content": "Hello"}],
+            streaming=False,
+            tools=tools,
+        )
+    assert exc_info.value.provider == "qwencloud"
+    assert canary not in str(exc_info.value)
+    captured = capsys.readouterr()
+    assert canary not in captured.out
+    assert canary not in captured.err
+
+
+@pytest.mark.parametrize(
+    "api_mode",
+    ("responses", "chat_completions"),
+    ids=("responses", "chat-completions"),
+)
+@pytest.mark.parametrize(
+    "rejected_tools",
+    (
         [{"type": "web_search"}],
         [{"type": "function", "function": {"name": "", "parameters": {}}}],
         [{"type": "function", "function": {"name": "   ", "parameters": {}}}],
         [
-            valid_function,
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "parameters": {"type": "object"},
+                },
+            },
             {
                 "type": "function",
                 "function": {
@@ -562,25 +649,65 @@ def test_invalid_or_builtin_tools_fail_before_network() -> None:
                 },
             }
         ],
-    )
-    for mode in ("responses", "chat_completions"):
-        for rejected_tools in rejected_tool_sets:
-            with pytest.raises(ChatBadRequestError) as exc_info:
-                build_qwencloud_payload(
-                    api_mode=mode,
-                    **base,
-                    tools=rejected_tools,  # type: ignore[arg-type]
-                )
-            assert exc_info.value.provider == "qwencloud"
+    ),
+    ids=(
+        "builtin-web-search",
+        "empty-function-name",
+        "blank-function-name",
+        "duplicate-function-name",
+        "non-object-parameters",
+        "array-parameters-schema",
+        "nested-builtin-tool-type",
+    ),
+)
+def test_invalid_or_builtin_tools_fail_before_network(
+    api_mode: str,
+    rejected_tools: list[dict[str, object]],
+) -> None:
+    with pytest.raises(ChatBadRequestError) as exc_info:
+        build_qwencloud_payload(
+            api_mode=api_mode,  # type: ignore[arg-type]
+            model="qwen3.8-max",
+            system_message=None,
+            messages_payload=[{"role": "user", "content": "Hello"}],
+            streaming=False,
+            tools=rejected_tools,  # type: ignore[arg-type]
+        )
+    assert exc_info.value.provider == "qwencloud"
 
-        for rejected_choice in ("required", "lookup", {"type": "function"}):
-            with pytest.raises(ChatBadRequestError):
-                build_qwencloud_payload(
-                    api_mode=mode,
-                    **base,
-                    tools=[valid_function],
-                    tool_choice=rejected_choice,
-                )
+
+@pytest.mark.parametrize(
+    "api_mode",
+    ("responses", "chat_completions"),
+    ids=("responses", "chat-completions"),
+)
+@pytest.mark.parametrize(
+    "rejected_choice",
+    ("required", "lookup", {"type": "function"}),
+    ids=("required", "forced-name", "mapping-choice"),
+)
+def test_forced_function_tool_choices_fail_before_network(
+    api_mode: str,
+    rejected_choice: object,
+) -> None:
+    with pytest.raises(ChatBadRequestError):
+        build_qwencloud_payload(
+            api_mode=api_mode,  # type: ignore[arg-type]
+            model="qwen3.8-max",
+            system_message=None,
+            messages_payload=[{"role": "user", "content": "Hello"}],
+            streaming=False,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            tool_choice=rejected_choice,  # type: ignore[arg-type]
+        )
 
 
 @pytest.mark.parametrize(

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -2103,6 +2103,164 @@ def test_direct_adapter_loads_only_qwencloud_config_when_arguments_are_none(
         assert canary not in serialized
 
 
+def test_direct_adapter_loads_alias_only_qwencloud_config_without_mutation_or_leakage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _TransportResponse(
+        {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+    )
+    session = _RecordingSession(response)
+    monkeypatch.setattr(
+        qwencloud,
+        "requests",
+        SimpleNamespace(Session=lambda: session),
+    )
+    monkeypatch.setenv("QWEN_ALIAS_KEY", "alias-key-canary")
+    source = {
+        "api_settings": {
+            "QwenCloud": {
+                "api_mode": "chat_completions",
+                "api_base_url": "https://alias.example/compatible-mode/v1",
+                "api_key_env_var": "QWEN_ALIAS_KEY",
+                "model": "alias-model",
+                "timeout": 19,
+                "retries": 0,
+                "retry_delay": 0.25,
+            }
+        }
+    }
+    original = deepcopy(source)
+    retry_configuration: list[tuple[int, float]] = []
+    real_build_retry_policy = qwencloud._build_retry_policy
+
+    def record_retry_policy(*, retries: int, retry_delay: float):
+        retry_configuration.append((retries, retry_delay))
+        return real_build_retry_policy(retries=retries, retry_delay=retry_delay)
+
+    monkeypatch.setattr(qwencloud, "_build_retry_policy", record_retry_policy)
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(values=source),
+    )
+
+    with _captured_qwencloud_logs() as logs:
+        chat_with_qwencloud(
+            input_data=[{"role": "user", "content": "hello"}],
+            model=None,
+            api_key=None,
+            streaming=False,
+            api_base_url=None,
+            api_mode=None,
+        )
+
+    assert source == original
+    assert retry_configuration == [(0, 0.25)]
+    assert len(session.posts) == 1
+    request = session.posts[0]
+    assert request["url"] == (
+        "https://alias.example/compatible-mode/v1/chat/completions"
+    )
+    assert request["headers"]["Authorization"] == "Bearer alias-key-canary"
+    assert request["json"]["model"] == "alias-model"
+    assert request["timeout"] == 19.0
+    assert "alias-key-canary" not in "".join(logs)
+
+
+@pytest.mark.parametrize("canonical_first", [False, True])
+def test_direct_adapter_canonical_qwencloud_config_overrides_alias_in_any_order(
+    monkeypatch: pytest.MonkeyPatch,
+    canonical_first: bool,
+) -> None:
+    response = _TransportResponse(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "ok"}],
+                }
+            ],
+        }
+    )
+    session = _RecordingSession(response)
+    monkeypatch.setattr(
+        qwencloud,
+        "requests",
+        SimpleNamespace(Session=lambda: session),
+    )
+    monkeypatch.setenv("QWEN_ALIAS_KEY", "alias-key-canary")
+    monkeypatch.setenv("QWEN_CANONICAL_KEY", "canonical-key-canary")
+    alias = {
+        "api_mode": "chat_completions",
+        "api_base_url": "https://alias.example/compatible-mode/v1",
+        "api_key_env_var": "QWEN_ALIAS_KEY",
+        "model": "alias-model",
+        "timeout": 17,
+        "retries": 4,
+        "retry_delay": 0.75,
+    }
+    canonical = {
+        "api_mode": "responses",
+        "api_base_url": "https://canonical.example/compatible-mode/v1",
+        "api_key_env_var": "QWEN_CANONICAL_KEY",
+        "model": "canonical-model",
+        "timeout": 23,
+        "retries": 0,
+        "retry_delay": 0.5,
+    }
+    entries = (
+        [("qwencloud", canonical), ("QwenCloud", alias)]
+        if canonical_first
+        else [("QwenCloud", alias), ("qwencloud", canonical)]
+    )
+    source = {"api_settings": dict(entries)}
+    original = deepcopy(source)
+    retry_configuration: list[tuple[int, float]] = []
+    real_build_retry_policy = qwencloud._build_retry_policy
+
+    def record_retry_policy(*, retries: int, retry_delay: float):
+        retry_configuration.append((retries, retry_delay))
+        return real_build_retry_policy(retries=retries, retry_delay=retry_delay)
+
+    monkeypatch.setattr(qwencloud, "_build_retry_policy", record_retry_policy)
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(values=source),
+    )
+
+    with _captured_qwencloud_logs() as logs:
+        chat_with_qwencloud(
+            input_data=[{"role": "user", "content": "hello"}],
+            model=None,
+            api_key=None,
+            streaming=False,
+            api_base_url=None,
+            api_mode=None,
+        )
+
+    assert source == original
+    assert retry_configuration == [(0, 0.5)]
+    assert len(session.posts) == 1
+    request = session.posts[0]
+    assert request["url"] == ("https://canonical.example/compatible-mode/v1/responses")
+    assert request["headers"]["Authorization"] == "Bearer canonical-key-canary"
+    assert request["json"]["model"] == "canonical-model"
+    assert request["timeout"] == 23.0
+    disclosure = repr(request) + "".join(logs)
+    assert "alias-key-canary" not in disclosure
+    assert "canonical-key-canary" not in "".join(logs)
+
+
 @pytest.mark.parametrize(
     "api_settings",
     (

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -2,17 +2,116 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager, nullcontext
 from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+from types import SimpleNamespace
+from typing import Any, Iterator
 
 import pytest
+import requests
+from loguru import logger
+from urllib3.exceptions import (
+    ConnectTimeoutError,
+    MaxRetryError,
+    ReadTimeoutError,
+)
+from urllib3.util import Retry
 
-from tldw_chatbook.Chat.Chat_Deps import ChatBadRequestError, ChatConfigurationError
+from tldw_chatbook.Chat.Chat_Deps import (
+    ChatAuthenticationError,
+    ChatBadRequestError,
+    ChatConfigurationError,
+    ChatProviderError,
+    ChatRateLimitError,
+)
+import tldw_chatbook.LLM_Calls.qwencloud as qwencloud
 from tldw_chatbook.LLM_Calls.qwencloud import (
     build_qwencloud_payload,
+    chat_with_qwencloud,
     normalize_qwencloud_api_mode,
     normalize_qwencloud_base_url,
     resolve_qwencloud_api_key,
 )
+from tldw_chatbook.Utils.sensitive_llm_logging import sensitive_llm_request
+
+
+class _TransportResponse:
+    def __init__(
+        self,
+        payload: dict[str, Any],
+        *,
+        status_code: int = 200,
+        text: str = "",
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+        self.headers = headers or {}
+        self.closed = False
+
+    def json(self) -> dict[str, Any]:
+        return deepcopy(self._payload)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(response=self)  # type: ignore[arg-type]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _RecordingSession:
+    def __init__(
+        self,
+        response: _TransportResponse,
+        *,
+        error: requests.exceptions.RequestException | None = None,
+    ) -> None:
+        self.response = response
+        self.error = error
+        self.mounts: list[tuple[str, object]] = []
+        self.posts: list[dict[str, Any]] = []
+        self.closed = False
+
+    def __enter__(self) -> _RecordingSession:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+    def mount(self, prefix: str, adapter: object) -> None:
+        self.mounts.append((prefix, adapter))
+
+    def post(self, url: str, **kwargs: Any) -> _TransportResponse:
+        self.posts.append({"url": url, **deepcopy(kwargs)})
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _RetryResponse:
+    def __init__(self, status: int, *, headers: dict[str, str] | None = None) -> None:
+        self.status = status
+        self.headers = headers or {}
+
+    def get_redirect_location(self) -> None:
+        return None
+
+
+@contextmanager
+def _captured_qwencloud_logs() -> Iterator[list[str]]:
+    records: list[str] = []
+    sink_id = logger.add(lambda message: records.append(str(message)), level="DEBUG")
+    try:
+        yield records
+    finally:
+        logger.remove(sink_id)
 
 
 def test_api_mode_config_then_default_and_exact_values() -> None:
@@ -1047,3 +1146,814 @@ def test_responses_rejects_unpairable_tool_batches_before_network() -> None:
                 streaming=False,
             )
         assert exc_info.value.provider == "qwencloud"
+
+
+def test_nonstream_normalizes_text_tools_finish_and_usage() -> None:
+    responses_mixed = qwencloud.normalize_qwencloud_response(
+        {
+            "id": "resp_123",
+            "object": "response",
+            "status": "completed",
+            "output": [
+                {
+                    "id": "msg_123",
+                    "type": "message",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "I will check both."}],
+                },
+                {
+                    "id": "fc_transport_A",
+                    "type": "function_call",
+                    "status": "completed",
+                    "call_id": "call_A",
+                    "name": "first_tool",
+                    "arguments": '{"value":1}',
+                },
+                {
+                    "id": "fc_transport_B",
+                    "type": "function_call",
+                    "status": "completed",
+                    "call_id": "call_B",
+                    "name": "second_tool",
+                    "arguments": '{"value":2}',
+                },
+            ],
+            "usage": {
+                "input_tokens": 11,
+                "output_tokens": 7,
+                "total_tokens": 18,
+                "input_tokens_details": {"cached_tokens": 3},
+            },
+        },
+        api_mode="responses",
+    )
+    assert responses_mixed == {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "I will check both.",
+                    "tool_calls": [
+                        {
+                            "id": "call_A",
+                            "type": "function",
+                            "function": {
+                                "name": "first_tool",
+                                "arguments": '{"value":1}',
+                            },
+                        },
+                        {
+                            "id": "call_B",
+                            "type": "function",
+                            "function": {
+                                "name": "second_tool",
+                                "arguments": '{"value":2}',
+                            },
+                        },
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "total_tokens": 18,
+            "input_tokens_details": {"cached_tokens": 3},
+        },
+    }
+
+    responses_text = qwencloud.normalize_qwencloud_response(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "status": "completed",
+                    "content": [
+                        {"type": "output_text", "text": "Hello"},
+                        {"type": "output_text", "text": " world"},
+                    ],
+                }
+            ],
+        },
+        api_mode="responses",
+    )
+    assert responses_text["choices"][0] == {
+        "message": {"role": "assistant", "content": "Hello world"},
+        "finish_reason": "stop",
+    }
+    assert responses_text["usage"] == {}
+
+    responses_tool_only = qwencloud.normalize_qwencloud_response(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "function_call",
+                    "status": "completed",
+                    "call_id": "call_only",
+                    "name": "lookup",
+                    "arguments": "{}",
+                }
+            ],
+        },
+        api_mode="responses",
+    )
+    assert responses_tool_only["choices"][0]["message"]["content"] is None
+    assert responses_tool_only["choices"][0]["finish_reason"] == "tool_calls"
+
+    responses_partial = qwencloud.normalize_qwencloud_response(
+        {
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "output": [
+                {
+                    "type": "message",
+                    "status": "incomplete",
+                    "content": [{"type": "output_text", "text": "Partial answer"}],
+                }
+            ],
+        },
+        api_mode="responses",
+    )
+    assert responses_partial["choices"][0] == {
+        "message": {"role": "assistant", "content": "Partial answer"},
+        "finish_reason": "length",
+    }
+
+    chat_mixed = qwencloud.normalize_qwencloud_response(
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Checking now.",
+                        "tool_calls": [
+                            {
+                                "id": "call_chat_A",
+                                "type": "function",
+                                "function": {
+                                    "name": "first_tool",
+                                    "arguments": "{}",
+                                },
+                            },
+                            {
+                                "id": "call_chat_B",
+                                "type": "function",
+                                "function": {
+                                    "name": "second_tool",
+                                    "arguments": '{"x":2}',
+                                },
+                            },
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 5,
+                "total_tokens": 14,
+            },
+        },
+        api_mode="chat_completions",
+    )
+    assert chat_mixed["choices"][0]["message"] == {
+        "role": "assistant",
+        "content": "Checking now.",
+        "tool_calls": [
+            {
+                "id": "call_chat_A",
+                "type": "function",
+                "function": {"name": "first_tool", "arguments": "{}"},
+            },
+            {
+                "id": "call_chat_B",
+                "type": "function",
+                "function": {"name": "second_tool", "arguments": '{"x":2}'},
+            },
+        ],
+    }
+    assert chat_mixed["choices"][0]["finish_reason"] == "tool_calls"
+    assert chat_mixed["usage"] == {
+        "prompt_tokens": 9,
+        "completion_tokens": 5,
+        "total_tokens": 14,
+    }
+
+
+def test_nonstream_rejects_empty_success_and_malformed_shapes() -> None:
+    malformed_cases = (
+        ("responses", {"status": "completed", "output": []}),
+        ("responses", {"status": "completed", "output": {}}),
+        ("responses", {"status": "failed", "output": []}),
+        ("responses", {"status": "cancelled", "output": []}),
+        (
+            "responses",
+            {
+                "status": "incomplete",
+                "incomplete_details": {"reason": "content_filter"},
+                "output": [
+                    {
+                        "type": "message",
+                        "status": "incomplete",
+                        "content": [{"type": "output_text", "text": "private"}],
+                    }
+                ],
+            },
+        ),
+        (
+            "responses",
+            {
+                "status": "incomplete",
+                "incomplete_details": {"reason": "max_output_tokens"},
+                "output": [
+                    {
+                        "type": "function_call",
+                        "status": "in_progress",
+                        "call_id": "call_partial",
+                        "name": "lookup",
+                        "arguments": "{",
+                    }
+                ],
+            },
+        ),
+        ("chat_completions", {"choices": []}),
+        ("chat_completions", {"choices": {}}),
+        ("chat_completions", {"choices": [{"message": "bad"}]}),
+        (
+            "chat_completions",
+            {
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": None},
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        ),
+        (
+            "chat_completions",
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_bad",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "lookup",
+                                        "arguments": 7,
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            },
+        ),
+    )
+    for api_mode, payload in malformed_cases:
+        with pytest.raises(ChatProviderError) as exc_info:
+            qwencloud.normalize_qwencloud_response(
+                payload,  # type: ignore[arg-type]
+                api_mode=api_mode,  # type: ignore[arg-type]
+            )
+        assert exc_info.value.provider == "qwencloud"
+        assert "private" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("api_mode", "suffix", "response_payload"),
+    (
+        (
+            "responses",
+            "/responses",
+            {
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "ok"}],
+                    }
+                ],
+            },
+        ),
+        (
+            "chat_completions",
+            "/chat/completions",
+            {
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        ),
+    ),
+)
+def test_nonstream_transport_uses_exact_mode_url_headers_and_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    api_mode: str,
+    suffix: str,
+    response_payload: dict[str, Any],
+) -> None:
+    response = _TransportResponse(response_payload)
+    session = _RecordingSession(response)
+    monkeypatch.setattr(
+        qwencloud,
+        "requests",
+        SimpleNamespace(Session=lambda: session),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    "qwencloud": {"timeout": 37, "retries": 0, "retry_delay": 0}
+                }
+            }
+        ),
+        raising=False,
+    )
+
+    chat_with_qwencloud(
+        input_data=[{"role": "user", "content": "hello"}],
+        model="qwen3.8-max",
+        api_key="qwen-secret",
+        streaming=False,
+        api_base_url="https://qwen.example/compatible-mode/v1/responses",
+        api_mode=api_mode,
+    )
+
+    assert len(session.posts) == 1
+    request = session.posts[0]
+    assert request["url"] == f"https://qwen.example/compatible-mode/v1{suffix}"
+    assert request["headers"] == {
+        "Authorization": "Bearer qwen-secret",
+        "Content-Type": "application/json",
+    }
+    assert request["timeout"] == 37.0
+    assert request["json"]["model"] == "qwen3.8-max"
+    assert request["json"]["stream"] is False
+    assert session.closed is True
+    assert response.closed is True
+
+
+def test_direct_adapter_loads_only_qwencloud_config_when_arguments_are_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _TransportResponse(
+        {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+    )
+    session = _RecordingSession(response)
+    monkeypatch.setattr(
+        qwencloud,
+        "requests",
+        SimpleNamespace(Session=lambda: session),
+        raising=False,
+    )
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "qwen-env-lower-priority")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-env-canary")
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    "qwencloud": {
+                        "api_mode": "chat_completions",
+                        "api_base_url": "https://qwen-only.example/compatible-mode/v1",
+                        "api_key": "qwen-modern-key",
+                        "model": "qwen-config-model",
+                        "timeout": 41,
+                        "retries": 0,
+                        "retry_delay": 0,
+                    },
+                    "openai": {
+                        "api_base_url": "https://openai-canary.example/v1",
+                        "api_key": "openai-config-canary",
+                        "model": "openai-model-canary",
+                    },
+                    "deepseek": {
+                        "api_base_url": "https://deepseek-canary.example/v1",
+                        "api_key": "deepseek-config-canary",
+                    },
+                }
+            }
+        ),
+        raising=False,
+    )
+
+    chat_with_qwencloud(
+        input_data=[{"role": "user", "content": "hello"}],
+        model=None,
+        api_key=None,
+        streaming=False,
+        api_base_url=None,
+        api_mode=None,
+    )
+
+    assert len(session.posts) == 1
+    request = session.posts[0]
+    assert request["url"] == (
+        "https://qwen-only.example/compatible-mode/v1/chat/completions"
+    )
+    assert request["headers"]["Authorization"] == "Bearer qwen-modern-key"
+    assert request["json"]["model"] == "qwen-config-model"
+    assert request["timeout"] == 41.0
+    serialized = repr(request)
+    for canary in (
+        "openai-env-canary",
+        "openai-config-canary",
+        "openai-model-canary",
+        "openai-canary.example",
+        "deepseek-config-canary",
+        "deepseek-canary.example",
+    ):
+        assert canary not in serialized
+
+
+def _mounted_retry_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    retries: object,
+    retry_delay: object,
+    sensitive: bool = False,
+) -> Retry:
+    response = _TransportResponse(
+        {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+    )
+    session = _RecordingSession(response)
+    monkeypatch.setattr(
+        qwencloud,
+        "requests",
+        SimpleNamespace(Session=lambda: session),
+    )
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    "qwencloud": {
+                        "timeout": 3,
+                        "retries": retries,
+                        "retry_delay": retry_delay,
+                    }
+                }
+            }
+        ),
+    )
+
+    request_context = sensitive_llm_request() if sensitive else nullcontext()
+    with request_context:
+        chat_with_qwencloud(
+            input_data=[{"role": "user", "content": "hello"}],
+            model="qwen3.8-max",
+            api_key="key",
+            streaming=False,
+            api_base_url="https://qwen.example/v1",
+            api_mode="chat_completions",
+        )
+
+    assert {prefix for prefix, _adapter in session.mounts} == {"http://", "https://"}
+    retry_policies = {
+        id(adapter.max_retries): adapter.max_retries
+        for _prefix, adapter in session.mounts
+    }
+    assert len(retry_policies) == 1
+    return next(iter(retry_policies.values()))
+
+
+def _attempts_until_exhausted(
+    retry: Retry,
+    *,
+    response: _RetryResponse | None = None,
+    error: Exception | None = None,
+) -> int:
+    attempts = 1
+    current = retry
+    while True:
+        try:
+            current = current.increment(
+                method="POST",
+                url="https://qwen.example/v1/chat/completions",
+                response=response,
+                error=error,
+            )
+        except MaxRetryError:
+            return attempts
+        attempts += 1
+
+
+def test_retry_policy_counts_status_connection_and_timeout_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    retry = _mounted_retry_policy(monkeypatch, retries=2, retry_delay=0.25)
+
+    assert retry.total == 2
+    assert retry.allowed_methods == frozenset({"POST"})
+    assert retry.status_forcelist == frozenset({429, 500, 502, 503, 504})
+    assert retry.respect_retry_after_header is True
+    assert _attempts_until_exhausted(retry, response=_RetryResponse(503)) == 3
+    assert (
+        _attempts_until_exhausted(
+            retry, error=ConnectTimeoutError(None, "connection canary")
+        )
+        == 3
+    )
+    assert (
+        _attempts_until_exhausted(
+            retry, error=ReadTimeoutError(None, None, "timeout canary")
+        )
+        == 3
+    )
+
+    integer_retry_after = retry.get_retry_after(
+        _RetryResponse(429, headers={"Retry-After": "4"})  # type: ignore[arg-type]
+    )
+    assert integer_retry_after == 4
+    date_header = format_datetime(datetime.now(timezone.utc) + timedelta(seconds=5))
+    date_retry_after = retry.get_retry_after(
+        _RetryResponse(429, headers={"Retry-After": date_header})  # type: ignore[arg-type]
+    )
+    assert date_retry_after is not None
+    assert 3 <= date_retry_after <= 6
+
+    after_one = retry.increment(
+        method="POST",
+        url="https://qwen.example/v1/chat/completions",
+        error=ConnectTimeoutError(None, "first"),
+    )
+    after_two = after_one.increment(
+        method="POST",
+        url="https://qwen.example/v1/chat/completions",
+        error=ConnectTimeoutError(None, "second"),
+    )
+    assert after_two.get_backoff_time() == pytest.approx(0.5)
+
+    negative = _mounted_retry_policy(monkeypatch, retries=-9, retry_delay=1)
+    assert negative.total == 0
+
+
+def test_sensitive_request_forces_zero_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    retry = _mounted_retry_policy(monkeypatch, retries=7, retry_delay=1, sensitive=True)
+    assert retry.total == 0
+    assert _attempts_until_exhausted(retry, response=_RetryResponse(503)) == 1
+
+
+def test_nontransient_4xx_and_mode_model_mismatch_are_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = (
+        _TransportResponse(
+            {"error": {"message": "ordinary validation failure"}},
+            status_code=422,
+            text='{"error":{"message":"ordinary validation failure"}}',
+        ),
+        _TransportResponse(
+            {
+                "error": {
+                    "message": (
+                        "model qwen-canary is not supported by the Responses API "
+                        "RAW-MISMATCH-CANARY"
+                    )
+                }
+            },
+            status_code=400,
+            text=(
+                "model qwen-canary is not supported by the Responses API "
+                "RAW-MISMATCH-CANARY"
+            ),
+        ),
+    )
+    for index, response in enumerate(responses):
+        session = _RecordingSession(response)
+        monkeypatch.setattr(
+            qwencloud,
+            "requests",
+            SimpleNamespace(Session=lambda: session),
+        )
+        monkeypatch.setattr(
+            qwencloud,
+            "get_runtime_config_snapshot",
+            lambda: SimpleNamespace(
+                values={
+                    "api_settings": {
+                        "qwencloud": {
+                            "timeout": 3,
+                            "retries": 8,
+                            "retry_delay": 0,
+                        }
+                    }
+                }
+            ),
+        )
+
+        with pytest.raises(ChatBadRequestError) as exc_info:
+            chat_with_qwencloud(
+                input_data=[{"role": "user", "content": "private"}],
+                model="qwen3.8-max",
+                api_key="key",
+                streaming=False,
+                api_base_url="https://qwen.example/v1",
+                api_mode="responses",
+            )
+        assert len(session.posts) == 1
+        assert exc_info.value.provider == "qwencloud"
+        if index == 1:
+            recovery = str(exc_info.value)
+            assert "compatible model" in recovery
+            assert "api_mode" in recovery
+            assert "RAW-MISMATCH-CANARY" not in recovery
+
+
+def test_qwencloud_errors_and_logs_redact_private_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    canaries = (
+        "AUTHORIZATION-CANARY",
+        "MESSAGE-CANARY",
+        "TOOL-DESCRIPTION-CANARY",
+        "TOOL-ARGUMENT-CANARY",
+        "TOOL-CALL-ARGUMENT-CANARY",
+        "TOOL-RESULT-CANARY",
+        "RAW-BODY-CANARY",
+    )
+    response = _TransportResponse(
+        {"error": {"message": "RAW-BODY-CANARY"}},
+        status_code=500,
+        text='{"error":{"message":"RAW-BODY-CANARY"}}',
+    )
+    session = _RecordingSession(response)
+    monkeypatch.setattr(
+        qwencloud,
+        "requests",
+        SimpleNamespace(Session=lambda: session),
+    )
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    "qwencloud": {
+                        "timeout": 3,
+                        "retries": 0,
+                        "retry_delay": 0,
+                    }
+                }
+            }
+        ),
+    )
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "TOOL-DESCRIPTION-CANARY",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "type": "string",
+                            "description": "TOOL-ARGUMENT-CANARY",
+                        }
+                    },
+                },
+            },
+        }
+    ]
+
+    with (
+        _captured_qwencloud_logs() as logs,
+        pytest.raises(ChatProviderError) as exc_info,
+    ):
+        chat_with_qwencloud(
+            input_data=[
+                {"role": "user", "content": "MESSAGE-CANARY"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_private",
+                            "type": "function",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": ('{"secret":"TOOL-CALL-ARGUMENT-CANARY"}'),
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_private",
+                    "content": "TOOL-RESULT-CANARY",
+                },
+            ],
+            model="qwen3.8-max",
+            api_key="AUTHORIZATION-CANARY",
+            streaming=False,
+            tools=tools,
+            api_base_url="https://qwen.example/v1",
+            api_mode="chat_completions",
+        )
+
+    assert exc_info.value.provider == "qwencloud"
+    captured = "\n".join(logs) + "\n" + str(exc_info.value)
+    for canary in canaries:
+        assert canary not in captured
+    assert "qwencloud" in captured.lower()
+    assert "status=500" in captured
+    assert session.closed is True
+    assert response.closed is True
+
+    for status_code, expected_type in (
+        (401, ChatAuthenticationError),
+        (403, ChatAuthenticationError),
+        (429, ChatRateLimitError),
+    ):
+        status_response = _TransportResponse(
+            {"error": {"message": "RAW-BODY-CANARY"}},
+            status_code=status_code,
+            text="RAW-BODY-CANARY",
+        )
+        status_session = _RecordingSession(status_response)
+        monkeypatch.setattr(
+            qwencloud,
+            "requests",
+            SimpleNamespace(Session=lambda: status_session),
+        )
+        with (
+            _captured_qwencloud_logs() as status_logs,
+            pytest.raises(expected_type) as status_exc,
+        ):
+            chat_with_qwencloud(
+                input_data=[{"role": "user", "content": "MESSAGE-CANARY"}],
+                model="qwen3.8-max",
+                api_key="AUTHORIZATION-CANARY",
+                streaming=False,
+                api_base_url="https://qwen.example/v1",
+                api_mode="chat_completions",
+            )
+        status_capture = "\n".join(status_logs) + "\n" + str(status_exc.value)
+        for canary in canaries:
+            assert canary not in status_capture
+        assert f"status={status_code}" in status_capture
+        assert status_session.closed is True
+        assert status_response.closed is True
+
+    for network_error in (
+        requests.exceptions.ConnectionError("RAW-BODY-CANARY"),
+        requests.exceptions.Timeout("RAW-BODY-CANARY"),
+    ):
+        network_session = _RecordingSession(_TransportResponse({}), error=network_error)
+        monkeypatch.setattr(
+            qwencloud,
+            "requests",
+            SimpleNamespace(Session=lambda: network_session),
+        )
+        with (
+            _captured_qwencloud_logs() as network_logs,
+            pytest.raises(ChatProviderError) as network_exc,
+        ):
+            chat_with_qwencloud(
+                input_data=[{"role": "user", "content": "MESSAGE-CANARY"}],
+                model="qwen3.8-max",
+                api_key="AUTHORIZATION-CANARY",
+                streaming=False,
+                api_base_url="https://qwen.example/v1",
+                api_mode="chat_completions",
+            )
+        network_capture = "\n".join(network_logs) + "\n" + str(network_exc.value)
+        for canary in canaries:
+            assert canary not in network_capture
+        assert network_session.closed is True

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -42,12 +42,15 @@ class _TransportResponse:
         status_code: int = 200,
         text: str = "",
         headers: dict[str, str] | None = None,
+        chunks: list[bytes] | None = None,
     ) -> None:
         self._payload = payload
         self.status_code = status_code
         self.text = text
         self.headers = headers or {}
+        self.chunks = chunks or []
         self.closed = False
+        self.close_calls = 0
 
     def json(self) -> dict[str, Any]:
         return deepcopy(self._payload)
@@ -57,7 +60,12 @@ class _TransportResponse:
             raise requests.exceptions.HTTPError(response=self)  # type: ignore[arg-type]
 
     def close(self) -> None:
+        self.close_calls += 1
         self.closed = True
+
+    def iter_content(self, chunk_size: int) -> Iterator[bytes]:
+        assert chunk_size > 0
+        yield from self.chunks
 
 
 class _RecordingSession:
@@ -1884,6 +1892,53 @@ def test_nonstream_transport_uses_exact_mode_url_headers_and_timeout(
     assert request["json"]["stream"] is False
     assert session.closed is True
     assert response.closed is True
+
+
+def test_streaming_transport_transfers_response_and_session_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _TransportResponse(
+        {},
+        chunks=[
+            b'data: {"choices":[{"delta":{"content":"owned"},'
+            b'"finish_reason":null}]}\n\n',
+            b"data: [DONE]\n\n",
+        ],
+    )
+    session = _RecordingSession(response)
+    monkeypatch.setattr(
+        qwencloud,
+        "requests",
+        SimpleNamespace(Session=lambda: session),
+    )
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    "qwencloud": {"timeout": 9, "retries": 0, "retry_delay": 0}
+                }
+            }
+        ),
+    )
+
+    stream = chat_with_qwencloud(
+        input_data=[{"role": "user", "content": "hello"}],
+        model="qwen3.8-max",
+        api_key="qwen-secret",
+        streaming=True,
+        api_base_url="https://qwen.example/compatible-mode/v1",
+        api_mode="chat_completions",
+    )
+
+    assert not isinstance(stream, dict)
+    assert session.closed is False
+    assert response.closed is False
+    assert next(stream)["choices"][0]["delta"]["content"] == "owned"
+    assert list(stream) == []
+    assert session.closed is True
+    assert response.close_calls == 1
 
 
 def test_direct_adapter_loads_only_qwencloud_config_when_arguments_are_none(

--- a/Tests/LLM_Calls/test_qwencloud.py
+++ b/Tests/LLM_Calls/test_qwencloud.py
@@ -29,6 +29,13 @@ def test_api_mode_config_then_default_and_exact_values() -> None:
         )
         == "responses"
     )
+    assert (
+        normalize_qwencloud_api_mode(
+            "responses",
+            provider_settings=7,  # type: ignore[arg-type]
+        )
+        == "responses"
+    )
 
     for rejected in ("response", "chat", "chat-completions", "unknown", ""):
         with pytest.raises(ChatConfigurationError) as exc_info:
@@ -77,6 +84,20 @@ def test_base_url_rejects_unsafe_or_malformed_values() -> None:
         assert "secret" not in str(exc_info.value)
 
 
+def test_base_url_rejects_malformed_authorities() -> None:
+    malformed_authorities = (
+        "https://good.example\\evil/v1",
+        "https://%zz/v1",
+        "https://good.example|evil/v1",
+        "https://good.example^evil/v1",
+        "https://good.example\x00evil/v1",
+    )
+    for value in malformed_authorities:
+        with pytest.raises(ChatConfigurationError) as exc_info:
+            normalize_qwencloud_base_url(value)
+        assert exc_info.value.provider == "qwencloud"
+
+
 def test_api_key_precedence_is_provider_isolated() -> None:
     environ = {
         "DASHSCOPE_API_KEY": "default-env-key",
@@ -96,7 +117,23 @@ def test_api_key_precedence_is_provider_isolated() -> None:
         == "trusted-key"
     )
     assert (
+        resolve_qwencloud_api_key(
+            "trusted-key",
+            provider_settings=7,  # type: ignore[arg-type]
+            environ=7,  # type: ignore[arg-type]
+        )
+        == "trusted-key"
+    )
+    assert (
         resolve_qwencloud_api_key(None, provider_settings=settings, environ=environ)
+        == "modern-key"
+    )
+    assert (
+        resolve_qwencloud_api_key(
+            None,
+            provider_settings={"api_key": "modern-key"},
+            environ=7,  # type: ignore[arg-type]
+        )
         == "modern-key"
     )
     assert (
@@ -117,6 +154,31 @@ def test_api_key_precedence_is_provider_isolated() -> None:
         )
     assert exc_info.value.provider == "qwencloud"
     assert "do-not-use" not in str(exc_info.value)
+
+
+def test_resolution_helpers_reject_invalid_mapping_shapes() -> None:
+    with pytest.raises(ChatConfigurationError) as exc_info:
+        normalize_qwencloud_api_mode(
+            None,
+            provider_settings=7,  # type: ignore[arg-type]
+        )
+    assert exc_info.value.provider == "qwencloud"
+
+    with pytest.raises(ChatConfigurationError) as exc_info:
+        resolve_qwencloud_api_key(
+            None,
+            provider_settings=7,
+            environ={},  # type: ignore[arg-type]
+        )
+    assert exc_info.value.provider == "qwencloud"
+
+    with pytest.raises(ChatConfigurationError) as exc_info:
+        resolve_qwencloud_api_key(
+            None,
+            provider_settings={},
+            environ=7,  # type: ignore[arg-type]
+        )
+    assert exc_info.value.provider == "qwencloud"
 
 
 def test_responses_payload_has_exact_allowlist_and_stateless_invariants() -> None:
@@ -222,6 +284,33 @@ def test_responses_system_message_maps_to_instructions() -> None:
                 {"role": "system", "content": "Too late."},
             ],
         )
+
+
+def test_leading_system_row_with_tool_calls_is_rejected() -> None:
+    messages = [
+        {
+            "role": "system",
+            "content": "Never execute tools.",
+            "tool_calls": [
+                {
+                    "id": "call_system",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "user", "content": "Hello"},
+    ]
+    for mode in ("responses", "chat_completions"):
+        with pytest.raises(ChatBadRequestError) as exc_info:
+            build_qwencloud_payload(
+                api_mode=mode,
+                model="qwen3.8-max",
+                system_message=None,
+                messages_payload=messages,
+                streaming=False,
+            )
+        assert exc_info.value.provider == "qwencloud"
 
 
 def test_responses_reasoning_effort_enum_is_exact() -> None:
@@ -338,6 +427,23 @@ def test_chat_payload_has_exact_allowlist_and_thinking_invariant() -> None:
                 streaming=False,
                 response_format=rejected_format,
             )
+
+
+def test_chat_stop_sequence_is_deep_copied() -> None:
+    stop = ["END", "DONE"]
+    payload = build_qwencloud_payload(
+        api_mode="chat_completions",
+        model="qwen3.8-max",
+        system_message=None,
+        messages_payload=[{"role": "user", "content": "Hello"}],
+        streaming=False,
+        stop=stop,
+    )
+
+    assert payload["stop"] == ["END", "DONE"]
+    assert payload["stop"] is not stop
+    stop.append("MUTATED")
+    assert payload["stop"] == ["END", "DONE"]
 
 
 def test_function_tools_translate_by_mode() -> None:
@@ -475,6 +581,32 @@ def test_invalid_or_builtin_tools_fail_before_network() -> None:
                     tools=[valid_function],
                     tool_choice=rejected_choice,
                 )
+
+
+@pytest.mark.parametrize(
+    "invalid_override",
+    (
+        {"messages_payload": None},
+        {"tools": 7},
+        {"response_format": 7},
+    ),
+    ids=("messages-none", "tools-int", "response-format-int"),
+)
+def test_invalid_public_build_shapes_raise_typed_error(
+    invalid_override: dict[str, object],
+) -> None:
+    kwargs: dict[str, object] = {
+        "api_mode": "chat_completions",
+        "model": "qwen3.8-max",
+        "system_message": None,
+        "messages_payload": [{"role": "user", "content": "Hello"}],
+        "streaming": False,
+    }
+    kwargs.update(invalid_override)
+
+    with pytest.raises(ChatBadRequestError) as exc_info:
+        build_qwencloud_payload(**kwargs)  # type: ignore[arg-type]
+    assert exc_info.value.provider == "qwencloud"
 
 
 def test_message_content_translation_is_role_safe_and_immutable() -> None:
@@ -703,6 +835,37 @@ def test_responses_pairs_out_of_order_results_by_call_id() -> None:
         streaming=False,
     )
     assert chat["messages"] == original
+
+
+def test_tool_call_arguments_reject_non_finite_json_constants() -> None:
+    for arguments in ('{"x":NaN}', '{"x":Infinity}', '{"x":-Infinity}'):
+        history = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_strict_json",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": arguments},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_strict_json",
+                "content": "ok",
+            },
+        ]
+        with pytest.raises(ChatBadRequestError) as exc_info:
+            build_qwencloud_payload(
+                api_mode="responses",
+                model="qwen3.8-max",
+                system_message=None,
+                messages_payload=history,
+                streaming=False,
+            )
+        assert exc_info.value.provider == "qwencloud"
 
 
 def test_responses_rejects_unpairable_tool_batches_before_network() -> None:

--- a/Tests/LLM_Calls/test_qwencloud_streaming.py
+++ b/Tests/LLM_Calls/test_qwencloud_streaming.py
@@ -1,0 +1,813 @@
+"""Streaming contracts for the QwenCloud dual-API adapter."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import requests
+
+from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
+import tldw_chatbook.LLM_Calls.qwencloud as qwencloud
+from tldw_chatbook.LLM_Calls.qwencloud_streaming import (
+    QwenCloudStream,
+    QwenResponsesStreamTranslator,
+    iter_sse_data_records,
+)
+
+
+class _ByteStreamResponse:
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.chunks = chunks
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.close_calls = 0
+        self.iter_content_calls = 0
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(response=self)  # type: ignore[arg-type]
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+    def iter_content(self, chunk_size: int) -> Any:
+        assert chunk_size > 0
+        self.iter_content_calls += 1
+        yield from self.chunks
+
+
+class _ByteStreamSession:
+    def __init__(self, responses: list[_ByteStreamResponse]) -> None:
+        self.responses = responses
+        self.posts: list[dict[str, Any]] = []
+        self.mounts: list[tuple[str, object]] = []
+        self.close_calls = 0
+
+    def mount(self, prefix: str, adapter: object) -> None:
+        self.mounts.append((prefix, adapter))
+
+    def post(self, url: str, **kwargs: Any) -> _ByteStreamResponse:
+        self.posts.append({"url": url, **deepcopy(kwargs)})
+        return self.responses[len(self.posts) - 1]
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def _message_item(
+    item_id: str, text: str, *, status: str = "completed"
+) -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "type": "message",
+        "role": "assistant",
+        "status": status,
+        "content": [{"type": "output_text", "text": text, "annotations": []}],
+    }
+
+
+def _function_item(
+    item_id: str,
+    call_id: str,
+    name: str,
+    arguments: str,
+    *,
+    status: str = "completed",
+) -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "type": "function_call",
+        "status": status,
+        "call_id": call_id,
+        "name": name,
+        "arguments": arguments,
+    }
+
+
+def _function_added(
+    sequence: int,
+    output_index: int,
+    item_id: str,
+    call_id: str,
+    name: str,
+) -> dict[str, Any]:
+    return {
+        "type": "response.output_item.added",
+        "sequence_number": sequence,
+        "output_index": output_index,
+        "item": _function_item(item_id, call_id, name, "", status="in_progress"),
+    }
+
+
+def _arguments_delta(
+    sequence: int,
+    output_index: int,
+    item_id: str,
+    delta: str,
+) -> dict[str, Any]:
+    return {
+        "type": "response.function_call_arguments.delta",
+        "sequence_number": sequence,
+        "output_index": output_index,
+        "item_id": item_id,
+        "delta": delta,
+    }
+
+
+def _arguments_done(
+    sequence: int,
+    output_index: int,
+    item_id: str,
+    arguments: str,
+) -> dict[str, Any]:
+    return {
+        "type": "response.function_call_arguments.done",
+        "sequence_number": sequence,
+        "output_index": output_index,
+        "item_id": item_id,
+        "arguments": arguments,
+    }
+
+
+def _message_added(sequence: int, output_index: int, item_id: str) -> dict[str, Any]:
+    return {
+        "type": "response.output_item.added",
+        "sequence_number": sequence,
+        "output_index": output_index,
+        "item": {
+            "id": item_id,
+            "type": "message",
+            "role": "assistant",
+            "status": "in_progress",
+            "content": [],
+        },
+    }
+
+
+def _content_added(
+    sequence: int,
+    output_index: int,
+    item_id: str,
+    *,
+    content_index: int = 0,
+) -> dict[str, Any]:
+    return {
+        "type": "response.content_part.added",
+        "sequence_number": sequence,
+        "output_index": output_index,
+        "item_id": item_id,
+        "content_index": content_index,
+        "part": {"type": "output_text", "text": "", "annotations": []},
+    }
+
+
+def _text_delta(
+    sequence: int,
+    output_index: int,
+    item_id: str,
+    delta: str,
+    *,
+    content_index: int = 0,
+) -> dict[str, Any]:
+    return {
+        "type": "response.output_text.delta",
+        "sequence_number": sequence,
+        "output_index": output_index,
+        "item_id": item_id,
+        "content_index": content_index,
+        "delta": delta,
+        "logprobs": [],
+    }
+
+
+def _text_done(
+    sequence: int,
+    output_index: int,
+    item_id: str,
+    text: str,
+    *,
+    content_index: int = 0,
+) -> dict[str, Any]:
+    return {
+        "type": "response.output_text.done",
+        "sequence_number": sequence,
+        "output_index": output_index,
+        "item_id": item_id,
+        "content_index": content_index,
+        "text": text,
+        "logprobs": [],
+    }
+
+
+def _content_done(
+    sequence: int,
+    output_index: int,
+    item_id: str,
+    text: str,
+    *,
+    content_index: int = 0,
+) -> dict[str, Any]:
+    return {
+        "type": "response.content_part.done",
+        "sequence_number": sequence,
+        "output_index": output_index,
+        "item_id": item_id,
+        "content_index": content_index,
+        "part": {"type": "output_text", "text": text, "annotations": []},
+    }
+
+
+def _output_done(
+    sequence: int, output_index: int, item: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "type": "response.output_item.done",
+        "sequence_number": sequence,
+        "output_index": output_index,
+        "item": deepcopy(item),
+    }
+
+
+def _terminal(
+    sequence: int,
+    output: list[dict[str, Any]],
+    *,
+    event_type: str = "response.completed",
+    status: str = "completed",
+    usage: dict[str, Any] | None = None,
+    incomplete_reason: str | None = None,
+) -> dict[str, Any]:
+    response: dict[str, Any] = {
+        "id": "resp_verbatim",
+        "object": "response",
+        "status": status,
+        "output": deepcopy(output),
+    }
+    if usage is not None:
+        response["usage"] = deepcopy(usage)
+    if incomplete_reason is not None:
+        response["incomplete_details"] = {"reason": incomplete_reason}
+    return {
+        "type": event_type,
+        "sequence_number": sequence,
+        "response": response,
+    }
+
+
+def test_sse_records_survive_adversarial_byte_boundaries() -> None:
+    wire = (
+        b'data: {"type":"response.output_text.delta","delta":"caf\xc3\xa9"}\r\n'
+        b"\r\n"
+        b'data: {"type":"response.completed"}\n\n'
+    )
+    split_points = sorted(
+        {
+            1,
+            wire.index(b"data:") + 3,
+            wire.index(b"\xc3") + 1,
+            wire.index(b"\r\n") + 1,
+            wire.index(b"\r\n\r\n") + 3,
+            len(wire) - 1,
+        }
+    )
+    chunks: list[bytes] = []
+    start = 0
+    for stop in split_points:
+        chunks.append(wire[start:stop])
+        start = stop
+    chunks.append(wire[start:])
+
+    assert list(iter_sse_data_records(chunks)) == [
+        '{"type":"response.output_text.delta","delta":"café"}',
+        '{"type":"response.completed"}',
+    ]
+
+
+def test_sse_comments_and_multiline_data_frame_without_decoding() -> None:
+    chunks = [
+        b": heartbeat\r",
+        b"\nevent: response.output_text.delta\r\nid: 17\r\n",
+        b'data: {"type":"response.output_text.delta",\r\n',
+        b'data: "delta":"safe"}\r\nretry: 1000\r\n\r',
+        b"\n: keepalive\ndata: [DONE]\n\n",
+    ]
+
+    assert list(iter_sse_data_records(chunks)) == [
+        '{"type":"response.output_text.delta",\n"delta":"safe"}',
+        "[DONE]",
+    ]
+
+
+def test_responses_text_delta_done_recovery_is_exactly_once() -> None:
+    translator = QwenResponsesStreamTranslator()
+    chunks: list[dict[str, Any]] = []
+
+    chunks.extend(translator.feed(_message_added(0, 0, "msg_primary")))
+    chunks.extend(translator.feed(_content_added(1, 0, "msg_primary")))
+    chunks.extend(translator.feed(_text_delta(2, 0, "msg_primary", "Hel")))
+    chunks.extend(translator.feed(_text_delta(3, 0, "msg_primary", "lo")))
+    chunks.extend(translator.feed(_text_done(4, 0, "msg_primary", "Hello")))
+    chunks.extend(translator.feed(_content_done(5, 0, "msg_primary", "Hello")))
+    chunks.extend(
+        translator.feed(_output_done(6, 0, _message_item("msg_primary", "Hello")))
+    )
+
+    chunks.extend(translator.feed(_message_added(7, 1, "msg_recovered")))
+    chunks.extend(translator.feed(_content_added(8, 1, "msg_recovered")))
+    chunks.extend(translator.feed(_text_done(9, 1, "msg_recovered", " recovered")))
+    chunks.extend(translator.feed(_content_done(10, 1, "msg_recovered", " recovered")))
+    chunks.extend(
+        translator.feed(
+            _output_done(11, 1, _message_item("msg_recovered", " recovered"))
+        )
+    )
+    chunks.extend(
+        translator.feed(
+            _terminal(
+                12,
+                [
+                    _message_item("msg_primary", "Hello"),
+                    _message_item("msg_recovered", " recovered"),
+                ],
+                usage={"input_tokens": 4, "output_tokens": 2, "total_tokens": 6},
+            )
+        )
+    )
+
+    assert [chunk["choices"][0]["delta"]["content"] for chunk in chunks] == [
+        "Hel",
+        "lo",
+        " recovered",
+        "",
+    ]
+    assert translator.finish() == ()
+
+
+def test_responses_sequence_duplicate_conflict_and_decrease() -> None:
+    translator = QwenResponsesStreamTranslator()
+    created = {
+        "type": "response.created",
+        "sequence_number": 10,
+        "response": {"id": "resp_safe", "status": "in_progress", "output": []},
+    }
+    in_progress = {
+        "type": "response.in_progress",
+        "sequence_number": 11,
+        "response": {"id": "resp_safe", "status": "in_progress", "output": []},
+    }
+    assert translator.feed(created) == ()
+    assert translator.feed(in_progress) == ()
+    assert translator.feed(deepcopy(created)) == ()
+
+    conflicting_duplicate = deepcopy(created)
+    conflicting_duplicate["type"] = "response.in_progress"
+    with pytest.raises(ChatProviderError, match="sequence") as conflict_info:
+        translator.feed(conflicting_duplicate)
+    assert conflict_info.value.provider == "qwencloud"
+
+    decreasing = QwenResponsesStreamTranslator()
+    assert decreasing.feed(created) == ()
+    with pytest.raises(ChatProviderError, match="sequence") as decrease_info:
+        decreasing.feed(
+            {
+                "type": "response.in_progress",
+                "sequence_number": 9,
+                "response": {
+                    "id": "resp_safe",
+                    "status": "in_progress",
+                    "output": [],
+                },
+            }
+        )
+    assert decrease_info.value.provider == "qwencloud"
+
+    with pytest.raises(ChatProviderError, match="sequence"):
+        QwenResponsesStreamTranslator().feed({"type": "response.created"})
+
+
+def test_responses_terminal_usage_finish_and_empty_delta() -> None:
+    usage = {
+        "input_tokens": 9,
+        "input_tokens_details": {"cached_tokens": 2},
+        "output_tokens": 3,
+        "output_tokens_details": {"reasoning_tokens": 1},
+        "total_tokens": 12,
+    }
+    translator = QwenResponsesStreamTranslator()
+    assert translator.feed(_message_added(0, 0, "msg_terminal")) == ()
+    assert translator.feed(_content_added(1, 0, "msg_terminal")) == ()
+    empty_delta = translator.feed(_text_delta(2, 0, "msg_terminal", ""))
+    text_delta = translator.feed(_text_delta(3, 0, "msg_terminal", "safe"))
+    terminal = translator.feed(
+        _terminal(4, [_message_item("msg_terminal", "safe")], usage=usage)
+    )
+
+    assert empty_delta == ({"choices": [{"delta": {"content": ""}}]},)
+    assert text_delta == ({"choices": [{"delta": {"content": "safe"}}]},)
+    assert terminal == (
+        {
+            "choices": [{"delta": {"content": ""}, "finish_reason": "stop"}],
+            "usage": usage,
+        },
+    )
+    with pytest.raises(ChatProviderError, match="terminal"):
+        translator.feed(
+            {
+                "type": "response.in_progress",
+                "sequence_number": 5,
+                "response": {"status": "in_progress", "output": []},
+            }
+        )
+
+    incomplete = QwenResponsesStreamTranslator()
+    incomplete.feed(_message_added(0, 0, "msg_partial"))
+    incomplete.feed(_content_added(1, 0, "msg_partial"))
+    incomplete.feed(_text_delta(2, 0, "msg_partial", "partial"))
+    assert incomplete.feed(
+        _terminal(
+            3,
+            [_message_item("msg_partial", "partial", status="incomplete")],
+            event_type="response.incomplete",
+            status="incomplete",
+            incomplete_reason="max_output_tokens",
+        )
+    ) == (
+        {
+            "choices": [{"delta": {"content": ""}, "finish_reason": "length"}],
+            "usage": {},
+        },
+    )
+
+    for event_type, status in (
+        ("response.failed", "failed"),
+        ("response.cancelled", "cancelled"),
+    ):
+        with pytest.raises(ChatProviderError) as failure_info:
+            QwenResponsesStreamTranslator().feed(
+                _terminal(0, [], event_type=event_type, status=status)
+            )
+        assert failure_info.value.provider == "qwencloud"
+
+    with pytest.raises(ChatProviderError, match="terminal"):
+        QwenResponsesStreamTranslator().finish()
+    malformed_terminal = _terminal(0, [])
+    del malformed_terminal["response"]["status"]
+    with pytest.raises(ChatProviderError) as malformed_info:
+        QwenResponsesStreamTranslator().feed(malformed_terminal)
+    assert malformed_info.value.provider == "qwencloud"
+
+
+def test_responses_function_call_fragments_recover_without_duplication() -> None:
+    translator = QwenResponsesStreamTranslator()
+    chunks: list[dict[str, Any]] = []
+    chunks.extend(
+        translator.feed(_function_added(0, 0, "fc_transport_a", "call_a", "alpha"))
+    )
+    chunks.extend(
+        translator.feed(_function_added(1, 1, "fc_transport_b", "call_b", "beta"))
+    )
+    chunks.extend(translator.feed(_arguments_delta(2, 1, "fc_transport_b", '{"b":')))
+    chunks.extend(translator.feed(_arguments_delta(3, 0, "fc_transport_a", '{"a":1')))
+    chunks.extend(translator.feed(_arguments_done(4, 0, "fc_transport_a", '{"a":1}')))
+    chunks.extend(
+        translator.feed(
+            _output_done(
+                5,
+                1,
+                _function_item("fc_transport_b", "call_b", "beta", '{"b":2}'),
+            )
+        )
+    )
+    chunks.extend(
+        translator.feed(_function_added(6, 2, "fc_transport_c", "call_c", "gamma"))
+    )
+    terminal_output = [
+        _function_item("fc_transport_a", "call_a", "alpha", '{"a":1}'),
+        _function_item("fc_transport_b", "call_b", "beta", '{"b":2}'),
+        _function_item("fc_transport_c", "call_c", "gamma", '{"c":3}'),
+    ]
+    chunks.extend(
+        translator.feed(
+            _terminal(
+                7,
+                terminal_output,
+                usage={"input_tokens": 5, "output_tokens": 7, "total_tokens": 12},
+            )
+        )
+    )
+
+    fragments: dict[int, list[str]] = {0: [], 1: [], 2: []}
+    identities: dict[int, tuple[str, str]] = {}
+    terminal_chunks: list[dict[str, Any]] = []
+    for chunk in chunks:
+        choice = chunk["choices"][0]
+        if choice.get("finish_reason") is not None:
+            terminal_chunks.append(chunk)
+            continue
+        for tool_delta in choice["delta"].get("tool_calls", []):
+            index = tool_delta["index"]
+            function = tool_delta.get("function", {})
+            fragments[index].append(function.get("arguments", ""))
+            if "id" in tool_delta:
+                identities[index] = (tool_delta["id"], function["name"])
+
+    assert identities == {
+        0: ("call_a", "alpha"),
+        1: ("call_b", "beta"),
+        2: ("call_c", "gamma"),
+    }
+    assert "fc_transport_a" not in repr(chunks)
+    assert "fc_transport_b" not in repr(chunks)
+    assert "fc_transport_c" not in repr(chunks)
+    assert {index: "".join(parts) for index, parts in fragments.items()} == {
+        0: '{"a":1}',
+        1: '{"b":2}',
+        2: '{"c":3}',
+    }
+    assert terminal_chunks == [
+        {
+            "choices": [{"delta": {"content": ""}, "finish_reason": "tool_calls"}],
+            "usage": {"input_tokens": 5, "output_tokens": 7, "total_tokens": 12},
+        }
+    ]
+    assert translator.finish() == ()
+
+
+def test_responses_partial_or_mismatched_call_never_surfaces() -> None:
+    invalid_json = QwenResponsesStreamTranslator()
+    invalid_json.feed(
+        _function_added(0, 0, "fc_private", "call_private", "private_tool")
+    )
+    invalid_json.feed(
+        _arguments_delta(1, 0, "fc_private", '{"RAW-CALL-PRIVATE-CANARY":')
+    )
+    with pytest.raises(ChatProviderError) as invalid_info:
+        invalid_json.feed(
+            _arguments_done(2, 0, "fc_private", '{"RAW-CALL-PRIVATE-CANARY":')
+        )
+    assert invalid_info.value.provider == "qwencloud"
+    assert "RAW-CALL-PRIVATE-CANARY" not in str(invalid_info.value)
+    assert invalid_info.value.__cause__ is None
+    assert invalid_info.value.__context__ is None
+
+    non_object = QwenResponsesStreamTranslator()
+    non_object.feed(_function_added(0, 0, "fc_array", "call_array", "lookup"))
+    with pytest.raises(ChatProviderError):
+        non_object.feed(_arguments_done(1, 0, "fc_array", "[]"))
+
+    for malformed_item in (
+        _function_item("fc_missing_id", "", "lookup", ""),
+        _function_item("fc_missing_name", "call_name", "", ""),
+    ):
+        with pytest.raises(ChatProviderError):
+            QwenResponsesStreamTranslator().feed(
+                {
+                    "type": "response.output_item.added",
+                    "sequence_number": 0,
+                    "output_index": 0,
+                    "item": malformed_item,
+                }
+            )
+
+    duplicate = QwenResponsesStreamTranslator()
+    duplicate.feed(_function_added(0, 0, "fc_first", "call_dup", "lookup"))
+    with pytest.raises(ChatProviderError):
+        duplicate.feed(_function_added(1, 1, "fc_second", "call_dup", "lookup"))
+
+    mismatches = (
+        _arguments_delta(1, 1, "fc_expected", "{}"),
+        _arguments_delta(1, 0, "fc_wrong_transport", "{}"),
+        _output_done(
+            1,
+            0,
+            _function_item("fc_expected", "call_wrong", "lookup", "{}"),
+        ),
+        _output_done(
+            1,
+            0,
+            _function_item("fc_expected", "call_expected", "wrong_name", "{}"),
+        ),
+    )
+    for mismatched_event in mismatches:
+        translator = QwenResponsesStreamTranslator()
+        translator.feed(_function_added(0, 0, "fc_expected", "call_expected", "lookup"))
+        with pytest.raises(ChatProviderError) as mismatch_info:
+            translator.feed(mismatched_event)
+        assert mismatch_info.value.provider == "qwencloud"
+
+    conflicting_arguments = QwenResponsesStreamTranslator()
+    conflicting_arguments.feed(
+        _function_added(0, 0, "fc_conflict", "call_conflict", "lookup")
+    )
+    conflicting_arguments.feed(_arguments_delta(1, 0, "fc_conflict", '{"value":1}'))
+    with pytest.raises(ChatProviderError):
+        conflicting_arguments.feed(
+            _output_done(
+                2,
+                0,
+                _function_item("fc_conflict", "call_conflict", "lookup", '{"value":2}'),
+            )
+        )
+
+    missing_terminal_call = QwenResponsesStreamTranslator()
+    missing_terminal_call.feed(
+        _function_added(0, 0, "fc_missing", "call_missing", "lookup")
+    )
+    with pytest.raises(ChatProviderError) as terminal_info:
+        missing_terminal_call.feed(_terminal(1, []))
+    assert terminal_info.value.provider == "qwencloud"
+
+
+def test_chat_stream_preserves_openai_deltas_and_usage() -> None:
+    events = [
+        {
+            "id": "chatcmpl_safe",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "Hel"},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl_safe",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_safe",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": '{"q":'},
+                            }
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl_safe",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": '"safe"}'}}
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl_safe",
+            "choices": [],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 3, "total_tokens": 7},
+        },
+    ]
+    wire = (
+        b"".join(
+            b"data: " + json.dumps(event, separators=(",", ":")).encode() + b"\r\n\r\n"
+            for event in events
+        )
+        + b"data: [DONE]\r\n\r\n"
+    )
+    response = _ByteStreamResponse([wire[:17], wire[17:89], wire[89:]])
+    session = _ByteStreamSession([response])
+
+    assert (
+        list(
+            QwenCloudStream(
+                response=response,  # type: ignore[arg-type]
+                session=session,  # type: ignore[arg-type]
+                api_mode="chat_completions",
+            )
+        )
+        == events
+    )
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+def test_stream_retries_only_before_first_consumed_byte(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    retryable = _ByteStreamResponse([], status_code=503)
+    malformed_after_body = _ByteStreamResponse(
+        [b'data: {"choices":[{"delta":{"content":"private"}}]}\n\n', b"data: {"]
+    )
+    replay_canary = _ByteStreamResponse(
+        [b'data: {"choices":[{"delta":{"content":"replayed"}}]}\n\n']
+    )
+    session = _ByteStreamSession([retryable, malformed_after_body, replay_canary])
+    monkeypatch.setattr(
+        qwencloud,
+        "requests",
+        SimpleNamespace(Session=lambda: session),
+    )
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    "qwencloud": {"timeout": 3, "retries": 2, "retry_delay": 0}
+                }
+            }
+        ),
+    )
+
+    stream = qwencloud.chat_with_qwencloud(
+        input_data=[{"role": "user", "content": "hello"}],
+        model="qwen3.8-max",
+        api_key="key",
+        streaming=True,
+        api_base_url="https://qwen.example/v1",
+        api_mode="chat_completions",
+    )
+
+    assert not isinstance(stream, dict)
+    assert len(session.posts) == 2
+    assert retryable.close_calls == 1
+    assert malformed_after_body.close_calls == 0
+    assert next(stream)["choices"][0]["delta"]["content"] == "private"
+    with pytest.raises(ChatProviderError) as exc_info:
+        next(stream)
+    assert exc_info.value.provider == "qwencloud"
+    assert len(session.posts) == 2
+    assert replay_canary.iter_content_calls == 0
+    assert malformed_after_body.close_calls == 1
+    assert session.close_calls == 1
+
+
+def test_stream_close_is_idempotent_and_closes_response_and_session() -> None:
+    response = _ByteStreamResponse(
+        [b'data: {"choices":[{"delta":{"content":"unused"}}]}\n\n']
+    )
+    session = _ByteStreamSession([response])
+    stream = QwenCloudStream(
+        response=response,  # type: ignore[arg-type]
+        session=session,  # type: ignore[arg-type]
+        api_mode="chat_completions",
+    )
+
+    stream.close()
+    stream.close()
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+@pytest.mark.parametrize(
+    "chunks",
+    (
+        [b"data: {not-json}\n\n"],
+        [b"data: [1,2,3]\n\n"],
+        [b'data: {"type":"error","error":{"message":"RAW-ERROR-CANARY"}}\n\n'],
+        [b"data: \xff\n\n"],
+        [b'data: {"choices":[]}'],
+    ),
+    ids=(
+        "malformed-json",
+        "non-object-json",
+        "provider-error-event",
+        "invalid-utf8",
+        "incomplete-record",
+    ),
+)
+def test_stream_malformed_json_and_error_event_are_typed_closed_and_not_retried(
+    chunks: list[bytes],
+) -> None:
+    response = _ByteStreamResponse(chunks)
+    session = _ByteStreamSession([response])
+    stream = QwenCloudStream(
+        response=response,  # type: ignore[arg-type]
+        session=session,  # type: ignore[arg-type]
+        api_mode="chat_completions",
+    )
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        list(stream)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert "RAW-ERROR-CANARY" not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert response.iter_content_calls == 1
+    assert response.close_calls == 1
+    assert session.close_calls == 1

--- a/Tests/LLM_Calls/test_qwencloud_streaming.py
+++ b/Tests/LLM_Calls/test_qwencloud_streaming.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from copy import deepcopy
 import inspect
 import json
-from types import SimpleNamespace
+from types import MappingProxyType, SimpleNamespace
 from typing import Any
 
 import pytest
@@ -495,6 +495,46 @@ def test_stream_caps_provider_controlled_event_and_record_sizes(
     assert session.close_calls == 1
 
 
+@pytest.mark.parametrize("cap", ("segments", "data-lines"))
+def test_stream_caps_sse_reference_counts_and_closes(
+    monkeypatch: pytest.MonkeyPatch,
+    cap: str,
+) -> None:
+    if cap == "segments":
+        monkeypatch.setattr(
+            qwencloud_streaming, "_MAX_SSE_LINE_SEGMENTS", 2, raising=False
+        )
+        event = json.dumps(_chat_text_terminal(), separators=(",", ":")).encode()
+        chunks = [b"data: ", event[:1], event[1:], b"\n\ndata: [DONE]\n\n"]
+    else:
+        monkeypatch.setattr(
+            qwencloud_streaming, "_MAX_SSE_DATA_LINES", 2, raising=False
+        )
+        chunks = [
+            b'data: {"id":"RAW-SSE-REFERENCE-CANARY",\n',
+            b'data: "choices":\n',
+            b'data: [{"index":0,"delta":{"content":"safe"},',
+            b'"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+        ]
+    response = _ByteStreamResponse(chunks)
+    session = _ByteStreamSession([response])
+    stream = QwenCloudStream(
+        response=response,  # type: ignore[arg-type]
+        session=session,  # type: ignore[arg-type]
+        api_mode="chat_completions",
+    )
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        list(stream)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert "RAW-SSE-REFERENCE-CANARY" not in str(exc_info.value)
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
 def test_sse_accepts_long_valid_record_below_private_caps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -650,7 +690,13 @@ def test_responses_accumulated_output_cap_is_typed_and_redacted(
     monkeypatch: pytest.MonkeyPatch,
     kind: str,
 ) -> None:
-    monkeypatch.setattr(qwencloud_streaming, "_MAX_OUTPUT_CHARS", 5, raising=False)
+    metadata_chars = len("msg_cap") if kind == "text" else len("fc_capcall_caplookup")
+    monkeypatch.setattr(
+        qwencloud_streaming,
+        "_MAX_OUTPUT_CHARS",
+        metadata_chars + 5,
+        raising=False,
+    )
     translator = QwenResponsesStreamTranslator()
     if kind == "text":
         translator.feed(_message_added(0, 0, "msg_cap"))
@@ -693,6 +739,111 @@ def test_responses_text_and_argument_fragments_use_linear_lists_then_release() -
     translator.feed(_arguments_done(8, 1, "fc_fragments", '{"a":1}'))
     assert call_state.argument_fragments == []
     assert call_state.final_arguments == '{"a":1}'
+
+
+def test_responses_retained_metadata_is_charged_exactly_once() -> None:
+    translator = QwenResponsesStreamTranslator()
+    expected_characters = 0
+    for index in range(500):
+        item_id = f"fc_{index}_" + "i" * 64
+        call_id = f"call_{index}_" + "c" * 64
+        name = f"tool_{index}_" + "n" * 64
+        translator.feed(_function_added(index, index, item_id, call_id, name))
+        expected_characters += len(item_id) + len(call_id) + len(name)
+
+    assert translator._output_chars == expected_characters  # noqa: SLF001
+    last_item_id = "fc_499_" + "i" * 64
+    translator.feed(_arguments_delta(500, 499, last_item_id, "{}"))
+    assert translator._output_chars == expected_characters + 2  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("message-id", "reasoning-id", "function-id", "call-id", "name", "cumulative"),
+)
+def test_responses_retained_metadata_fields_are_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+) -> None:
+    monkeypatch.setattr(qwencloud_streaming, "_MAX_METADATA_CHARS", 8, raising=False)
+    monkeypatch.setattr(qwencloud_streaming, "_MAX_OUTPUT_CHARS", 16, raising=False)
+    too_long = "RAW-METADATA-CANARY"
+    if field == "message-id":
+        event = _message_added(0, 0, too_long)
+    elif field == "reasoning-id":
+        event = _reasoning_added(0, 0, too_long)
+    else:
+        event = _function_added(
+            0,
+            0,
+            too_long
+            if field == "function-id"
+            else "item12"
+            if field == "cumulative"
+            else "item",
+            too_long
+            if field == "call-id"
+            else "call12"
+            if field == "cumulative"
+            else "call",
+            too_long
+            if field == "name"
+            else "tool12"
+            if field == "cumulative"
+            else "tool",
+        )
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        QwenResponsesStreamTranslator().feed(event)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert too_long not in str(exc_info.value)
+
+
+@pytest.mark.parametrize("field", ("id", "name", "cumulative"))
+def test_chat_retained_tool_metadata_is_bounded_and_charged_once(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+) -> None:
+    monkeypatch.setattr(qwencloud_streaming, "_MAX_METADATA_CHARS", 8, raising=False)
+    monkeypatch.setattr(qwencloud_streaming, "_MAX_OUTPUT_CHARS", 16, raising=False)
+    start = _chat_tool_start()
+    tool = start["choices"][0]["delta"]["tool_calls"][0]
+    too_long = "RAW-METADATA-CANARY"
+    if field == "id":
+        tool["id"] = too_long
+    elif field == "name":
+        tool["function"]["name"] = too_long
+    else:
+        tool["id"] = "12345678"
+        tool["function"]["name"] = "abcdefgh"
+        tool["function"]["arguments"] = "x"
+    stream, response, session = _chat_stream([start, _chat_tool_terminal()])
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        list(stream)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert too_long not in str(exc_info.value)
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+def test_chat_repeated_tool_metadata_is_not_double_charged() -> None:
+    start = _chat_tool_start()
+    terminal = _chat_tool_terminal()
+    terminal_tool = terminal["choices"][0]["delta"]["tool_calls"][0]
+    terminal_tool["id"] = "call_metadata"
+    terminal_tool["type"] = "function"
+    terminal_tool["function"]["name"] = "lookup"
+    stream, _, _ = _chat_stream([start, terminal])
+
+    list(stream)
+
+    expected = len("call_metadata") + len("lookup") + len('{"safe":true}')
+    assert stream._translator._output_chars == expected  # noqa: SLF001
 
 
 def test_responses_terminal_replay_is_strict_and_finish_safe() -> None:
@@ -752,6 +903,41 @@ def test_responses_sequence_replay_uses_type_sensitive_json_equality(
         translator.feed(conflict)
 
     assert exc_info.value.provider == "qwencloud"
+
+
+def test_responses_direct_feed_rejects_non_json_nested_containers() -> None:
+    event = {
+        "type": "response.created",
+        "sequence_number": 0,
+        "response": {
+            "id": "resp_direct",
+            "status": "in_progress",
+            "output": ({"index": 0},),
+        },
+    }
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        QwenResponsesStreamTranslator().feed(event)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+
+
+def test_responses_direct_feed_accepts_top_level_mapping_copy() -> None:
+    event = MappingProxyType(
+        {
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": {
+                "id": "resp_direct",
+                "status": "in_progress",
+                "output": [],
+            },
+        }
+    )
+
+    assert QwenResponsesStreamTranslator().feed(event) == ()
 
 
 def test_responses_terminal_usage_finish_and_empty_delta() -> None:
@@ -1556,6 +1742,142 @@ def test_chat_stream_drops_unvalidated_private_extras_without_coercion() -> None
         ],
     }
     assert "RAW-PRIVATE-CANARY" not in repr(emitted)
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+@pytest.mark.parametrize("nullable_field", ("tool_calls", "usage"))
+def test_chat_stream_nullable_projection_paths_close_normally(
+    nullable_field: str,
+) -> None:
+    terminal = _chat_text_terminal()
+    if nullable_field == "tool_calls":
+        terminal["choices"][0]["delta"]["tool_calls"] = None
+    else:
+        terminal["usage"] = None
+    stream, response, session = _chat_stream([terminal])
+
+    assert list(stream) == [_chat_text_terminal()]
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+def test_chat_stream_nullable_fields_preserve_valid_accumulator_flow() -> None:
+    events = [
+        {
+            "id": "chatcmpl_nullable",
+            "usage": None,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_nullable",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": ""},
+                            }
+                        ],
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl_nullable",
+            "usage": None,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "safe", "tool_calls": None},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl_nullable",
+            "usage": None,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"arguments": '{"safe":true}'},
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl_nullable",
+            "choices": [],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+        },
+    ]
+    expected = deepcopy(events)
+    for event in expected[:3]:
+        event.pop("usage")
+    expected[0]["choices"][0]["delta"].pop("content")
+    expected[1]["choices"][0]["delta"].pop("tool_calls")
+    stream, response, session = _chat_stream(events)
+
+    chunks = list(stream)
+
+    from tldw_chatbook.Chat.console_provider_gateway import _ToolCallAccumulator
+
+    accumulator = _ToolCallAccumulator()
+    for chunk in chunks:
+        accumulator.feed_payload(chunk)
+    assert chunks == expected
+    assert accumulator.calls() == (
+        {
+            "id": "call_nullable",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": '{"safe":true}'},
+        },
+    )
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+@pytest.mark.parametrize("stage", ("decode", "feed", "finish"))
+def test_stream_unexpected_exceptions_are_typed_redacted_and_closed(
+    stage: str,
+) -> None:
+    canary = "RAW-UNEXPECTED-STREAM-CANARY"
+    stream, response, session = _chat_stream([_chat_text_terminal()])
+
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError(canary)
+
+    if stage == "decode":
+        stream._decode_event = explode  # type: ignore[method-assign]  # noqa: SLF001
+    elif stage == "feed":
+        stream._translator.feed = explode  # type: ignore[method-assign]  # noqa: SLF001
+    else:
+        stream._translator.finish = explode  # type: ignore[method-assign]  # noqa: SLF001
+
+    records: list[str] = []
+    sink_id = logger.add(lambda message: records.append(str(message)), level="DEBUG")
+    try:
+        if stage == "finish":
+            assert next(stream)["choices"][0]["finish_reason"] == "stop"
+        with pytest.raises(ChatProviderError) as exc_info:
+            next(stream)
+    finally:
+        logger.remove(sink_id)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert canary not in str(exc_info.value) + "".join(records)
     assert response.close_calls == 1
     assert session.close_calls == 1
 

--- a/Tests/LLM_Calls/test_qwencloud_streaming.py
+++ b/Tests/LLM_Calls/test_qwencloud_streaming.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import inspect
 import json
 from types import SimpleNamespace
 from typing import Any
@@ -13,6 +14,7 @@ from loguru import logger
 
 from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
 import tldw_chatbook.LLM_Calls.qwencloud as qwencloud
+import tldw_chatbook.LLM_Calls.qwencloud_streaming as qwencloud_streaming
 from tldw_chatbook.LLM_Calls.qwencloud_streaming import (
     QwenCloudStream,
     QwenResponsesStreamTranslator,
@@ -64,6 +66,12 @@ class _FailingByteStreamResponse(_ByteStreamResponse):
         raise self.error
 
 
+class _CloseFailingByteStreamResponse(_ByteStreamResponse):
+    def close(self) -> None:
+        self.close_calls += 1
+        raise RuntimeError("RAW-RESPONSE-CLOSE-CANARY")
+
+
 class _ByteStreamSession:
     def __init__(self, responses: list[_ByteStreamResponse]) -> None:
         self.responses = responses
@@ -80,6 +88,12 @@ class _ByteStreamSession:
 
     def close(self) -> None:
         self.close_calls += 1
+
+
+class _CloseFailingByteStreamSession(_ByteStreamSession):
+    def close(self) -> None:
+        self.close_calls += 1
+        raise RuntimeError("RAW-SESSION-CLOSE-CANARY")
 
 
 def _message_item(
@@ -319,6 +333,85 @@ def _terminal(
     }
 
 
+def _chat_wire(events: list[dict[str, Any]], *, done: bool = True) -> list[bytes]:
+    wire = b"".join(
+        b"data: " + json.dumps(event, separators=(",", ":")).encode() + b"\n\n"
+        for event in events
+    )
+    if done:
+        wire += b"data: [DONE]\n\n"
+    return [wire]
+
+
+def _chat_stream(
+    events: list[dict[str, Any]], *, done: bool = True
+) -> tuple[QwenCloudStream, _ByteStreamResponse, _ByteStreamSession]:
+    response = _ByteStreamResponse(_chat_wire(events, done=done))
+    session = _ByteStreamSession([response])
+    stream = QwenCloudStream(
+        response=response,  # type: ignore[arg-type]
+        session=session,  # type: ignore[arg-type]
+        api_mode="chat_completions",
+    )
+    return stream, response, session
+
+
+def _chat_tool_start() -> dict[str, Any]:
+    return {
+        "id": "chatcmpl_metadata",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_metadata",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": ""},
+                        }
+                    ],
+                },
+                "finish_reason": None,
+            }
+        ],
+    }
+
+
+def _chat_tool_terminal() -> dict[str, Any]:
+    return {
+        "id": "chatcmpl_metadata",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"arguments": '{"safe":true}'},
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+
+
+def _chat_text_terminal(*, reason: str = "stop") -> dict[str, Any]:
+    return {
+        "id": "chatcmpl_metadata",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": "safe"},
+                "finish_reason": reason,
+            }
+        ],
+    }
+
+
 def test_sse_records_survive_adversarial_byte_boundaries() -> None:
     wire = (
         b'data: {"type":"response.output_text.delta","delta":"caf\xc3\xa9"}\r\n'
@@ -361,6 +454,68 @@ def test_sse_comments_and_multiline_data_frame_without_decoding() -> None:
         '{"type":"response.output_text.delta",\n"delta":"safe"}',
         "[DONE]",
     ]
+
+
+@pytest.mark.parametrize("cap", ("events", "line", "record"))
+def test_stream_caps_provider_controlled_event_and_record_sizes(
+    monkeypatch: pytest.MonkeyPatch,
+    cap: str,
+) -> None:
+    events = [
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant"},
+                    "finish_reason": None,
+                }
+            ]
+        },
+        _chat_text_terminal(),
+    ]
+    if cap == "events":
+        monkeypatch.setattr(qwencloud_streaming, "_MAX_STREAM_EVENTS", 1, raising=False)
+    elif cap == "line":
+        monkeypatch.setattr(
+            qwencloud_streaming, "_MAX_SSE_LINE_CHARS", 32, raising=False
+        )
+    else:
+        monkeypatch.setattr(
+            qwencloud_streaming, "_MAX_SSE_RECORD_CHARS", 32, raising=False
+        )
+    stream, response, session = _chat_stream(events)
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        list(stream)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+def test_sse_accepts_long_valid_record_below_private_caps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(qwencloud_streaming, "_MAX_SSE_LINE_CHARS", 2048, raising=False)
+    monkeypatch.setattr(
+        qwencloud_streaming, "_MAX_SSE_RECORD_CHARS", 2048, raising=False
+    )
+    terminal = _chat_text_terminal()
+    terminal["choices"][0]["delta"]["content"] = "x" * 512
+    stream, response, session = _chat_stream([terminal])
+
+    assert list(stream) == [terminal]
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+def test_sse_line_accumulation_is_structurally_linear() -> None:
+    source = inspect.getsource(qwencloud_streaming._iter_utf8_lines)
+
+    assert "buffered +=" not in source
+    assert "segments" in source
 
 
 def test_responses_text_delta_done_recovery_is_exactly_once() -> None:
@@ -450,6 +605,96 @@ def test_responses_sequence_duplicate_conflict_and_decrease() -> None:
         QwenResponsesStreamTranslator().feed({"type": "response.created"})
 
 
+def test_responses_sequence_state_is_compact_and_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(qwencloud_streaming, "_MAX_TRACKED_SEQUENCES", 2, raising=False)
+    translator = QwenResponsesStreamTranslator()
+    created = {
+        "type": "response.created",
+        "sequence_number": 0,
+        "response": {
+            "id": "resp_compact_RAW-SEQUENCE-CANARY",
+            "status": "in_progress",
+            "output": [],
+        },
+    }
+    translator.feed(created)
+    stored = translator._seen_sequences[0]  # noqa: SLF001
+    assert isinstance(stored, bytes)
+    assert len(stored) <= 64
+    assert "RAW-SEQUENCE-CANARY" not in repr(stored)
+    translator.feed(
+        {
+            "type": "response.in_progress",
+            "sequence_number": 1,
+            "response": {"id": "resp_compact", "status": "in_progress"},
+        }
+    )
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        translator.feed(
+            {
+                "type": "response.in_progress",
+                "sequence_number": 2,
+                "response": {"id": "resp_compact", "status": "in_progress"},
+            }
+        )
+
+    assert exc_info.value.provider == "qwencloud"
+    assert "RAW-SEQUENCE-CANARY" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize("kind", ("text", "arguments"))
+def test_responses_accumulated_output_cap_is_typed_and_redacted(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+) -> None:
+    monkeypatch.setattr(qwencloud_streaming, "_MAX_OUTPUT_CHARS", 5, raising=False)
+    translator = QwenResponsesStreamTranslator()
+    if kind == "text":
+        translator.feed(_message_added(0, 0, "msg_cap"))
+        translator.feed(_content_added(1, 0, "msg_cap"))
+        translator.feed(_text_delta(2, 0, "msg_cap", "abc"))
+        crossing = _text_delta(3, 0, "msg_cap", "RAW")
+    else:
+        translator.feed(_function_added(0, 0, "fc_cap", "call_cap", "lookup"))
+        translator.feed(_arguments_delta(1, 0, "fc_cap", "abc"))
+        crossing = _arguments_delta(2, 0, "fc_cap", "RAW")
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        translator.feed(crossing)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert "RAW" not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+
+
+def test_responses_text_and_argument_fragments_use_linear_lists_then_release() -> None:
+    translator = QwenResponsesStreamTranslator()
+    translator.feed(_message_added(0, 0, "msg_fragments"))
+    translator.feed(_content_added(1, 0, "msg_fragments"))
+    translator.feed(_text_delta(2, 0, "msg_fragments", "ab"))
+    translator.feed(_text_delta(3, 0, "msg_fragments", "cd"))
+    text_state = translator._text_parts[(0, 0)]  # noqa: SLF001
+    assert text_state.fragments == ["ab", "cd"]
+    assert not hasattr(text_state, "emitted_text")
+    translator.feed(_text_done(4, 0, "msg_fragments", "abcd"))
+    assert text_state.fragments == []
+    assert text_state.final_text == "abcd"
+
+    translator.feed(_function_added(5, 1, "fc_fragments", "call_fragments", "lookup"))
+    translator.feed(_arguments_delta(6, 1, "fc_fragments", '{"a":'))
+    translator.feed(_arguments_delta(7, 1, "fc_fragments", "1}"))
+    call_state = translator._function_calls[1]  # noqa: SLF001
+    assert call_state.argument_fragments == ['{"a":', "1}"]
+    assert not hasattr(call_state, "emitted_arguments")
+    translator.feed(_arguments_done(8, 1, "fc_fragments", '{"a":1}'))
+    assert call_state.argument_fragments == []
+    assert call_state.final_arguments == '{"a":1}'
+
+
 def test_responses_terminal_replay_is_strict_and_finish_safe() -> None:
     translator = QwenResponsesStreamTranslator()
     translator.feed(_message_added(0, 0, "msg_replay"))
@@ -463,6 +708,12 @@ def test_responses_terminal_replay_is_strict_and_finish_safe() -> None:
 
     assert translator.feed(completed)[-1]["choices"][0]["finish_reason"] == "stop"
     assert translator.feed(deepcopy(completed)) == ()
+    reordered = {
+        "response": deepcopy(completed["response"]),
+        "sequence_number": completed["sequence_number"],
+        "type": completed["type"],
+    }
+    assert translator.feed(reordered) == ()
     assert translator.finish() == ()
 
     with pytest.raises(ChatProviderError, match="object"):
@@ -649,6 +900,80 @@ def test_responses_function_call_fragments_recover_without_duplication() -> None
         }
     ]
     assert translator.finish() == ()
+
+
+def test_responses_function_indexes_preserve_terminal_output_order() -> None:
+    translator = QwenResponsesStreamTranslator()
+    chunks: list[dict[str, Any]] = []
+    chunks.extend(
+        translator.feed(_function_added(0, 1, "fc_one", "call_one", "second"))
+    )
+    chunks.extend(
+        translator.feed(_function_added(1, 0, "fc_zero", "call_zero", "first"))
+    )
+    chunks.extend(
+        translator.feed(
+            _terminal(
+                2,
+                [
+                    _function_item("fc_zero", "call_zero", "first", '{"n":0}'),
+                    _function_item("fc_one", "call_one", "second", '{"n":1}'),
+                ],
+            )
+        )
+    )
+
+    identities = {
+        tool_call["index"]: tool_call["id"]
+        for chunk in chunks
+        for tool_call in chunk["choices"][0]["delta"].get("tool_calls", [])
+        if "id" in tool_call
+    }
+    assert identities == {1: "call_one", 0: "call_zero"}
+    assert [identities[index] for index in sorted(identities)] == [
+        "call_zero",
+        "call_one",
+    ]
+
+
+def test_responses_stable_function_indexes_survive_interleaved_output_types() -> None:
+    translator = QwenResponsesStreamTranslator()
+    chunks: list[dict[str, Any]] = []
+    chunks.extend(
+        translator.feed(_function_added(0, 3, "fc_three", "call_three", "third"))
+    )
+    chunks.extend(translator.feed(_message_added(1, 0, "msg_zero")))
+    chunks.extend(translator.feed(_content_added(2, 0, "msg_zero")))
+    chunks.extend(translator.feed(_text_delta(3, 0, "msg_zero", "safe")))
+    chunks.extend(translator.feed(_reasoning_added(4, 1, "reasoning_one")))
+    chunks.extend(
+        translator.feed(_function_added(5, 2, "fc_two", "call_two", "second"))
+    )
+    chunks.extend(
+        translator.feed(
+            _terminal(
+                6,
+                [
+                    _message_item("msg_zero", "safe"),
+                    _reasoning_item("reasoning_one", status="completed"),
+                    _function_item("fc_two", "call_two", "second", '{"n":2}'),
+                    _function_item("fc_three", "call_three", "third", '{"n":3}'),
+                ],
+            )
+        )
+    )
+
+    identities = {
+        tool_call["index"]: tool_call["id"]
+        for chunk in chunks
+        for tool_call in chunk["choices"][0]["delta"].get("tool_calls", [])
+        if "id" in tool_call
+    }
+    assert identities == {3: "call_three", 2: "call_two"}
+    assert [identities[index] for index in sorted(identities)] == [
+        "call_two",
+        "call_three",
+    ]
 
 
 def test_responses_partial_or_mismatched_call_never_surfaces() -> None:
@@ -930,6 +1255,311 @@ def test_responses_reasoning_status_is_validated_without_surface() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "case",
+    (
+        "choice-index-bool",
+        "choice-index-float",
+        "choice-index-negative",
+        "tool-index-bool",
+        "tool-index-float",
+        "tool-index-negative",
+        "id-number",
+        "id-blank",
+        "type-other",
+        "type-mapping",
+        "function-nonmapping",
+        "name-number",
+        "name-blank",
+        "arguments-number",
+        "content-number",
+        "role-number",
+    ),
+)
+def test_chat_stream_rejects_malformed_choice_and_tool_metadata(case: str) -> None:
+    start = _chat_tool_start()
+    choice = start["choices"][0]
+    tool = choice["delta"]["tool_calls"][0]
+    if case == "choice-index-bool":
+        choice["index"] = False
+    elif case == "choice-index-float":
+        choice["index"] = 0.0
+    elif case == "choice-index-negative":
+        choice["index"] = -1
+    elif case == "tool-index-bool":
+        tool["index"] = False
+    elif case == "tool-index-float":
+        tool["index"] = 0.0
+    elif case == "tool-index-negative":
+        tool["index"] = -1
+    elif case == "id-number":
+        tool["id"] = 7
+    elif case == "id-blank":
+        tool["id"] = "   "
+    elif case == "type-other":
+        tool["type"] = "builtin"
+    elif case == "type-mapping":
+        tool["type"] = {"RAW-METADATA-CANARY": True}
+    elif case == "function-nonmapping":
+        tool["function"] = "RAW-METADATA-CANARY"
+    elif case == "name-number":
+        tool["function"]["name"] = 7
+    elif case == "name-blank":
+        tool["function"]["name"] = "   "
+    elif case == "arguments-number":
+        tool["function"]["arguments"] = 7
+    elif case == "content-number":
+        choice["delta"]["content"] = 7
+    else:
+        choice["delta"]["role"] = 7
+    stream, response, session = _chat_stream([start, _chat_tool_terminal()])
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        list(stream)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert "RAW-METADATA-CANARY" not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+@pytest.mark.parametrize("case", ("conflicting-id", "conflicting-name", "duplicate-id"))
+def test_chat_stream_rejects_conflicting_or_duplicate_tool_identity(case: str) -> None:
+    start = _chat_tool_start()
+    later = _chat_tool_terminal()
+    later_tool = later["choices"][0]["delta"]["tool_calls"][0]
+    if case == "conflicting-id":
+        later_tool["id"] = "call_conflict"
+    elif case == "conflicting-name":
+        later_tool["function"]["name"] = "other_tool"
+    else:
+        duplicate = deepcopy(start["choices"][0]["delta"]["tool_calls"][0])
+        duplicate["index"] = 1
+        start["choices"][0]["delta"]["tool_calls"].append(duplicate)
+        later["choices"][0]["delta"]["tool_calls"].append(
+            {"index": 1, "function": {"arguments": "{}"}}
+        )
+    stream, response, session = _chat_stream([start, later])
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        list(stream)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    "case",
+    (
+        "arbitrary-reason",
+        "blank-reason",
+        "missing-reason",
+        "stop-with-tools",
+        "length-with-tools",
+        "tool-calls-without-tools",
+    ),
+)
+def test_chat_stream_terminal_reason_matches_tool_fragment_state(case: str) -> None:
+    if case in {"stop-with-tools", "length-with-tools"}:
+        terminal = _chat_tool_terminal()
+        terminal["choices"][0]["finish_reason"] = case.removesuffix("-with-tools")
+        events = [_chat_tool_start(), terminal]
+    else:
+        terminal = _chat_text_terminal(
+            reason={
+                "arbitrary-reason": "content_filter",
+                "blank-reason": "   ",
+                "missing-reason": "stop",
+                "tool-calls-without-tools": "tool_calls",
+            }[case]
+        )
+        if case == "missing-reason":
+            del terminal["choices"][0]["finish_reason"]
+        events = [terminal]
+    stream, response, session = _chat_stream(events)
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        list(stream)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    "case",
+    (
+        "done-before-terminal",
+        "eof-before-terminal",
+        "usage-before-terminal",
+        "chunk-after-terminal",
+        "one-of-two-choices-unterminated",
+    ),
+)
+def test_chat_stream_requires_ordered_complete_terminal_lifecycle(case: str) -> None:
+    done = case != "eof-before-terminal"
+    if case in {"done-before-terminal", "eof-before-terminal"}:
+        events = [
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "partial"},
+                        "finish_reason": None,
+                    }
+                ]
+            }
+        ]
+    elif case == "usage-before-terminal":
+        events = [
+            {"choices": [], "usage": {"total_tokens": 1}},
+            _chat_text_terminal(),
+        ]
+    elif case == "chunk-after-terminal":
+        events = [
+            _chat_text_terminal(),
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "late"},
+                        "finish_reason": None,
+                    }
+                ]
+            },
+        ]
+    else:
+        events = [
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "done"},
+                        "finish_reason": "stop",
+                    },
+                    {
+                        "index": 1,
+                        "delta": {"content": "partial"},
+                        "finish_reason": None,
+                    },
+                ]
+            }
+        ]
+    stream, response, session = _chat_stream(events, done=done)
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        list(stream)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+def test_chat_stream_preserves_multiple_valid_choices_role_tools_and_usage() -> None:
+    events = [
+        {
+            "id": "chatcmpl_multi",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant"},
+                    "finish_reason": None,
+                },
+                {
+                    "index": 1,
+                    "delta": {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "index": 2,
+                                "id": "call_multi",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": "{"},
+                            }
+                        ],
+                    },
+                    "finish_reason": None,
+                },
+            ],
+        },
+        {
+            "id": "chatcmpl_multi",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "safe"},
+                    "finish_reason": "stop",
+                },
+                {
+                    "index": 1,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 2,
+                                "function": {"arguments": "}"},
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                },
+            ],
+        },
+        {
+            "id": "chatcmpl_multi",
+            "choices": [],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+        },
+    ]
+    stream, response, session = _chat_stream(events)
+
+    assert list(stream) == events
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+def test_chat_stream_drops_unvalidated_private_extras_without_coercion() -> None:
+    event = _chat_tool_start()
+    event["id"] = "chatcmpl_safe"
+    event["private"] = "RAW-PRIVATE-CANARY"
+    choice = event["choices"][0]
+    choice["private"] = "RAW-PRIVATE-CANARY"
+    choice["delta"]["private"] = "RAW-PRIVATE-CANARY"
+    tool = choice["delta"]["tool_calls"][0]
+    tool["private"] = "RAW-PRIVATE-CANARY"
+    tool["function"]["private"] = "RAW-PRIVATE-CANARY"
+    terminal = _chat_tool_terminal()
+    stream, response, session = _chat_stream([event, terminal])
+
+    emitted = list(stream)
+
+    assert emitted[0] == {
+        "id": "chatcmpl_safe",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_metadata",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": ""},
+                        }
+                    ],
+                },
+                "finish_reason": None,
+            }
+        ],
+    }
+    assert "RAW-PRIVATE-CANARY" not in repr(emitted)
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
 def test_chat_stream_preserves_openai_deltas_and_usage() -> None:
     events = [
         {
@@ -1010,10 +1640,17 @@ def test_stream_retries_only_before_first_consumed_byte(
 ) -> None:
     retryable = _ByteStreamResponse([], status_code=503)
     malformed_after_body = _ByteStreamResponse(
-        [b'data: {"choices":[{"delta":{"content":"private"}}]}\n\n', b"data: {"]
+        [
+            b'data: {"choices":[{"index":0,"delta":{"content":"private"},'
+            b'"finish_reason":null}]}\n\n',
+            b"data: {",
+        ]
     )
     replay_canary = _ByteStreamResponse(
-        [b'data: {"choices":[{"delta":{"content":"replayed"}}]}\n\n']
+        [
+            b'data: {"choices":[{"index":0,"delta":{"content":"replayed"},'
+            b'"finish_reason":"stop"}]}\n\n'
+        ]
     )
     session = _ByteStreamSession([retryable, malformed_after_body, replay_canary])
     monkeypatch.setattr(
@@ -1074,7 +1711,12 @@ def test_stream_body_read_failures_are_typed_closed_and_never_retried(
 ) -> None:
     canary = "RAW-STREAM-READ-CANARY"
     chunks = (
-        [b'data: {"choices":[{"delta":{"content":"safe"}}]}\n\n'] if after_event else []
+        [
+            b'data: {"choices":[{"index":0,"delta":{"content":"safe"},'
+            b'"finish_reason":null}]}\n\n'
+        ]
+        if after_event
+        else []
     )
     response = _FailingByteStreamResponse(chunks, error=error_type(canary))
     session = _ByteStreamSession([response])
@@ -1143,6 +1785,43 @@ def test_stream_close_is_idempotent_and_closes_response_and_session() -> None:
         next(stream)
 
 
+@pytest.mark.parametrize("path", ("primary-error", "normal", "explicit"))
+def test_stream_cleanup_failures_never_mask_primary_or_normal_result(path: str) -> None:
+    terminal = _chat_text_terminal()
+    chunks = (
+        [b"data: {not-json}\n\n"] if path == "primary-error" else _chat_wire([terminal])
+    )
+    response = _CloseFailingByteStreamResponse(chunks)
+    session = _CloseFailingByteStreamSession([response])
+    stream = QwenCloudStream(
+        response=response,  # type: ignore[arg-type]
+        session=session,  # type: ignore[arg-type]
+        api_mode="chat_completions",
+    )
+    records: list[str] = []
+    sink_id = logger.add(lambda message: records.append(str(message)), level="DEBUG")
+    try:
+        if path == "primary-error":
+            with pytest.raises(ChatProviderError) as exc_info:
+                list(stream)
+            assert exc_info.value.provider == "qwencloud"
+            assert exc_info.value.__cause__ is None
+            assert exc_info.value.__context__ is None
+            disclosure = str(exc_info.value) + "".join(records)
+            assert "RAW-RESPONSE-CLOSE-CANARY" not in disclosure
+            assert "RAW-SESSION-CLOSE-CANARY" not in disclosure
+        elif path == "normal":
+            assert list(stream) == [terminal]
+        else:
+            assert stream.close() is None
+            assert stream.close() is None
+    finally:
+        logger.remove(sink_id)
+
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
 @pytest.mark.parametrize(
     "chunks",
     (
@@ -1181,3 +1860,96 @@ def test_stream_malformed_json_and_error_event_are_typed_closed_and_not_retried(
     assert response.iter_content_calls == 1
     assert response.close_calls == 1
     assert session.close_calls == 1
+
+
+@pytest.mark.parametrize("case", ("raw-recursion", "depth-cap", "node-cap"))
+def test_stream_deep_json_is_typed_redacted_and_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+) -> None:
+    canary = "RAW-DEEP-JSON-CANARY"
+    if case == "raw-recursion":
+        nested = "[" * 1200 + json.dumps(canary) + "]" * 1200
+        raw = (
+            '{"choices":[{"index":0,"delta":{"content":"safe"},'
+            '"finish_reason":"stop"}],"private":' + nested + "}"
+        )
+        response = _ByteStreamResponse(
+            [b"data: " + raw.encode("utf-8") + b"\n\ndata: [DONE]\n\n"]
+        )
+        session = _ByteStreamSession([response])
+        stream = QwenCloudStream(
+            response=response,  # type: ignore[arg-type]
+            session=session,  # type: ignore[arg-type]
+            api_mode="chat_completions",
+        )
+    else:
+        terminal = _chat_text_terminal()
+        if case == "depth-cap":
+            monkeypatch.setattr(
+                qwencloud_streaming, "_MAX_JSON_DEPTH", 4, raising=False
+            )
+            terminal["private"] = {"a": {"b": {"c": canary}}}
+        else:
+            monkeypatch.setattr(
+                qwencloud_streaming, "_MAX_JSON_NODES", 8, raising=False
+            )
+            terminal["private"] = [canary] * 20
+        stream, response, session = _chat_stream([terminal])
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        list(stream)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert canary not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert response.close_calls == 1
+    assert session.close_calls == 1
+
+
+def test_responses_deep_direct_event_is_typed_and_redacted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(qwencloud_streaming, "_MAX_JSON_DEPTH", 4, raising=False)
+    event = {
+        "type": "response.created",
+        "sequence_number": 0,
+        "response": {
+            "id": "resp_deep",
+            "status": "in_progress",
+            "private": {"a": {"b": {"RAW-DEEP-EVENT-CANARY": True}}},
+        },
+    }
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        QwenResponsesStreamTranslator().feed(event)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert "RAW-DEEP-EVENT-CANARY" not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+
+
+@pytest.mark.parametrize("case", ("depth-cap", "raw-recursion"))
+def test_responses_deep_function_arguments_are_typed_and_redacted(
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+) -> None:
+    if case == "depth-cap":
+        monkeypatch.setattr(qwencloud_streaming, "_MAX_JSON_DEPTH", 4, raising=False)
+        arguments = '{"a":{"b":{"c":{"RAW-DEEP-ARGS-CANARY":true}}}}'
+    else:
+        arguments = (
+            '{"value":' + "[" * 1200 + '"RAW-DEEP-ARGS-CANARY"' + "]" * 1200 + "}"
+        )
+    translator = QwenResponsesStreamTranslator()
+    translator.feed(_function_added(0, 0, "fc_deep", "call_deep", "lookup"))
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        translator.feed(_arguments_done(1, 0, "fc_deep", arguments))
+
+    assert exc_info.value.provider == "qwencloud"
+    assert "RAW-DEEP-ARGS-CANARY" not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None

--- a/Tests/LLM_Calls/test_qwencloud_streaming.py
+++ b/Tests/LLM_Calls/test_qwencloud_streaming.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 import requests
+from loguru import logger
 
 from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
 import tldw_chatbook.LLM_Calls.qwencloud as qwencloud
@@ -44,6 +45,23 @@ class _ByteStreamResponse:
         assert chunk_size > 0
         self.iter_content_calls += 1
         yield from self.chunks
+
+
+class _FailingByteStreamResponse(_ByteStreamResponse):
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        error: requests.exceptions.RequestException,
+    ) -> None:
+        super().__init__(chunks)
+        self.error = error
+
+    def iter_content(self, chunk_size: int) -> Any:
+        assert chunk_size > 0
+        self.iter_content_calls += 1
+        yield from self.chunks
+        raise self.error
 
 
 class _ByteStreamSession:
@@ -100,12 +118,19 @@ def _function_added(
     item_id: str,
     call_id: str,
     name: str,
+    *,
+    status: str | None = "in_progress",
 ) -> dict[str, Any]:
+    item = _function_item(item_id, call_id, name, "", status="in_progress")
+    if status is None:
+        del item["status"]
+    else:
+        item["status"] = status
     return {
         "type": "response.output_item.added",
         "sequence_number": sequence,
         "output_index": output_index,
-        "item": _function_item(item_id, call_id, name, "", status="in_progress"),
+        "item": item,
     }
 
 
@@ -139,18 +164,48 @@ def _arguments_done(
     }
 
 
-def _message_added(sequence: int, output_index: int, item_id: str) -> dict[str, Any]:
+def _message_added(
+    sequence: int,
+    output_index: int,
+    item_id: str,
+    *,
+    status: str | None = "in_progress",
+) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "id": item_id,
+        "type": "message",
+        "role": "assistant",
+        "content": [],
+    }
+    if status is not None:
+        item["status"] = status
     return {
         "type": "response.output_item.added",
         "sequence_number": sequence,
         "output_index": output_index,
-        "item": {
-            "id": item_id,
-            "type": "message",
-            "role": "assistant",
-            "status": "in_progress",
-            "content": [],
-        },
+        "item": item,
+    }
+
+
+def _reasoning_item(item_id: str, *, status: str | None) -> dict[str, Any]:
+    item: dict[str, Any] = {"id": item_id, "type": "reasoning", "summary": []}
+    if status is not None:
+        item["status"] = status
+    return item
+
+
+def _reasoning_added(
+    sequence: int,
+    output_index: int,
+    item_id: str,
+    *,
+    status: str | None = "in_progress",
+) -> dict[str, Any]:
+    return {
+        "type": "response.output_item.added",
+        "sequence_number": sequence,
+        "output_index": output_index,
+        "item": _reasoning_item(item_id, status=status),
     }
 
 
@@ -395,6 +450,59 @@ def test_responses_sequence_duplicate_conflict_and_decrease() -> None:
         QwenResponsesStreamTranslator().feed({"type": "response.created"})
 
 
+def test_responses_terminal_replay_is_strict_and_finish_safe() -> None:
+    translator = QwenResponsesStreamTranslator()
+    translator.feed(_message_added(0, 0, "msg_replay"))
+    translator.feed(_content_added(1, 0, "msg_replay"))
+    translator.feed(_text_delta(2, 0, "msg_replay", "safe"))
+    completed = _terminal(
+        3,
+        [_message_item("msg_replay", "safe")],
+        usage={"input_tokens": 0, "output_tokens": 1, "total_tokens": 1},
+    )
+
+    assert translator.feed(completed)[-1]["choices"][0]["finish_reason"] == "stop"
+    assert translator.feed(deepcopy(completed)) == ()
+    assert translator.finish() == ()
+
+    with pytest.raises(ChatProviderError, match="object"):
+        translator.feed([])  # type: ignore[arg-type]
+    with pytest.raises(ChatProviderError, match="sequence"):
+        translator.feed({"type": "response.in_progress"})
+    with pytest.raises(ChatProviderError, match="terminal"):
+        translator.feed(
+            {
+                "type": "response.in_progress",
+                "sequence_number": 4,
+                "response": {"status": "in_progress", "output": []},
+            }
+        )
+
+
+@pytest.mark.parametrize("replacement", (False, 0.0), ids=("bool", "float"))
+def test_responses_sequence_replay_uses_type_sensitive_json_equality(
+    replacement: bool | float,
+) -> None:
+    translator = QwenResponsesStreamTranslator()
+    event = {
+        "type": "response.created",
+        "sequence_number": 0,
+        "response": {
+            "id": "resp_strict",
+            "status": "in_progress",
+            "output": [{"index": 0}],
+        },
+    }
+    assert translator.feed(event) == ()
+    conflict = deepcopy(event)
+    conflict["response"]["output"][0]["index"] = replacement
+
+    with pytest.raises(ChatProviderError, match="sequence") as exc_info:
+        translator.feed(conflict)
+
+    assert exc_info.value.provider == "qwencloud"
+
+
 def test_responses_terminal_usage_finish_and_empty_delta() -> None:
     usage = {
         "input_tokens": 9,
@@ -628,6 +736,200 @@ def test_responses_partial_or_mismatched_call_never_surfaces() -> None:
     assert terminal_info.value.provider == "qwencloud"
 
 
+@pytest.mark.parametrize("source", ("output-item-done", "terminal-only"))
+@pytest.mark.parametrize(
+    "status", ("incomplete", "failed", "cancelled", "unknown", None)
+)
+def test_responses_function_status_cannot_become_successful_execution(
+    source: str,
+    status: str | None,
+) -> None:
+    translator = QwenResponsesStreamTranslator()
+    chunks = list(
+        translator.feed(_function_added(0, 0, "fc_status", "call_status", "lookup"))
+    )
+    item = _function_item("fc_status", "call_status", "lookup", '{"safe":true}')
+    if status is None:
+        del item["status"]
+    else:
+        item["status"] = status
+    event = (
+        _output_done(1, 0, item)
+        if source == "output-item-done"
+        else _terminal(1, [item])
+    )
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        chunks.extend(translator.feed(event))
+
+    assert exc_info.value.provider == "qwencloud"
+    assert all(
+        chunk["choices"][0].get("finish_reason") != "tool_calls" for chunk in chunks
+    )
+
+
+@pytest.mark.parametrize("status", ("failed", "cancelled", "unknown", None))
+def test_responses_completed_message_status_must_be_completed(
+    status: str | None,
+) -> None:
+    translator = QwenResponsesStreamTranslator()
+    translator.feed(_message_added(0, 0, "msg_status"))
+    translator.feed(_content_added(1, 0, "msg_status"))
+    translator.feed(_text_delta(2, 0, "msg_status", "safe"))
+    item = _message_item("msg_status", "safe")
+    if status is None:
+        del item["status"]
+    else:
+        item["status"] = status
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        translator.feed(_terminal(3, [item]))
+
+    assert exc_info.value.provider == "qwencloud"
+
+
+@pytest.mark.parametrize("item_type", ("message", "function_call", "reasoning"))
+@pytest.mark.parametrize("status", ("completed", "incomplete", "unknown", None))
+def test_responses_output_item_added_requires_in_progress_status(
+    item_type: str,
+    status: str | None,
+) -> None:
+    if item_type == "message":
+        event = _message_added(0, 0, "item_status", status=status)
+    elif item_type == "function_call":
+        event = _function_added(
+            0,
+            0,
+            "item_status",
+            "call_status",
+            "lookup",
+            status=status,
+        )
+    else:
+        event = _reasoning_added(0, 0, "item_status", status=status)
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        QwenResponsesStreamTranslator().feed(event)
+
+    assert exc_info.value.provider == "qwencloud"
+
+
+def test_responses_done_terminal_and_incomplete_statuses_are_consistent() -> None:
+    done_mismatch = QwenResponsesStreamTranslator()
+    done_mismatch.feed(_message_added(0, 0, "msg_done"))
+    done_mismatch.feed(_content_added(1, 0, "msg_done"))
+    done_mismatch.feed(_text_delta(2, 0, "msg_done", "safe"))
+    done_mismatch.feed(
+        _output_done(3, 0, _message_item("msg_done", "safe", status="completed"))
+    )
+    with pytest.raises(ChatProviderError):
+        done_mismatch.feed(
+            _terminal(
+                4,
+                [_message_item("msg_done", "safe", status="incomplete")],
+                event_type="response.incomplete",
+                status="incomplete",
+                incomplete_reason="max_output_tokens",
+            )
+        )
+
+    terminal_mismatch = QwenResponsesStreamTranslator()
+    terminal_mismatch.feed(_message_added(0, 0, "msg_partial"))
+    terminal_mismatch.feed(_content_added(1, 0, "msg_partial"))
+    terminal_mismatch.feed(_text_delta(2, 0, "msg_partial", "partial"))
+    with pytest.raises(ChatProviderError):
+        terminal_mismatch.feed(
+            _terminal(
+                3,
+                [_message_item("msg_partial", "partial", status="completed")],
+                event_type="response.incomplete",
+                status="incomplete",
+                incomplete_reason="max_output_tokens",
+            )
+        )
+
+    valid_partial = QwenResponsesStreamTranslator()
+    valid_partial.feed(_message_added(0, 0, "msg_partial"))
+    valid_partial.feed(_content_added(1, 0, "msg_partial"))
+    valid_partial.feed(_text_delta(2, 0, "msg_partial", "partial"))
+    assert (
+        valid_partial.feed(
+            _terminal(
+                3,
+                [_message_item("msg_partial", "partial", status="incomplete")],
+                event_type="response.incomplete",
+                status="incomplete",
+                incomplete_reason="max_output_tokens",
+            )
+        )[-1]["choices"][0]["finish_reason"]
+        == "length"
+    )
+
+
+def test_responses_reasoning_status_is_validated_without_surface() -> None:
+    translator = QwenResponsesStreamTranslator()
+    assert translator.feed(_reasoning_added(0, 0, "reasoning_safe")) == ()
+    assert translator.feed(_message_added(1, 1, "msg_safe")) == ()
+    assert translator.feed(_content_added(2, 1, "msg_safe")) == ()
+    assert translator.feed(_text_delta(3, 1, "msg_safe", "safe"))
+    with pytest.raises(ChatProviderError):
+        translator.feed(
+            _output_done(
+                4,
+                0,
+                _reasoning_item("reasoning_safe", status="failed"),
+            )
+        )
+
+    terminal = QwenResponsesStreamTranslator()
+    terminal.feed(_reasoning_added(0, 0, "reasoning_safe"))
+    terminal.feed(_message_added(1, 1, "msg_safe"))
+    terminal.feed(_content_added(2, 1, "msg_safe"))
+    terminal.feed(_text_delta(3, 1, "msg_safe", "safe"))
+    with pytest.raises(ChatProviderError):
+        terminal.feed(
+            _terminal(
+                4,
+                [
+                    _reasoning_item("reasoning_safe", status="unknown"),
+                    _message_item("msg_safe", "safe"),
+                ],
+            )
+        )
+
+    valid = QwenResponsesStreamTranslator()
+    assert valid.feed(_reasoning_added(0, 0, "reasoning_safe")) == ()
+    assert valid.feed(_message_added(1, 1, "msg_safe")) == ()
+    assert valid.feed(_content_added(2, 1, "msg_safe")) == ()
+    text = valid.feed(_text_delta(3, 1, "msg_safe", "safe"))
+    assert (
+        valid.feed(
+            _output_done(
+                4,
+                0,
+                _reasoning_item("reasoning_safe", status="completed"),
+            )
+        )
+        == ()
+    )
+    terminal_chunks = valid.feed(
+        _terminal(
+            5,
+            [
+                _reasoning_item("reasoning_safe", status="completed"),
+                _message_item("msg_safe", "safe"),
+            ],
+        )
+    )
+    assert text == ({"choices": [{"delta": {"content": "safe"}}]},)
+    assert terminal_chunks == (
+        {
+            "choices": [{"delta": {"content": ""}, "finish_reason": "stop"}],
+            "usage": {},
+        },
+    )
+
+
 def test_chat_stream_preserves_openai_deltas_and_usage() -> None:
     events = [
         {
@@ -751,6 +1053,74 @@ def test_stream_retries_only_before_first_consumed_byte(
     assert len(session.posts) == 2
     assert replay_canary.iter_content_calls == 0
     assert malformed_after_body.close_calls == 1
+    assert session.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    "error_type",
+    (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.ChunkedEncodingError,
+        requests.exceptions.Timeout,
+    ),
+)
+@pytest.mark.parametrize(
+    "after_event", (False, True), ids=("before-bytes", "after-event")
+)
+def test_stream_body_read_failures_are_typed_closed_and_never_retried(
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[requests.exceptions.RequestException],
+    after_event: bool,
+) -> None:
+    canary = "RAW-STREAM-READ-CANARY"
+    chunks = (
+        [b'data: {"choices":[{"delta":{"content":"safe"}}]}\n\n'] if after_event else []
+    )
+    response = _FailingByteStreamResponse(chunks, error=error_type(canary))
+    session = _ByteStreamSession([response])
+    monkeypatch.setattr(
+        qwencloud,
+        "requests",
+        SimpleNamespace(Session=lambda: session),
+    )
+    monkeypatch.setattr(
+        qwencloud,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    "qwencloud": {"timeout": 3, "retries": 3, "retry_delay": 0}
+                }
+            }
+        ),
+    )
+    records: list[str] = []
+    sink_id = logger.add(lambda message: records.append(str(message)), level="DEBUG")
+    try:
+        stream = qwencloud.chat_with_qwencloud(
+            input_data=[{"role": "user", "content": "hello"}],
+            model="qwen3.8-max",
+            api_key="key",
+            streaming=True,
+            api_base_url="https://qwen.example/v1",
+            api_mode="chat_completions",
+        )
+        if after_event:
+            assert next(stream)["choices"][0]["delta"]["content"] == "safe"
+        with pytest.raises(ChatProviderError) as exc_info:
+            next(stream)
+    finally:
+        logger.remove(sink_id)
+
+    assert exc_info.value.provider == "qwencloud"
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    disclosure = str(exc_info.value) + "".join(records)
+    assert canary not in disclosure
+    assert "data:" not in disclosure
+    assert len(session.posts) == 1
+    assert response.iter_content_calls == 1
+    assert response.close_calls == 1
     assert session.close_calls == 1
 
 

--- a/Tests/LLM_Provider_Catalog/test_app_model_catalog_wiring.py
+++ b/Tests/LLM_Provider_Catalog/test_app_model_catalog_wiring.py
@@ -256,7 +256,7 @@ async def test_refresh_swallows_and_logs_errors(monkeypatch):
     # Context: the provider list keys being refreshed + the exception type name.
     assert (
         "Model catalog auto-refresh failed "
-        "(OpenAI, Anthropic, MistralAI, Moonshot, OpenRouter, ZAI): RuntimeError"
+        "(OpenAI, Anthropic, MistralAI, Moonshot, OpenRouter, QwenCloud, ZAI): RuntimeError"
     ) in text
     # No traceback (diagnose=True would dump frame locals) and no exception
     # message, which may carry endpoint URLs or credentials.

--- a/Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py
+++ b/Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py
@@ -1,6 +1,6 @@
 import json
 from copy import deepcopy
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from loguru import logger
@@ -667,6 +667,39 @@ async def test_local_llm_provider_catalog_service_rejects_invalid_endpoint_befor
     assert result.error is not None
     assert result.error.kind == "unsupported_endpoint"
     discovery_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://workspace.example/api//v2",
+        "https://workspace.example/api/v2/../responses",
+        "https://workspace.example/api/v2/models/models",
+        "https://workspace.example/api/v2/models/responses",
+        "https://workspace.example%evil/api/v2",
+        "https://workspace.example\\@evil.example/api/v2",
+    ],
+)
+async def test_qwencloud_structural_rejection_stops_before_discovery_client(endpoint):
+    discovery_client = AsyncMock()
+    service = LocalLLMProviderCatalogService(
+        provider_catalog_loader=lambda: {"QwenCloud": ["qwen3.8-max"]},
+        settings_loader=lambda: {
+            "providers": {"QwenCloud": ["qwen3.8-max"]},
+            "api_settings": {
+                "qwencloud": {"api_base_url": endpoint},
+            },
+        },
+        discovery_client=discovery_client,
+    )
+
+    result = await service.discover_models(provider="QwenCloud")
+
+    assert result.status == "unsupported"
+    assert result.error is not None
+    assert result.error.kind == "unsupported_endpoint"
+    discovery_client.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py
+++ b/Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py
@@ -1,17 +1,28 @@
+import json
+from copy import deepcopy
 from unittest.mock import Mock
 
 import pytest
+from loguru import logger
 
 from tldw_chatbook.LLM_Provider_Catalog.model_discovery_contracts import (
     DiscoveredModel,
+    ModelDiscoveryError,
     ModelDiscoveryResult,
 )
 from tldw_chatbook.LLM_Provider_Catalog.local_llm_provider_catalog_service import (
     LocalLLMProviderCatalogService,
 )
+from tldw_chatbook.LLM_Provider_Catalog.model_catalog_settings import (
+    ModelCatalogSettings,
+)
+from tldw_chatbook.LLM_Provider_Catalog.model_discovery_disk_cache import (
+    ModelCatalogDiskStore,
+)
 from tldw_chatbook.LLM_Provider_Catalog.openai_compatible_model_discovery import (
     build_models_url,
     fingerprint_endpoint,
+    normalize_models_response,
 )
 from tldw_chatbook.runtime_policy import PolicyDeniedError
 
@@ -216,6 +227,313 @@ async def test_local_llm_provider_catalog_service_staged_endpoint_and_key_win_fo
             "endpoint": "https://staged.test/v1",
             "api_key": "staged-key",
         }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("configured_key", "expected_key", "alias_first"),
+    [
+        ("modern-qwen-secret-canary", "modern-qwen-secret-canary", True),
+        ("modern-qwen-secret-canary", "modern-qwen-secret-canary", False),
+        ("", "environment-qwen-secret-canary", True),
+        ("<API_KEY_HERE>", "environment-qwen-secret-canary", False),
+        ("YOUR_KEY", "environment-qwen-secret-canary", True),
+        ("your_key", "environment-qwen-secret-canary", False),
+        ("your-api-key", "environment-qwen-secret-canary", True),
+        (42, "environment-qwen-secret-canary", False),
+    ],
+)
+async def test_qwencloud_discovery_uses_only_its_modern_or_environment_key(
+    configured_key,
+    expected_key,
+    alias_first,
+):
+    discovery_calls = []
+    log_messages: list[str] = []
+
+    async def discover_models(**kwargs):
+        discovery_calls.append(kwargs)
+        return ModelDiscoveryResult(
+            provider=kwargs["provider"],
+            provider_list_key=kwargs["provider_list_key"],
+            endpoint_fingerprint=fingerprint_endpoint(kwargs["endpoint"]),
+            status="success",
+        )
+
+    alias_settings = {
+        "api_key": "alias-qwen-secret-canary",
+        "api_base_url": "https://wrong-qwen.example/compatible-mode/v1",
+    }
+    canonical_settings = {
+        "api_key": configured_key,
+        "api_key_env_var": "DASHSCOPE_API_KEY",
+        "api_base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    }
+    qwen_items = (
+        [("QWENCLOUD", alias_settings), ("qwencloud", canonical_settings)]
+        if alias_first
+        else [("qwencloud", canonical_settings), ("QWENCLOUD", alias_settings)]
+    )
+    settings = {
+        "providers": {"QwenCloud": ["qwen3.8-max"]},
+        "api_settings": dict(
+            qwen_items + [("openai", {"api_key": "other-provider-secret-canary"})]
+        ),
+    }
+    original_settings = deepcopy(settings)
+    service = LocalLLMProviderCatalogService(
+        provider_catalog_loader=lambda: settings["providers"],
+        settings_loader=lambda: settings,
+        discovery_client=discover_models,
+        environ={
+            "DASHSCOPE_API_KEY": "environment-qwen-secret-canary",
+            "OPENAI_API_KEY": "other-provider-environment-secret-canary",
+        },
+    )
+    sink_id = logger.add(log_messages.append, format="{message}")
+    try:
+        result = await service.discover_models(provider="QwenCloud")
+    finally:
+        logger.remove(sink_id)
+
+    assert result.status == "success"
+    assert discovery_calls == [
+        {
+            "provider": "QwenCloud",
+            "provider_list_key": "QwenCloud",
+            "endpoint": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+            "api_key": expected_key,
+        }
+    ]
+    assert all("secret-canary" not in message for message in log_messages)
+    assert "secret-canary" not in repr(result)
+    assert settings == original_settings
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_discovery_accepts_alias_only_settings_without_mutation():
+    discovery_calls = []
+
+    async def discover_models(**kwargs):
+        discovery_calls.append(kwargs)
+        return ModelDiscoveryResult(
+            provider=kwargs["provider"],
+            provider_list_key=kwargs["provider_list_key"],
+            endpoint_fingerprint=fingerprint_endpoint(kwargs["endpoint"]),
+            status="success",
+        )
+
+    settings = {
+        "providers": {"QwenCloud": ["qwen3.8-max"]},
+        "api_settings": {
+            "QWENCLOUD": {
+                "api_key": "alias-only-secret-canary",
+                "api_base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+            }
+        },
+    }
+    original_settings = deepcopy(settings)
+    service = LocalLLMProviderCatalogService(
+        provider_catalog_loader=lambda: settings["providers"],
+        settings_loader=lambda: settings,
+        discovery_client=discover_models,
+        environ={"DASHSCOPE_API_KEY": "environment-secret-canary"},
+    )
+
+    result = await service.discover_models(provider="QwenCloud")
+
+    assert result.status == "success"
+    assert discovery_calls[0]["api_key"] == "alias-only-secret-canary"
+    assert settings == original_settings
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("malformed_settings", [None, False, [], "not-a-table"])
+async def test_qwencloud_discovery_rejects_malformed_canonical_settings_safely(
+    malformed_settings,
+):
+    discovery_client = Mock()
+    settings = {
+        "providers": {"QwenCloud": ["qwen3.8-max"]},
+        "api_settings": {
+            "QWENCLOUD": {
+                "api_key": "alias-secret-canary",
+                "api_base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+            },
+            "qwencloud": malformed_settings,
+        },
+    }
+    original_settings = deepcopy(settings)
+    service = LocalLLMProviderCatalogService(
+        provider_catalog_loader=lambda: settings["providers"],
+        settings_loader=lambda: settings,
+        discovery_client=discovery_client,
+        environ={"DASHSCOPE_API_KEY": "environment-secret-canary"},
+    )
+
+    result = await service.discover_models(provider="QwenCloud")
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.kind == "missing_endpoint"
+    assert "secret-canary" not in repr(result)
+    assert settings == original_settings
+    discovery_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_catalog_normalization_cache_fallback_and_write_through(
+    tmp_path,
+):
+    endpoint = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    fingerprint = fingerprint_endpoint(endpoint)
+    settings = {
+        "providers": {"QwenCloud": ["configured-model"]},
+        "api_settings": {
+            "qwencloud": {
+                "api_key": "qwen-secret-canary",
+                "api_base_url": endpoint,
+            }
+        },
+    }
+    save_calls = []
+    responses = [
+        ModelDiscoveryResult(
+            provider="QwenCloud",
+            provider_list_key="QwenCloud",
+            endpoint_fingerprint=fingerprint,
+            status="success",
+            models=normalize_models_response(
+                {
+                    "data": [
+                        {"id": " cached-model "},
+                        {"id": "cached-model"},
+                        {"id": "runtime-model"},
+                    ]
+                },
+                provider="QwenCloud",
+                provider_list_key="QwenCloud",
+                endpoint_fingerprint=fingerprint,
+                now_iso="2026-08-11T00:00:00Z",
+            ),
+        ),
+        ModelDiscoveryResult(
+            provider="QwenCloud",
+            provider_list_key="QwenCloud",
+            endpoint_fingerprint=fingerprint,
+            status="error",
+            error=ModelDiscoveryError(
+                kind="invalid_response",
+                message="Invalid models response.",
+                recovery_hint="Retry later.",
+            ),
+        ),
+        ModelDiscoveryResult(
+            provider="QwenCloud",
+            provider_list_key="QwenCloud",
+            endpoint_fingerprint=fingerprint,
+            status="success",
+            models=normalize_models_response(
+                {
+                    "data": [
+                        {"id": "configured-model"},
+                        {"id": "cached-model"},
+                        {"id": "runtime-model"},
+                        {"id": "write-through-model"},
+                    ]
+                },
+                provider="QwenCloud",
+                provider_list_key="QwenCloud",
+                endpoint_fingerprint=fingerprint,
+                now_iso="2026-08-11T00:01:00Z",
+            ),
+        ),
+    ]
+
+    async def discover_models(**_kwargs):
+        return responses.pop(0)
+
+    service = LocalLLMProviderCatalogService(
+        provider_catalog_loader=lambda: settings["providers"],
+        settings_loader=lambda: settings,
+        discovery_client=discover_models,
+        save_discovered_models_callback=lambda values: (
+            save_calls.append(values) or True
+        ),
+        environ={},
+    )
+
+    first = await service.discover_models(provider="QwenCloud")
+    malformed = await service.discover_models(provider="QwenCloud")
+    cached_after_malformed = service.list_discovered_models(provider="QwenCloud")
+    configured_fallback = LocalLLMProviderCatalogService(
+        provider_catalog_loader=lambda: settings["providers"],
+        settings_loader=lambda: settings,
+        environ={},
+    ).merge_saved_and_discovered_models(provider="QwenCloud")
+    store = ModelCatalogDiskStore(tmp_path / "model_catalog_cache.json")
+    report = await service.refresh_stale_configured_providers(
+        catalog_settings=ModelCatalogSettings(write_to_config=frozenset({"qwencloud"})),
+        disk_store=store,
+        force=True,
+    )
+
+    assert first.status == "success"
+    assert malformed.status == "error"
+    assert [model.model_id for model in cached_after_malformed] == [
+        "cached-model",
+        "runtime-model",
+    ]
+    assert [entry.model_id for entry in configured_fallback] == ["configured-model"]
+    qwen_outcome = next(
+        outcome
+        for outcome in report.outcomes
+        if outcome.provider_list_key == "QwenCloud"
+    )
+    assert qwen_outcome.new_model_ids == ("write-through-model",)
+    assert qwen_outcome.saved_model_ids == ("write-through-model",)
+    assert save_calls == [
+        {"providers": {"QwenCloud": ["configured-model", "write-through-model"]}}
+    ]
+    cache_text = (tmp_path / "model_catalog_cache.json").read_text(encoding="utf-8")
+    assert "write-through-model" in cache_text
+    assert "qwen-secret-canary" not in cache_text
+
+    dirty_cache_path = tmp_path / "dirty-model-catalog-cache.json"
+    dirty_cache_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "entries": {
+                    "qwen": {
+                        "provider_list_key": "QwenCloud",
+                        "endpoint_fingerprint": fingerprint,
+                        "fetched_at": "2026-08-11T00:00:00Z",
+                        "models": [
+                            "",
+                            "cached-model",
+                            "cached-model",
+                            42,
+                            "runtime-model",
+                        ],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    dirty_service = LocalLLMProviderCatalogService(
+        provider_catalog_loader=lambda: settings["providers"],
+        settings_loader=lambda: settings,
+        environ={},
+    )
+    ModelCatalogDiskStore(dirty_cache_path).load_into(dirty_service.discovery_cache)
+    dirty_merged = dirty_service.merge_saved_and_discovered_models(provider="QwenCloud")
+    assert [entry.model_id for entry in dirty_merged] == [
+        "configured-model",
+        "cached-model",
+        "runtime-model",
     ]
 
 

--- a/Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py
+++ b/Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py
@@ -673,6 +673,39 @@ async def test_local_llm_provider_catalog_service_rejects_invalid_endpoint_befor
 @pytest.mark.parametrize(
     "endpoint",
     [
+        "http://workspace.example%evil/v1",
+        "http://workspace.example|evil/v1",
+        "http://workspace.example^evil/v1",
+        "http://workspace.example/v1//",
+        "http://workspace.example/%zz/v1/chat/completions",
+        "http://workspace.example/../v1/chat/completions",
+        "http://workspace.example/api%2fv1/chat/completions",
+        "http://workspace.example/v1/chat/completions/chat/completions",
+    ],
+)
+async def test_non_qwen_structural_rejection_stops_before_discovery_client(endpoint):
+    discovery_client = AsyncMock()
+    service = LocalLLMProviderCatalogService(
+        provider_catalog_loader=lambda: {"VLLM": ["local-model"]},
+        settings_loader=lambda: {
+            "providers": {"VLLM": ["local-model"]},
+            "api_settings": {"vllm": {"api_base_url": endpoint}},
+        },
+        discovery_client=discovery_client,
+    )
+
+    result = await service.discover_models(provider="VLLM")
+
+    assert result.status == "unsupported"
+    assert result.error is not None
+    assert result.error.kind == "unsupported_endpoint"
+    discovery_client.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "endpoint",
+    [
         "https://workspace.example/api//v2",
         "https://workspace.example/api/v2/../responses",
         "https://workspace.example/api/v2/models/models",
@@ -685,10 +718,16 @@ async def test_local_llm_provider_catalog_service_rejects_invalid_endpoint_befor
         "https://workspace.example/api/v2/chat/%63ompletions",
         "https://workspace.example/api/v2/res%2570onses",
         "https://workspace.example/api/v2/res%252570onses",
+        "https://user:secret-canary@workspace.example/api/v2",
+        "https://workspace.example/api/v2?api_key=secret-canary",
+        "https://workspace.example/api/v2#secret-canary",
+        "https://[fe80::1%25eth0]:8000/api/v2",
+        f"https://workspace.example/{'a' * 2000}",
     ],
 )
 async def test_qwencloud_structural_rejection_stops_before_discovery_client(endpoint):
     discovery_client = AsyncMock()
+    log_messages: list[str] = []
     service = LocalLLMProviderCatalogService(
         provider_catalog_loader=lambda: {"QwenCloud": ["qwen3.8-max"]},
         settings_loader=lambda: {
@@ -700,11 +739,17 @@ async def test_qwencloud_structural_rejection_stops_before_discovery_client(endp
         discovery_client=discovery_client,
     )
 
-    result = await service.discover_models(provider="QwenCloud")
+    sink_id = logger.add(log_messages.append, format="{message}")
+    try:
+        result = await service.discover_models(provider="QwenCloud")
+    finally:
+        logger.remove(sink_id)
 
     assert result.status == "unsupported"
     assert result.error is not None
     assert result.error.kind == "unsupported_endpoint"
+    assert "secret-canary" not in repr(result)
+    assert "secret-canary" not in "".join(log_messages)
     discovery_client.assert_not_awaited()
 
 
@@ -820,7 +865,9 @@ def test_local_discovered_model_cache_operations_enforce_runtime_policy():
         ("openrouter", "OpenRouter", "https://openrouter.ai/api/v1/models"),
     ],
 )
-async def test_cloud_provider_default_endpoints_resolve(provider, list_key, expected_url):
+async def test_cloud_provider_default_endpoints_resolve(
+    provider, list_key, expected_url
+):
     seen_urls: list[str] = []
 
     async def fake_client(**kwargs):

--- a/Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py
+++ b/Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py
@@ -679,6 +679,12 @@ async def test_local_llm_provider_catalog_service_rejects_invalid_endpoint_befor
         "https://workspace.example/api/v2/models/responses",
         "https://workspace.example%evil/api/v2",
         "https://workspace.example\\@evil.example/api/v2",
+        "https://workspace.example/api%2fv2",
+        "https://workspace.example/api/v2/%252e%252e/responses",
+        "https://workspace.example/api/v2/res%70onses",
+        "https://workspace.example/api/v2/chat/%63ompletions",
+        "https://workspace.example/api/v2/res%2570onses",
+        "https://workspace.example/api/v2/res%252570onses",
     ],
 )
 async def test_qwencloud_structural_rejection_stops_before_discovery_client(endpoint):

--- a/Tests/LLM_Provider_Catalog/test_model_catalog_settings.py
+++ b/Tests/LLM_Provider_Catalog/test_model_catalog_settings.py
@@ -1,7 +1,6 @@
 from tldw_chatbook.LLM_Provider_Catalog.model_catalog_settings import (
     AUTO_REFRESH_PROVIDER_LIST_KEYS,
     SELECTOR_MERGE_CAP,
-    ModelCatalogSettings,
     load_model_catalog_settings,
 )
 
@@ -44,8 +43,15 @@ def test_zero_stale_hours_is_allowed():
     assert settings.stale_after_hours == 0.0
 
 
-def test_six_providers_and_cap():
+def test_qwencloud_is_seventh_auto_refresh_cloud_provider():
     assert set(AUTO_REFRESH_PROVIDER_LIST_KEYS) == {
-        "OpenAI", "Anthropic", "MistralAI", "Moonshot", "OpenRouter", "ZAI",
+        "OpenAI",
+        "Anthropic",
+        "MistralAI",
+        "Moonshot",
+        "OpenRouter",
+        "QwenCloud",
+        "ZAI",
     }
+    assert len(AUTO_REFRESH_PROVIDER_LIST_KEYS) == 7
     assert SELECTOR_MERGE_CAP == 50

--- a/Tests/LLM_Provider_Catalog/test_model_discovery_provider_identity.py
+++ b/Tests/LLM_Provider_Catalog/test_model_discovery_provider_identity.py
@@ -7,6 +7,7 @@ import pytest
 
 from tldw_chatbook.LLM_Provider_Catalog.model_discovery_contracts import DiscoveredModel
 from tldw_chatbook.LLM_Provider_Catalog.model_discovery_provider_identity import (
+    _MODEL_DISCOVERY_PROVIDER_HANDLER_KEYS,
     resolve_provider_list_key,
 )
 
@@ -18,6 +19,17 @@ def test_resolves_exact_top_level_provider_key_for_openrouter():
 
     assert result.status == "resolved"
     assert result.provider_list_key == "OpenRouter"
+
+
+def test_qwencloud_model_discovery_identity_uses_qwencloud():
+    providers = {"QwenCloud": ["qwen3.8-max"], "OpenAI": ["gpt-4.1"]}
+
+    result = resolve_provider_list_key(" QwenCloud ", providers)
+
+    assert result.status == "resolved"
+    assert result.normalized_provider == "qwencloud"
+    assert result.provider_list_key == "QwenCloud"
+    assert "qwencloud" in _MODEL_DISCOVERY_PROVIDER_HANDLER_KEYS
 
 
 def test_preserves_custom_2_key_spelling():

--- a/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
+++ b/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
@@ -46,9 +46,35 @@ def test_qwencloud_models_url_normalizes_base_and_both_request_endpoints(endpoin
 @pytest.mark.parametrize(
     "endpoint",
     [
+        "https://workspace.example/api/v2",
+        "https://workspace.example/api/v2/",
+        "https://workspace.example/api/v2/responses",
+        "https://workspace.example/api/v2/responses/",
+        "https://workspace.example/api/v2/chat/completions",
+        "https://workspace.example/api/v2/chat/completions/",
+        "https://user:secret@workspace.example/api/v2/responses?api_key=secret#fragment",
+    ],
+)
+def test_qwencloud_custom_prefix_normalizes_base_and_request_endpoints(endpoint):
+    original_endpoint = endpoint
+
+    assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is True
+    assert (
+        build_models_url(endpoint, "qwencloud")
+        == "https://workspace.example/api/v2/models"
+    )
+    assert endpoint == original_endpoint
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/responses-extra",
         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions-extra",
-        "https://dashscope-intl.aliyuncs.com/not-compatible-mode/v1/responses",
+        "https://workspace.example/api/v2/myresponses",
+        "https://workspace.example/api/v2/responses/extra",
+        "https://workspace.example/api/v2/chat/completions/extra",
+        "https://user:secret@/api/v2/responses",
         "https://user:secret@[::1/compatible-mode/v1/responses?api_key=secret",
     ],
 )
@@ -57,10 +83,13 @@ def test_qwencloud_discovery_rejects_lookalike_or_malformed_paths(endpoint):
 
 
 def test_responses_suffix_is_not_broadly_inferred_for_other_endpoint_shapes():
-    endpoint = "https://api.example.test/v1/responses"
-
-    assert supports_openai_compatible_model_discovery("openai", endpoint) is False
-    assert build_models_url(endpoint, "openai") == endpoint
+    for endpoint in (
+        "https://api.example.test/v1/responses",
+        "https://api.example.test/api/v2/responses",
+        "https://api.example.test/compatible-mode/v1/responses",
+    ):
+        assert supports_openai_compatible_model_discovery("openai", endpoint) is False
+        assert build_models_url(endpoint, "openai") == endpoint
 
 
 def test_llamacpp_completion_url_maps_to_v1_models():

--- a/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
+++ b/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
@@ -105,6 +105,55 @@ def test_qwencloud_discovery_rejects_structurally_unsafe_endpoints(endpoint):
     assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is False
 
 
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://workspace.example/api%2fv2",
+        "https://workspace.example/api%252Fv2",
+        "https://workspace.example/api%5Cv2",
+        "https://workspace.example/api/v2/%2e/responses",
+        "https://workspace.example/api/v2/%2E%2e/responses",
+        "https://workspace.example/api/v2/%252e%252e/responses",
+        "https://workspace.example/api/v2/res%70onses",
+        "https://workspace.example/api/v2/RES%70ONSES",
+        "https://workspace.example/api/v2/chat/%63ompletions",
+        "https://workspace.example/api/v2/mod%65ls",
+        "https://workspace.example/api/v2/res%2570onses",
+        "https://workspace.example/api/v2/chat/%2563ompletions",
+        "https://workspace.example/api/v2/mod%2565ls",
+        "https://workspace.example/api/v2/res%252570onses",
+    ],
+)
+def test_qwencloud_discovery_rejects_encoded_endpoint_structure(endpoint):
+    assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is False
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    [
+        (
+            "https://workspace.example/tenant%20alpha/api/v2",
+            "https://workspace.example/tenant%20alpha/api/v2/models",
+        ),
+        (
+            "https://workspace.example/caf%C3%A9/api/v2/responses",
+            "https://workspace.example/caf%C3%A9/api/v2/models",
+        ),
+        (
+            "https://workspace.example/tenant%2520alpha/api/v2/chat/completions",
+            "https://workspace.example/tenant%2520alpha/api/v2/models",
+        ),
+        (
+            "https://workspace.example/mod%65ls/api/v2/chat/completions",
+            "https://workspace.example/mod%65ls/api/v2/models",
+        ),
+    ],
+)
+def test_qwencloud_discovery_preserves_safe_encoded_prefix_data(endpoint, expected):
+    assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is True
+    assert build_models_url(endpoint, "qwencloud") == expected
+
+
 def test_qwencloud_discovery_preserves_valid_ipv6_port_and_safe_url_stripping():
     endpoint = (
         "https://user:secret@[2001:db8::1]:8443/api/v2/responses/"

--- a/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
+++ b/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import httpx
 import pytest
 
+from tldw_chatbook.Chat.Chat_Deps import ChatConfigurationError
+from tldw_chatbook.LLM_Calls.qwencloud import normalize_qwencloud_base_url
 from tldw_chatbook.LLM_Provider_Catalog.openai_compatible_model_discovery import (
     build_models_url,
     discover_openai_compatible_models,
@@ -29,7 +33,6 @@ def test_chat_completions_url_maps_to_models_url():
         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/responses/",
         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions/",
-        "https://user:secret@dashscope-intl.aliyuncs.com/compatible-mode/v1/responses?api_key=secret#fragment",
     ],
 )
 def test_qwencloud_models_url_normalizes_base_and_both_request_endpoints(endpoint):
@@ -52,7 +55,6 @@ def test_qwencloud_models_url_normalizes_base_and_both_request_endpoints(endpoin
         "https://workspace.example/api/v2/responses/",
         "https://workspace.example/api/v2/chat/completions",
         "https://workspace.example/api/v2/chat/completions/",
-        "https://user:secret@workspace.example/api/v2/responses?api_key=secret#fragment",
     ],
 )
 def test_qwencloud_custom_prefix_normalizes_base_and_request_endpoints(endpoint):
@@ -69,9 +71,6 @@ def test_qwencloud_custom_prefix_normalizes_base_and_request_endpoints(endpoint)
 @pytest.mark.parametrize(
     "endpoint",
     [
-        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/responses-extra",
-        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions-extra",
-        "https://workspace.example/api/v2/myresponses",
         "https://workspace.example/api/v2/responses/extra",
         "https://workspace.example/api/v2/chat/completions/extra",
         "https://user:secret@/api/v2/responses",
@@ -154,17 +153,126 @@ def test_qwencloud_discovery_preserves_safe_encoded_prefix_data(endpoint, expect
     assert build_models_url(endpoint, "qwencloud") == expected
 
 
-def test_qwencloud_discovery_preserves_valid_ipv6_port_and_safe_url_stripping():
-    endpoint = (
-        "https://user:secret@[2001:db8::1]:8443/api/v2/responses/"
-        "?api_key=secret#fragment"
-    )
+@pytest.mark.parametrize(
+    ("endpoint", "expected_base"),
+    [
+        ("https://workspace.example", "https://workspace.example"),
+        ("https://workspace.example/api/v2", "https://workspace.example/api/v2"),
+        (
+            "https://workspace.example/api/v2/responses",
+            "https://workspace.example/api/v2",
+        ),
+        (
+            "https://workspace.example/api/v2/chat/completions/",
+            "https://workspace.example/api/v2",
+        ),
+        (
+            "https://workspace.example/api/RESPONSES",
+            "https://workspace.example/api/RESPONSES",
+        ),
+        (
+            "https://workspace.example/tenant-responses/api/v2",
+            "https://workspace.example/tenant-responses/api/v2",
+        ),
+        (
+            "https://workspace.example/completion-gateway/api/v2",
+            "https://workspace.example/completion-gateway/api/v2",
+        ),
+        (
+            "https://workspace.example/api/v2/responses-extra",
+            "https://workspace.example/api/v2/responses-extra",
+        ),
+        (
+            "https://workspace.example/api/v2/chat/completions-extra",
+            "https://workspace.example/api/v2/chat/completions-extra",
+        ),
+        (
+            "https://workspace.example/api/v2/myresponses",
+            "https://workspace.example/api/v2/myresponses",
+        ),
+    ],
+)
+def test_qwencloud_discovery_matches_runtime_base_contract(endpoint, expected_base):
+    original_endpoint = endpoint
+
+    assert normalize_qwencloud_base_url(endpoint) == expected_base
+    assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is True
+    assert build_models_url(endpoint, "qwencloud") == f"{expected_base}/models"
+    assert endpoint == original_endpoint
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://user:secret-canary@workspace.example/api/v2",
+        "https://workspace.example/api/v2?api_key=secret-canary",
+        "https://workspace.example/api/v2#secret-canary",
+        "https://[fe80::1%25eth0]:8000/api/v2",
+    ],
+)
+def test_qwencloud_discovery_rejects_runtime_invalid_endpoint_without_secret_output(
+    endpoint,
+):
+    with pytest.raises(ChatConfigurationError):
+        normalize_qwencloud_base_url(endpoint)
+
+    assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is False
+    assert "secret-canary" not in build_models_url(endpoint, "qwencloud")
+    assert "secret-canary" not in fingerprint_endpoint(endpoint)
+
+
+def test_qwencloud_discovery_rejects_oversized_endpoint_before_classification():
+    endpoint = f"https://workspace.example/{'a' * 2000}"
+
+    with pytest.raises(ChatConfigurationError):
+        normalize_qwencloud_base_url(endpoint)
+
+    assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is False
+
+
+def test_catalog_rejects_oversized_endpoint_before_url_parsing(monkeypatch):
+    endpoint = f"https://workspace.example/{'a' * 2000}"
+    parser = Mock(side_effect=AssertionError("oversized endpoint was parsed"))
+    monkeypatch.setattr(openai_compatible_model_discovery, "urlparse", parser)
+
+    assert supports_openai_compatible_model_discovery("vllm", endpoint) is False
+    assert fingerprint_endpoint(endpoint) == endpoint
+    parser.assert_not_called()
+
+
+def test_qwencloud_discovery_preserves_valid_ipv6_port():
+    endpoint = "https://[2001:db8::1]:8443/api/v2/responses/"
 
     assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is True
     assert (
         build_models_url(endpoint, "qwencloud")
         == "https://[2001:db8::1]:8443/api/v2/models"
     )
+
+
+def test_non_qwen_discovery_preserves_scoped_ipv6_zone_id_support():
+    endpoint = "http://[fe80::1%25eth0]:8000/v1"
+
+    assert supports_openai_compatible_model_discovery("vllm", endpoint) is True
+    assert build_models_url(endpoint, "vllm") == f"{endpoint}/models"
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://workspace.example%evil/v1",
+        "http://workspace.example|evil/v1",
+        "http://workspace.example^evil/v1",
+        "http://workspace.example/v1//",
+        "http://workspace.example/%zz/v1/chat/completions",
+        "http://workspace.example/../v1/chat/completions",
+        "http://workspace.example/api%2fv1/chat/completions",
+        "http://workspace.example/res%70onses/v1/chat/completions",
+        "http://workspace.example/v1/chat/completions/chat/completions",
+    ],
+)
+def test_non_qwen_discovery_still_rejects_malformed_endpoint_structure(endpoint):
+    assert supports_openai_compatible_model_discovery("vllm", endpoint) is False
 
 
 def test_qwencloud_discovery_preserves_safe_reserved_word_inside_custom_prefix():
@@ -630,9 +738,12 @@ async def test_discovery_returns_typed_error_for_unsupported_endpoint():
 
 
 def test_openrouter_api_v1_path_maps_to_models():
-    assert supports_openai_compatible_model_discovery(
-        "openrouter", "https://openrouter.ai/api/v1"
-    ) is True
+    assert (
+        supports_openai_compatible_model_discovery(
+            "openrouter", "https://openrouter.ai/api/v1"
+        )
+        is True
+    )
     assert (
         build_models_url("https://openrouter.ai/api/v1", "openrouter")
         == "https://openrouter.ai/api/v1/models"
@@ -640,9 +751,12 @@ def test_openrouter_api_v1_path_maps_to_models():
 
 
 def test_zai_paas_v4_path_maps_to_models():
-    assert supports_openai_compatible_model_discovery(
-        "zai", "https://api.z.ai/api/paas/v4"
-    ) is True
+    assert (
+        supports_openai_compatible_model_discovery(
+            "zai", "https://api.z.ai/api/paas/v4"
+        )
+        is True
+    )
     assert (
         build_models_url("https://api.z.ai/api/paas/v4", "zai")
         == "https://api.z.ai/api/paas/v4/models"
@@ -672,9 +786,17 @@ async def test_anthropic_paginates_with_after_id():
         seen_headers.update({k.lower(): v for k, v in request.headers.items()})
         page = len(requests)
         payload = (
-            {"data": [{"id": f"claude-{page}"}], "has_more": True, "last_id": f"claude-{page}"}
+            {
+                "data": [{"id": f"claude-{page}"}],
+                "has_more": True,
+                "last_id": f"claude-{page}",
+            }
             if page == 1
-            else {"data": [{"id": "claude-2"}], "has_more": False, "last_id": "claude-2"}
+            else {
+                "data": [{"id": "claude-2"}],
+                "has_more": False,
+                "last_id": "claude-2",
+            }
         )
         return httpx.Response(200, json=payload)
 

--- a/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
+++ b/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
@@ -82,6 +82,52 @@ def test_qwencloud_discovery_rejects_lookalike_or_malformed_paths(endpoint):
     assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is False
 
 
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://workspace.example/api//v2",
+        "https://workspace.example/api/v2/./responses",
+        "https://workspace.example/api/v2/../responses",
+        "https://workspace.example/api/v2/%zz/responses",
+        "https://workspace.example/api/v2/models/models",
+        "https://workspace.example/api/v2/models/responses",
+        "https://workspace.example/api/v2/models/chat/completions",
+        "https://workspace.example/api/v2/chat/completions/bridge/responses",
+        "https://workspace.example%evil/api/v2",
+        "https://workspace.example|evil/api/v2",
+        "https://workspace.example^evil/api/v2",
+        "https://workspace.example:/api/v2",
+        "https://workspace.example\\@evil.example/api/v2",
+        "https://workspace.example\x1f.evil/api/v2",
+    ],
+)
+def test_qwencloud_discovery_rejects_structurally_unsafe_endpoints(endpoint):
+    assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is False
+
+
+def test_qwencloud_discovery_preserves_valid_ipv6_port_and_safe_url_stripping():
+    endpoint = (
+        "https://user:secret@[2001:db8::1]:8443/api/v2/responses/"
+        "?api_key=secret#fragment"
+    )
+
+    assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is True
+    assert (
+        build_models_url(endpoint, "qwencloud")
+        == "https://[2001:db8::1]:8443/api/v2/models"
+    )
+
+
+def test_qwencloud_discovery_preserves_safe_reserved_word_inside_custom_prefix():
+    endpoint = "https://workspace.example/models/api/v2/chat/completions"
+
+    assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is True
+    assert (
+        build_models_url(endpoint, "qwencloud")
+        == "https://workspace.example/models/api/v2/models"
+    )
+
+
 def test_responses_suffix_is_not_broadly_inferred_for_other_endpoint_shapes():
     for endpoint in (
         "https://api.example.test/v1/responses",

--- a/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
+++ b/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
@@ -20,6 +20,49 @@ def test_chat_completions_url_maps_to_models_url():
     )
 
 
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/",
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/responses",
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/responses/",
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions/",
+        "https://user:secret@dashscope-intl.aliyuncs.com/compatible-mode/v1/responses?api_key=secret#fragment",
+    ],
+)
+def test_qwencloud_models_url_normalizes_base_and_both_request_endpoints(endpoint):
+    original_endpoint = endpoint
+
+    assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is True
+    assert (
+        build_models_url(endpoint, "qwencloud")
+        == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models"
+    )
+    assert endpoint == original_endpoint
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/responses-extra",
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions-extra",
+        "https://dashscope-intl.aliyuncs.com/not-compatible-mode/v1/responses",
+        "https://user:secret@[::1/compatible-mode/v1/responses?api_key=secret",
+    ],
+)
+def test_qwencloud_discovery_rejects_lookalike_or_malformed_paths(endpoint):
+    assert supports_openai_compatible_model_discovery("qwencloud", endpoint) is False
+
+
+def test_responses_suffix_is_not_broadly_inferred_for_other_endpoint_shapes():
+    endpoint = "https://api.example.test/v1/responses"
+
+    assert supports_openai_compatible_model_discovery("openai", endpoint) is False
+    assert build_models_url(endpoint, "openai") == endpoint
+
+
 def test_llamacpp_completion_url_maps_to_v1_models():
     assert (
         build_models_url("http://127.0.0.1:9099/completion", "llama_cpp")

--- a/Tests/Provider/test_provider_model_resolution.py
+++ b/Tests/Provider/test_provider_model_resolution.py
@@ -36,12 +36,13 @@ def _entry(
     model_id: str,
     *,
     source: str,
+    provider: str = "OpenAI",
     capability_status: str = "unknown",
     persisted: bool = False,
 ) -> MergedModelEntry:
     return MergedModelEntry(
-        provider="OpenAI",
-        provider_list_key="OpenAI",
+        provider=provider,
+        provider_list_key=provider,
         model_id=model_id,
         display_name=model_id,
         source=source,
@@ -182,6 +183,41 @@ async def test_model_options_enforce_the_configured_merge_cap_boundary(
 
     assert len(options) == expected_count
     assert options[0].model_id == "saved"
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_discovered_models_use_capped_selector_merge() -> None:
+    at_cap = tuple(
+        _entry(
+            f"qwen-runtime-{index}",
+            source="runtime_discovered",
+            provider="QwenCloud",
+        )
+        for index in range(SELECTOR_MERGE_CAP)
+    )
+    over_cap = at_cap + (
+        _entry(
+            "qwen-runtime-over-cap",
+            source="runtime_discovered",
+            provider="QwenCloud",
+        ),
+    )
+
+    capped_options = await resolve_provider_model_options(
+        {"QwenCloud": ["saved-model"]},
+        CatalogScopeFixture(at_cap),
+        provider="QwenCloud",
+    )
+    oversized_options = await resolve_provider_model_options(
+        {"QwenCloud": ["saved-model"]},
+        CatalogScopeFixture(over_cap),
+        provider="QwenCloud",
+    )
+
+    assert [option.model_id for option in capped_options] == [
+        f"qwen-runtime-{index}" for index in range(SELECTOR_MERGE_CAP)
+    ]
+    assert oversized_options == []
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_provider_model_resolution.py
+++ b/Tests/UI/test_provider_model_resolution.py
@@ -132,6 +132,31 @@ async def test_uncapped_returns_full_catalog_for_picker():
 
 
 @pytest.mark.asyncio
+async def test_qwencloud_full_catalog_remains_searchable_in_model_popover():
+    discovered = _entries(
+        "QwenCloud",
+        [f"qwen-model-{index}" for index in range(SELECTOR_MERGE_CAP + 10)],
+    )
+
+    dropdown = await resolve_provider_model_options(
+        {"QwenCloud": ["saved-model"]},
+        _FakeScope(discovered),
+        provider="QwenCloud",
+    )
+    searchable = await resolve_provider_model_options(
+        {"QwenCloud": ["saved-model"]},
+        _FakeScope(discovered),
+        provider="QwenCloud",
+        merge_cap=None,
+    )
+
+    assert dropdown == []
+    assert [option.model_id for option in searchable] == [
+        f"qwen-model-{index}" for index in range(SELECTOR_MERGE_CAP + 10)
+    ]
+
+
+@pytest.mark.asyncio
 async def test_current_model_inserted_as_transient_when_missing():
     options = await resolve_provider_model_options(
         {"OpenAI": ["saved-1"]},

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -6508,7 +6508,14 @@ async def test_settings_provider_category_saves_and_clears_local_api_key(monkeyp
             == "sk-test-new-local-key"
         )
 
-        await pilot.click("#settings-provider-api-key-clear")
+        await pilot.pause()
+        clear_button = screen.query_one("#settings-provider-api-key-clear", Button)
+        assert clear_button.disabled is False
+        clear_button.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["api_key"] == ""
         await pilot.click("#settings-save-category")
 
     assert ("api_settings.openai", "api_key", "") in saved

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -732,6 +732,7 @@ def test_settings_ownership_records_cover_categories_and_runtime_boundaries():
         "api_settings.<provider>.endpoint",
         "api_settings.<provider>.api_key",
         "api_settings.<provider>.api_key_env_var",
+        "api_settings.<provider>.api_mode",
         "api_settings.<provider>.model_defaults.<model>",
     )
     assert records_by_category[

--- a/Tests/UI/test_settings_qwencloud_api_mode.py
+++ b/Tests/UI/test_settings_qwencloud_api_mode.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 from copy import deepcopy
 
 import pytest
@@ -371,6 +372,122 @@ async def test_qwencloud_canonical_multifield_save_uses_one_atomic_mutation(
 
 
 @pytest.mark.asyncio
+async def test_qwencloud_atomic_save_consumes_deferred_api_key_clear_once(
+    monkeypatch,
+):
+    app = _qwencloud_app(api_mode="responses")
+
+    atomic_write_count = 0
+
+    def save_batch(_section_values, *, delete_keys=None):
+        nonlocal atomic_write_count
+        atomic_write_count += 1
+        return True
+
+    legacy_write_count = 0
+
+    def save_legacy(_section, _key, _value):
+        nonlocal legacy_write_count
+        legacy_write_count += 1
+        return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_settings_to_cli_config",
+        save_batch,
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        save_legacy,
+    )
+    host = DestinationHarness(app, "settings")
+    credential = "local-test-credential"
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        endpoint = screen.query_one("#settings-provider-endpoint-value", Input)
+        api_key = screen.query_one("#settings-provider-api-key", Input)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+
+        endpoint.value = "https://new.example.test/compatible-mode/v1"
+        api_key.focus()
+        await pilot.pause()
+        await pilot.press(*tuple(credential))
+        mode.value = "chat_completions"
+        await pilot.pause()
+
+        assert endpoint.value == "https://new.example.test/compatible-mode/v1"
+        assert len(api_key.value) == len(credential)
+        assert mode.value == "chat_completions"
+
+        await pilot.click("#settings-save-category")
+        for _ in range(4):
+            await pilot.pause()
+
+        assert atomic_write_count == 1
+        assert legacy_write_count == 0
+        assert api_key.value == ""
+        assert SettingsCategoryId.PROVIDERS_MODELS not in screen._settings_drafts
+        stored_provider = app.app_config["api_settings"]["qwencloud"]
+        assert stored_provider["api_base_url"] == (
+            "https://new.example.test/compatible-mode/v1"
+        )
+        assert stored_provider["api_mode"] == "chat_completions"
+        stored_key = stored_provider["api_key"]
+        assert isinstance(stored_key, str)
+        assert hmac.compare_digest(stored_key, credential)
+
+        await pilot.click("#settings-save-category")
+        for _ in range(2):
+            await pilot.pause()
+
+        assert atomic_write_count == 1
+        assert legacy_write_count == 0
+        assert SettingsCategoryId.PROVIDERS_MODELS not in screen._settings_drafts
+        stored_key = app.app_config["api_settings"]["qwencloud"]["api_key"]
+        assert isinstance(stored_key, str)
+        assert hmac.compare_digest(stored_key, credential)
+
+
+@pytest.mark.asyncio
+async def test_provider_switch_clear_is_suppressed_but_user_key_clear_is_staged():
+    app = _qwencloud_app(api_mode="responses")
+    app.app_config["api_settings"]["openai"] = {
+        "api_base_url": "https://api.openai.com/v1",
+        "api_key": "saved-test-credential",
+        "model": "gpt-4.1",
+    }
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        api_key = screen.query_one("#settings-provider-api-key", Input)
+        api_key.focus()
+        await pilot.pause()
+        await pilot.press("x")
+
+        provider = screen.query_one("#settings-provider-value", Select)
+        provider.value = "openai"
+        screen.handle_provider_value_changed(Select.Changed(provider, "openai"))
+        for _ in range(3):
+            await pilot.pause()
+
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert api_key.value == ""
+        assert "api_key" not in draft.values
+
+        api_key.focus()
+        await pilot.pause()
+        await pilot.press("x")
+        await pilot.press("backspace")
+        await pilot.pause()
+
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["api_key"] == ""
+
+
+@pytest.mark.asyncio
 async def test_qwencloud_api_mode_draft_survives_provider_switch():
     app = _qwencloud_app(api_mode="responses")
     app.app_config["api_settings"]["openai"] = {
@@ -720,11 +837,77 @@ async def test_qwencloud_malformed_canonical_table_uses_canonical_recovery_witho
 
         assert screen._provider_config_entry("QwenCloud")[0] == "qwencloud"
         assert selector.value is Select.NULL
-        assert "choose Responses or Chat Completions" in str(guidance.content)
+        recovery = str(guidance.content)
+        assert "api_settings.qwencloud is not a table" in recovery
+        assert "Advanced Config" in recovery
+        assert "config.toml" in recovery
         assert env_var.value == ""
+        assert "Provider settings invalid" in screen._provider_key_status("QwenCloud")
         assert "ALIAS-SECRET-CANARY" not in screen._provider_key_status("QwenCloud")
         assert "ALIAS_ENV_CANARY" not in screen._provider_key_status("QwenCloud")
         assert app.app_config["api_settings"] == original_api_settings
+
+
+@pytest.mark.asyncio
+async def test_malformed_qwencloud_table_selection_test_and_save_stay_blocked(
+    monkeypatch,
+):
+    app = _qwencloud_app()
+    app.app_config["api_settings"] = {"qwencloud": ["not-a-table"]}
+    original_api_settings = deepcopy(app.app_config["api_settings"])
+    writes: list[tuple[str, str, object]] = []
+    atomic_writes: list[dict] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda section, key, value: writes.append((section, key, value)) or True,
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_screen.save_settings_to_cli_config",
+        lambda section_values, *, delete_keys=None: (
+            atomic_writes.append(deepcopy(dict(section_values))) or True
+        ),
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        guidance = screen.query_one("#settings-provider-api-mode-guidance", Static)
+
+        assert mode.value is Select.NULL
+        assert mode.has_class("settings-invalid-input")
+        assert "Advanced Config" in str(guidance.content)
+
+        mode.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.press("down")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert mode.value == "responses"
+        assert mode.has_class("settings-invalid-input")
+        assert "api_settings.qwencloud is not a table" in str(guidance.content)
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["provider_api_mode:qwencloud"] == "responses"
+
+        await pilot.click("#settings-test-provider")
+        assert "Invalid provider settings" in str(
+            screen.query_one("#settings-provider-test-result", Static).content
+        )
+
+        await pilot.click("#settings-save-category")
+        await pilot.pause()
+
+        assert writes == []
+        assert atomic_writes == []
+        assert app.app_config["api_settings"] == original_api_settings
+        assert "Advanced Config" in str(
+            screen.query_one("#settings-provider-save-result", Static).content
+        )
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["provider_api_mode:qwencloud"] == "responses"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_settings_qwencloud_api_mode.py
+++ b/Tests/UI/test_settings_qwencloud_api_mode.py
@@ -592,6 +592,107 @@ async def test_qwencloud_alias_mode_migration_waits_for_other_provider_writes(
 
 
 @pytest.mark.asyncio
+async def test_qwencloud_alias_mode_migration_waits_for_profile_write(
+    monkeypatch,
+):
+    app = _qwencloud_app(api_mode="responses")
+    app.app_config["api_settings"] = {
+        "QwenCloud": {
+            "api_mode": "responses",
+            "api_key_env_var": "DASHSCOPE_API_KEY",
+            "model": "qwen3.8-max",
+        }
+    }
+    atomic_mutations: list[dict] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_screen.save_settings_to_cli_config",
+        lambda section_values, *, delete_keys=None: (
+            atomic_mutations.append(dict(section_values)) or True
+        ),
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda _section, key, _value: key != "model_defaults",
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        profile = screen.query_one("#settings-model-profile-temperature", Input)
+        profile.value = "0.25"
+        await pilot.pause()
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        mode.value = "chat_completions"
+        screen.handle_provider_api_mode_changed(
+            Select.Changed(mode, "chat_completions")
+        )
+
+        await pilot.click("#settings-save-category")
+
+        assert atomic_mutations == []
+        assert "qwencloud" not in app.app_config["api_settings"]
+        assert app.app_config["api_settings"]["QwenCloud"]["api_mode"] == "responses"
+        assert mode.value == "chat_completions"
+        assert profile.value == "0.25"
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["provider_api_mode:qwencloud"] == "chat_completions"
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_alias_mode_migration_waits_for_context_write(
+    monkeypatch,
+):
+    app = _qwencloud_app(api_mode="responses")
+    app.app_config["api_settings"] = {
+        "QwenCloud": {
+            "api_mode": "responses",
+            "api_key_env_var": "DASHSCOPE_API_KEY",
+            "model": "qwen3.8-max",
+        }
+    }
+    app.app_config["model_capabilities"] = {}
+    atomic_mutations: list[dict] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_screen.save_settings_to_cli_config",
+        lambda section_values, *, delete_keys=None: (
+            atomic_mutations.append(dict(section_values)) or True
+        ),
+    )
+
+    def save_setting(section, _key, _value):
+        return section != "model_capabilities.models"
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        save_setting,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        context = screen.query_one("#settings-model-context-window", Input)
+        context.value = "32768"
+        await pilot.pause()
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        mode.value = "chat_completions"
+        screen.handle_provider_api_mode_changed(
+            Select.Changed(mode, "chat_completions")
+        )
+
+        await pilot.click("#settings-save-category")
+
+        assert atomic_mutations == []
+        assert "qwencloud" not in app.app_config["api_settings"]
+        assert app.app_config["api_settings"]["QwenCloud"]["api_mode"] == "responses"
+        assert mode.value == "chat_completions"
+        assert context.value == "32768"
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["provider_api_mode:qwencloud"] == "chat_completions"
+
+
+@pytest.mark.asyncio
 async def test_qwencloud_canonical_mode_wins_over_alias_for_settings_and_readiness():
     app = _qwencloud_app(api_mode="responses")
     app.app_config["api_settings"] = {

--- a/Tests/UI/test_settings_qwencloud_api_mode.py
+++ b/Tests/UI/test_settings_qwencloud_api_mode.py
@@ -12,7 +12,10 @@ from Tests.UI.test_destination_shells import (
     _active_destination_screen,
 )
 from Tests.UI.test_screen_navigation import _build_test_app
-from Tests.UI.test_settings_configuration_hub import _open_settings_category
+from Tests.UI.test_settings_configuration_hub import (
+    _open_settings_category,
+    _settle_settings_mount_storm,
+)
 from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
 from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderGateway
 from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
@@ -75,6 +78,30 @@ async def test_qwencloud_api_mode_selector_visibility_options_and_default():
 
         assert selector.disabled is True
         assert row.has_class("settings-gated-profile-hidden") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    ("API mode", "api_settings.<provider>.api_mode", "mode"),
+)
+async def test_qwencloud_api_mode_field_search_enter_focuses_selector(query):
+    app = _qwencloud_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        await pilot.click("#settings-category-search")
+        await pilot.press(*tuple(query))
+        await pilot.press("enter")
+        for _ in range(8):
+            await pilot.pause()
+
+        screen = _active_destination_screen(host)
+        assert screen.active_category == SettingsCategoryId.PROVIDERS_MODELS.value
+        assert host.focused is not None
+        assert host.focused.id == "settings-provider-api-mode"
+        assert screen.query_one("#settings-provider-api-mode", Select).disabled is False
 
 
 @pytest.mark.asyncio
@@ -218,6 +245,129 @@ async def test_qwencloud_save_failure_preserves_mode_input_and_draft(monkeypatch
         assert "Failed to save" in str(
             screen.query_one("#settings-provider-save-result", Static).content
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing_key", ["api_base_url", "api_mode"])
+async def test_qwencloud_canonical_multifield_save_failure_is_atomic(
+    monkeypatch,
+    failing_key,
+):
+    app = _qwencloud_app(api_mode="responses")
+    original_api_settings = deepcopy(app.app_config["api_settings"])
+    disk_api_settings = deepcopy(original_api_settings)
+    legacy_calls: list[tuple[str, str, object]] = []
+    atomic_calls: list[dict] = []
+
+    def legacy_save(section, key, value):
+        legacy_calls.append((section, key, value))
+        if section != "api_settings.qwencloud":
+            return True
+        if key == failing_key:
+            return False
+        disk_api_settings["qwencloud"][key] = value
+        return True
+
+    def atomic_save(section_values, *, delete_keys=None):
+        atomic_calls.append(deepcopy(dict(section_values)))
+        values = section_values["api_settings.qwencloud"]
+        if failing_key in values:
+            return False
+        disk_api_settings["qwencloud"].update(values)
+        return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        legacy_save,
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_settings_to_cli_config",
+        atomic_save,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        endpoint = screen.query_one("#settings-provider-endpoint-value", Input)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        endpoint.value = "https://new.example.test/compatible-mode/v1"
+        mode.value = "chat_completions"
+        screen.handle_provider_api_mode_changed(
+            Select.Changed(mode, "chat_completions")
+        )
+        await pilot.pause()
+
+        await pilot.click("#settings-save-category")
+
+        assert atomic_calls == [
+            {
+                "api_settings.qwencloud": {
+                    "api_base_url": "https://new.example.test/compatible-mode/v1",
+                    "api_mode": "chat_completions",
+                }
+            }
+        ]
+        assert legacy_calls == []
+        assert disk_api_settings == original_api_settings
+        assert app.app_config["api_settings"] == original_api_settings
+        assert endpoint.value == "https://new.example.test/compatible-mode/v1"
+        assert mode.value == "chat_completions"
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["endpoint"] == endpoint.value
+        assert draft.values["provider_api_mode:qwencloud"] == "chat_completions"
+        assert "Failed to save" in str(
+            screen.query_one("#settings-provider-save-result", Static).content
+        )
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_canonical_multifield_save_uses_one_atomic_mutation(
+    monkeypatch,
+):
+    app = _qwencloud_app(api_mode="responses")
+    atomic_calls: list[dict] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda *_args: pytest.fail("canonical Qwen batch must not save per key"),
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_settings_to_cli_config",
+        lambda section_values, *, delete_keys=None: (
+            atomic_calls.append(deepcopy(dict(section_values))) or True
+        ),
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        endpoint = screen.query_one("#settings-provider-endpoint-value", Input)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        endpoint.value = "https://new.example.test/compatible-mode/v1"
+        mode.value = "chat_completions"
+        screen.handle_provider_api_mode_changed(
+            Select.Changed(mode, "chat_completions")
+        )
+        await pilot.pause()
+
+        await pilot.click("#settings-save-category")
+
+        assert atomic_calls == [
+            {
+                "api_settings.qwencloud": {
+                    "api_base_url": "https://new.example.test/compatible-mode/v1",
+                    "api_mode": "chat_completions",
+                }
+            }
+        ]
+        assert app.app_config["api_settings"]["qwencloud"]["api_base_url"] == (
+            "https://new.example.test/compatible-mode/v1"
+        )
+        assert app.app_config["api_settings"]["qwencloud"]["api_mode"] == (
+            "chat_completions"
+        )
+        assert SettingsCategoryId.PROVIDERS_MODELS not in screen._settings_drafts
 
 
 @pytest.mark.asyncio
@@ -538,6 +688,120 @@ async def test_qwencloud_alias_mode_save_migrates_only_mode_to_canonical_owner(
     )
     assert resolution.ready is True
     assert resolution.api_mode == "chat_completions"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("canonical_first", [False, True])
+async def test_qwencloud_malformed_canonical_table_uses_canonical_recovery_without_alias_credentials(
+    canonical_first,
+):
+    app = _qwencloud_app()
+    alias = {
+        "api_mode": "chat_completions",
+        "api_key": "ALIAS-SECRET-CANARY",
+        "api_key_env_var": "ALIAS_ENV_CANARY",
+        "model": "alias-model",
+    }
+    entries = (
+        [("qwencloud", []), ("QwenCloud", alias)]
+        if canonical_first
+        else [("QwenCloud", alias), ("qwencloud", [])]
+    )
+    app.app_config["api_settings"] = dict(entries)
+    original_api_settings = deepcopy(app.app_config["api_settings"])
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        selector = screen.query_one("#settings-provider-api-mode", Select)
+        guidance = screen.query_one("#settings-provider-api-mode-guidance", Static)
+        env_var = screen.query_one("#settings-provider-credential-env-var", Input)
+
+        assert screen._provider_config_entry("QwenCloud")[0] == "qwencloud"
+        assert selector.value is Select.NULL
+        assert "choose Responses or Chat Completions" in str(guidance.content)
+        assert env_var.value == ""
+        assert "ALIAS-SECRET-CANARY" not in screen._provider_key_status("QwenCloud")
+        assert "ALIAS_ENV_CANARY" not in screen._provider_key_status("QwenCloud")
+        assert app.app_config["api_settings"] == original_api_settings
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("canonical_first", [False, True])
+async def test_qwencloud_malformed_alias_never_becomes_save_owner_when_canonical_is_valid(
+    canonical_first,
+    monkeypatch,
+):
+    app = _qwencloud_app(api_mode="responses")
+    canonical = {
+        "api_mode": "responses",
+        "api_key_env_var": "CANONICAL_ENV",
+        "model": "qwen3.8-max",
+    }
+    entries = (
+        [("qwencloud", canonical), ("QwenCloud", [])]
+        if canonical_first
+        else [("QwenCloud", []), ("qwencloud", canonical)]
+    )
+    app.app_config["api_settings"] = dict(entries)
+    writes: list[tuple[str, str, object]] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda section, key, value: writes.append((section, key, value)) or True,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+
+        assert screen._provider_config_entry("QwenCloud")[0] == "qwencloud"
+        assert screen.query_one("#settings-provider-api-mode", Select).value == (
+            "responses"
+        )
+        assert (
+            screen.query_one("#settings-provider-credential-env-var", Input).value
+            == "CANONICAL_ENV"
+        )
+        endpoint = screen.query_one("#settings-provider-endpoint-value", Input)
+        endpoint.value = "https://new.example.test/compatible-mode/v1"
+        await pilot.pause()
+        await pilot.click("#settings-save-category")
+
+        assert writes == [
+            (
+                "api_settings.qwencloud",
+                "api_base_url",
+                "https://new.example.test/compatible-mode/v1",
+            )
+        ]
+        assert app.app_config["api_settings"]["QwenCloud"] == []
+        assert app.app_config["api_settings"]["qwencloud"]["api_base_url"] == (
+            "https://new.example.test/compatible-mode/v1"
+        )
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_alias_only_malformed_table_uses_canonical_recovery_owner():
+    app = _qwencloud_app()
+    app.app_config["api_settings"] = {"QwenCloud": ["SECRET-CANARY"]}
+    original_api_settings = deepcopy(app.app_config["api_settings"])
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+
+        assert screen._provider_config_entry("QwenCloud")[0] == "qwencloud"
+        assert screen.query_one("#settings-provider-api-mode", Select).value is (
+            Select.NULL
+        )
+        assert (
+            screen.query_one("#settings-provider-credential-env-var", Input).value == ""
+        )
+        assert "SECRET-CANARY" not in screen._provider_key_status("QwenCloud")
+        assert app.app_config["api_settings"] == original_api_settings
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_settings_qwencloud_api_mode.py
+++ b/Tests/UI/test_settings_qwencloud_api_mode.py
@@ -1,0 +1,443 @@
+"""Canonical Settings coverage for QwenCloud's provider-scoped API mode."""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Select, Static
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    _active_destination_screen,
+)
+from Tests.UI.test_screen_navigation import _build_test_app
+from Tests.UI.test_settings_configuration_hub import _open_settings_category
+from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
+from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderGateway
+from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
+
+
+def _qwencloud_app(*, api_mode: object = "__absent__"):
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {
+        "provider": "QwenCloud",
+        "model": "qwen3.8-max",
+    }
+    qwencloud = {
+        "api_base_url": ("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
+        "api_key_env_var": "DASHSCOPE_API_KEY",
+        "model": "qwen3.8-max",
+    }
+    if api_mode != "__absent__":
+        qwencloud["api_mode"] = api_mode
+    app.app_config["api_settings"] = {"qwencloud": qwencloud}
+    return app
+
+
+def _switch_to_qwencloud(screen) -> None:
+    """Select QwenCloud through the first-class Settings provider inventory."""
+    provider = screen.query_one("#settings-provider-value", Select)
+    provider.value = "qwencloud"
+    screen.handle_provider_value_changed(Select.Changed(provider, "qwencloud"))
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_api_mode_selector_visibility_options_and_default():
+    app = _qwencloud_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        selector = screen.query_one("#settings-provider-api-mode", Select)
+        row = screen.query_one("#settings-provider-api-mode-row")
+        provider = screen.query_one("#settings-provider-value", Select)
+
+        assert selector.value == "responses"
+        assert selector.disabled is False
+        assert selector.can_focus is True
+        assert row.has_class("settings-gated-profile-hidden") is False
+        assert {
+            (str(label), str(value))
+            for label, value in selector._options
+            if value is not Select.NULL
+        } == {
+            ("Responses", "responses"),
+            ("Chat Completions", "chat_completions"),
+        }
+        assert "API mode" in str(row.query_one(".settings-input-label", Static).content)
+        assert provider.value == "qwencloud"
+
+        provider.value = "openai"
+        screen.handle_provider_value_changed(Select.Changed(provider, "openai"))
+        await pilot.pause()
+
+        assert selector.disabled is True
+        assert row.has_class("settings-gated-profile-hidden") is True
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_api_mode_loads_saved_chat_completions():
+    app = _qwencloud_app(api_mode="chat_completions")
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+
+        selector = screen.query_one("#settings-provider-api-mode", Select)
+        assert selector.value == "chat_completions"
+        assert selector.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_normalized_saved_qwencloud_mode_does_not_create_mount_draft():
+    app = _qwencloud_app(api_mode="  Chat_Completions  ")
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+
+        assert (
+            screen.query_one("#settings-provider-api-mode", Select).value
+            == "chat_completions"
+        )
+        assert SettingsCategoryId.PROVIDERS_MODELS not in screen._settings_drafts
+
+
+@pytest.mark.asyncio
+async def test_returning_qwencloud_mode_to_original_removes_only_its_namespace():
+    app = _qwencloud_app(api_mode="responses")
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        screen._stage_provider_value("model", "qwen3.8-max-draft")
+
+        mode.value = "chat_completions"
+        screen.handle_provider_api_mode_changed(
+            Select.Changed(mode, "chat_completions")
+        )
+        mode.value = "responses"
+        screen.handle_provider_api_mode_changed(Select.Changed(mode, "responses"))
+
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["model"] == "qwen3.8-max-draft"
+        assert "provider_api_mode:qwencloud" not in draft.values
+        assert "provider_api_mode:qwencloud" not in draft.originals
+
+
+@pytest.mark.asyncio
+async def test_immediate_qwencloud_save_snapshots_visible_mode(monkeypatch):
+    app = _qwencloud_app(api_mode="responses")
+    saved: list[tuple[str, str, object]] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda section, key, value: saved.append((section, key, value)) or True,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+
+        mode.value = "chat_completions"
+        screen.action_settings_save_category(allow_text_entry_focus=True)
+
+        assert saved == [("api_settings.qwencloud", "api_mode", "chat_completions")]
+        assert app.app_config["api_settings"]["qwencloud"]["api_mode"] == (
+            "chat_completions"
+        )
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_api_mode_accepts_normalized_provider_identity():
+    app = _qwencloud_app(api_mode="responses")
+    app.app_config["chat_defaults"]["provider"] = "  QWENCLOUD  "
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+
+        assert screen.query_one("#settings-provider-value", Select).value == "qwencloud"
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        assert mode.disabled is False
+        assert mode.value == "responses"
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_readiness_overlays_draft_mode_without_persisting():
+    app = _qwencloud_app(api_mode="responses")
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+
+        mode.value = "chat_completions"
+        screen.handle_provider_api_mode_changed(
+            Select.Changed(mode, "chat_completions")
+        )
+        staged = screen._provider_test_staged_config("QWENCLOUD")
+
+        assert staged["api_settings"]["qwencloud"]["api_mode"] == ("chat_completions")
+        assert app.app_config["api_settings"]["qwencloud"]["api_mode"] == "responses"
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_save_failure_preserves_mode_input_and_draft(monkeypatch):
+    app = _qwencloud_app(api_mode="responses")
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda _section, _key, _value: False,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+
+        mode.value = "chat_completions"
+        screen.handle_provider_api_mode_changed(
+            Select.Changed(mode, "chat_completions")
+        )
+        screen.action_settings_save_category(allow_text_entry_focus=True)
+
+        assert mode.value == "chat_completions"
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["provider_api_mode:qwencloud"] == "chat_completions"
+        assert app.app_config["api_settings"]["qwencloud"]["api_mode"] == "responses"
+        assert "Failed to save" in str(
+            screen.query_one("#settings-provider-save-result", Static).content
+        )
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_api_mode_draft_survives_provider_switch():
+    app = _qwencloud_app(api_mode="responses")
+    app.app_config["api_settings"]["openai"] = {
+        "api_base_url": "https://api.openai.com/v1",
+        "model": "gpt-4.1",
+    }
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        provider = screen.query_one("#settings-provider-value", Select)
+
+        # Switch immediately after changing the widget. The provider transition
+        # must snapshot QwenCloud even if its queued Changed event has not run.
+        mode.value = "chat_completions"
+        provider.value = "openai"
+        screen.handle_provider_value_changed(Select.Changed(provider, "openai"))
+        await pilot.pause()
+
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["provider_api_mode:qwencloud"] == "chat_completions"
+        assert mode.disabled is True
+
+        _switch_to_qwencloud(screen)
+        await pilot.pause()
+
+        assert mode.value == "chat_completions"
+        assert mode.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_saving_other_provider_never_mutates_qwencloud_mode(monkeypatch):
+    app = _qwencloud_app(api_mode="responses")
+    app.app_config["api_settings"]["openai"] = {
+        "api_base_url": "https://api.openai.com/v1",
+        "model": "gpt-4.1",
+    }
+    saved: list[tuple[str, str, object]] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda section, key, value: saved.append((section, key, value)) or True,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        provider = screen.query_one("#settings-provider-value", Select)
+
+        mode.value = "chat_completions"
+        screen.handle_provider_api_mode_changed(
+            Select.Changed(mode, "chat_completions")
+        )
+        provider.value = "openai"
+        screen.handle_provider_value_changed(Select.Changed(provider, "openai"))
+        await pilot.pause()
+        await pilot.click("#settings-save-category")
+
+        assert app.app_config["api_settings"]["qwencloud"]["api_mode"] == "responses"
+        assert not any(section == "api_settings.qwencloud" for section, _, _ in saved)
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["provider_api_mode:qwencloud"] == "chat_completions"
+
+        _switch_to_qwencloud(screen)
+        await pilot.pause()
+        assert mode.value == "chat_completions"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("saved_mode", "selected_mode"),
+    [
+        ("responses", "chat_completions"),
+        ("chat_completions", "responses"),
+    ],
+)
+async def test_qwencloud_api_mode_save_and_revert_exact_values(
+    monkeypatch,
+    saved_mode: str,
+    selected_mode: str,
+):
+    app = _qwencloud_app(api_mode=saved_mode)
+    saved: list[tuple[str, str, object]] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda section, key, value: saved.append((section, key, value)) or True,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+
+        mode.value = selected_mode
+        screen.handle_provider_api_mode_changed(Select.Changed(mode, selected_mode))
+        await pilot.click("#settings-save-category")
+
+        assert saved == [
+            ("api_settings.qwencloud", "api_mode", selected_mode),
+        ]
+        assert app.app_config["api_settings"]["qwencloud"]["api_mode"] == selected_mode
+        draft = screen._settings_drafts.get(SettingsCategoryId.PROVIDERS_MODELS)
+        assert draft is None or "provider_api_mode:qwencloud" not in draft.values
+
+        mode.value = saved_mode
+        screen.handle_provider_api_mode_changed(Select.Changed(mode, saved_mode))
+        await pilot.click("#settings-revert-category")
+        await pilot.pause()
+        await pilot.click("#confirm-button")
+        await pilot.pause()
+
+        assert mode.value == selected_mode
+        assert SettingsCategoryId.PROVIDERS_MODELS not in screen._settings_drafts
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "invalid_mode",
+    ["response", "", "   ", 42, False, [], {}],
+    ids=("unknown", "empty", "whitespace", "integer", "boolean", "list", "mapping"),
+)
+async def test_invalid_persisted_qwencloud_mode_blocks_save_and_send(
+    monkeypatch,
+    invalid_mode: object,
+):
+    app = _qwencloud_app(api_mode=invalid_mode)
+    app.app_config["api_settings"]["qwencloud"]["api_key"] = "KEY-CANARY"
+    saved: list[tuple[str, str, object]] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda section, key, value: saved.append((section, key, value)) or True,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+
+        assert mode.has_class("settings-invalid-input")
+        screen.action_settings_save_category(allow_text_entry_focus=True)
+        await pilot.pause()
+
+        assert saved == []
+        assert "QwenCloud API mode is invalid" in str(
+            screen.query_one("#settings-provider-save-result", Static).content
+        )
+        assert app.app_config["api_settings"]["qwencloud"]["api_mode"] == invalid_mode
+
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: app.app_config,
+        environ={},
+        chat_api_call_fn=lambda **_kwargs: pytest.fail(
+            "invalid QwenCloud mode must block before dispatch"
+        ),
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider="QwenCloud")
+    )
+
+    assert resolution.ready is False
+    assert "invalid API mode setting" in resolution.visible_copy
+    assert "KEY-CANARY" not in resolution.visible_copy
+
+
+@pytest.mark.asyncio
+async def test_invalid_qwencloud_mode_can_be_explicitly_corrected_to_responses(
+    monkeypatch,
+):
+    app = _qwencloud_app(api_mode="invalid")
+    saved: list[tuple[str, str, object]] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda section, key, value: saved.append((section, key, value)) or True,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        mode.focus()
+        await pilot.pause()
+
+        screen.handle_provider_api_mode_changed(Select.Changed(mode, "responses"))
+        screen.action_settings_save_category(allow_text_entry_focus=True)
+
+        assert saved == [("api_settings.qwencloud", "api_mode", "responses")]
+        assert app.app_config["api_settings"]["qwencloud"]["api_mode"] == "responses"
+        assert mode.has_class("settings-invalid-input") is False
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_api_mode_field_guide_describes_mode_contract():
+    app = _qwencloud_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        mode.focus()
+        await pilot.pause()
+
+        assert screen._active_settings_field_id == "settings-provider-api-mode"
+        guide = " | ".join(
+            f"{label}: {value}"
+            for label, value in screen._provider_field_guidance_rows()
+        )
+        assert "Focused setting: API mode" in guide
+        assert "api_settings.qwencloud.api_mode" in guide
+        assert "Responses is stateless with store=false" in guide
+        assert "Chat Completions disables thinking replay" in guide
+        assert "existing function tools work in both" in guide
+        assert "QwenCloud built-in tools are excluded" in guide
+
+        ownership = screen._ownership_record(SettingsCategoryId.PROVIDERS_MODELS)
+        assert "api_settings.<provider>.api_mode" in ownership.owns_config_sections

--- a/Tests/UI/test_settings_qwencloud_api_mode.py
+++ b/Tests/UI/test_settings_qwencloud_api_mode.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
+
 import pytest
-from textual.widgets import Select, Static
+from textual.widgets import Input, Select, Static
 
 from Tests.UI.test_destination_shells import (
     DestinationHarness,
@@ -362,7 +364,9 @@ async def test_invalid_persisted_qwencloud_mode_blocks_save_and_send(
         screen = _active_destination_screen(host)
         mode = screen.query_one("#settings-provider-api-mode", Select)
 
+        assert mode.value is Select.NULL
         assert mode.has_class("settings-invalid-input")
+        assert SettingsCategoryId.PROVIDERS_MODELS not in screen._settings_drafts
         screen.action_settings_save_category(allow_text_entry_focus=True)
         await pilot.pause()
 
@@ -389,7 +393,7 @@ async def test_invalid_persisted_qwencloud_mode_blocks_save_and_send(
 
 
 @pytest.mark.asyncio
-async def test_invalid_qwencloud_mode_can_be_explicitly_corrected_to_responses(
+async def test_invalid_qwencloud_mode_keyboard_selection_repairs_to_responses(
     monkeypatch,
 ):
     app = _qwencloud_app(api_mode="invalid")
@@ -404,15 +408,31 @@ async def test_invalid_qwencloud_mode_can_be_explicitly_corrected_to_responses(
         await _open_settings_category(pilot, "#settings-category-providers-models")
         screen = _active_destination_screen(host)
         mode = screen.query_one("#settings-provider-api-mode", Select)
+
+        assert mode.value is Select.NULL
+        assert SettingsCategoryId.PROVIDERS_MODELS not in screen._settings_drafts
+        assert "Open API mode and choose Responses or Chat Completions" in str(
+            screen.query_one("#settings-provider-api-mode-guidance", Static).content
+        )
+
         mode.focus()
         await pilot.pause()
+        await pilot.press("enter")
+        assert mode.expanded is True
+        await pilot.press("down")
+        await pilot.press("enter")
+        await pilot.pause()
 
-        screen.handle_provider_api_mode_changed(Select.Changed(mode, "responses"))
-        screen.action_settings_save_category(allow_text_entry_focus=True)
+        assert mode.expanded is False
+        assert mode.value == "responses"
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["provider_api_mode:qwencloud"] == "responses"
+        assert mode.has_class("settings-invalid-input") is False
+
+        await pilot.click("#settings-save-category")
 
         assert saved == [("api_settings.qwencloud", "api_mode", "responses")]
         assert app.app_config["api_settings"]["qwencloud"]["api_mode"] == "responses"
-        assert mode.has_class("settings-invalid-input") is False
 
 
 @pytest.mark.asyncio
@@ -441,3 +461,201 @@ async def test_qwencloud_api_mode_field_guide_describes_mode_contract():
 
         ownership = screen._ownership_record(SettingsCategoryId.PROVIDERS_MODELS)
         assert "api_settings.<provider>.api_mode" in ownership.owns_config_sections
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_alias_mode_save_migrates_only_mode_to_canonical_owner(
+    monkeypatch,
+):
+    app = _qwencloud_app(api_mode="responses")
+    alias_fields = {
+        "api_mode": "responses",
+        "api_base_url": "https://proxy.example.com/compatible-mode/v1",
+        "api_key_env_var": "DASHSCOPE_API_KEY",
+        "model": "qwen3.8-max",
+    }
+    other_provider = {"api_base_url": "https://api.openai.com/v1"}
+    app.app_config["api_settings"] = {
+        "QwenCloud": dict(alias_fields),
+        "openai": dict(other_provider),
+    }
+    atomic_mutations: list[tuple[dict, dict | None]] = []
+    noncanonical_writes: list[tuple[str, str, object]] = []
+
+    def save_atomic(section_values, *, delete_keys=None):
+        atomic_mutations.append(
+            (
+                deepcopy(dict(section_values)),
+                deepcopy(dict(delete_keys)) if delete_keys is not None else None,
+            )
+        )
+        return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_screen.save_settings_to_cli_config",
+        save_atomic,
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda section, key, value: (
+            noncanonical_writes.append((section, key, value)) or True
+        ),
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+
+        mode.value = "chat_completions"
+        screen.handle_provider_api_mode_changed(
+            Select.Changed(mode, "chat_completions")
+        )
+        await pilot.click("#settings-save-category")
+
+    assert noncanonical_writes == []
+    assert atomic_mutations == [
+        (
+            {"api_settings.qwencloud": {"api_mode": "chat_completions"}},
+            {"api_settings.QwenCloud": ("api_mode",)},
+        )
+    ]
+    assert app.app_config["api_settings"]["qwencloud"] == {
+        "api_mode": "chat_completions"
+    }
+    assert app.app_config["api_settings"]["QwenCloud"] == {
+        key: value for key, value in alias_fields.items() if key != "api_mode"
+    }
+    assert app.app_config["api_settings"]["openai"] == other_provider
+
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: app.app_config,
+        environ={"DASHSCOPE_API_KEY": "TEST-KEY"},
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider="QwenCloud")
+    )
+    assert resolution.ready is True
+    assert resolution.api_mode == "chat_completions"
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_alias_mode_migration_waits_for_other_provider_writes(
+    monkeypatch,
+):
+    app = _qwencloud_app(api_mode="responses")
+    app.app_config["api_settings"] = {
+        "QwenCloud": {
+            "api_mode": "responses",
+            "api_base_url": "https://old.example.test/compatible-mode/v1",
+            "api_key_env_var": "DASHSCOPE_API_KEY",
+            "model": "qwen3.8-max",
+        }
+    }
+    atomic_mutations: list[tuple[dict, dict | None]] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_screen.save_settings_to_cli_config",
+        lambda section_values, *, delete_keys=None: (
+            atomic_mutations.append(
+                (dict(section_values), dict(delete_keys) if delete_keys else None)
+            )
+            or True
+        ),
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda _section, _key, _value: False,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        endpoint = screen.query_one("#settings-provider-endpoint-value", Input)
+        endpoint.value = "https://new.example.test/compatible-mode/v1"
+        screen._stage_provider_value("endpoint", endpoint.value)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        mode.value = "chat_completions"
+        screen.handle_provider_api_mode_changed(
+            Select.Changed(mode, "chat_completions")
+        )
+
+        await pilot.click("#settings-save-category")
+
+        assert atomic_mutations == []
+        assert "qwencloud" not in app.app_config["api_settings"]
+        assert app.app_config["api_settings"]["QwenCloud"]["api_mode"] == "responses"
+        draft = screen._settings_drafts[SettingsCategoryId.PROVIDERS_MODELS]
+        assert draft.values["provider_api_mode:qwencloud"] == "chat_completions"
+        assert endpoint.value == "https://new.example.test/compatible-mode/v1"
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_canonical_mode_wins_over_alias_for_settings_and_readiness():
+    app = _qwencloud_app(api_mode="responses")
+    app.app_config["api_settings"] = {
+        "QwenCloud": {
+            "api_mode": "chat_completions",
+            "api_base_url": "https://proxy.example.com/compatible-mode/v1",
+            "api_key_env_var": "DASHSCOPE_API_KEY",
+            "model": "qwen3.8-max",
+        },
+        "qwencloud": {"api_mode": "responses"},
+    }
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+
+        assert mode.value == "responses"
+        assert SettingsCategoryId.PROVIDERS_MODELS not in screen._settings_drafts
+
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: app.app_config,
+        environ={"DASHSCOPE_API_KEY": "TEST-KEY"},
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider="QwenCloud")
+    )
+    assert resolution.ready is True
+    assert resolution.api_mode == "responses"
+
+
+@pytest.mark.asyncio
+async def test_qwencloud_alias_config_readiness_overlay_uses_draft_canonical_mode():
+    app = _qwencloud_app(api_mode="responses")
+    app.app_config["api_settings"] = {
+        "QwenCloud": {
+            "api_mode": "responses",
+            "api_key_env_var": "DASHSCOPE_API_KEY",
+            "model": "qwen3.8-max",
+        },
+        "qwencloud": {"api_mode": "responses"},
+    }
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        mode = screen.query_one("#settings-provider-api-mode", Select)
+        mode.value = "chat_completions"
+        screen.handle_provider_api_mode_changed(
+            Select.Changed(mode, "chat_completions")
+        )
+
+        staged = screen._provider_test_staged_config("QwenCloud")
+
+    assert staged["api_settings"]["qwencloud"]["api_mode"] == "chat_completions"
+    assert app.app_config["api_settings"]["qwencloud"]["api_mode"] == "responses"
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: staged,
+        environ={"DASHSCOPE_API_KEY": "TEST-KEY"},
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(provider="QwenCloud")
+    )
+    assert resolution.ready is True
+    assert resolution.api_mode == "chat_completions"

--- a/Tests/UI/test_settings_save_commit_models.py
+++ b/Tests/UI/test_settings_save_commit_models.py
@@ -171,6 +171,7 @@ def test_guidance_row_builders_keep_a_uniform_row_count():
         "settings-provider-manual-value",
         "settings-model-value",
         "settings-provider-endpoint-value",
+        "settings-provider-api-mode",
         "settings-provider-api-key",
         "settings-provider-credential-env-var",
         "settings-model-profile-temperature",

--- a/backlog/decisions/045-qwencloud-dual-api-provider-boundary.md
+++ b/backlog/decisions/045-qwencloud-dual-api-provider-boundary.md
@@ -18,13 +18,28 @@ the dedicated QwenCloud adapter's endpoint, request mapping, and response/event
 translation. It does not create separate provider identities, model catalogs,
 readiness systems, Console paths, or agent runtimes.
 
+Console resolves and pins that value, with the effective QwenCloud base URL,
+in its ordinary provider resolution before a run. Shared resolution and
+dispatch code only carries those values; it never branches on the mode to map
+wire formats or continue tools. Direct callers may pass an explicit mode, and
+the adapter otherwise applies the same config/default resolution.
+
 Both external APIs normalize to Chatbook's existing OpenAI-style internal
 message contract. QwenCloud therefore uses the existing provider dispatcher,
 Console gateway, native tool-call accumulator, `AgentService`, `agent_runtime`,
 approval/execution policies, budgets, cancellation, run logs, and model-catalog
 pipeline. Responses continuations are stateless translations of the canonical
 assistant `tool_calls` and paired `role="tool"` history; Chatbook does not use
-or persist `previous_response_id`.
+or persist `previous_response_id` or a QwenCloud conversation ID. The
+Responses mapper emits each `function_call` immediately followed by its paired
+`function_call_output`, as QwenCloud requires, even though canonical history
+stores a call batch before its result batch.
+
+Chatbook does not persist private reasoning content. The Chat Completions
+adapter therefore disables preserved-thinking replay, which `qwen3.8-max`
+otherwise enables by default and requires callers to echo exactly. Responses
+requests include `store=false` where the compatible endpoint honors it, but
+Chatbook makes no claim about provider operational retention.
 
 Only existing Chatbook function tools are supported in this tranche.
 QwenCloud-hosted built-in tools are excluded and require a separate decision
@@ -72,9 +87,15 @@ those established boundaries to QwenCloud's two external APIs.
 - The adapter is more involved than a simple OpenAI-compatible wrapper because
   Responses needs bidirectional message/tool translation and stream-event
   normalization.
+- The Responses mapper validates exact one-to-one tool call/results and
+  reorders only within a canonical call/result batch to meet the external
+  adjacency rule.
+- Chat Completions deliberately gives up preserved historical reasoning until
+  Chatbook has an explicit, privacy-reviewed reasoning-content contract.
 - Tool behavior remains provider-neutral: the adapter never executes a tool or
   decides continuation policy.
-- No schema migration or durable QwenCloud response state is introduced.
+- No schema migration or durable QwenCloud response/conversation state is
+  introduced.
 - Adding hosted QwenCloud tools, per-session API-mode overrides, or server-side
   Responses state later requires a new ADR check.
 
@@ -88,6 +109,11 @@ forwards schemas, returns canonical calls, and accepts canonical tool history.
 
 Optional paid live checks remain explicitly gated, credential-isolated, and
 outside the default suite.
+
+The contract suite also proves mode/base pinning through the shared resolution
+and dispatcher, Responses call/output adjacency, Qwen SSE framing and
+delta/terminal de-duplication, terminal usage/finish normalization, Chat
+streaming usage opt-in, and the adapter-owned state/reasoning invariants.
 
 ## Links
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -226,6 +226,31 @@ after the fact** over raising inside code that catches broadly.
 
 ---
 
+## Trigger cancellation from the state the test claims to cancel
+
+**TASK-3771, 2026-08-11.** A QwenCloud native-tool regression claimed to prove
+that cancelling after an incomplete streamed function call never executes the
+tool. The test actually set its cancellation flag in the mock server's
+``on_request`` callback, before the response body or partial call reached the
+stream parser. Replacing both partial-call fixtures with ordinary final text
+still passed: the test proved only pre-response cancellation and closure.
+
+The corrected test waits until the real ``ConsoleChatStore`` receives a visible
+checkpoint that follows an incomplete tool-call delta, then requests
+cancellation while the chunked response remains non-terminal. A text-only
+mutation now fails at the fixture guard, and the test separately proves the
+live response closes exactly once without executing or pairing the partial
+call.
+
+**What to do.** If a cancellation test names a lifecycle state (after headers,
+after one chunk, after partial tool state), trigger cancellation from an
+observation downstream of that exact state. Do not trigger it at request
+receipt and infer that later layers ran. Mutation-replace the special prefix
+with a normal successful response; the test must fail for the reason it claims
+to cover.
+
+---
+
 ## A surviving mutant usually means a SECOND writer satisfies your assertion
 
 **The trap.** You delete the code under test, the test stays green, and the reflex is

--- a/backlog/tasks/task-3771 - Add-QwenCloud-dual-API-provider-support.md
+++ b/backlog/tasks/task-3771 - Add-QwenCloud-dual-API-provider-support.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-03 03:24'
-updated_date: '2026-08-07'
+updated_date: '2026-08-11'
 labels:
   - provider
   - qwencloud
@@ -14,6 +14,7 @@ labels:
 dependencies: []
 references:
   - Docs/superpowers/specs/2026-08-02-qwencloud-dual-api-provider-design.md
+  - Docs/superpowers/plans/2026-08-11-qwencloud-dual-api-provider-implementation.md
   - backlog/decisions/045-qwencloud-dual-api-provider-boundary.md
   - backlog/decisions/006-provider-aware-generation-settings.md
   - backlog/decisions/012-provider-credential-settings-boundary.md
@@ -33,14 +34,14 @@ or Chat Completions as its external API mode.
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 QwenCloud is selectable anywhere an ordinary hosted Console provider is selectable and passes shared provider readiness with its own endpoint and credential configuration.
-- [ ] #2 `api_mode` persists under `api_settings.qwencloud`, defaults to `responses`, and accepts only `responses` or `chat_completions`.
-- [ ] #3 Streaming and non-streaming text work through the standard provider dispatcher and Console gateway in both API modes.
-- [ ] #4 Existing Chatbook function tools work in both modes through the existing native Console agent runtime, including multiple calls, paired tool results, errors, cancellation, and structured continuation without synthetic user messages.
+- [ ] #2 `api_mode` persists under `api_settings.qwencloud`, defaults to `responses`, accepts only `responses` or `chat_completions`, and is pinned with the effective base URL for every turn of a Console run.
+- [ ] #3 Streaming and non-streaming text, finish state, and token usage work through the standard provider dispatcher and Console gateway in both API modes.
+- [ ] #4 Existing Chatbook function tools work in both modes through the existing native Console agent runtime, including provider-emitted multiple-call batches, exact call/result pairing, errors, cancellation, and structured continuation without synthetic user messages.
 - [ ] #5 QwenCloud model discovery participates in the existing cached model-catalog pipeline and does not create a parallel model source.
 - [ ] #6 Canonical F9 Settings exposes QwenCloud API mode without changing another provider's configuration or behavior.
-- [ ] #7 Request translation uses mode-specific parameter allowlists; invalid tools, messages, endpoints, modes, and unsupported content fail before network I/O.
-- [ ] #8 Automated tests cover provider parity, registration, configuration, translation, streaming, native-tool continuation, discovery, retries, cancellation, and safe errors without paid API calls.
-- [ ] #9 Provider documentation records setup, API-mode behavior, parameter limitations, existing function-tool support, built-in-tool exclusion, and optional isolated live verification.
+- [ ] #7 Request translation uses mode-specific parameter allowlists and enforces Responses call/output adjacency and stateless-request invariants plus Chat Completions reasoning-replay safety; invalid tools, messages, endpoints, modes, and unsupported content fail before network I/O.
+- [ ] #8 Automated tests cover provider parity, registration, pinned resolution, configuration, translation, SSE framing/de-duplication, usage, native-tool continuation, discovery, retries, cancellation, and safe errors without paid API calls.
+- [ ] #9 Provider documentation records setup, API-mode behavior, regional endpoint guidance, state/reasoning behavior, parameter limitations, existing function-tool support, built-in-tool exclusion, and optional isolated live verification.
 <!-- AC:END -->
 
 ## Task Identity Note
@@ -50,3 +51,27 @@ sweep found an older SoundDevice/VAD task using the same identifier. It moved
 again from `TASK-3603` to `TASK-3771` after the completed Watchlists phase 3
 task merged to `dev` with the same identifier. `TASK-3771` was unclaimed across
 all remote refs and checked worktrees on 2026-08-08.
+
+## Implementation Plan
+
+The executable TDD plan is
+`Docs/superpowers/plans/2026-08-11-qwencloud-dual-api-provider-implementation.md`.
+Its work is ordered as follows:
+
+1. Register QwenCloud configuration, identity, readiness, and endpoint rules.
+2. Implement fail-closed dual-mode request, history, and tool translation.
+3. Add non-streaming transport, normalization, retries, dispatch, and safe errors.
+4. Add record-aware SSE translation and deterministic stream closure.
+5. Pin mode/base in Console and carry usage/cancellation through the gateway.
+6. Prove the real native-tool continuation path in both modes before enabling it.
+7. Add the provider-isolated API mode selector to canonical F9 Settings.
+8. Join the existing cached model-catalog pipeline.
+9. Document, verify, self-review, and close out the task only when all evidence is complete.
+
+ADR required: yes
+
+ADR path: `backlog/decisions/045-qwencloud-dual-api-provider-boundary.md`
+
+Reason: QwenCloud changes a provider/runtime boundary; ADR-045 already records
+the approved dual-mode adapter ownership and pinned Console handoff, so a new
+ADR would duplicate the existing decision.

--- a/backlog/tasks/task-3771 - Add-QwenCloud-dual-API-provider-support.md
+++ b/backlog/tasks/task-3771 - Add-QwenCloud-dual-API-provider-support.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-3771
 title: Add QwenCloud dual API provider support
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-03 03:24'
-updated_date: '2026-08-11'
+updated_date: '2026-08-12 13:44'
 labels:
   - provider
   - qwencloud
@@ -14,7 +14,8 @@ labels:
 dependencies: []
 references:
   - Docs/superpowers/specs/2026-08-02-qwencloud-dual-api-provider-design.md
-  - Docs/superpowers/plans/2026-08-11-qwencloud-dual-api-provider-implementation.md
+  - >-
+    Docs/superpowers/plans/2026-08-11-qwencloud-dual-api-provider-implementation.md
   - backlog/decisions/045-qwencloud-dual-api-provider-boundary.md
   - backlog/decisions/006-provider-aware-generation-settings.md
   - backlog/decisions/012-provider-credential-settings-boundary.md
@@ -33,27 +34,20 @@ or Chat Completions as its external API mode.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 QwenCloud is selectable anywhere an ordinary hosted Console provider is selectable and passes shared provider readiness with its own endpoint and credential configuration.
-- [ ] #2 `api_mode` persists under `api_settings.qwencloud`, defaults to `responses`, accepts only `responses` or `chat_completions`, and is pinned with the effective base URL for every turn of a Console run.
-- [ ] #3 Streaming and non-streaming text, finish state, and token usage work through the standard provider dispatcher and Console gateway in both API modes.
-- [ ] #4 Existing Chatbook function tools work in both modes through the existing native Console agent runtime, including provider-emitted multiple-call batches, exact call/result pairing, errors, cancellation, and structured continuation without synthetic user messages.
-- [ ] #5 QwenCloud model discovery participates in the existing cached model-catalog pipeline and does not create a parallel model source.
-- [ ] #6 Canonical F9 Settings exposes QwenCloud API mode without changing another provider's configuration or behavior.
-- [ ] #7 Request translation uses mode-specific parameter allowlists and enforces Responses call/output adjacency and stateless-request invariants plus Chat Completions reasoning-replay safety; invalid tools, messages, endpoints, modes, and unsupported content fail before network I/O.
-- [ ] #8 Automated tests cover provider parity, registration, pinned resolution, configuration, translation, SSE framing/de-duplication, usage, native-tool continuation, discovery, retries, cancellation, and safe errors without paid API calls.
-- [ ] #9 Provider documentation records setup, API-mode behavior, regional endpoint guidance, state/reasoning behavior, parameter limitations, existing function-tool support, built-in-tool exclusion, and optional isolated live verification.
+- [x] #1 QwenCloud is selectable anywhere an ordinary hosted Console provider is selectable and passes shared provider readiness with its own endpoint and credential configuration.
+- [x] #2 `api_mode` persists under `api_settings.qwencloud`, defaults to `responses`, accepts only `responses` or `chat_completions`, and is pinned with the effective base URL for every turn of a Console run.
+- [x] #3 Streaming and non-streaming text, finish state, and token usage work through the standard provider dispatcher and Console gateway in both API modes.
+- [x] #4 Existing Chatbook function tools work in both modes through the existing native Console agent runtime, including provider-emitted multiple-call batches, exact call/result pairing, errors, cancellation, and structured continuation without synthetic user messages.
+- [x] #5 QwenCloud model discovery participates in the existing cached model-catalog pipeline and does not create a parallel model source.
+- [x] #6 Canonical F9 Settings exposes QwenCloud API mode without changing another provider's configuration or behavior.
+- [x] #7 Request translation uses mode-specific parameter allowlists and enforces Responses call/output adjacency and stateless-request invariants plus Chat Completions reasoning-replay safety; invalid tools, messages, endpoints, modes, and unsupported content fail before network I/O.
+- [x] #8 Automated tests cover provider parity, registration, pinned resolution, configuration, translation, SSE framing/de-duplication, usage, native-tool continuation, discovery, retries, cancellation, and safe errors without paid API calls.
+- [x] #9 Provider documentation records setup, API-mode behavior, regional endpoint guidance, state/reasoning behavior, parameter limitations, existing function-tool support, built-in-tool exclusion, and optional isolated live verification.
 <!-- AC:END -->
-
-## Task Identity Note
-
-This task was renumbered from `TASK-1336` after a full remote-ref and worktree
-sweep found an older SoundDevice/VAD task using the same identifier. It moved
-again from `TASK-3603` to `TASK-3771` after the completed Watchlists phase 3
-task merged to `dev` with the same identifier. `TASK-3771` was unclaimed across
-all remote refs and checked worktrees on 2026-08-08.
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 The executable TDD plan is
 `Docs/superpowers/plans/2026-08-11-qwencloud-dual-api-provider-implementation.md`.
 Its work is ordered as follows:
@@ -75,11 +69,11 @@ ADR path: `backlog/decisions/045-qwencloud-dual-api-provider-boundary.md`
 Reason: QwenCloud changes a provider/runtime boundary; ADR-045 already records
 the approved dual-mode adapter ownership and pinned Console handoff, so a new
 ADR would duplicate the existing decision.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
-*Draft — final closeout pending.*
-
+<!-- SECTION:NOTES:BEGIN -->
 - Added one first-class `qwencloud` provider across configuration, readiness,
   dispatch, Console, canonical F9 Settings, native function tools, and the
   shared cached model catalog. The dedicated adapter normalizes Responses and
@@ -98,25 +92,43 @@ ADR would duplicate the existing decision.
   `README.md` and the Settings/Console user guides. Added a two-mode live test
   isolated by `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `TLDW_CONFIG_PATH`,
   and `[paths].data_dir` before Chatbook imports.
-- Evidence to date: the focused adapter, streaming, provider-contract,
-  native-tool, Settings, model-discovery, and live-test collection suite passed
-  outside the managed sandbox with `530 passed, 2 skipped`. The two skips are
-  the paid live modes; the user did not authorize paid calls, so
-  `TLDW_LIVE_QWENCLOUD` remained unset and no live QwenCloud request was made.
-  The identical in-sandbox run had 18 localhost fixture bind failures
-  (`PermissionError`) and otherwise `512 passed, 2 skipped`; rerunning where
-  localhost binding is permitted resolved all 18.
-- Task 9 checks also verified both paid cases collect and skip by default;
-  Ruff, Ruff format, MyPy, compileall, `git diff --check`, and the scoped
-  documentation term/link/anchor check pass. No credential, prompt, or
-  response content is emitted by the live harness. Structural guards verify
-  that its expected calculator-derived marker is absent from the initial
-  prompts, a mutated calculator result fails validation, and profile paths are
-  isolated before Chatbook imports. The follow-up live-harness and exact
-  parameter checks passed with `16 passed, 2 skipped`; the skips remained the
-  paid modes, and no paid live request was run.
+- Rebased the complete feature stack onto current `origin/dev` (`1b30717cb`)
+  before final verification. The focused adapter, streaming, provider
+  contract, native-tool, Settings, readiness, catalog, gateway, bridge, usage,
+  and live-test collection gate passed with `517 passed, 2 skipped, 423
+  deselected`. The two skips are the paid live modes; `TLDW_LIVE_QWENCLOUD`
+  remained unset and no paid request was made.
+- Every changed test file then produced `1498 passed, 2 skipped, 2 xfailed, 4
+  failed`. The four failures were the existing canonical Settings nodes
+  `test_settings_ownership_records_cover_categories_and_runtime_boundaries`,
+  `test_settings_console_behavior_saves_display_name_exactly`,
+  `test_settings_provider_category_saves_provider_defaults_without_sampling`,
+  and `test_settings_provider_switch_does_not_save_stale_endpoint`; the exact
+  four-node command failed identically on a clean current `origin/dev`
+  worktree. A repository-wide run reached 89% after 8h35m before becoming stale
+  when `origin/dev` advanced; it was interrupted and is not used as passing
+  feature evidence.
+- Ruff lint, MyPy for the QwenCloud URL/request/stream and discovery modules,
+  compileall, and `git diff --check` pass on the rebased tree. Ruff format finds
+  the same four legacy shared files on both the branch and clean
+  `origin/dev`; all feature-owned/new files are formatted and there is no new
+  formatter debt. Documentation term/link/anchor and live-harness isolation
+  checks pass; no credential, prompt, or response content is emitted.
+- Added the TASK-3771 cancellation incident to
+  `backlog/docs/lessons-testing-evidence.md`: the original test cancelled at
+  request receipt and survived a text-only mutation, while the corrected test
+  triggers from a real downstream partial-tool checkpoint and proves exact
+  stream closure without execution.
 - Architecture: follows
   [ADR-045](../decisions/045-qwencloud-dual-api-provider-boundary.md), with no
   implementation deviation from its provider/runtime ownership. No schema
-  migration was required. Final whole-repository verification, acceptance
-  checklist updates, and status transition remain for closeout.
+  migration was required.
+<!-- SECTION:NOTES:END -->
+
+## Task Identity Note
+
+This task was renumbered from `TASK-1336` after a full remote-ref and worktree
+sweep found an older SoundDevice/VAD task using the same identifier. It moved
+again from `TASK-3603` to `TASK-3771` after the completed Watchlists phase 3
+task merged to `dev` with the same identifier. `TASK-3771` was unclaimed across
+all remote refs and checked worktrees on 2026-08-08.

--- a/backlog/tasks/task-3771 - Add-QwenCloud-dual-API-provider-support.md
+++ b/backlog/tasks/task-3771 - Add-QwenCloud-dual-API-provider-support.md
@@ -75,3 +75,40 @@ ADR path: `backlog/decisions/045-qwencloud-dual-api-provider-boundary.md`
 Reason: QwenCloud changes a provider/runtime boundary; ADR-045 already records
 the approved dual-mode adapter ownership and pinned Console handoff, so a new
 ADR would duplicate the existing decision.
+
+## Implementation Notes
+
+*Draft — final closeout pending.*
+
+- Added one first-class `qwencloud` provider across configuration, readiness,
+  dispatch, Console, canonical F9 Settings, native function tools, and the
+  shared cached model catalog. The dedicated adapter normalizes Responses and
+  Chat Completions into the existing internal contracts; no Qwen-specific
+  agent loop, cache, Settings surface, or built-in-tool execution path was
+  introduced.
+- Implemented stateless Responses history with `store=false`, exact
+  call/output pairing, Chat preserved-thinking replay disabled, fail-closed
+  mode-specific parameters, record-aware streaming, terminal usage, bounded
+  retries, and deterministic response closure/cancellation.
+- Documented setup, endpoint and mode selection, parameter limits, tool scope,
+  discovery, pricing uncertainty, recovery, and optional paid verification in
+  `README.md` and the Settings/Console user guides. Added a two-mode live test
+  isolated by `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `TLDW_CONFIG_PATH`,
+  and `[paths].data_dir` before Chatbook imports.
+- Evidence to date: the focused adapter, streaming, provider-contract,
+  native-tool, Settings, model-discovery, and live-test collection suite passed
+  outside the managed sandbox with `530 passed, 2 skipped`. The two skips are
+  the paid live modes; the user did not authorize paid calls, so
+  `TLDW_LIVE_QWENCLOUD` remained unset and no live QwenCloud request was made.
+  The identical in-sandbox run had 18 localhost fixture bind failures
+  (`PermissionError`) and otherwise `512 passed, 2 skipped`; rerunning where
+  localhost binding is permitted resolved all 18.
+- Task 9 checks also verified both paid cases collect and skip by default;
+  Ruff, Ruff format, MyPy, compileall, `git diff --check`, and the scoped
+  documentation term/link/anchor check pass. No credential, prompt, or
+  response content is emitted by the live harness.
+- Architecture: follows
+  [ADR-045](../decisions/045-qwencloud-dual-api-provider-boundary.md), with no
+  implementation deviation from its provider/runtime ownership. No schema
+  migration was required. Final whole-repository verification, acceptance
+  checklist updates, and status transition remain for closeout.

--- a/backlog/tasks/task-3771 - Add-QwenCloud-dual-API-provider-support.md
+++ b/backlog/tasks/task-3771 - Add-QwenCloud-dual-API-provider-support.md
@@ -86,7 +86,10 @@ ADR would duplicate the existing decision.
   Chat Completions into the existing internal contracts; no Qwen-specific
   agent loop, cache, Settings surface, or built-in-tool execution path was
   introduced.
-- Implemented stateless Responses history with `store=false`, exact
+- Implemented Chatbook-side stateless Responses history without sending
+  provider continuation IDs, requesting `store=false` where honored, and
+  without relying on provider-managed session state. This makes no claim
+  about provider operational retention or caching. Also implemented exact
   call/output pairing, Chat preserved-thinking replay disabled, fail-closed
   mode-specific parameters, record-aware streaming, terminal usage, bounded
   retries, and deterministic response closure/cancellation.
@@ -106,7 +109,12 @@ ADR would duplicate the existing decision.
 - Task 9 checks also verified both paid cases collect and skip by default;
   Ruff, Ruff format, MyPy, compileall, `git diff --check`, and the scoped
   documentation term/link/anchor check pass. No credential, prompt, or
-  response content is emitted by the live harness.
+  response content is emitted by the live harness. Structural guards verify
+  that its expected calculator-derived marker is absent from the initial
+  prompts, a mutated calculator result fails validation, and profile paths are
+  isolated before Chatbook imports. The follow-up live-harness and exact
+  parameter checks passed with `16 passed, 2 skipped`; the skips remained the
+  paid modes, and no paid live request was run.
 - Architecture: follows
   [ADR-045](../decisions/045-qwencloud-dual-api-provider-boundary.md), with no
   implementation deviation from its provider/runtime ownership. No schema

--- a/tldw_chatbook/Agents/native_tools.py
+++ b/tldw_chatbook/Agents/native_tools.py
@@ -32,6 +32,10 @@ NATIVE_TOOLS_PROVIDERS = frozenset(
         "mistral",
         "deepseek",
         "moonshot",
+        # TASK-3771: both QwenCloud wire modes normalize function calls to
+        # OpenAI shape and translate canonical assistant/tool continuation.
+        # Joined Console tests exercise the real dispatcher and HTTP boundary.
+        "qwencloud",
         "custom-openai-api",
         "custom-openai-api-2",
         # task-263: chat_with_anthropic converts OpenAI tools/tool-history to

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -77,6 +77,7 @@ from tldw_chatbook.LLM_Calls.LLM_API_Calls_Local import (  # noqa: E402
     chat_with_custom_openai_2,
     chat_with_mlx_lm,
 )
+from tldw_chatbook.LLM_Calls.qwencloud import chat_with_qwencloud  # noqa: E402
 from tldw_chatbook.Utils.Utils import generate_unique_filename  # noqa: E402
 from tldw_chatbook.Utils.sensitive_llm_logging import (  # noqa: E402
     is_sensitive_llm_request,
@@ -116,6 +117,7 @@ API_CALL_HANDLERS = {
     "huggingface": chat_with_huggingface,
     "moonshot": chat_with_moonshot,
     "zai": chat_with_zai,
+    "qwencloud": chat_with_qwencloud,
     "llama_cpp": chat_with_llama,
     "koboldcpp": chat_with_kobold,
     "oobabooga": chat_with_oobabooga,
@@ -153,6 +155,7 @@ SENSITIVE_AUXILIARY_AUDITED_ENDPOINTS = frozenset(
         "huggingface",
         "moonshot",
         "zai",
+        "qwencloud",
         "llama_cpp",
         "koboldcpp",
         "oobabooga",
@@ -181,6 +184,29 @@ FIXME: The mappings and handlers should be validated for correctness.
 # 2. Parameter mapping for each provider
 # Maps generic chat_api_call param name to provider-specific param name
 PROVIDER_PARAM_MAP = {
+    "qwencloud": {
+        "messages_payload": "input_data",
+        "model": "model",
+        "api_key": "api_key",
+        "system_message": "system_message",
+        "temp": "temp",
+        "streaming": "streaming",
+        "topp": "topp",
+        "topk": "topk",
+        "max_tokens": "max_tokens",
+        "seed": "seed",
+        "stop": "stop",
+        "logprobs": "logprobs",
+        "top_logprobs": "top_logprobs",
+        "presence_penalty": "presence_penalty",
+        "response_format": "response_format",
+        "n": "n",
+        "tools": "tools",
+        "tool_choice": "tool_choice",
+        "reasoning_effort": "reasoning_effort",
+        "api_base_url": "api_base_url",
+        "api_mode": "api_mode",
+    },
     "openai": {
         "api_key": "api_key",
         "messages_payload": "input_data",
@@ -780,6 +806,7 @@ def chat_api_call(
     prompt_caching: Optional[bool] = None,
     llm_fixed_tokens_kobold: Optional[bool] = False,  # Added
     api_base_url: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ):
     """
     Acts as a unified dispatcher to call various LLM API providers.
@@ -794,6 +821,8 @@ def chat_api_call(
         messages_payload: A list of message objects (OpenAI format: `{'role': ..., 'content': ...}`)
                           representing the conversation history and current user message.
         api_base_url: Optional request-pinned provider endpoint override.
+        api_mode: Optional provider-specific external API mode. Only mapped
+            providers receive this value.
         api_key: The API key for the specified provider.
         temp: Temperature for sampling, controlling randomness.
         system_message: An optional system-level instruction for the LLM. How this is

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -68,6 +68,8 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleMessageRole,
 )
 from tldw_chatbook.Chat.console_provider_gateway import (
+    ConsoleProviderCallSignals,
+    ConsoleProviderGateway,
     ConsoleProviderStreamSignals,
     ProviderToolCalls,
 )
@@ -283,6 +285,7 @@ FIND_LOAD_DISCOVERY_HINT = (
     "schemas before calling them."
 )
 
+
 def _combine_state_scopes(scopes: list) -> "Any | None":
     """Combine per-turn state scopes into the one ``review_state_scope`` seam.
 
@@ -326,7 +329,9 @@ def _combine_state_scopes(scopes: list) -> "Any | None":
     return _combined
 
 
-def compose_agent_system_prompt(session_prompt: str, *, offer_find_load: bool = False) -> str:
+def compose_agent_system_prompt(
+    session_prompt: str, *, offer_find_load: bool = False
+) -> str:
     """Compose the primary system prompt: session prompt first, agent prompt appended.
 
     Args:
@@ -563,9 +568,7 @@ def _pair_step_diff(
 STEP_APPROVAL_TIMEOUT = "approval_timeout"
 
 
-def format_change_summary_marker(
-    files_changed: int, adds: int, dels: int
-) -> str:
+def format_change_summary_marker(files_changed: int, adds: int, dels: int) -> str:
     """The change-summary transcript row for one turn (TASK-1972).
 
     Shared by the live emit (run_reply's finally) and resume re-derivation
@@ -582,10 +585,7 @@ def format_change_summary_marker(
         The row text.
     """
     noun = "file" if files_changed == 1 else "files"
-    return (
-        f"✎ Edited {files_changed} {noun}  +{adds} −{dels}"
-        " — review with `v`"
-    )
+    return f"✎ Edited {files_changed} {noun}  +{adds} −{dels} — review with `v`"
 
 
 #: PR3a-1 Task 6c (audit F2): which window a ``change_snapshots`` row
@@ -1102,6 +1102,49 @@ class _ModelCallLifeline:
             self.loop.close()
 
 
+def _openai_usage_from_provider_call(
+    payload: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if payload is None:
+        return None
+
+    def token_count(*keys: str) -> int | None:
+        for key in keys:
+            value = payload.get(key)
+            if type(value) is int and value >= 0:
+                return value
+        return None
+
+    prompt_tokens = token_count("prompt_tokens", "input_tokens")
+    completion_tokens = token_count("completion_tokens", "output_tokens")
+    total_tokens = token_count("total_tokens")
+    if (
+        total_tokens is None
+        and prompt_tokens is not None
+        and completion_tokens is not None
+    ):
+        total_tokens = prompt_tokens + completion_tokens
+    if total_tokens is None or total_tokens <= 0:
+        return None
+
+    usage: dict[str, Any] = {"total_tokens": total_tokens}
+    if prompt_tokens is not None:
+        usage["prompt_tokens"] = prompt_tokens
+    if completion_tokens is not None:
+        usage["completion_tokens"] = completion_tokens
+    prompt_details = payload.get(
+        "prompt_tokens_details", payload.get("input_tokens_details")
+    )
+    if isinstance(prompt_details, Mapping):
+        usage["prompt_tokens_details"] = dict(prompt_details)
+    completion_details = payload.get(
+        "completion_tokens_details", payload.get("output_tokens_details")
+    )
+    if isinstance(completion_details, Mapping):
+        usage["completion_tokens_details"] = dict(completion_details)
+    return usage
+
+
 class _StreamingModelAdapter:
     """chat_call-compatible adapter that streams every PRIMARY turn live.
 
@@ -1294,6 +1337,16 @@ class _StreamingModelAdapter:
         gate = StreamGate()
         any_streamed = False
         native_calls: list[dict] = []
+        call_signals: ConsoleProviderCallSignals | None = None
+        gateway_signals: (
+            ConsoleProviderStreamSignals | ConsoleProviderCallSignals | None
+        ) = self._provider_stream_signals
+        if isinstance(self._gateway, ConsoleProviderGateway):
+            aggregate_signals = (
+                self._provider_stream_signals or ConsoleProviderStreamSignals()
+            )
+            call_signals = aggregate_signals.new_usage_call()
+            gateway_signals = call_signals
 
         async def _consume() -> None:
             nonlocal any_streamed
@@ -1308,8 +1361,8 @@ class _StreamingModelAdapter:
             # this task's own `tools=None` contract see identical behavior
             # either way, since the callee-side default is also None.
             stream_kwargs = {"tools": tools} if tools is not None else {}
-            if self._provider_stream_signals is not None:
-                stream_kwargs["signals"] = self._provider_stream_signals
+            if gateway_signals is not None:
+                stream_kwargs["signals"] = gateway_signals
             async for chunk in self._gateway.stream_chat(
                 self._resolution, messages_payload, **stream_kwargs
             ):
@@ -1362,8 +1415,7 @@ class _StreamingModelAdapter:
         except FuturesTimeoutError:
             future.cancel()
             raise TimeoutError(
-                "provider turn did not complete within "
-                f"{_CHAT_CALL_TIMEOUT_SECONDS}s"
+                f"provider turn did not complete within {_CHAT_CALL_TIMEOUT_SECONDS}s"
             ) from None
         if any_streamed and not is_subagent:
             # Finding A: this turn leaked prose to the store before it was
@@ -1381,7 +1433,12 @@ class _StreamingModelAdapter:
         message: dict = {"content": gate.full_text}
         if native_calls:
             message["tool_calls"] = native_calls
-        return {"choices": [{"message": message}]}
+        response: dict[str, Any] = {"choices": [{"message": message}]}
+        if call_signals is not None:
+            usage = _openai_usage_from_provider_call(call_signals.usage_snapshot())
+            if usage is not None:
+                response["usage"] = usage
+        return response
 
     @staticmethod
     def _is_subagent(messages_payload) -> bool:
@@ -1489,10 +1546,7 @@ def _non_colliding_skill_entries(
     name set) in agreement with dispatch.
     """
     collision_names = (
-        set(builtin_names)
-        | set(local_names)
-        | set(library_names)
-        | RUNTIME_TOOL_NAMES
+        set(builtin_names) | set(local_names) | set(library_names) | RUNTIME_TOOL_NAMES
     )
     return [
         item
@@ -2842,6 +2896,7 @@ class ConsoleAgentBridge:
                 if _inner_review is None:
                     return {}
                 return _inner_review(calls, run_id)
+
         service = AgentService(
             self._db,
             registry,
@@ -3011,9 +3066,7 @@ class ConsoleAgentBridge:
                     )
                     _records = self._change_tracker.end_turn(
                         change_handle,
-                        touched_paths=ChangeTurnTracker.tool_touched_paths(
-                            _steps
-                        ),
+                        touched_paths=ChangeTurnTracker.tool_touched_paths(_steps),
                     )
                     if "run_id" in locals():
                         self._record_change_snapshots(
@@ -4019,9 +4072,7 @@ class ConsoleAgentBridge:
         # resume (finding 3).
         snap_by_run: dict[str, list[dict]] = {}
         try:
-            for _row in self._db.change_snapshots_for_conversation(
-                conversation_id
-            ):
+            for _row in self._db.change_snapshots_for_conversation(conversation_id):
                 snap_by_run.setdefault(str(_row["run_id"]), []).append(_row)
         except Exception:  # noqa: BLE001 -- resume must not die on this
             snap_by_run = {}

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -73,6 +73,7 @@ from tldw_chatbook.Chat.console_provider_gateway import (
     ConsoleProviderStreamSignals,
     ProviderToolCalls,
 )
+from tldw_chatbook.Chat.provider_usage import ProviderUsage
 from tldw_chatbook.Chat.console_skill_resolver import SKILL_UNTRUSTED_REFUSE
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 from tldw_chatbook.Workspaces.change_turn_tracker import ChangeTurnTracker
@@ -1104,39 +1105,38 @@ class _ModelCallLifeline:
 
 def _openai_usage_from_provider_call(
     payload: Mapping[str, Any] | None,
+    *,
+    provider: str,
+    model: str,
 ) -> dict[str, Any] | None:
-    if payload is None:
+    if not isinstance(payload, Mapping):
+        return None
+    normalized = ProviderUsage.from_provider_payload(
+        payload,
+        provider=provider,
+        model=model,
+    )
+    if normalized is None or normalized.total_tokens <= 0:
         return None
 
-    def token_count(*keys: str) -> int | None:
-        for key in keys:
-            value = payload.get(key)
-            if type(value) is int and value >= 0:
-                return value
-        return None
-
-    prompt_tokens = token_count("prompt_tokens", "input_tokens")
-    completion_tokens = token_count("completion_tokens", "output_tokens")
-    total_tokens = token_count("total_tokens")
-    if (
-        total_tokens is None
-        and prompt_tokens is not None
-        and completion_tokens is not None
-    ):
-        total_tokens = prompt_tokens + completion_tokens
-    if total_tokens is None or total_tokens <= 0:
-        return None
-
-    usage: dict[str, Any] = {"total_tokens": total_tokens}
-    if prompt_tokens is not None:
-        usage["prompt_tokens"] = prompt_tokens
-    if completion_tokens is not None:
-        usage["completion_tokens"] = completion_tokens
+    prompt_tokens = (
+        normalized.uncached_input + normalized.cache_read + normalized.cache_write
+    )
+    usage: dict[str, Any] = {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": normalized.output,
+        "total_tokens": normalized.total_tokens,
+    }
     prompt_details = payload.get(
         "prompt_tokens_details", payload.get("input_tokens_details")
     )
-    if isinstance(prompt_details, Mapping):
-        usage["prompt_tokens_details"] = dict(prompt_details)
+    normalized_prompt_details = (
+        dict(prompt_details) if isinstance(prompt_details, Mapping) else {}
+    )
+    if "cached_tokens" in normalized_prompt_details or normalized.cache_read:
+        normalized_prompt_details["cached_tokens"] = normalized.cache_read
+    if normalized_prompt_details:
+        usage["prompt_tokens_details"] = normalized_prompt_details
     completion_details = payload.get(
         "completion_tokens_details", payload.get("output_tokens_details")
     )
@@ -1435,7 +1435,11 @@ class _StreamingModelAdapter:
             message["tool_calls"] = native_calls
         response: dict[str, Any] = {"choices": [{"message": message}]}
         if call_signals is not None:
-            usage = _openai_usage_from_provider_call(call_signals.usage_snapshot())
+            usage = _openai_usage_from_provider_call(
+                call_signals.usage_snapshot(),
+                provider=self._resolution.provider,
+                model=self._resolution.model or model or "",
+            )
             if usage is not None:
                 response["usage"] = usage
         return response

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1120,7 +1120,15 @@ _BUDGET_USAGE_DETAILS_KEYS = (
     "output_tokens_details",
     "output_token_details",
 )
-_BUDGET_USAGE_DETAIL_COUNT_KEYS = ("cached_tokens", "reasoning_tokens")
+_BUDGET_USAGE_DETAIL_COUNT_KEYS = (
+    "cached_tokens",
+    "reasoning_tokens",
+    "audio_tokens",
+    "text_tokens",
+    "image_tokens",
+    "accepted_prediction_tokens",
+    "rejected_prediction_tokens",
+)
 
 
 def _has_strict_budget_usage_counts(payload: Mapping[str, Any]) -> bool:
@@ -1140,6 +1148,15 @@ def _has_strict_budget_usage_counts(payload: Mapping[str, Any]) -> bool:
                 value = details[count_key]
                 if type(value) is not int or value < 0:
                     return False
+        if "cached_tokens_details" in details:
+            cached_details = details["cached_tokens_details"]
+            if not isinstance(cached_details, Mapping):
+                return False
+            for count_key in _BUDGET_USAGE_DETAIL_COUNT_KEYS:
+                if count_key in cached_details:
+                    value = cached_details[count_key]
+                    if type(value) is not int or value < 0:
+                        return False
     return True
 
 

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1103,13 +1103,53 @@ class _ModelCallLifeline:
             self.loop.close()
 
 
+_BUDGET_USAGE_COUNT_KEYS = (
+    "prompt_tokens",
+    "input_tokens",
+    "completion_tokens",
+    "output_tokens",
+    "total_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+)
+_BUDGET_USAGE_DETAILS_KEYS = (
+    "prompt_tokens_details",
+    "input_tokens_details",
+    "input_token_details",
+    "completion_tokens_details",
+    "output_tokens_details",
+    "output_token_details",
+)
+_BUDGET_USAGE_DETAIL_COUNT_KEYS = ("cached_tokens", "reasoning_tokens")
+
+
+def _has_strict_budget_usage_counts(payload: Mapping[str, Any]) -> bool:
+    for key in _BUDGET_USAGE_COUNT_KEYS:
+        if key in payload:
+            value = payload[key]
+            if type(value) is not int or value < 0:
+                return False
+    for key in _BUDGET_USAGE_DETAILS_KEYS:
+        if key not in payload:
+            continue
+        details = payload[key]
+        if not isinstance(details, Mapping):
+            return False
+        for count_key in _BUDGET_USAGE_DETAIL_COUNT_KEYS:
+            if count_key in details:
+                value = details[count_key]
+                if type(value) is not int or value < 0:
+                    return False
+    return True
+
+
 def _openai_usage_from_provider_call(
     payload: Mapping[str, Any] | None,
     *,
     provider: str,
     model: str,
 ) -> dict[str, Any] | None:
-    if not isinstance(payload, Mapping):
+    if not isinstance(payload, Mapping) or not _has_strict_budget_usage_counts(payload):
         return None
     normalized = ProviderUsage.from_provider_payload(
         payload,

--- a/tldw_chatbook/Chat/console_provider_endpoints.py
+++ b/tldw_chatbook/Chat/console_provider_endpoints.py
@@ -23,6 +23,7 @@ URL_BASED_PROVIDER_KEYS = frozenset(
         "local_vllm",
         "ollama",
         "oobabooga",
+        "qwencloud",
         "tabbyapi",
         "vllm",
     }
@@ -58,6 +59,7 @@ _BUILTIN_PROVIDER_ENDPOINTS = {
     "moonshot": "https://api.moonshot.ai/v1",
     "openai": "https://api.openai.com/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "qwencloud": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
     "zai": "https://api.z.ai/api/paas/v4",
 }
 

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -29,6 +29,7 @@ from tldw_chatbook.Chat.Chat_Deps import (
 from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
 from tldw_chatbook.Chat.console_provider_endpoints import (
     effective_provider_endpoint,
+    first_configured_endpoint,
     generic_endpoint_differs,
     provider_uses_endpoint,
     unsaved_endpoint_copy,
@@ -50,6 +51,10 @@ from tldw_chatbook.Chat.provider_readiness import (
     provider_config_key,
 )
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
+from tldw_chatbook.LLM_Calls.qwencloud import (
+    normalize_qwencloud_api_mode,
+    normalize_qwencloud_base_url,
+)
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.sensitive_llm_logging import (
     is_sensitive_llm_request,
@@ -319,6 +324,7 @@ class ConsoleProviderResolution:
             breakpoint. Set only for Anthropic resolutions (and only when
             ``[caching] anthropic_enabled`` is on); ``None`` everywhere else,
             which drops the kwarg entirely in ``_chat_api_kwargs``.
+        api_mode: Pinned QwenCloud wire mode; ``None`` for every other provider.
     """
 
     provider: str
@@ -345,6 +351,7 @@ class ConsoleProviderResolution:
     thinking_budget_tokens: int | None = None
     streaming: bool = True
     prompt_caching: bool | None = None
+    api_mode: str | None = None
 
 
 def _freeze_auxiliary_value(value: Any) -> Any:
@@ -608,12 +615,31 @@ def _tee_tool_calls(response: Any, accumulator: _ToolCallAccumulator) -> Any:
     if not _is_iterable_response(response):
         return response
 
-    def generator():
-        for item in response:
-            accumulator.feed_payload(_decode_stream_item(item))
-            yield item
+    class _ToolCallTee(Iterator[Any]):
+        def __init__(self) -> None:
+            self._close_lock = threading.Lock()
+            self._closed = False
 
-    return generator()
+        def __next__(self) -> Any:
+            try:
+                item = next(response)
+            except BaseException:
+                self.close()
+                raise
+            accumulator.feed_payload(_decode_stream_item(item))
+            return item
+
+        def close(self) -> None:
+            with self._close_lock:
+                if self._closed:
+                    return
+                self._closed = True
+            close = getattr(response, "close", None)
+            if callable(close):
+                with contextlib.suppress(Exception):
+                    close()
+
+    return _ToolCallTee()
 
 
 def build_llamacpp_chat_payload(
@@ -1242,9 +1268,66 @@ class ConsoleProviderGateway:
                 execution_key=identity.execution_key,
             )
 
-        if provider_uses_endpoint(
-            identity.readiness_key, provider_settings
-        ) and generic_endpoint_differs(selection.base_url, provider_settings):
+        api_mode: str | None = None
+        qwencloud_configured_base_url: str | None = None
+        effective_base_url = effective_provider_endpoint(
+            identity.readiness_key,
+            selection.base_url,
+            provider_settings,
+        )
+        if identity.execution_key == "qwencloud":
+            try:
+                api_mode = normalize_qwencloud_api_mode(
+                    None,
+                    provider_settings=provider_settings,
+                )
+            except ChatConfigurationError:
+                return self._blocked_resolution(
+                    selection,
+                    provider=selection.provider,
+                    model=model,
+                    visible_copy=(
+                        "QwenCloud blocked: invalid API mode setting. Choose "
+                        "'responses' or 'chat_completions' in Settings."
+                    ),
+                    readiness_key=identity.readiness_key,
+                    execution_key=identity.execution_key,
+                )
+            try:
+                effective_base_url = normalize_qwencloud_base_url(effective_base_url)
+                configured_base_url = first_configured_endpoint(provider_settings)
+                if configured_base_url is not None:
+                    qwencloud_configured_base_url = normalize_qwencloud_base_url(
+                        configured_base_url
+                    )
+            except ChatConfigurationError:
+                return self._blocked_resolution(
+                    selection,
+                    provider=selection.provider,
+                    model=model,
+                    visible_copy=(
+                        "QwenCloud blocked: invalid API base URL setting. Enter an "
+                        "absolute HTTP(S) compatible-mode base URL in Settings."
+                    ),
+                    readiness_key=identity.readiness_key,
+                    execution_key=identity.execution_key,
+                )
+
+        endpoint_differs = generic_endpoint_differs(
+            selection.base_url, provider_settings
+        )
+        if identity.execution_key == "qwencloud" and (
+            isinstance(selection.base_url, str) and selection.base_url.strip()
+        ):
+            endpoint_differs = (
+                qwencloud_configured_base_url is None
+                or effective_base_url != qwencloud_configured_base_url
+            )
+
+        if (
+            provider_uses_endpoint(identity.readiness_key, provider_settings)
+            and endpoint_differs
+        ):
             return self._blocked_resolution(
                 selection,
                 provider=selection.provider,
@@ -1295,12 +1378,7 @@ class ConsoleProviderGateway:
 
         return ConsoleProviderResolution(
             provider=selection.provider,
-            base_url=effective_provider_endpoint(
-                identity.readiness_key,
-                selection.base_url,
-                provider_settings,
-            )
-            or "",
+            base_url=effective_base_url or "",
             model=model,
             ready=True,
             readiness_key=identity.readiness_key,
@@ -1308,6 +1386,7 @@ class ConsoleProviderGateway:
             api_key=readiness.api_key,
             api_key_source=readiness.api_key_source,
             prompt_caching=prompt_caching,
+            api_mode=api_mode,
             temperature=selection.temperature,
             top_p=selection.top_p,
             min_p=selection.min_p,
@@ -1657,6 +1736,9 @@ class ConsoleProviderGateway:
                 else None
             ),
         }
+        if resolution.execution_key == "qwencloud":
+            kwargs["api_mode"] = resolution.api_mode
+            kwargs["api_base_url"] = resolution.base_url or None
         return {key: value for key, value in kwargs.items() if value is not None}
 
     async def stream_chat(
@@ -1770,6 +1852,25 @@ class ConsoleProviderGateway:
         loop = asyncio.get_running_loop()
         queue: asyncio.Queue[_QueueItem] = asyncio.Queue()
         stop_event = threading.Event()
+        response_lock = threading.Lock()
+        retained_response: Any = None
+        response_close_attempted = False
+
+        def retain_response(response: Any) -> None:
+            nonlocal retained_response
+            with response_lock:
+                retained_response = response
+
+        def close_response() -> None:
+            nonlocal response_close_attempted
+            with response_lock:
+                if response_close_attempted or retained_response is None:
+                    return
+                response_close_attempted = True
+                close = getattr(retained_response, "close", None)
+            if callable(close):
+                with contextlib.suppress(Exception):
+                    close()
 
         def enqueue(item: _QueueItem) -> None:
             if stop_event.is_set():
@@ -1784,6 +1885,7 @@ class ConsoleProviderGateway:
                 accumulator = _ToolCallAccumulator() if request.tools else None
                 if accumulator is not None:
                     response = _tee_tool_calls(response, accumulator)
+                retain_response(response)
                 emitted_content = False
                 # tools= runs: fallback UI copy must never leak into agent
                 # history, so it is suppressed at GENERATION (not filtered
@@ -1838,6 +1940,7 @@ class ConsoleProviderGateway:
                     )
                 )
             finally:
+                close_response()
                 enqueue(_QueueItem.done())
 
         worker_task = asyncio.create_task(asyncio.to_thread(worker))
@@ -1867,6 +1970,7 @@ class ConsoleProviderGateway:
                     yield item.text
         finally:
             stop_event.set()
+            close_response()
             if not worker_task.done():
                 worker_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
@@ -1977,7 +2081,10 @@ class ConsoleProviderGateway:
             ),
             "prompt_caching": resolution.prompt_caching,
         }
-        if resolution.execution_key == "anthropic":
+        if resolution.execution_key == "qwencloud":
+            kwargs["api_mode"] = resolution.api_mode
+            kwargs["api_base_url"] = resolution.base_url or None
+        elif resolution.execution_key == "anthropic":
             kwargs["api_base_url"] = resolution.base_url or None
         elif (
             resolution.execution_key == "openai" and request.response_format is not None
@@ -2046,7 +2153,10 @@ class ConsoleProviderGateway:
             # for byte what they were before prompt caching existed.
             "prompt_caching": resolution.prompt_caching,
         }
-        if resolution.execution_key == "anthropic":
+        if resolution.execution_key == "qwencloud":
+            kwargs["api_mode"] = resolution.api_mode
+            kwargs["api_base_url"] = resolution.base_url or None
+        elif resolution.execution_key == "anthropic":
             # task-2114: `resolve_for_send` already resolves the effective
             # endpoint (configured `[api_settings.anthropic].api_base_url`,
             # or the built-in default when unset -- see

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -29,7 +29,6 @@ from tldw_chatbook.Chat.Chat_Deps import (
 from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
 from tldw_chatbook.Chat.console_provider_endpoints import (
     effective_provider_endpoint,
-    first_configured_endpoint,
     generic_endpoint_differs,
     provider_uses_endpoint,
     unsaved_endpoint_copy,
@@ -1270,11 +1269,7 @@ class ConsoleProviderGateway:
 
         api_mode: str | None = None
         qwencloud_configured_base_url: str | None = None
-        effective_base_url = effective_provider_endpoint(
-            identity.readiness_key,
-            selection.base_url,
-            provider_settings,
-        )
+        effective_base_url: str | None
         if identity.execution_key == "qwencloud":
             try:
                 api_mode = normalize_qwencloud_api_mode(
@@ -1293,13 +1288,37 @@ class ConsoleProviderGateway:
                     readiness_key=identity.readiness_key,
                     execution_key=identity.execution_key,
                 )
-            try:
-                effective_base_url = normalize_qwencloud_base_url(effective_base_url)
-                configured_base_url = first_configured_endpoint(provider_settings)
-                if configured_base_url is not None:
-                    qwencloud_configured_base_url = normalize_qwencloud_base_url(
-                        configured_base_url
+
+            configured_base_url: str | None = None
+            if "api_base_url" in provider_settings:
+                raw_configured_base_url = provider_settings["api_base_url"]
+                if not isinstance(raw_configured_base_url, str) or not (
+                    raw_configured_base_url.strip()
+                ):
+                    return self._blocked_resolution(
+                        selection,
+                        provider=selection.provider,
+                        model=model,
+                        visible_copy=(
+                            "QwenCloud blocked: invalid API base URL setting. Enter "
+                            "an absolute HTTP(S) compatible-mode base URL in Settings."
+                        ),
+                        readiness_key=identity.readiness_key,
+                        execution_key=identity.execution_key,
                     )
+                configured_base_url = raw_configured_base_url
+
+            try:
+                qwencloud_configured_base_url = normalize_qwencloud_base_url(
+                    configured_base_url
+                )
+                selected_base_url = selection.base_url
+                if selected_base_url is None or (
+                    isinstance(selected_base_url, str) and not selected_base_url.strip()
+                ):
+                    effective_base_url = qwencloud_configured_base_url
+                else:
+                    effective_base_url = normalize_qwencloud_base_url(selected_base_url)
             except ChatConfigurationError:
                 return self._blocked_resolution(
                     selection,
@@ -1312,16 +1331,21 @@ class ConsoleProviderGateway:
                     readiness_key=identity.readiness_key,
                     execution_key=identity.execution_key,
                 )
+        else:
+            effective_base_url = effective_provider_endpoint(
+                identity.readiness_key,
+                selection.base_url,
+                provider_settings,
+            )
 
-        endpoint_differs = generic_endpoint_differs(
-            selection.base_url, provider_settings
-        )
-        if identity.execution_key == "qwencloud" and (
-            isinstance(selection.base_url, str) and selection.base_url.strip()
-        ):
+        if identity.execution_key == "qwencloud":
             endpoint_differs = (
                 qwencloud_configured_base_url is None
                 or effective_base_url != qwencloud_configured_base_url
+            )
+        else:
+            endpoint_differs = generic_endpoint_differs(
+                selection.base_url, provider_settings
             )
 
         if (
@@ -1854,16 +1878,27 @@ class ConsoleProviderGateway:
         stop_event = threading.Event()
         response_lock = threading.Lock()
         retained_response: Any = None
+        close_requested = False
         response_close_attempted = False
 
-        def retain_response(response: Any) -> None:
-            nonlocal retained_response
+        def retain_response(response: Any) -> bool:
+            nonlocal retained_response, response_close_attempted
+            close = None
             with response_lock:
                 retained_response = response
+                iteration_permitted = not close_requested
+                if close_requested and not response_close_attempted:
+                    response_close_attempted = True
+                    close = getattr(retained_response, "close", None)
+            if callable(close):
+                with contextlib.suppress(Exception):
+                    close()
+            return iteration_permitted
 
         def close_response() -> None:
-            nonlocal response_close_attempted
+            nonlocal close_requested, response_close_attempted
             with response_lock:
+                close_requested = True
                 if response_close_attempted or retained_response is None:
                     return
                 response_close_attempted = True
@@ -1885,18 +1920,22 @@ class ConsoleProviderGateway:
                 accumulator = _ToolCallAccumulator() if request.tools else None
                 if accumulator is not None:
                     response = _tee_tool_calls(response, accumulator)
-                retain_response(response)
+                if not retain_response(response) or stop_event.is_set():
+                    return
                 emitted_content = False
                 # tools= runs: fallback UI copy must never leak into agent
                 # history, so it is suppressed at GENERATION (not filtered
                 # by string equality — review minor m4: a real answer that
                 # happens to equal the copy text now flows through).
-                for text in self.normalize_provider_response(
+                normalized_response = self.normalize_provider_response(
                     response,
                     suppress_fallback_copy=accumulator is not None,
                     signals=signals,
-                ):
-                    if stop_event.is_set():
+                )
+                while not stop_event.is_set():
+                    try:
+                        text = next(normalized_response)
+                    except StopIteration:
                         break
                     if text:
                         emitted_content = True

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -45,15 +45,13 @@ from tldw_chatbook.Chat.console_history_budget import DEFAULT_PER_IMAGE_TOKENS
 from tldw_chatbook.Chat.console_provider_support import (
     resolve_console_provider_identity,
 )
-from tldw_chatbook.Chat.provider_readiness import (
-    get_provider_readiness,
-    provider_settings_for_key,
-)
+from tldw_chatbook.Chat.provider_readiness import get_provider_readiness
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
 from tldw_chatbook.LLM_Calls.qwencloud import (
     normalize_qwencloud_api_mode,
     normalize_qwencloud_base_url,
 )
+from tldw_chatbook.config import provider_settings_for_key
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.sensitive_llm_logging import (
     is_sensitive_llm_request,

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -51,7 +51,7 @@ from tldw_chatbook.LLM_Calls.qwencloud import (
     normalize_qwencloud_api_mode,
     normalize_qwencloud_base_url,
 )
-from tldw_chatbook.config import provider_settings_for_key
+from tldw_chatbook.config import ProviderSettingsError, provider_settings_for_key
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.sensitive_llm_logging import (
     is_sensitive_llm_request,
@@ -1356,7 +1356,19 @@ class ConsoleProviderGateway:
             )
 
         app_config = self._config_provider() or {}
-        provider_settings = _provider_settings(app_config, identity.readiness_key)
+        try:
+            provider_settings = _provider_settings(app_config, identity.readiness_key)
+        except ProviderSettingsError:
+            return self._blocked_resolution(
+                selection,
+                provider=selection.provider,
+                visible_copy=(
+                    "QwenCloud blocked: provider settings must be a configuration "
+                    "table under api_settings.qwencloud."
+                ),
+                readiness_key=identity.readiness_key,
+                execution_key=identity.execution_key,
+            )
         model = _first_string(
             selection.explicit_model,
             selection.configured_model,

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -115,6 +115,11 @@ class ConsoleProviderStreamSignals:
         default_factory=list,
         repr=False,
     )
+    _active_usage_payloads: dict[object, dict[str, Any]] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
     _usage_lock: threading.Lock = field(
         default_factory=threading.Lock,
         init=False,
@@ -162,7 +167,82 @@ class ConsoleProviderStreamSignals:
             payloads = [dict(payload) for payload in self.completed_usage_payloads]
             if self.usage_payload is not None:
                 payloads.append(dict(self.usage_payload))
+            payloads.extend(
+                dict(payload) for payload in self._active_usage_payloads.values()
+            )
             return payloads
+
+    def new_usage_call(self) -> "ConsoleProviderCallSignals":
+        """Return an isolated usage recorder for one provider call."""
+        return ConsoleProviderCallSignals(self)
+
+    def _record_scoped_usage_call(
+        self,
+        token: object,
+        payload: Mapping[str, Any],
+    ) -> None:
+        with self._usage_lock:
+            self._active_usage_payloads[token] = dict(payload)
+
+    def _complete_scoped_usage_call(
+        self,
+        token: object,
+        payload: Mapping[str, Any],
+    ) -> None:
+        with self._usage_lock:
+            self._active_usage_payloads.pop(token, None)
+            self.completed_usage_payloads.append(dict(payload))
+
+
+@dataclass(slots=True)
+class ConsoleProviderCallSignals:
+    """Call-scoped signal view that publishes usage to one aggregate."""
+
+    _aggregate: ConsoleProviderStreamSignals = field(repr=False)
+    _token: object = field(default_factory=object, init=False, repr=False)
+    _usage_payload: dict[str, Any] | None = field(default=None, repr=False)
+    _closed: bool = field(default=False, init=False, repr=False)
+    _usage_lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        init=False,
+        repr=False,
+    )
+
+    @property
+    def synthetic_fallback_emitted(self) -> bool:
+        return self._aggregate.synthetic_fallback_emitted
+
+    def mark_synthetic_fallback(self) -> None:
+        self._aggregate.mark_synthetic_fallback()
+
+    def record_usage_payload(self, payload: Mapping[str, Any]) -> None:
+        with self._usage_lock:
+            if self._closed:
+                return
+            merged = dict(self._usage_payload or {})
+            merged.update(payload)
+            self._usage_payload = merged
+            self._aggregate._record_scoped_usage_call(self._token, merged)
+
+    def close_usage_call(self) -> None:
+        with self._usage_lock:
+            if self._closed:
+                return
+            self._closed = True
+            payload = (
+                dict(self._usage_payload) if self._usage_payload is not None else None
+            )
+        if payload is not None:
+            self._aggregate._complete_scoped_usage_call(self._token, payload)
+
+    def usage_snapshot(self) -> dict[str, Any] | None:
+        with self._usage_lock:
+            return (
+                dict(self._usage_payload) if self._usage_payload is not None else None
+            )
+
+
+_ProviderStreamSignals = ConsoleProviderStreamSignals | ConsoleProviderCallSignals
 
 
 def safe_provider_error_copy(provider: str, exc: BaseException) -> str:
@@ -609,7 +689,14 @@ def _tee_tool_calls(response: Any, accumulator: _ToolCallAccumulator) -> Any:
     three shapes ``chat_api_call`` returns: a full mapping (non-streaming),
     an iterator of mappings, or an iterator of SSE strings."""
     if isinstance(response, Mapping):
-        accumulator.feed_payload(response)
+        try:
+            accumulator.feed_payload(response)
+        except BaseException:
+            close = getattr(response, "close", None)
+            if callable(close):
+                with contextlib.suppress(BaseException):
+                    close()
+            raise
         return response
     if not _is_iterable_response(response):
         return response
@@ -620,12 +707,22 @@ def _tee_tool_calls(response: Any, accumulator: _ToolCallAccumulator) -> Any:
             self._closed = False
 
         def __next__(self) -> Any:
+            with self._close_lock:
+                if self._closed:
+                    raise StopIteration
             try:
                 item = next(response)
             except BaseException:
                 self.close()
                 raise
-            accumulator.feed_payload(_decode_stream_item(item))
+            try:
+                with self._close_lock:
+                    if self._closed:
+                        raise StopIteration
+                    accumulator.feed_payload(_decode_stream_item(item))
+            except BaseException:
+                self.close()
+                raise
             return item
 
         def close(self) -> None:
@@ -635,7 +732,7 @@ def _tee_tool_calls(response: Any, accumulator: _ToolCallAccumulator) -> Any:
                 self._closed = True
             close = getattr(response, "close", None)
             if callable(close):
-                with contextlib.suppress(Exception):
+                with contextlib.suppress(BaseException):
                     close()
 
     return _ToolCallTee()
@@ -1772,7 +1869,7 @@ class ConsoleProviderGateway:
         | PreparedConsoleRequest
         | PreparedProviderRequest,
         tools: list | None = None,
-        signals: ConsoleProviderStreamSignals | None = None,
+        signals: _ProviderStreamSignals | None = None,
     ) -> AsyncIterator[str | ProviderToolCalls]:
         """Dispatch streaming for a resolved Console provider.
 
@@ -1798,6 +1895,13 @@ class ConsoleProviderGateway:
         # so the in-flight usage payload is closed out here, at the only
         # seam that knows where a call ends -- never in the consumer, which
         # cannot see the boundary at all.
+        call_signals = (
+            signals
+            if isinstance(signals, ConsoleProviderCallSignals)
+            else signals.new_usage_call()
+            if signals is not None
+            else None
+        )
         try:
             if not resolution.ready or not resolution.model:
                 return
@@ -1858,19 +1962,19 @@ class ConsoleProviderGateway:
                 return
             if resolution.execution_key:
                 async for chunk in self._stream_generic_chat(
-                    effective_resolution, prepared, signals=signals
+                    effective_resolution, prepared, signals=call_signals
                 ):
                     yield chunk
                 return
         finally:
-            if signals is not None:
-                signals.close_usage_call()
+            if call_signals is not None:
+                call_signals.close_usage_call()
 
     async def _stream_generic_chat(
         self,
         resolution: ConsoleProviderResolution,
         request: PreparedProviderRequest,
-        signals: ConsoleProviderStreamSignals | None = None,
+        signals: _ProviderStreamSignals | None = None,
     ) -> AsyncIterator[str | ProviderToolCalls]:
         """Bridge synchronous chat_api_call responses into async Console chunks."""
         loop = asyncio.get_running_loop()
@@ -2019,7 +2123,7 @@ class ConsoleProviderGateway:
     def normalize_provider_response(
         response: Any,
         suppress_fallback_copy: bool = False,
-        signals: ConsoleProviderStreamSignals | None = None,
+        signals: _ProviderStreamSignals | None = None,
     ) -> Iterator[str]:
         """Yield safe assistant-visible chunks from generic provider output.
 
@@ -2398,7 +2502,7 @@ def _is_iterable_response(response: Any) -> bool:
 
 def _maybe_record_usage(
     payload: Mapping[str, Any],
-    signals: "ConsoleProviderStreamSignals | None",
+    signals: "_ProviderStreamSignals | None",
 ) -> None:
     if signals is None:
         return
@@ -2410,7 +2514,7 @@ def _maybe_record_usage(
 def _content_from_provider_item(
     item: Any,
     *,
-    signals: "ConsoleProviderStreamSignals | None" = None,
+    signals: "_ProviderStreamSignals | None" = None,
 ) -> str | object:
     if isinstance(item, str):
         if item.startswith("data:"):
@@ -2430,7 +2534,7 @@ def _content_from_provider_item(
 def _content_from_sse_data(
     line: str,
     *,
-    signals: "ConsoleProviderStreamSignals | None" = None,
+    signals: "_ProviderStreamSignals | None" = None,
 ) -> str | object:
     ConsoleProviderGateway._raise_for_sse_error(line)
     data = line.removeprefix("data:").strip()

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -707,23 +707,34 @@ def _tee_tool_calls(response: Any, accumulator: _ToolCallAccumulator) -> Any:
             self._closed = False
 
         def __next__(self) -> Any:
-            with self._close_lock:
-                if self._closed:
-                    raise StopIteration
+            if self._is_closed():
+                raise StopIteration
             try:
                 item = next(response)
             except BaseException:
                 self.close()
                 raise
+            if self._is_closed():
+                raise StopIteration
             try:
-                with self._close_lock:
-                    if self._closed:
-                        raise StopIteration
-                    accumulator.feed_payload(_decode_stream_item(item))
+                payload = _decode_stream_item(item)
             except BaseException:
                 self.close()
                 raise
+            if self._is_closed():
+                raise StopIteration
+            try:
+                accumulator.feed_payload(payload)
+            except BaseException:
+                self.close()
+                raise
+            if self._is_closed():
+                raise StopIteration
             return item
+
+        def _is_closed(self) -> bool:
+            with self._close_lock:
+                return self._closed
 
         def close(self) -> None:
             with self._close_lock:

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -171,7 +171,11 @@ class ConsoleProviderStreamSignals:
             return payloads
 
     def new_usage_call(self) -> "ConsoleProviderCallSignals":
-        """Return an isolated usage recorder for one provider call."""
+        """Create an isolated usage recorder for one provider call.
+
+        Returns:
+            A call-scoped signal view publishing into this aggregate.
+        """
         return ConsoleProviderCallSignals(self)
 
     def _record_scoped_usage_call(
@@ -208,12 +212,19 @@ class ConsoleProviderCallSignals:
 
     @property
     def synthetic_fallback_emitted(self) -> bool:
+        """Return whether the aggregate emitted synthetic fallback usage."""
         return self._aggregate.synthetic_fallback_emitted
 
     def mark_synthetic_fallback(self) -> None:
+        """Mark synthetic fallback usage on the aggregate signal."""
         self._aggregate.mark_synthetic_fallback()
 
     def record_usage_payload(self, payload: Mapping[str, Any]) -> None:
+        """Merge a provider usage payload into this call's snapshot.
+
+        Args:
+            payload: Provider usage fields observed for this call.
+        """
         with self._usage_lock:
             if self._closed:
                 return
@@ -223,6 +234,7 @@ class ConsoleProviderCallSignals:
             self._aggregate._record_scoped_usage_call(self._token, merged)
 
     def close_usage_call(self) -> None:
+        """Publish this call's final usage snapshot exactly once."""
         with self._usage_lock:
             if self._closed:
                 return
@@ -234,6 +246,11 @@ class ConsoleProviderCallSignals:
             self._aggregate._complete_scoped_usage_call(self._token, payload)
 
     def usage_snapshot(self) -> dict[str, Any] | None:
+        """Return a defensive copy of this call's current usage.
+
+        Returns:
+            The merged usage payload, or ``None`` before usage is observed.
+        """
         with self._usage_lock:
             return (
                 dict(self._usage_payload) if self._usage_payload is not None else None

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -47,7 +47,7 @@ from tldw_chatbook.Chat.console_provider_support import (
 )
 from tldw_chatbook.Chat.provider_readiness import (
     get_provider_readiness,
-    provider_config_key,
+    provider_settings_for_key,
 )
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
 from tldw_chatbook.LLM_Calls.qwencloud import (
@@ -2613,10 +2613,7 @@ def _provider_settings(
     app_config: Mapping[str, object], provider_key: str
 ) -> Mapping[str, object]:
     api_settings = _mapping_value(app_config, "api_settings")
-    for configured_provider, configured_value in api_settings.items():
-        if provider_config_key(str(configured_provider)) == provider_key:
-            return configured_value if isinstance(configured_value, Mapping) else {}
-    return {}
+    return provider_settings_for_key(api_settings, provider_key)
 
 
 def _first_string(*values: object) -> str | None:

--- a/tldw_chatbook/Chat/console_provider_support.py
+++ b/tldw_chatbook/Chat/console_provider_support.py
@@ -78,6 +78,7 @@ _PROVIDER_DISPLAY_NAMES = {
     "moonshot": "Moonshot",
     "openai": "OpenAI",
     "openrouter": "OpenRouter",
+    "qwencloud": "QwenCloud",
     "vllm": "vLLM",
     "zai": "Z.ai",
 }

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -24,8 +24,8 @@ from tldw_chatbook.Chat.console_provider_endpoints import (
 from tldw_chatbook.Chat.provider_readiness import (
     get_provider_readiness,
     provider_config_key,
-    provider_settings_for_key,
 )
+from tldw_chatbook.config import provider_settings_for_key
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.token_counter import count_tokens_messages
 

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -24,6 +24,7 @@ from tldw_chatbook.Chat.console_provider_endpoints import (
 from tldw_chatbook.Chat.provider_readiness import (
     get_provider_readiness,
     provider_config_key,
+    provider_settings_for_key,
 )
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.token_counter import count_tokens_messages
@@ -840,12 +841,7 @@ def _provider_settings(
     app_config: Mapping[str, object], provider_key: str
 ) -> Mapping[str, object]:
     api_settings = _mapping_value(app_config, "api_settings")
-    value = {}
-    for configured_provider, configured_value in api_settings.items():
-        if provider_config_key(configured_provider) == provider_key:
-            value = configured_value
-            break
-    return value if isinstance(value, Mapping) else {}
+    return provider_settings_for_key(api_settings, provider_key)
 
 
 def _model_default_profile(

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -57,6 +57,7 @@ CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS = frozenset(
         "oobabooga",
         "openai",
         "openrouter",
+        "qwencloud",
         "tabbyapi",
         "vllm",
         "zai",

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -25,7 +25,7 @@ from tldw_chatbook.Chat.provider_readiness import (
     get_provider_readiness,
     provider_config_key,
 )
-from tldw_chatbook.config import provider_settings_for_key
+from tldw_chatbook.config import ProviderSettingsError, provider_settings_for_key
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.token_counter import count_tokens_messages
 
@@ -841,7 +841,10 @@ def _provider_settings(
     app_config: Mapping[str, object], provider_key: str
 ) -> Mapping[str, object]:
     api_settings = _mapping_value(app_config, "api_settings")
-    return provider_settings_for_key(api_settings, provider_key)
+    try:
+        return provider_settings_for_key(api_settings, provider_key)
+    except ProviderSettingsError:
+        return {}
 
 
 def _model_default_profile(

--- a/tldw_chatbook/Chat/provider_catalog.py
+++ b/tldw_chatbook/Chat/provider_catalog.py
@@ -36,6 +36,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     "oobabooga": "Text Generation WebUI (Oobabooga)",
     "openai": "OpenAI",
     "openrouter": "OpenRouter",
+    "qwencloud": "QwenCloud",
     "tabbyapi": "TabbyAPI",
     "vllm": "vLLM",
     "zai": "Z.ai",

--- a/tldw_chatbook/Chat/provider_readiness.py
+++ b/tldw_chatbook/Chat/provider_readiness.py
@@ -43,6 +43,7 @@ PROVIDERS_REQUIRING_API_KEY_KEYS = frozenset(
         "moonshot",
         "openai",
         "openrouter",
+        "qwencloud",
         "zai",
     }
 )
@@ -91,6 +92,7 @@ KNOWN_PROVIDER_KEYS = PROVIDERS_REQUIRING_API_KEY_KEYS | KEYLESS_PROVIDER_KEYS
 
 _DEFAULT_API_KEY_ENV_VAR_ALIASES = {
     "mistralai": "MISTRAL_API_KEY",
+    "qwencloud": "DASHSCOPE_API_KEY",
 }
 
 

--- a/tldw_chatbook/Chat/provider_readiness.py
+++ b/tldw_chatbook/Chat/provider_readiness.py
@@ -211,7 +211,7 @@ def get_provider_readiness(
             reason="Invalid provider settings",
             recovery=(
                 "Replace api_settings.qwencloud with a configuration table "
-                "in Settings or config.toml."
+                "in Advanced Config or config.toml."
             ),
         )
 

--- a/tldw_chatbook/Chat/provider_readiness.py
+++ b/tldw_chatbook/Chat/provider_readiness.py
@@ -159,13 +159,41 @@ def default_api_key_env_var(provider_key: str) -> Optional[str]:
     )
 
 
-def _provider_settings_for_key(
+def provider_settings_for_key(
     api_settings: object,
     provider_key: str,
 ) -> Mapping[str, object]:
-    """Return settings whose configured provider key normalizes to provider_key."""
+    """Return provider settings without mutating the loaded configuration.
+
+    QwenCloud historically accepted normalized alias table names.  When an
+    exact canonical table is also present, alias fields remain fallbacks while
+    exact ``api_settings.qwencloud`` fields win regardless of insertion order.
+    Other providers retain the existing first-normalized-match behavior.
+    """
     if not isinstance(api_settings, Mapping):
         return {}
+
+    if provider_key == "qwencloud":
+        alias_settings: Mapping[str, object] = {}
+        alias_found = False
+        canonical_settings: Mapping[str, object] = {}
+        for configured_provider, configured_value in api_settings.items():
+            configured_key = str(configured_provider)
+            if provider_config_key(configured_key) != provider_key:
+                continue
+            if configured_key == provider_key:
+                if isinstance(configured_value, Mapping):
+                    canonical_settings = configured_value
+                continue
+            if not alias_found:
+                alias_found = True
+                if isinstance(configured_value, Mapping):
+                    alias_settings = configured_value
+        if canonical_settings:
+            merged = dict(alias_settings)
+            merged.update(canonical_settings)
+            return merged
+        return alias_settings
 
     for configured_provider, configured_value in api_settings.items():
         if provider_config_key(str(configured_provider)) != provider_key:
@@ -212,7 +240,7 @@ def get_provider_readiness(
         )
 
     api_settings = app_config.get("api_settings", {})
-    provider_settings = _provider_settings_for_key(api_settings, provider_key)
+    provider_settings = provider_settings_for_key(api_settings, provider_key)
 
     requires_api_key = _requires_api_key(provider_key)
     configured_key = _valid_api_key(provider_settings.get("api_key"))

--- a/tldw_chatbook/Chat/provider_readiness.py
+++ b/tldw_chatbook/Chat/provider_readiness.py
@@ -26,6 +26,8 @@ from typing import Mapping, Optional
 # imports (`DB.*`, `Utils.*`) never reach into `Chat`.
 from ..config import (
     is_valid_provider_api_key,
+    normalize_provider_config_key,
+    provider_settings_for_key,
     resolve_provider_api_key as _valid_api_key,
 )
 
@@ -126,7 +128,7 @@ class ProviderReadiness:
 
 def provider_config_key(provider: Optional[str]) -> str:
     """Return the normalized key used under ``api_settings``."""
-    return (provider or "").strip().lower().replace(" ", "_").replace("-", "_")
+    return normalize_provider_config_key(provider)
 
 
 def _requires_api_key(provider_key: str) -> bool:
@@ -157,52 +159,6 @@ def default_api_key_env_var(provider_key: str) -> Optional[str]:
     return _DEFAULT_API_KEY_ENV_VAR_ALIASES.get(
         provider_key, f"{provider_key.upper()}_API_KEY"
     )
-
-
-def provider_settings_for_key(
-    api_settings: object,
-    provider_key: str,
-) -> Mapping[str, object]:
-    """Return provider settings without mutating the loaded configuration.
-
-    QwenCloud historically accepted normalized alias table names.  When an
-    exact canonical table is also present, alias fields remain fallbacks while
-    exact ``api_settings.qwencloud`` fields win regardless of insertion order.
-    Other providers retain the existing first-normalized-match behavior.
-    """
-    if not isinstance(api_settings, Mapping):
-        return {}
-
-    if provider_key == "qwencloud":
-        alias_settings: Mapping[str, object] = {}
-        alias_found = False
-        canonical_settings: Mapping[str, object] = {}
-        for configured_provider, configured_value in api_settings.items():
-            configured_key = str(configured_provider)
-            if provider_config_key(configured_key) != provider_key:
-                continue
-            if configured_key == provider_key:
-                if isinstance(configured_value, Mapping):
-                    canonical_settings = configured_value
-                continue
-            if not alias_found:
-                alias_found = True
-                if isinstance(configured_value, Mapping):
-                    alias_settings = configured_value
-        if canonical_settings:
-            merged = dict(alias_settings)
-            merged.update(canonical_settings)
-            return merged
-        return alias_settings
-
-    for configured_provider, configured_value in api_settings.items():
-        if provider_config_key(str(configured_provider)) != provider_key:
-            continue
-        if isinstance(configured_value, Mapping):
-            return configured_value
-        return {}
-
-    return {}
 
 
 def get_provider_readiness(

--- a/tldw_chatbook/Chat/provider_readiness.py
+++ b/tldw_chatbook/Chat/provider_readiness.py
@@ -25,6 +25,7 @@ from typing import Mapping, Optional
 # already takes, and cannot cycle back: `config.py`'s own top-level
 # imports (`DB.*`, `Utils.*`) never reach into `Chat`.
 from ..config import (
+    ProviderSettingsError,
     is_valid_provider_api_key,
     normalize_provider_config_key,
     provider_settings_for_key,
@@ -196,7 +197,23 @@ def get_provider_readiness(
         )
 
     api_settings = app_config.get("api_settings", {})
-    provider_settings = provider_settings_for_key(api_settings, provider_key)
+    try:
+        provider_settings = provider_settings_for_key(api_settings, provider_key)
+    except ProviderSettingsError:
+        return ProviderReadiness(
+            provider=provider_name,
+            provider_key=provider_key,
+            requires_api_key=_requires_api_key(provider_key),
+            ready=False,
+            api_key=None,
+            api_key_source=None,
+            env_var=None,
+            reason="Invalid provider settings",
+            recovery=(
+                "Replace api_settings.qwencloud with a configuration table "
+                "in Settings or config.toml."
+            ),
+        )
 
     requires_api_key = _requires_api_key(provider_key)
     configured_key = _valid_api_key(provider_settings.get("api_key"))

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -32,6 +32,10 @@ def _bad_request(message: str) -> ChatBadRequestError:
     return ChatBadRequestError(provider="qwencloud", message=message)
 
 
+def _reject_non_finite_json_constant(value: str) -> None:
+    raise ValueError(f"Non-finite JSON constant is not supported: {value}")
+
+
 def normalize_qwencloud_api_mode(
     api_mode: str | None,
     *,
@@ -49,7 +53,11 @@ def normalize_qwencloud_api_mode(
     Raises:
         ChatConfigurationError: If the resolved value is not an exact mode.
     """
-    configured = provider_settings.get("api_mode") if provider_settings else None
+    configured = None
+    if api_mode is None:
+        if provider_settings is not None and not isinstance(provider_settings, Mapping):
+            raise _configuration_error("QwenCloud provider settings must be an object.")
+        configured = provider_settings.get("api_mode") if provider_settings else None
     candidate = api_mode if api_mode is not None else configured
     if candidate is None:
         candidate = "responses"
@@ -82,6 +90,7 @@ def normalize_qwencloud_base_url(api_base_url: str | None) -> str:
     candidate = candidate.strip().rstrip("/")
     if (
         any(character.isspace() for character in candidate)
+        or any(ord(character) < 32 or ord(character) == 127 for character in candidate)
         or "?" in candidate
         or "#" in candidate
     ):
@@ -101,6 +110,8 @@ def normalize_qwencloud_base_url(api_base_url: str | None) -> str:
         raise _configuration_error(
             "QwenCloud API base URL must not contain credentials."
         )
+    if any(character in parsed.netloc for character in '\\%|^{}<>"`'):
+        raise _configuration_error("QwenCloud API base URL authority is malformed.")
     if parsed.query or parsed.fragment:
         raise _configuration_error(
             "QwenCloud API base URL must not contain a query or fragment."
@@ -161,11 +172,18 @@ def resolve_qwencloud_api_key(
     """
     if isinstance(explicit_api_key, str) and explicit_api_key.strip():
         return explicit_api_key
+    if provider_settings is not None and not isinstance(provider_settings, Mapping):
+        raise _configuration_error("QwenCloud provider settings must be an object.")
 
     settings = provider_settings or {}
     configured = settings.get("api_key")
     if isinstance(configured, str) and configured.strip():
         return configured
+
+    if environ is not None and not isinstance(environ, Mapping):
+        raise _configuration_error(
+            "QwenCloud credential environment must be an object."
+        )
 
     env_name = settings.get("api_key_env_var", _DEFAULT_KEY_ENV_VAR)
     if not isinstance(env_name, str) or not env_name.strip():
@@ -270,7 +288,9 @@ def _validate_tool_calls(
                 "QwenCloud function call arguments must be a JSON string."
             )
         try:
-            decoded_arguments = json.loads(arguments)
+            decoded_arguments = json.loads(
+                arguments, parse_constant=_reject_non_finite_json_constant
+            )
         except (TypeError, ValueError) as exc:
             raise _bad_request(
                 "QwenCloud function call arguments must contain valid JSON."
@@ -290,6 +310,10 @@ def _translate_messages(
 ) -> tuple[str | None, list[dict[str, Any]], list[dict[str, Any]]]:
     if system_message is not None and not isinstance(system_message, str):
         raise _bad_request("QwenCloud system instructions must be a string.")
+    if not isinstance(messages_payload, Sequence) or isinstance(
+        messages_payload, (str, bytes)
+    ):
+        raise _bad_request("QwenCloud messages must be a list.")
     messages: list[dict[str, Any]] = []
     for message in messages_payload:
         if not isinstance(message, Mapping):
@@ -299,6 +323,8 @@ def _translate_messages(
     leading_system: str | None = None
     if messages and messages[0].get("role") == "system":
         system_row = messages.pop(0)
+        if "tool_calls" in system_row:
+            raise _bad_request("QwenCloud tool calls require the assistant role.")
         normalized, _ = _normalize_message_content(
             "system", system_row.get("content"), has_tool_calls=False
         )
@@ -411,6 +437,8 @@ def _translate_function_tools(
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     if tools is None:
         return [], []
+    if not isinstance(tools, Sequence) or isinstance(tools, (str, bytes)):
+        raise _bad_request("QwenCloud function tools must be a list.")
 
     chat_tools: list[dict[str, Any]] = []
     responses_tools: list[dict[str, Any]] = []
@@ -523,7 +551,6 @@ def build_qwencloud_payload(
             ("max_completion_tokens", max_tokens),
             ("seed", seed),
             ("presence_penalty", presence_penalty),
-            ("stop", stop),
             ("logprobs", logprobs),
             ("top_logprobs", top_logprobs),
             ("reasoning_effort", reasoning_effort),
@@ -531,7 +558,11 @@ def build_qwencloud_payload(
         for key, value in optional_values:
             if value is not None:
                 chat_payload[key] = value
+        if stop is not None:
+            chat_payload["stop"] = deepcopy(stop)
         if response_format is not None:
+            if not isinstance(response_format, Mapping):
+                raise _bad_request("QwenCloud response format must be an object.")
             copied_format = deepcopy(dict(response_format))
             if copied_format not in ({"type": "text"}, {"type": "json_object"}):
                 raise _bad_request("Unsupported QwenCloud response format.")

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -1,0 +1,585 @@
+"""Pure request translation for QwenCloud's compatible API modes."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Mapping
+from collections.abc import Sequence
+from copy import deepcopy
+from typing import Any, Literal
+from urllib.parse import urlsplit
+
+from tldw_chatbook.Chat.Chat_Deps import ChatBadRequestError, ChatConfigurationError
+
+QwenCloudAPIMode = Literal["responses", "chat_completions"]
+
+_DEFAULT_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+_DEFAULT_KEY_ENV_VAR = "DASHSCOPE_API_KEY"
+_API_MODES: frozenset[str] = frozenset({"responses", "chat_completions"})
+_ENDPOINT_SUFFIXES = ("/chat/completions", "/responses")
+_REASONING_EFFORTS: frozenset[str] = frozenset(
+    {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+)
+
+
+def _configuration_error(message: str) -> ChatConfigurationError:
+    return ChatConfigurationError(provider="qwencloud", message=message)
+
+
+def _bad_request(message: str) -> ChatBadRequestError:
+    return ChatBadRequestError(provider="qwencloud", message=message)
+
+
+def normalize_qwencloud_api_mode(
+    api_mode: str | None,
+    *,
+    provider_settings: Mapping[str, Any] | None = None,
+) -> QwenCloudAPIMode:
+    """Resolve and validate the selected QwenCloud API mode.
+
+    Args:
+        api_mode: Explicit trusted-caller override, when supplied.
+        provider_settings: QwenCloud's isolated provider settings.
+
+    Returns:
+        The normalized supported API mode.
+
+    Raises:
+        ChatConfigurationError: If the resolved value is not an exact mode.
+    """
+    configured = provider_settings.get("api_mode") if provider_settings else None
+    candidate = api_mode if api_mode is not None else configured
+    if candidate is None:
+        candidate = "responses"
+    if not isinstance(candidate, str):
+        raise _configuration_error("QwenCloud API mode must be a string.")
+
+    normalized = candidate.strip().lower()
+    if normalized not in _API_MODES:
+        raise _configuration_error(
+            "QwenCloud API mode must be 'responses' or 'chat_completions'."
+        )
+    return normalized  # type: ignore[return-value]
+
+
+def normalize_qwencloud_base_url(api_base_url: str | None) -> str:
+    """Normalize a QwenCloud base URL without constructing an endpoint.
+
+    Args:
+        api_base_url: Configured compatible-API base or pasted endpoint.
+
+    Returns:
+        A validated base URL without a recognized terminal endpoint suffix.
+
+    Raises:
+        ChatConfigurationError: If the URL is unsafe or malformed.
+    """
+    candidate = _DEFAULT_BASE_URL if api_base_url is None else api_base_url
+    if not isinstance(candidate, str) or not candidate.strip():
+        raise _configuration_error("QwenCloud API base URL is required.")
+    candidate = candidate.strip().rstrip("/")
+    if (
+        any(character.isspace() for character in candidate)
+        or "?" in candidate
+        or "#" in candidate
+    ):
+        raise _configuration_error("QwenCloud API base URL is malformed.")
+
+    try:
+        parsed = urlsplit(candidate)
+        parsed_port = parsed.port
+    except ValueError as exc:
+        raise _configuration_error("QwenCloud API base URL is malformed.") from exc
+
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        raise _configuration_error(
+            "QwenCloud API base URL must be an absolute HTTP(S) URL."
+        )
+    if parsed.username is not None or parsed.password is not None:
+        raise _configuration_error(
+            "QwenCloud API base URL must not contain credentials."
+        )
+    if parsed.query or parsed.fragment:
+        raise _configuration_error(
+            "QwenCloud API base URL must not contain a query or fragment."
+        )
+    if parsed.netloc.endswith(":") or (
+        parsed_port is not None and not 0 < parsed_port < 65536
+    ):
+        raise _configuration_error("QwenCloud API base URL is malformed.")
+    if (
+        "\\" in parsed.path
+        or "//" in parsed.path
+        or re.search(r"%(?![0-9A-Fa-f]{2})", parsed.path) is not None
+        or any(character.isspace() for character in parsed.path)
+        or any(segment in {".", ".."} for segment in parsed.path.split("/"))
+    ):
+        raise _configuration_error("QwenCloud API base URL path is malformed.")
+
+    path = parsed.path.rstrip("/")
+    if path.endswith("/models"):
+        raise _configuration_error(
+            "QwenCloud API base URL must not use the models endpoint."
+        )
+    if "/responses/" in path or "/chat/completions/" in path:
+        raise _configuration_error(
+            "QwenCloud API base URL contains a non-terminal request endpoint."
+        )
+    for suffix in _ENDPOINT_SUFFIXES:
+        if path.endswith(suffix):
+            path = path[: -len(suffix)]
+            if any(path.endswith(other) for other in _ENDPOINT_SUFFIXES):
+                raise _configuration_error(
+                    "QwenCloud API base URL contains a repeated endpoint suffix."
+                )
+            break
+
+    authority = parsed.netloc
+    return f"{parsed.scheme.lower()}://{authority}{path}".rstrip("/")
+
+
+def resolve_qwencloud_api_key(
+    explicit_api_key: str | None,
+    *,
+    provider_settings: Mapping[str, Any] | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    """Resolve QwenCloud credentials from provider-isolated sources.
+
+    Args:
+        explicit_api_key: Credential already resolved by a trusted caller.
+        provider_settings: QwenCloud's isolated provider settings.
+        environ: Environment mapping, injectable for pure tests.
+
+    Returns:
+        The resolved credential value.
+
+    Raises:
+        ChatConfigurationError: If no QwenCloud credential is configured.
+    """
+    if isinstance(explicit_api_key, str) and explicit_api_key.strip():
+        return explicit_api_key
+
+    settings = provider_settings or {}
+    configured = settings.get("api_key")
+    if isinstance(configured, str) and configured.strip():
+        return configured
+
+    env_name = settings.get("api_key_env_var", _DEFAULT_KEY_ENV_VAR)
+    if not isinstance(env_name, str) or not env_name.strip():
+        env_name = _DEFAULT_KEY_ENV_VAR
+    environment = os.environ if environ is None else environ
+    from_environment = environment.get(env_name.strip())
+    if isinstance(from_environment, str) and from_environment.strip():
+        return from_environment
+
+    raise _configuration_error("QwenCloud API key is required but not configured.")
+
+
+def _normalize_message_content(
+    role: str,
+    content: Any,
+    *,
+    has_tool_calls: bool,
+) -> tuple[Any, Any]:
+    if content is None:
+        if role == "assistant" and has_tool_calls:
+            return None, None
+        raise _bad_request("QwenCloud message content must be text or text parts.")
+    if isinstance(content, str):
+        if role == "assistant":
+            return content, [{"type": "output_text", "text": content}]
+        return content, content
+    if not isinstance(content, Sequence) or isinstance(content, (str, bytes)):
+        raise _bad_request("QwenCloud message content must be text or text parts.")
+
+    chat_parts: list[dict[str, Any]] = []
+    responses_parts: list[dict[str, Any]] = []
+    text_values: list[str] = []
+    has_image = False
+    for part in content:
+        if not isinstance(part, Mapping):
+            raise _bad_request("QwenCloud message content part is malformed.")
+        part_type = part.get("type")
+        if part_type == "text":
+            text = part.get("text")
+            if not isinstance(text, str):
+                raise _bad_request("QwenCloud text content must be a string.")
+            text_values.append(text)
+            copied_part = deepcopy(dict(part))
+            chat_parts.append(copied_part)
+            responses_parts.append({"type": "input_text", "text": text})
+            continue
+        if part_type == "image_url":
+            if role != "user":
+                raise _bad_request(
+                    "QwenCloud images are supported only for user messages."
+                )
+            image_url = part.get("image_url")
+            if not isinstance(image_url, Mapping):
+                raise _bad_request("QwenCloud image URL content is malformed.")
+            url = image_url.get("url")
+            if not isinstance(url, str) or not url:
+                raise _bad_request("QwenCloud image URL must be a non-empty string.")
+            has_image = True
+            chat_parts.append(deepcopy(dict(part)))
+            responses_parts.append({"type": "input_image", "image_url": url})
+            continue
+        raise _bad_request("QwenCloud message content type is unsupported.")
+
+    if not has_image:
+        collapsed = "".join(text_values)
+        if role == "assistant":
+            return collapsed, [{"type": "output_text", "text": collapsed}]
+        return collapsed, collapsed
+    return chat_parts, responses_parts
+
+
+def _validate_tool_calls(
+    raw_calls: Any,
+    *,
+    seen_call_ids: set[str],
+) -> list[dict[str, str]]:
+    if (
+        not isinstance(raw_calls, Sequence)
+        or isinstance(raw_calls, (str, bytes))
+        or not raw_calls
+    ):
+        raise _bad_request("QwenCloud assistant tool calls must be a non-empty list.")
+
+    validated: list[dict[str, str]] = []
+    for raw_call in raw_calls:
+        if not isinstance(raw_call, Mapping) or raw_call.get("type") != "function":
+            raise _bad_request("QwenCloud history supports only function tool calls.")
+        call_id = raw_call.get("id")
+        function = raw_call.get("function")
+        if not isinstance(call_id, str) or not call_id.strip():
+            raise _bad_request("QwenCloud tool call IDs must be non-empty strings.")
+        if call_id in seen_call_ids:
+            raise _bad_request("QwenCloud tool call IDs must be unique.")
+        if not isinstance(function, Mapping):
+            raise _bad_request("QwenCloud function call history is malformed.")
+        name = function.get("name")
+        arguments = function.get("arguments")
+        if not isinstance(name, str) or not name.strip():
+            raise _bad_request("QwenCloud function call names must be non-empty.")
+        if not isinstance(arguments, str):
+            raise _bad_request(
+                "QwenCloud function call arguments must be a JSON string."
+            )
+        try:
+            decoded_arguments = json.loads(arguments)
+        except (TypeError, ValueError) as exc:
+            raise _bad_request(
+                "QwenCloud function call arguments must contain valid JSON."
+            ) from exc
+        if not isinstance(decoded_arguments, Mapping):
+            raise _bad_request(
+                "QwenCloud function call arguments must encode an object."
+            )
+        seen_call_ids.add(call_id)
+        validated.append({"call_id": call_id, "name": name, "arguments": arguments})
+    return validated
+
+
+def _translate_messages(
+    system_message: str | None,
+    messages_payload: Sequence[Mapping[str, Any]],
+) -> tuple[str | None, list[dict[str, Any]], list[dict[str, Any]]]:
+    if system_message is not None and not isinstance(system_message, str):
+        raise _bad_request("QwenCloud system instructions must be a string.")
+    messages: list[dict[str, Any]] = []
+    for message in messages_payload:
+        if not isinstance(message, Mapping):
+            raise _bad_request("QwenCloud messages must be objects.")
+        messages.append(deepcopy(dict(message)))
+
+    leading_system: str | None = None
+    if messages and messages[0].get("role") == "system":
+        system_row = messages.pop(0)
+        normalized, _ = _normalize_message_content(
+            "system", system_row.get("content"), has_tool_calls=False
+        )
+        if not isinstance(normalized, str):
+            raise _bad_request("QwenCloud system content must contain only text.")
+        leading_system = normalized
+    if leading_system is not None and system_message is not None:
+        if leading_system != system_message:
+            raise _bad_request("QwenCloud system instructions conflict.")
+    instructions = system_message if system_message is not None else leading_system
+
+    chat_messages: list[dict[str, Any]] = []
+    responses_input: list[dict[str, Any]] = []
+    if instructions is not None:
+        chat_messages.append({"role": "system", "content": instructions})
+
+    seen_call_ids: set[str] = set()
+    index = 0
+    while index < len(messages):
+        message = messages[index]
+        role = message.get("role")
+        if not isinstance(role, str) or role not in {
+            "system",
+            "user",
+            "assistant",
+            "tool",
+        }:
+            raise _bad_request("QwenCloud message role is unsupported.")
+        if role == "system":
+            raise _bad_request("QwenCloud accepts a system message only at the start.")
+        if role == "tool":
+            raise _bad_request("QwenCloud tool result has no preceding call batch.")
+        if "tool_calls" in message and role != "assistant":
+            raise _bad_request("QwenCloud tool calls require the assistant role.")
+
+        has_tool_calls = "tool_calls" in message
+        chat_content, responses_content = _normalize_message_content(
+            role, message.get("content"), has_tool_calls=has_tool_calls
+        )
+        chat_message: dict[str, Any] = {"role": role, "content": chat_content}
+
+        if not has_tool_calls:
+            chat_messages.append(chat_message)
+            responses_input.append({"role": role, "content": responses_content})
+            index += 1
+            continue
+
+        validated_calls = _validate_tool_calls(
+            message.get("tool_calls"), seen_call_ids=seen_call_ids
+        )
+        chat_message["tool_calls"] = deepcopy(message["tool_calls"])
+        chat_messages.append(chat_message)
+        if chat_content not in (None, ""):
+            responses_input.append({"role": "assistant", "content": responses_content})
+
+        expected_ids = {call["call_id"] for call in validated_calls}
+        results: dict[str, str] = {}
+        result_index = index + 1
+        while (
+            result_index < len(messages)
+            and messages[result_index].get("role") == "tool"
+        ):
+            result = messages[result_index]
+            call_id = result.get("tool_call_id")
+            output = result.get("content")
+            if not isinstance(call_id, str) or not call_id.strip():
+                raise _bad_request(
+                    "QwenCloud tool results require a non-empty call ID."
+                )
+            if call_id not in expected_ids:
+                raise _bad_request(
+                    "QwenCloud tool result does not match this call batch."
+                )
+            if call_id in results:
+                raise _bad_request("QwenCloud tool results must be unique per call.")
+            if not isinstance(output, str):
+                raise _bad_request("QwenCloud tool result content must be a string.")
+            results[call_id] = output
+            chat_messages.append(
+                {"role": "tool", "tool_call_id": call_id, "content": output}
+            )
+            result_index += 1
+        if set(results) != expected_ids:
+            raise _bad_request("QwenCloud tool call batch is missing paired results.")
+
+        for call in validated_calls:
+            call_id = call["call_id"]
+            responses_input.append(
+                {
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": call["name"],
+                    "arguments": call["arguments"],
+                }
+            )
+            responses_input.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": results[call_id],
+                }
+            )
+        index = result_index
+
+    return instructions, chat_messages, responses_input
+
+
+def _translate_function_tools(
+    tools: Sequence[Mapping[str, Any]] | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if tools is None:
+        return [], []
+
+    chat_tools: list[dict[str, Any]] = []
+    responses_tools: list[dict[str, Any]] = []
+    names: set[str] = set()
+    for tool in tools:
+        if not isinstance(tool, Mapping) or tool.get("type") != "function":
+            raise _bad_request("QwenCloud supports only existing function tools.")
+        function = tool.get("function")
+        if not isinstance(function, Mapping):
+            raise _bad_request("QwenCloud function tool definition is malformed.")
+        unsupported_fields = set(function) - {
+            "name",
+            "description",
+            "parameters",
+            "strict",
+        }
+        if unsupported_fields:
+            raise _bad_request("QwenCloud function tool fields are unsupported.")
+        name = function.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise _bad_request("QwenCloud function tool names must be non-empty.")
+        if name in names:
+            raise _bad_request("QwenCloud function tool names must be unique.")
+        names.add(name)
+        parameters = function.get("parameters")
+        if (
+            not isinstance(parameters, Mapping)
+            or parameters.get("type", "object") != "object"
+        ):
+            raise _bad_request(
+                "QwenCloud function parameters must be an object schema."
+            )
+
+        copied_tool = deepcopy(dict(tool))
+        copied_function = deepcopy(dict(function))
+        chat_tools.append(copied_tool)
+        responses_tools.append({"type": "function", **copied_function})
+    return chat_tools, responses_tools
+
+
+def build_qwencloud_payload(
+    *,
+    api_mode: QwenCloudAPIMode,
+    model: str,
+    system_message: str | None,
+    messages_payload: Sequence[Mapping[str, Any]],
+    streaming: bool,
+    tools: Sequence[Mapping[str, Any]] | None = None,
+    tool_choice: str | Mapping[str, Any] | None = None,
+    temp: float | None = None,
+    topp: float | None = None,
+    topk: int | None = None,
+    max_tokens: int | None = None,
+    seed: int | None = None,
+    presence_penalty: float | None = None,
+    stop: str | Sequence[str] | None = None,
+    response_format: Mapping[str, str] | None = None,
+    n: int | None = None,
+    logprobs: bool | None = None,
+    top_logprobs: int | None = None,
+    reasoning_effort: str | None = None,
+) -> dict[str, Any]:
+    """Build a fail-closed request payload for one QwenCloud API mode.
+
+    Args:
+        api_mode: Validated external API mode.
+        model: QwenCloud model identifier.
+        system_message: Optional separate leading instruction.
+        messages_payload: Canonical Chatbook chat-shaped history.
+        streaming: Whether the caller requests a streaming response.
+        tools: Existing nested OpenAI function-tool definitions.
+        tool_choice: Supported function-tool selection policy.
+        temp: Sampling temperature.
+        topp: Nucleus-sampling probability.
+        topk: Chat Completions top-k sampling value.
+        max_tokens: Maximum generated tokens.
+        seed: Chat Completions random seed.
+        presence_penalty: Chat Completions presence penalty.
+        stop: Chat Completions stop sequence or sequences.
+        response_format: Chat Completions response-format object.
+        n: Chat Completions result count.
+        logprobs: Chat Completions log-probability flag.
+        top_logprobs: Chat Completions returned log-probability count.
+        reasoning_effort: Mode-specific reasoning-effort value.
+
+    Returns:
+        A newly allocated request dictionary containing only allowed keys.
+
+    Raises:
+        ChatBadRequestError: If request history or parameters are unsupported.
+    """
+    if tool_choice is not None and tool_choice not in ("auto", "none"):
+        raise _bad_request("Unsupported QwenCloud function tool choice.")
+    chat_tools, responses_tools = _translate_function_tools(tools)
+    instructions, chat_messages, responses_input = _translate_messages(
+        system_message, messages_payload
+    )
+
+    if api_mode == "chat_completions":
+        chat_payload: dict[str, Any] = {
+            "model": model,
+            "messages": chat_messages,
+            "stream": streaming,
+            "preserve_thinking": False,
+        }
+        optional_values = (
+            ("temperature", temp),
+            ("top_p", topp),
+            ("top_k", topk),
+            ("max_completion_tokens", max_tokens),
+            ("seed", seed),
+            ("presence_penalty", presence_penalty),
+            ("stop", stop),
+            ("logprobs", logprobs),
+            ("top_logprobs", top_logprobs),
+            ("reasoning_effort", reasoning_effort),
+        )
+        for key, value in optional_values:
+            if value is not None:
+                chat_payload[key] = value
+        if response_format is not None:
+            copied_format = deepcopy(dict(response_format))
+            if copied_format not in ({"type": "text"}, {"type": "json_object"}):
+                raise _bad_request("Unsupported QwenCloud response format.")
+            chat_payload["response_format"] = copied_format
+        if chat_tools:
+            if n is not None and n != 1:
+                raise _bad_request("QwenCloud tool requests require n=1.")
+            chat_payload["n"] = 1
+            chat_payload["tools"] = chat_tools
+            if tool_choice is not None:
+                chat_payload["tool_choice"] = deepcopy(tool_choice)
+        elif n is not None:
+            chat_payload["n"] = n
+        if streaming:
+            chat_payload["stream_options"] = {"include_usage": True}
+        return chat_payload
+    if api_mode != "responses":
+        raise _bad_request("Unsupported QwenCloud API mode for request translation.")
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "input": responses_input,
+        "stream": streaming,
+        "store": False,
+    }
+    if instructions is not None:
+        payload["instructions"] = instructions
+    if temp is not None:
+        payload["temperature"] = temp
+    if topp is not None:
+        payload["top_p"] = topp
+    if max_tokens is not None:
+        if (
+            not isinstance(max_tokens, int)
+            or isinstance(max_tokens, bool)
+            or max_tokens < 16
+        ):
+            raise _bad_request("QwenCloud max output tokens must be at least 16.")
+        payload["max_output_tokens"] = max_tokens
+    if reasoning_effort is not None:
+        if (
+            not isinstance(reasoning_effort, str)
+            or reasoning_effort not in _REASONING_EFFORTS
+        ):
+            raise _bad_request("Unsupported QwenCloud reasoning effort.")
+        payload["reasoning"] = {"effort": reasoning_effort}
+    if responses_tools:
+        payload["tools"] = responses_tools
+        if tool_choice is not None:
+            payload["tool_choice"] = tool_choice
+    return payload

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -1,4 +1,4 @@
-"""Pure request translation for QwenCloud's compatible API modes."""
+"""QwenCloud dual-API transport, translation, and response normalization."""
 
 from __future__ import annotations
 
@@ -6,13 +6,33 @@ import json
 import math
 import os
 import re
-from collections.abc import Mapping
-from collections.abc import Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from copy import deepcopy
-from typing import Any, Literal, cast
+from typing import Any, Literal, Never, cast
 from urllib.parse import urlsplit
 
-from tldw_chatbook.Chat.Chat_Deps import ChatBadRequestError, ChatConfigurationError
+import requests
+from loguru import logger
+from requests.adapters import HTTPAdapter
+from requests.exceptions import (
+    ConnectionError as RequestsConnectionError,
+    HTTPError,
+    RequestException,
+    Timeout as RequestsTimeout,
+)
+from urllib3.util import Retry
+
+from tldw_chatbook.Chat.Chat_Deps import (
+    ChatAuthenticationError,
+    ChatBadRequestError,
+    ChatConfigurationError,
+    ChatProviderError,
+    ChatRateLimitError,
+)
+from tldw_chatbook.config import get_runtime_config_snapshot
+from tldw_chatbook.Utils.sensitive_llm_logging import llm_retry_count
+
+logger = logger.bind(module="qwencloud")
 
 QwenCloudAPIMode = Literal["responses", "chat_completions"]
 
@@ -23,6 +43,7 @@ _ENDPOINT_SUFFIXES = ("/chat/completions", "/responses")
 _REASONING_EFFORTS: frozenset[str] = frozenset(
     {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
 )
+_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
 
 
 def _configuration_error(message: str) -> ChatConfigurationError:
@@ -31,6 +52,97 @@ def _configuration_error(message: str) -> ChatConfigurationError:
 
 def _bad_request(message: str) -> ChatBadRequestError:
     return ChatBadRequestError(provider="qwencloud", message=message)
+
+
+def _provider_error(message: str, *, status_code: int = 502) -> ChatProviderError:
+    return ChatProviderError(
+        provider="qwencloud", message=message, status_code=status_code
+    )
+
+
+def _retry_configuration(
+    provider_settings: Mapping[str, Any],
+) -> tuple[int, float]:
+    configured_retries = provider_settings.get("retries", 3)
+    if isinstance(configured_retries, bool):
+        raise _configuration_error("QwenCloud retries must be an integer.")
+    try:
+        retries = max(0, int(configured_retries))
+    except (TypeError, ValueError) as exc:
+        raise _configuration_error("QwenCloud retries must be an integer.") from exc
+
+    configured_delay = provider_settings.get("retry_delay", 1)
+    if isinstance(configured_delay, bool):
+        raise _configuration_error("QwenCloud retry delay must be numeric.")
+    try:
+        retry_delay = float(configured_delay)
+    except (TypeError, ValueError) as exc:
+        raise _configuration_error("QwenCloud retry delay must be numeric.") from exc
+    if not math.isfinite(retry_delay) or retry_delay < 0:
+        raise _configuration_error(
+            "QwenCloud retry delay must be non-negative and finite."
+        )
+    return llm_retry_count(retries), retry_delay
+
+
+def _is_mode_model_mismatch(response: requests.Response) -> bool:
+    detail = ""
+    try:
+        payload = response.json()
+    except (TypeError, ValueError):
+        payload = None
+    if isinstance(payload, Mapping):
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            message = error.get("message")
+            if isinstance(message, str):
+                detail = message
+    if not detail:
+        raw_text = getattr(response, "text", "")
+        detail = raw_text if isinstance(raw_text, str) else ""
+    lowered = detail.lower()
+    incompatible = any(
+        marker in lowered
+        for marker in ("not supported", "unsupported", "incompatible", "not compatible")
+    )
+    mentions_mode = any(
+        marker in lowered
+        for marker in ("responses api", "chat completions", "api mode", "api_mode")
+    )
+    return "model" in lowered and incompatible and mentions_mode
+
+
+def _raise_qwencloud_http_error(response: requests.Response) -> Never:
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    logger.error(
+        "QwenCloud request failed; status={}; error_type=http_error",
+        status_code,
+    )
+    if status_code in {401, 403}:
+        raise ChatAuthenticationError(
+            provider="qwencloud",
+            message="QwenCloud authentication failed. Check the QwenCloud API key.",
+        ) from None
+    if status_code == 429:
+        raise ChatRateLimitError(
+            provider="qwencloud",
+            message="QwenCloud rate limit exceeded. Retry after the provider delay.",
+        ) from None
+    if 400 <= status_code < 500:
+        if _is_mode_model_mismatch(response):
+            message = (
+                "QwenCloud model is not compatible with the selected API mode; "
+                "choose a compatible model or switch api_mode."
+            )
+        else:
+            message = f"QwenCloud rejected the request (status {status_code})."
+        raise ChatBadRequestError(provider="qwencloud", message=message) from None
+    if 500 <= status_code < 600:
+        raise _provider_error(
+            f"QwenCloud service failed (status {status_code}).",
+            status_code=status_code,
+        ) from None
+    raise _provider_error("QwenCloud returned an unexpected HTTP failure.") from None
 
 
 def _validate_optional_number(name: str, value: Any) -> None:
@@ -697,3 +809,391 @@ def build_qwencloud_payload(
         if tool_choice is not None:
             payload["tool_choice"] = tool_choice
     return payload
+
+
+def _normalize_response_usage(payload: Mapping[str, Any]) -> dict[str, Any]:
+    usage = payload.get("usage")
+    if usage is None:
+        return {}
+    if not isinstance(usage, Mapping):
+        raise _provider_error("QwenCloud returned malformed token usage.")
+    return deepcopy(dict(usage))
+
+
+def _normalize_response_tool_call(raw_call: Mapping[str, Any]) -> dict[str, Any]:
+    call_id = raw_call.get("call_id", raw_call.get("id"))
+    name = raw_call.get("name")
+    arguments = raw_call.get("arguments")
+    if (
+        not isinstance(call_id, str)
+        or not call_id.strip()
+        or not isinstance(name, str)
+        or not name.strip()
+        or not isinstance(arguments, str)
+    ):
+        raise _provider_error("QwenCloud returned an incomplete function call.")
+    try:
+        decoded_arguments = json.loads(
+            arguments, parse_constant=_reject_non_finite_json_constant
+        )
+    except (TypeError, ValueError) as exc:
+        raise _provider_error(
+            "QwenCloud returned malformed function-call arguments."
+        ) from exc
+    if not isinstance(decoded_arguments, Mapping):
+        raise _provider_error("QwenCloud returned non-object function-call arguments.")
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+def _normalize_responses_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    status = payload.get("status")
+    if status in {"failed", "cancelled"}:
+        raise _provider_error("QwenCloud did not complete the response.")
+    if status not in {"completed", "incomplete"}:
+        raise _provider_error("QwenCloud returned a malformed response status.")
+
+    output = payload.get("output")
+    if not isinstance(output, Sequence) or isinstance(output, (str, bytes)):
+        raise _provider_error("QwenCloud returned a malformed response envelope.")
+
+    text_fragments: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    call_ids: set[str] = set()
+    for raw_item in output:
+        if not isinstance(raw_item, Mapping):
+            raise _provider_error("QwenCloud returned a malformed output item.")
+        item_type = raw_item.get("type")
+        if item_type == "reasoning":
+            continue
+        if item_type == "message":
+            content = raw_item.get("content")
+            if not isinstance(content, Sequence) or isinstance(content, (str, bytes)):
+                raise _provider_error("QwenCloud returned malformed message content.")
+            for raw_part in content:
+                if not isinstance(raw_part, Mapping):
+                    raise _provider_error(
+                        "QwenCloud returned a malformed message content part."
+                    )
+                part_type = raw_part.get("type")
+                if part_type == "output_text":
+                    text = raw_part.get("text")
+                    if not isinstance(text, str):
+                        raise _provider_error(
+                            "QwenCloud returned malformed output text."
+                        )
+                    text_fragments.append(text)
+                    continue
+                if part_type == "refusal":
+                    raise _provider_error("QwenCloud refused the response.")
+                raise _provider_error(
+                    "QwenCloud returned an unsupported message content part."
+                )
+            continue
+        if item_type == "function_call":
+            if status != "completed" or raw_item.get("status") not in {
+                None,
+                "completed",
+            }:
+                raise _provider_error("QwenCloud returned an incomplete function call.")
+            normalized_call = _normalize_response_tool_call(raw_item)
+            call_id = normalized_call["id"]
+            if call_id in call_ids:
+                raise _provider_error("QwenCloud returned duplicate function-call IDs.")
+            call_ids.add(call_id)
+            tool_calls.append(normalized_call)
+            continue
+        raise _provider_error("QwenCloud returned an unsupported output item.")
+
+    content = "".join(text_fragments)
+    has_usable_text = bool(content.strip())
+    if status == "incomplete":
+        incomplete_details = payload.get("incomplete_details")
+        reason = (
+            incomplete_details.get("reason")
+            if isinstance(incomplete_details, Mapping)
+            else None
+        )
+        if reason != "max_output_tokens" or not has_usable_text or tool_calls:
+            raise _provider_error("QwenCloud returned an incomplete response.")
+        finish_reason = "length"
+    elif tool_calls:
+        finish_reason = "tool_calls"
+    else:
+        finish_reason = "stop"
+
+    if not has_usable_text and not tool_calls:
+        raise _provider_error("QwenCloud returned no usable response content.")
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": content if has_usable_text else None,
+    }
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return {
+        "choices": [{"message": message, "finish_reason": finish_reason}],
+        "usage": _normalize_response_usage(payload),
+    }
+
+
+def _normalize_chat_completions_payload(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    choices = payload.get("choices")
+    if (
+        not isinstance(choices, Sequence)
+        or isinstance(choices, (str, bytes))
+        or not choices
+        or not isinstance(choices[0], Mapping)
+    ):
+        raise _provider_error("QwenCloud returned a malformed choices envelope.")
+    choice = choices[0]
+    raw_message = choice.get("message")
+    if not isinstance(raw_message, Mapping):
+        raise _provider_error("QwenCloud returned a malformed assistant message.")
+
+    content = raw_message.get("content")
+    if content is not None and not isinstance(content, str):
+        raise _provider_error("QwenCloud returned malformed assistant text.")
+    raw_calls = raw_message.get("tool_calls")
+    tool_calls: list[dict[str, Any]] = []
+    call_ids: set[str] = set()
+    if raw_calls is not None:
+        if (
+            not isinstance(raw_calls, Sequence)
+            or isinstance(raw_calls, (str, bytes))
+            or not raw_calls
+        ):
+            raise _provider_error("QwenCloud returned malformed function calls.")
+        for raw_call in raw_calls:
+            if (
+                not isinstance(raw_call, Mapping)
+                or raw_call.get("type") != "function"
+                or not isinstance(raw_call.get("function"), Mapping)
+            ):
+                raise _provider_error("QwenCloud returned a malformed function call.")
+            function = raw_call["function"]
+            normalized_call = _normalize_response_tool_call(
+                {
+                    "call_id": raw_call.get("id"),
+                    "name": function.get("name"),
+                    "arguments": function.get("arguments"),
+                }
+            )
+            call_id = normalized_call["id"]
+            if call_id in call_ids:
+                raise _provider_error("QwenCloud returned duplicate function-call IDs.")
+            call_ids.add(call_id)
+            tool_calls.append(normalized_call)
+
+    has_usable_text = isinstance(content, str) and bool(content.strip())
+    if not has_usable_text and not tool_calls:
+        raise _provider_error("QwenCloud returned no usable response content.")
+    raw_finish_reason = choice.get("finish_reason")
+    if tool_calls:
+        finish_reason = "tool_calls"
+    elif isinstance(raw_finish_reason, str) and raw_finish_reason:
+        finish_reason = raw_finish_reason
+    else:
+        raise _provider_error("QwenCloud returned no completion finish reason.")
+
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": content if has_usable_text else None,
+    }
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return {
+        "choices": [{"message": message, "finish_reason": finish_reason}],
+        "usage": _normalize_response_usage(payload),
+    }
+
+
+def normalize_qwencloud_response(
+    payload: Mapping[str, Any], *, api_mode: QwenCloudAPIMode
+) -> dict[str, Any]:
+    """Normalize a successful QwenCloud response to Chatbook's chat contract.
+
+    Args:
+        payload: Decoded provider JSON response.
+        api_mode: The API mode used for the request.
+
+    Returns:
+        A standard choices/message/finish/usage mapping.
+
+    Raises:
+        ChatProviderError: If the successful HTTP response is malformed or empty.
+    """
+    if not isinstance(payload, Mapping):
+        raise _provider_error("QwenCloud response envelope must be an object.")
+    if api_mode == "responses":
+        return _normalize_responses_payload(payload)
+    if api_mode == "chat_completions":
+        return _normalize_chat_completions_payload(payload)
+    raise _provider_error("QwenCloud response used an unknown API mode.")
+
+
+def chat_with_qwencloud(
+    input_data: list[dict[str, Any]],
+    model: str | None = None,
+    api_key: str | None = None,
+    system_message: str | None = None,
+    temp: float | None = None,
+    streaming: bool | None = False,
+    topp: float | None = None,
+    topk: int | None = None,
+    max_tokens: int | None = None,
+    seed: int | None = None,
+    stop: str | list[str] | None = None,
+    logprobs: bool | None = None,
+    top_logprobs: int | None = None,
+    presence_penalty: float | None = None,
+    response_format: dict[str, str] | None = None,
+    n: int | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: str | dict[str, Any] | None = None,
+    reasoning_effort: str | None = None,
+    api_base_url: str | None = None,
+    api_mode: str | None = None,
+) -> dict[str, Any] | Iterator[dict[str, Any]]:
+    """Send a QwenCloud request through the selected compatible API mode.
+
+    Transport timeout and retry policy are owned by QwenCloud's modern provider
+    settings rather than the generic dispatcher.
+    """
+    config_values = get_runtime_config_snapshot().values
+    api_settings = config_values.get("api_settings", {})
+    provider_settings: Mapping[str, Any] = {}
+    if isinstance(api_settings, Mapping):
+        configured_qwencloud = api_settings.get("qwencloud", {})
+        if isinstance(configured_qwencloud, Mapping):
+            provider_settings = configured_qwencloud
+
+    final_mode = normalize_qwencloud_api_mode(
+        api_mode, provider_settings=provider_settings
+    )
+    configured_base = provider_settings.get("api_base_url")
+    final_base = normalize_qwencloud_base_url(
+        api_base_url
+        if api_base_url is not None
+        else configured_base
+        if isinstance(configured_base, str)
+        else None
+    )
+    final_api_key = resolve_qwencloud_api_key(
+        api_key, provider_settings=provider_settings
+    )
+    configured_model = provider_settings.get("model")
+    final_model = (
+        model
+        if model is not None
+        else configured_model
+        if isinstance(configured_model, str)
+        else "qwen3.8-max"
+    )
+    final_streaming = False if streaming is None else streaming
+    if final_streaming:
+        raise _configuration_error(
+            "QwenCloud streaming transport is not available in this adapter version."
+        )
+
+    payload = build_qwencloud_payload(
+        api_mode=final_mode,
+        model=final_model,
+        system_message=system_message,
+        messages_payload=input_data,
+        streaming=final_streaming,
+        tools=tools,
+        tool_choice=tool_choice,
+        temp=temp,
+        topp=topp,
+        topk=topk,
+        max_tokens=max_tokens,
+        seed=seed,
+        stop=stop,
+        logprobs=logprobs,
+        top_logprobs=top_logprobs,
+        presence_penalty=presence_penalty,
+        response_format=response_format,
+        n=n,
+        reasoning_effort=reasoning_effort,
+    )
+    timeout_value = provider_settings.get("timeout", 120)
+    try:
+        timeout = float(timeout_value)
+    except (TypeError, ValueError) as exc:
+        raise _configuration_error("QwenCloud timeout must be numeric.") from exc
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise _configuration_error("QwenCloud timeout must be positive and finite.")
+    retries, retry_delay = _retry_configuration(provider_settings)
+    retry_policy = Retry(
+        total=retries,
+        backoff_factor=retry_delay,
+        status_forcelist=_RETRYABLE_STATUS_CODES,
+        allowed_methods=frozenset({"POST"}),
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry_policy)
+
+    suffix = "/responses" if final_mode == "responses" else "/chat/completions"
+    api_url = f"{final_base}{suffix}"
+    headers = {
+        "Authorization": f"Bearer {final_api_key}",
+        "Content-Type": "application/json",
+    }
+
+    response: requests.Response | None = None
+    with requests.Session() as session:
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        try:
+            response = session.post(
+                api_url,
+                headers=headers,
+                json=payload,
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            result = response.json()
+            if not isinstance(result, Mapping):
+                raise _provider_error("QwenCloud response envelope must be an object.")
+            return normalize_qwencloud_response(result, api_mode=final_mode)
+        except HTTPError as exc:
+            failed_response = exc.response if exc.response is not None else response
+            if failed_response is None:
+                logger.error(
+                    "QwenCloud request failed; status=unknown; error_type=http_error"
+                )
+                raise _provider_error(
+                    "QwenCloud returned an HTTP failure without a response."
+                ) from None
+            _raise_qwencloud_http_error(failed_response)
+        except (RequestsConnectionError, RequestsTimeout) as exc:
+            logger.error(
+                "QwenCloud request failed; status=none; error_type={}",
+                type(exc).__name__,
+            )
+            raise _provider_error(
+                "QwenCloud network request failed.",
+                status_code=504 if isinstance(exc, RequestsTimeout) else 502,
+            ) from None
+        except RequestException as exc:
+            logger.error(
+                "QwenCloud request failed; status=none; error_type={}",
+                type(exc).__name__,
+            )
+            raise _provider_error("QwenCloud network request failed.") from None
+        except (TypeError, ValueError) as exc:
+            logger.error(
+                "QwenCloud request failed; status={}; error_type={}",
+                getattr(response, "status_code", "unknown"),
+                type(exc).__name__,
+            )
+            raise _provider_error("QwenCloud returned malformed JSON.") from None
+        finally:
+            if response is not None:
+                response.close()

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 from collections.abc import Mapping
 from collections.abc import Sequence
 from copy import deepcopy
-from typing import Any, Literal
+from typing import Any, Literal, cast
 from urllib.parse import urlsplit
 
 from tldw_chatbook.Chat.Chat_Deps import ChatBadRequestError, ChatConfigurationError
@@ -30,6 +31,72 @@ def _configuration_error(message: str) -> ChatConfigurationError:
 
 def _bad_request(message: str) -> ChatBadRequestError:
     return ChatBadRequestError(provider="qwencloud", message=message)
+
+
+def _validate_optional_number(name: str, value: Any) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise _bad_request(f"QwenCloud {name} must be numeric.")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise _bad_request(f"QwenCloud {name} must be finite.")
+
+
+def _validate_optional_integer(name: str, value: Any) -> None:
+    if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+        raise _bad_request(f"QwenCloud {name} must be an integer.")
+
+
+def _normalize_stop(stop: Any) -> str | list[str] | None:
+    if stop is None or isinstance(stop, str):
+        return stop
+    if not isinstance(stop, Sequence) or isinstance(stop, (str, bytes)):
+        raise _bad_request("QwenCloud stop must be a string or sequence of strings.")
+    if any(not isinstance(item, str) for item in stop):
+        raise _bad_request("QwenCloud stop sequences must contain only strings.")
+    return list(stop)
+
+
+def _validate_scalar_parameters(
+    *,
+    model: Any,
+    streaming: Any,
+    temp: Any,
+    topp: Any,
+    topk: Any,
+    max_tokens: Any,
+    seed: Any,
+    presence_penalty: Any,
+    stop: Any,
+    n: Any,
+    logprobs: Any,
+    top_logprobs: Any,
+    reasoning_effort: Any,
+) -> str | list[str] | None:
+    if not isinstance(model, str) or not model.strip():
+        raise _bad_request("QwenCloud model must be a non-empty string.")
+    if not isinstance(streaming, bool):
+        raise _bad_request("QwenCloud streaming must be a boolean.")
+    if logprobs is not None and not isinstance(logprobs, bool):
+        raise _bad_request("QwenCloud logprobs must be a boolean.")
+    if reasoning_effort is not None and not isinstance(reasoning_effort, str):
+        raise _bad_request("QwenCloud reasoning effort must be a string.")
+
+    for name, value in (
+        ("temperature", temp),
+        ("top_p", topp),
+        ("presence penalty", presence_penalty),
+    ):
+        _validate_optional_number(name, value)
+    for name, value in (
+        ("top_k", topk),
+        ("max tokens", max_tokens),
+        ("seed", seed),
+        ("n", n),
+        ("top_logprobs", top_logprobs),
+    ):
+        _validate_optional_integer(name, value)
+    return _normalize_stop(stop)
 
 
 def _reject_non_finite_json_constant(value: str) -> None:
@@ -69,7 +136,7 @@ def normalize_qwencloud_api_mode(
         raise _configuration_error(
             "QwenCloud API mode must be 'responses' or 'chat_completions'."
         )
-    return normalized  # type: ignore[return-value]
+    return cast(QwenCloudAPIMode, normalized)
 
 
 def normalize_qwencloud_base_url(api_base_url: str | None) -> str:
@@ -446,6 +513,8 @@ def _translate_function_tools(
     for tool in tools:
         if not isinstance(tool, Mapping) or tool.get("type") != "function":
             raise _bad_request("QwenCloud supports only existing function tools.")
+        if set(tool) != {"type", "function"}:
+            raise _bad_request("QwenCloud function tool fields are unsupported.")
         function = tool.get("function")
         if not isinstance(function, Mapping):
             raise _bad_request("QwenCloud function tool definition is malformed.")
@@ -472,9 +541,8 @@ def _translate_function_tools(
                 "QwenCloud function parameters must be an object schema."
             )
 
-        copied_tool = deepcopy(dict(tool))
         copied_function = deepcopy(dict(function))
-        chat_tools.append(copied_tool)
+        chat_tools.append({"type": "function", "function": copied_function})
         responses_tools.append({"type": "function", **copied_function})
     return chat_tools, responses_tools
 
@@ -530,6 +598,21 @@ def build_qwencloud_payload(
     Raises:
         ChatBadRequestError: If request history or parameters are unsupported.
     """
+    normalized_stop = _validate_scalar_parameters(
+        model=model,
+        streaming=streaming,
+        temp=temp,
+        topp=topp,
+        topk=topk,
+        max_tokens=max_tokens,
+        seed=seed,
+        presence_penalty=presence_penalty,
+        stop=stop,
+        n=n,
+        logprobs=logprobs,
+        top_logprobs=top_logprobs,
+        reasoning_effort=reasoning_effort,
+    )
     if tool_choice is not None and tool_choice not in ("auto", "none"):
         raise _bad_request("Unsupported QwenCloud function tool choice.")
     chat_tools, responses_tools = _translate_function_tools(tools)
@@ -558,8 +641,8 @@ def build_qwencloud_payload(
         for key, value in optional_values:
             if value is not None:
                 chat_payload[key] = value
-        if stop is not None:
-            chat_payload["stop"] = deepcopy(stop)
+        if normalized_stop is not None:
+            chat_payload["stop"] = normalized_stop
         if response_format is not None:
             if not isinstance(response_format, Mapping):
                 raise _bad_request("QwenCloud response format must be an object.")

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -16,11 +16,16 @@ import requests
 from loguru import logger
 from requests.adapters import HTTPAdapter
 from requests.exceptions import (
+    ChunkedEncodingError,
     ConnectionError as RequestsConnectionError,
+    ContentDecodingError,
     HTTPError,
+    InvalidJSONError,
+    JSONDecodeError as RequestsJSONDecodeError,
     RequestException,
     Timeout as RequestsTimeout,
 )
+from urllib3.exceptions import InvalidHeader as Urllib3InvalidHeader
 from urllib3.util import Retry
 
 from tldw_chatbook.Chat.Chat_Deps import (
@@ -30,7 +35,10 @@ from tldw_chatbook.Chat.Chat_Deps import (
     ChatProviderError,
     ChatRateLimitError,
 )
-from tldw_chatbook.config import get_runtime_config_snapshot
+from tldw_chatbook.config import (
+    get_runtime_config_snapshot,
+    resolve_provider_api_key,
+)
 from tldw_chatbook.Utils.sensitive_llm_logging import llm_retry_count
 
 logger = logger.bind(module="qwencloud")
@@ -116,7 +124,10 @@ def _advance_retry_policy(
     retry_after: float | None = None
     if response is not None:
         retry_response = _RetryStatusResponse(response)
-        retry_after = retry_policy.get_retry_after(cast(Any, retry_response))
+        try:
+            retry_after = retry_policy.get_retry_after(cast(Any, retry_response))
+        except Urllib3InvalidHeader:
+            retry_after = None
         next_policy = retry_policy.increment(
             method="POST",
             url=api_url,
@@ -412,14 +423,15 @@ def resolve_qwencloud_api_key(
     Raises:
         ChatConfigurationError: If no QwenCloud credential is configured.
     """
-    if isinstance(explicit_api_key, str) and explicit_api_key.strip():
-        return explicit_api_key
+    explicit = resolve_provider_api_key(explicit_api_key)
+    if explicit is not None:
+        return explicit
     if provider_settings is not None and not isinstance(provider_settings, Mapping):
         raise _configuration_error("QwenCloud provider settings must be an object.")
 
     settings = provider_settings or {}
-    configured = settings.get("api_key")
-    if isinstance(configured, str) and configured.strip():
+    configured = resolve_provider_api_key(settings.get("api_key"))
+    if configured is not None:
         return configured
 
     if environ is not None and not isinstance(environ, Mapping):
@@ -431,8 +443,8 @@ def resolve_qwencloud_api_key(
     if not isinstance(env_name, str) or not env_name.strip():
         env_name = _DEFAULT_KEY_ENV_VAR
     environment = os.environ if environ is None else environ
-    from_environment = environment.get(env_name.strip())
-    if isinstance(from_environment, str) and from_environment.strip():
+    from_environment = resolve_provider_api_key(environment.get(env_name.strip()))
+    if from_environment is not None:
         return from_environment
 
     raise _configuration_error("QwenCloud API key is required but not configured.")
@@ -1056,12 +1068,17 @@ def _normalize_chat_completions_payload(
     if not has_usable_text and not tool_calls:
         raise _provider_error("QwenCloud returned no usable response content.")
     raw_finish_reason = choice.get("finish_reason")
-    if tool_calls:
-        finish_reason = "tool_calls"
-    elif isinstance(raw_finish_reason, str) and raw_finish_reason:
-        finish_reason = raw_finish_reason
-    else:
-        raise _provider_error("QwenCloud returned no completion finish reason.")
+    if not isinstance(raw_finish_reason, str) or raw_finish_reason not in {
+        "stop",
+        "length",
+        "tool_calls",
+    }:
+        raise _provider_error("QwenCloud returned an invalid completion finish reason.")
+    if bool(tool_calls) != (raw_finish_reason == "tool_calls"):
+        raise _provider_error(
+            "QwenCloud returned an inconsistent completion finish reason."
+        )
+    finish_reason = raw_finish_reason
 
     message: dict[str, Any] = {
         "role": "assistant",
@@ -1129,22 +1146,19 @@ def chat_with_qwencloud(
     """
     config_values = get_runtime_config_snapshot().values
     api_settings = config_values.get("api_settings", {})
-    provider_settings: Mapping[str, Any] = {}
-    if isinstance(api_settings, Mapping):
-        configured_qwencloud = api_settings.get("qwencloud", {})
-        if isinstance(configured_qwencloud, Mapping):
-            provider_settings = configured_qwencloud
+    if not isinstance(api_settings, Mapping):
+        raise _configuration_error("QwenCloud API settings must be an object.")
+    configured_qwencloud = api_settings.get("qwencloud", {})
+    if not isinstance(configured_qwencloud, Mapping):
+        raise _configuration_error("QwenCloud provider settings must be an object.")
+    provider_settings: Mapping[str, Any] = configured_qwencloud
 
     final_mode = normalize_qwencloud_api_mode(
         api_mode, provider_settings=provider_settings
     )
     configured_base = provider_settings.get("api_base_url")
     final_base = normalize_qwencloud_base_url(
-        api_base_url
-        if api_base_url is not None
-        else configured_base
-        if isinstance(configured_base, str)
-        else None
+        api_base_url if api_base_url is not None else configured_base
     )
     final_api_key = resolve_qwencloud_api_key(
         api_key, provider_settings=provider_settings
@@ -1242,6 +1256,34 @@ def chat_with_qwencloud(
                         "QwenCloud returned an HTTP failure without a response."
                     ) from None
                 _raise_qwencloud_http_error(failed_response)
+            except (
+                RequestsJSONDecodeError,
+                InvalidJSONError,
+                ContentDecodingError,
+            ):
+                logger.error(
+                    "QwenCloud request failed; status={}; "
+                    "error_type=malformed_response",
+                    getattr(response, "status_code", "unknown"),
+                )
+                raise _provider_error(
+                    "QwenCloud returned malformed provider JSON or content."
+                ) from None
+            except ChunkedEncodingError as exc:
+                if attempt_index < retries:
+                    retry_policy, retry_sleep = _advance_retry_policy(
+                        retry_policy,
+                        api_url=api_url,
+                        error=exc,
+                    )
+                else:
+                    logger.error(
+                        "QwenCloud request failed; "
+                        "status=none; error_type=incomplete_body"
+                    )
+                    raise _provider_error(
+                        "QwenCloud network response was incomplete."
+                    ) from None
             except (RequestsConnectionError, RequestsTimeout) as exc:
                 if attempt_index < retries:
                     retry_policy, retry_sleep = _advance_retry_policy(

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -6,6 +6,7 @@ import json
 import math
 import os
 import re
+import time
 from collections.abc import Iterator, Mapping, Sequence
 from copy import deepcopy
 from typing import Any, Literal, Never, cast
@@ -83,6 +84,66 @@ def _retry_configuration(
             "QwenCloud retry delay must be non-negative and finite."
         )
     return llm_retry_count(retries), retry_delay
+
+
+class _RetryStatusResponse:
+    def __init__(self, response: requests.Response) -> None:
+        self.status = int(response.status_code)
+        self.headers = response.headers
+
+    def get_redirect_location(self) -> None:
+        return None
+
+
+def _build_retry_policy(*, retries: int, retry_delay: float) -> Retry:
+    return Retry(
+        total=retries,
+        backoff_factor=retry_delay,
+        status_forcelist=_RETRYABLE_STATUS_CODES,
+        allowed_methods=frozenset({"POST"}),
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+
+
+def _advance_retry_policy(
+    retry_policy: Retry,
+    *,
+    api_url: str,
+    response: requests.Response | None = None,
+    error: RequestException | None = None,
+) -> tuple[Retry, float]:
+    retry_after: float | None = None
+    if response is not None:
+        retry_response = _RetryStatusResponse(response)
+        retry_after = retry_policy.get_retry_after(cast(Any, retry_response))
+        next_policy = retry_policy.increment(
+            method="POST",
+            url=api_url,
+            response=cast(Any, retry_response),
+        )
+    else:
+        next_policy = retry_policy.increment(
+            method="POST",
+            url=api_url,
+            error=error,
+        )
+    delay = retry_after if retry_after is not None else next_policy.get_backoff_time()
+    return next_policy, delay
+
+
+def _transport_without_hidden_retries() -> HTTPAdapter:
+    retry_policy = Retry(
+        total=0,
+        connect=0,
+        read=0,
+        redirect=0,
+        status=0,
+        other=0,
+        allowed_methods=frozenset({"POST"}),
+        raise_on_status=False,
+    )
+    return HTTPAdapter(max_retries=retry_policy)
 
 
 def _is_mode_model_mismatch(response: requests.Response) -> bool:
@@ -821,7 +882,7 @@ def _normalize_response_usage(payload: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _normalize_response_tool_call(raw_call: Mapping[str, Any]) -> dict[str, Any]:
-    call_id = raw_call.get("call_id", raw_call.get("id"))
+    call_id = raw_call.get("call_id")
     name = raw_call.get("name")
     arguments = raw_call.get("arguments")
     if (
@@ -1129,15 +1190,8 @@ def chat_with_qwencloud(
     if not math.isfinite(timeout) or timeout <= 0:
         raise _configuration_error("QwenCloud timeout must be positive and finite.")
     retries, retry_delay = _retry_configuration(provider_settings)
-    retry_policy = Retry(
-        total=retries,
-        backoff_factor=retry_delay,
-        status_forcelist=_RETRYABLE_STATUS_CODES,
-        allowed_methods=frozenset({"POST"}),
-        respect_retry_after_header=True,
-        raise_on_status=False,
-    )
-    adapter = HTTPAdapter(max_retries=retry_policy)
+    retry_policy = _build_retry_policy(retries=retries, retry_delay=retry_delay)
+    adapter = _transport_without_hidden_retries()
 
     suffix = "/responses" if final_mode == "responses" else "/chat/completions"
     api_url = f"{final_base}{suffix}"
@@ -1146,54 +1200,82 @@ def chat_with_qwencloud(
         "Content-Type": "application/json",
     }
 
-    response: requests.Response | None = None
     with requests.Session() as session:
         session.mount("https://", adapter)
         session.mount("http://", adapter)
-        try:
-            response = session.post(
-                api_url,
-                headers=headers,
-                json=payload,
-                timeout=timeout,
-            )
-            response.raise_for_status()
-            result = response.json()
-            if not isinstance(result, Mapping):
-                raise _provider_error("QwenCloud response envelope must be an object.")
-            return normalize_qwencloud_response(result, api_mode=final_mode)
-        except HTTPError as exc:
-            failed_response = exc.response if exc.response is not None else response
-            if failed_response is None:
-                logger.error(
-                    "QwenCloud request failed; status=unknown; error_type=http_error"
+        for attempt_index in range(retries + 1):
+            response: requests.Response | None = None
+            retry_sleep: float | None = None
+            try:
+                response = session.post(
+                    api_url,
+                    headers=headers,
+                    json=payload,
+                    timeout=timeout,
+                    stream=True,
                 )
-                raise _provider_error(
-                    "QwenCloud returned an HTTP failure without a response."
-                ) from None
-            _raise_qwencloud_http_error(failed_response)
-        except (RequestsConnectionError, RequestsTimeout) as exc:
-            logger.error(
-                "QwenCloud request failed; status=none; error_type={}",
-                type(exc).__name__,
-            )
-            raise _provider_error(
-                "QwenCloud network request failed.",
-                status_code=504 if isinstance(exc, RequestsTimeout) else 502,
-            ) from None
-        except RequestException as exc:
-            logger.error(
-                "QwenCloud request failed; status=none; error_type={}",
-                type(exc).__name__,
-            )
-            raise _provider_error("QwenCloud network request failed.") from None
-        except (TypeError, ValueError) as exc:
-            logger.error(
-                "QwenCloud request failed; status={}; error_type={}",
-                getattr(response, "status_code", "unknown"),
-                type(exc).__name__,
-            )
-            raise _provider_error("QwenCloud returned malformed JSON.") from None
-        finally:
-            if response is not None:
-                response.close()
+                status_code = int(response.status_code)
+                if status_code in _RETRYABLE_STATUS_CODES and attempt_index < retries:
+                    retry_policy, retry_sleep = _advance_retry_policy(
+                        retry_policy,
+                        api_url=api_url,
+                        response=response,
+                    )
+                else:
+                    response.raise_for_status()
+                    result = response.json()
+                    if not isinstance(result, Mapping):
+                        raise _provider_error(
+                            "QwenCloud response envelope must be an object."
+                        )
+                    return normalize_qwencloud_response(result, api_mode=final_mode)
+            except HTTPError as exc:
+                failed_response = exc.response if exc.response is not None else response
+                if failed_response is None:
+                    logger.error(
+                        "QwenCloud request failed; "
+                        "status=unknown; error_type=http_error"
+                    )
+                    raise _provider_error(
+                        "QwenCloud returned an HTTP failure without a response."
+                    ) from None
+                _raise_qwencloud_http_error(failed_response)
+            except (RequestsConnectionError, RequestsTimeout) as exc:
+                if attempt_index < retries:
+                    retry_policy, retry_sleep = _advance_retry_policy(
+                        retry_policy,
+                        api_url=api_url,
+                        error=exc,
+                    )
+                else:
+                    logger.error(
+                        "QwenCloud request failed; status=none; error_type={}",
+                        type(exc).__name__,
+                    )
+                    raise _provider_error(
+                        "QwenCloud network request failed.",
+                        status_code=504 if isinstance(exc, RequestsTimeout) else 502,
+                    ) from None
+            except RequestException as exc:
+                logger.error(
+                    "QwenCloud request failed; status=none; error_type={}",
+                    type(exc).__name__,
+                )
+                raise _provider_error("QwenCloud network request failed.") from None
+            except (TypeError, ValueError) as exc:
+                logger.error(
+                    "QwenCloud request failed; status={}; error_type={}",
+                    getattr(response, "status_code", "unknown"),
+                    type(exc).__name__,
+                )
+                raise _provider_error("QwenCloud returned malformed JSON.") from None
+            finally:
+                if response is not None:
+                    response.close()
+
+            if retry_sleep is None:
+                raise _provider_error("QwenCloud retry state was incomplete.")
+            if retry_sleep > 0:
+                time.sleep(retry_sleep)
+
+    raise _provider_error("QwenCloud request attempts were exhausted.")

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -150,6 +150,8 @@ def _is_mode_model_mismatch(response: requests.Response) -> bool:
     detail = ""
     try:
         payload = response.json()
+    except RequestException:
+        return False
     except (TypeError, ValueError):
         payload = None
     if isinstance(payload, Mapping):

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -36,6 +36,7 @@ from tldw_chatbook.Chat.Chat_Deps import (
     ChatRateLimitError,
 )
 from tldw_chatbook.config import (
+    ProviderSettingsError,
     get_runtime_config_snapshot,
     provider_settings_for_key,
     resolve_provider_api_key,
@@ -299,7 +300,7 @@ def _reject_non_finite_json_constant(value: str) -> None:
 
 
 def normalize_qwencloud_api_mode(
-    api_mode: str | None,
+    api_mode: object | None,
     *,
     provider_settings: Mapping[str, Any] | None = None,
 ) -> QwenCloudAPIMode:
@@ -1157,13 +1158,14 @@ def chat_with_qwencloud(
     api_settings = config_values.get("api_settings", {})
     if not isinstance(api_settings, Mapping):
         raise _configuration_error("QwenCloud API settings must be an object.")
-    if "qwencloud" in api_settings and not isinstance(
-        api_settings.get("qwencloud"), Mapping
-    ):
-        raise _configuration_error("QwenCloud provider settings must be an object.")
-    provider_settings = cast(
-        Mapping[str, Any], provider_settings_for_key(api_settings, "qwencloud")
-    )
+    try:
+        provider_settings = cast(
+            Mapping[str, Any], provider_settings_for_key(api_settings, "qwencloud")
+        )
+    except ProviderSettingsError as exc:
+        raise _configuration_error(
+            "QwenCloud provider settings must be a configuration table."
+        ) from exc
 
     final_mode = normalize_qwencloud_api_mode(
         api_mode, provider_settings=provider_settings

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -69,6 +69,14 @@ def _provider_error(message: str, *, status_code: int = 502) -> ChatProviderErro
     )
 
 
+def _best_effort_close(resource: Any) -> None:
+    """Attempt one close without allowing cleanup failures to mask results."""
+    try:
+        resource.close()
+    except Exception:
+        pass
+
+
 def _retry_configuration(
     provider_settings: Mapping[str, Any],
 ) -> tuple[int, float]:
@@ -1326,7 +1334,7 @@ def chat_with_qwencloud(
                 raise _provider_error("QwenCloud returned malformed JSON.") from None
             finally:
                 if response is not None:
-                    response.close()
+                    _best_effort_close(response)
 
             if retry_sleep is None:
                 raise _provider_error("QwenCloud retry state was incomplete.")
@@ -1334,6 +1342,6 @@ def chat_with_qwencloud(
                 time.sleep(retry_sleep)
     finally:
         if not stream_owns_session:
-            session.close()
+            _best_effort_close(session)
 
     raise _provider_error("QwenCloud request attempts were exhausted.")

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -37,6 +37,7 @@ from tldw_chatbook.Chat.Chat_Deps import (
 )
 from tldw_chatbook.config import (
     get_runtime_config_snapshot,
+    provider_settings_for_key,
     resolve_provider_api_key,
 )
 from tldw_chatbook.Utils.sensitive_llm_logging import llm_retry_count
@@ -1156,10 +1157,13 @@ def chat_with_qwencloud(
     api_settings = config_values.get("api_settings", {})
     if not isinstance(api_settings, Mapping):
         raise _configuration_error("QwenCloud API settings must be an object.")
-    configured_qwencloud = api_settings.get("qwencloud", {})
-    if not isinstance(configured_qwencloud, Mapping):
+    if "qwencloud" in api_settings and not isinstance(
+        api_settings.get("qwencloud"), Mapping
+    ):
         raise _configuration_error("QwenCloud provider settings must be an object.")
-    provider_settings: Mapping[str, Any] = configured_qwencloud
+    provider_settings = cast(
+        Mapping[str, Any], provider_settings_for_key(api_settings, "qwencloud")
+    )
 
     final_mode = normalize_qwencloud_api_mode(
         api_mode, provider_settings=provider_settings

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import json
 import math
 import os
-import re
 import time
 from collections.abc import Iterator, Mapping, Sequence
 from copy import deepcopy
 from typing import Any, Literal, Never, cast
-from urllib.parse import urlsplit
 
 import requests
 from loguru import logger
@@ -35,6 +33,10 @@ from tldw_chatbook.Chat.Chat_Deps import (
     ChatProviderError,
     ChatRateLimitError,
 )
+from tldw_chatbook.LLM_Calls.qwencloud_url import (
+    QwenCloudBaseURLValidationError,
+    normalize_qwencloud_base_url as _normalize_qwencloud_base_url,
+)
 from tldw_chatbook.config import (
     ProviderSettingsError,
     get_runtime_config_snapshot,
@@ -47,10 +49,8 @@ logger = logger.bind(module="qwencloud")
 
 QwenCloudAPIMode = Literal["responses", "chat_completions"]
 
-_DEFAULT_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 _DEFAULT_KEY_ENV_VAR = "DASHSCOPE_API_KEY"
 _API_MODES: frozenset[str] = frozenset({"responses", "chat_completions"})
-_ENDPOINT_SUFFIXES = ("/chat/completions", "/responses")
 _REASONING_EFFORTS: frozenset[str] = frozenset(
     {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
 )
@@ -347,71 +347,10 @@ def normalize_qwencloud_base_url(api_base_url: str | None) -> str:
     Raises:
         ChatConfigurationError: If the URL is unsafe or malformed.
     """
-    candidate = _DEFAULT_BASE_URL if api_base_url is None else api_base_url
-    if not isinstance(candidate, str) or not candidate.strip():
-        raise _configuration_error("QwenCloud API base URL is required.")
-    candidate = candidate.strip().rstrip("/")
-    if (
-        any(character.isspace() for character in candidate)
-        or any(ord(character) < 32 or ord(character) == 127 for character in candidate)
-        or "?" in candidate
-        or "#" in candidate
-    ):
-        raise _configuration_error("QwenCloud API base URL is malformed.")
-
     try:
-        parsed = urlsplit(candidate)
-        parsed_port = parsed.port
-    except ValueError as exc:
-        raise _configuration_error("QwenCloud API base URL is malformed.") from exc
-
-    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
-        raise _configuration_error(
-            "QwenCloud API base URL must be an absolute HTTP(S) URL."
-        )
-    if parsed.username is not None or parsed.password is not None:
-        raise _configuration_error(
-            "QwenCloud API base URL must not contain credentials."
-        )
-    if any(character in parsed.netloc for character in '\\%|^{}<>"`'):
-        raise _configuration_error("QwenCloud API base URL authority is malformed.")
-    if parsed.query or parsed.fragment:
-        raise _configuration_error(
-            "QwenCloud API base URL must not contain a query or fragment."
-        )
-    if parsed.netloc.endswith(":") or (
-        parsed_port is not None and not 0 < parsed_port < 65536
-    ):
-        raise _configuration_error("QwenCloud API base URL is malformed.")
-    if (
-        "\\" in parsed.path
-        or "//" in parsed.path
-        or re.search(r"%(?![0-9A-Fa-f]{2})", parsed.path) is not None
-        or any(character.isspace() for character in parsed.path)
-        or any(segment in {".", ".."} for segment in parsed.path.split("/"))
-    ):
-        raise _configuration_error("QwenCloud API base URL path is malformed.")
-
-    path = parsed.path.rstrip("/")
-    if path.endswith("/models"):
-        raise _configuration_error(
-            "QwenCloud API base URL must not use the models endpoint."
-        )
-    if "/responses/" in path or "/chat/completions/" in path:
-        raise _configuration_error(
-            "QwenCloud API base URL contains a non-terminal request endpoint."
-        )
-    for suffix in _ENDPOINT_SUFFIXES:
-        if path.endswith(suffix):
-            path = path[: -len(suffix)]
-            if any(path.endswith(other) for other in _ENDPOINT_SUFFIXES):
-                raise _configuration_error(
-                    "QwenCloud API base URL contains a repeated endpoint suffix."
-                )
-            break
-
-    authority = parsed.netloc
-    return f"{parsed.scheme.lower()}://{authority}{path}".rstrip("/")
+        return _normalize_qwencloud_base_url(api_base_url)
+    except QwenCloudBaseURLValidationError as exc:
+        raise _configuration_error(str(exc)) from exc
 
 
 def resolve_qwencloud_api_key(

--- a/tldw_chatbook/LLM_Calls/qwencloud.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud.py
@@ -1172,10 +1172,6 @@ def chat_with_qwencloud(
         else "qwen3.8-max"
     )
     final_streaming = False if streaming is None else streaming
-    if final_streaming:
-        raise _configuration_error(
-            "QwenCloud streaming transport is not available in this adapter version."
-        )
 
     payload = build_qwencloud_payload(
         api_mode=final_mode,
@@ -1216,7 +1212,9 @@ def chat_with_qwencloud(
         "Content-Type": "application/json",
     }
 
-    with requests.Session() as session:
+    session = requests.Session()
+    stream_owns_session = False
+    try:
         session.mount("https://", adapter)
         session.mount("http://", adapter)
         for attempt_index in range(retries + 1):
@@ -1239,6 +1237,19 @@ def chat_with_qwencloud(
                     )
                 else:
                     response.raise_for_status()
+                    if final_streaming:
+                        from tldw_chatbook.LLM_Calls.qwencloud_streaming import (
+                            QwenCloudStream,
+                        )
+
+                        stream = QwenCloudStream(
+                            response=response,
+                            session=session,
+                            api_mode=final_mode,
+                        )
+                        response = None
+                        stream_owns_session = True
+                        return stream
                     result = response.json()
                     if not isinstance(result, Mapping):
                         raise _provider_error(
@@ -1321,5 +1332,8 @@ def chat_with_qwencloud(
                 raise _provider_error("QwenCloud retry state was incomplete.")
             if retry_sleep > 0:
                 time.sleep(retry_sleep)
+    finally:
+        if not stream_owns_session:
+            session.close()
 
     raise _provider_error("QwenCloud request attempts were exhausted.")

--- a/tldw_chatbook/LLM_Calls/qwencloud_streaming.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud_streaming.py
@@ -1,0 +1,719 @@
+"""Record-aware streaming normalization for the QwenCloud adapter."""
+
+from __future__ import annotations
+
+import codecs
+import json
+from collections import deque
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Never, cast
+
+import requests
+
+from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
+
+if TYPE_CHECKING:
+    from tldw_chatbook.LLM_Calls.qwencloud import QwenCloudAPIMode
+
+_JSON_DECODE_FAILED = object()
+_STREAM_END = object()
+_STREAM_READ_FAILED = object()
+
+
+def _stream_error(message: str) -> ChatProviderError:
+    return ChatProviderError(provider="qwencloud", message=message, status_code=502)
+
+
+def _raise_malformed(message: str) -> Never:
+    raise _stream_error(message)
+
+
+def _reject_json_constant(_value: str) -> Never:
+    raise ValueError
+
+
+def _strict_json_loads(value: str) -> Any:
+    try:
+        return json.loads(value, parse_constant=_reject_json_constant)
+    except (TypeError, ValueError):
+        return _JSON_DECODE_FAILED
+
+
+def _required_index(event: Mapping[str, Any], name: str) -> int:
+    value = event.get(name)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        _raise_malformed("QwenCloud stream index is malformed.")
+    return value
+
+
+def _required_string(
+    source: Mapping[str, Any], name: str, *, allow_empty: bool = False
+) -> str:
+    value = source.get(name)
+    if not isinstance(value, str) or (not allow_empty and not value.strip()):
+        _raise_malformed("QwenCloud stream event identity is malformed.")
+    return value
+
+
+@dataclass
+class _OutputItemState:
+    item_id: str
+    item_type: str
+
+
+@dataclass
+class _TextPartState:
+    item_id: str
+    emitted_text: str = ""
+    delta_count: int = 0
+    final_text: str | None = None
+
+
+@dataclass
+class _FunctionCallState:
+    item_id: str
+    call_id: str
+    name: str
+    tool_index: int
+    emitted_arguments: str = ""
+    final_arguments: str | None = None
+
+
+class QwenResponsesStreamTranslator:
+    """Translate stateful QwenCloud Responses events into chat deltas."""
+
+    def __init__(self) -> None:
+        self._seen_sequences: dict[int, dict[str, Any]] = {}
+        self._highest_sequence = -1
+        self._output_items: dict[int, _OutputItemState] = {}
+        self._text_parts: dict[tuple[int, int], _TextPartState] = {}
+        self._function_calls: dict[int, _FunctionCallState] = {}
+        self._call_ids: set[str] = set()
+        self._terminal = False
+
+    def feed(self, event: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
+        """Consume one decoded Responses event and return normalized chunks."""
+        if self._terminal:
+            _raise_malformed("QwenCloud stream event arrived after the terminal event.")
+        if not isinstance(event, Mapping):
+            _raise_malformed("QwenCloud stream event must be an object.")
+        event_copy = deepcopy(dict(event))
+        sequence = event.get("sequence_number")
+        if not isinstance(sequence, int) or isinstance(sequence, bool) or sequence < 0:
+            _raise_malformed("QwenCloud stream sequence number is malformed.")
+        previous = self._seen_sequences.get(sequence)
+        if previous is not None:
+            if previous == event_copy:
+                return ()
+            _raise_malformed("QwenCloud stream sequence replay conflicts.")
+        if sequence <= self._highest_sequence:
+            _raise_malformed("QwenCloud stream sequence number decreased.")
+        self._seen_sequences[sequence] = event_copy
+        self._highest_sequence = sequence
+
+        event_type = event.get("type")
+        if not isinstance(event_type, str) or not event_type:
+            _raise_malformed("QwenCloud stream event type is malformed.")
+        if event_type in {"response.created", "response.in_progress"}:
+            response = event.get("response")
+            if not isinstance(response, Mapping):
+                _raise_malformed("QwenCloud stream lifecycle event is malformed.")
+            return ()
+        if event_type == "response.output_item.added":
+            return self._handle_output_item_added(event)
+        if event_type == "response.content_part.added":
+            return self._handle_content_part_added(event)
+        if event_type == "response.output_text.delta":
+            return self._handle_text_delta(event)
+        if event_type == "response.output_text.done":
+            return self._handle_text_done(event)
+        if event_type == "response.function_call_arguments.delta":
+            return self._handle_arguments_delta(event)
+        if event_type == "response.function_call_arguments.done":
+            return self._handle_arguments_done(event)
+        if event_type == "response.content_part.done":
+            return self._handle_content_part_done(event)
+        if event_type == "response.output_item.done":
+            return self._handle_output_item_done(event)
+        if event_type in {
+            "response.completed",
+            "response.incomplete",
+            "response.failed",
+            "response.cancelled",
+        }:
+            return self._handle_terminal(event_type, event)
+        _raise_malformed("QwenCloud stream event type is unsupported.")
+
+    def finish(self) -> tuple[dict[str, Any], ...]:
+        """Validate that the Responses stream supplied one terminal event."""
+        if not self._terminal:
+            _raise_malformed("QwenCloud stream terminal event is missing.")
+        return ()
+
+    def _handle_output_item_added(
+        self, event: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], ...]:
+        output_index = _required_index(event, "output_index")
+        item = event.get("item")
+        if not isinstance(item, Mapping):
+            _raise_malformed("QwenCloud stream output item is malformed.")
+        item_id = _required_string(item, "id")
+        item_type = _required_string(item, "type")
+        if output_index in self._output_items:
+            _raise_malformed("QwenCloud stream output index was reused.")
+        if any(state.item_id == item_id for state in self._output_items.values()):
+            _raise_malformed("QwenCloud stream output item identity was reused.")
+        if item_type not in {"message", "reasoning", "function_call"}:
+            _raise_malformed("QwenCloud stream output item type is unsupported.")
+        self._output_items[output_index] = _OutputItemState(item_id, item_type)
+        if item_type == "function_call":
+            call_id = _required_string(item, "call_id")
+            name = _required_string(item, "name")
+            arguments = _required_string(item, "arguments", allow_empty=True)
+            if call_id in self._call_ids:
+                _raise_malformed("QwenCloud stream function-call ID was reused.")
+            self._call_ids.add(call_id)
+            call_state = _FunctionCallState(
+                item_id=item_id,
+                call_id=call_id,
+                name=name,
+                tool_index=len(self._function_calls),
+                emitted_arguments=arguments,
+            )
+            self._function_calls[output_index] = call_state
+            return (
+                self._tool_chunk(
+                    call_state,
+                    arguments=arguments,
+                    include_identity=True,
+                ),
+            )
+        return ()
+
+    def _message_state(
+        self, event: Mapping[str, Any]
+    ) -> tuple[int, int, _OutputItemState]:
+        output_index = _required_index(event, "output_index")
+        content_index = _required_index(event, "content_index")
+        item_id = _required_string(event, "item_id")
+        item_state = self._output_items.get(output_index)
+        if (
+            item_state is None
+            or item_state.item_type != "message"
+            or item_state.item_id != item_id
+        ):
+            _raise_malformed("QwenCloud stream text event identity is inconsistent.")
+        return output_index, content_index, item_state
+
+    def _handle_content_part_added(
+        self, event: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], ...]:
+        output_index, content_index, item_state = self._message_state(event)
+        part = event.get("part")
+        if not isinstance(part, Mapping) or part.get("type") != "output_text":
+            _raise_malformed("QwenCloud stream content part is unsupported.")
+        text = part.get("text", "")
+        if not isinstance(text, str) or text:
+            _raise_malformed("QwenCloud stream content part start is malformed.")
+        key = (output_index, content_index)
+        if key in self._text_parts:
+            _raise_malformed("QwenCloud stream content index was reused.")
+        self._text_parts[key] = _TextPartState(item_id=item_state.item_id)
+        return ()
+
+    def _text_state(
+        self, event: Mapping[str, Any]
+    ) -> tuple[_TextPartState, tuple[int, int]]:
+        output_index, content_index, item_state = self._message_state(event)
+        key = (output_index, content_index)
+        state = self._text_parts.get(key)
+        if state is None or state.item_id != item_state.item_id:
+            _raise_malformed("QwenCloud stream text part was not established.")
+        return state, key
+
+    @staticmethod
+    def _text_chunk(text: str) -> dict[str, Any]:
+        return {"choices": [{"delta": {"content": text}}]}
+
+    def _handle_text_delta(
+        self, event: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], ...]:
+        state, _ = self._text_state(event)
+        if state.final_text is not None:
+            _raise_malformed(
+                "QwenCloud stream text delta arrived after text completion."
+            )
+        delta = _required_string(event, "delta", allow_empty=True)
+        state.emitted_text += delta
+        state.delta_count += 1
+        return (self._text_chunk(delta),)
+
+    def _accept_final_text(
+        self, state: _TextPartState, text: Any
+    ) -> tuple[dict[str, Any], ...]:
+        if not isinstance(text, str):
+            _raise_malformed("QwenCloud stream final text is malformed.")
+        if state.final_text is not None:
+            if state.final_text != text:
+                _raise_malformed("QwenCloud stream final text conflicts.")
+            return ()
+        if state.delta_count:
+            if state.emitted_text != text:
+                _raise_malformed("QwenCloud stream final text conflicts with deltas.")
+            state.final_text = text
+            return ()
+        state.emitted_text = text
+        state.final_text = text
+        return (self._text_chunk(text),) if text else ()
+
+    @staticmethod
+    def _tool_chunk(
+        state: _FunctionCallState,
+        *,
+        arguments: str,
+        include_identity: bool = False,
+    ) -> dict[str, Any]:
+        function: dict[str, Any] = {"arguments": arguments}
+        tool_call: dict[str, Any] = {
+            "index": state.tool_index,
+            "function": function,
+        }
+        if include_identity:
+            tool_call.update({"id": state.call_id, "type": "function"})
+            function["name"] = state.name
+        return {"choices": [{"delta": {"tool_calls": [tool_call]}}]}
+
+    def _call_state(self, event: Mapping[str, Any]) -> _FunctionCallState:
+        output_index = _required_index(event, "output_index")
+        item_id = _required_string(event, "item_id")
+        item_state = self._output_items.get(output_index)
+        call_state = self._function_calls.get(output_index)
+        if (
+            item_state is None
+            or item_state.item_type != "function_call"
+            or item_state.item_id != item_id
+            or call_state is None
+            or call_state.item_id != item_id
+        ):
+            _raise_malformed("QwenCloud stream function-call identity is inconsistent.")
+        return call_state
+
+    def _handle_arguments_delta(
+        self, event: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], ...]:
+        state = self._call_state(event)
+        if state.final_arguments is not None:
+            _raise_malformed(
+                "QwenCloud stream function arguments arrived after completion."
+            )
+        delta = _required_string(event, "delta", allow_empty=True)
+        state.emitted_arguments += delta
+        return (self._tool_chunk(state, arguments=delta),)
+
+    @staticmethod
+    def _validate_arguments_object(arguments: str) -> None:
+        decoded = _strict_json_loads(arguments)
+        if decoded is _JSON_DECODE_FAILED:
+            _raise_malformed("QwenCloud stream function arguments are malformed.")
+        if not isinstance(decoded, Mapping):
+            _raise_malformed("QwenCloud stream function arguments must be an object.")
+
+    def _accept_final_arguments(
+        self, state: _FunctionCallState, arguments: Any
+    ) -> tuple[dict[str, Any], ...]:
+        if not isinstance(arguments, str):
+            _raise_malformed("QwenCloud stream final function arguments are malformed.")
+        if state.final_arguments is not None:
+            if state.final_arguments != arguments:
+                _raise_malformed("QwenCloud stream final function arguments conflict.")
+            return ()
+        if not arguments.startswith(state.emitted_arguments):
+            _raise_malformed(
+                "QwenCloud stream final function arguments conflict with deltas."
+            )
+        self._validate_arguments_object(arguments)
+        suffix = arguments[len(state.emitted_arguments) :]
+        state.emitted_arguments = arguments
+        state.final_arguments = arguments
+        return (self._tool_chunk(state, arguments=suffix),) if suffix else ()
+
+    def _handle_arguments_done(
+        self, event: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], ...]:
+        state = self._call_state(event)
+        return self._accept_final_arguments(state, event.get("arguments"))
+
+    def _handle_text_done(self, event: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
+        state, _ = self._text_state(event)
+        return self._accept_final_text(state, event.get("text"))
+
+    def _handle_content_part_done(
+        self, event: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], ...]:
+        state, _ = self._text_state(event)
+        part = event.get("part")
+        if not isinstance(part, Mapping) or part.get("type") != "output_text":
+            _raise_malformed("QwenCloud stream completed content part is malformed.")
+        return self._accept_final_text(state, part.get("text"))
+
+    def _validate_message_item(
+        self,
+        output_index: int,
+        item: Mapping[str, Any],
+    ) -> tuple[dict[str, Any], ...]:
+        item_state = self._output_items.get(output_index)
+        if item_state is None or item_state.item_type != "message":
+            _raise_malformed("QwenCloud stream message output was not established.")
+        if item.get("type") != "message" or item.get("id") != item_state.item_id:
+            _raise_malformed("QwenCloud stream message output identity conflicts.")
+        content = item.get("content")
+        if not isinstance(content, Sequence) or isinstance(content, (str, bytes)):
+            _raise_malformed("QwenCloud stream message content is malformed.")
+
+        chunks: list[dict[str, Any]] = []
+        expected_keys: set[tuple[int, int]] = set()
+        for content_index, part in enumerate(content):
+            if not isinstance(part, Mapping) or part.get("type") != "output_text":
+                _raise_malformed("QwenCloud stream message content is unsupported.")
+            key = (output_index, content_index)
+            expected_keys.add(key)
+            state = self._text_parts.get(key)
+            if state is None:
+                state = _TextPartState(item_id=item_state.item_id)
+                self._text_parts[key] = state
+            elif state.item_id != item_state.item_id:
+                _raise_malformed("QwenCloud stream text identity conflicts.")
+            chunks.extend(self._accept_final_text(state, part.get("text")))
+        if any(
+            key[0] == output_index and key not in expected_keys
+            for key in self._text_parts
+        ):
+            _raise_malformed("QwenCloud stream terminal text parts are incomplete.")
+        return tuple(chunks)
+
+    def _handle_output_item_done(
+        self, event: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], ...]:
+        output_index = _required_index(event, "output_index")
+        item = event.get("item")
+        if not isinstance(item, Mapping):
+            _raise_malformed("QwenCloud stream completed output item is malformed.")
+        if item.get("type") == "reasoning":
+            item_state = self._output_items.get(output_index)
+            if (
+                item_state is None
+                or item_state.item_type != "reasoning"
+                or item.get("id") != item_state.item_id
+            ):
+                _raise_malformed("QwenCloud stream reasoning identity conflicts.")
+            return ()
+        if item.get("type") == "function_call":
+            return self._validate_function_item(output_index, item)
+        return self._validate_message_item(output_index, item)
+
+    def _validate_function_item(
+        self, output_index: int, item: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], ...]:
+        item_state = self._output_items.get(output_index)
+        call_state = self._function_calls.get(output_index)
+        if (
+            item_state is None
+            or item_state.item_type != "function_call"
+            or call_state is None
+            or item.get("type") != "function_call"
+            or item.get("id") != item_state.item_id
+            or item.get("call_id") != call_state.call_id
+            or item.get("name") != call_state.name
+        ):
+            _raise_malformed("QwenCloud stream completed function identity conflicts.")
+        return self._accept_final_arguments(call_state, item.get("arguments"))
+
+    def _handle_terminal(
+        self, event_type: str, event: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], ...]:
+        response = event.get("response")
+        if not isinstance(response, Mapping):
+            _raise_malformed("QwenCloud stream terminal response is malformed.")
+        status = response.get("status")
+        expected_status = event_type.removeprefix("response.")
+        if status != expected_status:
+            _raise_malformed("QwenCloud stream terminal status is malformed.")
+        if status in {"failed", "cancelled"}:
+            raise _stream_error("QwenCloud did not complete the streamed response.")
+        if status not in {"completed", "incomplete"}:
+            _raise_malformed("QwenCloud stream terminal status is unsupported.")
+
+        output = response.get("output")
+        if not isinstance(output, Sequence) or isinstance(output, (str, bytes)):
+            _raise_malformed("QwenCloud stream terminal output is malformed.")
+        chunks: list[dict[str, Any]] = []
+        terminal_indexes: set[int] = set()
+        for output_index, item in enumerate(output):
+            if not isinstance(item, Mapping):
+                _raise_malformed("QwenCloud stream terminal output item is malformed.")
+            terminal_indexes.add(output_index)
+            item_type = item.get("type")
+            if item_type == "reasoning":
+                item_state = self._output_items.get(output_index)
+                if item_state is not None and (
+                    item_state.item_type != "reasoning"
+                    or item.get("id") != item_state.item_id
+                ):
+                    _raise_malformed("QwenCloud stream reasoning identity conflicts.")
+                continue
+            if item_type == "function_call":
+                chunks.extend(self._validate_function_item(output_index, item))
+                continue
+            if item_type != "message":
+                _raise_malformed("QwenCloud stream terminal output is unsupported.")
+            chunks.extend(self._validate_message_item(output_index, item))
+        if set(self._output_items) != terminal_indexes:
+            _raise_malformed("QwenCloud stream terminal output is incomplete.")
+
+        usable_text = any(
+            state.emitted_text.strip() for state in self._text_parts.values()
+        )
+        complete_calls = bool(self._function_calls) and all(
+            state.final_arguments is not None for state in self._function_calls.values()
+        )
+        if self._function_calls and not complete_calls:
+            _raise_malformed("QwenCloud stream function call is incomplete.")
+        if not usable_text and not complete_calls:
+            _raise_malformed("QwenCloud stream returned no usable content.")
+        if status == "incomplete":
+            details = response.get("incomplete_details")
+            reason = details.get("reason") if isinstance(details, Mapping) else None
+            if reason != "max_output_tokens" or complete_calls:
+                _raise_malformed("QwenCloud stream incomplete reason is unsupported.")
+            finish_reason = "length"
+        elif complete_calls:
+            finish_reason = "tool_calls"
+        else:
+            finish_reason = "stop"
+
+        usage = response.get("usage", {})
+        if not isinstance(usage, Mapping):
+            _raise_malformed("QwenCloud stream terminal usage is malformed.")
+        chunks.append(
+            {
+                "choices": [{"delta": {"content": ""}, "finish_reason": finish_reason}],
+                "usage": deepcopy(dict(usage)),
+            }
+        )
+        self._terminal = True
+        return tuple(chunks)
+
+
+class QwenCloudStream(Iterator[dict[str, Any]]):
+    """Own and normalize one live QwenCloud streaming response."""
+
+    def __init__(
+        self,
+        *,
+        response: requests.Response,
+        session: requests.Session,
+        api_mode: QwenCloudAPIMode,
+    ) -> None:
+        self._response = response
+        self._session = session
+        self._api_mode = api_mode
+        self._records = iter_sse_data_records(response.iter_content(chunk_size=8192))
+        self._translator = (
+            QwenResponsesStreamTranslator() if api_mode == "responses" else None
+        )
+        self._pending: deque[dict[str, Any]] = deque()
+        self._closed = False
+
+    def __iter__(self) -> QwenCloudStream:
+        return self
+
+    def __next__(self) -> dict[str, Any]:
+        if self._closed:
+            raise StopIteration
+        while not self._pending:
+            record_result = self._read_record()
+            if record_result is _STREAM_END:
+                try:
+                    if self._translator is not None:
+                        self._pending.extend(self._translator.finish())
+                except ChatProviderError:
+                    self.close()
+                    raise
+                self.close()
+                if not self._pending:
+                    raise StopIteration
+                break
+            if record_result is _STREAM_READ_FAILED:
+                self.close()
+                raise _stream_error("QwenCloud returned malformed streaming data.")
+            record = cast(str, record_result)
+
+            if record == "[DONE]":
+                try:
+                    if self._translator is not None:
+                        self._pending.extend(self._translator.finish())
+                except ChatProviderError:
+                    self.close()
+                    raise
+                self.close()
+                if not self._pending:
+                    raise StopIteration
+                break
+
+            try:
+                event = self._decode_event(record)
+                if self._translator is None:
+                    self._pending.append(self._normalize_chat_event(event))
+                else:
+                    self._pending.extend(self._translator.feed(event))
+            except ChatProviderError:
+                self.close()
+                raise
+        return self._pending.popleft()
+
+    def _read_record(self) -> str | object:
+        try:
+            return next(self._records)
+        except StopIteration:
+            return _STREAM_END
+        except (TypeError, UnicodeDecodeError, ValueError):
+            return _STREAM_READ_FAILED
+
+    def close(self) -> None:
+        """Close the response and its dedicated session exactly once."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._response.close()
+        finally:
+            self._session.close()
+
+    @staticmethod
+    def _decode_event(record: str) -> Mapping[str, Any]:
+        decoded = _strict_json_loads(record)
+        if decoded is _JSON_DECODE_FAILED:
+            _raise_malformed("QwenCloud returned malformed streaming JSON.")
+        if not isinstance(decoded, Mapping):
+            _raise_malformed("QwenCloud streaming event must be an object.")
+        if decoded.get("type") == "error" or "error" in decoded:
+            raise _stream_error("QwenCloud reported a streaming provider error.")
+        return decoded
+
+    @staticmethod
+    def _normalize_chat_event(event: Mapping[str, Any]) -> dict[str, Any]:
+        choices = event.get("choices")
+        usage = event.get("usage")
+        if choices is None:
+            _raise_malformed("QwenCloud chat stream choices are missing.")
+        if not isinstance(choices, Sequence) or isinstance(choices, (str, bytes)):
+            _raise_malformed("QwenCloud chat stream choices are malformed.")
+        if usage is not None and not isinstance(usage, Mapping):
+            _raise_malformed("QwenCloud chat stream usage is malformed.")
+        if not choices and usage is None:
+            _raise_malformed("QwenCloud chat stream event is empty.")
+        for choice in choices:
+            if not isinstance(choice, Mapping):
+                _raise_malformed("QwenCloud chat stream choice is malformed.")
+            delta = choice.get("delta")
+            if not isinstance(delta, Mapping):
+                _raise_malformed("QwenCloud chat stream delta is malformed.")
+            finish_reason = choice.get("finish_reason")
+            if finish_reason is not None and not isinstance(finish_reason, str):
+                _raise_malformed("QwenCloud chat stream finish state is malformed.")
+            tool_calls = delta.get("tool_calls")
+            if tool_calls is not None and (
+                not isinstance(tool_calls, Sequence)
+                or isinstance(tool_calls, (str, bytes))
+            ):
+                _raise_malformed("QwenCloud chat stream tool delta is malformed.")
+        return deepcopy(dict(event))
+
+
+def _iter_utf8_lines(chunks: Iterable[bytes]) -> Iterator[tuple[str, bool]]:
+    """Decode arbitrary byte chunks and yield universal-newline-delimited lines."""
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="strict")
+    buffered = ""
+    for chunk in chunks:
+        if not isinstance(chunk, bytes):
+            raise TypeError("QwenCloud SSE chunks must be bytes.")
+        buffered += decoder.decode(chunk, final=False)
+        cursor = 0
+        while cursor < len(buffered):
+            lf_index = buffered.find("\n", cursor)
+            cr_index = buffered.find("\r", cursor)
+            indexes = [index for index in (lf_index, cr_index) if index >= 0]
+            if not indexes:
+                break
+            newline_index = min(indexes)
+            newline = buffered[newline_index]
+            if newline == "\r" and newline_index + 1 == len(buffered):
+                break
+            yield buffered[cursor:newline_index], True
+            cursor = newline_index + 1
+            if newline == "\r" and buffered[cursor : cursor + 1] == "\n":
+                cursor += 1
+        buffered = buffered[cursor:]
+
+    buffered += decoder.decode(b"", final=True)
+    cursor = 0
+    while cursor < len(buffered):
+        lf_index = buffered.find("\n", cursor)
+        cr_index = buffered.find("\r", cursor)
+        indexes = [index for index in (lf_index, cr_index) if index >= 0]
+        if not indexes:
+            break
+        newline_index = min(indexes)
+        newline = buffered[newline_index]
+        yield buffered[cursor:newline_index], True
+        cursor = newline_index + 1
+        if newline == "\r" and buffered[cursor : cursor + 1] == "\n":
+            cursor += 1
+    if cursor < len(buffered):
+        yield buffered[cursor:], False
+
+
+def iter_sse_data_records(chunks: Iterable[bytes]) -> Iterator[str]:
+    """Yield complete SSE data records from arbitrary response byte chunks.
+
+    The parser incrementally decodes strict UTF-8, recognizes LF, CR, and CRLF,
+    ignores comments and non-data fields, and joins multiple ``data:`` fields
+    with newlines. A data record is emitted only after its blank terminator.
+
+    Args:
+        chunks: Raw response-body byte chunks.
+
+    Yields:
+        Complete data-field payloads without JSON decoding.
+
+    Raises:
+        UnicodeDecodeError: If the byte stream is not valid UTF-8.
+        TypeError: If a chunk is not bytes.
+        ValueError: If EOF interrupts a data record before its blank terminator.
+    """
+    data_lines: list[str] = []
+    for line, terminated in _iter_utf8_lines(chunks):
+        if not terminated:
+            if line.startswith("data:") or line == "data" or data_lines:
+                raise ValueError("QwenCloud SSE data record is incomplete.")
+            continue
+        if line == "":
+            if data_lines:
+                yield "\n".join(data_lines)
+                data_lines.clear()
+            continue
+        if line.startswith(":"):
+            continue
+        field, separator, value = line.partition(":")
+        if field != "data":
+            continue
+        if not separator:
+            value = ""
+        elif value.startswith(" "):
+            value = value[1:]
+        data_lines.append(value)
+
+    if data_lines:
+        raise ValueError("QwenCloud SSE data record is incomplete.")

--- a/tldw_chatbook/LLM_Calls/qwencloud_streaming.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud_streaming.py
@@ -41,6 +41,35 @@ def _strict_json_loads(value: str) -> Any:
         return _JSON_DECODE_FAILED
 
 
+def _strict_json_equal(left: Any, right: Any) -> bool:
+    """Compare JSON-like values without Python's bool/int coercion."""
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, Mapping):
+        right_items = list(cast(Mapping[Any, Any], right).items())
+        if len(left) != len(right_items):
+            return False
+        for left_key, left_value in left.items():
+            for index, (right_key, right_value) in enumerate(right_items):
+                if _strict_json_equal(left_key, right_key) and _strict_json_equal(
+                    left_value, right_value
+                ):
+                    del right_items[index]
+                    break
+            else:
+                return False
+        return True
+    if isinstance(left, Sequence) and not isinstance(left, (str, bytes)):
+        right_sequence = cast(Sequence[Any], right)
+        return len(left) == len(right_sequence) and all(
+            _strict_json_equal(left_value, right_value)
+            for left_value, right_value in zip(left, right_sequence, strict=True)
+        )
+    if left is None or isinstance(left, (str, bool, int, float)):
+        return bool(left == right)
+    return False
+
+
 def _required_index(event: Mapping[str, Any], name: str) -> int:
     value = event.get(name)
     if not isinstance(value, int) or isinstance(value, bool) or value < 0:
@@ -61,6 +90,7 @@ def _required_string(
 class _OutputItemState:
     item_id: str
     item_type: str
+    done_status: str | None = None
 
 
 @dataclass
@@ -95,8 +125,6 @@ class QwenResponsesStreamTranslator:
 
     def feed(self, event: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
         """Consume one decoded Responses event and return normalized chunks."""
-        if self._terminal:
-            _raise_malformed("QwenCloud stream event arrived after the terminal event.")
         if not isinstance(event, Mapping):
             _raise_malformed("QwenCloud stream event must be an object.")
         event_copy = deepcopy(dict(event))
@@ -105,9 +133,11 @@ class QwenResponsesStreamTranslator:
             _raise_malformed("QwenCloud stream sequence number is malformed.")
         previous = self._seen_sequences.get(sequence)
         if previous is not None:
-            if previous == event_copy:
+            if _strict_json_equal(previous, event_copy):
                 return ()
             _raise_malformed("QwenCloud stream sequence replay conflicts.")
+        if self._terminal:
+            _raise_malformed("QwenCloud stream event arrived after the terminal event.")
         if sequence <= self._highest_sequence:
             _raise_malformed("QwenCloud stream sequence number decreased.")
         self._seen_sequences[sequence] = event_copy
@@ -161,6 +191,8 @@ class QwenResponsesStreamTranslator:
             _raise_malformed("QwenCloud stream output item is malformed.")
         item_id = _required_string(item, "id")
         item_type = _required_string(item, "type")
+        if item.get("status") != "in_progress":
+            _raise_malformed("QwenCloud stream output item status is malformed.")
         if output_index in self._output_items:
             _raise_malformed("QwenCloud stream output index was reused.")
         if any(state.item_id == item_id for state in self._output_items.values()):
@@ -362,12 +394,21 @@ class QwenResponsesStreamTranslator:
         self,
         output_index: int,
         item: Mapping[str, Any],
+        *,
+        allowed_statuses: frozenset[str],
+        mark_done: bool = False,
     ) -> tuple[dict[str, Any], ...]:
         item_state = self._output_items.get(output_index)
         if item_state is None or item_state.item_type != "message":
             _raise_malformed("QwenCloud stream message output was not established.")
         if item.get("type") != "message" or item.get("id") != item_state.item_id:
             _raise_malformed("QwenCloud stream message output identity conflicts.")
+        self._validate_item_status(
+            item_state,
+            item,
+            allowed_statuses=allowed_statuses,
+            mark_done=mark_done,
+        )
         content = item.get("content")
         if not isinstance(content, Sequence) or isinstance(content, (str, bytes)):
             _raise_malformed("QwenCloud stream message content is malformed.")
@@ -391,7 +432,28 @@ class QwenResponsesStreamTranslator:
             for key in self._text_parts
         ):
             _raise_malformed("QwenCloud stream terminal text parts are incomplete.")
+        if mark_done:
+            item_state.done_status = cast(str, item.get("status"))
         return tuple(chunks)
+
+    @staticmethod
+    def _validate_item_status(
+        item_state: _OutputItemState,
+        item: Mapping[str, Any],
+        *,
+        allowed_statuses: frozenset[str],
+        mark_done: bool,
+    ) -> None:
+        status = item.get("status")
+        if not isinstance(status, str) or status not in allowed_statuses:
+            _raise_malformed("QwenCloud stream output item status is malformed.")
+        if item_state.done_status is not None:
+            if mark_done:
+                _raise_malformed(
+                    "QwenCloud stream output item completed more than once."
+                )
+            if status != item_state.done_status:
+                _raise_malformed("QwenCloud stream output item status conflicts.")
 
     def _handle_output_item_done(
         self, event: Mapping[str, Any]
@@ -401,20 +463,53 @@ class QwenResponsesStreamTranslator:
         if not isinstance(item, Mapping):
             _raise_malformed("QwenCloud stream completed output item is malformed.")
         if item.get("type") == "reasoning":
-            item_state = self._output_items.get(output_index)
-            if (
-                item_state is None
-                or item_state.item_type != "reasoning"
-                or item.get("id") != item_state.item_id
-            ):
-                _raise_malformed("QwenCloud stream reasoning identity conflicts.")
-            return ()
+            return self._validate_reasoning_item(
+                output_index,
+                item,
+                allowed_statuses=frozenset({"completed", "incomplete"}),
+                mark_done=True,
+            )
         if item.get("type") == "function_call":
-            return self._validate_function_item(output_index, item)
-        return self._validate_message_item(output_index, item)
+            return self._validate_function_item(output_index, item, mark_done=True)
+        return self._validate_message_item(
+            output_index,
+            item,
+            allowed_statuses=frozenset({"completed", "incomplete"}),
+            mark_done=True,
+        )
+
+    def _validate_reasoning_item(
+        self,
+        output_index: int,
+        item: Mapping[str, Any],
+        *,
+        allowed_statuses: frozenset[str],
+        mark_done: bool = False,
+    ) -> tuple[dict[str, Any], ...]:
+        item_state = self._output_items.get(output_index)
+        if (
+            item_state is None
+            or item_state.item_type != "reasoning"
+            or item.get("type") != "reasoning"
+            or item.get("id") != item_state.item_id
+        ):
+            _raise_malformed("QwenCloud stream reasoning identity conflicts.")
+        self._validate_item_status(
+            item_state,
+            item,
+            allowed_statuses=allowed_statuses,
+            mark_done=mark_done,
+        )
+        if mark_done:
+            item_state.done_status = cast(str, item.get("status"))
+        return ()
 
     def _validate_function_item(
-        self, output_index: int, item: Mapping[str, Any]
+        self,
+        output_index: int,
+        item: Mapping[str, Any],
+        *,
+        mark_done: bool = False,
     ) -> tuple[dict[str, Any], ...]:
         item_state = self._output_items.get(output_index)
         call_state = self._function_calls.get(output_index)
@@ -428,7 +523,16 @@ class QwenResponsesStreamTranslator:
             or item.get("name") != call_state.name
         ):
             _raise_malformed("QwenCloud stream completed function identity conflicts.")
-        return self._accept_final_arguments(call_state, item.get("arguments"))
+        self._validate_item_status(
+            item_state,
+            item,
+            allowed_statuses=frozenset({"completed"}),
+            mark_done=mark_done,
+        )
+        chunks = self._accept_final_arguments(call_state, item.get("arguments"))
+        if mark_done:
+            item_state.done_status = cast(str, item.get("status"))
+        return chunks
 
     def _handle_terminal(
         self, event_type: str, event: Mapping[str, Any]
@@ -456,19 +560,31 @@ class QwenResponsesStreamTranslator:
             terminal_indexes.add(output_index)
             item_type = item.get("type")
             if item_type == "reasoning":
-                item_state = self._output_items.get(output_index)
-                if item_state is not None and (
-                    item_state.item_type != "reasoning"
-                    or item.get("id") != item_state.item_id
-                ):
-                    _raise_malformed("QwenCloud stream reasoning identity conflicts.")
+                reasoning_statuses = (
+                    frozenset({"completed"})
+                    if status == "completed"
+                    else frozenset({"completed", "incomplete"})
+                )
+                chunks.extend(
+                    self._validate_reasoning_item(
+                        output_index,
+                        item,
+                        allowed_statuses=reasoning_statuses,
+                    )
+                )
                 continue
             if item_type == "function_call":
                 chunks.extend(self._validate_function_item(output_index, item))
                 continue
             if item_type != "message":
                 _raise_malformed("QwenCloud stream terminal output is unsupported.")
-            chunks.extend(self._validate_message_item(output_index, item))
+            chunks.extend(
+                self._validate_message_item(
+                    output_index,
+                    item,
+                    allowed_statuses=frozenset({status}),
+                )
+            )
         if set(self._output_items) != terminal_indexes:
             _raise_malformed("QwenCloud stream terminal output is incomplete.")
 
@@ -578,7 +694,12 @@ class QwenCloudStream(Iterator[dict[str, Any]]):
             return next(self._records)
         except StopIteration:
             return _STREAM_END
-        except (TypeError, UnicodeDecodeError, ValueError):
+        except (
+            TypeError,
+            UnicodeDecodeError,
+            ValueError,
+            requests.exceptions.RequestException,
+        ):
             return _STREAM_READ_FAILED
 
     def close(self) -> None:

--- a/tldw_chatbook/LLM_Calls/qwencloud_streaming.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud_streaming.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import codecs
+import hashlib
 import json
+import math
 from collections import deque
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Never, cast
 
 import requests
@@ -20,6 +22,17 @@ if TYPE_CHECKING:
 _JSON_DECODE_FAILED = object()
 _STREAM_END = object()
 _STREAM_READ_FAILED = object()
+_FINGERPRINT_FAILED = object()
+
+# These ceilings are deliberately far above supported model outputs while
+# bounding memory and CPU controlled by a provider stream.
+_MAX_SSE_LINE_CHARS = 16 * 1024 * 1024
+_MAX_SSE_RECORD_CHARS = 16 * 1024 * 1024
+_MAX_OUTPUT_CHARS = 32 * 1024 * 1024
+_MAX_STREAM_EVENTS = 200_000
+_MAX_TRACKED_SEQUENCES = 200_000
+_MAX_JSON_DEPTH = 128
+_MAX_JSON_NODES = 1_000_000
 
 
 def _stream_error(message: str) -> ChatProviderError:
@@ -30,44 +43,77 @@ def _raise_malformed(message: str) -> Never:
     raise _stream_error(message)
 
 
+def _best_effort_close(resource: Any) -> None:
+    """Attempt one close without exposing provider-controlled cleanup failures."""
+    try:
+        resource.close()
+    except Exception:
+        pass
+
+
 def _reject_json_constant(_value: str) -> Never:
     raise ValueError
 
 
 def _strict_json_loads(value: str) -> Any:
     try:
-        return json.loads(value, parse_constant=_reject_json_constant)
-    except (TypeError, ValueError):
+        decoded = json.loads(value, parse_constant=_reject_json_constant)
+    except (RecursionError, TypeError, ValueError):
         return _JSON_DECODE_FAILED
+    if not _json_shape_is_safe(decoded):
+        return _JSON_DECODE_FAILED
+    return decoded
 
 
-def _strict_json_equal(left: Any, right: Any) -> bool:
-    """Compare JSON-like values without Python's bool/int coercion."""
-    if type(left) is not type(right):
-        return False
-    if isinstance(left, Mapping):
-        right_items = list(cast(Mapping[Any, Any], right).items())
-        if len(left) != len(right_items):
-            return False
-        for left_key, left_value in left.items():
-            for index, (right_key, right_value) in enumerate(right_items):
-                if _strict_json_equal(left_key, right_key) and _strict_json_equal(
-                    left_value, right_value
-                ):
-                    del right_items[index]
-                    break
-            else:
+def _json_shape_is_safe(value: Any) -> bool:
+    """Validate JSON types, depth, and nodes iteratively before recursive work."""
+    stack: list[tuple[Any, int]] = [(value, 1)]
+    scheduled_nodes = 1
+    try:
+        while stack:
+            node, depth = stack.pop()
+            if depth > _MAX_JSON_DEPTH:
                 return False
-        return True
-    if isinstance(left, Sequence) and not isinstance(left, (str, bytes)):
-        right_sequence = cast(Sequence[Any], right)
-        return len(left) == len(right_sequence) and all(
-            _strict_json_equal(left_value, right_value)
-            for left_value, right_value in zip(left, right_sequence, strict=True)
-        )
-    if left is None or isinstance(left, (str, bool, int, float)):
-        return bool(left == right)
-    return False
+            if isinstance(node, Mapping):
+                for key, child in node.items():
+                    if not isinstance(key, str):
+                        return False
+                    scheduled_nodes += 1
+                    if scheduled_nodes > _MAX_JSON_NODES:
+                        return False
+                    stack.append((child, depth + 1))
+                continue
+            if isinstance(node, Sequence) and not isinstance(node, (str, bytes)):
+                for child in node:
+                    scheduled_nodes += 1
+                    if scheduled_nodes > _MAX_JSON_NODES:
+                        return False
+                    stack.append((child, depth + 1))
+                continue
+            if node is None or isinstance(node, (str, bool)):
+                continue
+            if isinstance(node, int) and not isinstance(node, bool):
+                continue
+            if isinstance(node, float) and math.isfinite(node):
+                continue
+            return False
+    except (RecursionError, TypeError, ValueError):
+        return False
+    return True
+
+
+def _canonical_json_digest(value: Any) -> bytes | object:
+    try:
+        canonical = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (RecursionError, TypeError, ValueError):
+        return _FINGERPRINT_FAILED
+    return hashlib.sha256(canonical).digest()
 
 
 def _required_index(event: Mapping[str, Any], name: str) -> int:
@@ -96,7 +142,7 @@ class _OutputItemState:
 @dataclass
 class _TextPartState:
     item_id: str
-    emitted_text: str = ""
+    fragments: list[str] = field(default_factory=list)
     delta_count: int = 0
     final_text: str | None = None
 
@@ -107,40 +153,60 @@ class _FunctionCallState:
     call_id: str
     name: str
     tool_index: int
-    emitted_arguments: str = ""
+    argument_fragments: list[str] = field(default_factory=list)
     final_arguments: str | None = None
+
+
+@dataclass(frozen=True)
+class _ChatToolState:
+    call_id: str
+    name: str
+
+
+@dataclass
+class _ChatChoiceState:
+    tools: dict[int, _ChatToolState]
+    call_ids: set[str]
+    terminal_reason: str | None = None
 
 
 class QwenResponsesStreamTranslator:
     """Translate stateful QwenCloud Responses events into chat deltas."""
 
     def __init__(self) -> None:
-        self._seen_sequences: dict[int, dict[str, Any]] = {}
+        self._seen_sequences: dict[int, bytes] = {}
         self._highest_sequence = -1
         self._output_items: dict[int, _OutputItemState] = {}
         self._text_parts: dict[tuple[int, int], _TextPartState] = {}
         self._function_calls: dict[int, _FunctionCallState] = {}
         self._call_ids: set[str] = set()
+        self._output_chars = 0
         self._terminal = False
 
     def feed(self, event: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
         """Consume one decoded Responses event and return normalized chunks."""
         if not isinstance(event, Mapping):
             _raise_malformed("QwenCloud stream event must be an object.")
-        event_copy = deepcopy(dict(event))
+        if not _json_shape_is_safe(event):
+            _raise_malformed("QwenCloud stream event is malformed.")
         sequence = event.get("sequence_number")
         if not isinstance(sequence, int) or isinstance(sequence, bool) or sequence < 0:
             _raise_malformed("QwenCloud stream sequence number is malformed.")
+        digest = _canonical_json_digest(event)
+        if digest is _FINGERPRINT_FAILED:
+            _raise_malformed("QwenCloud stream event is malformed.")
         previous = self._seen_sequences.get(sequence)
         if previous is not None:
-            if _strict_json_equal(previous, event_copy):
+            if previous == digest:
                 return ()
             _raise_malformed("QwenCloud stream sequence replay conflicts.")
         if self._terminal:
             _raise_malformed("QwenCloud stream event arrived after the terminal event.")
         if sequence <= self._highest_sequence:
             _raise_malformed("QwenCloud stream sequence number decreased.")
-        self._seen_sequences[sequence] = event_copy
+        if len(self._seen_sequences) >= _MAX_TRACKED_SEQUENCES:
+            _raise_malformed("QwenCloud stream sequence limit was exceeded.")
+        self._seen_sequences[sequence] = cast(bytes, digest)
         self._highest_sequence = sequence
 
         event_type = event.get("type")
@@ -211,9 +277,10 @@ class QwenResponsesStreamTranslator:
                 item_id=item_id,
                 call_id=call_id,
                 name=name,
-                tool_index=len(self._function_calls),
-                emitted_arguments=arguments,
+                tool_index=output_index,
+                argument_fragments=[arguments] if arguments else [],
             )
+            self._reserve_output(len(arguments))
             self._function_calls[output_index] = call_state
             return (
                 self._tool_chunk(
@@ -278,7 +345,8 @@ class QwenResponsesStreamTranslator:
                 "QwenCloud stream text delta arrived after text completion."
             )
         delta = _required_string(event, "delta", allow_empty=True)
-        state.emitted_text += delta
+        self._reserve_output(len(delta))
+        state.fragments.append(delta)
         state.delta_count += 1
         return (self._text_chunk(delta),)
 
@@ -292,11 +360,13 @@ class QwenResponsesStreamTranslator:
                 _raise_malformed("QwenCloud stream final text conflicts.")
             return ()
         if state.delta_count:
-            if state.emitted_text != text:
+            emitted_text = "".join(state.fragments)
+            if emitted_text != text:
                 _raise_malformed("QwenCloud stream final text conflicts with deltas.")
             state.final_text = text
+            state.fragments.clear()
             return ()
-        state.emitted_text = text
+        self._reserve_output(len(text))
         state.final_text = text
         return (self._text_chunk(text),) if text else ()
 
@@ -341,7 +411,8 @@ class QwenResponsesStreamTranslator:
                 "QwenCloud stream function arguments arrived after completion."
             )
         delta = _required_string(event, "delta", allow_empty=True)
-        state.emitted_arguments += delta
+        self._reserve_output(len(delta))
+        state.argument_fragments.append(delta)
         return (self._tool_chunk(state, arguments=delta),)
 
     @staticmethod
@@ -361,15 +432,22 @@ class QwenResponsesStreamTranslator:
             if state.final_arguments != arguments:
                 _raise_malformed("QwenCloud stream final function arguments conflict.")
             return ()
-        if not arguments.startswith(state.emitted_arguments):
+        emitted_arguments = "".join(state.argument_fragments)
+        if not arguments.startswith(emitted_arguments):
             _raise_malformed(
                 "QwenCloud stream final function arguments conflict with deltas."
             )
         self._validate_arguments_object(arguments)
-        suffix = arguments[len(state.emitted_arguments) :]
-        state.emitted_arguments = arguments
+        suffix = arguments[len(emitted_arguments) :]
+        self._reserve_output(len(suffix))
+        state.argument_fragments.clear()
         state.final_arguments = arguments
         return (self._tool_chunk(state, arguments=suffix),) if suffix else ()
+
+    def _reserve_output(self, characters: int) -> None:
+        if characters < 0 or self._output_chars + characters > _MAX_OUTPUT_CHARS:
+            _raise_malformed("QwenCloud stream output limit was exceeded.")
+        self._output_chars += characters
 
     def _handle_arguments_done(
         self, event: Mapping[str, Any]
@@ -589,7 +667,8 @@ class QwenResponsesStreamTranslator:
             _raise_malformed("QwenCloud stream terminal output is incomplete.")
 
         usable_text = any(
-            state.emitted_text.strip() for state in self._text_parts.values()
+            state.final_text is not None and state.final_text.strip()
+            for state in self._text_parts.values()
         )
         complete_calls = bool(self._function_calls) and all(
             state.final_arguments is not None for state in self._function_calls.values()
@@ -622,6 +701,175 @@ class QwenResponsesStreamTranslator:
         return tuple(chunks)
 
 
+class _ChatCompletionsStreamTranslator:
+    """Validate Chat stream metadata without accumulating tool arguments."""
+
+    _TERMINAL_REASONS = frozenset({"stop", "length", "tool_calls"})
+
+    def __init__(self) -> None:
+        self._choices: dict[int, _ChatChoiceState] = {}
+        self._output_chars = 0
+        self._usage_seen = False
+
+    def feed(self, event: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
+        choices = event.get("choices")
+        usage = event.get("usage")
+        if not isinstance(choices, Sequence) or isinstance(choices, (str, bytes)):
+            _raise_malformed("QwenCloud chat stream choices are malformed.")
+        if usage is not None and not isinstance(usage, Mapping):
+            _raise_malformed("QwenCloud chat stream usage is malformed.")
+        if self._usage_seen:
+            _raise_malformed("QwenCloud chat stream data arrived after usage.")
+        if not choices:
+            if usage is None:
+                _raise_malformed("QwenCloud chat stream event is empty.")
+            if not self._choices or not self._all_choices_terminal():
+                _raise_malformed("QwenCloud chat stream usage arrived before terminal.")
+            self._usage_seen = True
+            return (self._safe_event(event),)
+        if usage is not None:
+            _raise_malformed("QwenCloud chat stream usage event is malformed.")
+
+        event_choice_indexes: set[int] = set()
+        for choice in choices:
+            if not isinstance(choice, Mapping):
+                _raise_malformed("QwenCloud chat stream choice is malformed.")
+            choice_index = _required_index(choice, "index")
+            if choice_index in event_choice_indexes:
+                _raise_malformed("QwenCloud chat stream choice index was duplicated.")
+            event_choice_indexes.add(choice_index)
+            state = self._choices.setdefault(
+                choice_index, _ChatChoiceState(tools={}, call_ids=set())
+            )
+            if state.terminal_reason is not None:
+                _raise_malformed("QwenCloud chat stream choice arrived after terminal.")
+            delta = choice.get("delta")
+            if not isinstance(delta, Mapping):
+                _raise_malformed("QwenCloud chat stream delta is malformed.")
+            self._validate_delta(state, delta)
+
+            finish_reason = choice.get("finish_reason")
+            if finish_reason is not None:
+                if (
+                    not isinstance(finish_reason, str)
+                    or finish_reason not in self._TERMINAL_REASONS
+                ):
+                    _raise_malformed("QwenCloud chat stream finish state is malformed.")
+                has_tools = bool(state.tools)
+                if (finish_reason == "tool_calls") != has_tools:
+                    _raise_malformed(
+                        "QwenCloud chat stream finish state conflicts with tools."
+                    )
+                state.terminal_reason = finish_reason
+        return (self._safe_event(event),)
+
+    def finish(self) -> tuple[dict[str, Any], ...]:
+        if not self._choices or not self._all_choices_terminal():
+            _raise_malformed("QwenCloud chat stream terminal event is missing.")
+        return ()
+
+    def _all_choices_terminal(self) -> bool:
+        return all(
+            state.terminal_reason is not None for state in self._choices.values()
+        )
+
+    def _validate_delta(
+        self, state: _ChatChoiceState, delta: Mapping[str, Any]
+    ) -> None:
+        if "role" in delta and delta.get("role") != "assistant":
+            _raise_malformed("QwenCloud chat stream role is malformed.")
+        if "content" in delta:
+            content = delta.get("content")
+            if not isinstance(content, str):
+                _raise_malformed("QwenCloud chat stream content is malformed.")
+            self._reserve_output(len(content))
+        tool_calls = delta.get("tool_calls")
+        if tool_calls is None:
+            return
+        if not isinstance(tool_calls, Sequence) or isinstance(tool_calls, (str, bytes)):
+            _raise_malformed("QwenCloud chat stream tool delta is malformed.")
+        event_tool_indexes: set[int] = set()
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, Mapping):
+                _raise_malformed("QwenCloud chat stream tool call is malformed.")
+            tool_index = _required_index(tool_call, "index")
+            if tool_index in event_tool_indexes:
+                _raise_malformed("QwenCloud chat stream tool index was duplicated.")
+            event_tool_indexes.add(tool_index)
+            function = tool_call.get("function")
+            if not isinstance(function, Mapping):
+                _raise_malformed("QwenCloud chat stream tool function is malformed.")
+            if "arguments" in function:
+                arguments = function.get("arguments")
+                if not isinstance(arguments, str):
+                    _raise_malformed(
+                        "QwenCloud chat stream tool arguments are malformed."
+                    )
+                self._reserve_output(len(arguments))
+            existing = state.tools.get(tool_index)
+            if existing is None:
+                call_id = _required_string(tool_call, "id")
+                if tool_call.get("type") != "function":
+                    _raise_malformed("QwenCloud chat stream tool type is malformed.")
+                name = _required_string(function, "name")
+                if call_id in state.call_ids:
+                    _raise_malformed("QwenCloud chat stream tool ID was duplicated.")
+                state.call_ids.add(call_id)
+                state.tools[tool_index] = _ChatToolState(call_id=call_id, name=name)
+                continue
+            if "id" in tool_call and tool_call.get("id") != existing.call_id:
+                _raise_malformed("QwenCloud chat stream tool identity conflicts.")
+            if "type" in tool_call and tool_call.get("type") != "function":
+                _raise_malformed("QwenCloud chat stream tool type conflicts.")
+            if "name" in function and function.get("name") != existing.name:
+                _raise_malformed("QwenCloud chat stream tool name conflicts.")
+
+    def _reserve_output(self, characters: int) -> None:
+        if characters < 0 or self._output_chars + characters > _MAX_OUTPUT_CHARS:
+            _raise_malformed("QwenCloud chat stream output limit was exceeded.")
+        self._output_chars += characters
+
+    @staticmethod
+    def _safe_event(event: Mapping[str, Any]) -> dict[str, Any]:
+        """Copy only metadata consumed by the shared OpenAI accumulator."""
+        result: dict[str, Any] = {}
+        if "id" in event:
+            result["id"] = _required_string(event, "id")
+        choices = cast(Sequence[Mapping[str, Any]], event["choices"])
+        safe_choices: list[dict[str, Any]] = []
+        for choice in choices:
+            safe_choice: dict[str, Any] = {"index": choice["index"]}
+            delta = cast(Mapping[str, Any], choice["delta"])
+            safe_delta: dict[str, Any] = {}
+            for key in ("role", "content"):
+                if key in delta:
+                    safe_delta[key] = delta[key]
+            if "tool_calls" in delta:
+                safe_tools: list[dict[str, Any]] = []
+                for tool in cast(Sequence[Mapping[str, Any]], delta["tool_calls"]):
+                    safe_tool: dict[str, Any] = {"index": tool["index"]}
+                    for key in ("id", "type"):
+                        if key in tool:
+                            safe_tool[key] = tool[key]
+                    function = cast(Mapping[str, Any], tool["function"])
+                    safe_function = {
+                        key: function[key]
+                        for key in ("name", "arguments")
+                        if key in function
+                    }
+                    safe_tool["function"] = safe_function
+                    safe_tools.append(safe_tool)
+                safe_delta["tool_calls"] = safe_tools
+            safe_choice["delta"] = safe_delta
+            if "finish_reason" in choice:
+                safe_choice["finish_reason"] = choice["finish_reason"]
+            safe_choices.append(safe_choice)
+        result["choices"] = safe_choices
+        if "usage" in event:
+            result["usage"] = deepcopy(dict(cast(Mapping[str, Any], event["usage"])))
+        return result
+
+
 class QwenCloudStream(Iterator[dict[str, Any]]):
     """Own and normalize one live QwenCloud streaming response."""
 
@@ -637,9 +885,12 @@ class QwenCloudStream(Iterator[dict[str, Any]]):
         self._api_mode = api_mode
         self._records = iter_sse_data_records(response.iter_content(chunk_size=8192))
         self._translator = (
-            QwenResponsesStreamTranslator() if api_mode == "responses" else None
+            QwenResponsesStreamTranslator()
+            if api_mode == "responses"
+            else _ChatCompletionsStreamTranslator()
         )
         self._pending: deque[dict[str, Any]] = deque()
+        self._event_count = 0
         self._closed = False
 
     def __iter__(self) -> QwenCloudStream:
@@ -652,8 +903,7 @@ class QwenCloudStream(Iterator[dict[str, Any]]):
             record_result = self._read_record()
             if record_result is _STREAM_END:
                 try:
-                    if self._translator is not None:
-                        self._pending.extend(self._translator.finish())
+                    self._pending.extend(self._translator.finish())
                 except ChatProviderError:
                     self.close()
                     raise
@@ -668,8 +918,7 @@ class QwenCloudStream(Iterator[dict[str, Any]]):
 
             if record == "[DONE]":
                 try:
-                    if self._translator is not None:
-                        self._pending.extend(self._translator.finish())
+                    self._pending.extend(self._translator.finish())
                 except ChatProviderError:
                     self.close()
                     raise
@@ -680,10 +929,10 @@ class QwenCloudStream(Iterator[dict[str, Any]]):
 
             try:
                 event = self._decode_event(record)
-                if self._translator is None:
-                    self._pending.append(self._normalize_chat_event(event))
-                else:
-                    self._pending.extend(self._translator.feed(event))
+                if self._event_count >= _MAX_STREAM_EVENTS:
+                    _raise_malformed("QwenCloud stream event limit was exceeded.")
+                self._event_count += 1
+                self._pending.extend(self._translator.feed(event))
             except ChatProviderError:
                 self.close()
                 raise
@@ -707,10 +956,8 @@ class QwenCloudStream(Iterator[dict[str, Any]]):
         if self._closed:
             return
         self._closed = True
-        try:
-            self._response.close()
-        finally:
-            self._session.close()
+        _best_effort_close(self._response)
+        _best_effort_close(self._session)
 
     @staticmethod
     def _decode_event(record: str) -> Mapping[str, Any]:
@@ -723,77 +970,61 @@ class QwenCloudStream(Iterator[dict[str, Any]]):
             raise _stream_error("QwenCloud reported a streaming provider error.")
         return decoded
 
-    @staticmethod
-    def _normalize_chat_event(event: Mapping[str, Any]) -> dict[str, Any]:
-        choices = event.get("choices")
-        usage = event.get("usage")
-        if choices is None:
-            _raise_malformed("QwenCloud chat stream choices are missing.")
-        if not isinstance(choices, Sequence) or isinstance(choices, (str, bytes)):
-            _raise_malformed("QwenCloud chat stream choices are malformed.")
-        if usage is not None and not isinstance(usage, Mapping):
-            _raise_malformed("QwenCloud chat stream usage is malformed.")
-        if not choices and usage is None:
-            _raise_malformed("QwenCloud chat stream event is empty.")
-        for choice in choices:
-            if not isinstance(choice, Mapping):
-                _raise_malformed("QwenCloud chat stream choice is malformed.")
-            delta = choice.get("delta")
-            if not isinstance(delta, Mapping):
-                _raise_malformed("QwenCloud chat stream delta is malformed.")
-            finish_reason = choice.get("finish_reason")
-            if finish_reason is not None and not isinstance(finish_reason, str):
-                _raise_malformed("QwenCloud chat stream finish state is malformed.")
-            tool_calls = delta.get("tool_calls")
-            if tool_calls is not None and (
-                not isinstance(tool_calls, Sequence)
-                or isinstance(tool_calls, (str, bytes))
-            ):
-                _raise_malformed("QwenCloud chat stream tool delta is malformed.")
-        return deepcopy(dict(event))
-
 
 def _iter_utf8_lines(chunks: Iterable[bytes]) -> Iterator[tuple[str, bool]]:
-    """Decode arbitrary byte chunks and yield universal-newline-delimited lines."""
+    """Decode byte chunks with linear segment accumulation and newline framing."""
     decoder = codecs.getincrementaldecoder("utf-8")(errors="strict")
-    buffered = ""
-    for chunk in chunks:
-        if not isinstance(chunk, bytes):
-            raise TypeError("QwenCloud SSE chunks must be bytes.")
-        buffered += decoder.decode(chunk, final=False)
-        cursor = 0
-        while cursor < len(buffered):
-            lf_index = buffered.find("\n", cursor)
-            cr_index = buffered.find("\r", cursor)
-            indexes = [index for index in (lf_index, cr_index) if index >= 0]
-            if not indexes:
-                break
-            newline_index = min(indexes)
-            newline = buffered[newline_index]
-            if newline == "\r" and newline_index + 1 == len(buffered):
-                break
-            yield buffered[cursor:newline_index], True
-            cursor = newline_index + 1
-            if newline == "\r" and buffered[cursor : cursor + 1] == "\n":
-                cursor += 1
-        buffered = buffered[cursor:]
 
-    buffered += decoder.decode(b"", final=True)
-    cursor = 0
-    while cursor < len(buffered):
-        lf_index = buffered.find("\n", cursor)
-        cr_index = buffered.find("\r", cursor)
-        indexes = [index for index in (lf_index, cr_index) if index >= 0]
-        if not indexes:
-            break
-        newline_index = min(indexes)
-        newline = buffered[newline_index]
-        yield buffered[cursor:newline_index], True
-        cursor = newline_index + 1
-        if newline == "\r" and buffered[cursor : cursor + 1] == "\n":
+    def decoded_segments() -> Iterator[str]:
+        for chunk in chunks:
+            if not isinstance(chunk, bytes):
+                raise TypeError("QwenCloud SSE chunks must be bytes.")
+            decoded = decoder.decode(chunk, final=False)
+            if decoded:
+                yield decoded
+        final = decoder.decode(b"", final=True)
+        if final:
+            yield final
+
+    segments: list[str] = []
+    line_chars = 0
+    skip_leading_lf = False
+    for decoded in decoded_segments():
+        cursor = 0
+        if skip_leading_lf:
+            if decoded.startswith("\n"):
+                cursor = 1
+            skip_leading_lf = False
+        segment_start = cursor
+        while cursor < len(decoded):
+            character = decoded[cursor]
+            if character not in {"\r", "\n"}:
+                cursor += 1
+                continue
+            segment = decoded[segment_start:cursor]
+            if segment:
+                line_chars += len(segment)
+                if line_chars > _MAX_SSE_LINE_CHARS:
+                    raise ValueError("QwenCloud SSE line limit was exceeded.")
+                segments.append(segment)
+            yield "".join(segments), True
+            segments.clear()
+            line_chars = 0
             cursor += 1
-    if cursor < len(buffered):
-        yield buffered[cursor:], False
+            if character == "\r":
+                if cursor < len(decoded) and decoded[cursor] == "\n":
+                    cursor += 1
+                elif cursor == len(decoded):
+                    skip_leading_lf = True
+            segment_start = cursor
+        segment = decoded[segment_start:]
+        if segment:
+            line_chars += len(segment)
+            if line_chars > _MAX_SSE_LINE_CHARS:
+                raise ValueError("QwenCloud SSE line limit was exceeded.")
+            segments.append(segment)
+    if segments:
+        yield "".join(segments), False
 
 
 def iter_sse_data_records(chunks: Iterable[bytes]) -> Iterator[str]:
@@ -815,6 +1046,7 @@ def iter_sse_data_records(chunks: Iterable[bytes]) -> Iterator[str]:
         ValueError: If EOF interrupts a data record before its blank terminator.
     """
     data_lines: list[str] = []
+    record_chars = 0
     for line, terminated in _iter_utf8_lines(chunks):
         if not terminated:
             if line.startswith("data:") or line == "data" or data_lines:
@@ -824,6 +1056,7 @@ def iter_sse_data_records(chunks: Iterable[bytes]) -> Iterator[str]:
             if data_lines:
                 yield "\n".join(data_lines)
                 data_lines.clear()
+                record_chars = 0
             continue
         if line.startswith(":"):
             continue
@@ -834,6 +1067,10 @@ def iter_sse_data_records(chunks: Iterable[bytes]) -> Iterator[str]:
             value = ""
         elif value.startswith(" "):
             value = value[1:]
+        added_chars = len(value) + (1 if data_lines else 0)
+        if record_chars + added_chars > _MAX_SSE_RECORD_CHARS:
+            raise ValueError("QwenCloud SSE record limit was exceeded.")
+        record_chars += added_chars
         data_lines.append(value)
 
     if data_lines:

--- a/tldw_chatbook/LLM_Calls/qwencloud_streaming.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud_streaming.py
@@ -22,13 +22,20 @@ if TYPE_CHECKING:
 _JSON_DECODE_FAILED = object()
 _STREAM_END = object()
 _STREAM_READ_FAILED = object()
+_STREAM_TRANSLATION_FAILED = object()
 _FINGERPRINT_FAILED = object()
+_MAPPING_COPY_FAILED = object()
 
 # These ceilings are deliberately far above supported model outputs while
 # bounding memory and CPU controlled by a provider stream.
 _MAX_SSE_LINE_CHARS = 16 * 1024 * 1024
 _MAX_SSE_RECORD_CHARS = 16 * 1024 * 1024
+# Bound Python object overhead independently of decoded character ceilings.
+_MAX_SSE_LINE_SEGMENTS = 65_536
+_MAX_SSE_DATA_LINES = 65_536
 _MAX_OUTPUT_CHARS = 32 * 1024 * 1024
+# Provider identities and function names are retained for stream correlation.
+_MAX_METADATA_CHARS = 4 * 1024
 _MAX_STREAM_EVENTS = 200_000
 _MAX_TRACKED_SEQUENCES = 200_000
 _MAX_JSON_DEPTH = 128
@@ -74,8 +81,8 @@ def _json_shape_is_safe(value: Any) -> bool:
             node, depth = stack.pop()
             if depth > _MAX_JSON_DEPTH:
                 return False
-            if isinstance(node, Mapping):
-                for key, child in node.items():
+            if type(node) is dict:
+                for key, child in cast(dict[Any, Any], node).items():
                     if not isinstance(key, str):
                         return False
                     scheduled_nodes += 1
@@ -83,8 +90,8 @@ def _json_shape_is_safe(value: Any) -> bool:
                         return False
                     stack.append((child, depth + 1))
                 continue
-            if isinstance(node, Sequence) and not isinstance(node, (str, bytes)):
-                for child in node:
+            if type(node) is list:
+                for child in cast(list[Any], node):
                     scheduled_nodes += 1
                     if scheduled_nodes > _MAX_JSON_NODES:
                         return False
@@ -116,6 +123,13 @@ def _canonical_json_digest(value: Any) -> bytes | object:
     return hashlib.sha256(canonical).digest()
 
 
+def _copy_top_mapping(value: Mapping[str, Any]) -> dict[str, Any] | object:
+    try:
+        return dict(value)
+    except Exception:
+        return _MAPPING_COPY_FAILED
+
+
 def _required_index(event: Mapping[str, Any], name: str) -> int:
     value = event.get(name)
     if not isinstance(value, int) or isinstance(value, bool) or value < 0:
@@ -130,6 +144,12 @@ def _required_string(
     if not isinstance(value, str) or (not allow_empty and not value.strip()):
         _raise_malformed("QwenCloud stream event identity is malformed.")
     return value
+
+
+def _metadata_characters(*values: str) -> int:
+    if any(len(value) > _MAX_METADATA_CHARS for value in values):
+        _raise_malformed("QwenCloud stream metadata limit was exceeded.")
+    return sum(len(value) for value in values)
 
 
 @dataclass
@@ -187,8 +207,10 @@ class QwenResponsesStreamTranslator:
         """Consume one decoded Responses event and return normalized chunks."""
         if not isinstance(event, Mapping):
             _raise_malformed("QwenCloud stream event must be an object.")
-        if not _json_shape_is_safe(event):
+        event_copy = _copy_top_mapping(event)
+        if event_copy is _MAPPING_COPY_FAILED or not _json_shape_is_safe(event_copy):
             _raise_malformed("QwenCloud stream event is malformed.")
+        event = cast(dict[str, Any], event_copy)
         sequence = event.get("sequence_number")
         if not isinstance(sequence, int) or isinstance(sequence, bool) or sequence < 0:
             _raise_malformed("QwenCloud stream sequence number is malformed.")
@@ -265,13 +287,16 @@ class QwenResponsesStreamTranslator:
             _raise_malformed("QwenCloud stream output item identity was reused.")
         if item_type not in {"message", "reasoning", "function_call"}:
             _raise_malformed("QwenCloud stream output item type is unsupported.")
-        self._output_items[output_index] = _OutputItemState(item_id, item_type)
         if item_type == "function_call":
             call_id = _required_string(item, "call_id")
             name = _required_string(item, "name")
             arguments = _required_string(item, "arguments", allow_empty=True)
             if call_id in self._call_ids:
                 _raise_malformed("QwenCloud stream function-call ID was reused.")
+            self._reserve_output(
+                _metadata_characters(item_id, call_id, name) + len(arguments)
+            )
+            self._output_items[output_index] = _OutputItemState(item_id, item_type)
             self._call_ids.add(call_id)
             call_state = _FunctionCallState(
                 item_id=item_id,
@@ -280,7 +305,6 @@ class QwenResponsesStreamTranslator:
                 tool_index=output_index,
                 argument_fragments=[arguments] if arguments else [],
             )
-            self._reserve_output(len(arguments))
             self._function_calls[output_index] = call_state
             return (
                 self._tool_chunk(
@@ -289,6 +313,8 @@ class QwenResponsesStreamTranslator:
                     include_identity=True,
                 ),
             )
+        self._reserve_output(_metadata_characters(item_id))
+        self._output_items[output_index] = _OutputItemState(item_id, item_type)
         return ()
 
     def _message_state(
@@ -780,9 +806,10 @@ class _ChatCompletionsStreamTranslator:
             _raise_malformed("QwenCloud chat stream role is malformed.")
         if "content" in delta:
             content = delta.get("content")
-            if not isinstance(content, str):
+            if content is not None and not isinstance(content, str):
                 _raise_malformed("QwenCloud chat stream content is malformed.")
-            self._reserve_output(len(content))
+            if isinstance(content, str):
+                self._reserve_output(len(content))
         tool_calls = delta.get("tool_calls")
         if tool_calls is None:
             return
@@ -799,13 +826,14 @@ class _ChatCompletionsStreamTranslator:
             function = tool_call.get("function")
             if not isinstance(function, Mapping):
                 _raise_malformed("QwenCloud chat stream tool function is malformed.")
+            argument_chars = 0
             if "arguments" in function:
                 arguments = function.get("arguments")
                 if not isinstance(arguments, str):
                     _raise_malformed(
                         "QwenCloud chat stream tool arguments are malformed."
                     )
-                self._reserve_output(len(arguments))
+                argument_chars = len(arguments)
             existing = state.tools.get(tool_index)
             if existing is None:
                 call_id = _required_string(tool_call, "id")
@@ -814,6 +842,9 @@ class _ChatCompletionsStreamTranslator:
                 name = _required_string(function, "name")
                 if call_id in state.call_ids:
                     _raise_malformed("QwenCloud chat stream tool ID was duplicated.")
+                self._reserve_output(
+                    _metadata_characters(call_id, name) + argument_chars
+                )
                 state.call_ids.add(call_id)
                 state.tools[tool_index] = _ChatToolState(call_id=call_id, name=name)
                 continue
@@ -823,6 +854,7 @@ class _ChatCompletionsStreamTranslator:
                 _raise_malformed("QwenCloud chat stream tool type conflicts.")
             if "name" in function and function.get("name") != existing.name:
                 _raise_malformed("QwenCloud chat stream tool name conflicts.")
+            self._reserve_output(argument_chars)
 
     def _reserve_output(self, characters: int) -> None:
         if characters < 0 or self._output_chars + characters > _MAX_OUTPUT_CHARS:
@@ -841,10 +873,11 @@ class _ChatCompletionsStreamTranslator:
             safe_choice: dict[str, Any] = {"index": choice["index"]}
             delta = cast(Mapping[str, Any], choice["delta"])
             safe_delta: dict[str, Any] = {}
-            for key in ("role", "content"):
-                if key in delta:
-                    safe_delta[key] = delta[key]
-            if "tool_calls" in delta:
+            if "role" in delta:
+                safe_delta["role"] = delta["role"]
+            if isinstance(delta.get("content"), str):
+                safe_delta["content"] = delta["content"]
+            if delta.get("tool_calls") is not None:
                 safe_tools: list[dict[str, Any]] = []
                 for tool in cast(Sequence[Mapping[str, Any]], delta["tool_calls"]):
                     safe_tool: dict[str, Any] = {"index": tool["index"]}
@@ -865,7 +898,7 @@ class _ChatCompletionsStreamTranslator:
                 safe_choice["finish_reason"] = choice["finish_reason"]
             safe_choices.append(safe_choice)
         result["choices"] = safe_choices
-        if "usage" in event:
+        if isinstance(event.get("usage"), Mapping):
             result["usage"] = deepcopy(dict(cast(Mapping[str, Any], event["usage"])))
         return result
 
@@ -903,10 +936,13 @@ class QwenCloudStream(Iterator[dict[str, Any]]):
             record_result = self._read_record()
             if record_result is _STREAM_END:
                 try:
-                    self._pending.extend(self._translator.finish())
+                    finish_result = self._finish_translation()
                 except ChatProviderError:
                     self.close()
                     raise
+                if finish_result is _STREAM_TRANSLATION_FAILED:
+                    self.close()
+                    raise _stream_error("QwenCloud returned malformed streaming data.")
                 self.close()
                 if not self._pending:
                     raise StopIteration
@@ -918,37 +954,56 @@ class QwenCloudStream(Iterator[dict[str, Any]]):
 
             if record == "[DONE]":
                 try:
-                    self._pending.extend(self._translator.finish())
+                    finish_result = self._finish_translation()
                 except ChatProviderError:
                     self.close()
                     raise
+                if finish_result is _STREAM_TRANSLATION_FAILED:
+                    self.close()
+                    raise _stream_error("QwenCloud returned malformed streaming data.")
                 self.close()
                 if not self._pending:
                     raise StopIteration
                 break
 
             try:
-                event = self._decode_event(record)
-                if self._event_count >= _MAX_STREAM_EVENTS:
-                    _raise_malformed("QwenCloud stream event limit was exceeded.")
-                self._event_count += 1
-                self._pending.extend(self._translator.feed(event))
+                translation_result = self._translate_record(record)
             except ChatProviderError:
                 self.close()
                 raise
+            if translation_result is _STREAM_TRANSLATION_FAILED:
+                self.close()
+                raise _stream_error("QwenCloud returned malformed streaming data.")
         return self._pending.popleft()
+
+    def _finish_translation(self) -> object:
+        try:
+            self._pending.extend(self._translator.finish())
+        except ChatProviderError:
+            raise
+        except Exception:
+            return _STREAM_TRANSLATION_FAILED
+        return None
+
+    def _translate_record(self, record: str) -> object:
+        try:
+            event = self._decode_event(record)
+            if self._event_count >= _MAX_STREAM_EVENTS:
+                _raise_malformed("QwenCloud stream event limit was exceeded.")
+            self._event_count += 1
+            self._pending.extend(self._translator.feed(event))
+        except ChatProviderError:
+            raise
+        except Exception:
+            return _STREAM_TRANSLATION_FAILED
+        return None
 
     def _read_record(self) -> str | object:
         try:
             return next(self._records)
         except StopIteration:
             return _STREAM_END
-        except (
-            TypeError,
-            UnicodeDecodeError,
-            ValueError,
-            requests.exceptions.RequestException,
-        ):
+        except Exception:
             return _STREAM_READ_FAILED
 
     def close(self) -> None:
@@ -1006,6 +1061,8 @@ def _iter_utf8_lines(chunks: Iterable[bytes]) -> Iterator[tuple[str, bool]]:
                 line_chars += len(segment)
                 if line_chars > _MAX_SSE_LINE_CHARS:
                     raise ValueError("QwenCloud SSE line limit was exceeded.")
+                if len(segments) >= _MAX_SSE_LINE_SEGMENTS:
+                    raise ValueError("QwenCloud SSE line segment limit was exceeded.")
                 segments.append(segment)
             yield "".join(segments), True
             segments.clear()
@@ -1022,6 +1079,8 @@ def _iter_utf8_lines(chunks: Iterable[bytes]) -> Iterator[tuple[str, bool]]:
             line_chars += len(segment)
             if line_chars > _MAX_SSE_LINE_CHARS:
                 raise ValueError("QwenCloud SSE line limit was exceeded.")
+            if len(segments) >= _MAX_SSE_LINE_SEGMENTS:
+                raise ValueError("QwenCloud SSE line segment limit was exceeded.")
             segments.append(segment)
     if segments:
         yield "".join(segments), False
@@ -1070,6 +1129,8 @@ def iter_sse_data_records(chunks: Iterable[bytes]) -> Iterator[str]:
         added_chars = len(value) + (1 if data_lines else 0)
         if record_chars + added_chars > _MAX_SSE_RECORD_CHARS:
             raise ValueError("QwenCloud SSE record limit was exceeded.")
+        if len(data_lines) >= _MAX_SSE_DATA_LINES:
+            raise ValueError("QwenCloud SSE data line limit was exceeded.")
         record_chars += added_chars
         data_lines.append(value)
 

--- a/tldw_chatbook/LLM_Calls/qwencloud_url.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud_url.py
@@ -1,0 +1,150 @@
+"""Dependency-free QwenCloud base URL normalization."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import unquote, urlsplit
+
+
+DEFAULT_QWENCLOUD_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+_MAX_URL_LENGTH = 2000
+_MAX_PATH_DECODE_PASSES = 3
+_ENDPOINT_TAILS = (("models",), ("responses",), ("chat", "completions"))
+_REQUEST_ENDPOINT_TAILS = _ENDPOINT_TAILS[1:]
+_PERCENT_ESCAPE_RE = re.compile(r"%[0-9A-Fa-f]{2}")
+_ENCODED_PATH_SEPARATOR_RE = re.compile(r"%(?:2[fF]|5[cC])")
+
+
+class QwenCloudBaseURLValidationError(ValueError):
+    """Raised when a QwenCloud base URL is unsafe or malformed."""
+
+
+def _invalid(message: str) -> QwenCloudBaseURLValidationError:
+    return QwenCloudBaseURLValidationError(message)
+
+
+def _has_unsafe_endpoint_tail_structure(path: str) -> bool:
+    segments = tuple(segment for segment in path.strip("/").split("/") if segment)
+    request_tails = [
+        (tail, index + len(tail))
+        for tail in _REQUEST_ENDPOINT_TAILS
+        for index in range(len(segments) - len(tail) + 1)
+        if segments[index : index + len(tail)] == tail
+    ]
+    if len(request_tails) > 1 or any(
+        end != len(segments) for _tail, end in request_tails
+    ):
+        return True
+    return any(
+        segments[-len(first + second) :] == first + second
+        for first in _ENDPOINT_TAILS
+        for second in _ENDPOINT_TAILS
+    )
+
+
+def _reserved_endpoint_markers(path: str) -> frozenset[tuple[int, str]]:
+    segments = tuple(segment.lower() for segment in path.strip("/").split("/"))
+    markers = {
+        (index, segment)
+        for index, segment in enumerate(segments)
+        if segment == "responses"
+        or (segment == "models" and index == len(segments) - 1)
+    }
+    markers.update(
+        (index, "chat/completions")
+        for index in range(len(segments) - 1)
+        if segments[index : index + 2] == ("chat", "completions")
+    )
+    return frozenset(markers)
+
+
+def _validate_percent_encoded_path(path: str) -> None:
+    validation_path = path
+    markers = _reserved_endpoint_markers(validation_path)
+    for _pass in range(_MAX_PATH_DECODE_PASSES):
+        if _ENCODED_PATH_SEPARATOR_RE.search(validation_path):
+            raise _invalid("QwenCloud API base URL path is malformed.")
+        try:
+            decoded_path = unquote(validation_path, errors="strict")
+        except UnicodeDecodeError as exc:
+            raise _invalid("QwenCloud API base URL path is malformed.") from exc
+        if decoded_path == validation_path:
+            break
+        decoded_markers = _reserved_endpoint_markers(decoded_path)
+        if (
+            any(
+                ord(character) < 32 or ord(character) == 127
+                for character in decoded_path
+            )
+            or any(segment in {".", ".."} for segment in decoded_path.split("/"))
+            or _has_unsafe_endpoint_tail_structure(decoded_path)
+            or decoded_markers - markers
+        ):
+            raise _invalid("QwenCloud API base URL path is malformed.")
+        validation_path = decoded_path
+        markers = decoded_markers
+    if _PERCENT_ESCAPE_RE.search(validation_path) is not None:
+        raise _invalid("QwenCloud API base URL path is malformed.")
+
+
+def normalize_qwencloud_base_url(api_base_url: str | None) -> str:
+    """Return one validated QwenCloud base URL without a request suffix.
+
+    Args:
+        api_base_url: Configured base URL or a pasted request endpoint. ``None``
+            selects the QwenCloud default.
+
+    Returns:
+        The validated base URL with a terminal lowercase request path removed.
+
+    Raises:
+        QwenCloudBaseURLValidationError: If the URL is malformed or unsafe.
+    """
+    candidate = DEFAULT_QWENCLOUD_BASE_URL if api_base_url is None else api_base_url
+    if not isinstance(candidate, str) or not candidate.strip():
+        raise _invalid("QwenCloud API base URL is required.")
+    if len(candidate) > _MAX_URL_LENGTH:
+        raise _invalid("QwenCloud API base URL is malformed.")
+    candidate = candidate.strip().rstrip("/")
+    if (
+        any(character.isspace() for character in candidate)
+        or any(ord(character) < 32 or ord(character) == 127 for character in candidate)
+        or "?" in candidate
+        or "#" in candidate
+    ):
+        raise _invalid("QwenCloud API base URL is malformed.")
+
+    try:
+        parsed = urlsplit(candidate)
+        port = parsed.port
+    except ValueError as exc:
+        raise _invalid("QwenCloud API base URL is malformed.") from exc
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        raise _invalid("QwenCloud API base URL must be an absolute HTTP(S) URL.")
+    if parsed.username is not None or parsed.password is not None:
+        raise _invalid("QwenCloud API base URL must not contain credentials.")
+    if any(character in parsed.netloc for character in '\\%|^{}<>"`'):
+        raise _invalid("QwenCloud API base URL authority is malformed.")
+    if parsed.query or parsed.fragment:
+        raise _invalid("QwenCloud API base URL must not contain a query or fragment.")
+    if parsed.netloc.endswith(":") or (port is not None and not 0 < port < 65536):
+        raise _invalid("QwenCloud API base URL is malformed.")
+    if (
+        "\\" in parsed.path
+        or "//" in parsed.path
+        or re.search(r"%(?![0-9A-Fa-f]{2})", parsed.path) is not None
+        or any(character.isspace() for character in parsed.path)
+        or any(segment in {".", ".."} for segment in parsed.path.split("/"))
+        or _has_unsafe_endpoint_tail_structure(parsed.path)
+    ):
+        raise _invalid("QwenCloud API base URL path is malformed.")
+    _validate_percent_encoded_path(parsed.path)
+
+    path = parsed.path.rstrip("/")
+    if path.endswith("/models"):
+        raise _invalid("QwenCloud API base URL must not use the models endpoint.")
+    for suffix in ("/chat/completions", "/responses"):
+        if path.endswith(suffix):
+            path = path[: -len(suffix)]
+            break
+    return f"{parsed.scheme.lower()}://{parsed.netloc}{path}".rstrip("/")

--- a/tldw_chatbook/LLM_Provider_Catalog/local_llm_provider_catalog_service.py
+++ b/tldw_chatbook/LLM_Provider_Catalog/local_llm_provider_catalog_service.py
@@ -55,21 +55,18 @@ from tldw_chatbook.LLM_Provider_Catalog.openai_compatible_model_discovery import
 )
 from tldw_chatbook.Utils.input_validation import validate_url
 
-from ..config import LOCAL_PROVIDERS, get_cli_providers_and_models, load_settings
+from ..config import (
+    LOCAL_PROVIDERS,
+    ProviderSettingsError,
+    get_cli_providers_and_models,
+    load_settings,
+    provider_settings_for_key,
+    resolve_provider_api_key,
+)
 
 
 DiscoveryClient = Callable[..., Awaitable[ModelDiscoveryResult]]
 SettingsLoader = Callable[[], Mapping[str, Any]]
-
-_PLACEHOLDER_KEYS = frozenset(
-    {
-        "",
-        "<API_KEY_HERE>",
-        "YOUR_KEY",
-        "your_key",
-        "your-api-key",
-    }
-)
 
 
 class LocalLLMProviderCatalogService:
@@ -191,6 +188,13 @@ class LocalLLMProviderCatalogService:
         settings: Mapping[str, Any] | None,
         provider_key: str,
     ) -> Mapping[str, Any]:
+        if provider_key == "qwencloud":
+            api_settings = (
+                settings.get("api_settings", {})
+                if isinstance(settings, Mapping)
+                else {}
+            )
+            return provider_settings_for_key(api_settings, provider_key)
         matches = cls._provider_settings_matches(settings, provider_key)
         return matches[0] if len(matches) == 1 else {}
 
@@ -200,6 +204,8 @@ class LocalLLMProviderCatalogService:
         settings: Mapping[str, Any] | None,
         provider_key: str,
     ) -> bool:
+        if provider_key == "qwencloud":
+            return False
         return len(cls._provider_settings_matches(settings, provider_key)) > 1
 
     @staticmethod
@@ -208,13 +214,6 @@ class LocalLLMProviderCatalogService:
             return None
         stripped = value.strip()
         return stripped or None
-
-    @classmethod
-    def _valid_api_key(cls, value: object) -> str | None:
-        stripped = cls._valid_text(value)
-        if stripped in _PLACEHOLDER_KEYS:
-            return None
-        return stripped
 
     @classmethod
     def _endpoint_from_provider_settings(
@@ -229,18 +228,20 @@ class LocalLLMProviderCatalogService:
         saved_settings: Mapping[str, Any],
         staged_settings: Mapping[str, Any] | None,
     ) -> str | None:
-        staged_provider_settings = self._provider_settings_for_key(
-            staged_settings, provider_key
-        )
+        try:
+            staged_provider_settings = self._provider_settings_for_key(
+                staged_settings, provider_key
+            )
+            saved_provider_settings = self._provider_settings_for_key(
+                saved_settings, provider_key
+            )
+        except ProviderSettingsError:
+            return None
         staged_endpoint = self._endpoint_from_provider_settings(
             staged_provider_settings
         )
         if staged_endpoint:
             return staged_endpoint
-
-        saved_provider_settings = self._provider_settings_for_key(
-            saved_settings, provider_key
-        )
         return effective_provider_endpoint(
             provider_key,
             staged_endpoint,
@@ -250,13 +251,13 @@ class LocalLLMProviderCatalogService:
     def _api_key_from_provider_settings(
         self, provider_settings: Mapping[str, Any]
     ) -> str | None:
-        configured_key = self._valid_api_key(provider_settings.get("api_key"))
+        configured_key = resolve_provider_api_key(provider_settings.get("api_key"))
         if configured_key:
             return configured_key
 
         env_var = self._valid_text(provider_settings.get("api_key_env_var"))
         if env_var:
-            return self._valid_api_key(self.environ.get(env_var))
+            return resolve_provider_api_key(self.environ.get(env_var))
         return None
 
     def _resolve_api_key(
@@ -267,16 +268,18 @@ class LocalLLMProviderCatalogService:
         saved_settings: Mapping[str, Any],
         staged_settings: Mapping[str, Any] | None,
     ) -> str | None:
-        staged_provider_settings = self._provider_settings_for_key(
-            staged_settings, provider_key
-        )
+        try:
+            staged_provider_settings = self._provider_settings_for_key(
+                staged_settings, provider_key
+            )
+            saved_provider_settings = self._provider_settings_for_key(
+                saved_settings, provider_key
+            )
+        except ProviderSettingsError:
+            return None
         staged_key = self._api_key_from_provider_settings(staged_provider_settings)
         if staged_key:
             return staged_key
-
-        saved_provider_settings = self._provider_settings_for_key(
-            saved_settings, provider_key
-        )
         saved_key = self._api_key_from_provider_settings(saved_provider_settings)
         if saved_key:
             return saved_key

--- a/tldw_chatbook/LLM_Provider_Catalog/model_catalog_settings.py
+++ b/tldw_chatbook/LLM_Provider_Catalog/model_catalog_settings.py
@@ -16,6 +16,7 @@ AUTO_REFRESH_PROVIDER_LIST_KEYS: tuple[str, ...] = (
     "MistralAI",
     "Moonshot",
     "OpenRouter",
+    "QwenCloud",
     "ZAI",
 )
 

--- a/tldw_chatbook/LLM_Provider_Catalog/model_discovery_provider_identity.py
+++ b/tldw_chatbook/LLM_Provider_Catalog/model_discovery_provider_identity.py
@@ -19,6 +19,7 @@ _MODEL_DISCOVERY_PROVIDER_HANDLER_KEYS = frozenset(
         "custom-openai-api-2",
         "local-llm",
         "mistralai",
+        "qwencloud",
     }
 )
 

--- a/tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py
+++ b/tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any
@@ -25,6 +26,12 @@ _NATIVE_ENDPOINT_PATHS_BY_PROVIDER = {
     "local_ollama": frozenset({"/api/tags"}),
 }
 _QWENCLOUD_PROVIDER_KEY = "qwencloud"
+_ENDPOINT_TAILS = (
+    ("models",),
+    ("responses",),
+    ("chat", "completions"),
+)
+_REQUEST_ENDPOINT_TAILS = _ENDPOINT_TAILS[1:]
 _BASE_URL_INFERABLE_PROVIDER_KEYS = frozenset(
     {
         "aphrodite",
@@ -140,6 +147,11 @@ def _parse_endpoint(endpoint: str | None) -> ParseResult | None:
     if not raw_endpoint:
         return None
     candidate = raw_endpoint if "://" in raw_endpoint else f"http://{raw_endpoint}"
+    if "\\" in candidate or any(
+        character.isspace() or ord(character) < 32 or ord(character) == 127
+        for character in candidate
+    ):
+        return None
     try:
         parsed = urlparse(candidate)
     except ValueError:
@@ -154,7 +166,45 @@ def _parse_endpoint(endpoint: str | None) -> ParseResult | None:
         parsed.port
     except ValueError:
         return None
+    if not _is_structurally_safe_endpoint(parsed):
+        return None
     return parsed
+
+
+def _is_structurally_safe_endpoint(parsed: ParseResult) -> bool:
+    """Return whether a parsed endpoint is safe to classify or normalize."""
+    if (
+        any(character in parsed.netloc for character in '\\%|^{}<>"`')
+        or parsed.netloc.endswith(":")
+        or "//" in parsed.path
+        or re.search(r"%(?![0-9A-Fa-f]{2})", parsed.path) is not None
+        or any(segment in {".", ".."} for segment in parsed.path.split("/"))
+    ):
+        return False
+
+    path_segments = tuple(
+        segment.lower() for segment in parsed.path.strip("/").split("/") if segment
+    )
+    request_endpoint_tails = [
+        (tail, index + len(tail))
+        for tail in _REQUEST_ENDPOINT_TAILS
+        for index in range(len(path_segments) - len(tail) + 1)
+        if path_segments[index : index + len(tail)] == tail
+    ]
+    if len(request_endpoint_tails) > 1 or any(
+        end != len(path_segments) for _tail, end in request_endpoint_tails
+    ):
+        return False
+    for first_tail in _ENDPOINT_TAILS:
+        for second_tail in _ENDPOINT_TAILS:
+            stacked_tail = first_tail + second_tail
+            if path_segments[-len(stacked_tail) :] == stacked_tail:
+                return False
+
+    safe_url = urlunparse(
+        (parsed.scheme, _safe_netloc(parsed), parsed.path or "/", "", "", "")
+    )
+    return validate_url(safe_url)
 
 
 def _normalized_path(parsed: ParseResult) -> str:

--- a/tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py
+++ b/tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
+from ipaddress import IPv6Address
 from typing import Any
 from urllib.parse import ParseResult, unquote, urlparse, urlunparse
 
 import httpx
 
 from tldw_chatbook.Chat.console_session_settings import normalize_llamacpp_base_url
+from tldw_chatbook.LLM_Calls.qwencloud_url import (
+    QwenCloudBaseURLValidationError,
+    normalize_qwencloud_base_url,
+)
 from tldw_chatbook.LLM_Provider_Catalog.model_discovery_contracts import (
     DiscoveredModel,
     DiscoveryErrorKind,
@@ -26,15 +31,13 @@ _NATIVE_ENDPOINT_PATHS_BY_PROVIDER = {
     "local_ollama": frozenset({"/api/tags"}),
 }
 _QWENCLOUD_PROVIDER_KEY = "qwencloud"
-_ENDPOINT_TAILS = (
-    ("models",),
-    ("responses",),
-    ("chat", "completions"),
-)
-_REQUEST_ENDPOINT_TAILS = _ENDPOINT_TAILS[1:]
-_MAX_PATH_VALIDATION_DECODE_PASSES = 2
+_MAX_ENDPOINT_LENGTH = 2000
+_MAX_GENERIC_PATH_DECODE_PASSES = 2
+_GENERIC_ENDPOINT_TAILS = (("models",), ("responses",), ("chat", "completions"))
+_GENERIC_REQUEST_ENDPOINT_TAILS = _GENERIC_ENDPOINT_TAILS[1:]
 _PERCENT_ESCAPE_RE = re.compile(r"%[0-9A-Fa-f]{2}")
 _ENCODED_PATH_SEPARATOR_RE = re.compile(r"%(?:2[fF]|5[cC])")
+_ZONE_ID_RE = re.compile(r"[A-Za-z0-9._~-]+")
 _BASE_URL_INFERABLE_PROVIDER_KEYS = frozenset(
     {
         "aphrodite",
@@ -118,7 +121,9 @@ _ANTHROPIC_MODELS_PAGE_LIMIT = 1000
 _ANTHROPIC_MAX_MODEL_PAGES = 10
 
 
-def build_discovery_auth_headers(provider_identity: str, api_key: str | None) -> dict[str, str]:
+def build_discovery_auth_headers(
+    provider_identity: str, api_key: str | None
+) -> dict[str, str]:
     """Return provider-appropriate auth headers for a models request.
 
     Args:
@@ -147,7 +152,7 @@ def _normalized_provider_identity(provider_identity: str | None) -> str:
 def _parse_endpoint(endpoint: str | None) -> ParseResult | None:
     """Parse a configured endpoint, accepting host-only local URLs."""
     raw_endpoint = str(endpoint or "").strip()
-    if not raw_endpoint:
+    if not raw_endpoint or len(raw_endpoint) > _MAX_ENDPOINT_LENGTH:
         return None
     candidate = raw_endpoint if "://" in raw_endpoint else f"http://{raw_endpoint}"
     if "\\" in candidate or any(
@@ -169,59 +174,58 @@ def _parse_endpoint(endpoint: str | None) -> ParseResult | None:
         parsed.port
     except ValueError:
         return None
-    if not _is_structurally_safe_endpoint(parsed):
-        return None
-    return parsed
+    return parsed if _is_structurally_safe_generic_endpoint(parsed) else None
 
 
-def _is_structurally_safe_endpoint(parsed: ParseResult) -> bool:
-    """Return whether a parsed endpoint is safe to classify or normalize."""
-    if (
-        any(character in parsed.netloc for character in '\\%|^{}<>"`')
-        or parsed.netloc.endswith(":")
-        or "//" in parsed.path
-        or re.search(r"%(?![0-9A-Fa-f]{2})", parsed.path) is not None
-        or any(segment in {".", ".."} for segment in parsed.path.split("/"))
-    ):
+def _is_structurally_safe_generic_endpoint(parsed: ParseResult) -> bool:
+    """Validate generic discovery structure without provider suffix policy."""
+    if not _is_safe_generic_authority(parsed.netloc):
         return False
-
-    if _has_unsafe_endpoint_tail_structure(parsed.path):
+    if not _is_safe_generic_path(parsed.path):
         return False
-
     safe_url = urlunparse(
         (parsed.scheme, _safe_netloc(parsed), parsed.path or "/", "", "", "")
     )
-    return _is_safe_percent_encoded_path(parsed.path) and validate_url(safe_url)
+    return validate_url(safe_url)
 
 
-def _has_unsafe_endpoint_tail_structure(path: str) -> bool:
-    """Return whether request/model endpoint tails are repeated or non-terminal."""
-    path_segments = tuple(
-        segment.lower() for segment in path.strip("/").split("/") if segment
-    )
-    request_endpoint_tails = [
-        (tail, index + len(tail))
-        for tail in _REQUEST_ENDPOINT_TAILS
-        for index in range(len(path_segments) - len(tail) + 1)
-        if path_segments[index : index + len(tail)] == tail
-    ]
-    if len(request_endpoint_tails) > 1 or any(
-        end != len(path_segments) for _tail, end in request_endpoint_tails
-    ):
+def _is_safe_generic_authority(netloc: str) -> bool:
+    """Allow percent only for an RFC 6874 bracketed IPv6 zone identifier."""
+    if any(character in netloc for character in '\\|^{}<>"`') or netloc.endswith(":"):
+        return False
+    if "%" not in netloc:
         return True
-    for first_tail in _ENDPOINT_TAILS:
-        for second_tail in _ENDPOINT_TAILS:
-            stacked_tail = first_tail + second_tail
-            if path_segments[-len(stacked_tail) :] == stacked_tail:
-                return True
-    return False
+
+    host_port = netloc.rsplit("@", 1)[-1]
+    closing_bracket = host_port.find("]")
+    if not host_port.startswith("[") or closing_bracket < 0:
+        return False
+    bracketed_host = host_port[1:closing_bracket]
+    remainder = host_port[closing_bracket + 1 :]
+    if bracketed_host.count("%25") != 1 or (
+        remainder and not re.fullmatch(r":\d+", remainder)
+    ):
+        return False
+    address, zone_id = bracketed_host.split("%25", 1)
+    try:
+        IPv6Address(address)
+    except ValueError:
+        return False
+    return _ZONE_ID_RE.fullmatch(zone_id) is not None
 
 
-def _is_safe_percent_encoded_path(path: str) -> bool:
-    """Validate decoded path structure without rewriting the request URL."""
+def _is_safe_generic_path(path: str) -> bool:
+    """Reject parser-ambiguous path structure without rewriting the URL."""
+    if (
+        "//" in path
+        or re.search(r"%(?![0-9A-Fa-f]{2})", path) is not None
+        or any(segment in {".", ".."} for segment in path.split("/"))
+        or _has_unsafe_generic_endpoint_tail_structure(path)
+    ):
+        return False
+
     validation_path = path
-    reserved_markers = _reserved_path_markers(validation_path)
-    for _pass in range(_MAX_PATH_VALIDATION_DECODE_PASSES):
+    for _pass in range(_MAX_GENERIC_PATH_DECODE_PASSES):
         if _ENCODED_PATH_SEPARATOR_RE.search(validation_path):
             return False
         try:
@@ -230,40 +234,37 @@ def _is_safe_percent_encoded_path(path: str) -> bool:
             return False
         if decoded_path == validation_path:
             break
-        decoded_markers = _reserved_path_markers(decoded_path)
         if (
             any(
                 ord(character) < 32 or ord(character) == 127
                 for character in decoded_path
             )
             or any(segment in {".", ".."} for segment in decoded_path.split("/"))
-            or _has_unsafe_endpoint_tail_structure(decoded_path)
-            or decoded_markers - reserved_markers
+            or _has_unsafe_generic_endpoint_tail_structure(decoded_path)
         ):
             return False
         validation_path = decoded_path
-        reserved_markers = decoded_markers
     return _PERCENT_ESCAPE_RE.search(validation_path) is None
 
 
-def _reserved_path_markers(path: str) -> frozenset[tuple[int, str]]:
-    """Return reserved endpoint words and tails with their segment positions."""
+def _has_unsafe_generic_endpoint_tail_structure(path: str) -> bool:
+    """Reject repeated or non-terminal generic request endpoint tails."""
     segments = tuple(segment.lower() for segment in path.strip("/").split("/"))
-    markers = set()
-    for index, segment in enumerate(segments):
-        if "responses" in segment:
-            markers.add((index, "responses"))
-        if "completion" in segment:
-            markers.add((index, "completion"))
-        if segment == "models" and index == len(segments) - 1:
-            markers.add((index, "models"))
-    markers.update(
-        (index, "/".join(tail))
-        for tail in (("chat", "completions"),)
+    request_tails = [
+        (tail, index + len(tail))
+        for tail in _GENERIC_REQUEST_ENDPOINT_TAILS
         for index in range(len(segments) - len(tail) + 1)
         if segments[index : index + len(tail)] == tail
+    ]
+    if len(request_tails) > 1 or any(
+        end != len(segments) for _tail, end in request_tails
+    ):
+        return True
+    return any(
+        segments[-len(first + second) :] == first + second
+        for first in _GENERIC_ENDPOINT_TAILS
+        for second in _GENERIC_ENDPOINT_TAILS
     )
-    return frozenset(markers)
 
 
 def _normalized_path(parsed: ParseResult) -> str:
@@ -287,7 +288,7 @@ def _safe_netloc(parsed: ParseResult) -> str:
 def _parse_endpoint_for_fingerprint(endpoint: str | None) -> ParseResult | None:
     """Parse any URL-like endpoint so safe display can strip credentials."""
     raw_endpoint = str(endpoint or "").strip()
-    if not raw_endpoint:
+    if not raw_endpoint or len(raw_endpoint) > _MAX_ENDPOINT_LENGTH:
         return None
     candidate = raw_endpoint if "://" in raw_endpoint else f"http://{raw_endpoint}"
     try:
@@ -297,34 +298,7 @@ def _parse_endpoint_for_fingerprint(endpoint: str | None) -> ParseResult | None:
     return parsed if parsed.scheme and parsed.netloc and parsed.hostname else None
 
 
-def _qwencloud_models_path_for_endpoint_path(path: str) -> str | None:
-    """Return a models path for a valid QwenCloud compatible-API path."""
-    normalized_path = (path or "/").rstrip("/").lower() or "/"
-    segments = normalized_path.strip("/").split("/")
-    responses_segments = [segment for segment in segments if "responses" in segment]
-    completion_segments = [segment for segment in segments if "completion" in segment]
-
-    if segments[-1] == "responses" and responses_segments == ["responses"]:
-        base_path = normalized_path.removesuffix("/responses")
-        return f"{base_path}/models"
-    if (
-        segments[-2:] == ["chat", "completions"]
-        and not responses_segments
-        and completion_segments == ["completions"]
-    ):
-        base_path = normalized_path.removesuffix("/chat/completions")
-        return f"{base_path}/models"
-    if responses_segments or completion_segments:
-        return None
-    if segments[-1] == "models":
-        return normalized_path
-    return f"{normalized_path}/models"
-
-
-def _models_path_for_endpoint_path(
-    path: str,
-    provider_identity: str | None = None,
-) -> str | None:
+def _models_path_for_endpoint_path(path: str) -> str | None:
     """Return the OpenAI-compatible models path for a supported endpoint path."""
     normalized_path = (path or "/").rstrip("/").lower() or "/"
     if normalized_path == "/":
@@ -337,8 +311,6 @@ def _models_path_for_endpoint_path(
         return f"{normalized_path}/models"
     if normalized_path in {"/completion", "/completions"}:
         return "/v1/models"
-    if _normalized_provider_identity(provider_identity) == _QWENCLOUD_PROVIDER_KEY:
-        return _qwencloud_models_path_for_endpoint_path(normalized_path)
     if normalized_path.endswith("/v1/chat/completions"):
         return f"{normalized_path.removesuffix('/chat/completions')}/models"
     if normalized_path.endswith("/chat/completions"):
@@ -346,26 +318,17 @@ def _models_path_for_endpoint_path(
     return None
 
 
-def _models_path_preserving_encoding(
-    path: str,
-    provider_identity: str | None = None,
-) -> str:
+def _models_path_preserving_encoding(path: str) -> str:
     """Return the models path without decoding or recasing its base prefix."""
     raw_path = (path or "/").rstrip("/") or "/"
     normalized_path = raw_path.lower()
-    normalized_models_path = _models_path_for_endpoint_path(
-        normalized_path, provider_identity
-    )
+    normalized_models_path = _models_path_for_endpoint_path(normalized_path)
     if normalized_models_path is None:
         return raw_path
     if normalized_path == "/" or normalized_path in {"/completion", "/completions"}:
         return normalized_models_path
     if normalized_path.endswith("/chat/completions"):
         return f"{raw_path[: -len('/chat/completions')]}/models"
-    if _normalized_provider_identity(
-        provider_identity
-    ) == _QWENCLOUD_PROVIDER_KEY and normalized_path.endswith("/responses"):
-        return f"{raw_path[: -len('/responses')]}/models"
     if normalized_path.endswith("/models"):
         return raw_path
     return f"{raw_path}/models"
@@ -377,19 +340,11 @@ def _is_base_url_path(path: str) -> bool:
     return normalized_path == "/"
 
 
-def _is_explicit_openai_compatible_path(
-    path: str,
-    provider_identity: str | None = None,
-) -> bool:
+def _is_explicit_openai_compatible_path(path: str) -> bool:
     """Return whether a path explicitly opts into OpenAI-compatible discovery."""
     normalized_path = (path or "/").rstrip("/").lower() or "/"
-    return (
-        normalized_path in _EXPLICIT_OPENAI_COMPATIBLE_ENDPOINT_PATHS
-        or normalized_path.endswith("/chat/completions")
-        or (
-            _normalized_provider_identity(provider_identity) == _QWENCLOUD_PROVIDER_KEY
-            and _qwencloud_models_path_for_endpoint_path(normalized_path) is not None
-        )
+    return normalized_path in _EXPLICIT_OPENAI_COMPATIBLE_ENDPOINT_PATHS or (
+        normalized_path.endswith("/chat/completions")
     )
 
 
@@ -403,11 +358,18 @@ def supports_openai_compatible_model_discovery(
     provider discovery URLs are rejected even when the provider can also expose
     an OpenAI-compatible API at another configured endpoint.
     """
+    provider_key = _normalized_provider_identity(provider_identity)
+    if provider_key == _QWENCLOUD_PROVIDER_KEY:
+        try:
+            normalize_qwencloud_base_url(normalized_endpoint)
+        except QwenCloudBaseURLValidationError:
+            return False
+        return True
+
     parsed = _parse_endpoint(normalized_endpoint)
     if parsed is None:
         return False
 
-    provider_key = _normalized_provider_identity(provider_identity)
     path = _normalized_path(parsed)
     native_paths = _NATIVE_ENDPOINT_PATHS_BY_PROVIDER.get(provider_key, frozenset())
     if path in native_paths:
@@ -416,13 +378,20 @@ def supports_openai_compatible_model_discovery(
     if _is_base_url_path(path):
         return provider_key in _BASE_URL_INFERABLE_PROVIDER_KEYS
 
-    return _is_explicit_openai_compatible_path(path, provider_key) and (
-        _models_path_for_endpoint_path(path, provider_key) is not None
+    return _is_explicit_openai_compatible_path(path) and (
+        _models_path_for_endpoint_path(path) is not None
     )
 
 
 def build_models_url(endpoint: str, provider_identity: str) -> str:
     """Return the OpenAI-compatible models endpoint for a configured URL."""
+    if _normalized_provider_identity(provider_identity) == _QWENCLOUD_PROVIDER_KEY:
+        try:
+            base_url = normalize_qwencloud_base_url(endpoint)
+        except QwenCloudBaseURLValidationError:
+            return fingerprint_endpoint(endpoint)
+        return f"{base_url}/models"
+
     parsed = _parse_endpoint(endpoint)
     if parsed is None:
         return str(endpoint or "").strip()
@@ -443,7 +412,7 @@ def build_models_url(endpoint: str, provider_identity: str) -> str:
                 )
             )
 
-    models_path = _models_path_preserving_encoding(parsed.path, provider_identity)
+    models_path = _models_path_preserving_encoding(parsed.path)
 
     return urlunparse((parsed.scheme, _safe_netloc(parsed), models_path, "", "", ""))
 
@@ -637,7 +606,9 @@ async def discover_openai_compatible_models(
         )
         for _page in range(_ANTHROPIC_MAX_MODEL_PAGES if paginate else 1):
             try:
-                response = await active_client.get(models_url, headers=headers, params=params)
+                response = await active_client.get(
+                    models_url, headers=headers, params=params
+                )
                 response.raise_for_status()
             except httpx.HTTPStatusError as exc:
                 if exc.response.status_code in {401, 403}:
@@ -689,7 +660,9 @@ async def discover_openai_compatible_models(
                         "Use an endpoint that returns a JSON object with a data array of model IDs.",
                     ),
                 )
-            if not isinstance(payload, Mapping) or not isinstance(payload.get("data"), list):
+            if not isinstance(payload, Mapping) or not isinstance(
+                payload.get("data"), list
+            ):
                 return None, ModelDiscoveryResult(
                     provider=provider,
                     provider_list_key=provider_list_key,
@@ -748,7 +721,9 @@ async def discover_openai_compatible_models(
     for payload in payloads:
         combined_data.extend(payload["data"])
 
-    now_iso = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    now_iso = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
     try:
         models = normalize_models_response(
             {"data": combined_data},

--- a/tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py
+++ b/tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py
@@ -24,7 +24,7 @@ _NATIVE_ENDPOINT_PATHS_BY_PROVIDER = {
     "ollama": frozenset({"/api/tags"}),
     "local_ollama": frozenset({"/api/tags"}),
 }
-_QWENCLOUD_COMPATIBLE_BASE_PATH = "/compatible-mode/v1"
+_QWENCLOUD_PROVIDER_KEY = "qwencloud"
 _BASE_URL_INFERABLE_PROVIDER_KEYS = frozenset(
     {
         "aphrodite",
@@ -53,9 +53,6 @@ _EXPLICIT_OPENAI_COMPATIBLE_ENDPOINT_PATHS = frozenset(
         "/completions",
         "/api/v1",
         "/api/paas/v4",
-        _QWENCLOUD_COMPATIBLE_BASE_PATH,
-        f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/models",
-        f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/responses",
     }
 )
 _EXACT_SENSITIVE_METADATA_KEYS = frozenset(
@@ -191,7 +188,34 @@ def _parse_endpoint_for_fingerprint(endpoint: str | None) -> ParseResult | None:
     return parsed if parsed.scheme and parsed.netloc and parsed.hostname else None
 
 
-def _models_path_for_endpoint_path(path: str) -> str | None:
+def _qwencloud_models_path_for_endpoint_path(path: str) -> str | None:
+    """Return a models path for a valid QwenCloud compatible-API path."""
+    normalized_path = (path or "/").rstrip("/").lower() or "/"
+    segments = normalized_path.strip("/").split("/")
+    responses_segments = [segment for segment in segments if "responses" in segment]
+    completion_segments = [segment for segment in segments if "completion" in segment]
+
+    if segments[-1] == "responses" and responses_segments == ["responses"]:
+        base_path = normalized_path.removesuffix("/responses")
+        return f"{base_path}/models"
+    if (
+        segments[-2:] == ["chat", "completions"]
+        and not responses_segments
+        and completion_segments == ["completions"]
+    ):
+        base_path = normalized_path.removesuffix("/chat/completions")
+        return f"{base_path}/models"
+    if responses_segments or completion_segments:
+        return None
+    if segments[-1] == "models":
+        return normalized_path
+    return f"{normalized_path}/models"
+
+
+def _models_path_for_endpoint_path(
+    path: str,
+    provider_identity: str | None = None,
+) -> str | None:
     """Return the OpenAI-compatible models path for a supported endpoint path."""
     normalized_path = (path or "/").rstrip("/").lower() or "/"
     if normalized_path == "/":
@@ -202,15 +226,10 @@ def _models_path_for_endpoint_path(path: str) -> str | None:
         return "/v1/models"
     if normalized_path in {"/api/v1", "/api/paas/v4"}:
         return f"{normalized_path}/models"
-    if normalized_path in {
-        _QWENCLOUD_COMPATIBLE_BASE_PATH,
-        f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/models",
-        f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/responses",
-        f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/chat/completions",
-    }:
-        return f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/models"
     if normalized_path in {"/completion", "/completions"}:
         return "/v1/models"
+    if _normalized_provider_identity(provider_identity) == _QWENCLOUD_PROVIDER_KEY:
+        return _qwencloud_models_path_for_endpoint_path(normalized_path)
     if normalized_path.endswith("/v1/chat/completions"):
         return f"{normalized_path.removesuffix('/chat/completions')}/models"
     if normalized_path.endswith("/chat/completions"):
@@ -224,12 +243,19 @@ def _is_base_url_path(path: str) -> bool:
     return normalized_path == "/"
 
 
-def _is_explicit_openai_compatible_path(path: str) -> bool:
+def _is_explicit_openai_compatible_path(
+    path: str,
+    provider_identity: str | None = None,
+) -> bool:
     """Return whether a path explicitly opts into OpenAI-compatible discovery."""
     normalized_path = (path or "/").rstrip("/").lower() or "/"
     return (
         normalized_path in _EXPLICIT_OPENAI_COMPATIBLE_ENDPOINT_PATHS
         or normalized_path.endswith("/chat/completions")
+        or (
+            _normalized_provider_identity(provider_identity) == _QWENCLOUD_PROVIDER_KEY
+            and _qwencloud_models_path_for_endpoint_path(normalized_path) is not None
+        )
     )
 
 
@@ -256,8 +282,8 @@ def supports_openai_compatible_model_discovery(
     if _is_base_url_path(path):
         return provider_key in _BASE_URL_INFERABLE_PROVIDER_KEYS
 
-    return _is_explicit_openai_compatible_path(path) and (
-        _models_path_for_endpoint_path(path) is not None
+    return _is_explicit_openai_compatible_path(path, provider_key) and (
+        _models_path_for_endpoint_path(path, provider_key) is not None
     )
 
 
@@ -283,7 +309,7 @@ def build_models_url(endpoint: str, provider_identity: str) -> str:
                 )
             )
 
-    models_path = _models_path_for_endpoint_path(path) or path
+    models_path = _models_path_for_endpoint_path(path, provider_identity) or path
 
     return urlunparse((parsed.scheme, _safe_netloc(parsed), models_path, "", "", ""))
 

--- a/tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py
+++ b/tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py
@@ -24,6 +24,7 @@ _NATIVE_ENDPOINT_PATHS_BY_PROVIDER = {
     "ollama": frozenset({"/api/tags"}),
     "local_ollama": frozenset({"/api/tags"}),
 }
+_QWENCLOUD_COMPATIBLE_BASE_PATH = "/compatible-mode/v1"
 _BASE_URL_INFERABLE_PROVIDER_KEYS = frozenset(
     {
         "aphrodite",
@@ -38,6 +39,7 @@ _BASE_URL_INFERABLE_PROVIDER_KEYS = frozenset(
         "local_vllm",
         "openai",
         "openrouter",
+        "qwencloud",
         "tabbyapi",
         "vllm",
     }
@@ -51,6 +53,9 @@ _EXPLICIT_OPENAI_COMPATIBLE_ENDPOINT_PATHS = frozenset(
         "/completions",
         "/api/v1",
         "/api/paas/v4",
+        _QWENCLOUD_COMPATIBLE_BASE_PATH,
+        f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/models",
+        f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/responses",
     }
 )
 _EXACT_SENSITIVE_METADATA_KEYS = frozenset(
@@ -197,6 +202,13 @@ def _models_path_for_endpoint_path(path: str) -> str | None:
         return "/v1/models"
     if normalized_path in {"/api/v1", "/api/paas/v4"}:
         return f"{normalized_path}/models"
+    if normalized_path in {
+        _QWENCLOUD_COMPATIBLE_BASE_PATH,
+        f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/models",
+        f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/responses",
+        f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/chat/completions",
+    }:
+        return f"{_QWENCLOUD_COMPATIBLE_BASE_PATH}/models"
     if normalized_path in {"/completion", "/completions"}:
         return "/v1/models"
     if normalized_path.endswith("/v1/chat/completions"):

--- a/tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py
+++ b/tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any
-from urllib.parse import ParseResult, urlparse, urlunparse
+from urllib.parse import ParseResult, unquote, urlparse, urlunparse
 
 import httpx
 
@@ -32,6 +32,9 @@ _ENDPOINT_TAILS = (
     ("chat", "completions"),
 )
 _REQUEST_ENDPOINT_TAILS = _ENDPOINT_TAILS[1:]
+_MAX_PATH_VALIDATION_DECODE_PASSES = 2
+_PERCENT_ESCAPE_RE = re.compile(r"%[0-9A-Fa-f]{2}")
+_ENCODED_PATH_SEPARATOR_RE = re.compile(r"%(?:2[fF]|5[cC])")
 _BASE_URL_INFERABLE_PROVIDER_KEYS = frozenset(
     {
         "aphrodite",
@@ -182,8 +185,19 @@ def _is_structurally_safe_endpoint(parsed: ParseResult) -> bool:
     ):
         return False
 
+    if _has_unsafe_endpoint_tail_structure(parsed.path):
+        return False
+
+    safe_url = urlunparse(
+        (parsed.scheme, _safe_netloc(parsed), parsed.path or "/", "", "", "")
+    )
+    return _is_safe_percent_encoded_path(parsed.path) and validate_url(safe_url)
+
+
+def _has_unsafe_endpoint_tail_structure(path: str) -> bool:
+    """Return whether request/model endpoint tails are repeated or non-terminal."""
     path_segments = tuple(
-        segment.lower() for segment in parsed.path.strip("/").split("/") if segment
+        segment.lower() for segment in path.strip("/").split("/") if segment
     )
     request_endpoint_tails = [
         (tail, index + len(tail))
@@ -194,17 +208,62 @@ def _is_structurally_safe_endpoint(parsed: ParseResult) -> bool:
     if len(request_endpoint_tails) > 1 or any(
         end != len(path_segments) for _tail, end in request_endpoint_tails
     ):
-        return False
+        return True
     for first_tail in _ENDPOINT_TAILS:
         for second_tail in _ENDPOINT_TAILS:
             stacked_tail = first_tail + second_tail
             if path_segments[-len(stacked_tail) :] == stacked_tail:
-                return False
+                return True
+    return False
 
-    safe_url = urlunparse(
-        (parsed.scheme, _safe_netloc(parsed), parsed.path or "/", "", "", "")
+
+def _is_safe_percent_encoded_path(path: str) -> bool:
+    """Validate decoded path structure without rewriting the request URL."""
+    validation_path = path
+    reserved_markers = _reserved_path_markers(validation_path)
+    for _pass in range(_MAX_PATH_VALIDATION_DECODE_PASSES):
+        if _ENCODED_PATH_SEPARATOR_RE.search(validation_path):
+            return False
+        try:
+            decoded_path = unquote(validation_path, errors="strict")
+        except UnicodeDecodeError:
+            return False
+        if decoded_path == validation_path:
+            break
+        decoded_markers = _reserved_path_markers(decoded_path)
+        if (
+            any(
+                ord(character) < 32 or ord(character) == 127
+                for character in decoded_path
+            )
+            or any(segment in {".", ".."} for segment in decoded_path.split("/"))
+            or _has_unsafe_endpoint_tail_structure(decoded_path)
+            or decoded_markers - reserved_markers
+        ):
+            return False
+        validation_path = decoded_path
+        reserved_markers = decoded_markers
+    return _PERCENT_ESCAPE_RE.search(validation_path) is None
+
+
+def _reserved_path_markers(path: str) -> frozenset[tuple[int, str]]:
+    """Return reserved endpoint words and tails with their segment positions."""
+    segments = tuple(segment.lower() for segment in path.strip("/").split("/"))
+    markers = set()
+    for index, segment in enumerate(segments):
+        if "responses" in segment:
+            markers.add((index, "responses"))
+        if "completion" in segment:
+            markers.add((index, "completion"))
+        if segment == "models" and index == len(segments) - 1:
+            markers.add((index, "models"))
+    markers.update(
+        (index, "/".join(tail))
+        for tail in (("chat", "completions"),)
+        for index in range(len(segments) - len(tail) + 1)
+        if segments[index : index + len(tail)] == tail
     )
-    return validate_url(safe_url)
+    return frozenset(markers)
 
 
 def _normalized_path(parsed: ParseResult) -> str:
@@ -287,6 +346,31 @@ def _models_path_for_endpoint_path(
     return None
 
 
+def _models_path_preserving_encoding(
+    path: str,
+    provider_identity: str | None = None,
+) -> str:
+    """Return the models path without decoding or recasing its base prefix."""
+    raw_path = (path or "/").rstrip("/") or "/"
+    normalized_path = raw_path.lower()
+    normalized_models_path = _models_path_for_endpoint_path(
+        normalized_path, provider_identity
+    )
+    if normalized_models_path is None:
+        return raw_path
+    if normalized_path == "/" or normalized_path in {"/completion", "/completions"}:
+        return normalized_models_path
+    if normalized_path.endswith("/chat/completions"):
+        return f"{raw_path[: -len('/chat/completions')]}/models"
+    if _normalized_provider_identity(
+        provider_identity
+    ) == _QWENCLOUD_PROVIDER_KEY and normalized_path.endswith("/responses"):
+        return f"{raw_path[: -len('/responses')]}/models"
+    if normalized_path.endswith("/models"):
+        return raw_path
+    return f"{raw_path}/models"
+
+
 def _is_base_url_path(path: str) -> bool:
     """Return whether a path requires provider identity to infer ``/v1/models``."""
     normalized_path = (path or "/").rstrip("/").lower() or "/"
@@ -359,7 +443,7 @@ def build_models_url(endpoint: str, provider_identity: str) -> str:
                 )
             )
 
-    models_path = _models_path_for_endpoint_path(path, provider_identity) or path
+    models_path = _models_path_preserving_encoding(parsed.path, provider_identity)
 
     return urlunparse((parsed.scheme, _safe_netloc(parsed), models_path, "", "", ""))
 

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -98,6 +98,7 @@ from ...Chat.provider_catalog import (
     PROVIDER_GROUP_LOCAL,
     PROVIDER_GROUP_ORDER,
 )
+from ...Chat.provider_readiness import provider_settings_for_key
 from ...config import (
     DEFAULT_CONFIG_FROM_TOML,
     DEFAULT_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
@@ -7598,7 +7599,7 @@ class SettingsScreen(BaseAppScreen):
         draft.originals.update(originals)
         draft.values.update(values)
 
-    def _provider_api_mode_display_value(self, provider: object) -> tuple[str, bool]:
+    def _provider_api_mode_display_value(self, provider: object) -> tuple[object, bool]:
         """Return a safe selector value and whether the saved/draft mode is valid."""
         if provider_config_key(str(provider or "")) != "qwencloud":
             return "responses", True
@@ -7607,7 +7608,7 @@ class SettingsScreen(BaseAppScreen):
                 self._provider_api_mode_value(provider)
             ), True
         except ChatConfigurationError:
-            return "responses", False
+            return Select.NULL, False
 
     def _resolve_provider_model_for_settings(self):
         draft = self._provider_draft()
@@ -8160,16 +8161,37 @@ class SettingsScreen(BaseAppScreen):
         target_key = provider_config_key(provider)
         if not target_key:
             return None, {}
+        section_key = None
         for configured_provider, configured_settings in api_settings.items():
             if provider_config_key(str(configured_provider)) == target_key:
-                if isinstance(configured_settings, Mapping):
-                    return str(configured_provider), configured_settings
-                return str(configured_provider), {}
-        return None, {}
+                section_key = str(configured_provider)
+                break
+        if section_key is None:
+            return None, {}
+        return section_key, provider_settings_for_key(api_settings, target_key)
 
     def _provider_config(self, provider: str) -> Mapping[str, object]:
         _section_key, provider_config = self._provider_config_entry(provider)
         return provider_config
+
+    def _qwencloud_alias_mode_sections(self) -> tuple[str, ...]:
+        """Return noncanonical QwenCloud tables that own an ``api_mode`` key."""
+        app_config = getattr(self.app_instance, "app_config", {}) or {}
+        api_settings = (
+            app_config.get("api_settings", {})
+            if isinstance(app_config, Mapping)
+            else {}
+        )
+        if not isinstance(api_settings, Mapping):
+            return ()
+        return tuple(
+            str(configured_provider)
+            for configured_provider, configured_settings in api_settings.items()
+            if str(configured_provider) != "qwencloud"
+            and provider_config_key(str(configured_provider)) == "qwencloud"
+            and isinstance(configured_settings, Mapping)
+            and "api_mode" in configured_settings
+        )
 
     def _provider_credential_env_var(self, provider: str) -> str:
         env_var = self._provider_config(provider).get("api_key_env_var", "")
@@ -8421,9 +8443,11 @@ class SettingsScreen(BaseAppScreen):
             return
         value = self._select_value_text(selector.value)
         if not value:
+            if selector.has_focus:
+                self._stage_provider_api_mode(provider, "")
             return
-        display_value, current_value_is_valid = (
-            self._provider_api_mode_display_value(provider)
+        display_value, current_value_is_valid = self._provider_api_mode_display_value(
+            provider
         )
         draft = self._provider_draft()
         draft_key = self._provider_api_mode_draft_key(provider)
@@ -8824,6 +8848,7 @@ class SettingsScreen(BaseAppScreen):
         app_config = getattr(self.app_instance, "app_config", {}) or {}
         draft = self._provider_draft()
         dirty = draft.dirty_keys if draft is not None else set()
+        provider_key = provider_config_key(provider)
         api_mode_draft_key = self._provider_api_mode_draft_key(provider)
         if not (
             {"endpoint", "credential_env_var", "api_key", api_mode_draft_key}
@@ -8847,7 +8872,12 @@ class SettingsScreen(BaseAppScreen):
             endpoint = str(values.get("endpoint") or "").strip()
             env_var = str(values.get("credential_env_var") or "").strip()
             api_key = str(values.get("api_key") or "").strip()
-        return overlay_provider_draft_config(
+        draft_api_mode = (
+            self._provider_api_mode_value(provider)
+            if api_mode_draft_key in dirty
+            else None
+        )
+        staged_config = overlay_provider_draft_config(
             app_config,
             provider_save_key=provider_save_key,
             endpoint_key=self._provider_endpoint_setting_key(provider),
@@ -8855,11 +8885,16 @@ class SettingsScreen(BaseAppScreen):
             draft_env_var=env_var if "credential_env_var" in dirty else None,
             draft_api_key=api_key if "api_key" in dirty else None,
             draft_api_mode=(
-                self._provider_api_mode_value(provider)
-                if api_mode_draft_key in dirty
+                draft_api_mode
+                if provider_key == "qwencloud" and provider_save_key == "qwencloud"
                 else None
             ),
         )
+        if draft_api_mode is not None and provider_key == "qwencloud":
+            staged_api_settings = staged_config.setdefault("api_settings", {})
+            canonical_settings = staged_api_settings.setdefault("qwencloud", {})
+            canonical_settings["api_mode"] = draft_api_mode
+        return staged_config
 
     def _provider_discovery_staged_settings(self, provider: str) -> dict[str, object]:
         provider_key = provider_config_key(provider)
@@ -10478,12 +10513,13 @@ class SettingsScreen(BaseAppScreen):
                     QWENCLOUD_API_MODE_OPTIONS,
                     value=api_mode_value,
                     id="settings-provider-api-mode",
+                    prompt="Choose Responses or Chat Completions",
                     classes=(
                         "settings-compact-select"
                         if api_mode_valid
                         else "settings-compact-select settings-invalid-input"
                     ),
-                    allow_blank=False,
+                    allow_blank=True,
                     compact=True,
                     disabled=provider_config_key(provider) != "qwencloud",
                 )
@@ -16963,9 +16999,20 @@ class SettingsScreen(BaseAppScreen):
             return
         value = self._select_value_text(event.value)
         if not value:
+            if event.select.has_focus:
+                self._stage_provider_api_mode(provider, "")
+                event.select.add_class("settings-invalid-input")
+                self._set_static_text(
+                    "#settings-provider-api-mode-guidance",
+                    QWENCLOUD_API_MODE_INVALID_COPY,
+                )
+                self._update_provider_dynamic_widgets()
+                self._update_draft_status_widgets(
+                    SettingsCategoryId.PROVIDERS_MODELS
+                )
             return
-        display_value, current_value_is_valid = (
-            self._provider_api_mode_display_value(provider)
+        display_value, current_value_is_valid = self._provider_api_mode_display_value(
+            provider
         )
         draft = self._provider_draft()
         draft_key = self._provider_api_mode_draft_key(provider)
@@ -17594,6 +17641,14 @@ class SettingsScreen(BaseAppScreen):
                 provider_settings_values["api_key_env_var"] = credential_env_var
             if api_mode_dirty and normalized_api_mode is not None:
                 provider_settings_values["api_mode"] = normalized_api_mode
+            alias_mode_sections = self._qwencloud_alias_mode_sections()
+            qwencloud_mode_requires_canonical_save = bool(
+                api_mode_dirty
+                and normalized_api_mode is not None
+                and (provider_section_key != "qwencloud" or alias_mode_sections)
+            )
+            if qwencloud_mode_requires_canonical_save:
+                provider_settings_values.pop("api_mode", None)
             if provider_settings_values and provider_key:
                 provider_save_key = provider_section_key or provider_key
                 provider_settings_saved = SettingsConfigAdapter().save_values(
@@ -17601,6 +17656,20 @@ class SettingsScreen(BaseAppScreen):
                     provider_settings_values,
                 )
                 saved = saved and provider_settings_saved
+            if qwencloud_mode_requires_canonical_save and saved:
+                delete_keys = {
+                    f"api_settings.{section_key}": ("api_mode",)
+                    for section_key in alias_mode_sections
+                }
+                canonical_mode_saved = save_settings_to_cli_config(
+                    {
+                        "api_settings.qwencloud": {
+                            "api_mode": normalized_api_mode,
+                        }
+                    },
+                    delete_keys=delete_keys or None,
+                )
+                saved = saved and canonical_mode_saved
             next_model_defaults = None
             if model_profile_dirty and provider_key and model:
                 provider_save_key = provider_section_key or provider_key
@@ -17676,6 +17745,20 @@ class SettingsScreen(BaseAppScreen):
                         provider_settings = {}
                         api_settings[provider_save_key] = provider_settings
                     provider_settings.update(provider_settings_values)
+                    if (
+                        api_mode_dirty
+                        and normalized_api_mode is not None
+                        and qwencloud_mode_requires_canonical_save
+                    ):
+                        canonical_settings = api_settings.setdefault("qwencloud", {})
+                        if not isinstance(canonical_settings, dict):
+                            canonical_settings = {}
+                            api_settings["qwencloud"] = canonical_settings
+                        canonical_settings["api_mode"] = normalized_api_mode
+                        for alias_section in alias_mode_sections:
+                            alias_settings = api_settings.get(alias_section)
+                            if isinstance(alias_settings, dict):
+                                alias_settings.pop("api_mode", None)
                     if next_model_defaults is not None:
                         provider_settings["model_defaults"] = next_model_defaults
                 if (

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -45,6 +45,7 @@ from textual.widgets import (
 
 from tldw_chatbook.Utils.about_text import ABOUT_MARKDOWN, get_app_version
 
+from ...Chat.Chat_Deps import ChatConfigurationError
 from ...Chat.console_chat_models import CONSOLE_DEFAULT_MAX_PARALLEL_RUNS
 from ...Chat.console_context_policy import (
     CompactionFailureBehavior,
@@ -118,6 +119,7 @@ from ...LLM_Provider_Catalog.model_catalog_settings import (
     AUTO_REFRESH_PROVIDER_LIST_KEYS,
     load_model_catalog_settings,
 )
+from ...LLM_Calls.qwencloud import normalize_qwencloud_api_mode
 from ...TTS.adapter_types import TTSNativeCapabilityObservation
 from ...Utils.input_validation import (
     provider_api_key_validation_error,
@@ -567,6 +569,19 @@ PROVIDER_ENDPOINT_PLACEHOLDERS = {
     "vllm": "http://127.0.0.1:8000/v1",
 }
 PROVIDER_CREDENTIAL_ENV_VAR_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+QWENCLOUD_API_MODE_OPTIONS: tuple[tuple[str, str], ...] = (
+    ("Responses", "responses"),
+    ("Chat Completions", "chat_completions"),
+)
+QWENCLOUD_API_MODE_HELP_COPY = (
+    "Responses is stateless with store=false; Chat Completions disables thinking "
+    "replay; existing function tools work in both; QwenCloud built-in tools are "
+    "excluded."
+)
+QWENCLOUD_API_MODE_INVALID_COPY = (
+    "QwenCloud API mode is invalid. Open API mode and choose Responses or Chat "
+    "Completions, then Save."
+)
 # THEME and SPLASH_SCREEN are intentionally excluded; they manage their own
 # persistence models (theme files and immediate splash config writes).
 GUIDED_SETTINGS_MUTATION_CATEGORIES = frozenset(
@@ -1686,6 +1701,7 @@ def overlay_provider_draft_config(
     draft_endpoint: str | None,
     draft_env_var: str | None,
     draft_api_key: str | None,
+    draft_api_mode: object | None = None,
 ) -> dict:
     """Return a deep copy of ``app_config`` with unsaved draft provider fields overlaid.
 
@@ -1696,6 +1712,7 @@ def overlay_provider_draft_config(
         draft_endpoint: Draft endpoint, or ``None`` to leave the saved endpoint.
         draft_env_var: Draft credential env-var name, or ``None`` to leave saved.
         draft_api_key: Draft API key (``""`` models an explicit clear), or ``None``.
+        draft_api_mode: Draft QwenCloud API mode, or ``None`` to leave saved.
 
     Returns:
         A new config dict; ``app_config`` is never mutated.
@@ -1715,6 +1732,8 @@ def overlay_provider_draft_config(
         section["api_key_env_var"] = draft_env_var
     if draft_api_key is not None:
         section["api_key"] = draft_api_key
+    if draft_api_mode is not None:
+        section["api_mode"] = draft_api_mode
     return merged
 
 
@@ -1957,6 +1976,7 @@ class SettingsScreen(BaseAppScreen):
         self._model_discovery_models: tuple[object, ...] = ()
         self._model_discovery_selected_model_ids: set[str] = set()
         self._syncing_provider_endpoint = False
+        self._syncing_provider_api_mode = False
         self._syncing_provider_api_key = False
         self._syncing_provider_credential_env_var = False
         self._syncing_provider_model_profile = False
@@ -2864,6 +2884,7 @@ class SettingsScreen(BaseAppScreen):
                     "api_settings.<provider>.endpoint",
                     "api_settings.<provider>.api_key",
                     "api_settings.<provider>.api_key_env_var",
+                    "api_settings.<provider>.api_mode",
                     "api_settings.<provider>.model_defaults.<model>",
                     "model_capabilities.models.<model>.context_window",
                 ),
@@ -7485,6 +7506,109 @@ class SettingsScreen(BaseAppScreen):
             draft.values.get(key) if draft is not None and key in draft.values else None
         )
 
+    @staticmethod
+    def _provider_api_mode_draft_key(provider: object) -> str:
+        """Return the provider-scoped draft key for an API mode control."""
+        return f"provider_api_mode:{provider_config_key(str(provider or ''))}"
+
+    def _provider_api_mode_value(self, provider: object) -> object:
+        """Resolve a provider API mode from draft, saved config, then default."""
+        provider_key = provider_config_key(str(provider or ""))
+        if not provider_key:
+            return ""
+        draft_key = self._provider_api_mode_draft_key(provider_key)
+        draft = self._provider_draft()
+        if draft is not None and draft_key in draft.values:
+            return draft.values[draft_key]
+        return self._provider_saved_api_mode_value(provider_key)
+
+    def _provider_saved_api_mode_value(self, provider: object) -> object:
+        """Resolve a provider API mode without consulting the session draft."""
+        provider_key = provider_config_key(str(provider or ""))
+        if not provider_key:
+            return ""
+        provider_config = self._provider_config(provider_key)
+        if "api_mode" in provider_config:
+            return provider_config["api_mode"]
+        return "responses" if provider_key == "qwencloud" else ""
+
+    def _stage_provider_api_mode(self, provider: object, value: object) -> None:
+        """Stage one provider's mode without disturbing another provider's draft."""
+        provider_key = provider_config_key(str(provider or ""))
+        if provider_key != "qwencloud":
+            return
+        category = SettingsCategoryId.PROVIDERS_MODELS
+        draft = self._settings_drafts.setdefault(
+            category, SettingsDraft(category=category)
+        )
+        draft_key = self._provider_api_mode_draft_key(provider_key)
+        original = draft.originals.get(
+            draft_key, self._provider_saved_api_mode_value(provider_key)
+        )
+        draft.set_value(draft_key, original, value)
+        try:
+            value_matches_original = normalize_qwencloud_api_mode(
+                value
+            ) == normalize_qwencloud_api_mode(original)
+        except ChatConfigurationError:
+            value_matches_original = value == original
+        if value_matches_original:
+            draft.values.pop(draft_key, None)
+            draft.originals.pop(draft_key, None)
+        if not draft.is_dirty:
+            self._settings_drafts.pop(category, None)
+        self._mark_provider_test_result_stale()
+
+    def _provider_api_mode_draft_snapshot(
+        self, *, excluding_provider: object | None = None
+    ) -> tuple[dict[str, object], dict[str, object]]:
+        """Copy unsaved API-mode namespaces that a provider save must retain."""
+        draft = self._provider_draft()
+        if draft is None:
+            return {}, {}
+        excluded_key = (
+            self._provider_api_mode_draft_key(excluding_provider)
+            if provider_config_key(str(excluding_provider or "")) == "qwencloud"
+            else ""
+        )
+        values = {
+            key: value
+            for key, value in draft.values.items()
+            if key.startswith("provider_api_mode:") and key != excluded_key
+        }
+        originals = {
+            key: value
+            for key, value in draft.originals.items()
+            if key in values
+        }
+        return originals, values
+
+    def _restore_provider_api_mode_draft_snapshot(
+        self,
+        snapshot: tuple[dict[str, object], dict[str, object]],
+    ) -> None:
+        """Restore provider API-mode namespaces after another provider saves."""
+        originals, values = snapshot
+        if not values:
+            return
+        category = SettingsCategoryId.PROVIDERS_MODELS
+        draft = self._settings_drafts.setdefault(
+            category, SettingsDraft(category=category)
+        )
+        draft.originals.update(originals)
+        draft.values.update(values)
+
+    def _provider_api_mode_display_value(self, provider: object) -> tuple[str, bool]:
+        """Return a safe selector value and whether the saved/draft mode is valid."""
+        if provider_config_key(str(provider or "")) != "qwencloud":
+            return "responses", True
+        try:
+            return normalize_qwencloud_api_mode(
+                self._provider_api_mode_value(provider)
+            ), True
+        except ChatConfigurationError:
+            return "responses", False
+
     def _resolve_provider_model_for_settings(self):
         draft = self._provider_draft()
         settings_provider = (
@@ -7526,6 +7650,7 @@ class SettingsScreen(BaseAppScreen):
             "endpoint": self._provider_endpoint_value(provider),
             "api_key": "",
             "credential_env_var": self._provider_credential_env_var(provider),
+            "api_mode": self._provider_saved_api_mode_value(provider),
             "model_context_window": self._provider_model_context_window(provider, model)
             or "",
             "model_profile_temperature": profile.get("temperature", ""),
@@ -7549,12 +7674,14 @@ class SettingsScreen(BaseAppScreen):
     def _provider_setting_values(self) -> dict[str, object]:
         loaded = self._provider_loaded_setting_values()
         draft = self._provider_draft()
-        return {
+        values = {
             key: draft.values[key]
             if draft is not None and key in draft.values
             else value
             for key, value in loaded.items()
         }
+        values["api_mode"] = self._provider_api_mode_value(values.get("provider"))
+        return values
 
     def _provider_setting_values_mapping(self) -> Mapping[str, object]:
         values = self._provider_setting_values()
@@ -7906,6 +8033,7 @@ class SettingsScreen(BaseAppScreen):
             "#settings-provider-credential-env-var",
             Input,
         ).value.strip()
+        api_mode = self._provider_api_mode_value(provider)
         model_context_window = self._normalise_model_context_window(
             self.query_one("#settings-model-context-window", Input).value
         )
@@ -7982,6 +8110,7 @@ class SettingsScreen(BaseAppScreen):
             "endpoint": endpoint,
             "api_key": api_key,
             "credential_env_var": credential_env_var,
+            "api_mode": api_mode,
             "model_context_window": model_context_window,
             "model_profile_temperature": model_profile_temperature,
             "model_profile_top_p": model_profile_top_p,
@@ -8253,6 +8382,58 @@ class SettingsScreen(BaseAppScreen):
             )
         finally:
             self._syncing_provider_manual = False
+
+    def _sync_provider_api_mode_widget(self, provider: str) -> None:
+        """Show QwenCloud's mode selector and hide it for every other provider."""
+        try:
+            row = self.query_one("#settings-provider-api-mode-row", Horizontal)
+            selector = self.query_one("#settings-provider-api-mode", Select)
+            guidance = self.query_one(
+                "#settings-provider-api-mode-guidance", Static
+            )
+        except QueryError:
+            return
+        is_qwencloud = provider_config_key(provider) == "qwencloud"
+        display_value, valid = self._provider_api_mode_display_value(provider)
+        row.set_class(not is_qwencloud, "settings-gated-profile-hidden")
+        guidance.set_class(not is_qwencloud, "settings-gated-profile-hidden")
+        selector.disabled = not is_qwencloud
+        selector.set_class(is_qwencloud and not valid, "settings-invalid-input")
+        if selector.value != display_value:
+            self._syncing_provider_api_mode = True
+            try:
+                selector.value = display_value
+            finally:
+                self._syncing_provider_api_mode = False
+        guidance.update(
+            QWENCLOUD_API_MODE_INVALID_COPY
+            if is_qwencloud and not valid
+            else QWENCLOUD_API_MODE_HELP_COPY
+        )
+
+    def _snapshot_provider_api_mode_widget(self, provider: object) -> None:
+        """Capture the visible QwenCloud selector before switching providers."""
+        if provider_config_key(str(provider or "")) != "qwencloud":
+            return
+        try:
+            selector = self.query_one("#settings-provider-api-mode", Select)
+        except QueryError:
+            return
+        value = self._select_value_text(selector.value)
+        if not value:
+            return
+        display_value, current_value_is_valid = (
+            self._provider_api_mode_display_value(provider)
+        )
+        draft = self._provider_draft()
+        draft_key = self._provider_api_mode_draft_key(provider)
+        if (
+            not current_value_is_valid
+            and (draft is None or draft_key not in draft.values)
+            and value == display_value
+        ):
+            return
+        self._stage_provider_api_mode(provider, value)
 
     def _provider_catalog_summary(self) -> str:
         # task-180: show grouped display names, never a raw config-key dump.
@@ -8643,7 +8824,11 @@ class SettingsScreen(BaseAppScreen):
         app_config = getattr(self.app_instance, "app_config", {}) or {}
         draft = self._provider_draft()
         dirty = draft.dirty_keys if draft is not None else set()
-        if not ({"endpoint", "credential_env_var", "api_key"} & dirty):
+        api_mode_draft_key = self._provider_api_mode_draft_key(provider)
+        if not (
+            {"endpoint", "credential_env_var", "api_key", api_mode_draft_key}
+            & dirty
+        ):
             return app_config
         provider_save_key, _config = self._provider_config_entry(provider)
         provider_save_key = provider_save_key or provider_config_key(provider)
@@ -8669,6 +8854,11 @@ class SettingsScreen(BaseAppScreen):
             draft_endpoint=endpoint if "endpoint" in dirty else None,
             draft_env_var=env_var if "credential_env_var" in dirty else None,
             draft_api_key=api_key if "api_key" in dirty else None,
+            draft_api_mode=(
+                self._provider_api_mode_value(provider)
+                if api_mode_draft_key in dirty
+                else None
+            ),
         )
 
     def _provider_discovery_staged_settings(self, provider: str) -> dict[str, object]:
@@ -9389,6 +9579,7 @@ class SettingsScreen(BaseAppScreen):
         except QueryError:
             pass
         self._refresh_generation_support_summary(provider)
+        self._sync_provider_api_mode_widget(provider)
         self._refresh_provider_field_guidance()
 
     def _detail_row(
@@ -9508,6 +9699,13 @@ class SettingsScreen(BaseAppScreen):
                 ),
                 ("Saved as", endpoint_key),
                 ("Validation", "must start with http:// or https:// when set"),
+            )
+        if field_id == "settings-provider-api-mode":
+            return (
+                ("Focused setting", "API mode"),
+                ("Purpose", QWENCLOUD_API_MODE_HELP_COPY),
+                ("Saved as", "api_settings.qwencloud.api_mode"),
+                ("Validation", "responses or chat_completions"),
             )
         if field_id == "settings-provider-api-key":
             return (
@@ -10266,6 +10464,43 @@ class SettingsScreen(BaseAppScreen):
                     validators=[ProviderEndpointURLValidator()],
                     validate_on={"blur", "submitted"},
                 )
+            api_mode_value, api_mode_valid = self._provider_api_mode_display_value(
+                provider
+            )
+            api_mode_row_classes = "settings-input-row settings-select-row"
+            if provider_config_key(provider) != "qwencloud":
+                api_mode_row_classes += " settings-gated-profile-hidden"
+            with Horizontal(
+                id="settings-provider-api-mode-row", classes=api_mode_row_classes
+            ):
+                yield Static("API mode", classes="settings-input-label")
+                yield Select(
+                    QWENCLOUD_API_MODE_OPTIONS,
+                    value=api_mode_value,
+                    id="settings-provider-api-mode",
+                    classes=(
+                        "settings-compact-select"
+                        if api_mode_valid
+                        else "settings-compact-select settings-invalid-input"
+                    ),
+                    allow_blank=False,
+                    compact=True,
+                    disabled=provider_config_key(provider) != "qwencloud",
+                )
+            yield Static(
+                (
+                    QWENCLOUD_API_MODE_INVALID_COPY
+                    if provider_config_key(provider) == "qwencloud"
+                    and not api_mode_valid
+                    else QWENCLOUD_API_MODE_HELP_COPY
+                ),
+                id="settings-provider-api-mode-guidance",
+                classes=(
+                    "settings-status-row"
+                    if provider_config_key(provider) == "qwencloud"
+                    else "settings-status-row settings-gated-profile-hidden"
+                ),
+            )
             yield Static("Credentials", classes="destination-section")
             yield Static(
                 self._provider_credential_status(provider),
@@ -14477,6 +14712,7 @@ class SettingsScreen(BaseAppScreen):
             "settings-provider-manual-value",
             "settings-model-value",
             "settings-provider-endpoint-value",
+            "settings-provider-api-mode",
             "settings-provider-api-key",
             "settings-provider-api-key-clear",
             "settings-provider-credential-env-var",
@@ -16547,6 +16783,7 @@ class SettingsScreen(BaseAppScreen):
         previous_provider = str(
             self._provider_setting_values_mapping().get("provider") or ""
         )
+        self._snapshot_provider_api_mode_widget(previous_provider)
         provider_changed = bool(provider) and provider_config_key(
             provider
         ) != provider_config_key(previous_provider)
@@ -16710,6 +16947,42 @@ class SettingsScreen(BaseAppScreen):
             return
         self._stage_provider_value("endpoint", event.value.strip())
         self._reset_provider_model_discovery_state()
+        self._update_provider_dynamic_widgets()
+        self._update_draft_status_widgets(SettingsCategoryId.PROVIDERS_MODELS)
+
+    @on(Select.Changed, "#settings-provider-api-mode")
+    def handle_provider_api_mode_changed(self, event: Select.Changed) -> None:
+        """Stage QwenCloud's selected API wire mode in its provider namespace."""
+        event.stop()
+        if self._syncing_provider_api_mode:
+            return
+        provider = str(
+            self._provider_setting_values_mapping().get("provider") or ""
+        ).strip()
+        if provider_config_key(provider) != "qwencloud":
+            return
+        value = self._select_value_text(event.value)
+        if not value:
+            return
+        display_value, current_value_is_valid = (
+            self._provider_api_mode_display_value(provider)
+        )
+        draft = self._provider_draft()
+        draft_key = self._provider_api_mode_draft_key(provider)
+        if (
+            (draft is None or draft_key not in draft.values)
+            and value == display_value
+            and (current_value_is_valid or not event.select.has_focus)
+        ):
+            # Select emits its constructor value after mount. Do not create a
+            # false draft or silently repair an invalid persisted setting.
+            return
+        self._stage_provider_api_mode(provider, value)
+        event.select.remove_class("settings-invalid-input")
+        self._set_static_text(
+            "#settings-provider-api-mode-guidance",
+            QWENCLOUD_API_MODE_HELP_COPY,
+        )
         self._update_provider_dynamic_widgets()
         self._update_draft_status_widgets(SettingsCategoryId.PROVIDERS_MODELS)
 
@@ -17084,6 +17357,10 @@ class SettingsScreen(BaseAppScreen):
             panel.request_save()
             return
         if category is SettingsCategoryId.PROVIDERS_MODELS:
+            current_provider = str(
+                self._provider_setting_values_mapping().get("provider") or ""
+            ).strip()
+            self._snapshot_provider_api_mode_widget(current_provider)
             try:
                 values = self._provider_form_values_from_widgets()
             except ValueError as exc:
@@ -17103,13 +17380,34 @@ class SettingsScreen(BaseAppScreen):
             api_key = str(values.get("api_key") or "").strip()
             credential_env_var = str(values.get("credential_env_var") or "").strip()
             draft = self._settings_drafts.get(category)
-            if not provider_config_key(provider):
+            provider_key = provider_config_key(provider)
+            if not provider_key:
                 self._provider_save_result = "Provider is required."
                 self._set_static_text(
                     "#settings-provider-save-result", self._provider_save_result
                 )
                 self.app.notify(self._provider_save_result, severity="error")
                 return
+            normalized_api_mode: str | None = None
+            if provider_key == "qwencloud":
+                try:
+                    normalized_api_mode = normalize_qwencloud_api_mode(
+                        values.get("api_mode")
+                    )
+                except ChatConfigurationError:
+                    self._provider_save_result = QWENCLOUD_API_MODE_INVALID_COPY
+                    self._set_static_text(
+                        "#settings-provider-save-result", self._provider_save_result
+                    )
+                    try:
+                        self.query_one(
+                            "#settings-provider-api-mode", Select
+                        ).add_class("settings-invalid-input")
+                    except QueryError:
+                        pass
+                    self.app.notify(self._provider_save_result, severity="error")
+                    return
+                values["api_mode"] = normalized_api_mode
             endpoint_touched = draft is not None and "endpoint" in draft.dirty_keys
             loaded_endpoint = str(loaded_values.get("endpoint") or "").strip()
             if (
@@ -17157,6 +17455,14 @@ class SettingsScreen(BaseAppScreen):
                 if key in chat_defaults_keys and loaded_values.get(key) != value
             }
             dirty_keys = draft.dirty_keys if draft is not None else set()
+            api_mode_draft_key = self._provider_api_mode_draft_key(provider)
+            api_mode_dirty = bool(
+                provider_key == "qwencloud"
+                and draft is not None
+                and api_mode_draft_key in dirty_keys
+                and normalized_api_mode
+                != self._provider_saved_api_mode_value(provider)
+            )
             selected_profile = self._provider_model_profile(provider, model)
             model_profile_dirty = any(
                 key in dirty_keys
@@ -17174,7 +17480,6 @@ class SettingsScreen(BaseAppScreen):
                 draft is not None and draft.values.get("model_context_window_reset")
             )
             context_window_dirty = context_window_dirty or context_window_reset
-            provider_key = provider_config_key(provider)
             provider_section_key, _provider_config = self._provider_config_entry(
                 provider
             )
@@ -17250,15 +17555,22 @@ class SettingsScreen(BaseAppScreen):
                 )
                 self.app.notify(self._provider_save_result, severity="error")
                 return
+            retained_api_mode_draft = self._provider_api_mode_draft_snapshot(
+                excluding_provider=provider
+            )
             if (
                 not dirty_values
                 and not endpoint_dirty
                 and not credential_dirty
                 and not api_key_dirty
+                and not api_mode_dirty
                 and not model_profile_dirty
                 and not context_window_dirty
             ):
                 self._settings_drafts.pop(category, None)
+                self._restore_provider_api_mode_draft_snapshot(
+                    retained_api_mode_draft
+                )
                 self._update_provider_dynamic_widgets()
                 self._update_draft_status_widgets(category)
                 self._provider_save_result = "Provider settings: no changes to save."
@@ -17280,6 +17592,8 @@ class SettingsScreen(BaseAppScreen):
                 provider_settings_values["api_key"] = api_key
             if credential_dirty:
                 provider_settings_values["api_key_env_var"] = credential_env_var
+            if api_mode_dirty and normalized_api_mode is not None:
+                provider_settings_values["api_mode"] = normalized_api_mode
             if provider_settings_values and provider_key:
                 provider_save_key = provider_section_key or provider_key
                 provider_settings_saved = SettingsConfigAdapter().save_values(
@@ -17345,6 +17659,7 @@ class SettingsScreen(BaseAppScreen):
                     endpoint_dirty
                     or credential_dirty
                     or api_key_dirty
+                    or api_mode_dirty
                     or next_model_defaults is not None
                 ) and provider_key:
                     app_config = getattr(self.app_instance, "app_config", None)
@@ -17384,6 +17699,9 @@ class SettingsScreen(BaseAppScreen):
                         model_entries[model] = dict(next_model_capabilities)
                     reload_capabilities()
                 self._settings_drafts.pop(category, None)
+                self._restore_provider_api_mode_draft_snapshot(
+                    retained_api_mode_draft
+                )
                 self._provider_save_result = "Provider settings saved."
                 self._set_static_text(
                     "#settings-provider-save-result", self._provider_save_result

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -106,6 +106,7 @@ from ...config import (
     MAX_CONSOLE_TOOL_RESULT_DISPLAY_CHARS,
     MIN_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
     MIN_CONSOLE_TOOL_RESULT_DISPLAY_CHARS,
+    ProviderSettingsError,
     _default_base_data_dir,
     apply_settings_mutation_to_cli_config,
     coerce_bool_setting,
@@ -583,6 +584,7 @@ QWENCLOUD_API_MODE_INVALID_COPY = (
     "QwenCloud API mode is invalid. Open API mode and choose Responses or Chat "
     "Completions, then Save."
 )
+_INVALID_QWENCLOUD_PROVIDER_SETTINGS = object()
 # THEME and SPLASH_SCREEN are intentionally excluded; they manage their own
 # persistence models (theme files and immediate splash config writes).
 GUIDED_SETTINGS_MUTATION_CATEGORIES = frozenset(
@@ -1008,6 +1010,11 @@ def _build_field_search_index() -> None:
             ),
             SettingsCategoryId.PROVIDERS_MODELS: (
                 ("settings-provider-value", "Provider"),
+                ("settings-provider-api-mode", "API mode"),
+                (
+                    "settings-provider-api-mode",
+                    "api_settings.<provider>.api_mode",
+                ),
                 ("settings-model-value", "Model"),
                 ("settings-provider-endpoint-value", "Endpoint"),
                 ("settings-provider-api-key", "API key"),
@@ -8161,14 +8168,24 @@ class SettingsScreen(BaseAppScreen):
         target_key = provider_config_key(provider)
         if not target_key:
             return None, {}
-        section_key = None
-        for configured_provider, configured_settings in api_settings.items():
-            if provider_config_key(str(configured_provider)) == target_key:
-                section_key = str(configured_provider)
-                break
+        section_key = (
+            "qwencloud"
+            if target_key == "qwencloud" and "qwencloud" in api_settings
+            else None
+        )
+        if section_key is None:
+            for configured_provider in api_settings:
+                if provider_config_key(str(configured_provider)) == target_key:
+                    section_key = str(configured_provider)
+                    break
         if section_key is None:
             return None, {}
-        return section_key, provider_settings_for_key(api_settings, target_key)
+        try:
+            return section_key, provider_settings_for_key(api_settings, target_key)
+        except ProviderSettingsError:
+            return "qwencloud", {
+                "api_mode": _INVALID_QWENCLOUD_PROVIDER_SETTINGS,
+            }
 
     def _provider_config(self, provider: str) -> Mapping[str, object]:
         _section_key, provider_config = self._provider_config_entry(provider)
@@ -17651,10 +17668,21 @@ class SettingsScreen(BaseAppScreen):
                 provider_settings_values.pop("api_mode", None)
             if provider_settings_values and provider_key:
                 provider_save_key = provider_section_key or provider_key
-                provider_settings_saved = SettingsConfigAdapter().save_values(
-                    f"api_settings.{provider_save_key}",
-                    provider_settings_values,
-                )
+                provider_section = f"api_settings.{provider_save_key}"
+                adapter = SettingsConfigAdapter()
+                if (
+                    provider_save_key == "qwencloud"
+                    and "api_mode" in provider_settings_values
+                    and len(provider_settings_values) > 1
+                ):
+                    provider_settings_saved = adapter.save_sections(
+                        {provider_section: provider_settings_values}
+                    )
+                else:
+                    provider_settings_saved = adapter.save_values(
+                        provider_section,
+                        provider_settings_values,
+                    )
                 saved = saved and provider_settings_saved
             next_model_defaults = None
             if model_profile_dirty and provider_key and model:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -98,7 +98,6 @@ from ...Chat.provider_catalog import (
     PROVIDER_GROUP_LOCAL,
     PROVIDER_GROUP_ORDER,
 )
-from ...Chat.provider_readiness import provider_settings_for_key
 from ...config import (
     DEFAULT_CONFIG_FROM_TOML,
     DEFAULT_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
@@ -114,6 +113,7 @@ from ...config import (
     get_cli_config_path,
     get_runtime_config_snapshot,
     load_settings,
+    provider_settings_for_key,
     save_settings_to_cli_config,
 )
 from ...LLM_Provider_Catalog.model_catalog_settings import (
@@ -17656,20 +17656,6 @@ class SettingsScreen(BaseAppScreen):
                     provider_settings_values,
                 )
                 saved = saved and provider_settings_saved
-            if qwencloud_mode_requires_canonical_save and saved:
-                delete_keys = {
-                    f"api_settings.{section_key}": ("api_mode",)
-                    for section_key in alias_mode_sections
-                }
-                canonical_mode_saved = save_settings_to_cli_config(
-                    {
-                        "api_settings.qwencloud": {
-                            "api_mode": normalized_api_mode,
-                        }
-                    },
-                    delete_keys=delete_keys or None,
-                )
-                saved = saved and canonical_mode_saved
             next_model_defaults = None
             if model_profile_dirty and provider_key and model:
                 provider_save_key = provider_section_key or provider_key
@@ -17721,6 +17707,20 @@ class SettingsScreen(BaseAppScreen):
                         {model: next_model_capabilities},
                     )
                 saved = saved and capability_saved
+            if qwencloud_mode_requires_canonical_save and saved:
+                delete_keys = {
+                    f"api_settings.{section_key}": ("api_mode",)
+                    for section_key in alias_mode_sections
+                }
+                canonical_mode_saved = save_settings_to_cli_config(
+                    {
+                        "api_settings.qwencloud": {
+                            "api_mode": normalized_api_mode,
+                        }
+                    },
+                    delete_keys=delete_keys or None,
+                )
+                saved = saved and canonical_mode_saved
             if saved:
                 defaults = self._chat_defaults()
                 defaults.update(dirty_values)

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -584,7 +584,12 @@ QWENCLOUD_API_MODE_INVALID_COPY = (
     "QwenCloud API mode is invalid. Open API mode and choose Responses or Chat "
     "Completions, then Save."
 )
-_INVALID_QWENCLOUD_PROVIDER_SETTINGS = object()
+QWENCLOUD_PROVIDER_TABLE_INVALID_COPY = (
+    "QwenCloud provider settings are invalid: api_settings.qwencloud is not a "
+    "table. Replace it with a table in Advanced Config or config.toml; normal "
+    "category Save cannot repair this configuration."
+)
+_MALFORMED_QWENCLOUD_PROVIDER_TABLE = object()
 # THEME and SPLASH_SCREEN are intentionally excluded; they manage their own
 # persistence models (theme files and immediate splash config writes).
 GUIDED_SETTINGS_MUTATION_CATEGORIES = frozenset(
@@ -1985,7 +1990,10 @@ class SettingsScreen(BaseAppScreen):
         self._model_discovery_selected_model_ids: set[str] = set()
         self._syncing_provider_endpoint = False
         self._syncing_provider_api_mode = False
-        self._syncing_provider_api_key = False
+        # Input.Changed is delivered after a programmatic value assignment
+        # returns, so a synchronous boolean cannot suppress that deferred
+        # message. Consume exact expected values once instead.
+        self._provider_api_key_suppress_queue: list[str] = []
         self._syncing_provider_credential_env_var = False
         self._syncing_provider_model_profile = False
         self._syncing_provider_model_value = False
@@ -7535,6 +7543,8 @@ class SettingsScreen(BaseAppScreen):
         provider_key = provider_config_key(str(provider or ""))
         if not provider_key:
             return ""
+        if self._qwencloud_provider_table_is_malformed(provider_key):
+            return _MALFORMED_QWENCLOUD_PROVIDER_TABLE
         provider_config = self._provider_config(provider_key)
         if "api_mode" in provider_config:
             return provider_config["api_mode"]
@@ -8183,9 +8193,24 @@ class SettingsScreen(BaseAppScreen):
         try:
             return section_key, provider_settings_for_key(api_settings, target_key)
         except ProviderSettingsError:
-            return "qwencloud", {
-                "api_mode": _INVALID_QWENCLOUD_PROVIDER_SETTINGS,
-            }
+            return "qwencloud", {}
+
+    def _qwencloud_provider_table_is_malformed(self, provider: object) -> bool:
+        """Return whether QwenCloud's authoritative provider entry is non-table."""
+        target_key = provider_config_key(str(provider or ""))
+        if target_key != "qwencloud":
+            return False
+        app_config = getattr(self.app_instance, "app_config", {}) or {}
+        api_settings = (
+            app_config.get("api_settings", {})
+            if isinstance(app_config, Mapping)
+            else {}
+        )
+        try:
+            provider_settings_for_key(api_settings, target_key)
+        except ProviderSettingsError:
+            return True
+        return False
 
     def _provider_config(self, provider: str) -> Mapping[str, object]:
         _section_key, provider_config = self._provider_config_entry(provider)
@@ -8254,6 +8279,8 @@ class SettingsScreen(BaseAppScreen):
             provider,
             self._provider_readiness_app_config(),
         )
+        if readiness.reason == "Invalid provider settings":
+            return "Provider settings invalid; repair in Advanced Config or config.toml"
         if self._provider_saved_api_key_present(provider):
             return "API key source: local config key saved"
         if readiness.api_key_source and readiness.api_key_source.startswith("env:"):
@@ -8427,17 +8454,19 @@ class SettingsScreen(BaseAppScreen):
         try:
             row = self.query_one("#settings-provider-api-mode-row", Horizontal)
             selector = self.query_one("#settings-provider-api-mode", Select)
-            guidance = self.query_one(
-                "#settings-provider-api-mode-guidance", Static
-            )
+            guidance = self.query_one("#settings-provider-api-mode-guidance", Static)
         except QueryError:
             return
         is_qwencloud = provider_config_key(provider) == "qwencloud"
+        provider_table_malformed = self._qwencloud_provider_table_is_malformed(provider)
         display_value, valid = self._provider_api_mode_display_value(provider)
         row.set_class(not is_qwencloud, "settings-gated-profile-hidden")
         guidance.set_class(not is_qwencloud, "settings-gated-profile-hidden")
         selector.disabled = not is_qwencloud
-        selector.set_class(is_qwencloud and not valid, "settings-invalid-input")
+        selector.set_class(
+            is_qwencloud and (provider_table_malformed or not valid),
+            "settings-invalid-input",
+        )
         if selector.value != display_value:
             self._syncing_provider_api_mode = True
             try:
@@ -8445,9 +8474,13 @@ class SettingsScreen(BaseAppScreen):
             finally:
                 self._syncing_provider_api_mode = False
         guidance.update(
-            QWENCLOUD_API_MODE_INVALID_COPY
-            if is_qwencloud and not valid
-            else QWENCLOUD_API_MODE_HELP_COPY
+            QWENCLOUD_PROVIDER_TABLE_INVALID_COPY
+            if is_qwencloud and provider_table_malformed
+            else (
+                QWENCLOUD_API_MODE_INVALID_COPY
+                if is_qwencloud and not valid
+                else QWENCLOUD_API_MODE_HELP_COPY
+            )
         )
 
     def _snapshot_provider_api_mode_widget(self, provider: object) -> None:
@@ -8588,7 +8621,6 @@ class SettingsScreen(BaseAppScreen):
             api_key_input = None
         draft = self._provider_draft()
         self._syncing_provider_credential_env_var = True
-        self._syncing_provider_api_key = True
         try:
             if credential_input is not None:
                 credential_input.value = self._provider_credential_env_var(provider)
@@ -8596,15 +8628,29 @@ class SettingsScreen(BaseAppScreen):
                     provider
                 )
             if api_key_input is not None:
-                api_key_input.value = (
+                api_key_value = (
                     str(draft.values.get("api_key") or "")
                     if draft is not None and "api_key" in draft.values
                     else ""
                 )
+                self._set_provider_api_key_input_value(
+                    api_key_input,
+                    api_key_value,
+                )
                 api_key_input.placeholder = self._provider_api_key_placeholder(provider)
         finally:
             self._syncing_provider_credential_env_var = False
-            self._syncing_provider_api_key = False
+
+    def _set_provider_api_key_input_value(
+        self,
+        api_key_input: Input,
+        value: str,
+    ) -> None:
+        """Assign a key widget value and queue its deferred change once."""
+        if api_key_input.value == value:
+            return
+        self._provider_api_key_suppress_queue.append(value)
+        api_key_input.value = value
 
     def _sync_provider_model_profile_widgets(self, provider: str, model: str) -> None:
         profile = self._provider_model_profile(provider, model)
@@ -8831,6 +8877,8 @@ class SettingsScreen(BaseAppScreen):
             provider,
             self._provider_readiness_app_config(),
         )
+        if readiness.reason == "Invalid provider settings":
+            return "Provider settings invalid; repair in Advanced Config or config.toml"
         if readiness.api_key_source:
             return f"API key: {readiness.api_key_source}"
         if not readiness.requires_api_key:
@@ -8863,6 +8911,11 @@ class SettingsScreen(BaseAppScreen):
             A config mapping the Test's readiness check can evaluate.
         """
         app_config = getattr(self.app_instance, "app_config", {}) or {}
+        if self._qwencloud_provider_table_is_malformed(provider):
+            # A normal category draft cannot replace a malformed table. Keep
+            # readiness fail-closed instead of manufacturing a valid table in
+            # the test-only overlay.
+            return app_config
         draft = self._provider_draft()
         dirty = draft.dirty_keys if draft is not None else set()
         provider_key = provider_config_key(provider)
@@ -9753,9 +9806,14 @@ class SettingsScreen(BaseAppScreen):
                 ("Validation", "must start with http:// or https:// when set"),
             )
         if field_id == "settings-provider-api-mode":
+            purpose = (
+                QWENCLOUD_PROVIDER_TABLE_INVALID_COPY
+                if self._qwencloud_provider_table_is_malformed(provider)
+                else QWENCLOUD_API_MODE_HELP_COPY
+            )
             return (
                 ("Focused setting", "API mode"),
-                ("Purpose", QWENCLOUD_API_MODE_HELP_COPY),
+                ("Purpose", purpose),
                 ("Saved as", "api_settings.qwencloud.api_mode"),
                 ("Validation", "responses or chat_completions"),
             )
@@ -10519,6 +10577,9 @@ class SettingsScreen(BaseAppScreen):
             api_mode_value, api_mode_valid = self._provider_api_mode_display_value(
                 provider
             )
+            provider_table_malformed = self._qwencloud_provider_table_is_malformed(
+                provider
+            )
             api_mode_row_classes = "settings-input-row settings-select-row"
             if provider_config_key(provider) != "qwencloud":
                 api_mode_row_classes += " settings-gated-profile-hidden"
@@ -10533,7 +10594,7 @@ class SettingsScreen(BaseAppScreen):
                     prompt="Choose Responses or Chat Completions",
                     classes=(
                         "settings-compact-select"
-                        if api_mode_valid
+                        if api_mode_valid and not provider_table_malformed
                         else "settings-compact-select settings-invalid-input"
                     ),
                     allow_blank=True,
@@ -10542,10 +10603,15 @@ class SettingsScreen(BaseAppScreen):
                 )
             yield Static(
                 (
-                    QWENCLOUD_API_MODE_INVALID_COPY
+                    QWENCLOUD_PROVIDER_TABLE_INVALID_COPY
                     if provider_config_key(provider) == "qwencloud"
-                    and not api_mode_valid
-                    else QWENCLOUD_API_MODE_HELP_COPY
+                    and provider_table_malformed
+                    else (
+                        QWENCLOUD_API_MODE_INVALID_COPY
+                        if provider_config_key(provider) == "qwencloud"
+                        and not api_mode_valid
+                        else QWENCLOUD_API_MODE_HELP_COPY
+                    )
                 ),
                 id="settings-provider-api-mode-guidance",
                 classes=(
@@ -14567,6 +14633,7 @@ class SettingsScreen(BaseAppScreen):
                 return
         if category_value != SettingsCategoryId.PROVIDERS_MODELS.value:
             self._active_settings_field_id = None
+            self._provider_api_key_suppress_queue.clear()
         # Task 3 (541 v2 UX AC3): the remembered "last-expanded RAG group"
         # scope must not leak into a later LIBRARY_RAG visit -- e.g. leaving
         # with "Chunking" expanded and coming back to a freshly recomposed
@@ -16851,6 +16918,11 @@ class SettingsScreen(BaseAppScreen):
         )
         self._stage_provider_value("provider", staged_provider or None)
         self._sync_provider_manual_widget(staged_provider)
+        # Provider-scoped endpoint/credential/profile drafts belong to the
+        # provider being left. Drop them before resyncing the shared widgets,
+        # otherwise the old API-key draft is programmed straight back into
+        # the newly selected provider's input.
+        self._clear_provider_auxiliary_draft_keys()
         try:
             endpoint_input = self.query_one("#settings-provider-endpoint-value", Input)
         except QueryError:
@@ -16878,7 +16950,6 @@ class SettingsScreen(BaseAppScreen):
                 pass
         model = str(self._provider_setting_values_mapping().get("model") or "")
         self._sync_provider_model_profile_widgets(staged_provider, model)
-        self._clear_provider_auxiliary_draft_keys()
         self._reset_provider_model_discovery_state()
         self._update_provider_dynamic_widgets()
         self._update_draft_status_widgets(SettingsCategoryId.PROVIDERS_MODELS)
@@ -17014,6 +17085,7 @@ class SettingsScreen(BaseAppScreen):
         ).strip()
         if provider_config_key(provider) != "qwencloud":
             return
+        provider_table_malformed = self._qwencloud_provider_table_is_malformed(provider)
         value = self._select_value_text(event.value)
         if not value:
             if event.select.has_focus:
@@ -17021,7 +17093,9 @@ class SettingsScreen(BaseAppScreen):
                 event.select.add_class("settings-invalid-input")
                 self._set_static_text(
                     "#settings-provider-api-mode-guidance",
-                    QWENCLOUD_API_MODE_INVALID_COPY,
+                    QWENCLOUD_PROVIDER_TABLE_INVALID_COPY
+                    if provider_table_malformed
+                    else QWENCLOUD_API_MODE_INVALID_COPY,
                 )
                 self._update_provider_dynamic_widgets()
                 self._update_draft_status_widgets(
@@ -17042,10 +17116,15 @@ class SettingsScreen(BaseAppScreen):
             # false draft or silently repair an invalid persisted setting.
             return
         self._stage_provider_api_mode(provider, value)
-        event.select.remove_class("settings-invalid-input")
+        event.select.set_class(
+            provider_table_malformed,
+            "settings-invalid-input",
+        )
         self._set_static_text(
             "#settings-provider-api-mode-guidance",
-            QWENCLOUD_API_MODE_HELP_COPY,
+            QWENCLOUD_PROVIDER_TABLE_INVALID_COPY
+            if provider_table_malformed
+            else QWENCLOUD_API_MODE_HELP_COPY,
         )
         self._update_provider_dynamic_widgets()
         self._update_draft_status_widgets(SettingsCategoryId.PROVIDERS_MODELS)
@@ -17070,7 +17149,9 @@ class SettingsScreen(BaseAppScreen):
         Returns:
             None.
         """
-        if self._syncing_provider_api_key:
+        queue = self._provider_api_key_suppress_queue
+        if queue and event.value == queue[0]:
+            queue.pop(0)
             self._update_provider_dynamic_widgets()
             return
         self._stage_provider_value("api_key", event.value.strip())
@@ -17094,12 +17175,8 @@ class SettingsScreen(BaseAppScreen):
         except QueryError:
             api_key_input = None
         self._stage_provider_value("api_key", "")
-        self._syncing_provider_api_key = True
-        try:
-            if api_key_input is not None:
-                api_key_input.value = ""
-        finally:
-            self._syncing_provider_api_key = False
+        if api_key_input is not None:
+            self._set_provider_api_key_input_value(api_key_input, "")
         self._reset_provider_model_discovery_state()
         self._update_provider_dynamic_widgets()
         self._update_draft_status_widgets(SettingsCategoryId.PROVIDERS_MODELS)
@@ -17454,6 +17531,19 @@ class SettingsScreen(BaseAppScreen):
                 return
             normalized_api_mode: str | None = None
             if provider_key == "qwencloud":
+                if self._qwencloud_provider_table_is_malformed(provider):
+                    self._provider_save_result = QWENCLOUD_PROVIDER_TABLE_INVALID_COPY
+                    self._set_static_text(
+                        "#settings-provider-save-result", self._provider_save_result
+                    )
+                    try:
+                        self.query_one("#settings-provider-api-mode", Select).add_class(
+                            "settings-invalid-input"
+                        )
+                    except QueryError:
+                        pass
+                    self.app.notify(self._provider_save_result, severity="error")
+                    return
                 try:
                     normalized_api_mode = normalize_qwencloud_api_mode(
                         values.get("api_mode")
@@ -18264,7 +18354,10 @@ class SettingsScreen(BaseAppScreen):
                     provider
                 )
                 api_key_input = self.query_one("#settings-provider-api-key", Input)
-                api_key_input.value = str(values.get("api_key") or "")
+                self._set_provider_api_key_input_value(
+                    api_key_input,
+                    str(values.get("api_key") or ""),
+                )
                 api_key_input.placeholder = self._provider_api_key_placeholder(provider)
                 credential_input = self.query_one(
                     "#settings-provider-credential-env-var",

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -865,7 +865,15 @@ def is_valid_provider_api_key(value: object) -> bool:
 
 
 def normalize_provider_config_key(provider: object) -> str:
-    """Return the canonical lookup form used for provider config tables."""
+    """Return the canonical lookup form used for provider config tables.
+
+    Args:
+        provider: Provider label or key to normalize.
+
+    Returns:
+        A stripped, lowercase provider key with spaces and hyphens replaced by
+        underscores.
+    """
     return str(provider or "").strip().lower().replace(" ", "_").replace("-", "_")
 
 
@@ -883,6 +891,13 @@ def provider_settings_for_key(
     exact canonical table is also present, alias fields remain fallbacks while
     exact ``api_settings.qwencloud`` fields win regardless of insertion order.
     Other providers retain the existing first-normalized-match behavior.
+
+    Args:
+        api_settings: Loaded ``api_settings`` value.
+        provider_key: Canonical provider key to resolve.
+
+    Returns:
+        The resolved provider settings, or an empty mapping when none exist.
 
     Raises:
         ProviderSettingsError: If QwenCloud's authoritative table is present

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2832,6 +2832,7 @@ HuggingFace = ["openai/gpt-oss-120b", "meta-llama/Meta-Llama-3.1-8B-Instruct", "
 MistralAI = ["open-mistral-nemo", "mistral-medium-2505", "codestral-2501", "mistral-saba-2502", "mistral-large-2411", "ministral-3b-2410", "ministral-8b-2410", "mistral-moderation-2411", "devstral-small-2505", "mistral-small-2503", ]
 Moonshot = ["kimi-latest", "kimi-thinking-preview", "moonshot-v1-auto", "moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k", "moonshot-v1-8k-vision-preview", "moonshot-v1-32k-vision-preview", "moonshot-v1-128k-vision-preview", "kimi-k2-0711-preview"]
 OpenRouter = ["openai/gpt-4o-mini", "anthropic/claude-3.7-sonnet", "google/gemini-2.0-flash-001", "google/gemini-2.5-pro-preview", "google/gemini-2.5-flash-preview", "deepseek/deepseek-chat-v3-0324:free", "deepseek/deepseek-chat-v3-0324", "openai/gpt-4.1", "anthropic/claude-sonnet-4", "deepseek/deepseek-r1:free", "anthropic/claude-3.7-sonnet:thinking", "google/gemini-flash-1.5-8b", "mistralai/mistral-nemo", "google/gemini-2.5-flash-preview-05-20", ]
+QwenCloud = ["qwen3.8-max"]
 ZAI = ["glm-4.6", "glm-4.5", "glm-4.5-air", "glm-4.5-flash", "glm-4.5v", "glm-4-32b-0414-128k"]
 # Local Providers
 Llama_cpp = ["None"]
@@ -2991,6 +2992,16 @@ write_to_config = [] # exact [providers] keys whose new models append to this fi
     retries = 3
     retry_delay = 1.0
     streaming = false
+
+    [api_settings.qwencloud]
+    api_mode = "responses"
+    api_key_env_var = "DASHSCOPE_API_KEY"
+    api_base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    model = "qwen3.8-max"
+    timeout = 120
+    retries = 3
+    retry_delay = 1
+    streaming = true
 
     [api_settings.zai] # Matches key in [providers]
     api_key_env_var = "ZAI_API_KEY"
@@ -6295,6 +6306,7 @@ _cloud_provider_keys = [
     "MistralAI",
     "Moonshot",
     "OpenRouter",
+    "QwenCloud",
     "ZAI",
 ]  # Example list
 

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -869,6 +869,10 @@ def normalize_provider_config_key(provider: object) -> str:
     return str(provider or "").strip().lower().replace(" ", "_").replace("-", "_")
 
 
+class ProviderSettingsError(ValueError):
+    """Raised when a selected provider's config table is not a mapping."""
+
+
 def provider_settings_for_key(
     api_settings: object,
     provider_key: str,
@@ -879,31 +883,45 @@ def provider_settings_for_key(
     exact canonical table is also present, alias fields remain fallbacks while
     exact ``api_settings.qwencloud`` fields win regardless of insertion order.
     Other providers retain the existing first-normalized-match behavior.
+
+    Raises:
+        ProviderSettingsError: If QwenCloud's authoritative table is present
+            but malformed, or its first normalized alias is malformed when no
+            canonical table exists.
     """
     if not isinstance(api_settings, Mapping):
         return {}
 
     if provider_key == "qwencloud":
-        alias_settings: Mapping[str, object] = {}
-        alias_found = False
-        canonical_settings: Mapping[str, object] = {}
-        for configured_provider, configured_value in api_settings.items():
-            configured_key = str(configured_provider)
-            if normalize_provider_config_key(configured_key) != provider_key:
-                continue
-            if configured_key == provider_key:
-                if isinstance(configured_value, Mapping):
-                    canonical_settings = configured_value
-                continue
-            if not alias_found:
-                alias_found = True
+        if provider_key in api_settings:
+            canonical_settings = api_settings[provider_key]
+            if not isinstance(canonical_settings, Mapping):
+                raise ProviderSettingsError(
+                    "api_settings.qwencloud must be a configuration table."
+                )
+            alias_settings: Mapping[str, object] = {}
+            for configured_provider, configured_value in api_settings.items():
+                configured_key = str(configured_provider)
+                if configured_key == provider_key:
+                    continue
+                if normalize_provider_config_key(configured_key) != provider_key:
+                    continue
                 if isinstance(configured_value, Mapping):
                     alias_settings = configured_value
-        if canonical_settings:
+                break
             merged = dict(alias_settings)
             merged.update(canonical_settings)
             return merged
-        return alias_settings
+
+        for configured_provider, configured_value in api_settings.items():
+            if normalize_provider_config_key(configured_provider) != provider_key:
+                continue
+            if not isinstance(configured_value, Mapping):
+                raise ProviderSettingsError(
+                    "api_settings.qwencloud must be a configuration table."
+                )
+            return configured_value
+        return {}
 
     for configured_provider, configured_value in api_settings.items():
         if normalize_provider_config_key(configured_provider) != provider_key:

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -864,6 +864,57 @@ def is_valid_provider_api_key(value: object) -> bool:
     return resolve_provider_api_key(value) is not None
 
 
+def normalize_provider_config_key(provider: object) -> str:
+    """Return the canonical lookup form used for provider config tables."""
+    return str(provider or "").strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def provider_settings_for_key(
+    api_settings: object,
+    provider_key: str,
+) -> Mapping[str, object]:
+    """Return provider settings without mutating the loaded configuration.
+
+    QwenCloud historically accepted normalized alias table names. When an
+    exact canonical table is also present, alias fields remain fallbacks while
+    exact ``api_settings.qwencloud`` fields win regardless of insertion order.
+    Other providers retain the existing first-normalized-match behavior.
+    """
+    if not isinstance(api_settings, Mapping):
+        return {}
+
+    if provider_key == "qwencloud":
+        alias_settings: Mapping[str, object] = {}
+        alias_found = False
+        canonical_settings: Mapping[str, object] = {}
+        for configured_provider, configured_value in api_settings.items():
+            configured_key = str(configured_provider)
+            if normalize_provider_config_key(configured_key) != provider_key:
+                continue
+            if configured_key == provider_key:
+                if isinstance(configured_value, Mapping):
+                    canonical_settings = configured_value
+                continue
+            if not alias_found:
+                alias_found = True
+                if isinstance(configured_value, Mapping):
+                    alias_settings = configured_value
+        if canonical_settings:
+            merged = dict(alias_settings)
+            merged.update(canonical_settings)
+            return merged
+        return alias_settings
+
+    for configured_provider, configured_value in api_settings.items():
+        if normalize_provider_config_key(configured_provider) != provider_key:
+            continue
+        if isinstance(configured_value, Mapping):
+            return configured_value
+        return {}
+
+    return {}
+
+
 #: Providers whose legacy `[API] <provider>_api_key` TOML key and
 #: `<PROVIDER>_API_KEY` environment variable both follow the plain
 #: `_normalize_legacy_provider_api_key` convention, keyed by the SAME
@@ -5599,7 +5650,7 @@ def get_cli_providers_and_models() -> Dict[str, List[str]]:
 
 def _normalize_provider_lookup_key(provider: Any) -> str:
     """Return the canonical lookup form used for provider key comparisons."""
-    return str(provider or "").strip().lower().replace(" ", "_").replace("-", "_")
+    return normalize_provider_config_key(provider)
 
 
 def resolve_provider_name(


### PR DESCRIPTION
## Summary

- add QwenCloud as a first-class hosted provider across configuration, readiness, Console dispatch, canonical F9 Settings, and the shared model catalog
- support both Responses (default) and Chat Completions through an explicit `api_settings.qwencloud.api_mode`, with pinned mode/base resolution and strict mode-specific request translation
- support existing Chatbook function tools in both modes, including multi-call continuation, streaming usage, retries, cancellation, and deterministic stream cleanup; QwenCloud built-in tools remain out of scope
- document setup, regional/custom endpoints, stateless Responses behavior, parameter limits, model discovery, and opt-in paid live verification

## Architecture

- follows ADR-045 for the dual-API provider boundary
- uses the existing Console agent runtime and cached model-catalog pipeline; no Qwen-specific agent loop, Settings surface, or parallel catalog
- requests `store=false` where honored and sends no Responses continuation IDs; Chat thinking replay is disabled

## Verification

- `517 passed, 2 skipped, 423 deselected` in the fresh pre-PR QwenCloud integration gate
- the two skips are paid live API checks gated by both `TLDW_LIVE_QWENCLOUD=1` and `DASHSCOPE_API_KEY`; no paid request was made
- changed-test surface: `1498 passed, 2 skipped, 2 xfailed`; four canonical Settings failures reproduced identically on clean current `origin/dev`
- Ruff lint, scoped MyPy, compileall, and `git diff --check` pass
- Ruff format reports the same four legacy shared files on clean `origin/dev`; no new formatter debt

## Tracking

- TASK-3771 is Done with all acceptance criteria checked
- design: `Docs/superpowers/specs/2026-08-02-qwencloud-dual-api-provider-design.md`
- plan: `Docs/superpowers/plans/2026-08-11-qwencloud-dual-api-provider-implementation.md`
- ADR: `backlog/decisions/045-qwencloud-dual-api-provider-boundary.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds QwenCloud as a first‑class provider with a provider‑scoped dual API mode (Responses default, Chat Completions optional). Console pins the normalized mode and base URL per run and supports native tools, streaming, retries, cancellation, usage tracking, and cached model discovery.

- Provider identity, readiness, and discovery are integrated: QwenCloud appears in pickers and catalog auto‑refresh; `DASHSCOPE_API_KEY` is recognized; regional/custom compatible‑mode bases are validated and normalized; canonical `api_settings.qwencloud` overrides `QwenCloud` alias fields. Gateway resolution pins `api_mode` and base for the run; Responses resends history, omits provider conversation/continuation IDs, and requests `store=false` where honored.
- New adapter in `tldw_chatbook/LLM_Calls/qwencloud*.py` implements dual‑API transport, payload/tool mapping, retries/timeouts, error typing, streaming normalization/close, and usage normalization. Existing Console tool runtime continues multi‑call chains unchanged. Qwen built‑in tools remain out of scope.
- Settings/UI adds a provider‑scoped “API mode” selector (no per‑session override). Config helpers `normalize_provider_config_key` and `provider_settings_for_key` unify canonical/alias lookups; readiness prefers canonical fields. Discovery uses validated QwenCloud compatible‑mode endpoints and participates in auto‑refresh. Console usage budget validation and nested usage details checks are hardened.
- Tests add unit/integration/streaming/native‑tool/cancellation coverage; live paid checks are opt‑in behind `TLDW_LIVE_QWENCLOUD=1` and `DASHSCOPE_API_KEY`. Completes TASK‑3771 requirements.

**Rollout**
- Set a QwenCloud API key via `DASHSCOPE_API_KEY` or save a local key in Settings.
- Optional: set a regional or custom compatible‑mode base; default is `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`.
- Choose an API mode under F9 ▸ Providers & Models; Responses is the default. No other migration is required.

<sup>Written for commit 2200998503c54e4e0035d93bc8ac03ac44d75905. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

