### PR TITLE
fix(tests): bind four new unbounded background waits (task-15211 sweep, catch 1)

### DIFF
--- a/Tests/UI/test_library_ingest_canvas.py
+++ b/Tests/UI/test_library_ingest_canvas.py
@@ -27,6 +27,7 @@ from textual.widgets import (
     TextArea,
 )
 
+from Tests.UI.background_signals import wait_for_background_signal
 from Tests.UI.app_factory import _build_test_app
 from Tests.UI.test_library_shell import (
     LIBRARY_TEST_SIZE,
@@ -2148,7 +2149,11 @@ async def test_external_vad_worker_cancellation_reaches_underlying_install(
             _vad_only_report(tmp_path),
         )
     )
-    await entered.wait()
+    await wait_for_background_signal(
+        entered,
+        task,
+        what="the external VAD provision entering the underlying install",
+    )
 
     task.cancel()
     with pytest.raises(asyncio.CancelledError):

--- a/Tests/UI/test_stts_profile_library.py
+++ b/Tests/UI/test_stts_profile_library.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+
+from Tests.UI.background_signals import wait_for_background_signal
 import json
 import sys
 from dataclasses import replace
@@ -3877,7 +3879,9 @@ async def test_unmount_racing_existing_invalidation_joins_once_and_releases_task
         library._voice_bundle_service = bundle_service
         library._active_bundle_handle = handle
         cleanup = asyncio.create_task(library._invalidate_bundle_handle(handle))
-        await started.wait()
+        await wait_for_background_signal(
+            started, cleanup, what="the bundle invalidation starting"
+        )
 
         async def _remove_library() -> None:
             await library.remove()
@@ -3910,7 +3914,9 @@ async def test_completed_invalidation_cannot_clear_a_replacement_task() -> None:
         library, _loaded = await _select_action_profile(app, pilot)
         library._voice_bundle_service = bundle_service
         cleanup = asyncio.create_task(library._invalidate_bundle_handle(handle))
-        await started.wait()
+        await wait_for_background_signal(
+            started, cleanup, what="the bundle invalidation starting"
+        )
         original = library._bundle_invalidation_tasks[handle]
         replacement = asyncio.create_task(asyncio.sleep(60))
         library._bundle_invalidation_tasks[handle] = replacement
@@ -3994,7 +4000,9 @@ async def test_cancelled_handle_cleanup_joins_without_masking_cancellation() -> 
         library, _loaded = await _select_action_profile(app, pilot)
         library._voice_bundle_service = bundle_service
         cleanup = asyncio.create_task(library._invalidate_bundle_handle(handle))
-        await started.wait()
+        await wait_for_background_signal(
+            started, cleanup, what="the bundle invalidation starting"
+        )
         cleanup.cancel()
         release.set()
 


### PR DESCRIPTION
## What

First catch from the task-15211 full `Tests/UI` sweep: the task-14912 AST guard
flagged **four new unbounded background waits** that landed on dev after the
guard shipped — `await entered.wait()` in `test_library_ingest_canvas.py` and
three `await started.wait()` in `test_stts_profile_library.py`.

The hang class these belong to: the awaited event can only be set by a spawned
task; if that task dies with its exception swallowed, the wait blocks forever,
pytest's `timeout_method = thread` kills the **whole process**, and every later
test in the run is silently lost. This class cost a full run twice in the
August sweeps.

All four now go through `wait_for_background_signal`, which bounds the wait and
re-raises the background task's own exception when it finishes without
signalling. Guard + all four tests green (11 passed).

The sweep continues on an untouched worktree; this fix is on its own branch so
the sweep's inputs stay frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds four background waits in UI tests to prevent hangs that kill the pytest process. Old: unbounded `Event.wait()` on background-set signals. New: route waits through `wait_for_background_signal`, which times out and re-raises the background task’s exception.

- Replaces one `await entered.wait()` in `Tests/UI/test_library_ingest_canvas.py` and three `await started.wait()` in `Tests/UI/test_stts_profile_library.py` with `wait_for_background_signal(event, task, what=...)`.
- No change when signals fire; tests now fail fast if the background task exits early or errors.
- Aligns with the task-14912 guard; part of the task-15211 sweep.
- Migration: when a test waits on a signal set by a background task, use `wait_for_background_signal(event, task, what=...)` instead of `event.wait()`.

<sup>Written for commit 93df64c8a2a0e82970510973bc721de61d65ec7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

