### PR TITLE
docs: profile the Watchlists push and refute all three named levers (task-15462)

### DIFF
--- a/Docs/Design/2026-08-11-input-latency-audit.md
+++ b/Docs/Design/2026-08-11-input-latency-audit.md
@@ -96,6 +96,13 @@ per keystroke → **15458**. Warm visits compose 2–3× → **15459**.
 **15460**. Section click = 2+ whole-screen rebuilds; tree click = 4 recomposes; z/Z/[/] rebuilds all
 four regions → **15461**. Heaviest never-profiled screen → **15462** (profile first — the
 defer-past-first-paint series proved hidden-widget weight predicts nothing when sync/DB-bound).
+**15462 is now done and this line's numbers are superseded** — see its Investigation Notes. After
+15460/15461/15463/15464, live push is **0.50 s, not 0.89 s** (−44%); the screen is widget-bound, only
+**3% of its tree is hidden** (no deferral possible), and one whole push runs **13 loop-thread sqlite
+statements / ~10 ms of application code**. With an empty feed the screen pushes in 200 ms — the median
+of every other screen — so its entire excess is the 224 widgets of the 100-item article feed
+(`_ArticleRow`/`_DayHeader` each wrap a `Static`). `compose`'s inline `resolve_latest_follow_item()`,
+flagged above, measures 0.1–0.3 ms and is retired as a concern.
 SubscriptionsDB rebuilt per op + scheduler due-checks run sqlite + `ET.fromstring` inline on the loop,
 enabled by default on any tab → **15463**. Items feed selects `content` for list rows and sorts the whole
 table on a computed datetime → **15464**.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -3545,3 +3545,37 @@ absolute count, first make it deterministic in PRODUCTION (here: the guard),
 then pin it — a total that is only stable on one OS is evidence about the OS.
 And treat a count that differs from the notes' recorded value as a defect
 report until proven otherwise: the number was right, the code was wrong.
+## When a screen really is widget-bound, COUNT widgets — a wall-clock A/B can't resolve the change (task-15462, 2026-08-13)
+
+**What happened.** Profiling the Watchlists push turned up a genuine piece of waste: the
+screen's `region_layout` reactive defaults to "nothing collapsed" while the shipped
+first-run default collapses the RIGHT_RAIL, so every visit composes the expanded
+Inspector rail and `on_mount` immediately swaps it for the one-line collapsed header. A
+prototype removing the swap was measured against dev the obvious way — run the probe
+process on dev, then run it with the fix, compare medians. It reported **35% faster**.
+
+That number was an artifact. Re-run with the two arms interleaved *inside a single app
+run* and ABBA-ordered (so monotonic machine drift cancels instead of favouring whichever
+arm is measured second), the same change came out at **median delta −1 ms, faster in 6 of
+12 pairs**. Repeated identical configurations on this machine ranged **360–925 ms within
+one run** — the noise floor swallows anything under roughly 30%.
+
+The noise-free measurement had been available all along and agreed with the paired
+result: instrumenting the swap showed it discards **13 widgets** and mounts 1. A
+dose-response sweep (feed page 0/24/60/100 items → 86/170/260/344 widgets →
+200/218/244/342 ms) put the screen's cost at **~0.55 ms per widget**, so 13 widgets is
+5–10 ms of a ~450 ms push — 1–2%, exactly what the paired A/B failed to detect.
+
+**What to do.** Establish whether the screen is widget-bound *first* (survey + a
+dose-response sweep over something that varies the widget count). If it is, size every
+candidate lever by the widgets it removes and use wall clock only to confirm a prediction
+big enough to clear the noise floor. If you must A/B by wall clock, interleave the arms
+within one process and alternate their order; a fixed dev-then-fix ordering across
+processes measures drift as effect.
+
+This is the mirror of the defer-past-first-paint lesson, not a contradiction of it.
+There, widget count *over*-predicted, because Schedules and Console were sync/DB-bound and
+their hidden mass cost nothing to skip. Watchlists is genuinely widget-bound — 13 sqlite
+statements and ~10 ms of application code for a whole push, everything else Textual's
+per-widget CSS apply and mount. The rule is the same in both cases: find out what the
+screen is bound by before choosing what to count.

--- a/backlog/tasks/task-15462 - Watchlists---profile-the-screen-push-before-choosing-a-lever.md
+++ b/backlog/tasks/task-15462 - Watchlists---profile-the-screen-push-before-choosing-a-lever.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15462
 title: Watchlists: profile the screen push before choosing a lever
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-11 12:05'
 labels:
@@ -20,7 +20,225 @@ Depends on: 15460/15461 landing first will change the profile — run the profil
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A recorded cProfile + widget survey of one Watchlists push names the top costs, committed to the task
-- [ ] #2 The chosen lever (deferral, service, or none) is justified against the profile; a wrong-lever conclusion is recorded like task-2902 if applicable
-- [ ] #3 If a lever ships: first-paint latency before/after plus the recipe's mechanism and integrity tests
+- [x] #1 A recorded cProfile + widget survey of one Watchlists push names the top costs, committed to the task
+- [x] #2 The chosen lever (deferral, service, or none) is justified against the profile; a wrong-lever conclusion is recorded like task-2902 if applicable
+- [x] #3 If a lever ships: first-paint latency before/after plus the recipe's mechanism and integrity tests — N/A, marked complete honestly: **no lever ships**. All three levers this task named were measured and refuted (below); the one lever the profile actually found is handed over as a follow-up rather than riddened onto an investigation task, exactly as task-2725 declined to rider its own recommended fix.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Fresh baseline first — the audit's 0.89 s predates 15460/15461/15463/15464.
+   Measure live (real app, real terminal) AND headless, both on one seeded
+   corpus, both against the other screens so a ratio exists.
+2. task-2725 method: widget survey (total / hidden / top hidden roots) +
+   cProfile of one warm push.
+3. Instrument the application layer directly (per-method timers + a
+   thread-exact sqlite trace on the loop connection) so "framework vs app"
+   is measured, not inferred from a framework-dominated profile.
+4. Decide against the profile: deferral / service-data / batching the swap
+   mounts / none. Refute or adopt each with a number.
+5. Ship only a lever the evidence supports; otherwise record and hand over.
+<!-- SECTION:PLAN:END -->
+
+## Investigation Notes (2026-08-13 — profiled, all three named levers refuted, NO LEVER SHIPPED)
+
+<!-- SECTION:NOTES:BEGIN -->
+Profiled at dev `6ee09eebc` — i.e. **after** all four of this programme's
+Watchlists merges (15460 in-place filtering, 15461 scoped rebuilds, 15463
+backend singleton/off-loop, 15464 items query). Corpus seeded through the
+real DB APIs: 3 watchlists, 12 sources, 300 items (~3 KB bodies), 40 runs,
+6 briefings, 5 alert rules. Isolated HOME/XDG/`TLDW_CONFIG_PATH` throughout;
+no repo or live-config writes.
+
+### 1. Fresh baseline — the audit's 0.89 s is now 0.50 s
+
+**Live** (real `TldwCli` under tmux 235x52, real config/services/stylesheet;
+only the measurement injected — `handle_screen_navigation` wrapped to log its
+own duration, which is the audit's click→nav-highlight metric; navigation
+driven through the command palette; 3 reps after warming every route's
+module import):
+
+| route | median | runs |
+|---|---|---|
+| logs | 110 ms | 124/110/78 |
+| workflows | 113 ms | 117/106/113 |
+| artifacts | 171 ms | 650/170/171 |
+| library | 175 ms | 310/175/171 |
+| mcp | 226 ms | 291/226/216 |
+| settings | 237 ms | 251/224/237 |
+| schedules | 263 ms | 481/263/240 |
+| **watchlists_collections** | **498 ms** | 620/445/498 |
+| personas (Roleplay) | 580 ms | 732/570/580 |
+
+Median of the other eight: **201 ms**. Watchlists is **2.48×** it — outside
+task-2725's ≤2×-median rule, and stated that way rather than rounded down.
+But in absolute terms the four merges moved it **0.89 s → 0.50 s (-44%)**,
+and it is no longer the app's heaviest screen (Roleplay is, again).
+
+**Headless** (same harness, `run_test(size=(235,52))`, 3 reps): watchlists
+328 ms paint / 719 ms settled; median of the other eight 197 ms → 1.66×.
+Headless is used below for everything that needs repeatability.
+
+### 2. Widget survey — nothing to defer
+
+318 widgets at settle, **10 hidden (3%)**. Every hidden root is a single
+widget: `Static#items-new-items-pill`, `Static#items-empty-state`,
+`Static#footer-token-count`, `Static#internal-db-size-indicator`,
+`Static#nav-overflow-hint-left`, `Button#nav-overflow-hint`, two
+`SelectOverlay`, two `NonSelectableStatic`. Top classes: `Static` 129,
+`_ArticleRow` 100, `Button` 26, `NavigationButton` 13, `_DayHeader` 12.
+
+For contrast, the screen the recipe was built for (task-2725, Personas) had
+494 widgets with **358 hidden in one stack**. There is no deferrable mass
+here at all.
+
+### 3. cProfile + application-layer instrumentation — it is not the app
+
+cProfile of one warm push (2.886 s under the profiler; ~8.9 M calls). Top
+cumulative entries are Textual, top to bottom: `stylesheet.apply` 723 calls
+/ 1.184 s, `update_node_styles`→`App.update_styles` **221 subtree sweeps** /
+0.651 s, `Widget._compose` 503 / 0.765 s, `widget.mount` 153 / 0.275 s,
+compositor `render_update` 0.277 s, `css/model.py:__hash__` **2,167,650
+calls**. The 2725 shape exactly: widget count is the lever, per-widget CSS
+cost the multiplier.
+
+Application code, sliced out of the same profile (`tldw_chatbook/` only),
+totals **~5 ms of tottime**. Largest app-code entries are thin wrappers
+around framework work: `watchlist_tree.compose` 0.159 s cumulative,
+`article_list.watch_items`/`_rebuild_rows` 0.145 s,
+`watchlists_tab_strip.compose` 0.084 s.
+
+Direct instrumentation (per-method timers + `sqlite3.Connection.
+set_trace_callback` on the loop thread's connection, which is thread-exact
+rather than timing-based) confirms it independently:
+
+| | |
+|---|---|
+| loop-thread sqlite statements, whole push | **13** (all sub-ms; 10 distinct) |
+| `SubscriptionsDB.__init__` during a push | **0** (15463 holds) |
+| every screen/controller/service method, summed | **~10 ms**, nesting double-counted |
+| `resolve_latest_follow_item` (the audit's compose-inline concern) | 3 calls, **0.1–0.3 ms total** |
+
+**`compose` running `resolve_latest_follow_item()` inline is a non-issue.**
+It is memoized per `WatchlistsConsoleHandoff` instance
+(`_latest_console_follow_loaded`), so it resolves once per screen and costs
+tenths of a millisecond. The audit flagged it from the code, correctly; the
+measurement retires it.
+
+### 4. The structural fact: a median screen plus a 224-widget feed
+
+Item-count sweep (sources/runs/briefings held constant, feed page varied;
+4 doses, headless, 4–5 reps each):
+
+| items in feed | widgets at paint | paint median | settled median |
+|---|---|---|---|
+| 0 | **86** | **200 ms** | 434 ms |
+| 24 | 170 | 218 ms | 580 ms |
+| 60 | 260 | 244 ms | 665 ms |
+| 100 (page cap) | 344 | 342 ms | 720 ms |
+
+Monotone dose-response, slope **~0.55 ms/widget** at paint (~1.1 ms/widget
+at settle). Read it as: **the Watchlists screen's own chrome pushes in
+200 ms — dead on the median of every other screen. Everything above the
+median is the article feed**, and the feed is 224 widgets because
+`_load_items` pages at a hard-coded `limit=100` and every `_ArticleRow` /
+`_DayHeader` is a `ListItem` wrapping one `Static` (112 rows × 2).
+
+The rows are built exactly **once** per push (`_ArticleRow.__init__` = 100
+calls; `_build_rows` runs 3× but twice over an empty list). No duplicated
+work to remove.
+
+### 5. The three named levers, each refuted with a number
+
+**(a) Defer-past-first-paint — REFUTED.** 3% of the tree is hidden, all of
+it single widgets. There is nothing to defer. The one thing that *could* be
+deferred past paint is the feed itself (the 112 rows mount inside the switch
+window: 310 of the 318 widgets are present when `handle_screen_navigation`
+returns) — and deferring it is deferring the screen's payload. On Personas
+the deferred mass was non-active-mode surfaces nobody was waiting for; here
+the rows *are* what the user came to read, so moving them past first paint
+moves the pixels, not the wait. Declined on those grounds, not on cost.
+
+**(b) A service/data fix — REFUTED, and already done.** 13 sqlite statements
+on the loop thread for the entire push, one `SubscriptionsDB`, ~10 ms of
+service time. 15463 and 15464 took this lever; there is nothing left on it.
+
+**(c) Batching the swap mounts — REFUTED for the push path, and it found a
+real (but immaterial) defect on the way.** Exactly **one** region swap
+happens per push, and tracing it showed why: the screen's reactive default
+is `region_layout = RegionLayout()` (nothing collapsed), while the shipped
+first-run default is `_FIRST_RUN_DEFAULT = RegionLayout(collapsed={RIGHT_
+RAIL})`. So every single visit **composes the expanded Inspector rail, and
+`on_mount`'s `_apply_layout(load_region_layout())` immediately tears it down
+and mounts the one-line collapsed header instead**. `on_mount`'s own comment
+documents the correctness half of this ("the WatchlistsWorkbench child was
+built with whatever `region_layout` held at THAT moment"); nobody had
+measured the waste half.
+
+Measured, noise-free, by instrumenting the swap: **13 widgets discarded, 1
+mounted in their place.** At the sweep's 0.55 ms/widget that is ~5–10 ms of
+a ~450 ms push — **1–2%**. A prototype of the fix (seed `region_layout` from
+`load_region_layout()` before compose) was built and verified to remove the
+swap entirely (`_apply_layout` sees `equal=True`, zero `_swap_region_widget`
+calls, identical 310/318 final widget counts) — and a paired A/B could not
+detect it: **preseed faster in 6/12 pairs, median delta −1 ms.** Not shipped:
+1–2%, against moving a config-writing loader (`load_region_layout` performs
+a one-time synchronous migration write) into screen construction and ahead
+of the `_last_persisted_collapsed` priming that `_schedule_layout_persist`'s
+no-op guard depends on. Recorded here so the next reader does not re-derive
+it. (Batching remains relevant to *section switches*, which 15461 measured
+separately; it is simply not in the push path.)
+
+### 6. The one lever the profile does point at — handed over, not riddened
+
+Collapse `_ArticleRow` / `_DayHeader` from a `ListItem`-wrapping-a-`Static`
+into a single self-rendering `ListItem`. That removes **112 widgets**, 36%
+of the screen's tree. Two independent estimates agree: the sweep slope
+(112 × 0.55 ms ≈ 62 ms ≈ **15–18%** of the push) and a prototype in which
+the rows render the same `Text` with no child widget (interleaved runs:
+paint 414/479 ms → 335/372 ms). It is not shipped here because it is a
+structural rewrite of `article_list.py` — a file hardened by 15460 three
+tasks ago — requiring an audit of `.article-row`/`.article-day-header` and
+any `ListItem > Static` selectors across the 21,479-line bundle, plus
+rerouting `_repaint_row`'s `query_one(Static).update()`, plus re-validating
+in-place filtering, `j`/`k` cursor skipping and highlight styling. That is
+its own reviewable change, not a rider on a profiling task — the identical
+call task-2725 made about its own recommended fix. **A follow-up task is
+being filed by the controlling session** (not from this worktree: five-digit
+ids need a repo-wide sweep). A cheaper variant worth considering in the same
+task: `_load_items`' hard-coded `limit=100` is not viewport-proportionate.
+
+### 7. Method note worth keeping
+
+On this machine, cross-process A/B of a screen push is **not resolvable**
+below ~30%: repeated identical configurations ranged 360–925 ms within a
+single run. A naive dev-first-then-preseed comparison across processes
+reported the layout pre-seed as "35% faster"; the same change under paired
+ABBA ordering came out at −1 ms, and the noise-free widget count said 1–2%
+all along. **Widget count was the reliable predictor here and wall-clock A/B
+was not** — the exact mirror of the defer series' lesson, which is that
+widget count *over*-predicts when a screen is sync/DB-bound (Schedules,
+Console). Watchlists is neither: it is genuinely widget-bound, so counting
+widgets beats timing them. Any future claim on this screen should be
+anchored on a widget count or a dose-response sweep and only then confirmed
+by wall clock.
+
+### Verdict
+
+Watchlists is **widget-bound, not DB-bound and not deferrable**. Its own
+chrome is a median-cost screen; its excess over the median is 224 widgets of
+article feed that the user opened the screen to read. The four merged tasks
+took it from 0.89 s to 0.50 s. The remaining prize is one structural change
+worth ~15–18%, filed separately. No lever ships from this task.
+
+Evidence produced: `Docs/Design/2026-08-11-input-latency-audit.md` (Watchlists
+row updated to point here). Probe recipe: seed via the real DB APIs against
+a `_build_test_app` instance before `run_test`; drive
+`app.handle_screen_navigation(NavigateToScreen(route))` directly (the
+production handler, minus only the worker-dispatch hop); survey with
+`screen.query("*")` walking each node's ancestor chain for `display`;
+cProfile enabled around the whole push so loop callbacks are captured;
+`set_trace_callback` on `app.subscriptions_db.conn` with a
+`threading.get_ident()` guard for loop-thread-exact sqlite counting.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

Task 15462 from the input-latency audit — the investigation-first task. Verdict: **no lever shipped, by evidence** (the task-2725/2902 wrong-lever precedent).

- Fresh baseline: 498 ms live push, down from the audit's 0.89 s (−44% from this programme's four Watchlists merges)
- All three candidate levers refuted with numbers: deferral (only 10 of 318 widgets hidden — nothing to defer), service/DB (13 loop statements ≈ 10 ms — already spent by 15463/15464; the audit's inline resolve_latest_follow_item concern measured 0.1–0.3 ms, memoized, retired), swap-batching (one swap; a working no-swap prototype measured −1 ms)
- **The load-bearing evidence is a dose-response sweep**: with an empty feed the screen pushes in 200 ms — exactly the app's screen median. The entire excess is the 100-item feed's own 224 widgets (2 per row). Reviewer independently reproduced the shape with a near-exact hidden-widget match
- Two concrete finds recorded for filing: a region_layout default-disagreement (every visit composes then discards 13 Inspector-rail widgets) and the row-collapse follow-up (ListItem+Static → 1 widget, ~15-18%) — both with actionable detail
- Methodology lesson banked: a naive cross-process A/B reported '35% faster' until interleaved ABBA ordering measured the true −1 ms (30% noise floor)

## Verification
Independent review: Approved — dose-response reproduced on a different corpus (widget counts 100→301 monotone, identical 10 hidden widgets by name), the region_layout defect verified at source, ACs honestly marked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Profiles the Watchlists screen push and records why no lever ships. Old baseline was 0.89 s; live push is ~0.50 s after recent merges, and the screen is widget-bound.

- Adds evidence to `Docs/Design/2026-08-11-input-latency-audit.md`, `backlog/docs/lessons-testing-evidence.md`, and the task record.
- Dose-response shows the excess is the 224 widgets from the 100‑item feed; only 3% of the tree is hidden; ~10 ms of app code and 13 loop-thread `sqlite3` statements per push.
- Refutes deferral, service/DB, and swap-batching with measurements; documents a layout preseed defect at 1–2% (not shipped).
- Follow-up: collapse each `_ArticleRow`/`_DayHeader` from `ListItem`+`Static` to a single `ListItem` (~15–18%); filed separately.
- No production code changed; no rollout or migration.

**Task-15462 alignment**
- Meets ACs: recorded cProfile and widget survey; justified “no lever ships” with numbers; documented findings and follow-ups in the task.

<sup>Written for commit af09cea662f84cad6ac28b9cae8ab6796e47962d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

