### PR TITLE
perf(library): stop the media viewer parsing a document twice per open (task-15458 delta)

### DIFF
--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -4943,7 +4943,122 @@ async def test_library_shell_media_viewer_inplace_large_document_latency_and_par
         assert screen.query_one("#library-media-viewer") is viewer_before
         assert set(observed_viewer_ids) == {id(viewer_before)}
         assert unique_markdown_ids == {id(markdown_before)}
+        # Opening the item parses the document exactly once. Before
+        # task-15458's arrival guard this was two on macOS (deterministically,
+        # 3/3 runs): the open-time "Loading media…" recompose was still
+        # awaiting its own child teardown when the detail worker landed, so
+        # that compose already rendered the document AND the worker's
+        # unconditional second recompose parsed all 49 KB again. Windows
+        # happened to win the race the other way, which is exactly why this
+        # count must be pinned rather than observed.
         assert markdown_updates == [id(markdown_before)]
+
+
+@pytest.mark.asyncio
+async def test_library_shell_media_viewer_detail_arrival_does_not_reparse_rendered_detail(
+    monkeypatch,
+):
+    """Catch the media-detail worker reparsing a document the compose already rendered."""
+    markdown_updates: list[int] = []
+    original_update = Markdown.update
+
+    def recording_update(markdown_widget: Markdown, source: str):
+        markdown_updates.append(id(markdown_widget))
+        return original_update(markdown_widget, source)
+
+    monkeypatch.setattr(Markdown, "update", recording_update)
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_large_markdown_media_item())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_media_viewer(screen, pilot)
+        markdown_before = screen.query_one(
+            "#library-media-viewer-content-markdown", Markdown
+        )
+        viewer_before = screen.query_one("#library-media-viewer", LibraryMediaViewer)
+
+        # The composed viewer records the exact detail it rendered.
+        assert screen._library_media_composed_detail is screen._library_media_detail
+
+        # A detail arrival for the detail already on screen must not recompose.
+        parses_before = len(markdown_updates)
+        screen._recompose_library_media_detail_if_unrendered()
+        await pilot.pause()
+        await pilot.pause()
+        assert len(markdown_updates) == parses_before
+        assert screen.query_one("#library-media-viewer") is viewer_before
+        assert (
+            screen.query_one("#library-media-viewer-content-markdown")
+            is markdown_before
+        )
+
+        # ...and the guard still recomposes when the compose has NOT yet
+        # rendered the current detail, so it can never strand the viewer on
+        # its loading line.
+        screen._library_media_composed_detail = None
+        screen._recompose_library_media_detail_if_unrendered()
+        await pilot.pause()
+        await pilot.pause()
+        assert len(markdown_updates) == parses_before + 1
+        assert screen.query_one("#library-media-viewer") is not viewer_before
+
+
+@pytest.mark.asyncio
+async def test_library_shell_media_viewer_inplace_navigation_holds_at_compact_size(
+    monkeypatch,
+):
+    """Catch match navigation degrading at a compact 80x24 terminal."""
+    markdown_updates: list[int] = []
+    original_update = Markdown.update
+
+    def recording_update(markdown_widget: Markdown, source: str):
+        markdown_updates.append(id(markdown_widget))
+        return original_update(markdown_widget, source)
+
+    monkeypatch.setattr(Markdown, "update", recording_update)
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_large_markdown_media_item())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(80, 24)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_media_viewer(screen, pilot)
+        await _submit_content_search_query(screen, pilot, "budget")
+
+        viewer = screen.query_one("#library-media-viewer", LibraryMediaViewer)
+        markdown = screen.query_one(
+            "#library-media-viewer-content-markdown", Markdown
+        )
+        status = screen.query_one("#library-media-content-search-status", Static)
+        next_button = screen.query_one("#library-media-content-search-next", Button)
+        body = screen.query_one(
+            "#library-media-viewer-content", LibraryMediaContentBody
+        )
+        assert status.region.bottom <= body.region.y
+        assert str(status.render()) == "Match 1 of 101 matches"
+
+        parses_before_navigation = len(markdown_updates)
+        next_button.focus()
+        next_button.press()
+        await pilot.pause()
+        await pilot.pause()
+
+        # At 80x24 the whole viewer scrolls (the nav row sits below the fold
+        # until focused), so this pins the model-and-focus contract rather
+        # than a painted row: identity held, focus held, status advanced, and
+        # no reparse -- the same guarantees the 170x48 chrome test proves
+        # visually.
+        assert screen.query_one("#library-media-viewer") is viewer
+        assert screen.query_one("#library-media-viewer-content-markdown") is markdown
+        assert screen.query_one("#library-media-content-search-next") is next_button
+        assert screen.query_one("#library-media-content-search-status") is status
+        assert screen.focused is next_button
+        assert str(status.render()) == "Match 2 of 101 matches"
+        assert len(markdown_updates) == parses_before_navigation
 
 
 @pytest.mark.asyncio

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -3515,3 +3515,33 @@ can be satisfied by a different code path.** Neutering the sync-rows region rebu
 left all six evidence tests green, because the assertion read a summary `Static` that
 another path keeps current. Assert on the widgets ONLY the mechanism under test
 writes, then mutation-check by neutering that mechanism.
+
+## An absolute event-count pin records which side of a race the author's machine won (TASK-15458, 2026-08-13)
+
+**Incident.** Task-15458's perf pin asserted `markdown_updates ==
+[id(markdown_before)]` — "opening the media item parses the document exactly
+once". It was written and verified on Windows, where it passed. On macOS it
+failed 3/3 with `markdown_update_count=2`, and it had been red on `dev` from
+the moment it merged. The count was not flaky, and it was not a platform quirk
+of the test: it was reporting a real defect that the authoring machine happened
+to hide. Opening a media item issues two `refresh(recompose=True)` calls — the
+"Loading media…" one at click time, and one when the detail worker resolves.
+Textual's `recompose()` awaits child teardown BEFORE it calls `compose()`, so a
+worker landing inside that await gets picked up by the in-flight compose, and
+the worker's own recompose then parses the whole 49 KB / 2,000-line document a
+SECOND time. Windows lost that race the other way (both refreshes coalesced
+into one recompose), so the same production code produced 1 there and 2 here.
+A/B on the open click: 922/914/935 ms and 2 parses with the arrival recompose
+unconditional, 710/730/841 ms and 1 parse with an identity guard on the
+already-composed detail.
+
+**What to do.** An absolute count over a window that spans a scheduling race
+pins your machine's timing, not the contract. Two habits fix it. First, scope
+the count to the interaction the claim is about — the sibling test in the same
+file already did this (`parse_count_before_navigation = len(markdown_updates)`,
+then assert no growth across the click), and it was green on both platforms
+because the delta cannot absorb an unrelated race. Second, when you do want an
+absolute count, first make it deterministic in PRODUCTION (here: the guard),
+then pin it — a total that is only stable on one OS is evidence about the OS.
+And treat a count that differs from the notes' recorded value as a defect
+report until proven otherwise: the number was right, the code was wrong.

--- a/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
+++ b/backlog/tasks/task-15458 - Library-media-viewer---in-place-match-navigation-instead-of-full-document-re-parse.md
@@ -325,3 +325,69 @@ as the only deviation. The existing testing-evidence lesson already covers the
 model-state-versus-painted-frame trap, so no duplicate lesson was added. With
 the Windows full-suite baseline limitation explicitly attributed, all
 task-scoped Definition of Done items are complete and the task is Done.
+
+### macOS re-verification (2026-08-13) and the open-path double-parse it found
+
+Re-verified this task's shipped behavior at dev `ebf56a763` — the first run of
+its evidence on macOS, and the first since task-15457's Library reconciliation
+merged on top of it (#1581 landed after #1586, touching `library_screen.py`).
+
+The in-place conversion itself held: with the recorder scoped to the click, the
+submit/Next/Prev sequence performs ZERO Markdown parses, keeps one viewer, one
+Markdown, one status and both nav buttons, and retains focus. The legacy Media
+panel's 250 ms generation-guarded debounce and the removed `update("")`
+pre-parse also hold.
+
+One test was red on macOS, deterministically (3/3):
+`test_library_shell_media_viewer_inplace_large_document_latency_and_parse_proxy`
+asserted a whole-session total of one `Markdown.update` and observed two. It
+was reporting a real defect rather than a platform quirk. Opening a media item
+issues two whole-screen recomposes — the "Loading media…" one at click time and
+the detail worker's arrival one — and Textual's `recompose()` awaits child
+teardown BEFORE calling `compose()`. A worker landing inside that await is
+already picked up by the in-flight compose, so the arrival recompose parses the
+same 49 KB / 2,000-line document a second time. Windows lost that race the
+other way (the two refreshes coalesced), which is why the original evidence
+recorded one parse.
+
+Fix: `_refresh_library_media_detail` no longer recomposes unconditionally. It
+defers one message via `call_next` to
+`_recompose_library_media_detail_if_unrendered`, which skips the recompose only
+when the composed viewer already rendered the exact current detail Mapping
+(identity, recorded in `compose_content`; reset wherever
+`_library_media_detail` is cleared, so a cached Mapping can never strand the
+viewer on its loading line). Any other state — no detail, list view, a detail
+no compose has rendered — still recomposes.
+
+Open-click A/B on the 49 KB fixture, same process, three pairs: 922.970 /
+914.755 / 935.161 ms with 2 parses before, 710.736 / 730.087 / 841.238 ms with
+1 parse after. The match-navigation median on this hardware is 112.672 ms
+(compare the pre-conversion 1091.689 ms recorded above).
+
+Tests added to `Tests/UI/test_library_shell.py`:
+
+- `..._detail_arrival_does_not_reparse_rendered_detail` — born red
+  (`AttributeError: no attribute '_library_media_composed_detail'`); pins both
+  directions of the guard (skips for an already-rendered detail, still
+  recomposes when the compose has not rendered it).
+- `..._inplace_navigation_holds_at_compact_size` — 80x24 companion to the
+  existing 170x48 chrome test. At that size the nav row sits below the fold
+  until focused (the viewer scrolls it into view; verified reachable), so this
+  pins identity, focus, the advancing status text and zero reparse rather than
+  a painted row.
+
+Mutation evidence: disabling the guard's condition fails both the new arrival
+pin and the latency pin; restoring `self.refresh(recompose=True)` in
+`_advance_library_media_content_match` fails the new compact test at the viewer
+identity assertion.
+
+Not fixed here, recorded instead: at 80x24 the viewer's search status and
+Prev/Next sit below the visible fold until focused. That is the viewer's
+overall vertical density, not the in-place conversion (the controls container
+is `height: auto` and the stack order is unchanged), and needs a layout
+decision rather than a perf change.
+
+Ruff on the touched files reports only the pre-existing `F401` in
+`test_library_shell.py`. Lesson recorded in
+`backlog/docs/lessons-testing-evidence.md` ("An absolute event-count pin
+records which side of a race the author's machine won").

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -2870,6 +2870,15 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_trash_notice: str = ""
         self._selected_media_trash_id: str = ""
         self._library_media_detail: Mapping[str, Any] | None = None
+        # task-15458: the exact detail object the last viewer compose rendered,
+        # compared by IDENTITY. ``_refresh_library_media_detail``'s arrival
+        # recompose is skipped when it matches, which is what keeps a long
+        # document from being parsed twice per open (see
+        # ``_recompose_library_media_detail_if_unrendered``). Reset to None
+        # wherever ``_library_media_detail`` is cleared, so a service that
+        # hands back a cached Mapping cannot make a fresh open look "already
+        # rendered" and strand the viewer on its loading line.
+        self._library_media_composed_detail: Mapping[str, Any] | None = None
         self._library_media_editing: bool = False
         self._library_media_confirming_delete: bool = False
         self._library_media_highlights: list[dict[str, Any]] = []
@@ -8219,6 +8228,15 @@ class LibraryScreen(BaseAppScreen):
                             markup=False,
                         )
                     else:
+                        # task-15458: record what this compose renders BEFORE
+                        # yielding it. Textual's ``recompose()`` awaits its
+                        # child teardown before it runs this generator, so a
+                        # detail worker can land mid-teardown and be picked up
+                        # right here; the arrival guard reads this to know its
+                        # own recompose would only re-parse the same document.
+                        self._library_media_composed_detail = (
+                            self._library_media_detail
+                        )
                         yield LibraryMediaViewer(
                             build_library_media_viewer_state(
                                 self._library_media_detail,
@@ -9434,6 +9452,7 @@ class LibraryScreen(BaseAppScreen):
         get_media_item = getattr(service, "get_media_item", None)
         if not callable(get_media_item):
             self._library_media_detail = None
+            self._library_media_composed_detail = None
             self._library_media_highlights = []
             if self.is_mounted:
                 self.refresh(recompose=True)
@@ -9495,7 +9514,37 @@ class LibraryScreen(BaseAppScreen):
                 notify("Media item is unavailable.", severity="warning")
             self._library_media_view = "list"
         if self.is_mounted:
-            self.refresh(recompose=True)
+            # task-15458: deliberately NOT an immediate ``refresh(recompose=
+            # True)``. The open-time "Loading media…" recompose may still be
+            # awaiting its own child teardown right now -- Textual removes
+            # children BEFORE it calls ``compose()`` -- in which case that
+            # compose is about to render this very detail, and recomposing
+            # again would parse the whole document a second time (measured:
+            # 2 parses of a 49 KB / 2,000-line item per open, deterministic
+            # on macOS). The screen's message pump runs this callback after
+            # that in-flight compose finishes, which is the earliest point
+            # where the question can be answered instead of guessed.
+            self.call_next(self._recompose_library_media_detail_if_unrendered)
+
+    def _recompose_library_media_detail_if_unrendered(self) -> None:
+        """Recompose unless a compose already rendered the current media detail.
+
+        Deferred follow-up for ``_refresh_library_media_detail`` (task-15458).
+        Identity, not equality: the guard must only skip a recompose for the
+        exact Mapping a compose has already put on screen.
+
+        Returns:
+            None.
+        """
+        if not self.is_mounted:
+            return
+        if (
+            self._library_media_view == "viewer"
+            and self._library_media_detail is not None
+            and self._library_media_composed_detail is self._library_media_detail
+        ):
+            return
+        self.refresh(recompose=True)
 
     async def _fetch_library_media_highlights(
         self, media_id: str
@@ -12995,6 +13044,7 @@ class LibraryScreen(BaseAppScreen):
         # Media again must show the list, not the stale viewer).
         self._library_media_view = "list"
         self._library_media_detail = None
+        self._library_media_composed_detail = None
         self._library_media_editing = False
         self._library_media_confirming_delete = False
         self._library_media_highlights = []
@@ -14111,6 +14161,7 @@ class LibraryScreen(BaseAppScreen):
         # the viewer and reappear (stale) on the way back.
         self._library_media_type_choices_visible = False
         self._library_media_detail = None
+        self._library_media_composed_detail = None
         self._library_media_editing = False
         self._library_media_confirming_delete = False
         self._library_media_highlights = []
@@ -25617,6 +25668,7 @@ class LibraryScreen(BaseAppScreen):
                 self._library_media_delete_receipt_ids = (media_id,)
                 self._library_media_view = "list"
                 self._library_media_detail = None
+                self._library_media_composed_detail = None
                 self._library_media_highlights = []
                 self._library_media_editing_analysis = False
                 self._library_media_content_query = ""
@@ -27342,6 +27394,7 @@ class LibraryScreen(BaseAppScreen):
             self._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
             self._library_media_view = "viewer"
             self._library_media_detail = None
+            self._library_media_composed_detail = None
             self._library_media_editing = False
             self._library_media_confirming_delete = False
             self._library_media_highlights = []


### PR DESCRIPTION
## Summary

Task 15458 was implemented and merged by another session (PR #1586) with Windows-authored evidence — this branch is the macOS re-verification at HEAD, which found a real defect the merged pin missed: **the media open composes twice, parsing the document twice**, and the parse-count pin was red on dev from merge day (an absolute event-count pin records which side of a race the author's machine won — lesson banked).

- Root cause: two `refresh(recompose=True)` per open (loading line + detail-worker arrival); Textual's recompose awaits teardown before compose, so a worker landing in that await is picked up by the in-flight compose on some machines and not others
- Fix: the detail arrival defers one message via `call_next` to a guard that recomposes only if compose hasn't already rendered the exact current detail Mapping (identity-based; all five detail-clearing sites reset the marker; `get_media_item` builds fresh dicts at every layer so identity cannot false-match across fetches — reviewer traced all three orderings through Textual's snapshot-and-clear callback flush)
- Open click 923→711 ms median (one 49 KB parse instead of two); match-nav in-place behavior from #1586 verified intact (zero parses across submit/Next/Prev)
- Born-red pins both directions + an 80×24 compact companion; mutations verified (one caught even wider blast radius than claimed)

## Verification
Independent review: Approved, no findings — double-compose reproduced 3/3 on base, guard sub-claims traced through Textual 8.2.8 source, 76-test wider media slice green. Recorded for filing: the WorkspaceProbe test-double drift (pre-existing) and the 80×24 below-fold viewer layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Library media viewer from parsing a document twice on open. Previously the open-time “Loading…” recompose and the detail-arrival recompose could both parse; now arrival defers one tick and only recomposes if the current compose did not already render the same detail identity, improving open latency (~0.92s → ~0.71s on the 49 KB fixture).

- Core change: replace the unconditional `refresh(recompose=True)` in `_refresh_library_media_detail` with `call_next(self._recompose_library_media_detail_if_unrendered)`. The guard recomposes only when needed (no detail, list view, or a different detail).
- State tracking: new `_library_media_composed_detail`, recorded in `compose_content` before yielding the viewer and reset anywhere `_library_media_detail` is cleared (open, item-by-id open, selection changes, delete, and no-service branch).
- Preserved behavior (task-15458): in-place match navigation still performs zero parses and preserves viewer identity and focus.
- Tests: add an arrival-guard regression test and an 80×24 compact navigation test; both fail if the guard or in-place path regresses.

<sup>Written for commit e41a8db0b17d43635b1dc936a22f3390c095ad48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

