### PR TITLE
perf(library): update media matches in place

### DIFF
--- a/Docs/superpowers/plans/2026-08-12-library-media-viewer-inplace.md
+++ b/Docs/superpowers/plans/2026-08-12-library-media-viewer-inplace.md
@@ -6,6 +6,8 @@
 
 **Architecture:** `LibraryScreen` remains the canonical owner of query, match index, and mode. A focused search-controls widget and a focused lazy content-body widget own in-place presentation updates, while `LibraryMediaViewer` provides the narrow screen-facing coordination API. The legacy `MediaViewerPanel` keeps its existing search semantics but applies non-empty typing through a generation-guarded 250 ms timer and performs one Markdown update per applied search.
 
+Task 1 verification also repairs the Windows test-network boundary under ADR-058. The process-wide guard wraps the captured real `socket.socketpair()` with a same-thread dynamic exemption so Python's Windows Proactor bootstrap can create its internal wakeup channel without permitting ordinary or concurrent-thread application egress.
+
 **Tech Stack:** Python 3.11+, Textual 8.x, Rich `Text`, pytest, pytest-asyncio, Ruff.
 
 ## Global Constraints
@@ -20,9 +22,13 @@
 - A legacy search callback must be invalidated by newer input, clear, media replacement, clear-display, and unmount.
 - The legacy display path performs one `Markdown.update(content)` and never the empty-string cache-busting update.
 - Do not add dependencies, persistence, workers, or changes to Markdown source-line geometry.
-- ADR required: no.
-- ADR path: N/A.
-- ADR reason: the work applies existing widget ownership and Textual timer patterns without changing persistence, security, dependencies, services, or cross-module contracts.
+- Keep the test network guard installed at import time and default-deny for protected address families.
+- A socketpair exemption must be current-thread-only, nested, restored in `finally`, and must never mutate `_allowed` or `_INET_FAMILIES`.
+- Ordinary same-thread and concurrent-thread `AF_INET`/`AF_INET6` egress remains blocked and recorded.
+- Literal async pytest commands must work on Windows without the TASK-15100 guarded-family mutation workaround.
+- ADR required: yes.
+- ADR path: `backlog/decisions/058-thread-scoped-test-socketpair-exemption.md`.
+- ADR reason: the review-expanded scope changes the repository-wide test network security boundary and its runtime interception contract.
 
 ## File Structure
 
@@ -33,6 +39,9 @@
 - Modify `Tests/UI/test_library_shell.py`: product-path regressions for Enter submission, screen/viewer/Markdown identity, focus, highlighting, scrolling, mode reuse, and latency evidence.
 - Modify `tldw_chatbook/Widgets/Media/media_viewer_panel.py`: guarded legacy debounce lifecycle and single-update rendering.
 - Create `Tests/UI/test_media_viewer_content_search_debounce.py`: mounted timer and Markdown update-count regressions.
+- Modify `Tests/network_guard.py`: wrap the captured real socketpair with a nested thread-local dynamic exemption while preserving default denial everywhere else.
+- Modify `Tests/test_network_guard.py`: prove real Windows socketpair operation, cross-thread isolation, exceptional restoration, idempotence, and ordinary denial.
+- Modify `backlog/docs/lessons-testing-evidence.md`: replace the temporary TASK-15100 workaround guidance with the verified ADR-058 resolution and literal command evidence.
 - Modify `backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md`: status, implementation plan, evidence, completed criteria, and implementation notes.
 
 ---
@@ -43,6 +52,9 @@
 
 - Create: `tldw_chatbook/Widgets/Library/library_media_content.py`
 - Create: `Tests/Library/test_library_media_content.py`
+- Modify: `Tests/network_guard.py`
+- Modify: `Tests/test_network_guard.py`
+- Modify: `backlog/docs/lessons-testing-evidence.md`
 
 **Interfaces:**
 
@@ -50,6 +62,7 @@
 - Produces: `LibraryMediaContentSearchControls(is_markdown: bool, query: str, matches: tuple[int, ...], match_index: int, **kwargs)`.
 - Produces: `sync_query_state(*, is_markdown: bool, query: str, matches: tuple[int, ...], match_index: int) -> None`.
 - Produces: `sync_match_index(*, matches: tuple[int, ...], match_index: int) -> None`.
+- Produces: a private guarded `socket.socketpair` wrapper whose exemption is limited to the current thread's dynamic call extent.
 
 - [ ] **Step 1: Write mounted failing tests for structural and in-place update paths**
 
@@ -196,6 +209,108 @@ Run the focused test command from Step 2. Then temporarily replace the `sync_mat
 ```powershell
 git add tldw_chatbook/Widgets/Library/library_media_content.py Tests/Library/test_library_media_content.py
 git commit -m "feat(library): add scoped media search controls"
+```
+
+- [ ] **Step 6: Add failing status and Windows network-guard regressions**
+
+In `Tests/Library/test_library_media_content.py`, directly cover both status branches omitted by the first implementation review:
+
+```python
+def test_status_text_reports_no_matches() -> None:
+    controls = LibraryMediaContentSearchControls(
+        is_markdown=True,
+        query="missing",
+        matches=(),
+        match_index=0,
+    )
+    assert controls._status_text() == "No matches"
+
+
+def test_status_text_wraps_match_index_before_formatting() -> None:
+    controls = LibraryMediaContentSearchControls(
+        is_markdown=True,
+        query="budget",
+        matches=(2, 8),
+        match_index=3,
+    )
+    assert controls._status_text() == "Match 2 of 2 matches"
+```
+
+In `Tests/test_network_guard.py`, add a Windows-only real socketpair test that exchanges one byte, closes both sockets in `finally`, and asserts `network_guard.blocked_attempts() == ()`:
+
+```python
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows TCP fallback only")
+def test_windows_socketpair_bootstrap_is_allowed_without_guard_mutation() -> None:
+    families_before = network_guard._INET_FAMILIES
+    left, right = socket.socketpair()
+    try:
+        left.sendall(b"x")
+        assert right.recv(1) == b"x"
+    finally:
+        left.close()
+        right.close()
+    assert network_guard._INET_FAMILIES is families_before
+    assert network_guard.blocked_attempts() == ()
+```
+
+Add a cross-thread test that monkeypatches `network_guard._real_socketpair` with a function that sets an `entered` event and waits on a `release` event. Start `socket.socketpair()` in one thread; while that thread is inside the wrapper, attempt a direct `AF_INET` `socket.connect()` from the test thread and assert `BlockedNetworkAccess` plus a drained record. Release and join the worker in `finally`, asserting it terminated.
+
+Add a failure-restoration test that monkeypatches `_real_socketpair` to raise `RuntimeError("socketpair failed")`, asserts `socket.socketpair()` propagates that error, then asserts a direct `AF_INET` `socket.connect()` is blocked and recorded. Add an idempotence assertion that repeated `network_guard.install()` leaves `socket.socketpair is network_guard._guarded_socketpair`.
+
+- [ ] **Step 7: Run literal commands and verify the pre-fix failures**
+
+Run without changing `network_guard._INET_FAMILIES`:
+
+```powershell
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/test_network_guard.py -q
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/Library/test_library_media_content.py -q
+```
+
+Expected before implementation: the Windows real-socketpair test and literal async component tests fail when `_fallback_socketpair()` reaches the guarded loopback connect. The status tests expose any missing `No matches` or modulo formatting behavior.
+
+- [ ] **Step 8: Implement the minimal thread-scoped socketpair exemption**
+
+In `Tests/network_guard.py`, import `threading`, capture `_real_socketpair = socket.socketpair` beside the other captured functions, and create `_socketpair_state = threading.local()`. Add:
+
+```python
+def _inside_socketpair() -> bool:
+    return getattr(_socketpair_state, "depth", 0) > 0
+
+
+def _guarded_socketpair(*args: Any, **kwargs: Any):  # noqa: ANN401
+    previous_depth = getattr(_socketpair_state, "depth", 0)
+    _socketpair_state.depth = previous_depth + 1
+    try:
+        return _real_socketpair(*args, **kwargs)
+    finally:
+        _socketpair_state.depth = previous_depth
+```
+
+Change `_should_block` to deny only when neither the existing explicit global opt-in nor the current thread's socketpair extent permits the operation:
+
+```python
+return not _allowed and not _inside_socketpair() and family in _INET_FAMILIES
+```
+
+Apply the same `_inside_socketpair()` condition to `_guarded_create_connection`, because a future standard-library socketpair implementation may use that captured public helper rather than `socket.connect` directly. In `install()`, assign `socket.socketpair = _guarded_socketpair` during the same idempotent patch operation. Do not change `_allowed`, `_INET_FAMILIES`, `_deny`, or the recording contract.
+
+- [ ] **Step 9: Run guard and component tests, then mutation-check isolation**
+
+Run both literal commands from Step 7. Then temporarily replace the thread-local state with one process-global depth; confirm the cross-thread test fails because the direct connection is permitted. Restore `threading.local()` and rerun both commands green.
+
+Run the existing synchronous denial tests together with the async component test and confirm protected families remain unchanged before and after the process:
+
+```powershell
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/test_network_guard.py Tests/Library/test_library_media_content.py -q
+```
+
+- [ ] **Step 10: Record the resolved Windows incident and commit Task 1 review fixes**
+
+Update the TASK-15100 Windows follow-up in `backlog/docs/lessons-testing-evidence.md` with the ADR-058 resolution: the real socketpair is wrapped with a nested current-thread exemption; ordinary and concurrent-thread egress remain denied; the literal async pytest command now passes without mutating protected families. Preserve the original incident as evidence rather than deleting it.
+
+```powershell
+git add Tests/network_guard.py Tests/test_network_guard.py Tests/Library/test_library_media_content.py backlog/docs/lessons-testing-evidence.md
+git commit -m "fix(testing): allow guarded Windows socketpair bootstrap"
 ```
 
 ---
@@ -613,6 +728,7 @@ git commit -m "perf(media): debounce legacy content search"
 
 ```powershell
 & 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/Library/test_library_media_content.py Tests/UI/test_media_viewer_content_search_debounce.py -v
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/test_network_guard.py -q
 & 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_library_shell.py -k 'media_content_search or media_viewer_raw_toggle or media_viewer_defaults_markdown or media_viewer_inplace' -v -s
 & 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_media_window_v2_parity.py Tests/UI/test_media_handoffs.py -q
 ```
@@ -622,7 +738,7 @@ Expected: all focused tests pass; the output includes the after-change median la
 - [ ] **Step 2: Run static analysis and the broader regression suite**
 
 ```powershell
-& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m ruff check tldw_chatbook/Widgets/Library/library_media_content.py tldw_chatbook/Widgets/Library/library_media_viewer.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/Widgets/Media/media_viewer_panel.py Tests/Library/test_library_media_content.py Tests/UI/test_library_shell.py Tests/UI/test_media_viewer_content_search_debounce.py
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m ruff check tldw_chatbook/Widgets/Library/library_media_content.py tldw_chatbook/Widgets/Library/library_media_viewer.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/Widgets/Media/media_viewer_panel.py Tests/network_guard.py Tests/test_network_guard.py Tests/Library/test_library_media_content.py Tests/UI/test_library_shell.py Tests/UI/test_media_viewer_content_search_debounce.py
 & 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest -q
 git diff --check origin/dev...HEAD
 ```
@@ -637,7 +753,7 @@ Record terminal size, media fixture size, actions, visible results, and any limi
 
 - [ ] **Step 4: Complete the Backlog task source of truth**
 
-Directly edit the five-digit task file, as required by `backlog/docs/lessons-backlog-hygiene.md`, because Backlog CLI 1.44.0 corrupts five-digit IDs. Check all three acceptance criteria, add measured before/after latency and parse/identity counts, list exact verification commands, and add:
+Directly edit the five-digit task file, as required by `backlog/docs/lessons-backlog-hygiene.md`, because Backlog CLI 1.44.0 corrupts five-digit IDs. Check all four acceptance criteria, add measured before/after latency and parse/identity counts, list exact verification commands, and add:
 
 ```markdown
 ## Implementation Notes
@@ -645,7 +761,8 @@ Directly edit the five-digit task file, as required by `backlog/docs/lessons-bac
 - Extracted scoped Library search controls and a lazy persistent content body so match navigation updates status/highlighting/scroll state without remounting the screen or reparsing Markdown.
 - Preserved Enter-to-search, Rendered-by-default Markdown behavior, Raw highlighting, wraparound navigation, and focus continuity.
 - Debounced legacy content search at 250 ms with monotonic lifecycle invalidation and one Markdown update per applied query.
-- ADR required: no; the implementation follows existing Textual widget ownership and timer boundaries.
+- Repaired Windows async-test bootstrap under ADR-058 with a nested current-thread socketpair exemption; literal pytest commands pass while ordinary and concurrent-thread egress remain denied and recorded.
+- ADR required: yes; followed `backlog/decisions/058-thread-scoped-test-socketpair-exemption.md` for the review-expanded test security boundary.
 ```
 
 Add a lessons entry only if implementation or UAT exposes a reproducible trap that generalizes beyond this task; do not add one merely to fill the checklist.

--- a/Docs/superpowers/plans/2026-08-12-library-media-viewer-inplace.md
+++ b/Docs/superpowers/plans/2026-08-12-library-media-viewer-inplace.md
@@ -1,0 +1,660 @@
+# Library Media Viewer In-Place Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve Library content-search behavior while eliminating screen remounts and repeated full-document Markdown parses from match navigation, mode switching, and legacy per-keystroke search.
+
+**Architecture:** `LibraryScreen` remains the canonical owner of query, match index, and mode. A focused search-controls widget and a focused lazy content-body widget own in-place presentation updates, while `LibraryMediaViewer` provides the narrow screen-facing coordination API. The legacy `MediaViewerPanel` keeps its existing search semantics but applies non-empty typing through a generation-guarded 250 ms timer and performs one Markdown update per applied search.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, Rich `Text`, pytest, pytest-asyncio, Ruff.
+
+## Global Constraints
+
+- Preserve the Library viewer's current Enter-to-search interaction; `Input.Changed` must not apply Library searches.
+- Preserve the current Rendered default for Markdown Library items and Raw default for non-Markdown items.
+- Preserve case-insensitive, one-match-per-source-line counting and first-occurrence-per-line Raw highlighting.
+- Preserve wraparound Previous/Next navigation and source-line scrolling.
+- Never call `LibraryScreen.refresh(recompose=True)`, viewer recompose, or `Markdown.update()` for Library match navigation.
+- Keep already-mounted Raw and Rendered content widgets mounted; mode changes use visibility after each view's first lazy mount.
+- Use `MEDIA_CONTENT_SEARCH_DEBOUNCE_SECONDS = 0.25` for legacy content search.
+- A legacy search callback must be invalidated by newer input, clear, media replacement, clear-display, and unmount.
+- The legacy display path performs one `Markdown.update(content)` and never the empty-string cache-busting update.
+- Do not add dependencies, persistence, workers, or changes to Markdown source-line geometry.
+- ADR required: no.
+- ADR path: N/A.
+- ADR reason: the work applies existing widget ownership and Textual timer patterns without changing persistence, security, dependencies, services, or cross-module contracts.
+
+## File Structure
+
+- Create `tldw_chatbook/Widgets/Library/library_media_content.py`: focused Library search chrome, Raw renderable construction, and lazy persistent Raw/Rendered body ownership.
+- Modify `tldw_chatbook/Widgets/Library/library_media_viewer.py`: compose the focused children and expose screen-facing synchronization methods; retain metadata, analysis, highlights, and action composition.
+- Modify `tldw_chatbook/UI/Screens/library_screen.py`: replace content-search and mode full-screen recomposes with viewer synchronization and post-layout scrolling.
+- Create `Tests/Library/test_library_media_content.py`: mounted component contracts for scoped search updates, lazy mode mounting, search state, focus, identity, and rapid-mode races.
+- Modify `Tests/UI/test_library_shell.py`: product-path regressions for Enter submission, screen/viewer/Markdown identity, focus, highlighting, scrolling, mode reuse, and latency evidence.
+- Modify `tldw_chatbook/Widgets/Media/media_viewer_panel.py`: guarded legacy debounce lifecycle and single-update rendering.
+- Create `Tests/UI/test_media_viewer_content_search_debounce.py`: mounted timer and Markdown update-count regressions.
+- Modify `backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md`: status, implementation plan, evidence, completed criteria, and implementation notes.
+
+---
+
+### Task 1: Scoped Library Search Controls
+
+**Files:**
+
+- Create: `tldw_chatbook/Widgets/Library/library_media_content.py`
+- Create: `Tests/Library/test_library_media_content.py`
+
+**Interfaces:**
+
+- Consumes: Textual `Input`, `Static`, `Button`, `Horizontal`, and `Widget.refresh(recompose=True)`.
+- Produces: `LibraryMediaContentSearchControls(is_markdown: bool, query: str, matches: tuple[int, ...], match_index: int, **kwargs)`.
+- Produces: `sync_query_state(*, is_markdown: bool, query: str, matches: tuple[int, ...], match_index: int) -> None`.
+- Produces: `sync_match_index(*, matches: tuple[int, ...], match_index: int) -> None`.
+
+- [ ] **Step 1: Write mounted failing tests for structural and in-place update paths**
+
+Add a minimal `App` harness and tests that begin with an active query, capture both navigation button objects, focus Next, and update only the match index:
+
+```python
+class SearchControlsHarness(App[None]):
+    def compose(self) -> ComposeResult:
+        yield LibraryMediaContentSearchControls(
+            is_markdown=True,
+            query="budget",
+            matches=(2, 8),
+            match_index=0,
+            id="controls",
+        )
+
+
+@pytest.mark.asyncio
+async def test_match_index_sync_preserves_navigation_identity_and_focus() -> None:
+    app = SearchControlsHarness()
+    async with app.run_test() as pilot:
+        controls = app.query_one("#controls", LibraryMediaContentSearchControls)
+        previous = app.query_one("#library-media-content-search-prev", Button)
+        next_button = app.query_one("#library-media-content-search-next", Button)
+        next_button.focus()
+
+        controls.sync_match_index(matches=(2, 8), match_index=1)
+        await pilot.pause()
+
+        assert app.query_one("#library-media-content-search-prev") is previous
+        assert app.query_one("#library-media-content-search-next") is next_button
+        assert app.focused is next_button
+        assert str(app.query_one("#library-media-content-search-status", Static).renderable) == (
+            "Match 2 of 2 matches"
+        )
+```
+
+Add separate tests proving:
+
+```python
+controls.sync_query_state(
+    is_markdown=True,
+    query="cost",
+    matches=(4,),
+    match_index=0,
+)
+assert app.query_one("#library-media-content-search", Input) is search_input
+assert app.query_one("#library-media-content-search-next", Button) is next_button
+
+controls.sync_query_state(
+    is_markdown=True,
+    query="",
+    matches=(),
+    match_index=0,
+)
+await pilot.pause()
+assert not app.query("#library-media-content-search-status")
+```
+
+The active-to-active test must assert Input and buttons retain identity. The active-to-blank test must assert status and buttons are removed after `await pilot.pause()`. The blank-to-active test must re-query the structurally replaced Input and assert the Markdown-specific placeholder remains `"Search content (raw text)…"`.
+
+- [ ] **Step 2: Run the focused tests and verify the missing module fails**
+
+Run:
+
+```powershell
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/Library/test_library_media_content.py -v
+```
+
+Expected: collection fails because `tldw_chatbook.Widgets.Library.library_media_content` does not exist.
+
+- [ ] **Step 3: Implement the search-controls widget with one structural boundary**
+
+Add the class and status formatter. The implementation must update existing widgets for active-to-active and match-only changes, and recompose only for blank/non-blank structure changes:
+
+```python
+class LibraryMediaContentSearchControls(Vertical):
+    def __init__(
+        self,
+        *,
+        is_markdown: bool,
+        query: str,
+        matches: tuple[int, ...],
+        match_index: int,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.is_markdown = is_markdown
+        self.query = query
+        self.matches = matches
+        self.match_index = match_index
+
+    def compose(self) -> ComposeResult:
+        yield Input(
+            value=self.query,
+            placeholder=(
+                "Search content (raw text)…"
+                if self.is_markdown
+                else "Search content…"
+            ),
+            id="library-media-content-search",
+        )
+        if not self.query:
+            return
+        yield Static(
+            self._status_text(),
+            id="library-media-content-search-status",
+            markup=False,
+        )
+        toolbar = Horizontal(classes="ds-toolbar")
+        toolbar.styles.height = "auto"
+        with toolbar:
+            yield Button(
+                "◀ Prev",
+                id="library-media-content-search-prev",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Button(
+                "Next ▶",
+                id="library-media-content-search-next",
+                classes="library-canvas-action",
+                compact=True,
+            )
+
+    def sync_match_index(
+        self, *, matches: tuple[int, ...], match_index: int
+    ) -> None:
+        self.matches = matches
+        self.match_index = match_index
+        self.query_one("#library-media-content-search-status", Static).update(
+            self._status_text()
+        )
+```
+
+In `sync_query_state`, capture `was_active = bool(self.query)` before assignment and `is_active = bool(query)` after assignment. Call `self.refresh(recompose=True)` only when those booleans differ. Otherwise update the mounted Input value/placeholder and mounted status in place. `_status_text()` returns `""`, `"No matches"`, or `f"Match {wrapped + 1} of {len(self.matches)} matches"`.
+
+- [ ] **Step 4: Run the controls tests and mutation-check the identity guard**
+
+Run the focused test command from Step 2. Then temporarily replace the `sync_match_index` status update with `self.refresh(recompose=True)` and rerun `test_match_index_sync_preserves_navigation_identity_and_focus`; confirm it fails on identity or focus. Restore the in-place implementation and rerun the full file green.
+
+- [ ] **Step 5: Commit the scoped controls**
+
+```powershell
+git add tldw_chatbook/Widgets/Library/library_media_content.py Tests/Library/test_library_media_content.py
+git commit -m "feat(library): add scoped media search controls"
+```
+
+---
+
+### Task 2: Lazy Persistent Library Content Body
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Library/library_media_content.py`
+- Modify: `Tests/Library/test_library_media_content.py`
+
+**Interfaces:**
+
+- Consumes: `front_matter_parser_factory()`, Rich `Text`, and `find_content_matches(content: str, query: str) -> tuple[int, ...]`.
+- Produces: `LibraryMediaContentBody(content: str, is_markdown: bool, mode: str, query: str, match_index: int, **kwargs)`.
+- Produces: `async sync_mode(mode: str) -> None`.
+- Produces: `sync_search(query: str, match_index: int) -> None`.
+
+- [ ] **Step 1: Write failing lazy-mount, reuse, hidden-state, and race tests**
+
+Add a body harness whose constructor accepts a body instance. Test a Markdown body initialized in Raw mode:
+
+```python
+body = LibraryMediaContentBody(
+    content="# Heading\n\nbudget one\nbudget two",
+    is_markdown=True,
+    mode="raw",
+    query="",
+    match_index=0,
+    id="library-media-viewer-content",
+)
+async with BodyHarness(body).run_test() as pilot:
+    raw = body.query_one("#library-media-viewer-content-text", Static)
+    assert not body.query("#library-media-viewer-content-markdown")
+
+    await body.sync_mode("rendered")
+    markdown = body.query_one("#library-media-viewer-content-markdown", Markdown)
+    await body.sync_mode("raw")
+    await body.sync_mode("rendered")
+
+    assert body.query_one("#library-media-viewer-content-text") is raw
+    assert body.query_one("#library-media-viewer-content-markdown") is markdown
+```
+
+Add a Rendered-initial test that calls `body.sync_search("budget", 1)` before Raw has mounted, then switches to Raw and asserts the newly mounted Rich `Text` contains two styled `budget` spans with only the second using `reverse bold`.
+
+Add a rapid-mode test that delays the first Rendered mount behind an `asyncio.Event`, starts `rendered_task = asyncio.create_task(body.sync_mode("rendered"))`, starts `raw_task = asyncio.create_task(body.sync_mode("raw"))`, releases the event, awaits both tasks, and asserts Raw is displayed, Rendered is hidden, and each ID occurs exactly once.
+
+- [ ] **Step 2: Run the body tests and verify missing interfaces fail**
+
+Run:
+
+```powershell
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/Library/test_library_media_content.py -k 'body or mode or raw' -v
+```
+
+Expected: failures report that `LibraryMediaContentBody` and its synchronization methods are absent.
+
+- [ ] **Step 3: Implement Raw renderable construction and lazy child ownership**
+
+Move the existing safe Rich slicing algorithm into a module helper that accepts complete values rather than viewer state:
+
+```python
+def build_raw_content_renderable(
+    content: str, query: str, match_index: int
+) -> Text | str:
+    display_content = content or "No stored content."
+    normalized_query = query.strip()
+    if not normalized_query or not content:
+        return display_content
+    matches = find_content_matches(content, normalized_query)
+    if not matches:
+        return display_content
+    current_line = matches[match_index % len(matches)]
+    needle = normalized_query.lower()
+    text = Text()
+    for line_index, line in enumerate(display_content.split("\n")):
+        if line_index:
+            text.append("\n")
+        hit = line.lower().find(needle)
+        if hit < 0:
+            text.append(line)
+            continue
+        text.append(line[:hit])
+        text.append(
+            line[hit : hit + len(needle)],
+            style="reverse bold" if line_index == current_line else "reverse",
+        )
+        text.append(line[hit + len(needle) :])
+    return text
+```
+
+Implement `LibraryMediaContentBody(VerticalScroll)` with `_raw_widget`, `_markdown_widget`, `_desired_mode`, `_mount_lock`, `_query`, and `_match_index`. `compose()` constructs only the selected initial mode. `_ensure_mode_mounted(mode)` awaits `self.mount(...)` only when the corresponding reference is `None`.
+
+Implement synchronization with latest-request-wins visibility:
+
+```python
+async def sync_mode(self, mode: str) -> None:
+    self._desired_mode = mode
+    async with self._mount_lock:
+        await self._ensure_mode_mounted(mode)
+        desired = self._desired_mode
+        await self._ensure_mode_mounted(desired)
+        if self._raw_widget is not None:
+            self._raw_widget.display = desired == "raw"
+        if self._markdown_widget is not None:
+            self._markdown_widget.display = desired == "rendered"
+
+def sync_search(self, query: str, match_index: int) -> None:
+    self._query = query
+    self._match_index = match_index
+    if self._raw_widget is not None:
+        self._raw_widget.update(
+            build_raw_content_renderable(self.content, query, match_index)
+        )
+```
+
+Reject modes outside `{"raw", "rendered"}` with `ValueError`. Non-Markdown bodies normalize every requested mode to Raw and never construct Markdown.
+
+- [ ] **Step 4: Run body tests and mutation-check latest-request-wins**
+
+Run the command from Step 2. Then temporarily apply visibility from the method's `mode` argument rather than `_desired_mode`; confirm the rapid Rendered-then-Raw test fails. Restore latest-desired visibility and rerun the entire component test file green.
+
+- [ ] **Step 5: Commit the content body**
+
+```powershell
+git add tldw_chatbook/Widgets/Library/library_media_content.py Tests/Library/test_library_media_content.py
+git commit -m "feat(library): keep media content views mounted"
+```
+
+---
+
+### Task 3: Integrate In-Place Updates Through the Library Product Path
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Library/library_media_viewer.py:5-18,67-159,246-402`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:24815-24972`
+- Modify: `Tests/UI/test_library_shell.py:4478-4928`
+
+**Interfaces:**
+
+- Consumes: `LibraryMediaContentSearchControls.sync_query_state`, `LibraryMediaContentSearchControls.sync_match_index`, `LibraryMediaContentBody.sync_search`, and `LibraryMediaContentBody.sync_mode` from Tasks 1-2.
+- Produces: `LibraryMediaViewer.sync_query_state(*, query: str, matches: tuple[int, ...], match_index: int) -> None`.
+- Produces: `LibraryMediaViewer.sync_match_index(*, matches: tuple[int, ...], match_index: int) -> None`.
+- Produces: `async LibraryMediaViewer.sync_mode(mode: str) -> None`.
+
+- [ ] **Step 1: Add failing full-path identity, parse-count, focus, mode-reuse, and latency regressions**
+
+Extend the existing Library harness tests. After opening a Markdown item, capture the exact screen, viewer, and Markdown objects, submit a query, focus and press Next, and assert all identities survive:
+
+```python
+screen_before = screen
+viewer_before = screen.query_one("#library-media-viewer", LibraryMediaViewer)
+markdown_before = screen.query_one(
+    "#library-media-viewer-content-markdown", Markdown
+)
+
+await _submit_content_search_query(screen, pilot, "budget")
+next_button = screen.query_one("#library-media-content-search-next", Button)
+previous_button = screen.query_one("#library-media-content-search-prev", Button)
+next_button.focus()
+next_button.press()
+await pilot.pause()
+
+assert screen is screen_before
+assert screen.query_one("#library-media-viewer") is viewer_before
+assert screen.query_one("#library-media-viewer-content-markdown") is markdown_before
+assert screen.query_one("#library-media-content-search-next") is next_button
+assert screen.query_one("#library-media-content-search-prev") is previous_button
+assert screen.focused is next_button
+```
+
+Wrap `Markdown.update` with a recording spy before navigation, await every returned `AwaitComplete`, and assert navigation adds zero calls. Update the existing Raw/Rendered test to assert both child objects remain mounted after their first use and only `display` changes. Preserve the existing `test_library_shell_media_viewer_defaults_markdown_item_to_rendered` expectation.
+
+Add a Rendered-search test: submit while Rendered is visible, switch to Raw, and assert the Raw renderable already marks the selected query. Add a scroll spy and assert `scroll_to(y=selected_line, animate=False)` runs only after a Pilot refresh boundary.
+
+For evidence, build a deterministic document with 2,000 Markdown lines and 100 matching lines. Time the identical submit/Next/Prev sequence with `time.perf_counter()`, print `TASK-15458 latency median_ms=<value>` under `pytest -s`, collect the unique Markdown object IDs observed after every action as the construction-count proxy, and assert identity and Markdown update counts rather than a wall-clock threshold. Capture the failing pre-change measurement in the task's Implementation Notes before changing production code.
+
+- [ ] **Step 2: Run the new product-path tests and record the red baseline**
+
+Run:
+
+```powershell
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_library_shell.py -k 'media_content_search or media_viewer_raw_toggle or media_viewer_defaults_markdown or media_viewer_inplace' -v -s
+```
+
+Expected: identity tests fail because current handlers recompose the screen/viewer, mode reuse fails because inactive content widgets are removed, and the recorded baseline shows Markdown reconstruction during navigation.
+
+- [ ] **Step 3: Compose focused children and add viewer coordination methods**
+
+In `LibraryMediaViewer.compose`, replace `_compose_content_search()` and the inline `VerticalScroll` branch with:
+
+```python
+matches = find_content_matches(self.viewer.content, self.content_query)
+yield LibraryMediaContentSearchControls(
+    is_markdown=self.viewer.is_markdown,
+    query=self.content_query,
+    matches=matches,
+    match_index=self.content_match_index,
+    id="library-media-content-search-controls",
+)
+yield LibraryMediaContentBody(
+    content=self.viewer.content,
+    is_markdown=self.viewer.is_markdown,
+    mode=self.content_mode,
+    query=self.content_query,
+    match_index=self.content_match_index,
+    id="library-media-viewer-content",
+)
+```
+
+Delete the moved search composition/status and Raw-renderable methods. Add narrow coordinators:
+
+```python
+def sync_query_state(
+    self, *, query: str, matches: tuple[int, ...], match_index: int
+) -> None:
+    self.content_query = query
+    self.content_match_index = match_index
+    self.query_one(LibraryMediaContentSearchControls).sync_query_state(
+        is_markdown=self.viewer.is_markdown,
+        query=query,
+        matches=matches,
+        match_index=match_index,
+    )
+    self.query_one(LibraryMediaContentBody).sync_search(query, match_index)
+
+def sync_match_index(
+    self, *, matches: tuple[int, ...], match_index: int
+) -> None:
+    self.content_match_index = match_index
+    self.query_one(LibraryMediaContentSearchControls).sync_match_index(
+        matches=matches,
+        match_index=match_index,
+    )
+    self.query_one(LibraryMediaContentBody).sync_search(
+        self.content_query, match_index
+    )
+```
+
+`sync_mode` updates `content_mode`, both toggle labels, both `-selected` classes, requests `refresh(layout=True)` for changed auto-width labels, and awaits the body method. Query only the exact child types/IDs and catch no exceptions here; screen teardown handling belongs at the screen boundary.
+
+- [ ] **Step 4: Replace screen recomposes with narrow synchronization**
+
+Add a helper that returns the mounted viewer or `None`, catching only `NoMatches` and `QueryError`:
+
+```python
+def _mounted_library_media_viewer(self) -> LibraryMediaViewer | None:
+    try:
+        return self.query_one("#library-media-viewer", LibraryMediaViewer)
+    except (NoMatches, QueryError):
+        return None
+```
+
+On submission, trim once and return immediately when the result equals the canonical query. Otherwise store the query and zero index, compute matches once, call `viewer.sync_query_state(...)`, schedule `_focus_library_media_content_search_input`, and schedule scroll only when matches exist. Do not recompose the screen.
+
+On Next/Previous, compute matches once, wrap the canonical index, call `viewer.sync_match_index(...)`, and use `call_after_refresh(self._scroll_library_media_content_to_line, line_index)` so Rich `Text` wrapping/layout settles before scrolling.
+
+Make mode handlers and `_set_library_media_content_mode` async:
+
+```python
+async def _set_library_media_content_mode(self, mode: str) -> None:
+    if self._library_media_view != "viewer":
+        return
+    if self._library_media_content_mode == mode:
+        return
+    self._library_media_content_mode = mode
+    viewer = self._mounted_library_media_viewer()
+    if viewer is None:
+        return
+    await viewer.sync_mode(mode)
+```
+
+The button handlers stop their events and await this method. Update docstrings that currently explain full-screen recomposition.
+
+- [ ] **Step 5: Run product-path tests and mutation-check the no-recompose guarantee**
+
+Run the command from Step 2 and the full `Tests/Library/test_library_media_content.py`. Then temporarily restore `self.refresh(recompose=True)` in `_advance_library_media_content_match`; confirm the identity/focus test fails. Restore the narrow call and rerun green. Record the post-change latency, object identities, and Markdown counts beside the baseline in the task notes.
+
+- [ ] **Step 6: Commit Library product-path integration**
+
+```powershell
+git add tldw_chatbook/Widgets/Library/library_media_viewer.py tldw_chatbook/UI/Screens/library_screen.py Tests/UI/test_library_shell.py backlog/tasks/task-15458*.md
+git commit -m "perf(library): update media matches in place"
+```
+
+---
+
+### Task 4: Debounce Legacy Media Content Search
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Media/media_viewer_panel.py:1-20,981-1008,1204-1315`
+- Create: `Tests/UI/test_media_viewer_content_search_debounce.py`
+
+**Interfaces:**
+
+- Consumes: Textual `Widget.set_timer(delay: float, callback) -> Timer`, synchronous `Timer.stop()`, and `Markdown.update(markdown: str) -> AwaitComplete`.
+- Produces: `MEDIA_CONTENT_SEARCH_DEBOUNCE_SECONDS = 0.25`.
+- Produces private lifecycle methods `_invalidate_content_search_timer() -> int` and `_apply_debounced_content_search(generation: int, query: str) -> None`.
+
+- [ ] **Step 1: Write mounted failing debounce and stale-lifecycle tests**
+
+Create a minimal app mounting a real `MediaViewerPanel`, load content containing multiple `budget` hits, and wrap the mounted `#content-display` Markdown instance's `update` method. Clear the recording list after the initial media render completes so the assertions measure search-triggered updates only:
+
+```python
+updates: list[tuple[str, AwaitComplete]] = []
+original_update = content_display.update
+
+def recording_update(markdown: str) -> AwaitComplete:
+    completion = original_update(markdown)
+    updates.append((markdown, completion))
+    return completion
+
+monkeypatch.setattr(content_display, "update", recording_update)
+```
+
+Set the Input value to `"b"`, `"bu"`, and `"budget"` with pauses shorter than 250 ms. Assert no update occurs before the window, then wait past the window, await every recorded completion, and assert exactly one non-empty payload.
+
+Add separate tests that arm a query and then:
+
+- clear the Input before 250 ms and assert one immediate unhighlighted update plus no later update;
+- call `load_media()` with a different record before 250 ms and assert the old query never appears in the new payload;
+- call `clear_display()` before 250 ms and assert the cleared display remains authoritative;
+- remove the panel before 250 ms and assert the stale callback performs no update;
+- load two records with the same or missing ID and assert the generation, not record identity, invalidates the first query.
+
+- [ ] **Step 2: Run the new tests and verify current per-keystroke behavior fails**
+
+Run:
+
+```powershell
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_media_viewer_content_search_debounce.py -v
+```
+
+Expected: burst tests observe immediate renders and the empty-string plus content double update.
+
+- [ ] **Step 3: Add guarded timer state and remove the double update**
+
+Import `partial` and `Timer`, define the constant, and initialize:
+
+```python
+self._content_search_timer: Timer | None = None
+self._content_search_generation = 0
+self._content_search_query = ""
+```
+
+Implement invalidation and the guarded callback:
+
+```python
+def _invalidate_content_search_timer(self) -> int:
+    if self._content_search_timer is not None:
+        self._content_search_timer.stop()
+        self._content_search_timer = None
+    self._content_search_generation += 1
+    return self._content_search_generation
+
+def _apply_debounced_content_search(self, generation: int, query: str) -> None:
+    if generation != self._content_search_generation:
+        return
+    if query != self._content_search_query or not self.is_mounted:
+        return
+    self._content_search_timer = None
+    self.search_content(query)
+```
+
+For non-empty `Input.Changed`, invalidate, store the exact value, and schedule the guarded callback:
+
+```python
+generation = self._invalidate_content_search_timer()
+self._content_search_query = event.value
+self._content_search_timer = self.set_timer(
+    MEDIA_CONTENT_SEARCH_DEBOUNCE_SECONDS,
+    partial(self._apply_debounced_content_search, generation, event.value),
+)
+```
+
+For empty input, invalidate, clear `_content_search_query`, and call `clear_search()` immediately.
+
+Call invalidation before state changes in `load_media`, `clear_display`, and `on_unmount`. In `update_content_display`, delete `content_display.update("")` and retain exactly one `content_display.update(content)` call. Keep navigation's immediate `highlight_current_match()` behavior unchanged.
+
+- [ ] **Step 4: Run debounce tests and mutation-check generation invalidation**
+
+Run the command from Step 2 plus:
+
+```powershell
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_media_window_v2_parity.py Tests/UI/test_media_handoffs.py -q
+```
+
+Temporarily remove the generation increment from `load_media`; confirm the same/missing-ID stale-query test fails. Restore it and rerun both commands green.
+
+- [ ] **Step 5: Commit the legacy debounce**
+
+```powershell
+git add tldw_chatbook/Widgets/Media/media_viewer_panel.py Tests/UI/test_media_viewer_content_search_debounce.py
+git commit -m "perf(media): debounce legacy content search"
+```
+
+---
+
+### Task 5: Verification, Evidence, and Task Closeout
+
+**Files:**
+
+- Modify: `backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md`
+- Modify only if the task revealed a reusable incident: `backlog/docs/lessons-testing-evidence.md`
+
+**Interfaces:**
+
+- Consumes: all behavior and evidence produced by Tasks 1-4.
+- Produces: completed acceptance criteria, exact verification evidence, and concise implementation notes.
+
+- [ ] **Step 1: Run focused behavior and performance verification**
+
+```powershell
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/Library/test_library_media_content.py Tests/UI/test_media_viewer_content_search_debounce.py -v
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_library_shell.py -k 'media_content_search or media_viewer_raw_toggle or media_viewer_defaults_markdown or media_viewer_inplace' -v -s
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_media_window_v2_parity.py Tests/UI/test_media_handoffs.py -q
+```
+
+Expected: all focused tests pass; the output includes the after-change median latency, stable identities, and zero Markdown updates for Library navigation.
+
+- [ ] **Step 2: Run static analysis and the broader regression suite**
+
+```powershell
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m ruff check tldw_chatbook/Widgets/Library/library_media_content.py tldw_chatbook/Widgets/Library/library_media_viewer.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/Widgets/Media/media_viewer_panel.py Tests/Library/test_library_media_content.py Tests/UI/test_library_shell.py Tests/UI/test_media_viewer_content_search_debounce.py
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest -q
+git diff --check origin/dev...HEAD
+```
+
+Expected: Ruff and the full suite pass, and the branch diff has no whitespace errors. If the repository-wide suite has a pre-existing unrelated failure, rerun the exact failing test against the unchanged `origin/dev` worktree and record both outputs rather than attributing it to this task.
+
+- [ ] **Step 3: Perform a rendered keyboard UAT**
+
+Run the app from this worktree with the parent worktree virtual environment. In Library, open a long Markdown media item and verify: Markdown opens Rendered; typing does not apply until Enter; Enter retains search focus; Next/Previous retain their own focus, wrap, update the status, and scroll; Raw shows the selected highlight; repeated Raw/Rendered toggles retain content and do not flash/remount. In the legacy Media screen, type a burst into content search and verify results appear once after the silent 250 ms pause, then clear and switch records before the pause to verify no stale repaint.
+
+Record terminal size, media fixture size, actions, visible results, and any limitation in the task notes. Use the rendered frame or terminal capture as the visual oracle, not widget properties alone.
+
+- [ ] **Step 4: Complete the Backlog task source of truth**
+
+Directly edit the five-digit task file, as required by `backlog/docs/lessons-backlog-hygiene.md`, because Backlog CLI 1.44.0 corrupts five-digit IDs. Check all three acceptance criteria, add measured before/after latency and parse/identity counts, list exact verification commands, and add:
+
+```markdown
+## Implementation Notes
+
+- Extracted scoped Library search controls and a lazy persistent content body so match navigation updates status/highlighting/scroll state without remounting the screen or reparsing Markdown.
+- Preserved Enter-to-search, Rendered-by-default Markdown behavior, Raw highlighting, wraparound navigation, and focus continuity.
+- Debounced legacy content search at 250 ms with monotonic lifecycle invalidation and one Markdown update per applied query.
+- ADR required: no; the implementation follows existing Textual widget ownership and timer boundaries.
+```
+
+Add a lessons entry only if implementation or UAT exposes a reproducible trap that generalizes beyond this task; do not add one merely to fill the checklist.
+
+- [ ] **Step 5: Commit closeout documentation**
+
+```powershell
+git add backlog/tasks/task-15458*.md backlog/docs/lessons-testing-evidence.md
+git commit -m "docs(library): close task 15458"
+```
+
+If no lessons file changed, stage only the task file. Confirm `git status --short` is empty after the commit.

--- a/Docs/superpowers/specs/2026-08-12-library-media-viewer-inplace-design.md
+++ b/Docs/superpowers/specs/2026-08-12-library-media-viewer-inplace-design.md
@@ -73,27 +73,38 @@ safe no-ops; they do not trigger a screen-level fallback recompose.
 ### 2. Search chrome becomes a scoped child widget
 
 Extract the search input, optional status line, and optional Previous/Next
-toolbar into a small `LibraryMediaContentSearchControls` child. It receives a
-complete state consisting of:
+toolbar into a small `LibraryMediaContentSearchControls` child in
+`tldw_chatbook/Widgets/Library/library_media_content.py`. It receives a complete
+state consisting of:
 
 - whether the media is Markdown (for placeholder copy),
 - the submitted query,
 - the ordered matching source-line indices,
 - the current wrapped match index.
 
-Its public `sync_state(...)` replaces the complete snapshot and recomposes only
-that child. This preserves the existing structural behavior: status and
-navigation widgets do not exist for an empty query. The Input is recreated on
-Enter, matching current behavior; `LibraryScreen` restores its focus after the
-scoped update.
+The child has two update paths:
 
-The child exposes the exact signature
-`sync_state(*, is_markdown: bool, query: str, matches: tuple[int, ...],`
-`match_index: int) -> None`.
+- `sync_query_state(*, is_markdown: bool, query: str, matches: tuple[int, ...],`
+  `match_index: int) -> None` replaces the complete query snapshot. It
+  recomposes the child only when the structure changes between inactive
+  (blank query) and active (non-blank query). A non-blank query changing to
+  another non-blank query updates the existing Input and status in place.
+- `sync_match_index(*, matches: tuple[int, ...], match_index: int) -> None`
+  updates only the existing status `Static`. It never recomposes the child.
+
+This preserves the existing structural behavior: status and navigation widgets
+do not exist for an empty query. The Input is recreated only when search chrome
+transitions between inactive and active structure; `LibraryScreen` restores its
+focus after that structural update. Next/Previous preserve the identity and
+focus state of both navigation buttons, avoiding removal of a pressed widget
+during its own event dispatch.
 
 ### 3. Content body owns lazy, persistent view instances
 
-Extract the scrollable content body into `LibraryMediaContentBody`.
+Extract the scrollable content body into `LibraryMediaContentBody` in
+`tldw_chatbook/Widgets/Library/library_media_content.py`. Keeping both focused
+content widgets in one module avoids growing the existing viewer and gives the
+performance boundary a direct unit-test surface.
 
 - Non-Markdown media mounts only the Raw `Static`.
 - Markdown media initially mounts only the selected mode. The default Raw view
@@ -120,6 +131,13 @@ to reach into child implementation details:
 names and signatures. The async mode method does not return until a first-use
 target has mounted and visibility is correct.
 
+The content body stores `_desired_mode` and serializes first-use mounts with an
+`asyncio.Lock`. Each call records its desired mode before waiting for the lock.
+After a mount completes, visibility is applied from the latest desired value,
+not from the possibly stale request that initiated the mount. This prevents a
+rapid Rendered then Raw sequence from ending in Rendered merely because its
+first parse completed last, and prevents duplicate children with the same ID.
+
 ### 4. Library handlers perform narrow synchronization
 
 Search submission:
@@ -129,7 +147,9 @@ Search submission:
 2. Store the query and reset the canonical match index to zero.
 3. Synchronize the search-controls child and Raw body renderable.
 4. Restore search-input focus after the scoped controls update.
-5. Scroll to the first matching source line when one exists.
+5. When a match exists, schedule scrolling with `call_after_refresh` so Raw
+   wrapping and layout reflect the new Rich `Text` before `scroll_to` reads
+   geometry.
 
 Next/Previous navigation:
 
@@ -137,9 +157,10 @@ Next/Previous navigation:
    query.
 2. No-op when there are no matches.
 3. Wrap the canonical index, synchronize the status and Raw renderable, and
-   scroll to the selected source line.
+   schedule post-layout scrolling to the selected source line.
 4. Never call `LibraryScreen.refresh(recompose=True)`, viewer recompose, or
-   `Markdown.update()`.
+   `Markdown.update()`. It also never recomposes the search-controls child, so
+   the pressed Previous/Next button retains identity and focus.
 
 Mode switching:
 
@@ -158,18 +179,20 @@ matching the Library prompt and STTS profile search convention.
 On non-empty `Input.Changed`:
 
 1. Cancel the prior content-search timer.
-2. Increment a search generation.
-3. Capture the generation, current media identity, and exact query.
+2. Increment a monotonic search generation.
+3. Capture the generation and exact query.
 4. Arm one 250 ms timer.
 
 When the timer fires, it applies the search only if all captured values still
-match current state. It then finds matches, updates match/status state, and
-calls the content display update exactly once.
+match current state. Loading media increments the same generation, so media IDs
+are not used as lifecycle evidence. A valid callback finds matches, updates
+match/status state, and calls the content display update exactly once.
 
 Clearing the input cancels the timer, increments the generation, clears search
 state immediately, and renders the unhighlighted document once. Loading another
-media item and unmounting the panel also cancel/invalidate pending work. A stale
-callback is a no-op.
+media item and unmounting the panel also stop the timer and increment the same
+generation. A stale callback is a no-op even when two records share or omit an
+ID.
 
 `update_content_display()` removes the preliminary `Markdown.update("")` and
 performs only `Markdown.update(content)`.
@@ -181,7 +204,8 @@ performs only `Markdown.update(content)`.
 - A search or navigation action with no open media detail or no matches is a
   no-op, preserving current behavior.
 - Lazy mounting is guarded against duplicate concurrent mounts. Repeated mode
-  presses cannot create two content widgets with the same ID.
+  presses cannot create two content widgets with the same ID, and only the
+  latest desired mode becomes visible after an awaited mount.
 - Debounce state is invalidated before programmatic input clearing during media
   replacement, preventing an old query from repainting a new item.
 - Search matching remains case-insensitive and operates on raw stored content
@@ -198,6 +222,8 @@ Mounted Textual tests will prove:
   already-mounted Markdown instance.
 - Next/Previous preserve those identities, wrap correctly, update the status,
   preserve Raw current-match emphasis, and scroll to the selected source line.
+- The mounted Previous and Next button identities survive every navigation
+  click, and keyboard focus remains on the activated navigation control.
 - `Markdown.update()` is not called during Library match navigation.
 - Empty submission removes status/navigation through only the scoped controls
   update.
@@ -216,6 +242,11 @@ Tests with the real mounted panel and a narrow Markdown update spy will prove:
 - The render payload is never the empty-string cache-busting update.
 - Clearing, loading different media, and unmounting invalidate pending work.
 - A single stable query still preserves match highlighting and status behavior.
+
+Because Textual 8's `Markdown.update()` returns `AwaitComplete` and performs its
+parse/mount work asynchronously, render-count tests await the returned
+completion before asserting final content and counts. They do not treat method
+invocation alone as proof that rendering finished.
 
 ### Performance evidence
 

--- a/Docs/superpowers/specs/2026-08-12-library-media-viewer-inplace-design.md
+++ b/Docs/superpowers/specs/2026-08-12-library-media-viewer-inplace-design.md
@@ -1,7 +1,7 @@
 # Library Media Viewer In-Place Search Design
 
-**Task:** TASK-15458  
-**Date:** 2026-08-12  
+**Task:** TASK-15458
+**Date:** 2026-08-12
 **Status:** Approved design
 
 ## Purpose

--- a/Docs/superpowers/specs/2026-08-12-library-media-viewer-inplace-design.md
+++ b/Docs/superpowers/specs/2026-08-12-library-media-viewer-inplace-design.md
@@ -1,0 +1,248 @@
+# Library Media Viewer In-Place Search Design
+
+**Task:** TASK-15458  
+**Date:** 2026-08-12  
+**Status:** Approved design
+
+## Purpose
+
+Remove full-screen remounts and unnecessary full-document Markdown parses from
+Library media content search and mode switching. Also debounce the legacy media
+panel's per-keystroke content search so one burst of typing produces at most one
+render.
+
+This work preserves the Library viewer's current Enter-to-search interaction,
+match counting, wraparound navigation, Raw-mode highlighting, and source-line
+scrolling behavior.
+
+## Scope
+
+### In scope
+
+- Library media viewer content-search submission, clearing, next/previous
+  navigation, and Rendered/Raw mode switching.
+- Stable identity for the Library screen, media viewer, and any already-mounted
+  Markdown document across those interactions.
+- Lazy first mounting and subsequent reuse of the Rendered Markdown document.
+- In-place Raw content highlighting and search-status updates.
+- Debounced content search in `MediaViewerPanel` with exactly one Markdown
+  update when a search is applied.
+- Stale-debounce protection across query changes, media changes, clear, and
+  unmount.
+- Focused behavior, identity, render-count, scrolling, and latency evidence.
+
+### Out of scope
+
+- Changing Library content search from Enter-to-search to live search.
+- Moving content matching or Markdown rendering to a worker thread.
+- Replacing Textual's Markdown renderer or mutating its internal block widget
+  implementation.
+- Redesigning how source-line indices map onto rendered Markdown block geometry.
+- Changing match cardinality: Library search continues to count one match per
+  matching source line and mark only the first occurrence on that line.
+
+## Existing Problems
+
+The Library viewer is composed as part of the 26k-line `LibraryScreen`. Search
+submission, match navigation, and content-mode toggles currently call a
+screen-level `refresh(recompose=True)`. That discards and recreates the viewer,
+including the full Markdown document, even when the only changed values are a
+counter, one Raw-mode highlight style, or visibility.
+
+The legacy `MediaViewerPanel` runs content search directly from every
+`Input.Changed` event. Its display refresh first calls `Markdown.update("")`
+and then `Markdown.update(content)`, causing two parses per keystroke. Its
+next/previous behavior remains outside the Library-screen remount problem; this
+task changes its typing path only.
+
+## Design Decisions
+
+### 1. Screen state stays canonical
+
+`LibraryScreen` continues to own:
+
+- `_library_media_content_query`
+- `_library_media_content_match_index`
+- `_library_media_content_mode`
+
+Handlers update those values first, calculate matches from the raw stored
+content, and then delegate presentation changes to the mounted
+`LibraryMediaViewer`. Missing mounted widgets during navigation or teardown are
+safe no-ops; they do not trigger a screen-level fallback recompose.
+
+### 2. Search chrome becomes a scoped child widget
+
+Extract the search input, optional status line, and optional Previous/Next
+toolbar into a small `LibraryMediaContentSearchControls` child. It receives a
+complete state consisting of:
+
+- whether the media is Markdown (for placeholder copy),
+- the submitted query,
+- the ordered matching source-line indices,
+- the current wrapped match index.
+
+Its public `sync_state(...)` replaces the complete snapshot and recomposes only
+that child. This preserves the existing structural behavior: status and
+navigation widgets do not exist for an empty query. The Input is recreated on
+Enter, matching current behavior; `LibraryScreen` restores its focus after the
+scoped update.
+
+The child exposes the exact signature
+`sync_state(*, is_markdown: bool, query: str, matches: tuple[int, ...],`
+`match_index: int) -> None`.
+
+### 3. Content body owns lazy, persistent view instances
+
+Extract the scrollable content body into `LibraryMediaContentBody`.
+
+- Non-Markdown media mounts only the Raw `Static`.
+- Markdown media initially mounts only the selected mode. The default Raw view
+  therefore does not pay a Markdown parse during initial viewer load.
+- The first switch to an unmounted mode dynamically mounts that mode's widget.
+- Once mounted, Raw and Rendered instances remain children of the content body;
+  subsequent toggles change `display` rather than remounting either instance.
+- The Rendered widget always receives the original stored content and is not
+  updated for match navigation.
+- The Raw widget receives a Rich `Text` renderable built from raw slices. Query
+  submission, clearing, and match navigation update that `Static` in place,
+  including while Raw is hidden, so returning from Rendered never exposes stale
+  highlighting.
+
+The content body exposes narrow public methods rather than allowing the screen
+to reach into child implementation details:
+
+- `async sync_mode(mode: str) -> None` ensures the target instance exists and
+  updates visibility.
+- `sync_search(query: str, match_index: int) -> None` updates only the Raw
+  renderable.
+
+`LibraryMediaViewer` exposes corresponding delegation methods with those same
+names and signatures. The async mode method does not return until a first-use
+target has mounted and visibility is correct.
+
+### 4. Library handlers perform narrow synchronization
+
+Search submission:
+
+1. Stop the event, trim the submitted query, and no-op if it equals the current
+   canonical query.
+2. Store the query and reset the canonical match index to zero.
+3. Synchronize the search-controls child and Raw body renderable.
+4. Restore search-input focus after the scoped controls update.
+5. Scroll to the first matching source line when one exists.
+
+Next/Previous navigation:
+
+1. Rebuild the ordered source-line match tuple from canonical raw content and
+   query.
+2. No-op when there are no matches.
+3. Wrap the canonical index, synchronize the status and Raw renderable, and
+   scroll to the selected source line.
+4. Never call `LibraryScreen.refresh(recompose=True)`, viewer recompose, or
+   `Markdown.update()`.
+
+Mode switching:
+
+1. Preserve the current no-op guard when the requested mode is already active.
+2. Store the canonical mode.
+3. Update toggle labels/classes in place and ask the content body to show the
+   target mode.
+4. Pay at most one necessary Markdown parse, on the first transition to an
+   unmounted Rendered view. Later toggles reuse the same widget identity.
+
+### 5. Legacy panel search uses a guarded 250 ms debounce
+
+`MediaViewerPanel` uses a named `MEDIA_CONTENT_SEARCH_DEBOUNCE_SECONDS = 0.25`,
+matching the Library prompt and STTS profile search convention.
+
+On non-empty `Input.Changed`:
+
+1. Cancel the prior content-search timer.
+2. Increment a search generation.
+3. Capture the generation, current media identity, and exact query.
+4. Arm one 250 ms timer.
+
+When the timer fires, it applies the search only if all captured values still
+match current state. It then finds matches, updates match/status state, and
+calls the content display update exactly once.
+
+Clearing the input cancels the timer, increments the generation, clears search
+state immediately, and renders the unhighlighted document once. Loading another
+media item and unmounting the panel also cancel/invalidate pending work. A stale
+callback is a no-op.
+
+`update_content_display()` removes the preliminary `Markdown.update("")` and
+performs only `Markdown.update(content)`.
+
+## Error and Lifecycle Handling
+
+- Narrow sync helpers catch only Textual absence/query exceptions expected
+  during navigation and teardown. Unexpected exceptions remain visible.
+- A search or navigation action with no open media detail or no matches is a
+  no-op, preserving current behavior.
+- Lazy mounting is guarded against duplicate concurrent mounts. Repeated mode
+  presses cannot create two content widgets with the same ID.
+- Debounce state is invalidated before programmatic input clearing during media
+  replacement, preventing an old query from repainting a new item.
+- Search matching remains case-insensitive and operates on raw stored content
+  in both Raw and Rendered modes.
+
+## Testing and Evidence
+
+### Library viewer behavior and identity
+
+Mounted Textual tests will prove:
+
+- Enter-to-search remains the only Library query-application path.
+- Search submission preserves `LibraryScreen`, `LibraryMediaViewer`, and an
+  already-mounted Markdown instance.
+- Next/Previous preserve those identities, wrap correctly, update the status,
+  preserve Raw current-match emphasis, and scroll to the selected source line.
+- `Markdown.update()` is not called during Library match navigation.
+- Empty submission removes status/navigation through only the scoped controls
+  update.
+- Opening Markdown media in Raw mode does not mount/parse Markdown; the first
+  Rendered switch mounts it once; Raw then Rendered reuses the same Markdown
+  instance.
+- A query submitted while Rendered updates the hidden Raw renderable before a
+  switch back.
+
+### Legacy panel debounce
+
+Tests with the real mounted panel and a narrow Markdown update spy will prove:
+
+- Multiple changes within 250 ms produce no early search render and exactly one
+  final render after the window.
+- The render payload is never the empty-string cache-busting update.
+- Clearing, loading different media, and unmounting invalidate pending work.
+- A single stable query still preserves match highlighting and status behavior.
+
+### Performance evidence
+
+Use one deterministic long Markdown document and the identical sequence of
+search submission plus repeated next/previous clicks before and after the
+change. Record:
+
+- median click latency,
+- screen/viewer/Markdown identity,
+- Markdown update/construct counts.
+
+The automated latency probe records measurements but uses no wall-clock pass
+threshold. Behavioral identity and parse-count assertions are the stable
+regression gate.
+
+## Documentation and Task Completion
+
+Update TASK-15458 with the implementation plan, completed acceptance criteria,
+measured before/after evidence, verification commands, and concise
+implementation notes. Update user documentation only if implementation exposes
+an observable interaction change; the approved design intentionally preserves
+the current interaction and copy.
+
+## ADR Check
+
+ADR required: no  
+ADR path: N/A  
+Reason: this applies the existing Library screen/canvas/widget ownership model
+and Textual timer patterns. It changes neither persistent state nor service,
+security, dependency, or cross-module architecture boundaries.

--- a/Docs/superpowers/specs/2026-08-12-library-media-viewer-inplace-design.md
+++ b/Docs/superpowers/specs/2026-08-12-library-media-viewer-inplace-design.md
@@ -107,8 +107,10 @@ content widgets in one module avoids growing the existing viewer and gives the
 performance boundary a direct unit-test surface.
 
 - Non-Markdown media mounts only the Raw `Static`.
-- Markdown media initially mounts only the selected mode. The default Raw view
-  therefore does not pay a Markdown parse during initial viewer load.
+- Markdown media initially mounts only the selected mode. The Library screen
+  preserves its current Rendered default for Markdown items; a body explicitly
+  initialized in Raw mode does not pay a Markdown parse until Rendered is first
+  requested.
 - The first switch to an unmounted mode dynamically mounts that mode's widget.
 - Once mounted, Raw and Rendered instances remain children of the content body;
   subsequent toggles change `display` rather than remounting either instance.
@@ -124,12 +126,16 @@ to reach into child implementation details:
 
 - `async sync_mode(mode: str) -> None` ensures the target instance exists and
   updates visibility.
-- `sync_search(query: str, match_index: int) -> None` updates only the Raw
-  renderable.
+- `sync_search(query: str, match_index: int) -> None` stores the complete Raw
+  search state and updates the Raw renderable when that widget is mounted. If
+  Raw has not mounted yet, its first mount uses the stored state.
 
-`LibraryMediaViewer` exposes corresponding delegation methods with those same
-names and signatures. The async mode method does not return until a first-use
-target has mounted and visibility is correct.
+`LibraryMediaViewer` exposes the screen-facing methods
+`sync_query_state(*, query: str, matches: tuple[int, ...], match_index: int)`,
+`sync_match_index(*, matches: tuple[int, ...], match_index: int)`, and
+`async sync_mode(mode: str)`. These methods coordinate the narrower child
+interfaces without exposing child implementation details. The async mode method
+does not return until a first-use target has mounted and visibility is correct.
 
 The content body stores `_desired_mode` and serializes first-use mounts with an
 `asyncio.Lock`. Each call records its desired mode before waiting for the lock.
@@ -227,11 +233,13 @@ Mounted Textual tests will prove:
 - `Markdown.update()` is not called during Library match navigation.
 - Empty submission removes status/navigation through only the scoped controls
   update.
-- Opening Markdown media in Raw mode does not mount/parse Markdown; the first
-  Rendered switch mounts it once; Raw then Rendered reuses the same Markdown
-  instance.
-- A query submitted while Rendered updates the hidden Raw renderable before a
-  switch back.
+- Constructing a Markdown body in Raw mode does not mount/parse Markdown; the
+  first Rendered switch mounts it once; Raw then Rendered reuses the same
+  Markdown instance. The full Library screen continues to open Markdown media
+  in its current Rendered default.
+- A query submitted while Rendered updates stored Raw search state and either
+  updates an already-mounted hidden Raw renderable or initializes the first Raw
+  mount with that state before it becomes visible.
 
 ### Legacy panel debounce
 

--- a/Docs/superpowers/specs/2026-08-12-library-media-viewer-inplace-design.md
+++ b/Docs/superpowers/specs/2026-08-12-library-media-viewer-inplace-design.md
@@ -280,8 +280,10 @@ the current interaction and copy.
 
 ## ADR Check
 
-ADR required: no  
-ADR path: N/A  
-Reason: this applies the existing Library screen/canvas/widget ownership model
-and Textual timer patterns. It changes neither persistent state nor service,
-security, dependency, or cross-module architecture boundaries.
+ADR required: yes
+ADR path: `backlog/decisions/058-thread-scoped-test-socketpair-exemption.md`
+Reason: the media-viewer design itself applies the existing Library
+screen/canvas/widget ownership model and Textual timer patterns. Task 1 review
+expanded the verification scope to repair the repository-wide Windows test
+network security boundary, which is governed by ADR-058 and the companion
+socketpair design.

--- a/Docs/superpowers/specs/2026-08-12-windows-test-network-guard-socketpair-design.md
+++ b/Docs/superpowers/specs/2026-08-12-windows-test-network-guard-socketpair-design.md
@@ -1,0 +1,113 @@
+# Windows Test Network Guard Socketpair Design
+
+**Task:** TASK-15458 review expansion
+**Date:** 2026-08-12
+**Status:** Approved
+**Decision:** [ADR-058](../../../backlog/decisions/058-thread-scoped-test-socketpair-exemption.md)
+
+## Purpose
+
+Make literal asynchronous pytest commands work on Windows while preserving the
+test suite's import-time, default-deny network guard. This removes the temporary
+TASK-15100 workaround that clears the guard's protected internet address
+families before pytest creates a Windows Proactor event loop.
+
+## Root Cause Evidence
+
+`Tests/conftest.py` installs `Tests.network_guard` at import time. The guard
+patches socket connection entry points and rejects `AF_INET` and `AF_INET6`
+unless a test explicitly opts into the existing global allow mechanism.
+
+On Windows with Python 3.12, `socket.socketpair()` is implemented by
+`socket._fallback_socketpair()`. That fallback creates a loopback listener and
+connects the client socket to it. Pytest's asynchronous setup reaches this
+internal loopback connect before an autouse fixture or marker can grant an
+exception, so the guard rejects event-loop bootstrap rather than application
+egress. `backlog/docs/lessons-testing-evidence.md` records the original
+TASK-15100 incident and the temporary guarded-family mutation workaround.
+
+## Scope
+
+In scope:
+
+- Allow only connections made dynamically inside the real
+  `socket.socketpair()` implementation on the calling thread.
+- Preserve all current network-denial and recording behavior outside that
+  dynamic extent.
+- Prove the exception cannot leak across concurrent threads or after failure.
+- Restore literal Windows pytest execution for the TASK-15458 focused tests.
+- Add the two small status-formatting assertions requested in Task 1 review.
+
+Out of scope:
+
+- General localhost access.
+- A new public network-test opt-in mechanism.
+- Changes to application networking or production code.
+- Changes to non-Windows socket behavior beyond routing calls through a
+  behavior-preserving wrapper.
+
+## Design
+
+### Preserve default denial
+
+The guard remains installed during `Tests.conftest` import. Direct
+`connect`, `connect_ex`, `sendto`, and `create_connection` calls for protected
+families remain blocked and recorded unless a test uses the existing explicit
+global allow mechanism. `AF_UNIX` behavior remains unaffected.
+
+### Use a thread-scoped dynamic exemption
+
+At install time, capture the real `socket.socketpair` before replacing it with
+a guard-owned wrapper. Maintain an integer nesting depth in `threading.local()`.
+The wrapper increments that depth, calls the captured real implementation, and
+restores the prior depth in `finally`.
+
+The guard's blocking predicate may allow a protected-family connection only
+when the current thread's socketpair depth is positive. It must not mutate the
+guard's global allow flag or the set of protected address families. A direct
+connection made by any other thread while socketpair is active therefore
+continues to be denied and recorded.
+
+### Preserve failure safety and idempotence
+
+The wrapper supports nested calls through a depth counter rather than a
+boolean. Restoration occurs in `finally`, including when the captured
+socketpair implementation raises. Repeated guard installation keeps the
+original captured functions and does not stack wrappers.
+
+## Verification Strategy
+
+Add tests that fail against the current guard before implementing the repair:
+
+1. A Windows-only synchronous test calls the real guarded
+   `socket.socketpair()`, exchanges a byte, and confirms no blocked-attempt
+   record is created.
+2. A concurrency test holds the socketpair wrapper open in one thread while a
+   second thread attempts a direct loopback connection; the second operation
+   remains blocked and recorded.
+3. A failure-path test substitutes a raising socketpair implementation and
+   proves the dynamic exemption is restored afterward.
+4. Existing network-guard tests continue to prove default denial, recording,
+   explicit opt-in, and unaffected local-family behavior.
+5. The literal Task 1 command runs without changing the guarded family set:
+   `python -m pytest Tests/Library/test_library_media_content.py -q`.
+6. The media-content tests directly cover the `No matches` status and wrapped
+   one-based match-index formatting.
+
+Mutation checks must demonstrate that removing the thread-local exemption or
+replacing it with a process-global allow causes the new tests to fail.
+
+## Documentation
+
+- Add the literal-command security property to TASK-15458's acceptance
+  criteria.
+- Amend the implementation plan before code changes begin.
+- Replace the TASK-15100 workaround note with a follow-up incident entry once
+  the literal command is verified.
+
+## ADR Check
+
+ADR required: yes
+ADR path: `backlog/decisions/058-thread-scoped-test-socketpair-exemption.md`
+Reason: the repair changes a repository-wide test security boundary and the
+runtime interception contract used to enforce it.

--- a/Tests/Library/test_library_media_content.py
+++ b/Tests/Library/test_library_media_content.py
@@ -1,0 +1,130 @@
+"""Mounted behavior tests for the Library media-content search controls.
+
+Each test protects the structural recompose boundary: changing active search
+state must replace controls, while changing match data must preserve them.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Input, Static
+
+from tldw_chatbook.Widgets.Library.library_media_content import (
+    LibraryMediaContentSearchControls,
+)
+
+
+class SearchControlsHarness(App[None]):
+    """Mount controls with an active Markdown query."""
+
+    def compose(self) -> ComposeResult:
+        yield LibraryMediaContentSearchControls(
+            is_markdown=True,
+            query="budget",
+            matches=(2, 8),
+            match_index=0,
+            id="controls",
+        )
+
+
+class BlankSearchControlsHarness(App[None]):
+    """Mount controls with no active query."""
+
+    def compose(self) -> ComposeResult:
+        yield LibraryMediaContentSearchControls(
+            is_markdown=True,
+            query="",
+            matches=(),
+            match_index=0,
+            id="controls",
+        )
+
+
+@pytest.mark.asyncio
+async def test_match_index_sync_preserves_navigation_identity_and_focus() -> None:
+    """Catch a match-index update that recompiles the navigation controls."""
+    app = SearchControlsHarness()
+    async with app.run_test() as pilot:
+        controls = app.query_one("#controls", LibraryMediaContentSearchControls)
+        previous = app.query_one("#library-media-content-search-prev", Button)
+        next_button = app.query_one("#library-media-content-search-next", Button)
+        next_button.focus()
+
+        controls.sync_match_index(matches=(2, 8), match_index=1)
+        await pilot.pause()
+
+        assert app.query_one("#library-media-content-search-prev") is previous
+        assert app.query_one("#library-media-content-search-next") is next_button
+        assert app.focused is next_button
+        assert str(app.query_one("#library-media-content-search-status", Static).renderable) == (
+            "Match 2 of 2 matches"
+        )
+
+
+@pytest.mark.asyncio
+async def test_active_query_sync_preserves_search_and_navigation_identity() -> None:
+    """Catch active-query updates that needlessly recompose mounted controls."""
+    app = SearchControlsHarness()
+    async with app.run_test() as pilot:
+        controls = app.query_one("#controls", LibraryMediaContentSearchControls)
+        search_input = app.query_one("#library-media-content-search", Input)
+        previous = app.query_one("#library-media-content-search-prev", Button)
+        next_button = app.query_one("#library-media-content-search-next", Button)
+
+        controls.sync_query_state(
+            is_markdown=True,
+            query="cost",
+            matches=(4,),
+            match_index=0,
+        )
+        await pilot.pause()
+
+        assert app.query_one("#library-media-content-search", Input) is search_input
+        assert app.query_one("#library-media-content-search-prev", Button) is previous
+        assert app.query_one("#library-media-content-search-next", Button) is next_button
+        assert search_input.value == "cost"
+        assert str(app.query_one("#library-media-content-search-status", Static).renderable) == (
+            "Match 1 of 1 matches"
+        )
+
+
+@pytest.mark.asyncio
+async def test_blank_query_sync_removes_active_search_controls() -> None:
+    """Catch a blank-query transition that leaves stale controls mounted."""
+    app = SearchControlsHarness()
+    async with app.run_test() as pilot:
+        controls = app.query_one("#controls", LibraryMediaContentSearchControls)
+
+        controls.sync_query_state(
+            is_markdown=True,
+            query="",
+            matches=(),
+            match_index=0,
+        )
+        await pilot.pause()
+
+        assert not app.query("#library-media-content-search-status")
+        assert not app.query("#library-media-content-search-prev")
+        assert not app.query("#library-media-content-search-next")
+
+
+@pytest.mark.asyncio
+async def test_active_query_sync_mounts_controls_and_markdown_placeholder() -> None:
+    """Catch a blank-to-active transition that fails to recompose its controls."""
+    app = BlankSearchControlsHarness()
+    async with app.run_test() as pilot:
+        controls = app.query_one("#controls", LibraryMediaContentSearchControls)
+        blank_input = app.query_one("#library-media-content-search", Input)
+
+        controls.sync_query_state(
+            is_markdown=True,
+            query="cost",
+            matches=(4,),
+            match_index=0,
+        )
+        await pilot.pause()
+
+        active_input = app.query_one("#library-media-content-search", Input)
+        assert active_input is not blank_input
+        assert active_input.placeholder == "Search content (raw text)…"
+        assert app.query_one("#library-media-content-search-prev", Button)
+        assert app.query_one("#library-media-content-search-next", Button)

--- a/Tests/Library/test_library_media_content.py
+++ b/Tests/Library/test_library_media_content.py
@@ -88,6 +88,36 @@ async def test_active_query_sync_preserves_search_and_navigation_identity() -> N
 
 
 @pytest.mark.asyncio
+async def test_match_index_sync_displays_no_matches() -> None:
+    """Catch a formatter that leaves a stale match count for an empty result."""
+    app = SearchControlsHarness()
+    async with app.run_test() as pilot:
+        controls = app.query_one("#controls", LibraryMediaContentSearchControls)
+
+        controls.sync_match_index(matches=(), match_index=0)
+        await pilot.pause()
+
+        assert str(app.query_one("#library-media-content-search-status", Static).renderable) == (
+            "No matches"
+        )
+
+
+@pytest.mark.asyncio
+async def test_match_index_sync_wraps_status_index() -> None:
+    """Catch a formatter that exposes an out-of-range rather than wrapped index."""
+    app = SearchControlsHarness()
+    async with app.run_test() as pilot:
+        controls = app.query_one("#controls", LibraryMediaContentSearchControls)
+
+        controls.sync_match_index(matches=(2, 8), match_index=3)
+        await pilot.pause()
+
+        assert str(app.query_one("#library-media-content-search-status", Static).renderable) == (
+            "Match 2 of 2 matches"
+        )
+
+
+@pytest.mark.asyncio
 async def test_blank_query_sync_removes_active_search_controls() -> None:
     """Catch a blank-query transition that leaves stale controls mounted."""
     app = SearchControlsHarness()

--- a/Tests/Library/test_library_media_content.py
+++ b/Tests/Library/test_library_media_content.py
@@ -1,14 +1,14 @@
-"""Mounted behavior tests for the Library media-content search controls.
+"""Mounted behavior tests for the Library media-content widgets."""
 
-Each test protects the structural recompose boundary: changing active search
-state must replace controls, while changing match data must preserve them.
-"""
+import asyncio
 
 import pytest
+from rich.text import Text
 from textual.app import App, ComposeResult
-from textual.widgets import Button, Input, Static
+from textual.widgets import Button, Input, Markdown, Static
 
 from tldw_chatbook.Widgets.Library.library_media_content import (
+    LibraryMediaContentBody,
     LibraryMediaContentSearchControls,
 )
 
@@ -37,6 +37,143 @@ class BlankSearchControlsHarness(App[None]):
             match_index=0,
             id="controls",
         )
+
+
+class BodyHarness(App[None]):
+    """Mount one supplied body instance without rebuilding it."""
+
+    def __init__(self, body: LibraryMediaContentBody) -> None:
+        super().__init__()
+        self._body = body
+
+    def compose(self) -> ComposeResult:
+        yield self._body
+
+
+class DelayedRenderedBody(LibraryMediaContentBody):
+    """Hold the first Rendered mount until the test selects a winner."""
+
+    def __init__(
+        self,
+        *args: object,
+        mount_started: asyncio.Event,
+        release: asyncio.Event,
+        raw_started: asyncio.Event,
+        release_raw: asyncio.Event,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._mount_started = mount_started
+        self._release = release
+        self._raw_started = raw_started
+        self._release_raw = release_raw
+        self._delay_rendered_mount = True
+        self._raw_ensure_calls = 0
+
+    async def _ensure_mode_mounted(self, mode: str) -> None:
+        if mode == "rendered" and self._delay_rendered_mount:
+            self._delay_rendered_mount = False
+            self._mount_started.set()
+            await self._release.wait()
+        if mode == "raw":
+            self._raw_ensure_calls += 1
+            if self._raw_ensure_calls == 2:
+                self._raw_started.set()
+                await self._release_raw.wait()
+        await super()._ensure_mode_mounted(mode)
+
+
+@pytest.mark.asyncio
+async def test_body_lazily_mounts_each_mode_once_and_reuses_widgets() -> None:
+    """Catch mode changes that recompose an already-mounted content view."""
+    body = LibraryMediaContentBody(
+        content="# Heading\n\nbudget one\nbudget two",
+        is_markdown=True,
+        mode="raw",
+        query="",
+        match_index=0,
+        id="library-media-viewer-content",
+    )
+    async with BodyHarness(body).run_test() as _pilot:
+        raw = body.query_one("#library-media-viewer-content-text", Static)
+        assert not body.query("#library-media-viewer-content-markdown")
+
+        await body.sync_mode("rendered")
+        markdown = body.query_one("#library-media-viewer-content-markdown", Markdown)
+        await body.sync_mode("raw")
+        await body.sync_mode("rendered")
+
+        assert body.query_one("#library-media-viewer-content-text") is raw
+        assert body.query_one("#library-media-viewer-content-markdown") is markdown
+
+
+@pytest.mark.asyncio
+async def test_body_search_updates_lazily_mounted_raw_rich_highlights() -> None:
+    """Catch Raw construction that loses search state set while Rendered is visible."""
+    body = LibraryMediaContentBody(
+        content="# Heading\n\nbudget one\nbudget two",
+        is_markdown=True,
+        mode="rendered",
+        query="",
+        match_index=0,
+        id="library-media-viewer-content",
+    )
+    async with BodyHarness(body).run_test() as _pilot:
+        body.sync_search("budget", 1)
+        await body.sync_mode("raw")
+
+        raw = body.query_one("#library-media-viewer-content-text", Static)
+        assert isinstance(raw.renderable, Text)
+        budget_spans = [
+            span
+            for span in raw.renderable.spans
+            if raw.renderable.plain[span.start : span.end] == "budget"
+        ]
+        assert len(budget_spans) == 2
+        assert [str(span.style) for span in budget_spans] == [
+            "reverse",
+            "reverse bold",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_body_rapid_mode_changes_leave_latest_mode_visible_once() -> None:
+    """Catch an earlier delayed request overriding the latest mode visibility."""
+    mount_started = asyncio.Event()
+    release = asyncio.Event()
+    raw_started = asyncio.Event()
+    release_raw = asyncio.Event()
+    body = DelayedRenderedBody(
+        content="# Heading",
+        is_markdown=True,
+        mode="raw",
+        query="",
+        match_index=0,
+        id="library-media-viewer-content",
+        mount_started=mount_started,
+        release=release,
+        raw_started=raw_started,
+        release_raw=release_raw,
+    )
+    async with BodyHarness(body).run_test() as _pilot:
+        rendered_task = asyncio.create_task(body.sync_mode("rendered"))
+        await mount_started.wait()
+        raw_task = asyncio.create_task(body.sync_mode("raw"))
+        release.set()
+        await raw_started.wait()
+
+        raw = body.query_one("#library-media-viewer-content-text", Static)
+        markdown = body.query_one("#library-media-viewer-content-markdown", Markdown)
+        assert raw.display
+        assert not markdown.display
+
+        release_raw.set()
+        await asyncio.gather(rendered_task, raw_task)
+
+        assert raw.display
+        assert not markdown.display
+        assert len(body.query("#library-media-viewer-content-text")) == 1
+        assert len(body.query("#library-media-viewer-content-markdown")) == 1
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -4474,7 +4474,7 @@ def _media_item_with_two_hits_on_one_line():
 
 
 def _large_markdown_media_item():
-    """A deterministic 2,000-line Markdown item with exactly 100 match lines."""
+    """A deterministic 2,000-line Markdown item with exactly 101 match lines."""
     items = _markdown_media_item()
     lines = ["# Large budget document"]
     lines.extend(
@@ -4921,6 +4921,103 @@ async def test_library_shell_media_viewer_inplace_large_document_latency_and_par
         assert set(observed_viewer_ids) == {id(viewer_before)}
         assert unique_markdown_ids == {id(markdown_before)}
         assert markdown_updates == [id(markdown_before)]
+
+
+@pytest.mark.asyncio
+async def test_library_shell_media_viewer_inplace_search_chrome_paints_above_content(
+    monkeypatch,
+):
+    """Catch content painting over search status and navigation at 170x48."""
+    markdown_updates: list[int] = []
+    original_update = Markdown.update
+
+    def recording_update(markdown_widget: Markdown, source: str):
+        markdown_updates.append(id(markdown_widget))
+        return original_update(markdown_widget, source)
+
+    monkeypatch.setattr(Markdown, "update", recording_update)
+    app = _build_test_app()
+    items = _large_markdown_media_item()
+    assert len(items[0]["content"]) == 49_288
+    _seed_conversations(app, _two_conversations(), media=items)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_media_viewer(screen, pilot)
+        viewer = screen.query_one("#library-media-viewer", LibraryMediaViewer)
+        markdown = screen.query_one(
+            "#library-media-viewer-content-markdown", Markdown
+        )
+
+        await _submit_content_search_query(screen, pilot, "budget")
+        controls = screen.query_one(
+            "#library-media-content-search-controls",
+            LibraryMediaContentSearchControls,
+        )
+        status = screen.query_one("#library-media-content-search-status", Static)
+        previous = screen.query_one("#library-media-content-search-prev", Button)
+        next_button = screen.query_one("#library-media-content-search-next", Button)
+        body = screen.query_one(
+            "#library-media-viewer-content", LibraryMediaContentBody
+        )
+        await pilot.pause()
+
+        strips = screen._compositor.render_strips()
+        rows = ["".join(segment.text for segment in strip) for strip in strips]
+        painted = "\n".join(rows)
+        heading_row = next(
+            (index for index, row in enumerate(rows) if "Large budget document" in row),
+            None,
+        )
+        visible_strings = tuple(
+            text
+            for text in (
+                "Match 1 of 101 matches",
+                "◀ Prev",
+                "Next ▶",
+                "Large budget document",
+            )
+            if text in painted
+        )
+        print(
+            "TASK-15458 rendered UAT "
+            f"controls={controls.region} status={status.region} "
+            f"previous={previous.region} next={next_button.region} "
+            f"content={body.region} heading_row={heading_row} "
+            f"visible_strings={ascii(visible_strings)}"
+        )
+
+        assert controls.region.bottom <= body.region.y
+        assert status.region.bottom <= body.region.y
+        assert previous.region.bottom <= body.region.y
+        assert next_button.region.bottom <= body.region.y
+        assert "Match 1 of 101 matches" in painted
+        assert "◀ Prev" in painted
+        assert "Next ▶" in painted
+        assert heading_row is not None
+        assert heading_row >= body.region.y
+        assert body.styles.min_height is not None
+        assert body.styles.min_height.value == 3
+        assert body.styles.max_height is not None
+        assert body.styles.max_height.value == 18
+
+        parse_count_before_navigation = len(markdown_updates)
+        next_button.focus()
+        next_button.press()
+        await pilot.pause()
+
+        assert screen.query_one("#library-media-viewer") is viewer
+        assert screen.query_one("#library-media-viewer-content-markdown") is markdown
+        assert screen.query_one("#library-media-content-search-prev") is previous
+        assert screen.query_one("#library-media-content-search-next") is next_button
+        assert screen.focused is next_button
+        assert len(markdown_updates) == parse_count_before_navigation
+        assert body.max_scroll_y > 0
+        body.scroll_to(y=10, animate=False, immediate=True)
+        await pilot.pause()
+        assert body.scroll_y > 0
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -5,6 +5,7 @@ import asyncio
 import dataclasses
 import json
 import re
+import statistics
 import threading
 import time
 from datetime import datetime, timezone
@@ -15,7 +16,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from rich.cells import cell_len
 from textual.app import App, ComposeResult
-from textual.containers import Vertical
+from textual.containers import Vertical, VerticalScroll
 from textual.screen import Screen
 from textual.widgets import Button, Collapsible, Input, Markdown, Static, TextArea
 
@@ -92,6 +93,10 @@ from tldw_chatbook.UI.Screens import library_screen as library_screen_module
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
 from tldw_chatbook.Widgets.Library.library_ingest_canvas import LibraryIngestCanvas
+from tldw_chatbook.Widgets.Library.library_media_content import (
+    LibraryMediaContentBody,
+)
+from tldw_chatbook.Widgets.Library.library_media_viewer import LibraryMediaViewer
 from tldw_chatbook.Widgets.Library.library_notes_canvas import LibraryNotesCanvas
 from tldw_chatbook.Widgets.Library.library_rail import (
     LIBRARY_RAIL_ROW_PREFIX,
@@ -4467,6 +4472,18 @@ def _media_item_with_two_hits_on_one_line():
     return items
 
 
+def _large_markdown_media_item():
+    """A deterministic 2,000-line Markdown item with exactly 100 match lines."""
+    items = _markdown_media_item()
+    lines = ["# Large budget document"]
+    lines.extend(
+        f"Line {index}: {'budget checkpoint' if index % 20 == 0 else 'ordinary text'}"
+        for index in range(1_999)
+    )
+    items[0]["content"] = "\n".join(lines)
+    return items
+
+
 async def _open_media_viewer(screen, pilot):
     """Navigate to the media list and open the first row's viewer."""
     screen.query_one("#library-row-browse-media").press()
@@ -4689,6 +4706,188 @@ async def test_library_shell_media_content_search_next_prev_advances_match_index
 
 
 @pytest.mark.asyncio
+async def test_library_shell_media_viewer_inplace_search_preserves_identity_focus_and_parse_count(
+    monkeypatch,
+):
+    """Catch submit/navigation rebuilding the viewer or reparsing Markdown."""
+    markdown_updates: list[tuple[int, str]] = []
+    original_update = Markdown.update
+
+    def recording_update(markdown_widget: Markdown, source: str):
+        markdown_updates.append((id(markdown_widget), source))
+        return original_update(markdown_widget, source)
+
+    monkeypatch.setattr(Markdown, "update", recording_update)
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_markdown_media_item())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_media_viewer(screen, pilot)
+
+        screen_before = screen
+        viewer_before = screen.query_one("#library-media-viewer", LibraryMediaViewer)
+        markdown_before = screen.query_one(
+            "#library-media-viewer-content-markdown", Markdown
+        )
+        await _submit_content_search_query(screen, pilot, "setup")
+        parse_count_before_navigation = len(markdown_updates)
+        next_button = screen.query_one("#library-media-content-search-next", Button)
+        previous_button = screen.query_one("#library-media-content-search-prev", Button)
+        next_button.focus()
+        next_button.press()
+        await pilot.pause()
+
+        assert screen is screen_before
+        assert screen.query_one("#library-media-viewer") is viewer_before
+        assert (
+            screen.query_one("#library-media-viewer-content-markdown")
+            is markdown_before
+        )
+        assert screen.query_one("#library-media-content-search-next") is next_button
+        assert screen.query_one("#library-media-content-search-prev") is previous_button
+        assert screen.focused is next_button
+        assert len(markdown_updates) == parse_count_before_navigation
+
+
+@pytest.mark.asyncio
+async def test_library_shell_media_viewer_inplace_search_applies_only_on_enter():
+    """Catch Input.Changed applying the Library query before Enter is submitted."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_markdown_media_item())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_media_viewer(screen, pilot)
+        search_input = screen.query_one("#library-media-content-search", Input)
+
+        search_input.value = "setup"
+        await pilot.pause()
+
+        assert screen._library_media_content_query == ""
+        assert screen.query_one("#library-media-content-search", Input) is search_input
+        assert not screen.query("#library-media-content-search-status")
+
+
+@pytest.mark.asyncio
+async def test_library_shell_media_viewer_inplace_scroll_waits_for_refresh_boundary(
+    monkeypatch,
+):
+    """Catch match navigation scrolling synchronously before refreshed layout settles."""
+    app = _build_test_app()
+    _seed_conversations(
+        app, _two_conversations(), media=_media_item_with_multiline_content()
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_media_viewer_and_submit_content_search(screen, pilot, "budget")
+        body = screen.query_one(
+            "#library-media-viewer-content", LibraryMediaContentBody
+        )
+        scroll_calls: list[tuple[int | None, bool]] = []
+        original_scroll_to = VerticalScroll.scroll_to
+
+        def recording_scroll_to(
+            scroll: VerticalScroll,
+            *,
+            y: int | None = None,
+            animate: bool = True,
+            **kwargs,
+        ):
+            if scroll is body:
+                scroll_calls.append((y, animate))
+            return original_scroll_to(scroll, y=y, animate=animate, **kwargs)
+
+        monkeypatch.setattr(VerticalScroll, "scroll_to", recording_scroll_to)
+
+        screen.query_one("#library-media-content-search-next", Button).press()
+        assert scroll_calls == []
+        await pilot.pause()
+
+        assert scroll_calls == [(3, False)]
+
+
+@pytest.mark.asyncio
+async def test_library_shell_media_viewer_inplace_large_document_latency_and_parse_proxy(
+    monkeypatch,
+):
+    """Record deterministic submit/Next/Prev latency and Markdown construction proxy."""
+    markdown_updates: list[int] = []
+    original_update = Markdown.update
+
+    def recording_update(markdown_widget: Markdown, source: str):
+        markdown_updates.append(id(markdown_widget))
+        return original_update(markdown_widget, source)
+
+    monkeypatch.setattr(Markdown, "update", recording_update)
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_large_markdown_media_item())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_media_viewer(screen, pilot)
+        viewer_before = screen.query_one("#library-media-viewer", LibraryMediaViewer)
+        markdown_before = screen.query_one(
+            "#library-media-viewer-content-markdown", Markdown
+        )
+        observed_viewer_ids = [id(viewer_before)]
+        observed_markdown_ids = [id(markdown_before)]
+        durations_ms: list[float] = []
+
+        started = time.perf_counter()
+        await _submit_content_search_query(screen, pilot, "budget")
+        durations_ms.append((time.perf_counter() - started) * 1_000)
+        observed_markdown_ids.append(
+            id(screen.query_one("#library-media-viewer-content-markdown", Markdown))
+        )
+        observed_viewer_ids.append(
+            id(screen.query_one("#library-media-viewer", LibraryMediaViewer))
+        )
+
+        for selector in (
+            "#library-media-content-search-next",
+            "#library-media-content-search-prev",
+        ):
+            started = time.perf_counter()
+            screen.query_one(selector, Button).press()
+            await pilot.pause()
+            await pilot.pause()
+            durations_ms.append((time.perf_counter() - started) * 1_000)
+            observed_markdown_ids.append(
+                id(screen.query_one("#library-media-viewer-content-markdown", Markdown))
+            )
+            observed_viewer_ids.append(
+                id(screen.query_one("#library-media-viewer", LibraryMediaViewer))
+            )
+
+        median_ms = statistics.median(durations_ms)
+        unique_markdown_ids = set(observed_markdown_ids)
+        print(f"TASK-15458 latency median_ms={median_ms:.3f}")
+        print(
+            "TASK-15458 evidence "
+            f"screen_id={id(screen)} "
+            f"viewer_ids={observed_viewer_ids} "
+            f"markdown_ids={observed_markdown_ids} "
+            f"unique_markdown_ids={len(unique_markdown_ids)} "
+            f"markdown_update_count={len(markdown_updates)}"
+        )
+
+        assert screen.query_one("#library-media-viewer") is viewer_before
+        assert set(observed_viewer_ids) == {id(viewer_before)}
+        assert unique_markdown_ids == {id(markdown_before)}
+        assert markdown_updates == [id(markdown_before)]
+
+
+@pytest.mark.asyncio
 async def test_library_shell_media_content_search_resets_on_back():
     """Returning to the media list clears the in-content search state."""
     app = _build_test_app()
@@ -4816,25 +5015,60 @@ async def test_library_shell_media_viewer_raw_toggle_restores_literal_markdown()
         await _wait_for_library_shell(screen, pilot)
         await _open_media_viewer(screen, pilot)
 
+        markdown = screen.query_one("#library-media-viewer-content-markdown", Markdown)
+
         screen.query_one("#library-media-content-mode-raw", Button).press()
         await pilot.pause()
         await pilot.pause()
 
         assert screen._library_media_content_mode == "raw"
-        raw_text = _markdown_text_widget_plain(
-            screen.query_one("#library-media-viewer-content-text")
-        )
+        raw = screen.query_one("#library-media-viewer-content-text", Static)
+        raw_text = _markdown_text_widget_plain(raw)
         assert "# Setup Guide" in raw_text
         assert "| --- | --- |" in raw_text
-        assert not screen.query("#library-media-viewer-content-markdown")
+        assert screen.query_one("#library-media-viewer-content-markdown") is markdown
+        assert raw.display
+        assert not markdown.display
 
         screen.query_one("#library-media-content-mode-rendered", Button).press()
         await pilot.pause()
         await pilot.pause()
 
         assert screen._library_media_content_mode == "rendered"
-        assert screen.query_one("#library-media-viewer-content-markdown")
-        assert not screen.query("#library-media-viewer-content-text")
+        assert screen.query_one("#library-media-viewer-content-markdown") is markdown
+        assert screen.query_one("#library-media-viewer-content-text") is raw
+        assert markdown.display
+        assert not raw.display
+
+
+@pytest.mark.asyncio
+async def test_library_shell_media_viewer_inplace_rendered_search_primes_raw_highlight():
+    """Catch Rendered search state being lost when Raw mounts lazily afterward."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_markdown_media_item())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_media_viewer(screen, pilot)
+
+        await _submit_content_search_query(screen, pilot, "setup")
+        screen.query_one("#library-media-content-mode-raw", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+
+        raw = screen.query_one("#library-media-viewer-content-text", Static)
+        assert raw.display
+        assert raw.renderable.plain.rstrip() == _markdown_media_item()[0][
+            "content"
+        ].rstrip()
+        selected = [
+            raw.renderable.plain[span.start : span.end]
+            for span in raw.renderable.spans
+            if str(span.style) == "reverse bold"
+        ]
+        assert selected == ["Setup"]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -95,6 +95,7 @@ from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
 from tldw_chatbook.Widgets.Library.library_ingest_canvas import LibraryIngestCanvas
 from tldw_chatbook.Widgets.Library.library_media_content import (
     LibraryMediaContentBody,
+    LibraryMediaContentSearchControls,
 )
 from tldw_chatbook.Widgets.Library.library_media_viewer import LibraryMediaViewer
 from tldw_chatbook.Widgets.Library.library_notes_canvas import LibraryNotesCanvas
@@ -4771,6 +4772,41 @@ async def test_library_shell_media_viewer_inplace_search_applies_only_on_enter()
         assert screen._library_media_content_query == ""
         assert screen.query_one("#library-media-content-search", Input) is search_input
         assert not screen.query("#library-media-content-search-status")
+
+
+@pytest.mark.asyncio
+async def test_library_shell_media_viewer_inplace_teardown_contains_child_query_errors():
+    """Catch mounted-viewer coordinators leaking child teardown query failures."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_markdown_media_item())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_media_viewer(screen, pilot)
+        viewer = screen.query_one("#library-media-viewer", LibraryMediaViewer)
+        search_input = screen.query_one("#library-media-content-search", Input)
+        controls = viewer.query_one(
+            "#library-media-content-search-controls",
+            LibraryMediaContentSearchControls,
+        )
+
+        await controls.remove()
+        assert screen.query_one("#library-media-viewer") is viewer
+
+        screen.handle_library_media_content_search_submitted(
+            Input.Submitted(search_input, "setup")
+        )
+        screen._advance_library_media_content_match(1)
+
+        body = viewer.query_one(
+            "#library-media-viewer-content", LibraryMediaContentBody
+        )
+        await body.remove()
+        assert screen.query_one("#library-media-viewer") is viewer
+
+        await screen._set_library_media_content_mode("raw")
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_media_viewer_content_search_debounce.py
+++ b/Tests/UI/test_media_viewer_content_search_debounce.py
@@ -1,0 +1,161 @@
+"""Regression coverage for legacy MediaViewerPanel content-search timing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.await_complete import AwaitComplete
+from textual.widgets import Input, Markdown
+
+from tldw_chatbook.Widgets.Media.media_viewer_panel import MediaViewerPanel
+
+
+pytestmark = pytest.mark.allow_network
+
+CONTENT = "budget planning mentions budget twice, then a third budget follows."
+NEW_CONTENT = "replacement budget transcript with a fresh matching word."
+
+
+class _TestMediaViewerPanel(MediaViewerPanel):
+    def populate_providers(self) -> None:
+        pass
+
+
+class _MediaViewerApp(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.panel = _TestMediaViewerPanel(Mock())
+
+    def compose(self) -> ComposeResult:
+        yield self.panel
+
+
+def _record_content_updates(
+    monkeypatch: pytest.MonkeyPatch, panel: MediaViewerPanel
+) -> tuple[Markdown, list[tuple[str, AwaitComplete]]]:
+    content_display = panel.query_one("#content-display", Markdown)
+    updates: list[tuple[str, AwaitComplete]] = []
+    original_update = content_display.update
+
+    def recording_update(markdown: str) -> AwaitComplete:
+        completion = original_update(markdown)
+        updates.append((markdown, completion))
+        return completion
+
+    monkeypatch.setattr(content_display, "update", recording_update)
+    return content_display, updates
+
+
+async def _await_updates(updates: list[tuple[str, AwaitComplete]]) -> None:
+    for _, completion in updates:
+        await completion
+
+
+async def _mounted_panel(
+    pilot, monkeypatch: pytest.MonkeyPatch, *, record_id: str | None = "media-1"
+) -> tuple[MediaViewerPanel, Input, list[tuple[str, AwaitComplete]]]:
+    panel = pilot.app.panel
+    panel.load_media({"id": record_id, "title": "Budget", "content": CONTENT})
+    await pilot.pause()
+    _, updates = _record_content_updates(monkeypatch, panel)
+    return panel, panel.query_one("#content-search-input", Input), updates
+
+
+@pytest.mark.asyncio
+async def test_content_search_burst_renders_only_final_query_after_debounce(monkeypatch):
+    app = _MediaViewerApp()
+    async with app.run_test() as pilot:
+        _, search_input, updates = await _mounted_panel(pilot, monkeypatch)
+        search_input.value = "b"
+        await pilot.pause(0.04)
+        search_input.value = "bu"
+        await pilot.pause(0.04)
+        search_input.value = "budget"
+        await pilot.pause(0.10)
+        assert updates == []
+        await pilot.pause(0.20)
+        await _await_updates(updates)
+        assert len(updates) == 1
+        assert updates[0][0]
+        assert "▶ budget ◀" in updates[0][0]
+
+
+@pytest.mark.asyncio
+async def test_clearing_search_renders_unhighlighted_content_without_stale_callback(monkeypatch):
+    app = _MediaViewerApp()
+    async with app.run_test() as pilot:
+        _, search_input, updates = await _mounted_panel(pilot, monkeypatch)
+        search_input.value = "budget"
+        await pilot.pause(0.05)
+        search_input.value = ""
+        await pilot.pause()
+        await pilot.pause(0.30)
+        await _await_updates(updates)
+        assert len(updates) == 1
+        assert "▶" not in updates[0][0]
+        assert CONTENT in updates[0][0]
+
+
+@pytest.mark.asyncio
+async def test_loading_replacement_prevents_pending_query_from_rendering_on_new_content(monkeypatch):
+    app = _MediaViewerApp()
+    async with app.run_test() as pilot:
+        panel, search_input, updates = await _mounted_panel(pilot, monkeypatch)
+        search_input.value = "budget"
+        await pilot.pause(0.05)
+        panel.load_media({"id": "media-2", "title": "New", "content": NEW_CONTENT})
+        await pilot.pause(0.30)
+        await _await_updates(updates)
+        assert updates
+        assert all("▶ budget ◀" not in markdown for markdown, _ in updates)
+        assert updates[-1][0] == NEW_CONTENT
+
+
+@pytest.mark.asyncio
+async def test_clear_display_remains_authoritative_after_pending_query(monkeypatch):
+    app = _MediaViewerApp()
+    async with app.run_test() as pilot:
+        panel, search_input, updates = await _mounted_panel(pilot, monkeypatch)
+        search_input.value = "budget"
+        await pilot.pause(0.05)
+        panel.clear_display()
+        await pilot.pause(0.30)
+        await _await_updates(updates)
+        assert updates
+        assert updates[-1][0] == "*No item selected*"
+        assert all("▶ budget ◀" not in markdown for markdown, _ in updates)
+
+
+@pytest.mark.asyncio
+async def test_unmounted_panel_ignores_pending_search_callback(monkeypatch):
+    app = _MediaViewerApp()
+    async with app.run_test() as pilot:
+        panel, search_input, updates = await _mounted_panel(pilot, monkeypatch)
+        search_input.value = "budget"
+        await pilot.pause(0.05)
+        await panel.remove()
+        await pilot.pause(0.30)
+        assert updates == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("record_id", ["same-id", None])
+async def test_generation_invalidates_pending_query_for_same_or_missing_record_id(
+    monkeypatch, record_id
+):
+    app = _MediaViewerApp()
+    async with app.run_test() as pilot:
+        panel, _, updates = await _mounted_panel(
+            pilot, monkeypatch, record_id=record_id
+        )
+        panel.handle_content_search(SimpleNamespace(value="budget"))
+        await pilot.pause(0.05)
+        panel.load_media({"id": record_id, "title": "Second", "content": NEW_CONTENT})
+        await pilot.pause(0.30)
+        await _await_updates(updates)
+        assert updates
+        assert updates[-1][0] == NEW_CONTENT
+        assert all("▶ budget ◀" not in markdown for markdown, _ in updates)

--- a/Tests/UI/test_media_viewer_content_search_debounce.py
+++ b/Tests/UI/test_media_viewer_content_search_debounce.py
@@ -13,8 +13,6 @@ from textual.widgets import Input, Markdown
 from tldw_chatbook.Widgets.Media.media_viewer_panel import MediaViewerPanel
 
 
-pytestmark = pytest.mark.allow_network
-
 CONTENT = "budget planning mentions budget twice, then a third budget follows."
 NEW_CONTENT = "replacement budget transcript with a fresh matching word."
 

--- a/Tests/network_guard.py
+++ b/Tests/network_guard.py
@@ -43,6 +43,7 @@ A test that genuinely needs a socket marks itself
 from __future__ import annotations
 
 import socket
+import threading
 from typing import Any
 
 __all__ = [
@@ -78,6 +79,9 @@ _real_connect = socket.socket.connect
 _real_connect_ex = socket.socket.connect_ex
 _real_create_connection = socket.create_connection
 _real_sendto = socket.socket.sendto
+_real_socketpair = socket.socketpair
+
+_socketpair_state = threading.local()
 
 _INET_FAMILIES = frozenset({socket.AF_INET, socket.AF_INET6})
 
@@ -138,7 +142,22 @@ def _deny(call: str, address: Any) -> BlockedNetworkAccess:
 
 def _should_block(family: Any) -> bool:
     """Return whether egress on this address family is guarded."""
-    return not _allowed and family in _INET_FAMILIES
+    return not (_allowed or _inside_socketpair()) and family in _INET_FAMILIES
+
+
+def _inside_socketpair() -> bool:
+    """Return whether this thread is executing the real socketpair call."""
+    return getattr(_socketpair_state, "depth", 0) > 0
+
+
+def _guarded_socketpair(*args: Any, **kwargs: Any):  # noqa: ANN401
+    """Call socketpair while allowing only its current-thread bootstrap connect."""
+    prior_depth = getattr(_socketpair_state, "depth", 0)
+    _socketpair_state.depth = prior_depth + 1
+    try:
+        return _real_socketpair(*args, **kwargs)
+    finally:
+        _socketpair_state.depth = prior_depth
 
 
 def _guarded_connect(self: socket.socket, address: Any):  # noqa: ANN401
@@ -161,7 +180,7 @@ def _guarded_sendto(self: socket.socket, *args: Any, **kwargs: Any):  # noqa: AN
 
 
 def _guarded_create_connection(address: Any, *args: Any, **kwargs: Any):  # noqa: ANN401
-    if not _allowed:
+    if not _allowed and not _inside_socketpair():
         raise _deny("socket.create_connection", address)
     return _real_create_connection(address, *args, **kwargs)
 
@@ -175,4 +194,5 @@ def install() -> None:
     socket.socket.connect_ex = _guarded_connect_ex  # type: ignore[method-assign]
     socket.socket.sendto = _guarded_sendto  # type: ignore[method-assign]
     socket.create_connection = _guarded_create_connection  # type: ignore[assignment]
+    socket.socketpair = _guarded_socketpair  # type: ignore[assignment]
     _installed = True

--- a/Tests/test_network_guard.py
+++ b/Tests/test_network_guard.py
@@ -264,6 +264,77 @@ def test_socketpair_exception_restores_network_denial(monkeypatch) -> None:
     assert ("socket.connect", "127.0.0.1:8080") in _drain_expecting()
 
 
+def test_nested_socketpair_restores_outer_dynamic_exemption(monkeypatch) -> None:
+    """Catch nested socketpair cleanup that resets rather than restores depth."""
+    inner_pair = (object(), object())
+    outer_pair = (object(), object())
+    calls = 0
+    permitted_connects: list[tuple[str, int]] = []
+
+    def fake_connect(_sock, address):  # noqa: ANN001
+        permitted_connects.append(address)
+        return None
+
+    def recursive_socketpair(*args, **kwargs):  # noqa: ANN002, ANN003
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            return inner_pair
+
+        assert socket.socketpair(*args, **kwargs) == inner_pair
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            client.connect(("127.0.0.1", 8080))
+        finally:
+            client.close()
+        return outer_pair
+
+    monkeypatch.setattr(network_guard, "_real_connect", fake_connect)
+    monkeypatch.setattr(network_guard, "_real_socketpair", recursive_socketpair)
+
+    assert socket.socketpair() == outer_pair
+    assert permitted_connects == [("127.0.0.1", 8080)]
+    assert network_guard.blocked_attempts() == ()
+
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(network_guard.BlockedNetworkAccess):
+            client.connect(("127.0.0.1", 8080))
+    finally:
+        client.close()
+    assert ("socket.connect", "127.0.0.1:8080") in _drain_expecting()
+
+
+def test_create_connection_is_exempt_only_inside_socketpair_scope(monkeypatch) -> None:
+    """Catch create_connection omitting or leaking its socketpair exemption."""
+    connection_sentinel = object()
+    socketpair_sentinels = (object(), object())
+    calls: list[tuple[tuple[str, int], tuple[object, ...], dict[str, object]]] = []
+
+    def fake_create_connection(address, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        calls.append((address, args, kwargs))
+        return connection_sentinel
+
+    def fake_socketpair(*_args, **_kwargs):  # noqa: ANN002, ANN003
+        result = socket.create_connection(("127.0.0.1", 8080), timeout=1)
+        assert result is connection_sentinel
+        assert network_guard.blocked_attempts() == ()
+        return socketpair_sentinels
+
+    monkeypatch.setattr(
+        network_guard, "_real_create_connection", fake_create_connection
+    )
+    monkeypatch.setattr(network_guard, "_real_socketpair", fake_socketpair)
+
+    assert socket.socketpair() == socketpair_sentinels
+    assert calls == [(("127.0.0.1", 8080), (), {"timeout": 1})]
+    assert network_guard.blocked_attempts() == ()
+
+    with pytest.raises(network_guard.BlockedNetworkAccess):
+        socket.create_connection(("127.0.0.1", 8080), timeout=1)
+    assert ("socket.create_connection", "127.0.0.1:8080") in _drain_expecting()
+
+
 def test_repeated_install_keeps_one_guarded_socketpair_wrapper() -> None:
     """Catch repeated installation stacking socketpair wrappers."""
     wrapper = socket.socketpair

--- a/Tests/test_network_guard.py
+++ b/Tests/test_network_guard.py
@@ -12,6 +12,7 @@ explicit opt-in works.
 from __future__ import annotations
 
 import socket
+import sys
 import threading
 
 import pytest
@@ -117,6 +118,7 @@ def test_a_swallowed_block_still_fails_the_test() -> None:
     assert recorded[0][1] == "127.0.0.1:8080"
 
 
+@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="AF_UNIX unavailable")
 def test_unix_domain_sockets_are_not_blocked(tmp_path, monkeypatch) -> None:
     """AF_UNIX is local IPC used by system libraries, not network egress."""
     # Bound by a RELATIVE name from inside tmp_path: macOS caps sun_path at
@@ -179,3 +181,93 @@ def test_denial_is_restored_after_an_opted_in_test() -> None:
     with pytest.raises(network_guard.BlockedNetworkAccess):
         socket.create_connection(("127.0.0.1", 8080), timeout=1)
     _drain_expecting()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows socketpair fallback")
+def test_guarded_socketpair_exchanges_data_without_weakening_family_denial() -> None:
+    """Catch a socketpair bootstrap path that requires clearing guarded families."""
+    protected_families = network_guard._INET_FAMILIES
+
+    left, right = socket.socketpair()
+    try:
+        left.sendall(b"x")
+        assert right.recv(1) == b"x"
+    finally:
+        left.close()
+        right.close()
+
+    assert network_guard._INET_FAMILIES is protected_families
+    assert network_guard.blocked_attempts() == ()
+
+
+def test_socketpair_exemption_does_not_escape_to_another_thread(monkeypatch) -> None:
+    """Catch a process-global socketpair exemption that leaks concurrent egress."""
+    entered = threading.Event()
+    release = threading.Event()
+    worker_errors: list[BaseException] = []
+    real_socketpair = getattr(network_guard, "_real_socketpair", socket.socketpair)
+
+    def held_socketpair(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        entered.set()
+        assert release.wait(timeout=5), "test did not release held socketpair"
+        return real_socketpair(*args, **kwargs)
+
+    monkeypatch.setattr(network_guard, "_real_socketpair", held_socketpair, raising=False)
+
+    def run_socketpair() -> None:
+        try:
+            left, right = socket.socketpair()
+            left.close()
+            right.close()
+        except BaseException as exc:  # pragma: no cover - assertion aid
+            worker_errors.append(exc)
+
+    worker = threading.Thread(target=run_socketpair)
+    worker.start()
+    try:
+        assert entered.wait(timeout=5), "guarded socketpair did not enter wrapper"
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            with pytest.raises(network_guard.BlockedNetworkAccess):
+                client.connect(("127.0.0.1", 8080))
+        finally:
+            client.close()
+        assert ("socket.connect", "127.0.0.1:8080") in _drain_expecting()
+    finally:
+        release.set()
+        worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert not worker_errors
+
+
+def test_socketpair_exception_restores_network_denial(monkeypatch) -> None:
+    """Catch an exception path that leaves the dynamic socketpair exemption set."""
+    class SocketpairFailure(RuntimeError):
+        pass
+
+    def raising_socketpair(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        raise SocketpairFailure("socketpair failed")
+
+    monkeypatch.setattr(
+        network_guard, "_real_socketpair", raising_socketpair, raising=False
+    )
+    with pytest.raises(SocketpairFailure, match="socketpair failed"):
+        socket.socketpair()
+
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(network_guard.BlockedNetworkAccess):
+            client.connect(("127.0.0.1", 8080))
+    finally:
+        client.close()
+    assert ("socket.connect", "127.0.0.1:8080") in _drain_expecting()
+
+
+def test_repeated_install_keeps_one_guarded_socketpair_wrapper() -> None:
+    """Catch repeated installation stacking socketpair wrappers."""
+    wrapper = socket.socketpair
+    network_guard.install()
+
+    assert socket.socketpair is wrapper
+    assert socket.socketpair is network_guard._guarded_socketpair

--- a/backlog/decisions/058-thread-scoped-test-socketpair-exemption.md
+++ b/backlog/decisions/058-thread-scoped-test-socketpair-exemption.md
@@ -1,0 +1,75 @@
+# ADR-058: Thread-Scoped Test Socketpair Exemption
+
+**Status:** Accepted
+**Date:** 2026-08-12
+**Related task:** [TASK-15458](../tasks/task-15458%20-%20Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md)
+
+## Allocation
+
+The allocation checked `origin/dev` and every open pull-request head visible on
+2026-08-12. ADR-057 was the highest allocated number and no ADR-058 was found.
+
+## Context
+
+The test suite installs a process-wide, default-deny network guard when
+`Tests.conftest` is imported. On Windows with Python 3.12, asynchronous event
+loop bootstrap calls the standard library's fallback `socket.socketpair()`.
+That fallback creates an internal loopback TCP connection, which the guard
+cannot distinguish from application egress and therefore blocks before pytest
+fixtures or markers can run.
+
+TASK-15100 documented a temporary command-line workaround that removes
+`AF_INET` and `AF_INET6` from the guard's protected families. That makes pytest
+run, but it also disables the property the guard exists to enforce. TASK-15458
+review requires its literal focused pytest command to work without weakening
+ordinary or concurrent-thread network denial.
+
+## Decision
+
+The network guard will capture the real `socket.socketpair` during its
+idempotent installation and replace it with a wrapper. The wrapper maintains a
+nested depth counter in `threading.local()`, calls the captured implementation,
+and restores the prior depth in `finally`.
+
+The guard permits protected-family connections only while the current thread's
+socketpair depth is positive. The exception is therefore limited to the
+dynamic extent of a standard-library socketpair call on that same thread. It
+does not toggle the process-global explicit-test allow flag and does not alter
+the protected-family set.
+
+The following boundaries are required:
+
+- Import-time installation and default denial remain in force.
+- Direct `connect`, `connect_ex`, `sendto`, and `create_connection` attempts
+  remain blocked and recorded.
+- The exception applies only to the current thread and only during the captured
+  socketpair call.
+- Nested calls and all exceptional exits restore the previous depth.
+- A concurrent thread remains denied while another thread is in socketpair.
+- The existing explicit global allow remains the sole general test opt-in.
+- `AF_UNIX` and other unprotected address families remain unaffected.
+- Tests cover real Windows socketpair behavior, cross-thread isolation,
+  exceptional restoration, ordinary denial, and literal async pytest startup.
+
+## Alternatives Considered
+
+| Alternative | Rejected because |
+| --- | --- |
+| Temporarily enable the global allow flag | Creates a process-wide race in which concurrent application egress can escape the guard. |
+| Allow loopback or ephemeral ports generally | Reintroduces the original class of localhost-network escapes and cannot reliably identify socketpair traffic. |
+| Inspect the Python call stack | Is brittle across Python versions and alternative runtimes, and is easier for tested code to imitate. |
+| Install the guard after event-loop setup | Weakens import-time coverage and leaves early application imports unguarded. |
+| Keep mutating the protected-family set in test commands | Makes successful runs cease to be evidence that the network guard works. |
+
+## Consequences
+
+Literal Windows async pytest commands can initialize their event loops while
+the suite retains meaningful default-deny evidence. The implementation gains a
+small thread-local wrapper and Windows-specific regression tests. Future Python
+runtime changes to `socket.socketpair` remain observable through focused tests,
+and any broader exception requires a separate decision.
+
+## References
+
+- [Windows test network guard socketpair design](../../Docs/superpowers/specs/2026-08-12-windows-test-network-guard-socketpair-design.md)
+- [Testing evidence lessons](../docs/lessons-testing-evidence.md)

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -52,6 +52,9 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-053](053-mcp-unified-standalone-runtime-boundary.md) | Accepted | Replace FastMCP with the public `mcp-unified` strict stdio runtime while preserving Chatbook's standalone catalog, in-app Library boundary, permission policy, and bounded canonical mappings. |
 | [ADR-054](054-deterministic-visual-transcript-compaction.md) | Accepted | Keep visual transcript pages deterministic, on-device, request-scoped, exactly accounted, capability-gated, and safely recoverable through text compaction. |
 | [ADR-055](055-library-destructive-action-reversibility-rule.md) | Accepted | One reversibility rule for Library destructive actions: soft deletes owe a receipt + Undo with Trash as the durable story, hard deletes state permanence, draft discards confirm without receipts, and blank-note GC is the guarded named exception. |
+| [ADR-056](056-context-use-visual-compaction-evaluation.md) | Accepted | Evaluate visual transcript compaction by using image history as context for downstream answers rather than requiring full transcript OCR. |
+| [ADR-057](057-portable-chatbook-prompt-records.md) | Accepted | Add versioned portable Prompt records inside the existing Chatbook 1.0 Prompt content seam. |
+| [ADR-058](058-thread-scoped-test-socketpair-exemption.md) | Accepted | Permit only same-thread connections made dynamically inside the real socketpair implementation while preserving the test network guard's process-wide default denial. |
 
 ## Historical Decision Material
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -2775,8 +2775,15 @@ test using SQLite or injected fakes.
 loopback self-pipe from application egress *before* async fixtures are created (or use a
 guarding layer that does not intercept the runtime's wakeup channel). Do not paper over
 the issue by marking broad UI suites `allow_network`: that restores the exact application
-escape the guard exists to detect. Until the shared harness is corrected, record the
-scoped guard workaround with focused-test evidence and keep live/external clients stubbed.
+escape the guard exists to detect. TASK-15458 replaced the temporary family-set workaround
+with ADR-058's thread-local, dynamic `socketpair()` exemption: only the calling thread is
+permitted while the captured real socketpair call is active, and `finally` restores nested
+depth on success or error. Literal Windows commands
+`python -m pytest Tests/test_network_guard.py -q`,
+`python -m pytest Tests/Library/test_library_media_content.py -q`, and their combined form
+passed without changing `_INET_FAMILIES`; focused tests also proved same-thread direct
+egress stays blocked and recorded after an exception, while concurrent-thread egress stays
+blocked and recorded during socketpair. Keep live/external clients stubbed.
 
 ---
 

--- a/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
+++ b/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
@@ -84,7 +84,7 @@ latest-request-wins body contract. No dependencies, persistence, workers, legacy
 Media debounce, or geometry rules changed.
 
 The required focused product-path command passed all 16 selected tests. Its
-2,000-line/100-match evidence recorded `TASK-15458 latency median_ms=120.913`,
+2,000-line/101-match evidence recorded `TASK-15458 latency median_ms=120.913`,
 one stable screen ID (`2247968276448`), one stable viewer ID
 (`2247963750576` across all four observations), one stable Markdown ID
 (`2247965990096` across all four observations), and one `Markdown.update` call

--- a/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
+++ b/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15458
 title: Library media viewer: in-place match navigation instead of full-document re-parse
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-11 12:05'
 labels:
@@ -22,7 +22,7 @@ Fix direction: keep the Markdown widget mounted and move match-highlight and scr
 <!-- AC:BEGIN -->
 - [x] #1 Match navigation does not re-parse the document or remount the screen (evidence)
 - [x] #2 Search-while-typing performs at most one deferred re-render per debounce window and never the double update(\"\")/update(content) parse
-- [ ] #3 Match highlighting and scroll behavior preserved (tests); click latency before/after on a long document recorded
+- [x] #3 Match highlighting and scroll behavior preserved (tests); click latency before/after on a long document recorded
 - [x] #4 Literal async pytest commands run on Windows without mutating the guarded network families, while ordinary same-thread and concurrent-thread application egress remains blocked and recorded
 <!-- AC:END -->
 
@@ -207,3 +207,100 @@ driver was removed after capture and is not part of the implementation.
 Closeout status: blocked on the rendered Library status/navigation overlap.
 Task status remains In Progress; no layout fix was attempted in this verification
 checkpoint.
+
+### Task 5 final closeout after rendered-layout correction
+
+The reviewed layout correction at `ae757d8d4` makes the focused search-controls
+container size to its content, so the persistent media body starts below the
+status and navigation chrome without changing the in-place ownership model. The
+new 170x48 compositor regression passed and recorded these non-overlapping
+regions:
+
+```text
+controls: (x=35, y=19, width=129, height=7)
+status:   (x=35, y=23, width=129, height=1)
+Previous: (x=36, y=25, width=16,  height=1)
+Next:     (x=53, y=25, width=16,  height=1)
+content:  (x=35, y=26, width=129, height=18)
+heading:  row 29
+```
+
+The rendered frame visibly contained `Match 1 of 101 matches`, `◀ Prev`,
+`Next ▶`, and `Large budget document`. Every control's bottom is at or above
+content row 26, the heading remains within the content region, and the content
+body retains its 3/18 row min/max bounds.
+
+#### Final focused verification
+
+The required commands were rerun from the isolated worktree with the parent
+Python 3.12 virtual environment:
+
+```powershell
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_library_shell.py::test_library_shell_media_viewer_inplace_search_chrome_paints_above_content -v -s
+# 1 passed
+
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/Library/test_library_media_content.py Tests/UI/test_media_viewer_content_search_debounce.py -v
+# 16 passed
+
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/test_network_guard.py -q
+# 12 passed, 1 skipped (AF_UNIX unavailable on Windows)
+
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_library_shell.py -k 'media_content_search or media_viewer_raw_toggle or media_viewer_defaults_markdown or media_viewer_inplace' -v -s
+# 18 passed, 546 deselected
+
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_media_window_v2_parity.py Tests/UI/test_media_handoffs.py -q
+# 38 passed
+```
+
+The complete non-duplicated focused matrix is 84 passed with one expected
+Windows platform skip. The fresh final 2,000-line submit/Next/Previous median is
+`103.962 ms`, compared with `1091.689 ms` before the change. All four viewer
+observations and all four Markdown observations retained one identity, with
+`markdown_update_count=1` for initial construction only; navigation performed
+zero Markdown updates.
+
+The installed `C:\Python312\Scripts\ruff.exe` again reported only the eight
+attributed unchanged-line baseline findings (one `F401` and seven `E721`) on the
+complete task surface, and that surface passed when only those two pre-existing
+rule classes were excluded. `git diff --check origin/dev...HEAD` passed. The
+previous full-suite Windows collection evidence remains applicable because the
+layout correction cannot affect collection: the run stopped after 225.85
+seconds on baseline `signal.SIGSTOP`/`SIGCONT` and `fcntl` incompatibilities in
+two files byte-identical to `origin/dev`. No redundant full-suite rerun was
+performed. Cache-permission, pytest-asyncio loop-scope, SQLite privacy,
+optional-dependency, and missing mapping warnings remain environment/baseline
+warnings.
+
+#### Final rendered keyboard UAT
+
+No configured real-data Library profile was available, so the final UAT used
+the same mounted real `LibraryScreen`/production stylesheet and real legacy
+`MediaViewerPanel` harnesses, drove keyboard events, and rendered compositor
+frames. The ephemeral driver was removed afterward.
+
+- Library at 170x48 used the 49,288-character, 2,000-line fixture with 101
+  `budget` matches. Search remained unapplied until Enter and retained focus.
+  Previous visibly wrapped `Match 1` to `Match 101`, retained focus, and
+  scrolled y=0 to y=404; Next visibly wrapped back to `Match 1`, retained focus,
+  and returned to y=0. The status, both buttons, and heading were painted in the
+  non-overlapping regions above. Raw visibly showed `# Large budget document`
+  with selected span `budget`. Four further Raw/Rendered keyboard toggles kept
+  the same viewer, Markdown, Raw, Previous, and Next identities; content stayed
+  present and the Markdown update count remained one.
+- Legacy Media at 120x36 used the 67-character fixture. A rapid keyboard-event
+  `budget` burst caused no update through the 0.10-second silent observation,
+  then exactly one highlighted repaint (`1/3` visibly painted; 0.510 seconds
+  observed including harness pauses). Loading a replacement during the next
+  pending burst visibly painted the replacement and caused zero stale
+  highlighted updates.
+
+ADR-058 remains the governing decision for the thread-scoped Windows test
+socketpair exemption; the layout correction introduced no new architecture
+decision. Final self-review confirmed all four acceptance criteria, component,
+product-path, network/default-deny, companion, performance, debounce, static,
+diff, and rendered-UAT evidence. The implementation plan was followed, with the
+interim compositor finding and subsequent reviewed geometry correction recorded
+as the only deviation. The existing testing-evidence lesson already covers the
+model-state-versus-painted-frame trap, so no duplicate lesson was added. With
+the Windows full-suite baseline limitation explicitly attributed, all
+task-scoped Definition of Done items are complete and the task is Done.

--- a/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
+++ b/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
@@ -259,17 +259,38 @@ observations and all four Markdown observations retained one identity, with
 `markdown_update_count=1` for initial construction only; navigation performed
 zero Markdown updates.
 
-The installed `C:\Python312\Scripts\ruff.exe` again reported only the eight
-attributed unchanged-line baseline findings (one `F401` and seven `E721`) on the
-complete task surface, and that surface passed when only those two pre-existing
-rule classes were excluded. `git diff --check origin/dev...HEAD` passed. The
-previous full-suite Windows collection evidence remains applicable because the
-layout correction cannot affect collection: the run stopped after 225.85
-seconds on baseline `signal.SIGSTOP`/`SIGCONT` and `fcntl` incompatibilities in
-two files byte-identical to `origin/dev`. No redundant full-suite rerun was
-performed. Cache-permission, pytest-asyncio loop-scope, SQLite privacy,
-optional-dependency, and missing mapping warnings remain environment/baseline
-warnings.
+The broad/static evidence is reproducible with these literal commands:
+
+```powershell
+& 'C:\Python312\Scripts\ruff.exe' check tldw_chatbook/Widgets/Library/library_media_content.py tldw_chatbook/Widgets/Library/library_media_viewer.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/Widgets/Media/media_viewer_panel.py Tests/network_guard.py Tests/test_network_guard.py Tests/Library/test_library_media_content.py Tests/UI/test_library_shell.py Tests/UI/test_media_viewer_content_search_debounce.py --output-format concise
+# 8 attributed unchanged-line baseline findings: 1 F401 and 7 E721
+
+& 'C:\Python312\Scripts\ruff.exe' check tldw_chatbook/Widgets/Library/library_media_content.py tldw_chatbook/Widgets/Library/library_media_viewer.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/Widgets/Media/media_viewer_panel.py Tests/network_guard.py Tests/test_network_guard.py Tests/Library/test_library_media_content.py Tests/UI/test_library_shell.py Tests/UI/test_media_viewer_content_search_debounce.py --ignore E721,F401
+# All checks passed
+
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest -q
+# Collection stopped after 225.85 seconds on the two Windows baseline errors below
+
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/Media_Playback/test_player_pipeline.py Tests/TTS/test_profile_reference_materialization.py -q
+# Reproduced in 0.68 seconds: unavailable signal.SIGSTOP/SIGCONT and fcntl
+
+git -c safe.directory='C:/Users/GDesktop-1/Working/Github/tldw_tui/.worktrees/task-15458-media-viewer-inplace' rev-parse origin/dev:Tests/Media_Playback/test_player_pipeline.py
+git -c safe.directory='C:/Users/GDesktop-1/Working/Github/tldw_tui/.worktrees/task-15458-media-viewer-inplace' hash-object Tests/Media_Playback/test_player_pipeline.py
+# Both: d8333dc722565ba4afeaced66e797b30f3729c25
+
+git -c safe.directory='C:/Users/GDesktop-1/Working/Github/tldw_tui/.worktrees/task-15458-media-viewer-inplace' rev-parse origin/dev:Tests/TTS/test_profile_reference_materialization.py
+git -c safe.directory='C:/Users/GDesktop-1/Working/Github/tldw_tui/.worktrees/task-15458-media-viewer-inplace' hash-object Tests/TTS/test_profile_reference_materialization.py
+# Both: 0dd418c8d4c48ca713529d71e0bb173ef4eded88
+
+git -c safe.directory='C:/Users/GDesktop-1/Working/Github/tldw_tui/.worktrees/task-15458-media-viewer-inplace' diff --check origin/dev...HEAD
+# Passed
+```
+
+The previous full-suite Windows collection evidence remains applicable because
+the layout correction cannot affect collection. No redundant full-suite rerun
+was performed after that correction. Cache-permission, pytest-asyncio
+loop-scope, SQLite privacy, optional-dependency, and missing mapping warnings
+remain environment/baseline warnings.
 
 #### Final rendered keyboard UAT
 

--- a/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
+++ b/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15458
 title: Library media viewer: in-place match navigation instead of full-document re-parse
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-11 12:05'
 labels:
@@ -24,3 +24,19 @@ Fix direction: keep the Markdown widget mounted and move match-highlight and scr
 - [ ] #2 Search-while-typing performs at most one deferred re-render per debounce window and never the double update(\"\")/update(content) parse
 - [ ] #3 Match highlighting and scroll behavior preserved (tests); click latency before/after on a long document recorded
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Add mounted tests and a focused `LibraryMediaContentSearchControls` widget whose match-only updates preserve navigation identity and focus.
+2. Add mounted tests and a lazy `LibraryMediaContentBody` that stores Raw search state, mounts each selected mode at most once, and applies latest-request-wins visibility.
+3. Integrate the focused children through `LibraryMediaViewer` and replace Library screen recomposes with narrow query, match-index, mode, and post-layout scroll synchronization.
+4. Add mounted legacy-panel tests and a generation-guarded 250 ms content-search debounce; remove the empty Markdown cache-busting update.
+5. Record deterministic before/after latency and parse/identity evidence, run focused and full verification, complete rendered keyboard UAT, and close the task documentation.
+
+Detailed plan: `Docs/superpowers/plans/2026-08-12-library-media-viewer-inplace.md`
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this applies existing Textual widget ownership and timer patterns without changing persistence, security, dependencies, services, or cross-module contracts.

--- a/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
+++ b/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
@@ -20,10 +20,10 @@ Fix direction: keep the Markdown widget mounted and move match-highlight and scr
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Match navigation does not re-parse the document or remount the screen (evidence)
-- [ ] #2 Search-while-typing performs at most one deferred re-render per debounce window and never the double update(\"\")/update(content) parse
+- [x] #1 Match navigation does not re-parse the document or remount the screen (evidence)
+- [x] #2 Search-while-typing performs at most one deferred re-render per debounce window and never the double update(\"\")/update(content) parse
 - [ ] #3 Match highlighting and scroll behavior preserved (tests); click latency before/after on a long document recorded
-- [ ] #4 Literal async pytest commands run on Windows without mutating the guarded network families, while ordinary same-thread and concurrent-thread application egress remains blocked and recorded
+- [x] #4 Literal async pytest commands run on Windows without mutating the guarded network families, while ordinary same-thread and concurrent-thread application egress remains blocked and recorded
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -54,8 +54,9 @@ replaced on search/navigation, the persistent content body was not mounted,
 inactive Raw/Rendered children were removed, and Rendered search state did not
 reach a later Raw mount. The Enter-only regression already passed.
 
-The deterministic 2,000-line Markdown document contained exactly 100 matching
-source lines. The isolated repeat of the identical submit/Next/Prev sequence
+The deterministic 2,000-line Markdown document contained 101 matching source
+lines: 100 generated match lines plus the heading, which also contains
+`budget`. The isolated repeat of the identical submit/Next/Prev sequence
 recorded `TASK-15458 latency median_ms=1091.689`. The screen stayed at object ID
 `2237538817072`, while the viewer IDs were `2235866381104`, `2237674891232`,
 `2235874008944`, and `2235896514272`, and the Markdown IDs were `2235871484416`,
@@ -100,3 +101,109 @@ The whole-file Ruff baseline still reports pre-existing `E721` findings in
 `library_screen.py` and one pre-existing unused import in `test_library_shell.py`;
 the scoped verification excluded only those existing rule findings. `git diff
 --check` was clean.
+
+### Task 5 interim verification checkpoint (blocked)
+
+- Extracted scoped Library search controls and a lazy persistent content body so
+  match navigation updates status/highlighting/scroll state without remounting
+  the screen or reparsing Markdown.
+- Preserved Enter-to-search, Rendered-by-default Markdown behavior, Raw
+  highlighting, wraparound navigation, and focus continuity in the mounted
+  product-path tests. Rendered UAT found that the Library status and navigation
+  controls are nevertheless occluded by the content body at 170x48; therefore
+  acceptance criterion #3 remains open and this task remains In Progress.
+- Debounced legacy content search at 250 ms with monotonic lifecycle invalidation
+  and one Markdown update per applied query.
+- Repaired Windows async-test bootstrap under ADR-058 with a nested
+  current-thread socketpair exemption; literal pytest commands pass while
+  ordinary and concurrent-thread egress remain denied and recorded.
+- ADR required: yes; followed
+  `backlog/decisions/058-thread-scoped-test-socketpair-exemption.md` for the
+  review-expanded test security boundary.
+
+#### Fresh focused verification
+
+All required task-focused commands ran literally with the parent checkout's
+Python 3.12 virtual environment and default network denial:
+
+```powershell
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/Library/test_library_media_content.py Tests/UI/test_media_viewer_content_search_debounce.py -v
+# 16 passed
+
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/test_network_guard.py -q
+# 12 passed, 1 skipped (AF_UNIX unavailable on Windows)
+
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_library_shell.py -k 'media_content_search or media_viewer_raw_toggle or media_viewer_defaults_markdown or media_viewer_inplace' -v -s
+# 17 passed, 546 deselected
+
+& 'C:\Users\GDesktop-1\Working\Github\tldw_tui\.venv\Scripts\python.exe' -m pytest Tests/UI/test_media_window_v2_parity.py Tests/UI/test_media_handoffs.py -q
+# 38 passed
+```
+
+The combined focused result is 83 passed and one expected platform skip. The
+fresh 2,000-line product-path measurement was `103.287 ms` median for
+submit/Next/Previous, compared with the isolated pre-change `1091.689 ms`
+median. The four viewer observations had one stable viewer identity; the four
+Markdown observations had one stable Markdown identity; and
+`markdown_update_count=1` represented initial construction only, so navigation
+caused zero Markdown updates. The fixture is 49,288 characters and contains
+2,000 lines and 101 matching source lines; earlier notes that called this 100
+matches omitted the matching heading.
+
+The parent virtual environment does not contain the Ruff module, so the literal
+`python -m ruff` command reports `No module named ruff`. The documented installed
+binary, `C:\Python312\Scripts\ruff.exe`, reports eight whole-file baseline
+findings on unchanged lines (one `F401` in `test_library_shell.py` and seven
+`E721` findings in `library_screen.py`). The complete task surface passes when
+only those two pre-existing rule classes are excluded. The branch diff check
+initially found two trailing spaces in the design document's Task/Date metadata;
+those spaces were removed and the check was rerun.
+
+The full `pytest -q` run stopped during Windows collection after 225.85 seconds:
+`Tests/Media_Playback/test_player_pipeline.py` references unavailable
+`signal.SIGSTOP`/`SIGCONT`, and
+`Tests/TTS/test_profile_reference_materialization.py` imports unavailable
+`fcntl`. An exact two-module rerun reproduced both errors in 0.68 seconds, and
+both files are byte-identical to `origin/dev`; these are unrelated Windows
+baseline failures rather than task regressions. Existing pytest cache-permission,
+pytest-asyncio loop-scope, SQLite privacy, optional-dependency, and missing
+OpenAI-TTS-mapping warnings also remain attributable to the environment/baseline.
+
+#### Rendered keyboard UAT
+
+No configured real-data Library profile was used. The UAT therefore mounted the
+real `LibraryScreen` with the production stylesheet and deterministic media
+fixture through the existing product-path harness, plus the real legacy
+`MediaViewerPanel`; it drove keyboard events and used
+`screen._compositor.render_strips()` as the visual oracle. The ephemeral UAT
+driver was removed after capture and is not part of the implementation.
+
+- Library terminal: 170x48. Fixture: 49,288 characters, 2,000 lines, 101
+  `budget` matches. Markdown opened Rendered. Typing `budget` left the applied
+  query blank until Enter; Enter retained search focus. Previous retained its
+  focus, wrapped 1 to 101, and scrolled the content body from y=0 to y=404;
+  Next retained its focus, wrapped 101 to 1, and scrolled back to y=0. Raw
+  visibly rendered the literal `# Large budget document`, and its selected
+  Rich span was `budget`. Four subsequent Raw/Rendered keyboard toggles retained
+  the same viewer, Markdown, and Raw identities, retained content, and caused
+  no additional Markdown update (one initial update total), so no remount/blank
+  frame was observed.
+- Library blocker: the status widget has region `(x=35, y=23, width=128,
+  height=1)`, is displayed, and contains `Match 1 of 101 matches`, but the
+  content body occupies `(x=35, y=20, width=129, height=18)` and paints its
+  Markdown heading at terminal row 23. The compositor frame therefore contains
+  neither the status text nor visible Previous/Next controls
+  (`status_painted=False`, `previous_painted=False`, `next_painted=False`).
+  Model-state assertions alone had hidden this overlap. Because visible status
+  and navigation behavior are part of criterion #3, that criterion is not
+  complete.
+- Legacy Media terminal: 120x36. Fixture: 67 characters. A `budget` input burst
+  produced no update during the silent window and exactly one highlighted
+  repaint after debounce (observed elapsed 0.390 seconds including harness
+  pauses). Clearing, typing another burst, and loading a replacement record
+  before expiry produced the replacement content with zero stale highlighted
+  repaint.
+
+Closeout status: blocked on the rendered Library status/navigation overlap.
+Task status remains In Progress; no layout fix was attempted in this verification
+checkpoint.

--- a/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
+++ b/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
@@ -43,3 +43,60 @@ ADR path: `backlog/decisions/058-thread-scoped-test-socketpair-exemption.md`
 Reason: the media-viewer changes apply existing Textual ownership patterns, but
 the review-expanded verification scope changes the repository-wide test network
 security boundary and its runtime interception contract.
+
+## Implementation Notes
+
+### Task 3 pre-change product-path evidence
+
+The exact Task 3 focused command selected 16 tests. Before production changes,
+five new regressions failed for the intended missing behavior: the viewer was
+replaced on search/navigation, the persistent content body was not mounted,
+inactive Raw/Rendered children were removed, and Rendered search state did not
+reach a later Raw mount. The Enter-only regression already passed.
+
+The deterministic 2,000-line Markdown document contained exactly 100 matching
+source lines. The isolated repeat of the identical submit/Next/Prev sequence
+recorded `TASK-15458 latency median_ms=1091.689`. The screen stayed at object ID
+`2237538817072`, while the viewer IDs were `2235866381104`, `2237674891232`,
+`2235874008944`, and `2235896514272`, and the Markdown IDs were `2235871484416`,
+`2235878885376`, `2235889419760`, and `2235894721824`. The construction proxy
+therefore observed four distinct viewers and Markdown objects, plus four
+parse-triggering `Markdown.update` calls (initial mount plus one for every action).
+These process-local IDs are evidence of replacement, not stable identifiers
+expected to recur across runs. The preceding full-slice run measured 1239.726 ms
+and the same four-object/four-parse shape.
+
+ADR required: no additional ADR for Task 3. This slice applies the already
+reviewed widget-ownership interface without changing storage, runtime, security,
+dependency, or cross-module service boundaries. The parent task's ADR-058 remains
+the governing decision for the separate Windows network-guard verification scope.
+
+### Task 3 implementation and post-change evidence
+
+Integrated the reviewed search-controls and persistent-body components through
+`LibraryMediaViewer`, then replaced Library screen query, navigation, and mode
+recomposes with narrow mounted-viewer synchronization. Search remains
+Enter-submitted; navigation wraps and schedules source-line scrolling after a
+refresh boundary; Rendered remains the Markdown default; Raw and Rendered remain
+mounted after first use; and async mode synchronization delegates to the existing
+latest-request-wins body contract. No dependencies, persistence, workers, legacy
+Media debounce, or geometry rules changed.
+
+The required focused product-path command passed all 16 selected tests. Its
+2,000-line/100-match evidence recorded `TASK-15458 latency median_ms=120.913`,
+one stable screen ID (`2247968276448`), one stable viewer ID
+(`2247963750576` across all four observations), one stable Markdown ID
+(`2247965990096` across all four observations), and one `Markdown.update` call
+for the initial mount only. An isolated repeat measured 89.561 ms with the same
+one-viewer/one-Markdown/one-parse shape. This compares with the isolated
+pre-change 1091.689 ms median, four viewer objects, four Markdown objects, and
+four parses.
+
+The full `Tests/Library/test_library_media_content.py` suite passed 9 tests. A
+mutation that restored `self.refresh(recompose=True)` in match navigation made
+the identity/focus/parse regression fail at the viewer identity assertion; after
+restoring the narrow path, that regression passed. Task-scoped Ruff checks passed.
+The whole-file Ruff baseline still reports pre-existing `E721` findings in
+`library_screen.py` and one pre-existing unused import in `test_library_shell.py`;
+the scoped verification excluded only those existing rule findings. `git diff
+--check` was clean.

--- a/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
+++ b/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
@@ -23,6 +23,7 @@ Fix direction: keep the Markdown widget mounted and move match-highlight and scr
 - [ ] #1 Match navigation does not re-parse the document or remount the screen (evidence)
 - [ ] #2 Search-while-typing performs at most one deferred re-render per debounce window and never the double update(\"\")/update(content) parse
 - [ ] #3 Match highlighting and scroll behavior preserved (tests); click latency before/after on a long document recorded
+- [ ] #4 Literal async pytest commands run on Windows without mutating the guarded network families, while ordinary same-thread and concurrent-thread application egress remains blocked and recorded
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -35,8 +36,10 @@ Fix direction: keep the Markdown widget mounted and move match-highlight and scr
 
 Detailed plan: `Docs/superpowers/plans/2026-08-12-library-media-viewer-inplace.md`
 
-ADR required: no
+ADR required: yes
 
-ADR path: N/A
+ADR path: `backlog/decisions/058-thread-scoped-test-socketpair-exemption.md`
 
-Reason: this applies existing Textual widget ownership and timer patterns without changing persistence, security, dependencies, services, or cross-module contracts.
+Reason: the media-viewer changes apply existing Textual ownership patterns, but
+the review-expanded verification scope changes the repository-wide test network
+security boundary and its runtime interception contract.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -24831,13 +24831,9 @@ class LibraryScreen(BaseAppScreen):
     ) -> None:
         """Set the in-content search query and jump to the first match.
 
-        Submitted (rather than Changed) is used deliberately: recomposing
-        the whole screen on every keystroke would remount
-        ``#library-media-content-search`` and drop focus/cursor position
-        mid-typing, so the query only takes effect on Enter -- mirroring
-        ``handle_library_search_submitted``'s rail search box. A no-op
-        guard (mirroring ``update_library_rag_query``) skips the recompose
-        entirely when the submitted text matches the current query.
+        Submitted (rather than Changed) is used deliberately, so the query
+        only takes effect on Enter. The mounted viewer coordinates its focused
+        search controls and persistent body without rebuilding the screen.
 
         Args:
             event: Input submit event emitted by the content search box.
@@ -24850,11 +24846,6 @@ class LibraryScreen(BaseAppScreen):
             return
         self._library_media_content_query = submitted
         self._library_media_content_match_index = 0
-        self.refresh(recompose=True)
-        self.call_after_refresh(self._focus_library_media_content_search_input)
-        # Bring the first match into view on submit; otherwise the status line
-        # claims "Match 1 of N" while the hit stays below the fold until the
-        # user cycles Next all the way around.
         detail = (
             self._library_media_detail
             if isinstance(self._library_media_detail, Mapping)
@@ -24862,26 +24853,39 @@ class LibraryScreen(BaseAppScreen):
         )
         content = build_library_media_viewer_state(detail).content if detail else ""
         matches = find_content_matches(content, self._library_media_content_query)
+        viewer = self._mounted_library_media_viewer()
+        if viewer is None:
+            return
+        viewer.sync_query_state(
+            query=submitted,
+            matches=matches,
+            match_index=0,
+        )
+        self.call_after_refresh(self._focus_library_media_content_search_input)
+        # Bring the first match into view after Rich text wrapping/layout settles.
         if matches:
             self.call_after_refresh(
                 self._scroll_library_media_content_to_line, matches[0]
             )
 
-    def _focus_library_media_content_search_input(self) -> None:
-        """Re-focus the content search box after a submit-triggered recompose.
+    def _mounted_library_media_viewer(self) -> LibraryMediaViewer | None:
+        """Return the mounted media viewer, or ``None`` during teardown."""
+        try:
+            return self.query_one("#library-media-viewer", LibraryMediaViewer)
+        except (NoMatches, QueryError):
+            return None
 
-        Mirrors ``_focus_library_search_input``: the Submitted-driven
-        recompose above remounts a brand-new
-        ``#library-media-content-search``, so without this, focus falls
-        back to the screen after every search.
-        """
+    def _focus_library_media_content_search_input(self) -> None:
+        """Focus the mounted content search box after controls synchronize."""
         try:
             self.query_one("#library-media-content-search", Input).focus()
         except (NoMatches, QueryError):
             pass
 
     @on(Button.Pressed, "#library-media-content-mode-rendered")
-    def handle_library_media_content_mode_rendered(self, event: Button.Pressed) -> None:
+    async def handle_library_media_content_mode_rendered(
+        self, event: Button.Pressed
+    ) -> None:
         """Switch the open media item's Content section to the Rendered (Markdown) view.
 
         Args:
@@ -24889,10 +24893,12 @@ class LibraryScreen(BaseAppScreen):
                 "Rendered" action.
         """
         event.stop()
-        self._set_library_media_content_mode("rendered")
+        await self._set_library_media_content_mode("rendered")
 
     @on(Button.Pressed, "#library-media-content-mode-raw")
-    def handle_library_media_content_mode_raw(self, event: Button.Pressed) -> None:
+    async def handle_library_media_content_mode_raw(
+        self, event: Button.Pressed
+    ) -> None:
         """Switch the open media item's Content section to the Raw text view.
 
         Args:
@@ -24900,15 +24906,13 @@ class LibraryScreen(BaseAppScreen):
                 action.
         """
         event.stop()
-        self._set_library_media_content_mode("raw")
+        await self._set_library_media_content_mode("raw")
 
-    def _set_library_media_content_mode(self, mode: str) -> None:
+    async def _set_library_media_content_mode(self, mode: str) -> None:
         """Shared Rendered/Raw toggle: no-op when already in ``mode``.
 
-        A plain screen-state flip + recompose -- unlike the note editor's
-        Preview toggle, there is nothing to save here (the media viewer has
-        no editable body while browsing), so there is no write for this to
-        accidentally trigger.
+        The persistent body lazily mounts each view once; no media write is
+        involved because the viewer has no editable body while browsing.
 
         Args:
             mode: ``"rendered"`` or ``"raw"``.
@@ -24919,7 +24923,10 @@ class LibraryScreen(BaseAppScreen):
         ):
             return
         self._library_media_content_mode = mode
-        self.refresh(recompose=True)
+        viewer = self._mounted_library_media_viewer()
+        if viewer is None:
+            return
+        await viewer.sync_mode(mode)
 
     @on(Button.Pressed, "#library-media-content-search-next")
     def handle_library_media_content_search_next(self, event: Button.Pressed) -> None:
@@ -24964,7 +24971,13 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_content_match_index + step
         ) % len(matches)
         line_index = matches[self._library_media_content_match_index]
-        self.refresh(recompose=True)
+        viewer = self._mounted_library_media_viewer()
+        if viewer is None:
+            return
+        viewer.sync_match_index(
+            matches=matches,
+            match_index=self._library_media_content_match_index,
+        )
         self.call_after_refresh(self._scroll_library_media_content_to_line, line_index)
 
     def _scroll_library_media_content_to_line(self, line_index: int) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -24856,11 +24856,14 @@ class LibraryScreen(BaseAppScreen):
         viewer = self._mounted_library_media_viewer()
         if viewer is None:
             return
-        viewer.sync_query_state(
-            query=submitted,
-            matches=matches,
-            match_index=0,
-        )
+        try:
+            viewer.sync_query_state(
+                query=submitted,
+                matches=matches,
+                match_index=0,
+            )
+        except (NoMatches, QueryError):
+            return
         self.call_after_refresh(self._focus_library_media_content_search_input)
         # Bring the first match into view after Rich text wrapping/layout settles.
         if matches:
@@ -24926,7 +24929,10 @@ class LibraryScreen(BaseAppScreen):
         viewer = self._mounted_library_media_viewer()
         if viewer is None:
             return
-        await viewer.sync_mode(mode)
+        try:
+            await viewer.sync_mode(mode)
+        except (NoMatches, QueryError):
+            return
 
     @on(Button.Pressed, "#library-media-content-search-next")
     def handle_library_media_content_search_next(self, event: Button.Pressed) -> None:
@@ -24974,10 +24980,13 @@ class LibraryScreen(BaseAppScreen):
         viewer = self._mounted_library_media_viewer()
         if viewer is None:
             return
-        viewer.sync_match_index(
-            matches=matches,
-            match_index=self._library_media_content_match_index,
-        )
+        try:
+            viewer.sync_match_index(
+                matches=matches,
+                match_index=self._library_media_content_match_index,
+            )
+        except (NoMatches, QueryError):
+            return
         self.call_after_refresh(self._scroll_library_media_content_to_line, line_index)
 
     def _scroll_library_media_content_to_line(self, line_index: int) -> None:

--- a/tldw_chatbook/Widgets/Library/library_media_content.py
+++ b/tldw_chatbook/Widgets/Library/library_media_content.py
@@ -1,0 +1,104 @@
+"""Search controls for content displayed in the Library media viewer."""
+
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, Input, Static
+
+
+class LibraryMediaContentSearchControls(Vertical):
+    """Maintain search controls while preserving active widget identity."""
+
+    def __init__(
+        self,
+        *,
+        is_markdown: bool,
+        query: str,
+        matches: tuple[int, ...],
+        match_index: int,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.is_markdown = is_markdown
+        self.query = query
+        self.matches = matches
+        self.match_index = match_index
+
+    def compose(self) -> ComposeResult:
+        yield Input(
+            value=self.query,
+            placeholder=self._placeholder_text(),
+            id="library-media-content-search",
+        )
+        if not self.query:
+            return
+        yield Static(
+            self._status_text(),
+            id="library-media-content-search-status",
+            markup=False,
+        )
+        toolbar = Horizontal(classes="ds-toolbar")
+        toolbar.styles.height = "auto"
+        with toolbar:
+            yield Button(
+                "◀ Prev",
+                id="library-media-content-search-prev",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            yield Button(
+                "Next ▶",
+                id="library-media-content-search-next",
+                classes="library-canvas-action",
+                compact=True,
+            )
+
+    def sync_query_state(
+        self,
+        *,
+        is_markdown: bool,
+        query: str,
+        matches: tuple[int, ...],
+        match_index: int,
+    ) -> None:
+        """Synchronize query data and recompose only across active-state changes."""
+        was_active = bool(self.query)
+        self.is_markdown = is_markdown
+        self.query = query
+        self.matches = matches
+        self.match_index = match_index
+        is_active = bool(query)
+
+        if was_active != is_active:
+            self.refresh(recompose=True)
+            return
+
+        search_input = self.query_one("#library-media-content-search", Input)
+        search_input.value = self.query
+        search_input.placeholder = self._placeholder_text()
+        if is_active:
+            self.query_one("#library-media-content-search-status", Static).update(
+                self._status_text()
+            )
+
+    def sync_match_index(
+        self, *, matches: tuple[int, ...], match_index: int
+    ) -> None:
+        """Synchronize a navigation update without rebuilding controls."""
+        self.matches = matches
+        self.match_index = match_index
+        self.query_one("#library-media-content-search-status", Static).update(
+            self._status_text()
+        )
+
+    def _placeholder_text(self) -> str:
+        return "Search content (raw text)…" if self.is_markdown else "Search content…"
+
+    def _status_text(self) -> str:
+        if not self.query:
+            return ""
+        if not self.matches:
+            return "No matches"
+        wrapped = self.match_index % len(self.matches)
+        return f"Match {wrapped + 1} of {len(self.matches)} matches"

--- a/tldw_chatbook/Widgets/Library/library_media_content.py
+++ b/tldw_chatbook/Widgets/Library/library_media_content.py
@@ -135,6 +135,12 @@ class LibraryMediaContentBody(VerticalScroll):
 class LibraryMediaContentSearchControls(Vertical):
     """Maintain search controls while preserving active widget identity."""
 
+    DEFAULT_CSS = """
+    LibraryMediaContentSearchControls {
+        height: auto;
+    }
+    """
+
     def __init__(
         self,
         *,

--- a/tldw_chatbook/Widgets/Library/library_media_content.py
+++ b/tldw_chatbook/Widgets/Library/library_media_content.py
@@ -1,10 +1,135 @@
-"""Search controls for content displayed in the Library media viewer."""
+"""Persistent content widgets for the Library media viewer."""
+
+import asyncio
 
 from typing import Any
 
+from rich.text import Text
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
-from textual.widgets import Button, Input, Static
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widgets import Button, Input, Markdown, Static
+
+from tldw_chatbook.Library.library_media_viewer_state import find_content_matches
+from tldw_chatbook.Utils.markdown_parsing import front_matter_parser_factory
+
+
+def build_raw_content_renderable(
+    content: str, query: str, match_index: int
+) -> Text | str:
+    """Build raw text content, safely highlighting matching source lines."""
+    display_content = content or "No stored content."
+    normalized_query = query.strip()
+    if not normalized_query or not content:
+        return display_content
+    matches = find_content_matches(content, normalized_query)
+    if not matches:
+        return display_content
+    current_line = matches[match_index % len(matches)]
+    needle = normalized_query.lower()
+    text = Text()
+    for line_index, line in enumerate(display_content.split("\n")):
+        if line_index:
+            text.append("\n")
+        hit = line.lower().find(needle)
+        if hit < 0:
+            text.append(line)
+            continue
+        text.append(line[:hit])
+        text.append(
+            line[hit : hit + len(needle)],
+            style="reverse bold" if line_index == current_line else "reverse",
+        )
+        text.append(line[hit + len(needle) :])
+    return text
+
+
+class LibraryMediaContentBody(VerticalScroll):
+    """Lazily mount and retain the Raw and Rendered media content views."""
+
+    _VALID_MODES = frozenset({"raw", "rendered"})
+
+    def __init__(
+        self,
+        *,
+        content: str,
+        is_markdown: bool,
+        mode: str,
+        query: str,
+        match_index: int,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.content = content
+        self.is_markdown = is_markdown
+        self._raw_widget: Static | None = None
+        self._markdown_widget: Markdown | None = None
+        self._desired_mode = self._normalize_mode(mode)
+        self._mount_lock = asyncio.Lock()
+        self._query = query
+        self._match_index = match_index
+
+    def compose(self) -> ComposeResult:
+        """Construct only the selected initial content view."""
+        if self._desired_mode == "rendered":
+            self._markdown_widget = self._build_markdown_widget()
+            yield self._markdown_widget
+            return
+        self._raw_widget = self._build_raw_widget()
+        yield self._raw_widget
+
+    async def sync_mode(self, mode: str) -> None:
+        """Show the latest requested view, mounting each view at most once."""
+        self._desired_mode = self._normalize_mode(mode)
+        async with self._mount_lock:
+            await self._ensure_mode_mounted(self._desired_mode)
+            desired = self._desired_mode
+            await self._ensure_mode_mounted(desired)
+            if self._raw_widget is not None:
+                self._raw_widget.display = desired == "raw"
+            if self._markdown_widget is not None:
+                self._markdown_widget.display = desired == "rendered"
+
+    def sync_search(self, query: str, match_index: int) -> None:
+        """Refresh mounted Raw content while retaining the rendered view."""
+        self._query = query
+        self._match_index = match_index
+        if self._raw_widget is not None:
+            self._raw_widget.update(
+                build_raw_content_renderable(self.content, query, match_index)
+            )
+
+    async def _ensure_mode_mounted(self, mode: str) -> None:
+        """Mount the requested view only when it has not been constructed."""
+        if mode == "raw":
+            if self._raw_widget is None:
+                self._raw_widget = self._build_raw_widget()
+                await self.mount(self._raw_widget)
+            return
+        if self._markdown_widget is None:
+            self._markdown_widget = self._build_markdown_widget()
+            await self.mount(self._markdown_widget)
+
+    def _normalize_mode(self, mode: str) -> str:
+        """Validate a mode and force non-Markdown bodies to their Raw view."""
+        if mode not in self._VALID_MODES:
+            raise ValueError(f"Unsupported Library media content mode: {mode!r}")
+        return mode if self.is_markdown else "raw"
+
+    def _build_raw_widget(self) -> Static:
+        return Static(
+            build_raw_content_renderable(
+                self.content, self._query, self._match_index
+            ),
+            id="library-media-viewer-content-text",
+            markup=False,
+        )
+
+    def _build_markdown_widget(self) -> Markdown:
+        return Markdown(
+            self.content or "No stored content.",
+            id="library-media-viewer-content-markdown",
+            parser_factory=front_matter_parser_factory(),
+        )
 
 
 class LibraryMediaContentSearchControls(Vertical):

--- a/tldw_chatbook/Widgets/Library/library_media_content.py
+++ b/tldw_chatbook/Widgets/Library/library_media_content.py
@@ -16,7 +16,17 @@ from tldw_chatbook.Utils.markdown_parsing import front_matter_parser_factory
 def build_raw_content_renderable(
     content: str, query: str, match_index: int
 ) -> Text | str:
-    """Build raw text content, safely highlighting matching source lines."""
+    """Build raw text content with matching source lines highlighted.
+
+    Args:
+        content: Source text to display.
+        query: Case-insensitive search text to highlight.
+        match_index: Zero-based index of the active matching line.
+
+    Returns:
+        Highlighted Rich text when a match is active; otherwise, the source
+        text or its empty-state message.
+    """
     display_content = content or "No stored content."
     normalized_query = query.strip()
     if not normalized_query or not content:
@@ -78,7 +88,17 @@ class LibraryMediaContentBody(VerticalScroll):
         yield self._raw_widget
 
     async def sync_mode(self, mode: str) -> None:
-        """Show the latest requested view, mounting each view at most once."""
+        """Show the requested view while mounting each view at most once.
+
+        Args:
+            mode: Requested content mode, either ``"raw"`` or ``"rendered"``.
+
+        Returns:
+            None.
+
+        Raises:
+            ValueError: If ``mode`` is not a supported content mode.
+        """
         self._desired_mode = self._normalize_mode(mode)
         async with self._mount_lock:
             await self._ensure_mode_mounted(self._desired_mode)
@@ -90,7 +110,15 @@ class LibraryMediaContentBody(VerticalScroll):
                 self._markdown_widget.display = desired == "rendered"
 
     def sync_search(self, query: str, match_index: int) -> None:
-        """Refresh mounted Raw content while retaining the rendered view."""
+        """Refresh mounted Raw content while retaining the rendered view.
+
+        Args:
+            query: Case-insensitive search text to highlight.
+            match_index: Zero-based index of the active matching line.
+
+        Returns:
+            None.
+        """
         self._query = query
         self._match_index = match_index
         if self._raw_widget is not None:
@@ -193,7 +221,17 @@ class LibraryMediaContentSearchControls(Vertical):
         matches: tuple[int, ...],
         match_index: int,
     ) -> None:
-        """Synchronize query data and recompose only across active-state changes."""
+        """Synchronize query data, recomposing only when activity changes.
+
+        Args:
+            is_markdown: Whether the content supports a rendered Markdown view.
+            query: Submitted content-search query.
+            matches: Source-line indexes matching ``query``.
+            match_index: Zero-based index of the active match.
+
+        Returns:
+            None.
+        """
         was_active = bool(self.query)
         self.is_markdown = is_markdown
         self.query = query
@@ -216,7 +254,15 @@ class LibraryMediaContentSearchControls(Vertical):
     def sync_match_index(
         self, *, matches: tuple[int, ...], match_index: int
     ) -> None:
-        """Synchronize a navigation update without rebuilding controls."""
+        """Synchronize match navigation without rebuilding controls.
+
+        Args:
+            matches: Source-line indexes matching the active query.
+            match_index: Zero-based index of the active match.
+
+        Returns:
+            None.
+        """
         self.matches = matches
         self.match_index = match_index
         self.query_one("#library-media-content-search-status", Static).update(

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -283,7 +283,16 @@ class LibraryMediaViewer(Vertical):
     def sync_query_state(
         self, *, query: str, matches: tuple[int, ...], match_index: int
     ) -> None:
-        """Synchronize a submitted query without rebuilding the viewer."""
+        """Synchronize a submitted query without rebuilding the viewer.
+
+        Args:
+            query: Submitted content-search query.
+            matches: Source-line indexes matching ``query``.
+            match_index: Zero-based index of the active match.
+
+        Returns:
+            None.
+        """
         self.content_query = query
         self.content_match_index = match_index
         self.query_one(
@@ -302,7 +311,15 @@ class LibraryMediaViewer(Vertical):
     def sync_match_index(
         self, *, matches: tuple[int, ...], match_index: int
     ) -> None:
-        """Synchronize match navigation without rebuilding viewer children."""
+        """Synchronize match navigation without rebuilding viewer children.
+
+        Args:
+            matches: Source-line indexes matching the active query.
+            match_index: Zero-based index of the active match.
+
+        Returns:
+            None.
+        """
         self.content_match_index = match_index
         self.query_one(
             "#library-media-content-search-controls",
@@ -313,7 +330,17 @@ class LibraryMediaViewer(Vertical):
         ).sync_search(self.content_query, match_index)
 
     async def sync_mode(self, mode: str) -> None:
-        """Synchronize toggle state and reuse the persistent content views."""
+        """Synchronize toggle state and reuse the persistent content views.
+
+        Args:
+            mode: Requested content mode, either ``"raw"`` or ``"rendered"``.
+
+        Returns:
+            None.
+
+        Raises:
+            ValueError: If ``mode`` is not a supported content mode.
+        """
         self.content_mode = mode
         rendered_selected = mode == "rendered"
         rendered_button = self.query_one(

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -7,15 +7,18 @@ from typing import Any, Sequence
 from rich.color import Color
 from rich.text import Text
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.widgets import Button, Collapsible, Input, Markdown, Static, TextArea
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, Collapsible, Input, Static, TextArea
 
 from tldw_chatbook.Library.library_media_viewer_state import (
     LibraryMediaHighlightRow,
     LibraryMediaViewerState,
     find_content_matches,
 )
-from tldw_chatbook.Utils.markdown_parsing import front_matter_parser_factory
+from tldw_chatbook.Widgets.Library.library_media_content import (
+    LibraryMediaContentBody,
+    LibraryMediaContentSearchControls,
+)
 
 
 class LibraryMediaViewer(Vertical):
@@ -136,26 +139,22 @@ class LibraryMediaViewer(Vertical):
             classes="destination-section",
         )
         yield from self._compose_content_mode_toggle()
-        yield from self._compose_content_search()
-        with VerticalScroll(id="library-media-viewer-content"):
-            if self.viewer.is_markdown and self.content_mode == "rendered":
-                # LIB-13: the SAME render path Notes Preview uses
-                # (``library_notes_canvas.py``'s ``_compose_editor``) --
-                # reused verbatim, not a second markdown pipeline.
-                # ``Markdown`` parses and escapes internally (never Rich
-                # markup), so this stays the same terminal-escaping path
-                # the raw ``Static`` branch below uses for its own content.
-                yield Markdown(
-                    self.viewer.content or "No stored content.",
-                    id="library-media-viewer-content-markdown",
-                    parser_factory=front_matter_parser_factory(),
-                )
-            else:
-                yield Static(
-                    self._content_renderable(),
-                    id="library-media-viewer-content-text",
-                    markup=False,
-                )
+        matches = find_content_matches(self.viewer.content, self.content_query)
+        yield LibraryMediaContentSearchControls(
+            is_markdown=self.viewer.is_markdown,
+            query=self.content_query,
+            matches=matches,
+            match_index=self.content_match_index,
+            id="library-media-content-search-controls",
+        )
+        yield LibraryMediaContentBody(
+            content=self.viewer.content,
+            is_markdown=self.viewer.is_markdown,
+            mode=self.content_mode,
+            query=self.content_query,
+            match_index=self.content_match_index,
+            id="library-media-viewer-content",
+        )
         yield from self._compose_analysis()
 
         yield from self._compose_highlights()
@@ -281,125 +280,57 @@ class LibraryMediaViewer(Vertical):
             raw_button.set_class(raw_selected, "-selected")
             yield raw_button
 
-    def _compose_content_search(self) -> ComposeResult:
-        """Render the in-content search box, and its status/prev-next only while active.
-
-        The search ``Input`` always renders, full-width above the content
-        ``VerticalScroll``. The match-count status ``Static`` and the
-        prev/next ``ds-toolbar`` only render while ``self.content_query``
-        is non-empty -- with no active search there is nothing to page
-        through, so the status line and toolbar are omitted entirely
-        rather than left showing as empty/orphaned chrome. When present,
-        Input and Static are each their own row and prev/next live in a
-        plain ``ds-toolbar`` of buttons only, matching the render-safety
-        rule on ``compose`` above (never mix a ``1fr`` sibling with a
-        fixed-width widget in one ``Horizontal``).
-
-        The search always matches against the RAW stored text (never the
-        rendered Markdown's visual output) regardless of which content
-        view is showing -- LIB-13's decision. When a Rendered|Raw toggle
-        is offered, the placeholder says so explicitly so a search made
-        while viewing Rendered is never mistaken for searching the
-        on-screen (rendered) text.
-
-        Returns:
-            ComposeResult for the content search row and, when a query is
-            active, the status line and prev/next action toolbar.
-        """
-        placeholder = (
-            "Search content (raw text)…"
-            if self.viewer.is_markdown
-            else "Search content…"
+    def sync_query_state(
+        self, *, query: str, matches: tuple[int, ...], match_index: int
+    ) -> None:
+        """Synchronize a submitted query without rebuilding the viewer."""
+        self.content_query = query
+        self.content_match_index = match_index
+        self.query_one(
+            "#library-media-content-search-controls",
+            LibraryMediaContentSearchControls,
+        ).sync_query_state(
+            is_markdown=self.viewer.is_markdown,
+            query=query,
+            matches=matches,
+            match_index=match_index,
         )
-        yield Input(
-            value=self.content_query,
-            placeholder=placeholder,
-            id="library-media-content-search",
+        self.query_one(
+            "#library-media-viewer-content", LibraryMediaContentBody
+        ).sync_search(query, match_index)
+
+    def sync_match_index(
+        self, *, matches: tuple[int, ...], match_index: int
+    ) -> None:
+        """Synchronize match navigation without rebuilding viewer children."""
+        self.content_match_index = match_index
+        self.query_one(
+            "#library-media-content-search-controls",
+            LibraryMediaContentSearchControls,
+        ).sync_match_index(matches=matches, match_index=match_index)
+        self.query_one(
+            "#library-media-viewer-content", LibraryMediaContentBody
+        ).sync_search(self.content_query, match_index)
+
+    async def sync_mode(self, mode: str) -> None:
+        """Synchronize toggle state and reuse the persistent content views."""
+        self.content_mode = mode
+        rendered_selected = mode == "rendered"
+        rendered_button = self.query_one(
+            "#library-media-content-mode-rendered", Button
         )
-        if not self.content_query:
-            return
-        matches = find_content_matches(self.viewer.content, self.content_query)
-        yield Static(
-            self._content_search_status_text(matches),
-            id="library-media-content-search-status",
-            markup=False,
+        raw_button = self.query_one("#library-media-content-mode-raw", Button)
+        rendered_button.label = (
+            "Rendered (selected)" if rendered_selected else "Rendered"
         )
-        search_toolbar = Horizontal(classes="ds-toolbar")
-        search_toolbar.styles.height = "auto"
-        with search_toolbar:
-            yield Button(
-                "◀ Prev",
-                id="library-media-content-search-prev",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            yield Button(
-                "Next ▶",
-                id="library-media-content-search-next",
-                classes="library-canvas-action",
-                compact=True,
-            )
-
-    def _content_search_status_text(self, matches: tuple[int, ...]) -> str:
-        """Build the in-content search status line text.
-
-        Args:
-            matches: Ordered line indices matching ``self.content_query``,
-                as returned by ``find_content_matches``.
-
-        Returns:
-            "" when the query is blank (no search active), "No matches"
-            when a non-blank query has no hits, otherwise
-            "Match {i} of {n} matches" for the current (wrapped) index.
-        """
-        if not self.content_query:
-            return ""
-        if not matches:
-            return "No matches"
-        index = self.content_match_index % len(matches)
-        return f"Match {index + 1} of {len(matches)} matches"
-
-    def _content_renderable(self) -> Text | str:
-        """Return the content body, marking the matched lines while searching.
-
-        With no active search this is the plain content string. While a
-        search is active, the first occurrence of the query on each matching
-        line is marked (case-insensitive), so the number of visible marks
-        equals the line-based "Match N of M" count from
-        ``find_content_matches`` -- otherwise the count and the highlighting
-        would disagree on any line that contains the query twice. The
-        currently-focused match (``content_match_index``) is marked
-        ``reverse bold`` while the others are ``reverse``, so prev/next has a
-        visible target. Built as a Rich ``Text`` from raw slices (never
-        markup) so arbitrary content cannot inject styles.
-
-        Returns:
-            The plain content ``str`` when idle, or a Rich ``Text`` with the
-            matched lines marked while searching.
-        """
-        content = self.viewer.content or "No stored content."
-        query = (self.content_query or "").strip()
-        if not query or not self.viewer.content:
-            return content
-        matches = find_content_matches(self.viewer.content, query)
-        if not matches:
-            return content
-        current_line = matches[self.content_match_index % len(matches)]
-        needle = query.lower()
-        span = len(needle)
-        text = Text()
-        for index, line in enumerate(content.split("\n")):
-            if index:
-                text.append("\n")
-            hit = line.lower().find(needle)
-            if hit == -1:
-                text.append(line)
-                continue
-            style = "reverse bold" if index == current_line else "reverse"
-            text.append(line[:hit])
-            text.append(line[hit : hit + span], style=style)
-            text.append(line[hit + span :])
-        return text
+        raw_button.label = "Raw" if rendered_selected else "Raw (selected)"
+        rendered_button.set_class(rendered_selected, "-selected")
+        raw_button.set_class(not rendered_selected, "-selected")
+        rendered_button.refresh(layout=True)
+        raw_button.refresh(layout=True)
+        await self.query_one(
+            "#library-media-viewer-content", LibraryMediaContentBody
+        ).sync_mode(mode)
 
     def _compose_edit_form(self) -> ComposeResult:
         """Render the metadata edit inputs, prefilled from ``viewer.edit_fields``.

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -8,11 +8,13 @@ This component provides:
 - Analysis display
 """
 
+from functools import partial
 from typing import TYPE_CHECKING, Dict, Optional, List, Tuple, Any
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 from textual.reactive import reactive
+from textual.timer import Timer
 from textual.widgets import (
     Static,
     Button,
@@ -65,6 +67,7 @@ ANALYSIS_NAV_PREVIOUS_ENABLED_TOOLTIP = "Show the previous analysis version."
 ANALYSIS_NAV_PREVIOUS_DISABLED_TOOLTIP = "Already viewing the first analysis version."
 ANALYSIS_NAV_NEXT_ENABLED_TOOLTIP = "Show the next analysis version."
 ANALYSIS_NAV_NEXT_DISABLED_TOOLTIP = "Already viewing the last analysis version."
+MEDIA_CONTENT_SEARCH_DEBOUNCE_SECONDS = 0.25
 READING_HIGHLIGHT_ADD_TOOLTIP = "Add a reading highlight to this media item."
 READING_HIGHLIGHT_UPDATE_DISABLED_TOOLTIP = (
     "Select a reading highlight before updating it."
@@ -584,11 +587,19 @@ class MediaViewerPanel(Container):
         super().__init__(**kwargs)
         self.app_instance = app_instance
         self._original_data = None
+        self._content_search_timer: Timer | None = None
+        self._content_search_generation = 0
+        self._content_search_query = ""
 
     def on_mount(self) -> None:
         """Called when the widget is mounted."""
         # Populate providers on mount
         self.populate_providers()
+
+    def on_unmount(self) -> None:
+        """Cancel deferred content searches before the panel is detached."""
+        self._invalidate_content_search_timer()
+        self._content_search_query = ""
 
     def compose(self) -> ComposeResult:
         """Compose the viewer panel UI."""
@@ -1001,8 +1012,6 @@ class MediaViewerPanel(Container):
                 # Update search status
                 self._update_search_status()
 
-            # Clear and update to ensure proper refresh
-            content_display.update("")
             content_display.update(content)
         except Exception as e:
             logger.error(f"Error updating content display: {e}")
@@ -1043,6 +1052,8 @@ class MediaViewerPanel(Container):
     def clear_display(self) -> None:
         """Clear all displays when no item is selected."""
         try:
+            self._invalidate_content_search_timer()
+            self._content_search_query = ""
             self.media_data = None
             self.all_analyses = []
             self.current_analysis = None
@@ -1205,9 +1216,33 @@ class MediaViewerPanel(Container):
     def handle_content_search(self, event: Input.Changed) -> None:
         """Handle content search input."""
         if event.value:
-            self.search_content(event.value)
+            generation = self._invalidate_content_search_timer()
+            self._content_search_query = event.value
+            self._content_search_timer = self.set_timer(
+                MEDIA_CONTENT_SEARCH_DEBOUNCE_SECONDS,
+                partial(self._apply_debounced_content_search, generation, event.value),
+            )
         else:
+            self._invalidate_content_search_timer()
+            self._content_search_query = ""
             self.clear_search()
+
+    def _invalidate_content_search_timer(self) -> int:
+        """Stop a pending content search and advance its lifecycle generation."""
+        if self._content_search_timer is not None:
+            self._content_search_timer.stop()
+            self._content_search_timer = None
+        self._content_search_generation += 1
+        return self._content_search_generation
+
+    def _apply_debounced_content_search(self, generation: int, query: str) -> None:
+        """Run a delayed content search only if its lifecycle is still current."""
+        if generation != self._content_search_generation:
+            return
+        if query != self._content_search_query or not self.is_mounted:
+            return
+        self._content_search_timer = None
+        self.search_content(query)
 
     @on(Button.Pressed, "#prev-match")
     def handle_prev_match(self) -> None:
@@ -1301,6 +1336,7 @@ class MediaViewerPanel(Container):
 
     def load_media(self, media_data: Dict[str, Any]) -> None:
         """Load new media data into the viewer."""
+        self._invalidate_content_search_timer()
         self.media_data = media_data
         self.edit_mode = False
         self.clear_search()


### PR DESCRIPTION
## Summary

- keep Library media search/navigation in place with persistent Raw/Rendered content widgets, stable focus/identity, post-refresh scrolling, and visible non-overlapping navigation chrome
- debounce legacy Media content search at 250 ms with lifecycle generation invalidation and exactly one Markdown update per applied query
- add ADR-058's thread-scoped Windows socketpair exemption while preserving import-time default-deny network protection
- close TASK-15458 with deterministic performance evidence and rendered keyboard/compositor UAT

## Evidence

- deterministic 2,000-line sequence: median 1091.689 ms before; 103.962 ms closeout measurement; final verification 77.787 ms
- one stable viewer and Markdown identity; one initial Markdown update and zero navigation reparses
- rendered UAT passed at Library 170x48 and legacy Media 120x36
- final focused verification: 86 passed, 1 expected Windows AF_UNIX skip
- Ruff and `git diff --check origin/dev...HEAD` pass

## Known baseline limitations

The repository-wide Windows suite stops during collection on two files unchanged from `origin/dev`:

- `Tests/Media_Playback/test_player_pipeline.py` uses unavailable `SIGSTOP`/`SIGCONT`
- `Tests/TTS/test_profile_reference_materialization.py` imports unavailable `fcntl`

Exact focused and baseline-attribution commands are recorded in TASK-15458.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Library media content search and match navigation in place instead of remounting and re-parsing Markdown; legacy content search in the Media viewer now debounces at 250 ms. On Windows, asyncio boots under the default-deny guard via a thread-scoped `socket.socketpair()` exemption.

**Review focus**
- Library viewer: `LibraryMediaViewer` composes `LibraryMediaContentSearchControls` and `LibraryMediaContentBody` to update query, match index, mode, and highlights in place; Raw mode uses a safe line-highlighting renderable; search chrome stays above content.
- Legacy panel: `MediaViewerPanel` applies typing through `MEDIA_CONTENT_SEARCH_DEBOUNCE_SECONDS=0.25` and performs exactly one Markdown update per applied query.
- Tests/guard: `Tests.network_guard` wraps `socketpair()` with a thread-local exemption; import-time default-deny for `AF_INET`/`AF_INET6` remains. New tests pin mounted behavior, debounce timing, and Windows fallback boundaries; `AF_UNIX` tests skip where unavailable.
- Docs: design/plan specs added and ADR-058 recorded.

**Rollout and notes**
- No migrations or config changes required.
- Performance: 2,000-line navigation median improved from ~1091 ms to ~104 ms (final verification ~78 ms).
- TASK-15458 is satisfied by stable in-place updates, preserved highlighting/scroll, and deterministic timing evidence.

<sup>Written for commit 98d6912cb5625f6b5b6d04398ea4298301943e1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

