### PR TITLE
feat(stt): recycle idle workers for model deletion

### DIFF
--- a/Docs/superpowers/plans/2026-08-12-task-2061-idle-worker-recycle.md
+++ b/Docs/superpowers/plans/2026-08-12-task-2061-idle-worker-recycle.md
@@ -1,0 +1,465 @@
+# TASK-2061 Idle Worker Recycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` to implement this plan task by task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a confirmed managed-model deletion unload an exact idle local-STT
+resident and retry once without cancelling active work or bypassing artifact
+leases.
+
+**Architecture:** Extend the existing resident envelope with the verified managed
+lease closure, retain that closure in the app-owned executor, and expose one
+lock-protected idle-only recycle method. Inject the existing executor owner into
+`InstalledView`; the view keeps deletion in its current background worker, retries
+the existing artifact-service deletion once, and renders path-private recovery
+states.
+
+**Tech stack:** Python 3.12, multiprocessing spawn workers, existing
+`LocalSTTExecutor`, existing `ModelArtifactService` leases, Textual 8 workers and
+mounted Pilot tests, pytest, Ruff.
+
+**Approved design:**
+`Docs/superpowers/specs/2026-08-12-task-2061-idle-worker-recycle-design.md`
+
+**ADR required:** no.
+
+**ADR path:**
+`backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`.
+
+**Reason:** ADR-025 already assigns resident leases and generation recycling to
+the app-owned local STT executor. This task completes the browser integration
+explicitly deferred by the TASK-596 design.
+
+## File map
+
+**Production**
+
+- `tldw_chatbook/STT/executor.py`: resident protocol, parent lease-set state,
+  exact idle-only recycle operation, reset behavior.
+- `tldw_chatbook/STT/executor_worker.py`: derive and report the verified handle's
+  complete managed lease set.
+- `tldw_chatbook/app.py`: snapshot the existing app-owned executor and forward an
+  exact recycle request without constructing one.
+- `tldw_chatbook/UI/LLM_Management_Window.py`: inject the app callback into the
+  deferred Installed view.
+- `tldw_chatbook/UI/Screens/model_installed_view.py`: one-retry delete recovery,
+  policy recheck, and distinct row status.
+
+**Tests**
+
+- `Tests/STT/test_local_stt_executor.py`: protocol, full closure, idle recycle,
+  active/nonmatching refusal, lease release, and generation cleanup.
+- `Tests/App/test_submit_library_ingest_job.py`: app ownership and no-create
+  behavior.
+- `Tests/UI/test_model_installed_view.py`: mounted host wiring, delete ordering,
+  retry bound, policy recheck, rendered states, and privacy.
+
+No new module, enum, registry, timer, service API, or dependency is planned.
+
+## Task 1: Report the worker-confirmed managed lease closure
+
+**Files:**
+
+- Modify: `Tests/STT/test_local_stt_executor.py`
+- Modify: `tldw_chatbook/STT/executor.py:310-321`
+- Modify: `tldw_chatbook/STT/executor_worker.py:51-70,298-333,857-865`
+
+- [ ] **Step 1: Write protocol and worker RED tests**
+
+Add a protocol test that round-trips canonical lease references and rejects a
+malformed component:
+
+```python
+lease_refs = (
+    ("parakeet-v2", "root-revision", "int8"),
+    ("silero-vad", "vad-revision", "f32"),
+)
+resident = ExecutorResident(3, "attempt-1", _identity(), lease_refs)
+assert pickle.loads(pickle.dumps(resident)).managed_lease_refs == lease_refs
+```
+
+Extend the direct resident-load tests so a managed root reports the root plus
+declared dependency and an external root reports only its exact managed VAD.
+
+- [ ] **Step 2: Run the RED tests**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/STT/test_local_stt_executor.py::test_protocol_objects_are_frozen_slotted_and_picklable \
+  Tests/STT/test_local_stt_executor.py::test_provider_builder_receives_the_full_verified_managed_handle \
+  Tests/STT/test_local_stt_executor.py::test_external_runtime_holds_exact_vad_lease_across_reuse_and_close
+```
+
+Expected: FAIL because `ExecutorResident` and `_ResidentRuntime` do not expose the
+verified lease references.
+
+- [ ] **Step 3: Implement the minimal protocol and worker report**
+
+Add one defaulted tuple to the frozen envelope:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ExecutorResident:
+    generation: int
+    attempt_id: str
+    identity: ModelIdentity
+    managed_lease_refs: tuple[tuple[str, str, str], ...] = ()
+```
+
+Validate and canonicalize it with the existing three-string tuple boundary. Add
+the same field to `_ResidentRuntime`. In `_load_resident`, derive it only from the
+verified handle:
+
+```python
+if handle is None:
+    managed_lease_refs = ()
+elif request.managed_artifact_ref is not None:
+    managed_lease_refs = tuple(
+        (ref.artifact_id, ref.revision, ref.variant) for ref in handle.closure
+    )
+else:
+    managed_lease_refs = tuple(
+        (ref.artifact_id, ref.revision, ref.variant) for ref in handle.references
+    )
+```
+
+Send `resident.managed_lease_refs` in the one `ExecutorResident` envelope. Keep the
+default empty tuple so dependency-free test workers and unmanaged providers remain
+source-compatible.
+
+- [ ] **Step 4: Run the focused tests to GREEN**
+
+Run the exact Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Commit the protocol slice**
+
+```bash
+git add Tests/STT/test_local_stt_executor.py \
+  tldw_chatbook/STT/executor.py tldw_chatbook/STT/executor_worker.py
+git commit -m "feat(stt): report resident artifact leases"
+```
+
+## Task 2: Recycle only an exact idle resident
+
+**Files:**
+
+- Modify: `Tests/STT/test_local_stt_executor.py`
+- Modify: `tldw_chatbook/STT/executor.py:465-520,800-821,988-1038`
+
+- [ ] **Step 1: Write idle, active, nonmatching, and cleanup RED tests**
+
+Use the existing real resident worker and installed root/dependency fixtures.
+Parameterize root and dependency targets:
+
+```python
+@pytest.mark.parametrize("target_name", ("root", "dependency"))
+def test_idle_resident_recycle_releases_exact_managed_lease(...):
+    # Submit and wait for a successful terminal result, leaving the runtime idle.
+    assert executor.recycle_idle_managed_reference(_ref_tuple(target)) is True
+    ModelArtifactService(store).delete(target)
+```
+
+Add an active `test_worker_hold` case proving recycle returns false while the same
+attempt remains alive and no terminal callback is delivered. Add a nonmatching key
+case proving the idle generation is retained. Add a retirement-proof case by making
+the existing retirement primitive return false and asserting recycle cannot report
+success.
+
+- [ ] **Step 2: Run the RED tests**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/STT/test_local_stt_executor.py \
+  -k 'idle_resident_recycle or active_resident_refuses_recycle or nonmatching_resident_refuses_recycle or unproven_idle_recycle'
+```
+
+Expected: FAIL because the parent does not retain the worker-confirmed lease set and
+has no public idle recycle operation.
+
+- [ ] **Step 3: Implement parent state and the narrow recycle operation**
+
+Add `_resident_lease_refs`, set it only from a matching `ExecutorResident`, and
+clear it everywhere the current resident identity is cleared. Do not clear it on an
+ordinary terminal request result or failure while the generation remains alive.
+
+Add:
+
+```python
+def recycle_idle_managed_reference(
+    self,
+    reference: tuple[str, str, str],
+) -> bool:
+    canonical = _canonical_dependency_refs((reference,))[0]
+    with self._lock:
+        if (
+            self._closed
+            or self._unavailable
+            or self._busy
+            or self._retiring
+            or self._resident_identity is None
+            or canonical not in self._resident_lease_refs
+        ):
+            return False
+        return self._retire_idle_worker_locked()
+```
+
+Do not alter cancellation state, active callbacks, or `force_stop()`.
+
+- [ ] **Step 4: Run the focused tests to GREEN**
+
+Run the exact Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Perform and restore executor mutations**
+
+Temporarily remove the `_busy` guard; the active test must fail because an active
+generation is detached. Restore it. Temporarily remove the exact-reference
+membership check; the nonmatching test must fail. Restore it. Temporarily replace
+the worker-confirmed closure with the request root only; the dependency test must
+fail. Restore it.
+
+- [ ] **Step 6: Commit the controller slice**
+
+```bash
+git add Tests/STT/test_local_stt_executor.py tldw_chatbook/STT/executor.py
+git commit -m "feat(stt): recycle exact idle residents"
+```
+
+## Task 3: Bind deletion to the existing app-owned executor
+
+**Files:**
+
+- Modify: `Tests/App/test_submit_library_ingest_job.py`
+- Modify: `Tests/UI/test_model_installed_view.py`
+- Modify: `tldw_chatbook/app.py:2869-2883`
+- Modify: `tldw_chatbook/UI/LLM_Management_Window.py:611-619`
+
+- [ ] **Step 1: Write app ownership and mounted host RED tests**
+
+In the app test, prove no executor is created merely to answer a delete request:
+
+```python
+app._create_local_stt_executor = MagicMock()
+assert app._recycle_idle_local_stt_reference(reference) is False
+app._create_local_stt_executor.assert_not_called()
+```
+
+Then install an executor double and assert the exact three-string tuple is forwarded.
+Extend the existing mounted Models host test to prove `InstalledView` uses the bound
+app callback after `_ensure_local_stt_executor` is replaced with a failing sentinel.
+
+- [ ] **Step 2: Run the RED tests**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/App/test_submit_library_ingest_job.py::test_recycle_idle_local_stt_reference_uses_existing_executor_without_creating \
+  Tests/UI/test_model_installed_view.py::test_models_host_lazily_wires_parakeet_activation_and_deletion
+```
+
+Expected: FAIL because the app callback and Installed-view injection do not exist.
+
+- [ ] **Step 3: Implement app forwarding and host injection**
+
+Add a type-checking-only `ArtifactRef` import. Snapshot the executor while holding
+`_local_stt_executor_lock`, release the app lock, and then forward to the executor:
+
+```python
+def _recycle_idle_local_stt_reference(self, reference: "ArtifactRef") -> bool:
+    with self._local_stt_executor_lock:
+        if self._ingest_shutdown:
+            return False
+        executor = getattr(self, "_local_stt_executor", None)
+    if executor is None:
+        return False
+    return executor.recycle_idle_managed_reference(
+        (reference.artifact_id, reference.revision, reference.variant)
+    )
+```
+
+Inject this bound method as `recycle_idle` beside the existing `may_delete` callback.
+Do not call `_ensure_local_stt_executor()` from either path.
+
+- [ ] **Step 4: Run the focused tests to GREEN**
+
+Run the exact Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Commit the ownership slice**
+
+```bash
+git add Tests/App/test_submit_library_ingest_job.py \
+  Tests/UI/test_model_installed_view.py tldw_chatbook/app.py \
+  tldw_chatbook/UI/LLM_Management_Window.py
+git commit -m "feat(models): bind idle STT recycle"
+```
+
+## Task 4: Retry confirmed deletion once with visible recovery state
+
+**Files:**
+
+- Modify: `Tests/UI/test_model_installed_view.py`
+- Modify: `tldw_chatbook/UI/Screens/model_installed_view.py:127-160,250-292,511-570`
+
+- [ ] **Step 1: Write delete-flow and mounted-state RED tests**
+
+Add a service double whose first delete raises `ArtifactInUseError` and whose second
+delete succeeds. Record this exact order:
+
+```python
+assert events == [
+    "delete-1",
+    "recycle",
+    "policy-recheck",
+    "delete-2",
+]
+```
+
+Add cases where recycle returns false, policy becomes blocked after retirement, and
+both delete attempts raise `ArtifactInUseError`. Assert respectively: no retry; no
+retry after policy; and exactly two service calls plus one recycle call.
+
+Mount the view with blocking events around recycle and the second delete. Assert the
+painted row first contains `Checking for an idle model to unload…`, then
+`Idle model unloaded; retrying deletion…`; the final hard blocker remains the
+existing sanitized notification. Include a unique path marker in the final lease
+and callback exceptions, attach a Loguru sink, and assert the marker reaches none of
+rendered text, notifications, or logs.
+
+- [ ] **Step 2: Run the RED tests**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/UI/test_model_installed_view.py \
+  -k 'delete_recycles_idle_owner or delete_rechecks_policy or delete_retries_once or mounted_idle_recycle_state'
+```
+
+Expected: FAIL because the callback, recovery states, and retry do not exist.
+
+- [ ] **Step 3: Implement the minimal recovery flow**
+
+Add one optional callback:
+
+```python
+recycle_idle: Callable[[ArtifactRef], bool] | None = None
+```
+
+Render a status `Static` only when the row matches `_operation_reference` and
+`_operation_name` is `recycle-check` or `recycle-retry`. Add one UI-thread method
+that changes the operation name and recomposes.
+
+In `_delete_model`, special-case only the first `ArtifactInUseError`:
+
+1. marshal `recycle-check`;
+2. call the injected callback off-loop;
+3. refuse with the original sanitized hard blocker when false;
+4. marshal `recycle-retry` when true;
+5. re-run `_may_delete` via `app.call_from_thread`;
+6. retry `service.delete(reference)` exactly once; and
+7. route the final result through existing lifecycle completion.
+
+Unexpected callback errors are final sanitized deletion failures. Do not log the
+first recoverable lease exception. A final lease blocker is logged only with the
+bounded artifact identity, without its exception/cause chain; unexpected non-lease
+deletion failures retain the existing diagnostic logging behavior.
+
+- [ ] **Step 4: Run the focused tests to GREEN**
+
+Run the exact Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Perform and restore the retry mutation**
+
+Temporarily let a second `ArtifactInUseError` invoke recycle again. The bounded-retry
+test must fail on recycle count or delete count. Restore the one-retry implementation.
+
+- [ ] **Step 6: Commit the browser slice**
+
+```bash
+git add Tests/UI/test_model_installed_view.py \
+  tldw_chatbook/UI/Screens/model_installed_view.py
+git commit -m "feat(models): retry deletion after idle unload"
+```
+
+## Task 5: Verify, simplify, and close TASK-2061
+
+**Files:**
+
+- Modify: `backlog/tasks/task-2061 - Idle-heavy-worker-recycle-for-managed-model-deletion.md`
+- Modify only if a generalized incident is found:
+  `backlog/docs/lessons-testing-evidence.md`
+
+- [ ] **Step 1: Run the exact affected test files**
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/STT/test_local_stt_executor.py \
+  Tests/App/test_submit_library_ingest_job.py \
+  Tests/UI/test_model_installed_view.py
+```
+
+Expected: all pass, with only documented environment warnings/skips.
+
+- [ ] **Step 2: Run focused static checks**
+
+```bash
+../../.venv/bin/ruff check \
+  tldw_chatbook/STT/executor.py \
+  tldw_chatbook/STT/executor_worker.py \
+  tldw_chatbook/app.py \
+  tldw_chatbook/UI/LLM_Management_Window.py \
+  tldw_chatbook/UI/Screens/model_installed_view.py \
+  Tests/STT/test_local_stt_executor.py \
+  Tests/App/test_submit_library_ingest_job.py \
+  Tests/UI/test_model_installed_view.py
+../../.venv/bin/python -m py_compile \
+  tldw_chatbook/STT/executor.py \
+  tldw_chatbook/STT/executor_worker.py \
+  tldw_chatbook/app.py \
+  tldw_chatbook/UI/LLM_Management_Window.py \
+  tldw_chatbook/UI/Screens/model_installed_view.py
+git diff --check origin/dev...HEAD
+```
+
+The current tree has known whole-file Ruff-format debt in six affected legacy files.
+Use `git diff -U0` to identify each edited logical range and run
+`ruff format --check --range START:END FILE` on those ranges only; do not bulk-format
+unrelated code.
+
+- [ ] **Step 3: Perform the Ponytail and correctness review**
+
+Confirm there is still one callback, one boolean executor API, one retry, and no new
+registry/timer/controller. Trace active submission, idle retirement, worker exit,
+app shutdown, source-policy change, second lease conflict, and UI unmount. Remove any
+duplicate helper or speculative state that is not required by a focused test.
+
+- [ ] **Step 4: Update TASK-2061 through Backlog CLI only**
+
+After every acceptance criterion and Definition-of-Done item is verified:
+
+```bash
+backlog task edit 2061 \
+  --check-ac 1 --check-ac 2 --check-ac 3 \
+  --notes "Implemented exact idle resident recycling through the app-owned local STT executor. The worker reports its verified managed lease closure; active and unrelated residents refuse recycling; Installed deletion shows path-private recovery states, rechecks policy, and retries the lease-enforced delete once. Focused STT, app, mounted UI, mutation, Ruff, compile, and diff checks passed. ADR-025 remains governing; no new ADR was required." \
+  -s Done --plain
+```
+
+Do not add a lessons entry unless implementation exposes a new recurring trap with
+concrete evidence.
+
+- [ ] **Step 5: Commit closeout metadata**
+
+```bash
+git add "backlog/tasks/task-2061 - Idle-heavy-worker-recycle-for-managed-model-deletion.md"
+git commit -m "docs(stt): close task 2061"
+```
+
+- [ ] **Step 6: Final verification**
+
+Re-run the exact affected test command after the metadata commit, verify
+`git status --short` is empty, and report exact pass/skip/warning counts plus every
+mutation result. Do not claim completion if any required check or acceptance
+criterion remains open.

--- a/Docs/superpowers/specs/2026-08-12-task-2061-idle-worker-recycle-design.md
+++ b/Docs/superpowers/specs/2026-08-12-task-2061-idle-worker-recycle-design.md
@@ -1,0 +1,158 @@
+# TASK-2061: Idle worker recycle for managed model deletion
+
+**Status:** Approved design
+
+**Date:** 2026-08-12
+
+**Task:** TASK-2061
+
+**Governing decision:** ADR-025, Shared STT Artifacts and Runtime Routing
+
+## Context
+
+The managed-model browser already deletes through `ModelArtifactService.delete()`.
+That service takes an exclusive artifact lease and reports `ArtifactInUseError`
+instead of bypassing a shared lease. A local STT worker intentionally keeps its
+verified model closure leased while the native runtime remains resident, including
+while the worker is idle.
+
+This is correct for active work, but an idle resident can indefinitely block a
+confirmed browser deletion. The artifact service cannot solve that problem because
+the app-owned `LocalSTTExecutor`, not the store, owns worker lifetime.
+
+## Goals
+
+- Let one confirmed deletion ask an exact idle STT resident to unload, then retry
+  normal lease-enforced deletion once.
+- Never retire or cancel an active STT request.
+- Match every exact artifact leased by the resident, including dependencies.
+- Show idle-unload progress separately from a final hard blocker.
+- Keep paths, exception details, and process details out of user-visible text.
+
+## Non-goals
+
+- No lease bypass, forced deletion, or active-job cancellation.
+- No idle timeout, global lease-owner registry, or generic worker framework.
+- No change to artifact-service deletion semantics.
+- No automatic executor creation from the model browser.
+- No second confirmation after the existing permanent-delete confirmation.
+
+## Decision
+
+The browser keeps ownership of the delete flow. It first calls the existing
+`ModelArtifactService.delete()`. Only an `ArtifactInUseError` permits one recovery
+attempt through an app-injected callback. The callback consults an already-created
+`LocalSTTExecutor`; it never constructs one.
+
+The executor exposes one narrow operation accepting a canonical managed artifact
+key `(artifact_id, revision, variant)` and returning whether a matching idle
+resident was safely retired. The operation runs under the executor's existing lock
+and succeeds only when:
+
+- the executor has a live resident generation;
+- the worker has confirmed that the exact key is in its held managed lease set;
+- no request is active;
+- no retirement or shutdown is underway; and
+- bounded worker-tree retirement proves the generation dead.
+
+The operation reuses the executor's existing idle-retirement path. It does not call
+`cancel()` or `force_stop()`. The app snapshots an existing executor reference
+under its ownership lock, releases that lock, and only then calls the executor;
+deletion therefore cannot introduce app-lock/executor-lock inversion.
+
+## Worker-confirmed lease set
+
+`ExecutorResident` will include canonical `managed_lease_refs`. The child derives
+these references from the verified handle that owns the live leases:
+
+- managed roots report `ArtifactHandle.closure`;
+- external roots report `ArtifactDependencyHandle.references`; and
+- unmanaged runtimes report an empty tuple.
+
+The parent records the references only from a matching `ExecutorResident` envelope.
+They remain valid for the resident generation, including across ordinary terminal
+request failures that leave the runtime alive. They are cleared whenever the
+generation starts, detaches, exits, recycles, or closes.
+
+Reporting the verified closure is necessary because a resident managed root leases
+both itself and its declared dependencies. Request fields alone cannot prove that a
+dependency such as Silero VAD is held by that resident.
+
+## Delete flow
+
+1. The user accepts the existing delete confirmation.
+2. `InstalledView` starts its existing off-event-loop deletion worker.
+3. The worker calls `ModelArtifactService.delete(reference)`.
+4. Any result other than `ArtifactInUseError` completes through the existing success
+   or sanitized failure handling.
+5. On `ArtifactInUseError`, the row renders `Checking for an idle model to unload…`.
+6. The injected app callback asks the existing executor to recycle the exact key.
+7. If the callback refuses or cannot prove retirement, the UI reports the existing
+   hard blocker and does not retry.
+8. After proven retirement, the row renders
+   `Idle model unloaded; retrying deletion…`.
+9. The source-policy deletion guard is checked again on the UI thread. A newly
+   configured external source can therefore still preserve its required VAD.
+10. If policy still permits deletion, the worker calls the same service deletion
+    method exactly once more.
+
+The first recoverable lease failure is not logged as an error. A final failure is
+logged with the existing bounded artifact identity fields and rendered through
+sanitized copy.
+
+## Concurrency and failure behavior
+
+The executor lock makes idle detection and worker detachment atomic with executor
+submission. If an active request holds the slot, recycle returns false without
+changing cancellation state, callbacks, generation, or process ownership.
+
+Normal artifact leases remain the final concurrency authority. A new request or
+another process can acquire the artifact after retirement and before the one retry.
+If that happens, deletion remains blocked; the new work is never cancelled.
+
+If process-tree death cannot be proven, the existing retirement path marks the
+executor unavailable and retains scratch safety. Deletion remains blocked.
+
+Shutdown is safe in either order: app shutdown may detach and close the executor
+first, causing recycle to refuse, or executor retirement may finish before shutdown
+continues. Both paths serialize on existing locks.
+
+## UI states
+
+The installed row keeps all lifecycle controls disabled throughout the confirmed
+operation. Its operation text distinguishes:
+
+- checking/requesting idle unload;
+- proven idle unload and delete retry; and
+- final hard-blocked notification.
+
+The status uses only catalog identity and static copy. No local path, PID, lease
+path, exception message, or provider detail is rendered.
+
+## Verification
+
+Focused tests will prove:
+
+- worker envelopes report the full verified root/dependency lease set;
+- idle root and dependency matches retire the worker and release their leases;
+- active and nonmatching residents are unchanged;
+- unproven death cannot authorize retry;
+- deletion performs at most one recycle and one retry;
+- policy is rechecked after retirement;
+- mounted UI paints distinct checking/retrying and hard-blocked states;
+- host wiring uses an existing app executor without lazy construction; and
+- all new user-visible and logged recovery paths remain path-private.
+
+Mutation checks will independently remove the active-work guard, exact-reference
+match, worker-confirmed closure report, and one-retry fence. Each mutation must make
+its focused regression test fail before restoration.
+
+## ADR check
+
+**ADR required:** no
+
+**ADR path:** `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`
+
+**Reason:** ADR-025 already assigns resident model leases and generation recycling
+to the app-owned local STT executor. TASK-2061 completes the deletion integration
+explicitly deferred by the TASK-596 browser design without changing that boundary.

--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -9,7 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from textual.app import App
@@ -22,6 +22,7 @@ from tldw_chatbook.Library.library_ingest_jobs import (
     LibraryIngestJobRegistry,
 )
 from tldw_chatbook.Library.library_ingest_state import LibraryIngestFormState
+from tldw_chatbook.Model_Artifacts.service import ArtifactRef
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 from tldw_chatbook.app import TldwCli
 import tldw_chatbook.app as app_module
@@ -87,6 +88,28 @@ def test_local_stt_accessors_share_one_executor_and_coordinator_without_deadlock
     assert len(executors) == 1
     assert len(coordinators) == 1
     assert resolved[0][1]._executor is resolved[0][0]
+
+
+def test_recycle_idle_local_stt_reference_uses_existing_executor_without_creating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _minimal_stt_app()
+    create_executor = MagicMock(side_effect=AssertionError("must stay lazy"))
+    monkeypatch.setattr(app, "_create_local_stt_executor", create_executor)
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+
+    assert app._recycle_idle_local_stt_reference(reference) is False
+    create_executor.assert_not_called()
+
+    executor = MagicMock()
+    executor.recycle_idle_managed_reference.return_value = True
+    app._local_stt_executor = executor
+
+    assert app._recycle_idle_local_stt_reference(reference) is True
+    executor.recycle_idle_managed_reference.assert_called_once_with(
+        ("parakeet-v2", "immutable-revision", "int8")
+    )
+    create_executor.assert_not_called()
 
 
 def test_console_dictation_factory_injects_app_owned_coordinator() -> None:

--- a/Tests/STT/test_local_stt_executor.py
+++ b/Tests/STT/test_local_stt_executor.py
@@ -1544,6 +1544,37 @@ def _managed_request_values(
     return service, root, dependency, identity
 
 
+def _managed_reference_tuple(reference: object) -> tuple[str, str, str]:
+    return (reference.artifact_id, reference.revision, reference.variant)
+
+
+def _submit_managed_runtime(
+    executor: LocalSTTExecutor,
+    tmp_path: Path,
+    root: object,
+    identity: ModelIdentity,
+    callbacks: _Callbacks,
+    *,
+    attempt_id: str,
+    hold: bool = False,
+) -> int:
+    options = {"transcription_provider": "parakeet-onnx"}
+    if hold:
+        options["test_worker_hold"] = True
+    return executor.submit(
+        attempt_id=attempt_id,
+        job_id=f"job-{attempt_id}",
+        source=FileAudioSource(tmp_path / "fixture.wav"),
+        identity=identity,
+        options=options,
+        managed_store_root=tmp_path / "store",
+        managed_artifact_ref=_managed_reference_tuple(root.reference),
+        on_event=callbacks.on_event,
+        on_result=callbacks.on_result,
+        on_failure=callbacks.on_failure,
+    )
+
+
 def _external_dependency_request(
     tmp_path: Path,
     dependency: object,
@@ -1614,6 +1645,151 @@ def test_worker_reuses_runtime_and_holds_managed_closure_lease_until_exit(
 
     ModelArtifactService(tmp_path / "store").delete(dependency.reference)
     assert service.artifact_path(dependency.reference).exists() is False
+
+
+@pytest.mark.parametrize("target_name", ("root", "dependency"))
+def test_idle_resident_recycle_releases_exact_managed_lease(
+    tmp_path: Path,
+    target_name: str,
+) -> None:
+    service, root, dependency, identity = _managed_request_values(tmp_path)
+    target = root.reference if target_name == "root" else dependency.reference
+    executor = _resident_executor()
+    callbacks = _Callbacks()
+    try:
+        _submit_managed_runtime(
+            executor,
+            tmp_path,
+            root,
+            identity,
+            callbacks,
+            attempt_id=f"idle-{target_name}",
+        )
+        _wait_for_terminal(callbacks)
+        with pytest.raises(ArtifactInUseError):
+            ModelArtifactService(
+                tmp_path / "store",
+                lease_timeout_seconds=0.01,
+            ).delete(target)
+
+        assert (
+            executor.recycle_idle_managed_reference(_managed_reference_tuple(target))
+            is True
+        )
+        assert executor.resident_identity is None
+        service.delete(target)
+        assert service.artifact_path(target).exists() is False
+    finally:
+        executor.close()
+
+
+def test_active_resident_refuses_recycle_without_cancelling_attempt(
+    tmp_path: Path,
+) -> None:
+    _service, root, dependency, identity = _managed_request_values(tmp_path)
+    executor = _resident_executor()
+    callbacks = _Callbacks()
+    try:
+        _submit_managed_runtime(
+            executor,
+            tmp_path,
+            root,
+            identity,
+            callbacks,
+            attempt_id="active-recycle",
+            hold=True,
+        )
+        _wait_until(
+            lambda: any(
+                event.phase is WorkerPhase.TRANSCRIBING for event in callbacks.events
+            )
+        )
+
+        assert (
+            executor.recycle_idle_managed_reference(
+                _managed_reference_tuple(dependency.reference)
+            )
+            is False
+        )
+        assert executor.busy is True
+        assert callbacks.terminal.is_set() is False
+        with pytest.raises(ArtifactInUseError):
+            ModelArtifactService(
+                tmp_path / "store",
+                lease_timeout_seconds=0.01,
+            ).delete(dependency.reference)
+    finally:
+        executor.force_stop("active-recycle")
+        executor.close()
+
+
+def test_nonmatching_resident_refuses_recycle_and_remains_reusable(
+    tmp_path: Path,
+) -> None:
+    _service, root, _dependency, identity = _managed_request_values(tmp_path)
+    executor = _resident_executor()
+    first = _Callbacks()
+    second = _Callbacks()
+    try:
+        first_generation = _submit_managed_runtime(
+            executor,
+            tmp_path,
+            root,
+            identity,
+            first,
+            attempt_id="nonmatching-first",
+        )
+        _wait_for_terminal(first)
+
+        assert (
+            executor.recycle_idle_managed_reference(
+                ("other-model", "other-revision", "f32")
+            )
+            is False
+        )
+        second_generation = _submit_managed_runtime(
+            executor,
+            tmp_path,
+            root,
+            identity,
+            second,
+            attempt_id="nonmatching-second",
+        )
+        _wait_for_terminal(second)
+
+        assert second_generation == first_generation
+        assert second.results[0].payload["runtime_load_number"] == 1
+    finally:
+        executor.close()
+
+
+def test_unproven_idle_recycle_cannot_report_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _service, root, _dependency, identity = _managed_request_values(tmp_path)
+    executor = _resident_executor()
+    callbacks = _Callbacks()
+    try:
+        _submit_managed_runtime(
+            executor,
+            tmp_path,
+            root,
+            identity,
+            callbacks,
+            attempt_id="unproven-idle",
+        )
+        _wait_for_terminal(callbacks)
+        monkeypatch.setattr(executor, "_retire_idle_worker_locked", lambda: False)
+
+        assert (
+            executor.recycle_idle_managed_reference(
+                _managed_reference_tuple(root.reference)
+            )
+            is False
+        )
+    finally:
+        executor.close()
 
 
 def test_provider_builder_receives_the_full_verified_managed_handle(

--- a/Tests/STT/test_local_stt_executor.py
+++ b/Tests/STT/test_local_stt_executor.py
@@ -55,6 +55,7 @@ from tldw_chatbook.STT.executor import (
     ExecutorEvent,
     ExecutorFailure,
     ExecutorRequest,
+    ExecutorResident,
     ExecutorResult,
     ExecutorUnavailableError,
     LocalSourceChangedError,
@@ -108,9 +109,14 @@ def _request() -> ExecutorRequest:
 
 def test_protocol_objects_are_frozen_slotted_and_picklable() -> None:
     request = _request()
+    lease_refs = (
+        ("parakeet-v2", "revision-a", "int8"),
+        ("silero-vad", "vad-revision", "f32"),
+    )
     envelopes = (
         request,
         ExecutorEvent(3, "attempt-1", WorkerPhase.LOADING),
+        ExecutorResident(3, "attempt-1", request.identity, lease_refs),
         ExecutorResult(3, "attempt-1", {"content": "hello"}),
         ExecutorFailure(
             generation=3,
@@ -126,6 +132,16 @@ def test_protocol_objects_are_frozen_slotted_and_picklable() -> None:
     assert all(hasattr(type(value), "__slots__") for value in envelopes)
     with pytest.raises(FrozenInstanceError):
         request.generation = 4  # type: ignore[misc]
+
+
+def test_resident_managed_lease_references_require_canonical_tuples() -> None:
+    with pytest.raises(ValueError, match="managed_lease_refs"):
+        ExecutorResident(
+            3,
+            "attempt-1",
+            _identity(),
+            (("parakeet-v2", "", "int8"),),
+        )
 
 
 def test_executor_request_accepts_file_and_buffer_sources_without_a_job_id() -> None:
@@ -1641,6 +1657,14 @@ def test_provider_builder_receives_the_full_verified_managed_handle(
         assert handle.lease_keys == (
             *(reference.lease_key() for reference in handle.closure),
         )
+        assert resident.managed_lease_refs == tuple(
+            (
+                reference.artifact_id,
+                reference.revision,
+                reference.variant,
+            )
+            for reference in handle.closure
+        )
         assert captured["is_cancelled"]() is False
     finally:
         resident.close()
@@ -1666,6 +1690,13 @@ def test_external_runtime_holds_exact_vad_lease_across_reuse_and_close(
         handle = captured["handle"]
         assert captured["model_root"] == model.parent
         assert handle.references == (dependency.reference,)
+        assert resident.managed_lease_refs == (
+            (
+                dependency.reference.artifact_id,
+                dependency.reference.revision,
+                dependency.reference.variant,
+            ),
+        )
         assert dict(handle.paths)[dependency.reference] == service.artifact_path(
             dependency.reference
         )

--- a/Tests/STT/test_local_stt_executor.py
+++ b/Tests/STT/test_local_stt_executor.py
@@ -79,6 +79,8 @@ from tldw_chatbook.STT.executor_worker import (
     _validate_reuse,
 )
 
+FAST_LEASE_TIMEOUT_SECONDS = 0.01
+
 
 def _identity(**overrides: object) -> ModelIdentity:
     values: dict[str, object] = {
@@ -1636,7 +1638,10 @@ def test_worker_reuses_runtime_and_holds_managed_closure_lease_until_exit(
 
         assert first.results[0].payload["runtime_load_number"] == 1
         assert second.results[0].payload["runtime_load_number"] == 1
-        contender = ModelArtifactService(tmp_path / "store", lease_timeout_seconds=0.01)
+        contender = ModelArtifactService(
+            tmp_path / "store",
+            lease_timeout_seconds=FAST_LEASE_TIMEOUT_SECONDS,
+        )
         for reference in (root.reference, dependency.reference):
             with pytest.raises(ArtifactInUseError):
                 contender.delete(reference)
@@ -1669,7 +1674,7 @@ def test_idle_resident_recycle_releases_exact_managed_lease(
         with pytest.raises(ArtifactInUseError):
             ModelArtifactService(
                 tmp_path / "store",
-                lease_timeout_seconds=0.01,
+                lease_timeout_seconds=FAST_LEASE_TIMEOUT_SECONDS,
             ).delete(target)
 
         assert (
@@ -1716,7 +1721,7 @@ def test_active_resident_refuses_recycle_without_cancelling_attempt(
         with pytest.raises(ArtifactInUseError):
             ModelArtifactService(
                 tmp_path / "store",
-                lease_timeout_seconds=0.01,
+                lease_timeout_seconds=FAST_LEASE_TIMEOUT_SECONDS,
             ).delete(dependency.reference)
     finally:
         executor.force_stop("active-recycle")
@@ -1878,9 +1883,10 @@ def test_external_runtime_holds_exact_vad_lease_across_reuse_and_close(
         )
         _validate_reuse(request, resident)
         with pytest.raises(ArtifactInUseError):
-            ModelArtifactService(tmp_path / "store", lease_timeout_seconds=0.01).delete(
-                dependency.reference
-            )
+            ModelArtifactService(
+                tmp_path / "store",
+                lease_timeout_seconds=FAST_LEASE_TIMEOUT_SECONDS,
+            ).delete(dependency.reference)
     finally:
         resident.close()
 
@@ -2048,7 +2054,10 @@ def test_external_dependency_failure_keeps_stable_worker_taxonomy(
         monkeypatch.setattr(
             artifacts,
             "ModelArtifactService",
-            lambda root: ModelArtifactService(root, lease_timeout_seconds=0.01),
+            lambda root: ModelArtifactService(
+                root,
+                lease_timeout_seconds=FAST_LEASE_TIMEOUT_SECONDS,
+            ),
         )
     request, _model = _external_dependency_request(
         tmp_path,
@@ -2188,9 +2197,10 @@ def test_executor_recycles_before_dispatch_when_external_vad_reference_changes(
         first_generation = submit("first-vad", first_dependency.reference, first)
         _wait_for_terminal(first)
         with pytest.raises(ArtifactInUseError):
-            ModelArtifactService(tmp_path / "store", lease_timeout_seconds=0.01).delete(
-                first_dependency.reference
-            )
+            ModelArtifactService(
+                tmp_path / "store",
+                lease_timeout_seconds=FAST_LEASE_TIMEOUT_SECONDS,
+            ).delete(first_dependency.reference)
 
         second_generation = submit("second-vad", second_dependency.reference, second)
         _wait_for_terminal(second)
@@ -2200,9 +2210,10 @@ def test_executor_recycles_before_dispatch_when_external_vad_reference_changes(
         assert second.failures == []
         ModelArtifactService(tmp_path / "store").delete(first_dependency.reference)
         with pytest.raises(ArtifactInUseError):
-            ModelArtifactService(tmp_path / "store", lease_timeout_seconds=0.01).delete(
-                second_dependency.reference
-            )
+            ModelArtifactService(
+                tmp_path / "store",
+                lease_timeout_seconds=FAST_LEASE_TIMEOUT_SECONDS,
+            ).delete(second_dependency.reference)
     finally:
         executor.close()
 

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -96,7 +96,7 @@ async def test_models_host_lazily_wires_parakeet_activation_and_deletion(
     )
     app = _build_test_app()
 
-    class _Executor:
+    class ExecutorDouble:
         def recycle_idle_managed_reference(
             self,
             reference: tuple[str, str, str],
@@ -107,7 +107,7 @@ async def test_models_host_lazily_wires_parakeet_activation_and_deletion(
         def close(self) -> None:
             return None
 
-    app._local_stt_executor = _Executor()
+    app._local_stt_executor = ExecutorDouble()
     monkeypatch.setattr(
         app,
         "_create_local_stt_executor",
@@ -741,6 +741,7 @@ def test_delete_recycle_callback_failure_is_path_private(
         module.logger.remove(sink_id)
 
     assert service.delete.call_count == 1
+    assert "RuntimeError" in "".join(logs)
     assert marker not in "".join(logs)
     assert marker not in str(fake_app.notify.mock_calls)
 

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -1,5 +1,6 @@
 """Focused tests for the managed-model Installed view."""
 
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -551,6 +552,295 @@ def test_deletion_guard_blocks_before_and_after_confirmation(monkeypatch) -> Non
         "Managed dependency is required by an external source.",
     )
     assert fake_app.notify.call_args.kwargs["severity"] == "warning"
+
+
+def _direct_delete_view(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    service: object,
+    recycle_idle,
+    may_delete,
+):
+    from tldw_chatbook.UI.Screens import model_installed_view as module
+
+    fake_app = MagicMock()
+    fake_app.call_from_thread.side_effect = lambda callback, *args: callback(*args)
+    monkeypatch.setattr(module.InstalledView, "app", property(lambda self: fake_app))
+    view = module.InstalledView(
+        service_factory=lambda: service,
+        legacy_dir=tmp_path,
+        recycle_idle=recycle_idle,
+        may_delete=may_delete,
+    )
+    view.ensure_loaded = MagicMock()
+    view.refresh = MagicMock()
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    view._operation_reference = reference
+    view._operation_name = "delete"
+    return module, view, fake_app, reference
+
+
+def test_delete_recycles_idle_owner_and_retries_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A confirmed delete retires one idle owner before one service retry."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactInUseError
+
+    events: list[str] = []
+
+    class _Service:
+        def delete(self, _reference: ArtifactRef) -> None:
+            attempt = sum(event.startswith("delete-") for event in events) + 1
+            events.append(f"delete-{attempt}")
+            if attempt == 1:
+                raise ArtifactInUseError("private lease")
+
+    def recycle(_reference: ArtifactRef) -> bool:
+        events.append("recycle")
+        return True
+
+    def policy(_reference: ArtifactRef) -> None:
+        events.append("policy-recheck")
+        return None
+
+    module, view, fake_app, reference = _direct_delete_view(
+        monkeypatch,
+        tmp_path,
+        service=_Service(),
+        recycle_idle=recycle,
+        may_delete=policy,
+    )
+
+    module.InstalledView._delete_model.__wrapped__(view, reference)
+
+    assert events == ["delete-1", "recycle", "policy-recheck", "delete-2"]
+    assert fake_app.notify.call_args.args[0] == "Model delete completed."
+    assert fake_app.notify.call_args.kwargs["severity"] == "information"
+
+
+def test_delete_recycles_idle_owner_refusal_stays_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A busy or unrelated resident never authorizes a delete retry."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactInUseError
+
+    service = MagicMock()
+    service.delete.side_effect = ArtifactInUseError("private lease")
+    recycle = MagicMock(return_value=False)
+    policy = MagicMock(return_value=None)
+    module, view, fake_app, reference = _direct_delete_view(
+        monkeypatch,
+        tmp_path,
+        service=service,
+        recycle_idle=recycle,
+        may_delete=policy,
+    )
+
+    module.InstalledView._delete_model.__wrapped__(view, reference)
+
+    service.delete.assert_called_once_with(reference)
+    recycle.assert_called_once_with(reference)
+    policy.assert_not_called()
+    assert "in use" in fake_app.notify.call_args.args[0]
+    assert fake_app.notify.call_args.kwargs["severity"] == "error"
+
+
+def test_delete_rechecks_policy_after_idle_owner_recycle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A newly required dependency remains installed after idle retirement."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactInUseError
+
+    service = MagicMock()
+    service.delete.side_effect = ArtifactInUseError("private lease")
+    blocker = "Managed dependency is required by an external source."
+    module, view, fake_app, reference = _direct_delete_view(
+        monkeypatch,
+        tmp_path,
+        service=service,
+        recycle_idle=lambda _reference: True,
+        may_delete=lambda _reference: blocker,
+    )
+
+    module.InstalledView._delete_model.__wrapped__(view, reference)
+
+    service.delete.assert_called_once_with(reference)
+    assert fake_app.notify.call_args.args[0] == blocker
+    assert fake_app.notify.call_args.kwargs["severity"] == "warning"
+
+
+def test_delete_retries_once_when_new_lease_wins(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A second lease conflict is final and never starts another recycle."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactInUseError
+    from tldw_chatbook.UI.Screens import model_installed_view as module
+
+    marker = "PRIVATE-LEASE-PATH"
+    service = MagicMock()
+    service.delete.side_effect = (
+        ArtifactInUseError(marker),
+        ArtifactInUseError(marker),
+        None,
+    )
+    recycle = MagicMock(return_value=True)
+    logs: list[str] = []
+    sink_id = module.logger.add(lambda message: logs.append(str(message)))
+    _module, view, fake_app, reference = _direct_delete_view(
+        monkeypatch,
+        tmp_path,
+        service=service,
+        recycle_idle=recycle,
+        may_delete=lambda _reference: None,
+    )
+
+    try:
+        module.InstalledView._delete_model.__wrapped__(view, reference)
+    finally:
+        module.logger.remove(sink_id)
+
+    assert service.delete.call_count == 2
+    recycle.assert_called_once_with(reference)
+    assert marker not in "".join(logs)
+    assert marker not in str(fake_app.notify.mock_calls)
+
+
+def test_delete_recycle_callback_failure_is_path_private(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unexpected recycle failures retain no callback detail in logs or copy."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactInUseError
+    from tldw_chatbook.UI.Screens import model_installed_view as module
+
+    marker = "PRIVATE-CALLBACK-PATH"
+    service = MagicMock()
+    service.delete.side_effect = ArtifactInUseError("private lease")
+    logs: list[str] = []
+    sink_id = module.logger.add(lambda message: logs.append(str(message)))
+
+    def failed_recycle(_reference: ArtifactRef) -> bool:
+        raise RuntimeError(marker)
+
+    _module, view, fake_app, reference = _direct_delete_view(
+        monkeypatch,
+        tmp_path,
+        service=service,
+        recycle_idle=failed_recycle,
+        may_delete=lambda _reference: None,
+    )
+
+    try:
+        module.InstalledView._delete_model.__wrapped__(view, reference)
+    finally:
+        module.logger.remove(sink_id)
+
+    assert service.delete.call_count == 1
+    assert marker not in "".join(logs)
+    assert marker not in str(fake_app.notify.mock_calls)
+
+
+@pytest.mark.asyncio
+async def test_mounted_idle_recycle_state_is_distinct_and_path_private(
+    tmp_path: Path,
+) -> None:
+    """The matching row paints checking and retrying while controls stay pending."""
+    from tldw_chatbook.UI.Screens.model_browser_state import InventoryRow
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    recycle_entered = threading.Event()
+    recycle_release = threading.Event()
+    retry_entered = threading.Event()
+    retry_release = threading.Event()
+    policy_threads: list[int] = []
+
+    class _Service:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def delete(self, _reference: ArtifactRef) -> None:
+            from tldw_chatbook.Model_Artifacts.service import ArtifactInUseError
+
+            self.calls += 1
+            if self.calls == 1:
+                raise ArtifactInUseError("PRIVATE-LEASE-PATH")
+            retry_entered.set()
+            assert retry_release.wait(timeout=2.0)
+
+    def recycle(_reference: ArtifactRef) -> bool:
+        recycle_entered.set()
+        assert recycle_release.wait(timeout=2.0)
+        return True
+
+    def policy(_reference: ArtifactRef) -> None:
+        policy_threads.append(threading.get_ident())
+        return None
+
+    row = InventoryRow(
+        path=tmp_path / "managed",
+        reference=reference,
+        model_label="Parakeet v2",
+        revision=reference.revision,
+        precision="INT8",
+        dependencies=(),
+        ready=True,
+        active=False,
+        activation_allowed=True,
+        is_broken=False,
+        is_unmanaged=False,
+        provenance="Managed",
+        action_hint="Ready",
+        error=None,
+        size_bytes=1024,
+        installed_store_bytes=1024,
+        staging_store_bytes=0,
+        free_bytes=4096,
+    )
+    view = InstalledView(
+        service_factory=_Service,
+        legacy_dir=tmp_path,
+        recycle_idle=recycle,
+        may_delete=policy,
+    )
+    view._loaded = True
+    view._rows = (row,)
+    app = _InstalledApp(view)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+
+        async def wait_for(event: threading.Event) -> None:
+            for _ in range(50):
+                if event.is_set():
+                    return
+                await pilot.pause()
+            assert event.is_set()
+
+        view._operation_reference = reference
+        view._operation_name = "delete"
+        view.refresh(recompose=True)
+        worker = view._delete_model(reference)
+        await wait_for(recycle_entered)
+        await pilot.pause()
+        checking = "\n".join(str(item.renderable) for item in view.query("Static"))
+        assert "Checking for an idle model to unload…" in checking
+        assert "PRIVATE-LEASE-PATH" not in checking
+
+        recycle_release.set()
+        await wait_for(retry_entered)
+        await pilot.pause()
+        retrying = "\n".join(str(item.renderable) for item in view.query("Static"))
+        assert "Idle model unloaded; retrying deletion…" in retrying
+        assert "PRIVATE-LEASE-PATH" not in retrying
+        assert policy_threads == [app._thread_id]
+
+        retry_release.set()
+        await worker.wait()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -52,6 +52,7 @@ async def test_models_host_lazily_wires_parakeet_activation_and_deletion(
     vad = ArtifactRef("silero-vad", "immutable-revision", "f32")
     ui_thread = threading.get_ident()
     lifecycle_threads: list[tuple[str, int]] = []
+    recycled: list[tuple[str, str, str]] = []
 
     class _Source:
         def __init__(self) -> None:
@@ -93,6 +94,24 @@ async def test_models_host_lazily_wires_parakeet_activation_and_deletion(
         lambda _window: False,
     )
     app = _build_test_app()
+
+    class _Executor:
+        def recycle_idle_managed_reference(
+            self,
+            reference: tuple[str, str, str],
+        ) -> bool:
+            recycled.append(reference)
+            return True
+
+        def close(self) -> None:
+            return None
+
+    app._local_stt_executor = _Executor()
+    monkeypatch.setattr(
+        app,
+        "_create_local_stt_executor",
+        MagicMock(side_effect=AssertionError("Models must not create an executor")),
+    )
 
     def create_source_service() -> _Source:
         lifecycle_threads.append(("construct", threading.get_ident()))
@@ -144,6 +163,8 @@ async def test_models_host_lazily_wires_parakeet_activation_and_deletion(
 
         assert view._may_delete(vad) == "Managed dependency is in use."
         assert source.deletion_checks == [vad]
+        assert view._recycle_idle(vad) is True
+        assert recycled == [("silero-vad", "immutable-revision", "f32")]
         ensure_after_mount.assert_not_called()
 
 

--- a/backlog/tasks/task-2061 - Idle-heavy-worker-recycle-for-managed-model-deletion.md
+++ b/backlog/tasks/task-2061 - Idle-heavy-worker-recycle-for-managed-model-deletion.md
@@ -4,7 +4,7 @@ title: Idle heavy-worker recycle for managed model deletion
 status: In Progress
 assignee: []
 created_date: '2026-08-03 20:11'
-updated_date: '2026-08-12 20:25'
+updated_date: '2026-08-12 20:49'
 labels:
   - stt
   - artifacts
@@ -12,6 +12,7 @@ labels:
 dependencies: []
 documentation:
   - Docs/superpowers/specs/2026-08-12-task-2061-idle-worker-recycle-design.md
+  - Docs/superpowers/plans/2026-08-12-task-2061-idle-worker-recycle.md
 priority: medium
 ---
 
@@ -27,3 +28,13 @@ Split from TASK-596 AC #5. The browser's deletion flow reports lease blockers ho
 - [ ] #2 An active (non-idle) lease is never bypassed and an active job is never silently cancelled
 - [ ] #3 The browser's blocked-deletion UI shows recycle-requested state distinctly from hard-blocked
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Test-drive worker-confirmed resident lease-closure reporting.
+2. Test-drive exact idle-only executor recycling with active and nonmatching refusal.
+3. Bind the existing app-owned executor into the Installed model view without lazy construction.
+4. Test-drive one lease-enforced deletion retry with policy recheck and distinct path-private UI states.
+5. Run focused tests, required mutations, static checks, Ponytail/correctness review, and close the task only after all criteria pass.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-2061 - Idle-heavy-worker-recycle-for-managed-model-deletion.md
+++ b/backlog/tasks/task-2061 - Idle-heavy-worker-recycle-for-managed-model-deletion.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-2061
 title: Idle heavy-worker recycle for managed model deletion
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-03 20:11'
-updated_date: '2026-08-12 20:49'
+updated_date: '2026-08-12 21:14'
 labels:
   - stt
   - artifacts
@@ -24,9 +24,9 @@ Split from TASK-596 AC #5. The browser's deletion flow reports lease blockers ho
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A deletion blocked only by an idle resident model can request a recycle and proceed once the worker unloads
-- [ ] #2 An active (non-idle) lease is never bypassed and an active job is never silently cancelled
-- [ ] #3 The browser's blocked-deletion UI shows recycle-requested state distinctly from hard-blocked
+- [x] #1 A deletion blocked only by an idle resident model can request a recycle and proceed once the worker unloads
+- [x] #2 An active (non-idle) lease is never bypassed and an active job is never silently cancelled
+- [x] #3 The browser's blocked-deletion UI shows recycle-requested state distinctly from hard-blocked
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -38,3 +38,9 @@ Split from TASK-596 AC #5. The browser's deletion flow reports lease blockers ho
 4. Test-drive one lease-enforced deletion retry with policy recheck and distinct path-private UI states.
 5. Run focused tests, required mutations, static checks, Ponytail/correctness review, and close the task only after all criteria pass.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented exact idle resident recycling through the app-owned local STT executor. The worker reports its verified managed lease closure; active and unrelated residents refuse recycling; Installed deletion shows path-private recovery states, rechecks policy, and retries the lease-enforced delete once. Focused STT, app, mounted UI, mutation, Ruff, compile, format-range, and diff checks passed. ADR-025 remains governing; no new ADR was required.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2061 - Idle-heavy-worker-recycle-for-managed-model-deletion.md
+++ b/backlog/tasks/task-2061 - Idle-heavy-worker-recycle-for-managed-model-deletion.md
@@ -1,14 +1,17 @@
 ---
 id: TASK-2061
 title: Idle heavy-worker recycle for managed model deletion
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-03 20:11'
+updated_date: '2026-08-12 20:25'
 labels:
   - stt
   - artifacts
   - architecture
 dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-08-12-task-2061-idle-worker-recycle-design.md
 priority: medium
 ---
 

--- a/tldw_chatbook/STT/executor.py
+++ b/tldw_chatbook/STT/executor.py
@@ -53,6 +53,8 @@ def _require_nonempty_text(field_name: str, value: str) -> None:
 
 def _canonical_dependency_refs(
     references: tuple[tuple[str, str, str], ...],
+    *,
+    field_name: str = "managed_dependency_refs",
 ) -> tuple[tuple[str, str, str], ...]:
     if type(references) is not tuple or any(
         type(reference) is not tuple
@@ -63,7 +65,7 @@ def _canonical_dependency_refs(
         )
         for reference in references
     ):
-        raise ValueError("managed_dependency_refs must contain three-string tuples")
+        raise ValueError(f"{field_name} must contain three-string tuples")
     return tuple(sorted(set(references)))
 
 
@@ -314,11 +316,20 @@ class ExecutorResident:
     generation: int
     attempt_id: str
     identity: ModelIdentity
+    managed_lease_refs: tuple[tuple[str, str, str], ...] = ()
 
     def __post_init__(self) -> None:
         _require_generation_and_attempt(self.generation, self.attempt_id)
         if type(self.identity) is not ModelIdentity:
             raise TypeError("identity must be a ModelIdentity")
+        object.__setattr__(
+            self,
+            "managed_lease_refs",
+            _canonical_dependency_refs(
+                self.managed_lease_refs,
+                field_name="managed_lease_refs",
+            ),
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/tldw_chatbook/STT/executor.py
+++ b/tldw_chatbook/STT/executor.py
@@ -676,7 +676,14 @@ class LocalSTTExecutor:
         self,
         reference: tuple[str, str, str],
     ) -> bool:
-        """Retire an idle resident that leases one exact managed artifact."""
+        """Retire an idle resident that leases one exact managed artifact.
+
+        Args:
+            reference: Canonical artifact ID, revision, and variant.
+
+        Returns:
+            True only when a matching idle generation is proven retired.
+        """
 
         canonical = _canonical_dependency_refs(
             (reference,),

--- a/tldw_chatbook/STT/executor.py
+++ b/tldw_chatbook/STT/executor.py
@@ -489,6 +489,7 @@ class LocalSTTExecutor:
         self._terminal_guard: _AttemptTerminalGuard | None = None
         self._resident_identity: ModelIdentity | None = None
         self._resident_dependency_refs: tuple[tuple[str, str, str], ...] = ()
+        self._resident_lease_refs: tuple[tuple[str, str, str], ...] = ()
         self._unhealthy_identity: ModelIdentity | None = None
         self._latest_phase: WorkerPhase | None = None
         self._completed_jobs = 0
@@ -671,6 +672,28 @@ class LocalSTTExecutor:
 
         return self._retirement_complete.wait(timeout)
 
+    def recycle_idle_managed_reference(
+        self,
+        reference: tuple[str, str, str],
+    ) -> bool:
+        """Retire an idle resident that leases one exact managed artifact."""
+
+        canonical = _canonical_dependency_refs(
+            (reference,),
+            field_name="reference",
+        )[0]
+        with self._lock:
+            if (
+                self._closed
+                or self._unavailable
+                or self._busy
+                or self._retiring
+                or self._resident_identity is None
+                or canonical not in self._resident_lease_refs
+            ):
+                return False
+            return self._retire_idle_worker_locked()
+
     def clear_unhealthy_identity(self, identity: ModelIdentity) -> bool:
         """Clear the one session-local unhealthy identity for explicit retry."""
 
@@ -690,6 +713,7 @@ class LocalSTTExecutor:
                 self._clear_active_locked()
                 detached = self._detach_worker_locked()
                 self._resident_dependency_refs = ()
+                self._resident_lease_refs = ()
             retirement = self._retirement_thread
         if detached is not None:
             self._terminate_detached(detached, update_state=False)
@@ -780,6 +804,7 @@ class LocalSTTExecutor:
         self._scratch_path = scratch_path
         self._resident_identity = None
         self._resident_dependency_refs = ()
+        self._resident_lease_refs = ()
         self._completed_jobs = 0
         reader = threading.Thread(
             target=self._reader_loop,
@@ -829,6 +854,7 @@ class LocalSTTExecutor:
                     return
                 self._resident_identity = envelope.identity
                 self._resident_dependency_refs = request.managed_dependency_refs
+                self._resident_lease_refs = envelope.managed_lease_refs
             elif type(envelope) in {ExecutorResult, ExecutorFailure}:
                 if not self._matches_active(envelope):
                     return
@@ -1045,6 +1071,7 @@ class LocalSTTExecutor:
         self._reader_thread = None
         self._resident_identity = None
         self._resident_dependency_refs = ()
+        self._resident_lease_refs = ()
         self._completed_jobs = 0
         return detached
 

--- a/tldw_chatbook/STT/executor_worker.py
+++ b/tldw_chatbook/STT/executor_worker.py
@@ -56,6 +56,7 @@ class _ResidentRuntime:
     managed_store_root: Path | None
     managed_artifact_ref: tuple[str, str, str] | None
     managed_dependency_refs: tuple[tuple[str, str, str], ...]
+    managed_lease_refs: tuple[tuple[str, str, str], ...]
     lease: Any | None = None
     reported: bool = False
 
@@ -316,6 +317,18 @@ def _load_resident(
         if lease is not None:
             lease.close()
         raise
+    if handle is None:
+        managed_lease_refs = ()
+    elif request.managed_artifact_ref is not None:
+        managed_lease_refs = tuple(
+            (reference.artifact_id, reference.revision, reference.variant)
+            for reference in handle.closure
+        )
+    else:
+        managed_lease_refs = tuple(
+            (reference.artifact_id, reference.revision, reference.variant)
+            for reference in handle.references
+        )
     return _ResidentRuntime(
         identity=request.identity,
         provider=provider,
@@ -329,6 +342,7 @@ def _load_resident(
         ),
         managed_artifact_ref=request.managed_artifact_ref,
         managed_dependency_refs=request.managed_dependency_refs,
+        managed_lease_refs=managed_lease_refs,
         lease=lease,
     )
 
@@ -860,6 +874,7 @@ def _run_executor_worker(
                             generation,
                             request.attempt_id,
                             request.identity,
+                            resident.managed_lease_refs,
                         )
                     )
                     resident.reported = True

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -615,6 +615,7 @@ class LLMManagementWindow(Container):
                 legacy_dir=legacy_dir,
                 on_root_activated=source_service.on_root_activated,
                 may_delete=source_service.may_delete,
+                recycle_idle=self.app_instance._recycle_idle_local_stt_reference,
                 id="installed-models-view",
             )
         )

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -542,12 +542,13 @@ class InstalledView(Widget):
                 return
             try:
                 recycled = self._recycle_idle(reference)
-            except Exception:
+            except Exception as recycle_exc:
                 logger.error(
-                    "Managed model idle recycle failed for {}@{}/{}",
+                    "Managed model idle recycle failed for {}@{}/{}; error_type={}",
                     reference.artifact_id,
                     reference.revision,
                     reference.variant,
+                    type(recycle_exc).__name__,
                 )
                 self.app.call_from_thread(
                     self._apply_lifecycle_result,

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -131,6 +131,7 @@ class InstalledView(Widget):
         legacy_dir: Path | None = None,
         on_root_activated: Callable[[ArtifactRef], None] | None = None,
         may_delete: Callable[[ArtifactRef], str | None] | None = None,
+        recycle_idle: Callable[[ArtifactRef], bool] | None = None,
         id: str | None = None,
     ) -> None:
         """Create an idle view; no filesystem work occurs here.
@@ -140,12 +141,14 @@ class InstalledView(Widget):
             legacy_dir: Legacy downloader directory to scan on activation.
             on_root_activated: Called after successful core activation.
             may_delete: Return a user-visible reason to block deletion.
+            recycle_idle: Retire an idle worker that leases the exact artifact.
             id: Optional Textual widget id.
         """
         self._service_factory = service_factory
         self._legacy_dir = legacy_dir or Path("~/Downloads/tldw_models").expanduser()
         self._on_root_activated = on_root_activated or (lambda _reference: None)
         self._may_delete = may_delete or (lambda _reference: None)
+        self._recycle_idle = recycle_idle or (lambda _reference: False)
         self._service: ModelArtifactService | None = None
         self._rows: tuple[InventoryRow, ...] = ()
         self._usage: ArtifactDiskUsage | None = None

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -49,6 +49,10 @@ if TYPE_CHECKING:
 MAX_UNMANAGED_MODELS = 500
 _MODEL_EXTENSIONS = frozenset({".gguf", ".bin", ".safetensors", ".pt", ".pth", ".onnx"})
 _MIN_LEGACY_MODEL_BYTES = 1024 * 1024
+_DELETE_RECOVERY_TEXT = {
+    "recycle-check": "Checking for an idle model to unload…",
+    "recycle-retry": "Idle model unloaded; retrying deletion…",
+}
 
 
 def lifecycle_failure_message(exc: BaseException, *, operation: str) -> str:
@@ -148,7 +152,9 @@ class InstalledView(Widget):
         self._legacy_dir = legacy_dir or Path("~/Downloads/tldw_models").expanduser()
         self._on_root_activated = on_root_activated or (lambda _reference: None)
         self._may_delete = may_delete or (lambda _reference: None)
-        self._recycle_idle = recycle_idle or (lambda _reference: False)
+        self._recycle_idle = (
+            recycle_idle if recycle_idle is not None else lambda _reference: False
+        )
         self._service: ModelArtifactService | None = None
         self._rows: tuple[InventoryRow, ...] = ()
         self._usage: ArtifactDiskUsage | None = None
@@ -277,6 +283,16 @@ class InstalledView(Widget):
         if row.size_bytes is not None:
             children.append(Static(f"Size: {format_mib(row.size_bytes)}"))
         children.append(Static(row.action_hint, markup=False))
+        if row.reference == self._operation_reference:
+            recovery_text = _DELETE_RECOVERY_TEXT.get(self._operation_name or "")
+            if recovery_text is not None:
+                children.append(
+                    Static(
+                        recovery_text,
+                        classes="installed-model-muted",
+                        markup=False,
+                    )
+                )
         if row.reference is not None and not row.is_broken:
             children.append(
                 ModelActivationControls(
@@ -513,23 +529,104 @@ class InstalledView(Widget):
 
     @work(thread=True, group="installed_models_lifecycle", exclusive=True, exit_on_error=False)
     def _delete_model(self, reference: ArtifactRef) -> None:
-        """Delete one exact model without bypassing service leases."""
+        """Delete one exact model, retrying once after proven idle recycle."""
         try:
-            self._service_for_worker().delete(reference)
+            service = self._service_for_worker()
+            service.delete(reference)
+        except ArtifactInUseError as exc:
+            if not self.app.call_from_thread(
+                self._set_delete_phase,
+                reference,
+                "recycle-check",
+            ):
+                return
+            try:
+                recycled = self._recycle_idle(reference)
+            except Exception:
+                logger.error(
+                    "Managed model idle recycle failed for {}@{}/{}",
+                    reference.artifact_id,
+                    reference.revision,
+                    reference.variant,
+                )
+                self.app.call_from_thread(
+                    self._apply_lifecycle_result,
+                    "delete",
+                    "Model deletion failed. See the application log for details.",
+                )
+                return
+            if not recycled:
+                self._finish_delete_failure(reference, exc)
+                return
+            if not self.app.call_from_thread(self._prepare_delete_retry, reference):
+                return
+            try:
+                service.delete(reference)
+            except Exception as retry_exc:
+                self._finish_delete_failure(reference, retry_exc)
+                return
         except Exception as exc:
+            self._finish_delete_failure(reference, exc)
+            return
+        self.app.call_from_thread(self._apply_lifecycle_result, "delete", None)
+
+    def _finish_delete_failure(
+        self,
+        reference: ArtifactRef,
+        exc: BaseException,
+    ) -> None:
+        """Report one final delete failure without exposing lease details."""
+        if isinstance(exc, ArtifactInUseError):
+            logger.warning(
+                "Managed model deletion blocked by a lease for {}@{}/{}",
+                reference.artifact_id,
+                reference.revision,
+                reference.variant,
+            )
+        else:
             logger.opt(exception=True).error(
                 "Managed model deletion failed for {}@{}/{}",
                 reference.artifact_id,
                 reference.revision,
                 reference.variant,
             )
-            self.app.call_from_thread(
-                self._apply_lifecycle_result,
-                "delete",
-                lifecycle_failure_message(exc, operation="deletion"),
-            )
-            return
-        self.app.call_from_thread(self._apply_lifecycle_result, "delete", None)
+        self.app.call_from_thread(
+            self._apply_lifecycle_result,
+            "delete",
+            lifecycle_failure_message(exc, operation="deletion"),
+        )
+
+    def _set_delete_phase(
+        self,
+        reference: ArtifactRef,
+        phase: str,
+    ) -> bool:
+        """Paint one current delete-recovery phase on the event loop."""
+        if self._operation_reference != reference or self._operation_name not in {
+            "delete",
+            "recycle-check",
+            "recycle-retry",
+        }:
+            return False
+        self._operation_name = phase
+        self.refresh(recompose=True)
+        return True
+
+    def _prepare_delete_retry(self, reference: ArtifactRef) -> bool:
+        """Recheck source policy and authorize one deletion retry."""
+        if (
+            self._operation_reference != reference
+            or self._operation_name != "recycle-check"
+        ):
+            return False
+        blocked = self._may_delete(reference)
+        if blocked is not None:
+            self._operation_reference = None
+            self._operation_name = None
+            self.notify(blocked, severity="warning")
+            self.ensure_loaded(force=True)
+            return False
+        return self._set_delete_phase(reference, "recycle-retry")
 
     @work(thread=True, group="installed_models_lifecycle", exclusive=True, exit_on_error=False)
     def _repair_store(self) -> None:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -608,6 +608,7 @@ from tldw_chatbook.Audio_Services_Interop import (  # noqa: E402
 from .Evals.eval_orchestrator import EvaluationOrchestrator  # noqa: E402
 
 if TYPE_CHECKING:
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
     from tldw_chatbook.LLM_Provider_Catalog.model_discovery_disk_cache import (
         ModelCatalogDiskStore,
     )
@@ -2880,6 +2881,19 @@ class LibraryIngestQueueMixin:
                 executor = self._create_local_stt_executor()
                 self._local_stt_executor = executor
             return executor
+
+    def _recycle_idle_local_stt_reference(self, reference: "ArtifactRef") -> bool:
+        """Recycle an existing idle STT resident that leases ``reference``."""
+
+        with self._local_stt_executor_lock:
+            if self._ingest_shutdown:
+                return False
+            executor = getattr(self, "_local_stt_executor", None)
+        if executor is None:
+            return False
+        return executor.recycle_idle_managed_reference(
+            (reference.artifact_id, reference.revision, reference.variant)
+        )
 
     def _create_parakeet_source_service(self) -> Any:
         """Construct the shared download-free Parakeet source service lazily."""


### PR DESCRIPTION
## Summary
- report each resident STT worker's verified managed artifact lease closure
- recycle only exact idle residents through the existing app-owned executor
- retry confirmed managed-model deletion once with policy recheck and distinct path-private UI states

## Safety
- active work, unrelated residents, and unproven worker retirement fail closed
- deletion continues to use normal artifact leases and never bypasses or cancels active work
- the Models surface never creates an executor solely for deletion

## Test plan
- [x] 222 affected tests passed
- [x] required active/reference/closure/retry mutations failed before restoration
- [x] Ruff checks passed
- [x] production modules compiled
- [x] changed-range Ruff formatting and git diff checks passed

Closes TASK-2061

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recycles idle local STT residents so managed-model deletions can proceed. Previously an idle resident held leases and blocked deletion; now the UI requests an exact idle unload via the app-owned executor, rechecks policy, and retries `ModelArtifactService.delete()` once without creating an executor or cancelling work.

- Worker reports the verified managed lease set via `ExecutorResident.managed_lease_refs` (closure for managed roots; references for external roots); parent tracks `_resident_lease_refs`.
- Adds `LocalSTTExecutor.recycle_idle_managed_reference((artifact_id, revision, variant))`: lock-guarded; succeeds only when idle, exact lease match, and proven retirement; never cancels active work or bypasses leases.
- App exposes `_recycle_idle_local_stt_reference` that forwards to an existing executor; the Models surface never constructs an executor.
- Installed view handles the first `ArtifactInUseError`: shows “Checking for an idle model to unload…” then “Idle model unloaded; retrying deletion…”, rechecks `may_delete`, retries once, and logs lease blockers with bounded artifact identity only; unexpected recycle errors are sanitized.
- Focused tests cover worker-reported leases, idle recycle for roots/dependencies, active/nonmatching refusal, unproven retirement, app wiring, policy recheck, single-retry bound, and UI privacy.

Satisfies TASK-2061 acceptance criteria; adds design and plan docs. No migrations or service API changes.

<sup>Written for commit 8986b4d66349e7982e38ecf581543865885cde5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

