### PR TITLE
perf: harden the merged transcript windowing with the reconciled 15455 delta

### DIFF
--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -159,11 +159,18 @@ under you, keeping the same message in view; the jump-to-latest pill or a new
 send takes you back to the tail. Nothing is deleted: exports, `/rewind`, and the
 context sent to the model always use the full history. Very long sessions still
 stop growing the view at the height watermarks, and once the mounted view
-reaches that limit scrolling further back stops loading more (the alternative is
-the view churning rows in and out indefinitely). Tune it under `[chat_defaults]`
-in `config.toml` — `transcript_window_lines` (rows kept at load; set it to `0`
-to mount everything, as before), `transcript_scrollback_lines` (rows added per
-step), and the `prune_*_watermark` pair.
+reaches `prune_low_watermark` (12,000 rows by default) scrolling further back
+stops loading more — the alternative is the view churning rows in and out
+indefinitely. Tune it under `[chat_defaults]` in `config.toml`:
+
+- `transcript_window_lines` (144) and `transcript_scrollback_lines` (96) are
+  **floors**, not the budget. The window actually used is the larger of the
+  floor and your terminal height ×6 (×4 per scroll-back step), so on any
+  terminal 24 rows or taller the shipped floors change nothing — raise them
+  above `height × 6` to widen the window, or set `transcript_window_lines` to
+  `0` to mount the whole history at load, as before.
+- `prune_low_watermark` / `prune_high_watermark` bound the mounted view itself
+  and keep working with the window disabled.
 
 ### Composer
 

--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -149,6 +149,22 @@ composer-level strip below shows once setup completes.
 | **Approvals** | Pending approvals; press Enter or Space on it to jump to the approval card. |
 | **Scope** | Appears when retrieval is narrowed ("Scope: N"); Enter or Space opens the scope picker. |
 
+### Long conversations
+
+Opening or switching to a long conversation shows the most recent stretch of it
+first, rather than mounting the whole history up front — a 500-message session
+opens in about a second instead of tens of seconds. Scroll to the top of what is
+shown (wheel, Page Up, or the scrollbar) and the previous chunk is prepended
+under you, keeping the same message in view; the jump-to-latest pill or a new
+send takes you back to the tail. Nothing is deleted: exports, `/rewind`, and the
+context sent to the model always use the full history. Very long sessions still
+stop growing the view at the height watermarks, and once the mounted view
+reaches that limit scrolling further back stops loading more (the alternative is
+the view churning rows in and out indefinitely). Tune it under `[chat_defaults]`
+in `config.toml` — `transcript_window_lines` (rows kept at load; set it to `0`
+to mount everything, as before), `transcript_scrollback_lines` (rows added per
+step), and the `prune_*_watermark` pair.
+
 ### Composer
 
 Editing keys, send/stream/stop, attachments, and Mic dictation live in
@@ -273,4 +289,7 @@ outranks that provider's environment variable. Verified against
 42b28089f — 2026-08-06 (task-2852: live check on a fresh profile — a
 Library Search/RAG handoff staged while locked now shows a receipt line
 on the Get started card, and the same handoff on a configured Console
-still lands on the unchanged staged-evidence strip).*
+still lands on the unchanged staged-evidence strip). "Long conversations"
+verified against the TASK-15455 windowing (PR #1538) plus its reconciliation
+delta — shipped tests and an isolated 500-message load probe; not re-checked
+live.*

--- a/Tests/UI/test_console_transcript_window_reconcile.py
+++ b/Tests/UI/test_console_transcript_window_reconcile.py
@@ -1,0 +1,434 @@
+"""TASK-15455 reconciliation: the review-hardened delta on top of the merged window.
+
+Two sessions implemented this task independently. The merged-first
+implementation (PR #1538) owns the design: ONE contiguous hidden prefix
+(`_pruned_message_ids`), a viewport-derived line budget, turn-aligned
+boundaries, and wheel/page-up/scroll-boundary hydration. Its four tests
+(`test_console_transcript_windowing.py`) stay green and unmodified.
+
+This file carries what the second implementation's review round found and the
+merged one does not have: the prune/hydration fixed point, reading-state
+restore into a windowed-out selection, a config surface with a kill switch, and
+the load-shape pins that were written before either implementation existed.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.Widgets.Console.console_transcript import (
+    DEFAULT_INITIAL_WINDOW_LINES,
+    DEFAULT_SCROLLBACK_CHUNK_LINES,
+    ConsoleTranscript,
+    get_console_transcript_window_lines,
+)
+
+
+class ReconcileHarness(App):
+    """Transcript host with explicit watermarks and window settings."""
+
+    CSS = "ConsoleTranscript { height: 24; width: 100; }"
+
+    def __init__(
+        self,
+        *,
+        low: int = 12_000,
+        high: int = 0,
+        window_lines: int | None = None,
+        scrollback_lines: int | None = None,
+    ) -> None:
+        super().__init__()
+        chat_defaults: dict[str, object] = {
+            "assistant_markdown": False,
+            "prune_low_watermark": low,
+            "prune_high_watermark": high,
+        }
+        if window_lines is not None:
+            chat_defaults["transcript_window_lines"] = window_lines
+        if scrollback_lines is not None:
+            chat_defaults["transcript_scrollback_lines"] = scrollback_lines
+        self.app_config = {"chat_defaults": chat_defaults}
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleTranscript(id="console-native-transcript")
+
+
+def _messages(count: int, *, prefix: str = "m") -> list[ConsoleChatMessage]:
+    return [
+        ConsoleChatMessage(
+            id=f"{prefix}{index}",
+            role=(
+                ConsoleMessageRole.USER
+                if index % 2 == 0
+                else ConsoleMessageRole.ASSISTANT
+            ),
+            content="\n".join(f"message {index} line {line}" for line in range(4)),
+        )
+        for index in range(count)
+    ]
+
+
+def _mounted_message_ids(transcript: ConsoleTranscript) -> list[str]:
+    return [row.message_id for row in transcript.query(".console-transcript-message")]
+
+
+async def _wait_for(pilot, predicate, *, attempts: int = 80) -> bool:
+    for _ in range(attempts):
+        await pilot.pause()
+        if predicate():
+            return True
+    return False
+
+
+async def _settle(pilot, *, times: int = 8) -> None:
+    for _ in range(times):
+        await pilot.pause()
+
+
+# ---------------------------------------------------------------------------
+# Load-shape pins (written before either implementation; adapted to this API).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pin_long_load_is_bounded_and_leaves_the_reader_at_the_tail():
+    """A 500-message load mounts a bounded tail and stays anchored to it."""
+    app = ReconcileHarness()
+    history = _messages(500)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        mounted = _mounted_message_ids(transcript)
+        assert 0 < len(mounted) <= 60, f"the load window must be bounded: {len(mounted)}"
+        assert mounted[-1] == "m499"
+        assert transcript._is_following_tail(), "load must keep tail-follow engaged"
+        assert transcript.scroll_y == transcript.max_scroll_y
+        assert len(transcript._messages) == 500, "the store snapshot is untouched"
+        # Exports still render the whole history, mounted or not.
+        plain = transcript.to_plain_text(width=40)
+        assert "message 0 line 0" in plain
+        assert "message 499 line 3" in plain
+
+
+@pytest.mark.asyncio
+async def test_pin_session_switch_rewindows_on_the_new_history():
+    """Switching sessions drops every old row and re-windows on the new tail."""
+    app = ReconcileHarness()
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(200))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        transcript.set_messages(_messages(200, prefix="other"))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        mounted = _mounted_message_ids(transcript)
+        assert mounted, "the new session must render rows"
+        assert all(message_id.startswith("other") for message_id in mounted)
+        assert mounted[-1] == "other199"
+        assert len(mounted) < 200, "the new session gets a bounded window too"
+        assert transcript._is_following_tail()
+
+
+@pytest.mark.asyncio
+async def test_pin_watermarks_still_bound_the_mounted_height():
+    """The height watermarks keep bounding the transcript under windowing."""
+    app = ReconcileHarness(low=45, high=70)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(200))
+        await transcript.refresh_messages()
+        assert await _wait_for(pilot, lambda: transcript.virtual_size.height <= 70), (
+            f"height {transcript.virtual_size.height} escaped the high watermark"
+        )
+        assert len(transcript._messages) == 200
+
+
+# ---------------------------------------------------------------------------
+# Selection into windowed-out history (the merged implementation already does
+# this; nothing pinned it).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_selecting_a_windowed_out_message_reveals_it_contiguously():
+    """`select_message` reveals through the target, keeping ONE tail stretch."""
+    app = ReconcileHarness()
+    history = _messages(300)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        assert "m10" not in _mounted_message_ids(transcript), "target must start hidden"
+
+        transcript.select_message("m10")
+        assert await _wait_for(
+            pilot, lambda: "m10" in _mounted_message_ids(transcript)
+        ), "selecting a windowed-out message never mounted it"
+        assert transcript.selected_message_id == "m10"
+        assert transcript.query(".console-transcript-action-row"), (
+            "the revealed selection must show its action row"
+        )
+
+        mounted = _mounted_message_ids(transcript)
+        expected = [message.id for message in history[history.index(history[10]) :]]
+        assert mounted == expected[: len(mounted)], "the reveal must stay contiguous"
+        assert mounted[-1] == "m299"
+
+
+@pytest.mark.asyncio
+async def test_mounted_rows_stay_one_contiguous_suffix_after_prune_and_jump():
+    """Why no gap marker is needed here: the hidden set is always a PREFIX.
+
+    A jump above a pruned stretch cannot produce an island in this design —
+    both the watermark walk and every reveal path move the same single
+    boundary. (The second implementation, which tracked pruning and windowing
+    as two sets, could produce islands and needed a seam row.)
+    """
+    app = ReconcileHarness(low=45, high=70)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(200)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        assert await _wait_for(pilot, lambda: bool(transcript._pruned_message_ids))
+        await _settle(pilot)
+
+        transcript.select_message("m20")
+        assert await _wait_for(
+            pilot, lambda: "m20" in _mounted_message_ids(transcript)
+        )
+        await _settle(pilot)
+
+        mounted = _mounted_message_ids(transcript)
+        first = int(mounted[0][1:])
+        assert mounted == [f"m{index}" for index in range(first, 200)], (
+            f"mounted rows must be one contiguous suffix, got {mounted[:5]}…"
+        )
+        hidden = transcript._pruned_message_ids
+        assert hidden == {f"m{index}" for index in range(first)}, (
+            "the hidden set must stay a contiguous prefix"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The prune/hydration fixed point (the merged implementation churns forever).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scrollback_hydration_and_pruning_reach_a_fixed_point():
+    """Idle frames must not churn rows in and out.
+
+    Measured on the merged implementation before this fix: with the reader at
+    the scroll boundary and the transcript over its high watermark, the hidden
+    prefix oscillated between 169 and 152 messages (height 47 <-> 115) forever,
+    with no user input — the prune's own scroll restoration re-triggers the
+    boundary hydration that produced it.
+    """
+    app = ReconcileHarness(low=45, high=70)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(180))
+        await transcript.refresh_messages()
+        await _settle(pilot, times=5)
+
+        transcript.release_anchor()
+        transcript.scroll_to(y=0, animate=False)
+        samples: list[int] = []
+        for _ in range(40):
+            await pilot.pause()
+            samples.append(len(transcript._pruned_message_ids))
+
+        assert len(set(samples[-12:])) == 1, (
+            f"the window must settle, not churn: {samples[-12:]}"
+        )
+        assert transcript.virtual_size.height <= 70, (
+            "the settled window must still respect the high watermark"
+        )
+
+
+@pytest.mark.asyncio
+async def test_explicit_hydration_still_works_below_the_low_watermark():
+    """The fixed point must not cost ordinary scrollback its hydration."""
+    app = ReconcileHarness()  # pruning disabled: the default reader case
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(180))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        hidden_before = len(transcript._pruned_message_ids)
+        transcript.release_anchor()
+        transcript.scroll_to(y=0, animate=False)
+        assert await _wait_for(
+            pilot, lambda: len(transcript._pruned_message_ids) < hidden_before
+        ), "reaching the boundary must still hydrate earlier history"
+
+
+# ---------------------------------------------------------------------------
+# Reading-state restore into a windowed-out selection.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restored_reading_state_reveals_its_selected_message():
+    """`restore_reading_state` assigns the id directly — it must reveal it first."""
+    from tldw_chatbook.UI.Console_Modules.transcript import (
+        ConsoleTranscriptRegion,
+        _ConsoleTranscriptReadingState,
+    )
+
+    app = ReconcileHarness()
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(300))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        assert "m12" not in _mounted_message_ids(transcript)
+
+        region = ConsoleTranscriptRegion.__new__(ConsoleTranscriptRegion)
+        region._transcript_or_none = lambda: transcript  # type: ignore[method-assign]
+        ConsoleTranscriptRegion.restore_reading_state(
+            region,
+            _ConsoleTranscriptReadingState(
+                anchored=False, scroll_y=6.0, selected_message_id="m12"
+            ),
+        )
+        assert await _wait_for(
+            pilot, lambda: "m12" in _mounted_message_ids(transcript)
+        ), "the restored selection was never revealed"
+        assert transcript.selected_message_id == "m12"
+
+
+@pytest.mark.asyncio
+async def test_restored_offset_is_applied_against_the_revealed_window():
+    """The offset must be clamped against the window the restore produces.
+
+    Read order matters: applying `scroll_y` before the revealed rows mount
+    clamps it against the SMALLER pre-reveal `max_scroll_y`, silently dropping
+    the reader somewhere else. (The second implementation shipped the mirror
+    image of this bug — it evaluated tail-following against the pre-restore
+    anchor — and its re-review caught it.)
+    """
+    from tldw_chatbook.UI.Console_Modules.transcript import (
+        ConsoleTranscriptRegion,
+        _ConsoleTranscriptReadingState,
+    )
+
+    app = ReconcileHarness()
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(300))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        pre_reveal_max = transcript.max_scroll_y
+        target_offset = float(pre_reveal_max) + 40.0
+
+        region = ConsoleTranscriptRegion.__new__(ConsoleTranscriptRegion)
+        region._transcript_or_none = lambda: transcript  # type: ignore[method-assign]
+        ConsoleTranscriptRegion.restore_reading_state(
+            region,
+            _ConsoleTranscriptReadingState(
+                anchored=False,
+                scroll_y=target_offset,
+                selected_message_id="m12",
+            ),
+        )
+        assert await _wait_for(
+            pilot, lambda: "m12" in _mounted_message_ids(transcript)
+        )
+        await _settle(pilot)
+
+        assert transcript.max_scroll_y > pre_reveal_max, (
+            "the reveal must have grown the scrollable region"
+        )
+        assert transcript.scroll_y == pytest.approx(target_offset, abs=1.0), (
+            "the restored offset must survive the reveal, not be clamped to the "
+            f"pre-reveal maximum ({transcript.scroll_y} vs {target_offset})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config surface + kill switch.
+# ---------------------------------------------------------------------------
+
+
+def test_window_line_settings_resolve_from_config():
+    """Defaults, invalid values, and the kill switch."""
+    assert get_console_transcript_window_lines(None) == (
+        DEFAULT_INITIAL_WINDOW_LINES,
+        DEFAULT_SCROLLBACK_CHUNK_LINES,
+    )
+    assert get_console_transcript_window_lines({"chat_defaults": "nope"}) == (
+        DEFAULT_INITIAL_WINDOW_LINES,
+        DEFAULT_SCROLLBACK_CHUNK_LINES,
+    )
+    assert get_console_transcript_window_lines(
+        {"chat_defaults": {"transcript_window_lines": "x"}}
+    ) == (DEFAULT_INITIAL_WINDOW_LINES, DEFAULT_SCROLLBACK_CHUNK_LINES)
+    assert get_console_transcript_window_lines(
+        {
+            "chat_defaults": {
+                "transcript_window_lines": 500,
+                "transcript_scrollback_lines": 250,
+            }
+        }
+    ) == (500, 250)
+    # Kill switch is preserved verbatim; the chunk floor is clamped to >= 1.
+    assert get_console_transcript_window_lines(
+        {
+            "chat_defaults": {
+                "transcript_window_lines": 0,
+                "transcript_scrollback_lines": 0,
+            }
+        }
+    ) == (0, 1)
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_mounts_the_whole_history():
+    """`transcript_window_lines = 0` restores the pre-task behavior."""
+    app = ReconcileHarness(window_lines=0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(120))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        assert transcript._pruned_message_ids == set()
+        assert len(_mounted_message_ids(transcript)) == 120
+
+
+@pytest.mark.asyncio
+async def test_configured_window_lines_change_the_load_window():
+    """A larger configured floor mounts more of the tail."""
+    small = ReconcileHarness(window_lines=1)
+    async with small.run_test(size=(100, 30)) as pilot:
+        transcript = small.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(300))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        default_window = len(_mounted_message_ids(transcript))
+
+    big = ReconcileHarness(window_lines=800)
+    async with big.run_test(size=(100, 30)) as pilot:
+        transcript = big.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(300))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        big_window = len(_mounted_message_ids(transcript))
+
+    assert big_window > default_window, (
+        f"the configured floor must widen the window ({big_window} vs {default_window})"
+    )
+    assert big_window < 300, "a configured floor is still a window"

--- a/Tests/UI/test_console_transcript_window_reconcile.py
+++ b/Tests/UI/test_console_transcript_window_reconcile.py
@@ -259,8 +259,14 @@ async def test_scrollback_hydration_and_pruning_reach_a_fixed_point():
 
 @pytest.mark.asyncio
 async def test_explicit_hydration_still_works_below_the_low_watermark():
-    """The fixed point must not cost ordinary scrollback its hydration."""
-    app = ReconcileHarness()  # pruning disabled: the default reader case
+    """The fixed point must not cost ordinary scrollback its hydration.
+
+    Watermarks are ENABLED here (the shipped defaults) so the new gate is
+    actually evaluated: a normal transcript sits far below the low mark, and
+    hydration must be allowed. With `high = 0` the gate short-circuits and this
+    test would prove nothing about it.
+    """
+    app = ReconcileHarness(low=12_000, high=20_000)
     async with app.run_test(size=(100, 30)) as pilot:
         transcript = app.query_one(ConsoleTranscript)
         transcript.set_messages(_messages(180))
@@ -432,3 +438,55 @@ async def test_configured_window_lines_change_the_load_window():
         f"the configured floor must widen the window ({big_window} vs {default_window})"
     )
     assert big_window < 300, "a configured floor is still a window"
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_does_not_resurrect_watermark_pruned_rows():
+    """The kill switch disables WINDOWING, not the height watermarks.
+
+    Measured before the fix: forcing the window start to 0 on every ingest
+    cleared the pruned prefix, so an over-watermark session re-mounted its
+    whole history on each 0.2s sync tick and pruned it back down again (180
+    rows remounted, settled to 11, every tick). The default-watermark kill
+    switch test cannot see this — nothing is ever pruned there.
+    """
+    app = ReconcileHarness(low=45, high=70, window_lines=0)
+    history = _messages(180)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        assert await _wait_for(pilot, lambda: bool(transcript._pruned_message_ids)), (
+            "the watermarks must still prune with windowing disabled"
+        )
+        await _settle(pilot)
+        pruned = set(transcript._pruned_message_ids)
+        settled_mounted = len(_mounted_message_ids(transcript))
+        assert settled_mounted < 30, "the fixture must settle well under the history"
+
+        mounted_per_tick: list[int] = []
+        original_mount = transcript.mount
+
+        def _recording_mount(*widgets, **kwargs):
+            mounted_per_tick.append(len(widgets))
+            return original_mount(*widgets, **kwargs)
+
+        transcript.mount = _recording_mount  # type: ignore[method-assign]
+        try:
+            for _ in range(3):
+                transcript.set_messages(list(history))
+                assert transcript._pruned_message_ids >= pruned, (
+                    "an ingest must not resurrect watermark-pruned rows"
+                )
+                await transcript.refresh_messages()
+                assert len(_mounted_message_ids(transcript)) <= settled_mounted, (
+                    "the tick must not re-mount the full history"
+                )
+                await _settle(pilot, times=4)
+        finally:
+            transcript.mount = original_mount  # type: ignore[method-assign]
+
+        assert sum(mounted_per_tick) < 60, (
+            f"steady-state ticks must mount almost nothing, saw {mounted_per_tick}"
+        )
+        assert len(transcript._messages) == 180

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -280,6 +280,34 @@ sessions spanning many hours each. That single command would have caught both.
 The board is not a lock. Treat a claim as documentation, and the PR list as the
 actual source of truth about who is building what.
 
+**Third instance: TASK-15455, 2026-08-11 — same day, same task, neither session
+ran the command.** The Console transcript windowing task was implemented twice
+in parallel: `codex/console-transcript-windowing` (PR #1538, merged 13:26) and
+`task/15455-windowed-mount` (PR #1556, closed unmerged). Both sessions worked
+for hours; both wrote their own pin suites, probes, and lessons entries; neither
+ran `gh pr list --search "15455"` before designing or during the build. The
+duplication was found only when the second PR was opened against a dev that
+already contained the first.
+
+The cost is measurable this time: the merged-first rule stood, and the second
+implementation's ~1,500 lines became a ~250-line reconciliation delta — roughly
+one full task cycle spent twice, plus a third cycle to port. What survived was
+only what the second session's REVIEW round had found (a prune/hydration
+oscillation the merged build genuinely had, a reading-state restore gap, the
+config kill switch); every line of its actual windowing mechanism was thrown
+away because the merged design was equivalent or better.
+
+Two notes for the next time this happens. First, the reconciliation is worth
+doing properly rather than abandoning: the second implementation's review had
+found a real infinite-churn defect in the merged one, which no amount of "we
+merged first" makes untrue. Second, the porting brief that starts a
+reconciliation is written by someone who has read neither implementation
+closely — verify every "the incumbent is missing X" claim against the incumbent
+at YOUR head before porting X. One of the four items in this reconciliation's
+brief (selection into windowed-out history) was already implemented and
+working; porting it blind would have duplicated a mechanism inside a PR whose
+whole purpose was undoing duplication.
+
 ---
 
 ## A duplicate ID on dev may be a resurrected ghost — check for a renumbered twin BEFORE renumbering

--- a/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
+++ b/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
@@ -42,6 +42,103 @@ Reason: This is an internal performance refinement of the existing Console trans
 
 ## Implementation Notes
 
+> **Two independent implementations.** This task was implemented twice in
+> parallel on 2026-08-11 by two sessions that never saw each other's work
+> (neither ran the `gh pr list --search` check the backlog-hygiene lesson
+> prescribes — see the incident recorded there). PR #1538 (branch
+> `codex/console-transcript-windowing`, commit `84baf5689`) merged first and,
+> per the repo's merged-first rule, owns the design. The second implementation
+> (branch `task/15455-windowed-mount`, PR #1556) was closed unmerged; its
+> review-hardened findings were ported onto the merged design in this PR. Both
+> sessions' work is credited below.
+
+### Part 1 — merged implementation (PR #1538), design of record
+
+- Viewport-scaled, turn-aligned tail projection built before row signatures or
+  Markdown widgets. The complete history stays in the transcript model for
+  export, persistence, selection, and branch operations.
+- Coalesced scrollback hydration on upward scroll, wheel-at-boundary, and Page
+  Up; prepended rows compensate the scroll offset by measured virtual height.
+- Batched reconciliation (`remove_children` + multi-widget `mount`), reorder
+  contract intact.
+- ONE contiguous hidden prefix: pruning and windowing share
+  `_pruned_message_ids`, so hydration is simply the boundary moving back.
+- Probe on that session's host: 19.85 s -> 0.24 s for a 500-message swap.
+- Tests: `Tests/UI/test_console_transcript_windowing.py` (4), green and
+  unmodified here.
+
+### Part 2 — reconciliation delta (this PR)
+
+Ported from the closed implementation after its review round, adapted to the
+merged design. What was **dropped**: that implementation's 40-message window
+(the viewport-derived line budget is better), its separate unhydrated/pruned
+sets, its `_scrollback_protected` latch, and its gap-seam row — see below.
+
+- **Prune/hydration fixed point (the headline).** Measured on the merged build
+  before this change: with the reader at the scroll boundary and a 45/70
+  watermark configuration, the hidden prefix oscillated between 169 and 152
+  messages (height 47 <-> 115) on every idle frame, indefinitely, with no user
+  input — the prune's own scroll restoration lands back at the boundary and
+  re-triggers the hydration that produced it. Automatic hydration is now
+  refused at/above the LOW watermark; since the walk fires only above the HIGH
+  mark and always leaves the remainder above the low one, a prune can never
+  restore a hydratable state. Explicit `_hydrate_scrollback()` stays ungated
+  (the merged watermark test calls it directly and still passes).
+- **`restore_reading_state`** now reveals the selection it assigns directly,
+  and applies the restored offset only AFTER those rows mount — clamping
+  against the pre-reveal `max_scroll_y` silently drops the reader elsewhere.
+  (This is the mirror of the read-order defect the second implementation's
+  re-review found in its own latch.)
+- **Config surface + kill switch**: `[chat_defaults] transcript_window_lines` /
+  `transcript_scrollback_lines` are floors over the viewport-derived budget;
+  `transcript_window_lines = 0` mounts the whole history as before this task.
+  Documented in `config.py` and the Console user guide ("Long conversations",
+  including the caveat that scroll-back stops once the mounted view reaches the
+  watermark).
+- **`reveal_message()`** factors the boundary move out of `select_message` so
+  selection, the task-501 swipe handoff, and reading-state restore share one
+  implementation.
+- **No gap-seam row was ported.** It was necessary in the closed design, whose
+  pruned and unhydrated sets were independent and could mount two islands with
+  no seam between them. Here the hidden set is always a PREFIX and every reveal
+  path extends the same boundary, so mounted rows are one contiguous suffix —
+  now pinned by a test rather than asserted in a comment.
+- **Correction to the porting brief**: `select_message` on a windowed-out id
+  was reported missing from the merged implementation; it is present and works
+  (probe: selecting `m10` of 500 reveals and mounts through it, action row
+  included). Nothing was ported; a regression test was added, since the merged
+  suite had none.
+
+**Verification (this PR).** 12 new tests in
+`Tests/UI/test_console_transcript_window_reconcile.py`, of which 6 were born
+red on the merged build (fixed point, restore reveal, restore offset, config
+resolution, kill switch, configured floors) and 6 are pins that were already
+green (load bound, session switch, watermark bound, reveal-on-select,
+contiguity). Merged suite 4/4 green unmodified; transcript suites 52 passed;
+broader console suites (native transcript, markdown, fence throttle, sibling
+nav, composer collapse) 195 passed; ruff clean. Load probe (500 messages,
+120x40, medians of 3): 10.9 s with everything mounted vs 1.08 s windowed, 1002
+-> 58 rows and 5502 -> 310 widgets. Delta overhead against a merged-equivalent
+arm (window budget patched back to the constants, same build, same window
+size): 357.3 ms vs 360.0 ms medians over 5 runs each — inside run-to-run noise,
+no regression.
+
+**Files (this PR).** `tldw_chatbook/Widgets/Console/console_transcript.py`,
+`tldw_chatbook/UI/Console_Modules/transcript.py`, `tldw_chatbook/config.py`,
+`Docs/User_Guide/console.md`,
+`Tests/UI/test_console_transcript_window_reconcile.py`, this task file, and
+`backlog/docs/lessons-backlog-hygiene.md`.
+
+**ACs re-verified against the combined result**: #1 (500-message load mounts a
+bounded tail — probe + `test_pin_long_load_is_bounded_...`), #2 (scrollback
+hydrates without breaking anchor/tail-follow, selection, or branch navigation —
+merged suite + the reveal/restore tests here), #3 (watermarks still bound the
+mounted height — `test_pin_watermarks_still_bound_the_mounted_height`, and the
+fixed-point test proves they do so without churning).
+
+### Appendix — merged session's original notes
+
+
 - Added a viewport-scaled, turn-aligned tail projection before row signatures or Markdown widgets are built. The complete history remains in the transcript model for export, persistence, selection, and branch operations.
 - Added coalesced scrollback hydration for upward scrolling, wheel-at-boundary, and Page Up. Prepended rows compensate the scroll offset by their measured virtual height, preserving the reader's visible message and detached follow state.
 - Reconciliation now removes stale direct children and mounts contiguous missing runs through Textual's batch DOM APIs. The existing reorder contract remains intact.

--- a/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
+++ b/backlog/tasks/task-15455 - Console-transcript---windowed-mount-for-long-conversation-load.md
@@ -123,6 +123,34 @@ arm (window budget patched back to the constants, same build, same window
 size): 357.3 ms vs 360.0 ms medians over 5 runs each — inside run-to-run noise,
 no regression.
 
+**Review round (reconciliation).** One Important: the kill switch
+(`transcript_window_lines = 0`) forced `window_start = 0` on EVERY ingest,
+which cleared the watermark-pruned prefix — an over-watermark session
+re-mounted its whole history on each 0.2s sync tick and pruned it back down
+(reproduced: 180 rows remounted, settled to 11, every tick). Pre-task code kept
+pruning sticky across ingests; the disabled branch now carries the preserved
+boundary forward (`0 if preserved_start is None else preserved_start`), so a
+fresh/disjoint ingest still mounts everything while the watermarks keep their
+prefix. Regression test runs at churn-triggering marks (45/70, 180 messages,
+repeated ingests, instrumented mounts) — the default-watermark kill-switch test
+cannot see this, because nothing is ever pruned there. Minors: the
+"still hydrates" test now runs with watermarks ENABLED so the new gate is
+actually evaluated, and the guide states that the two line settings are FLOORS
+under `viewport x 6` (inert at the shipped 144 on any terminal >= 24 rows) and
+names the LOW watermark as the scroll-back ceiling.
+
+**Residuals, untracked (for the controller to file).**
+1. *Unbounded reveal.* Selecting/jumping to a message near the start of a long
+   session reveals everything from it to the tail in one pass — measured ~490
+   rows mounted for `m10` of 500. Inherited from the merged design, not
+   introduced here, and latent for any future "jump to search hit" feature.
+2. *Scroll-back reachability ceiling.* Once the mounted view reaches the low
+   watermark (~12,000 rendered rows by default) scroll-back stops loading
+   older history; the content is reachable only via export or a jump. Removing
+   the ceiling needs two-sided windowing (trim the tail as the head grows),
+   which neither implementation has and which would touch tail-follow,
+   streaming, and the jump pill — a design task, not a tweak.
+
 **Files (this PR).** `tldw_chatbook/Widgets/Console/console_transcript.py`,
 `tldw_chatbook/UI/Console_Modules/transcript.py`, `tldw_chatbook/config.py`,
 `Docs/User_Guide/console.md`,

--- a/tldw_chatbook/UI/Console_Modules/transcript.py
+++ b/tldw_chatbook/UI/Console_Modules/transcript.py
@@ -227,15 +227,34 @@ class ConsoleTranscriptRegion(Vertical):
         transcript = self._transcript_or_none()
         if transcript is None:
             return
+        revealed = False
+        if state.selected_message_id is not None:
+            # TASK-15455: assigning the id directly bypasses `select_message`,
+            # so a selection captured before the transcript re-windowed (a
+            # session switch between capture and restore) could name a message
+            # with no mounted row. Inert whenever the id is already mounted.
+            revealed = transcript.reveal_message(state.selected_message_id)
         transcript.selected_message_id = state.selected_message_id
-        if state.anchored:
-            transcript.anchor()
+
+        def _apply_reading_position() -> None:
+            if state.anchored:
+                transcript.anchor()
+                return
+            transcript.release_anchor()
+            transcript.scroll_to(
+                y=min(state.scroll_y, float(transcript.max_scroll_y)),
+                animate=False,
+            )
+
+        if revealed:
+            # Read order matters: the offset is clamped against
+            # `max_scroll_y`, which only grows once the revealed rows are
+            # mounted. Applying it first silently drops the reader at the
+            # pre-reveal maximum instead of where they were.
+            transcript.call_later(transcript.refresh_messages)
+            transcript.call_after_refresh(_apply_reading_position)
             return
-        transcript.release_anchor()
-        transcript.scroll_to(
-            y=min(state.scroll_y, float(transcript.max_scroll_y)),
-            animate=False,
-        )
+        _apply_reading_position()
 
     def note_follow_intent(self) -> None:
         """Stamp a programmatic jump-to-tail intent on the transcript (TASK-336).

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -2075,7 +2075,16 @@ class ConsoleTranscript(VerticalScroll):
             # transcript_window_lines = 0` mounts the whole history, the
             # behaviour that shipped before this task. The escape hatch is the
             # point: a windowing bug must be switchable off without a release.
-            window_start = 0
+            #
+            # It must still leave the WATERMARK prune alone. Forcing 0 here
+            # cleared `_pruned_message_ids` on every ingest, so an
+            # over-watermark session re-mounted its entire history on each
+            # 0.2s sync tick and pruned it back down again (measured: 180 rows
+            # remounted, settled to 11, every tick). Pre-task code kept pruning
+            # sticky across ingests (`_pruned_message_ids &= message_ids`);
+            # carrying the preserved boundary forward reproduces that, while a
+            # fresh or disjoint ingest still starts at 0 = mount everything.
+            window_start = 0 if preserved_start is None else preserved_start
         elif preserved_start is None:
             window_start = self._tail_window_start(
                 self._messages,

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -170,6 +170,38 @@ def get_console_prune_watermarks(
     return low, high
 
 
+def get_console_transcript_window_lines(
+    app_config: Mapping[str, object] | None,
+) -> tuple[int, int]:
+    """Resolve the transcript window line floors from config.
+
+    Reads ``[chat_defaults] transcript_window_lines`` /
+    ``transcript_scrollback_lines``, falling back to
+    :data:`DEFAULT_INITIAL_WINDOW_LINES` / :data:`DEFAULT_SCROLLBACK_CHUNK_LINES`
+    when missing or invalid. Both are FLOORS: the effective budget is the
+    larger of the floor and the viewport-derived value. A
+    ``transcript_window_lines <= 0`` disables windowing entirely (the kill
+    switch: every message mounts at load, as it did before TASK-15455).
+
+    Args:
+        app_config: The loaded application config dict (``app.app_config``).
+
+    Returns:
+        Tuple of ``(initial_window_lines, scrollback_chunk_lines)``.
+    """
+    chat_defaults = (app_config or {}).get("chat_defaults", {})
+    if not isinstance(chat_defaults, Mapping):
+        chat_defaults = {}
+    initial_lines = _coerce_prune_int(
+        chat_defaults.get("transcript_window_lines"), DEFAULT_INITIAL_WINDOW_LINES
+    )
+    chunk_lines = _coerce_prune_int(
+        chat_defaults.get("transcript_scrollback_lines"),
+        DEFAULT_SCROLLBACK_CHUNK_LINES,
+    )
+    return initial_lines, max(1, chunk_lines)
+
+
 def _message_role_label(message: ConsoleChatMessage) -> str:
     role = message.role.value if hasattr(message.role, "value") else str(message.role)
     return role.title()
@@ -1811,17 +1843,29 @@ class ConsoleTranscript(VerticalScroll):
         """Return a stable viewport height for line-budget calculations."""
         return max(1, int(self.size.height or 24))
 
+    def _window_line_settings(self) -> tuple[int, int]:
+        """Return the configured ``(initial, scrollback)`` line floors."""
+        try:
+            app_config = getattr(self.app, "app_config", None)
+        except NoActiveAppError:
+            app_config = None
+        return get_console_transcript_window_lines(app_config)
+
+    def _windowing_enabled(self) -> bool:
+        """Return False when the config kill switch asks for the whole history."""
+        return self._window_line_settings()[0] > 0
+
     def _initial_window_line_budget(self) -> int:
         """Return the tail-first render budget in estimated terminal lines."""
         return max(
-            DEFAULT_INITIAL_WINDOW_LINES,
+            self._window_line_settings()[0],
             self._window_viewport_height() * 6,
         )
 
     def _scrollback_chunk_line_budget(self) -> int:
         """Return the amount of earlier history prepended per boundary request."""
         return max(
-            DEFAULT_SCROLLBACK_CHUNK_LINES,
+            self._window_line_settings()[1],
             self._window_viewport_height() * 4,
         )
 
@@ -1884,7 +1928,23 @@ class ConsoleTranscript(VerticalScroll):
         }
 
     def _schedule_scrollback_hydration(self) -> None:
-        """Coalesce one lazy prepend after explicit detached upward scrolling."""
+        """Coalesce one lazy prepend after explicit detached upward scrolling.
+
+        TASK-15455 (reconciliation): automatic hydration is additionally
+        refused once the mounted height reaches the LOW watermark. Without
+        that gate, hydration and the watermark walk chase each other forever
+        — measured on a 180-message transcript with a 45/70 configuration and
+        the reader at the boundary: the hidden prefix oscillated between 169
+        and 152 messages (height 47 <-> 115) across every idle frame, because
+        the prune's own scroll restoration lands back at the boundary and
+        re-triggers the hydration that produced it.
+
+        The gate makes the loop impossible rather than unlikely: the walk only
+        fires ABOVE the high mark and always leaves the remainder ABOVE the low
+        mark, so a prune can never restore a hydratable state. An explicit
+        ``_hydrate_scrollback()`` call is deliberately NOT gated — a caller
+        asking for one chunk is not a loop.
+        """
         if (
             self._scrollback_hydration_scheduled
             or self._hydrating_scrollback
@@ -1892,6 +1952,9 @@ class ConsoleTranscript(VerticalScroll):
             or self._is_following_tail()
             or self._first_visible_message_index() <= 0
         ):
+            return
+        low_mark, high_mark = self._prune_watermarks()
+        if high_mark > 0 and self.virtual_size.height >= low_mark:
             return
         self._scrollback_hydration_scheduled = True
         self.call_later(self._hydrate_scrollback)
@@ -2007,7 +2070,13 @@ class ConsoleTranscript(VerticalScroll):
             if message_id in index_by_id
         ]
         preserved_start = min(preserved_indices) if preserved_indices else None
-        if preserved_start is None:
+        if not self._windowing_enabled():
+            # TASK-15455 (reconciliation): `[chat_defaults]
+            # transcript_window_lines = 0` mounts the whole history, the
+            # behaviour that shipped before this task. The escape hatch is the
+            # point: a windowing bug must be switchable off without a release.
+            window_start = 0
+        elif preserved_start is None:
             window_start = self._tail_window_start(
                 self._messages,
                 line_budget=self._initial_window_line_budget(),
@@ -2371,21 +2440,41 @@ class ConsoleTranscript(VerticalScroll):
         """
         return self._message_by_id(message_id)
 
+    def reveal_message(self, message_id: str) -> bool:
+        """Extend the mounted window back through ``message_id`` when hidden.
+
+        The single implementation behind every "jump to a message the window
+        does not currently show" path: selection, the task-501 swipe handoff,
+        and reading-state restore. Extending the SAME contiguous boundary is
+        what keeps mounted rows one unbroken suffix of the history — no
+        islands, so no gap markers are needed anywhere.
+
+        Args:
+            message_id: Identifier of the message that must have a row.
+
+        Returns:
+            True when the window moved (a refresh is required to see it),
+            False when the message was already mounted or is not in this
+            transcript. Deliberately does NOT refresh: callers already own a
+            refresh, and the restore path needs to sequence its own.
+        """
+        for index, message in enumerate(self._messages):
+            if message.id != message_id:
+                continue
+            if index >= self._first_visible_message_index():
+                return False
+            self._set_hidden_prefix(self._turn_aligned_start(self._messages, index))
+            return True
+        return False
+
     def select_message(self, message_id: str) -> None:
         """Select one message and show its contextual action row."""
-        index_by_id = {
-            message.id: index for index, message in enumerate(self._messages)
-        }
-        if message_id not in index_by_id:
+        if not any(message.id == message_id for message in self._messages):
             return
-        selected_index = index_by_id[message_id]
-        if selected_index < self._first_visible_message_index():
-            # Keep the public pre-windowing contract: callers may select any
-            # message in the complete transcript model.  Reveal the contiguous
-            # prefix through that turn before mounting its action row.
-            self._set_hidden_prefix(
-                self._turn_aligned_start(self._messages, selected_index)
-            )
+        # Keep the public pre-windowing contract: callers may select any
+        # message in the complete transcript model.  Reveal the contiguous
+        # prefix through that turn before mounting its action row.
+        self.reveal_message(message_id)
         self.selected_message_id = message_id
         if self.is_mounted:
             self.call_later(self.refresh_messages)

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3258,6 +3258,15 @@ strip_thinking_tags = true
 prune_high_watermark = 20000
 prune_low_watermark = 12000
 
+# Console transcript load window: opening or switching to a conversation
+# mounts only a tail of it, and scrolling to the top of that tail prepends
+# more. Both values are FLOORS in terminal rows -- the effective budget is the
+# larger of the floor and the mounted viewport (6x for the initial window, 4x
+# per scrollback step). Set transcript_window_lines <= 0 to mount the whole
+# history at load, as before.
+transcript_window_lines = 144
+transcript_scrollback_lines = 96
+
 # Render assistant replies as full markdown (code blocks, tables, lists,
 # links) in the Console transcript. Set false to restore the lightweight
 # span renderer, which keeps roleplay speech/action flavor colors.


### PR DESCRIPTION
## Summary

Reconciliation for TASK-15455 after a duplicate implementation: PR #1538 (another session) merged transcript windowing first, so the closed parallel implementation's (#1556) review-proven behaviors are ported here as a delta onto the incumbent design — plus a real defect the cross-implementation review found in the merged build.

- **Churn fix (the find):** the merged build's hidden prefix oscillated 169↔152 on every idle frame (prune's scroll restoration re-triggering hydration). Fixed structurally — automatic hydration refuses at/above the low watermark; the reviewer verified the gate-pair cannot both fire across a 10-config sweep, and the weaker high-mark alternative still churns (mutation-pinned)
- restore_reading_state hydration with the latch-read-order fix; contiguity PINNED by test (no islands possible — hidden set is a strict prefix by construction); the briefed select_message port was verified ALREADY PRESENT in the incumbent and correctly not ported (a regression test added instead; verify-before-porting lesson recorded)
- Config surface (viewport-derived budget floors + kill switch) + honest Guide (floors inert at ≥24-row terminals; prune_low_watermark named as the scroll-back ceiling)
- Review round: the kill switch itself resurrected the watermark-pruned prefix on every ingest (full-history remount per 0.2s tick — worse than what it escapes); one-line preserved-start fix, pinned by a SYNCHRONOUS assertion (settled-state tests were provably blind to the churn)
- Load probe: 0.41 s / 32 rows windowed vs 8.31 s / 500 rows with the kill switch (reviewer-reproduced)

## Verification
Two opus/sonnet review rounds; churn defect reproduced on base and killed on HEAD; 5/6 born-red claims mutation-verified; 17+43-test suites reproduced; incumbent's 4 tests byte-identical green. Residuals filed in the task notes (unbounded far-jump reveal; scroll-back reachability ceiling → two-sided windowing follow-up). Task file carries the honest two-implementation account; the duplicate-implementation incident is recorded as the lesson's third instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Console transcript windowing for TASK-15455 by eliminating watermark-driven churn, fixing reading-state restore, and adding a configurable window with a kill switch. Previously, automatic scrollback hydration could oscillate at the watermarks and `restore_reading_state` could land at the wrong offset; now hydration is gated at/above the low watermark, restore reveals the selection before applying the offset, and disabling the window no longer resurrects watermark-pruned rows.

- Stops prune/hydrate oscillation: automatic hydration is refused when the mounted height is at/above the low watermark; explicit `_hydrate_scrollback()` still works.
- Reading-state and selection: `restore_reading_state` reveals its selected message then applies anchor/offset; new `reveal_message` centralizes boundary moves; mounted rows remain one contiguous suffix (no gap seam needed).
- Config: `[chat_defaults]` adds `transcript_window_lines` and `transcript_scrollback_lines` as floors over the viewport-derived budget; `transcript_window_lines = 0` disables windowing while keeping watermark pruning sticky across ingests.
- Tests and docs: 12 new UI tests cover the fixed point, restore behavior, and config; user guide documents “Long conversations” and the window/scrollback floors.

Bold rollout notes
- No migration required. Optional: tune `transcript_window_lines`/`transcript_scrollback_lines` under `[chat_defaults]`, or set `transcript_window_lines = 0` to mount full history at load.
- If any automation relied on automatic hydration near watermarks, invoke explicit hydration instead.

<sup>Written for commit 7c2d70458fa692cf2f93f579693a0aa89ec479fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

