### PR TITLE
fix: STTS auto-chapters — dead switch queries removed, detection threaded with a generation guard (task-15478)

### DIFF
--- a/Tests/UI/test_speech_audiobook_chapter_detection.py
+++ b/Tests/UI/test_speech_audiobook_chapter_detection.py
@@ -14,28 +14,36 @@ left to turn it off) but:
   - moves the keystroke-path call behind a debounce timer, since detection
     walks the *entire* pasted text with `ChapterDetector.detect_chapters`
     and pops a notify toast -- unacceptable once per keystroke;
-  - moves the detection itself off the event loop entirely (review
-    follow-up): `ChapterDetector.detect_chapters` was benchmarked at
-    ~19ms/90k words, ~60ms/300k, ~200ms on a 6MB paste -- past the repo's
-    100ms worker budget for exactly the large pastes an audiobook feature
-    invites -- so it now runs in a `@work(thread=True)` worker with results
+  - moves the detection itself off the event loop entirely (review round
+    2): `ChapterDetector.detect_chapters` was benchmarked at ~19ms/90k
+    words, ~60ms/300k, ~200ms on a 6MB paste -- past the repo's 100ms
+    worker budget for exactly the large pastes an audiobook feature invites
+    -- so it now runs in a `@work(thread=True)` worker with results
     marshaled back via `call_from_thread`, for all four call sites, not
     just the debounced one;
   - only pops the "Detected N chapters" toast when N actually changes since
     the last toast, so a debounced re-paste that keeps re-running detection
-    does not spam a toast per settle.
+    does not spam a toast per settle;
+  - (review round 3) guards against a slower, superseded detection
+    overwriting a faster, newer one with a monotonically-increasing
+    dispatch generation (`exclusive=True` alone cannot interrupt an
+    already-running OS thread);
+  - (review round 3) resets the toast-dedup memory on every new "Import
+    Content" action, so a genuinely new import that happens to detect the
+    same chapter count as a previous session still gets its own toast.
 """
 
 from __future__ import annotations
 
 import asyncio
+import threading
 from unittest.mock import Mock
 
 import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import TextArea
 
-from tldw_chatbook.TTS.audiobook_generator import Chapter
+from tldw_chatbook.TTS.audiobook_generator import Chapter, ChapterDetector
 from tldw_chatbook.UI.STTS_Window import AudioBookGenerationWidget
 
 
@@ -44,20 +52,29 @@ class _Host(App[None]):
         yield AudioBookGenerationWidget()
 
 
-def _make_large_book(n_words: int) -> str:
-    """Build synthetic book text with a "Chapter N" header every 2000 words.
+def _make_large_book(n_words: int, *, words_per_chapter: int = 60_000) -> str:
+    """Build synthetic book text with a "Chapter N" header every so often.
 
     Mirrors the shape the reviewer benchmarked ChapterDetector against
     (~19ms/90k words, ~60ms/300k, ~200ms on a 6MB paste): plain prose lines
     interspersed with chapter markers the detector's regexes actually match,
-    not degenerate all-blank or all-matching input.
+    not degenerate all-blank or all-matching input. Detection time is driven
+    by total line/word count, not chapter count, so `words_per_chapter`
+    defaults high enough (~50 chapters for a 3,000,000-word book) to stay
+    realistic -- an earlier, denser default (one chapter every 2000 words,
+    999 chapters for 3M words) produced a chapter count high enough to
+    intermittently trip an unrelated, pre-existing race in
+    `ChapterEditorWidget`/`Select`'s mount sequence when the chapter table
+    populates that many rows in one reactive update (observed once in a
+    full-file run, not reproducible in isolation -- a real flake, but not
+    one this task owns fixing).
     """
     words_per_line = 12
     lines: list[str] = []
     total = 0
     chapter = 1
     while total < n_words:
-        if total % 2000 == 0:
+        if total % words_per_chapter == 0:
             lines.append(f"Chapter {chapter}")
             chapter += 1
         lines.append(" ".join(["word"] * words_per_line))
@@ -143,9 +160,9 @@ async def test_file_import_still_auto_detects_without_the_missing_switch(tmp_pat
     a keystroke path, so they keep running detection unconditionally --
     matching the removed switch's `value=True` default, with no dead query.
 
-    Detection itself now runs in a background thread worker (review
-    follow-up), so this waits for it to actually finish rather than
-    asserting immediately after dispatch.
+    Detection itself now runs in a background thread worker (review round
+    2), so this waits for it to actually finish rather than asserting
+    immediately after dispatch.
     """
     book_path = tmp_path / "book.txt"
     book_path.write_text("Chapter 1\nOnce upon a time.\n\nChapter 2\nThe end.\n")
@@ -167,25 +184,30 @@ async def test_file_import_still_auto_detects_without_the_missing_switch(tmp_pat
 
 @pytest.mark.asyncio
 async def test_event_loop_stays_responsive_during_large_paste_chapter_detection():
-    """The actual perf bug (task-15478 review): chapter detection used to
-    run synchronously on the event loop per debounce settle.
+    """The actual perf bug (task-15478 review round 2): chapter detection
+    used to run synchronously on the event loop per debounce settle.
     `ChapterDetector.detect_chapters` was benchmarked at ~19ms/90k words,
     ~60ms/300k, ~200ms on a 6MB paste -- well past the repo's 100ms worker
     budget, for exactly the large pastes an audiobook feature invites.
 
-    Same heartbeat-seam pattern as
-    `Tests/UI/test_llm_screen_ollama_probe_nonblocking.py` (task-15473): a
-    concurrent task ticks every 5ms while detection is in flight. This
-    brackets the heartbeat measurement tightly around `_detect_chapters()`
-    and its worker's completion only (bypassing the debounce timer and its
-    own ~1s of unrelated real-time sleep, which is covered separately by
-    `test_a_burst_of_keystrokes_runs_detection_once_after_it_settles` and
-    would otherwise dilute the signal -- confirmed empirically: with the
-    debounce wait included, a deliberately-reintroduced synchronous
-    detection call still cleared >100 heartbeats, because ~1s of real
-    `asyncio.sleep` swamped a ~700ms block). Over this tight window, a loop
-    frozen by a synchronous call lands at 0 ticks (measured); a correctly
-    threaded call clears double digits.
+    Load-robust design (task-15478 review round 3): an earlier version of
+    this test asserted an absolute heartbeat-count threshold (`>= 10`),
+    which failed 4/6 runs under real machine load (0-9 heartbeats) despite
+    the fix being structurally sound -- the threshold conflated "is the
+    mechanism correct" with "is this machine fast enough right now".
+    Instead, this compares two arms measured back to back IN THE SAME RUN,
+    under identical load: (A) a synchronous control call, made directly
+    against `ChapterDetector` in the test itself with no `await` inside its
+    wrapper, and (B) the real threaded call through the widget. Arm A is
+    *guaranteed* zero heartbeats by construction, not by luck: a coroutine
+    with no internal `await` point never yields control back to the event
+    loop, so a concurrently-scheduled heartbeat task cannot run even once
+    while it executes -- this is a hard property of Python's cooperative
+    scheduling, true on any machine at any speed. Arm B only has to beat
+    that guaranteed zero, which survives load far better than clearing an
+    absolute count: as long as the loop gets scheduled even once during
+    detection, the assertion holds. The 0-vs-N mutation contrast is thus
+    built into the test itself rather than depended on as a threshold.
     """
     app = _Host()
     async with app.run_test(size=(120, 48)) as pilot:
@@ -195,59 +217,258 @@ async def test_event_loop_stays_responsive_during_large_paste_chapter_detection(
         content_preview.disabled = False
 
         # ~3,000,000 words / ~15MB -- comfortably north of the reviewer's 6MB
-        # reference point, for a clear, low-flake margin above the assertion
-        # threshold (measured ~650-700ms of detection, ~25-35 heartbeats).
-        widget.content_text = _make_large_book(3_000_000)
+        # reference point (measured ~650-700ms of detection on this
+        # machine), for a workload big enough that even a single heartbeat
+        # tick landing during it is a meaningful signal.
+        big_content = _make_large_book(3_000_000)
+        widget.content_text = big_content
 
-        heartbeats = 0
-        stop = asyncio.Event()
+        async def _count_heartbeats(run_blocking_work) -> int:
+            heartbeats = 0
+            stop = asyncio.Event()
 
-        async def _heartbeat() -> None:
-            nonlocal heartbeats
-            while not stop.is_set():
-                heartbeats += 1
-                await asyncio.sleep(0.005)
+            async def _heartbeat() -> None:
+                nonlocal heartbeats
+                while not stop.is_set():
+                    heartbeats += 1
+                    await asyncio.sleep(0.005)
 
-        hb_task = asyncio.create_task(_heartbeat())
-        try:
+            hb_task = asyncio.create_task(_heartbeat())
+            try:
+                await run_blocking_work()
+            finally:
+                stop.set()
+                await hb_task
+            return heartbeats
+
+        # Arm A: synchronous control. Same content, same event loop, same
+        # machine load as arm B below -- this is what "the loop is frozen"
+        # looks like, right now, on this exact machine.
+        async def _synchronous_control() -> None:
+            ChapterDetector.detect_chapters(big_content)
+
+        sync_heartbeats = await _count_heartbeats(_synchronous_control)
+
+        # Arm B: the real threaded call through the widget.
+        async def _threaded_call() -> None:
             widget._detect_chapters()
-            # Wait for the threaded detector to actually finish -- this is
-            # the window the heartbeat must keep ticking through.
             await app.workers.wait_for_complete()
-        finally:
-            stop.set()
-            await hb_task
+
+        threaded_heartbeats = await _count_heartbeats(_threaded_call)
+
+        # Diagnostic evidence (task-15478 review round 3, item 3's "prove
+        # it" ask): visible with `pytest -s`, harmless otherwise.
+        print(
+            f"[heartbeat-seam] sync={sync_heartbeats} "
+            f"threaded={threaded_heartbeats}"
+        )
 
         assert widget.detected_chapters
-        assert heartbeats >= 10, (
-            f"event loop looks starved during chapter detection: only "
-            f"{heartbeats} heartbeat ticks landed"
+        assert sync_heartbeats == 0, (
+            f"synchronous control arm ticked {sync_heartbeats} times -- "
+            "this should be structurally impossible (a coroutine with no "
+            "internal await point cannot yield); investigate before "
+            "trusting the comparison below"
+        )
+        assert threaded_heartbeats > sync_heartbeats, (
+            f"threaded call ({threaded_heartbeats} heartbeats) did not "
+            f"beat the synchronous control ({sync_heartbeats}) -- the "
+            "event loop looks starved during chapter detection"
         )
 
 
 @pytest.mark.asyncio
 async def test_notify_only_fires_when_the_chapter_count_changes():
-    """Minor fix (task-15478 review): a debounced re-paste can re-run
-    detection several times as the user keeps typing; before this, every
-    settle popped its own "Detected N chapters" toast even when N hadn't
-    moved.
+    """Minor fix (task-15478 review round 2): a debounced re-paste can
+    re-run detection several times as the user keeps typing; before this,
+    every settle popped its own "Detected N chapters" toast even when N
+    hadn't moved. This is the "same session" direction: same-count spam
+    within one session (no new `_import_content` action in between) must
+    still be suppressed after round 3's dedup-reset fix.
+    """
+    app = _Host()
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(AudioBookGenerationWidget)
+        generation = widget._chapter_detect_generation
+
+        notify = Mock()
+        app.notify = notify
+
+        # Same count twice in a row, no import action in between: only the
+        # first call should toast.
+        widget._apply_detected_chapters(
+            [_stub_chapter(1), _stub_chapter(2)], generation
+        )
+        await pilot.pause()
+        widget._apply_detected_chapters(
+            [_stub_chapter(1), _stub_chapter(2)], generation
+        )
+        await pilot.pause()
+        assert notify.call_count == 1
+
+        # Count changes: a new toast fires.
+        widget._apply_detected_chapters([_stub_chapter(1)], generation)
+        await pilot.pause()
+        assert notify.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_notify_dedup_resets_on_a_new_import_action():
+    """The other direction (task-15478 review round 3): the dedup memory
+    used to never reset, so a genuinely NEW import that happens to detect
+    the same chapter count as whatever the previous session last toasted
+    was silently un-toasted -- reproduced by the reviewer. `_import_content`
+    (the single dispatcher all four source types funnel through, including
+    "paste": `_import_from_paste` is the app's own signal that the user is
+    about to start a fresh paste session) is the chosen reset seam -- see
+    its docstring/comment for the justification.
+    """
+    app = _Host()
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(AudioBookGenerationWidget)
+        generation = widget._chapter_detect_generation
+
+        # First "session": detect 2 chapters, toast once.
+        widget._apply_detected_chapters(
+            [_stub_chapter(1), _stub_chapter(2)], generation
+        )
+        await pilot.pause()
+
+        notify = Mock()
+        app.notify = notify
+
+        # A brand-new import action begins. Call `_import_content` directly
+        # rather than driving it through the "Import From" Select: that
+        # widget's `options=[(id, label), ...]` are backwards from what
+        # `_import_content`'s `if import_source == "file":` branches expect
+        # (a separate, pre-existing bug, out of scope here -- confirmed via
+        # `sel._options`, whose values are the display labels, not the
+        # lowercase source ids, so no branch can ever match). The reset
+        # line runs unconditionally as `_import_content`'s first action,
+        # before any source branch is even reached, so calling it directly
+        # still exercises exactly the reset behavior under test regardless
+        # of that separate bug. `reset_mock()` guards against a toast from
+        # a source branch that DOES fire, in case that bug gets fixed later
+        # and this test isn't revisited.
+        widget._import_content()
+        await pilot.pause()
+        notify.reset_mock()
+
+        # The new session detects the SAME count (2) as the prior session's
+        # last toast -- it must still fire, not be silently suppressed by
+        # memory belonging to the previous, now-superseded session.
+        widget._apply_detected_chapters(
+            [_stub_chapter(1), _stub_chapter(2)], widget._chapter_detect_generation
+        )
+        await pilot.pause()
+        assert notify.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_detected_chapters_rejects_a_stale_generation():
+    """The core guard, isolated from worker/thread timing (task-15478
+    review round 3): `_apply_detected_chapters` must drop a result whose
+    generation no longer matches the latest dispatched one, rather than
+    overwrite whatever a newer, already-applied result set.
     """
     app = _Host()
     async with app.run_test(size=(120, 48)) as pilot:
         await pilot.pause()
         widget = app.query_one(AudioBookGenerationWidget)
 
-        notify = Mock()
-        app.notify = notify
+        # Simulate: two detections were dispatched (generations 1 then 2);
+        # generation 2's (fresher) result already landed...
+        widget._chapter_detect_generation = 2
+        widget._apply_detected_chapters([_stub_chapter(2)], 2)
+        await pilot.pause()
+        assert [c.number for c in widget.detected_chapters] == [2]
 
-        # Same count twice in a row: only the first call should toast.
-        widget._apply_detected_chapters([_stub_chapter(1), _stub_chapter(2)])
+        # ...then generation 1's (staler) result arrives late, exactly as
+        # it would if its OS thread simply kept running past its own
+        # supersession. It must be dropped, not applied.
+        widget._apply_detected_chapters([_stub_chapter(999)], 1)
         await pilot.pause()
-        widget._apply_detected_chapters([_stub_chapter(1), _stub_chapter(2)])
-        await pilot.pause()
-        assert notify.call_count == 1
+        assert [c.number for c in widget.detected_chapters] == [2]
 
-        # Count changes: a new toast fires.
-        widget._apply_detected_chapters([_stub_chapter(1)])
+
+@pytest.mark.asyncio
+async def test_a_slower_superseded_detection_never_overwrites_a_faster_one(
+    monkeypatch,
+):
+    """Reviewer's exact repro shape (task-15478 review round 3): dispatch
+    slow-A then fast-B in one exclusive group; only B's result must stick.
+
+    `exclusive=True` on `_detect_chapters_worker` cancels a *queued* worker
+    in the same group; it cannot interrupt one already executing on its OS
+    thread (`Worker.cancel()` cancels the wrapping asyncio Task, not the
+    underlying thread). The reviewer reproduced 3/3 a slower, superseded
+    worker's `call_from_thread` overwriting a newer result -- realistic
+    because the three one-shot import paths have no debounce between them,
+    and detection can run up to ~700ms.
+
+    Uses real threads with `threading.Event` rendezvous rather than content
+    size to force A slower than B, so the ordering is deterministic
+    (load-independent) rather than a timing race: A blocks until B's result
+    has actually landed, then proceeds and attempts its own (stale) apply.
+    """
+    app = _Host()
+    async with app.run_test(size=(120, 48)) as pilot:
         await pilot.pause()
-        assert notify.call_count == 2
+        widget = app.query_one(AudioBookGenerationWidget)
+
+        a_started = threading.Event()
+        b_applied = threading.Event()
+
+        def fake_detect_chapters(content: str):
+            if content == "SLOW":
+                a_started.set()
+                # Block until B's (fresher) result has actually been
+                # applied to the widget -- this is what "A's OS thread
+                # outlives B, despite being logically superseded" looks
+                # like, deterministically, independent of real detector
+                # speed or machine load.
+                if not b_applied.wait(timeout=5):
+                    raise AssertionError("B's result never landed within 5s")
+                return [_stub_chapter(999)]  # A's STALE result
+            return [_stub_chapter(1)]  # B's FRESH result
+
+        monkeypatch.setattr(
+            ChapterDetector,
+            "detect_chapters",
+            staticmethod(fake_detect_chapters),
+        )
+
+        # Dispatch A ("slow"): starts running on a worker thread and blocks.
+        widget.content_text = "SLOW"
+        widget._detect_chapters()
+
+        for _ in range(500):
+            if a_started.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert a_started.is_set(), "worker A never started"
+
+        # Dispatch B ("fast"), in the same exclusive group as A. Its own
+        # detect_chapters call returns immediately (no blocking branch).
+        widget.content_text = "FAST"
+        widget._detect_chapters()
+
+        for _ in range(500):
+            if widget.detected_chapters and widget.detected_chapters[0].number == 1:
+                break
+            await asyncio.sleep(0.01)
+        assert (
+            widget.detected_chapters and widget.detected_chapters[0].number == 1
+        ), "B's (fast, newer) result never applied"
+
+        # Release A. Its thread resumes, computes its STALE result, and
+        # attempts to marshal it back -- this must be dropped.
+        b_applied.set()
+        await asyncio.sleep(0.3)
+
+        assert widget.detected_chapters and widget.detected_chapters[0].number == 1, (
+            "A's stale result overwrote B's newer one: "
+            f"detected_chapters={[c.number for c in widget.detected_chapters]}"
+        )

--- a/Tests/UI/test_speech_audiobook_chapter_detection.py
+++ b/Tests/UI/test_speech_audiobook_chapter_detection.py
@@ -1,0 +1,117 @@
+"""AudioBook auto-chapter detection must not crash the paste box (task-15478).
+
+`on_text_area_changed` (the handler behind the "Paste Text" content-preview
+box) used to gate chapter detection on `query_one("#auto-chapters-switch",
+Switch)`. That id was composed nowhere: the "Chapter Settings" collapsible
+that used to own it was replaced by `ChapterEditorWidget` in commit
+`256911ea6` ("audiobook work", 2025-07-22), and the four query sites were
+never updated. The result was a `NoMatches` raised on every keystroke in the
+paste box.
+
+The fix keeps auto-detection (its switch defaulted to on, and there is no UI
+left to turn it off) but:
+  - drops the dead query on all four sites;
+  - moves the keystroke-path call behind a debounce timer, since detection
+    walks the *entire* pasted text with `ChapterDetector.detect_chapters`
+    and pops a notify toast -- unacceptable once per keystroke.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import TextArea
+
+from tldw_chatbook.UI.STTS_Window import AudioBookGenerationWidget
+
+
+class _Host(App[None]):
+    def compose(self) -> ComposeResult:
+        yield AudioBookGenerationWidget()
+
+
+@pytest.mark.asyncio
+async def test_typing_in_the_paste_box_raises_no_exception():
+    """Regression repro: this used to raise NoMatches on every keystroke.
+
+    Simulates real typing (one `TextArea.Changed` message per keypress) in
+    the enabled content-preview TextArea and asserts the app is still alive
+    and the widget observed the content afterward.
+    """
+    app = _Host()
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(AudioBookGenerationWidget)
+        content_preview = app.query_one("#content-preview", TextArea)
+        content_preview.disabled = False
+        content_preview.focus()
+
+        for ch in "Hi there":
+            await pilot.press(ch if ch != " " else "space")
+
+        await pilot.pause()
+
+        assert widget.content_text == "Hi there"
+
+
+@pytest.mark.asyncio
+async def test_a_burst_of_keystrokes_runs_detection_once_after_it_settles():
+    """Detection must run off the keystroke path (task-15478 AC #2).
+
+    A burst of changes inside the debounce window must not call
+    `_detect_chapters` synchronously; it should fire exactly once, only
+    after the input goes quiet for the debounce interval.
+    """
+    app = _Host()
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(AudioBookGenerationWidget)
+        content_preview = app.query_one("#content-preview", TextArea)
+        content_preview.disabled = False
+
+        detect = Mock()
+        widget._detect_chapters = detect
+
+        debounce = widget._CHAPTER_DETECT_DEBOUNCE_SECONDS
+
+        # A rapid burst: several changes, each well inside the debounce
+        # window of the previous one.
+        content_preview.text = "Chapter 1"
+        await pilot.pause(debounce / 4)
+        content_preview.text = "Chapter 1\nChapter 2"
+        await pilot.pause(debounce / 4)
+        content_preview.text = "Chapter 1\nChapter 2\nChapter 3"
+
+        # Still inside the window from the last change: no call yet.
+        await pilot.pause(debounce / 4)
+        assert detect.call_count == 0
+
+        # Let the debounce interval elapse from the *last* change.
+        await pilot.pause(debounce + 0.2)
+
+        assert detect.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_file_import_still_auto_detects_without_the_missing_switch(tmp_path):
+    """The three one-shot import paths (file/notes/conversation) are not on
+    a keystroke path, so they keep running detection unconditionally --
+    matching the removed switch's `value=True` default, with no dead query.
+    """
+    book_path = tmp_path / "book.txt"
+    book_path.write_text("Chapter 1\nOnce upon a time.\n\nChapter 2\nThe end.\n")
+
+    app = _Host()
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(AudioBookGenerationWidget)
+
+        assert widget.detected_chapters == []
+
+        widget._handle_file_selection(str(book_path))
+        await pilot.pause()
+
+        assert widget.content_text.startswith("Chapter 1")
+        assert len(widget.detected_chapters) >= 1

--- a/Tests/UI/test_speech_audiobook_chapter_detection.py
+++ b/Tests/UI/test_speech_audiobook_chapter_detection.py
@@ -13,23 +13,66 @@ left to turn it off) but:
   - drops the dead query on all four sites;
   - moves the keystroke-path call behind a debounce timer, since detection
     walks the *entire* pasted text with `ChapterDetector.detect_chapters`
-    and pops a notify toast -- unacceptable once per keystroke.
+    and pops a notify toast -- unacceptable once per keystroke;
+  - moves the detection itself off the event loop entirely (review
+    follow-up): `ChapterDetector.detect_chapters` was benchmarked at
+    ~19ms/90k words, ~60ms/300k, ~200ms on a 6MB paste -- past the repo's
+    100ms worker budget for exactly the large pastes an audiobook feature
+    invites -- so it now runs in a `@work(thread=True)` worker with results
+    marshaled back via `call_from_thread`, for all four call sites, not
+    just the debounced one;
+  - only pops the "Detected N chapters" toast when N actually changes since
+    the last toast, so a debounced re-paste that keeps re-running detection
+    does not spam a toast per settle.
 """
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import Mock
 
 import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import TextArea
 
+from tldw_chatbook.TTS.audiobook_generator import Chapter
 from tldw_chatbook.UI.STTS_Window import AudioBookGenerationWidget
 
 
 class _Host(App[None]):
     def compose(self) -> ComposeResult:
         yield AudioBookGenerationWidget()
+
+
+def _make_large_book(n_words: int) -> str:
+    """Build synthetic book text with a "Chapter N" header every 2000 words.
+
+    Mirrors the shape the reviewer benchmarked ChapterDetector against
+    (~19ms/90k words, ~60ms/300k, ~200ms on a 6MB paste): plain prose lines
+    interspersed with chapter markers the detector's regexes actually match,
+    not degenerate all-blank or all-matching input.
+    """
+    words_per_line = 12
+    lines: list[str] = []
+    total = 0
+    chapter = 1
+    while total < n_words:
+        if total % 2000 == 0:
+            lines.append(f"Chapter {chapter}")
+            chapter += 1
+        lines.append(" ".join(["word"] * words_per_line))
+        total += words_per_line
+    return "\n".join(lines)
+
+
+def _stub_chapter(number: int) -> Chapter:
+    return Chapter(
+        number=number,
+        title=f"Chapter {number}",
+        content="Some words go here for this chapter.",
+        start_position=0,
+        end_position=0,
+    )
 
 
 @pytest.mark.asyncio
@@ -99,6 +142,10 @@ async def test_file_import_still_auto_detects_without_the_missing_switch(tmp_pat
     """The three one-shot import paths (file/notes/conversation) are not on
     a keystroke path, so they keep running detection unconditionally --
     matching the removed switch's `value=True` default, with no dead query.
+
+    Detection itself now runs in a background thread worker (review
+    follow-up), so this waits for it to actually finish rather than
+    asserting immediately after dispatch.
     """
     book_path = tmp_path / "book.txt"
     book_path.write_text("Chapter 1\nOnce upon a time.\n\nChapter 2\nThe end.\n")
@@ -112,6 +159,95 @@ async def test_file_import_still_auto_detects_without_the_missing_switch(tmp_pat
 
         widget._handle_file_selection(str(book_path))
         await pilot.pause()
+        await app.workers.wait_for_complete()
 
         assert widget.content_text.startswith("Chapter 1")
         assert len(widget.detected_chapters) >= 1
+
+
+@pytest.mark.asyncio
+async def test_event_loop_stays_responsive_during_large_paste_chapter_detection():
+    """The actual perf bug (task-15478 review): chapter detection used to
+    run synchronously on the event loop per debounce settle.
+    `ChapterDetector.detect_chapters` was benchmarked at ~19ms/90k words,
+    ~60ms/300k, ~200ms on a 6MB paste -- well past the repo's 100ms worker
+    budget, for exactly the large pastes an audiobook feature invites.
+
+    Same heartbeat-seam pattern as
+    `Tests/UI/test_llm_screen_ollama_probe_nonblocking.py` (task-15473): a
+    concurrent task ticks every 5ms while detection is in flight. This
+    brackets the heartbeat measurement tightly around `_detect_chapters()`
+    and its worker's completion only (bypassing the debounce timer and its
+    own ~1s of unrelated real-time sleep, which is covered separately by
+    `test_a_burst_of_keystrokes_runs_detection_once_after_it_settles` and
+    would otherwise dilute the signal -- confirmed empirically: with the
+    debounce wait included, a deliberately-reintroduced synchronous
+    detection call still cleared >100 heartbeats, because ~1s of real
+    `asyncio.sleep` swamped a ~700ms block). Over this tight window, a loop
+    frozen by a synchronous call lands at 0 ticks (measured); a correctly
+    threaded call clears double digits.
+    """
+    app = _Host()
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(AudioBookGenerationWidget)
+        content_preview = app.query_one("#content-preview", TextArea)
+        content_preview.disabled = False
+
+        # ~3,000,000 words / ~15MB -- comfortably north of the reviewer's 6MB
+        # reference point, for a clear, low-flake margin above the assertion
+        # threshold (measured ~650-700ms of detection, ~25-35 heartbeats).
+        widget.content_text = _make_large_book(3_000_000)
+
+        heartbeats = 0
+        stop = asyncio.Event()
+
+        async def _heartbeat() -> None:
+            nonlocal heartbeats
+            while not stop.is_set():
+                heartbeats += 1
+                await asyncio.sleep(0.005)
+
+        hb_task = asyncio.create_task(_heartbeat())
+        try:
+            widget._detect_chapters()
+            # Wait for the threaded detector to actually finish -- this is
+            # the window the heartbeat must keep ticking through.
+            await app.workers.wait_for_complete()
+        finally:
+            stop.set()
+            await hb_task
+
+        assert widget.detected_chapters
+        assert heartbeats >= 10, (
+            f"event loop looks starved during chapter detection: only "
+            f"{heartbeats} heartbeat ticks landed"
+        )
+
+
+@pytest.mark.asyncio
+async def test_notify_only_fires_when_the_chapter_count_changes():
+    """Minor fix (task-15478 review): a debounced re-paste can re-run
+    detection several times as the user keeps typing; before this, every
+    settle popped its own "Detected N chapters" toast even when N hadn't
+    moved.
+    """
+    app = _Host()
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(AudioBookGenerationWidget)
+
+        notify = Mock()
+        app.notify = notify
+
+        # Same count twice in a row: only the first call should toast.
+        widget._apply_detected_chapters([_stub_chapter(1), _stub_chapter(2)])
+        await pilot.pause()
+        widget._apply_detected_chapters([_stub_chapter(1), _stub_chapter(2)])
+        await pilot.pause()
+        assert notify.call_count == 1
+
+        # Count changes: a new toast fires.
+        widget._apply_detected_chapters([_stub_chapter(1)])
+        await pilot.pause()
+        assert notify.call_count == 2

--- a/backlog/tasks/task-15478 - STTS-audiobook-paste-box-queries-a-switch-that-is-never-composed.md
+++ b/backlog/tasks/task-15478 - STTS-audiobook-paste-box-queries-a-switch-that-is-never-composed.md
@@ -196,3 +196,97 @@ was re-added): 341 passed, 0 failed (339 baseline + 2 new tests this round).
 **Files changed**:
 - `tldw_chatbook/UI/STTS_Window.py`
 - `Tests/UI/test_speech_audiobook_chapter_detection.py` (new; 5 tests)
+
+## Review follow-up (round 3)
+
+Three findings from a re-review of round 2, all addressed -- see
+`Tests/UI/test_speech_audiobook_chapter_detection.py` and
+`tldw_chatbook/UI/STTS_Window.py` for the full detail; summary below.
+
+1. **Stale-result overwrite (Important).** `exclusive=True` on
+   `_detect_chapters_worker` cancels a *queued* worker in its group but
+   cannot interrupt one already executing on its OS thread
+   (`Worker.cancel()` cancels the wrapping asyncio Task, not the thread) --
+   the reviewer reproduced 3/3 a slower, superseded dispatch's
+   `call_from_thread` overwriting a newer result, realistic because the
+   three one-shot import paths have no debounce between them and detection
+   can run up to ~700ms. Fixed with a monotonically-increasing
+   `_chapter_detect_generation` id, captured in `_detect_chapters` and
+   threaded through the worker; `_apply_detected_chapters` now applies a
+   result only if its `generation` still matches the latest dispatched one
+   -- the guard runs entirely on the main thread (both the increment and
+   the check), so there is no cross-thread race on the counter itself.
+   Deliberately did NOT also add the suggested optional
+   `get_current_worker().is_cancelled` early-exit: adding it during
+   implementation caused the end-to-end reproduction test to pass even with
+   the generation guard *disabled* (mutation-tested), because in that
+   scenario the worker's own cancelled flag was already true by the time it
+   resumed -- i.e. it would have quietly masked whether the "real" guard
+   actually mattered. Left out in favor of one unambiguous correctness
+   mechanism.
+2. **Toast reset semantics.** `_last_notified_chapter_count` never reset,
+   so a genuinely new import that happened to detect the same count as a
+   previous session was silently un-toasted (reviewer reproduced). Reset
+   seam: `_import_content` -- the single dispatcher all four source types
+   (file/notes/conversation/paste) funnel through, and the app's own signal
+   that "a new bring-in-content action began" (for "paste" specifically,
+   this is what unlocks the previously-disabled content-preview box).
+   Detections re-run later within the same session with no further
+   `_import_content` call in between -- e.g. the paste box's debounced
+   re-detection -- still dedupe against each other, since this is the only
+   reset point.
+3. **Flaky gate.** The heartbeat test asserted an absolute count (`>= 10`),
+   which failed 4/6 runs under real machine load despite the fix being
+   structurally sound. Redesigned as a same-run, load-independent
+   comparison: a synchronous control arm (`ChapterDetector.detect_chapters`
+   called directly inside an `async def` wrapper with no internal `await`)
+   is *guaranteed* zero heartbeats by construction -- a coroutine with no
+   await point cannot yield, so a concurrently scheduled heartbeat task
+   cannot run even once during it, independent of machine speed -- and the
+   real threaded call only has to beat that guaranteed zero
+   (`threaded_heartbeats > sync_heartbeats`). Also reduced
+   `_make_large_book`'s chapter-header density (2000 -> 60,000 words per
+   chapter): the original density produced ~999 chapters for a 3M-word
+   book, which intermittently tripped an unrelated, pre-existing race in
+   `ChapterEditorWidget`/`Select`'s mount sequence when the chapter table
+   populated that many rows in one reactive update (observed once in a
+   full-file run, reproducible 0/4 afterward at the reduced density -- a
+   real but out-of-scope flake, not owned by this task).
+
+**Also found and worked around, out of scope:** the "Import From" `Select`
+(`#import-source-select`) is composed with `options=[(id, label), ...]`
+(e.g. `("file", "Text File")`), but Textual's `Select.options` order is
+`(renderable, value)` -- so the widget's actual `.value` is the display
+label ("Text File"), never the lowercase id `_import_content`'s
+`if import_source == "file":` branches check against. This means the
+"Import Content" button's source dispatch is non-functional today for all
+four sources, regardless of this task's changes. Not fixed here (separate,
+pre-existing bug); the round-3 dedup-reset test calls `_import_content`
+directly rather than driving it through the Select, since the reset line
+runs unconditionally before the (currently dead) branching.
+
+**Verification (round 3):**
+- Mutation-tested both new guards: disabling the generation check in
+  `_apply_detected_chapters` failed both
+  `test_apply_detected_chapters_rejects_a_stale_generation` and
+  `test_a_slower_superseded_detection_never_overwrites_a_faster_one` red;
+  disabling the `_import_content` reset failed
+  `test_notify_dedup_resets_on_a_new_import_action` red. Restored, all
+  green.
+- Ran `Tests/UI/test_speech_audiobook_chapter_detection.py` 6x consecutively
+  with `-s`: **all 6 green** (8 tests each), heartbeat-seam counts recorded
+  each run: `sync=0 threaded=24`, `sync=0 threaded=25` (x4), `sync=0
+  threaded=24` -- sync is deterministically 0 every run as designed;
+  threaded consistently clears 24-25, far above the old flaky threshold.
+- Full STTS/Speech batch (same 9 files): **344 passed**, 0 failed (341
+  baseline + 3 new tests this round).
+- `ruff check` on both changed files: all checks passed.
+
+**Files changed (round 3, on top of rounds 1-2):**
+- `tldw_chatbook/UI/STTS_Window.py` -- generation guard, `_import_content`
+  dedup reset.
+- `Tests/UI/test_speech_audiobook_chapter_detection.py` -- 3 new tests
+  (stale-generation unit test, end-to-end slow/fast dispatch test,
+  dedup-reset test), heartbeat test redesigned load-robust, `_make_large_book`
+  chapter density reduced, notify tests updated for the new `generation`
+  parameter.

--- a/backlog/tasks/task-15478 - STTS-audiobook-paste-box-queries-a-switch-that-is-never-composed.md
+++ b/backlog/tasks/task-15478 - STTS-audiobook-paste-box-queries-a-switch-that-is-never-composed.md
@@ -102,22 +102,97 @@ UI.
   content (via `git show HEAD:...`, since nothing was committed yet) and
   confirmed all three new tests fail red with the exact reported symptom
   (`NoMatches: No nodes match '#auto-chapters-switch'` raised out of
-  `on_text_area_changed`), including confirming the three import paths were
-  ALSO silently swallowing the same exception through their outer
-  `except Exception` blocks (e.g. `_handle_file_selection` showed a false
-  "Failed to import file: ..." error toast on an import that had actually
-  succeeded). Restored the fix afterward and reconfirmed green.
+  `on_text_area_changed`). Restored the fix afterward and reconfirmed green.
+- **Correction (review round 2):** the original version of this note claimed
+  all three pre-fix import paths "silently swallowed" the same `NoMatches`
+  into a false toast. That is only true for `_handle_file_selection` --
+  verified per-path severity below.
 
-**Tests**: new file `Tests/UI/test_speech_audiobook_chapter_detection.py`
-(3 tests, all born red against the pre-fix code, green after): typing raises
-no exception; a burst of keystrokes inside the debounce window calls
-`_detect_chapters` zero times until the window elapses, then exactly once;
-a one-shot file import still populates `detected_chapters` with no switch.
-Also ran the full STTS/Speech suite (`grep -rl STTS_Window Tests/` plus
-`test_speech_audiobook_layout.py`, which asserts the collapsible-group
-layout is unchanged -- confirming no switch UI was re-added): 339 passed, 0
-failed.
+**Per-path pre-fix failure severity** (corrected; the code fix itself did
+not change based on this -- all four dead queries were removed
+unconditionally either way):
+
+- `_handle_file_selection`: its own `try/except Exception` wraps the entire
+  callback body, so the dead-switch `NoMatches` WAS caught there, producing
+  a false `"Failed to import file: ..."` error toast on an import that had
+  actually already succeeded. Confirmed live in the mutation-test run above
+  (captured log: `ERROR ... Failed to import file: No nodes match
+  '#auto-chapters-switch' ...`).
+- `_import_from_notes`'s `handle_note_selection` and
+  `_import_from_conversation`'s `handle_conversation_selection`: **not** a
+  toast. Both are passed as the `callback` to `self.app.push_screen(dialog,
+  callback)`. Textual delivers a screen-dismiss callback via
+  `ResultCallback.__call__` -> `self.requester.call_next(self.callback,
+  result)` (`textual/screen.py`), i.e. as a `Callback` message processed on
+  a LATER message-pump cycle of the widget -- by which point the `try`
+  block that lexically surrounds the `push_screen()` call has already
+  returned and is no longer on the stack. Neither nested callback has a
+  `try/except` of its own. Verified with a minimal standalone repro
+  (`push_screen(dialog, callback)` where `callback` raises `NoMatches`,
+  no per-callback try/except, matching this file's exact shape): the outer
+  `try` printed as having "completed normally" (never entered its
+  `except`), and the `NoMatches` instead surfaced through
+  `message_pump._flush_next_callbacks` all the way out as an unhandled
+  exception -- a crash-class error, not a caught-and-converted toast.
+
+## Review follow-up (round 2)
+
+Two Important findings from review, both addressed without changing the
+chosen resolution (keep detection, no switch UI):
+
+1. **Per-fire cost still on the loop.** `_detect_chapters()`'s CPU-bound
+   part (`ChapterDetector.detect_chapters`, O(len(content)) regex scanning)
+   still ran synchronously wherever it was called from -- including the
+   debounce timer's callback, which runs on the event loop. Benchmarked
+   locally: ~30ms/90k words, ~48ms/300k, ~150ms/1,000,000 words (~5MB) --
+   consistent with the reviewer's own ~19/60/200ms figures and well past the
+   repo's 100ms worker budget, for exactly the pastes an audiobook feature
+   invites. Fixed by splitting `_detect_chapters()` into a thin dispatcher
+   plus `_detect_chapters_worker` (a `@work(thread=True, exclusive=True)`
+   method) that runs the detector off the event loop and marshals the
+   result back to `_apply_detected_chapters` via `self.app.call_from_thread`
+   -- for all four call sites, not just the debounced one. The three
+   one-shot import paths do not have genuinely bounded content either (a
+   file/note/conversation import can be just as large as a paste), so they
+   route through the same threaded path rather than being special-cased as
+   "small enough."
+   - Minor also fixed here: `_notify_chapter_count` now only pops the
+     "Detected N chapters" toast when N changed since the last toast, so a
+     debounced re-paste that re-runs detection several times does not spam
+     one toast per settle.
+2. **Notes accuracy** -- see the corrected per-path section above.
+
+## Verification (round 2)
+
+Heartbeat-seam pattern (same idiom as
+`Tests/UI/test_llm_screen_ollama_probe_nonblocking.py`, task-15473): a
+concurrent `asyncio` task ticking every 5ms, bracketed tightly around
+`_detect_chapters()` + `await app.workers.wait_for_complete()` for a
+~3,000,000-word (~15MB) paste. Mutation-tested by temporarily forcing a
+synchronous call (bypassing the worker): heartbeats dropped from ~25-35 to
+**0** over the same window, confirming the test actually discriminates the
+regression -- an earlier draft of this test bracketed the debounce timer's
+own ~1s of unrelated real-time sleep too, which was proven (empirically) to
+swamp the signal: a deliberately-reintroduced synchronous call still
+cleared 173 heartbeats in that wider window, a false pass.
+
+**Tests**: `Tests/UI/test_speech_audiobook_chapter_detection.py` now has 5
+tests (all born red against the applicable pre-fix code, green after):
+typing raises no exception; a burst of keystrokes inside the debounce window
+calls `_detect_chapters` zero times until the window elapses, then exactly
+once; a one-shot file import still populates `detected_chapters` with no
+switch (now also awaits `app.workers.wait_for_complete()` since detection is
+threaded); the event loop stays responsive (heartbeats >= 10, mutation-tested
+per above) during a large-paste detection; a toast fires only when the
+detected chapter count changes (mutation-tested: removing the dedup check
+made the test fail red).
+
+Re-ran: the 5-test file alone (5 passed), plus the full STTS/Speech suite
+(`grep -rl STTS_Window Tests/` plus `test_speech_audiobook_layout.py`, which
+asserts the collapsible-group layout is unchanged -- confirming no switch UI
+was re-added): 341 passed, 0 failed (339 baseline + 2 new tests this round).
+`ruff check` on both changed files: all checks passed.
 
 **Files changed**:
 - `tldw_chatbook/UI/STTS_Window.py`
-- `Tests/UI/test_speech_audiobook_chapter_detection.py` (new)
+- `Tests/UI/test_speech_audiobook_chapter_detection.py` (new; 5 tests)

--- a/backlog/tasks/task-15478 - STTS-audiobook-paste-box-queries-a-switch-that-is-never-composed.md
+++ b/backlog/tasks/task-15478 - STTS-audiobook-paste-box-queries-a-switch-that-is-never-composed.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15478
 title: STTS audiobook paste box queries a switch that is never composed
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - bug
@@ -20,7 +21,103 @@ Decide: restore the switch with detection moved to Submit or a debounced worker,
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Typing in the audiobook paste box raises no exceptions (evidence)
-- [ ] #2 If chapter detection is kept, it runs off the keystroke path (Submit or debounced worker)
-- [ ] #3 The chosen behavior is covered by a test
+- [x] #1 Typing in the audiobook paste box raises no exceptions (evidence)
+- [x] #2 If chapter detection is kept, it runs off the keystroke path (Submit or debounced worker)
+- [x] #3 The chosen behavior is covered by a test
 <!-- AC:END -->
+
+## Implementation Plan
+
+**Decision: keep chapter detection, drop the dead switch, debounce the
+keystroke path.** Evidence (`git log --all --oneline -S'auto-chapters-switch'`):
+the switch WAS composed (`Switch(id="auto-chapters-switch", value=True)`,
+commit `74ec9b62b`) and was removed by commit `256911ea6` ("audiobook work",
+2025-07-22) when the whole "Chapter Settings" collapsible was replaced by the
+`ChapterEditorWidget` (its own pattern input + manual "Detect" button). The
+four `query_one("#auto-chapters-switch", ...)` guards were never updated in
+that same commit -- an oversight, not a deliberate kill of the auto-detect
+feature. `_detect_chapters()` itself (STTS_Window.py:700) is fully wired to
+the still-composed `#chapter-editor-widget` and works; only the phantom
+switch guard is dead. The switch defaulted to `value=True` and the app now
+exposes no UI to turn it off, so the faithful reading of "current intended
+behavior" is "detection always runs" for the three one-shot import paths
+(file/notes/conversation) -- no keystroke repetition there, so AC #2 is moot
+for them. Only `on_text_area_changed` (the paste box) fires per keystroke;
+that path keeps detection but moves it behind a debounce timer instead of
+running synchronously per keystroke, per AC #2's explicit "debounced worker"
+option. Not restoring the switch UI itself avoids re-growing the collapsible
+group count that `Tests/UI/test_speech_audiobook_layout.py`'s docstring
+documents as deliberately fixed ("the grouping itself is unchanged").
+
+1. `_handle_file_selection`, `_import_from_notes`, `_import_from_conversation`:
+   drop the dead `if self.query_one("#auto-chapters-switch", Switch).value:`
+   guard, call `self._detect_chapters()` unconditionally (matches the
+   pre-refactor default).
+2. `on_text_area_changed`: drop the dead guard; queue `_detect_chapters()` on
+   a cancel-and-restart `self.set_timer(...)` debounce (same idiom as
+   `library_screen.py`'s `_queue_library_prompts_search`), so a burst of
+   keystrokes runs detection once, ~1s after the user stops typing, off the
+   message-pump path. Stop the pending timer `on_unmount`.
+3. Tests in `Tests/UI/test_speech_audiobook_chapter_detection.py`, mounting
+   `AudioBookGenerationWidget` directly in a minimal `App` host (pattern from
+   `Tests/UI/test_stts_settings_widget.py`'s `_Host`):
+   - typing/loading text into `#content-preview` raises no exception (the
+     repro of the current bug, born red against the unmodified code);
+   - the debounce timer is armed (not an immediate synchronous call) on
+     `TextArea.Changed`, and `_detect_chapters` runs once after it elapses,
+     not once per keystroke;
+   - a one-shot import path (`_handle_file_selection`) still populates
+     `detected_chapters` without needing any switch.
+4. Run the STTS window suites (`grep -rl STTS_Window Tests/`) plus the new
+   file; read the pass counts.
+
+## Implementation Notes
+
+Implemented exactly the plan above: kept auto-detect, deleted the four dead
+`query_one("#auto-chapters-switch", ...)` guards, did not restore any switch
+UI.
+
+- `_handle_file_selection`, `_import_from_notes`'s `handle_note_selection`,
+  `_import_from_conversation`'s `handle_conversation_selection`: the dead
+  guard is gone; each now calls `self._detect_chapters()` unconditionally
+  after loading content into `#content-preview`. These are one-shot,
+  user-triggered paths (file pick / note pick / conversation pick), not
+  keystroke-repeated, so AC #2 does not apply to them and no debounce was
+  needed.
+- `on_text_area_changed` (the paste box): now calls
+  `_queue_debounced_chapter_detection()`, which (re)arms a
+  `self.set_timer(_CHAPTER_DETECT_DEBOUNCE_SECONDS, ...)` (1.0s) on every
+  `TextArea.Changed`, cancelling any prior pending timer first. Detection
+  (`ChapterDetector.detect_chapters` over the full text + a notify toast)
+  now runs at most once per pause in typing, never synchronously inside the
+  message handler. The timer is stopped in a new `on_unmount` to avoid a
+  stray callback after the widget is gone.
+- Confirmed via `git log --all -S'auto-chapters-switch'` that the switch WAS
+  composed once (`74ec9b62b`) and was dropped by `256911ea6`
+  ("audiobook work", 2025-07-22) when the "Chapter Settings" collapsible was
+  replaced by `ChapterEditorWidget` -- an oversight in that refactor, not a
+  deliberate feature removal, since `_detect_chapters()` itself stayed fully
+  wired to the still-composed `#chapter-editor-widget`.
+- Mutation-tested the regression test: temporarily restored the pre-fix file
+  content (via `git show HEAD:...`, since nothing was committed yet) and
+  confirmed all three new tests fail red with the exact reported symptom
+  (`NoMatches: No nodes match '#auto-chapters-switch'` raised out of
+  `on_text_area_changed`), including confirming the three import paths were
+  ALSO silently swallowing the same exception through their outer
+  `except Exception` blocks (e.g. `_handle_file_selection` showed a false
+  "Failed to import file: ..." error toast on an import that had actually
+  succeeded). Restored the fix afterward and reconfirmed green.
+
+**Tests**: new file `Tests/UI/test_speech_audiobook_chapter_detection.py`
+(3 tests, all born red against the pre-fix code, green after): typing raises
+no exception; a burst of keystrokes inside the debounce window calls
+`_detect_chapters` zero times until the window elapses, then exactly once;
+a one-shot file import still populates `detected_chapters` with no switch.
+Also ran the full STTS/Speech suite (`grep -rl STTS_Window Tests/` plus
+`test_speech_audiobook_layout.py`, which asserts the collapsible-group
+layout is unchanged -- confirming no switch UI was re-added): 339 passed, 0
+failed.
+
+**Files changed**:
+- `tldw_chatbook/UI/STTS_Window.py`
+- `Tests/UI/test_speech_audiobook_chapter_detection.py` (new)

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -22,6 +22,7 @@ from textual.widgets import (
 )
 from textual.css.query import QueryError
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widget import Widget
 from textual.reactive import reactive
 from textual import on
@@ -179,6 +180,12 @@ class VoiceProfilePickerModal(ModalScreen[TTSPlaygroundSelectionPreset | None]):
 class AudioBookGenerationWidget(Widget):
     """AudioBook/Podcast Generation widget"""
 
+    # How long to wait after the last keystroke in the content-preview paste
+    # box before running chapter detection (task-15478). Detection walks the
+    # full pasted text with ChapterDetector.detect_chapters and pops a notify
+    # toast, so it must not run on every TextArea.Changed message.
+    _CHAPTER_DETECT_DEBOUNCE_SECONDS = 1.0
+
     DEFAULT_CSS = """
     AudioBookGenerationWidget {
         height: 100%;
@@ -213,6 +220,7 @@ class AudioBookGenerationWidget(Widget):
         self.content_text = ""
         self.detected_chapters = []
         self.generated_audiobook_path = None
+        self._chapter_detect_debounce_timer: Optional[Timer] = None
 
     def compose(self) -> ComposeResult:
         """Compose the AudioBook/Podcast UI.
@@ -345,6 +353,12 @@ class AudioBookGenerationWidget(Widget):
         # Delay initialization to ensure widgets are ready
         self.set_timer(0.1, self._initialize_audiobook_defaults)
 
+    def on_unmount(self) -> None:
+        """Cancel any pending debounced chapter detection."""
+        if self._chapter_detect_debounce_timer is not None:
+            self._chapter_detect_debounce_timer.stop()
+            self._chapter_detect_debounce_timer = None
+
     def _initialize_audiobook_defaults(self) -> None:
         """Initialize default values after widgets are ready"""
         try:
@@ -454,9 +468,11 @@ class AudioBookGenerationWidget(Widget):
             )
             content_preview.disabled = False
 
-            # Detect chapters if enabled
-            if self.query_one("#auto-chapters-switch", Switch).value:
-                self._detect_chapters()
+            # Auto-detect chapters. This used to be gated by an
+            # "#auto-chapters-switch" that no longer exists in the composed UI
+            # (task-15478) -- it defaulted to on and there is currently no
+            # control to turn it off, so a one-shot import always detects.
+            self._detect_chapters()
 
             self.app.notify(
                 f"Imported {len(content)} characters from {Path(path).name}",
@@ -509,9 +525,9 @@ class AudioBookGenerationWidget(Widget):
                     content_preview.load_text(preview_text)
                     content_preview.disabled = False
 
-                    # Detect chapters if enabled
-                    if self.query_one("#auto-chapters-switch", Switch).value:
-                        self._detect_chapters()
+                    # Auto-detect chapters (see task-15478: the switch that
+                    # used to gate this is gone from the composed UI).
+                    self._detect_chapters()
 
                     self.app.notify(
                         f"Imported {len(selected_ids)} note(s)", severity="information"
@@ -593,10 +609,10 @@ class AudioBookGenerationWidget(Widget):
                     content_preview.load_text(preview_text)
                     content_preview.disabled = False
 
-                    # Auto-detect chapters might not be suitable for conversations
-                    # but run it if enabled
-                    if self.query_one("#auto-chapters-switch", Switch).value:
-                        self._detect_chapters()
+                    # Auto-detect chapters might not be suitable for
+                    # conversations, but run it anyway (see task-15478: the
+                    # switch that used to gate this is gone from the UI).
+                    self._detect_chapters()
 
                     self.app.notify(
                         f"Imported conversation with {len(messages)} messages",
@@ -626,12 +642,34 @@ class AudioBookGenerationWidget(Widget):
         """Handle text area content changes"""
         if event.text_area.id == "content-preview":
             self.content_text = event.text_area.text
-            # Detect chapters if auto-detect is enabled
-            if (
-                self.query_one("#auto-chapters-switch", Switch).value
-                and self.content_text
-            ):
-                self._detect_chapters()
+            self._queue_debounced_chapter_detection()
+
+    def _queue_debounced_chapter_detection(self) -> None:
+        """Debounce chapter detection while the user is still typing/pasting.
+
+        `_detect_chapters()` walks the entire `content_text` with
+        `ChapterDetector.detect_chapters` and pops a notify toast, so running
+        it synchronously from `TextArea.Changed` -- which fires once per
+        keystroke -- is unacceptable (task-15478; this replaced a since
+        removed "#auto-chapters-switch" guard). Instead, (re)arm a timer on
+        every change and only run detection once the input goes quiet.
+        """
+        if self._chapter_detect_debounce_timer is not None:
+            self._chapter_detect_debounce_timer.stop()
+            self._chapter_detect_debounce_timer = None
+
+        if not self.content_text:
+            return
+
+        self._chapter_detect_debounce_timer = self.set_timer(
+            self._CHAPTER_DETECT_DEBOUNCE_SECONDS,
+            self._run_debounced_chapter_detection,
+        )
+
+    def _run_debounced_chapter_detection(self) -> None:
+        """Timer callback: run detection once, then clear the timer handle."""
+        self._chapter_detect_debounce_timer = None
+        self._detect_chapters()
 
     def on_chapter_edit_event(self, event) -> None:
         """Handle chapter edit events from the chapter editor"""

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -224,8 +224,18 @@ class AudioBookGenerationWidget(Widget):
         # Last chapter count a "Detected N chapters" toast was shown for
         # (task-15478 review): a debounced re-paste can re-run detection
         # several times as the user keeps typing, and every settle used to
-        # pop its own toast even when the count hadn't moved.
+        # pop its own toast even when the count hadn't moved. Reset in
+        # `_import_content` -- see that method's comment for why that's the
+        # right seam.
         self._last_notified_chapter_count: Optional[int] = None
+        # Monotonically-increasing dispatch id (task-15478 review round 2):
+        # `exclusive=True` on the detection worker cancels QUEUED workers in
+        # its group, but cannot interrupt one already running on an OS
+        # thread -- a slower, superseded dispatch can still finish after a
+        # faster, newer one and overwrite its result. `_apply_detected_
+        # chapters` only applies a result whose generation matches the
+        # latest dispatched one.
+        self._chapter_detect_generation: int = 0
 
     def compose(self) -> ComposeResult:
         """Compose the AudioBook/Podcast UI.
@@ -420,6 +430,22 @@ class AudioBookGenerationWidget(Widget):
     def _import_content(self) -> None:
         """Import content for audiobook generation"""
         import_source = self.query_one("#import-source-select", Select).value
+
+        # Every source (including "paste": this is the app's own signal
+        # that the user is about to start pasting a new document, since
+        # `_import_from_paste` is what enables and focuses the previously
+        # disabled content-preview box) is a deliberate, one-shot "bring in
+        # new content" action. Reset the notify-dedup memory here, not
+        # inside `_detect_chapters`/`_apply_detected_chapters`, so a freshly
+        # imported document that happens to detect the same chapter count
+        # as whatever the PREVIOUS session last toasted still gets its own
+        # toast (task-15478 review: this used to never reset, so a
+        # genuinely new import could go silently un-toasted). Detections
+        # re-run later within the SAME session -- e.g. the paste box's
+        # debounced re-detection as the user keeps typing after this point,
+        # with no further `_import_content` call in between -- still dedupe
+        # against each other, since this is the only reset point.
+        self._last_notified_chapter_count = None
 
         if import_source == "file":
             self._import_from_file()
@@ -758,18 +784,41 @@ class AudioBookGenerationWidget(Widget):
         The CPU-bound detection itself runs in `_detect_chapters_worker` (a
         `@work(thread=True)` method); this method only snapshots
         `content_text` and dispatches it.
+
+        `exclusive=True` on that worker only cancels a prior *queued* run in
+        the same group -- it cannot interrupt one already executing on an OS
+        thread. A stale, slower dispatch can therefore still finish and
+        marshal its result back AFTER a newer, faster one (task-15478
+        review round 2; reproduced 3/3 with two back-to-back dispatches, no
+        debounce between them, which is exactly what happens across the
+        three one-shot import paths). A monotonically-increasing generation
+        id is captured here and threaded through; `_apply_detected_chapters`
+        only applies a result whose generation still matches the latest one
+        dispatched.
         """
         if not self.content_text:
             return
-        self._detect_chapters_worker(self.content_text)
+        self._chapter_detect_generation += 1
+        generation = self._chapter_detect_generation
+        self._detect_chapters_worker(self.content_text, generation)
 
     @work(thread=True, exclusive=True, group="audiobook-chapter-detection")
-    def _detect_chapters_worker(self, content: str) -> None:
+    def _detect_chapters_worker(self, content: str, generation: int) -> None:
         """Thread: run the CPU-bound detector, then marshal the result back.
 
-        `exclusive=True` cancels any prior in-flight detection in this same
-        group -- if content changes again before a run finishes, only the
-        latest result should ever reach `_apply_detected_chapters`.
+        `exclusive=True` cancels any prior *queued* worker in this same
+        group; it does not stop one already mid-execution on its OS thread
+        (`Worker.cancel()` cannot interrupt a running thread). Deliberately
+        NOT also checking `get_current_worker().is_cancelled` here as a
+        "skip the wasted marshal" shortcut, tempting as that is: it would
+        make the one-marshal-always-arrives, `_apply_detected_chapters`
+        never-overwrites-a-newer-result contract depend on a second,
+        cross-thread-timing-sensitive mechanism whose semantics are a
+        Textual implementation detail, for a saving that only matters on
+        the rare superseded path anyway. The `generation` stamp -- checked
+        in `_apply_detected_chapters`, on the main thread, with no
+        cross-thread race since only that thread ever reads or writes it --
+        is the one real correctness guard.
         """
         try:
             from tldw_chatbook.TTS.audiobook_generator import ChapterDetector
@@ -784,14 +833,27 @@ class AudioBookGenerationWidget(Widget):
             )
             return
 
-        self.app.call_from_thread(self._apply_detected_chapters, chapters)
+        self.app.call_from_thread(
+            self._apply_detected_chapters, chapters, generation
+        )
 
-    def _apply_detected_chapters(self, chapters: List) -> None:
+    def _apply_detected_chapters(self, chapters: List, generation: int) -> None:
         """Main-thread half of chapter detection: apply results to the UI.
 
         Called via `call_from_thread` from `_detect_chapters_worker`, so it
-        must stay main-thread-only (widget queries/mutation, notify).
+        must stay main-thread-only (widget queries/mutation, notify). Only
+        applies a result if `generation` still matches the most recently
+        dispatched detection -- a superseded (stale) result is dropped
+        rather than overwriting a newer, already-applied one.
         """
+        if generation != self._chapter_detect_generation:
+            logger.debug(
+                "Dropping stale chapter-detection result "
+                f"(generation {generation}, current "
+                f"{self._chapter_detect_generation})"
+            )
+            return
+
         self.detected_chapters = chapters
 
         try:

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -25,7 +25,7 @@ from textual.screen import ModalScreen
 from textual.timer import Timer
 from textual.widget import Widget
 from textual.reactive import reactive
-from textual import on
+from textual import on, work
 from loguru import logger
 
 # Local imports
@@ -221,6 +221,11 @@ class AudioBookGenerationWidget(Widget):
         self.detected_chapters = []
         self.generated_audiobook_path = None
         self._chapter_detect_debounce_timer: Optional[Timer] = None
+        # Last chapter count a "Detected N chapters" toast was shown for
+        # (task-15478 review): a debounced re-paste can re-run detection
+        # several times as the user keeps typing, and every settle used to
+        # pop its own toast even when the count hadn't moved.
+        self._last_notified_chapter_count: Optional[int] = None
 
     def compose(self) -> ComposeResult:
         """Compose the AudioBook/Podcast UI.
@@ -736,51 +741,103 @@ class AudioBookGenerationWidget(Widget):
             logger.info(f"Voice assigned: {event.character_name} → {event.voice_id}")
 
     def _detect_chapters(self) -> None:
-        """Detect chapters in the content"""
+        """Detect chapters in the content, off the event loop.
+
+        `ChapterDetector.detect_chapters` is O(len(content)) regex scanning
+        over every line -- benchmarked (task-15478 review) at ~19ms for 90k
+        words, ~60ms for 300k, and ~200ms on a 6MB paste. That is well past
+        the repo's 100ms worker budget, for exactly the large pastes an
+        audiobook feature invites, and it used to run synchronously on the
+        event loop from all four call sites (three one-shot imports, plus
+        the debounced paste-box timer). None of the three import paths have
+        a genuinely bounded size either -- a book imported from a file, a
+        note, or a long conversation can all be just as large as a paste --
+        so all four now route through this one threaded path rather than
+        special-casing which callers are "small enough".
+
+        The CPU-bound detection itself runs in `_detect_chapters_worker` (a
+        `@work(thread=True)` method); this method only snapshots
+        `content_text` and dispatches it.
+        """
         if not self.content_text:
             return
+        self._detect_chapters_worker(self.content_text)
 
+    @work(thread=True, exclusive=True, group="audiobook-chapter-detection")
+    def _detect_chapters_worker(self, content: str) -> None:
+        """Thread: run the CPU-bound detector, then marshal the result back.
+
+        `exclusive=True` cancels any prior in-flight detection in this same
+        group -- if content changes again before a run finishes, only the
+        latest result should ever reach `_apply_detected_chapters`.
+        """
         try:
             from tldw_chatbook.TTS.audiobook_generator import ChapterDetector
+
+            chapters = ChapterDetector.detect_chapters(content)
+        except Exception as e:
+            logger.error(f"Failed to detect chapters: {e}")
+            self.app.call_from_thread(
+                self.app.notify,
+                f"Failed to detect chapters: {e}",
+                severity="error",
+            )
+            return
+
+        self.app.call_from_thread(self._apply_detected_chapters, chapters)
+
+    def _apply_detected_chapters(self, chapters: List) -> None:
+        """Main-thread half of chapter detection: apply results to the UI.
+
+        Called via `call_from_thread` from `_detect_chapters_worker`, so it
+        must stay main-thread-only (widget queries/mutation, notify).
+        """
+        self.detected_chapters = chapters
+
+        try:
             from tldw_chatbook.Widgets.TTS.chapter_editor_widget import (
                 ChapterEditorWidget,
             )
-
-            # Detect chapters
-            self.detected_chapters = ChapterDetector.detect_chapters(self.content_text)
 
             # Update the chapter editor widget
             try:
                 chapter_editor = self.query_one(
                     "#chapter-editor-widget", ChapterEditorWidget
                 )
-                chapter_editor.set_chapters(self.detected_chapters)
-                self.app.notify(
-                    f"Detected {len(self.detected_chapters)} chapters",
-                    severity="information",
-                )
+                chapter_editor.set_chapters(chapters)
+                self._notify_chapter_count(len(chapters))
             except Exception as e:
                 logger.warning(f"Could not update chapter editor: {e}")
                 # Fall back to old display method if chapter editor not found
                 chapter_list = self.query_one("#chapter-list", Static)
-                if self.detected_chapters:
+                if chapters:
                     chapter_display = []
-                    for i, chapter in enumerate(self.detected_chapters):
+                    for i, chapter in enumerate(chapters):
                         chapter_display.append(
                             f"{i + 1}. {chapter.title} ({len(chapter.content.split())} words)"
                         )
 
                     chapter_list.update("\n".join(chapter_display))
-                    self.app.notify(
-                        f"Detected {len(self.detected_chapters)} chapters",
-                        severity="information",
-                    )
+                    self._notify_chapter_count(len(chapters))
                 else:
                     chapter_list.update("No chapters detected")
 
         except Exception as e:
             logger.error(f"Failed to detect chapters: {e}")
             self.app.notify(f"Failed to detect chapters: {e}", severity="error")
+
+    def _notify_chapter_count(self, count: int) -> None:
+        """Toast only when the detected chapter count changed since the last
+        toast (task-15478 review Minor).
+
+        A debounced re-paste can re-run detection several times as the user
+        keeps typing; before this, every settle popped its own
+        "Detected N chapters" toast even when N hadn't moved.
+        """
+        if count == self._last_notified_chapter_count:
+            return
+        self._last_notified_chapter_count = count
+        self.app.notify(f"Detected {count} chapters", severity="information")
 
     def _generate_audiobook(self) -> None:
         """Generate the audiobook"""


### PR DESCRIPTION
## Summary

Task 15478 from the input-latency audit's bug set. Typing in the audiobook paste box raised NoMatches on every keystroke (four queries against `#auto-chapters-switch`, an id dropped in a historical refactor with the guards left behind).

- Dead queries removed; detection kept (the dropped switch defaulted on — git archaeology verified) and moved off the keystroke path: 1s debounce + `@work(thread=True)` worker for all four call sites (reviewer benchmarked up to ~200ms per fire on large pastes — over the loop budget)
- **Stale-result guard**: review empirically disproved the `exclusive=True` "latest wins" assumption for thread workers (a superseded OS thread's callback still fires) — a main-thread-only generation counter now gates `_apply_detected_chapters`; the reviewer-suggested `is_cancelled` early-exit was deliberately dropped after mutation-testing showed it masked the guard's load-bearing-ness
- Toast dedup with reset at the shared import seam (new deliberate action re-toasts; same-session re-settles stay quiet — both directions tested)
- The flaky heartbeat gate redesigned as a same-run comparison against a structurally-zero synchronous control arm — 9 consecutive stable runs recorded across implementer + reviewer
- Two pre-existing bugs discovered and documented for filing: the import-source Select's options tuple is BACKWARDS (`(value, label)` vs Textual's `(label, value)`), making all four import dispatch branches non-functional today; and a ChapterEditorWidget/Select mount race under DataTable churn

## Verification
Three review rounds; every guard mutation-verified independently (each kills exactly its tests); 344/344 on the 9-file batch reproduced; pre-existing claims verified via per-commit file-touch evidence and a standalone Select repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes dead `#auto-chapters-switch` lookups and moves chapter detection off the event loop with a debounce and generation guard to stop paste-box crashes and UI stalls. Previously each keystroke queried a missing switch and ran detection synchronously; now detection runs in a threaded worker, applies only if current, and notifications dedupe correctly.

- Paste box: 1s debounce routes to a `@work(thread=True, exclusive=True)` worker; a main-thread generation counter prevents stale result overwrites. Pending timers cancel on unmount.
- Imports (file/notes/conversation): drop the dead switch queries; always run detection (the removed switch defaulted true).
- UI updates: apply results on the main thread; toast only when the chapter count changes; reset toast memory on `_import_content` so new sessions re-toast.
- Tests: regression (no keystroke crash), debounce single-fire, large-paste responsiveness (load-robust heartbeat comparison), stale-generation drop, deterministic slow-then-fast overwrite prevention, and dedup reset.
- Not in scope but documented: `Select` options use `(label, value)` in `textual`; current `(id, label)` wiring makes import-source branching non-functional. No behavior change here.
- Satisfies TASK-15478 acceptance criteria: no exceptions while typing, detection off the keystroke path, and tests cover the behavior.

<sup>Written for commit 2a3195303ef9b0ff3b00198e6ceeb8537556fb8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

