### PR TITLE
docs: complete ComfyUI H3 player UAT

### DIFF
--- a/Docs/superpowers/qa/2026-08-09-comfyui-h3-console-generation-uat.md
+++ b/Docs/superpowers/qa/2026-08-09-comfyui-h3-console-generation-uat.md
@@ -8,7 +8,7 @@ TASK-3401.14 tests the packaged Base and Spectrum H3 workflows through the real 
 
 - The app ran with isolated home, config, and data directories under a disposable temporary root.
 - A read-only prerequisite probe against the configured trusted server found both packaged workflow node sets and the required video-output class.
-- No production profile path was targeted.
+- The run was configured only with disposable profile paths. A post-run containment check caught and recovered the separate cross-profile default-write defect described below.
 - No generated-media filename, prompt, credential, server identity, or private source-workflow identity is recorded here.
 
 ## Results
@@ -23,7 +23,8 @@ TASK-3401.14 tests the packaged Base and Spectrum H3 workflows through the real 
 | Base stored bytes | Pass | MP4-family container; H.264 864×480 at 24 FPS; 124 frames; 5.167 seconds; AAC audio; observed MIME `video/mp4`. |
 | Spectrum stored bytes | Pass | MP4-family container; H.264 864×480 at 24 FPS; 124 frames; 5.167 seconds; AAC audio; observed MIME `video/mp4`. |
 | Cancellation | Pass | Stop cleared the running queue, rendered an explicit user-cancelled terminal message, left no pending card, and retained no partial file. |
-| Full player and save copy | Blocked | Persisted video identity diverged from its storage key (TASK-3401.17), inline-preview activation terminated the app with an unhandled `AttributeError` (TASK-3401.18), and session cleanup reran on Console remount (TASK-3401.19). |
+| Full player | Pass | The real selected-message Play action opened the full Textual player, started its decoder/audio-bearing playback pipeline, rendered terminal video frames to completion, and reported a 5-second run with bounded drift and no player error. The source contained one H.264 video stream and one AAC audio stream with 163 audio packets. |
+| Save copy | Pass | The real selected-message Save action wrote one MP4 copy. The copy was byte-identical to the managed artifact and independently probed as MP4-family, 864×480 at 24 FPS, 5.167 seconds, with H.264 video and AAC audio. |
 
 ## Defect evidence
 
@@ -31,7 +32,9 @@ TASK-3401.14 tests the packaged Base and Spectrum H3 workflows through the real 
 - A Console lifecycle transition under session retention reapplied the startup sweep and removed a current-run generated video. Session retention must describe the app session, not each screen instance.
 - Explicit inline-preview activation was followed by an app-level unhandled `AttributeError` and shutdown in the isolated persistent log. The log contained no prompt or media bytes.
 - These issues are tracked atomically in TASK-3401.17, TASK-3401.18, and TASK-3401.19. No production fix was made inside this UAT task.
+- A follow-up run after those tasks completed verified that identity persistence, preview lifecycle, remount retention, full-player launch, and save-copy no longer block this acceptance path.
+- The follow-up isolated launch also exposed a separate config-containment defect: startup appended built-in default keys to the unrelated user config even though an isolated config override was active. No existing value changed; the exact pre-run file was restored, and TASK-15674 tracks the product fix.
 
 ## Cleanup
 
-The isolated app session was stopped. Before deletion, the validated scratch root contained no symlinks and no partial downloads; its disposable generated media and diagnostic state were then permanently removed. A before/after fingerprint check confirmed the real user config was unchanged. TASK-3401.14 remains In Progress with only full-player/save-copy acceptance open.
+The isolated app session was stopped. Before deletion, the validated scratch root contained no symlinks and no partial downloads. Its disposable profile, managed generation, save copy, and diagnostic state were permanently removed. The real user config was restored from the validated pre-run snapshot and verified byte-for-byte before that recovery snapshot was removed. TASK-3401.14 now satisfies all acceptance criteria.

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -116,6 +116,16 @@ directory. `TLDW_CONFIG_PATH` controls the config file only; it does not relocat
 data paths selected from that config. Keep before/after fingerprints as the final
 backstop because path isolation and proof of non-mutation are separate claims.
 
+**A fourth incident, same rule (TASK-3401.14 / TASK-15674).** A real Textual UAT
+launch set `HOME`, every XDG directory, `TLDW_CONFIG_PATH`, and `[paths].data_dir`
+to one disposable profile. The run itself used the scratch databases and media,
+yet startup still appended built-in default keys to the unrelated user config.
+The mandatory byte-for-byte post-run comparison caught it; existing values had
+not changed, and the exact pre-run snapshot was restored before scratch cleanup.
+Do not delete the recovery snapshot merely because all configured paths look
+isolated. Compare first, restore if necessary, and file any cross-profile writer
+as a product defect.
+
 ---
 
 ## A schema bump is a one-way door for every OTHER worktree on this machine (2026-08-04)

--- a/backlog/tasks/task-15674 - Honor-TLDW_CONFIG_PATH-when-persisting-startup-defaults.md
+++ b/backlog/tasks/task-15674 - Honor-TLDW_CONFIG_PATH-when-persisting-startup-defaults.md
@@ -1,0 +1,28 @@
+---
+id: TASK-15674
+title: Honor TLDW_CONFIG_PATH when persisting startup defaults
+status: To Do
+assignee: []
+created_date: '2026-08-12 06:35'
+labels:
+  - bug
+  - config
+  - privacy
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prevent app startup under an isolated config profile from writing normalized default keys into the user's default config file. This was reproduced during generated-video player UAT: the profile remained isolated for reads, but startup appended defaults to the unrelated real config; the exact pre-run file was restored from a validated snapshot.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Starting the real app with `TLDW_CONFIG_PATH` pointing to a scratch profile leaves the default user config byte-for-byte unchanged.
+- [ ] #2 Defaults needed by the isolated run are written only to the effective profile path if persistence is required.
+- [ ] #3 A regression test uses distinct profile and decoy default configs and proves no cross-profile write.
+- [ ] #4 Existing no-override startup persistence behavior remains covered.
+- [ ] #5 No config values or credentials are emitted in diagnostics.
+<!-- AC:END -->

--- a/backlog/tasks/task-3401.14 - UAT-end-to-end-ComfyUI-H3-generation-through-Console.md
+++ b/backlog/tasks/task-3401.14 - UAT-end-to-end-ComfyUI-H3-generation-through-Console.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-3401.14
 title: 'UAT: end-to-end ComfyUI H3 generation through Console'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-09 14:45'
-updated_date: '2026-08-09 16:51'
+updated_date: '2026-08-12 06:37'
 labels:
   - video
   - generation
@@ -31,7 +31,7 @@ Run prompt-safe live acceptance testing of the shipped Base and Spectrum MiniMax
 - [x] #1 With Base H3 selected in Video Generation settings, a generation requested through the actual Console command completes and produces a user-visible video card without direct adapter invocation.
 - [x] #2 With Spectrum selected through settings, the same Console path completes or reports the missing Spectrum node by its documented class name before submission.
 - [x] #3 Each successful result is verified from the ephemeral stored bytes as MP4-family video at 864×480, 24 FPS, approximately five seconds, with an audio stream; displayed generation metadata agrees with the verified media.
-- [ ] #4 The generated card opens in the full player with working video and audio, and save-copy behavior preserves a playable MP4.
+- [x] #4 The generated card opens in the full player with working video and audio, and save-copy behavior preserves a playable MP4.
 - [x] #5 Cancellation or a deliberately unavailable backend produces a clear terminal UI state without leaving a pending card or retained partial media.
 - [x] #6 A prompt-free UAT report records outcomes and sanitized diagnostics only; temporary generations and save copies are removed after verification, and any product defect is filed separately rather than fixed within this UAT task.
 <!-- AC:END -->
@@ -50,6 +50,17 @@ ADR path: backlog/decisions/044-ephemeral-generated-video-storage-playback-and-s
 Reason: this task verifies the existing ADR-044 user-facing generation and ephemeral-storage contracts without changing architecture.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Completed the remaining full-player and save-copy acceptance through the real Textual Console against the trusted configured ComfyUI service; no adapter shortcut was used.
+- Verified the managed and copied media from bytes only, including container, duration, dimensions, frame rate, video/audio stream presence, and byte-for-byte copy preservation. Prompt, host, credential, filename, media, and private workflow identities were excluded from tracked evidence.
+- Re-ran the focused player and Console video-action/message tests before UAT (94 passed). No production code changed in this task.
+- Restored the real config exactly after detecting a cross-profile default-write leak and filed TASK-15674 rather than expanding this UAT task into a product fix.
+- Recorded the incident and recovery-snapshot rule in `backlog/docs/lessons-live-verification.md` so later live runs retain their snapshot until the byte-for-byte containment check passes.
+- ADR required: no new ADR. Existing ADR-044 remains the governing ephemeral generated-video storage/playback boundary.
+<!-- SECTION:NOTES:END -->
+
 ## UAT Progress
 
 - 2026-08-09: A trusted live ComfyUI server passed the prompt-free prerequisite probe for both packaged H3 variants and the required video-output class.
@@ -57,5 +68,7 @@ Reason: this task verifies the existing ADR-044 user-facing generation and ephem
 - TASK-3401.15 and TASK-3401.16 were fixed and live-verified: Video Gen was reachable through Settings, a workflow change saved successfully, and the same running Console honored the refreshed runtime configuration.
 - Base and Spectrum each completed through the actual Console command and rendered ready video cards. Stored-byte probes for both results matched the displayed 864×480, 24 FPS, approximately five-second metadata and found H.264 video plus AAC audio in an MP4-family container.
 - Explicit cancellation cleared the remote running queue, produced a terminal user-cancelled Console message, created no pending card, and retained no partial file.
-- Full-player and save-copy acceptance remain open. The live run exposed generated-video identity persistence (TASK-3401.17), an inline-preview app crash (TASK-3401.18), and per-remount retention cleanup (TASK-3401.19); per this task's contract, those defects were filed separately rather than fixed here.
-- The isolated session was stopped and its validated symlink-free scratch root, generated media, and diagnostic state were permanently removed; the real user config fingerprint remained unchanged.
+- The follow-up full-player run confirmed TASK-3401.17, TASK-3401.18, and TASK-3401.19 no longer block the user path: the ready card opened the real full player, rendered video frames to completion through the decoder pipeline, and exercised the audio-bearing playback path without a player error.
+- The card's real Save action wrote one MP4 copy. It was byte-identical to the managed artifact and independently probed as MP4-family, 864×480, 24 FPS, 5.167 seconds, with one H.264 video stream and one AAC audio stream.
+- Startup under the isolated profile unexpectedly appended built-in defaults to the unrelated user config. Existing values were unchanged, the exact pre-run file was restored from a validated snapshot, and the cross-profile write was filed separately as TASK-15674.
+- The isolated session was stopped and its validated symlink-free scratch root, generated media, save copy, and diagnostic state were permanently removed; the real user config was verified byte-for-byte restored before cleanup.


### PR DESCRIPTION
## Summary

- close TASK-3401.14 after prompt-safe live Console verification of full-player and save-copy behavior
- record sanitized playback/copy evidence and the recovery-snapshot lesson
- file TASK-15674 for the separately observed cross-profile startup-default write

## Verification

- 94 focused Media Playback and Console video action/message tests passed
- real generated card opened the full Textual player and rendered to completion without a player error
- real Save action produced a byte-identical, independently playable MP4 copy
- temporary profile/media removed and real config restored byte-for-byte
- git diff --check and tracked-evidence privacy scan passed

## Scope

Documentation/backlog only; no production code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes ComfyUI H3 generation UAT through the real Console by verifying full player and save copy; marks TASK-3401.14 Done. Documents a cross-profile startup-default write found during UAT and files TASK-15674 to ensure `TLDW_CONFIG_PATH` is honored.

- UAT doc: old state — full player/save copy blocked by identity persistence, inline-preview crash, and remount retention; new state — full player runs to completion with video and audio, and Save produces a byte‑identical playable MP4. Acceptance criteria #4 checked; sanitized evidence recorded.
- Live‑verification lessons: keep a byte‑for‑byte recovery snapshot and compare before cleanup; notes the cross‑profile default‑write incident under an isolated profile.
- Backlog: adds TASK-15674 with AC to prevent writing startup defaults to the user config when an isolated config path is active; retain diagnostics without emitting config or credentials.
- Scope: docs/backlog only; no production code changes or migrations.

<sup>Written for commit 4720e01c14a064e9ff9626d6748d8814be7a6ec1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

