### PR TITLE
fix(console): stop derived-state churn from wiping a completed run state (task-15511)

### DIFF
--- a/Tests/Chat/test_console_turn_execution_context.py
+++ b/Tests/Chat/test_console_turn_execution_context.py
@@ -572,6 +572,12 @@ def test_screen_selection_builder_targets_session_without_switching_view():
         settings=_settings("anthropic", "model-b", "system-b"),
     )
     fake_screen = SimpleNamespace(
+        # Real ChatScreen carries this as a CLASS-attribute default (None =
+        # no derivation pass open); the derivation path reads it
+        # unconditionally, and a SimpleNamespace double has no class default
+        # to fall back on. Went red on dev when the memo landed without this
+        # double being taught about it -- the stale-double class again.
+        _console_derivation_memo=None,
         _provider_readiness_app_config=lambda: {
             "api_settings": {
                 "openai": {"model": "configured-a"},
@@ -596,6 +602,15 @@ def test_screen_selection_builder_targets_session_without_switching_view():
             )
         ),
         _normalize_llamacpp_base_url=lambda value: value,
+    )
+    # task-15452 split the builder into a memo wrapper plus
+    # `_build_console_provider_selection_uncached`; the wrapper under test
+    # delegates to the latter through `self`, so the double borrows the real
+    # uncached half exactly as the memo-less path binds it in production.
+    fake_screen._build_console_provider_selection_uncached = (
+        lambda session_id=None: ChatScreen._build_console_provider_selection_uncached(
+            fake_screen, session_id
+        )
     )
 
     selection = ChatScreen._build_console_provider_selection(

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -2168,17 +2168,6 @@ def _select_llamacpp_console(console: ChatScreen) -> None:
     console._sync_console_control_bar()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "task-15511: a completed non-streaming send leaves run_state at IDLE "
-    "instead of COMPLETED. Measured stable across ~0.8s of pumping, so not a "
-    "race; either the transition is missing or the send used a different "
-    "controller instance than _ensure_console_chat_controller() returns. "
-    "Passed only while the harness booted with a near-empty config "
-    "(task-15270). strict=True so a fix flips this loudly."
-    ),
-)
 @pytest.mark.asyncio
 async def test_console_native_generic_provider_send_renders_completed_message(
     monkeypatch,
@@ -11377,16 +11366,6 @@ async def test_clear_attachment_button_resyncs_composer_blocked_state(monkeypatc
         )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "task-15511: the inline image row appears after prep but disappears on the "
-    "first pixels -> graphics toggle, where it is asserted still present -- "
-    "likely a config-selected render mode that draws nothing instead of "
-    "falling back. Passed only while the harness booted with a near-empty "
-    "config (task-15270). strict=True so a fix flips this loudly."
-    ),
-)
 @pytest.mark.asyncio
 async def test_image_message_gets_inline_row_after_prep_and_toggle_cycles():
     app = _build_test_app()
@@ -11395,7 +11374,20 @@ async def test_image_message_gets_inline_row_after_prep_and_toggle_cycles():
     # cycle below is deterministic; leaving this on "auto" resolves from the
     # host terminal's TERM/TERM_PROGRAM env vars (see resolve_default_mode),
     # which varies across dev machines and CI.
-    app.app_config["chat"] = {"images": {"default_render_mode": "pixels"}}
+    #
+    # task-15511: the pin must land where production READS it.
+    # `_chat_images_config` prefers `COMPREHENSIVE_CONFIG_RAW` whenever the
+    # config carries one -- and the real (task-15270) harness config always
+    # does -- so writing only `app_config["chat"]` is the dead seam the
+    # 15270 triage called out by name: the pin never reached production, the
+    # ambient default resolved from the terminal overrides (graphics on this
+    # machine), and the FIRST toggle landed on hidden -- the row vanishing
+    # one step early was this test's premise being lost, not a render bug.
+    images_pin = {"images": {"default_render_mode": "pixels"}}
+    app.app_config["chat"] = dict(images_pin)
+    raw = app.app_config.get("COMPREHENSIVE_CONFIG_RAW")
+    if isinstance(raw, dict):
+        raw.setdefault("chat", {})["images"] = dict(images_pin["images"])
     host = ConsoleHarness(app)
     async with host.run_test(size=(160, 48)) as pilot:
         console = host.screen_stack[-1]

--- a/backlog/tasks/task-15511 - Console-run-state-and-image-toggle-diverge-under-a-realistic-config.md
+++ b/backlog/tasks/task-15511 - Console-run-state-and-image-toggle-diverge-under-a-realistic-config.md
@@ -1,7 +1,7 @@
 ---
 id: task-15511
 title: Console run state and image toggle diverge under a realistic config
-status: To Do
+status: Done
 assignee: []
 labels:
   - bug
@@ -42,7 +42,57 @@ back -- if so the user-visible symptom is an image vanishing on toggle.
 
 ## Acceptance Criteria
 
-- [ ] The cause of the IDLE run state is identified as either a missing transition or a controller-identity mismatch, and stated with evidence
-- [ ] If the run state is genuinely not settling to COMPLETED after a successful send, it is fixed and the user-visible affordances driven by it are checked
-- [ ] The image row survives the pixels -> graphics toggle, or the toggle falls back to a mode that renders something and the test asserts that instead
-- [ ] Both tests pass with their xfail(strict=True) markers removed
+- [x] The cause of the IDLE run state is identified as either a missing transition or a controller-identity mismatch, and stated with evidence
+- [x] If the run state is genuinely not settling to COMPLETED after a successful send, it is fixed and the user-visible affordances driven by it are checked
+- [x] The image row survives the pixels -> graphics toggle, or the toggle falls back to a mode that renders something and the test asserts that instead
+- [x] Both tests pass with their xfail(strict=True) markers removed
+
+## Implementation Plan
+
+1. Probe the run-state map and session keying at assertion time
+2. Spy the terminal-state clear to find its caller, then diff the trigger
+3. Reproduce the image default-mode resolution outside the test
+4. Mutation-check the controller fix; run the module whole
+
+## Implementation Notes
+
+**Run state: neither of the filed candidates.** The transition was not missing
+(the session's history reads IDLE -> VALIDATING -> STREAMING -> COMPLETED) and
+the controller/session identity matched. The COMPLETED state was recorded and
+then WIPED: the post-send UI resync (`_sync_native_console_chat_ui ->
+_sync_console_chat_core_state -> update_provider_selection`) compared selection
+tuples, saw `configured_model` flip `None -> "gpt-5.6-terra"`, and took the
+"user changed provider settings" branch, which clears the active session's
+terminal run state. `configured_model` is DERIVED state -- the config fallback
+model, late-resolving once a provider key exists -- so its churn through a
+routine resync is not a user action. Third instance of the task-15740/15673
+class: the app's own derived-state churn read as user input.
+
+Fix: the clear-trigger now compares EFFECTIVE selections -- the model term is
+`self.model or self.configured_model`, the exact resolution the send path uses
+(`model = selection.explicit_model or selection.configured_model`). A
+configured-model change with an explicit model set changes nothing about what
+would run and no longer wipes the state; with NO explicit model it still
+clears, because the effective model genuinely changed. User-visible effect of
+the bug: a completed run's terminal state (and everything driven by it)
+vanishing right after completion whenever late resolution churned.
+Mutation-checked: restoring the two-field comparison turns the test red.
+
+**Image toggle: the product was right; the test's premise never arrived.** The
+test already pinned `default_render_mode = "pixels"` -- through
+`app_config["chat"]`, the dead seam the task-15270 triage called out by name:
+`_chat_images_config` prefers `COMPREHENSIVE_CONFIG_RAW`, which the real
+harness config always carries. Measured on this machine: `auto` resolves via
+`terminal_overrides` (iterm2 -> regular) to **graphics**, so the first toggle
+in the pixels -> graphics -> hidden cycle landed on hidden and the row
+vanished one step "early". The pin now writes through the RAW section too.
+
+Also repaired (pre-existing on untouched dev, same neighbourhood):
+`test_screen_selection_builder_targets_session_without_switching_view` -- its
+SimpleNamespace double predates task-15452's memo split
+(`_console_derivation_memo` + `_build_console_provider_selection_uncached`);
+taught the double the class-default and bound the borrowed uncached half.
+
+Modified: `tldw_chatbook/Chat/console_chat_controller.py`,
+`Tests/UI/test_console_native_chat_flow.py`,
+`Tests/Chat/test_console_turn_execution_context.py`.

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -2742,10 +2742,17 @@ class ConsoleChatController:
 
     def update_provider_selection(self, selection: ConsoleProviderSelection) -> None:
         """Sync controller provider settings from a Console selection."""
+        # task-15511: the clear-below compares EFFECTIVE selections, so the
+        # model term is what would actually run -- `explicit or configured`
+        # (the exact resolution `_build_console_turn_execution_context` and
+        # the send path use). `configured_model` alone is DERIVED state: it
+        # resolves late (e.g. once a provider key exists) and can flip on a
+        # routine resync with nothing user-visible changing. Comparing it
+        # separately made that churn look like a settings change and wiped a
+        # COMPLETED run state seconds after the run finished.
         previous_selection = (
             self.provider,
-            self.model,
-            self.configured_model,
+            self.model or self.configured_model,
             self.base_url,
             self.temperature,
             self.top_p,
@@ -2784,8 +2791,7 @@ class ConsoleChatController:
         self.system_prompt = selection.system_prompt
         current_selection = (
             self.provider,
-            self.model,
-            self.configured_model,
+            self.model or self.configured_model,
             self.base_url,
             self.temperature,
             self.top_p,


### PR DESCRIPTION
## What

Both halves of task-15511 resolved: one real product bug fixed, one test premise repaired. Both xfail(strict=True) markers removed; the module runs **308 passed, 1 xfailed** (task-15120's, unrelated).

## The run-state bug — a third instance of the 15740/15673 class

The task filed two candidate causes for `run_state` reading IDLE after a successful send: a missing transition, or a controller-identity mismatch. **Measured: neither.** The session's own history reads `IDLE → VALIDATING → STREAMING → COMPLETED`, under the exact session id the facade reads. The COMPLETED state was recorded — and then **wiped** by the post-send resync:

```
_sync_native_console_chat_ui → _sync_console_chat_core_state
  → update_provider_selection:2811 → _clear_terminal_run_state
```

The trigger, isolated by diffing every compared field across the clearing call: `configured_model` flipped `None → 'gpt-5.6-terra'`. That field is **derived** — the config's fallback model, late-resolving once a provider key exists — but the tuple comparison read its churn as "the user changed provider settings" and cleared the run state.

Same class as the Settings save/nav-preselect bug fixed in #1554: **the app's own state churn treated as user action.** Third instance in three days.

### Fix

The clear-trigger now compares **effective** selections — the model term is `self.model or self.configured_model`, the exact resolution the send path itself uses (`model = selection.explicit_model or selection.configured_model`). So:

- explicit model set + configured model late-resolves → nothing about what would run changed → **no clear** (the bug)
- no explicit model + configured model changes → the effective model genuinely changed → **still clears** (the guard's intent, preserved)

Mutation-checked: restoring the two-field comparison turns the test red.

## The image-toggle half — product was right, the test's premise never arrived

The `pixels → graphics → hidden` cycle is correct. The test already pinned `default_render_mode = "pixels"` — but wrote it to `app_config["chat"]`, the dead seam the task-15270 triage called out **by name**: `_chat_images_config` prefers `COMPREHENSIVE_CONFIG_RAW` whenever it is present, and the real harness config always carries it. Measured on this machine: `auto` resolves to **graphics** via the iterm2 terminal override, so the first toggle landed on hidden and the row vanished one step "early". The pin now writes through the RAW section.

## Also repaired

`test_screen_selection_builder_targets_session_without_switching_view` — red on untouched dev (confirmed on a clean worktree): its SimpleNamespace double predates task-15452's memo split. Taught it the `_console_derivation_memo` class-default and bound the borrowed `_build_console_provider_selection_uncached`. 189/189 in the two controller-context modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents post-send resync from clearing a completed console run. Previously, late resolution of configured_model was treated as a user settings change and reset the run state to IDLE; now we compare the effective model so only real changes clear state.

- Core change: in `update_provider_selection`, the comparison tuples use the effective model (`self.model or self.configured_model`) instead of separate `model`/`configured_model`. Explicit-model sessions no longer lose COMPLETED; sessions without an explicit model still clear when the configured model truly changes.
- Tests: removed xfail(strict=True) markers; image toggle test now pins `default_render_mode="pixels"` in both `app_config["chat"]` and `COMPREHENSIVE_CONFIG_RAW`; fixed a stale SimpleNamespace double by setting `_console_derivation_memo=None` and borrowing `_build_console_provider_selection_uncached`.
- Scope and risk: localized to the selection-compare guard; no migrations or config changes. Validated by module runs (308 passed, 1 unrelated xfail). Addresses task-15511’s acceptance criteria.

<sup>Written for commit d585b188d6147b89b63bdc9c7ab285b5ed8b64ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

