### PR TITLE
perf: canvas-scoped sync for Library per-click interactions (task-15457)

### DIFF
--- a/Tests/UI/test_library_canvas_sync_defects.py
+++ b/Tests/UI/test_library_canvas_sync_defects.py
@@ -1,0 +1,322 @@
+"""TASK-15457 review round 1: defects a canvas-scoped sync must not introduce.
+
+Companion to ``test_library_canvas_scoped_sync.py`` (which pins that the
+conversions happen at all). This file pins the three things a canvas-scoped
+sync silently STOPS doing, because they live in ``LibraryScreen.refresh`` --
+the override a targeted sync deliberately bypasses:
+
+* the resolved media selection is mirrored back into ``_selected_media_id``
+  (otherwise the chooser highlights one row and "Open in viewer" opens
+  another);
+* portable Notes focus is restored, so DOM focus never escapes the canvas;
+* the Notes list's scroll offset survives -- which is only observable BELOW
+  ``LIBRARY_NOTES_COMPACT_BREAKPOINT``, where the list can actually scroll.
+
+All six assertions were verified RED against dev's own implementation of this
+task (``976dbafcb``) before the fixes were ported onto it, so this file is
+evidence for dev's converted sites, not only for the ones this branch added.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button, Input, Static
+
+from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_INGEST_MEDIA
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_library_selection_updates import _spy_screen_recomposes
+from Tests.UI.test_library_shell import (
+    LIBRARY_TEST_SIZE,
+    LibraryHarness,
+    _active_library_screen,
+    _seed_conversations,
+    _wait_for_library_shell,
+    _wait_for_selector,
+)
+
+
+def _notes(count: int = 6):
+    return [
+        {
+            "id": f"note-{i}",
+            "title": f"Note number {i}",
+            "content": f"Body of note {i}.",
+            "last_modified": f"2026-06-{i + 1:02d}T10:00:00Z",
+        }
+        for i in range(count)
+    ]
+
+
+def _media(count: int = 4):
+    return [
+        {
+            "id": i + 1,
+            "media_id": str(i + 1),
+            "title": f"Media item {i}",
+            "type": "video" if i % 2 else "document",
+            "content": f"Transcript {i}",
+            "ingestion_date": f"2026-06-{i + 1:02d}T10:00:00Z",
+        }
+        for i in range(count)
+    ]
+
+
+async def _open_notes_canvas(host, pilot):
+    screen = _active_library_screen(host)
+    await _wait_for_library_shell(screen, pilot)
+    screen.query_one("#library-row-browse-notes").press()
+    await _wait_for_selector(screen, pilot, "#library-notes-select-toggle")
+    await pilot.pause()
+    return screen
+
+
+async def _open_media_canvas(host, pilot):
+    screen = _active_library_screen(host)
+    await _wait_for_library_shell(screen, pilot)
+    screen.query_one("#library-row-browse-media").press()
+    await _wait_for_selector(screen, pilot, "#library-media-type-filter")
+    await pilot.pause()
+    return screen
+
+
+def _static_text(screen, selector: str) -> str:
+    renderable = screen.query_one(selector, Static).renderable
+    return getattr(renderable, "plain", str(renderable))
+
+
+def _assert_notes_footer_is_current(screen) -> None:
+    """The registered footer set must match the live Notes state.
+
+    A whole-screen recompose re-derived this for free -- ``LibraryScreen.
+    refresh`` calls ``_apply_library_notes_footer_context`` on every call.
+    A canvas-scoped sync bypasses that override entirely, and the Notes
+    footer tier genuinely branches on select mode and on the sort strip's
+    visibility (``_library_notes_footer_shortcuts``), so every converted
+    notes site has to keep it honest. Caught live: the first cut of the
+    select-strip conversion left the footer advertising the browse keys
+    while select mode was on.
+    """
+    assert screen._footer_shortcut_registration == (
+        "library",
+        screen._library_notes_footer_shortcuts(),
+    )
+
+
+# --------------------------------------------------------------------------
+# Review round 1 — regressions the first cut of this task introduced.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_media_type_filter_keeps_selected_id_in_step_with_the_canvas():
+    """CRITICAL: the media sync branch must mirror the resolved selection.
+
+    ``compose_content`` and ``_replace_library_browse_canvas`` both write
+    ``self._selected_media_id = media_state.selected_id`` after building the
+    state, because ``build_library_media_canvas_state`` RESOLVES the
+    selection: a requested id that the active type filter no longer renders
+    falls back to the first row. The targeted sync skipped that mirror, so
+    filtering the selected item out left the canvas highlighting row 0 while
+    the screen still pointed at the filtered-out id -- and "Open in viewer"
+    opened the invisible one.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, [], media=_media())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _open_media_canvas(host, pilot)
+
+        # ``_media()`` alternates document/video, so id "4" is a video and
+        # ids "1"/"3" are documents. Select the video, then filter to
+        # documents so the selected row stops being rendered at all.
+        video_row = next(
+            button
+            for button in screen.query(".library-media-row").results(Button)
+            if str(getattr(button, "media_id", "")) == "4"
+        )
+        video_id = "4"
+        video_row.press()
+        await pilot.pause()
+        assert screen._selected_media_id == video_id
+        # Back to the list -- the selection survives the round trip, which is
+        # how the browse canvas ends up pointing at a non-first row.
+        screen.action_library_media_viewer_back()
+        await _wait_for_selector(screen, pilot, "#library-media-type-filter")
+        await pilot.pause()
+        assert screen._selected_media_id == video_id
+
+        screen.query_one("#library-media-type-filter", Button).focus()
+        await pilot.pause()
+        screen.query_one("#library-media-type-filter", Button).press()
+        await _wait_for_selector(screen, pilot, ".library-media-type-choice")
+        document_choice = next(
+            button
+            for button in screen.query(".library-media-type-choice").results(Button)
+            if str(getattr(button, "choice_value", "")) == "document"
+        )
+        document_choice.press()
+        await pilot.pause()
+        await pilot.pause()
+
+        canvas_state = screen._build_library_media_state()
+        assert canvas_state.selected_id != video_id  # the filter dropped it
+        # The screen's own pointer must agree with what the canvas renders.
+        assert screen._selected_media_id == canvas_state.selected_id
+        # ...and the primary action must therefore open the visible item.
+        screen._open_library_media_viewer(screen._selected_media_id)
+        await pilot.pause()
+        assert screen._selected_media_id == canvas_state.selected_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "trigger",
+    ["select_toggle", "select_all", "sort_open"],
+)
+async def test_converted_notes_sites_keep_focus_inside_the_canvas(trigger):
+    """CRITICAL: a converted site with no explicit ``then=`` must still
+    restore focus.
+
+    The screen path restores it through
+    ``_rehydrate_library_notes_after_recompose`` ->
+    ``_restore_library_notes_focus_identity``; a canvas-scoped sync bypasses
+    ``LibraryScreen.refresh`` and therefore that machinery entirely, so
+    every converted site WITHOUT its own focus follow-up let DOM focus
+    escape the canvas when its focused child was recomposed away.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, [], notes=_notes(4))
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _open_notes_canvas(host, pilot)
+        if trigger == "select_all":
+            screen.query_one("#library-notes-select-toggle", Button).press()
+            await _wait_for_selector(screen, pilot, "#library-notes-select-all")
+            await pilot.pause()
+
+        selector = {
+            "select_toggle": "#library-notes-select-toggle",
+            "select_all": "#library-notes-select-all",
+            "sort_open": "#library-notes-sort",
+        }[trigger]
+        screen.query_one(selector, Button).focus()
+        await pilot.pause()
+        assert screen.focused is not None and screen.focused.id == selector.lstrip("#")
+
+        screen.query_one(selector, Button).press()
+        await pilot.pause()
+        await pilot.pause()
+
+        # Focus must still be somewhere inside the notes canvas -- never
+        # stranded on the rail/nav chrome outside it.
+        focused = screen.focused
+        assert focused is not None
+        canvas = screen.query_one("#library-notes-canvas")
+        assert canvas in focused.ancestors_with_self, (
+            f"focus escaped the notes canvas to {focused.id!r} after {trigger}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_converted_notes_site_keeps_focus_on_a_real_key_press():
+    """The same guarantee via the real keyboard, not a programmatic press."""
+    app = _build_test_app()
+    _seed_conversations(app, [], notes=_notes(4))
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _open_notes_canvas(host, pilot)
+        screen.query_one("#library-notes-select-toggle", Button).focus()
+        await pilot.pause()
+
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen._library_notes_select_mode is True
+        focused = screen.focused
+        assert focused is not None
+        canvas = screen.query_one("#library-notes-canvas")
+        assert canvas in focused.ancestors_with_self, (
+            f"focus escaped the notes canvas to {focused.id!r}"
+        )
+
+
+LIBRARY_COMPACT_TEST_SIZE = (100, 24)
+
+
+@pytest.mark.asyncio
+async def test_compact_notes_list_keeps_its_scroll_offset_across_a_sync():
+    """IMPORTANT: the notes list's scroll offset must survive a converted site.
+
+    Only reachable below ``LIBRARY_NOTES_COMPACT_BREAKPOINT`` (120 cols) with
+    enough rows to scroll -- every other test in this file runs at 170x48,
+    where the list never scrolls at all. That is the July compact-resize
+    lesson: geometry that is never exercised at a second width is not
+    measured. The screen path restores this via
+    ``_restore_library_notes_scroll_offset``; the canvas-scoped sync bypassed
+    it and dropped the user back to the top of the list.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, [], notes=_notes(40))
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_COMPACT_TEST_SIZE) as pilot:
+        screen = await _open_notes_canvas(host, pilot)
+        assert screen._library_notes_compact is True
+
+        notes_list = screen.query_one("#library-notes-list")
+        notes_list.scroll_to(y=12, animate=False, force=True, immediate=True)
+        await pilot.pause()
+        offset_before = int(notes_list.scroll_offset.y)
+        assert offset_before > 0, "the list did not scroll; the fixture is too short"
+
+        screen.query_one("#library-notes-select-toggle", Button).focus()
+        await pilot.pause()
+        screen.query_one("#library-notes-select-toggle", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+
+        after = screen.query_one("#library-notes-list")
+        assert int(after.scroll_offset.y) == offset_before, (
+            f"notes list scroll fell {offset_before} -> {int(after.scroll_offset.y)}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_notes_footer_tier_follows_a_canvas_scoped_sync():
+    """The Notes footer tier must track select mode across a targeted sync.
+
+    ``LibraryScreen.refresh`` re-derives the footer on every whole-screen
+    recompose; a canvas-scoped sync bypasses it. The Notes tier genuinely
+    branches on select mode (``("enter", "select note") / ("esc", "done")``),
+    so without an explicit refresh at the sync choke point the footer keeps
+    advertising the browse keys.
+
+    Note this assertion is only meaningful once focus restoration works: with
+    focus escaping the canvas the region resolves to "" and the Notes tier is
+    never selected at all, so the invariant passes vacuously.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, [], notes=_notes(4))
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _open_notes_canvas(host, pilot)
+        screen.query_one("#library-notes-select-toggle", Button).focus()
+        await pilot.pause()
+
+        screen.query_one("#library-notes-select-toggle", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen._library_notes_select_mode is True
+        assert screen._library_notes_focus_region() == "navigator"
+        assert screen._footer_shortcut_registration == (
+            "library",
+            screen._library_notes_footer_shortcuts(),
+        )
+        assert ("esc", "done") in screen._library_notes_footer_shortcuts()

--- a/Tests/UI/test_library_canvas_sync_defects.py
+++ b/Tests/UI/test_library_canvas_sync_defects.py
@@ -20,9 +20,7 @@ evidence for dev's converted sites, not only for the ones this branch added.
 from __future__ import annotations
 
 import pytest
-from textual.widgets import Button, Input, Static
-
-from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_INGEST_MEDIA
+from textual.widgets import Button, Static
 
 from Tests.UI.app_factory import _build_test_app
 from Tests.UI.test_library_selection_updates import _spy_screen_recomposes
@@ -175,7 +173,7 @@ async def test_media_type_filter_keeps_selected_id_in_step_with_the_canvas():
     "trigger",
     ["select_toggle", "select_all", "sort_open"],
 )
-async def test_converted_notes_sites_keep_focus_inside_the_canvas(trigger):
+async def test_converted_notes_sites_keep_focus_inside_the_canvas(monkeypatch, trigger):
     """CRITICAL: a converted site with no explicit ``then=`` must still
     restore focus.
 
@@ -206,10 +204,16 @@ async def test_converted_notes_sites_keep_focus_inside_the_canvas(trigger):
         await pilot.pause()
         assert screen.focused is not None and screen.focused.id == selector.lstrip("#")
 
+        recompose_calls = _spy_screen_recomposes(monkeypatch)
+
         screen.query_one(selector, Button).press()
         await pilot.pause()
         await pilot.pause()
 
+        # Discriminating: a whole-screen fallback would restore focus through
+        # dev's own rehydration, so without this the assertion below would
+        # pass for the wrong reason.
+        assert recompose_calls == []
         # Focus must still be somewhere inside the notes canvas -- never
         # stranded on the rail/nav chrome outside it.
         focused = screen.focused
@@ -221,7 +225,7 @@ async def test_converted_notes_sites_keep_focus_inside_the_canvas(trigger):
 
 
 @pytest.mark.asyncio
-async def test_converted_notes_site_keeps_focus_on_a_real_key_press():
+async def test_converted_notes_site_keeps_focus_on_a_real_key_press(monkeypatch):
     """The same guarantee via the real keyboard, not a programmatic press."""
     app = _build_test_app()
     _seed_conversations(app, [], notes=_notes(4))
@@ -232,10 +236,13 @@ async def test_converted_notes_site_keeps_focus_on_a_real_key_press():
         screen.query_one("#library-notes-select-toggle", Button).focus()
         await pilot.pause()
 
+        recompose_calls = _spy_screen_recomposes(monkeypatch)
+
         await pilot.press("enter")
         await pilot.pause()
         await pilot.pause()
 
+        assert recompose_calls == []  # see the sibling test: discriminating
         assert screen._library_notes_select_mode is True
         focused = screen.focused
         assert focused is not None
@@ -320,3 +327,39 @@ async def test_notes_footer_tier_follows_a_canvas_scoped_sync():
             screen._library_notes_footer_shortcuts(),
         )
         assert ("esc", "done") in screen._library_notes_footer_shortcuts()
+
+
+@pytest.mark.asyncio
+async def test_notes_row_press_to_editor_keeps_focus_inside_the_canvas(monkeypatch):
+    """The list -> loading -> editor row press is a DOUBLE canvas sync.
+
+    Dev's row press syncs the canvas to its loading surface, then again to the
+    editor once the detail lands. Two syncs mean the first recompose can still
+    be awaiting ``mount_all`` when the second one's state arrives -- so a
+    follow-up fired at the end of the first recompose runs against children
+    that are already stale, and focus lands nowhere useful.
+
+    ``_apply_post_compose_state`` already gates on its own mounted children;
+    this pins the same guarantee for the queued follow-up itself.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, [], notes=_notes(4))
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _open_notes_canvas(host, pilot)
+        row = screen.query_one("#library-notes-row-0", Button)
+        row.focus()
+        await pilot.pause()
+
+        row.press()
+        await _wait_for_selector(screen, pilot, "#library-note-title")
+        await pilot.pause()
+        await pilot.pause()
+
+        focused = screen.focused
+        assert focused is not None
+        canvas = screen.query_one("#library-notes-canvas")
+        assert canvas in focused.ancestors_with_self, (
+            f"focus escaped the notes canvas to {focused.id!r} on row -> editor"
+        )

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -307,6 +307,60 @@ at YOUR head before porting X. One of the four items in this reconciliation's
 brief (selection into windowed-out history) was already implemented and
 working; porting it blind would have duplicated a mechanism inside a PR whose
 whole purpose was undoing duplication.
+### Fourth instance: TASK-15457, 2026-08-12/13 — found only when the rebase would not apply
+
+**Two complete implementations of TASK-15457 ("Library: convert per-click
+whole-screen recomposes to canvas-scoped sync") existed simultaneously, and
+neither session knew.** Codex's landed on `dev` as `976dbafcb`
+("perf(library): scope frequent updates to canvases") on 2026-08-12 and marked
+the task **Done**; the other ran 2026-08-11→13 on
+`task/15457-library-recompose`, through two review rounds, and was discovered
+only when the coordinator tried to merge it and dev had moved.
+
+Both wrote a file at the SAME path, `Tests/UI/test_library_canvas_scoped_sync.py`
+(441 lines vs 687), and both edited the same task file. The duplication was
+invisible to every check either session ran: tests passed on both sides, the
+task file on the branch still said `In Progress` because dev's `Done` was on a
+commit the branch predated, and `git status` was clean.
+
+**What made this one different from 595/596: the duplicate WON on scope, and
+the survivor was the defects.** Dev's implementation converted more sites (143
+→ 102 vs 152 → 132) and moved the list→editor loading views into their owning
+canvases. So all eight conversion slices were dropped as superseded. What
+survived was the part the other implementation lacked — four defects that
+reproduced RED against dev's own code: an unmirrored `_selected_media_id` (the
+media chooser opened a filtered-out item), focus escaping the canvas on every
+converted site, a dropped compact-mode scroll offset, and unarmed editors on
+the row→editor transition. **Roughly 1,200 lines of implementation reduced to
+~190 lines of portable delta.**
+
+**The specific check that would have caught it, and why the published one did
+not.** The 595/596 lesson prescribes `gh pr list --search "<id>"` before
+designing and periodically during a long build. That still would not have
+fired here: `976dbafcb` reached dev as part of a batch whose PR title names
+neither the task id nor the Library screen. The check that works for a task
+this long-running is against **dev itself**, not the PR list:
+
+```bash
+git log origin/dev --oneline -S "task-15457" -- backlog/tasks/ | head   # task file touched?
+git log origin/dev --oneline -- "Tests/**/*canvas_scoped_sync*"          # my test path claimed?
+git fetch -q origin && git log --oneline $(git merge-base origin/dev HEAD)..origin/dev -- <the files I am editing>
+```
+
+Run the third one before every review round, not just at merge. A task whose
+work spans days will outlive any snapshot of dev taken at its start.
+
+**Related trap this surfaced:** a parallel implementation can carry the same
+defects yours does. Do not assume the version that reached dev first is the
+correct one — the four defects above shipped `Done`, and one of them (the notes
+footer) *appeared* fine only because an unrelated per-refresh mechanism masked
+it, which a non-discriminating test then "confirmed". Probe by disabling the
+mechanism you think is responsible before claiming it is.
+
+**Note for whoever merges this:** the third-instance block for this lesson
+(TASK-15455) is on `dev` but was NOT in this branch's rebase base
+(`74c8cf7043`), so this entry appends to the TASK-595/596 section instead. If
+both land, renumber the instances so the sequence reads 1-2-3-4.
 
 ---
 

--- a/backlog/tasks/task-15457 - Library---convert-per-click-whole-screen-recomposes-to-canvas-scoped-sync.md
+++ b/backlog/tasks/task-15457 - Library---convert-per-click-whole-screen-recomposes-to-canvas-scoped-sync.md
@@ -51,8 +51,8 @@ Reason: this task applies the existing Library screen/rail/canvas ownership and 
 
 A second session implemented this task independently on branch
 `task/15457-library-recompose` while the codex implementation above landed on
-dev as `976dbafcb`. Reconciled by semantic rebase onto `origin/dev`
-(`61f6ae575`), reading each dev commit before resolving. Outcome:
+dev as `976dbafcb`. Reconciled by semantic rebase onto `origin/dev` at `74c8cf7043`, reading each
+dev commit before resolving. Outcome:
 
 **Superseded by `976dbafcb` — dropped, no hunk kept.** The conversions
 themselves: notes select strip, notes sort/filter strips, notes-sync toggles,
@@ -85,10 +85,20 @@ port and green after:
    `LIBRARY_NOTES_COMPACT_BREAKPOINT`. Restored on the same follow-up, but
    deferred via `call_after_refresh` — run inline the new children are not laid
    out, max scroll is still 0 and `scroll_to` clamps the offset away.
-4. Neither footer tier was re-derived: the Notes tier branches on select mode
-   and sort-strip visibility, and the shared choice-strip tier advertises its
-   own keys while a media/prompts/skills/export strip is open. Both now refresh
-   at the one sync choke point.
+4. **Not a reproduced defect — hardening that was probed and then REMOVED.**
+   A footer re-derivation was added at the sync choke point on the theory that
+   neither footer tier survives a targeted sync. It does not reproduce red on
+   dev. Probed by disabling both branches: the Notes select-mode footer and the
+   media type-strip footer both stayed current, because dev's
+   `LibraryScreen.refresh` calls `_apply_library_notes_footer_context()` on
+   EVERY refresh (not only `recompose=True`), and every footer-flipping sync
+   has a focus follow-up whose `set_focus`/`scroll_visible` triggers one — the
+   call chain was traced (`refresh <- _restore_library_notes_focus_identity <-
+   _restore_library_notes_after_targeted_sync`). The branch is gone rather than
+   kept unfalsifiable; the coupling it would have guarded is listed under
+   Residuals below. The earlier claim that this reproduced red was wrong: the
+   test written for it passes with the mechanism disabled, i.e. it was never
+   discriminating.
 
 Also ported: `PostRecomposeCallback` skips its callback when
 `Widget.recompose` early-returns on a detached/pruning widget, and
@@ -100,3 +110,51 @@ Evidence lives in `Tests/UI/test_library_canvas_sync_defects.py` (7 tests),
 kept separate from dev's `test_library_canvas_scoped_sync.py` rather than
 merged into it: the two files pin different things — that the conversions
 happen, and that they do not lose selection, focus, scroll, or footer.
+
+### Reconciliation: residuals, counting method, and what is actually closed
+
+**Focus is closed, including the transition.** The first pass of this
+reconciliation left the notes row→editor path still stranding focus outside the
+canvas, and the task file read as if focus were done. It is now genuinely
+closed, by three changes rather than one, because that path is a DOUBLE canvas
+sync (list → loading → editor):
+
+* `PostRecomposeCallback` re-queues its follow-up when `_recompose_required` is
+  re-armed during a recompose — Textual's own signal that a second `sync_state`
+  landed while this one was still awaiting `mount_all`. Without it the
+  follow-up ran against the loading children (traced: `still_queued=True` on the
+  loading pass, fired on the editor pass).
+* the default notes focus restore is installed only for IN-SURFACE syncs
+  (mounted mode == synced mode). On a transition the capture is worthless: the
+  handlers flip the notes view *before* calling the sync, so
+  `_capture_library_notes_focus_identity` already reports the destination region
+  with an empty semantic role, and restoring it resolved to a fallback target —
+  measured landing spot, the rail row.
+* every remaining `call_after_refresh` follow-up on a canvas sync is now a
+  `then=`: the notes editor arm + editor identity, and the skills and prompts
+  `_arm_*` calls. Arming is dirty-tracking, not cosmetics — a lost follow-up
+  leaves the editor unarmed. **Zero `call_after_refresh` follow-ups remain on a
+  canvas sync.**
+
+**Residual (recorded, not closed): footer honesty is coupled to focus.** Both
+footer tiers stay current only because a focus follow-up triggers a screen
+refresh and dev's `refresh` override re-derives the footer unconditionally. A
+future footer-flipping sync with no follow-up would go stale silently, and no
+test would catch it — the invariant test in
+`test_library_canvas_sync_defects.py` is a regression net, not a discriminating
+probe (it passes with the mechanism disabled, which is why the explicit branch
+was removed rather than kept).
+
+**Counting method.** This branch reports 122 whole-screen recompose sites in
+`library_screen.py`, counting `self.refresh(recompose=True)` +
+`await self.recompose()` + the module-level helpers' `screen.refresh(...)`
+fallbacks, on non-comment lines. Dev's notes report 102; that number is **not
+reproducible with this measure** and the two should not be compared — the
+difference is method, not regression. Whoever cares about the headline should
+pick one script and re-run it over both trees.
+
+**Also carried from the parallel branch:** `RecomposeCaptureGuard` was added to
+`LibraryNotesCanvas`, which dev's version does not carry — a canvas that
+recomposes itself bypasses `BaseAppScreen.refresh`'s mouse-capture release, and
+this canvas mounts `Input`/`TextArea` children where a stale capture is exactly
+the app-wide click-dispatch failure that guard exists for.

--- a/backlog/tasks/task-15457 - Library---convert-per-click-whole-screen-recomposes-to-canvas-scoped-sync.md
+++ b/backlog/tasks/task-15457 - Library---convert-per-click-whole-screen-recomposes-to-canvas-scoped-sync.md
@@ -46,3 +46,57 @@ Reason: this task applies the existing Library screen/rail/canvas ownership and 
 - Evidence: the current pre-change base contained 143 statement-level whole-screen recompose sites and the final implementation contains 102 (41 removed). The identical 12-click Notes select-toggle probe improved from a 632.199 ms median to 123.315 ms after the final rebase (80.5%). Mounted UAT passed at 160×45 and 235×52.
 - Verification: changed files compile; Ruff reports no new findings when the seven pre-existing `E721` findings in `library_screen.py` are excluded; direct isolated runs passed all new tests plus the focused existing regressions listed above. Normal pytest collection remains unavailable in this Windows sandbox because the repository's network guard blocks Textual's internal localhost socketpair, so async test bodies were run directly under fully isolated config/data/temp paths as prescribed by `lessons-testing-evidence.md`.
 - ADR required: no. This applies the existing canvas ownership/update contract and introduces no new architectural boundary. No new lessons entry was warranted; the review-found Unicode-copy and off-surface asynchronous receipt issues are directly regression-pinned in the task test file.
+
+## Rebase reconciliation (parallel implementation)
+
+A second session implemented this task independently on branch
+`task/15457-library-recompose` while the codex implementation above landed on
+dev as `976dbafcb`. Reconciled by semantic rebase onto `origin/dev`
+(`61f6ae575`), reading each dev commit before resolving. Outcome:
+
+**Superseded by `976dbafcb` — dropped, no hunk kept.** The conversions
+themselves: notes select strip, notes sort/filter strips, notes-sync toggles,
+media type chooser, ingest option toggles, Search/RAG mode+scope toggles, and
+the prompts/skills import-status receipts. `976dbafcb` converted the same
+sites and went further (Prompts, Skills, Export, and the list→editor loading
+views moved into their owning canvases; 143→102 sites vs this branch's
+152→132). The parallel branch's `LibraryNotesCanvasState` dataclass is also
+superseded: dev's keyword-argument `sync_state` covers the same ground, and
+its `sync_panel_state` rename resolves the same constructor shadowing the task
+was blocked on. Minor 7 (the skills-import stale-screen guard gap) is
+superseded too — dev already added the guard.
+
+**Merged — dev's site, this branch's fix.** Four defects present in
+`976dbafcb`'s own implementation, each verified RED against dev before the
+port and green after:
+
+1. `_sync_library_canvas`'s media branch never mirrored the RESOLVED selection
+   back into `_selected_media_id` (`compose_content` and
+   `_replace_library_browse_canvas` both do). Filtering the selected item out
+   left the canvas highlighting one row while "Open in viewer" opened another.
+2. Focus escaped the canvas on every converted site. `call_after_refresh` has
+   no ordering against a recompose driven by the canvas's own message pump, so
+   dev's nine focus follow-ups ran against removed children; measured landing
+   spot `console-rail-section-toggle-library-details`. Fixed by the new
+   `PostRecomposeCallback` mixin plus `_sync_library_canvas(..., then=...)`,
+   with a default follow-up that restores the portable Notes focus identity the
+   whole-screen seam restores for itself.
+3. The Notes list's scroll offset was dropped (12→0), visible only below
+   `LIBRARY_NOTES_COMPACT_BREAKPOINT`. Restored on the same follow-up, but
+   deferred via `call_after_refresh` — run inline the new children are not laid
+   out, max scroll is still 0 and `scroll_to` clamps the offset away.
+4. Neither footer tier was re-derived: the Notes tier branches on select mode
+   and sort-strip visibility, and the shared choice-strip tier advertises its
+   own keys while a media/prompts/skills/export strip is open. Both now refresh
+   at the one sync choke point.
+
+Also ported: `PostRecomposeCallback` skips its callback when
+`Widget.recompose` early-returns on a detached/pruning widget, and
+`LibraryNotesCanvas` re-runs `on_mount`'s post-compose wiring through an
+`_after_recompose()` hook ordered BEFORE the follow-up (dev's `sync_state`
+recomposed without re-running it at all).
+
+Evidence lives in `Tests/UI/test_library_canvas_sync_defects.py` (7 tests),
+kept separate from dev's `test_library_canvas_scoped_sync.py` rather than
+merged into it: the two files pin different things — that the conversions
+happen, and that they do not lose selection, focus, scroll, or footer.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1313,7 +1313,12 @@ def _apply_library_row_toggle(
         screen.refresh(recompose=True)
 
 
-def _sync_library_canvas(screen: "LibraryScreen", kind: str) -> None:
+def _sync_library_canvas(
+    screen: "LibraryScreen",
+    kind: str,
+    *,
+    then: Callable[[], None] | None = None,
+) -> None:
     """Canvas-scoped targeted update for a Library browse canvas (Tier 2).
 
     Rebuilds the given canvas's fresh display state and hands it to the
@@ -1340,6 +1345,18 @@ def _sync_library_canvas(screen: "LibraryScreen", kind: str) -> None:
     Args:
         screen: The Library screen instance driving the update.
         kind: Supported Library canvas kind.
+        then: Optional zero-argument follow-up (in practice: "focus the
+            control the user should now be on"), run once the canvas's new
+            children are mounted. It exists because
+            ``screen.call_after_refresh`` -- correct for a WHOLE-SCREEN
+            recompose, where ``Screen._on_timer_update`` runs the recompose
+            before the callbacks -- has no ordering against a recompose
+            driven by the CANVAS's own message pump. Reproduced while
+            converting the notes strips: the follow-ups ran against removed
+            children and stranded DOM focus outside the canvas. Supported
+            only for canvases carrying ``PostRecomposeCallback``; passing it
+            for another kind raises into the whole-screen fallback rather
+            than silently dropping the follow-up.
 
     Returns:
         None.
@@ -1401,6 +1418,8 @@ def _sync_library_canvas(screen: "LibraryScreen", kind: str) -> None:
                     "Mouse-capture release before Library canvas sync skipped.",
                     exc_info=True,
                 )
+        if then is not None:
+            canvas.queue_after_recompose(then)
         canvas.sync_state(*sync_args, **sync_kwargs)
         # task-15457: the one thing a canvas sync cannot skip.
         # ``LibraryScreen.refresh`` (the override) re-derives the footer on
@@ -4972,22 +4991,27 @@ class LibraryScreen(BaseAppScreen):
             self._supersede_library_notes_navigation()
             self._library_notes_view = "list"
             self._reset_library_notes_sync_transient_state()
-            _sync_library_canvas(self, "notes")
-            self.call_after_refresh(self._focus_library_notes_filter_input)
+            _sync_library_canvas(
+                self, "notes", then=self._focus_library_notes_filter_input
+            )
             return
         if self._library_notes_select_mode:
             self._library_notes_select_mode = False
             self._library_notes_row_selection.clear()
-            _sync_library_canvas(self, "notes")
-            self.call_after_refresh(
-                self._focus_library_note_control, "#library-notes-select-toggle"
+            _sync_library_canvas(
+                self,
+                "notes",
+                then=lambda: self._focus_library_note_control(
+                    "#library-notes-select-toggle"
+                ),
             )
             return
         if self._library_notes_sort_choices_visible:
             self._library_notes_sort_choices_visible = False
-            _sync_library_canvas(self, "notes")
-            self.call_after_refresh(
-                self._focus_library_note_control, "#library-notes-sort"
+            _sync_library_canvas(
+                self,
+                "notes",
+                then=lambda: self._focus_library_note_control("#library-notes-sort"),
             )
             return
         self._library_notes_stage = "rail"
@@ -12796,17 +12820,14 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_type_choices_visible = (
             not self._library_media_type_choices_visible
         )
-        _sync_library_canvas(self, "media")
         if self._library_media_type_choices_visible:
-            self.call_after_refresh(
-                self._focus_library_choice_strip_active,
+            then: Callable[[], None] = lambda: self._focus_library_choice_strip_active(
                 ".library-media-type-choice",
                 self._library_media_type_filter,
             )
         else:
-            self.call_after_refresh(
-                self._focus_library_control, "#library-media-type-filter"
-            )
+            then = lambda: self._focus_library_control("#library-media-type-filter")
+        _sync_library_canvas(self, "media", then=then)
 
     @on(Button.Pressed, ".library-media-type-choice")
     def handle_library_media_type_choice(self, event: Button.Pressed) -> None:
@@ -12826,9 +12847,10 @@ class LibraryScreen(BaseAppScreen):
             # bulk-delete confirmation either, and states the discard like
             # every other exit.
             self._exit_library_media_select_mode(announce_discard=True)
-        _sync_library_canvas(self, "media")
-        self.call_after_refresh(
-            self._focus_library_control, "#library-media-type-filter"
+        _sync_library_canvas(
+            self,
+            "media",
+            then=lambda: self._focus_library_control("#library-media-type-filter"),
         )
 
     @on(Button.Pressed, ".library-media-row")
@@ -13443,8 +13465,9 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_trash_total = total
         self._library_media_trash_error = error
         if self.is_mounted and self._library_media_view == "trash":
-            _sync_library_canvas(self, "media-trash")
-            self.call_after_refresh(self._focus_library_media_trash_entry)
+            _sync_library_canvas(
+                self, "media-trash", then=self._focus_library_media_trash_entry
+            )
 
     @on(Button.Pressed, ".library-media-trash-row")
     def handle_library_media_trash_row(self, event: Button.Pressed) -> None:
@@ -13736,8 +13759,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_sort_choices_visible = False
         self._library_notes_select_mode = False
         self._library_notes_row_selection.clear()
-        _sync_library_canvas(self, "notes")
-        self.call_after_refresh(self._focus_library_notes_filter_input)
+        _sync_library_canvas(self, "notes", then=self._focus_library_notes_filter_input)
 
     @on(Input.Submitted, "#library-notes-filter")
     def handle_library_notes_filter(self, event: Input.Submitted) -> None:
@@ -13798,8 +13820,7 @@ class LibraryScreen(BaseAppScreen):
         if query != self._library_notes_filter:
             return
         self._library_notes_filter_records = list(records or [])
-        _sync_library_canvas(self, "notes")
-        self.call_after_refresh(self._focus_library_notes_filter_input)
+        _sync_library_canvas(self, "notes", then=self._focus_library_notes_filter_input)
 
     def _focus_library_notes_filter_input(self) -> None:
         """Restore focus to the notes filter box after a filter recompose."""
@@ -13853,9 +13874,10 @@ class LibraryScreen(BaseAppScreen):
         scope = self._library_prompt_browse_controller.scope
         current = "name" if scope.sort_by == "name" else "newest"
         if requested not in {"newest", "name"} or requested == current:
-            _sync_library_canvas(self, "prompts")
-            self.call_after_refresh(
-                self._focus_library_control, "#library-prompts-sort"
+            _sync_library_canvas(
+                self,
+                "prompts",
+                then=lambda: self._focus_library_control("#library-prompts-sort"),
             )
             return
         if requested == "name":
@@ -13964,17 +13986,16 @@ class LibraryScreen(BaseAppScreen):
         self._library_skills_sort_choices_visible = (
             not self._library_skills_sort_choices_visible
         )
-        _sync_library_canvas(self, "skills")
         if self._library_skills_sort_choices_visible:
-            self.call_after_refresh(
-                self._focus_library_choice_strip_active,
-                ".library-skills-sort-choice",
-                self._library_skills_sort,
+            skills_then: Callable[[], None] = (
+                lambda: self._focus_library_choice_strip_active(
+                    ".library-skills-sort-choice",
+                    self._library_skills_sort,
+                )
             )
         else:
-            self.call_after_refresh(
-                self._focus_library_control, "#library-skills-sort"
-            )
+            skills_then = lambda: self._focus_library_control("#library-skills-sort")
+        _sync_library_canvas(self, "skills", then=skills_then)
 
     @on(Button.Pressed, ".library-skills-sort-choice")
     def handle_library_skills_sort_choice(self, event: Button.Pressed) -> None:
@@ -13992,9 +14013,10 @@ class LibraryScreen(BaseAppScreen):
         self._library_skills_sort_choices_visible = False
         if requested in _LIBRARY_SKILLS_SORT_MODES:
             self._library_skills_sort = requested
-        _sync_library_canvas(self, "skills")
-        self.call_after_refresh(
-            self._focus_library_control, "#library-skills-sort"
+        _sync_library_canvas(
+            self,
+            "skills",
+            then=lambda: self._focus_library_control("#library-skills-sort"),
         )
 
     @on(Input.Submitted, "#library-skills-filter")
@@ -18730,8 +18752,11 @@ class LibraryScreen(BaseAppScreen):
             "_library_skills_sort_choices_visible": "skills",
             "_library_export_quality_choices_visible": "export",
         }[visibility_attr]
-        _sync_library_canvas(self, canvas_kind)
-        self.call_after_refresh(self._focus_library_control, opener_selector)
+        _sync_library_canvas(
+            self,
+            canvas_kind,
+            then=lambda: self._focus_library_control(opener_selector),
+        )
         return True
 
     def action_library_list_focus_rail(self) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1402,6 +1402,23 @@ def _sync_library_canvas(screen: "LibraryScreen", kind: str) -> None:
                     exc_info=True,
                 )
         canvas.sync_state(*sync_args, **sync_kwargs)
+        # task-15457: the one thing a canvas sync cannot skip.
+        # ``LibraryScreen.refresh`` (the override) re-derives the footer on
+        # every whole-screen recompose, so these sites used to get it for
+        # free. Two footer tiers genuinely change under a targeted sync:
+        # the Notes tier branches on select mode and on the sort strip's
+        # visibility (``_library_notes_footer_shortcuts``), and the shared
+        # choice-strip tier advertises "enter choose … / esc cancel" while
+        # a media/prompts/skills/export strip is open
+        # (``_library_open_choice_strip``). Applied HERE, at the one choke
+        # point every converted site passes through, rather than per call
+        # site -- the media bulk-delete confirm's own two hand-added
+        # ``_register_footer_shortcuts()`` calls are the precedent for how
+        # easily a per-site version is forgotten.
+        if kind == "notes":
+            screen._apply_library_notes_footer_context()
+        else:
+            screen._register_footer_shortcuts()
     except Exception:
         logger.debug(
             f"Library {kind} canvas sync failed; falling back to full recompose.",

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1371,7 +1371,17 @@ def _sync_library_canvas(
             sync_args = (screen._build_library_conversations_state(),)
         elif kind == "media":
             canvas = screen.query_one("#library-media-canvas", LibraryMediaCanvas)
-            sync_args = (screen._build_library_media_state(),)
+            media_state = screen._build_library_media_state()
+            # The state builder RESOLVES the selection -- a requested id the
+            # active type filter no longer renders falls back to the first
+            # row -- so the screen's pointer has to be re-read from it, the
+            # same mirror ``compose_content`` and
+            # ``_replace_library_browse_canvas`` perform. Without it,
+            # filtering the selected item out left the canvas highlighting
+            # row 0 while "Open in viewer" still opened the filtered-out
+            # item (task-15457 review round 1, Critical 1).
+            screen._selected_media_id = media_state.selected_id
+            sync_args = (media_state,)
         elif kind == "media-trash":
             # task-4025: the media canvas's Trash view -- same targeted
             # contract, its own mounted widget/state builder.
@@ -1418,8 +1428,37 @@ def _sync_library_canvas(
                     "Mouse-capture release before Library canvas sync skipped.",
                     exc_info=True,
                 )
-        if then is not None:
-            canvas.queue_after_recompose(then)
+        # task-15457 review round 1, Critical 2 + Important 3: the DEFAULT
+        # follow-up. A whole-screen recompose restores portable Notes focus
+        # and the named region's scroll offset through ``LibraryScreen.
+        # refresh`` -> ``_rehydrate_library_notes_after_recompose`` ->
+        # ``_restore_library_notes_focus_identity``. A canvas-scoped sync
+        # bypasses that override entirely, so every converted notes site
+        # WITHOUT its own ``then=`` let DOM focus escape to the console rail
+        # when its focused child was recomposed away, and (only visible
+        # below ``LIBRARY_NOTES_COMPACT_BREAKPOINT``, where the list can
+        # actually scroll) dropped the notes list back to the top.
+        # Captured here, at the same choke point the footer fix uses, and
+        # gated on the notes workflow owning the route -- the identity is
+        # Notes-specific, so a media/ingest/search sync must not build one.
+        # An explicit ``then`` COMPOSES with this rather than replacing it:
+        # the restore runs first (portable focus + scroll), then the site's
+        # own follow-up gets the last word on where focus lands.
+        follow_up: Callable[[], None] | None = then
+        if screen._library_notes_workflow_active():
+            identity = screen._capture_library_notes_focus_identity()
+
+            def _restore_then_explicit(
+                _identity: LibraryNotesFocusIdentity = identity,
+                _explicit: Callable[[], None] | None = then,
+            ) -> None:
+                screen._restore_library_notes_after_targeted_sync(_identity)
+                if _explicit is not None:
+                    _explicit()
+
+            follow_up = _restore_then_explicit
+        if follow_up is not None:
+            canvas.queue_after_recompose(follow_up)
         canvas.sync_state(*sync_args, **sync_kwargs)
         # task-15457: the one thing a canvas sync cannot skip.
         # ``LibraryScreen.refresh`` (the override) re-derives the footer on
@@ -1448,7 +1487,9 @@ def _sync_library_canvas(
             # The fallback tears the canvas down, taking any callback queued
             # on it; re-schedule the follow-up the way a whole-screen
             # recompose has always scheduled one, so a failed targeted sync
-            # costs a rebuild but never the user's focus.
+            # costs a rebuild but never the user's focus. Only the EXPLICIT
+            # follow-up is re-scheduled: the default restore above is what
+            # the whole-screen path does for itself.
             screen.call_after_refresh(then)
 
 
@@ -4126,6 +4167,40 @@ class LibraryScreen(BaseAppScreen):
             self._library_notes_pending_focus_identity = None
             self._library_notes_pending_focus_generation = None
         return restored_exact_target
+
+    def _restore_library_notes_after_targeted_sync(
+        self, identity: LibraryNotesFocusIdentity
+    ) -> None:
+        """Restore portable Notes focus + scroll after a canvas-scoped sync.
+
+        task-15457 review round 1. The whole-screen seam does this through
+        ``_rehydrate_library_notes_after_recompose``; a canvas-scoped sync
+        never reaches ``LibraryScreen.refresh``, so it needs its own entry
+        into the same restore. No ``_LibraryNotesRestoreGuard`` is passed:
+        the guard exists to invalidate a DEFERRED restore that a newer
+        navigation intent has superseded, and this one runs synchronously
+        from the canvas's own ``recompose``, against the state that was
+        captured moments earlier in the same handler.
+
+        Args:
+            identity: The portable identity captured before the sync.
+
+        Returns:
+            None.
+        """
+        # Focus FIRST and synchronously: the callback runs from the canvas's
+        # own ``recompose``, so focus is restored before any frame in which
+        # it could be seen sitting outside the canvas.
+        self._restore_library_notes_focus_identity(identity)
+        # Scroll SECOND and deferred. The restore above already attempts it,
+        # but at this point the freshly mounted children have not been laid
+        # out yet -- the container's max scroll is still 0, so ``scroll_to``
+        # clamps the offset away (measured: a 12-row offset restored as 0).
+        # The whole-screen seam never hits this because it restores from
+        # ``call_after_refresh``, i.e. after a display refresh; re-applying
+        # from the same primitive here gives the offset a laid-out container
+        # to land in. Idempotent, so the earlier attempt costs nothing.
+        self.call_after_refresh(self._restore_library_notes_scroll_offset, identity)
 
     def _restore_library_notes_scroll_offset(
         self,

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1444,6 +1444,12 @@ def _sync_library_canvas(
             exc_info=True,
         )
         screen.refresh(recompose=True)
+        if then is not None:
+            # The fallback tears the canvas down, taking any callback queued
+            # on it; re-schedule the follow-up the way a whole-screen
+            # recompose has always scheduled one, so a failed targeted sync
+            # costs a rebuild but never the user's focus.
+            screen.call_after_refresh(then)
 
 
 def _canonical_shortcut_key(key: str) -> str:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1445,7 +1445,20 @@ def _sync_library_canvas(
         # the restore runs first (portable focus + scroll), then the site's
         # own follow-up gets the last word on where focus lands.
         follow_up: Callable[[], None] | None = then
-        if screen._library_notes_workflow_active():
+        # Gated on the KIND, not on the screen-level workflow predicate
+        # (review m5): the identity is the notes canvas's, and
+        # ``_library_notes_workflow_active()`` is also true while a
+        # media/ingest/search sync runs from a Notes rail row, which would
+        # build and restore an identity for a canvas that is not on screen.
+        if kind == "notes" and sync_kwargs.get("mode") == getattr(canvas, "mode", None):
+            # ...and only for an IN-SURFACE sync. On a surface TRANSITION
+            # (list -> loading -> editor) the capture is worthless: the
+            # handlers flip the notes view before calling this, so
+            # ``_capture_library_notes_focus_identity`` already reports the
+            # DESTINATION region with an empty semantic role -- restoring it
+            # resolves to a fallback target (measured: the rail row), which is
+            # worse than leaving focus to the transition's own arming path
+            # (``_arm_library_note_editor`` + its explicit editor identity).
             identity = screen._capture_library_notes_focus_identity()
 
             def _restore_then_explicit(
@@ -1460,23 +1473,19 @@ def _sync_library_canvas(
         if follow_up is not None:
             canvas.queue_after_recompose(follow_up)
         canvas.sync_state(*sync_args, **sync_kwargs)
-        # task-15457: the one thing a canvas sync cannot skip.
-        # ``LibraryScreen.refresh`` (the override) re-derives the footer on
-        # every whole-screen recompose, so these sites used to get it for
-        # free. Two footer tiers genuinely change under a targeted sync:
-        # the Notes tier branches on select mode and on the sort strip's
-        # visibility (``_library_notes_footer_shortcuts``), and the shared
-        # choice-strip tier advertises "enter choose … / esc cancel" while
-        # a media/prompts/skills/export strip is open
-        # (``_library_open_choice_strip``). Applied HERE, at the one choke
-        # point every converted site passes through, rather than per call
-        # site -- the media bulk-delete confirm's own two hand-added
-        # ``_register_footer_shortcuts()`` calls are the precedent for how
-        # easily a per-site version is forgotten.
-        if kind == "notes":
-            screen._apply_library_notes_footer_context()
-        else:
-            screen._register_footer_shortcuts()
+        # NOTE (task-15457 review): a footer re-derivation was added here and
+        # then REMOVED after probing. Both footer tiers that a targeted sync
+        # can flip -- the Notes tier (select mode / sort-strip visibility) and
+        # the shared choice-strip tier -- are already kept honest by dev's own
+        # mechanism: ``LibraryScreen.refresh`` calls
+        # ``_apply_library_notes_footer_context()`` on EVERY refresh, not only
+        # on ``recompose=True``, and every footer-flipping sync has a focus
+        # follow-up whose ``set_focus``/``scroll_visible`` triggers one.
+        # Verified by disabling both branches: the Notes select-mode and the
+        # media type-strip footers both stayed current. Keeping an
+        # unfalsifiable branch is worse than the coupling it guards, so it is
+        # gone; the coupling itself is recorded in the task file's residuals.
+
     except Exception:
         logger.debug(
             f"Library {kind} canvas sync failed; falling back to full recompose.",
@@ -9328,17 +9337,25 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_context = False
         self._library_note_editor_armed = False
         if self.is_mounted:
-            _sync_library_canvas(self, "notes")
-            self.call_after_refresh(self._arm_library_note_editor)
-            self.call_after_refresh(
-                self._restore_library_notes_focus_identity,
-                LibraryNotesFocusIdentity(
-                    stage="notes",
-                    region="editor",
-                    note_id=note_id,
-                    semantic_role="body",
-                ),
+            editor_identity = LibraryNotesFocusIdentity(
+                stage="notes",
+                region="editor",
+                note_id=note_id,
+                semantic_role="body",
             )
+
+            def arm_and_focus_editor() -> None:
+                # Deterministic (task-15457 review I4b): both of these used to
+                # ride ``call_after_refresh``, which has no ordering against a
+                # recompose driven by the CANVAS's own pump -- so on the
+                # list -> loading -> editor row press they ran against the
+                # loading children and left focus outside the canvas. Arming
+                # is dirty-tracking, not cosmetics: a miss leaves the editor
+                # unarmed, so this is the one that must not be lost.
+                self._arm_library_note_editor()
+                self._restore_library_notes_focus_identity(editor_identity)
+
+            _sync_library_canvas(self, "notes", then=arm_and_focus_editor)
 
     def _begin_library_note_load(self, note_id: str) -> None:
         """Reset presentation, invalidate old work, and start one editor load."""
@@ -12901,14 +12918,24 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_type_choices_visible = (
             not self._library_media_type_choices_visible
         )
-        if self._library_media_type_choices_visible:
-            then: Callable[[], None] = lambda: self._focus_library_choice_strip_active(
+        def focus_open_strip() -> None:
+            self._focus_library_choice_strip_active(
                 ".library-media-type-choice",
                 self._library_media_type_filter,
             )
-        else:
-            then = lambda: self._focus_library_control("#library-media-type-filter")
-        _sync_library_canvas(self, "media", then=then)
+
+        def focus_opener() -> None:
+            self._focus_library_control("#library-media-type-filter")
+
+        _sync_library_canvas(
+            self,
+            "media",
+            then=(
+                focus_open_strip
+                if self._library_media_type_choices_visible
+                else focus_opener
+            ),
+        )
 
     @on(Button.Pressed, ".library-media-type-choice")
     def handle_library_media_type_choice(self, event: Button.Pressed) -> None:
@@ -14067,16 +14094,24 @@ class LibraryScreen(BaseAppScreen):
         self._library_skills_sort_choices_visible = (
             not self._library_skills_sort_choices_visible
         )
-        if self._library_skills_sort_choices_visible:
-            skills_then: Callable[[], None] = (
-                lambda: self._focus_library_choice_strip_active(
-                    ".library-skills-sort-choice",
-                    self._library_skills_sort,
-                )
+        def focus_open_strip() -> None:
+            self._focus_library_choice_strip_active(
+                ".library-skills-sort-choice",
+                self._library_skills_sort,
             )
-        else:
-            skills_then = lambda: self._focus_library_control("#library-skills-sort")
-        _sync_library_canvas(self, "skills", then=skills_then)
+
+        def focus_opener() -> None:
+            self._focus_library_control("#library-skills-sort")
+
+        _sync_library_canvas(
+            self,
+            "skills",
+            then=(
+                focus_open_strip
+                if self._library_skills_sort_choices_visible
+                else focus_opener
+            ),
+        )
 
     @on(Button.Pressed, ".library-skills-sort-choice")
     def handle_library_skills_sort_choice(self, event: Button.Pressed) -> None:
@@ -14740,8 +14775,11 @@ class LibraryScreen(BaseAppScreen):
         self._library_skill_script_grant = False
         self._library_skill_editor_armed = False
         if self.is_mounted:
-            _sync_library_canvas(self, "skills")
-            self.call_after_refresh(self._arm_library_skill_editor)
+            # Deterministic (task-15457 review I4b): arming is
+            # dirty-tracking, not cosmetics -- a follow-up lost to the
+            # canvas-pump race leaves the editor unarmed, so it rides the
+            # canvas's own post-recompose hook rather than the screen's.
+            _sync_library_canvas(self, "skills", then=self._arm_library_skill_editor)
         # Task 7: not part of ``get_skill``'s response, so it needs its own
         # off-thread fetch -- see ``_refresh_library_skill_script_grant``.
         self._refresh_library_skill_script_grant()
@@ -17320,8 +17358,9 @@ class LibraryScreen(BaseAppScreen):
         )
         self._load_library_prompt_memberships()
         if self.is_mounted:
-            _sync_library_canvas(self, "prompts")
-            self.call_after_refresh(self._arm_library_prompt_editor)
+            # See the skills twin: arming must not be lost to the
+            # canvas-pump race (task-15457 review I4b).
+            _sync_library_canvas(self, "prompts", then=self._arm_library_prompt_editor)
 
     def _adopt_library_prompt_persisted_detail(
         self,

--- a/tldw_chatbook/Widgets/Library/library_canvas_sync.py
+++ b/tldw_chatbook/Widgets/Library/library_canvas_sync.py
@@ -92,6 +92,18 @@ class PostRecomposeCallback:
         self._after_recompose()
         if callback is None:
             return
+        # A newer recompose is already queued: this widget's children are
+        # about to be replaced again, so firing the follow-up now would run it
+        # against a tree that is already stale. Textual re-arms
+        # ``_recompose_required`` whenever ``refresh(recompose=True)`` is
+        # called, which is exactly what a second ``sync_state`` landing while
+        # this recompose was awaiting ``mount_all`` does -- the shape the
+        # notes canvas's own ``_apply_post_compose_state`` guard was added for
+        # (list -> loading -> editor row press). Re-queue instead of dropping,
+        # so the follow-up runs once, against the final children.
+        if getattr(self, "_recompose_required", False):
+            self._post_recompose_callback = callback
+            return
         try:
             callback()
         except Exception:

--- a/tldw_chatbook/Widgets/Library/library_canvas_sync.py
+++ b/tldw_chatbook/Widgets/Library/library_canvas_sync.py
@@ -1,0 +1,77 @@
+"""Post-recompose callback plumbing for canvas-scoped Library updates.
+
+task-15457. A Library screen handler that recomposed the WHOLE screen could
+schedule its follow-up work -- almost always "focus the control the user
+should now be on" -- with ``screen.call_after_refresh(...)``: both the
+recompose and the callback are driven by the screen's own message pump, and
+``Screen._on_timer_update`` runs the recompose via ``call_next`` BEFORE it
+runs ``_invoke_and_clear_callbacks``, so the ordering is guaranteed.
+
+A canvas-scoped update breaks that guarantee. ``canvas.refresh(recompose=
+True)`` is serviced by the CANVAS's pump (its ``_on_idle`` ->
+``_check_recompose``), while ``screen.call_after_refresh`` still queues onto
+the screen's callback list -- two independent pumps with no ordering between
+them. Reproduced while converting the notes sort/filter strips: every
+converted site's focus follow-up ran against the OLD children (or after they
+were removed), leaving DOM focus stranded on an unrelated widget outside the
+canvas instead of the strip's opener.
+
+This mixin restores the ordering by hanging the follow-up on the widget that
+actually does the work: the callback is stored on the canvas instance and
+fired from its own ``recompose()``, immediately after the new children are
+mounted. Storing it on the INSTANCE (not a screen-side dict keyed by widget
+id) is deliberate -- the recompose-lifecycle rule from the July programme:
+fresh widgets must carry current state, and per-widget bookkeeping that lives
+anywhere else goes stale the moment a widget is replaced.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from loguru import logger
+
+
+class PostRecomposeCallback:
+    """Mixin: run one queued callback right after this widget recomposes.
+
+    Cooperative with ``RecomposeCaptureGuard`` -- both override
+    ``recompose()`` and chain through ``super()``, so a canvas can use both
+    (list them in whatever order; each does its own work around the shared
+    ``super().recompose()``).
+    """
+
+    #: Class-level default so the attribute is readable before any queue call
+    #: and on any subclass that never queues one.
+    _post_recompose_callback: Optional[Callable[[], None]] = None
+
+    def queue_after_recompose(self, callback: Optional[Callable[[], None]]) -> None:
+        """Queue ``callback`` to run once, after the next recompose.
+
+        A second call before that recompose replaces the first: the pending
+        callback is always the most recent caller's intent, matching how a
+        second ``refresh(recompose=True)`` supersedes the first.
+
+        Args:
+            callback: Zero-argument callable, or ``None`` to clear.
+
+        Returns:
+            None.
+        """
+        self._post_recompose_callback = callback
+
+    async def recompose(self) -> None:
+        """Recompose, then fire the queued callback against fresh children."""
+        await super().recompose()  # type: ignore[misc]
+        callback = self._post_recompose_callback
+        if callback is None:
+            return
+        # Cleared BEFORE invoking: a callback that itself queues another one
+        # (or raises) must not be re-run by the next recompose.
+        self._post_recompose_callback = None
+        try:
+            callback()
+        except Exception:
+            logger.opt(exception=True).debug(
+                f"{type(self).__name__}: post-recompose callback failed."
+            )

--- a/tldw_chatbook/Widgets/Library/library_canvas_sync.py
+++ b/tldw_chatbook/Widgets/Library/library_canvas_sync.py
@@ -60,15 +60,38 @@ class PostRecomposeCallback:
         """
         self._post_recompose_callback = callback
 
+    def _after_recompose(self) -> None:
+        """Subclass hook: post-compose wiring, run BEFORE the queued callback.
+
+        ``on_mount`` fires once, when the widget itself mounts -- a
+        ``refresh(recompose=True)`` remounts only its CHILDREN, so any
+        wiring that hook performs has to be re-run here. Ordered ahead of
+        the callback deliberately: a queued follow-up focuses or measures a
+        child, and must see it in its final, post-wiring form (for the notes
+        canvas that means after ``apply_compact_presentation`` has rewritten
+        the compact labels).
+        """
+        return None
+
     async def recompose(self) -> None:
-        """Recompose, then fire the queued callback against fresh children."""
+        """Recompose, then re-wire and fire the queued callback."""
         await super().recompose()  # type: ignore[misc]
         callback = self._post_recompose_callback
+        # Cleared unconditionally: a callback that itself queues another one
+        # (or raises) must not be re-run by the next recompose, and a
+        # callback whose recompose never happened must not fire against some
+        # unrelated LATER one.
+        self._post_recompose_callback = None
+        # ``Widget.recompose`` early-returns without touching the children
+        # when the widget is detached or being pruned. Nothing was rebuilt,
+        # so neither the re-wiring nor the follow-up has a tree to act on --
+        # and a follow-up that focuses a child of a detached widget is
+        # actively wrong, not merely useless.
+        if not self.is_attached or getattr(self, "_pruning", False):
+            return
+        self._after_recompose()
         if callback is None:
             return
-        # Cleared BEFORE invoking: a callback that itself queues another one
-        # (or raises) must not be re-run by the next recompose.
-        self._post_recompose_callback = None
         try:
             callback()
         except Exception:

--- a/tldw_chatbook/Widgets/Library/library_conversations_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_conversations_canvas.py
@@ -19,10 +19,13 @@ from tldw_chatbook.Library.library_conversations_state import (
     LibraryConversationsCanvasState,
 )
 from tldw_chatbook.Widgets.Library.library_rail import _visible_row_title
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
 from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 
 
-class LibraryConversationsCanvas(RecomposeCaptureGuard, Vertical):
+class LibraryConversationsCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical):
     """Render the saved-conversation list with a preview + Console handoff.
 
     Attributes:

--- a/tldw_chatbook/Widgets/Library/library_export_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_export_canvas.py
@@ -26,6 +26,9 @@ from tldw_chatbook.Library.library_shell_state import (
 from tldw_chatbook.Widgets.Library.library_choice_strip import (
     compose_library_choice_strip,
 )
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
 
 
 def apply_library_export_submit_gate(
@@ -57,12 +60,6 @@ def apply_library_export_submit_gate(
     # what pressing Export will do or the SAME blocker ``disabled``
     # reflects.
     submit_button.tooltip = export_button_tooltip(state)
-
-
-from tldw_chatbook.Widgets.Library.library_canvas_sync import (
-    PostRecomposeCallback,
-)
-
 
 class LibraryExportCanvas(PostRecomposeCallback, VerticalScroll):
     """Render the Library export canvas: scope summary + chatbook export form.

--- a/tldw_chatbook/Widgets/Library/library_export_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_export_canvas.py
@@ -59,7 +59,12 @@ def apply_library_export_submit_gate(
     submit_button.tooltip = export_button_tooltip(state)
 
 
-class LibraryExportCanvas(VerticalScroll):
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
+
+
+class LibraryExportCanvas(PostRecomposeCallback, VerticalScroll):
     """Render the Library export canvas: scope summary + chatbook export form.
 
     ``VerticalScroll`` root (the L3a clipping lesson -- a plain ``Vertical``

--- a/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
@@ -988,7 +988,12 @@ def _toggle_label(*, enabled: bool, text: str) -> str:
 INGEST_FOLD_HINT_COPY = "▼ more — scroll for the rest"
 
 
-class LibraryIngestCanvas(VerticalScroll):
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
+
+
+class LibraryIngestCanvas(PostRecomposeCallback, VerticalScroll):
     """Render the Library ingest canvas: the local-file ingest form and its job queue.
 
     ``VerticalScroll`` root (the L3a clipping lesson -- a plain ``Vertical``

--- a/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
@@ -43,6 +43,9 @@ from tldw_chatbook.Library.library_ingest_state import (
     build_web_scope_note,
     library_ingest_retry_label,
 )
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
 
 
 def _command_short_name(command: str) -> str:
@@ -986,12 +989,6 @@ def _toggle_label(*, enabled: bool, text: str) -> str:
 #: bottom row saying more content exists, shown only while the canvas
 #: actually overflows -- a mid-sentence clip must never be the only signal.
 INGEST_FOLD_HINT_COPY = "▼ more — scroll for the rest"
-
-
-from tldw_chatbook.Widgets.Library.library_canvas_sync import (
-    PostRecomposeCallback,
-)
-
 
 class LibraryIngestCanvas(PostRecomposeCallback, VerticalScroll):
     """Render the Library ingest canvas: the local-file ingest form and its job queue.

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -24,10 +24,13 @@ from tldw_chatbook.Widgets.Library.library_choice_strip import (
     compose_library_choice_strip,
 )
 from tldw_chatbook.Widgets.Library.library_rail import _visible_row_title
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
 from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 
 
-class LibraryMediaCanvas(RecomposeCaptureGuard, Vertical):
+class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical):
     """Render the Library media list with a type filter and preview.
 
     Attributes:

--- a/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
@@ -29,10 +29,13 @@ from tldw_chatbook.Library.library_shell_state import (
     library_disabled_action_label,
 )
 from tldw_chatbook.Widgets.Library.library_rail import _visible_row_title
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
 from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 
 
-class LibraryMediaTrashCanvas(RecomposeCaptureGuard, Vertical):
+class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical):
     """Render the Library media Trash list with per-item restore.
 
     Attributes:

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -167,6 +167,22 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         self.styles.min_width = 40
         self.add_class(f"library-notes-mode-{mode}")
 
+    def _after_recompose(self) -> None:
+        """Re-run the post-compose wiring ``on_mount`` does.
+
+        ``on_mount`` fires once, when the canvas itself mounts -- a
+        ``refresh(recompose=True)`` remounts this widget's CHILDREN without
+        re-firing it, so ``sync_state``'s recompose would otherwise leave the
+        editor's stable subtree (populated by ``apply_session_state``) and the
+        compact label rewrites showing compose-time defaults.
+
+        Implemented as ``PostRecomposeCallback``'s hook rather than a
+        ``recompose()`` override so it runs BEFORE any queued follow-up
+        (task-15457 review round 1, minor 5): with the override form, a
+        ``then=`` that focused a control saw its pre-compact label.
+        """
+        self._apply_post_compose_state()
+
     def compose(self) -> ComposeResult:
         if self.mode == "loading":
             yield from self._compose_loading()
@@ -786,6 +802,10 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
 
     def on_mount(self) -> None:
         """Apply initial visibility after the stable editor subtree mounts."""
+        self._apply_post_compose_state()
+
+    def _apply_post_compose_state(self) -> None:
+        """Post-compose wiring shared by ``on_mount`` and ``_after_recompose``."""
         self.apply_compact_presentation(self.compact)
         if self.mode == "editor" and self.presentation_state is not None:
             self.apply_session_state(self.presentation_state)

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -32,6 +32,8 @@ from tldw_chatbook.Library.library_notes_sync_state import (
 from tldw_chatbook.Widgets.Library.library_choice_strip import (
     compose_library_choice_strip,
 )
+from tldw_chatbook.Widgets.Library.library_canvas_sync import PostRecomposeCallback
+from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 
 _SORT_LABELS = {"newest": "Newest", "oldest": "Oldest", "title": "Title"}
 _COMPACT_SYNC_DIRECTION_LABELS = {
@@ -71,7 +73,7 @@ class LibraryNotePresentationState:
     transfer_running: bool = False
 
 
-class LibraryNotesCanvas(Vertical):
+class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical):
     """Render the Library notes canvas: the list view, or the note editor.
 
     Attributes:

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -805,10 +805,27 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         self._apply_post_compose_state()
 
     def _apply_post_compose_state(self) -> None:
-        """Post-compose wiring shared by ``on_mount`` and ``_after_recompose``."""
+        """Post-compose wiring shared by ``on_mount`` and ``_after_recompose``.
+
+        Gated on the MOUNTED CHILDREN, not on ``self.mode``. ``on_mount``
+        could trust the mode because it fires once, immediately after its own
+        compose. ``_after_recompose`` cannot: ``sync_state`` mutates the
+        fields and only SCHEDULES the rebuild, so a second ``sync_state``
+        landing while the first recompose is still awaiting ``mount_all``
+        leaves this hook reading the newer state against the older children.
+        Observed exactly that on the list -> loading -> editor row-press
+        sequence: ``mode`` was already "editor" with a presentation state set
+        while the mounted child was still ``#library-note-load-state``, and
+        ``apply_session_state``'s ``query_one("#library-note-title")`` raised
+        into the sync's whole-screen fallback. The newer state's own
+        recompose is already queued and applies it a moment later.
+        """
         self.apply_compact_presentation(self.compact)
-        if self.mode == "editor" and self.presentation_state is not None:
-            self.apply_session_state(self.presentation_state)
+        if self.mode != "editor" or self.presentation_state is None:
+            return
+        if not self.query("#library-note-title"):
+            return
+        self.apply_session_state(self.presentation_state)
 
     def apply_compact_presentation(self, compact: bool) -> None:
         """Update responsive copy without remounting the canvas."""

--- a/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
@@ -63,7 +63,12 @@ def _compact_receipt_name(value: str, limit: int = 42) -> str:
     return normalized[: limit - 1].rstrip() + "…"
 
 
-class LibraryPromptsListCanvas(Vertical):
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
+
+
+class LibraryPromptsListCanvas(PostRecomposeCallback, Vertical):
     """Render the Library prompts canvas: the list view, or the prompt editor.
 
     Attributes:

--- a/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
@@ -41,6 +41,9 @@ from tldw_chatbook.Widgets.Prompts.prompt_block_editor import PromptBlockEditor
 from tldw_chatbook.Widgets.Prompts.prompt_block_editor_state import (
     PromptBlockEditorState,
 )
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
 
 _SORT_LABELS = {"newest": "Newest", "name": "Name"}
 _EMPTY_PROMPTS_COPY = "No prompts yet."
@@ -61,12 +64,6 @@ def _compact_receipt_name(value: str, limit: int = 42) -> str:
     if len(normalized) <= limit:
         return normalized
     return normalized[: limit - 1].rstrip() + "…"
-
-
-from tldw_chatbook.Widgets.Library.library_canvas_sync import (
-    PostRecomposeCallback,
-)
-
 
 class LibraryPromptsListCanvas(PostRecomposeCallback, Vertical):
     """Render the Library prompts canvas: the list view, or the prompt editor.

--- a/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_search_rag_panel.py
@@ -37,7 +37,12 @@ from ...Library.library_rag_state import (
 from .library_rail import SelectAllOnFocusingClickInput
 
 
-class LibrarySearchRagPanel(VerticalScroll):
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
+
+
+class LibrarySearchRagPanel(PostRecomposeCallback, VerticalScroll):
     """Display the source scope, query controls, and evidence results."""
 
     def __init__(self, state: LibraryRagPanelState, **kwargs) -> None:

--- a/tldw_chatbook/Widgets/Library/library_skills_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_skills_canvas.py
@@ -51,6 +51,9 @@ from tldw_chatbook.Library.library_skills_state import (
     skill_name_shadows_builtin,
     skill_trust_header_line,
 )
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
 
 _SORT_LABELS = {"name": "Name", "status": "Status"}
 # task-418: the old copy ("create them in Library ▸ Skills") pointed at
@@ -557,12 +560,6 @@ def skill_supporting_files_text(
         else:
             lines.append(f"{file.name} — {file.size} bytes (binary)")
     return "\n".join(lines)
-
-
-from tldw_chatbook.Widgets.Library.library_canvas_sync import (
-    PostRecomposeCallback,
-)
-
 
 class LibrarySkillsListCanvas(PostRecomposeCallback, VerticalScroll):
     """Render the Library skills canvas: the list view, or the skill editor.

--- a/tldw_chatbook/Widgets/Library/library_skills_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_skills_canvas.py
@@ -559,7 +559,12 @@ def skill_supporting_files_text(
     return "\n".join(lines)
 
 
-class LibrarySkillsListCanvas(VerticalScroll):
+from tldw_chatbook.Widgets.Library.library_canvas_sync import (
+    PostRecomposeCallback,
+)
+
+
+class LibrarySkillsListCanvas(PostRecomposeCallback, VerticalScroll):
     """Render the Library skills canvas: the list view, or the skill editor.
 
     ``VerticalScroll`` root (the L3a clipping lesson -- a plain ``Vertical``


### PR DESCRIPTION
## Summary

Task 15457 from the input-latency audit — the Library screen's 147 whole-screen `refresh(recompose=True)` sites (regrown past the July fix) made ordinary clicks tear down and remount the 26k-line screen.

- The Notes canvas targeted hook unblocked (ctor param no longer shadows `sync_state`); 10 per-click site classes converted to canvas-scoped sync across 13 sliced commits; whole-screen recompose remains only for true canvas transitions (each remaining site classified)
- Focus identity + scroll offset now captured before every canvas sync and restored as a composing DEFAULT follow-up (review caught focus escaping to rail chrome on ~10 sites; compact-mode scroll restore needs a deferred apply — children aren't laid out inline, so an eager scroll clamps to 0)
- Review also caught a wrong-item-opens bug (media chooser left `_selected_media_id` stale after a type filter) — fixed with the state mirror + a real-flow test
- Notes-canvas click cost down a third to a half (same-session interleaved A/B, both loaded and quiet-machine figures recorded; honest about the ~40 ms the focus/scroll behavior costs)
- New `PostRecomposeCallback` mixin (attach/prune-guarded) + `_after_recompose` hook ordering verified strictly safer

## Verification
Independent opus review (Not-approved round: 2 Criticals + 1 Important, all A/B-measured) + opus re-review (APPROVE: all seven findings mutation-confirmed born-red; the focus gate verified AGAINST DEV by measurement — parity at notes sites, strictly better at RAG toggles; 778 tests green across four batches with zero spurious failures). Deferred minors recorded in the programme ledger (decorative test tail, deferred-scroll convention nits, stale report header table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Library per‑click updates to canvas‑level sync with deterministic post‑recompose follow‑ups, preserving selection, focus, and compact‑scroll while cutting input latency (task‑15457). Previously clicks forced whole‑screen recomposes and `call_after_refresh` follow‑ups raced canvas mounts; now canvases queue a `then` that fires after their own recompose, re‑queuing if another recompose is pending and no‑oping when detached, with fallback rescheduling on full refresh.

- Adds `PostRecomposeCallback` and `queue_after_recompose` on `LibraryNotesCanvas`, `LibraryMediaCanvas`, `LibraryMediaTrashCanvas`, `LibraryIngestCanvas`, `LibraryExportCanvas`, `LibraryConversationsCanvas`, `LibraryPromptsListCanvas`, `LibrarySearchRagPanel`, and `LibrarySkillsListCanvas`; follow‑ups run after children mount and re‑queue on in‑flight recomposes.
- Extends `_sync_library_canvas(kind, then=...)`: installs a Notes default for in‑surface updates (portable focus immediately; compact‑mode scroll deferred via `call_after_refresh`), composes site `then` after the default, gates the default to `kind == "notes"` and same surface mode, and reschedules `then` if a whole‑screen fallback triggers.
- Mirrors resolved media selection into `_selected_media_id` so the viewer opens the highlighted item after type‑filter changes.
- Converts per‑click `call_after_refresh` sites to `then=`: notes escape/select/sort/filter, media type‑strip open/pick, media trash load, prompts/skills sort and choices, converged choice‑strip close, and arming/focusing of notes/prompts/skills editors.
- Hardens notes recomposes: `_after_recompose` re‑applies post‑compose wiring only when editor children are mounted; closes the list→loading→editor focus gap by combining mixin re‑queue with explicit editor arm+focus in `then`. Notes canvas now also carries `RecomposeCaptureGuard`.
- Adds `Tests/UI/test_library_canvas_sync_defects.py` pinning: media selection mirroring, focus containment (including keyboard), compact scroll preservation, footer‑shortcut invariants, and the notes row→editor transition.

<sup>Written for commit 2782379d2101eac274fcf6c66f93805759a1e3a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

