### PR TITLE
perf: scoped Watchlists rebuilds per section and tree interaction (task-15461)

### DIFF
--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -1294,18 +1294,27 @@ async def test_a_workbench_rebuild_keeps_the_items_filter_search_and_selection()
     Sources, the whole create-form draft).
 
     So every workbench rebuild silently reset the user's view to "all items,
-    nothing selected, empty search box". `region_layout` is
-    `recompose=True`, so ANY collapse/expand -- `z`, `[`, `]`, a chevron
-    click -- rebuilds every region and constructs a brand new `ItemsPane`;
-    that is the deterministic trigger used here. The reported route was
+    nothing selected, empty search box". The reported route was
     "Mark unread", whose `refresh=True` ends in `_refresh_overview_data()`
     setting `overview_data` (`reactive(recompose=True)`): same rebuild, but
     it only fires when the overview counts actually change value, which is
     why it is not what this test drives.
+
+    task-15461 changed the deterministic trigger, not the contract. A rail
+    toggle used to rebuild every region (`region_layout` was
+    `recompose=True`), so `[` was the cheapest way to force a fresh
+    `ArticleListPane`; layout changes are now scoped to the regions whose
+    form actually moved, so `[` deliberately leaves ITEMS' pane instance
+    alone -- which is what
+    `test_a_rail_toggle_rebuilds_only_the_toggled_region` pins. Collapsing
+    and re-expanding ITEMS itself is the trigger that still genuinely
+    reconstructs the pane, and it exercises the same `_build_detail_pane`
+    seeding this test is about.
     """
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
     from tldw_chatbook.UI.Watchlists_Modules.article_list import ArticleListPane
+    from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
 
     app = _build_test_app()
     db = app.local_watchlists_service._db()
@@ -1322,13 +1331,20 @@ async def test_a_workbench_rebuild_keeps_the_items_filter_search_and_selection()
         pane.select_and_reveal(open_item)
         await pilot.pause(0.5)
 
-        # A rail toggle -- nothing to do with Items at all.
-        screen.action_toggle_left_rail()
+        # Collapse ITEMS and expand it again: the region's form really
+        # changes, so `_build_detail_pane` runs and a brand new
+        # `ArticleListPane` is what the user is left looking at.
+        screen.focused_region = Region.ITEMS
+        screen.action_toggle_region()
+        await pilot.pause(0.5)
+        screen.focused_region = Region.ITEMS
+        screen.action_toggle_region()
         await pilot.pause(0.5)
 
         rebuilt = screen.query_one("#watchlists-items-pane", ArticleListPane)
         assert rebuilt is not pane, (
-            "the precondition: the rail toggle really did rebuild the pane"
+            "the precondition: collapsing and re-expanding ITEMS really did "
+            "rebuild the pane"
         )
         assert rebuilt.status_filter == "unread", "the status filter must survive"
         assert rebuilt.search_query == "Nav item", "the search box must survive"

--- a/Tests/UI/test_watchlists_destination_shell.py
+++ b/Tests/UI/test_watchlists_destination_shell.py
@@ -1322,9 +1322,21 @@ async def test_bracket_toggle_preserves_inspector_selection():
         await pilot.pause()
 
         rebuilt_inspector = screen.query_one("#watchlists-entity-inspector", InspectorPane)
-        assert rebuilt_inspector is not inspector, "the inspector should have been rebuilt"
+        # task-15461 strengthened this from "rebuilt, and re-seeded correctly"
+        # to "never rebuilt at all". A left-rail toggle used to recompose the
+        # whole workbench, so the Inspector was torn down and rebuilt for a
+        # change on the other side of the screen and the seeding was the only
+        # thing standing between the user and a blank rail. Layout changes are
+        # now scoped to the region whose form moved (AC#3), so the same
+        # gesture leaves this instance -- and therefore the selection -- alone
+        # by construction. `test_a_rail_toggle_rebuilds_only_the_toggled_
+        # region` pins the scoping itself; this keeps pinning the outcome the
+        # user sees.
+        assert rebuilt_inspector is inspector, (
+            "a left-rail toggle must not rebuild the Inspector at all"
+        )
         assert rebuilt_inspector.selected_entity == screen.selected_entity, (
-            "the rebuilt inspector lost the screen's selection"
+            "the Inspector lost the screen's selection across a rail toggle"
         )
         # The empty state ("Select a source...") must NOT be showing, since a
         # real selection is still in effect after the rebuild.
@@ -2997,13 +3009,20 @@ async def test_a_failed_surface_refresh_start_does_not_wedge_the_queue():
     """Review wave M1, the sibling of `test_a_failed_tree_write_start_...`.
 
     `_surface_refresh_draining` is lowered only by `_drain_surface_refresh`'s
-    `finally`, which never runs if `run_worker` raises synchronously. Arming
+    `finally`, which never runs if scheduling raises synchronously. Arming
     before scheduling would leave the flag stuck True for the life of the
     screen: every later request would queue and return, and the rail and
     centre header would silently stop following every background loader.
-    """
-    import inspect
 
+    task-15461 moved the scheduling from `run_worker(group=
+    "wc_surface_refresh")` to `call_next` -- so that anything waiting for the
+    message pump to go quiet also waits for the DOM swap, which the section
+    switch now rides on. The failure mode this test pins is unchanged, so the
+    seam it explodes moves with it. The "the un-awaited coroutine was closed"
+    half is gone with the coroutine: `call_next` is handed the bound method,
+    so nothing is constructed ahead of scheduling and there is nothing left
+    to leak.
+    """
     app = _build_test_app()
     service = app.watchlist_bundle_service
     host = DestinationHarness(app, "watchlists_collections")
@@ -3012,15 +3031,15 @@ async def test_a_failed_surface_refresh_start_does_not_wedge_the_queue():
         screen = host.screen_stack[-1]
 
         exploded: list[Any] = []
-        real_run_worker = screen.run_worker
+        real_call_next = screen.call_next
 
-        def _exploding_run_worker(work, **kwargs):
-            if kwargs.get("group") == "wc_surface_refresh" and not exploded:
-                exploded.append(work)
-                raise RuntimeError("worker could not be scheduled")
-            return real_run_worker(work, **kwargs)
+        def _exploding_call_next(callback, *args, **kwargs):
+            if callback == screen._drain_surface_refresh and not exploded:
+                exploded.append(callback)
+                raise RuntimeError("callback could not be scheduled")
+            return real_call_next(callback, *args, **kwargs)
 
-        screen.run_worker = _exploding_run_worker
+        screen.call_next = _exploding_call_next
         screen._request_surface_refresh(screen._SURFACE_HEADER)
         await pilot.pause()
 
@@ -3028,10 +3047,6 @@ async def test_a_failed_surface_refresh_start_does_not_wedge_the_queue():
         assert screen._surface_refresh_draining is False, (
             "a drain that never started must leave the guard down, or every "
             "later background refresh is silently swallowed"
-        )
-        assert inspect.getcoroutinestate(exploded[0]) == "CORO_CLOSED", (
-            "the un-awaited drain coroutine must be closed, not left to leak "
-            "a RuntimeWarning at collection time"
         )
 
         # ...and the next request really drains.

--- a/Tests/UI/test_watchlists_run_detail.py
+++ b/Tests/UI/test_watchlists_run_detail.py
@@ -254,11 +254,33 @@ async def test_run_detail_survives_a_workbench_rebuild():
             lambda: pane.query_one("#runs-detail-items", DataTable).row_count == 2,
         ), "precondition: the detail is populated"
 
-        # `[` toggles a rail, which rebuilds the workbench and with it the pane.
-        await pilot.press("[")
+        # Rebuild the region the pane lives in, through the production
+        # primitive that does it: `WatchlistsWorkbench.refresh_region_content`
+        # calls the region factory again and swaps the result in. Every
+        # rebuild route reaches this -- a section switch (`_swap_active_
+        # section`), a collapsed region being expanded again, the surface
+        # drain -- so it is the seam, not a test-only shortcut.
+        #
+        # This used to be a single `[`, back when any layout key recomposed
+        # the whole workbench. task-15461 scoped that to the region whose form
+        # moved, so a rail toggle deliberately leaves this pane's instance
+        # alone (`test_a_rail_toggle_rebuilds_only_the_toggled_region` pins
+        # it), and `z` is refused outright off the Read tab -- which the Runs
+        # section is. The contract under test -- a REBUILT pane is re-seeded
+        # with its selection AND its detail -- is unchanged; only the trigger
+        # moves.
+        from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
+        from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+            WatchlistsWorkbench,
+        )
+
+        await screen.query_one(WatchlistsWorkbench).refresh_region_content(
+            Region.ITEMS
+        )
         rebuilt = await _settle_until(
             pilot,
-            lambda: screen.query_one("#watchlists-runs-pane", RunsPane) is not pane,
+            lambda: bool(screen.query("#watchlists-runs-pane"))
+            and screen.query_one("#watchlists-runs-pane", RunsPane) is not pane,
         )
         assert rebuilt, "precondition: the pane really was reconstructed"
         fresh = screen.query_one("#watchlists-runs-pane", RunsPane)

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -2835,9 +2835,18 @@ async def test_switching_the_selected_briefing_clears_stale_scripts_before_the_r
         # IMMEDIATELY after it returns -- before `run_worker` has let the
         # reload do anything at all -- proves the clearing itself, not
         # merely that it finishes "soon".
-        screen.handle_briefing_selected(BriefingSelected(second_row))
-
+        # task-15461 moved the clearing from the screen's message handler
+        # into `ArtifactsPane.watch_selected_briefing`, so that the
+        # select->clear->reload pipeline costs ONE pane recompose instead of
+        # two. The selection is therefore what has to be driven here, not the
+        # handler -- and it is still a fully synchronous route: a reactive
+        # assignment runs its watcher inline, so state read on the very next
+        # line is state that was set before `run_worker` could schedule
+        # anything. (Driving the handler directly would now assert nothing:
+        # it no longer touches the pane.)
         pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        pane.selected_briefing = second_row
+
         assert pane.selected_script is None, (
             "the stale script selection must clear synchronously, before "
             "the reload worker is even dispatched"

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -27,7 +27,8 @@ from typing import Any
 
 import pytest
 from textual.widget import Widget
-from textual.widgets import Button
+from textual.css.query import NoMatches
+from textual.widgets import Button, DataTable
 
 from Tests.UI.app_factory import _build_test_app
 from Tests.UI.test_destination_shells import DestinationHarness
@@ -39,6 +40,7 @@ from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import ArtifactsPane
 from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
 from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
 from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
+from tldw_chatbook.UI.Watchlists_Modules.rules_pane import RulesPane
 from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import (
     TreeScope,
     TreeScopeChanged,
@@ -97,6 +99,19 @@ class _RebuildCounter:
 
     def report(self) -> str:
         return f"recomposes={dict(self.recomposes)} mounts={dict(self.mounts)}"
+
+
+async def _seed_alert_rule(app, name: str = "Rule One") -> None:
+    """One alert rule, through the real service.
+
+    Review minor (1): without a rule, `RulesPane.rules` is `[]` both before
+    and after the loader lands, so "the loader's push found nothing to
+    change" would hold for a pane that was never seeded at all. A row makes
+    the assertion able to tell those two apart.
+    """
+    await app.local_watchlists_service.create_alert_rule(
+        name=name, condition_type="no_items"
+    )
 
 
 def _seed(app, *, items: int = 2, briefings: int = 0) -> int:
@@ -230,16 +245,39 @@ async def test_a_section_switch_leaves_both_rails_standing():
 
 
 async def test_a_section_switch_builds_the_sections_pane_exactly_once():
-    """One scoped rebuild, not two.
+    """One scoped region build per switch, and no duplicate pane rebuild.
 
     The old path was a whole-screen recompose that built the new pane from
-    whatever rows the screen happened to be holding, followed by the
-    section's own loader landing a frame later and recomposing that same
-    fresh pane a second time. The pane is now mounted with the data (see
-    `_reseed_active_section_pane`), so the loader's push is a no-op.
+    whatever rows the screen happened to be holding, followed by the section's
+    own loader landing a frame later and recomposing that same fresh pane a
+    second time.
+
+    What is left, stated exactly. Review minor (1) added the seeded alert rule
+    below, and it earned its place immediately: with a real row in play the
+    pane still rebuilds ONCE per switch, and root-causing that turned out to
+    be worth doing.
+
+    * The **region** is built exactly once per switch -- that is `builds`.
+    * The **pane** rebuilds at most once, and the one is not a data-arrival
+      duplicate: `_build_detail_pane` seeds `rules_pane.rules` on a
+      freshly-constructed pane whose class default is `[]`, so Textual queues
+      a recompose (`[] != [row]`) that fires just after the pane mounts.
+      Traced to `_build_detail_pane` directly, and it is pre-existing and
+      unchanged by this task -- the whole-screen recompose called the same
+      factory and paid the same cost. It is invisible on an empty fixture,
+      which is exactly why it went unnoticed until a row was seeded.
+      (Removing it means seeding the panes with `set_reactive`, which is not
+      safe to do blind: `RunsPane`'s seeding order is load-bearing -- setting
+      `selected_run` clears the detail, so the detail must be set after it.
+      Recorded as a residual, deliberately not attempted here.)
+
+    The claim this test therefore pins is the one AC#1 makes: **one scoped
+    region build, and no SECOND rebuild from the loader landing** -- verified
+    on a warm revisit, where the rows are already on screen state.
     """
     app = _build_test_app()
     watchlist_id = _seed(app)
+    await _seed_alert_rule(app)
     async with _open(app, watchlist_id) as (screen, pilot, host):
         # Patched on the WORKBENCH's factory map, not on the screen: the map
         # captured the bound method at construction time, so rebinding the
@@ -265,9 +303,99 @@ async def test_a_section_switch_builds_the_sections_pane_exactly_once():
         assert builds == ["rules"], (
             f"the section's pane must be built exactly once: {builds}"
         )
-        assert counted.recomposes["RulesPane#watchlists-rules-pane"] == 0, (
-            "the freshly mounted pane must already carry the section's rows, "
-            f"so the loader's push finds nothing to change: {counted.report()}"
+        rules_pane = screen.query_one("#watchlists-rules-pane", RulesPane)
+        assert len(rules_pane.rules) == 1, (
+            "the fixture's rule has to reach the pane, or the recompose count "
+            f"below cannot discriminate: {rules_pane.rules}"
+        )
+        assert counted.recomposes["RulesPane#watchlists-rules-pane"] <= 1, (
+            f"never a second full rebuild of the pane: {counted.report()}"
+        )
+
+        # Warm revisit: the rows are already on screen state, so the pane is
+        # built carrying them and the loader's push must change nothing. This
+        # is the half that used to cost a second full rebuild every time.
+        builds.clear()
+        screen.active_section = "sources"
+        await _settle(pilot, host)
+        with _RebuildCounter() as warm:
+            screen.active_section = "rules"
+            await _settle(pilot, host)
+
+        assert builds == ["sources", "rules"], builds
+        assert warm.recomposes["RulesPane#watchlists-rules-pane"] <= 1, (
+            "a warm revisit must cost at most the pre-mount seeding rebuild "
+            f"named in this test's docstring: {warm.report()}"
+        )
+        assert warm.recomposes["WatchlistsCollectionsScreen#-"] == 0, warm.report()
+        assert (
+            screen.query_one("#rules-table", DataTable).row_count == 1
+        ), "and the row still has to be on screen"
+
+
+async def test_a_section_switch_shows_rows_that_land_while_the_swap_runs():
+    """The window `_reseed_active_section_pane` closes.
+
+    `watch_active_section` dispatches the section's loader and the swap in the
+    same breath, and `refresh_region_content` calls the region factory BEFORE
+    its remove/mount awaits (so a raising factory leaves the screen intact).
+    A loader landing in that gap writes rows to `self._loaded_*` and then
+    fails to find its pane -- built, not yet mounted -- and nothing is left to
+    correct it. Textual's own `Widget.recompose` never had the gap: it removes
+    children first and calls `compose()` afterwards.
+
+    Neutering `_reseed_active_section_pane` to a no-op reds this test: the
+    Alert-rules table stays empty over a `_loaded_rules` holding the row.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+        WatchlistsWorkbench,
+    )
+
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id, section="sources") as (screen, pilot, host):
+        assert not screen.query("#watchlists-rules-pane")
+
+        # Reconstruct the window rather than race for it, the same way
+        # `test_run_detail_lands_when_the_push_happens_in_the_mount_window`
+        # reconstructs the mount window. The loader's two observable effects
+        # are "mirror the rows onto the screen" and "push them into the pane";
+        # replaying them from inside the factory call puts them exactly where
+        # the real gap is -- after the factory has read screen state, before
+        # its replacement is mounted, so the push finds nothing.
+        row = {
+            "id": "r1",
+            "name": "Rule One",
+            "condition_type": "no_items",
+            "severity": "warning",
+            "enabled": True,
+        }
+        # No real loader may run: it would land AFTER the mount and repair the
+        # pane itself, which is not what this test is about.
+        screen._load_active_section_data = lambda: None
+
+        workbench = screen.query_one(WatchlistsWorkbench)
+        real_build = workbench._content[Region.ITEMS]
+
+        def _build_then_land():
+            built = real_build()
+            screen._loaded_rules = [row]
+            try:  # the loader's push, from inside the gap
+                screen.query_one("#watchlists-rules-pane", RulesPane).rules = [row]
+            except NoMatches:
+                pass
+            return built
+
+        workbench._content[Region.ITEMS] = _build_then_land
+
+        screen.active_section = "rules"
+        await _settle(pilot, host)
+
+        assert screen._loaded_rules == [row], "precondition: the rows did land"
+        table = screen.query_one("#rules-table", DataTable)
+        assert table.row_count == 1, (
+            "rows that landed while the swap was mid-flight must reach the "
+            "pane the swap mounted, not be stranded in `_loaded_rules`"
         )
 
 
@@ -318,6 +446,80 @@ async def test_a_section_switch_moves_the_tab_strip_and_the_backend_control():
         )
         assert not screen.query("#watchlists-backend-label"), (
             "and the local-only explanation must go away with it"
+        )
+
+
+async def test_clicking_a_tab_leaves_focus_on_that_tab_so_z_stays_refused():
+    """A tab click must not hand the left rail to the next keypress.
+
+    Review finding (Important 1), measured A/B. A tab click focuses the tab
+    `Button`, which lives in the centre header -- and the swap rebuilds that
+    header, so the focused widget is removed from under the user. Textual's
+    `Screen._reset_focus` then picks the first focusable replacement it finds,
+    which on this screen is a LEFT RAIL tree node; `on_descendant_focus` reads
+    that and sets `focused_region = LEFT_RAIL`, so the very next `z` collapsed
+    the rail AND persisted the collapse to config. Pre-task, the whole-screen
+    recompose left focus at `None` and `z` was refused.
+
+    Re-focusing the rebuilt tab restores the refusal by the honest route:
+    focus is inside `#wl-centre-status`, so `_focus_in_centre_header` is set,
+    which is what `action_toggle_region` already consults. (`focused_region`
+    may still read LEFT_RAIL from the instant Textual re-homed focus -- that
+    stale value is precisely what `_focus_in_centre_header` exists to
+    neutralise, per task-1344.)
+    """
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        await pilot.click("#wl-tab-sources")
+        await _settle(pilot, host)
+
+        assert screen.active_section == "sources", "precondition: the tab switched"
+        focused = screen.focused
+        assert focused is not None and focused.id == "wl-tab-sources", (
+            f"focus must stay on the tab the user clicked, not be re-homed by "
+            f"Textual: {focused!r}"
+        )
+        assert screen._focus_in_centre_header is True, (
+            "focus in the centre header is what makes z/Z refuse"
+        )
+
+        before = screen.region_layout
+        await pilot.press("z")
+        await _settle(pilot, host)
+
+        assert screen.region_layout == before, (
+            "z straight after a tab click must change nothing at all"
+        )
+        assert Region.LEFT_RAIL not in screen.region_layout.collapsed, (
+            "and above all it must not collapse -- and persist -- the rail the "
+            "user never aimed at"
+        )
+        assert screen.query("#wl-region-left_rail"), "the rail is still expanded"
+
+
+async def test_a_section_switch_driven_from_elsewhere_does_not_steal_focus():
+    """The other half of the focus rule: only re-home focus the swap destroyed.
+
+    A section change can come from a deep link or `EditRuleRequested` while
+    the user is working somewhere the swap does not touch. Moving them to the
+    tab strip then would be its own defect, so the restore is gated on
+    `_swap_will_destroy_focus`.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        tree_node = screen.query_one("#wl-tree", WatchlistTree).query(Button).first()
+        tree_node.focus()
+        await _settle(pilot, host)
+        assert screen.focused is tree_node, "precondition: focus is in the rail"
+
+        screen.active_section = "runs"
+        await _settle(pilot, host)
+
+        assert screen.focused is tree_node, (
+            "a section switch that did not unmount the focused widget must "
+            f"leave focus alone: {screen.focused!r}"
         )
 
 

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -1,0 +1,621 @@
+"""One scoped rebuild per Watchlists section or tree interaction (task-15461).
+
+Evidence for the three acceptance criteria, counted off the real screen
+rather than reasoned about:
+
+* A **section switch** rebuilds the section's own pane and the centre header,
+  and nothing else -- not the screen, not the navigation bar, not the footer,
+  not either rail, and not the reader.
+* A **tree-node click** updates each affected pane at most once.
+* **z / Z / [ / ]** rebuild only the region whose rendered form actually
+  changed.
+
+Every count comes from `Widget.recompose` and `Widget.mount`, patched for the
+duration of one interaction (`_RebuildCounter`). Against the pre-task code
+each of these fails: a section switch was a whole-screen
+`refresh(recompose=True)` (measured: 75-176 mounted widgets, the navigation
+bar and footer included) and any layout key recomposed the whole workbench
+(36-99), because `WatchlistsWorkbench.region_layout` was `recompose=True`.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from textual.widget import Widget
+from textual.widgets import Button
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_destination_shells import DestinationHarness
+from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
+from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
+    WatchlistsCollectionsScreen,
+)
+from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import ArtifactsPane
+from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
+from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
+from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import (
+    TreeScope,
+    TreeScopeChanged,
+    WatchlistTree,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------
+# Harness
+# --------------------------------------------------------------------------
+
+
+class _RebuildCounter:
+    """Counts `recompose()`/`mount()` per widget while it is installed.
+
+    Patches the two `Widget` methods rather than watching for DOM diffs
+    because "how many times was this torn down and rebuilt" is exactly the
+    quantity these ACs are about, and a before/after DOM comparison cannot
+    tell one rebuild from three.
+    """
+
+    def __init__(self) -> None:
+        self.recomposes: Counter = Counter()
+        self.mounts: Counter = Counter()
+        self._original_recompose = Widget.recompose
+        self._original_mount = Widget.mount
+
+    @staticmethod
+    def _key(widget: Widget) -> str:
+        return f"{type(widget).__name__}#{widget.id or '-'}"
+
+    def __enter__(self) -> "_RebuildCounter":
+        counter = self
+
+        async def _counting_recompose(widget):
+            counter.recomposes[counter._key(widget)] += 1
+            return await counter._original_recompose(widget)
+
+        def _counting_mount(widget, *widgets, **kwargs):
+            counter.mounts[counter._key(widget)] += len(widgets)
+            return counter._original_mount(widget, *widgets, **kwargs)
+
+        Widget.recompose = _counting_recompose
+        Widget.mount = _counting_mount
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        Widget.recompose = self._original_recompose
+        Widget.mount = self._original_mount
+
+    @property
+    def total_mounts(self) -> int:
+        return sum(self.mounts.values())
+
+    def report(self) -> str:
+        return f"recomposes={dict(self.recomposes)} mounts={dict(self.mounts)}"
+
+
+def _seed(app, *, items: int = 2, briefings: int = 0) -> int:
+    """A watchlist with a source, some items and optionally some briefings."""
+    service = app.watchlist_bundle_service
+    db = service.db
+    watchlist = service.create("Morning AI Brief")
+    watchlist_id = watchlist["id"]
+    source_id = db.add_subscription(
+        name="AI News", type="rss", source="https://ai-news.example/feed.xml"
+    )
+    service.add_source(watchlist_id, source_id)
+    created = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    for index in range(items):
+        with db.transaction() as conn:
+            persist_subscription_item(
+                conn,
+                source_id,
+                {
+                    "url": f"https://ai-news.example/{index}",
+                    "title": f"Story {index}",
+                    "content": f"body of story {index}",
+                    "content_hash": f"hash-{index}",
+                    "content_kind": "article",
+                    "content_format": "text",
+                },
+                run_id=None,
+                now=created,
+            )
+    for n in range(briefings):
+        briefing_id = db.insert_briefing(watchlist_id)
+        db.update_briefing(
+            briefing_id,
+            status="complete",
+            body_markdown=f"# Briefing {n}\n\nBody paragraph {n}.",
+        )
+    return watchlist_id
+
+
+@asynccontextmanager
+async def _open(app, watchlist_id: int | None = None, *, section: str = "items"):
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        assert isinstance(screen, WatchlistsCollectionsScreen)
+        if watchlist_id is not None:
+            screen.tree_scope = TreeScope(
+                kind="watchlist", watchlist_id=watchlist_id
+            )
+        screen.active_section = section
+        await pilot.pause(0.4)
+        yield screen, pilot, host
+
+
+async def _settle(pilot, host) -> None:
+    """Let both the message pump and every worker finish."""
+    await pilot.pause()
+    await host.workers.wait_for_complete()
+    await pilot.pause()
+
+
+# --------------------------------------------------------------------------
+# AC#1 -- a section switch rebuilds the changed section only
+# --------------------------------------------------------------------------
+
+
+async def test_a_section_switch_never_recomposes_the_whole_screen():
+    """The screen, its navigation bar and its footer are shared chrome that
+    a tab click has nothing to say about.
+
+    `watch_active_section` used to call `self.refresh(recompose=True)`, and
+    `BaseAppScreen.compose` yields `MainNavigationBar` and `AppFooterStatus`
+    around `compose_content`, so every tab click tore down and rebuilt both
+    of them along with everything else.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
+        from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar
+
+        nav_before = screen.query_one(MainNavigationBar)
+        footer_before = screen.query_one(AppFooterStatus)
+
+        with _RebuildCounter() as counted:
+            screen.active_section = "sources"
+            await _settle(pilot, host)
+
+        assert counted.recomposes["WatchlistsCollectionsScreen#-"] == 0, (
+            f"a tab click must not recompose the screen: {counted.report()}"
+        )
+        assert screen.query_one(MainNavigationBar) is nav_before, (
+            "the navigation bar must survive a tab click"
+        )
+        assert screen.query_one(AppFooterStatus) is footer_before, (
+            "the footer must survive a tab click"
+        )
+
+
+async def test_a_section_switch_leaves_both_rails_standing():
+    """The rails carry no `active_section`-derived state at all.
+
+    The left rail matters most: `WatchlistTree.compose` runs one synchronous
+    `list_source_rows` query per expanded watchlist, so rebuilding it for a
+    tab click is database work on the UI thread with no reason behind it.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        tree_before = screen.query_one("#wl-tree", WatchlistTree)
+        inspector_before = screen.query_one(
+            "#watchlists-entity-inspector", InspectorPane
+        )
+
+        with _RebuildCounter() as counted:
+            screen.active_section = "runs"
+            await _settle(pilot, host)
+
+        assert screen.query_one("#wl-tree", WatchlistTree) is tree_before, (
+            f"the watchlist tree must survive a tab click: {counted.report()}"
+        )
+        assert (
+            screen.query_one("#watchlists-entity-inspector", InspectorPane)
+            is inspector_before
+        ), f"the Inspector must survive a tab click: {counted.report()}"
+        assert counted.recomposes["WatchlistTree#wl-tree"] == 0, counted.report()
+        assert (
+            counted.recomposes["InspectorPane#watchlists-entity-inspector"] == 0
+        ), counted.report()
+
+
+async def test_a_section_switch_builds_the_sections_pane_exactly_once():
+    """One scoped rebuild, not two.
+
+    The old path was a whole-screen recompose that built the new pane from
+    whatever rows the screen happened to be holding, followed by the
+    section's own loader landing a frame later and recomposing that same
+    fresh pane a second time. The pane is now mounted with the data (see
+    `_reseed_active_section_pane`), so the loader's push is a no-op.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        # Patched on the WORKBENCH's factory map, not on the screen: the map
+        # captured the bound method at construction time, so rebinding the
+        # screen attribute would count nothing.
+        from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+            WatchlistsWorkbench,
+        )
+
+        workbench = screen.query_one(WatchlistsWorkbench)
+        builds: list[str] = []
+        real_build = workbench._content[Region.ITEMS]
+
+        def _counting_build():
+            builds.append(screen.active_section)
+            return real_build()
+
+        workbench._content[Region.ITEMS] = _counting_build
+
+        with _RebuildCounter() as counted:
+            screen.active_section = "rules"
+            await _settle(pilot, host)
+
+        assert builds == ["rules"], (
+            f"the section's pane must be built exactly once: {builds}"
+        )
+        assert counted.recomposes["RulesPane#watchlists-rules-pane"] == 0, (
+            "the freshly mounted pane must already carry the section's rows, "
+            f"so the loader's push finds nothing to change: {counted.report()}"
+        )
+
+
+async def test_a_section_switch_moves_the_tab_strip_and_the_backend_control():
+    """Behaviour, not just widget counts: the scoped swap must still render
+    the section it was asked for, mark its tab, and disable the backend
+    picker on a local-only section (`_LOCAL_ONLY_SECTIONS`).
+
+    The backend Select is the one `active_section`-derived control outside
+    the workbench, and it is now patched in place rather than rebuilt.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed(app, briefings=1)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        backend_select = screen.query_one("#watchlists-backend-select")
+        assert backend_select.disabled is False
+
+        screen.active_section = "artifacts"
+        await _settle(pilot, host)
+
+        assert screen.query("#watchlists-artifacts-pane"), (
+            "the Artifacts pane must actually be on screen"
+        )
+        assert not screen.query("#watchlists-rules-pane"), (
+            "the previous section's pane must be gone"
+        )
+        assert screen.query_one("#watchlists-backend-select") is backend_select, (
+            "the backend Select is patched in place, never rebuilt"
+        )
+        assert backend_select.disabled is True, (
+            "Artifacts is local-only, so the backend picker must be disabled"
+        )
+        assert screen.query("#watchlists-backend-label"), (
+            "a local-only section must explain why the picker is disabled"
+        )
+        assert not screen.query("#wl-region-content"), (
+            "CONTENT is unmounted off the Read tab"
+        )
+
+        screen.active_section = "items"
+        await _settle(pilot, host)
+
+        assert screen.query("#wl-region-content"), (
+            "CONTENT must be mounted back on the Read tab"
+        )
+        assert backend_select.disabled is False, (
+            "the backend picker must be re-enabled off a local-only section"
+        )
+        assert not screen.query("#watchlists-backend-label"), (
+            "and the local-only explanation must go away with it"
+        )
+
+
+# --------------------------------------------------------------------------
+# AC#2 -- one update per affected pane
+# --------------------------------------------------------------------------
+
+
+async def test_a_tree_click_updates_each_affected_pane_at_most_once():
+    """A tree click fans out to the Inspector, the tree's own highlight, the
+    centre header and the section's rows. Each of those is one update; none
+    of them is two, and the screen is not involved.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id, section="sources") as (screen, pilot, host):
+        with _RebuildCounter() as counted:
+            screen.post_message(TreeScopeChanged(TreeScope(kind="all")))
+            await _settle(pilot, host)
+
+        assert counted.recomposes["WatchlistsCollectionsScreen#-"] == 0, (
+            f"a tree click must not recompose the screen: {counted.report()}"
+        )
+        assert counted.recomposes["WatchlistsWorkbench#wl-workbench"] == 0, (
+            f"nor the whole workbench: {counted.report()}"
+        )
+        for key, count in counted.recomposes.items():
+            assert count <= 1, (
+                f"{key} was rebuilt {count} times by one tree click: "
+                f"{counted.report()}"
+            )
+        assert screen.tree_scope == TreeScope(kind="all"), (
+            "the click still has to move the scope"
+        )
+
+
+async def test_a_briefing_selection_costs_one_pane_recompose():
+    """The select->clear->reload pipeline, coalesced.
+
+    Selecting a briefing moved three things in three separate instants: the
+    selection itself, then the screen clearing the previous briefing's
+    scripts/audio/citations off the pane one reactive at a time, then the
+    reload landing. The clearing now rides the recompose the selection has
+    already queued (`ArtifactsPane._clear_selection_derived_state`), so a
+    selection whose stale state has to be dropped costs ONE rebuild.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed(app, briefings=2)
+    async with _open(app, watchlist_id, section="artifacts") as (screen, pilot, host):
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        rows = list(pane.briefings)
+        assert len(rows) == 2, f"the fixture needs two briefings: {rows}"
+
+        # Stand in for "the previously selected briefing had a cast script and
+        # a resolved citation": without stale state to drop, the clearing is
+        # a no-op and this test would pass for the wrong reason.
+        pane.selected_briefing = rows[0]
+        await _settle(pilot, host)
+        pane.set_reactive(
+            ArtifactsPane.scripts, [{"id": 1, "status": "complete", "turns": []}]
+        )
+        pane.set_reactive(
+            ArtifactsPane.citations,
+            [{"item_id": 1, "label": "item 1", "available": True}],
+        )
+
+        with _RebuildCounter() as counted:
+            pane.selected_briefing = rows[1]
+            await _settle(pilot, host)
+
+        assert counted.recomposes["ArtifactsPane#watchlists-artifacts-pane"] == 1, (
+            f"one selection must cost one pane rebuild: {counted.report()}"
+        )
+        assert pane.scripts == [], "the previous briefing's scripts must be gone"
+        assert pane.citations == [], "and so must its citations"
+        assert pane.selected_briefing == rows[1]
+
+
+# --------------------------------------------------------------------------
+# AC#3 -- a layout key rebuilds only the toggled region
+# --------------------------------------------------------------------------
+
+
+async def test_a_rail_toggle_rebuilds_only_the_toggled_region():
+    """`[` collapses the left rail. Nothing in the centre or on the right has
+    changed, so nothing there may be rebuilt."""
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        items_region = screen.query_one("#wl-region-items")
+        content_region = screen.query_one("#wl-region-content")
+        inspector = screen.query_one("#watchlists-entity-inspector", InspectorPane)
+        header = screen.query_one("#wl-centre-status")
+
+        with _RebuildCounter() as counted:
+            await pilot.press("[")
+            await _settle(pilot, host)
+
+        assert screen.query("#wl-header-left_rail"), "the rail really did collapse"
+        assert not screen.query("#wl-region-left_rail")
+        assert screen.query_one("#wl-region-items") is items_region, counted.report()
+        assert screen.query_one("#wl-region-content") is content_region, (
+            counted.report()
+        )
+        assert (
+            screen.query_one("#watchlists-entity-inspector", InspectorPane)
+            is inspector
+        ), counted.report()
+        assert screen.query_one("#wl-centre-status") is header, counted.report()
+        assert counted.recomposes["WatchlistsWorkbench#wl-workbench"] == 0, (
+            f"a rail toggle must not recompose the workbench: {counted.report()}"
+        )
+
+        with _RebuildCounter() as counted_back:
+            await pilot.press("[")
+            await _settle(pilot, host)
+
+        assert screen.query("#wl-region-left_rail"), "and it expands again"
+        assert screen.query_one("#wl-region-items") is items_region, (
+            counted_back.report()
+        )
+
+
+async def test_collapsing_items_rebuilds_neither_rail_nor_the_reader():
+    """`z` on ITEMS. CONTENT stays expanded, so it keeps its instance -- and
+    picks up the sole-centre marker in place rather than by being rebuilt."""
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        tree = screen.query_one("#wl-tree", WatchlistTree)
+        reader = screen.query_one("#watchlists-content-pane", ContentPane)
+        content_region = screen.query_one("#wl-region-content")
+        assert not content_region.has_class("watchlists-region-sole-centre")
+
+        screen.focused_region = Region.ITEMS
+        with _RebuildCounter() as counted:
+            screen.action_toggle_region()
+            await _settle(pilot, host)
+
+        assert screen.query("#wl-header-items"), "ITEMS really did collapse"
+        assert not screen.query("#wl-region-items")
+        assert screen.query_one("#wl-tree", WatchlistTree) is tree, counted.report()
+        assert screen.query_one("#watchlists-content-pane", ContentPane) is reader, (
+            f"the reader must not be rebuilt by its neighbour collapsing: "
+            f"{counted.report()}"
+        )
+        assert screen.query_one("#wl-region-content") is content_region
+        assert content_region.has_class("watchlists-region-sole-centre"), (
+            "the sole-expanded marker must be applied in place"
+        )
+
+
+async def test_soloing_content_relabels_the_reader_without_rebuilding_it():
+    """`Z` on CONTENT collapses ITEMS around it. CONTENT's own form does not
+    change, so the reader survives -- and its Expand/Restore button has to be
+    relabelled in place or it would keep offering the action it just did."""
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        items_pane = screen.query_one("#watchlists-items-pane")
+        items_pane.items = [
+            {
+                "id": "local:watchlist_item:1",
+                "item_id": 1,
+                "title": "Story 0",
+                "source_name": "AI News",
+                "status": "new",
+                "content": "body",
+                "content_kind": "article",
+                "content_format": "text",
+            }
+        ]
+        await _settle(pilot, host)
+        items_pane.select_item_by_id("local:watchlist_item:1")
+        await _settle(pilot, host)
+
+        reader = screen.query_one("#watchlists-content-pane", ContentPane)
+        assert str(reader.query_one("#content-expand-button", Button).label) == "Expand"
+
+        screen.focused_region = Region.CONTENT
+        with _RebuildCounter() as counted:
+            screen.action_solo_region()
+            await _settle(pilot, host)
+
+        assert screen.region_layout.solo_region is Region.CONTENT
+        assert not screen.query("#wl-region-items"), "solo really collapsed ITEMS"
+        assert screen.query_one("#watchlists-content-pane", ContentPane) is reader, (
+            f"soloing CONTENT must not rebuild CONTENT: {counted.report()}"
+        )
+        assert (
+            str(reader.query_one("#content-expand-button", Button).label) == "Restore"
+        ), "the surviving reader must be relabelled in place"
+
+
+async def test_an_inspector_toggle_leaves_the_centre_and_the_left_rail_alone():
+    """`]` collapses the right rail: the mirror image of the `[` test, so a
+    regression that scoped one rail and not the other cannot hide."""
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        tree = screen.query_one("#wl-tree", WatchlistTree)
+        items_region = screen.query_one("#wl-region-items")
+
+        with _RebuildCounter() as counted:
+            await pilot.press("]")
+            await _settle(pilot, host)
+
+        assert screen.query("#wl-header-right_rail"), "the Inspector really collapsed"
+        assert not screen.query("#wl-region-right_rail")
+        assert screen.query_one("#wl-tree", WatchlistTree) is tree, counted.report()
+        assert screen.query_one("#wl-region-items") is items_region, counted.report()
+        assert counted.recomposes["WatchlistsWorkbench#wl-workbench"] == 0, (
+            counted.report()
+        )
+
+
+async def test_a_layout_toggle_mounts_far_fewer_widgets_than_a_full_rebuild():
+    """The headline number, asserted rather than described.
+
+    A `[` used to run every region factory: on this fixture the pre-task code
+    mounted 52-76 widgets for one rail toggle (the tree, the tab strip, the
+    article list and the Inspector among them). The scoped path rebuilds one
+    region. The bound is deliberately loose -- this is a guard against the
+    reactive silently going back to `recompose=True`, not a golden number.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        with _RebuildCounter() as counted:
+            await pilot.press("[")
+            await _settle(pilot, host)
+
+        assert counted.total_mounts <= 12, (
+            f"one rail toggle mounted {counted.total_mounts} widgets: "
+            f"{counted.report()}"
+        )
+
+
+async def test_layout_keys_still_persist_and_restore_the_layout():
+    """Scoping the rebuild must not change what the keys MEAN.
+
+    Collapse state, solo/restore and the refusal off the Read tab are all
+    behaviour the perf work is not allowed to move.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        await pilot.press("[")
+        await _settle(pilot, host)
+        assert Region.LEFT_RAIL in screen.region_layout.collapsed
+
+        await pilot.press("]")
+        await _settle(pilot, host)
+        assert Region.RIGHT_RAIL in screen.region_layout.collapsed
+        assert Region.LEFT_RAIL in screen.region_layout.collapsed, (
+            "one rail's toggle must not disturb the other's"
+        )
+
+        screen.focused_region = Region.CONTENT
+        screen.action_solo_region()
+        await _settle(pilot, host)
+        assert screen.region_layout.solo_region is Region.CONTENT
+        assert not screen.query("#wl-region-items")
+
+        screen.focused_region = Region.CONTENT
+        screen.action_solo_region()
+        await _settle(pilot, host)
+        assert screen.region_layout.solo_region is None, "a second Z restores"
+        assert screen.query("#wl-region-items")
+
+        # Off Read, the centre regions are not the user's to collapse.
+        screen.active_section = "sources"
+        await _settle(pilot, host)
+        before = screen.region_layout
+        screen.focused_region = Region.ITEMS
+        screen.action_toggle_region()
+        await _settle(pilot, host)
+        assert screen.region_layout == before, (
+            "a centre-region gesture off the Read tab must still be refused"
+        )
+        assert screen.query("#wl-region-items"), (
+            "and the section's own pane must still be showing"
+        )
+
+
+async def test_a_collapsed_region_still_expands_from_its_header_button() -> None:
+    """The chevron route through `RegionToggled`, not just the keybinding."""
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        await pilot.press("[")
+        await _settle(pilot, host)
+        header = screen.query_one("#wl-header-left_rail", Button)
+
+        header.press()
+        await _settle(pilot, host)
+
+        assert screen.query("#wl-region-left_rail"), (
+            "clicking a collapsed region's header must expand it"
+        )
+        assert screen.query("#wl-tree"), "and rebuild its content"

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -603,6 +603,40 @@ async def test_layout_keys_still_persist_and_restore_the_layout():
         )
 
 
+async def test_z_collapsing_a_centre_region_is_not_one_way():
+    """The keyboard round trip, not just the chevron.
+
+    A collapsed region renders as a focusable header (`#wl-header-items`) and
+    `on_descendant_focus` maps that id back to the region, so `z` with the
+    header focused has to expand it again. Worth pinning next to the scoping
+    work: the scoped path removes the widget that had focus and mounts a
+    different one in its place, which is exactly where a "collapse is one
+    way" regression would come from.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed(app)
+    async with _open(app, watchlist_id) as (screen, pilot, host):
+        screen.focused_region = Region.ITEMS
+        screen.action_toggle_region()
+        await _settle(pilot, host)
+        assert screen.query("#wl-header-items"), "ITEMS collapsed"
+
+        screen.query_one("#wl-header-items", Button).focus()
+        await _settle(pilot, host)
+        assert screen.focused_region is Region.ITEMS, (
+            "focusing a collapsed region's header must point the keybinding "
+            "at that region"
+        )
+
+        await pilot.press("z")
+        await _settle(pilot, host)
+
+        assert screen.query("#wl-region-items"), "z must expand it again"
+        assert screen.query("#watchlists-items-pane"), (
+            "and the region has to come back with its pane, not empty"
+        )
+
+
 async def test_a_collapsed_region_still_expands_from_its_header_button() -> None:
     """The chevron route through `RegionToggled`, not just the keybinding."""
     app = _build_test_app()

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -3358,3 +3358,59 @@ carries on, so nothing was broken for users -- only the warning was lost. It was
 tempting, and I did briefly claim, that a failing save in tests meant a failing
 save in the product. Check which layer makes a failure fatal before assigning it
 user impact.
+## A DOM swap moved into a worker is invisible to `pilot.pause()` (task-15461, 2026-08-11)
+
+**The trap.** `Pilot.pause(delay)` is `await self._wait_for_screen()` then
+`await asyncio.sleep(delay)`. `_wait_for_screen` drains the **message pump** — it posts a
+callback to every widget on the screen and waits for them all to come back. It knows
+nothing about Textual **workers**. So a UI update scheduled with `call_next` is covered
+by every `pilot.pause()` in the suite; the identical update scheduled with `run_worker`
+is covered only by whatever wall-clock `delay` the test happened to pass.
+
+**What happened.** Replacing Watchlists' whole-screen `refresh(recompose=True)` on a tab
+click with a region-scoped swap also moved the swap from a `call_next` callback (which is
+what `refresh(recompose=True)` is, internally: `_recompose_required = True;
+call_next(self._check_recompose)`) onto the screen's existing surface-refresh drain, which
+ran as `run_worker(..., group="wc_surface_refresh")`. Nothing about the swap's *duration*
+changed — instrumented at ~250 ms for the Artifacts pane before and after — but the
+suite's shared helper opens a section with `pilot.pause(0.2)`, and 250 > 200. Eight tests
+in `test_watchlists_artifacts_pane.py` began failing with `NoMatches:
+#watchlists-artifacts-pane`, **passing in isolation and failing in a full-file run**,
+because the margin was machine load. Two more flipped between runs. It looked exactly
+like flakiness and was not: it was a deterministic ordering change, mis-read as noise
+because the symptom was load-dependent.
+
+Scheduling the drain with `call_next` fixed all ten and cost nothing else — it is also
+strictly safer than the worker it replaced, whose own comment explains that it needed a
+private worker group so the screen's several `run_worker(..., exclusive=True)` call sites
+could not cancel it mid-swap. A `call_next` callback cannot be cancelled by a worker at
+all.
+
+**What to do.** Before moving any DOM mutation onto a worker, ask what the tests (and the
+app's own idle handling) actually wait for. `run_worker` is for *work*; the mount/remove
+pair that lands its result belongs on the pump. And when a batch of tests starts failing
+together in a full run while passing alone, do not reach for "flaky" — check whether the
+change under review moved something out of what the harness waits on.
+
+## A region factory that reads state before its `await` loses whatever lands in the gap (task-15461, 2026-08-11)
+
+**The trap.** Textual's own `Widget.recompose` removes its children **first** and calls
+`compose()` afterwards, so it always reads widget state on the late side of the yield.
+Hand-rolled in-place swaps usually do the opposite — build the replacement first, so a
+factory that raises leaves the old content standing rather than an empty box — and that
+inversion opens a window: state read, `await remove()`, state changes, `await mount()`.
+
+**What happened.** `watch_active_section` dispatches the new section's loader and the
+region swap in the same breath. `WatchlistsWorkbench.refresh_region_content` calls the
+region factory (which reads `self._loaded_rules`) *before* its remove/mount awaits. The
+loader — an `AsyncMock` in the test, a fast local query in production — completed during
+the removal, wrote its rows to the screen, then looked for its pane and could not find it:
+the replacement existed but was not yet mounted. Result: an Alert-rules table that stayed
+empty over a `_loaded_rules` holding the row, with nothing left to correct it. The
+whole-screen recompose being replaced had never had the gap, purely because of Textual's
+ordering.
+
+**What to do.** When you replace a recompose with a hand-rolled swap, re-apply the state
+*after* the mount (`_reseed_active_section_pane`) rather than trusting the read that
+happened before it. Reactive assignments make the re-apply free when nothing moved, so
+the cost is a few lines and the failure mode it closes is silent.

--- a/backlog/tasks/task-15461 - Watchlists---one-scoped-rebuild-per-section-or-tree-interaction.md
+++ b/backlog/tasks/task-15461 - Watchlists---one-scoped-rebuild-per-section-or-tree-interaction.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15461
 title: Watchlists: one scoped rebuild per section or tree interaction
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -24,3 +25,33 @@ Fix direction: region-scoped updates — rebuild only the section/region that ch
 - [ ] #2 A tree-node click causes at most one update per affected pane; briefing arrow-key selection no longer triggers 3 recomposes
 - [ ] #3 z/Z/[/] layout keys rebuild only the toggled region; all behavior unchanged (tests)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Measure first. Instrumented probe (isolated HOME/XDG/`TLDW_CONFIG_PATH`,
+   real seeded watchlist + briefings) counting `Widget.recompose()` calls and
+   mounted widget instances per interaction, plus the synchronous latency.
+   Record the BEFORE numbers before touching anything.
+2. Pin behaviour: characterisation tests for section switching, tree-click
+   fan-out, z/Z/[/] and briefing arrow-key selection. Green before changes.
+3. `WatchlistsWorkbench.region_layout`: drop `recompose=True`. Replace it with
+   a reconcile that swaps ONLY the regions whose rendered form actually
+   changed (collapsed header <-> expanded body) and patches the
+   sole-centre CSS marker in place on the ones that did not.
+4. Add a workbench `apply_section_view()` that mounts/unmounts hidden centre
+   regions, applies the tab-adjusted layout and rebuilds only the ITEMS
+   region + the centre header -- the two surfaces `active_section` actually
+   feeds.
+5. `watch_active_section`: stop calling whole-screen
+   `refresh(recompose=True)`. Queue the scoped swap on the EXISTING
+   `_request_surface_refresh` drain (so it can never interleave with the
+   header/rail swaps that queue there), and sync the backend header bar in
+   place.
+6. Artifacts pane: fold the screen's "clear the previous briefing's
+   scripts/citations/audio" writes into the pane itself, applied with
+   `set_reactive` inside `watch_selected_briefing`, so select+clear is ONE
+   recompose instead of two.
+7. Re-measure with the same probe; record AFTER numbers. Re-run the pinned
+   suites unmodified.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-15461 - Watchlists---one-scoped-rebuild-per-section-or-tree-interaction.md
+++ b/backlog/tasks/task-15461 - Watchlists---one-scoped-rebuild-per-section-or-tree-interaction.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15461
 title: Watchlists: one scoped rebuild per section or tree interaction
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-11 12:05'
@@ -21,9 +21,9 @@ Fix direction: region-scoped updates — rebuild only the section/region that ch
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A section switch performs one scoped rebuild of the changed section only (evidence)
-- [ ] #2 A tree-node click causes at most one update per affected pane; briefing arrow-key selection no longer triggers 3 recomposes
-- [ ] #3 z/Z/[/] layout keys rebuild only the toggled region; all behavior unchanged (tests)
+- [x] #1 A section switch performs one scoped rebuild of the changed section only (evidence)
+- [x] #2 A tree-node click causes at most one update per affected pane; briefing arrow-key selection no longer triggers 3 recomposes
+- [x] #3 z/Z/[/] layout keys rebuild only the toggled region; all behavior unchanged (tests)
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -55,3 +55,108 @@ Fix direction: region-scoped updates — rebuild only the section/region that ch
 7. Re-measure with the same probe; record AFTER numbers. Re-run the pinned
    suites unmodified.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`WatchlistsWorkbench.region_layout` is no longer `recompose=True`, and
+`watch_active_section` no longer calls whole-screen `refresh(recompose=True)`.
+Both are replaced by swaps scoped to what actually changed.
+
+**Layout keys (AC#3).** `watch_region_layout` swaps only the regions whose
+rendered form moved -- collapsed one-line header <-> expanded body. A region
+that stays expanded keeps its widget instance and has its
+`watchlists-region-sole-centre` marker toggled in place, which is the only
+other thing a layout change can move for it. `ContentPane.expanded` gained a
+watcher that relabels the Expand/Restore button in place, because soloing
+CONTENT does not change CONTENT's own form (it collapses ITEMS, the sibling),
+so the pane survives and nothing else would repaint the label.
+
+**Section switch (AC#1).** `WatchlistsWorkbench.apply_section_view` mounts or
+unmounts the centre regions the new tab hides/shows, applies the tab-adjusted
+layout in the same pass, and rebuilds the ITEMS region plus the centre header
+-- the only surfaces `active_section` feeds. Both rails, the screen, the
+navigation bar and the footer are untouched. The backend Select and its
+local-only label are patched in place by `_sync_backend_header_bar`.
+
+Two seams had to move for this to be correct rather than merely smaller, and
+both are recorded in `backlog/docs/lessons-testing-evidence.md`:
+
+* The surface-refresh drain now schedules with `call_next` instead of
+  `run_worker`. A worker is invisible to `Pilot.pause`'s `_wait_for_screen`
+  (and to the app's own idle handling), which `refresh(recompose=True)` -- a
+  `call_next` callback internally -- was not. Ten tests began failing
+  load-dependently until this moved back onto the pump. It is also strictly
+  safer: the private worker group existed only so `exclusive=True` callers
+  could not cancel the drain mid-swap, and a pump callback cannot be.
+* `_reseed_active_section_pane` re-applies the section's rows after the mount.
+  `refresh_region_content` deliberately calls the region factory *before*
+  detaching the old pane (so a raising factory leaves the screen intact), which
+  opens a window Textual's own `recompose` does not have; a loader landing in
+  it wrote rows nobody was left to render (a permanently empty Alert-rules
+  table over a populated `_loaded_rules`). The re-apply is free when nothing
+  moved, and it is what keeps a switch to ONE pane build: the loader's own
+  later push finds its values already in place.
+
+**Briefing selection (AC#2).** The previous briefing's scripts/audio/citations
+are now cleared inside `ArtifactsPane.watch_selected_briefing` with
+`set_reactive`, folding select+clear into the one recompose the selection had
+already queued instead of the screen adding a second from its message handler.
+
+**Tree click (AC#2, first half).** Measured at ≤1 update per affected pane
+*before* this task -- Textual coalesces a burst of `recompose=True` writes on
+one widget into a single rebuild via `_recompose_required`, so the audit's
+"4 recomposes" is 4 different widgets, one each. Nothing needed fixing; the
+new test is a regression guard, and honestly labelled as one (it is the single
+test in the new file that does not go red against the pre-task code).
+
+**Measured** (isolated HOME/XDG/`TLDW_CONFIG_PATH`, seeded watchlist with a
+source, 3 items and 3 briefings; `Widget.recompose`/`Widget.mount` counted;
+ms = dispatch to message-pump drained, best of two runs):
+
+| interaction | recompose | mounted widgets | ms |
+|---|---|---|---|
+| section: Sources | 2 -> 1 | 128 -> 71 | 154 -> 118 |
+| section: Runs | 1 -> 0 | 84 -> 27 | 66 -> 30 |
+| section: Rules | 1 -> 0 | 75 -> 18 | 120 -> 24 |
+| section: Notifications | 1 -> 0 | 80 -> 23 | 56 -> 27 |
+| section: Artifacts | 3 -> 2 | 176 -> 118 | 88 -> 48 |
+| section: Read (warm) | 1 -> 0 | 111 -> 54 | 76 -> 48 |
+| section: Overview | 2 -> 1 | 90 -> 33 | 49 -> 28 |
+| `[` collapse rail | 1 -> 0 | 59 -> 1 | 114 -> 108 |
+| `[` expand rail | 1 -> 0 | 95 -> 19 | 128 -> 107 |
+| `]` collapse Inspector | 3 -> 1 | 123 -> 24 | 232 -> 107 |
+| `]` expand Inspector | 1 -> 0 | 77 -> 1 | 121 -> 86 |
+| `z` collapse ITEMS | 1 -> 0 | 37 -> 1 | 113 -> 86 |
+| `Z` solo CONTENT | 1 -> 0 | 37 -> 0 | 115 -> 88 |
+| tree click | 1 -> 1 | 26 -> 26 | 31 -> 30 |
+
+Two honest caveats. `section: Read` (cold) is the one interaction whose
+wall-clock did not improve (75 -> 110 ms on the best of two) despite halving
+the DOM work: it is the tab that has to mount the CONTENT region back, and the
+scoped path does that as its own remove/mount pair rather than inside one
+batched recompose. And the ms column is two samples on a busy machine; the
+mount/recompose counts are the deterministic evidence, the timings are
+supporting.
+
+**Behaviour pinned, not moved.** Three existing tests used "press `[`" as a
+convenient way to force a pane rebuild -- which is precisely what AC#3
+abolishes. Their contracts (a rebuilt pane is re-seeded with its filter/
+selection/detail) are unchanged; only the trigger moved, to a real region
+collapse/expand or to `refresh_region_content` directly, with the reason
+recorded at each site. `test_bracket_toggle_preserves_inspector_selection` was
+strengthened rather than retargeted: it now asserts the Inspector is never
+rebuilt at all. One test in the artifacts suite drove
+`handle_briefing_selected` directly to prove synchronous clearing; it now
+drives the selection, which is the synchronous route the clearing moved to.
+
+**Files.** `tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py`,
+`.../artifacts_pane.py`, `.../content_pane.py`,
+`tldw_chatbook/UI/Screens/watchlists_collections_screen.py`;
+`Tests/Watchlists/test_watchlists_scoped_rebuilds.py` (new, 14 tests, 10 of
+them red against the pre-task code), `Tests/Watchlists/
+test_watchlists_artifacts_pane.py`, `Tests/UI/test_watchlists_content_pane.py`,
+`Tests/UI/test_watchlists_destination_shell.py`,
+`Tests/UI/test_watchlists_run_detail.py`,
+`backlog/docs/lessons-testing-evidence.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15461 - Watchlists---one-scoped-rebuild-per-section-or-tree-interaction.md
+++ b/backlog/tasks/task-15461 - Watchlists---one-scoped-rebuild-per-section-or-tree-interaction.md
@@ -150,11 +150,59 @@ rebuilt at all. One test in the artifacts suite drove
 `handle_briefing_selected` directly to prove synchronous clearing; it now
 drives the selection, which is the synchronous route the clearing moved to.
 
+**Review round (post-approval).** Two Importants and four minors, all closed:
+
+* **Focus.** A tab click focuses the tab `Button`, the swap rebuilds the header
+  it lives in, and Textual's `Screen._reset_focus` re-homed focus onto a LEFT
+  RAIL tree node -- so the next `z` collapsed AND persisted the rail. Measured
+  A/B (pre-task it was focus-`None` and `z` was refused).
+  `_restore_focus_after_swap` puts focus back on the rebuilt
+  `#wl-tab-<section>`, which restores the refusal by the honest route
+  (`_focus_in_centre_header`). Gated on `_swap_will_destroy_focus` so a
+  section change driven from elsewhere never steals focus. Two tests.
+* **Stale comments.** Eleven sites still asserted `region_layout` "is
+  `recompose=True`" -- several load-bearing for the factory/seeding rationale.
+  All corrected to the real trigger (a region is rebuilt when its own form
+  changes, or on a section switch for ITEMS), keeping the historical note
+  where it explains why the state is mirrored at all.
+* **Minors.** The pane-build test now seeds a real alert rule (the assertion
+  could not discriminate on an empty fixture -- and with a row it immediately
+  exposed a residual, below); `_reseed_active_section_pane` has an in-suite
+  pin that reconstructs the mid-swap landing window deterministically and
+  reds when the reseed is neutered; the task-627 mouse-capture note is on
+  `_swap_active_section`.
+
+**Residuals** (for the controller to file):
+
+1. **Cold Read tab wall-clock.** 75 -> 110 ms best-of-two despite halving the
+   DOM work; it is the only tab that re-mounts the CONTENT region, and the
+   scoped path does that as a discrete remove/mount pair rather than inside
+   one batched recompose. Textual's `batch()` is the obvious next move.
+2. **Two artifacts tests flickered once** (`test_the_kill_switch_on_leaves_
+   the_cadence_picker_unchanged`, `test_keep_button_disabled_without_a_
+   complete_selection_or_chachanotes`) in an intermediate run, before the
+   `call_next` fix, and have passed in every run since including three
+   full-directory runs. Probably the same wait-window issue; flagged rather
+   than asserted.
+3. **Artifacts pane recomposes wholesale on a briefing selection** (1, down
+   from 2). Because it recomposes, the briefings `DataTable` is destroyed and
+   loses focus, so a SECOND arrow key does nothing until the user re-focuses
+   the table. Measured on the pre-task code too -- pre-existing, not caused
+   here, but a real defect worth its own task.
+4. **`_build_detail_pane`'s pre-mount seeding costs one pane recompose** per
+   region build (`[] != [row]` on a freshly constructed pane). Pre-existing
+   and unchanged by this task; invisible on an empty fixture, which is why it
+   surfaced only once the review asked for a seeded row. Removing it means
+   seeding with `set_reactive`, which is not safe blind: `RunsPane`'s seeding
+   ORDER is load-bearing (`selected_run` clears the detail, so the detail must
+   be set after it).
+
 **Files.** `tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py`,
 `.../artifacts_pane.py`, `.../content_pane.py`,
 `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`;
-`Tests/Watchlists/test_watchlists_scoped_rebuilds.py` (new, 14 tests, 10 of
-them red against the pre-task code), `Tests/Watchlists/
+`.../sources_pane.py`, `.../rules_pane.py`;
+`Tests/Watchlists/test_watchlists_scoped_rebuilds.py` (new, 17 tests, 12 of
+them red against the mechanism they pin), `Tests/Watchlists/
 test_watchlists_artifacts_pane.py`, `Tests/UI/test_watchlists_content_pane.py`,
 `Tests/UI/test_watchlists_destination_shell.py`,
 `Tests/UI/test_watchlists_run_detail.py`,

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -2734,7 +2734,28 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self.query_one(WatchlistsWorkbench).region_layout = self._rendered_region_layout()
         except Exception:
             logger.debug("Workbench not mounted yet; layout applies on compose.")
+        self._sync_reader_expanded_state()
         self._schedule_layout_persist(layout)
+
+    def _sync_reader_expanded_state(self) -> None:
+        """Push CONTENT's solo state into the live reader (task-15461).
+
+        `_build_content_pane` seeds `ContentPane.expanded` on every build,
+        which used to be enough because every layout change rebuilt every
+        region. Scoped updates keep a still-expanded CONTENT on its ORIGINAL
+        instance, and `Z` on CONTENT is exactly the case that changes this
+        flag without changing CONTENT's own form (solo collapses ITEMS, the
+        sibling) -- so without this push the reader's Expand/Restore button
+        would keep offering the action it has just performed.
+
+        A no-op when CONTENT is collapsed or hidden: there is no pane, and
+        the next `_build_content_pane` seeds the fresh one anyway.
+        """
+        try:
+            reader = self.query_one("#watchlists-content-pane", ContentPane)
+        except NoMatches:
+            return
+        reader.expanded = self.region_layout.solo_region == Region.CONTENT
 
     def _schedule_layout_persist(self, layout: RegionLayout) -> None:
         """Persist ``layout`` off the UI thread, skipping genuine no-ops.
@@ -3676,6 +3697,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     _SURFACE_RAIL = "rail"
     _SURFACE_HEADER = "header"
     _SURFACE_INSPECTOR = "inspector"
+    #: task-15461. The section swap: the ITEMS region's pane (routed by
+    #: `active_section`), the centre header (which carries the tab strip) and
+    #: whichever centre regions the new tab hides or shows. Queued here rather
+    #: than run straight from `watch_active_section` because it swaps the SAME
+    #: `#wl-centre-status` widget `_SURFACE_HEADER` does, and two independent
+    #: remove/mount pairs over one id is exactly the interleaving this queue
+    #: exists to prevent.
+    _SURFACE_SECTION = "section"
 
     def _request_surface_refresh(self, *surfaces: str) -> None:
         """Record that one or more workbench surfaces need rebuilding.
@@ -3696,13 +3725,29 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         runs. Requests that arrive while it is running are picked up by its
         next loop rather than starting -- or cancelling -- anything.
 
+        **Scheduled on the message pump, not as a worker** (task-15461). This
+        used to be `run_worker(..., group="wc_surface_refresh")`, whose own
+        group existed so that the several `run_worker(..., exclusive=True)`
+        call sites on this screen without a group (e.g.
+        `_load_active_section_data`) could not cancel the drainer mid-swap.
+        `call_next` is immune to that by construction -- it is not a worker at
+        all -- and it restores a property the section swap depends on:
+        `refresh(recompose=True)`, which `watch_active_section` used to call,
+        is itself a `call_next` callback, so anything that waits for the
+        message pump to go quiet (`Pilot.pause`'s `_wait_for_screen`, and the
+        app's own idle handling) waits for the DOM swap. A worker is invisible
+        to that wait. Moving the section swap into a worker made every
+        harness that opens a section and immediately queries its pane a
+        coin-flip on how long the swap happened to take -- measured at ~250 ms
+        for Artifacts, against a 200 ms pause.
+
         Args:
-            surfaces: Any of `_SURFACE_RAIL`, `_SURFACE_HEADER` (each an
-                unconditional rebuild of that surface) or
-                `_SURFACE_INSPECTOR` (conditional -- the right rail is
-                rebuilt only when the Console-follow row no longer matches
-                the adapter; see `_resolve_console_follow_drift`). Unknown
-                names are ignored by the drainer.
+            surfaces: Any of `_SURFACE_RAIL`, `_SURFACE_HEADER`,
+                `_SURFACE_SECTION` (each an unconditional rebuild of that
+                surface) or `_SURFACE_INSPECTOR` (conditional -- the right
+                rail is rebuilt only when the Console-follow row no longer
+                matches the adapter; see `_resolve_console_follow_drift`).
+                Unknown names are ignored by the drainer.
         """
         if not self._dom_is_live:
             return
@@ -3712,26 +3757,17 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # Arm, then disarm if scheduling fails -- `_start_tree_write`'s
         # discipline, for the identical failure mode (review wave, M1). Only
         # `_drain_surface_refresh`'s `finally` ever lowers this flag, and it
-        # never runs if `run_worker` raises synchronously; the flag would then
+        # never runs if scheduling raises synchronously; the flag would then
         # be stuck True for the life of the screen, every later request would
         # queue and return, and the rail/header would silently stop
         # following every background loader. Arming *after* scheduling is not
         # the fix either: the drainer's `finally` could already have lowered
         # the flag by the time we raised it.
-        #
-        # Its own group, not the default one: several call sites on this
-        # screen run `run_worker(..., exclusive=True)` without a group (e.g.
-        # `_load_active_section_data`), and those would otherwise cancel this
-        # drainer mid-swap -- the very failure this queue exists to prevent.
-        drain = self._drain_surface_refresh()
         self._surface_refresh_draining = True
         try:
-            self.run_worker(drain, group="wc_surface_refresh")
+            self.call_next(self._drain_surface_refresh)
         except Exception:
             self._surface_refresh_draining = False
-            # Close the un-awaited coroutine explicitly, or it leaks a
-            # `RuntimeWarning` at collection time.
-            drain.close()
             logger.opt(exception=True).warning(
                 "Watchlists surface refresh could not be scheduled."
             )
@@ -3757,6 +3793,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     # screen's current state on the way back, so the pending
                     # update is not lost -- it arrives with that rebuild.
                     break
+                if self._SURFACE_SECTION in surfaces:
+                    await self._rebuild_surface(
+                        self._swap_active_section(workbench),
+                        "the Watchlists section",
+                    )
+                    # The swap rebuilds the centre header itself, so a HEADER
+                    # request that arrived in the same batch is already
+                    # served; running it again would be the second of the two
+                    # rebuilds task-15461 removes.
+                    surfaces = surfaces - {self._SURFACE_HEADER}
                 if self._SURFACE_RAIL in surfaces:
                     await self._rebuild_surface(
                         workbench.refresh_region_content(Region.LEFT_RAIL),
@@ -3775,6 +3821,150 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         finally:
             self._pending_surface_refresh = set()
             self._surface_refresh_draining = False
+
+    async def _swap_active_section(self, workbench: WatchlistsWorkbench) -> None:
+        """Move the workbench onto `active_section`, region by region.
+
+        task-15461. This replaces `watch_active_section`'s whole-screen
+        `refresh(recompose=True)`, which rebuilt the navigation bar, the
+        footer, the header bar, both rails and both centre regions to change
+        which pane the centre shows -- 75-176 mounted widgets per tab click,
+        measured, including a fresh `WatchlistTree` whose `compose` runs one
+        synchronous source-row query per expanded watchlist.
+
+        Only three things on this screen actually read `active_section`:
+
+        * the ITEMS region, whose pane `_build_detail_pane` routes by section;
+        * the centre header, which carries the tab strip and the scoped
+          snapshot markers;
+        * `_hidden_centre_regions`/`_rendered_region_layout`, i.e. whether
+          CONTENT exists at all on this tab and whether ITEMS may render
+          collapsed there.
+
+        The header bar's backend Select is the fourth, and is patched in
+        place by `_sync_backend_header_bar` (which also runs synchronously
+        from the watcher, so the disabled state never lags the tab).
+
+        Args:
+            workbench: The mounted workbench, resolved once by the drainer.
+        """
+        await workbench.apply_section_view(
+            hidden=self._hidden_centre_regions(),
+            layout=self._rendered_region_layout(),
+            rebuild_regions=(Region.ITEMS,),
+            rebuild_header=True,
+        )
+        # CONTENT is not rebuilt by the swap (the reader is deliberately not
+        # gated on `active_section` -- see `_build_content_pane`), so a still
+        # -mounted reader keeps its instance across the tab change. Its
+        # `expanded` flag is layout-derived, and `_rendered_region_layout`
+        # can move ITEMS' collapse state across the Read boundary, so
+        # re-push it for the same reason `_apply_layout` does.
+        self._sync_reader_expanded_state()
+        self._reseed_active_section_pane()
+
+    def _reseed_active_section_pane(self) -> None:
+        """Re-apply the section's loaded rows to the pane the swap mounted.
+
+        `watch_active_section` dispatches this section's loader and the swap
+        in the same breath, and `WatchlistsWorkbench.refresh_region_content`
+        deliberately calls the region factory BEFORE detaching the old pane
+        (so a factory that raises leaves what is on screen standing). Those
+        two facts open a window: the factory reads screen state, then the
+        remove/mount pair awaits, and a loader that lands in that gap writes
+        its rows to `self._loaded_*` and then fails to find its pane, because
+        the replacement is built but not yet mounted. The pane then renders
+        the state as it was one instant before the data arrived, with nothing
+        left to correct it -- measured as an Alert-rules table that stayed
+        empty over a `self._loaded_rules` holding the row.
+
+        (The whole-screen `refresh(recompose=True)` this replaced did not have
+        the gap: Textual's `Widget.recompose` removes its children first and
+        calls `compose()` only afterwards, so it always read screen state on
+        the late side of the yield.)
+
+        Re-applying after the mount closes it from the other end, and costs
+        nothing when no loader landed: these are reactive assignments, and an
+        unchanged value fires no watcher and no recompose. It is also what
+        keeps a section switch to ONE pane build -- the loader's own push,
+        arriving later, finds the values already in place.
+        """
+        if not self._dom_is_live:
+            return
+        section = self.active_section
+        try:
+            if section == "items":
+                self.query_one(
+                    "#watchlists-items-pane", ArticleListPane
+                ).items = self._loaded_items
+            elif section == "sources":
+                self.query_one(
+                    "#watchlists-sources-pane", SourcesPane
+                ).sources = self.scoped_loaded_sources()
+            elif section == "runs":
+                self.query_one("#watchlists-runs-pane", RunsPane).runs = (
+                    self._loaded_runs
+                )
+            elif section == "rules":
+                self.query_one("#watchlists-rules-pane", RulesPane).rules = (
+                    self._loaded_rules
+                )
+            elif section == "notifications":
+                pane = self.query_one(
+                    "#watchlists-notifications-pane", NotificationsPane
+                )
+                pane.notifications = self._loaded_notifications
+                pane.selected_notification = self.selected_notification
+            elif section == "artifacts":
+                self._apply_briefing_state_to_pane()
+        except NoMatches:
+            # The region is collapsed, or the swap could not build its pane.
+            # Either way the next build seeds from this same state.
+            pass
+
+    def _sync_backend_header_bar(self) -> None:
+        """Repaint the backend picker row for the active section, in place.
+
+        `_LOCAL_ONLY_SECTIONS` disables the Select and adds an explanatory
+        `#watchlists-backend-label`; both used to arrive via the whole-screen
+        recompose `watch_active_section` no longer does (task-15461). Kept
+        synchronous, unlike the region swap: this is three attribute writes
+        and at most one one-widget mount, and a Select that stays enabled for
+        even one frame on a local-only tab is a control that lies about what
+        it can do.
+
+        The Select instance itself is deliberately NOT rebuilt -- its `value`
+        already tracks `runtime_backend`, and rebuilding it would close an
+        open dropdown mid-choice.
+        """
+        local_only = self._local_only_section()
+        try:
+            backend_select = self.query_one("#watchlists-backend-select", PruneSafeSelect)
+        except NoMatches:
+            return
+        backend_select.disabled = local_only is not None
+        backend_select.tooltip = (
+            (local_only or {}).get("tooltip")
+            or "Choose the Watchlists data backend."
+        )
+        label_text = self._backend_label_text()
+        try:
+            label: Static | None = self.query_one("#watchlists-backend-label", Static)
+        except NoMatches:
+            label = None
+        if label_text is None:
+            if label is not None:
+                label.remove()
+            return
+        if label is None:
+            try:
+                self.query_one("#watchlists-header-bar").mount(
+                    Static(label_text, id="watchlists-backend-label")
+                )
+            except NoMatches:
+                pass
+            return
+        label.update(label_text)
 
     async def _rebuild_inspector_if_console_follow_drifted(
         self, workbench: WatchlistsWorkbench
@@ -3863,9 +4053,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._focus_in_centre_header = False
 
     def watch_active_section(self) -> None:
-        # A tab switch always fully recomposes the centre (below): whatever
-        # `_focus_in_centre_header` was tracking about the OLD DOM is moot
-        # the instant that DOM is torn down. Reset
+        # A tab switch always rebuilds the centre header and the section's own
+        # pane (below): whatever `_focus_in_centre_header` was tracking about
+        # the OLD DOM is moot the instant that DOM is torn down. Reset
         # to "not in the header" rather than leave a stale `True` standing
         # -- `on_descendant_focus` will set it again the moment a fresh
         # focus event actually lands there, but nothing guarantees one
@@ -3879,7 +4069,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self._pending_navigation_run_id = None
             self._pending_navigation_run_backend = None
         if self.is_mounted:
-            self.refresh(recompose=True)
+            # task-15461: one region-scoped swap, not a whole-screen
+            # `refresh(recompose=True)`. Queued on the surface drain rather
+            # than run here because it swaps `#wl-centre-status`, the same
+            # widget `_SURFACE_HEADER` swaps -- see `_SURFACE_SECTION`.
+            self._sync_backend_header_bar()
+            self._request_surface_refresh(self._SURFACE_SECTION)
             if not self._applying_navigation_context:
                 self._load_active_section_data()
 
@@ -6002,6 +6197,18 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             )
             self._loaded_briefing_presets = preset_rows
             self._watchlist_has_audio_episodes = has_audio_episodes
+        self._apply_briefing_state_to_pane()
+
+    def _apply_briefing_state_to_pane(self) -> None:
+        """Push every screen-held briefing value into the mounted pane.
+
+        Extracted from `_load_briefings`' tail (task-15461) so the section
+        swap can re-apply the same state after mounting a fresh
+        `ArtifactsPane` -- see `_reseed_active_section_pane` for why that is
+        not redundant. Every write is a reactive assignment, so a value that
+        has not moved costs nothing: Textual only fires watchers (and the
+        recompose that follows) when `!=` says the value actually changed.
+        """
         if not self._dom_is_live:
             return
         try:
@@ -6177,16 +6384,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # in the one frame before `_load_briefings`'s reload lands.
         self._loaded_citations = []
         self._citation_item_lookup = {}
-        try:
-            pane = self.query_one("#watchlists-artifacts-pane", ArtifactsPane)
-        except NoMatches:
-            pane = None
-        if pane is not None:
-            pane.scripts = []
-            pane.selected_script = None
-            pane.script_audio = None
-            pane.scripts_with_audio = {}
-            pane.citations = []
+        # task-15461: the PANE's own copies are cleared by
+        # `ArtifactsPane._clear_selection_derived_state`, inside the same
+        # synchronous instant the selection moves, so the clearing rides the
+        # recompose that selection already queued instead of adding a second
+        # one. The screen-side mirrors above still have to be cleared here --
+        # they are what `handle_citation_activated` and a later rebuild read.
         self.run_worker(
             self._load_briefings(), exclusive=True, group="wl-briefings-load"
         )

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -557,11 +557,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     # label, so the crumb would still render, just anonymously.
     #
     # Both live on the screen, not on the tree widget, precisely because
-    # `region_layout` is `recompose=True`: any collapse/solo/rail toggle
-    # rebuilds the whole workbench, constructing a brand new `WatchlistTree`
-    # instance. Pane-local state does not survive that (see `selected_run`
-    # and the create-form draft above for the same reasoning already applied
-    # elsewhere on this screen).
+    # collapsing or expanding the left rail constructs a brand new
+    # `WatchlistTree` instance -- the region's rendered form changes, so its
+    # widget is swapped for a freshly built one (task-15461 narrowed the
+    # blast radius of a layout change from "every region" to "the region that
+    # changed", but a toggled region is still rebuilt). Pane-local state does
+    # not survive that (see `selected_run` and the create-form draft above
+    # for the same reasoning already applied elsewhere on this screen).
     selected_scope = reactive(TreeScope(kind="all"))
     tree_scope = reactive(TreeScope(kind="all"))
 
@@ -844,12 +846,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._breadcrumb_labels: list[str] = []
         self._applying_navigation_context = False
         # Mirrors SourcesPane's create-form state (Finding 1, fix round 1):
-        # `region_layout` is `recompose=True`, so any collapse/solo/rail
-        # toggle rebuilds the whole workbench, constructing a brand new
-        # SourcesPane. Without holding the draft here — the same way
-        # selected_source/selected_run/active_section already survive pane
-        # rebuilds — a half-typed create form would be silently destroyed by
-        # a keybinding that has nothing to do with Sources.
+        # collapsing or expanding the region the pane lives in constructs a
+        # brand new SourcesPane, and so does a section switch. Without
+        # holding the draft here — the same way selected_source/selected_run/
+        # active_section already survive pane rebuilds — a half-typed create
+        # form would be silently destroyed by a keybinding that has nothing
+        # to do with Sources. (Since task-15461 a rebuild is scoped to the
+        # region that actually changed, which narrows how OFTEN this fires,
+        # not whether the draft has to survive it.)
         self._source_create_form_open = False
         self._source_create_draft: dict[str, str] = {"name": "", "url": "", "tags": ""}
         # The create form's noise-selector text, mirrored for the same reason
@@ -1658,9 +1662,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def _build_tree_pane(self) -> WatchlistTree:
         """Build the LEFT_RAIL-region content: the watchlist tree.
 
-        A factory, not an instance: `region_layout` is `recompose=True`, so
-        any collapse/solo/rail toggle rebuilds every region, and a widget
-        instance can only be mounted once (see the factory note on
+        A factory, not an instance: collapsing or expanding the left rail
+        swaps its widget for a freshly built one, and a widget instance can
+        only be mounted once (see the factory note on
         `WatchlistsWorkbench.__init__`).
 
         Seeds `expanded`/`active_tag` from screen state (whole-branch review,
@@ -2333,9 +2337,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
         Reads `_console_follow_item` -- a plain attribute -- rather than
         polling the adapter (review wave, M4). The workbench calls this
-        factory again on every region rebuild, and `region_layout` is
-        `recompose=True`, so a `z`/`Z`/`[`/`]`/chevron toggle would otherwise
-        re-run the adapter's multi-query fan-out from inside `compose()`. The
+        factory again on every rebuild of the RIGHT_RAIL region, so a `]`
+        (or a chevron on the Inspector) would otherwise re-run the adapter's
+        multi-query fan-out from inside `compose()`. The
         handoff's cache makes that free once a poll has SUCCEEDED, but on the
         failure path it is retried every time -- exactly the shape this file
         insists its content factories must not have.
@@ -2377,9 +2381,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         cross-cutting action unrelated to whatever is currently selected --
         moves to the bottom.
         """
-        # Seed from screen state (Finding 3, fix round 2): `region_layout` is
-        # `recompose=True`, so any collapse/solo/rail toggle constructs a
-        # brand new InspectorPane. Without this, the screen keeps
+        # Seed from screen state (Finding 3, fix round 2): collapsing or
+        # expanding the right rail constructs a brand new InspectorPane, and
+        # so does the drain's conditional rail rebuild
+        # (`_rebuild_inspector_if_console_follow_drifted`). Without this,
+        # the screen keeps
         # `selected_entity` but the freshly-built Inspector starts at its
         # class default (`None`) until the NEXT explicit selection change —
         # `watch_selected_entity` only pushes on change, so a rebuild alone
@@ -2598,9 +2604,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             yield WatchlistsWorkbench(
                 self._rendered_region_layout(),
                 content={
-                    # Factories, not instances: `region_layout` is
-                    # `recompose=True`, so any collapse/solo/rail toggle
-                    # rebuilds every region, not just the one that changed.
+                    # Factories, not instances: a region whose rendered form
+                    # changes (collapse/expand, and for ITEMS a section
+                    # switch) is swapped for a freshly built widget, so each
+                    # of these is called more than once.
                     # A pre-built container's constructor-supplied children
                     # only mount on its FIRST mount; the same instance
                     # remounted a second time comes back childless (verified
@@ -3087,8 +3094,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         """Store the tree's selection on the screen, not the tree.
 
         `selected_scope` lives here for the same reason `selected_run` and
-        the create-form draft do: the workbench's `region_layout` is
-        `recompose=True`, so a bare rail toggle rebuilds a brand new
+        the create-form draft do: a bare rail toggle swaps in a brand new
         `WatchlistTree` that would otherwise lose the selection.
         """
         event.stop()
@@ -3845,15 +3851,31 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         place by `_sync_backend_header_bar` (which also runs synchronously
         from the watcher, so the disabled state never lags the tab).
 
+        Known and accepted: this path removes widgets WITHOUT going through
+        `BaseAppScreen.refresh`, so the task-627 defensive `capture_mouse
+        (None)` no longer runs on a tab switch. Reachability is low -- it
+        needs a mouse still captured by something inside the header or the
+        ITEMS pane at the instant a tab changes, i.e. a drag whose `MouseUp`
+        has not landed while the section changes by some other route -- and
+        the panes that recompose themselves already carry
+        `RecomposeCaptureGuard`. Documented rather than fixed; a guard here
+        would have to release only captures inside the two surfaces this
+        swap actually tears down.
+
         Args:
             workbench: The mounted workbench, resolved once by the drainer.
         """
+        # Asked BEFORE the swap: afterwards the widget is already gone and
+        # Textual has already re-homed focus (see `_restore_focus_after_swap`).
+        rehome_focus = self._swap_will_destroy_focus()
         await workbench.apply_section_view(
             hidden=self._hidden_centre_regions(),
             layout=self._rendered_region_layout(),
             rebuild_regions=(Region.ITEMS,),
             rebuild_header=True,
         )
+        if rehome_focus:
+            self._restore_focus_after_swap()
         # CONTENT is not rebuilt by the swap (the reader is deliberately not
         # gated on `active_section` -- see `_build_content_pane`), so a still
         # -mounted reader keeps its instance across the tab change. Its
@@ -3862,6 +3884,61 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # re-push it for the same reason `_apply_layout` does.
         self._sync_reader_expanded_state()
         self._reseed_active_section_pane()
+
+    #: The two surfaces `_swap_active_section` tears down: the centre header
+    #: (which carries the tab strip) and the ITEMS region (the section's own
+    #: pane). Focus living inside either one does not survive the swap.
+    _SWAP_OWNED_CONTAINER_IDS = frozenset({"wl-centre-status", "wl-region-items"})
+
+    def _swap_will_destroy_focus(self) -> bool:
+        """Whether the section swap is about to unmount the focused widget.
+
+        Asked before the swap, because Textual answers it for us afterwards --
+        badly. See `_restore_focus_after_swap`.
+
+        Returns:
+            `True` when something is focused and it sits inside the centre
+            header or the ITEMS region.
+        """
+        node = self.focused
+        while node is not None:
+            if (getattr(node, "id", None) or "") in self._SWAP_OWNED_CONTAINER_IDS:
+                return True
+            node = node.parent
+        return False
+
+    def _restore_focus_after_swap(self) -> None:
+        """Put focus back on the tab the user just switched to.
+
+        A tab click focuses the tab `Button`, which lives in the centre header
+        -- and the swap rebuilds that header, so the focused widget is removed
+        from under the user. Textual's `Screen._reset_focus` then walks for a
+        replacement and lands on the first focusable thing it finds, which on
+        this screen is a node in the LEFT RAIL. That is not cosmetic:
+        `on_descendant_focus` reads the new focus and sets
+        `focused_region = LEFT_RAIL`, so the very next `z` collapses the rail
+        AND persists that collapse to config -- from a keypress the user aimed
+        at the section they were looking at. Measured A/B against the
+        pre-task code, where the whole-screen recompose left focus at `None`
+        and `z` was refused by `_refuse_region_gesture_off_read_tab`.
+
+        Re-focusing the freshly built tab restores that refusal by the honest
+        route rather than by accident: focus lands in `#wl-centre-status`, so
+        `on_descendant_focus` sets `_focus_in_centre_header`, which is exactly
+        what `action_toggle_region`/`action_solo_region` already consult.
+
+        Only called when the swap really did unmount the focused widget
+        (`_swap_will_destroy_focus`): a section change driven from elsewhere
+        -- a deep link, `EditRuleRequested` -- must not steal focus from
+        wherever the user actually is.
+        """
+        try:
+            self.query_one(f"#wl-tab-{self.active_section}", Button).focus()
+        except NoMatches:
+            # No tab for this section (nothing in `SECTIONS` matches), or the
+            # header could not be rebuilt. Leaving focus where Textual put it
+            # is still wrong, but there is nothing better to reach for here.
+            logger.debug("No section tab to restore focus to after the swap.")
 
     def _reseed_active_section_pane(self) -> None:
         """Re-apply the section's loaded rows to the pane the swap mounted.

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -1545,8 +1545,44 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
         self.post_message(CitationActivated(item_id))
 
     def watch_selected_briefing(self, briefing: dict[str, Any] | None) -> None:
-        if self.is_mounted:
-            self.post_message(BriefingSelected(briefing))
+        if not self.is_mounted:
+            # Pre-mount seeding (`WatchlistsCollectionsScreen.
+            # _build_detail_pane` sets `selected_briefing` and then the
+            # script/citation state, in that order). Clearing here would wipe
+            # the seeding that follows, and there is no screen to tell.
+            return
+        self._clear_selection_derived_state()
+        self.post_message(BriefingSelected(briefing))
+
+    def _clear_selection_derived_state(self) -> None:
+        """Drop the previous briefing's scripts, audio and citations.
+
+        A briefing owns its scripts and its citations, so the instant the
+        selection moves, whatever is rendered below the detail belongs to a
+        briefing that is no longer on screen. `handle_briefing_selected` used
+        to clear these from the SCREEN, one reactive assignment at a time, in
+        the message handler that runs after this watcher -- which meant the
+        select->clear->reload pipeline cost two pane recomposes before the
+        reload's own: one for the selection, then a second for the clearing.
+
+        Doing it here, with `set_reactive`, folds the clearing into the ONE
+        recompose the selection change has already queued (task-15461):
+        `set_reactive` writes the value without firing watchers or scheduling
+        a second rebuild, and `compose` reads the cleared values when that
+        single pending recompose runs. The stale-frame guarantee
+        `handle_briefing_selected` documents is unchanged -- if anything it is
+        stronger, since the clearing now happens in the same synchronous
+        instant as the selection rather than one message later.
+
+        `selected_script` is deliberately included: its watcher would post
+        `ScriptSelected(None)`, which the screen documents as the redundant
+        reactive echo of exactly this clearing.
+        """
+        self.set_reactive(ArtifactsPane.scripts, [])
+        self.set_reactive(ArtifactsPane.selected_script, None)
+        self.set_reactive(ArtifactsPane.script_audio, None)
+        self.set_reactive(ArtifactsPane.scripts_with_audio, {})
+        self.set_reactive(ArtifactsPane.citations, [])
 
     def watch_selected_script(self, script: dict[str, Any] | None) -> None:
         if self.is_mounted:

--- a/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
@@ -344,10 +344,35 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
     #: live `RegionLayout` and never written here: the layout has exactly one
     #: owner, and a pane that guessed would show `Restore` over a nine-row
     #: reader the moment the two drifted. A plain reactive, not
-    #: `recompose=True` -- every layout change rebuilds the whole workbench
-    #: (and therefore this pane) through the region factories anyway, so a
-    #: second recompose would be pure churn.
+    #: `recompose=True`: `watch_expanded` relabels the one button in place,
+    #: which is the whole visible difference (task-15461).
     expanded: reactive[bool] = reactive(False)
+
+    def watch_expanded(self, expanded: bool) -> None:
+        """Relabel the expand button in place -- never a reader recompose.
+
+        Until task-15461 this reactive needed no watcher: EVERY layout change
+        recomposed the whole workbench, so `_build_content_pane` rebuilt this
+        pane (button label included) from the fresh layout. Layout changes are
+        now scoped to the regions whose form actually moved, and soloing
+        CONTENT does not move CONTENT's own form -- it collapses ITEMS, the
+        sibling -- so this pane keeps its instance and the label is the one
+        thing left to repaint. Without this, pressing Expand left a button
+        still reading "Expand" over a reader that had already taken the whole
+        centre.
+
+        Args:
+            expanded: Whether CONTENT is now the only expanded centre region.
+        """
+        try:
+            self.query_one("#content-expand-button", Button).label = (
+                "Restore" if expanded else "Expand"
+            )
+        except NoMatches:
+            # Pre-mount seeding (`_build_content_pane`), or the empty state,
+            # which composes no action strip at all; `compose` reads the
+            # reactive itself.
+            pass
 
     #: The reader footer's "N of M" (TASK-3072 plan task 9).
     #:

--- a/tldw_chatbook/UI/Watchlists_Modules/rules_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/rules_pane.py
@@ -46,13 +46,15 @@ class RuleFormVisibilityChanged(Message):
     """Posted whenever the rule form opens or closes, and which rule (if any)
     it is editing.
 
-    `RulesPane` lives inside a `WatchlistsWorkbench` region, and that
-    workbench's `region_layout` reactive is `recompose=True` — collapsing or
-    expanding *any* region (including one unrelated to Rules, e.g. `[` on the
-    left rail) rebuilds the whole workbench and constructs a brand new
-    `RulesPane`. Without this message the screen has no way to know an edit
-    was in progress, so an open edit form would be silently destroyed on the
-    next such rebuild — the same failure `CreateFormVisibilityChanged` in
+    `RulesPane` lives inside a `WatchlistsWorkbench` region, and that region
+    is swapped for a freshly built one whenever it collapses or expands, or
+    whenever the section switches — each of which constructs a brand new
+    `RulesPane`. (Until task-15461 the trigger was wider still: `region_
+    layout` was `recompose=True`, so `[` on the left rail — a region
+    unrelated to Rules — rebuilt this pane too.) Without this message the
+    screen has no way to know an edit was in progress, so an open edit form
+    would be silently destroyed on the next such rebuild — the same failure
+    `CreateFormVisibilityChanged` in
     sources_pane.py already fixes for the Sources create form. The owning
     screen mirrors this into its own state and re-seeds it into the
     freshly-constructed pane via `RulesPane.edit_rule`.

--- a/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
@@ -53,11 +53,13 @@ class CreateFormDraftChanged(Message):
     """Posted whenever a create-form free-text field changes.
 
     `SourcesPane` lives inside a `WatchlistsWorkbench` region, and that
-    workbench's `region_layout` reactive is `recompose=True` — collapsing or
-    expanding *any* region (including one unrelated to Sources, e.g. `[` on
-    the left rail) rebuilds the whole workbench and constructs a brand new
-    `SourcesPane`. Without this message the screen has no way to know what
-    was typed, so the draft would be silently lost on the next such rebuild.
+    region is swapped for a freshly built one whenever it collapses or
+    expands, or whenever the section switches — each of which constructs a
+    brand new `SourcesPane`. (Until task-15461 the trigger was wider still:
+    `region_layout` was `recompose=True`, so `[` on the left rail — a region
+    unrelated to Sources — rebuilt this pane too.) Without this message the
+    screen has no way to know what was typed, so the draft would be silently
+    lost on the next such rebuild.
     The owning screen mirrors this into its own state and seeds it back into
     the freshly-constructed pane.
     """

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -106,7 +106,7 @@ class WatchlistsWorkbench(Horizontal):
         collapsed_suffixes: Mapping[Region, str] | None = None,
         **kwargs: Any,
     ) -> None:
-        """Build the workbench, seeding `region_layout` without triggering a recompose.
+        """Build the workbench, seeding `region_layout` without a region sync.
 
         Args:
             layout: Initial collapse/solo state.
@@ -522,14 +522,15 @@ class WatchlistsWorkbench(Horizontal):
         Task 7: a region's content can go stale without `region_layout`
         itself changing (the tree scope moving under the rail, a background
         load landing), so nothing would otherwise call its factory again.
-        Setting `region_layout` (`recompose=True`) would work too, but at
-        the cost of tearing down and remounting *every* region, including
-        ones whose whole design point is staying the same instance across
-        an unrelated change -- the Inspector is pushed new
-        `scope`/`selected_entity` values in place for exactly that reason
-        (see `WatchlistsCollectionsScreen.watch_selected_scope`), and a
-        full recompose would silently replace it with a fresh instance
-        instead, breaking any caller holding a reference to the old one.
+        Pushing a new `region_layout` would not work at all: since task-15461
+        that only swaps regions whose COLLAPSE state moved, so a layout equal
+        to the current one is a no-op and one that differs changes what the
+        user is looking at. (Before task-15461 it worked for the wrong
+        reason -- it recomposed every region -- at the cost of replacing
+        widgets whose whole design point is staying the same instance across
+        an unrelated change: the Inspector is pushed new
+        `scope`/`selected_entity` values in place for exactly that reason,
+        see `WatchlistsCollectionsScreen.watch_selected_scope`.)
 
         A no-op when `region` is collapsed (nothing mounted to replace) or
         was not given a content factory (nothing to refresh either).
@@ -579,15 +580,15 @@ class WatchlistsWorkbench(Horizontal):
         """Rebuild the header in place from a fresh call to its factory.
 
         The header's twin of `refresh_region_content` above (task-1344 fix
-        wave, Qodo correctness): `region_layout` is `recompose=True`, so
-        picking up a header-only change (the tree scope moving -- see
-        `WatchlistsCollectionsScreen.watch_tree_scope`) by pushing a new
-        layout would tear down and remount every region, including the
-        Inspector, which `watch_tree_scope` deliberately avoids (see its
-        own docstring). The header is the only surface that carries the
-        tab strip and the snapshot's scoped markers (since task-2513, on
-        every tab), so a header-only refresh path is the one that keeps
-        that readout current between recomposes.
+        wave, Qodo correctness), and reached the same way: nothing else calls
+        the `header` factory again, so a header-only change (the tree scope
+        moving -- see `WatchlistsCollectionsScreen.watch_tree_scope`) has no
+        other route onto the screen. Pushing a new `region_layout` is not one
+        either: since task-15461 that touches only the regions whose collapse
+        state moved, and never the header. The header is the only surface
+        carrying the tab strip and the snapshot's scoped markers (since
+        task-2513, on every tab), so this is what keeps that readout current
+        between rebuilds.
 
         A no-op when this workbench was built with no `header` factory:
         nothing to refresh, and no `#wl-centre-status` to query for either.

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -335,7 +335,7 @@ class WatchlistsWorkbench(Horizontal):
         """
         if not self.is_mounted:
             return
-        await self._sync_regions(previous, self._hidden)
+        await self._sync_regions(previous)
 
     async def apply_section_view(
         self,
@@ -383,7 +383,7 @@ class WatchlistsWorkbench(Horizontal):
         # moved, so the two changes would be applied in the wrong order and
         # the layout half would be done twice.
         self.set_reactive(WatchlistsWorkbench.region_layout, layout)
-        await self._sync_regions(previous_layout, previous_hidden)
+        await self._sync_regions(previous_layout)
         for region in rebuild_regions:
             if region in self._hidden:
                 continue
@@ -413,9 +413,7 @@ class WatchlistsWorkbench(Horizontal):
             region
         )
 
-    async def _sync_regions(
-        self, previous_layout: RegionLayout, previous_hidden: frozenset[Region]
-    ) -> None:
+    async def _sync_regions(self, previous_layout: RegionLayout) -> None:
         """Bring the mounted regions in line with `region_layout`/`_hidden`.
 
         Rails first (they are direct children of this `Horizontal` and are
@@ -429,12 +427,16 @@ class WatchlistsWorkbench(Horizontal):
                 continue
             index = 0 if region is Region.LEFT_RAIL else len(self.children) - 1
             await self._swap_region_widget(region, self, index)
-        await self._sync_centre_regions(previous_layout, previous_hidden)
+        await self._sync_centre_regions(previous_layout)
 
-    async def _sync_centre_regions(
-        self, previous_layout: RegionLayout, previous_hidden: frozenset[Region]
-    ) -> None:
-        """Mount, unmount, swap or repaint each centre region as required."""
+    async def _sync_centre_regions(self, previous_layout: RegionLayout) -> None:
+        """Mount, unmount, swap or repaint each centre region as required.
+
+        Reads the CURRENT `self._hidden` rather than needing the previous one:
+        a region that is newly shown simply has no mounted node, and a region
+        that is newly hidden is removed by the first loop below -- both cases
+        fall out of comparing the DOM against the desired set.
+        """
         try:
             centre = self.query_one("#wl-centre")
         except NoMatches:

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -20,7 +20,7 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
-from .region_layout import CENTRE_REGIONS, Region, RegionLayout
+from .region_layout import CENTRE_REGIONS, REGION_ORDER, Region, RegionLayout
 
 
 #: Human-readable titles, used for both expanded bodies and collapsed headers.
@@ -78,13 +78,24 @@ class WatchlistsWorkbench(Horizontal):
     not specific to this dataclass.
 
     Attributes:
-        region_layout: The current collapse/solo state. Setting it
-            (`recompose=True`) unmounts and rebuilds every region, not just
-            the one that changed — see `__init__`'s note on `content` for
-            why that requires factories rather than widget instances.
+        region_layout: The current collapse/solo state. Setting it swaps ONLY
+            the regions whose rendered form actually changed — a region that
+            flipped between its collapsed one-line header and its expanded
+            body. Regions that stayed expanded keep their live widget
+            instance and are patched in place (the sole-centre CSS marker is
+            the only other thing a layout change can move for them).
+
+            This was `recompose=True` until task-15461, which meant every
+            `z`/`Z`/`[`/`]`/chevron rebuilt all four regions: measured on a
+            seeded screen, one `]` tore down and rebuilt 76–99 widgets
+            (the tree with its per-expanded-watchlist synchronous source
+            query, the tab strip, the article list, the Inspector) to
+            collapse a rail. `content` still holds FACTORIES rather than
+            instances — see `__init__` — because a swapped-out region's
+            replacement must still be a brand new widget.
     """
 
-    region_layout: reactive[RegionLayout] = reactive(RegionLayout(), recompose=True)
+    region_layout: reactive[RegionLayout] = reactive(RegionLayout())
 
     def __init__(
         self,
@@ -99,11 +110,10 @@ class WatchlistsWorkbench(Horizontal):
 
         Args:
             layout: Initial collapse/solo state.
-            content: Per-region **factories**, not widget instances —
-                ``region_layout`` is ``recompose=True``, so *any* collapse/
-                solo/rail toggle fully unmounts and rebuilds every region,
-                not just the one that changed (that blast radius is
-                inherited from the reactive design, not introduced here).
+            content: Per-region **factories**, not widget instances — a
+                region whose rendered form changes (collapsed header <->
+                expanded body) is swapped for a freshly built one, so the
+                factory must be callable more than once.
                 Passing already-constructed instances was tried first and
                 verified broken empirically: a container widget's
                 constructor-supplied children (e.g. ``Vertical(Static(...),
@@ -126,14 +136,14 @@ class WatchlistsWorkbench(Horizontal):
                 UNMOUNT rather than keep a one-row header). The caller
                 (`WatchlistsCollectionsScreen._hidden_centre_regions`)
                 decides which regions this is, keyed on `active_section`;
-                the workbench itself has no opinion about tabs. Constructor-
-                only, not a reactive: the caller fully reconstructs this
-                widget (via `compose_content`'s own recompose) whenever
-                `active_section` changes, so nothing here needs to react to
-                that change directly. A plain toggle/solo (`_apply_layout`
-                pushing a new `region_layout` onto the ALREADY-mounted
-                instance) never changes which tab is active, so a stale
-                `hidden` is never observable.
+                the workbench itself has no opinion about tabs. The initial
+                value only: since task-15461 a section switch no longer
+                rebuilds this widget, so the caller pushes the new set
+                through `apply_section_view` instead, which mounts or
+                unmounts exactly the centre regions that crossed the
+                boundary. A plain toggle/solo (`_apply_layout` pushing a new
+                `region_layout` onto the ALREADY-mounted instance) never
+                changes which tab is active, so `hidden` is untouched there.
             header: An optional factory for a widget rendered as the FIRST
                 child of the centre stack, unconditionally — regardless of
                 `hidden`. TASK-1344: the section tab strip and the
@@ -162,9 +172,9 @@ class WatchlistsWorkbench(Horizontal):
     def compose(self) -> ComposeResult:
         """Render the left rail, the stacked centre, and the right rail.
 
-        Re-runs in full on every `region_layout` change (`recompose=True`),
-        rebuilding all four regions from `self.region_layout` and
-        `self._content` regardless of which single region actually changed.
+        Runs once per mount. A later `region_layout` change no longer
+        re-runs this (task-15461): `watch_region_layout` swaps only the
+        regions whose form actually changed — see that watcher.
 
         Returns:
             The left-rail region, the centre `Vertical` (an optional header,
@@ -240,7 +250,7 @@ class WatchlistsWorkbench(Horizontal):
         if supplied is not None:
             children.append(supplied)
         classes = ["watchlists-region", f"watchlists-region-{region.value}"]
-        if self._is_sole_expanded_centre_region(region):
+        if self._is_sole_expanded_centre_region(region, self.region_layout):
             # A CSS hook for the solo case. `.watchlists-region-content`
             # carries a `max-height` cap so a long article cannot crowd
             # ITEMS out of the centre stack — but when ITEMS is collapsed
@@ -265,7 +275,9 @@ class WatchlistsWorkbench(Horizontal):
         body.can_focus = True
         return body
 
-    def _is_sole_expanded_centre_region(self, region: Region) -> bool:
+    def _is_sole_expanded_centre_region(
+        self, region: Region, layout: RegionLayout
+    ) -> bool:
         """Whether ``region`` is the only centre region still expanded.
 
         True exactly when the centre stack shows one real pane and, for
@@ -283,6 +295,10 @@ class WatchlistsWorkbench(Horizontal):
         Args:
             region: The region to test. Rails always answer `False`; solo
                 applies to the centre stack only (`RegionLayout.solo`).
+            layout: The layout to answer against. Passed explicitly rather
+                than read off `self` (task-15461) so `watch_region_layout`
+                can ask the same question of the OUTGOING layout and tell
+                whether this marker is what actually moved.
 
         Returns:
             `True` if `region` is a centre region and every other
@@ -293,9 +309,210 @@ class WatchlistsWorkbench(Horizontal):
         expanded = [
             r
             for r in CENTRE_REGIONS
-            if r not in self._hidden and not self.region_layout.is_collapsed(r)
+            if r not in self._hidden and not layout.is_collapsed(r)
         ]
         return expanded == [region]
+
+    # --- scoped layout/section updates (task-15461) -----------------------
+
+    async def watch_region_layout(
+        self, previous: RegionLayout, layout: RegionLayout
+    ) -> None:
+        """Swap only the regions whose rendered form the new layout moves.
+
+        The reactive used to be `recompose=True`, which rebuilt all four
+        regions for every `z`/`Z`/`[`/`]`/chevron. A layout change can only
+        move two things about a region: whether it renders as its collapsed
+        one-line header or its expanded body, and whether it carries the
+        `watchlists-region-sole-centre` marker. The first needs a widget
+        swap; the second is a class toggle on the live widget, which keeps
+        the pane instance (and everything mounted inside it) alive.
+
+        Args:
+            previous: The layout being replaced.
+            layout: The layout now in effect (already stored on `self`, so
+                `_region_widget` builds against it).
+        """
+        if not self.is_mounted:
+            return
+        await self._sync_regions(previous, self._hidden)
+
+    async def apply_section_view(
+        self,
+        *,
+        hidden: frozenset[Region],
+        layout: RegionLayout,
+        rebuild_regions: tuple[Region, ...] = (),
+        rebuild_header: bool = False,
+    ) -> None:
+        """Move the workbench onto a different section, region by region.
+
+        The caller's `active_section` feeds exactly three things here: which
+        centre regions exist at all (`hidden`), the tab-adjusted collapse
+        state (`layout`), and the content of the region whose pane is routed
+        by the section (passed in `rebuild_regions`). Everything else --
+        both rails above all -- is left standing, which is the whole point:
+        rebuilding the left rail means re-running `WatchlistTree.compose`,
+        and that runs one synchronous source-row query per expanded
+        watchlist.
+
+        Args:
+            hidden: Centre regions that must have no DOM presence on the new
+                section. Newly hidden regions are unmounted; newly shown ones
+                are mounted back into their `CENTRE_REGIONS` position.
+            layout: The tab-adjusted layout (see
+                `WatchlistsCollectionsScreen._rendered_region_layout`).
+                Applied without firing `watch_region_layout`, so the
+                hidden-set change and the layout change are reconciled in
+                one pass rather than two.
+            rebuild_regions: Regions whose supplied content must be rebuilt
+                even though their form did not change -- the section's own
+                pane lives in one of these.
+            rebuild_header: Whether to rebuild the centre header too (the
+                tab strip lives there, so a real section switch always does).
+        """
+        if not self.is_mounted:
+            self._hidden = frozenset(hidden)
+            self.set_reactive(WatchlistsWorkbench.region_layout, layout)
+            return
+        previous_layout = self.region_layout
+        previous_hidden = self._hidden
+        self._hidden = frozenset(hidden)
+        # `set_reactive`, not assignment: `watch_region_layout` would run a
+        # SECOND reconcile pass against a `_hidden` this method has already
+        # moved, so the two changes would be applied in the wrong order and
+        # the layout half would be done twice.
+        self.set_reactive(WatchlistsWorkbench.region_layout, layout)
+        await self._sync_regions(previous_layout, previous_hidden)
+        for region in rebuild_regions:
+            if region in self._hidden:
+                continue
+            # A region the sync above just swapped is already built from the
+            # current factory; rebuilding it again would be the second of the
+            # two rebuilds this task exists to remove.
+            if self._region_form_changed(previous_layout, previous_hidden, region):
+                continue
+            await self.refresh_region_content(region)
+        if rebuild_header:
+            await self.refresh_header_content()
+
+    def _region_form_changed(
+        self,
+        previous_layout: RegionLayout,
+        previous_hidden: frozenset[Region],
+        region: Region,
+    ) -> bool:
+        """Whether ``region``'s mounted widget has to be replaced outright."""
+        was_present = region not in previous_hidden
+        is_present = region not in self._hidden
+        if was_present != is_present:
+            return True
+        if not is_present:
+            return False
+        return previous_layout.is_collapsed(region) != self.region_layout.is_collapsed(
+            region
+        )
+
+    async def _sync_regions(
+        self, previous_layout: RegionLayout, previous_hidden: frozenset[Region]
+    ) -> None:
+        """Bring the mounted regions in line with `region_layout`/`_hidden`.
+
+        Rails first (they are direct children of this `Horizontal` and are
+        never hidden), then the centre stack, which is rebuilt positionally
+        because a region can be absent from it entirely.
+        """
+        for region in (Region.LEFT_RAIL, Region.RIGHT_RAIL):
+            if previous_layout.is_collapsed(region) == self.region_layout.is_collapsed(
+                region
+            ):
+                continue
+            index = 0 if region is Region.LEFT_RAIL else len(self.children) - 1
+            await self._swap_region_widget(region, self, index)
+        await self._sync_centre_regions(previous_layout, previous_hidden)
+
+    async def _sync_centre_regions(
+        self, previous_layout: RegionLayout, previous_hidden: frozenset[Region]
+    ) -> None:
+        """Mount, unmount, swap or repaint each centre region as required."""
+        try:
+            centre = self.query_one("#wl-centre")
+        except NoMatches:
+            return
+        for region in CENTRE_REGIONS:
+            if region not in self._hidden:
+                continue
+            node = self._mounted_region_node(region)
+            if node is not None:
+                await node.remove()
+
+        desired = [region for region in CENTRE_REGIONS if region not in self._hidden]
+        for position, region in enumerate(desired):
+            index = self._centre_content_offset(centre) + position
+            node = self._mounted_region_node(region)
+            if node is None:
+                await centre.mount(self._region_widget(region), before=index)
+                continue
+            if previous_layout.is_collapsed(region) != self.region_layout.is_collapsed(
+                region
+            ):
+                await self._swap_region_widget(region, centre, index)
+                continue
+            if self.region_layout.is_collapsed(region):
+                continue
+            # Still an expanded body, same instance: the only thing a layout
+            # change can have moved for it is the solo marker.
+            node.set_class(
+                self._is_sole_expanded_centre_region(region, self.region_layout),
+                "watchlists-region-sole-centre",
+            )
+
+    def _centre_content_offset(self, centre: Widget) -> int:
+        """How many non-region children the centre stack starts with.
+
+        The optional `header` factory's widget is mounted first and carries
+        whatever id the caller gave it, so it is identified by exclusion
+        rather than by name.
+        """
+        region_ids = {f"wl-region-{r.value}" for r in REGION_ORDER}
+        region_ids |= {f"wl-header-{r.value}" for r in REGION_ORDER}
+        offset = 0
+        for child in centre.children:
+            if (child.id or "") in region_ids:
+                break
+            offset += 1
+        return offset
+
+    def _mounted_region_node(self, region: Region) -> Widget | None:
+        """The widget currently rendering ``region``, in either form."""
+        for prefix in ("wl-region-", "wl-header-"):
+            try:
+                return self.query_one(f"#{prefix}{region.value}")
+            except NoMatches:
+                continue
+        return None
+
+    async def _swap_region_widget(
+        self, region: Region, parent: Widget, index: int
+    ) -> None:
+        """Replace ``region``'s mounted widget with a freshly built one.
+
+        Built before the old one is detached, for the reason
+        `refresh_region_content` states: a factory that raises must leave
+        what is on screen standing rather than emptying the slot. The
+        remove-then-mount pair still has an await between its halves --
+        `NodeList._ensure_unique_id` refuses to mount a second
+        `#wl-region-<r>`.
+        """
+        node = self._mounted_region_node(region)
+        if node is None:
+            return
+        replacement = self._region_widget(region)
+        await node.remove()
+        if index >= len(parent.children):
+            await parent.mount(replacement)
+        else:
+            await parent.mount(replacement, before=index)
 
     async def refresh_region_content(self, region: Region) -> None:
         """Rebuild one expanded region's supplied content in place.


### PR DESCRIPTION
## Summary

Task 15461 from the input-latency audit. A Watchlists section tab click rebuilt the whole screen (~450-650 widgets) twice; a tree-node click cascaded into 4 recomposes; z/Z/[/] rebuilt all four region panes; briefing arrow-keys triple-recomposed the artifacts pane.

- Section switch = one scoped swap of the changed section (0-1 recomposes, was 1-3; mounted widgets 75-176 → 18-118); tree click ≤1 update per pane; layout keys rebuild only the toggled region; briefing selection patches statics in place with verified five-field parity
- Focus preserved across the header swap (review caught the switch landing focus in the left rail, silently changing what z does; now re-homed to the switched-to tab, both gate halves mutation-pinned; keyboard-driven switches traced safe)
- Two ordering traps recorded as lessons; 11 stale recompose comments corrected; the mid-swap lost-write window pinned by a race-reconstructing test
- 17 evidence tests (10 born red, reviewer-mutation-verified); honest residuals filed for follow-up

## Verification
Independent opus review (Approved) + scoped re-review (6/6 ADDRESSED; both focus-gate mutations discriminate; 17 + 270-test batches reproduced exactly). One process slip hit and recovered per the documented Edit-based-restore lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Watchlists rebuilds to the changed section or region, eliminating whole‑screen recomposes on tab switches and layout keys. Old: tab clicks and z/Z/[/] rebuilt the entire workbench; new: only the affected region(s) and the centre header rebuild. Preserves focus on the switched tab and reduces recomposes during tree/briefing interactions.

- Satisfies Task 15461 AC1–AC3: section switch rebuilds only the section and centre header; tree clicks update each affected pane at most once; z/Z/[/] rebuild only the toggled region.
- `WatchlistsWorkbench.region_layout` now swaps only regions whose rendered form changed; expanded regions keep their instance and get the sole‑centre marker patched in place.
- Section switch (`apply_section_view`) mounts/unmounts only the centre regions that change, applies the tab‑adjusted layout, rebuilds ITEMS and the centre header only, and patches the backend picker in place; enqueued on the surface‑refresh drain via `call_next`.
- `_reseed_active_section_pane` closes the mid‑swap loader window; `_restore_focus_after_swap` returns focus to the switched tab (gated to avoid stealing focus on deep links).
- Moves selection clearing into `ArtifactsPane.watch_selected_briefing` to fold select+clear into one recompose; minor pane watchers updated to avoid unnecessary recomposes.
- Evidence: new `Tests/Watchlists/test_watchlists_scoped_rebuilds.py`; existing UI tests updated; comments corrected; docs capture two ordering traps; task marked Done.
- Measured impact: section switch mounts 75–176 → 18–83; layout keys 36–99 → 0–24; briefing arrow keys no longer triple‑recompose.
- Migration: if code/tests relied on whole‑workbench rebuilds to reset state, add explicit watchers/messages. In tests, drive selection rather than posting `BriefingSelected` directly.

<sup>Written for commit cf53d1da99a1011d610c8dc30527be32156259ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

