### PR TITLE
fix(tests): keep the Lab/LLM screen's Ollama probe inside test isolation (task-15211, sweep catch 2)

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -587,6 +587,26 @@ def _no_local_server_probes(
 
     monkeypatch.setattr(local_server_discovery, "_get_models_payload", _no_endpoint)
 
+    # task-15211 (sweep catch): the Models/Lab screen has its own parallel
+    # chokepoint -- `llm_screen._probe_local_server`, a real TCP connect to
+    # 127.0.0.1:11434, scheduled from a 3s interval AND a deferred-mount
+    # one-shot. The one-shot flushes while `run_test` is tearing down, so
+    # widget-lifetime cancellation cannot fully close it: seven Lab/LLM
+    # tests hit the network guard AT TEARDOWN, and the probe (plus lab
+    # status polling) is the prime suspect for a full-suite chunk whose
+    # pytest printed its summary and then never exited. Same shape, same
+    # remedy, same opt-out marker as `_get_models_payload` above. The
+    # production caller resolves this at call time via a local import, so
+    # the module-attribute patch covers it; the probe's own unit test
+    # (`test_llm_screen_ollama_probe_nonblocking`) binds the real function
+    # by name at import and is deliberately unaffected.
+    from tldw_chatbook.UI.Screens import llm_screen
+
+    async def _no_ollama(host="127.0.0.1", port=11434):
+        return False
+
+    monkeypatch.setattr(llm_screen, "_probe_local_server", _no_ollama)
+
 
 @pytest.fixture(autouse=True)
 def _console_gateway_http_client_is_offline(

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -532,7 +532,7 @@ class LLMManagementWindow(Container):
         # longer exist at compose time (the autofill would otherwise
         # silently never fire, UX-078).
         self.call_after_refresh(self._finish_deferred_mount)
-        self.set_interval(3.0, self._update_ollama_api_state)
+        self.set_interval(3.0, self._schedule_ollama_api_state)
 
     async def _finish_deferred_mount(self) -> None:
         """Mount deferred views, then run everything that assumes them.
@@ -553,11 +553,12 @@ class LLMManagementWindow(Container):
             # Autofill the Ollama executable when it's discoverable (UX-078).
             self._autofill_ollama_path,
             # Keep the Ollama API controls gated on a live service (UX-091).
-            # task-15473: this step is now a coroutine function (it awaits
-            # the non-blocking Ollama probe) -- the others are still plain
-            # sync methods, so each result is awaited only if awaitable,
-            # preserving the per-step try/except isolation and ordering.
-            self._update_ollama_api_state,
+            # task-15473 made this step await the non-blocking Ollama
+            # probe; task-15211 then moved the await into a widget-owned
+            # worker (see _schedule_ollama_api_state) so an in-flight probe
+            # cannot outlive the screen. The step stays in this loop for
+            # its ordering slot, but it now only SCHEDULES.
+            self._schedule_ollama_api_state,
         ):
             try:
                 result = step()
@@ -649,6 +650,26 @@ class LLMManagementWindow(Container):
         from .Screens.llm_screen import _probe_local_server
 
         return await _probe_local_server()
+
+    def _schedule_ollama_api_state(self) -> None:
+        """Run the Ollama API-state refresh as a widget-owned worker.
+
+        task-15211 (sweep catch): the refresh awaits a real TCP probe of
+        127.0.0.1:11434, and a coroutine scheduled straight from the 3s
+        interval (or the deferred-mount one-shot) is NOT tied to this
+        widget's lifetime -- one already in flight when the screen unmounts
+        kept awaiting, and its socket fired during test teardown. Seven
+        Lab/LLM-screen tests hit the network guard exactly there. A worker
+        owned by this widget is cancelled at unmount, so the probe dies
+        with the screen; ``exclusive`` also collapses overlapping polls on
+        a slow probe instead of stacking them.
+        """
+        self.run_worker(
+            self._update_ollama_api_state(),
+            exclusive=True,
+            group="ollama-api-state",
+            exit_on_error=False,
+        )
 
     async def _update_ollama_api_state(self) -> None:
         """Disable API controls when no Ollama service is running.


### PR DESCRIPTION
## What

Sweep catch #2 from the task-15211 full `Tests/UI` run: **seven Lab/LLM-screen tests fire a real TCP connect to `127.0.0.1:11434` at teardown** — after the test body — from `llm_screen._probe_local_server`.

Two spawners: `LLMManagementWindow`'s 3-second `set_interval`, and the deferred-mount one-shot whose `call_after_refresh` flushes while `run_test` is already tearing down.

## Why two parts

**Lifetime alone cannot close it** — traced live with a stack-printing probe: the teardown-window spawn still fires under pure widget-lifetime control, because the one-shot is scheduled before unmount and runs during shutdown.

1. **Worker lifetime** — the refresh now runs as a widget-owned worker (cancelled at unmount, `exclusive` so a slow probe collapses overlapping polls instead of stacking).
2. **Harness seam** — the autouse `_no_local_server_probes` fixture (the exact remedy the Console screen got for this class in task-15111) now also stubs `llm_screen._probe_local_server`, same opt-out marker. The production caller resolves the probe at call time via a local import, so the module patch covers it; the probe's own unit test binds the real function by name at import and keeps exercising the real implementation.

## Related finding, recorded not fixed here

The probe is the prime suspect for the sweep's chunk 5, whose pytest **printed its final summary and then never exited** — zero CPU, main thread joining a non-daemon thread, two event-loop threads parked in kevent. That failure-to-exit goes in the sweep findings; this change removes the probe from the picture for every guarded test.

## Verification

The seven affected shapes + the probe's own test + the discovery opt-out module + the network guard: **56 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the Lab/LLM screen’s Ollama probe inside test isolation to stop teardown network calls to 127.0.0.1:11434 (task-15211). Previously the interval and deferred-mount paths awaited `_update_ollama_api_state` directly and could outlive the screen; now they schedule a widget-owned worker cancelled at unmount, and tests stub the probe.

**Review notes**
- UI: `set_interval(3.0, _schedule_ollama_api_state)` replaces direct `_update_ollama_api_state`; `_schedule_ollama_api_state` runs `_update_ollama_api_state` via `run_worker(..., exclusive=True)` and preserves deferred-mount ordering.
- Tests: autouse fixture patches `tldw_chatbook.UI.Screens.llm_screen._probe_local_server` to return False; the probe’s unit test binds the real function and remains unaffected.
- Impact: No runtime feature change to API gating. Prevents teardown socket connects and collapses overlapping polls. If a test needs the real probe, use the existing opt-out marker to bypass the autouse patch.

<sup>Written for commit c0fc73a5acbe2b461e29770263ae76e3a779c61e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

