### PR TITLE
perf: debounce the undebounced picker/filter family (task-15476)

### DIFF
--- a/Tests/Chat/test_console_style_picker.py
+++ b/Tests/Chat/test_console_style_picker.py
@@ -141,7 +141,9 @@ async def test_modal_typing_filters_rows_by_id_prefix():
 
         filter_input = app.screen.query_one(f"#{FILTER_INPUT_ID}", Input)
         filter_input.value = "style_"
-        await pilot.pause(0.1)
+        # Debounced (task-15476): the row list only re-renders once the
+        # filter settles, not on every keystroke.
+        await pilot.pause(picker_module.SEARCH_DEBOUNCE_SECONDS + 0.1)
 
         rows = app.screen.query(".console-style-picker-row")
         assert len(rows) == 3
@@ -159,7 +161,9 @@ async def test_modal_unmatched_filter_shows_empty_copy():
 
         filter_input = app.screen.query_one(f"#{FILTER_INPUT_ID}", Input)
         filter_input.value = "zzz-no-such-style"
-        await pilot.pause(0.1)
+        # Debounced (task-15476): the empty state only appears once the
+        # filter settles.
+        await pilot.pause(picker_module.SEARCH_DEBOUNCE_SECONDS + 0.1)
 
         empty = app.screen.query_one("#console-style-picker-empty", Static)
         assert str(empty.renderable) == EMPTY_STORE_COPY
@@ -258,7 +262,9 @@ async def test_modal_detail_shows_placeholder_when_no_matches():
 
         filter_input = app.screen.query_one(f"#{FILTER_INPUT_ID}", Input)
         filter_input.value = "zzz-no-such-style"
-        await pilot.pause(0.1)
+        # Debounced (task-15476): the detail preview only clears once the
+        # filter settles.
+        await pilot.pause(picker_module.SEARCH_DEBOUNCE_SECONDS + 0.1)
 
         detail = app.screen.query_one(f"#{DETAIL_STATIC_ID}", Static)
         assert str(detail.renderable) == DETAIL_EMPTY_COPY

--- a/Tests/UI/test_console_character_picker_debounce.py
+++ b/Tests/UI/test_console_character_picker_debounce.py
@@ -1,0 +1,99 @@
+"""Debounce-shape regression test for the Console character picker.
+
+Representative of the whole debounced picker/filter family fixed by
+task-15476 (see `console_prompt_picker_modal.py`'s established 0.2s
+timer + cancel shape, which every other converted site in the family
+mirrors): typing into a picker's filter `Input` must not synchronously
+rebuild the full result list on every keystroke. A debounce `Timer`
+re-arms on each keystroke, cancelling any previous pending one, so only
+the SETTLED query is ever applied to the rendered rows.
+
+`ConsoleCharacterPickerModal` is used as the representative site because
+it needs no database/app context (`options` are pre-supplied) and its
+debounce implementation was hand-written directly for task-15476, making
+it a faithful stand-in for the family's shared shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App
+from textual.widgets import Input
+
+from tldw_chatbook.Widgets.Console.console_character_picker_modal import (
+    SEARCH_DEBOUNCE_SECONDS,
+    ConsoleCharacterOption,
+    ConsoleCharacterPickerModal,
+)
+
+QUERY_INPUT_ID = "#console-character-picker-query"
+RESULT_ROW_CLASS = ".console-character-picker-result"
+
+
+def _options(n: int) -> tuple[ConsoleCharacterOption, ...]:
+    return tuple(
+        ConsoleCharacterOption(character_id=i, name=f"Character {i}") for i in range(n)
+    )
+
+
+class _Harness(App[None]):
+    """Hosts the picker modal with a fixed, pre-supplied option list."""
+
+    def __init__(self, options: tuple[ConsoleCharacterOption, ...]) -> None:
+        super().__init__()
+        self._options = options
+        self.result: object = "unset"
+
+    async def on_mount(self) -> None:
+        await self.push_screen(
+            ConsoleCharacterPickerModal(options=self._options),
+            callback=lambda choice: setattr(self, "result", choice),
+        )
+
+
+@pytest.mark.asyncio
+async def test_typing_does_not_rebuild_rows_before_the_debounce_settles():
+    """A keystroke alone must not synchronously rebuild the result rows."""
+    app = _Harness(_options(5))
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        assert len(app.screen.query(RESULT_ROW_CLASS)) == 5
+
+        app.screen.query_one(QUERY_INPUT_ID, Input).value = "Character 1"
+        # Even right up against the debounce window, the old rows are
+        # still on screen -- the rebuild has not fired yet.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS - 0.1)
+        assert len(app.screen.query(RESULT_ROW_CLASS)) == 5
+
+
+@pytest.mark.asyncio
+async def test_typing_then_settling_rebuilds_the_filtered_rows():
+    """Once the debounce settles, the row list reflects the typed query."""
+    app = _Harness(_options(20))
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        app.screen.query_one(QUERY_INPUT_ID, Input).value = "Character 5"
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
+        rows = app.screen.query(RESULT_ROW_CLASS)
+        assert len(rows) == 1
+        assert "Character 5" in str(rows[0].renderable)
+
+
+@pytest.mark.asyncio
+async def test_rapid_retyping_cancels_the_pending_timer_and_only_the_final_query_applies():
+    """Timer re-arm + cancel: two keystrokes in quick succession collapse
+    into one rebuild reflecting only the LAST query -- proving the
+    intermediate query's pending timer was cancelled, not merely
+    superseded after also running."""
+    app = _Harness(_options(20))
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        query_input = app.screen.query_one(QUERY_INPUT_ID, Input)
+        # Two back-to-back Input.Changed posts with no settling between
+        # them -- simulates paste/fast typing outpacing the debounce.
+        query_input.value = "Character 1"
+        query_input.value = "Character 12"
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
+        rows = app.screen.query(RESULT_ROW_CLASS)
+        assert len(rows) == 1
+        assert "Character 12" in str(rows[0].renderable)

--- a/Tests/UI/test_console_rail_sections.py
+++ b/Tests/UI/test_console_rail_sections.py
@@ -522,6 +522,7 @@ async def test_setup_backdrop_no_resume_intent_stays_paused_after_mount():
 # ---------------------------------------------------------------------------
 
 from tldw_chatbook.Widgets.Console.console_session_switcher_modal import (  # noqa: E402
+    SEARCH_DEBOUNCE_SECONDS,
     ConsoleSessionSwitcherModal,
     ConsoleSwitcherChoice,
 )
@@ -568,7 +569,9 @@ async def test_switcher_lists_recent_first_and_filters_on_typing():
         assert "Groq testing" in str(first.label)
         await pilot.click("#console-switcher-query")
         await pilot.press(*"refactor")
-        await pilot.pause()
+        # Debounced (task-15476): the result list only re-renders once the
+        # filter settles, not on every keystroke.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
         first = app.screen.query_one("#console-switcher-result-0", Button)
         assert "API refactor plan" in str(first.label)
         assert not list(app.screen.query("#console-switcher-result-1"))
@@ -580,7 +583,9 @@ async def test_switcher_enter_activates_first_result():
     async with app.run_test(size=(90, 30)) as pilot:
         await pilot.click("#console-switcher-query")
         await pilot.press(*"tides")
-        await pilot.pause()
+        # Debounced (task-15476): let the filter settle before Enter, or it
+        # would activate the still-unfiltered first result instead.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
         await pilot.press("enter")
         await pilot.pause()
         assert isinstance(app.result, ConsoleSwitcherChoice)
@@ -654,7 +659,9 @@ async def test_switcher_escape_dismisses_none_and_empty_query_shows_no_matches()
     async with app.run_test(size=(90, 30)) as pilot:
         await pilot.click("#console-switcher-query")
         await pilot.press(*"zzzz")
-        await pilot.pause()
+        # Debounced (task-15476): the empty state only appears once the
+        # filter settles.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
         assert list(app.screen.query("#console-switcher-empty"))
         await pilot.press("escape")
         await pilot.pause()
@@ -673,7 +680,9 @@ async def test_switcher_rapid_refresh_does_not_duplicate_ids():
         query_input = app.screen.query_one("#console-switcher-query", Input)
         query_input.value = "r"
         query_input.value = "refactor"
-        await pilot.pause()
+        # Debounced (task-15476): the second Input.Changed re-arms the timer
+        # and cancels the first, so only "refactor" is ever applied.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
         first = app.screen.query_one("#console-switcher-result-0", Button)
         assert "API refactor plan" in str(first.label)
         assert not list(app.screen.query("#console-switcher-result-1"))

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -38,6 +38,7 @@ from tldw_chatbook.UI.Screens.chat_screen import (
 from tldw_chatbook.UI.Screens import provider_model_resolution
 from tldw_chatbook.Chat.local_server_discovery import LocalModelProbeResult
 from tldw_chatbook.Widgets.Console.console_settings_modal import (
+    CONSOLE_SETTINGS_READINESS_DEBOUNCE_SECONDS,
     MODAL_BODY_MIN_HEIGHT,
     MODAL_CONTROL_HEIGHT,
     MODEL_DISCOVER_BUTTON_ID,
@@ -2666,8 +2667,10 @@ async def test_console_settings_modal_refreshes_readiness_after_returning_to_mod
             "#console-settings-provider-model-section"
         )
         model_input.value = ""
-        app.screen._sync_readiness_display()
-        await pilot.pause()
+        # Debounced (task-15476): let the production `Input.Changed`
+        # handler settle instead of forcing `_sync_readiness_display()`
+        # directly, which raced the (now-delayed) handler-driven update.
+        await pilot.pause(CONSOLE_SETTINGS_READINESS_DEBOUNCE_SECONDS + 0.1)
 
         assert model_input.value == ""
         assert picker.value is None

--- a/Tests/UI/test_conversation_attach_picker.py
+++ b/Tests/UI/test_conversation_attach_picker.py
@@ -3,6 +3,7 @@ from textual.app import App, ComposeResult
 from textual.widgets import Input, ListView
 
 from tldw_chatbook.Widgets.Persona_Widgets.conversation_attach_picker import (
+    SEARCH_DEBOUNCE_SECONDS,
     ConversationAttachPicker,
 )
 
@@ -50,7 +51,9 @@ async def test_picker_filter_narrows_then_selects():
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.screen.query_one("#conversation-attach-search", Input).value = "beta"
-        await pilot.pause()
+        # Debounced (task-15476): the list only rebuilds once the filter
+        # settles, not on every keystroke.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
         app.screen.query_one("#conversation-attach-list", ListView).index = 0
         await pilot.pause()
         await pilot.click("#conversation-attach-confirm")

--- a/Tests/UI/test_dictionary_attach_picker.py
+++ b/Tests/UI/test_dictionary_attach_picker.py
@@ -5,6 +5,7 @@ from textual.app import App
 from textual.widgets import Input, ListView
 
 from tldw_chatbook.Widgets.Persona_Widgets.dictionary_attach_picker import (
+    SEARCH_DEBOUNCE_SECONDS,
     DictionaryAttachPicker,
 )
 
@@ -46,7 +47,9 @@ async def test_picker_search_filters():
         await pilot.pause()
         picker = app.screen
         picker.query_one("#dict-attach-search", Input).value = "noir"
-        await pilot.pause()
+        # Debounced (task-15476): the list only rebuilds once the filter
+        # settles, not on every keystroke.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
         rows = picker.query_one("#dict-attach-list", ListView).children
         assert len(rows) == 1
         # select the only match, confirm
@@ -74,7 +77,9 @@ async def test_picker_stale_selection_after_filter_is_not_returned():
         await pilot.pause()
         # Narrow the list to the OTHER conversation only ("Lab notes").
         picker.query_one("#dict-attach-search", Input).value = "lab"
-        await pilot.pause()
+        # Debounced (task-15476): the list only rebuilds once the filter
+        # settles, not on every keystroke.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
         rows = picker.query_one("#dict-attach-list", ListView).children
         assert len(rows) == 1
         # Confirm WITHOUT re-selecting: no stale index should carry over.

--- a/Tests/UI/test_dictionary_picker.py
+++ b/Tests/UI/test_dictionary_picker.py
@@ -4,7 +4,10 @@ import pytest
 from textual.app import App
 from textual.widgets import Input, ListView
 
-from tldw_chatbook.Widgets.Persona_Widgets.dictionary_picker import DictionaryPicker
+from tldw_chatbook.Widgets.Persona_Widgets.dictionary_picker import (
+    SEARCH_DEBOUNCE_SECONDS,
+    DictionaryPicker,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -45,7 +48,9 @@ async def test_picker_search_filters_by_name():
         await pilot.pause()
         picker = app.screen
         picker.query_one("#dict-pick-search", Input).value = "slang"
-        await pilot.pause()
+        # Debounced (task-15476): the list only rebuilds once the filter
+        # settles, not on every keystroke.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
         assert len(picker.query_one("#dict-pick-list", ListView).children) == 1
         picker.query_one("#dict-pick-list", ListView).index = 0
         await pilot.pause()

--- a/Tests/UI/test_evals_card_picker.py
+++ b/Tests/UI/test_evals_card_picker.py
@@ -38,7 +38,7 @@ from textual.app import App, ComposeResult
 from textual.errors import NoWidget
 from textual.widgets import Button, Input
 
-from tldw_chatbook.UI.Evals.card_picker import CardPicker
+from tldw_chatbook.UI.Evals.card_picker import SEARCH_DEBOUNCE_SECONDS, CardPicker
 from tldw_chatbook.UI.Evals.evals_state import _LIST_LIMIT, EvalsViewModel
 
 CARDS = [
@@ -191,7 +191,9 @@ async def test_search_filters_rows_case_insensitively():
         picker = pilot.app.query_one(CardPicker)
         await pilot.click("#evals-card-search")
         await pilot.press(*"vex")
-        await pilot.pause()
+        # Debounced (task-15476): the row list only rebuilds once the
+        # filter settles, not on every keystroke.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
         shown = [w.card_name for w in picker.query(".evals-card-row")]
         assert shown == ["Vex", "vexing puzzle"]
 
@@ -263,7 +265,9 @@ async def test_a_search_with_no_matches_renders_an_explicit_empty_state():
         picker = pilot.app.query_one(CardPicker)
         await pilot.click("#evals-card-search")
         await pilot.press(*"zzz-no-such-card")
-        await pilot.pause()
+        # Debounced (task-15476): the empty state only appears once the
+        # filter settles.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
         assert len(picker.query(".evals-card-row")) == 0
         assert picker.query_one("#evals-card-picker-no-matches") is not None
 
@@ -305,7 +309,10 @@ async def test_control_below_the_picker_stays_hit_testable_after_search(size):
         await pilot.pause()
         await pilot.click("#evals-card-search")
         await pilot.press(*"Card 1")
-        await pilot.pause()
+        # Debounced (task-15476): the row list only rebuilds once the
+        # filter settles -- wait for it so this actually exercises the
+        # post-rebuild geometry the test's docstring describes.
+        await pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)
         screen = pilot.app.screen
         control = screen.query_one("#picker-host-done", Button)
         hit = _hit_widget(screen, control)

--- a/Tests/UI/test_logs_ux_fixes.py
+++ b/Tests/UI/test_logs_ux_fixes.py
@@ -14,7 +14,13 @@ import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import Input, RichLog
 
-from tldw_chatbook.UI.Logs_Window import LogsWindow, LogRecord, _passes_filter
+from tldw_chatbook.UI.Logs_Window import (
+    FILTER_DEBOUNCE_SECONDS,
+    MAX_RENDERED_LINES,
+    LogsWindow,
+    LogRecord,
+    _passes_filter,
+)
 
 
 def _records():
@@ -105,7 +111,9 @@ async def test_text_filter_narrows_view() -> None:
         window = app.logs_window
         window.load_from_app()
         app.query_one("#logs-filter-text", Input).value = "sync"
-        await pilot.pause()
+        # Debounced (task-15476): the view only re-renders once the filter
+        # settles, not on every keystroke.
+        await pilot.pause(FILTER_DEBOUNCE_SECONDS + 0.1)
         lines = app.query_one("#app-log-display", RichLog).lines
         assert len(lines) == 1
         assert "slow pull" in lines[0].text
@@ -152,3 +160,111 @@ async def test_empty_state_shows_guidance() -> None:
         text = str(empty.render())
         assert "No log entries yet" in text
         assert "share them when asking for help" in text
+
+
+# ---------------------------------------------------------------------------
+# task-15476 AC #2: capped rendered slice + truncation disclosure.
+# ---------------------------------------------------------------------------
+
+
+def _many_matching_records(count: int) -> deque:
+    """``count`` INFO records, oldest (lowest index) first -- mirrors the
+    buffer's own append order, so ``line {count - 1}`` is the most recent."""
+    return deque(
+        (
+            (
+                "INFO",
+                "app.bulk",
+                f"2026-08-11 00:00:00 - app.bulk - INFO - line {i}",
+            )
+            for i in range(count)
+        ),
+        maxlen=10000,
+    )
+
+
+class _ManyRecordsHarness(App[None]):
+    def __init__(self, count: int) -> None:
+        super().__init__()
+        self.logs_window = LogsWindow(
+            SimpleNamespace(_log_records=_many_matching_records(count)),
+            id="logs-window",
+        )
+
+    def compose(self) -> ComposeResult:
+        yield self.logs_window
+
+
+@pytest.mark.asyncio
+async def test_a_filter_matching_more_than_the_cap_renders_only_the_most_recent_slice() -> (
+    None
+):
+    """A render pass must clear+rewrite the RichLog with at most
+    `MAX_RENDERED_LINES` lines, even when far more records match -- the
+    defect this task fixes rewrote it with ALL matches, unbounded."""
+    total = MAX_RENDERED_LINES + 50
+    app = _ManyRecordsHarness(total)
+    async with app.run_test(size=(120, 36)) as pilot:
+        await pilot.pause()
+        app.logs_window.load_from_app()
+        await pilot.pause()
+
+        lines = app.query_one("#app-log-display", RichLog).lines
+        assert len(lines) == MAX_RENDERED_LINES
+        # The MOST RECENT matches are kept (highest indices -- the last
+        # ones appended), not the oldest: the earliest 50 records (0..49)
+        # are trimmed, leaving 50..1049 as the exact rendered window.
+        first_kept_index = total - MAX_RENDERED_LINES
+        assert lines[0].text.endswith(f"line {first_kept_index}")
+        assert lines[-1].text.endswith(f"line {total - 1}")
+
+
+@pytest.mark.asyncio
+async def test_the_status_line_discloses_the_render_cap_truncation() -> None:
+    """Honest accounting (task-15476 AC #2): when the cap trims output, the
+    status line must say so, not just silently under-report."""
+    total = MAX_RENDERED_LINES + 50
+    app = _ManyRecordsHarness(total)
+    async with app.run_test(size=(120, 36)) as pilot:
+        await pilot.pause()
+        app.logs_window.load_from_app()
+        await pilot.pause()
+
+        status = str(app.query_one("#logs-status-line").render())
+        assert f"Showing {MAX_RENDERED_LINES} of {total} lines" in status
+        assert f"filter matched {total}" in status
+        assert f"showing most recent {MAX_RENDERED_LINES}" in status
+
+
+@pytest.mark.asyncio
+async def test_a_filter_within_the_cap_discloses_no_truncation() -> None:
+    """Below the cap, the status line must not claim a truncation that
+    didn't happen."""
+    app = _ManyRecordsHarness(5)
+    async with app.run_test(size=(120, 36)) as pilot:
+        await pilot.pause()
+        app.logs_window.load_from_app()
+        await pilot.pause()
+
+        lines = app.query_one("#app-log-display", RichLog).lines
+        assert len(lines) == 5
+        status = str(app.query_one("#logs-status-line").render())
+        assert "Showing 5 of 5 lines" in status
+        assert "filter matched" not in status
+
+
+@pytest.mark.asyncio
+async def test_next_error_jump_targets_only_rendered_rows_when_capped() -> None:
+    """n/N error-jump indices must be computed against what's actually in
+    the RichLog (the capped slice), not the full (larger) match set --
+    otherwise a jump could target a row the widget never rendered."""
+    total = MAX_RENDERED_LINES + 20
+    app = _ManyRecordsHarness(total)
+    async with app.run_test(size=(120, 36)) as pilot:
+        await pilot.pause()
+        app.logs_window.load_from_app()
+        await pilot.pause()
+
+        # No ERROR/CRITICAL records were seeded -- the jump must find none
+        # rather than raising or indexing past the rendered slice.
+        assert app.logs_window._error_row_indices() == []

--- a/Tests/UI/test_tag_filter_picker.py
+++ b/Tests/UI/test_tag_filter_picker.py
@@ -46,11 +46,15 @@ def test_selected_row_returns_stored_value(index, expected):
 
 def test_search_narrows_rows_and_preserves_exact_tag_mapping():
     picker, listing = _picker(["alpha", "beta", "gamma"])
-    event = SimpleNamespace(value="beta", stop=Mock())
 
-    picker._filter(event)
+    # task-15476: `_filter` itself now only arms a debounce `Timer`, which
+    # requires a running Textual message pump this synchronous, unmounted
+    # unit test never provides. `_apply_filter_debounced` is where the
+    # actual filter-then-populate logic this test exercises now lives; the
+    # debounce mechanics themselves are covered by a dedicated test that
+    # runs a real App (`test_console_character_picker_debounce.py`).
+    picker._apply_filter_debounced("beta")
 
-    event.stop.assert_called_once_with()
     assert len(listing.rows) == 2
     assert picker._row_tags == [None, "beta"]
 

--- a/Tests/UI/test_ux_batch6.py
+++ b/Tests/UI/test_ux_batch6.py
@@ -15,6 +15,7 @@ async def test_queue_filter_narrows_rows_and_detail_follows_visible() -> None:
         WorkbenchTestAppWithService,
     )
     from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
+        QUEUE_FILTER_DEBOUNCE_SECONDS,
         SchedulesWorkbench,
     )
 
@@ -25,7 +26,9 @@ async def test_queue_filter_narrows_rows_and_detail_follows_visible() -> None:
         assert len(screen._visible_tasks) == len(screen._tasks)
 
         screen.query_one("#scheduling-queue-filter", Input).value = "no-such-task"
-        await pilot.pause()
+        # Debounced (task-15476): the queue table only rebuilds once the
+        # filter settles, not on every keystroke.
+        await pilot.pause(QUEUE_FILTER_DEBOUNCE_SECONDS + 0.1)
         assert screen._visible_tasks == []
         empty = str(
             screen.query_one("#scheduling-task-detail-empty-state", Static).render()
@@ -33,7 +36,7 @@ async def test_queue_filter_narrows_rows_and_detail_follows_visible() -> None:
         assert "No tasks match" in empty
 
         screen.query_one("#scheduling-queue-filter", Input).value = ""
-        await pilot.pause()
+        await pilot.pause(QUEUE_FILTER_DEBOUNCE_SECONDS + 0.1)
         assert len(screen._visible_tasks) == len(screen._tasks)
 
 

--- a/Tests/UI/test_world_book_picker.py
+++ b/Tests/UI/test_world_book_picker.py
@@ -47,7 +47,13 @@ def test_filter_then_select():
     ]
     picker, listing = _picker(books)
 
-    picker._filter(SimpleNamespace(value="beta", stop=Mock()))
+    # task-15476: `_filter` itself now only arms a debounce `Timer`, which
+    # requires a running Textual message pump this synchronous, unmounted
+    # unit test never provides. `_apply_filter_debounced` is where the
+    # actual filter-then-populate logic this test exercises now lives; the
+    # debounce mechanics themselves are covered by a dedicated test
+    # (`test_console_character_picker_debounce.py`) that runs a real App.
+    picker._apply_filter_debounced("beta")
     listing.index = 0
 
     assert picker._selected_id() == 20

--- a/backlog/tasks/task-15476 - Debounce-the-undebounced-picker-and-filter-family.md
+++ b/backlog/tasks/task-15476 - Debounce-the-undebounced-picker-and-filter-family.md
@@ -1,8 +1,8 @@
 ---
 id: TASK-15476
 title: Debounce the undebounced picker and filter family
-status: To Do
-assignee: []
+status: Done
+assignee: ['@claude']
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -20,7 +20,104 @@ Fix direction: copy the debounce shape from `console_prompt_picker_modal.py:203-
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 No listed site rebuilds its full result set on each keystroke — each converted or explicitly justified in the notes
-- [ ] #2 Logs filter renders a capped slice with a truncation disclosure; compiled pattern cached
-- [ ] #3 Picker behavior (selection, focus, empty states, schedules detail-pane selection) unchanged — tests on one representative per family
+- [x] #1 No listed site rebuilds its full result set on each keystroke — each converted or explicitly justified in the notes
+- [x] #2 Logs filter renders a capped slice with a truncation disclosure; compiled pattern cached
+- [x] #3 Picker behavior (selection, focus, empty states, schedules detail-pane selection) unchanged — tests on one representative per family
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Apply the `console_prompt_picker_modal.py` 0.2s-timer + cancel debounce shape to every site the description lists: the three sibling Console modals (character/session-switcher/style pickers), `card_picker.py`, `Chatbooks_Window_Improved.py`, `schedules_workbench.py`'s queue filter, the CCP dictionary/prompt editors, `collections_tag_window.py`, `template_selector.py`, the five Persona pickers, and `console_settings_modal.py`'s custom-model input.
+2. `Logs_Window.py`: debounce the free-text filter, cache the compiled regex pattern (was recompiled every render), and cap the RichLog render to the most recent `MAX_RENDERED_LINES` matches with a status-line truncation disclosure; re-key the n/N error-jump indices off the rendered (capped) slice, not the full match set.
+3. `schedules_workbench.py`: track the selected task by id (not row index) so a filter keystroke restores the same selection when it's still visible, instead of always resetting the detail pane to row 0.
+4. `speech_playground_pane.py`: delete the duplicate `on_text_area_changed` handler (Textual's implicit-name dispatch duplicating the `@on(TextArea.Changed)` handler's fallthrough) so `_sync_generate_enabled()` runs once per keystroke instead of twice.
+5. Judgment calls per the task brief: bounded (~20-row) sites may keep immediate rebuild if trivial; apply that lens per site and record the call in Notes.
+6. Update every existing test whose timing assumed synchronous (undebounced) filtering to await the new debounce window (established idiom already used by `console_prompt_picker_modal`/`console_skill_picker_modal`'s own tests: `pilot.pause(SEARCH_DEBOUNCE_SECONDS + 0.1)`); add one representative debounce-shape test (timer re-arm + cancel) and dedicated Logs render-cap tests.
+7. Run each touched site's test suite plus the new tests; read pass counts; self-review diffs.
+
+## Implementation Notes
+
+All 13 sites from the description converted (14 files; the five Persona pickers count as
+one family). Every site got the `console_prompt_picker_modal.py` shape: a 0.2s `Timer`
+armed on `Input`/`TextArea` change, stopped-and-re-armed on every subsequent keystroke
+(cancel), firing the actual rebuild only once typing settles. Two Console modals
+(character picker, session switcher) additionally route the settled call through
+`run_worker(..., exclusive=True)` since their rebuild is itself `async`; the rest call
+the rebuild directly from the timer callback since it's synchronous. No site was left at
+"bounded, keep immediate" — the smallest (session switcher, capped at 20 rows) was still
+converted since a full remove_children+mount_all cycle isn't "trivial" even at that size,
+and it was named explicitly in the task.
+
+Two sites needed more than the template:
+- `Logs_Window.py` (AC #2): `_compile_pattern` gained a one-entry cache keyed on filter
+  text (was recompiling on every render). `_render_view` now caps the RichLog write to
+  the most recent `MAX_RENDERED_LINES` (1000) matches instead of all of them, and
+  `_update_status_line` discloses `"(filter matched N; showing most recent 1000)"` when
+  the cap trims. The n/N error-jump (`_error_row_indices`) now indexes against
+  `_last_rendered` (what's actually in the widget) instead of the full match set --
+  otherwise a jump could target a row the cap never rendered.
+- `schedules_workbench.py`: beyond debouncing the queue filter, `_render_table` now
+  tracks the selected task by id (`_selected_task_id`) and restores that row (via
+  `DataTable.move_cursor`) when it's still visible after a filter narrows, instead of
+  unconditionally resetting the detail/inspector panes to row 0 on every keystroke (the
+  second defect the description called out for this site).
+- `speech_playground_pane.py`: deleted `on_text_area_changed` outright. Textual's
+  implicit `on_<message>` dispatch fired it for every `TextArea.Changed` in the pane
+  alongside the `@on(TextArea.Changed)`-decorated `on_tts_text_changed`, whose fallthrough
+  (`self.handle_text_changed`) already called the same `_sync_generate_enabled()` for
+  `tts-text-input`. Pure duplicate, not a debounce candidate -- confirmed by temporarily
+  restoring it and re-running the one test near this code path, which failed identically
+  with or without the handler (see below), proving that failure was unrelated and the
+  deletion itself introduces no behavior change.
+- `console_settings_modal.py`: only the custom-model-id `Input.Changed` handler is
+  debounced (`_sync_readiness_display` rebuilds a full ~15-field
+  `ConsoleSessionSettings` draft + re-validates). `picker.set_custom_value(...)` stays
+  immediate (cheap, keeps the `ModelSearchPicker`'s own mirror in sync without lag). Save
+  correctness is unaffected either way -- `_validated_result_or_show_errors` always
+  re-reads live widget values, never the debounced readiness display.
+
+Tests: every touched production file's existing suite was run and, where debounce timing
+broke a test's assumption that typing rebuilds synchronously, the test was updated to
+`await pilot.pause(<module>.SEARCH_DEBOUNCE_SECONDS + 0.1)` (or the file's equivalently-
+named constant) before asserting post-filter state -- the same idiom this codebase's own
+`console_prompt_picker_modal`/`console_skill_picker_modal` tests already use. Two
+mock-based unit tests (`world_book_picker`/`tag_filter_picker`, which construct the
+picker directly with no running Textual app) called `_filter(event)` synchronously outside
+any event loop; `Timer` scheduling requires one, so both were switched to call
+`_apply_filter_debounced(...)` directly -- the method that now holds the filter-then-
+populate logic those tests actually exercise. Added `Tests/UI/
+test_console_character_picker_debounce.py` (3 tests: pre-debounce no-rebuild, settled
+rebuild, rapid-retype cancel-and-reapply) as the one family-representative debounce-shape
+test, plus 4 new tests in `Tests/UI/test_logs_ux_fixes.py` for the render cap/disclosure/
+error-jump-reindexing.
+
+Pre-existing failures encountered and left alone (confirmed unrelated -- either in files
+this task never touches, or reproduced identically with the change reverted):
+`test_console_shell_chip_actions.py::test_swap_seeds_greeting_only_into_an_empty_chat`
+(unrelated `ConsoleSessionController` signature mismatch),
+`test_console_rail_sections.py::test_popover_apply_returns_replaced_settings`
+(`console_model_popover.py`, untouched, streaming-toggle assertion), `test_ux_batch5/6/7`'s
+Ollama/llama.cpp network-egress errors (task-15473's known probe), and a cluster of
+`test_destination_shells.py`/`test_destination_visual_parity_correction.py`/
+`test_console_live_work_handoffs.py` geometry/parity failures spanning schedules **and**
+several unrelated destinations (mcp, tools_settings, settings, watchlists) identically --
+systemic, not schedules-specific, and none of the failing assertions touch anything this
+task's diff changes (CSS/layout untouched). One deterministic failure
+(`test_speech_tts_settings_ownership_closeout.py::
+test_first_time_audio_cpp_setup_lab_generation_and_console_handoff`) was verified
+unrelated by temporarily restoring the deleted duplicate handler and re-running -- it
+failed identically either way.
+
+Modified: `tldw_chatbook/Widgets/Console/{console_character_picker_modal,
+console_session_switcher_modal,console_style_picker_modal,console_settings_modal}.py`,
+`tldw_chatbook/UI/Evals/card_picker.py`, `tldw_chatbook/UI/Chatbooks_Window_Improved.py`,
+`tldw_chatbook/UI/Logs_Window.py`,
+`tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py`,
+`tldw_chatbook/UI/Speech/speech_playground_pane.py`,
+`tldw_chatbook/Widgets/CCP_Widgets/{ccp_dictionary_editor_widget,
+ccp_prompt_editor_widget}.py`, `tldw_chatbook/Widgets/collections_tag_window.py`,
+`tldw_chatbook/Widgets/template_selector.py`,
+`tldw_chatbook/Widgets/Persona_Widgets/{dictionary_picker,world_book_picker,
+tag_filter_picker,dictionary_attach_picker,conversation_attach_picker}.py`, plus the
+corresponding test files (timing fixes) and one new test file
+(`Tests/UI/test_console_character_picker_debounce.py`).

--- a/tldw_chatbook/UI/Chatbooks_Window_Improved.py
+++ b/tldw_chatbook/UI/Chatbooks_Window_Improved.py
@@ -18,6 +18,7 @@ from textual.screen import Screen
 from textual.containers import Container, Horizontal, VerticalScroll, Grid
 from textual.widgets import Static, Button, Input, ListView, ListItem
 from textual.reactive import reactive
+from textual.timer import Timer
 from loguru import logger
 
 from ..Chatbooks.database_paths import (
@@ -382,6 +383,13 @@ class ChatbooksWindowImproved(RecomposeCaptureGuard, Screen):
     view_mode = reactive("grid")
     search_query = reactive("")
 
+    #: Debounce for the search `Input` -- mirrors the console picker
+    #: family's 0.2 s shape (`console_prompt_picker_modal.py`). Setting
+    #: `search_query` synchronously runs `_update_content()`, which tears
+    #: down and remounts a card/list item per chatbook; that must not
+    #: happen on every keystroke (task-15476).
+    SEARCH_DEBOUNCE_SECONDS = 0.2
+
     def __init__(self, app_instance: "TldwCli", **kwargs):
         """Store the owning app and resolve the default export directory.
 
@@ -394,6 +402,7 @@ class ChatbooksWindowImproved(RecomposeCaptureGuard, Screen):
         # the hardcoded ~/Documents/Chatbooks literal (task-984). Pre-existing
         # exports at the old location are not moved by this change.
         self._export_path = get_private_chatbooks_dir()
+        self._search_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         # Header
@@ -708,10 +717,20 @@ class ChatbooksWindowImproved(RecomposeCaptureGuard, Screen):
             elif element.id == "manage-action":
                 await self.action_manage_exports()
 
-    async def on_input_changed(self, event: Input.Changed) -> None:
-        """Handle search input changes."""
-        if event.input.id == "chatbook-search":
-            self.search_query = event.value
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Handle search input changes (debounced -- task-15476)."""
+        if event.input.id != "chatbook-search":
+            return
+        query = event.value
+        if self._search_debounce_timer is not None:
+            self._search_debounce_timer.stop()
+        self._search_debounce_timer = self.set_timer(
+            self.SEARCH_DEBOUNCE_SECONDS, lambda: self._apply_search_query(query)
+        )
+
+    def _apply_search_query(self, query: str) -> None:
+        self._search_debounce_timer = None
+        self.search_query = query
 
     async def action_create_chatbook(self, execution_mode: str = "local") -> None:
         """Launch the chatbook creation wizard."""

--- a/tldw_chatbook/UI/Evals/card_picker.py
+++ b/tldw_chatbook/UI/Evals/card_picker.py
@@ -31,7 +31,14 @@ from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.message import Message
+from textual.timer import Timer
 from textual.widgets import Button, Input, Static
+
+#: Debounce for the search `Input` -- mirrors the console picker family's
+#: 0.2 s shape (`console_prompt_picker_modal.py`). A full refresh removes
+#: and remounts up to `evals_state.py`'s ``_LIST_LIMIT`` (500) card rows,
+#: which should not happen on every keystroke (task-15476).
+SEARCH_DEBOUNCE_SECONDS = 0.2
 
 
 class CardRow(Button):
@@ -118,6 +125,7 @@ class CardPicker(Vertical):
         self._cards = [dict(card) for card in cards]
         self._selected: set[int] = {int(cid) for cid in selected_ids}
         self._filter = ""
+        self._refresh_timer: Timer | None = None
 
     def selected_ids(self) -> tuple[int, ...]:
         """Selected card ids, in the order the cards were supplied.
@@ -200,11 +208,24 @@ class CardPicker(Vertical):
             return
         event.stop()
         self._filter = event.value
-        # `call_after_refresh`, not an immediate `await` here (this handler
-        # is sync): lets Textual finish processing the keystroke that
-        # triggered this `Changed` event (including the `Input`'s own
-        # cursor/value update) before the row list underneath it is torn
-        # down and remounted.
+        # Debounced (task-15476): with up to `_LIST_LIMIT` (500) cards, a
+        # full remove_children()+mount_all() of the row list on every
+        # keystroke is the exact defect this task fixes. `call_after_refresh`
+        # alone (the previous approach) only deferred one frame -- it still
+        # rebuilt on every keystroke, just slightly later. A 0.2 s timer that
+        # re-arms on each keystroke settles once typing pauses instead.
+        if self._refresh_timer is not None:
+            self._refresh_timer.stop()
+        self._refresh_timer = self.set_timer(
+            SEARCH_DEBOUNCE_SECONDS, self._debounced_refresh_rows
+        )
+
+    def _debounced_refresh_rows(self) -> None:
+        self._refresh_timer = None
+        # `call_after_refresh`, not an immediate `await` here (this runs
+        # from a timer callback, not the Input's own Changed handler): lets
+        # Textual finish any in-flight layout pass before the row list
+        # underneath the search box is torn down and remounted.
         self.call_after_refresh(self._refresh_rows)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Logs_Window.py
+++ b/tldw_chatbook/UI/Logs_Window.py
@@ -17,6 +17,7 @@ from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal
+from textual.timer import Timer
 from textual.widgets import Button, Input, RichLog, Static
 from rich.text import Text
 
@@ -31,6 +32,19 @@ if TYPE_CHECKING:
 #: Bounded record buffer mirroring app._log_records (kept in sync by the
 #: app's PersistentLogHandler via ``append_record``).
 MAX_LOG_RECORDS = 10000
+
+#: Debounce for the free-text filter `Input` -- mirrors the picker/filter
+#: family's 0.2 s shape (`console_prompt_picker_modal.py`). Every render
+#: pass rescans up to `MAX_LOG_RECORDS` buffered records, so it must not run
+#: on every keystroke (task-15476).
+FILTER_DEBOUNCE_SECONDS = 0.2
+
+#: Cap the RichLog rendered slice: a filter matching thousands of buffered
+#: records must not clear+rewrite the widget with all of them on every
+#: render pass. The status line discloses when the cap trims output
+#: (task-15476, AC #2); the most RECENT matches are kept, mirroring the
+#: buffer's own oldest-evicted-first policy.
+MAX_RENDERED_LINES = 1000
 
 #: Level chips are THRESHOLDS, ordered by severity, matching the journalctl
 #: convention: each chip shows its level and above. "Info+" hides DEBUG/TRACE
@@ -153,6 +167,17 @@ class LogsWindow(Container):
         self._pending_while_paused = 0
         self._rendered_count = 0
         self._loaded_from_app = False
+        # task-15476: how many records the active filter actually matched
+        # (>= _rendered_count once MAX_RENDERED_LINES trims the render),
+        # the records actually written to the RichLog on the last render
+        # pass (n/N error-jump indexes against this, not the full matched
+        # set, since that's all that's really on screen to scroll to), and
+        # a one-entry cache so re-rendering with the same filter text does
+        # not recompile the same regex.
+        self._visible_total = 0
+        self._last_rendered: list[LogRecord] = []
+        self._compiled_pattern_cache: tuple[str, "re.Pattern | None"] | None = None
+        self._filter_debounce_timer: Timer | None = None
 
     # ------------------------------------------------------------------
     # Composition
@@ -285,16 +310,26 @@ class LogsWindow(Container):
             record, self._level_chip, text, self._compile_pattern(text)
         )
 
-    @staticmethod
-    def _compile_pattern(text: str) -> "re.Pattern | None":
+    def _compile_pattern(self, text: str) -> "re.Pattern | None":
         """Compile the filter text as a regex; invalid input falls back to
-        plain substring matching (None means: use substring)."""
+        plain substring matching (None means: use substring).
+
+        Cached on ``text`` (task-15476, AC #2): the level-chip buttons and
+        the debounced text filter both re-render through this on every
+        settle, and re-compiling the same pattern each time is pure waste.
+        """
+        cached = self._compiled_pattern_cache
+        if cached is not None and cached[0] == text:
+            return cached[1]
         if not text:
-            return None
-        try:
-            return re.compile(text, re.IGNORECASE)
-        except re.error:
-            return None
+            pattern = None
+        else:
+            try:
+                pattern = re.compile(text, re.IGNORECASE)
+            except re.error:
+                pattern = None
+        self._compiled_pattern_cache = (text, pattern)
+        return pattern
 
     def _visible_records(self) -> list[LogRecord]:
         text = self.query_one("#logs-filter-text", Input).value
@@ -306,11 +341,19 @@ class LogsWindow(Container):
         ]
 
     def _render_view(self) -> None:
-        """Re-render the log view from the record buffer."""
+        """Re-render the log view from the record buffer.
+
+        Caps the rendered slice to the most recent `MAX_RENDERED_LINES`
+        filter matches (task-15476, AC #2): a filter matching thousands of
+        the buffered records must not clear+rewrite the RichLog with all of
+        them. `_update_status_line` discloses the truncation.
+        """
         log_widget = self.query_one("#app-log-display", RichLog)
         empty_state = self.query_one("#logs-empty-state", Static)
         if not self._records:
             self._rendered_count = 0
+            self._visible_total = 0
+            self._last_rendered = []
             empty_state.display = "block"
             log_widget.display = False
         else:
@@ -318,9 +361,16 @@ class LogsWindow(Container):
             log_widget.display = True
             log_widget.clear()
             visible = self._visible_records()
-            for record in visible:
+            capped = (
+                visible[-MAX_RENDERED_LINES:]
+                if len(visible) > MAX_RENDERED_LINES
+                else visible
+            )
+            for record in capped:
                 log_widget.write(_styled_line(record))
-            self._rendered_count = len(visible)
+            self._rendered_count = len(capped)
+            self._visible_total = len(visible)
+            self._last_rendered = capped
             log_widget.scroll_end()
         self._update_status_line()
         self._update_filter_chips()
@@ -351,10 +401,17 @@ class LogsWindow(Container):
             chip.set_class(chip_id == self._level_chip, "is-active")
 
     def _update_status_line(self) -> None:
-        """Honest accounting of what's shown, filtered, and paused."""
+        """Honest accounting of what's shown, filtered, capped, and paused."""
         total = len(self._records)
         shown = self._rendered_count
         parts = [f"Showing {shown} of {total} lines"]
+        if self._visible_total > shown:
+            # task-15476 AC #2: the filter matched more than the rendered
+            # cap -- say so, rather than silently showing a partial result.
+            parts.append(
+                f"(filter matched {self._visible_total}; "
+                f"showing most recent {shown})"
+            )
         if total >= MAX_LOG_RECORDS:
             parts.append(f"(buffer keeps last {MAX_LOG_RECORDS:,})")
         if self._paused:
@@ -401,6 +458,17 @@ class LogsWindow(Container):
 
     @on(Input.Changed, "#logs-filter-text")
     def _on_filter_text_changed(self, event: Input.Changed) -> None:
+        """Debounced (task-15476): a render pass rescans up to
+        `MAX_LOG_RECORDS` buffered records and clears+rewrites the RichLog,
+        so it must not run on every keystroke."""
+        if self._filter_debounce_timer is not None:
+            self._filter_debounce_timer.stop()
+        self._filter_debounce_timer = self.set_timer(
+            FILTER_DEBOUNCE_SECONDS, self._apply_filter_text_debounced
+        )
+
+    def _apply_filter_text_debounced(self) -> None:
+        self._filter_debounce_timer = None
         self._render_view()
 
     @on(Button.Pressed, "#logs-pause")
@@ -498,10 +566,17 @@ class LogsWindow(Container):
         self._jump_to_error(-1)
 
     def _error_row_indices(self) -> list[int]:
-        """Indices of error/critical records within the current view."""
+        """Indices of error/critical records within the RENDERED view.
+
+        Indexed against `_last_rendered` (what `_render_view` actually
+        wrote to the RichLog), not the full filtered match set: when
+        `MAX_RENDERED_LINES` trims the render, an index computed from the
+        full match set could point past what the widget can `scroll_to`
+        (task-15476).
+        """
         return [
             index
-            for index, record in enumerate(self._visible_records())
+            for index, record in enumerate(self._last_rendered)
             if record.level in ("ERROR", "CRITICAL")
         ]
 

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -12,6 +12,7 @@ from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
+from textual.timer import Timer
 from textual.widgets import Button, DataTable, Input, Static, TabbedContent, TabPane
 
 from ...Navigation.base_app_screen import BaseAppScreen
@@ -50,6 +51,11 @@ logger = logger.bind(module="SchedulesWorkbench")
 
 SCHEDULES_COMPACT_WORKBENCH_MAX_WIDTH = 120
 
+#: Debounce for the queue filter `Input` -- mirrors the console picker
+#: family's 0.2 s shape (`console_prompt_picker_modal.py`). A full render
+#: pass clears and rebuilds the whole `DataTable` (task-15476).
+QUEUE_FILTER_DEBOUNCE_SECONDS = 0.2
+
 
 class SchedulesWorkbench(BaseAppScreen):
     """Main workbench for managing scheduled runs, reminders, and jobs."""
@@ -84,6 +90,11 @@ class SchedulesWorkbench(BaseAppScreen):
         self._tasks: list[ReminderTask | ScheduledTask] = []
         self._visible_tasks: list[ReminderTask | ScheduledTask] = []
         self._filter_text = ""
+        self._filter_debounce_timer: Timer | None = None
+        # task-15476: the task id currently shown in the detail/inspector
+        # panes, tracked independently of row index so a filter keystroke
+        # can restore the same selection instead of always jumping to row 0.
+        self._selected_task_id: str | None = None
         self._marked_ids: set[str] = set()
         self._sync_running = False
         self._current_console_follow_item = None
@@ -230,7 +241,14 @@ class SchedulesWorkbench(BaseAppScreen):
         await self._refresh_console_context()
 
     def _render_table(self) -> None:
-        """Rebuild the queue rows from the current tasks + filter text."""
+        """Rebuild the queue rows from the current tasks + filter text.
+
+        Restores the previously selected task's row (by id) when it is
+        still visible after the filter narrows, instead of always jumping
+        the detail/inspector panes back to row 0 (task-15476): a filter
+        keystroke must not discard what the user was looking at.
+        """
+        previous_selected_id = self._selected_task_id
         text = self._filter_text.strip().lower()
         self._visible_tasks = [
             task
@@ -257,8 +275,17 @@ class SchedulesWorkbench(BaseAppScreen):
             table.add_row(*row)
 
         if rows:
-            self._update_detail_for_index(0)
+            target_index = 0
+            if previous_selected_id is not None:
+                for index, task in enumerate(self._visible_tasks):
+                    if task.id == previous_selected_id:
+                        target_index = index
+                        break
+            if table.row_count:
+                table.move_cursor(row=target_index)
+            self._update_detail_for_index(target_index)
         else:
+            self._selected_task_id = None
             self.query_one("#scheduling-task-detail", TaskDetail).set_task(
                 None, queue_empty=not self._tasks
             )
@@ -274,8 +301,20 @@ class SchedulesWorkbench(BaseAppScreen):
 
     @on(Input.Changed, "#scheduling-queue-filter")
     def _on_queue_filter_changed(self, event: Input.Changed) -> None:
-        """Filter the queue rows by title substring."""
+        """Filter the queue rows by title substring (debounced).
+
+        A settled render clears and rebuilds the whole `DataTable`, so it
+        must not run on every keystroke (task-15476).
+        """
         self._filter_text = event.value
+        if self._filter_debounce_timer is not None:
+            self._filter_debounce_timer.stop()
+        self._filter_debounce_timer = self.set_timer(
+            QUEUE_FILTER_DEBOUNCE_SECONDS, self._apply_queue_filter_debounced
+        )
+
+    def _apply_queue_filter_debounced(self) -> None:
+        self._filter_debounce_timer = None
         self._render_table()
 
     @on(DataTable.RowHighlighted)
@@ -286,6 +325,7 @@ class SchedulesWorkbench(BaseAppScreen):
     def _update_detail_for_index(self, index: int) -> None:
         """Render task details in the detail and inspector panes."""
         if not (0 <= index < len(self._visible_tasks)):
+            self._selected_task_id = None
             self.query_one("#scheduling-task-detail", TaskDetail).set_task(
                 None, queue_empty=not self._tasks
             )
@@ -293,6 +333,7 @@ class SchedulesWorkbench(BaseAppScreen):
             return
 
         task = self._visible_tasks[index]
+        self._selected_task_id = task.id
         self.query_one("#scheduling-task-detail", TaskDetail).set_task(task)
         self.query_one("#scheduling-task-inspector", TaskInspector).set_task(task)
 

--- a/tldw_chatbook/UI/Speech/speech_playground_pane.py
+++ b/tldw_chatbook/UI/Speech/speech_playground_pane.py
@@ -1063,14 +1063,18 @@ class SpeechPlaygroundPane(
             return
         row.update_values(self.axis_values)
 
-    def on_text_area_changed(self, event: TextArea.Changed) -> None:
-        """Re-evaluate whether Generate is available.
-
-        Args:
-            event: The text change.
-        """
-        if event.text_area.id == "tts-text-input":
-            self._sync_generate_enabled()
+    # NOTE (task-15476): there used to be a second handler here,
+    # `on_text_area_changed`, matched by Textual's implicit
+    # `on_<message>` naming convention. Every `TextArea.Changed` in this
+    # pane is ALSO caught by the `@on(TextArea.Changed)`-decorated
+    # `on_tts_text_changed` above, which falls through to
+    # `self.handle_text_changed(event)` -> `_sync_generate_enabled()` for
+    # any text area other than the clone-reference one -- including
+    # `tts-text-input`. The two handlers fired on every keystroke into the
+    # main TTS text box, each independently materializing the full
+    # `TextArea.text` inside `_sync_generate_enabled`. Deleted as a pure
+    # duplicate; `_sync_generate_enabled()` still runs exactly once per
+    # keystroke via the fallthrough above.
 
     def _show_provider_specific_controls(self, provider: str) -> None:
         """Re-scope the parameter group and clip picker to `provider`.

--- a/tldw_chatbook/Widgets/CCP_Widgets/ccp_dictionary_editor_widget.py
+++ b/tldw_chatbook/Widgets/CCP_Widgets/ccp_dictionary_editor_widget.py
@@ -12,7 +12,14 @@ from textual.widgets import Static, Label, Input, TextArea, Button, Switch, Data
 from textual.reactive import reactive
 from textual import on
 from textual.message import Message
+from textual.timer import Timer
 from textual.validation import Length
+
+#: Debounce for the entries search `Input` -- mirrors the picker/filter
+#: family's 0.2 s shape (`console_prompt_picker_modal.py`). A settled
+#: search clears and rebuilds the whole entries `DataTable`, which should
+#: not happen on every keystroke (task-15476).
+SEARCH_DEBOUNCE_SECONDS = 0.2
 
 
 logger = logger.bind(module="CCPDictionaryEditorWidget")
@@ -408,6 +415,7 @@ class CCPDictionaryEditorWidget(Container):
         self._search_input: Optional[Input] = None
         self._stats_entries: Optional[Static] = None
         self._stats_size: Optional[Static] = None
+        self._search_debounce_timer: Optional[Timer] = None
 
         logger.debug("CCPDictionaryEditorWidget initialized")
 
@@ -847,14 +855,27 @@ class CCPDictionaryEditorWidget(Container):
 
     @on(Input.Changed, "#ccp-dictionary-search")
     async def handle_search_changed(self, event: Input.Changed) -> None:
-        """Handle search input changes."""
+        """Handle search input changes (debounced -- task-15476)."""
         self.search_filter = event.value
-        self._update_entries_table(event.value)
+        if self._search_debounce_timer is not None:
+            self._search_debounce_timer.stop()
+        self._search_debounce_timer = self.set_timer(
+            SEARCH_DEBOUNCE_SECONDS, self._apply_search_debounced
+        )
+
+    def _apply_search_debounced(self) -> None:
+        self._search_debounce_timer = None
+        self._update_entries_table(self.search_filter)
 
     @on(Button.Pressed, "#clear-search-btn")
     async def handle_clear_search(self, event: Button.Pressed) -> None:
         """Handle clear search button press."""
         event.stop()
+        # A pending debounced search would otherwise still fire ~0.2s later
+        # and re-render the (already-cleared) table a second time.
+        if self._search_debounce_timer is not None:
+            self._search_debounce_timer.stop()
+            self._search_debounce_timer = None
         if self._search_input:
             self._search_input.value = ""
         self.search_filter = ""

--- a/tldw_chatbook/Widgets/CCP_Widgets/ccp_prompt_editor_widget.py
+++ b/tldw_chatbook/Widgets/CCP_Widgets/ccp_prompt_editor_widget.py
@@ -12,10 +12,17 @@ from textual.widgets import Static, Label, Input, TextArea, Button, Select, Swit
 from textual.reactive import reactive
 from textual import on
 from textual.message import Message
+from textual.timer import Timer
 from textual.validation import Length
 
 
 logger = logger.bind(module="CCPPromptEditorWidget")
+
+#: Debounce for the prompt-content `TextArea` -- mirrors the picker/filter
+#: family's 0.2 s shape (`console_prompt_picker_modal.py`). Each settle
+#: rebuilds the preview `Static` from the full prompt text, which should
+#: not happen on every keystroke (task-15476).
+PREVIEW_DEBOUNCE_SECONDS = 0.2
 
 
 # ========== Messages ==========
@@ -378,6 +385,7 @@ class CCPPromptEditorWidget(Container):
         self._system_toggle: Optional[Switch] = None
         self._preview_area: Optional[Static] = None
         self._test_result_area: Optional[Static] = None
+        self._preview_debounce_timer: Optional[Timer] = None
 
         logger.debug("CCPPromptEditorWidget initialized")
 
@@ -875,7 +883,15 @@ class CCPPromptEditorWidget(Container):
 
     @on(TextArea.Changed, "#ccp-prompt-content")
     async def handle_prompt_content_changed(self, event: TextArea.Changed) -> None:
-        """Handle prompt content changes."""
+        """Handle prompt content changes (debounced -- task-15476)."""
+        if self._preview_debounce_timer is not None:
+            self._preview_debounce_timer.stop()
+        self._preview_debounce_timer = self.set_timer(
+            PREVIEW_DEBOUNCE_SECONDS, self._apply_preview_debounced
+        )
+
+    def _apply_preview_debounced(self) -> None:
+        self._preview_debounce_timer = None
         self._update_preview()
 
     @on(Switch.Changed, "#ccp-prompt-system-toggle")

--- a/tldw_chatbook/Widgets/Console/console_character_picker_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_character_picker_modal.py
@@ -19,6 +19,7 @@ from typing import Any, Literal, Sequence
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import Button, Input, Static
 
 CharacterPlacement = Literal["swap", "new"]
@@ -26,6 +27,12 @@ CharacterPlacement = Literal["swap", "new"]
 #: Bounds the result list so a large card library cannot mount hundreds of
 #: rows into a modal (the switcher modal caps its own list the same way).
 CHARACTER_PICKER_MAX_RESULTS = 40
+
+#: Debounce for the search `Input` -- mirrors the console picker family's
+#: 0.2 s shape (`console_prompt_picker_modal.py`). A full result refresh
+#: removes and remounts up to `CHARACTER_PICKER_MAX_RESULTS` `Static` rows,
+#: which should not happen on every keystroke (task-15476).
+SEARCH_DEBOUNCE_SECONDS = 0.2
 
 
 @dataclass(frozen=True)
@@ -148,6 +155,7 @@ class ConsoleCharacterPickerModal(ModalScreen["ConsoleCharacterChoice | None"]):
         self._results: tuple[ConsoleCharacterOption, ...] = ()
         self._selected_index = 0
         self._pending: ConsoleCharacterOption | None = None
+        self._query_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical(id="console-character-picker"):
@@ -238,11 +246,25 @@ class ConsoleCharacterPickerModal(ModalScreen["ConsoleCharacterChoice | None"]):
         )
         self.query_one("#console-character-placement-swap", Button).focus()
 
-    async def on_input_changed(self, event: Input.Changed) -> None:
+    def on_input_changed(self, event: Input.Changed) -> None:
         if event.input.id != "console-character-picker-query":
             return
         event.stop()
-        await self._refresh_results(event.value)
+        query = event.value
+        self._cancel_query_debounce()
+        self._query_debounce_timer = self.set_timer(
+            SEARCH_DEBOUNCE_SECONDS,
+            lambda: self.run_worker(
+                self._refresh_results(query),
+                exclusive=True,
+                group="console-character-picker-search",
+            ),
+        )
+
+    def _cancel_query_debounce(self) -> None:
+        if self._query_debounce_timer is not None:
+            self._query_debounce_timer.stop()
+            self._query_debounce_timer = None
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:
         if event.input.id != "console-character-picker-query":
@@ -263,6 +285,7 @@ class ConsoleCharacterPickerModal(ModalScreen["ConsoleCharacterChoice | None"]):
 
     def _finish(self, placement: CharacterPlacement) -> None:
         assert self._pending is not None
+        self._cancel_query_debounce()
         self.dismiss(
             ConsoleCharacterChoice(
                 character_id=self._pending.character_id,
@@ -298,4 +321,5 @@ class ConsoleCharacterPickerModal(ModalScreen["ConsoleCharacterChoice | None"]):
             row.update(f"{marker}{option.name}{current}")
 
     def action_dismiss_picker(self) -> None:
+        self._cancel_query_debounce()
         self.dismiss(None)

--- a/tldw_chatbook/Widgets/Console/console_session_switcher_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_session_switcher_modal.py
@@ -10,6 +10,7 @@ from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.css.query import NoMatches
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import Button, Input, Static
 
 from tldw_chatbook.Chat.console_switcher_state import (
@@ -19,6 +20,14 @@ from tldw_chatbook.Chat.console_switcher_state import (
 from tldw_chatbook.Workspaces.conversation_browser_state import (
     ConsoleConversationBrowserInputRow,
 )
+
+
+#: Debounce for the search `Input` -- mirrors the console picker family's
+#: 0.2 s shape (`console_prompt_picker_modal.py`). A full refresh removes
+#: and remounts one `Button` per matching entry (up to
+#: `CONSOLE_SWITCHER_RESULT_LIMIT`), which should not happen on every
+#: keystroke (task-15476).
+SEARCH_DEBOUNCE_SECONDS = 0.2
 
 
 @dataclass(frozen=True)
@@ -89,6 +98,7 @@ class ConsoleSessionSwitcherModal(ModalScreen["ConsoleSwitcherChoice | None"]):
         super().__init__(**kwargs)
         self._rows = rows
         self._entries: tuple[ConsoleSwitcherEntry, ...] = ()
+        self._query_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         """Build the search input and results container."""
@@ -151,14 +161,28 @@ class ConsoleSessionSwitcherModal(ModalScreen["ConsoleSwitcherChoice | None"]):
             await results.mount_all(buttons)
 
     @on(Input.Changed, "#console-switcher-query")
-    async def _query_changed(self, event: Input.Changed) -> None:
-        """Recompute results as the search query changes.
+    def _query_changed(self, event: Input.Changed) -> None:
+        """Recompute results as the search query changes (debounced).
 
         Args:
             event: The search input's change event.
         """
         event.stop()
-        await self._refresh_results(event.value)
+        query = event.value
+        self._cancel_query_debounce()
+        self._query_debounce_timer = self.set_timer(
+            SEARCH_DEBOUNCE_SECONDS,
+            lambda: self.run_worker(
+                self._refresh_results(query),
+                exclusive=True,
+                group="console-session-switcher-search",
+            ),
+        )
+
+    def _cancel_query_debounce(self) -> None:
+        if self._query_debounce_timer is not None:
+            self._query_debounce_timer.stop()
+            self._query_debounce_timer = None
 
     @on(Input.Submitted, "#console-switcher-query")
     def _query_submitted(self, event: Input.Submitted) -> None:
@@ -169,6 +193,7 @@ class ConsoleSessionSwitcherModal(ModalScreen["ConsoleSwitcherChoice | None"]):
         """
         event.stop()
         if self._entries:
+            self._cancel_query_debounce()
             self.dismiss(ConsoleSwitcherChoice("activate", self._entries[0]))
 
     def _result_buttons(self) -> list[Button]:
@@ -225,10 +250,12 @@ class ConsoleSessionSwitcherModal(ModalScreen["ConsoleSwitcherChoice | None"]):
         event.stop()
         index = self._result_index_from_widget_id(event.button.id or "")
         if index is not None and 0 <= index < len(self._entries):
+            self._cancel_query_debounce()
             self.dismiss(ConsoleSwitcherChoice("activate", self._entries[index]))
 
     def action_dismiss_switcher(self) -> None:
         """Dismiss the switcher with no result (Escape)."""
+        self._cancel_query_debounce()
         self.dismiss(None)
 
     def action_rename_entry(self) -> None:
@@ -246,10 +273,12 @@ class ConsoleSessionSwitcherModal(ModalScreen["ConsoleSwitcherChoice | None"]):
         if focused_index is not None and 0 <= focused_index < len(self._entries):
             focused_entry = self._entries[focused_index]
             if focused_entry.native_session_id:
+                self._cancel_query_debounce()
                 self.dismiss(ConsoleSwitcherChoice("rename", focused_entry))
                 return
         for entry in self._entries:
             if entry.native_session_id:
+                self._cancel_query_debounce()
                 self.dismiss(ConsoleSwitcherChoice("rename", entry))
                 return
 

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -12,6 +12,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, ScrollableContainer, Vertical
 from textual.css.query import NoMatches, QueryError
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import Button, Input, OptionList, Select, Static
 
 from tldw_chatbook.Chat.provider_readiness import provider_config_key
@@ -131,6 +132,11 @@ CONSOLE_SETTINGS_SCOPE_COPY = CONSOLE_SETTINGS_MODEL_SCOPE_COPY
 CONSOLE_SETTINGS_SAVE_DEFAULT_FAILED_COPY = (
     "Could not write defaults to the config file; session values still apply."
 )
+#: Debounce for the custom-model-id `Input` -- mirrors the picker/filter
+#: family's 0.2 s shape (`console_prompt_picker_modal.py`). Each settle
+#: rebuilds a full `ConsoleSessionSettings` draft from every form field and
+#: re-validates it, which must not happen on every keystroke (task-15476).
+CONSOLE_SETTINGS_READINESS_DEBOUNCE_SECONDS = 0.2
 # Draft fields persisted under [api_settings.<provider>] by Save as default.
 PROVIDER_DEFAULT_PERSIST_FIELDS = (
     "temperature",
@@ -352,6 +358,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSettingsResult | None]):
         )
         if initial_base_url:
             self._provider_base_url_drafts[settings.provider] = initial_base_url
+        self._readiness_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         provider_options = self._provider_select_options()
@@ -1535,11 +1542,30 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSettingsResult | None]):
 
     @on(Input.Changed, "#console-settings-model-input")
     def _model_input_changed(self, event: Input.Changed) -> None:
+        """Mirror the typed id into the picker now; debounce the rest.
+
+        `picker.set_custom_value` only touches the picker's own small
+        display state (its Input mirror, custom-mode button, status line),
+        so it stays immediate. `_sync_readiness_display` rebuilds a full
+        `ConsoleSessionSettings` draft from every form field and
+        re-validates it, and `_sync_visual_representation_availability`
+        does a model-capability lookup -- neither should run on every
+        keystroke (task-15476).
+        """
         picker = self.query_one(
             "#console-settings-model-picker", ModelSearchPicker
         )
         if picker.custom_mode:
             picker.set_custom_value(event.value)
+        if self._readiness_debounce_timer is not None:
+            self._readiness_debounce_timer.stop()
+        self._readiness_debounce_timer = self.set_timer(
+            CONSOLE_SETTINGS_READINESS_DEBOUNCE_SECONDS,
+            self._apply_readiness_sync_debounced,
+        )
+
+    def _apply_readiness_sync_debounced(self) -> None:
+        self._readiness_debounce_timer = None
         self._sync_readiness_display()
         self._sync_visual_representation_availability()
 

--- a/tldw_chatbook/Widgets/Console/console_style_picker_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_style_picker_modal.py
@@ -23,11 +23,16 @@ real DOM focus can never land on a row.
 
 The searched set is a small, static, in-memory list -- `get_all_templates`
 is cached for the process lifetime (see that function's docstring) -- so
-there is no injected async search callable, no debounce timer, and no
-search-token race to guard against (nothing here ever awaits I/O). Filtering
-runs synchronously on every keystroke; only the row mount/unmount itself is
-awaited (Textual's ``VerticalScroll.remove_children``/``mount_all`` are
-coroutines regardless of where the data came from).
+there is no injected async search callable and no search-token race to
+guard against (nothing here ever awaits I/O). Filtering itself is
+synchronous; what is NOT free is the row mount/unmount that follows it
+(``VerticalScroll.remove_children``/``mount_all`` tear down and rebuild
+every result ``Button``). task-15476: this modal used to run that rebuild
+on every keystroke -- its three sibling Console pickers
+(``ConsolePromptPickerModal``, ``ConsoleSkillPickerModal``,
+``ConsoleCharacterPickerModal``) already debounced theirs, and this one now
+matches: a 0.2 s timer (`SEARCH_DEBOUNCE_SECONDS`) re-arms on every
+keystroke and only the settled query is applied.
 
 Task-559 AC3 adds a template preview: a detail line below the results list
 that shows the highlighted template's base-prompt/negative-prompt snippet
@@ -54,6 +59,7 @@ from textual.app import ComposeResult
 from textual.containers import Vertical, VerticalScroll
 from textual.css.query import NoMatches, QueryError
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import Button, Input, Static
 
 from tldw_chatbook.Media_Creation.generation_templates import (
@@ -74,6 +80,10 @@ EMPTY_STORE_COPY = "No matching styles."
 DETAIL_EMPTY_COPY = "Highlight a style to preview its prompt."
 
 MODAL_TITLE = "Insert image style"
+
+#: Debounce for the search `Input` -- mirrors the console picker family's
+#: 0.2 s shape (`console_prompt_picker_modal.py`, task-15476).
+SEARCH_DEBOUNCE_SECONDS = 0.2
 
 _PREVIEW_SNIPPET_MAX_CHARS = 90
 """Max rendered length of each of the base-prompt/negative-prompt snippets
@@ -174,6 +184,7 @@ class ConsoleStylePickerModal(ModalScreen[Optional[Mapping[str, object]]]):
         # field, no duplicate/malformed-id fallback is needed here.
         self._row_ids: list[str] = []
         self._highlighted_index = 0
+        self._search_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical(id=MODAL_ID):
@@ -205,12 +216,27 @@ class ConsoleStylePickerModal(ModalScreen[Optional[Mapping[str, object]]]):
             pass
 
     def action_dismiss_picker(self) -> None:
+        self._cancel_search_debounce()
         self.dismiss(None)
 
     @on(Input.Changed, f"#{FILTER_INPUT_ID}")
-    async def _filter_changed(self, event: Input.Changed) -> None:
+    def _filter_changed(self, event: Input.Changed) -> None:
         event.stop()
-        await self._apply_filter(event.value)
+        self._cancel_search_debounce()
+        query = event.value
+        self._search_debounce_timer = self.set_timer(
+            SEARCH_DEBOUNCE_SECONDS,
+            lambda: self.run_worker(
+                self._apply_filter(query),
+                exclusive=True,
+                group="console-style-picker-search",
+            ),
+        )
+
+    def _cancel_search_debounce(self) -> None:
+        if self._search_debounce_timer is not None:
+            self._search_debounce_timer.stop()
+            self._search_debounce_timer = None
 
     @on(Input.Submitted, f"#{FILTER_INPUT_ID}")
     def _filter_submitted(self, event: Input.Submitted) -> None:
@@ -322,4 +348,5 @@ class ConsoleStylePickerModal(ModalScreen[Optional[Mapping[str, object]]]):
         self._select_record(self._results[self._highlighted_index])
 
     def _select_record(self, template: GenerationTemplate) -> None:
+        self._cancel_search_debounce()
         self.dismiss({"id": template.id, "name": template.name})

--- a/tldw_chatbook/Widgets/Persona_Widgets/conversation_attach_picker.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/conversation_attach_picker.py
@@ -11,7 +11,14 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import Button, Input, Label, ListItem, ListView, Static
+
+#: Debounce for the search `Input` -- mirrors the console picker family's
+#: 0.2 s shape (`console_prompt_picker_modal.py`). A full refresh clears
+#: and re-appends every matching `ListItem` into the `ListView`, which
+#: should not happen on every keystroke (task-15476).
+SEARCH_DEBOUNCE_SECONDS = 0.2
 
 
 class ConversationAttachPicker(ModalScreen[str | None]):
@@ -34,6 +41,7 @@ class ConversationAttachPicker(ModalScreen[str | None]):
         super().__init__(**kwargs)
         self._conversations = list(conversations)
         self._row_ids: list[str] = []
+        self._filter_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -71,7 +79,16 @@ class ConversationAttachPicker(ModalScreen[str | None]):
     @on(Input.Changed, "#conversation-attach-search")
     def _filter(self, event: Input.Changed) -> None:
         event.stop()
-        needle = event.value.strip().lower()
+        needle = event.value
+        if self._filter_debounce_timer is not None:
+            self._filter_debounce_timer.stop()
+        self._filter_debounce_timer = self.set_timer(
+            SEARCH_DEBOUNCE_SECONDS, lambda: self._apply_filter_debounced(needle)
+        )
+
+    def _apply_filter_debounced(self, raw_value: str) -> None:
+        self._filter_debounce_timer = None
+        needle = raw_value.strip().lower()
         rows = (
             [
                 c

--- a/tldw_chatbook/Widgets/Persona_Widgets/dictionary_attach_picker.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/dictionary_attach_picker.py
@@ -12,7 +12,14 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import Button, Input, Label, ListItem, ListView, Static
+
+#: Debounce for the search `Input` -- mirrors the console picker family's
+#: 0.2 s shape (`console_prompt_picker_modal.py`). A full refresh clears
+#: and re-appends every matching `ListItem` into the `ListView`, which
+#: should not happen on every keystroke (task-15476).
+SEARCH_DEBOUNCE_SECONDS = 0.2
 
 
 class DictionaryAttachPicker(ModalScreen[str | None]):
@@ -35,6 +42,7 @@ class DictionaryAttachPicker(ModalScreen[str | None]):
         super().__init__(**kwargs)
         self._conversations = list(conversations)
         self._row_ids: list[str] = []
+        self._filter_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -72,7 +80,16 @@ class DictionaryAttachPicker(ModalScreen[str | None]):
     @on(Input.Changed, "#dict-attach-search")
     def _filter(self, event: Input.Changed) -> None:
         event.stop()
-        needle = event.value.strip().lower()
+        needle = event.value
+        if self._filter_debounce_timer is not None:
+            self._filter_debounce_timer.stop()
+        self._filter_debounce_timer = self.set_timer(
+            SEARCH_DEBOUNCE_SECONDS, lambda: self._apply_filter_debounced(needle)
+        )
+
+    def _apply_filter_debounced(self, raw_value: str) -> None:
+        self._filter_debounce_timer = None
+        needle = raw_value.strip().lower()
         rows = (
             [
                 c

--- a/tldw_chatbook/Widgets/Persona_Widgets/dictionary_picker.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/dictionary_picker.py
@@ -12,7 +12,14 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import Button, Input, Label, ListItem, ListView, Static
+
+#: Debounce for the search `Input` -- mirrors the console picker family's
+#: 0.2 s shape (`console_prompt_picker_modal.py`). A full refresh clears
+#: and re-appends every matching `ListItem` into the `ListView`, which
+#: should not happen on every keystroke (task-15476).
+SEARCH_DEBOUNCE_SECONDS = 0.2
 
 
 class DictionaryPicker(ModalScreen[int | None]):
@@ -45,6 +52,7 @@ class DictionaryPicker(ModalScreen[int | None]):
         self._row_ids: list[int] = []
         self._title = title
         self._confirm_label = confirm_label
+        self._filter_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -78,7 +86,16 @@ class DictionaryPicker(ModalScreen[int | None]):
     @on(Input.Changed, "#dict-pick-search")
     def _filter(self, event: Input.Changed) -> None:
         event.stop()
-        needle = event.value.strip().lower()
+        needle = event.value
+        if self._filter_debounce_timer is not None:
+            self._filter_debounce_timer.stop()
+        self._filter_debounce_timer = self.set_timer(
+            SEARCH_DEBOUNCE_SECONDS, lambda: self._apply_filter_debounced(needle)
+        )
+
+    def _apply_filter_debounced(self, raw_value: str) -> None:
+        self._filter_debounce_timer = None
+        needle = raw_value.strip().lower()
         rows = (
             [
                 d

--- a/tldw_chatbook/Widgets/Persona_Widgets/tag_filter_picker.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/tag_filter_picker.py
@@ -14,7 +14,14 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import Input, Label, ListItem, ListView, Static
+
+#: Debounce for the search `Input` -- mirrors the console picker family's
+#: 0.2 s shape (`console_prompt_picker_modal.py`). A full refresh clears
+#: and re-appends every matching `ListItem` into the `ListView`, which
+#: should not happen on every keystroke (task-15476).
+SEARCH_DEBOUNCE_SECONDS = 0.2
 
 
 class TagFilterPicker(ModalScreen[str | None]):
@@ -46,6 +53,7 @@ class TagFilterPicker(ModalScreen[str | None]):
         self._tags = list(tags)
         self._current = current
         self._row_tags: list[str | None] = []
+        self._filter_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -79,7 +87,16 @@ class TagFilterPicker(ModalScreen[str | None]):
     @on(Input.Changed, "#tag-filter-search")
     def _filter(self, event: Input.Changed) -> None:
         event.stop()
-        needle = event.value.strip().lower()
+        needle = event.value
+        if self._filter_debounce_timer is not None:
+            self._filter_debounce_timer.stop()
+        self._filter_debounce_timer = self.set_timer(
+            SEARCH_DEBOUNCE_SECONDS, lambda: self._apply_filter_debounced(needle)
+        )
+
+    def _apply_filter_debounced(self, raw_value: str) -> None:
+        self._filter_debounce_timer = None
+        needle = raw_value.strip().lower()
         tags = [t for t in self._tags if needle in t.lower()] if needle else self._tags
         self._populate(tags)
 

--- a/tldw_chatbook/Widgets/Persona_Widgets/world_book_picker.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/world_book_picker.py
@@ -13,7 +13,14 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import Button, Input, Label, ListItem, ListView, Static
+
+#: Debounce for the search `Input` -- mirrors the console picker family's
+#: 0.2 s shape (`console_prompt_picker_modal.py`). A full refresh clears
+#: and re-appends every matching `ListItem` into the `ListView`, which
+#: should not happen on every keystroke (task-15476).
+SEARCH_DEBOUNCE_SECONDS = 0.2
 
 
 class WorldBookPicker(ModalScreen[int | None]):
@@ -46,6 +53,7 @@ class WorldBookPicker(ModalScreen[int | None]):
         self._row_ids: list[int] = []
         self._title = title
         self._confirm_label = confirm_label
+        self._filter_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -79,7 +87,16 @@ class WorldBookPicker(ModalScreen[int | None]):
     @on(Input.Changed, "#worldbook-pick-search")
     def _filter(self, event: Input.Changed) -> None:
         event.stop()
-        needle = event.value.strip().lower()
+        needle = event.value
+        if self._filter_debounce_timer is not None:
+            self._filter_debounce_timer.stop()
+        self._filter_debounce_timer = self.set_timer(
+            SEARCH_DEBOUNCE_SECONDS, lambda: self._apply_filter_debounced(needle)
+        )
+
+    def _apply_filter_debounced(self, raw_value: str) -> None:
+        self._filter_debounce_timer = None
+        needle = raw_value.strip().lower()
         rows = (
             [b for b in self._world_books if needle in str(b.get("name") or "").lower()]
             if needle

--- a/tldw_chatbook/Widgets/collections_tag_window.py
+++ b/tldw_chatbook/Widgets/collections_tag_window.py
@@ -11,11 +11,18 @@ from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 from textual.widgets import Static, Button, Label, Input, ListView, ListItem, Markdown
 from textual.reactive import reactive
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from loguru import logger
 
 if TYPE_CHECKING:
     from ..app import TldwCli
 
+
+#: Debounce for the keyword search `Input` -- mirrors the picker/filter
+#: family's 0.2 s shape (`console_prompt_picker_modal.py`). A settled
+#: search clears and re-appends every matching `ListItem`, which should
+#: not happen on every keystroke (task-15476).
+KEYWORD_SEARCH_DEBOUNCE_SECONDS = 0.2
 
 RENAME_KEYWORD_DISABLED_TOOLTIP = "Select exactly one keyword or tag before renaming."
 MERGE_KEYWORDS_DISABLED_TOOLTIP = "Select at least two keywords or tags before merging."
@@ -131,6 +138,7 @@ class CollectionsTagWindow(Container):
         super().__init__(**kwargs)
         self.app_instance = app_instance
         self.all_keywords: List[Dict[str, Any]] = []
+        self._search_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the UI structure."""
@@ -260,8 +268,16 @@ class CollectionsTagWindow(Container):
 
     @on(Input.Changed, "#keyword-search-input")
     def handle_search_change(self, event: Input.Changed) -> None:
-        """Handle keyword search input changes."""
+        """Handle keyword search input changes (debounced -- task-15476)."""
         self.keyword_search = event.value
+        if self._search_debounce_timer is not None:
+            self._search_debounce_timer.stop()
+        self._search_debounce_timer = self.set_timer(
+            KEYWORD_SEARCH_DEBOUNCE_SECONDS, self._apply_keyword_search_debounced
+        )
+
+    def _apply_keyword_search_debounced(self) -> None:
+        self._search_debounce_timer = None
         self.refresh_keyword_list()
 
     @on(ListView.Selected, "#keyword-list")

--- a/tldw_chatbook/Widgets/template_selector.py
+++ b/tldw_chatbook/Widgets/template_selector.py
@@ -17,6 +17,7 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Vertical, Horizontal
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import (
     Button,
     Label,
@@ -30,6 +31,12 @@ from textual.widgets import (
 )
 from loguru import logger
 
+
+#: Debounce for the template search `Input` -- mirrors the picker/filter
+#: family's 0.2 s shape (`console_prompt_picker_modal.py`). A settled
+#: search clears and rebuilds every category's `ListView`, which should
+#: not happen on every keystroke (task-15476).
+TEMPLATE_SEARCH_DEBOUNCE_SECONDS = 0.2
 
 TEMPLATE_CREATE_DISABLED_TOOLTIP = (
     "Select an evaluation template before creating a task."
@@ -151,6 +158,7 @@ class TemplateListWidget(Container):
         self.templates = templates
         self.on_template_selected = on_template_selected
         self.templates_by_category = self._organize_by_category()
+        self._search_debounce_timer: Timer | None = None
 
     def _organize_by_category(self) -> Dict[str, List[Dict[str, Any]]]:
         """Organize templates by category."""
@@ -183,8 +191,18 @@ class TemplateListWidget(Container):
 
     @on(Input.Changed, "#template-search")
     def handle_search(self, event: Input.Changed):
-        """Handle template search."""
-        search_term = event.value.lower()
+        """Handle template search (debounced -- task-15476)."""
+        raw_value = event.value
+        if self._search_debounce_timer is not None:
+            self._search_debounce_timer.stop()
+        self._search_debounce_timer = self.set_timer(
+            TEMPLATE_SEARCH_DEBOUNCE_SECONDS,
+            lambda: self._apply_search_debounced(raw_value),
+        )
+
+    def _apply_search_debounced(self, raw_value: str) -> None:
+        self._search_debounce_timer = None
+        search_term = raw_value.lower()
 
         # Filter and update template lists
         for category, templates in self.templates_by_category.items():


### PR DESCRIPTION
## Summary

Task 15476 from the input-latency audit. Eighteen picker/filter surfaces rebuilt their full result set on every keystroke (character picker: 500 Statics; session switcher: unbounded; Logs: regex over 10,000 records + full RichLog rewrite per character; schedules filter also reset the detail pane to row 0).

- All 18 sites converted to the sanctioned `console_prompt_picker_modal` debounce shape (0.2 s timer + cancel); Enter-before-debounce semantics verified to match the template (acts on the settled visible set)
- Logs: capped render slice with a truthful truncation disclosure + one-entry compiled-pattern cache; error-row jump indexes the rendered slice (no out-of-range)
- Schedules: selection restored by task id (survives filter-out with sane fallback; reorder-independent by construction)
- Duplicate speech TextArea.Changed handler deleted (full text was materialized twice per keystroke)
- ~1467 targeted tests green across 10 batches; 7 new representative tests

## Verification
Independent review: Approved — site table re-derived complete; Logs/Schedules risk centers verified by reading + reruns; reviewer wrote its own scratchpad smoke harness for the two zero-coverage CCP editor widgets (debounce + unmount lifecycle correct; also established both widgets are likely dead code — flagged for the owner rather than treated as reachable). Deferred minors recorded: a stray idempotent re-arm after Clear in the CCP dictionary editor; a report tally imprecision (31 vs 34 Logs tests, no missing coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Debounces all picker/filter UIs to avoid full-list rebuilds on each keystroke and caps Logs rendering; this reduces input latency and heavy reflows on large lists. Also preserves selection in Schedules when filtering and removes a duplicate Speech handler.

- Applies a 0.2 s timer-with-cancel debounce across the Console pickers, Persona pickers, `Evals` card picker, Chatbooks search, CCP editors, `collections_tag_window`, `template_selector`, and the Console Settings custom-model input. Rebuilds fire after typing settles; dismiss/selection cancels any pending timer.
- Logs: debounces the free-text filter, caches the compiled regex per text, caps RichLog writes to the most recent `MAX_RENDERED_LINES` matches, discloses truncation in the status line, and computes error-jump indices against the rendered slice.
- Schedules: debounces the queue filter and restores the previously selected task by id after filters change (no more always-reset-to-row-0).
- Speech: deletes a duplicate `TextArea.Changed` handler that ran alongside the decorated handler; functionality is unchanged, work is no longer duplicated.
- Tests: update timing to await the new debounce constants; add one representative debounce-shape test; adjust two unit tests to call the new `_apply_*_debounced` methods directly.

**Review and rollout notes**

- Verify each site cancels timers on dismiss/confirm and does not rebuild mid-dismiss; check exclusive `run_worker` groups where used.
- Logs: confirm status-line truncation wording and that error jumps never target non-rendered lines.
- Schedules: confirm selection persists when the selected task remains visible; sane fallback when it doesn’t.
- Migration for local tests/scripts: when asserting post-filter state, wait `SEARCH_DEBOUNCE_SECONDS` (or the module’s debounce constant), or call the `_apply_*_debounced` helper where provided.
- Addresses task-15476 ACs: 1) no per-keystroke rebuilds, 2) Logs cap + disclosure + regex cache, 3) picker behaviors preserved (selection, focus, empty states; schedules detail selection restored).

<sup>Written for commit d5b0e1d07c420e2f95e80e6326fa00ebcfd40c99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

