### PR TITLE
Library: add Collection delete Undo receipt

### DIFF
--- a/Docs/User_Guide/library/collections.md
+++ b/Docs/User_Guide/library/collections.md
@@ -25,6 +25,10 @@ The canvas is titled **"Collections (N)"** (task-2859: dropped the
 redundant "Library " prefix and matches the sibling "Name (n)" pattern
 Media/Notes/Prompts/Skills already use). Top to bottom:
 
+- **Delete receipt** (after a confirmed deletion): a persistent
+  `✓ deleted · Collection · name` toolbar with **Undo** and **Dismiss**.
+  It remains visible even when the deleted Collection was the last row.
+
 - **Empty state** (before your first Collection) — "No Collections yet.",
   "Create a local Collection record to start reviewing saved content.",
   "No stored collection items are available locally yet. Collections are
@@ -56,7 +60,9 @@ Media/Notes/Prompts/Skills already use). Top to bottom:
 | Create Collection | Adds a Collection record. Enabled once a valid, unused name is typed. |
 | Rename Collection | Renames the selected Collection to the typed name. |
 | Delete Collection | First press of the two-press delete: it arms deletion and reveals "Confirm delete". |
-| "Confirm delete" | Second press: actually deletes the selected Collection (tooltip: "Delete the selected local Collection. Its items stay in the Library; the deletion cannot be undone from Library."). |
+| "Confirm delete" | Second press: deletes the selected Collection. Its items stay in the Library, and the tooltip promises the Undo that appears in this panel. |
+| Undo | Restores the deleted Collection and its existing membership, then selects it again. |
+| Dismiss | Removes the recovery receipt without restoring the Collection. |
 | Collection rows | Click to select; the detail pane fills in. Row tooltip shows the sync status label. |
 
 Disabled buttons always carry their reason as a tooltip — for example
@@ -87,7 +93,9 @@ writes will be queued:
    the new name into "Collection name", then press Rename Collection.
 3. **Delete a Collection** — Click its row, press Delete Collection, then
    press the "Confirm delete" button that appears beside it. Deleting is
-   deliberately two presses; nothing is removed on the first press.
+   deliberately two presses; nothing is removed on the first press. After
+   deletion, choose **Undo** to restore the Collection and its membership,
+   or **Dismiss** to leave it deleted and remove the receipt.
 
 ## Keyboard & commands
 
@@ -141,3 +149,7 @@ footer advertises "esc focus rail".)*
 (task-14901 / ADR-055: the "Confirm delete" tooltip now states the
 consequence — member items survive, the Collection itself cannot be
 restored from Library.)*
+*Verified against codex/collection-delete-undo-receipt — 2026-08-12
+(TASK-15102 / ADR-055: deleting a Collection now leaves a named receipt
+with Undo and Dismiss actions; Undo restores the Collection and its
+membership, while member items always remain in the Library.)*

--- a/Tests/Library/test_library_collections_service.py
+++ b/Tests/Library/test_library_collections_service.py
@@ -93,6 +93,25 @@ def test_delete_collection_hides_record_from_list_and_get(tmp_path: Path) -> Non
     assert service.get_collection(collection.collection_id) is None
 
 
+def test_restore_collection_revives_record_with_membership(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    collection = service.create_collection("Research")
+    service.add_item_to_collection(
+        collection.collection_id,
+        source_type="note",
+        source_id="note-1",
+        title="Evidence",
+    )
+    assert service.delete_collection(collection.collection_id) is True
+
+    restored = service.restore_collection(collection.collection_id)
+
+    assert restored.collection_id == collection.collection_id
+    assert restored.name == "Research"
+    assert restored.item_count == 1
+    assert service.list_collections() == (restored,)
+
+
 def test_schema_version_and_foreign_keys_are_initialized(tmp_path: Path) -> None:
     db = LibraryCollectionsDB(tmp_path / "library_collections.db")
 

--- a/Tests/UI/test_product_maturity_phase39_library_collections.py
+++ b/Tests/UI/test_product_maturity_phase39_library_collections.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from types import SimpleNamespace
 
@@ -34,6 +35,8 @@ class FakeLibraryCollectionsService:
         self.created = []
         self.renamed = []
         self.deleted = []
+        self.restored = []
+        self._deleted_records = {}
         self._counter = len(self.records) + 1
         self._timestamp_counter = 0
 
@@ -86,11 +89,24 @@ class FakeLibraryCollectionsService:
 
     def delete_collection(self, collection_id):
         before = len(self.records)
+        self._deleted_records.update(
+            {
+                record.collection_id: record
+                for record in self.records
+                if record.collection_id == collection_id
+            }
+        )
         self.records = [
             record for record in self.records if record.collection_id != collection_id
         ]
         self.deleted.append(collection_id)
         return len(self.records) != before
+
+    def restore_collection(self, collection_id):
+        record = self._deleted_records.pop(collection_id)
+        self.records.append(record)
+        self.restored.append(collection_id)
+        return record
 
 
 class RaisingLibraryCollectionsService:
@@ -102,6 +118,18 @@ class DeleteFailsLibraryCollectionsService(FakeLibraryCollectionsService):
     def delete_collection(self, collection_id):
         self.deleted.append(collection_id)
         return False
+
+
+class DelayedRestoreLibraryCollectionsService(FakeLibraryCollectionsService):
+    def __init__(self, records=()):
+        super().__init__(records)
+        self.restore_started = asyncio.Event()
+        self.restore_release = asyncio.Event()
+
+    async def restore_collection(self, collection_id):
+        self.restore_started.set()
+        await self.restore_release.wait()
+        return super().restore_collection(collection_id)
 
 
 def _activate_server_sync_scope(app) -> None:
@@ -662,15 +690,102 @@ async def test_library_collections_create_rename_and_delete_workflow() -> None:
         screen.query_one("#library-delete-collection", Button).press()
         await _wait_for_selector(screen, pilot, "#library-confirm-delete-collection")
         assert service.deleted == []
+        confirm = screen.query_one("#library-confirm-delete-collection", Button)
+        assert "Undo" in str(confirm.tooltip)
+        assert "cannot be undone" not in str(confirm.tooltip)
 
-        screen.query_one("#library-confirm-delete-collection", Button).press()
-        await _wait_for_text(
-            screen,
-            pilot,
-            "No Collections yet.",
-        )
+        confirm.press()
+        await _wait_for_selector(screen, pilot, "#library-collections-delete-receipt")
+        assert "✓ deleted · Collection · Briefing Queue" in _visible_text(screen)
+        assert "Collections (0)" in _visible_text(screen)
+
+        screen.query_one("#library-collections-delete-undo", Button).press()
+        await _wait_for_text(screen, pilot, "Briefing Queue")
+        assert not screen.query("#library-collections-delete-receipt")
+        assert "Collections (1)" in _visible_text(screen)
 
     assert service.deleted == ["collection-1"]
+    assert service.restored == ["collection-1"]
+
+
+@pytest.mark.asyncio
+async def test_library_collection_undo_blocks_concurrent_create() -> None:
+    record = LibraryCollectionRecord(
+        collection_id="collection-1",
+        name="Research",
+        description="Policy sources",
+        item_count=2,
+        source_authority="local",
+        sync_status="local-only",
+        created_at="2026-05-08T04:00:00Z",
+        updated_at="2026-05-08T04:00:00Z",
+    )
+    app = _build_test_app()
+    _seed_library_sources(app)
+    service = DelayedRestoreLibraryCollectionsService((record,))
+    app.library_collections_service = service
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(170, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+        screen.query_one("#library-row-browse-collections", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-collections-panel")
+        screen.query_one("#library-delete-collection", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-confirm-delete-collection")
+        screen.query_one("#library-confirm-delete-collection", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-collections-delete-receipt")
+
+        screen.query_one("#library-collections-delete-undo", Button).press()
+        await asyncio.wait_for(service.restore_started.wait(), timeout=2.0)
+        screen._library_collection_name_input = "New while restoring"
+        create_event = SimpleNamespace(stop=lambda: None)
+        await screen.create_library_collection(create_event)
+
+        assert service.created == []
+        service.restore_release.set()
+        await _wait_for_text(screen, pilot, "Research")
+
+
+@pytest.mark.asyncio
+async def test_library_collection_delete_receipt_dismiss_keeps_record_deleted() -> None:
+    record = LibraryCollectionRecord(
+        collection_id="collection-1",
+        name="Research",
+        description="Policy sources",
+        item_count=0,
+        source_authority="local",
+        sync_status="local-only",
+        created_at="2026-05-08T04:00:00Z",
+        updated_at="2026-05-08T04:00:00Z",
+    )
+    app = _build_test_app()
+    _seed_library_sources(app)
+    service = FakeLibraryCollectionsService((record,))
+    app.library_collections_service = service
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(170, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+        screen.query_one("#library-row-browse-collections", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-collections-panel")
+        screen.query_one("#library-delete-collection", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-confirm-delete-collection")
+        screen.query_one("#library-confirm-delete-collection", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-collections-delete-receipt")
+
+        screen.query_one(
+            "#library-collections-delete-receipt-dismiss", Button
+        ).press()
+        for _ in range(20):
+            await pilot.pause()
+            if not screen.query("#library-collections-delete-receipt"):
+                break
+
+        assert not screen.query("#library-collections-delete-receipt")
+        assert service.restored == []
+        assert service.records == []
 
 
 @pytest.mark.asyncio

--- a/Tests/Widgets/test_library_collections_panel.py
+++ b/Tests/Widgets/test_library_collections_panel.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import pytest
-from textual.widgets import Collapsible, Static
+from textual.widgets import Button, Collapsible, Static
 
-from tldw_chatbook.Library.library_collections_state import LibraryCollectionsPanelState
+from tldw_chatbook.Library.library_collections_state import (
+    LibraryCollectionDeleteReceipt,
+    LibraryCollectionsPanelState,
+)
 from tldw_chatbook.Widgets.Library.library_collections_panel import (
     LIBRARY_COLLECTIONS_STATUS_LINE,
     LibraryCollectionsPanel,
@@ -43,6 +46,26 @@ async def test_library_collections_panel_empty_title_shows_zero_count(widget_pil
         await pilot.pause()
         title = pilot.app.query_one("#library-collections-title", Static)
         assert str(title.renderable) == "Collections (0)"
+
+
+async def test_library_collections_panel_renders_receipt_in_empty_state(widget_pilot):
+    state = LibraryCollectionsPanelState.from_values(
+        collections=(),
+        status="empty",
+        delete_receipt=LibraryCollectionDeleteReceipt(
+            collection_id="collection-1",
+            name="Research",
+        ),
+    )
+
+    async with await widget_pilot(LibraryCollectionsPanel, state=state) as pilot:
+        await pilot.pause()
+        copy = pilot.app.query_one("#library-collections-delete-receipt-copy", Static)
+        assert str(copy.renderable) == "✓ deleted · Collection · Research"
+        assert copy._render_markup is False
+        assert pilot.app.query_one("#library-collections-delete-undo", Button)
+        assert pilot.app.query_one("#library-collections-delete-receipt-dismiss", Button)
+        assert pilot.app.query_one("#library-collections-empty-title", Static)
 
 
 async def test_library_collections_panel_renders_read_only_sync_dry_run_detail(

--- a/backlog/tasks/task-15102 - Collection-delete-leaves-an-Undo-receipt-per-ADR-055.md
+++ b/backlog/tasks/task-15102 - Collection-delete-leaves-an-Undo-receipt-per-ADR-055.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15102
 title: Collection delete leaves an Undo receipt per ADR-055
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-11 06:20'
 labels:
   - library
@@ -34,7 +35,31 @@ content. Update the tooltip to promise the Undo once it exists.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 A successful Collection deletion leaves an in-place receipt in the Collections panel naming the deleted Collection, with Undo and Dismiss
-- [ ] #2 Undo restores the Collection and its membership through a service seam (no raw SQL) and the panel list/count update in place
-- [ ] #3 The confirm affordance copy promises exactly what exists (Undo), replacing "the deletion cannot be undone from Library"
+- [x] #1 A successful Collection deletion leaves an in-place receipt in the Collections panel naming the deleted Collection, with Undo and Dismiss
+- [x] #2 Undo restores the Collection and its membership through a service seam (no raw SQL) and the panel list/count update in place
+- [x] #3 The confirm affordance copy promises exactly what exists (Undo), replacing "the deletion cannot be undone from Library"
+- [x] #4 Create, rename, delete, and receipt Undo share one mutation admission gate so stale completions cannot overwrite Collection list/count/receipt state
 <!-- AC:END -->
+
+## Implementation Plan
+
+ADR required: no
+
+ADR path: `backlog/decisions/055-library-destructive-action-reversibility-rule.md`
+
+Reason: ADR-055 already defines the receipt, service-level restore, and shared state-mutation contract. The existing soft-delete schema and membership ownership remain unchanged.
+
+1. Add a service-level `restore_collection` operation that revives only a deleted Collection row and returns the restored record with its untouched membership count.
+2. Add pure receipt display state and render a literal named Undo/Dismiss toolbar above both populated and empty Collections states.
+3. Route create, rename, delete, and Undo through one Collections mutation admission flag; preserve the receipt on restore failure and refresh selection, list, and count from the service on success.
+4. Update both compose-time and targeted confirmation copy to promise the available list Undo.
+5. Add service, state/widget, and mounted production-screen regression coverage, then run focused tests, static checks, and self-review before completing the task record.
+
+## Implementation Notes
+
+- Added an atomic `restore_collection` service seam that clears the soft-delete marker and returns the restored Collection with its retained membership count in the same transaction.
+- Added a literal, bounded delete receipt above both populated and empty panel states. Undo restores and selects the Collection; Dismiss leaves it deleted; restore failures retain the receipt for retry.
+- Routed create, rename, delete, and Undo through one screen-level mutation gate, and updated compose-time plus targeted confirmation copy to promise the available Undo.
+- Reused the established `ds-toolbar` and semantic action classes per the product design register, avoiding a new decorative border or modal interaction. Updated the Collections user guide.
+- Verification: 60 focused service/state/widget/mounted-screen tests passed with one pre-existing stale empty-copy assertion deselected; its expected sentence is absent from both production state and the test's `origin/dev` baseline. The atomic restore regression also passed independently. `compileall`, Ruff (repository-compatible `E721` exclusion), and `git diff --check` passed.
+- ADR check: no new ADR required; implementation follows existing ADR-055 without changing storage ownership, schema, or conflict policy.

--- a/tldw_chatbook/Library/library_collections_service.py
+++ b/tldw_chatbook/Library/library_collections_service.py
@@ -99,6 +99,20 @@ class LibraryCollectionsService(Protocol):
     def delete_collection(self, collection_id: str) -> bool:
         """Soft-delete a local Library Collection."""
 
+    def restore_collection(self, collection_id: str) -> LibraryCollectionRecord:
+        """Restore one soft-deleted local Library Collection.
+
+        Args:
+            collection_id: Stable identifier of the deleted Collection.
+
+        Returns:
+            The restored Collection with its retained membership count.
+
+        Raises:
+            LibraryCollectionNotFound: If no deleted Collection matches the id.
+            LibraryCollectionsServiceError: If local persistence fails.
+        """
+
     def list_library_collections(
         self, *, limit: int = 20, offset: int = 0
     ) -> dict:
@@ -306,6 +320,58 @@ class LocalLibraryCollectionsService:
         except sqlite3.Error as exc:
             raise LibraryCollectionsServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         return cursor.rowcount > 0
+
+    def restore_collection(self, collection_id: str) -> LibraryCollectionRecord:
+        """Restore one soft-deleted Collection without changing membership.
+
+        Args:
+            collection_id: Stable identifier of the deleted Collection.
+
+        Returns:
+            The restored Collection with its retained membership count.
+
+        Raises:
+            LibraryCollectionNotFound: If no deleted Collection matches the id.
+            LibraryCollectionsServiceError: If local persistence fails.
+        """
+        now = self._now_factory()
+        try:
+            with self.db.transaction() as conn:
+                cursor = conn.execute(
+                    """
+                    UPDATE library_collections
+                    SET deleted_at = NULL,
+                        updated_at = ?
+                    WHERE collection_id = ?
+                        AND deleted_at IS NOT NULL
+                    """,
+                    (now, collection_id),
+                )
+                if cursor.rowcount < 1:
+                    raise LibraryCollectionNotFound(collection_id)
+                row = conn.execute(
+                    """
+                    SELECT
+                        collection.collection_id,
+                        collection.name,
+                        collection.description,
+                        collection.created_at,
+                        collection.updated_at,
+                        COUNT(item.membership_id) AS item_count
+                    FROM library_collections AS collection
+                    LEFT JOIN library_collection_items AS item
+                        ON item.collection_id = collection.collection_id
+                    WHERE collection.deleted_at IS NULL
+                        AND collection.collection_id = ?
+                    GROUP BY collection.collection_id
+                    """,
+                    (collection_id,),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            raise LibraryCollectionsServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        if row is None:
+            raise LibraryCollectionNotFound(collection_id)
+        return _record_from_row(row)
 
     def add_item_to_collection(
         self,

--- a/tldw_chatbook/Library/library_collections_state.py
+++ b/tldw_chatbook/Library/library_collections_state.py
@@ -360,6 +360,20 @@ class LibraryCollectionDetail:
 
 
 @dataclass(frozen=True)
+class LibraryCollectionDeleteReceipt:
+    """Stable identity for one Collection available to restore."""
+
+    collection_id: str
+    name: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.collection_id, str) or not self.collection_id.strip():
+            raise ValueError("Collection delete receipt id must be non-empty text.")
+        if not isinstance(self.name, str):
+            raise TypeError("Collection delete receipt name must be text.")
+
+
+@dataclass(frozen=True)
 class LibraryCollectionsPanelState:
     """Pure display state for the Library Collections management panel."""
 
@@ -371,6 +385,8 @@ class LibraryCollectionsPanelState:
     create_action: LibraryCollectionActionState
     rename_action: LibraryCollectionActionState
     delete_action: LibraryCollectionActionState
+    delete_receipt: LibraryCollectionDeleteReceipt | None = None
+    mutation_in_flight: bool = False
     sync_profile_status: SyncProfileStatusDisplay | None = None
     error_message: str = ""
     recovery_copy: str = ""
@@ -385,6 +401,8 @@ class LibraryCollectionsPanelState:
         error_message: Any = "",
         create_name: Any = "",
         rename_name: Any = None,
+        delete_receipt: LibraryCollectionDeleteReceipt | None = None,
+        mutation_in_flight: bool = False,
         sync_profile_summary: Mapping[str, Any] | None = None,
     ) -> "LibraryCollectionsPanelState":
         records = tuple(
@@ -444,6 +462,10 @@ class LibraryCollectionsPanelState:
         create_action = _create_action(create_name, summary_rows)
         rename_action = _rename_action(rename_name, selected_detail, summary_rows)
         delete_action = _delete_action(selected_detail)
+        if mutation_in_flight:
+            create_action = _busy_action(create_action)
+            rename_action = _busy_action(rename_action)
+            delete_action = _busy_action(delete_action)
         sync_profile_status = (
             SyncProfileStatusDisplay.from_summary(sync_profile_summary)
             if sync_profile_summary is not None
@@ -459,10 +481,22 @@ class LibraryCollectionsPanelState:
             create_action=create_action,
             rename_action=rename_action,
             delete_action=delete_action,
+            delete_receipt=delete_receipt,
+            mutation_in_flight=bool(mutation_in_flight),
             sync_profile_status=sync_profile_status,
             error_message=error_copy,
             recovery_copy=recovery_copy,
         )
+
+
+def _busy_action(action: LibraryCollectionActionState) -> LibraryCollectionActionState:
+    """Disable one action while a Collection mutation owns shared state."""
+    return LibraryCollectionActionState(
+        label=action.label,
+        enabled=False,
+        widget_id=action.widget_id,
+        disabled_reason="Another Collection change is in progress.",
+    )
 
 
 def _name_exists(

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -67,6 +67,7 @@ from ...Library.export_progress import (
 from ...Library.library_collections_service import LibraryCollectionsServiceError
 from ...Library.library_collections_state import (
     LibraryCollectionActionState,
+    LibraryCollectionDeleteReceipt,
     LibraryCollectionsPanelState,
 )
 from ...Library.library_conversations_state import build_library_conversations_state
@@ -2625,6 +2626,10 @@ class LibraryScreen(BaseAppScreen):
         self._library_collection_name_input = ""
         self._library_collection_description_input = ""
         self._library_collection_pending_delete_id = ""
+        self._library_collection_delete_receipt: LibraryCollectionDeleteReceipt | None = (
+            None
+        )
+        self._library_collections_mutation_in_flight = False
         self._library_workspace_depth_state_cache: LibraryWorkspaceDepthState | None = (
             None
         )
@@ -7400,6 +7405,8 @@ class LibraryScreen(BaseAppScreen):
             error_message=self._library_collections_error,
             create_name=self._library_collection_name_input,
             rename_name=self._library_collection_name_input,
+            delete_receipt=self._library_collection_delete_receipt,
+            mutation_in_flight=self._library_collections_mutation_in_flight,
             sync_profile_summary=self._library_sync_profile_summary,
         )
 
@@ -25104,6 +25111,23 @@ class LibraryScreen(BaseAppScreen):
         else:
             self.refresh(recompose=True)
 
+    def _claim_library_collections_mutation(self) -> bool:
+        """Admit one owner of Collection list/count/receipt mutations.
+
+        Returns:
+            ``True`` when the caller owns mutation state, otherwise ``False``.
+        """
+        if self._library_collections_mutation_in_flight:
+            return False
+        self._library_collections_mutation_in_flight = True
+        return True
+
+    def _release_library_collections_mutation(self) -> None:
+        """Release Collection mutation ownership and repaint action gates."""
+        self._library_collections_mutation_in_flight = False
+        if self.is_mounted:
+            self.refresh(recompose=True)
+
     async def _refresh_collections_panel_action_state_widgets(self) -> None:
         if self._library_selected_row_id != LIBRARY_ROW_BROWSE_COLLECTIONS or not list(
             self.query("#library-collections-panel")
@@ -25146,9 +25170,10 @@ class LibraryScreen(BaseAppScreen):
                         # compose-side copy in ``LibraryCollectionsPanel``.
                         tooltip=(
                             "Delete the selected local Collection. Its items "
-                            "stay in the Library; the deletion cannot be "
-                            "undone from Library."
+                            "stay in the Library. Undo will be available in "
+                            "this Collections panel."
                         ),
+                        disabled=self._library_collections_mutation_in_flight,
                     )
                 )
 
@@ -25685,13 +25710,15 @@ class LibraryScreen(BaseAppScreen):
     @on(Button.Pressed, "#library-create-collection")
     async def create_library_collection(self, event: Button.Pressed) -> None:
         event.stop()
+        if not self._claim_library_collections_mutation():
+            return
         service = getattr(self.app_instance, "library_collections_service", None)
         create_collection = getattr(service, "create_collection", None)
-        if not callable(create_collection):
-            self._library_collections_error = "Library Collections are unavailable."
-            await self._sync_collections_panel(refresh_snapshot=False)
-            return
         try:
+            if not callable(create_collection):
+                self._library_collections_error = "Library Collections are unavailable."
+                await self._sync_collections_panel(refresh_snapshot=False)
+                return
             created = await self._run_library_service_call(
                 create_collection,
                 self._library_collection_name_input,
@@ -25700,26 +25727,31 @@ class LibraryScreen(BaseAppScreen):
         except LibraryCollectionsServiceError as exc:
             self._notify_library_collections_warning(str(exc))
             return
-        self._library_collections_selected_id = (
-            getattr(created, "collection_id", "") or ""
-        )
-        self._library_collection_name_input = ""
-        self._library_collection_description_input = ""
-        self._library_collection_pending_delete_id = ""
-        await self._sync_collections_panel(refresh_snapshot=True)
+        else:
+            self._library_collections_selected_id = (
+                getattr(created, "collection_id", "") or ""
+            )
+            self._library_collection_name_input = ""
+            self._library_collection_description_input = ""
+            self._library_collection_pending_delete_id = ""
+            await self._sync_collections_panel(refresh_snapshot=True)
+        finally:
+            self._release_library_collections_mutation()
 
     @on(Button.Pressed, "#library-rename-collection")
     async def rename_library_collection(self, event: Button.Pressed) -> None:
         event.stop()
         if not self._library_collections_selected_id:
             return
+        if not self._claim_library_collections_mutation():
+            return
         service = getattr(self.app_instance, "library_collections_service", None)
         rename_collection = getattr(service, "rename_collection", None)
-        if not callable(rename_collection):
-            self._library_collections_error = "Library Collections are unavailable."
-            await self._sync_collections_panel(refresh_snapshot=False)
-            return
         try:
+            if not callable(rename_collection):
+                self._library_collections_error = "Library Collections are unavailable."
+                await self._sync_collections_panel(refresh_snapshot=False)
+                return
             renamed = await self._run_library_service_call(
                 rename_collection,
                 self._library_collections_selected_id,
@@ -25729,19 +25761,26 @@ class LibraryScreen(BaseAppScreen):
         except LibraryCollectionsServiceError as exc:
             self._notify_library_collections_warning(str(exc))
             return
-        self._library_collections_selected_id = (
-            getattr(renamed, "collection_id", "") or ""
-        )
-        self._library_collection_name_input = ""
-        self._library_collection_description_input = ""
-        self._library_collection_pending_delete_id = ""
-        await self._sync_collections_panel(refresh_snapshot=True)
+        else:
+            self._library_collections_selected_id = (
+                getattr(renamed, "collection_id", "") or ""
+            )
+            self._library_collection_name_input = ""
+            self._library_collection_description_input = ""
+            self._library_collection_pending_delete_id = ""
+            await self._sync_collections_panel(refresh_snapshot=True)
+        finally:
+            self._release_library_collections_mutation()
 
     @on(Button.Pressed, "#library-delete-collection")
     async def arm_library_collection_delete(self, event: Button.Pressed) -> None:
         event.stop()
-        if not self._library_collections_selected_id:
+        if (
+            not self._library_collections_selected_id
+            or self._library_collections_mutation_in_flight
+        ):
             return
+        self._library_collection_delete_receipt = None
         self._library_collection_pending_delete_id = (
             self._library_collections_selected_id
         )
@@ -25751,29 +25790,129 @@ class LibraryScreen(BaseAppScreen):
     async def confirm_library_collection_delete(self, event: Button.Pressed) -> None:
         event.stop()
         target_id = self._library_collection_pending_delete_id
-        if not target_id:
+        if not target_id or not self._claim_library_collections_mutation():
             return
+        target = next(
+            (
+                record
+                for record in self._library_collections_records
+                if _record_value(record, "collection_id") == target_id
+            ),
+            None,
+        )
+        target_name = _record_value(target, "name") or "Untitled"
         service = getattr(self.app_instance, "library_collections_service", None)
         delete_collection = getattr(service, "delete_collection", None)
-        if not callable(delete_collection):
-            self._library_collections_error = "Library Collections are unavailable."
-            await self._sync_collections_panel(refresh_snapshot=False)
-            return
         try:
+            if not callable(delete_collection):
+                self._library_collections_error = "Library Collections are unavailable."
+                await self._sync_collections_panel(refresh_snapshot=False)
+                return
             deleted = await self._run_library_service_call(delete_collection, target_id)
         except LibraryCollectionsServiceError as exc:
             self._notify_library_collections_warning(str(exc))
             return
-        if not deleted:
-            self._notify_library_collections_warning("Failed to delete Collection.")
+        else:
+            if not deleted:
+                self._notify_library_collections_warning("Failed to delete Collection.")
+                return
+            self._library_collections_selected_id = ""
+            self._library_collection_pending_delete_id = ""
+            self._library_collection_delete_receipt = LibraryCollectionDeleteReceipt(
+                collection_id=target_id,
+                name=target_name,
+            )
+            await self._sync_collections_panel(refresh_snapshot=True)
+        finally:
+            self._release_library_collections_mutation()
+
+    @on(Button.Pressed, "#library-collections-delete-undo")
+    def handle_library_collection_delete_undo(self, event: Button.Pressed) -> None:
+        """Start restoration for the Collection named by the receipt.
+
+        Args:
+            event: Press of the receipt's Undo button.
+
+        Returns:
+            None.
+        """
+        event.stop()
+        receipt = self._library_collection_delete_receipt
+        if receipt is None or not self._claim_library_collections_mutation():
             return
-        self._library_collections_selected_id = ""
-        self._library_collection_pending_delete_id = ""
-        await self._sync_collections_panel(refresh_snapshot=True)
+        self.refresh(recompose=True)
+        self.run_worker(
+            self._undo_library_collection_delete(receipt),
+            exclusive=True,
+            group="library_collection_mutation",
+        )
+
+    @on(Button.Pressed, "#library-collections-delete-receipt-dismiss")
+    def handle_library_collection_delete_receipt_dismiss(
+        self, event: Button.Pressed
+    ) -> None:
+        """Dismiss the Collection recovery receipt without restoring it.
+
+        Args:
+            event: Press of the receipt's Dismiss button.
+
+        Returns:
+            None.
+        """
+        event.stop()
+        if self._library_collections_mutation_in_flight:
+            return
+        self._library_collection_delete_receipt = None
+        self.refresh(recompose=True)
+
+    async def _undo_library_collection_delete(
+        self, receipt: LibraryCollectionDeleteReceipt
+    ) -> None:
+        """Restore one Collection and refresh its retained membership count.
+
+        Args:
+            receipt: Stable Collection identity captured after deletion.
+
+        Returns:
+            None. Success or failure is reflected in panel state and feedback.
+        """
+        restored = False
+        try:
+            service = getattr(self.app_instance, "library_collections_service", None)
+            restore_collection = getattr(service, "restore_collection", None)
+            if not callable(restore_collection):
+                raise LibraryCollectionsServiceError(
+                    "Collection restore is unavailable."
+                )
+            result = await self._run_library_service_call(
+                restore_collection,
+                receipt.collection_id,
+            )
+            restored_id = getattr(result, "collection_id", "")
+            if restored_id != receipt.collection_id:
+                raise LibraryCollectionsServiceError(
+                    "Collection restore returned a different record."
+                )
+            if self._library_collection_delete_receipt == receipt:
+                self._library_collection_delete_receipt = None
+            self._library_collections_selected_id = receipt.collection_id
+            restored = True
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"Failed to restore Library Collection {receipt.collection_id!r}."
+            )
+            self._notify_library_collections_warning(
+                "Could not restore this Collection; the receipt is still available."
+            )
+        finally:
+            self._library_collections_mutation_in_flight = False
+            await self._sync_collections_panel(refresh_snapshot=restored)
 
     @on(Button.Pressed, ".library-collection-row")
     async def select_library_collection(self, event: Button.Pressed) -> None:
         event.stop()
+        if self._library_collections_mutation_in_flight:
+            return
         collection_id = getattr(event.button, "collection_id", "")
         if not collection_id:
             return

--- a/tldw_chatbook/Widgets/Library/library_collections_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_collections_panel.py
@@ -16,6 +16,14 @@ LIBRARY_COLLECTIONS_STATUS_LINE = (
 )
 
 
+def _compact_receipt_name(value: str, limit: int = 42) -> str:
+    """Keep a Collection name literal, single-line, and bounded."""
+    normalized = " ".join(value.splitlines()).strip() or "Untitled"
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 1].rstrip() + "…"
+
+
 class LibraryCollectionsPanel(Vertical):
     """Render-only Library Collections list, detail, and form controls."""
 
@@ -83,19 +91,15 @@ class LibraryCollectionsPanel(Vertical):
                         ),
                     )
                 if self.delete_pending:
-                    # task-14901 (ADR-055): the confirm affordance states
-                    # the consequence -- members survive, the Collection
-                    # itself has no recovery surface. Keep in lockstep with
-                    # the in-place patcher in ``library_screen.py``
-                    # (``_refresh_collections_panel_action_state_widgets``).
                     yield Button(
                         "Confirm delete",
                         id="library-confirm-delete-collection",
                         tooltip=(
                             "Delete the selected local Collection. Its items "
-                            "stay in the Library; the deletion cannot be "
-                            "undone from Library."
+                            "stay in the Library. Undo will be available in "
+                            "this Collections panel."
                         ),
+                        disabled=self.state.mutation_in_flight,
                         classes="library-source-action library-collection-form-action",
                     )
 
@@ -110,6 +114,34 @@ class LibraryCollectionsPanel(Vertical):
             classes="destination-section",
             markup=False,
         )
+        receipt = self.state.delete_receipt
+        if receipt is not None:
+            receipt_row = Horizontal(
+                id="library-collections-delete-receipt", classes="ds-toolbar"
+            )
+            receipt_row.styles.height = "auto"
+            with receipt_row:
+                yield Static(
+                    "✓ deleted · Collection · "
+                    f"{_compact_receipt_name(receipt.name)}",
+                    id="library-collections-delete-receipt-copy",
+                    classes="library-toolbar-count",
+                    markup=False,
+                )
+                yield Button(
+                    "Undo",
+                    id="library-collections-delete-undo",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=self.state.mutation_in_flight,
+                )
+                yield Button(
+                    "Dismiss",
+                    id="library-collections-delete-receipt-dismiss",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=self.state.mutation_in_flight,
+                )
         if self.state.status == "error":
             yield Static(
                 self.state.recovery_copy or self.state.error_message,


### PR DESCRIPTION
## Summary

- leave a named Undo/Dismiss receipt after deleting a local Library Collection
- restore the soft-deleted Collection and retained membership through an atomic service seam
- serialize create, rename, delete, and Undo mutations to prevent stale UI state
- update confirmation copy, user documentation, and TASK-15102

## Verification

- 60 focused service, state, widget, and mounted-screen tests passed
- atomic restore regression passed independently
- Ruff, compileall, and git diff --check passed

One pre-existing stale empty-state-copy assertion was excluded; its expected sentence is absent from both production state and the origin/dev test baseline.

Backlog: TASK-15102
ADR: ADR-055

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-panel delete receipt for Library Collections with Undo and Dismiss. Previously, deletion was final and warned it couldn’t be undone; now a named receipt appears after delete, and Undo restores the soft-deleted Collection and its membership while blocking concurrent mutations to avoid stale UI.

- Service API: adds `restore_collection(collection_id) -> LibraryCollectionRecord` to `LibraryCollectionsService`; clears soft delete and returns the restored record; raises `LibraryCollectionNotFound`/`LibraryCollectionsServiceError`. Migration: implement `restore_collection` in any custom services and test doubles.
- UI/State: renders a receipt toolbar above the list and the empty state; Undo restores and reselects the Collection; Dismiss removes the receipt and keeps it deleted; the confirm tooltip now promises Undo; create/rename/delete/undo share one mutation gate that disables other actions and blocks create during restore.
- Data: no schema changes; membership is untouched.
- Docs/Tests: user guide updated; tests cover restore-with-membership, receipt in empty state, Undo blocking concurrent create, and Dismiss keeping deletion; satisfies TASK-15102 per ADR‑055.

<sup>Written for commit aa2930d9f2475aa3181c25f049a61af38da2399e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

