### PR TITLE
perf(library): scope frequent updates to canvases

### DIFF
--- a/Tests/UI/test_library_canvas_scoped_sync.py
+++ b/Tests/UI/test_library_canvas_scoped_sync.py
@@ -388,6 +388,12 @@ def test_import_status_lines_patch_the_mounted_static_without_recompose() -> Non
         LibraryScreen._apply_library_prompts_import_status(
             prompt_screen, "2 imported"
         )
+        prompt_screen._library_selected_row_id = (
+            library_screen_module.LIBRARY_ROW_BROWSE_NOTES
+        )
+        LibraryScreen._apply_library_prompts_import_status(
+            prompt_screen, "Imported after navigation"
+        )
         LibraryScreen._apply_library_skills_import_status(skill_screen, "Imported")
         skill_screen._library_selected_row_id = (
             library_screen_module.LIBRARY_ROW_BROWSE_NOTES
@@ -398,6 +404,7 @@ def test_import_status_lines_patch_the_mounted_static_without_recompose() -> Non
 
     prompt_line.update.assert_called_once_with("2 imported")
     skill_line.update.assert_called_once_with("Imported")
+    assert prompt_screen._library_prompts_import_status == "Imported after navigation"
     assert skill_screen._library_skills_import_status == "Imported after navigation"
 
 

--- a/Tests/UI/test_library_canvas_scoped_sync.py
+++ b/Tests/UI/test_library_canvas_scoped_sync.py
@@ -1,0 +1,441 @@
+"""TASK-15457: Library per-click canvas-scoped update evidence."""
+
+from __future__ import annotations
+
+from statistics import median
+from time import perf_counter
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Static
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.Skills.test_skills_library_flow import (
+    _real_skills_scope_service,
+    _skill_content,
+    _wire_empty_non_skill_services,
+)
+from Tests.UI.test_library_prompts_canvas import (
+    _real_prompt_scope_service,
+    _wire_empty_non_prompt_services,
+)
+from Tests.UI.test_library_shell import (
+    LIBRARY_TEST_SIZE,
+    LibraryHarness,
+    _active_library_screen,
+    _seed_conversations,
+    _two_conversations,
+    _two_media_items,
+    _two_notes,
+    _wait_for_library_shell,
+    _wait_for_selector,
+)
+from tldw_chatbook.Library.library_ingest_state import LibraryIngestFormState
+from tldw_chatbook.Library.library_notes_sync_state import auto_sync_label
+from tldw_chatbook.UI.Navigation.base_app_screen import BaseAppScreen
+from tldw_chatbook.UI.Screens import library_screen as library_screen_module
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Widgets.Library import (
+    LibraryMediaCanvas,
+    LibraryNotesCanvas,
+    LibraryPromptsListCanvas,
+    LibrarySearchRagPanel,
+    LibrarySkillsListCanvas,
+)
+
+
+def _screen_recompose_spy() -> tuple[list[BaseAppScreen], object]:
+    """Return a call list and a spy that preserves normal refresh behavior."""
+    calls: list[BaseAppScreen] = []
+    original = BaseAppScreen.refresh
+
+    def spy(self, *args, **kwargs):
+        if kwargs.get("recompose"):
+            calls.append(self)
+        return original(self, *args, **kwargs)
+
+    return calls, spy
+
+
+async def _wait_for_widget_text(
+    screen: LibraryScreen,
+    pilot,
+    selector: str,
+    expected: str,
+    *,
+    attempts: int = 80,
+) -> None:
+    """Wait for a recomposed widget to expose its new visible state."""
+    for _ in range(attempts):
+        matches = list(screen.query(selector))
+        if matches:
+            widget = matches[0]
+            visible = getattr(widget, "label", getattr(widget, "renderable", ""))
+            if expected in str(visible):
+                return
+        await pilot.pause(0.02)
+    raise AssertionError(f"{selector} did not render {expected!r}")
+
+
+@pytest.mark.asyncio
+async def test_loading_surfaces_keep_unicode_copy_and_notes_sync_hook() -> None:
+    """Canvas-owned loading views retain their user-facing glyphs and copy."""
+
+    class LoadingCanvasApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield LibraryNotesCanvas(mode="loading", id="notes")
+            yield LibraryPromptsListCanvas(mode="loading", id="prompts")
+            yield LibrarySkillsListCanvas(mode="loading", id="skills")
+
+    app = LoadingCanvasApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        notes = app.query_one("#notes", LibraryNotesCanvas)
+        assert callable(notes.sync_state)
+        assert str(app.query_one("#library-note-back", Button).label) == "‹ Notes"
+        assert str(app.query_one("#library-note-loading", Static).renderable) == (
+            "Loading note…"
+        )
+        assert str(app.query_one("#library-prompt-loading", Static).renderable) == (
+            "Loading prompt…"
+        )
+        assert str(app.query_one("#library-skill-loading", Static).renderable) == (
+            "Loading skill…"
+        )
+
+
+@pytest.mark.asyncio
+async def test_notes_per_click_updates_keep_screen_and_canvas_identity() -> None:
+    """Notes toggle/select/sort interactions never remount the Library shell."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-select-toggle")
+        rail_before = screen.query_one("#library-rail")
+        canvas_before = screen.query_one("#library-notes-canvas", LibraryNotesCanvas)
+        calls, spy = _screen_recompose_spy()
+
+        with patch.object(BaseAppScreen, "refresh", spy):
+            screen.query_one("#library-notes-select-toggle").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-select-all")
+            screen.query_one("#library-notes-select-all").press()
+            await _wait_for_widget_text(
+                screen, pilot, "#library-notes-selected-count", "2 selected"
+            )
+            assert screen._library_notes_row_selection.count == 2
+            screen.query_one("#library-notes-select-toggle").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-sort")
+            screen.query_one("#library-notes-sort").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-sort-oldest")
+            screen.query_one("#library-notes-sort-oldest").press()
+            await _wait_for_widget_text(
+                screen, pilot, "#library-notes-sort", "Oldest"
+            )
+            screen.query_one("#library-notes-sync-open").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-sync-folder")
+            screen.query_one(
+                "#library-notes-sync-direction-disk_to_db"
+            ).press()
+            await _wait_for_widget_text(
+                screen,
+                pilot,
+                "#library-notes-sync-direction-disk_to_db",
+                "✓",
+            )
+            screen.query_one("#library-notes-sync-conflict-disk_wins").press()
+            await _wait_for_widget_text(
+                screen,
+                pilot,
+                "#library-notes-sync-conflict-disk_wins",
+                "✓",
+            )
+            screen.query_one("#library-notes-sync-auto").press()
+            await _wait_for_widget_text(
+                screen, pilot, "#library-notes-sync-auto", auto_sync_label(True)
+            )
+            screen.query_one("#library-notes-sync-auto").press()
+            await _wait_for_widget_text(
+                screen, pilot, "#library-notes-sync-auto", auto_sync_label(False)
+            )
+            screen.query_one("#library-notes-sync-back").press()
+            await _wait_for_selector(screen, pilot, "#library-notes-sync-open")
+            screen.query_one("#library-notes-row-0").press()
+            await _wait_for_selector(screen, pilot, "#library-note-title")
+
+        assert calls == []
+        assert screen.query_one("#library-rail") is rail_before
+        assert (
+            screen.query_one("#library-notes-canvas", LibraryNotesCanvas)
+            is canvas_before
+        )
+        assert screen._library_notes_sort == "oldest"
+
+
+@pytest.mark.asyncio
+async def test_media_choice_and_rag_toggles_are_canvas_scoped() -> None:
+    """Media chooser/Escape and Search/RAG toggles preserve shell identity."""
+    app = _build_test_app()
+    _seed_conversations(
+        app,
+        _two_conversations(),
+        notes=_two_notes(),
+        media=_two_media_items(),
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        screen.query_one("#library-row-browse-media").press()
+        await _wait_for_selector(screen, pilot, "#library-media-type-filter")
+        media_rail = screen.query_one("#library-rail")
+        media_canvas = screen.query_one("#library-media-canvas", LibraryMediaCanvas)
+        calls, spy = _screen_recompose_spy()
+        with patch.object(BaseAppScreen, "refresh", spy):
+            screen.query_one("#library-media-type-filter").press()
+            await _wait_for_selector(screen, pilot, "#library-media-type-choice-1")
+            await pilot.press("escape")
+            await _wait_for_selector(screen, pilot, "#library-media-type-filter")
+        assert calls == []
+        assert screen.query_one("#library-rail") is media_rail
+        assert screen.query_one("#library-media-canvas", LibraryMediaCanvas) is media_canvas
+
+        screen.query_one("#library-row-browse-search").press()
+        await _wait_for_selector(screen, pilot, "#library-rag-mode-toggle")
+        rag_rail = screen.query_one("#library-rail")
+        rag_panel = screen.query_one("#library-search-rag-panel", LibrarySearchRagPanel)
+        calls.clear()
+        with patch.object(BaseAppScreen, "refresh", spy):
+            screen.query_one("#library-rag-mode-toggle").press()
+            await pilot.pause()
+            screen.query_one("#library-rag-scope-toggle-media").press()
+            await pilot.pause()
+        assert calls == []
+        assert screen.query_one("#library-rail") is rag_rail
+        assert (
+            screen.query_one("#library-search-rag-panel", LibrarySearchRagPanel)
+            is rag_panel
+        )
+
+
+@pytest.mark.asyncio
+async def test_prompt_and_skill_row_handlers_route_to_their_canvas() -> None:
+    """The two list-to-loading row transitions use their canvas hook."""
+    kinds: list[str] = []
+
+    async def permitted() -> bool:
+        return True
+
+    skill_screen = SimpleNamespace(
+        _flush_library_skill_save=permitted,
+        _notify_skill_dirty_veto=Mock(),
+        _reset_library_skill_editor_state=Mock(),
+        _selected_skill_name="",
+        _library_selected_row_id="",
+        _library_skills_view="list",
+        run_worker=Mock(),
+    )
+    skill_event = SimpleNamespace(
+        stop=Mock(), button=SimpleNamespace(skill_name=None)
+    )
+    prompt_screen = SimpleNamespace(
+        _library_prompts_mutation_in_flight=False,
+        _flush_library_prompt_save=permitted,
+        _invalidate_library_prompts_browse=Mock(),
+        _reset_library_prompt_editor_state=Mock(),
+        _selected_prompt_id=None,
+        _library_selected_row_id="",
+        _library_prompts_view="list",
+        run_worker=Mock(),
+    )
+    prompt_event = SimpleNamespace(
+        stop=Mock(), button=SimpleNamespace(prompt_id=None)
+    )
+
+    with patch.object(
+        library_screen_module,
+        "_sync_library_canvas",
+        side_effect=lambda _screen, kind: kinds.append(kind),
+    ):
+        await LibraryScreen.handle_library_skill_row(skill_screen, skill_event)
+        await LibraryScreen.handle_library_prompt_row(prompt_screen, prompt_event)
+
+    assert kinds == ["skills", "prompts"]
+    assert skill_screen._library_skills_view == "editor"
+    assert prompt_screen._library_prompts_view == "editor"
+
+
+@pytest.mark.asyncio
+async def test_real_prompt_and_skill_rows_keep_their_canvas_identity(tmp_path) -> None:
+    """Real service-backed list-to-editor loads avoid the screen fallback."""
+    prompt_path = tmp_path / "prompts"
+    prompt_path.mkdir()
+    prompt_db, prompt_service = _real_prompt_scope_service(prompt_path)
+    prompt_id, _uuid, _message = prompt_db.add_prompt(
+        name="Scoped prompt",
+        author="Test",
+        details="Canvas identity probe",
+        system_prompt="Stay concise.",
+        user_prompt="Summarize {text}",
+        keywords=["test"],
+    )
+    prompt_app = _build_test_app()
+    _wire_empty_non_prompt_services(prompt_app)
+    prompt_app.prompt_scope_service = prompt_service
+    prompt_host = LibraryHarness(prompt_app)
+
+    async with prompt_host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(prompt_host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-prompts").press()
+        row = await _wait_for_selector(
+            screen, pilot, f"#library-prompt-row-{prompt_id}"
+        )
+        canvas = screen.query_one("#library-prompts-canvas")
+        calls, spy = _screen_recompose_spy()
+        with patch.object(BaseAppScreen, "refresh", spy):
+            row.press()
+            await _wait_for_selector(screen, pilot, "#library-prompt-name")
+        assert calls == []
+        assert screen.query_one("#library-prompts-canvas") is canvas
+
+    skill_path = tmp_path / "skills"
+    skill_path.mkdir()
+    local_skills, skills_service = _real_skills_scope_service(skill_path)
+    await local_skills.create_skill(
+        name="scoped-skill",
+        content=_skill_content(title="Scoped", description="Identity probe"),
+    )
+    skills_app = _build_test_app()
+    _wire_empty_non_skill_services(skills_app)
+    skills_app.skills_scope_service = skills_service
+    skills_app.local_skill_trust_service = None
+    skills_host = LibraryHarness(skills_app)
+
+    async with skills_host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(skills_host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-skills").press()
+        row = await _wait_for_selector(
+            screen, pilot, "#library-skill-row-scoped-skill"
+        )
+        canvas = screen.query_one("#library-skills-canvas")
+        calls, spy = _screen_recompose_spy()
+        with patch.object(BaseAppScreen, "refresh", spy):
+            row.press()
+            await _wait_for_selector(screen, pilot, "#library-skill-name")
+        assert calls == []
+        assert screen.query_one("#library-skills-canvas") is canvas
+
+
+def test_ingest_checkbox_routes_to_ingest_canvas_sync() -> None:
+    """A structural ingest checkbox edit rebuilds only the ingest canvas."""
+    kinds: list[str] = []
+    form = LibraryIngestFormState()
+    screen = SimpleNamespace(
+        _library_ingest_form=form,
+        _invalidate_library_external_submission=Mock(),
+        _disarm_library_ingest_start_confirm=Mock(),
+        _disarm_library_ingest_retry_confirm=Mock(),
+    )
+    event = SimpleNamespace(
+        stop=Mock(), group="generic", name="analyze", value=True
+    )
+    with patch.object(
+        library_screen_module,
+        "_sync_library_canvas",
+        side_effect=lambda _screen, kind: kinds.append(kind),
+    ):
+        LibraryScreen.handle_library_ingest_option_value_changed(screen, event)
+
+    assert kinds == ["ingest"]
+    assert form.analyze is True
+    assert form.type_options["generic"]["analyze"] is True
+
+
+def test_import_status_lines_patch_the_mounted_static_without_recompose() -> None:
+    """One-line Prompt/Skill receipts update their existing Static only."""
+    prompt_line = SimpleNamespace(update=Mock())
+    prompt_screen = SimpleNamespace(
+        is_mounted=True,
+        _library_selected_row_id=library_screen_module.LIBRARY_ROW_BROWSE_PROMPTS,
+        _library_prompts_import_status="",
+        query_one=Mock(return_value=prompt_line),
+    )
+    prompt_screen.app = SimpleNamespace(screen=prompt_screen)
+    skill_line = SimpleNamespace(update=Mock())
+    skill_screen = SimpleNamespace(
+        is_mounted=True,
+        _library_selected_row_id=library_screen_module.LIBRARY_ROW_BROWSE_SKILLS,
+        _library_skills_import_status="",
+        query_one=Mock(return_value=skill_line),
+    )
+    skill_screen.app = SimpleNamespace(screen=skill_screen)
+
+    with patch.object(
+        library_screen_module,
+        "_sync_library_canvas",
+        side_effect=AssertionError("mounted status line must not recompose"),
+    ):
+        LibraryScreen._apply_library_prompts_import_status(
+            prompt_screen, "2 imported"
+        )
+        LibraryScreen._apply_library_skills_import_status(skill_screen, "Imported")
+        skill_screen._library_selected_row_id = (
+            library_screen_module.LIBRARY_ROW_BROWSE_NOTES
+        )
+        LibraryScreen._apply_library_skills_import_status(
+            skill_screen, "Imported after navigation"
+        )
+
+    prompt_line.update.assert_called_once_with("2 imported")
+    skill_line.update.assert_called_once_with("Imported")
+    assert skill_screen._library_skills_import_status == "Imported after navigation"
+
+
+@pytest.mark.asyncio
+async def test_notes_select_toggle_latency_probe() -> None:
+    """Measure the mounted Notes toggle with an identical before/after probe.
+
+    The task records the median externally; this test deliberately has no
+    timing threshold because wall-clock assertions are not stable CI evidence.
+    Its behavioral assertion is that every measured click completes the
+    expected list/select-mode transition.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+    samples: list[float] = []
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-select-toggle")
+
+        for index in range(12):
+            started = perf_counter()
+            screen.query_one("#library-notes-select-toggle").press()
+            expected = (
+                "#library-notes-select-all"
+                if index % 2 == 0
+                else "#library-notes-sort"
+            )
+            await _wait_for_selector(screen, pilot, expected)
+            samples.append((perf_counter() - started) * 1000.0)
+
+    assert len(samples) == 12
+    assert all(sample > 0 for sample in samples)
+    print(
+        "TASK-15457 notes-toggle latency: "
+        f"median={median(samples):.3f}ms samples="
+        + ",".join(f"{sample:.3f}" for sample in samples)
+    )

--- a/Tests/Widgets/Library/test_library_notes_canvas.py
+++ b/Tests/Widgets/Library/test_library_notes_canvas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from textual.widgets import Static
 
-from Tests.textual_test_utils import widget_pilot
+from Tests.textual_test_utils import widget_pilot  # noqa: F401
 from tldw_chatbook.Library.library_notes_state import LibraryNotesListState
 from tldw_chatbook.Library.library_notes_sync_state import LibraryNotesSyncState
 from tldw_chatbook.Widgets.Library.library_notes_canvas import LibraryNotesCanvas
@@ -38,7 +38,7 @@ def _sync_state() -> LibraryNotesSyncState:
 # concepts never related anywhere -- one placement sentence per surface.
 
 
-async def test_database_mode_list_carries_a_placement_sentence(widget_pilot):
+async def test_database_mode_list_carries_a_placement_sentence(widget_pilot):  # noqa: F811
     async with await widget_pilot(
         LibraryNotesCanvas,
         list_state=_list_state(),
@@ -53,11 +53,11 @@ async def test_database_mode_list_carries_a_placement_sentence(widget_pilot):
         assert "Sync" in text
 
 
-async def test_sync_mode_placement_sentence_names_files_mode(widget_pilot):
+async def test_sync_mode_placement_sentence_names_files_mode(widget_pilot):  # noqa: F811
     async with await widget_pilot(
         LibraryNotesCanvas,
         mode="sync",
-        sync_state=_sync_state(),
+        sync_panel_state=_sync_state(),
     ) as pilot:
         await pilot.pause()
         purpose = pilot.app.query_one(

--- a/backlog/tasks/task-15457 - Library---convert-per-click-whole-screen-recomposes-to-canvas-scoped-sync.md
+++ b/backlog/tasks/task-15457 - Library---convert-per-click-whole-screen-recomposes-to-canvas-scoped-sync.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15457
 title: Library: convert per-click whole-screen recomposes to canvas-scoped sync
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - codex
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -20,7 +21,28 @@ Fix direction: rename the shadowing param to unblock the targeted hook; extend t
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 None of the confirmed per-click interactions (notes row/toggles, sort/filter strips, media-type chooser, ingest toggles, RAG toggles, status lines) triggers a whole-screen recompose (evidence per site class)
-- [ ] #2 The LibraryNotesCanvas targeted hook is unblocked and used; behavior of every converted surface unchanged (tests)
-- [ ] #3 Remaining recompose site count re-measured and recorded; per-click latency before/after on the notes canvas
+- [x] #1 None of the confirmed per-click interactions (notes row/toggles, sort/filter strips, media-type chooser, ingest toggles, RAG toggles, status lines) triggers a whole-screen recompose (evidence per site class)
+- [x] #2 The LibraryNotesCanvas targeted hook is unblocked and used; behavior of every converted surface unchanged (tests)
+- [x] #3 Remaining recompose site count re-measured and recorded; per-click latency before/after on the notes canvas
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Record the current statement-level screen-recompose count and a mounted Library Notes per-click baseline, then add characterization tests for each confirmed interaction class.
+2. Rename the Notes sync-panel constructor field that shadows the canvas update method, add a canvas-owned state update hook, and extend `_sync_library_canvas` to build and route Notes state without remounting the Library screen.
+3. Convert the confirmed Media, Notes, Prompts, Skills, Ingest, Search/RAG, choice-strip, notes-sync, and status-line handlers to the narrowest mounted canvas or child-region update that preserves existing controls, focus behavior, and state ownership.
+4. Run focused mounted tests after each slice, record the remaining recompose count and identical before/after Notes latency probe, then run the full relevant Library UI suite serially.
+5. Perform a self-review and isolated live UAT at the supported terminal sizes; document implementation evidence, deviations, and any generalizable testing lesson.
+
+ADR required: no
+ADR path: N/A
+Reason: this task applies the existing Library screen/rail/canvas ownership and targeted-update pattern without changing storage, service contracts, security boundaries, dependencies, or long-lived application structure.
+
+## Implementation Notes
+
+- Extended the existing Library canvas-sync seam to Notes, Prompts, Skills, Ingest, Search/RAG, and Export, with complete screen-owned snapshots and canvas-local recomposition. Renamed the Notes sync-panel field so `LibraryNotesCanvas.sync_state()` is callable, and moved Notes/Prompt/Skill loading views into their owning canvases so list-to-editor loads preserve shell, rail, and canvas identity.
+- Converted the confirmed per-click Notes row/select/sort/filter/sync paths, Prompt and Skill rows/sort/filter paths, Media type chooser, Ingest structural options, Search/RAG toggles, choice-strip close, and import status receipts. Status receipts patch their mounted `Static` in place; asynchronous receipts arriving after navigation are retained without recomposing an unrelated surface.
+- Added mounted identity and timing coverage in `Tests/UI/test_library_canvas_scoped_sync.py`, including real Prompt/Skill service-backed transitions, Notes sync and row transitions, Media/RAG interactions, Ingest routing, status updates, Unicode loading copy, and shell-recompose spies. Existing Prompt, Skill, Notes create/filter/sync, Media filter, and Search/RAG regressions also pass after rebasing onto `origin/dev` at `ab42f0831`.
+- Evidence: the current pre-change base contained 143 statement-level whole-screen recompose sites and the final implementation contains 102 (41 removed). The identical 12-click Notes select-toggle probe improved from a 632.199 ms median to 123.315 ms after the final rebase (80.5%). Mounted UAT passed at 160×45 and 235×52.
+- Verification: changed files compile; Ruff reports no new findings when the seven pre-existing `E721` findings in `library_screen.py` are excluded; direct isolated runs passed all new tests plus the focused existing regressions listed above. Normal pytest collection remains unavailable in this Windows sandbox because the repository's network guard blocks Textual's internal localhost socketpair, so async test bodies were run directly under fully isolated config/data/temp paths as prescribed by `lessons-testing-evidence.md`.
+- ADR required: no. This applies the existing canvas ownership/update contract and introduces no new architectural boundary. No new lessons entry was warranted; the review-found Unicode-copy and off-surface asynchronous receipt issues are directly regression-pinned in the task test file.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1328,31 +1328,29 @@ def _sync_library_canvas(screen: "LibraryScreen", kind: str) -> None:
     ``App.mouse_captured`` referencing a removed widget forever,
     permanently breaking click dispatch app-wide.
 
-    Only "conversations" and "media" have a canvas ``sync_state`` hook
-    today -- ``LibraryNotesCanvas`` has none (see task-252's
-    Implementation Notes inventory: its constructor's own ``sync_state``
-    parameter, an unrelated notes-sync-panel display state, shadows the
-    method name a targeted-update hook would need). An unsupported
-    ``kind``, like any other failure here (e.g. the canvas isn't mounted
-    because a mode switch raced), falls back to the old whole-screen
-    recompose rather than raising.
+    TASK-15457 extends the contract to every high-frequency Library canvas.
+    An unsupported ``kind``, like any other failure here (e.g. the canvas
+    isn't mounted because a mode switch raced), falls back to the old
+    whole-screen recompose rather than raising.
 
     Args:
         screen: The Library screen instance driving the update.
-        kind: "conversations", "media", or "media-trash".
+        kind: Supported Library canvas kind.
 
     Returns:
         None.
     """
     try:
+        sync_args: tuple[Any, ...] = ()
+        sync_kwargs: dict[str, Any] = {}
         if kind == "conversations":
             canvas = screen.query_one(
                 "#library-conversations-canvas", LibraryConversationsCanvas
             )
-            new_state = screen._build_library_conversations_state()
+            sync_args = (screen._build_library_conversations_state(),)
         elif kind == "media":
             canvas = screen.query_one("#library-media-canvas", LibraryMediaCanvas)
-            new_state = screen._build_library_media_state()
+            sync_args = (screen._build_library_media_state(),)
         elif kind == "media-trash":
             # task-4025: the media canvas's Trash view -- same targeted
             # contract, its own mounted widget/state builder.
@@ -1361,6 +1359,32 @@ def _sync_library_canvas(screen: "LibraryScreen", kind: str) -> None:
             )
             new_state = screen._build_library_media_trash_state()
             screen._selected_media_trash_id = new_state.selected_id
+            sync_args = (new_state,)
+        elif kind == "notes":
+            canvas = screen.query_one("#library-notes-canvas", LibraryNotesCanvas)
+            sync_kwargs = screen._library_notes_canvas_kwargs()
+        elif kind == "prompts":
+            canvas = screen.query_one(
+                "#library-prompts-canvas", LibraryPromptsListCanvas
+            )
+            sync_kwargs = screen._library_prompts_canvas_kwargs()
+        elif kind == "skills":
+            canvas = screen.query_one(
+                "#library-skills-canvas", LibrarySkillsListCanvas
+            )
+            sync_kwargs = screen._library_skills_canvas_kwargs()
+        elif kind == "ingest":
+            canvas = screen.query_one("#library-ingest-canvas", LibraryIngestCanvas)
+            sync_args = (screen._build_library_ingest_state(),)
+        elif kind == "search":
+            canvas = screen.query_one(
+                "#library-search-rag-panel", LibrarySearchRagPanel
+            )
+            screen._library_rag_answer_render_key = None
+            sync_args = (screen._library_rag_panel_state(),)
+        elif kind == "export":
+            canvas = screen.query_one("#library-export-canvas", LibraryExportCanvas)
+            sync_args = (screen._build_library_export_state(),)
         else:
             raise ValueError(
                 f"Unsupported Library canvas kind for targeted sync: {kind!r}"
@@ -1373,7 +1397,7 @@ def _sync_library_canvas(screen: "LibraryScreen", kind: str) -> None:
                     "Mouse-capture release before Library canvas sync skipped.",
                     exc_info=True,
                 )
-        canvas.sync_state(new_state)
+        canvas.sync_state(*sync_args, **sync_kwargs)
     except Exception:
         logger.debug(
             f"Library {kind} canvas sync failed; falling back to full recompose.",
@@ -4927,20 +4951,20 @@ class LibraryScreen(BaseAppScreen):
             self._supersede_library_notes_navigation()
             self._library_notes_view = "list"
             self._reset_library_notes_sync_transient_state()
-            self.refresh(recompose=True)
+            _sync_library_canvas(self, "notes")
             self.call_after_refresh(self._focus_library_notes_filter_input)
             return
         if self._library_notes_select_mode:
             self._library_notes_select_mode = False
             self._library_notes_row_selection.clear()
-            self.refresh(recompose=True)
+            _sync_library_canvas(self, "notes")
             self.call_after_refresh(
                 self._focus_library_note_control, "#library-notes-select-toggle"
             )
             return
         if self._library_notes_sort_choices_visible:
             self._library_notes_sort_choices_visible = False
-            self.refresh(recompose=True)
+            _sync_library_canvas(self, "notes")
             self.call_after_refresh(
                 self._focus_library_note_control, "#library-notes-sort"
             )
@@ -7963,80 +7987,12 @@ class LibraryScreen(BaseAppScreen):
                             classes="destination-purpose",
                             markup=False,
                         )
-                elif (
-                    shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES
-                    and self._library_notes_view == "editor"
-                ):
-                    editor_state = self._library_note_editor_state()
-                    if editor_state is None:
-                        with Vertical(id="library-note-load-state"):
-                            with Horizontal(id="library-note-load-heading"):
-                                yield Button(
-                                    "‹ Notes",
-                                    id="library-note-back",
-                                    classes="library-canvas-action",
-                                    compact=True,
-                                )
-                                yield Static(
-                                    "Edit note",
-                                    id="library-note-loading-title",
-                                    markup=False,
-                                )
-                            load_copy = (
-                                self._library_note_load_message
-                                if self._library_note_load_state == "failed"
-                                else "Loading note…"
-                            )
-                            yield Static(
-                                load_copy,
-                                id="library-note-loading",
-                                classes="destination-purpose",
-                                markup=False,
-                            )
-                            with Vertical(id="library-note-loading-viewport"):
-                                if self._library_note_load_state == "failed":
-                                    yield Button(
-                                        "Retry",
-                                        id="library-note-load-retry",
-                                        classes="library-canvas-action",
-                                        compact=True,
-                                    )
-                    else:
-                        yield LibraryNotesCanvas(
-                            mode="editor",
-                            presentation_state=self._library_note_presentation_state(),
-                            compact=self._library_notes_compact,
-                            title_placeholder_only=(
-                                self._library_note_pending_blank_gc_id is not None
-                                and self._library_note_pending_blank_gc_id
-                                == self._selected_note_id
-                            ),
-                            id="library-notes-canvas",
-                        )
-                elif (
-                    shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES
-                    and self._library_notes_view == "sync"
+                elif shell.canvas_kind in (
+                    LIBRARY_CANVAS_KIND_NOTES,
+                    LIBRARY_CANVAS_KIND_NOTES_CREATE,
                 ):
                     yield LibraryNotesCanvas(
-                        mode="sync",
-                        sync_state=self._build_library_notes_sync_state(),
-                        compact=self._library_notes_compact,
-                        id="library-notes-canvas",
-                    )
-                elif shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES:
-                    yield LibraryNotesCanvas(
-                        self._build_library_notes_state(),
-                        sort_mode=self._library_notes_sort,
-                        filter_value=self._library_notes_filter,
-                        compact=self._library_notes_compact,
-                        id="library-notes-canvas",
-                    )
-                elif shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES_CREATE:
-                    yield LibraryNotesCanvas(
-                        mode="create",
-                        compact=self._library_notes_compact,
-                        create_running=self._library_note_create_running,
-                        create_status=self._library_note_create_status,
+                        **self._library_notes_canvas_kwargs(),
                         id="library-notes-canvas",
                     )
                 elif (
@@ -8625,7 +8581,176 @@ class LibraryScreen(BaseAppScreen):
             self._local_source_counts.get("notes", 0) + 1
         )
         return True
+    def _library_notes_canvas_kwargs(self) -> dict[str, Any]:
+        """Return every compose input for the mounted Database Notes canvas."""
+        values: dict[str, Any] = {
+            "list_state": None,
+            "sort_mode": self._library_notes_sort,
+            "filter_value": self._library_notes_filter,
+            "mode": "list",
+            "presentation_state": None,
+            "sync_panel_state": None,
+            "title_placeholder_only": False,
+            "compact": self._library_notes_compact,
+            "create_running": self._library_note_create_running,
+            "create_status": self._library_note_create_status,
+            "load_state": self._library_note_load_state,
+            "load_message": self._library_note_load_message,
+        }
+        if self._library_selected_row_id == LIBRARY_ROW_CREATE_NOTE:
+            values["mode"] = "create"
+        elif self._library_notes_view == "sync":
+            values["mode"] = "sync"
+            values["sync_panel_state"] = self._build_library_notes_sync_state()
+        elif self._library_notes_view == "editor":
+            presentation_state = self._library_note_editor_state()
+            if presentation_state is None:
+                values["mode"] = "loading"
+            else:
+                values["mode"] = "editor"
+                values["presentation_state"] = (
+                    self._library_note_presentation_state()
+                )
+                values["title_placeholder_only"] = (
+                    self._library_note_pending_blank_gc_id is not None
+                    and self._library_note_pending_blank_gc_id
+                    == self._selected_note_id
+                )
+        else:
+            values["list_state"] = self._build_library_notes_state()
+        return values
 
+    def _library_prompts_canvas_kwargs(self) -> dict[str, Any]:
+        """Return every compose input for the mounted Prompts canvas."""
+        membership_state = (
+            self._library_prompt_collections_controller.membership_state
+        )
+        values: dict[str, Any] = {
+            "state": None,
+            "sort_mode": "newest",
+            "filter_value": "",
+            "browse_result": None,
+            "mode": "list",
+            "editor_state": None,
+            "conflict": False,
+            "status": "",
+            "show_open_existing": False,
+            "import_open": False,
+            "import_path": "",
+            "import_status": "",
+            "dirty": self._library_prompt_dirty,
+            "can_update_original": False,
+            "include_starter_content": (
+                self._library_prompt_include_starter_content
+            ),
+            "history_state": self._library_prompt_history_state,
+            "history_current_compatible": self._library_prompt_block_state is not None,
+            "collection_label": "All prompts",
+            "membership_state": membership_state,
+            "sort_choices_visible": False,
+        }
+        if self._library_prompts_view == "editor":
+            values["mode"] = "editor"
+            if self._library_prompt_conflict_snapshot is not None:
+                values["editor_state"] = self._current_library_prompt_editor_state(
+                    self._library_prompt_conflict_snapshot
+                )
+                values["conflict"] = True
+            elif self._library_prompt_detail is None:
+                values["mode"] = "loading"
+            else:
+                values["editor_state"] = self._current_library_prompt_editor_state()
+                values["status"] = self._library_prompt_status
+                values["show_open_existing"] = (
+                    self._library_prompt_status
+                    == LIBRARY_PROMPT_SAVE_STATUS_COPY["name-in-use"]
+                )
+                values["can_update_original"] = (
+                    self._library_prompt_can_update_original()
+                )
+            return values
+
+        scope = self._library_prompt_browse_controller.scope
+        values.update(
+            {
+                "state": self._build_library_prompts_state(),
+                "sort_mode": "name" if scope.sort_by == "name" else "newest",
+                "filter_value": scope.query,
+                "browse_result": self._library_prompt_browse_controller.result,
+                "import_open": self._library_prompts_import_open,
+                "import_path": self._library_prompts_import_path,
+                "import_status": self._library_prompts_import_status,
+                "collection_label": self._library_prompt_collections_controller.collection_label(
+                    scope.collection_id
+                ),
+                "sort_choices_visible": self._library_prompts_sort_choices_visible,
+            }
+        )
+        return values
+
+    def _library_skills_canvas_kwargs(self) -> dict[str, Any]:
+        """Return every compose input for the mounted Skills canvas."""
+        values: dict[str, Any] = {
+            "state": None,
+            "sort_mode": self._library_skills_sort,
+            "filter_value": self._library_skills_filter,
+            "mode": "list",
+            "trust_posture": self._library_skills_trust_posture,
+            "confirming_reset": self._library_skill_trust_confirming_reset,
+            "editor_state": None,
+            "warnings": "",
+            "status": "",
+            "conflict": False,
+            "active_review": None,
+            "is_create": not self._selected_skill_name,
+            "dirty": self._library_skill_dirty,
+            "confirming_delete": self._library_skill_confirming_delete,
+            "scroll_to_actions": False,
+            "skill_path": "",
+            "import_open": False,
+            "import_path": "",
+            "import_status": "",
+            "import_review_name": "",
+            "sort_choices_visible": False,
+        }
+        if self._library_skills_view == "editor":
+            editor_state = self._library_skill_editor_state
+            if editor_state is None:
+                values["mode"] = "loading"
+            else:
+                values.update(
+                    {
+                        "mode": "editor",
+                        "editor_state": editor_state,
+                        "warnings": "\n".join(
+                            skill_editor_warning_lines(
+                                live_name=editor_state.name,
+                                trust_status=editor_state.trust_status,
+                                trust_blocked=editor_state.trust_blocked,
+                            )
+                        ),
+                        "status": self._library_skill_status,
+                        "conflict": self._library_skill_conflict,
+                        "active_review": self._library_skill_active_review,
+                        "scroll_to_actions": (
+                            self._consume_library_skill_scroll_pending()
+                        ),
+                        "skill_path": self._library_skill_on_disk_path(),
+                    }
+                )
+            return values
+
+        values.update(
+            {
+                "state": self._build_library_skills_state(),
+                "import_open": self._library_skills_import_open,
+                "import_path": self._library_skills_import_path,
+                "import_status": self._library_skills_import_status,
+                "import_review_name": self._library_skills_import_review_name,
+                "sort_choices_visible": self._library_skills_sort_choices_visible,
+            }
+        )
+        return values
     def _build_library_prompts_state(self):
         """Build the Library prompts canvas's list-view display state.
 
@@ -9059,7 +9184,7 @@ class LibraryScreen(BaseAppScreen):
             self._notify_library_note_missing_warning()
             self._refresh_local_source_snapshot()
             if self.is_mounted:
-                self.refresh(recompose=True)
+                _sync_library_canvas(self, "notes")
             return
         if outcome.kind is NoteLoadOutcomeKind.FAILED:
             self._library_note_load_state = "failed"
@@ -9067,7 +9192,7 @@ class LibraryScreen(BaseAppScreen):
                 outcome.message or "Unable to load note. Press Retry."
             )
             if self.is_mounted:
-                self.refresh(recompose=True)
+                _sync_library_canvas(self, "notes")
             return
 
         self._library_note_load_state = "loaded"
@@ -9077,7 +9202,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_context = False
         self._library_note_editor_armed = False
         if self.is_mounted:
-            self.refresh(recompose=True)
+            _sync_library_canvas(self, "notes")
             self.call_after_refresh(self._arm_library_note_editor)
             self.call_after_refresh(
                 self._restore_library_notes_focus_identity,
@@ -12280,10 +12405,7 @@ class LibraryScreen(BaseAppScreen):
                 ):
                     return False
                 canvas: Widget = LibraryNotesCanvas(
-                    self._build_library_notes_state(),
-                    sort_mode=self._library_notes_sort,
-                    filter_value=self._library_notes_filter,
-                    compact=self._library_notes_compact,
+                    **self._library_notes_canvas_kwargs(),
                     id="library-notes-canvas",
                 )
             elif shell.canvas_kind == "media":
@@ -12653,7 +12775,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_type_choices_visible = (
             not self._library_media_type_choices_visible
         )
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "media")
         if self._library_media_type_choices_visible:
             self.call_after_refresh(
                 self._focus_library_choice_strip_active,
@@ -12683,7 +12805,7 @@ class LibraryScreen(BaseAppScreen):
             # bulk-delete confirmation either, and states the discard like
             # every other exit.
             self._exit_library_media_select_mode(announce_discard=True)
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "media")
         self.call_after_refresh(
             self._focus_library_control, "#library-media-type-filter"
         )
@@ -13561,7 +13683,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_sort_choices_visible = (
             not self._library_notes_sort_choices_visible
         )
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, ".library-notes-sort-choice")
     def handle_library_notes_sort_choice(self, event: Button.Pressed) -> None:
@@ -13576,7 +13698,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_sort_choices_visible = False
         self._library_notes_select_mode = False
         self._library_notes_row_selection.clear()
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, "#library-notes-new")
     async def handle_library_notes_new(self, event: Button.Pressed) -> None:
@@ -13593,7 +13715,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_sort_choices_visible = False
         self._library_notes_select_mode = False
         self._library_notes_row_selection.clear()
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
         self.call_after_refresh(self._focus_library_notes_filter_input)
 
     @on(Input.Submitted, "#library-notes-filter")
@@ -13612,7 +13734,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_row_selection.clear()
         if not submitted:
             self._library_notes_filter_records = None
-            self.refresh(recompose=True)
+            _sync_library_canvas(self, "notes")
             return
         self.run_worker(
             self._run_library_notes_filter(submitted),
@@ -13621,7 +13743,7 @@ class LibraryScreen(BaseAppScreen):
         )
 
     async def _run_library_notes_filter(self, query: str) -> None:
-        """Fetch filtered notes from the ``search_notes`` seam and recompose.
+        """Fetch filtered notes and sync the mounted Notes canvas.
 
         Clearing the filter (an empty submit) is handled synchronously by
         ``handle_library_notes_filter`` and never starts this worker, so it
@@ -13655,7 +13777,7 @@ class LibraryScreen(BaseAppScreen):
         if query != self._library_notes_filter:
             return
         self._library_notes_filter_records = list(records or [])
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
         self.call_after_refresh(self._focus_library_notes_filter_input)
 
     def _focus_library_notes_filter_input(self) -> None:
@@ -13678,7 +13800,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_prompts_sort_choices_visible = (
             not self._library_prompts_sort_choices_visible
         )
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "prompts")
         if self._library_prompts_sort_choices_visible:
             current = (
                 "name"
@@ -13710,7 +13832,7 @@ class LibraryScreen(BaseAppScreen):
         scope = self._library_prompt_browse_controller.scope
         current = "name" if scope.sort_by == "name" else "newest"
         if requested not in {"newest", "name"} or requested == current:
-            self.refresh(recompose=True)
+            _sync_library_canvas(self, "prompts")
             self.call_after_refresh(
                 self._focus_library_control, "#library-prompts-sort"
             )
@@ -13821,7 +13943,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_skills_sort_choices_visible = (
             not self._library_skills_sort_choices_visible
         )
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "skills")
         if self._library_skills_sort_choices_visible:
             self.call_after_refresh(
                 self._focus_library_choice_strip_active,
@@ -13849,7 +13971,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_skills_sort_choices_visible = False
         if requested in _LIBRARY_SKILLS_SORT_MODES:
             self._library_skills_sort = requested
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "skills")
         self.call_after_refresh(
             self._focus_library_control, "#library-skills-sort"
         )
@@ -13870,7 +13992,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_skills_filter = self._safe_text(
             event.value, max_length=200
         ).strip()
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "skills")
 
     @on(Button.Pressed, "#library-skills-import")
     def handle_library_skills_import(self, event: Button.Pressed) -> None:
@@ -14054,10 +14176,18 @@ class LibraryScreen(BaseAppScreen):
         )
 
     def _apply_library_skills_import_status(self, text: str) -> None:
-        """Set the Import row's outcome line and recompose to show it."""
+        """Set and patch the Import row's one-line outcome in place."""
         self._library_skills_import_status = text
-        if self.is_mounted:
-            self.refresh(recompose=True)
+        if (
+            not self.is_mounted
+            or self.app.screen is not self
+            or self._library_selected_row_id != LIBRARY_ROW_BROWSE_SKILLS
+        ):
+            return
+        try:
+            self.query_one("#library-skills-import-status", Static).update(text)
+        except (NoMatches, QueryError):
+            _sync_library_canvas(self, "skills")
 
     async def _run_library_skills_import(self, raw_path: str) -> None:
         """Import ONE skill from a SKILL.md file path or a skill's own directory.
@@ -14412,7 +14542,7 @@ class LibraryScreen(BaseAppScreen):
                 exclusive=True,
                 group="library_skill_detail",
             )
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "skills")
 
     async def _refresh_library_skill_detail(self, skill_name: str) -> None:
         """Fetch and store the full detail for a selected Library skill.
@@ -14430,7 +14560,7 @@ class LibraryScreen(BaseAppScreen):
         if not callable(get_skill):
             self._library_skill_detail = None
             if self.is_mounted:
-                self.refresh(recompose=True)
+                _sync_library_canvas(self, "skills")
             return
         try:
             detail = await self._run_library_service_call(
@@ -14458,7 +14588,7 @@ class LibraryScreen(BaseAppScreen):
             self._reset_library_skill_editor_state()
             self._refresh_local_source_snapshot()
             if self.is_mounted:
-                self.refresh(recompose=True)
+                _sync_library_canvas(self, "skills")
             return
         self._apply_library_skill_detail(detail)
 
@@ -14486,7 +14616,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_skill_script_grant = False
         self._library_skill_editor_armed = False
         if self.is_mounted:
-            self.refresh(recompose=True)
+            _sync_library_canvas(self, "skills")
             self.call_after_refresh(self._arm_library_skill_editor)
         # Task 7: not part of ``get_skill``'s response, so it needs its own
         # off-thread fetch -- see ``_refresh_library_skill_script_grant``.
@@ -16667,7 +16797,7 @@ class LibraryScreen(BaseAppScreen):
         )
 
     def _apply_library_prompts_import_status(self, text: str) -> None:
-        """Set the Import row's outcome line and recompose to show it."""
+        """Set and patch the Import row's one-line outcome in place."""
         if (
             not self.is_mounted
             or self.app.screen is not self
@@ -16675,7 +16805,10 @@ class LibraryScreen(BaseAppScreen):
         ):
             return
         self._library_prompts_import_status = text
-        self.refresh(recompose=True)
+        try:
+            self.query_one("#library-prompts-import-status", Static).update(text)
+        except (NoMatches, QueryError):
+            _sync_library_canvas(self, "prompts")
 
     async def _run_library_prompts_import(self, raw_path: str) -> None:
         """Import prompts from a file or folder path, skipping duplicate names.
@@ -16968,7 +17101,7 @@ class LibraryScreen(BaseAppScreen):
                 exclusive=True,
                 group="library_prompt_detail",
             )
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "prompts")
 
     async def _refresh_library_prompt_detail(
         self,
@@ -17010,7 +17143,7 @@ class LibraryScreen(BaseAppScreen):
             self._library_prompt_detail = None
             self._library_prompt_version = None
             if self.is_mounted:
-                self.refresh(recompose=True)
+                _sync_library_canvas(self, "prompts")
             return
         try:
             detail = await self._run_library_service_call(
@@ -17063,7 +17196,7 @@ class LibraryScreen(BaseAppScreen):
         )
         self._load_library_prompt_memberships()
         if self.is_mounted:
-            self.refresh(recompose=True)
+            _sync_library_canvas(self, "prompts")
             self.call_after_refresh(self._arm_library_prompt_editor)
 
     def _adopt_library_prompt_persisted_detail(
@@ -18570,7 +18703,13 @@ class LibraryScreen(BaseAppScreen):
             return False
         _subject, opener_selector, visibility_attr = open_strip
         setattr(self, visibility_attr, False)
-        self.refresh(recompose=True)
+        canvas_kind = {
+            "_library_media_type_choices_visible": "media",
+            "_library_prompts_sort_choices_visible": "prompts",
+            "_library_skills_sort_choices_visible": "skills",
+            "_library_export_quality_choices_visible": "export",
+        }[visibility_attr]
+        _sync_library_canvas(self, canvas_kind)
         self.call_after_refresh(self._focus_library_control, opener_selector)
         return True
 
@@ -20035,7 +20174,7 @@ class LibraryScreen(BaseAppScreen):
         self._supersede_library_notes_navigation()
         self._ensure_library_notes_sync_config_loaded()
         self._library_notes_view = "sync"
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, "#library-notes-sync-back")
     async def handle_library_notes_sync_back(self, event: Button.Pressed) -> None:
@@ -20053,7 +20192,7 @@ class LibraryScreen(BaseAppScreen):
         self._supersede_library_notes_navigation()
         self._library_notes_view = "list"
         self._reset_library_notes_sync_transient_state()
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
 
     @on(Input.Changed, "#library-notes-sync-folder")
     def handle_library_notes_sync_folder_changed(self, event: Input.Changed) -> None:
@@ -20115,7 +20254,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_sync_folder_text = str(path)
         save_setting_to_cli_config("notes", "sync_directory", str(path))
         if self._library_notes_view == "sync":
-            self.refresh(recompose=True)
+            _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, ".library-notes-sync-direction-choice")
     def handle_library_notes_sync_direction(self, event: Button.Pressed) -> None:
@@ -20134,7 +20273,7 @@ class LibraryScreen(BaseAppScreen):
         save_setting_to_cli_config(
             "notes", "sync_direction", self._library_notes_sync_direction
         )
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, ".library-notes-sync-conflict-choice")
     def handle_library_notes_sync_conflict(self, event: Button.Pressed) -> None:
@@ -20153,7 +20292,7 @@ class LibraryScreen(BaseAppScreen):
         save_setting_to_cli_config(
             "notes", "sync_conflict_resolution", self._library_notes_sync_conflict
         )
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, "#library-notes-sync-auto")
     def handle_library_notes_sync_auto_toggle(self, event: Button.Pressed) -> None:
@@ -20178,7 +20317,7 @@ class LibraryScreen(BaseAppScreen):
             self._arm_library_notes_auto_sync_timer()
         else:
             self._cancel_library_notes_auto_sync_timer()
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, "#library-notes-sync-run")
     def handle_library_notes_sync_run(self, event: Button.Pressed) -> None:
@@ -20969,7 +21108,7 @@ class LibraryScreen(BaseAppScreen):
         cap = get_capabilities(event.group)
         field = next((f for f in cap.fields if f.name == event.name), None)
         if field is not None and field.type not in ("text", "number"):
-            self.refresh(recompose=True)
+            _sync_library_canvas(self, "ingest")
         elif field is not None:
             # (task-2130) Text/number edits deliberately skip the recompose
             # (cursor survival), which used to leave the panel-header receipt
@@ -23087,7 +23226,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_title_user_edited = False
         if note_id:
             self._begin_library_note_load(note_id)
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, "#library-notes-select-toggle")
     async def handle_library_notes_select_toggle(self, event: Button.Pressed) -> None:
@@ -23099,13 +23238,9 @@ class LibraryScreen(BaseAppScreen):
         unconditional here to mirror ``handle_library_notes_row``'s
         always-flush-first behavior.
 
-        Still a full ``self.refresh(recompose=True)`` (task-252 leaves
-        this un-converted, unlike its conversations/media equivalents):
-        ``LibraryNotesCanvas`` has no ``sync_state`` hook -- its
-        constructor's own ``sync_state`` parameter (the unrelated
-        notes-sync-panel display state) shadows that method name. See
-        ``_sync_library_canvas``'s docstring and task-252's
-        Implementation Notes inventory.
+        TASK-15457 renames the unrelated sync-panel constructor field and
+        routes this structural list change through the Notes canvas's own
+        ``sync_state`` hook.
 
         Args:
             event: Button press event emitted by the notes canvas's
@@ -23117,30 +23252,28 @@ class LibraryScreen(BaseAppScreen):
             return
         self._library_notes_select_mode = not self._library_notes_select_mode
         self._library_notes_row_selection.clear()
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, "#library-notes-select-all")
     def handle_library_notes_select_all(self, event: Button.Pressed) -> None:
         """Select every note row currently rendered by the canvas.
 
-        Full recompose, not converted -- see
-        ``handle_library_notes_select_toggle``'s docstring.
+        Rebuilds only the mounted Notes canvas.
         """
         event.stop()
         rows = self._build_library_notes_state().rows
         self._library_notes_row_selection.select_all(r.note_id for r in rows)
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, "#library-notes-select-clear")
     def handle_library_notes_select_clear(self, event: Button.Pressed) -> None:
         """Clear the current notes selection without leaving select mode.
 
-        Full recompose, not converted -- see
-        ``handle_library_notes_select_toggle``'s docstring.
+        Rebuilds only the mounted Notes canvas.
         """
         event.stop()
         self._library_notes_row_selection.clear()
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, "#library-notes-export-selected")
     async def handle_library_notes_export_selected(self, event: Button.Pressed) -> None:
@@ -25676,7 +25809,7 @@ class LibraryScreen(BaseAppScreen):
             "rag" if self._library_rag_mode == "search" else "search"
         )
         self._reset_library_rag_retrieval_state()
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "search")
 
     @on(Button.Pressed, ".library-rag-scope-toggle")
     def toggle_library_rag_scope_source(self, event: Button.Pressed) -> None:
@@ -25702,7 +25835,7 @@ class LibraryScreen(BaseAppScreen):
             self._library_rag_scope_deselected.discard(source_type)
         else:
             self._library_rag_scope_deselected.add(source_type)
-        self.refresh(recompose=True)
+        _sync_library_canvas(self, "search")
 
     @on(Collapsible.Toggled, "#library-rag-history")
     def sync_library_rag_history_collapsed(self, event: Collapsible.Toggled) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -16798,13 +16798,13 @@ class LibraryScreen(BaseAppScreen):
 
     def _apply_library_prompts_import_status(self, text: str) -> None:
         """Set and patch the Import row's one-line outcome in place."""
+        self._library_prompts_import_status = text
         if (
             not self.is_mounted
             or self.app.screen is not self
             or self._library_selected_row_id != LIBRARY_ROW_BROWSE_PROMPTS
         ):
             return
-        self._library_prompts_import_status = text
         try:
             self.query_one("#library-prompts-import-status", Static).update(text)
         except (NoMatches, QueryError):

--- a/tldw_chatbook/Widgets/Library/library_export_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_export_canvas.py
@@ -83,7 +83,11 @@ class LibraryExportCanvas(VerticalScroll):
         self.styles.min_width = 40
 
     def sync_state(self, state: LibraryExportFormState) -> None:
-        """Rebuild only the mounted export canvas from a complete snapshot."""
+        """Rebuild only the mounted export canvas from a complete snapshot.
+
+        Args:
+            state: Complete export form state to render.
+        """
         self.state = state
         self.refresh(recompose=True)
 

--- a/tldw_chatbook/Widgets/Library/library_export_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_export_canvas.py
@@ -82,6 +82,11 @@ class LibraryExportCanvas(VerticalScroll):
         self.styles.width = "1fr"
         self.styles.min_width = 40
 
+    def sync_state(self, state: LibraryExportFormState) -> None:
+        """Rebuild only the mounted export canvas from a complete snapshot."""
+        self.state = state
+        self.refresh(recompose=True)
+
     def compose(self) -> ComposeResult:
         state = self.state
         yield Static(

--- a/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
@@ -1066,6 +1066,12 @@ class LibraryIngestCanvas(VerticalScroll):
         # noise rather than a user edit -- see ``_handle_option_value_changed``.
         self._reported_option_values: dict[tuple[str, str], Any] = {}
 
+    def sync_state(self, state: LibraryIngestCanvasState) -> None:
+        """Rebuild only the mounted ingest canvas from a complete snapshot."""
+        self.state = state
+        self._reported_option_values.clear()
+        self.refresh(recompose=True)
+
     def _compose_type_group(
         self,
         group: str,

--- a/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
@@ -1067,7 +1067,11 @@ class LibraryIngestCanvas(VerticalScroll):
         self._reported_option_values: dict[tuple[str, str], Any] = {}
 
     def sync_state(self, state: LibraryIngestCanvasState) -> None:
-        """Rebuild only the mounted ingest canvas from a complete snapshot."""
+        """Rebuild only the mounted ingest canvas from a complete snapshot.
+
+        Args:
+            state: Complete ingest form and submission state to render.
+        """
         self.state = state
         self._reported_option_values.clear()
         self.refresh(recompose=True)

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -203,6 +203,20 @@ class LibraryNotesCanvas(Vertical):
         prevents list/editor/sync conditionals from retaining values from the
         previous surface while the Library shell, rail, and footer retain
         identity.
+
+        Args:
+            list_state: Notes list snapshot, or ``None`` outside list mode.
+            sort_mode: Active Notes sort identifier.
+            filter_value: Current Notes filter text.
+            mode: Canvas surface to render.
+            presentation_state: Note editor/create presentation snapshot.
+            sync_panel_state: Notes folder-sync panel snapshot.
+            title_placeholder_only: Whether the title is placeholder-only.
+            compact: Whether compact editor controls are enabled.
+            create_running: Whether note creation is in progress.
+            create_status: Current note-creation status copy.
+            load_state: Current note-loading state identifier.
+            load_message: Current note-loading status or error copy.
         """
         previous_mode = self.mode
         self.list_state = list_state

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -81,15 +81,18 @@ class LibraryNotesCanvas(Vertical):
             ``"title"``), used to label the sort control.
         filter_value: Current notes filter text, prefilled into the filter
             ``Input``.
-        mode: ``"list"`` renders the notes list; ``"editor"`` renders the
-            in-canvas note editor for ``presentation_state``; ``"create"`` renders
-            the Blank note / template picker reached from the rail's
-            Create > New note row; ``"sync"`` renders the in-canvas notes
-            sync panel for ``sync_state``.
+        mode: ``"list"`` renders the notes list; ``"loading"`` renders the
+            editor loading/retry receipt; ``"editor"`` renders the in-canvas
+            note editor for ``presentation_state``; ``"create"`` renders the
+            Blank note / template picker reached from the rail's Create > New
+            note row; ``"sync"`` renders the in-canvas notes sync panel for
+            ``sync_panel_state``.
         presentation_state: Canonical snapshot plus presentation-only state.
             Required when ``mode == "editor"``.
-        sync_state: The sync panel's display state. Required when
-            ``mode == "sync"``.
+        sync_panel_state: The sync panel's display state. Required when
+            ``mode == "sync"``. This deliberately does not use the name
+            ``sync_state`` because that name belongs to the mounted canvas's
+            targeted update hook.
         title_placeholder_only: When ``True`` (editor mode only), the title
             ``Input`` renders empty with an "Untitled" placeholder instead
             of a literal editable "Untitled" value -- LIB-14's fix for a
@@ -117,11 +120,13 @@ class LibraryNotesCanvas(Vertical):
         filter_value: str = "",
         mode: str = "list",
         presentation_state: LibraryNotePresentationState | None = None,
-        sync_state: LibraryNotesSyncState | None = None,
+        sync_panel_state: LibraryNotesSyncState | None = None,
         title_placeholder_only: bool = False,
         compact: bool = False,
         create_running: bool = False,
         create_status: str = "",
+        load_state: str = "loading",
+        load_message: str = "",
         **kwargs: Any,
     ) -> None:
         """Initialize one list, editor, create, or sync canvas.
@@ -130,14 +135,17 @@ class LibraryNotesCanvas(Vertical):
             list_state: List-mode rows, counts, selection, and empty-state copy.
             sort_mode: Active list sort key.
             filter_value: Text prefilled into the list filter.
-            mode: Canvas surface to compose: list, editor, create, or sync.
+            mode: Canvas surface to compose: list, loading, editor, create,
+                or sync.
             presentation_state: Canonical editor snapshot and UI-only flags.
-            sync_state: Display state for the sync surface.
+            sync_panel_state: Display state for the sync surface.
             title_placeholder_only: Render an empty title with an Untitled
                 placeholder for a pristine newly-created note.
             compact: Whether 60-column-safe controls and labels are active.
             create_running: Whether note creation is in progress.
             create_status: Visible creation completion or recovery status.
+            load_state: Editor-load state (``"loading"`` or ``"failed"``).
+            load_message: Recovery copy shown after an editor-load failure.
             **kwargs: Additional keyword arguments forwarded to ``Vertical``.
         """
         super().__init__(**kwargs)
@@ -146,16 +154,21 @@ class LibraryNotesCanvas(Vertical):
         self.filter_value = filter_value
         self.mode = mode
         self.presentation_state = presentation_state
-        self.sync_state = sync_state
+        self.sync_panel_state = sync_panel_state
         self.title_placeholder_only = title_placeholder_only
         self.compact = compact
         self.create_running = create_running
         self.create_status = create_status
+        self.load_state = load_state
+        self.load_message = load_message
         self.styles.width = "1fr"
         self.styles.min_width = 40
         self.add_class(f"library-notes-mode-{mode}")
 
     def compose(self) -> ComposeResult:
+        if self.mode == "loading":
+            yield from self._compose_loading()
+            return
         if self.mode == "editor":
             yield from self._compose_editor()
             return
@@ -166,6 +179,81 @@ class LibraryNotesCanvas(Vertical):
             yield from self._compose_sync()
             return
         yield from self._compose_list()
+
+    def sync_state(
+        self,
+        *,
+        list_state: LibraryNotesListState | None,
+        sort_mode: str,
+        filter_value: str,
+        mode: str,
+        presentation_state: LibraryNotePresentationState | None,
+        sync_panel_state: LibraryNotesSyncState | None,
+        title_placeholder_only: bool,
+        compact: bool,
+        create_running: bool,
+        create_status: str,
+        load_state: str,
+        load_message: str,
+    ) -> None:
+        """Apply a complete screen-owned snapshot within this canvas only.
+
+        The method intentionally replaces every compose input before asking
+        Textual to rebuild this widget's children. Keeping the update complete
+        prevents list/editor/sync conditionals from retaining values from the
+        previous surface while the Library shell, rail, and footer retain
+        identity.
+        """
+        previous_mode = self.mode
+        self.list_state = list_state
+        self.sort_mode = sort_mode
+        self.filter_value = filter_value
+        self.mode = mode
+        self.presentation_state = presentation_state
+        self.sync_panel_state = sync_panel_state
+        self.title_placeholder_only = title_placeholder_only
+        self.compact = compact
+        self.create_running = create_running
+        self.create_status = create_status
+        self.load_state = load_state
+        self.load_message = load_message
+        if previous_mode != mode:
+            self.remove_class(f"library-notes-mode-{previous_mode}")
+            self.add_class(f"library-notes-mode-{mode}")
+        self.refresh(recompose=True)
+
+    def _compose_loading(self) -> ComposeResult:
+        """Render the existing note-loading/retry surface inside the canvas."""
+        with Vertical(id="library-note-load-state"):
+            with Horizontal(id="library-note-load-heading"):
+                yield Button(
+                    "‹ Notes",
+                    id="library-note-back",
+                    classes="library-canvas-action",
+                    compact=True,
+                )
+                yield Static(
+                    "Edit note",
+                    id="library-note-loading-title",
+                    markup=False,
+                )
+            load_copy = (
+                self.load_message if self.load_state == "failed" else "Loading note…"
+            )
+            yield Static(
+                load_copy,
+                id="library-note-loading",
+                classes="destination-purpose",
+                markup=False,
+            )
+            with Vertical(id="library-note-loading-viewport"):
+                if self.load_state == "failed":
+                    yield Button(
+                        "Retry",
+                        id="library-note-load-retry",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
 
     def _compose_list(self) -> ComposeResult:
         list_state = self.list_state
@@ -719,7 +807,7 @@ class LibraryNotesCanvas(Vertical):
                     export_base, button.disabled
                 )
             return
-        if self.mode != "sync" or self.sync_state is None:
+        if self.mode != "sync" or self.sync_panel_state is None:
             return
         for value in ("bidirectional", "disk_to_db", "db_to_disk"):
             label = (
@@ -727,7 +815,7 @@ class LibraryNotesCanvas(Vertical):
                 if compact
                 else sync_direction_label(value)
             )
-            prefix = "✓ " if value == self.sync_state.direction else ""
+            prefix = "✓ " if value == self.sync_panel_state.direction else ""
             choices = self.query(f"#library-notes-sync-direction-{value}")
             if choices:
                 choices.first(Button).label = f"{prefix}{label}"
@@ -737,11 +825,11 @@ class LibraryNotesCanvas(Vertical):
                 if compact
                 else sync_conflict_label(value)
             )
-            prefix = "✓ " if value == self.sync_state.conflict else ""
+            prefix = "✓ " if value == self.sync_panel_state.conflict else ""
             choices = self.query(f"#library-notes-sync-conflict-{value}")
             if choices:
                 choices.first(Button).label = f"{prefix}{label}"
-        auto_label = auto_sync_label(self.sync_state.auto_sync)
+        auto_label = auto_sync_label(self.sync_panel_state.auto_sync)
         if compact:
             auto_label = auto_label.replace("auto-sync: every ", "Auto ", 1)
         auto = self.query("#library-notes-sync-auto")
@@ -1005,7 +1093,7 @@ class LibraryNotesCanvas(Vertical):
         Auto-sync stays a direct toggle button. All mutable controls are
         disabled while a sync run is active.
         """
-        sync_state = self.sync_state
+        sync_state = self.sync_panel_state
         if sync_state is None:
             return
         with Horizontal(id="library-notes-sync-heading"):

--- a/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
@@ -170,10 +170,65 @@ class LibraryPromptsListCanvas(Vertical):
         self.styles.min_width = 40
 
     def compose(self) -> ComposeResult:
+        if self.mode == "loading":
+            yield Static(
+                "Loading prompt…",
+                id="library-prompt-loading",
+                classes="destination-purpose",
+                markup=False,
+            )
+            return
         if self.mode == "editor":
             yield from self._compose_editor()
             return
         yield from self._compose_list()
+
+    def sync_state(
+        self,
+        *,
+        state: PromptsListState | None,
+        sort_mode: str,
+        filter_value: str,
+        browse_result: PromptBrowseResult | None,
+        mode: str,
+        editor_state: PromptEditorState | None,
+        conflict: bool,
+        status: str,
+        show_open_existing: bool,
+        import_open: bool,
+        import_path: str,
+        import_status: str,
+        dirty: bool,
+        can_update_original: bool,
+        include_starter_content: bool,
+        history_state: PromptHistoryState | None,
+        history_current_compatible: bool,
+        collection_label: str,
+        membership_state: PromptMembershipState | None,
+        sort_choices_visible: bool,
+    ) -> None:
+        """Apply a complete prompt snapshot within the mounted canvas."""
+        self.state = state
+        self.sort_mode = sort_mode
+        self.filter_value = filter_value
+        self.browse_result = browse_result
+        self.mode = mode
+        self.editor_state = editor_state
+        self.conflict = conflict
+        self.status = status
+        self.show_open_existing = show_open_existing
+        self.import_open = import_open
+        self.import_path = import_path
+        self.import_status = import_status
+        self.dirty = dirty
+        self.can_update_original = can_update_original
+        self.include_starter_content = include_starter_content
+        self.history_state = history_state
+        self.history_current_compatible = history_current_compatible
+        self.collection_label = collection_label
+        self.membership_state = membership_state
+        self.sort_choices_visible = sort_choices_visible
+        self.refresh(recompose=True)
 
     def _compose_list(self) -> ComposeResult:
         state = self.state

--- a/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
@@ -207,7 +207,30 @@ class LibraryPromptsListCanvas(Vertical):
         membership_state: PromptMembershipState | None,
         sort_choices_visible: bool,
     ) -> None:
-        """Apply a complete prompt snapshot within the mounted canvas."""
+        """Apply a complete prompt snapshot within the mounted canvas.
+
+        Args:
+            state: Prompt list snapshot, or ``None`` outside list mode.
+            sort_mode: Active prompt sort identifier.
+            filter_value: Current prompt filter text.
+            browse_result: Paginated prompt browse result.
+            mode: Canvas surface to render.
+            editor_state: Prompt editor snapshot.
+            conflict: Whether the open prompt has an edit conflict.
+            status: Current prompt editor status copy.
+            show_open_existing: Whether to offer opening an existing prompt.
+            import_open: Whether the prompt import form is expanded.
+            import_path: Current prompt import path.
+            import_status: Current prompt import outcome copy.
+            dirty: Whether the prompt editor has unsaved changes.
+            can_update_original: Whether save may update the original prompt.
+            include_starter_content: Whether create mode uses starter content.
+            history_state: Prompt version-history snapshot.
+            history_current_compatible: Whether history matches the open prompt.
+            collection_label: Collection membership label for the prompt.
+            membership_state: Prompt collection-membership snapshot.
+            sort_choices_visible: Whether the sort chooser is expanded.
+        """
         self.state = state
         self.sort_mode = sort_mode
         self.filter_value = filter_value

--- a/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
@@ -45,7 +45,11 @@ class LibrarySearchRagPanel(VerticalScroll):
         self.state = state
 
     def sync_state(self, state: LibraryRagPanelState) -> None:
-        """Rebuild only this mounted Search/RAG panel from ``state``."""
+        """Rebuild only this mounted Search/RAG panel from ``state``.
+
+        Args:
+            state: Complete Search/RAG controls and results state to render.
+        """
         self.state = state
         self.refresh(recompose=True)
 

--- a/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
@@ -44,6 +44,11 @@ class LibrarySearchRagPanel(VerticalScroll):
         super().__init__(**kwargs)
         self.state = state
 
+    def sync_state(self, state: LibraryRagPanelState) -> None:
+        """Rebuild only this mounted Search/RAG panel from ``state``."""
+        self.state = state
+        self.refresh(recompose=True)
+
     def compose(self) -> ComposeResult:
         # task-2859 item 7: drop the "Library " prefix (this canvas already
         # lives inside the Library destination) and match the rail row's

--- a/tldw_chatbook/Widgets/Library/library_skills_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_skills_canvas.py
@@ -717,7 +717,31 @@ class LibrarySkillsListCanvas(VerticalScroll):
         import_review_name: str,
         sort_choices_visible: bool,
     ) -> None:
-        """Apply a complete skills snapshot within the mounted canvas."""
+        """Apply a complete skills snapshot within the mounted canvas.
+
+        Args:
+            state: Skills list snapshot, or ``None`` outside list mode.
+            sort_mode: Active skill sort identifier.
+            filter_value: Current skill filter text.
+            mode: Canvas surface to render.
+            trust_posture: Trust state for the selected skill.
+            confirming_reset: Whether reset confirmation is armed.
+            editor_state: Skill editor snapshot.
+            warnings: Current skill validation warning copy.
+            status: Current skill editor status copy.
+            conflict: Whether the selected skill has an edit conflict.
+            active_review: Active trust-review data, if any.
+            is_create: Whether the editor is creating a skill.
+            dirty: Whether the skill editor has unsaved changes.
+            confirming_delete: Whether delete confirmation is armed.
+            scroll_to_actions: Whether to reveal the editor action row.
+            skill_path: Filesystem path for the selected skill.
+            import_open: Whether the skill import form is expanded.
+            import_path: Current skill import path.
+            import_status: Current skill import outcome copy.
+            import_review_name: Skill awaiting post-import trust review.
+            sort_choices_visible: Whether the sort chooser is expanded.
+        """
         self.state = state
         self.sort_mode = sort_mode
         self.filter_value = filter_value

--- a/tldw_chatbook/Widgets/Library/library_skills_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_skills_canvas.py
@@ -679,10 +679,68 @@ class LibrarySkillsListCanvas(VerticalScroll):
         self.styles.min_width = 40
 
     def compose(self) -> ComposeResult:
+        if self.mode == "loading":
+            yield Static(
+                "Loading skill…",
+                id="library-skill-loading",
+                classes="destination-purpose",
+                markup=False,
+            )
+            return
         if self.mode == "editor":
             yield from self._compose_editor()
             return
         yield from self._compose_list()
+
+    def sync_state(
+        self,
+        *,
+        state: SkillsListState | None,
+        sort_mode: str,
+        filter_value: str,
+        mode: str,
+        trust_posture: str,
+        confirming_reset: bool,
+        editor_state: SkillEditorState | None,
+        warnings: str,
+        status: str,
+        conflict: bool,
+        active_review: Mapping[str, Any] | None,
+        is_create: bool,
+        dirty: bool,
+        confirming_delete: bool,
+        scroll_to_actions: bool,
+        skill_path: str,
+        import_open: bool,
+        import_path: str,
+        import_status: str,
+        import_review_name: str,
+        sort_choices_visible: bool,
+    ) -> None:
+        """Apply a complete skills snapshot within the mounted canvas."""
+        self.state = state
+        self.sort_mode = sort_mode
+        self.filter_value = filter_value
+        self.mode = mode
+        self.trust_posture = trust_posture
+        self.confirming_reset = confirming_reset
+        self.editor_state = editor_state
+        self.warnings = warnings
+        self.status = status
+        self.conflict = conflict
+        self.active_review = active_review
+        self.is_create = is_create
+        self.dirty = dirty
+        self.confirming_delete = confirming_delete
+        self.scroll_to_actions = scroll_to_actions
+        self.skill_path = skill_path
+        self.import_open = import_open
+        self.import_path = import_path
+        self.import_status = import_status
+        self.import_review_name = import_review_name
+        self.sort_choices_visible = sort_choices_visible
+        self.refresh(recompose=True)
+        self._schedule_scroll_to_actions()
 
     def on_mount(self) -> None:
         """task-417: a recompose lands a fresh canvas scrolled to the top.
@@ -692,6 +750,10 @@ class LibrarySkillsListCanvas(VerticalScroll):
         user still sees the Save button and its status line they just
         acted on.
         """
+        self._schedule_scroll_to_actions()
+
+    def _schedule_scroll_to_actions(self) -> None:
+        """Preserve the post-save scroll receipt across canvas-only syncs."""
         if not (self.scroll_to_actions and self.mode == "editor"):
             return
 


### PR DESCRIPTION
## Summary
- scope frequent Library interactions to their mounted Notes, Prompts, Skills, Ingest, Search/RAG, Media, and Export canvases
- preserve the Library shell, rail, and active canvas identity during per-click updates while patching one-line import status receipts in place
- add TASK-15457 regression coverage for routing, mounted identity, loading copy, and the Notes toggle latency probe

## Verification
- TASK-15457 focused post-rebase suite: 8/8 passed
- Notes toggle latency probe median: 120.964 ms (baseline recorded in task: 632.199 ms)
- Python compileall: passed for all changed Python files
- Ruff: passed for all changed Python files (`E721` ignored because `library_screen.py` contains pre-existing instances outside this task)
- `git diff --check`: passed

The full repository suite was intentionally not pursued further per user direction because collection reaches two unrelated Windows/POSIX incompatibilities: `signal.SIGSTOP` in Media Playback and `fcntl` in TTS. Neither module is changed by this PR.

## Backlog
- TASK-15457
- ADR required: no; this implements the existing Library canvas ownership boundary without changing storage, service contracts, or long-lived architecture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes frequent Library updates to their mounted canvases to eliminate whole‑screen recomposes on common clicks. Old behavior re-rendered the entire Library screen; new behavior syncs only the active canvas/panel, preserving shell/rail/canvas identity and cutting per‑click latency.

- Extends `_sync_library_canvas` to `notes`, `prompts`, `skills`, `ingest`, `search`/RAG, and `export`; replaces many `refresh(recompose=True)` calls with canvas `sync_state` updates. Satisfies TASK-15457.
- Adds `sync_state` to `LibraryNotesCanvas`, `LibraryPromptsListCanvas`, `LibrarySkillsListCanvas`, `LibraryIngestCanvas`, `LibrarySearchRagPanel`, and `LibraryExportCanvas`; moves Notes/Prompt/Skill loading/editor/sync surfaces into their canvases and adds a Notes `loading` mode.
- Routes list→editor transitions and common toggles through canvas sync: notes list/select/sort/filter/sync, prompts/skills sort/filter and row handlers, media type chooser (and Escape), ingest structural options, RAG mode/scope toggles, and choice‑strip close.
- Patches Prompt/Skill import status lines in place on the mounted canvas; late receipts after navigation update stored status without recomposition.
- Adds focused tests in `Tests/UI/test_library_canvas_scoped_sync.py` for mounted identity, routing, Unicode loading copy, real prompt/skill service transitions, ingest routing, status‑line patching, and a 12‑sample notes select‑toggle latency probe (median improved from 632.199 ms to ~121 ms). Lint/compile for changed files passes (pre‑existing `E721` ignored).

**Migration**
- If you construct `LibraryNotesCanvas` directly, rename constructor param `sync_state` to `sync_panel_state`. No other actions required.

<sup>Written for commit 2b23dc854ca35a9708bcdc4cda3c8403746541c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

