### PR TITLE
perf: panel-scoped updates for Settings, Evals, and speech settings (task-15475)

### DIFF
--- a/Tests/UI/test_console_visit_dispatch_dedupe.py
+++ b/Tests/UI/test_console_visit_dispatch_dedupe.py
@@ -1,0 +1,112 @@
+"""Console dispatches its per-visit refreshes ONCE per visit (task-15475).
+
+The input-latency audit (Docs/Design/2026-08-11-input-latency-audit.md) found
+Console doing every per-visit refresh twice on the FIRST visit: Textual posts
+``ScreenResume`` when a screen is pushed, so ``on_mount`` and the mount's own
+``on_screen_resume`` both fire, and both dispatched
+``_refresh_console_skill_candidates`` (a non-exclusive worker, so neither call
+cancelled the other) and both synced task-resume state.
+
+These tests pin the whole contract, not just the halved count: a LATER resume
+-- returning from a pushed screen, where a skill may have been installed while
+Console was suspended -- must still refresh. A dedupe that suppressed that
+would be a correctness regression wearing a performance badge.
+
+Spy shape mirrors ``test_console_agent_fleet_sync_coalescing.py``: the CLASS
+method is patched before the screen is pushed, so the counters observe the
+real first mount rather than a replayed one.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual import events
+
+from Tests.UI.app_factory import _build_test_app
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture()
+def visit_spy(monkeypatch):
+    """Count the two per-visit Console refreshes, PER screen instance.
+
+    Per-instance, not global: ``_build_test_app`` already stands a Console
+    screen up for the app's initial tab, so a global counter would conflate
+    two screens' visits and could not tell "one each" from "two on one".
+    """
+    counts: dict[int, dict[str, int]] = {}
+
+    def bucket(screen: ChatScreen) -> dict[str, int]:
+        return counts.setdefault(id(screen), {"skills": 0, "task_resume": 0})
+
+    real_skills = ChatScreen._refresh_console_skill_candidates
+    real_sync = ChatScreen.sync_task_resume_state
+
+    async def counting_skills(self):
+        bucket(self)["skills"] += 1
+        return await real_skills(self)
+
+    def counting_sync(self):
+        bucket(self)["task_resume"] += 1
+        return real_sync(self)
+
+    monkeypatch.setattr(
+        ChatScreen, "_refresh_console_skill_candidates", counting_skills
+    )
+    monkeypatch.setattr(ChatScreen, "sync_task_resume_state", counting_sync)
+    return counts
+
+
+async def test_console_first_visit_refreshes_skills_and_task_resume_once(visit_spy):
+    """AC#3: the mount and its own ScreenResume collapse into ONE of each."""
+    app = _build_test_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = ChatScreen(app)
+        await app.push_screen(screen)
+        # Long enough for on_mount's 0.05s task-resume timer to fire.
+        for _ in range(10):
+            await pilot.pause(0.05)
+
+        counted = visit_spy[id(screen)]
+        assert counted["skills"] == 1, (
+            "Console dispatched the skill-candidate refresh "
+            f"{counted['skills']}x for one visit."
+        )
+        assert counted["task_resume"] == 1, (
+            "Console synced task-resume state "
+            f"{counted['task_resume']}x for one visit."
+        )
+
+
+async def test_console_later_resume_still_refreshes(visit_spy):
+    """The dedupe is per-visit, not permanent: a real suspend/resume refreshes."""
+    app = _build_test_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = ChatScreen(app)
+        await app.push_screen(screen)
+        for _ in range(10):
+            await pilot.pause(0.05)
+        counted = visit_spy[id(screen)]
+        baseline_skills = counted["skills"]
+        baseline_sync = counted["task_resume"]
+
+        # The event Textual delivers on every return to this screen (pop of a
+        # pushed screen, tab switch back). Posted directly rather than driven
+        # through push/pop: this app runs several Console screens on the stack
+        # at once in the test harness, so a pop does not reliably re-activate
+        # THIS instance -- and the message is the seam under test either way.
+        screen.post_message(events.ScreenResume())
+        for _ in range(10):
+            await pilot.pause(0.05)
+
+        assert counted["skills"] == baseline_skills + 1, (
+            "Returning to Console must re-read the skill catalog: a skill may "
+            "have been installed while it was suspended."
+        )
+        assert counted["task_resume"] == baseline_sync + 1, (
+            "Returning to Console must re-sync task-resume state."
+        )

--- a/Tests/UI/test_evals_selection_scoped_regions.py
+++ b/Tests/UI/test_evals_selection_scoped_regions.py
@@ -1,0 +1,152 @@
+"""Evals rail selection swaps regions, not the whole screen (task-15475).
+
+The input-latency audit measured a rail click recomposing 150-300 widgets:
+``EvalsScreen.select()`` answered every selection with
+``self.refresh(recompose=True)``, which tears the whole ``BaseAppScreen``
+down -- nav bar, footer, header row, mode strip, the ``LabWorkbench`` and
+all three of its regions -- to repaint the detail pane and inspector.
+
+A rail click cannot change the rail's row SET (the rail is the thing that
+posted it), only which row is marked active, so the hot path leaves the rail
+alone and rebuilds two regions. Mutation callers (a save, a finished run, a
+delete) DO change the rows, so ``select()`` keeps rebuilding the rail by
+default -- the last test pins that safe default, because a dedupe that got
+it backwards would leave a stale rail after every save.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button, Input
+
+from tldw_chatbook.UI.Evals.library_rail import LibraryRail
+from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar
+from Tests.UI.test_evals_screen import (  # noqa: F401 -- fixtures
+    EvalsHarness,
+    evals_app,
+    evals_db,
+    seeded_bench,
+)
+
+pytestmark = pytest.mark.asyncio
+
+#: Chrome a selection change has no business rebuilding.
+_STABLE_CHROME = (
+    "#lab-header-row",
+    "#lab-mode-strip",
+    "#lab-workbench",
+    "#lab-rail",
+    "#lab-body",
+    "#lab-inspector",
+    "#screen-footer-status",
+)
+
+
+def _identities(screen, selectors) -> dict[str, int]:
+    return {selector: id(screen.query_one(selector)) for selector in selectors}
+
+
+async def test_rail_click_leaves_the_chrome_and_the_rail_widget_in_place(
+    evals_app, seeded_bench
+):
+    """AC#1: the rail click path rebuilds the detail/inspector regions only."""
+    async with evals_app.run_test() as pilot:
+        await pilot.pause()
+        screen = evals_app.screen
+        before = _identities(screen, _STABLE_CHROME)
+        nav_before = id(screen.query_one(MainNavigationBar))
+        rail_before = id(screen.query_one(LibraryRail))
+
+        await pilot.click("#evals-rail-row-benches-0")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert _identities(screen, _STABLE_CHROME) == before, (
+            "A rail selection rebuilt screen chrome that does not read the "
+            "selection."
+        )
+        assert id(screen.query_one(MainNavigationBar)) == nav_before
+        assert id(screen.query_one(LibraryRail)) == rail_before, (
+            "A rail click cannot change the rail's rows -- only which one is "
+            "active -- so the rail must not be rebuilt."
+        )
+        # ...and the panes it DOES own actually repainted.
+        assert screen.query_one("#evals-bench-name", Input).value == "loaded-nouns v1"
+
+
+async def test_rail_click_marks_the_selected_row_active_in_place(
+    evals_app, seeded_bench
+):
+    """The active marker is what the rail rebuild used to provide; patching
+    it in place has to give the same result."""
+    async with evals_app.run_test() as pilot:
+        await pilot.pause()
+        screen = evals_app.screen
+        row = screen.query_one("#evals-rail-row-benches-0", Button)
+        assert not row.has_class("is-active")
+
+        await pilot.click("#evals-rail-row-benches-0")
+        await pilot.pause()
+
+        assert screen.query_one("#evals-rail-row-benches-0", Button).has_class(
+            "is-active"
+        )
+        assert screen.query_one(LibraryRail).selection.kind == "bench"
+
+
+async def test_rail_click_keeps_focus_on_the_clicked_row(evals_app, seeded_bench):
+    """The screen recompose destroyed the button under the user's cursor and
+    dropped focus with it; the row survives a scoped swap, so focus stays."""
+    async with evals_app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#evals-rail-row-benches-0")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert (
+            getattr(evals_app.focused, "id", None) == "evals-rail-row-benches-0"
+        ), "Focus escaped the rail row the user just clicked."
+
+
+async def test_rail_initiated_creation_still_refreshes_the_rail(
+    evals_app, seeded_bench
+):
+    """The trap the opt-out has to avoid: the rail posts a selection change
+    for its OWN mutations too ("+ New bench", dataset/probe import), and
+    those DO change its rows. Treating "came from the rail" as "rows
+    unchanged" left the newly created bench missing from the rail -- caught
+    by the continuation e2e, pinned here at the seam."""
+    async with evals_app.run_test() as pilot:
+        await pilot.pause()
+        screen = evals_app.screen
+        assert not screen.query("#evals-rail-row-benches-1")
+
+        await pilot.click("#evals-rail-new-bench")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen._selection.kind == "bench"
+        assert screen.query("#evals-rail-row-benches-1"), (
+            "The rail must show the bench the user just created from it."
+        )
+
+
+async def test_select_rebuilds_the_rail_by_default(evals_app, seeded_bench):
+    """A mutation caller (save, finished run, delete) changes the rail's rows,
+    so the DEFAULT must still rebuild it -- only the rail-click path opts out."""
+    async with evals_app.run_test() as pilot:
+        await pilot.pause()
+        screen = evals_app.screen
+        rail_before = id(screen.query_one(LibraryRail))
+
+        screen.select(kind="bench", id=seeded_bench)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert id(screen.query_one(LibraryRail)) != rail_before, (
+            "select() without an explicit opt-out must refresh the rail: its "
+            "rows may have changed under it."
+        )
+        assert screen.query_one("#evals-rail-row-benches-0", Button).has_class(
+            "is-active"
+        )

--- a/Tests/UI/test_evals_selection_scoped_regions.py
+++ b/Tests/UI/test_evals_selection_scoped_regions.py
@@ -21,11 +21,11 @@ from textual.widgets import Button, Input
 
 from tldw_chatbook.UI.Evals.library_rail import LibraryRail
 from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar
-from Tests.UI.test_evals_screen import (  # noqa: F401 -- fixtures
-    EvalsHarness,
-    evals_app,
-    evals_db,
-    seeded_bench,
+from .test_evals_screen import EvalsHarness as EvalsHarness  # noqa: F401
+from .test_evals_screen import evals_app as evals_app  # noqa: F401 -- fixture re-export
+from .test_evals_screen import evals_db as evals_db  # noqa: F401 -- fixture re-export
+from .test_evals_screen import (  # noqa: F401 -- fixture re-export
+    seeded_bench as seeded_bench,
 )
 
 pytestmark = pytest.mark.asyncio

--- a/Tests/UI/test_evals_selection_scoped_regions.py
+++ b/Tests/UI/test_evals_selection_scoped_regions.py
@@ -108,6 +108,127 @@ async def test_rail_click_keeps_focus_on_the_clicked_row(evals_app, seeded_bench
         ), "Focus escaped the rail row the user just clicked."
 
 
+async def test_region_swaps_never_destroy_the_frames_collapse_headers(
+    evals_app, seeded_bench
+):
+    """The frame composes each region's collapse header as its FIRST child.
+
+    `#lab-rail` and `#lab-inspector` are not empty containers the mode fills:
+    `LabWorkbench.compose` puts a title + collapse button in each, because
+    collapse is frame-owned (which is exactly why `LabScreen._populate_regions`
+    APPENDS mode content with `mount_all`). A blanket `remove_children()` in
+    the selection swap destroyed both headers on the first rail click --
+    permanently, since no screen recompose remains to rebuild them and the
+    collapse buttons have no keyboard binding.
+
+    Driven through EvalsScreen, not a probe LabScreen: the defect only exists
+    on the path a real selection takes.
+    """
+    async with evals_app.run_test() as pilot:
+        await pilot.pause()
+        screen = evals_app.screen
+
+        def _header_state() -> dict[str, str]:
+            state: dict[str, str] = {}
+            for button_id, title in (
+                ("lab-rail-collapse", "Catalog"),
+                ("lab-inspector-collapse", "Inspector"),
+            ):
+                button = screen.query_one(f"#{button_id}", Button)
+                header = button.parent
+                titles = [
+                    str(child.renderable)
+                    for child in header.children
+                    if child is not button
+                ]
+                state[button_id] = f"{titles}"
+                assert title in state[button_id], f"{title} title row is gone"
+            return state
+
+        before = _header_state()
+
+        # Several rail clicks (rail_dirty=False path)...
+        for _ in range(3):
+            await pilot.click("#evals-rail-row-benches-0")
+            await pilot.pause()
+            await pilot.pause()
+            assert _header_state() == before
+
+        # ...and a rail-rebuilding swap (rail_dirty defaults True).
+        screen.select(kind="none")
+        await pilot.pause()
+        await pilot.pause()
+        assert _header_state() == before, (
+            "a rail-rebuilding swap destroyed the frame's collapse chrome"
+        )
+        # Exactly one of each -- not duplicated by the remount either.
+        assert len(screen.query("#lab-rail-collapse")) == 1
+        assert len(screen.query("#lab-inspector-collapse")) == 1
+        assert len(screen.query(".console-rail-header")) == 2
+
+
+async def test_rail_rebuild_returns_focus_to_the_row_the_user_was_on(
+    evals_app, seeded_bench
+):
+    """Focus must not escape into a rail section TOGGLE across a rebuild.
+
+    Textual's `_reset_focus` moves focus to a neighbour when the focused
+    widget is removed; on a rail rebuild that neighbour is the section toggle,
+    one Space away from collapsing the section the user is working in. Rail
+    row ids are stable across the rebuild, so the swap restores the identity.
+    """
+    async with evals_app.run_test() as pilot:
+        await pilot.pause()
+        screen = evals_app.screen
+        row = screen.query_one("#evals-rail-row-benches-0", Button)
+        row.focus()
+        await pilot.pause()
+        assert getattr(evals_app.focused, "id", None) == "evals-rail-row-benches-0"
+
+        # A mutation-shaped selection: rebuilds the rail under the focus.
+        screen.select(kind="bench", id=seeded_bench)
+        for _ in range(6):
+            await pilot.pause()
+
+        assert getattr(evals_app.focused, "id", None) == "evals-rail-row-benches-0", (
+            "focus escaped the rail row across a rail-rebuilding swap"
+        )
+
+
+async def test_a_burst_of_selections_leaves_every_region_populated(
+    evals_app, seeded_bench
+):
+    """Superseding must never strand a half-torn-down region.
+
+    An exclusive worker group cancels the in-flight swap, and the cancellation
+    can land INSIDE `remove_children` -- leaving a region emptied and never
+    refilled if the superseding swap does not rebuild that one (a rail-click
+    swap does not rebuild the rail). Superseded swaps now lose a revision
+    check and return before touching a widget instead.
+    """
+    async with evals_app.run_test() as pilot:
+        await pilot.pause()
+        screen = evals_app.screen
+
+        # Interleave rail-rebuilding and rail-preserving selections back to
+        # back, with no pause between them, so each supersedes the last.
+        screen.select(kind="bench", id=seeded_bench)
+        screen.select(kind="none", rail_dirty=False)
+        screen.select(kind="bench", id=seeded_bench)
+        screen.select(kind="none", rail_dirty=False)
+        for _ in range(10):
+            await pilot.pause()
+
+        assert screen.query("#evals-library-pane"), "the rail was left empty"
+        assert screen.query("#evals-detail-pane"), "the detail pane was left empty"
+        assert screen.query("#evals-inspector-pane"), "the inspector was left empty"
+        assert len(screen.query("#evals-library-pane")) == 1, "the rail was duplicated"
+        assert screen.query("#lab-rail-collapse")
+        assert screen.query("#lab-inspector-collapse")
+        # The LAST selection is what is on screen.
+        assert screen._selection.kind == "none"
+
+
 async def test_rail_initiated_creation_still_refreshes_the_rail(
     evals_app, seeded_bench
 ):

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -5297,15 +5297,25 @@ async def test_settings_provider_category_renders_catalog_select_with_visible_va
         assert "llama.cpp" in _visible_text(screen)
 
 
-# task-15510 was pinned here as a strict xfail: navigation preselect applied
-# the provider, which itself marked Providers & Models dirty, and the DEFERRED
-# `_apply_navigation_provider_context` then hit its unsaved-changes guard and
-# returned without writing the model. task-15475 changed when that callback
-# runs -- `_after_category_panes` fires it as soon as the rebuilt detail pane
-# exists, before the preselect's own `Select.Changed` has been dispatched and
-# marked the category dirty -- so the model now lands. A genuine pre-existing
-# user draft is still protected: that dirty mark predates the navigation. The
-# strict xfail did its job (it flipped loudly); the test is a live pin again.
+# task-15510 was pinned here as a strict xfail, and task-15475 flipped it to
+# XPASS. Spy-probed rather than reasoned about, because the obvious story is
+# wrong: `_apply_navigation_provider_context` still runs and its
+# unsaved-changes guard still returns early (measured `guard_dirty=True` on
+# this tree, as on dev) -- it writes nothing either way.
+#
+# What actually lands the model is the DETAIL PANE's own compose:
+# `_provider_display_setting_values()` returns the navigation provider/model
+# whenever no provider draft exists yet, and task-15475 leaves the pane
+# composed exactly once in that state (measured: a single call, `draft=False`,
+# returning huggingface / meta-llama/test-model). The screen-level recomposes
+# this task removed were what re-composed the pane later, after a draft
+# existed, snapping the field back to the previous provider's model.
+#
+# So the user-visible defect is fixed here, but the ordering task-15510
+# describes -- the guard firing against a draft the navigation itself created
+# -- is untouched and remains that task's to close. Its sibling xfail
+# (`..._does_not_create_provider_draft`) still xfails for the same reason.
+# The strict marker did its job by flipping loudly; the test is a live pin now.
 @pytest.mark.asyncio
 async def test_settings_navigation_context_can_preselect_provider_category_target():
     app = _build_test_app()

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -5297,6 +5297,15 @@ async def test_settings_provider_category_renders_catalog_select_with_visible_va
         assert "llama.cpp" in _visible_text(screen)
 
 
+# task-15510 was pinned here as a strict xfail: navigation preselect applied
+# the provider, which itself marked Providers & Models dirty, and the DEFERRED
+# `_apply_navigation_provider_context` then hit its unsaved-changes guard and
+# returned without writing the model. task-15475 changed when that callback
+# runs -- `_after_category_panes` fires it as soon as the rebuilt detail pane
+# exists, before the preselect's own `Select.Changed` has been dispatched and
+# marked the category dirty -- so the model now lands. A genuine pre-existing
+# user draft is still protected: that dirty mark predates the navigation. The
+# strict xfail did its job (it flipped loudly); the test is a live pin again.
 @pytest.mark.asyncio
 async def test_settings_navigation_context_can_preselect_provider_category_target():
     app = _build_test_app()
@@ -9402,9 +9411,14 @@ def test_settings_screen_resume_skips_refresh_while_manual_sync_run_in_flight(mo
 
 @pytest.mark.asyncio
 async def test_settings_overview_disclosures_stay_expanded_across_sync_row_recompose():
-    """task-1369 (review): sync rows are recompose=True reactives, so any row
-    change rebuilds the Overview Collapsibles. An expanded disclosure must
-    stay expanded -- the user expands it precisely to watch a sync run."""
+    """An expanded Overview disclosure survives a sync-row change -- the user
+    expands it precisely to watch a sync run.
+
+    task-1369 (review) pinned this when the sync rows were `recompose=True`
+    reactives that rebuilt the Collapsibles and had to restore their state.
+    task-15475 made the rows their own region, so the Collapsibles are not
+    rebuilt at all: the property is now structural, and this test asserts
+    that stronger fact (same widget instances) alongside the outcome."""
     app = _build_test_app()
     host = DestinationHarness(app, "settings")
 
@@ -9420,8 +9434,7 @@ async def test_settings_overview_disclosures_stay_expanded_across_sync_row_recom
         ownership_details.collapsed = False
         await pilot.pause()
 
-        # A sync-row state change (e.g. the confirm callback's "running"
-        # rows) triggers a full recompose.
+        # A sync-row state change (e.g. the confirm callback's "running" rows).
         screen.manual_sync_rows = (
             ("Manual sync status", "running"),
             ("Manual sync result", "Manual Sync is running after explicit user request."),
@@ -9430,14 +9443,19 @@ async def test_settings_overview_disclosures_stay_expanded_across_sync_row_recom
         await pilot.pause()
         await pilot.pause()
 
-        # The recompose destroyed and recreated both Collapsibles.
         rebuilt_sync = screen.query_one("#settings-overview-sync-details", Collapsible)
         rebuilt_ownership = screen.query_one(
             "#settings-overview-ownership-details", Collapsible
         )
-        assert rebuilt_sync is not sync_details
+        assert rebuilt_sync is sync_details, (
+            "the sync rows own their own region now; the Collapsible around "
+            "them must not be rebuilt"
+        )
+        assert rebuilt_ownership is ownership_details
         assert rebuilt_sync.collapsed is False
         assert rebuilt_ownership.collapsed is False
+        # ...and the rows themselves did update.
+        assert "running" in _visible_text(screen)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_settings_panel_scoped_updates.py
+++ b/Tests/UI/test_settings_panel_scoped_updates.py
@@ -1,0 +1,220 @@
+"""Settings updates one region at a time, not the whole screen (task-15475).
+
+Three defects from the 2026-08-11 input-latency audit, pinned here:
+
+1. ``active_category`` was a screen-level ``recompose=True`` reactive, so every
+   rail click rebuilt the nav bar, the footer, the category rail itself and
+   the mode strip alongside the 60-150-widget detail pane.
+2. The two sync-row reactives were screen-level ``recompose=True`` too, so
+   landing on Overview recomposed the screen a SECOND time when the sync-rows
+   worker reported, and "Sync preview"/"Run" each recomposed the whole screen
+   to change three status lines.
+3. ``_queue_sync_rows_refresh`` ran on both ``on_mount`` and the mount's OWN
+   ``on_screen_resume`` (Textual posts ``ScreenResume`` when a screen is
+   pushed), so the first visit paid for two full sync previews.
+
+Identity is the evidence: a widget that survives is the same Python object.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button, Static
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    _active_destination_screen,
+    _build_test_app,
+)
+from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar
+from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
+
+pytestmark = pytest.mark.asyncio
+
+#: Chrome and rail: nothing here reads the active category's CONTENT.
+_STABLE = (
+    "#settings-shell",
+    "#settings-workbench",
+    "#settings-category-pane",
+    "#settings-category-list",
+    "#settings-category-search",
+    "#settings-category-overview",
+    "#settings-category-storage",
+    "#settings-detail-pane",
+    "#settings-impact-pane",
+    "#settings-focus-help",
+    "#screen-footer-status",
+)
+
+
+def _identities(screen, selectors) -> dict[str, int]:
+    return {selector: id(screen.query_one(selector)) for selector in selectors}
+
+
+def _text(widget) -> str:
+    return str(getattr(widget.renderable, "plain", widget.renderable))
+
+
+async def _settle(pilot) -> None:
+    await pilot.app.workers.wait_for_complete()
+    for _ in range(4):
+        await pilot.pause()
+
+
+async def _open_settings(pilot):
+    await _settle(pilot)
+    return _active_destination_screen(pilot.app)
+
+
+async def test_category_switch_rebuilds_only_the_two_category_panes():
+    """AC#1: a rail click leaves every widget that does not read the
+    category's content exactly where it was."""
+    host = DestinationHarness(_build_test_app(), "settings")
+    async with host.run_test(size=(160, 45)) as pilot:
+        screen = await _open_settings(pilot)
+        before = _identities(screen, _STABLE)
+        nav_before = id(screen.query_one(MainNavigationBar))
+
+        await pilot.click("#settings-category-storage")
+        await _settle(pilot)
+
+        assert _identities(screen, _STABLE) == before, (
+            "A Settings category switch rebuilt chrome that does not read the "
+            "category."
+        )
+        assert id(screen.query_one(MainNavigationBar)) == nav_before
+        # ...and the panes it DOES own actually repainted.
+        assert screen.active_category == "storage"
+        assert "Storage" in _text(screen.query_one("#settings-category-label", Static))
+
+
+async def test_category_switch_moves_the_active_rail_marker():
+    """The rail is no longer rebuilt, so the active marker has to be patched
+    onto the surviving buttons -- with the same result as a fresh compose."""
+    host = DestinationHarness(_build_test_app(), "settings")
+    async with host.run_test(size=(160, 45)) as pilot:
+        screen = await _open_settings(pilot)
+        assert screen.query_one("#settings-category-overview", Button).has_class(
+            "settings-active-section"
+        )
+
+        await pilot.click("#settings-category-storage")
+        await _settle(pilot)
+
+        assert screen.query_one("#settings-category-storage", Button).has_class(
+            "settings-active-section"
+        )
+        assert not screen.query_one("#settings-category-overview", Button).has_class(
+            "settings-active-section"
+        )
+
+
+async def test_category_switch_lands_focus_on_the_selected_rail_button():
+    """What the recompose provided via `_pending_category_focus_value`: after
+    a switch, focus is on the newly selected category button."""
+    host = DestinationHarness(_build_test_app(), "settings")
+    async with host.run_test(size=(160, 45)) as pilot:
+        screen = await _open_settings(pilot)
+
+        await pilot.click("#settings-category-storage")
+        await _settle(pilot)
+
+        assert getattr(host.focused, "id", None) == "settings-category-storage"
+
+
+async def test_category_switch_keeps_compact_pane_classes_at_a_compact_size():
+    """Compact geometry is only measured at a compact size.
+
+    The compact classes used to be re-applied by `compose_content` on every
+    category recompose. The panes are not recomposed by the screen any more,
+    so the classes have to SURVIVE a switch instead -- and a pane that lost
+    them would only be wrong below the 90-column breakpoint, where no
+    170x48 test looks.
+    """
+    host = DestinationHarness(_build_test_app(), "settings")
+    async with host.run_test(size=(80, 24)) as pilot:
+        screen = await _open_settings(pilot)
+        assert screen._workbench_compact is True, "harness is not at a compact width"
+        for pane in ("#settings-detail-pane", "#settings-impact-pane"):
+            assert screen.query_one(pane).has_class("settings-workbench-compact-pane")
+
+        screen._select_category("storage")
+        await _settle(pilot)
+
+        assert screen.active_category == "storage"
+        for pane in ("#settings-detail-pane", "#settings-impact-pane"):
+            assert screen.query_one(pane).has_class(
+                "settings-workbench-compact-pane"
+            ), f"{pane} lost its compact class across a category switch"
+        assert screen.query("#settings-storage-card"), (
+            "the new category did not render at a compact size"
+        )
+
+
+async def test_sync_row_refresh_patches_rows_without_rebuilding_the_screen():
+    """AC#1: the sync rows update in place; nothing outside them moves."""
+    host = DestinationHarness(_build_test_app(), "settings")
+    async with host.run_test(size=(160, 45)) as pilot:
+        screen = await _open_settings(pilot)
+        assert screen.active_category == "overview"
+        before = _identities(screen, _STABLE)
+        nav_before = id(screen.query_one(MainNavigationBar))
+        card_before = id(screen.query_one("#settings-overview-card"))
+
+        screen.manual_sync_rows = (
+            ("Manual sync status", "ready"),
+            ("Manual sync preview", "Nothing pending."),
+            ("Pending outgoing", "none"),
+        )
+        await _settle(pilot)
+
+        assert _identities(screen, _STABLE) == before, (
+            "A sync-rows refresh recomposed the screen."
+        )
+        assert id(screen.query_one(MainNavigationBar)) == nav_before
+        assert id(screen.query_one("#settings-overview-card")) == card_before, (
+            "The sync rows live in their own container; the Overview card "
+            "around them must not be rebuilt."
+        )
+        summary = _text(screen.query_one("#settings-overview-sync-summary", Static))
+        assert "ready" in summary and "none" in summary
+
+
+async def test_sync_rows_refresh_runs_once_per_visit(monkeypatch):
+    """AC#3: on_mount and the mount's own ScreenResume must not both run it.
+
+    Replays the two hooks against a fully MOUNTED screen deliberately. Their
+    real firing order varies with how the screen was pushed, and on one of
+    those orders `on_mount` runs before `is_mounted` flips and dispatches
+    nothing at all -- which would let a naive dedupe suppress the only
+    refresh. The replay pins the ordering the audit measured, and the second
+    half pins that a genuinely later resume still refreshes.
+    """
+    calls: list[object] = []
+    real = SettingsScreen._refresh_sync_rows
+
+    def counting(self):
+        calls.append(self)
+        return real(self)
+
+    monkeypatch.setattr(SettingsScreen, "_refresh_sync_rows", counting)
+
+    host = DestinationHarness(_build_test_app(), "settings")
+    async with host.run_test(size=(160, 45)) as pilot:
+        screen = await _open_settings(pilot)
+        assert len(calls) >= 1, "The visit never refreshed the sync rows at all."
+
+        calls.clear()
+        screen.on_mount()
+        screen.on_screen_resume()
+        await _settle(pilot)
+        assert len(calls) == 1, (
+            f"Settings ran its sync-rows refresh {len(calls)}x for one visit."
+        )
+
+        screen.on_screen_resume()
+        await _settle(pilot)
+        assert len(calls) == 2, (
+            "A later resume must refresh again: sync state can move while "
+            "Settings is suspended."
+        )

--- a/Tests/UI/test_settings_panel_scoped_updates.py
+++ b/Tests/UI/test_settings_panel_scoped_updates.py
@@ -152,6 +152,57 @@ async def test_category_switch_keeps_compact_pane_classes_at_a_compact_size():
         )
 
 
+async def test_same_category_rebuild_keeps_focus_on_the_control_used():
+    """A SAME-category pane rebuild must not throw focus into the rail.
+
+    Workspaces rebuilds its pane in place (row click, "Show archived"), which
+    destroys the control under the user. Textual's `_reset_focus` then lands
+    them on the rail's Domain Defaults GROUP TOGGLE -- where the next Space
+    collapses the group they are not even looking at. Pane control ids are
+    stable across a same-category rebuild, so the swap restores the identity.
+    """
+    host = DestinationHarness(_build_test_app(), "settings")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = await _open_settings(pilot)
+        screen._select_category("workspaces")
+        await _settle(pilot)
+        assert screen.active_category == "workspaces"
+
+        toggle = screen.query_one("#settings-workspaces-show-archived")
+        toggle.focus()
+        await pilot.pause()
+        assert getattr(host.focused, "id", None) == "settings-workspaces-show-archived"
+
+        # The real in-place rebuild path.
+        screen._refresh_settings_workspaces_pane()
+        await _settle(pilot)
+
+        assert getattr(host.focused, "id", None) == (
+            "settings-workspaces-show-archived"
+        ), "focus escaped the pane on a same-category rebuild"
+
+
+def _sync_row_texts(screen) -> list[str]:
+    """The detail rows inside the two sync-row regions, in order.
+
+    Read from the REGIONS, not from the whole screen: these are the widgets
+    only `_sync_overview_sync_widgets`' region rebuild writes. Asserting on
+    screen-wide text (or on the front-door summary Static alone) passes even
+    with the rebuild removed, because a different path already keeps the
+    summary current -- which is exactly how a neutered rebuild survived a
+    first draft of this test.
+    """
+    rows: list[str] = []
+    for region_id in (
+        "#settings-overview-manual-sync-rows",
+        "#settings-overview-handoff-rows",
+    ):
+        rows.extend(
+            _text(row) for row in screen.query_one(region_id).query(Static)
+        )
+    return rows
+
+
 async def test_sync_row_refresh_patches_rows_without_rebuilding_the_screen():
     """AC#1: the sync rows update in place; nothing outside them moves."""
     host = DestinationHarness(_build_test_app(), "settings")
@@ -161,6 +212,8 @@ async def test_sync_row_refresh_patches_rows_without_rebuilding_the_screen():
         before = _identities(screen, _STABLE)
         nav_before = id(screen.query_one(MainNavigationBar))
         card_before = id(screen.query_one("#settings-overview-card"))
+        rows_before = _sync_row_texts(screen)
+        assert rows_before, "the sync-row regions rendered nothing to begin with"
 
         screen.manual_sync_rows = (
             ("Manual sync status", "ready"),
@@ -177,8 +230,40 @@ async def test_sync_row_refresh_patches_rows_without_rebuilding_the_screen():
             "The sync rows live in their own container; the Overview card "
             "around them must not be rebuilt."
         )
+        # The load-bearing half: the ROW statics themselves carry the new
+        # values. Only the region rebuild writes these.
+        rows_after = _sync_row_texts(screen)
+        assert rows_after != rows_before, "the sync-row regions never repainted"
+        assert "Manual sync status: ready" in rows_after
+        assert "Manual sync preview: Nothing pending." in rows_after
+        assert "Pending outgoing: none" in rows_after
+        # ...and the front door agrees.
         summary = _text(screen.query_one("#settings-overview-sync-summary", Static))
         assert "ready" in summary and "none" in summary
+
+
+async def test_sync_row_regions_repaint_when_the_row_SET_changes():
+    """A run result renames a row and appends two more -- the region rebuild
+    is what makes a variable row set possible at all (a per-row
+    `Static.update` patch could not express it)."""
+    host = DestinationHarness(_build_test_app(), "settings")
+    async with host.run_test(size=(160, 45)) as pilot:
+        screen = await _open_settings(pilot)
+
+        screen.manual_sync_rows = (
+            ("Manual sync status", "failed"),
+            ("Manual sync result", "Manual Sync failed: TimeoutError"),
+            ("Pending outgoing", "notes: 2"),
+            ("Conflict review", "notes | Note A | edited both sides"),
+        )
+        await _settle(pilot)
+
+        rows = _sync_row_texts(screen)
+        assert "Manual sync result: Manual Sync failed: TimeoutError" in rows
+        assert "Conflict review: notes | Note A | edited both sides" in rows
+        assert not any(row.startswith("Manual sync preview:") for row in rows), (
+            "the replaced row survived -- the region did not rebuild"
+        )
 
 
 async def test_sync_rows_refresh_runs_once_per_visit(monkeypatch):

--- a/Tests/UI/test_settings_panel_scoped_updates.py
+++ b/Tests/UI/test_settings_panel_scoped_updates.py
@@ -119,6 +119,7 @@ async def test_category_switch_lands_focus_on_the_selected_rail_button():
         await pilot.click("#settings-category-storage")
         await _settle(pilot)
 
+        assert screen.active_category == "storage"
         assert getattr(host.focused, "id", None) == "settings-category-storage"
 
 

--- a/Tests/UI/test_settings_rag_profile_region.py
+++ b/Tests/UI/test_settings_rag_profile_region.py
@@ -3941,11 +3941,19 @@ async def test_post_recompose_sweep_releases_a_capture_dispatched_during_the_tea
     forwarded MouseDown whose dispatch is still pending on the widget's
     pump when the enclosing screen's teardown begins.
 
-    Fixed by a post-``super().recompose()`` sweep in
-    ``BaseAppScreen.recompose()``: once the ENTIRE recompose (removal AND
-    remount) has finished, any still-captured widget that is NOT
-    ``is_attached`` is by definition stale (nothing legitimately captured
-    during remount would already be detached) and is released again.
+    Fixed by a post-teardown sweep (``BaseAppScreen.sweep_stale_mouse_
+    capture``, called by ``recompose()`` and by the region-scoped swaps):
+    once the ENTIRE teardown (removal AND remount) has finished, any
+    still-captured widget that is NOT ``is_attached`` is by definition stale
+    (nothing legitimately captured during remount would already be detached)
+    and is released again.
+
+    task-15475: the victim is taken from the DETAIL PANE, not the category
+    rail. A category switch no longer recomposes the screen -- it rebuilds
+    the detail and inspector panes -- so the rail's search Input is no longer
+    torn down by one, and a capture on a widget that stays mounted is not
+    stale at all (its own MouseUp releases it). The hazard this test exists
+    for lives wherever the teardown actually happens, which is here.
     """
     app = _build_test_app()
     host = DestinationHarness(app, "settings")
@@ -3953,7 +3961,7 @@ async def test_post_recompose_sweep_releases_a_capture_dispatched_during_the_tea
     async with host.run_test(size=(190, 55)) as pilot:
         await _open_settings_category(pilot, "#settings-category-library-rag")
         screen = _active_destination_screen(host)
-        victim = screen.query_one("#settings-category-search", Input)
+        victim = screen.query_one("#settings-detail-pane").query(Input).first()
 
         # Schedule the recompose first (screen next-callback), then queue a
         # capture-inducing message on the VICTIM's own pump -- modelling a

--- a/Tests/UI/test_speech_settings_panel_scoped_updates.py
+++ b/Tests/UI/test_speech_settings_panel_scoped_updates.py
@@ -1,0 +1,135 @@
+"""Speech & TTS settings dropdowns rebuild ONE card, not the panel (task-15475).
+
+The input-latency audit found every provider/policy dropdown in
+``SpeechTTSSettingsPanel`` calling ``await self.recompose()`` -- ~200 widgets
+destroyed and rebuilt to repaint the handful of rows that actually changed,
+with focus dropped on the floor every time (measured: ``app.focused`` is
+``None`` after the change, even though the user had just operated a Select).
+
+Identity, not counting, is the evidence here: a widget that survives a change
+is the SAME Python object. These tests pin which cards survive which change,
+plus the rendered outcome each change is supposed to produce (so a "scoped"
+update that silently stopped updating something would fail too).
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Input, Select
+
+from Tests.UI.test_settings_speech_tts_panel import _PanelHarness
+
+pytestmark = pytest.mark.asyncio
+
+_BANNER = "#settings-speech-scope-banner"
+_DEFAULTS = "#settings-speech-global-defaults"
+_SETUP = "#settings-speech-provider-setup"
+_REALTIME = "#settings-speech-realtime"
+_INSPECTOR = "#settings-speech-inspector"
+_ACTIONS = "#settings-speech-actions"
+
+
+def _identities(panel, selectors) -> dict[str, int]:
+    return {selector: id(panel.query_one(selector)) for selector in selectors}
+
+
+async def _settle(pilot) -> None:
+    for _ in range(8):
+        await pilot.pause()
+
+
+async def test_default_provider_change_rebuilds_only_defaults_and_inspector():
+    """AC#2: the Global defaults card (and the inspector that reads it) are
+    the only cards a Default TTS Provider change may replace."""
+    host = _PanelHarness(configure_provider="openai")
+    async with host.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        panel = host.query_one("#panel")
+        untouched = _identities(panel, (_BANNER, _SETUP, _REALTIME, _ACTIONS))
+        defaults_before = id(panel.query_one(_DEFAULTS))
+
+        selector = panel.query_one("#settings-speech-default-provider", Select)
+        selector.focus()
+        await pilot.pause()
+        selector.value = "audio_cpp"
+        await _settle(pilot)
+
+        assert _identities(panel, untouched) == untouched, (
+            "A Default TTS Provider change replaced cards it does not feed."
+        )
+        # The defaults card itself is NOT replaced -- only its children are --
+        # so the outcome, not the card's identity, is what proves it repainted.
+        assert id(panel.query_one(_DEFAULTS)) == defaults_before
+        assert isinstance(
+            panel.query_one("#settings-speech-model-value"), Select
+        ), "audio.cpp exposes Model value as a Select over its observed models."
+        assert panel.query_one("#settings-speech-speed", Input).disabled is True
+        constraints = panel.query_one("#settings-speech-default-constraints")
+        assert "audio.cpp requires WAV" in str(constraints.renderable)
+
+
+async def test_default_provider_change_keeps_focus_on_the_control_used():
+    """The whole-panel recompose dropped focus entirely; a scoped swap must
+    put the user back on the Select they just operated."""
+    host = _PanelHarness(configure_provider="openai")
+    async with host.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        panel = host.query_one("#panel")
+        selector = panel.query_one("#settings-speech-default-provider", Select)
+        selector.focus()
+        await pilot.pause()
+        assert getattr(host.focused, "id", None) == "settings-speech-default-provider"
+
+        selector.value = "audio_cpp"
+        await _settle(pilot)
+
+        assert getattr(host.focused, "id", None) == "settings-speech-default-provider"
+
+
+async def test_model_policy_change_rebuilds_only_defaults_and_inspector():
+    """The Model policy dropdown swaps the Model value control's enablement."""
+    host = _PanelHarness(configure_provider="openai")
+    async with host.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        panel = host.query_one("#panel")
+        untouched = _identities(panel, (_BANNER, _SETUP, _REALTIME, _ACTIONS))
+
+        policy = panel.query_one("#settings-speech-model-policy", Select)
+        policy.focus()
+        await pilot.pause()
+        policy.value = "first_available"
+        await _settle(pilot)
+
+        assert _identities(panel, untouched) == untouched
+        assert panel.query_one("#settings-speech-model-value", Input).disabled is True
+        assert getattr(host.focused, "id", None) == "settings-speech-model-policy"
+
+
+async def test_configure_provider_change_rebuilds_only_setup_and_inspector():
+    """Configure Provider owns the Provider setup card; it must not disturb
+    the Global defaults card (it deliberately does not change the default)."""
+    host = _PanelHarness(configure_provider="openai")
+    async with host.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        panel = host.query_one("#panel")
+        untouched = _identities(panel, (_BANNER, _DEFAULTS, _REALTIME, _ACTIONS))
+        default_provider_before = id(
+            panel.query_one("#settings-speech-default-provider")
+        )
+
+        selector = panel.query_one("#settings-speech-configure-provider", Select)
+        selector.focus()
+        await pilot.pause()
+        selector.value = "elevenlabs"
+        await _settle(pilot)
+
+        assert _identities(panel, untouched) == untouched
+        assert (
+            id(panel.query_one("#settings-speech-default-provider"))
+            == default_provider_before
+        ), "Configure Provider must not rebuild the Global defaults controls."
+        assert panel.query("#settings-speech-provider-elevenlabs"), (
+            "The Provider setup card must show the newly configured provider."
+        )
+        summary = panel.query_one("#settings-speech-inspector-summary")
+        assert "ElevenLabs" in str(summary.renderable)

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -3439,3 +3439,47 @@ after inspection. Do not assume every portable `stat_result` field has identical
 meaning across pathname and handle APIs. Preserve strict handle rechecks, test
 each stable identity field, and require native-platform evidence for filesystem
 security claims.
+## A whole-screen recompose is doing four things you did not ask it for
+
+**The trap.** Converting `refresh(recompose=True)` to a region-scoped rebuild looks
+like a pure narrowing: same content, fewer widgets. It is not. The recompose was also
+providing services the new path silently drops, and none of them fail loudly.
+
+**What happened.** Task-15475 (2026-08-11/13) converted four surfaces. Every one of
+these was caught by an EXISTING test, not by reading the diff:
+
+* **Mouse-capture release.** `BaseAppScreen.refresh`/`recompose` release
+  `App.mouse_captured` before and after the teardown (task-627): an `Input` has no
+  `_on_hide`, so a widget torn down while capturing leaves a dangling capture and
+  every mouse click app-wide is silently swallowed from then on. A region swap tears
+  widgets down too and got none of that. Now extracted to
+  `release_mouse_capture_for_teardown` / `sweep_stale_mouse_capture` and called by
+  both converted screens.
+* **Callback ordering.** Textual runs a screen's recompose BEFORE its
+  `call_after_refresh` callbacks, so "select the category, then focus a field in it"
+  worked by construction. A region rebuild driven from a worker (or from the region's
+  own `_check_recompose`) is a DIFFERENT pump with no ordering against the screen's
+  callback list: the Speech deep link ran against a pane that did not exist yet and
+  dropped its focus on the floor, leaving the user on `nav-home`. Follow-ups must hang
+  off the swap itself.
+* **Post-layout geometry.** Anything reading `virtual_size`/`container_size` (here an
+  inspector overflow indicator) must still run after a REFRESH; read inline at the end
+  of the swap it sees pre-layout zeros and renders the wrong state.
+* **The repaint short-circuit.** `Widget.refresh(recompose=True)` returns before
+  `_set_dirty`. Drop `recompose=True` and a plain reactive assignment now resolves
+  `self.app` — which raises `NoActiveAppError` in every bare-screen unit test that
+  sets that reactive. `repaint=False` restores the property honestly (the screen
+  renders nothing from the value; its children do).
+
+Also worth knowing: scoped is not automatically faster. Two separately-awaited region
+swaps each drove their own layout pass and measured 105 ms against the 69 ms the
+whole-screen recompose appeared to cost. Both numbers were wrong to compare — the Lab
+frame defers its body mount OUT of the recompose, so that 69 ms excluded the expensive
+half. Wrapping the swap in `self.batch()` (what `Widget.recompose` itself uses) took
+it to 88 ms, and the honest end-to-end measure — trigger to content actually on
+screen — was 325 ms before, 146 ms after.
+
+**What to do.** Before converting a recompose, list what it did besides re-render:
+grep the screen's `refresh`/`recompose` overrides, its `call_after_refresh` call
+sites, and any geometry reads. Port each explicitly. Measure trigger-to-content, never
+"time the two coroutines", and batch the swap.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -3483,3 +3483,35 @@ screen — was 325 ms before, 146 ms after.
 grep the screen's `refresh`/`recompose` overrides, its `call_after_refresh` call
 sites, and any geometry reads. Port each explicitly. Measure trigger-to-content, never
 "time the two coroutines", and batch the swap.
+
+**Review round 1 added three more, all measured, none visible in the diff:**
+
+* **A "container" you empty may not be yours.** `remove_children()` on a frame region
+  is only safe if the region holds nothing but mode content. `#lab-rail` and
+  `#lab-inspector` each carry a frame-composed collapse header as their FIRST child —
+  which is precisely why `LabScreen._populate_regions` APPENDS with `mount_all` and
+  says so. The blanket removal destroyed both collapse buttons on the first click,
+  permanently (no keyboard binding, no recompose left to restore them). If the
+  existing code mounts with `mount_all` rather than replacing, that is a signal:
+  something else already lives there.
+* **Focus does not "stay put" when the widget under it is destroyed — it MOVES, to a
+  neighbour you did not choose.** Both conversions landed the user on a collapse
+  affordance one Space away from destroying their own context
+  (`settings-category-group-domain-defaults`, `lab-rail-collapse`). Capture the focus
+  token before a teardown and restore it by id, but defer the restore and yield to
+  the rebuilt subtree — a freshly mounted widget may have focused itself ON PURPOSE
+  (`ResultsGrid` does, so its advertised shortcuts work), and an eager restore wins
+  the FIFO race and silently kills that.
+* **`exclusive=True` is the wrong supersede primitive for a teardown.** It cancels the
+  in-flight worker, and the cancellation can land inside `remove_children` — leaving a
+  region emptied and never refilled when the superseding swap does not rebuild that
+  same region, and skipping the post-teardown capture sweep. A lock plus a revision
+  check supersedes just as firmly and lets the loser return before touching a widget.
+  Accumulate any per-call flags (`rail_dirty`) across superseded calls, or the
+  survivor silently drops the loser's work.
+
+And one about the evidence itself: **a test that asserts on the nearest visible text
+can be satisfied by a different code path.** Neutering the sync-rows region rebuild
+left all six evidence tests green, because the assertion read a summary `Static` that
+another path keeps current. Assert on the widgets ONLY the mechanism under test
+writes, then mutation-check by neutering that mechanism.

--- a/backlog/tasks/task-15475 - Panel-scoped-updates-for-Settings,-Evals,-and-speech-settings;-dedupe-mount-resume-double-work.md
+++ b/backlog/tasks/task-15475 - Panel-scoped-updates-for-Settings,-Evals,-and-speech-settings;-dedupe-mount-resume-double-work.md
@@ -128,6 +128,44 @@ deep-linked model before the preselect's own dirty mark, while a genuine
 pre-existing draft still trips the guard. Marker removed, reasoning recorded
 in the test; task-15510 itself is left for its owner to close.
 
+**Review round 1** (1 Critical, 3 Important, 4 minors — all addressed):
+
+- *Critical.* `_replace_region` called `remove_children()` on `#lab-rail` /
+  `#lab-inspector`, whose FIRST child is the frame's collapse header (composed by
+  `LabWorkbench`, which is exactly why `_populate_regions` APPENDS with
+  `mount_all`). One rail click destroyed the Catalog and Inspector collapse
+  buttons permanently — no keyboard binding, and no screen recompose left to
+  rebuild them. The swap now removes only the mode-owned children. Test drives a
+  real `EvalsScreen` through three rail clicks and a rail-rebuilding swap.
+- *Focus escape (both surfaces).* Textual's `_reset_focus` dropped the user on the
+  rail's Domain Defaults GROUP TOGGLE after a same-category Settings rebuild
+  (measured: `settings-category-group-domain-defaults`) and on `lab-rail-collapse`
+  after an Evals rail rebuild — one Space from collapsing something they were not
+  looking at. Both swaps now capture the focus token when focus is inside a region
+  they are about to rebuild and restore it by id, mirroring
+  `_replace_card_bodies`. The Evals restore is deferred and yields to `#lab-body`,
+  so `ResultsGrid`'s deliberate autofocus still wins.
+- *task-15510 comment corrected.* Spy-probed instead of reasoned: the guard
+  returns early on this tree too (`guard_dirty=True`), so
+  `_apply_navigation_provider_context` writes nothing either way. What lands the
+  model is the detail pane composing once through
+  `_provider_display_setting_values()` while no draft exists. The guard-vs-draft
+  ordering task-15510 describes is untouched and remains its owner's.
+- *Overview statics under-protected.* Neutering the region rebuild left every
+  test green, because the added assertion read a summary Static a different path
+  keeps current. The test now reads the ROW statics inside the two regions, plus a
+  second test for a changed row SET; mutation-checked (`refresh(recompose=True)`
+  → `refresh()` fails 2 tests).
+- *Minors.* Exclusive worker groups replaced on both surfaces by a lock + revision
+  check: cancellation could land inside `remove_children` and strand a region
+  emptied but never refilled (and skip the capture sweep), whereas a superseded
+  swap now returns before touching a widget; `rail_dirty` accumulates across
+  superseded calls so a rebuild is never lost. `_category_pane_swap_pending` is
+  cleared only by the swap that still owns the revision. Stale `evals_screen`
+  module docstring rewritten. The duplicate `_update_inspector_overflow_hint`
+  queued by `_select_category` (which fired first, against the pane the swap had
+  not rebuilt yet) is now only queued on the no-switch path.
+
 Files: `UI/Screens/settings_screen.py`, `UI/Screens/evals_screen.py`,
 `UI/Screens/chat_screen.py`, `UI/Evals/library_rail.py`,
 `UI/Navigation/base_app_screen.py`,

--- a/backlog/tasks/task-15475 - Panel-scoped-updates-for-Settings,-Evals,-and-speech-settings;-dedupe-mount-resume-double-work.md
+++ b/backlog/tasks/task-15475 - Panel-scoped-updates-for-Settings,-Evals,-and-speech-settings;-dedupe-mount-resume-double-work.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15475
 title: Panel-scoped updates for Settings, Evals, and speech settings; dedupe mount/resume double-work
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -20,7 +21,116 @@ Fix direction: detail-pane-scoped swaps and targeted Static patches; per-instanc
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Settings rail clicks and Evals selections rebuild only the detail region (evidence per surface); sync preview updates statics in place
-- [ ] #2 Speech panel dropdown changes rebuild only the provider-form subsection
-- [ ] #3 The duplicated mount/resume workers run once per visit (evidence); all touched surfaces behaviorally unchanged (tests)
+- [x] #1 Settings rail clicks and Evals selections rebuild only the detail region (evidence per surface); sync preview updates statics in place
+- [x] #2 Speech panel dropdown changes rebuild only the provider-form subsection
+- [x] #3 The duplicated mount/resume workers run once per visit (evidence); all touched surfaces behaviorally unchanged (tests)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Four surfaces, one discipline: pin current behavior (render + focus + screen-path
+side effects) with a born-red evidence test, convert to a scoped update, re-run the
+surface's suites.
+
+1. **Console dedupe** (`chat_screen.py`). `on_mount` and the mount's OWN
+   `on_screen_resume` both dispatch `_refresh_console_skill_candidates` and both
+   sync task-resume state. Add a one-shot per-instance token set at mount and
+   consumed by exactly the next resume (class-level default, so `__new__`-built
+   fixtures read it safely). Later resumes (modal pop, tab return) still refresh.
+2. **Speech panel** (`speech_tts_settings_panel.py`). The four global-defaults
+   `Select.Changed` handlers and `_apply_configure_provider` call
+   `await self.recompose()` (whole panel, ~200 widgets). Add an awaited
+   region-swap helper (`remove_children()` then `mount_all()`, both awaited --
+   Textual's `remove` is deferred, see `speech_playground_pane`'s
+   `_replace_provider_regions`) and route each handler to the card it actually
+   changes: `#settings-speech-global-defaults` for the four, and
+   `#settings-speech-provider-setup` for Configure Provider; the inspector card
+   rebuilds alongside since it reads both.
+3. **Evals** (`evals_screen.py`). `select()` recomposes the whole screen. Swap the
+   Lab frame regions instead: rebuild `#evals-detail-pane` in `#lab-body` and
+   `#evals-inspector-pane` in `#lab-inspector`. The rail's row SET only changes on
+   a mutation, so `select()` grows `rail_dirty: bool = True` (safe default) and the
+   rail-click path -- the audit's hot path -- passes `False` and just re-marks
+   `is-active` in place via `LibraryRail`'s `_row_targets`.
+4. **Settings** (`settings_screen.py`). Drop `recompose=True` from
+   `active_category` and give the detail and impact panes their own recomposing
+   container widgets; `_select_category` patches the mode line, the rail's
+   active button, and the focus-help line in place and recomposes only the two
+   panes. Drop `recompose=True` from the two sync-row reactives too: their
+   Overview rows live in dedicated containers that rebuild alone, and the summary
+   row is a `Static.update`. Dedupe `_queue_sync_rows_refresh` between `on_mount`
+   and the mount's own `on_screen_resume` with the same one-shot token as (1).
+   Container-scoped recompose does NOT order against `screen.call_after_refresh`
+   (two pumps), so every post-swap follow-up (focus restore, overflow hint,
+   reveal-active-button) hangs off the container's own `recompose()`.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Four surfaces, four commits, one discipline: pin the current behavior, convert
+to a scoped update, prove the scope with widget IDENTITY (a widget that
+survives is the same Python object), then re-run the surface's suites.
+
+**Console** (`chat_screen.py`). Textual posts `ScreenResume` when a screen is
+PUSHED, so `on_mount` and the mount's own resume both fired and both dispatched
+the (non-exclusive, uncancelled) skill-candidate worker and the task-resume
+sync. A one-shot per-instance token set at mount and CONSUMED by the next
+resume collapses the pair; every later resume still refreshes, because a skill
+may have been installed while Console was suspended. 2 dispatches -> 1.
+
+**Speech panel** (`speech_tts_settings_panel.py`). The three cards a dropdown
+can invalidate became `_SpeechSettingsCard`s (Vertical subclasses with their
+own `compose()`), so `await card.recompose()` rebuilds one. Global-defaults
+handlers rebuild defaults+inspector (83 of 188 widgets, median 47.6 ms vs
+84.7 ms for the whole panel); Configure Provider rebuilds setup+inspector (40
+of 188). Focus is now retained on the control the user just operated -- the
+whole-panel recompose left `app.focused is None` every time.
+
+**Evals** (`evals_screen.py`, `library_rail.py`). `select()` swaps the Lab
+frame's regions instead of recomposing the screen. The rail is only rebuilt
+when its ROWS changed: `EvalsSelectionChanged` carries `rail_dirty` (default
+True) and only the row-press path opts out, because the rail also posts that
+message for its own mutations. End to end, 325 ms -> 146 ms median.
+
+**Settings** (`settings_screen.py`). All three screen-level `recompose=True`
+reactives are gone. The detail and inspector panes are `SettingsRegion`s; the
+mode line, rail active marker/label and focus-help are patched in place; the
+Overview sync rows own two small regions and the front-door summary is a
+`Static.update`. 69 of 138 widgets per category switch, 13 per sync-rows
+refresh; 270 ms -> 98 ms median.
+
+Trade-offs and things that were measured, not assumed:
+
+- Region swaps must be BATCHED. Two separately-awaited swaps each drove their
+  own layout pass (Evals: median 105 ms -> 88 ms inside `self.batch()`).
+- A naive "recompose vs swap" timing flatters the recompose, because the Lab
+  frame defers its body mount out of the recompose entirely. Every number
+  above is trigger-to-content-on-screen.
+- Four things the whole-screen recompose provided for free had to be ported,
+  each caught by an existing test: mouse-capture release around the teardown
+  (task-627; extracted to `BaseAppScreen.release_mouse_capture_for_teardown` /
+  `sweep_stale_mouse_capture` and used by both Settings and Evals), callback
+  ORDERING (`_after_category_panes`), post-layout timing for the inspector's
+  fold indicator, and `repaint=False` on the de-recomposed reactives.
+- No focus restore in the Evals swap, deliberately: the clicked row survives
+  now, and a fresh `ResultsGrid` focuses its own DataTable on purpose -- a
+  restore queued after it wins the FIFO race and kills the shortcuts the
+  footer advertises.
+
+Two existing tests were updated to keep MECHANISM assertions honest about the
+new mechanism (the capture-drain victim now comes from the pane that is
+actually torn down; the Overview disclosures test asserts the stronger fact
+that the Collapsibles are not rebuilt at all). task-15510's strict xfail
+flipped to XPASS: the reordered `_apply_navigation_provider_context` lands the
+deep-linked model before the preselect's own dirty mark, while a genuine
+pre-existing draft still trips the guard. Marker removed, reasoning recorded
+in the test; task-15510 itself is left for its owner to close.
+
+Files: `UI/Screens/settings_screen.py`, `UI/Screens/evals_screen.py`,
+`UI/Screens/chat_screen.py`, `UI/Evals/library_rail.py`,
+`UI/Navigation/base_app_screen.py`,
+`Widgets/Settings_Widgets/speech_tts_settings_panel.py`; new tests
+`Tests/UI/test_{console_visit_dispatch_dedupe,speech_settings_panel_scoped_updates,evals_selection_scoped_regions,settings_panel_scoped_updates}.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Evals/library_rail.py
+++ b/tldw_chatbook/UI/Evals/library_rail.py
@@ -76,6 +76,7 @@ from typing import Any, Callable, Optional
 from rich.markup import escape as escape_markup
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
+from textual.css.query import NoMatches
 from textual.message import Message
 from textual.widgets import Button, Static
 
@@ -309,11 +310,28 @@ class LibraryRail(NotifyMixin, Vertical):
     """Left rail: Benches, Datasets, Runs -- each collapsible, with counts."""
 
     class EvalsSelectionChanged(Message, namespace="library_rail"):
-        """Posted when the user presses a selectable row."""
+        """Posted when this rail changes the screen's selection.
 
-        def __init__(self, selection: EvalsSelection) -> None:
+        Two very different situations post this: a plain row press (the rows
+        on screen are exactly the rows that exist -- only the active marker
+        moves) and a rail-initiated MUTATION that selects what it just made
+        (dataset import, "+ New bench", "+ New dataset", probe-set import),
+        after which the rows on screen are stale.
+
+        ``rail_dirty`` tells them apart so the screen can skip rebuilding the
+        rail for the common case (task-15475). It defaults to ``True``, the
+        answer that is never wrong -- only ``on_button_pressed``'s row-press
+        path opts out. Getting this backwards leaves a rail missing the row
+        the user just created, which is exactly what a first draft of this
+        change did.
+        """
+
+        def __init__(
+            self, selection: EvalsSelection, *, rail_dirty: bool = True
+        ) -> None:
             super().__init__()
             self.selection = selection
+            self.rail_dirty = rail_dirty
 
     class SampleBenchRequested(Message, namespace="library_rail"):
         """Posted when "Create sample bench" is pressed.
@@ -390,6 +408,35 @@ class LibraryRail(NotifyMixin, Vertical):
             open_sections if open_sections is not None else _default_open_sections()
         )
         self._row_targets: dict[str, EvalsSelection] = {}
+
+    def apply_selection(self, selection: EvalsSelection) -> None:
+        """Re-mark the active row in place, without rebuilding the rail.
+
+        task-15475. A rail click cannot change which ROWS exist -- this
+        widget is what posted the selection -- only which one is marked
+        active, so the screen no longer rebuilds the rail for it. The marking
+        rule is the same one ``_row_button`` applies at compose time, read off
+        the same ``_row_targets`` map, so a re-marked rail and a
+        freshly-composed one agree by construction.
+
+        Callers whose rows genuinely changed (a save, a finished run, a
+        delete) must rebuild the rail instead -- see ``EvalsScreen.select``'s
+        ``rail_dirty``.
+
+        Args:
+            selection: The screen's new selection.
+
+        Returns:
+            None.
+        """
+        self.selection = selection
+        for button_id, target in self._row_targets.items():
+            try:
+                button = self.query_one(f"#{button_id}", Button)
+            except NoMatches:
+                # A collapsed/removed section's row; nothing to mark.
+                continue
+            button.set_class(target == selection, "is-active")
 
     def compose(self) -> ComposeResult:
         self._row_targets = {}
@@ -933,7 +980,10 @@ class LibraryRail(NotifyMixin, Vertical):
         if selection is None:
             return
         event.stop()
-        self.post_message(self.EvalsSelectionChanged(selection))
+        # The ONE opt-out (task-15475): a row press changes nothing about
+        # which rows exist -- this rail composed them -- so the screen
+        # re-marks the active row in place instead of rebuilding the rail.
+        self.post_message(self.EvalsSelectionChanged(selection, rail_dirty=False))
 
     def _create_new_dataset(self) -> None:
         db = self.view_model.db

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -159,25 +159,51 @@ class BaseAppScreen(Screen):
         interaction has since legitimately captured (which must be left
         alone).
         """
-        if self.is_running:
+        self.release_mouse_capture_for_teardown()
+        await super().recompose()
+        self.sweep_stale_mouse_capture()
+
+    def release_mouse_capture_for_teardown(self) -> None:
+        """Release any mouse capture before removing widgets.
+
+        Extracted from ``recompose`` (task-15475) so a screen that tears
+        widgets down WITHOUT a screen recompose -- a region-scoped swap, which
+        several screens now do instead of rebuilding themselves -- gets the
+        same protection. The captured widget is not identified first: any
+        teardown can orphan it, and ``Input`` has no ``_on_hide`` to release
+        the mouse on removal, so the release stays unconditional exactly as
+        ``recompose``'s own reasoning above requires.
+        """
+        if not self.is_running:
+            return
+        try:
+            self.app.capture_mouse(None)
+        except Exception:
+            logger.debug(
+                "Mouse-capture release before teardown skipped.",
+                exc_info=True,
+            )
+
+    def sweep_stale_mouse_capture(self) -> None:
+        """Drop a capture left pointing at a no-longer-attached widget.
+
+        The other half of ``release_mouse_capture_for_teardown``: a MouseDown
+        already queued on a child's own pump can capture that child DURING the
+        removal drain, after the pre-teardown release has run. ``is_attached``
+        distinguishes that stale case from a capture a later, unrelated
+        interaction legitimately holds (which must be left alone).
+        """
+        if not self.is_running:
+            return
+        captured = self.app.mouse_captured
+        if captured is not None and not captured.is_attached:
             try:
                 self.app.capture_mouse(None)
             except Exception:
                 logger.debug(
-                    "Mouse-capture release before recompose teardown skipped.",
+                    "Stale post-teardown mouse-capture sweep skipped.",
                     exc_info=True,
                 )
-        await super().recompose()
-        if self.is_running:
-            captured = self.app.mouse_captured
-            if captured is not None and not captured.is_attached:
-                try:
-                    self.app.capture_mouse(None)
-                except Exception:
-                    logger.debug(
-                        "Stale post-recompose mouse-capture sweep skipped.",
-                        exc_info=True,
-                    )
 
     def compose(self) -> ComposeResult:
         """Compose the screen with navigation bar and content."""

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3272,6 +3272,20 @@ class ChatScreen(BaseAppScreen):
     # Reactive property for sidebar state persistence
     sidebar_state = reactive({}, layout=False)
 
+    #: task-15475: one-shot "the mount already did this visit's refreshes"
+    #: token. Textual posts ``ScreenResume`` when a screen is PUSHED, so
+    #: ``on_mount`` and the mount's own ``on_screen_resume`` both fire on the
+    #: first visit -- and both used to dispatch the (non-exclusive, so
+    #: uncancelled) skill-candidate worker and both used to sync task-resume
+    #: state. ``on_mount`` sets this; the very next resume consumes it and
+    #: skips. Every LATER resume still refreshes, which is the point: a skill
+    #: may have been installed, or an approval may have landed, while Console
+    #: was suspended.
+    #:
+    #: Class-level default so it is readable on a screen built by ``__new__``
+    #: (several Console tests construct one without running ``__init__``).
+    _console_mount_visit_refreshed: bool = False
+
     def __init__(self, app_instance: "TldwCli", **kwargs):
         super().__init__(app_instance, "chat", **kwargs)
         self.console_session_surface: Optional[ConsoleSessionSurface] = None
@@ -14426,6 +14440,9 @@ class ChatScreen(BaseAppScreen):
         self.call_after_refresh(self._restore_console_workbench_focus)
         self.set_timer(0.2, self._restore_console_workbench_focus)
         self.run_worker(self._refresh_console_skill_candidates(), exclusive=False)
+        # task-15475: claim this visit's refreshes; the ScreenResume Textual
+        # posts for this very mount consumes the token and skips its own copy.
+        self._console_mount_visit_refreshed = True
 
     def _notify_console_fleet_teardown_if_any(self) -> None:
         """One-shot toast reporting a fleet the LAST Console instance lost.
@@ -21325,6 +21342,13 @@ class ChatScreen(BaseAppScreen):
     def on_screen_resume(self) -> None:
         """Called when returning to this screen."""
         logger.debug("Chat screen resuming")
+        # task-15475: consume the mount's one-shot token. On the FIRST visit
+        # this resume is the mount's own, and on_mount already dispatched the
+        # skill-candidate worker and scheduled the task-resume sync; running
+        # them again here just doubled the work. Consumed (not merely read),
+        # so every subsequent resume refreshes normally.
+        mount_already_refreshed = self._console_mount_visit_refreshed
+        self._console_mount_visit_refreshed = False
         # Re-evaluate setup-card/model readiness before touching focus. Some
         # recovery flows (e.g. certain providers' API-key recovery) navigate to
         # the full Settings screen and back rather than completing setup via
@@ -21334,7 +21358,8 @@ class ChatScreen(BaseAppScreen):
         # stale block and the modal could stick even after setup completed
         # elsewhere.
         self._sync_console_transcript_guidance()
-        self.sync_task_resume_state()
+        if not mount_already_refreshed:
+            self.sync_task_resume_state()
         self._register_console_footer_shortcuts()
         # Delayed exactly like the `on_mount` consumption below, to give the
         # native composer a chance to finish mounting on first navigation to
@@ -21354,7 +21379,8 @@ class ChatScreen(BaseAppScreen):
             and not self._consume_pending_console_identity_refresh()
         ):
             self._dispatch_active_console_roleplay_refresh()
-        self.run_worker(self._refresh_console_skill_candidates(), exclusive=False)
+        if not mount_already_refreshed:
+            self.run_worker(self._refresh_console_skill_candidates(), exclusive=False)
         # Note: BaseAppScreen doesn't have on_screen_resume, so no super() call
 
     def set_task_resume_state(self, task_state: TaskResumeState) -> None:

--- a/tldw_chatbook/UI/Screens/evals_screen.py
+++ b/tldw_chatbook/UI/Screens/evals_screen.py
@@ -33,6 +33,7 @@ from rich.markup import escape as escape_markup
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Vertical
+from textual.css.query import QueryError
 from textual.widgets import Button, Static
 
 from ...Chat.Chat_Functions import chat_api_call
@@ -380,7 +381,13 @@ class EvalsScreen(LabScreen):
         """
         return getattr(app_instance, "chachanotes_db", None)
 
-    def select(self, *, kind: SelectionKind, id: Optional[str] = None) -> None:  # noqa: A002
+    def select(  # noqa: A002
+        self,
+        *,
+        kind: SelectionKind,
+        id: Optional[str] = None,
+        rail_dirty: bool = True,
+    ) -> None:
         """Set the workbench's active selection and refresh dependent panes.
 
         Public, not just an internal message handler: it is the shell's own
@@ -388,11 +395,15 @@ class EvalsScreen(LabScreen):
         rail row press) routes here via ``_on_library_selection_changed``
         below, but a caller may also drive selection directly.
 
-        A plain (non-async) method: it only schedules the recompose
-        (``refresh(recompose=True)``), it does not await its
-        completion -- callers that need the panes settled should
-        ``await pilot.pause()`` afterward, mirroring every other
-        recompose-driven screen in this app.
+        A plain (non-async) method: it only SCHEDULES the region swap, it
+        does not await its completion -- callers that need the panes settled
+        should ``await pilot.pause()`` afterward, exactly as they did when
+        this scheduled a ``refresh(recompose=True)``.
+
+        task-15475: it no longer recomposes the screen. A screen recompose
+        rebuilt the nav bar, footer, header row, mode strip and the whole
+        ``LabWorkbench`` -- 150-300 widgets by the input-latency audit's
+        count -- to repaint two regions that read the selection.
 
         Args:
             kind: The selected object's kind (``SelectionKind`` --
@@ -401,12 +412,96 @@ class EvalsScreen(LabScreen):
             id: The selected object's id. Only meaningful for a non-
                 ``"none"`` ``kind``; may be ``None`` (e.g. for ``kind=
                 "none"``, or a caller clearing the selection).
+            rail_dirty: Whether the rail's ROWS (not just which one is
+                active) may have changed. Defaults to ``True``, the safe
+                answer for every mutation caller -- a save, a finished run, a
+                duplicate, a delete -- and for any caller outside this class.
+                Only the rail-click path passes ``False``: the rail is what
+                posted that selection, so its rows cannot have moved, and it
+                just re-marks the active row in place.
         """
         self._selection = EvalsSelection(kind=kind, id=id)
         self._preflight_cache = None
         self._register_grid_shortcuts()
         if self.is_mounted:
-            self.refresh(recompose=True)
+            self.run_worker(
+                self._swap_selection_regions(rail_dirty=rail_dirty),
+                group="evals-selection-regions",
+                exclusive=True,
+                exit_on_error=False,
+            )
+
+    async def _swap_selection_regions(self, *, rail_dirty: bool) -> None:
+        """Rebuild the Lab regions that read the selection, and only those.
+
+        The three regions are the frame's (``lab_frame.LabScreen``):
+        ``#lab-rail``, ``#lab-body``, ``#lab-inspector``. Everything outside
+        them -- the header row and its status chips (static for this mode),
+        the mode strip, the nav bar and the footer -- is unaffected by a
+        selection, so it now survives one.
+
+        Removals are awaited before the replacements mount: Textual's
+        ``remove`` is deferred, and every id here (``#evals-detail-pane``,
+        ``#evals-inspector-pane``, the rail's row ids) is re-used by the
+        replacement, so mounting early raises ``DuplicateIds``.
+
+        The whole swap runs inside ``self.batch()`` -- the same lock-plus-
+        ``batch_update`` ``Widget.recompose`` uses. Not a nicety: two
+        separately-awaited region swaps each drove their own layout/repaint
+        pass, and batching them cut the swap's own cost from a median of
+        105 ms to 88 ms on the isolated harness.
+
+        Runs in an exclusive worker group so a burst of selections (clicking
+        down a rail) collapses to the last one rather than interleaving two
+        teardown/mount cycles on the same regions.
+
+        Deliberately does NOT restore focus afterwards. On the hot path there
+        is nothing to restore -- the rail row the user clicked is not rebuilt,
+        so it simply keeps focus, which the whole-screen recompose could never
+        offer. On a rail-rebuilding path, a freshly mounted body may claim
+        focus ON PURPOSE (``ResultsGrid.on_mount`` focuses its DataTable so
+        the ``l``/``b``/``s``/``e`` keys the footer advertises actually work);
+        a restore queued after it wins the FIFO race and silently kills that
+        -- two grid tests caught exactly this.
+
+        Args:
+            rail_dirty: See ``select``.
+
+        Returns:
+            None.
+        """
+        async with self.batch():
+            if rail_dirty:
+                await self._replace_region("#lab-rail", list(self.compose_lab_rail()))
+            else:
+                try:
+                    self.query_one(LibraryRail).apply_selection(self._selection)
+                except QueryError:
+                    # No rail mounted (teardown race) -- the body/inspector
+                    # swap below is still worth doing if they are still there.
+                    pass
+
+            body = self.build_lab_body()
+            await self._replace_region("#lab-body", [] if body is None else [body])
+            await self._replace_region(
+                "#lab-inspector", list(self.compose_lab_inspector())
+            )
+        if not self.is_mounted:
+            return
+        # Same notification the frame's own deferred body mount fires, so a
+        # mode that re-wires itself against a fresh body keeps working.
+        self.on_lab_body_ready()
+
+    async def _replace_region(self, region_id: str, content: list[Any]) -> None:
+        """Swap one Lab region's children for ``content``."""
+        try:
+            region = self.query_one(region_id)
+        except QueryError:
+            logger.warning("Lab region {} missing; selection swap skipped.", region_id)
+            return
+        await region.remove_children()
+        if content and region.is_mounted:
+            await region.mount_all(content)
 
     def _selection_unmoved_since_launch(
         self, launch_selection: EvalsSelection, bench_task_id: Optional[str]
@@ -571,7 +666,14 @@ class EvalsScreen(LabScreen):
         self, event: LibraryRail.EvalsSelectionChanged
     ) -> None:
         event.stop()
-        self.select(kind=event.selection.kind, id=event.selection.id)
+        # task-15475: the RAIL knows whether it just mutated its own rows (an
+        # import, a "+ New bench") or merely reported a row press; forward its
+        # answer rather than assuming "came from the rail" means "unchanged".
+        self.select(
+            kind=event.selection.kind,
+            id=event.selection.id,
+            rail_dirty=event.rail_dirty,
+        )
 
     @on(BenchEditor.Saved)
     def _on_bench_editor_saved(self, event: BenchEditor.Saved) -> None:

--- a/tldw_chatbook/UI/Screens/evals_screen.py
+++ b/tldw_chatbook/UI/Screens/evals_screen.py
@@ -470,6 +470,11 @@ class EvalsScreen(LabScreen):
         Returns:
             None.
         """
+        # Same protection the whole-screen recompose gave (task-627): a widget
+        # about to be torn down -- the detail pane is full of `Input`s -- must
+        # not be left holding the mouse capture, or every click app-wide is
+        # silently swallowed from then on.
+        self.release_mouse_capture_for_teardown()
         async with self.batch():
             if rail_dirty:
                 await self._replace_region("#lab-rail", list(self.compose_lab_rail()))
@@ -486,6 +491,9 @@ class EvalsScreen(LabScreen):
             await self._replace_region(
                 "#lab-inspector", list(self.compose_lab_inspector())
             )
+        # A MouseDown already queued on a child's pump can capture that child
+        # DURING the removal drain, after the release above.
+        self.sweep_stale_mouse_capture()
         if not self.is_mounted:
             return
         # Same notification the frame's own deferred body mount fires, so a

--- a/tldw_chatbook/UI/Screens/evals_screen.py
+++ b/tldw_chatbook/UI/Screens/evals_screen.py
@@ -14,13 +14,18 @@ This screen replaces that architecture with the shared Lab frame
 (``lab_frame.LabScreen``): the library rail, detail body and readiness
 inspector are the frame's three regions, driven by selection state
 (``EvalsSelection``, ``evals_state.py``) instead of a hand-rolled screen
-stack. **No ``Screen`` subclass is mounted inside any region here.** Detail
-and inspector content is swapped by a screen-level
-``refresh(recompose=True)`` on selection change, which tears down and
-remounts plain widgets (``Static``/``Button``/``Vertical``) -- never a
-``Screen``. ``LabScreen.recompose()`` repopulates the regions and
-re-schedules the deferred body afterwards, which is what makes that
-selection-driven recompose safe here.
+stack. **No ``Screen`` subclass is mounted inside any region here.**
+
+Detail and inspector content is swapped REGION BY REGION on selection change
+(``select`` -> ``_swap_selection_regions``), tearing down and remounting plain
+widgets (``Static``/``Button``/``Vertical``) -- never a ``Screen``. Until
+task-15475 this was a screen-level ``refresh(recompose=True)``, which also
+rebuilt the nav bar, footer, header row and mode strip -- 150-300 widgets by
+the input-latency audit's count -- and is now reserved for whole-screen
+rebuilds. Two consequences worth knowing before touching the swap: the rail's
+ROWS are only rebuilt when a caller says they changed (``rail_dirty``), and
+each region's frame-owned collapse header is NOT mode content, so a swap
+removes only the children it put there (see ``_replace_region``).
 """
 
 from __future__ import annotations
@@ -72,6 +77,12 @@ from .lab_frame import LabScreen
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
+
+
+#: Class on the collapse header the WORKBENCH composes as the first child of
+#: `#lab-rail` and `#lab-inspector` (see `lab_workbench._region_collapse_header`).
+#: Frame-owned chrome, not mode content -- a region swap must step around it.
+_FRAME_REGION_HEADER_CLASS = "console-rail-header"
 
 
 def _extract_chat_reply_text(response: Any) -> str:
@@ -225,9 +236,16 @@ class EvalsScreen(LabScreen):
         #: reintroduce the duplicate run-group snapshot read that I2
         #: fixed. Cleared wherever the selection changes.
         self._preflight_cache: dict[str, PreflightResult] | None = None
+        #: task-15475: selection swaps are serialized by this lock and
+        #: superseded by revision rather than cancelled, so a teardown is
+        #: never interrupted half-done. `_selection_rail_dirty` accumulates
+        #: across superseded calls -- see `select`.
+        self._selection_swap_lock = asyncio.Lock()
+        self._selection_swap_revision = 0
+        self._selection_rail_dirty = False
         # Shared with LibraryRail by reference (see its own docstring) so
         # collapsed/expanded rail sections survive a selection-triggered
-        # recompose, which constructs a brand-new LibraryRail instance.
+        # rebuild, which constructs a brand-new LibraryRail instance.
         self._rail_open_sections: dict[str, bool] = {
             section_id: True for section_id in RAIL_SECTIONS
         }
@@ -423,15 +441,32 @@ class EvalsScreen(LabScreen):
         self._selection = EvalsSelection(kind=kind, id=id)
         self._preflight_cache = None
         self._register_grid_shortcuts()
-        if self.is_mounted:
-            self.run_worker(
-                self._swap_selection_regions(rail_dirty=rail_dirty),
-                group="evals-selection-regions",
-                exclusive=True,
-                exit_on_error=False,
-            )
+        if not self.is_mounted:
+            return
+        # Accumulated, never overwritten: if a rail-rebuilding selection is
+        # superseded by a rail-click one before either swap runs, the rail
+        # still has to be rebuilt.
+        self._selection_rail_dirty = self._selection_rail_dirty or rail_dirty
+        self._selection_swap_revision += 1
+        self.run_worker(
+            self._swap_selection_regions(
+                revision=self._selection_swap_revision,
+            ),
+            group="evals-selection-regions",
+            # NOT exclusive. An exclusive group cancels the in-flight swap,
+            # and the cancellation can land INSIDE `remove_children` -- which
+            # strands a region emptied but never refilled (the rail, if the
+            # superseding swap is a rail-click one that does not rebuild it)
+            # and skips the post-teardown mouse-capture sweep. A lock plus a
+            # revision check gets the same "only the newest wins" without ever
+            # interrupting a teardown: superseded swaps no-op BEFORE touching
+            # anything. Mirrors `speech_playground_pane`'s reconcile-to-current
+            # idiom in the same programme.
+            exclusive=False,
+            exit_on_error=False,
+        )
 
-    async def _swap_selection_regions(self, *, rail_dirty: bool) -> None:
+    async def _swap_selection_regions(self, *, revision: int) -> None:
         """Rebuild the Lab regions that read the selection, and only those.
 
         The three regions are the frame's (``lab_frame.LabScreen``):
@@ -451,63 +486,158 @@ class EvalsScreen(LabScreen):
         pass, and batching them cut the swap's own cost from a median of
         105 ms to 88 ms on the isolated harness.
 
-        Runs in an exclusive worker group so a burst of selections (clicking
-        down a rail) collapses to the last one rather than interleaving two
-        teardown/mount cycles on the same regions.
+        Serialized by a lock and superseded by revision, never cancelled --
+        see ``select`` for why an exclusive worker group was the wrong tool.
 
-        Deliberately does NOT restore focus afterwards. On the hot path there
-        is nothing to restore -- the rail row the user clicked is not rebuilt,
-        so it simply keeps focus, which the whole-screen recompose could never
-        offer. On a rail-rebuilding path, a freshly mounted body may claim
-        focus ON PURPOSE (``ResultsGrid.on_mount`` focuses its DataTable so
-        the ``l``/``b``/``s``/``e`` keys the footer advertises actually work);
-        a restore queued after it wins the FIFO race and silently kills that
-        -- two grid tests caught exactly this.
+        Focus is captured before the teardown and restored after IF it was
+        inside a region this swap rebuilds and its id still resolves. Ids are
+        stable across a rebuild (the rail's row ids, the detail pane's field
+        ids), so this beats what the whole-screen recompose managed -- it left
+        focus wherever Textual's ``_reset_focus`` happened to drop it, which
+        on a rail rebuild is a section TOGGLE, one Space away from collapsing
+        the section the user is working in.
+
+        The restore is deferred and yields to the body: a freshly mounted body
+        may claim focus ON PURPOSE (``ResultsGrid.on_mount`` focuses its
+        DataTable so the ``l``/``b``/``s``/``e`` keys the footer advertises
+        actually work). Anything focused inside ``#lab-body`` after the swap is
+        that deliberate claim and is left alone; anything else is Textual's
+        automatic reset, which the captured identity overrides.
 
         Args:
-            rail_dirty: See ``select``.
+            revision: The ``select`` call this swap belongs to. A swap whose
+                revision is no longer current returns without touching a
+                single widget.
 
         Returns:
             None.
         """
-        # Same protection the whole-screen recompose gave (task-627): a widget
-        # about to be torn down -- the detail pane is full of `Input`s -- must
-        # not be left holding the mouse capture, or every click app-wide is
-        # silently swallowed from then on.
-        self.release_mouse_capture_for_teardown()
-        async with self.batch():
-            if rail_dirty:
-                await self._replace_region("#lab-rail", list(self.compose_lab_rail()))
-            else:
-                try:
-                    self.query_one(LibraryRail).apply_selection(self._selection)
-                except QueryError:
-                    # No rail mounted (teardown race) -- the body/inspector
-                    # swap below is still worth doing if they are still there.
-                    pass
+        async with self._selection_swap_lock:
+            if revision != self._selection_swap_revision or not self.is_mounted:
+                # Superseded while queued (or the screen went away): the newest
+                # swap owns the work, including this one's rail_dirty.
+                return
+            rail_dirty = self._selection_rail_dirty
+            self._selection_rail_dirty = False
+            focus_id = self._focused_id_in_swapped_regions(rail_dirty=rail_dirty)
 
-            body = self.build_lab_body()
-            await self._replace_region("#lab-body", [] if body is None else [body])
-            await self._replace_region(
-                "#lab-inspector", list(self.compose_lab_inspector())
-            )
-        # A MouseDown already queued on a child's pump can capture that child
-        # DURING the removal drain, after the release above.
-        self.sweep_stale_mouse_capture()
+            # Same protection the whole-screen recompose gave (task-627): a
+            # widget about to be torn down -- the detail pane is full of
+            # `Input`s -- must not be left holding the mouse capture, or every
+            # click app-wide is silently swallowed from then on.
+            self.release_mouse_capture_for_teardown()
+            async with self.batch():
+                if rail_dirty:
+                    await self._replace_region(
+                        "#lab-rail", list(self.compose_lab_rail())
+                    )
+                else:
+                    try:
+                        self.query_one(LibraryRail).apply_selection(self._selection)
+                    except QueryError:
+                        # No rail mounted (teardown race) -- the body/inspector
+                        # swap below is still worth doing if they are there.
+                        pass
+
+                body = self.build_lab_body()
+                await self._replace_region(
+                    "#lab-body", [] if body is None else [body]
+                )
+                await self._replace_region(
+                    "#lab-inspector", list(self.compose_lab_inspector())
+                )
+            # A MouseDown already queued on a child's pump can capture that
+            # child DURING the removal drain, after the release above.
+            self.sweep_stale_mouse_capture()
+            if not self.is_mounted:
+                return
+            # Same notification the frame's own deferred body mount fires, so a
+            # mode that re-wires itself against a fresh body keeps working.
+            self.on_lab_body_ready()
+            if focus_id:
+                self.call_later(self._restore_selection_focus, focus_id)
+
+    def _focused_id_in_swapped_regions(self, *, rail_dirty: bool) -> Optional[str]:
+        """The focused widget's id, if this swap is about to destroy it.
+
+        Args:
+            rail_dirty: Whether ``#lab-rail`` is being rebuilt too.
+
+        Returns:
+            The id to restore afterwards, or None when focus is elsewhere,
+            unidentifiable, or on a widget that survives.
+        """
+        focused = self.app.focused if self.is_running else None
+        if focused is None or focused.screen is not self or not focused.id:
+            return None
+        region_ids = ["lab-body", "lab-inspector"]
+        if rail_dirty:
+            region_ids.append("lab-rail")
+        for ancestor in focused.ancestors_with_self:
+            if getattr(ancestor, "id", None) in region_ids:
+                return focused.id
+        return None
+
+    def _restore_selection_focus(self, focus_id: str) -> None:
+        """Put focus back on ``focus_id`` unless the new body claimed it.
+
+        Deferred (``call_later``) rather than immediate so it runs AFTER the
+        focus callbacks a freshly mounted widget queued from its own
+        ``on_mount`` -- which is what lets it see, and yield to, a deliberate
+        claim like ``ResultsGrid``'s.
+        """
         if not self.is_mounted:
             return
-        # Same notification the frame's own deferred body mount fires, so a
-        # mode that re-wires itself against a fresh body keeps working.
-        self.on_lab_body_ready()
+        focused = self.app.focused
+        if focused is not None:
+            for ancestor in focused.ancestors_with_self:
+                if getattr(ancestor, "id", None) == "lab-body":
+                    # A fresh body widget focused itself on purpose.
+                    return
+        try:
+            self.query_one(f"#{focus_id}").focus()
+        except QueryError:
+            # The widget has no counterpart in the rebuilt region (a different
+            # selection kind renders different controls) -- leave focus alone.
+            pass
 
     async def _replace_region(self, region_id: str, content: list[Any]) -> None:
-        """Swap one Lab region's children for ``content``."""
+        """Swap one Lab region's MODE-OWNED children for ``content``.
+
+        Mode-owned is the load-bearing word. ``#lab-rail`` and
+        ``#lab-inspector`` are not empty containers the mode fills: the
+        WORKBENCH composes a collapse header (title + collapse button) as
+        each region's first child, because collapse is frame-owned, not a
+        per-mode concern (``lab_workbench.LabWorkbench.compose``). That is
+        precisely why ``LabScreen._populate_regions`` mounts mode content with
+        ``mount_all``, which appends, and says so.
+
+        A blanket ``remove_children()`` here destroyed those headers on the
+        first selection -- permanently, since nothing recomposes the screen
+        any more and the collapse buttons have no keyboard binding. Removing
+        an explicit list of the non-header children keeps the frame's chrome
+        and leaves it first, exactly where a fresh compose puts it.
+
+        Args:
+            region_id: ``#``-prefixed id of the frame region to refill.
+            content: Widgets to mount after the existing mode content is gone.
+
+        Returns:
+            None.
+        """
         try:
             region = self.query_one(region_id)
         except QueryError:
             logger.warning("Lab region {} missing; selection swap skipped.", region_id)
             return
-        await region.remove_children()
+        mode_owned = [
+            child
+            for child in region.children
+            if not child.has_class(_FRAME_REGION_HEADER_CLASS)
+            and not child.has_class("-textual-system")
+        ]
+        if mode_owned:
+            await region.remove_children(mode_owned)
         if content and region.is_mounted:
             await region.mount_all(content)
 

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -7,13 +7,14 @@ legacy Chat window are deprecated parallels; new settings belong here.
 
 import asyncio
 import copy
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict
 import logging
 import os
 from pathlib import Path
 import re
 import tomllib
+from typing import Any
 
 from rich.cells import cell_len
 from rich.markup import escape as escape_markup
@@ -1860,6 +1861,41 @@ class RagProfileSwitchConfirmModal(ModalScreen[str]):
         self.dismiss("save")
 
 
+class SettingsRegion(Vertical):
+    """A Settings region that can be rebuilt without recomposing the screen.
+
+    task-15475. Textual only regenerates a widget's children from ITS OWN
+    ``compose()`` -- a plain ``Vertical`` yielded inline from the screen's
+    ``compose_content`` has none, so recomposing it directly would just wipe
+    it (the exact reason ``_refresh_settings_workspaces_pane`` used to force a
+    whole-screen recompose instead). Giving the region a ``compose()`` that
+    calls back into the screen is what makes a region-scoped rebuild possible.
+
+    The builder is a bound method of the owning screen: the screen outlives
+    its regions (a region rebuild never replaces the screen), and a screen
+    recompose mints fresh regions bound to the fresh screen, so it cannot go
+    stale.
+
+    Still a ``Vertical`` subclass, so every ``Vertical`` /
+    ``.destination-workbench-pane`` CSS rule that styled these panes keeps
+    matching (Textual type selectors match base classes too).
+    """
+
+    def __init__(self, builder: Callable[[], ComposeResult], **kwargs: Any) -> None:
+        """Store the screen-side builder for this region's children.
+
+        Args:
+            builder: Zero-argument callable yielding the region's children.
+            **kwargs: Forwarded to ``Vertical`` (id, classes, ...).
+        """
+        super().__init__(**kwargs)
+        self._builder = builder
+
+    def compose(self) -> ComposeResult:
+        """Yield this region's children from the screen's builder."""
+        yield from self._builder()
+
+
 class SettingsScreen(BaseAppScreen):
     """Global preferences, appearance, storage, and app behavior."""
 
@@ -1960,10 +1996,39 @@ class SettingsScreen(BaseAppScreen):
         }
     )
 
-    active_category = reactive(SettingsCategoryId.OVERVIEW.value, recompose=True)
+    # task-15475: none of these three is `recompose=True` any more. Each used
+    # to rebuild the WHOLE screen -- nav bar, footer, category rail, mode
+    # strip -- to repaint content that lives in one or two regions. They now
+    # drive region-scoped rebuilds through their watchers (see
+    # `watch_active_category` and `_sync_overview_sync_widgets`).
+    # `repaint=False`: the screen itself renders nothing from these values --
+    # its children do, and the watchers below repaint exactly those. It also
+    # keeps a pre-mount assignment (`restore_state`, and the bare-screen unit
+    # tests) from reaching `Widget._set_dirty`, which resolves `self.app` and
+    # raises `NoActiveAppError` off a running app. `recompose=True` used to
+    # mask that by short-circuiting before the repaint.
+    active_category = reactive(
+        SettingsCategoryId.OVERVIEW.value, repaint=False, layout=False
+    )
     category_search_query = reactive("")
-    server_sync_workspace_handoff_rows = reactive((), recompose=True)
-    manual_sync_rows = reactive((), recompose=True)
+    server_sync_workspace_handoff_rows = reactive((), repaint=False, layout=False)
+    manual_sync_rows = reactive((), repaint=False, layout=False)
+
+    #: task-15475: one-shot "the mount already queued this visit's sync-rows
+    #: refresh" token, set in `on_mount` and consumed by the mount's own
+    #: `on_screen_resume`. Class-level default so it is readable on a screen
+    #: built by `__new__` (several Settings tests construct one without
+    #: running `__init__`).
+    _settings_mount_visit_refreshed: bool = False
+
+    #: task-15475: True from the moment a category switch schedules its pane
+    #: swap until that swap finishes. `_after_category_panes` queues follow-up
+    #: work behind it (see that method for the ordering this preserves).
+    #: Class-level defaults for the same `__new__` fixtures. The queue starts
+    #: as None, never `[]`: a mutable class attribute would be SHARED by every
+    #: Settings screen ever built.
+    _category_pane_swap_pending: bool = False
+    _pending_pane_swap_callbacks: "list | None" = None
     # Deliberately NOT recompose=True (Qodo review of PR #1125): a recompose
     # here remounts the theme editor on the FIRST real user edit, discarding
     # the in-progress input and leaving the flag stale-True against a clean
@@ -2112,10 +2177,13 @@ class SettingsScreen(BaseAppScreen):
         # task-1369 (review): monotonic token so a cancelled/stale run
         # worker's finally cannot clear the flag of a newer confirmed run.
         self._manual_sync_run_token = 0
-        # task-1369 (review): the sync-rows reactives are recompose=True, so
-        # every row change rebuilds the Overview Collapsibles; persist their
-        # expanded/collapsed state across recomposes instead of snapping
-        # back to collapsed while the user is watching a run.
+        # task-1369 (review): a row change used to rebuild the Overview
+        # Collapsibles (the sync-rows reactives were recompose=True), so their
+        # expanded/collapsed state is persisted here rather than snapping back
+        # to collapsed while the user is watching a run. Since task-15475 the
+        # rows have their own region and the Collapsibles are not rebuilt at
+        # all -- but this still carries the state across a CATEGORY switch,
+        # which does rebuild the detail pane.
         self._overview_sync_details_collapsed = True
         self._overview_ownership_details_collapsed = True
         self._navigation_provider: str | None = None
@@ -2153,9 +2221,14 @@ class SettingsScreen(BaseAppScreen):
         #: navigation-away via _clear_navigation_provider_context.
         self._pending_navigation_focus_selector: str | None = None
         #: One-shot category focus intent (task-1338): set when a category
-        #: switch triggers a recompose; consumed by recompose() after the
-        #: fresh children mount so focus survives the rebuild.
+        #: switch tears the detail pane down; consumed by
+        #: `_swap_category_panes` once the fresh children are mounted, so
+        #: focus survives the rebuild. (`recompose()` still consumes it too,
+        #: for the rarer whole-screen rebuild.)
         self._pending_category_focus_value: str | None = None
+        #: task-15475: per-instance queue for `_after_category_panes` (the
+        #: class attribute is None precisely so this is never shared).
+        self._pending_pane_swap_callbacks: list[tuple[Callable[..., object], tuple]] = []
         self._diagnostics_validation_result = "Config validation: not run"
         self._diagnostics_reload_result = "Config reload: not run"
         self._storage_check_rows: tuple[str, ...] = (
@@ -2253,11 +2326,13 @@ class SettingsScreen(BaseAppScreen):
         # None = not yet synced; _sync_responsive_workbench() applies the
         # compact classes on first call (on_mount) and on every resize.
         self._workbench_compact: bool | None = None
-        # set_reactive, NOT plain assignment: assigning a recompose=True
-        # reactive here fires refresh(recompose=True) on the not-yet-mounted
-        # screen; the flag survives into mount and forces a full recompose of
-        # the JUST-composed screen -- a wasted startup recompose (task-290
-        # timeline: REFRESH pre-mount -> COMPOSE -> phantom re-COMPOSE).
+        # set_reactive, NOT plain assignment: a plain assignment fires the
+        # watcher on a not-yet-mounted screen. That used to schedule a full
+        # recompose that survived into mount and re-composed the JUST-composed
+        # screen (task-290 timeline: REFRESH pre-mount -> COMPOSE -> phantom
+        # re-COMPOSE); since task-15475 the watcher is region-scoped and
+        # self-guards on `is_mounted`, but seeding without firing it at all
+        # remains the correct, cheapest thing to do here.
         self.set_reactive(
             SettingsScreen.server_sync_workspace_handoff_rows,
             self._server_sync_workspace_handoff_loading_rows(),
@@ -2325,9 +2400,11 @@ class SettingsScreen(BaseAppScreen):
     def _register_footer_shortcuts(self) -> None:
         """Register Settings shortcuts via BaseAppScreen's persisting API.
 
-        Persistence matters here: this screen's `recompose=True` reactives
-        (`active_category`, the sync-row tuples) replace the footer widget on
-        every category switch; the registration must survive that.
+        Persistence matters here: a screen-level recompose replaces the footer
+        widget, so the registration must survive one. (Since task-15475 a
+        category switch no longer causes one -- the footer widget now simply
+        survives -- but the persisted registration is still what re-seeds it
+        after any whole-screen rebuild.)
 
         Task 6 (541 AC6): the rendered set is category-aware -- LIBRARY_RAG
         additionally advertises the a/c/b profile-workflow accelerators.
@@ -2392,14 +2469,158 @@ class SettingsScreen(BaseAppScreen):
         self._register_footer_shortcuts()
 
     def watch_active_category(self) -> None:
-        """Re-advertise the honest hint set on every category switch.
+        """Re-advertise the honest hint set, then repaint the two category panes.
 
         ADR-031 rule 4 (task-1340): the footer teaches only the keys that
         work in the ACTIVE category, so switching categories re-registers.
         Safe pre-mount: the persisting API stores the registration and the
         footer is seeded from it when compose() yields the widget.
+
+        task-15475: this reactive is no longer ``recompose=True``. The rail,
+        the mode line and the focus-help line are patched in place here (they
+        are three widgets, not a screen), and the detail and inspector panes
+        -- the only regions that render the category's content -- are rebuilt
+        by a worker. Pre-mount assignments (``restore_state`` sets this before
+        the screen mounts) are a no-op: ``compose_content`` reads
+        ``active_category`` fresh, so the first paint is already correct.
         """
         self._register_footer_shortcuts()
+        self._sync_category_chrome()
+        # `is_running`, not `is_mounted`: a bare `SettingsScreen(app)` built in
+        # a unit test reports mounted but has no active app, and `run_worker`
+        # goes through `self.app` (this is the same guard `BaseAppScreen.
+        # refresh` uses for its own recompose path).
+        if getattr(self, "is_running", False):
+            # Same protection the whole-screen recompose gave: a widget about
+            # to be torn down must not be left holding the mouse capture (an
+            # `Input` mid-click has no `_on_hide` to release it, and a stale
+            # capture silently swallows every click app-wide -- task-627).
+            self.release_mouse_capture_for_teardown()
+            self._category_pane_swap_pending = True
+            self.run_worker(
+                self._swap_category_panes(),
+                group="settings-category-panes",
+                exclusive=True,
+                exit_on_error=False,
+            )
+
+    def _sync_category_chrome(self) -> None:
+        """Patch the three category-dependent widgets outside the two panes.
+
+        The category rail is not rebuilt any more, so the active marker and
+        the per-button label (which carries the active glyph and the unsaved-
+        changes marker) are written onto the surviving buttons, using the same
+        rules ``_render_category_buttons`` applies at compose time.
+        """
+        if not getattr(self, "is_mounted", False):
+            return
+        self._set_static_text(
+            "#settings-category-label", self._mode_line_text(self._active_summary())
+        )
+        for summary in self._category_summaries():
+            try:
+                button = self.query_one(
+                    f"#settings-category-{summary.category.value}", Button
+                )
+            except QueryError:
+                continue
+            is_active = summary.category.value == self.active_category
+            button.set_class(is_active, "settings-active-section")
+            button.label = self._category_button_label(summary, is_active=is_active)
+        # The focus-help line described a control in the category being left;
+        # the whole-screen recompose used to clear it by construction.
+        self._set_static_text("#settings-focus-help", "")
+
+    async def _swap_category_panes(self) -> None:
+        """Rebuild the detail and inspector panes for the active category.
+
+        Batched (the same lock-plus-``batch_update`` ``Widget.recompose``
+        uses) so the two rebuilds drive one layout pass rather than two.
+
+        This is also where the category-switch follow-ups run. They cannot use
+        ``screen.call_after_refresh``: a REGION's recompose is serviced by that
+        region's own message pump, while the screen's callback list is
+        serviced by the screen's, and nothing orders the two -- a follow-up
+        queued on the screen fires against the OLD children or after they are
+        gone. Hanging them off the end of this coroutine, which awaits the
+        rebuilds, restores the ordering the whole-screen recompose gave for
+        free.
+        """
+        try:
+            self.release_mouse_capture_for_teardown()
+            async with self.batch():
+                for pane_id in ("#settings-detail-pane", "#settings-impact-pane"):
+                    try:
+                        pane = self.query_one(pane_id, SettingsRegion)
+                    except QueryError:
+                        # Screen torn down (navigated away) mid-swap.
+                        continue
+                    await pane.recompose()
+            # A MouseDown already queued on a child's pump can capture that
+            # child DURING the removal drain, after the release above.
+            self.sweep_stale_mouse_capture()
+            if not getattr(self, "is_mounted", False):
+                return
+            category_value = self._pending_category_focus_value
+            if category_value is not None:
+                self._pending_category_focus_value = None
+                self._focus_category(category_value)
+            self._drain_pane_swap_callbacks()
+            # After a REFRESH, not inline: the hint compares the inspector
+            # body's virtual and container heights, and the pane it belongs to
+            # was remounted a moment ago -- read synchronously here, the
+            # geometry is still the pre-layout zero and the hint stays hidden
+            # over an overflowing body (task-1623's exact defect).
+            self.call_after_refresh(self._update_inspector_overflow_hint)
+        finally:
+            # Also on cancellation: this worker group is exclusive, so a
+            # second category switch kills the first mid-swap and owns the
+            # flag from then on. A stranded True would send every later
+            # follow-up into a queue nothing drains.
+            self._category_pane_swap_pending = False
+
+    def _after_category_panes(self, callback: Callable[..., object], *args) -> None:
+        """Run ``callback`` once the new category's panes are on screen.
+
+        The replacement for ``call_after_refresh`` at the handful of call
+        sites that fire immediately after ``_select_category`` and then touch
+        the new category's widgets (deep links, field-targeted search).
+
+        Textual ran a screen's recompose BEFORE its ``call_after_refresh``
+        callbacks, so those callers were guaranteed the new pane. A
+        pane-scoped rebuild runs in a worker on a different pump and finishes
+        AFTER them: the deep-link callback found no panel and silently
+        dropped its focus, leaving the user on ``nav-home`` (caught by
+        ``test_bounded_speech_settings_deep_link_restores_provider_without_
+        action``). Queuing here restores both the guarantee and the order --
+        the category-focus restore runs first, then these, so a deep link's
+        field focus still wins over the rail button exactly as before.
+
+        Args:
+            callback: Zero-or-more-argument callable to run.
+            *args: Positional arguments for ``callback``.
+
+        Returns:
+            None.
+        """
+        if not self._category_pane_swap_pending:
+            self.call_after_refresh(callback, *args)
+            return
+        if self._pending_pane_swap_callbacks is None:
+            self._pending_pane_swap_callbacks = []
+        self._pending_pane_swap_callbacks.append((callback, args))
+
+    def _drain_pane_swap_callbacks(self) -> None:
+        """Run (and clear) everything queued behind the pane swap."""
+        callbacks = self._pending_pane_swap_callbacks or []
+        self._pending_pane_swap_callbacks = []
+        for callback, args in callbacks:
+            try:
+                callback(*args)
+            except Exception:
+                logger.debug(
+                    "Settings post-pane-swap callback failed.", exc_info=True
+                )
 
     def action_show_workbench_help(self) -> None:
         """F1 help: list the ACTIVE category's working shortcuts (task-1340).
@@ -2432,7 +2653,12 @@ class SettingsScreen(BaseAppScreen):
         # BaseAppScreen.on_mount separately for this Mount event.
         self._register_footer_shortcuts()
         self._sync_responsive_workbench()
-        self._queue_sync_rows_refresh()
+        # task-15475: claim this visit's sync-rows refresh -- but only if one
+        # actually started. Textual posts ScreenResume when a screen is
+        # PUSHED, so the mount's OWN resume follows immediately and used to
+        # run a second full manual-sync preview (a real DB/service round trip)
+        # for the same visit.
+        self._settings_mount_visit_refreshed = self._queue_sync_rows_refresh()
         # Task 4 (SP3): covers restored state (`restore_state` can set
         # `active_category` to LIBRARY_RAG before this screen is even
         # mounted) -- `_select_category` alone only covers a later in-session
@@ -2473,12 +2699,20 @@ class SettingsScreen(BaseAppScreen):
                 continue
 
     def on_screen_resume(self) -> None:
+        # task-15475: consume the mount's one-shot token. On the first visit
+        # this resume IS the mount's own and on_mount already queued the
+        # refresh. Consumed, not latched: every later resume refreshes again,
+        # which is the whole point of refreshing on resume (the sync state may
+        # have moved while Settings was suspended).
+        mount_already_refreshed = self._settings_mount_visit_refreshed
+        self._settings_mount_visit_refreshed = False
         if self._manual_sync_run_in_flight:
             # task-1369: a manual sync run is in flight; the resume refresh
             # would overwrite the "running" rows the confirm callback just
             # set. The run worker applies the result rows itself.
             return
-        self._queue_sync_rows_refresh()
+        if not mount_already_refreshed:
+            self._queue_sync_rows_refresh()
         self._maybe_refresh_rag_index_status_on_show()
         self._maybe_refresh_workspaces_pane_on_show()
 
@@ -2496,10 +2730,20 @@ class SettingsScreen(BaseAppScreen):
         if self._active_category_id() is SettingsCategoryId.WORKSPACES:
             self._refresh_settings_workspaces_pane()
 
-    def _queue_sync_rows_refresh(self) -> None:
+    def _queue_sync_rows_refresh(self) -> bool:
+        """Start the combined sync-rows refresh, if the screen can run one.
+
+        Returns:
+            bool: Whether a refresh was actually dispatched. ``on_mount``
+            records this as its visit token (task-15475): a mount that was too
+            early to dispatch (``is_mounted`` still ``False`` -- which happens,
+            depending on how the screen was pushed) must NOT suppress the
+            resume that follows it, or the rows never load at all.
+        """
         if not getattr(self, "is_mounted", False):
-            return
+            return False
         self._refresh_sync_rows()
+        return True
 
     @staticmethod
     def _server_sync_workspace_handoff_loading_rows() -> tuple[tuple[str, str], ...]:
@@ -5181,7 +5425,7 @@ class SettingsScreen(BaseAppScreen):
                     self._stage_speech_tts_navigation_target(speech_target)
             self._select_category(category_values[0], restore_focus=True)
             if speech_target is not None:
-                self.call_after_refresh(self._apply_speech_tts_navigation_context)
+                self._after_category_panes(self._apply_speech_tts_navigation_context)
             # task-1715: if the query named a field, land ON the field --
             # focusing it also fires its inspector guidance.
             opened = SettingsCategoryId(category_values[0])
@@ -5195,7 +5439,7 @@ class SettingsScreen(BaseAppScreen):
                     except QueryError:
                         pass
 
-                self.call_after_refresh(_focus_matched_field)
+                self._after_category_panes(_focus_matched_field)
             # task-1712: the filter has done its job -- clear it so the
             # rail returns to the full category map. Residue used to prune
             # the rail to the last search's matches for the rest of the
@@ -6674,12 +6918,16 @@ class SettingsScreen(BaseAppScreen):
         handoff_rows: tuple[tuple[str, str], ...],
         manual_rows: tuple[tuple[str, str], ...],
     ) -> None:
-        """Apply both row sets in one hop, preserving focus across the
-        recompose they trigger.
+        """Apply both row sets in one hop.
 
-        The recompose replaces every child, dropping whatever the user (or a
-        route-targeted navigation like ``_apply_navigation_provider_context``)
-        had focused -- restore it by id once the fresh children mount.
+        Historically these were ``recompose=True`` reactives and this method
+        existed to carry focus across the whole-screen rebuild they caused --
+        it dropped whatever the user (or a route-targeted navigation like
+        ``_apply_navigation_provider_context``) had focused. task-15475 scoped
+        the update to the rows' own region, and every widget in it is a
+        non-focusable ``Static``, so there is nothing left to drop. The
+        follow-up call is kept: it also re-evaluates the inspector's fold
+        indicator, and its focus half is a self-guarding no-op now.
         """
         changed = (
             handoff_rows != self.server_sync_workspace_handoff_rows
@@ -6700,10 +6948,10 @@ class SettingsScreen(BaseAppScreen):
             self.call_after_refresh(self._restore_focus_after_sync_rows, focused_id)
 
     def _restore_focus_after_sync_rows(self, widget_id: str | None) -> None:
-        # task-1716 (critique r4): the sync-rows recompose mints a fresh,
-        # hidden fold indicator AFTER on_mount's evaluation ran -- Overview
-        # (the only category whose pane recomposes on these rows) showed a
-        # mid-sentence inspector cut with no indicator.
+        # task-1716 (critique r4): a sync-rows change re-flows the Overview
+        # detail pane, so the inspector's fold indicator has to be re-judged
+        # against the new content height -- Overview showed a mid-sentence
+        # inspector cut with no indicator.
         self.call_after_refresh(self._update_inspector_overflow_hint)
         pending = self._pending_navigation_focus_selector
         self._pending_navigation_focus_selector = None
@@ -10432,6 +10680,53 @@ class SettingsScreen(BaseAppScreen):
         pending = rows.get("Pending outgoing", "unknown")
         return f"{status}; pending outgoing: {pending}"
 
+    def _compose_manual_sync_rows(self) -> ComposeResult:
+        """Yield the manual-sync detail rows (task-15475's own region)."""
+        for label, value in self.manual_sync_rows:
+            yield self._detail_row(label, value)
+
+    def _compose_server_sync_handoff_rows(self) -> ComposeResult:
+        """Yield the server/sync/workspace/handoff detail rows."""
+        for label, value in self.server_sync_workspace_handoff_rows:
+            yield self._detail_row(label, value)
+
+    def watch_manual_sync_rows(self) -> None:
+        """Repaint the sync rows in place (task-15475)."""
+        self._sync_overview_sync_widgets()
+
+    def watch_server_sync_workspace_handoff_rows(self) -> None:
+        """Repaint the handoff rows in place (task-15475)."""
+        self._sync_overview_sync_widgets()
+
+    def _sync_overview_sync_widgets(self) -> None:
+        """Push the current sync rows into the mounted Overview widgets.
+
+        Replaces a screen-level ``recompose=True`` on both row reactives. The
+        Overview front door's one-line summary is a ``Static.update``; the two
+        row lists rebuild their own containers. Every one of those widgets is
+        a non-focusable ``Static``, so unlike the recompose this cannot drop
+        the user's focus or scroll position -- including on the "Sync preview"
+        and "Run manual sync" buttons that sit right beside them and used to
+        be destroyed twice per press.
+
+        A no-op on every category but Overview: nothing else renders them.
+        """
+        if not getattr(self, "is_mounted", False):
+            return
+        self._set_static_text(
+            "#settings-overview-sync-summary",
+            f"Sync: {_fold_long_tokens(self._overview_sync_summary())}",
+        )
+        for region_id in (
+            "#settings-overview-manual-sync-rows",
+            "#settings-overview-handoff-rows",
+        ):
+            try:
+                region = self.query_one(region_id, SettingsRegion)
+            except QueryError:
+                continue
+            region.refresh(recompose=True)
+
     def _render_overview_detail(self) -> ComposeResult:
         # task-1369: the landing card leads with four primary status rows,
         # each with an Open-category affordance (the sync row carries the
@@ -10503,10 +10798,19 @@ class SettingsScreen(BaseAppScreen):
                     "Preview pending Notes/Chat changes before anything is sent to a server.",
                     classes="settings-help-copy",
                 )
-                for label, value in self.manual_sync_rows:
-                    yield self._detail_row(label, value)
-                for label, value in self.server_sync_workspace_handoff_rows:
-                    yield self._detail_row(label, value)
+                # task-15475: own containers so a sync-rows refresh rebuilds
+                # ELEVEN Statics instead of the whole screen. Containers, not
+                # per-row `Static.update` patches, because the row sets are not
+                # fixed: a run result renames "Manual sync preview" to "Manual
+                # sync result" and can append conflict/recovery rows.
+                yield SettingsRegion(
+                    self._compose_manual_sync_rows,
+                    id="settings-overview-manual-sync-rows",
+                )
+                yield SettingsRegion(
+                    self._compose_server_sync_handoff_rows,
+                    id="settings-overview-handoff-rows",
+                )
                 with Horizontal(classes="settings-action-row"):
                     yield Button(
                         "Switch Source / Server",
@@ -13141,13 +13445,14 @@ class SettingsScreen(BaseAppScreen):
         """Re-render the Workspaces category via the screen's existing
         category-recompose path (task 9).
 
-        `active_category` is a `recompose=True` reactive that already
-        drives every category switch (`_select_category`); forcing it here
-        with `mutate_reactive` reuses that same, already-proven path
-        instead of recomposing a bespoke nested container (Textual only
-        regenerates a widget's children from ITS OWN `compose()` -- a
-        generic `Vertical` yielded inline here has none, so recomposing it
-        directly would just wipe it). `_render_workspaces_detail` reads
+        `active_category`'s watcher already drives every category switch
+        (`_select_category`); forcing it here with `mutate_reactive` reuses
+        that same, already-proven path. Since task-15475 that path rebuilds
+        the two category panes rather than the whole screen -- the panes are
+        `SettingsRegion`s precisely so they CAN be rebuilt on their own
+        (Textual only regenerates a widget's children from ITS OWN
+        `compose()`, which a generic inline `Vertical` does not have).
+        `_render_workspaces_detail` reads
         the registry plus the plain `_settings_selected_workspace_id` /
         `_settings_show_archived_workspaces` attributes fresh on every
         call, so there is no separate watcher-populated cache that could
@@ -14262,32 +14567,23 @@ class SettingsScreen(BaseAppScreen):
                     ):
                         yield from self._render_category_buttons()
                 yield self._column_divider("settings-category-detail-divider")
-                detail_pane_container = (
-                    Vertical
-                    if active_summary.category is SettingsCategoryId.ADVANCED_CONFIG
-                    else VerticalScroll
-                )
-                detail_pane = Vertical(
+                # task-15475: the two category-dependent panes are
+                # `SettingsRegion`s so a category switch can rebuild THEM
+                # rather than the whole screen (which also rebuilt the nav
+                # bar, the footer, the rail and the mode strip -- none of
+                # which read the category's content).
+                detail_pane = SettingsRegion(
+                    self._compose_detail_pane_region,
                     id="settings-detail-pane",
                     classes="destination-workbench-pane" + pane_class_suffix,
                 )
                 # Inline height: same bundle-collapse guard as the impact
                 # pane below.
                 detail_pane.styles.height = "100%"
-                with detail_pane:
-                    # task-1716 (critique r4): ONE pinned State banner --
-                    # previously each category composed its own inside the
-                    # scrollable content, so the persistence badge (the
-                    # save-contract carrier) scrolled away mid-task (RAG
-                    # showed no State line at all in evidence).
-                    yield self._render_category_state_banner(active_summary.category)
-                    detail_body = detail_pane_container(id="settings-detail-pane-body")
-                    detail_body.styles.height = "1fr"
-                    detail_body.styles.scrollbar_size_vertical = 1
-                    with detail_body:
-                        yield from self._render_detail_pane()
+                yield detail_pane
                 yield self._column_divider("settings-detail-impact-divider")
-                impact_pane = Vertical(
+                impact_pane = SettingsRegion(
+                    self._compose_impact_pane_region,
                     id="settings-impact-pane",
                     classes="destination-workbench-pane ds-inspector"
                     + pane_class_suffix,
@@ -14297,28 +14593,7 @@ class SettingsScreen(BaseAppScreen):
                 # this the 1fr body below collapses to zero (StyledSettings
                 # harness caught it; the plain harness cannot).
                 impact_pane.styles.height = "100%"
-                with impact_pane:
-                    yield from self._render_impact_pane_header()
-                    impact_body = VerticalScroll(id="settings-impact-pane-body")
-                    # Inline styles, not CSS: the app-tier bundle outranks
-                    # screen CSS and a 100%-height default would collapse
-                    # inside the auto-flow wrapper (same guard as the image
-                    # viewer modal).
-                    impact_body.styles.height = "1fr"
-                    impact_body.styles.scrollbar_size_vertical = 1
-                    with impact_body:
-                        yield from self._render_impact_pane_body()
-                    # task-1623: reserved fold-indicator row -- 8 of 26
-                    # critique captures ended the inspector mid-sentence
-                    # with nothing saying more content exists.
-                    overflow_hint = Static(
-                        "▼ more — scroll the inspector",
-                        id="settings-impact-overflow-hint",
-                    )
-                    overflow_hint.styles.height = 1
-                    overflow_hint.styles.color = "gray"
-                    overflow_hint.display = False
-                    yield overflow_hint
+                yield impact_pane
             # task-2835: keyboard-reachable mirror of the focused control's
             # hover-only tooltip; updated by handle_descendant_focus.
             yield Static(
@@ -14327,6 +14602,53 @@ class SettingsScreen(BaseAppScreen):
                 classes="settings-focus-help",
                 markup=False,
             )
+
+    def _compose_detail_pane_region(self) -> ComposeResult:
+        """Yield the detail pane's children for the ACTIVE category.
+
+        Read fresh from ``self.active_category`` on every call (including the
+        region-scoped rebuilds a category switch now drives), so the pane can
+        never render a stale category.
+        """
+        active_summary = self._active_summary()
+        detail_pane_container = (
+            Vertical
+            if active_summary.category is SettingsCategoryId.ADVANCED_CONFIG
+            else VerticalScroll
+        )
+        # task-1716 (critique r4): ONE pinned State banner -- previously each
+        # category composed its own inside the scrollable content, so the
+        # persistence badge (the save-contract carrier) scrolled away mid-task
+        # (RAG showed no State line at all in evidence).
+        yield self._render_category_state_banner(active_summary.category)
+        detail_body = detail_pane_container(id="settings-detail-pane-body")
+        detail_body.styles.height = "1fr"
+        detail_body.styles.scrollbar_size_vertical = 1
+        with detail_body:
+            yield from self._render_detail_pane()
+
+    def _compose_impact_pane_region(self) -> ComposeResult:
+        """Yield the inspector pane's children for the ACTIVE category."""
+        yield from self._render_impact_pane_header()
+        impact_body = VerticalScroll(id="settings-impact-pane-body")
+        # Inline styles, not CSS: the app-tier bundle outranks screen CSS and
+        # a 100%-height default would collapse inside the auto-flow wrapper
+        # (same guard as the image viewer modal).
+        impact_body.styles.height = "1fr"
+        impact_body.styles.scrollbar_size_vertical = 1
+        with impact_body:
+            yield from self._render_impact_pane_body()
+        # task-1623: reserved fold-indicator row -- 8 of 26 critique captures
+        # ended the inspector mid-sentence with nothing saying more content
+        # exists.
+        overflow_hint = Static(
+            "▼ more — scroll the inspector",
+            id="settings-impact-overflow-hint",
+        )
+        overflow_hint.styles.height = 1
+        overflow_hint.styles.color = "gray"
+        overflow_hint.display = False
+        yield overflow_hint
 
     def _category_value_from_button(self, button: Button) -> str | None:
         if not button.id or not button.has_class("settings-category-button"):
@@ -14452,7 +14774,7 @@ class SettingsScreen(BaseAppScreen):
                 self._speech_tts_navigation_target = None
             self._clear_navigation_provider_context()
             self._select_category(category_value, restore_focus=True)
-            self.call_after_refresh(self._apply_speech_tts_navigation_context)
+            self._after_category_panes(self._apply_speech_tts_navigation_context)
             return
         if category_value != SettingsCategoryId.PROVIDERS_MODELS.value:
             self._clear_navigation_provider_context()
@@ -14478,7 +14800,7 @@ class SettingsScreen(BaseAppScreen):
         self._navigation_model = model
         self._navigation_field = field
         self._select_category(category_value, restore_focus=True)
-        self.call_after_refresh(
+        self._after_category_panes(
             self._apply_navigation_provider_context, provider, model, field
         )
 
@@ -14781,6 +15103,13 @@ class SettingsScreen(BaseAppScreen):
         self.call_after_refresh(self._update_inspector_overflow_hint)
 
     async def recompose(self) -> None:
+        """Restore a pending category focus after a WHOLE-screen rebuild.
+
+        No longer the category-switch path (task-15475 made that a pane swap,
+        which consumes the same intent itself) -- kept because any remaining
+        screen-level `refresh(recompose=True)` still destroys the rail button
+        the intent names.
+        """
         await super().recompose()
         category_value = self._pending_category_focus_value
         if category_value is None:
@@ -15917,7 +16246,10 @@ class SettingsScreen(BaseAppScreen):
                     severity="warning",
                 )
 
-        self.call_after_refresh(_focus_summary_prompt)
+        # After the panes, not after the next refresh: the Internal Prompts
+        # panel this reaches for is built by the detail pane's own rebuild
+        # (task-15475), which finishes later than a screen callback would.
+        self._after_category_panes(_focus_summary_prompt)
 
     @on(Input.Changed, "#settings-console-default-user-display-name")
     def handle_console_default_user_display_name_changed(

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -2029,6 +2029,9 @@ class SettingsScreen(BaseAppScreen):
     #: Settings screen ever built.
     _category_pane_swap_pending: bool = False
     _pending_pane_swap_callbacks: "list | None" = None
+    #: Bumped per switch; a swap whose revision is stale no-ops instead of
+    #: being cancelled mid-teardown (see `_swap_category_panes`).
+    _category_swap_revision: int = 0
     # Deliberately NOT recompose=True (Qodo review of PR #1125): a recompose
     # here remounts the theme editor on the FIRST real user edit, discarding
     # the in-progress input and leaving the flag stale-True against a clean
@@ -2229,6 +2232,9 @@ class SettingsScreen(BaseAppScreen):
         #: task-15475: per-instance queue for `_after_category_panes` (the
         #: class attribute is None precisely so this is never shared).
         self._pending_pane_swap_callbacks: list[tuple[Callable[..., object], tuple]] = []
+        #: Serializes category-pane swaps so a superseded one never interrupts
+        #: a teardown -- it loses the revision check and returns untouched.
+        self._category_swap_lock = asyncio.Lock()
         self._diagnostics_validation_result = "Config validation: not run"
         self._diagnostics_reload_result = "Config reload: not run"
         self._storage_check_rows: tuple[str, ...] = (
@@ -2497,10 +2503,16 @@ class SettingsScreen(BaseAppScreen):
             # capture silently swallows every click app-wide -- task-627).
             self.release_mouse_capture_for_teardown()
             self._category_pane_swap_pending = True
+            self._category_swap_revision += 1
             self.run_worker(
-                self._swap_category_panes(),
+                self._swap_category_panes(revision=self._category_swap_revision),
                 group="settings-category-panes",
-                exclusive=True,
+                # NOT exclusive: cancelling an in-flight swap can land inside
+                # `recompose()`'s removal and strand a pane emptied but never
+                # refilled, and it skips the post-teardown mouse-capture
+                # sweep. A lock plus a revision check supersedes just as
+                # firmly without ever interrupting a teardown.
+                exclusive=False,
                 exit_on_error=False,
             )
 
@@ -2531,11 +2543,14 @@ class SettingsScreen(BaseAppScreen):
         # the whole-screen recompose used to clear it by construction.
         self._set_static_text("#settings-focus-help", "")
 
-    async def _swap_category_panes(self) -> None:
+    async def _swap_category_panes(self, *, revision: int) -> None:
         """Rebuild the detail and inspector panes for the active category.
 
         Batched (the same lock-plus-``batch_update`` ``Widget.recompose``
-        uses) so the two rebuilds drive one layout pass rather than two.
+        uses) so the two rebuilds drive one layout pass rather than two, and
+        serialized by ``_category_swap_lock`` with a revision check so a
+        superseded swap no-ops BEFORE touching a widget instead of being
+        cancelled mid-teardown.
 
         This is also where the category-switch follow-ups run. They cannot use
         ``screen.call_after_refresh``: a REGION's recompose is serviced by that
@@ -2545,39 +2560,94 @@ class SettingsScreen(BaseAppScreen):
         gone. Hanging them off the end of this coroutine, which awaits the
         rebuilds, restores the ordering the whole-screen recompose gave for
         free.
+
+        Focus: a SAME-category rebuild (Workspaces row click, show-archived
+        toggle, `_refresh_settings_workspaces_pane`) destroys the control the
+        user is standing on, and Textual's ``_reset_focus`` then lands them on
+        the rail's Domain Defaults GROUP TOGGLE -- where the next Space
+        collapses the group. Pane control ids are stable across a same-category
+        rebuild, so the identity is captured and restored, mirroring
+        ``SpeechTTSSettingsPanel._replace_card_bodies``. A genuine category
+        CHANGE keeps the old behaviour instead (``_pending_category_focus_
+        value`` -> the new rail button), since the old category's ids are
+        meaningless in the new one.
+
+        Args:
+            revision: The switch this swap belongs to; a stale one returns
+                without touching anything.
+
+        Returns:
+            None.
         """
-        try:
-            self.release_mouse_capture_for_teardown()
-            async with self.batch():
-                for pane_id in ("#settings-detail-pane", "#settings-impact-pane"):
-                    try:
-                        pane = self.query_one(pane_id, SettingsRegion)
-                    except QueryError:
-                        # Screen torn down (navigated away) mid-swap.
-                        continue
-                    await pane.recompose()
-            # A MouseDown already queued on a child's pump can capture that
-            # child DURING the removal drain, after the release above.
-            self.sweep_stale_mouse_capture()
-            if not getattr(self, "is_mounted", False):
+        async with self._category_swap_lock:
+            if revision != self._category_swap_revision:
+                # Superseded while queued -- the newest swap owns the work,
+                # the pending flag, and the queued follow-ups.
                 return
-            category_value = self._pending_category_focus_value
-            if category_value is not None:
-                self._pending_category_focus_value = None
-                self._focus_category(category_value)
-            self._drain_pane_swap_callbacks()
-            # After a REFRESH, not inline: the hint compares the inspector
-            # body's virtual and container heights, and the pane it belongs to
-            # was remounted a moment ago -- read synchronously here, the
-            # geometry is still the pre-layout zero and the hint stays hidden
-            # over an overflowing body (task-1623's exact defect).
-            self.call_after_refresh(self._update_inspector_overflow_hint)
-        finally:
-            # Also on cancellation: this worker group is exclusive, so a
-            # second category switch kills the first mid-swap and owns the
-            # flag from then on. A stranded True would send every later
-            # follow-up into a queue nothing drains.
-            self._category_pane_swap_pending = False
+            try:
+                if not getattr(self, "is_mounted", False):
+                    return
+                focus_id = self._focused_id_in_category_panes()
+                self.release_mouse_capture_for_teardown()
+                async with self.batch():
+                    for pane_id in ("#settings-detail-pane", "#settings-impact-pane"):
+                        try:
+                            pane = self.query_one(pane_id, SettingsRegion)
+                        except QueryError:
+                            # Screen torn down (navigated away) mid-swap.
+                            continue
+                        await pane.recompose()
+                # A MouseDown already queued on a child's pump can capture that
+                # child DURING the removal drain, after the release above.
+                self.sweep_stale_mouse_capture()
+                if not getattr(self, "is_mounted", False):
+                    return
+                category_value = self._pending_category_focus_value
+                if category_value is not None:
+                    self._pending_category_focus_value = None
+                    self._focus_category(category_value)
+                elif focus_id:
+                    self._restore_category_pane_focus(focus_id)
+                self._drain_pane_swap_callbacks()
+                # After a REFRESH, not inline: the hint compares the inspector
+                # body's virtual and container heights, and the pane it belongs
+                # to was remounted a moment ago -- read synchronously here the
+                # geometry is still the pre-layout zero and the hint stays
+                # hidden over an overflowing body (task-1623's exact defect).
+                self.call_after_refresh(self._update_inspector_overflow_hint)
+            finally:
+                # Token-compared: only the swap that still owns the revision
+                # may clear the flag. A superseded one clearing it would send
+                # the winner's own follow-ups into a queue nothing drains.
+                if revision == self._category_swap_revision:
+                    self._category_pane_swap_pending = False
+
+    def _focused_id_in_category_panes(self) -> str | None:
+        """The focused widget's id, if this swap is about to destroy it.
+
+        Returns:
+            The id to restore afterwards, or None when focus is outside the
+            two rebuilt panes or on a widget with no id to find it by.
+        """
+        focused = self.app.focused if getattr(self, "is_running", False) else None
+        if focused is None or focused.screen is not self or not focused.id:
+            return None
+        for ancestor in focused.ancestors_with_self:
+            if getattr(ancestor, "id", None) in (
+                "settings-detail-pane",
+                "settings-impact-pane",
+            ):
+                return focused.id
+        return None
+
+    def _restore_category_pane_focus(self, focus_id: str) -> None:
+        """Re-focus ``focus_id`` if the rebuilt panes still contain it."""
+        try:
+            self.query_one(f"#{focus_id}").focus()
+        except QueryError:
+            # No counterpart in the rebuilt pane (a different category, or a
+            # control this state does not render) -- leave focus alone.
+            pass
 
     def _after_category_panes(self, callback: Callable[..., object], *args) -> None:
         """Run ``callback`` once the new category's panes are on screen.
@@ -15090,17 +15160,20 @@ class SettingsScreen(BaseAppScreen):
             self._image_gen_raw_section_cache = None
         if restore_focus:
             if category_changed:
-                # The recompose from assigning active_category destroys the
-                # focused widget; _select_category's call_after_refresh restore
-                # races that recompose (task-1338: focus ended up <none>), so
-                # record an intent consumed by recompose() after the fresh
-                # children mount.
+                # The pane swap from assigning active_category destroys the
+                # focused widget; a call_after_refresh restore races it
+                # (task-1338: focus ended up <none>), so record an intent the
+                # swap consumes after the fresh children mount.
                 self._pending_category_focus_value = category_value
             else:
                 self.call_after_refresh(self._focus_category, category_value)
-        # task-1623: the recompose minted a fresh (hidden) fold indicator;
-        # re-evaluate it against the new category's inspector content.
-        self.call_after_refresh(self._update_inspector_overflow_hint)
+        if not category_changed:
+            # task-1623: re-evaluate the fold indicator against the inspector's
+            # content. Only on the no-switch path: a real switch runs a pane
+            # swap, and that queues its own evaluation AFTERWARDS. Queuing one
+            # here too would fire first, against the pane the swap has not
+            # rebuilt yet -- pre-swap geometry, and a wasted pass.
+            self.call_after_refresh(self._update_inspector_overflow_hint)
 
     async def recompose(self) -> None:
         """Restore a pending category focus after a WHOLE-screen rebuild.

--- a/tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py
+++ b/tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 from loguru import logger
 from rich.text import Text
@@ -439,6 +439,39 @@ class _GlobalSpeechTTSLeaveModal(ModalScreen[LeaveChoice]):
     def handle_save(self, event: Button.Pressed) -> None:
         event.stop()
         self.dismiss("save")
+
+
+class _SpeechSettingsCard(Vertical):
+    """One Speech settings focus card, recomposable on its own (task-15475).
+
+    A plain ``Vertical`` whose children come from a builder the owning panel
+    supplies. The indirection buys exactly one thing: ``await card.recompose()``
+    rebuilds THIS card -- Textual only re-runs ``compose()`` on the widget that
+    owns it, so the card's contents have to be reachable from a ``compose()``
+    of its own rather than inline in the panel's.
+
+    Still a ``Vertical`` subclass, so every ``Vertical`` and
+    ``.settings-focus-card`` CSS rule that styled these cards before keeps
+    matching (Textual type selectors match base classes too).
+    """
+
+    def __init__(self, builder: Callable[[], ComposeResult], **kwargs: Any) -> None:
+        """Store the panel-side builder for this card's children.
+
+        Args:
+            builder: Zero-argument callable yielding the card's children. A
+                bound method of the owning panel: the panel outlives its
+                cards (a card recompose never replaces the panel), and a
+                panel recompose mints fresh cards bound to the fresh panel --
+                so the reference can never go stale.
+            **kwargs: Forwarded to ``Vertical`` (id, classes, ...).
+        """
+        super().__init__(**kwargs)
+        self._builder = builder
+
+    def compose(self) -> ComposeResult:
+        """Yield this card's children from the panel's builder."""
+        yield from self._builder()
 
 
 class SpeechTTSSettingsPanel(Vertical):
@@ -1460,6 +1493,110 @@ class SpeechTTSSettingsPanel(Vertical):
                 markup=False,
             )
 
+        yield _SpeechSettingsCard(
+            self._compose_global_defaults_body,
+            id=self._GLOBAL_DEFAULTS_CARD_ID,
+            classes="settings-focus-card",
+        )
+
+        yield _SpeechSettingsCard(
+            self._compose_provider_setup_body,
+            id=self._PROVIDER_SETUP_CARD_ID,
+            classes="settings-focus-card",
+        )
+
+        yield from self._compose_realtime_section()
+
+        yield _SpeechSettingsCard(
+            self._compose_inspector_body,
+            id=self._INSPECTOR_CARD_ID,
+            classes="settings-focus-card",
+        )
+
+        with Horizontal(id="settings-speech-actions", classes="settings-action-row"):
+            yield Button(
+                "Save",
+                id="settings-speech-save",
+                variant="primary",
+                disabled=self._latest_request_id is not None,
+            )
+            yield Button("Revert", id="settings-speech-revert")
+            yield Button(
+                "Restore Non-secret Defaults",
+                id="settings-speech-restore-defaults",
+            )
+            yield Button("Open Speech Lab", id="settings-speech-open-lab-bottom")
+        yield Static(
+            self.result_text,
+            id="settings-speech-save-result",
+            classes="settings-status-row",
+            markup=False,
+        )
+
+    #: task-15475: the three cards a dropdown change can invalidate, each
+    #: rebuildable on its own (see `_replace_card_bodies`). Composing their
+    #: contents from a method rather than inline in `compose()` is what makes
+    #: a card-scoped rebuild possible at all -- the whole-panel
+    #: `await self.recompose()` these handlers used to call destroyed ~200
+    #: widgets (and every one of them, per the audit) to repaint one card.
+    _GLOBAL_DEFAULTS_CARD_ID = "settings-speech-global-defaults"
+    _PROVIDER_SETUP_CARD_ID = "settings-speech-provider-setup"
+    _INSPECTOR_CARD_ID = "settings-speech-inspector"
+
+    async def _replace_card_bodies(self, *card_ids: str) -> None:
+        """Rebuild the named focus cards in place, keeping focus.
+
+        The card-scoped alternative to ``await self.recompose()``, which
+        destroyed and rebuilt every widget in the panel (~200 of them, per the
+        2026-08-11 input-latency audit) to repaint one card -- and dropped
+        focus entirely while doing it, so a keyboard user operating a Select
+        was left with ``app.focused is None`` after every change.
+
+        Delegates to each card's own ``recompose()`` rather than hand-rolling
+        ``remove_children()``/``mount_all()``: a body generator that opens a
+        container (``_compose_provider_setup_body`` does, via
+        ``_compose_provider_form``) can only be consumed inside a real compose
+        -- Textual's ``Widget.__enter__`` indexes ``app._compose_stacks[-1]``
+        and raises ``IndexError`` off one. ``recompose()`` sets that stack up,
+        awaits the removal before mounting (Textual's ``remove`` is deferred,
+        so mounting early raises ``DuplicateIds`` on every re-used id -- the
+        same trap ``speech_playground_pane._replace_provider_regions``
+        documents), and being awaited here it is ordered against the caller,
+        unlike a fire-and-forget ``refresh(recompose=True)``.
+
+        Focus is restored only when it was inside this panel to begin with:
+        restoring unconditionally would let a programmatic value change (a
+        test, a catalog load) STEAL focus from wherever the user actually is.
+
+        Args:
+            card_ids: Ids of the focus cards to rebuild, in mount order.
+
+        Returns:
+            None.
+        """
+        focused = self.app.focused if self.is_mounted else None
+        focus_token = (
+            self._focus_token(focused)
+            if focused is not None and self in focused.ancestors_with_self
+            else None
+        )
+        for card_id in card_ids:
+            try:
+                card = self.query_one(f"#{card_id}", _SpeechSettingsCard)
+            except QueryError:
+                # The panel was torn down (category switch, screen change)
+                # while this coroutine was suspended -- nothing to rebuild.
+                continue
+            await card.recompose()
+        self._restore_focus(focus_token)
+
+    def _compose_global_defaults_body(self) -> ComposeResult:
+        """Yield the Global defaults card's children.
+
+        Reads ``self.state.defaults`` only -- the Provider setup card is keyed
+        off ``self.configure_provider`` and the Realtime card off
+        ``self._realtime_draft``, so neither is affected by a change here.
+        """
         defaults = self.state.defaults
         audio_cpp_selected = defaults.provider_id == "audio_cpp"
         audio_cpp_choices = self._audio_cpp_choices() if audio_cpp_selected else None
@@ -1479,287 +1616,271 @@ class SpeechTTSSettingsPanel(Vertical):
                 ("Exact", "exact"),
                 ("Server default", "server_default"),
             ]
-        with Vertical(
-            id="settings-speech-global-defaults", classes="settings-focus-card"
-        ):
-            yield Static("Global defaults", classes="destination-section")
-            yield Static(
-                "Global default selection: "
-                f"{self._defaults_configuration_state().value} — effective source "
-                f"{self.state.defaults_source.value}.",
-                id="settings-speech-default-source",
-                classes="settings-status-row",
-                markup=False,
-            )
-            yield self._default_profile_row()
+        yield Static("Global defaults", classes="destination-section")
+        yield Static(
+            "Global default selection: "
+            f"{self._defaults_configuration_state().value} — effective source "
+            f"{self.state.defaults_source.value}.",
+            id="settings-speech-default-source",
+            classes="settings-status-row",
+            markup=False,
+        )
+        yield self._default_profile_row()
+        yield self._row(
+            "Default TTS Provider",
+            Select(
+                _PROVIDER_OPTIONS,
+                value=defaults.provider_id,
+                id="settings-speech-default-provider",
+                allow_blank=False,
+                compact=True,
+                classes="settings-compact-select settings-speech-draft-field",
+            ),
+            classes="settings-select-row",
+            error=self._default_error(
+                "provider_id",
+                "settings-speech-default-provider",
+            ),
+        )
+        yield self._row(
+            "Model policy",
+            Select(
+                model_policy_options,
+                value=defaults.model_mode,
+                id="settings-speech-model-policy",
+                allow_blank=False,
+                compact=True,
+                classes="settings-compact-select settings-speech-draft-field",
+            ),
+            classes="settings-select-row",
+            error=self._default_error(
+                "model_mode",
+                "settings-speech-model-policy",
+            ),
+        )
+        if audio_cpp_choices is not None:
             yield self._row(
-                "Default TTS Provider",
+                "Model value",
                 Select(
-                    _PROVIDER_OPTIONS,
-                    value=defaults.provider_id,
-                    id="settings-speech-default-provider",
-                    allow_blank=False,
+                    self._safe_exact_options(audio_cpp_choices.model.options),
+                    value=(
+                        defaults.model_id
+                        if defaults.model_mode == "exact" and defaults.model_id
+                        else Select.NULL
+                    ),
+                    id="settings-speech-model-value",
+                    allow_blank=defaults.model_mode != "exact",
                     compact=True,
-                    classes="settings-compact-select settings-speech-draft-field",
+                    disabled=defaults.model_mode != "exact",
+                    classes=("settings-compact-select settings-speech-draft-field"),
                 ),
                 classes="settings-select-row",
                 error=self._default_error(
-                    "provider_id",
-                    "settings-speech-default-provider",
+                    "default_model",
+                    "settings-speech-model-value",
                 ),
             )
+        else:
             yield self._row(
-                "Model policy",
-                Select(
-                    model_policy_options,
-                    value=defaults.model_mode,
-                    id="settings-speech-model-policy",
-                    allow_blank=False,
-                    compact=True,
-                    classes="settings-compact-select settings-speech-draft-field",
-                ),
-                classes="settings-select-row",
-                error=self._default_error(
-                    "model_mode",
-                    "settings-speech-model-policy",
-                ),
-            )
-            if audio_cpp_choices is not None:
-                yield self._row(
-                    "Model value",
-                    Select(
-                        self._safe_exact_options(audio_cpp_choices.model.options),
-                        value=(
-                            defaults.model_id
-                            if defaults.model_mode == "exact" and defaults.model_id
-                            else Select.NULL
-                        ),
-                        id="settings-speech-model-value",
-                        allow_blank=defaults.model_mode != "exact",
-                        compact=True,
-                        disabled=defaults.model_mode != "exact",
-                        classes=("settings-compact-select settings-speech-draft-field"),
-                    ),
-                    classes="settings-select-row",
-                    error=self._default_error(
-                        "default_model",
-                        "settings-speech-model-value",
-                    ),
-                )
-            else:
-                yield self._row(
-                    "Model value",
-                    Input(
-                        value=defaults.model_id or "",
-                        id="settings-speech-model-value",
-                        disabled=defaults.model_mode != "exact",
-                        placeholder="Exact model ID",
-                        classes="settings-compact-input settings-speech-draft-field",
-                    ),
-                    error=self._default_error(
-                        "default_model",
-                        "settings-speech-model-value",
-                    ),
-                )
-            yield self._row(
-                "Voice policy",
-                Select(
-                    voice_policy_options,
-                    value=defaults.voice_mode,
-                    id="settings-speech-voice-policy",
-                    allow_blank=False,
-                    compact=True,
-                    classes="settings-compact-select settings-speech-draft-field",
-                ),
-                classes="settings-select-row",
-                error=self._default_error(
-                    "voice_mode",
-                    "settings-speech-voice-policy",
-                ),
-            )
-            if audio_cpp_choices is not None:
-                yield self._row(
-                    "Voice value",
-                    Select(
-                        self._safe_exact_options(audio_cpp_choices.voice.options),
-                        value=(
-                            defaults.voice_id
-                            if defaults.voice_mode == "exact" and defaults.voice_id
-                            else Select.NULL
-                        ),
-                        id="settings-speech-voice-value",
-                        allow_blank=defaults.voice_mode != "exact",
-                        compact=True,
-                        disabled=defaults.voice_mode != "exact",
-                        classes=("settings-compact-select settings-speech-draft-field"),
-                    ),
-                    classes="settings-select-row",
-                    error=self._default_error(
-                        "default_voice",
-                        "settings-speech-voice-value",
-                    ),
-                )
-                yield Static(
-                    f"Model: {audio_cpp_choices.model.state.value} | "
-                    f"Voice: {audio_cpp_choices.voice.state.value}",
-                    id="settings-speech-audio-cpp-choice-status",
-                    classes="settings-status-row",
-                    markup=False,
-                )
-                yield Static(
-                    self._audio_cpp_observation_copy(audio_cpp_choices),
-                    id="settings-speech-audio-cpp-observation-provenance",
-                    classes="settings-detail-row",
-                    markup=False,
-                )
-                yield Static(
-                    "Settings reuses accepted in-memory observations only. Open "
-                    "Speech Lab to test the server or refresh models and voices.",
-                    classes="settings-detail-row",
-                    markup=False,
-                )
-            else:
-                yield self._row(
-                    "Voice value",
-                    Input(
-                        value=defaults.voice_id or "",
-                        id="settings-speech-voice-value",
-                        disabled=defaults.voice_mode != "exact",
-                        placeholder="Exact voice ID",
-                        classes="settings-compact-input settings-speech-draft-field",
-                    ),
-                    error=self._default_error(
-                        "default_voice",
-                        "settings-speech-voice-value",
-                    ),
-                )
-            yield self._row(
-                "Output format",
-                Select(
-                    [
-                        ("MP3", "mp3"),
-                        ("Opus", "opus"),
-                        ("AAC", "aac"),
-                        ("FLAC", "flac"),
-                        ("WAV", "wav"),
-                    ],
-                    value=defaults.response_format,
-                    id="settings-speech-output-format",
-                    allow_blank=False,
-                    compact=True,
-                    disabled=audio_cpp_selected,
-                    classes="settings-compact-select settings-speech-draft-field",
-                ),
-                classes="settings-select-row",
-                error=self._default_error(
-                    "response_format",
-                    "settings-speech-output-format",
-                ),
-            )
-            yield self._row(
-                "Speed",
+                "Model value",
                 Input(
-                    value=str(defaults.speed),
-                    id="settings-speech-speed",
-                    disabled=audio_cpp_selected,
-                    placeholder="0.25 - 4.0",
+                    value=defaults.model_id or "",
+                    id="settings-speech-model-value",
+                    disabled=defaults.model_mode != "exact",
+                    placeholder="Exact model ID",
                     classes="settings-compact-input settings-speech-draft-field",
                 ),
                 error=self._default_error(
-                    "default_speed",
-                    "settings-speech-speed",
+                    "default_model",
+                    "settings-speech-model-value",
                 ),
             )
-            yield Static(
-                "audio.cpp requires WAV output and speed 1.0."
-                if audio_cpp_selected
-                else "Provider capability constraints are validated before Save.",
-                id="settings-speech-default-constraints",
-                classes="settings-status-row",
-                markup=False,
-            )
-
-        with Vertical(
-            id="settings-speech-provider-setup", classes="settings-focus-card"
-        ):
-            yield Static("Provider setup", classes="destination-section")
-            yield Static(
-                "Configure Provider does not change the Default TTS Provider.",
-                classes="settings-detail-row",
-                markup=False,
-            )
+        yield self._row(
+            "Voice policy",
+            Select(
+                voice_policy_options,
+                value=defaults.voice_mode,
+                id="settings-speech-voice-policy",
+                allow_blank=False,
+                compact=True,
+                classes="settings-compact-select settings-speech-draft-field",
+            ),
+            classes="settings-select-row",
+            error=self._default_error(
+                "voice_mode",
+                "settings-speech-voice-policy",
+            ),
+        )
+        if audio_cpp_choices is not None:
             yield self._row(
-                "Configure Provider",
+                "Voice value",
                 Select(
-                    _PROVIDER_OPTIONS,
-                    value=self.configure_provider,
-                    id="settings-speech-configure-provider",
-                    allow_blank=False,
+                    self._safe_exact_options(audio_cpp_choices.voice.options),
+                    value=(
+                        defaults.voice_id
+                        if defaults.voice_mode == "exact" and defaults.voice_id
+                        else Select.NULL
+                    ),
+                    id="settings-speech-voice-value",
+                    allow_blank=defaults.voice_mode != "exact",
                     compact=True,
-                    classes="settings-compact-select",
+                    disabled=defaults.voice_mode != "exact",
+                    classes=("settings-compact-select settings-speech-draft-field"),
                 ),
                 classes="settings-select-row",
+                error=self._default_error(
+                    "default_voice",
+                    "settings-speech-voice-value",
+                ),
             )
-            yield from self._compose_provider_form(self.configure_provider)
-
-        yield from self._compose_realtime_section()
-
-        with Vertical(id="settings-speech-inspector", classes="settings-focus-card"):
-            yield Static("Configuration inspector", classes="destination-section")
             yield Static(
-                f"Selected setup: {TTS_PROVIDER_LABELS[self.configure_provider]}",
-                id="settings-speech-inspector-summary",
+                f"Model: {audio_cpp_choices.model.state.value} | "
+                f"Voice: {audio_cpp_choices.voice.state.value}",
+                id="settings-speech-audio-cpp-choice-status",
                 classes="settings-status-row",
                 markup=False,
             )
             yield Static(
-                "Selected provider setup source: "
-                f"{self.state.provider_sources[self.configure_provider].value}.",
-                id="settings-speech-provider-source",
-                classes="settings-status-row",
-                markup=False,
-            )
-            yield Static(
-                self._draft_impact_copy(),
-                id="settings-speech-draft-impact",
-                classes="settings-status-row",
-                markup=False,
-            )
-            projection = self._status_projection()
-            dirty_connection = self._provider_connection_draft_dirty(
-                self.configure_provider
-            )
-            for row in projection.rows(dirty_draft=dirty_connection):
-                yield Static(
-                    row.copy,
-                    id=f"settings-speech-status-{row.row_id}",
-                    classes="settings-status-row",
-                    markup=False,
-                )
-            yield Static(
-                "Ordinary Save validates and persists locally. Use Speech Lab for "
-                "connection tests, discovery, generation, and playback.",
+                self._audio_cpp_observation_copy(audio_cpp_choices),
+                id="settings-speech-audio-cpp-observation-provenance",
                 classes="settings-detail-row",
                 markup=False,
             )
-
-        with Horizontal(id="settings-speech-actions", classes="settings-action-row"):
-            yield Button(
-                "Save",
-                id="settings-speech-save",
-                variant="primary",
-                disabled=self._latest_request_id is not None,
+            yield Static(
+                "Settings reuses accepted in-memory observations only. Open "
+                "Speech Lab to test the server or refresh models and voices.",
+                classes="settings-detail-row",
+                markup=False,
             )
-            yield Button("Revert", id="settings-speech-revert")
-            yield Button(
-                "Restore Non-secret Defaults",
-                id="settings-speech-restore-defaults",
+        else:
+            yield self._row(
+                "Voice value",
+                Input(
+                    value=defaults.voice_id or "",
+                    id="settings-speech-voice-value",
+                    disabled=defaults.voice_mode != "exact",
+                    placeholder="Exact voice ID",
+                    classes="settings-compact-input settings-speech-draft-field",
+                ),
+                error=self._default_error(
+                    "default_voice",
+                    "settings-speech-voice-value",
+                ),
             )
-            yield Button("Open Speech Lab", id="settings-speech-open-lab-bottom")
+        yield self._row(
+            "Output format",
+            Select(
+                [
+                    ("MP3", "mp3"),
+                    ("Opus", "opus"),
+                    ("AAC", "aac"),
+                    ("FLAC", "flac"),
+                    ("WAV", "wav"),
+                ],
+                value=defaults.response_format,
+                id="settings-speech-output-format",
+                allow_blank=False,
+                compact=True,
+                disabled=audio_cpp_selected,
+                classes="settings-compact-select settings-speech-draft-field",
+            ),
+            classes="settings-select-row",
+            error=self._default_error(
+                "response_format",
+                "settings-speech-output-format",
+            ),
+        )
+        yield self._row(
+            "Speed",
+            Input(
+                value=str(defaults.speed),
+                id="settings-speech-speed",
+                disabled=audio_cpp_selected,
+                placeholder="0.25 - 4.0",
+                classes="settings-compact-input settings-speech-draft-field",
+            ),
+            error=self._default_error(
+                "default_speed",
+                "settings-speech-speed",
+            ),
+        )
         yield Static(
-            self.result_text,
-            id="settings-speech-save-result",
+            "audio.cpp requires WAV output and speed 1.0."
+            if audio_cpp_selected
+            else "Provider capability constraints are validated before Save.",
+            id="settings-speech-default-constraints",
             classes="settings-status-row",
+            markup=False,
+        )
+
+    def _compose_provider_setup_body(self) -> ComposeResult:
+        """Yield the Provider setup card's children.
+
+        Keyed off ``self.configure_provider`` and
+        ``self.state.providers`` -- independent of the Global defaults
+        card above (Configure Provider does not change the default).
+        """
+        yield Static("Provider setup", classes="destination-section")
+        yield Static(
+            "Configure Provider does not change the Default TTS Provider.",
+            classes="settings-detail-row",
+            markup=False,
+        )
+        yield self._row(
+            "Configure Provider",
+            Select(
+                _PROVIDER_OPTIONS,
+                value=self.configure_provider,
+                id="settings-speech-configure-provider",
+                allow_blank=False,
+                compact=True,
+                classes="settings-compact-select",
+            ),
+            classes="settings-select-row",
+        )
+        yield from self._compose_provider_form(self.configure_provider)
+
+    def _compose_inspector_body(self) -> ComposeResult:
+        """Yield the Configuration inspector card's children.
+
+        Reads BOTH the defaults and the configured provider, so it is
+        rebuilt alongside whichever of the two cards above changed.
+        """
+        yield Static("Configuration inspector", classes="destination-section")
+        yield Static(
+            f"Selected setup: {TTS_PROVIDER_LABELS[self.configure_provider]}",
+            id="settings-speech-inspector-summary",
+            classes="settings-status-row",
+            markup=False,
+        )
+        yield Static(
+            "Selected provider setup source: "
+            f"{self.state.provider_sources[self.configure_provider].value}.",
+            id="settings-speech-provider-source",
+            classes="settings-status-row",
+            markup=False,
+        )
+        yield Static(
+            self._draft_impact_copy(),
+            id="settings-speech-draft-impact",
+            classes="settings-status-row",
+            markup=False,
+        )
+        projection = self._status_projection()
+        dirty_connection = self._provider_connection_draft_dirty(
+            self.configure_provider
+        )
+        for row in projection.rows(dirty_draft=dirty_connection):
+            yield Static(
+                row.copy,
+                id=f"settings-speech-status-{row.row_id}",
+                classes="settings-status-row",
+                markup=False,
+            )
+        yield Static(
+            "Ordinary Save validates and persists locally. Use Speech Lab for "
+            "connection tests, discovery, generation, and playback.",
+            classes="settings-detail-row",
             markup=False,
         )
 
@@ -3704,7 +3825,9 @@ class SpeechTTSSettingsPanel(Vertical):
 
     async def _apply_configure_provider(self, requested_provider: str) -> None:
         self.configure_provider = requested_provider
-        await self.recompose()
+        await self._replace_card_bodies(
+            self._PROVIDER_SETUP_CARD_ID, self._INSPECTOR_CARD_ID
+        )
         self._announce_draft_state()
 
     async def _change_configure_provider(
@@ -3738,7 +3861,9 @@ class SpeechTTSSettingsPanel(Vertical):
                 self.state.defaults.voice_id = None
             self.state.defaults.response_format = "wav"
             self.state.defaults.speed = 1.0
-        await self.recompose()
+        await self._replace_card_bodies(
+            self._GLOBAL_DEFAULTS_CARD_ID, self._INSPECTOR_CARD_ID
+        )
         self._announce_draft_state()
 
     @on(Select.Changed, "#settings-speech-model-policy")
@@ -3754,7 +3879,9 @@ class SpeechTTSSettingsPanel(Vertical):
             choices = self._audio_cpp_choices().model.options
             if choices and not self.state.defaults.model_id:
                 self.state.defaults.model_id = choices[0][1]
-        await self.recompose()
+        await self._replace_card_bodies(
+            self._GLOBAL_DEFAULTS_CARD_ID, self._INSPECTOR_CARD_ID
+        )
         self._announce_draft_state()
 
     @on(Select.Changed, "#settings-speech-voice-policy")
@@ -3770,7 +3897,9 @@ class SpeechTTSSettingsPanel(Vertical):
             choices = self._audio_cpp_choices().voice.options
             if choices and not self.state.defaults.voice_id:
                 self.state.defaults.voice_id = choices[0][1]
-        await self.recompose()
+        await self._replace_card_bodies(
+            self._GLOBAL_DEFAULTS_CARD_ID, self._INSPECTOR_CARD_ID
+        )
         self._announce_draft_state()
 
     @on(Select.Changed, "#settings-speech-model-value")
@@ -3784,7 +3913,9 @@ class SpeechTTSSettingsPanel(Vertical):
         ):
             return
         self._collect_visible_state()
-        await self.recompose()
+        await self._replace_card_bodies(
+            self._GLOBAL_DEFAULTS_CARD_ID, self._INSPECTOR_CARD_ID
+        )
         self._announce_draft_state()
 
     @on(Input.Changed, "#settings-speech-audio_cpp-base-url")


### PR DESCRIPTION
## Summary

Task 15475 from the input-latency audit. Settings rebuilt the whole screen per rail click (twice on Overview; 'Sync preview' recomposed everything to change three Statics); Evals rail selection rebuilt 150-300 widgets; the speech panel rebuilt ~200 widgets per dropdown; Console dispatched its skill-candidates worker twice per visit.

- Detail-region swaps: Settings 270→98 ms per category click (69/138 widgets), sync-rows 13/138; Evals 325→146 ms; speech dropdowns rebuild only the provider card (83/188) with focus retained; Console visit dispatches 2→1
- Review round closed a measured Critical — the Evals region swap was destroying the Lab frame's collapse headers/titles permanently (invisible to ~1,080 headless tests) — plus focus-token restores on both swaps (born-red at the exact pre-fix escape targets), an honest rewrite of a disproved xfail-removal rationale, row-static evidence that actually discriminates, and lock+revision swap serialization replacing racy exclusive workers
- **Live-terminal pass performed before merge** (the defect classes here are headless-invisible): Settings category swaps verified live; Evals chrome survives rail clicks + a modal round-trip, and the rail collapse/re-expand cycle works

## Verification
Independent opus review (Not-approved round: 1 Critical + 3 Important, all measured) + scoped re-review (ALL 8 ADDRESSED — every mutation reproduced the documented failure verbatim; 22 evidence + 491 Evals + 318 hub tests reproduced) + live tmux verification. Found-in-passing for filing: stdlib-logger loguru-format TypeError in the settings save worker's error path (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes UI updates to affected regions in Settings, Evals, and Speech/TTS, and dedupes Console’s first-visit refreshes to reduce recomposition and preserve focus/UI chrome. Previously, category/rail/dropdown changes rebuilt whole screens and Console ran per-visit workers twice; now only targeted panels/cards rebuild and Console refreshes once on first visit, with later resumes still refreshing.

- Settings: detail and inspector become `SettingsRegion`s, so category switches rebuild only those panes; Overview sync rows are separate regions; statics update in place. Queues post-swap callbacks to preserve ordering and fixes inspector geometry timing. Ports mouse-capture release via `release_mouse_capture_for_teardown`/`sweep_stale_mouse_capture`. Measured: 270→98 ms per category switch; 13/138 widgets per sync-row update.
- Evals: selection swaps detail+inspector regions; rail rebuilds only on mutations. `library_rail.EvalsSelectionChanged(rail_dirty=True)` keeps the rail fresh by default; row presses opt out. Removes only non-header children to preserve collapse controls; defers focus restore so `ResultsGrid` autofocus wins. Batched swap reduces layout passes. Measured: 325→146 ms end-to-end.
- Speech/TTS: dropdowns recompose only the affected `_SpeechSettingsCard` plus the inspector; restores focus if the change came from inside the panel. Measured: defaults+inspector 83 of 188 widgets.
- Console: one-shot mount/resume token collapses duplicate first-visit refresh; later resumes still refresh.
- Swap serialization: replaces exclusive workers with a lock+revision check to avoid stranded empty regions and ensure the capture sweep runs.

**Tests and rollout**
- Adds UI tests for region-scoped behavior, focus retention, inspector/header survival, and Console dedupe.
- No migration required. For future scoped swaps, use `SettingsRegion`/`_SpeechSettingsCard` and call the teardown capture helpers.
- Linear `task-15475`: fulfills AC #1–#3.

<sup>Written for commit 26e99307ebe051d3a93096e822cebd37f9125b05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

