### PR TITLE
fix(library): explain dirty Prompt navigation veto

### DIFF
--- a/Docs/superpowers/plans/2026-08-13-task-2702-prompt-dirty-navigation.md
+++ b/Docs/superpowers/plans/2026-08-13-task-2702-prompt-dirty-navigation.md
@@ -1,36 +1,46 @@
 # TASK-2702 Prompt Dirty-Navigation Feedback Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` or `superpowers:executing-plans` to
+> implement this plan one RED→GREEN cycle at a time.
 
-**Goal:** Make a dirty Library Prompt navigation veto explain itself and give every dirty Prompt editor a truthful `Discard changes` recovery.
+**Goal:** Make a dirty Library Prompt navigation veto explain itself and give
+every dirty Prompt editor a truthful `Discard changes` recovery.
 
-**Architecture:** Mirror the existing Skill dirty-veto/discard pattern inside the existing Prompt canvas and `LibraryScreen`. Reuse the Prompt editor's current `dirty` state, in-place patch discipline, and clean-Back reset/list-return tail; add no new state owner, worker, modal, CSS, or shared abstraction.
+**Architecture:** Mirror the existing Skill dirty-veto/discard behavior in the
+existing Prompt canvas and `LibraryScreen`. Reuse the Prompt editor's current
+`dirty` state, in-place patch discipline, and clean-Back reset/list-return tail;
+add no state owner, worker, modal, CSS, or shared abstraction.
 
 **Tech Stack:** Python 3.12, Textual 8.x, pytest/Pilot, Ruff
 
-**ADR required:** no  
-**ADR path:** N/A  
-**Reason:** Routine UX bug fix applying an existing Library pattern without changing persistence, service contracts, ownership, security, or long-lived structure.
+**ADR required:** no
+**ADR path:** N/A
+**Reason:** Routine UX bug fix applying an existing Library pattern without
+changing persistence, service contracts, ownership, security, or long-lived
+structure.
 
 ---
 
-### Task 1: Pin the dirty-veto and discard contracts RED-first
+### Task 1: Explain only a dirty Prompt navigation veto
 
 **Files:**
-- Modify: `Tests/UI/test_library_prompts_canvas.py:7441-7463`
+- Modify: `Tests/UI/test_library_prompts_canvas.py:7440-7465`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:575-585,6003-6035`
 
-- [ ] **Step 1: Strengthen the mounted dirty-navigation test**
+- [ ] **Step 1: Strengthen the existing mounted flush regression**
 
-Record `app.notify`, keep the existing real SQLite Prompt/editor flow, and assert the fixed warning exactly once at warning severity while the dirty author field and dirty flag remain unchanged:
+In
+`test_library_prompt_flush_pending_work_vetoes_dirty_editor`, record
+`app.notify`. First call `flush_pending_work()` while the editor is clean and
+assert it returns `True` with no notification. Then edit the author, flush again,
+and assert:
 
 ```python
-notifications: list[tuple[str, dict[str, object]]] = []
-app.notify = lambda message, **kwargs: notifications.append((message, kwargs))
-
-allowed = await screen.flush_pending_work()
-
 assert allowed is False
-assert screen.query_one("#library-prompt-author", Input).value == "Changed mid switch"
+assert screen.query_one("#library-prompt-author", Input).value == (
+    "Changed mid switch"
+)
 assert screen._library_prompt_dirty is True
 assert notifications == [
     (
@@ -40,31 +50,73 @@ assert notifications == [
 ]
 ```
 
-- [ ] **Step 2: Add the clean/save state and no-convert compatibility discard test**
-
-Use the real Prompt database/service and mounted canvas. Prove `#library-prompt-discard` is disabled with a reason on a clean editor, enables without remounting after a metadata edit, and re-disables after a successful save. Add a compatibility-only structured artifact with blank System/User lanes; prove Update/Convert are disabled, metadata can still become dirty, Discard is enabled, and pressing it returns to the list without persisting the edit.
-
-- [ ] **Step 3: Run the exact tests and verify RED**
-
-Run:
+- [ ] **Step 2: Run the exact test and verify RED**
 
 ```bash
 ../../.venv/bin/python -m pytest \
-  Tests/UI/test_library_prompts_canvas.py \
-  -q -k 'flush_pending_work_vetoes_dirty_editor or prompt_discard'
+  Tests/UI/test_library_prompts_canvas.py::test_library_prompt_flush_pending_work_vetoes_dirty_editor \
+  -q
 ```
 
-Expected: failures because `#library-prompt-discard` and the Prompt warning do not exist.
+Expected RED: the dirty refusal produces no notification. The clean assertion
+must already pass, proving the future notifier is not unconditional.
 
-### Task 2: Implement the minimal Prompt sibling of the Skill pattern
+- [ ] **Step 3: Implement the fixed warning at the existing barrier**
+
+Add the content-free constant
+`LIBRARY_PROMPT_DIRTY_VETO_COPY = "Unsaved Prompt changes — Save or Discard changes first."`
+and `_notify_prompt_dirty_veto()` beside the Skill sibling. In
+`flush_pending_work()`, call it only when the awaited Prompt flush result is
+false. Leave every note/skill barrier and the combined return expression
+unchanged; notification failure must not change the fail-closed veto.
+
+- [ ] **Step 4: Rerun the exact test GREEN**
+
+Run the Step 2 command and require one pass.
+
+### Task 2: Render a truthful clean Discard action
 
 **Files:**
-- Modify: `tldw_chatbook/Widgets/Library/library_prompts_canvas.py:50-75,980-1010`
-- Modify: `tldw_chatbook/UI/Screens/library_screen.py:555-585,5994-6030,18250-18325,18588-18615,19000-19025,19290-19345`
+- Modify: `Tests/UI/test_library_prompts_canvas.py:7897-7940`
+- Modify: `tldw_chatbook/Widgets/Library/library_prompts_canvas.py:52-72,970-1020`
+- Modify: `tldw_chatbook/Widgets/Library/__init__.py:10-20,60-80`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:341-360`
 
-- [ ] **Step 1: Add literal Prompt discard copy and render the action**
+- [ ] **Step 1: Pin the clean action and literal reason**
 
-Define content-free clean/dirty tooltips beside the Prompt canvas constants. Render `Discard changes` in the existing editor action region for every non-mutation editor state:
+Extend
+`test_library_prompt_editing_shows_unsaved_marker_and_save_clears_it` only as
+far as the initial clean editor. Assert `#library-prompt-discard` is mounted,
+disabled, and carries exactly:
+
+```text
+No unsaved Prompt changes to discard.
+```
+
+- [ ] **Step 2: Run the exact test and verify RED**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/UI/test_library_prompts_canvas.py::test_library_prompt_editing_shows_unsaved_marker_and_save_clears_it \
+  -q
+```
+
+Expected RED: `#library-prompt-discard` is absent.
+
+- [ ] **Step 3: Add and export the Prompt tooltip constants, then render**
+
+Define beside the Prompt canvas constants:
+
+```python
+PROMPT_DISCARD_TOOLTIP_CLEAN = "No unsaved Prompt changes to discard."
+PROMPT_DISCARD_TOOLTIP_DIRTY = (
+    "Return to the Prompt list without saving these changes."
+)
+```
+
+Export both from `Widgets/Library/__init__.py`, import them through the existing
+`Widgets.Library` screen seam, and render `Discard changes` in the fixed editor
+action region for every normal, conflict, and compatibility editor:
 
 ```python
 yield Button(
@@ -81,93 +133,209 @@ yield Button(
 )
 ```
 
-- [ ] **Step 2: Add the fixed warning and live button patcher**
+Only mutation and a clean working copy disable this action.
 
-Add `LIBRARY_PROMPT_DIRTY_VETO_COPY`, `_notify_prompt_dirty_veto()`, and `_set_library_prompt_discard_enabled()`. The patcher updates both `disabled` and tooltip, matching the existing Skill implementation. Invoke it on the existing dirty false→true and save-success true→false targeted-update paths; do not recompose fields.
+- [ ] **Step 4: Rerun the exact test GREEN through the clean assertions**
 
-- [ ] **Step 3: Notify only when the Prompt barrier refuses app navigation**
+Run the Step 2 command and require the clean action assertions to pass.
 
-In `flush_pending_work()`, after awaiting `_flush_library_prompt_save()`, call `_notify_prompt_dirty_veto()` only when that result is false. Keep the combined return expression and every note/skill barrier unchanged.
+### Task 3: Patch Discard live across dirty and saved transitions
 
-- [ ] **Step 4: Add the explicit discard handler**
+**Files:**
+- Modify: `Tests/UI/test_library_prompts_canvas.py:7897-7940`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:18240-18335,18610-19010`
 
-Handle `#library-prompt-discard` at the screen seam. Refuse during mutation or when clean; otherwise reset the editor, request the current Prompt browse scope, refresh the local snapshot, and arm first-row focus—the established clean-Back exit tail—with no persistence call.
+- [ ] **Step 1: Strengthen the existing no-recompose regression**
 
-- [ ] **Step 5: Run focused GREEN verification**
+Capture the clean Discard widget identity. After editing, assert the same widget
+instance is enabled with exactly:
 
-Run:
+```text
+Return to the Prompt list without saving these changes.
+```
+
+After the existing real save reaches `Saved.`, assert the same widget instance
+is disabled again with the clean tooltip. This node already proves the Prompt
+meta and editor fields do not recompose.
+
+- [ ] **Step 2: Run the exact test and verify RED**
+
+Run the Task 2 Step 2 command.
+
+Expected RED: the mounted action stays in its clean disabled state after the
+field change.
+
+- [ ] **Step 3: Implement one targeted Discard patcher**
+
+Add `_set_library_prompt_discard_enabled()` beside
+`_sync_library_prompt_save_action_widgets()`. It updates only `disabled` and
+`tooltip`. Call it from both false→true dirty paths:
+
+- `_mark_library_prompt_dirty()`; and
+- `_capture_library_prompt_block_state()`.
+
+Call it from the common successful create/update save settlement after
+`_library_prompt_dirty = False`, so both branches re-disable the action. Paths
+that already recompose project the correct state from `dirty` and need no second
+mechanism.
+
+- [ ] **Step 4: Rerun the exact test GREEN**
+
+Run the Task 2 Step 2 command and require one pass.
+
+### Task 4: Make compatibility-only dirty editors escapable
+
+**Files:**
+- Modify: `Tests/UI/test_library_prompts_canvas.py` (new mounted regression near
+  the Prompt dirty-state tests)
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:19280-19335`
+
+- [ ] **Step 1: Add the compatibility dead-end regression**
+
+Use a real Prompt database/service and mount a compatibility-only structured
+artifact with blank System/User lanes. Prove `Update original` and
+`Convert and save as new Prompt` are unavailable, edit metadata, and assert
+Discard enables. Press it and prove all of the established clean-Back tail:
+
+- no persistence call and the stored metadata remains unchanged;
+- editor returns to the Prompt list;
+- the current browse scope is requested exactly once;
+- the local source snapshot refreshes exactly once; and
+- deferred first-row focus lands on the first Prompt row.
+
+- [ ] **Step 2: Run the exact new node and verify RED**
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/UI/test_library_prompts_canvas.py::test_library_prompt_compatibility_editor_discard_returns_to_current_list \
+  -q
+```
+
+Expected RED: pressing the mounted Discard action has no handler/list-return
+effect.
+
+- [ ] **Step 3: Add the explicit screen handler**
+
+Handle `#library-prompt-discard`. Refuse during mutation or while clean.
+Otherwise reset the Prompt editor, request the current Prompt browse scope,
+refresh the local source snapshot, and arm first-row focus using the same exact
+operations and ordering as the clean Back tail. Do not persist and do not add a
+confirmation modal or state.
+
+- [ ] **Step 4: Rerun the exact new node GREEN**
+
+Run the Step 2 command and require one pass.
+
+### Task 5: Mutation proofs and affected verification
+
+- [ ] **Step 1: Prove all behavior boundaries are non-vacuous**
+
+Temporarily bypass the Prompt notifier; Task 1's exact dirty-flush node must go
+RED while its clean assertion remains green. Restore it. Temporarily omit the
+live Discard dirty patch; Task 3's exact node must go RED on the disabled action.
+Restore it. Temporarily bypass the Discard handler; Task 4's exact node must go
+RED on its unchanged editor/list assertions. Restore and rerun all three GREEN.
+
+- [ ] **Step 2: Run focused sibling verification**
 
 ```bash
 ../../.venv/bin/python -m pytest \
   Tests/UI/test_library_prompts_canvas.py \
   Tests/UI/test_library_skills_canvas.py \
-  -q -k 'flush_pending_work_vetoes_dirty_editor or prompt_discard or flush_pending_work_skill_veto_notifies'
+  -q -k 'flush_pending_work_vetoes_dirty_editor or prompt_discard or editing_shows_unsaved_marker_and_save_clears_it or flush_pending_work_skill_veto_notifies'
 ```
 
-Expected: all selected tests pass.
-
-- [ ] **Step 6: Mutation-check both new boundaries**
-
-Temporarily bypass the Prompt notifier and confirm the dirty-navigation test fails. Restore it. Temporarily leave Discard disabled after dirty marking and confirm the compatibility test fails. Restore it and rerun both tests green.
-
-- [ ] **Step 7: Commit the behavior**
-
-```bash
-git add \
-  tldw_chatbook/UI/Screens/library_screen.py \
-  tldw_chatbook/Widgets/Library/library_prompts_canvas.py \
-  Tests/UI/test_library_prompts_canvas.py
-git commit -m "fix(library): explain dirty Prompt navigation veto"
-```
-
-### Task 3: Verify and close out TASK-2702
-
-**Files:**
-- Modify: `backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md`
-
-- [ ] **Step 1: Run bounded affected verification**
-
-Run the full Prompt canvas file once plus the focused Skill sibling:
+- [ ] **Step 3: Run the full Prompt canvas file once**
 
 ```bash
 ../../.venv/bin/python -m pytest Tests/UI/test_library_prompts_canvas.py -q
-../../.venv/bin/python -m pytest \
-  Tests/UI/test_library_skills_canvas.py::test_library_flush_pending_work_skill_veto_notifies \
-  -q
 ```
 
-Classify any failure against unchanged `origin/dev`; do not weaken unrelated tests.
+Classify any failure against unchanged `origin/dev`; do not weaken unrelated
+tests.
 
-- [ ] **Step 2: Run static and UI-hardening gates**
+- [ ] **Step 4: Run static checks over every owned Python file**
 
 ```bash
 ../../.venv/bin/ruff check \
   tldw_chatbook/UI/Screens/library_screen.py \
   tldw_chatbook/Widgets/Library/library_prompts_canvas.py \
+  tldw_chatbook/Widgets/Library/__init__.py \
   Tests/UI/test_library_prompts_canvas.py
-../../.venv/bin/ruff format --check Tests/UI/test_library_prompts_canvas.py
+../../.venv/bin/ruff format --check tldw_chatbook/Widgets/Library/__init__.py
+../../.venv/bin/ruff format --check --range=52-75 \
+  tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+../../.venv/bin/ruff format --check --range=960-1040 \
+  tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+../../.venv/bin/ruff format --check --range=330-365 \
+  tldw_chatbook/UI/Screens/library_screen.py
+../../.venv/bin/ruff format --check --range=545-590 \
+  tldw_chatbook/UI/Screens/library_screen.py
+../../.venv/bin/ruff format --check --range=5990-6045 \
+  tldw_chatbook/UI/Screens/library_screen.py
+../../.venv/bin/ruff format --check --range=18230-18340 \
+  tldw_chatbook/UI/Screens/library_screen.py
+../../.venv/bin/ruff format --check --range=18595-19015 \
+  tldw_chatbook/UI/Screens/library_screen.py
+../../.venv/bin/ruff format --check --range=19275-19340 \
+  tldw_chatbook/UI/Screens/library_screen.py
+../../.venv/bin/ruff format --check --range=7420-7485 \
+  Tests/UI/test_library_prompts_canvas.py
+../../.venv/bin/ruff format --check --range=7870-7985 \
+  Tests/UI/test_library_prompts_canvas.py
 ../../.venv/bin/python -m py_compile \
   tldw_chatbook/UI/Screens/library_screen.py \
-  tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+  tldw_chatbook/Widgets/Library/library_prompts_canvas.py \
+  tldw_chatbook/Widgets/Library/__init__.py
 git diff --check
+```
+
+The exact changed ranges above are baseline-green before implementation. If
+edits shift their end lines, widen only the affected range and record it. Do not
+whole-file-format the three monolithic files.
+
+- [ ] **Step 5: Run the Impeccable detector once at final state**
+
+```bash
 node /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.agents/skills/impeccable/scripts/detect.mjs \
   --json \
   tldw_chatbook/UI/Screens/library_screen.py \
   tldw_chatbook/Widgets/Library/library_prompts_canvas.py \
+  tldw_chatbook/Widgets/Library/__init__.py \
   Tests/UI/test_library_prompts_canvas.py
 ```
 
-Use changed-range Ruff formatting for the two monolithic production files if their unchanged whole-file baselines remain unformatted.
+### Task 6: Commit behavior and close out TASK-2702
 
-- [ ] **Step 3: Complete task hygiene**
+- [ ] **Step 1: Commit the verified behavior**
 
-Check all three ACs, add concise Implementation Notes with exact test/static evidence and the ADR decision, and set TASK-2702 to Done without using a CLI operation that strips the existing task sections. No lesson entry is expected unless implementation exposes a new generalizable incident.
+```bash
+git add \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  tldw_chatbook/Widgets/Library/library_prompts_canvas.py \
+  tldw_chatbook/Widgets/Library/__init__.py \
+  Tests/UI/test_library_prompts_canvas.py
+git commit -m "fix(library): explain dirty Prompt navigation veto"
+```
 
-- [ ] **Step 4: Commit closeout**
+- [ ] **Step 2: Complete task hygiene**
+
+Check all acceptance criteria, add concise Implementation Notes with exact
+test/static evidence and the ADR decision, and set TASK-2702 to Done without a
+CLI operation that strips existing task sections. Add a lesson only if a new,
+generalizable incident actually occurred.
+
+- [ ] **Step 3: Commit closeout and verify the cumulative branch**
 
 ```bash
 git add \
   'backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md' \
-  Docs/superpowers/plans/2026-08-13-task-2702-prompt-dirty-navigation.md
+  Docs/superpowers/plans/2026-08-13-task-2702-prompt-dirty-navigation.md \
+  Docs/superpowers/specs/2026-08-13-task-2702-prompt-dirty-navigation-design.md
 git commit -m "docs(library): complete TASK-2702"
+git diff --check origin/dev...HEAD
+git status --short
 ```
+
+The cumulative branch diff, not an empty post-commit working-tree diff, is the
+authoritative whitespace gate.

--- a/Docs/superpowers/plans/2026-08-13-task-2702-prompt-dirty-navigation.md
+++ b/Docs/superpowers/plans/2026-08-13-task-2702-prompt-dirty-navigation.md
@@ -1,0 +1,173 @@
+# TASK-2702 Prompt Dirty-Navigation Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a dirty Library Prompt navigation veto explain itself and give every dirty Prompt editor a truthful `Discard changes` recovery.
+
+**Architecture:** Mirror the existing Skill dirty-veto/discard pattern inside the existing Prompt canvas and `LibraryScreen`. Reuse the Prompt editor's current `dirty` state, in-place patch discipline, and clean-Back reset/list-return tail; add no new state owner, worker, modal, CSS, or shared abstraction.
+
+**Tech Stack:** Python 3.12, Textual 8.x, pytest/Pilot, Ruff
+
+**ADR required:** no  
+**ADR path:** N/A  
+**Reason:** Routine UX bug fix applying an existing Library pattern without changing persistence, service contracts, ownership, security, or long-lived structure.
+
+---
+
+### Task 1: Pin the dirty-veto and discard contracts RED-first
+
+**Files:**
+- Modify: `Tests/UI/test_library_prompts_canvas.py:7441-7463`
+
+- [ ] **Step 1: Strengthen the mounted dirty-navigation test**
+
+Record `app.notify`, keep the existing real SQLite Prompt/editor flow, and assert the fixed warning exactly once at warning severity while the dirty author field and dirty flag remain unchanged:
+
+```python
+notifications: list[tuple[str, dict[str, object]]] = []
+app.notify = lambda message, **kwargs: notifications.append((message, kwargs))
+
+allowed = await screen.flush_pending_work()
+
+assert allowed is False
+assert screen.query_one("#library-prompt-author", Input).value == "Changed mid switch"
+assert screen._library_prompt_dirty is True
+assert notifications == [
+    (
+        "Unsaved Prompt changes — Save or Discard changes first.",
+        {"severity": "warning"},
+    )
+]
+```
+
+- [ ] **Step 2: Add the clean/save state and no-convert compatibility discard test**
+
+Use the real Prompt database/service and mounted canvas. Prove `#library-prompt-discard` is disabled with a reason on a clean editor, enables without remounting after a metadata edit, and re-disables after a successful save. Add a compatibility-only structured artifact with blank System/User lanes; prove Update/Convert are disabled, metadata can still become dirty, Discard is enabled, and pressing it returns to the list without persisting the edit.
+
+- [ ] **Step 3: Run the exact tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/UI/test_library_prompts_canvas.py \
+  -q -k 'flush_pending_work_vetoes_dirty_editor or prompt_discard'
+```
+
+Expected: failures because `#library-prompt-discard` and the Prompt warning do not exist.
+
+### Task 2: Implement the minimal Prompt sibling of the Skill pattern
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Library/library_prompts_canvas.py:50-75,980-1010`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:555-585,5994-6030,18250-18325,18588-18615,19000-19025,19290-19345`
+
+- [ ] **Step 1: Add literal Prompt discard copy and render the action**
+
+Define content-free clean/dirty tooltips beside the Prompt canvas constants. Render `Discard changes` in the existing editor action region for every non-mutation editor state:
+
+```python
+yield Button(
+    "Discard changes",
+    id="library-prompt-discard",
+    classes="library-canvas-action",
+    compact=True,
+    disabled=self.mutation_in_flight or not self.dirty,
+    tooltip=(
+        PROMPT_DISCARD_TOOLTIP_DIRTY
+        if self.dirty
+        else PROMPT_DISCARD_TOOLTIP_CLEAN
+    ),
+)
+```
+
+- [ ] **Step 2: Add the fixed warning and live button patcher**
+
+Add `LIBRARY_PROMPT_DIRTY_VETO_COPY`, `_notify_prompt_dirty_veto()`, and `_set_library_prompt_discard_enabled()`. The patcher updates both `disabled` and tooltip, matching the existing Skill implementation. Invoke it on the existing dirty false→true and save-success true→false targeted-update paths; do not recompose fields.
+
+- [ ] **Step 3: Notify only when the Prompt barrier refuses app navigation**
+
+In `flush_pending_work()`, after awaiting `_flush_library_prompt_save()`, call `_notify_prompt_dirty_veto()` only when that result is false. Keep the combined return expression and every note/skill barrier unchanged.
+
+- [ ] **Step 4: Add the explicit discard handler**
+
+Handle `#library-prompt-discard` at the screen seam. Refuse during mutation or when clean; otherwise reset the editor, request the current Prompt browse scope, refresh the local snapshot, and arm first-row focus—the established clean-Back exit tail—with no persistence call.
+
+- [ ] **Step 5: Run focused GREEN verification**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest \
+  Tests/UI/test_library_prompts_canvas.py \
+  Tests/UI/test_library_skills_canvas.py \
+  -q -k 'flush_pending_work_vetoes_dirty_editor or prompt_discard or flush_pending_work_skill_veto_notifies'
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Mutation-check both new boundaries**
+
+Temporarily bypass the Prompt notifier and confirm the dirty-navigation test fails. Restore it. Temporarily leave Discard disabled after dirty marking and confirm the compatibility test fails. Restore it and rerun both tests green.
+
+- [ ] **Step 7: Commit the behavior**
+
+```bash
+git add \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  tldw_chatbook/Widgets/Library/library_prompts_canvas.py \
+  Tests/UI/test_library_prompts_canvas.py
+git commit -m "fix(library): explain dirty Prompt navigation veto"
+```
+
+### Task 3: Verify and close out TASK-2702
+
+**Files:**
+- Modify: `backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md`
+
+- [ ] **Step 1: Run bounded affected verification**
+
+Run the full Prompt canvas file once plus the focused Skill sibling:
+
+```bash
+../../.venv/bin/python -m pytest Tests/UI/test_library_prompts_canvas.py -q
+../../.venv/bin/python -m pytest \
+  Tests/UI/test_library_skills_canvas.py::test_library_flush_pending_work_skill_veto_notifies \
+  -q
+```
+
+Classify any failure against unchanged `origin/dev`; do not weaken unrelated tests.
+
+- [ ] **Step 2: Run static and UI-hardening gates**
+
+```bash
+../../.venv/bin/ruff check \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  tldw_chatbook/Widgets/Library/library_prompts_canvas.py \
+  Tests/UI/test_library_prompts_canvas.py
+../../.venv/bin/ruff format --check Tests/UI/test_library_prompts_canvas.py
+../../.venv/bin/python -m py_compile \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+git diff --check
+node /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.agents/skills/impeccable/scripts/detect.mjs \
+  --json \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  tldw_chatbook/Widgets/Library/library_prompts_canvas.py \
+  Tests/UI/test_library_prompts_canvas.py
+```
+
+Use changed-range Ruff formatting for the two monolithic production files if their unchanged whole-file baselines remain unformatted.
+
+- [ ] **Step 3: Complete task hygiene**
+
+Check all three ACs, add concise Implementation Notes with exact test/static evidence and the ADR decision, and set TASK-2702 to Done without using a CLI operation that strips the existing task sections. No lesson entry is expected unless implementation exposes a new generalizable incident.
+
+- [ ] **Step 4: Commit closeout**
+
+```bash
+git add \
+  'backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md' \
+  Docs/superpowers/plans/2026-08-13-task-2702-prompt-dirty-navigation.md
+git commit -m "docs(library): complete TASK-2702"
+```

--- a/Docs/superpowers/plans/2026-08-13-task-2702-prompt-dirty-navigation.md
+++ b/Docs/superpowers/plans/2026-08-13-task-2702-prompt-dirty-navigation.md
@@ -28,7 +28,7 @@ structure.
 - Modify: `Tests/UI/test_library_prompts_canvas.py:7440-7465`
 - Modify: `tldw_chatbook/UI/Screens/library_screen.py:575-585,6003-6035`
 
-- [ ] **Step 1: Strengthen the existing mounted flush regression**
+- [x] **Step 1: Strengthen the existing mounted flush regression**
 
 In
 `test_library_prompt_flush_pending_work_vetoes_dirty_editor`, record
@@ -50,7 +50,7 @@ assert notifications == [
 ]
 ```
 
-- [ ] **Step 2: Run the exact test and verify RED**
+- [x] **Step 2: Run the exact test and verify RED**
 
 ```bash
 ../../.venv/bin/python -m pytest \
@@ -61,7 +61,7 @@ assert notifications == [
 Expected RED: the dirty refusal produces no notification. The clean assertion
 must already pass, proving the future notifier is not unconditional.
 
-- [ ] **Step 3: Implement the fixed warning at the existing barrier**
+- [x] **Step 3: Implement the fixed warning at the existing barrier**
 
 Add the content-free constant
 `LIBRARY_PROMPT_DIRTY_VETO_COPY = "Unsaved Prompt changes — Save or Discard changes first."`
@@ -70,7 +70,7 @@ and `_notify_prompt_dirty_veto()` beside the Skill sibling. In
 false. Leave every note/skill barrier and the combined return expression
 unchanged; notification failure must not change the fail-closed veto.
 
-- [ ] **Step 4: Rerun the exact test GREEN**
+- [x] **Step 4: Rerun the exact test GREEN**
 
 Run the Step 2 command and require one pass.
 
@@ -82,7 +82,7 @@ Run the Step 2 command and require one pass.
 - Modify: `tldw_chatbook/Widgets/Library/__init__.py:10-20,60-80`
 - Modify: `tldw_chatbook/UI/Screens/library_screen.py:341-360`
 
-- [ ] **Step 1: Pin the clean action and literal reason**
+- [x] **Step 1: Pin the clean action and literal reason**
 
 Extend
 `test_library_prompt_editing_shows_unsaved_marker_and_save_clears_it` only as
@@ -93,7 +93,7 @@ disabled, and carries exactly:
 No unsaved Prompt changes to discard.
 ```
 
-- [ ] **Step 2: Run the exact test and verify RED**
+- [x] **Step 2: Run the exact test and verify RED**
 
 ```bash
 ../../.venv/bin/python -m pytest \
@@ -103,7 +103,7 @@ No unsaved Prompt changes to discard.
 
 Expected RED: `#library-prompt-discard` is absent.
 
-- [ ] **Step 3: Add and export the Prompt tooltip constants, then render**
+- [x] **Step 3: Add and export the Prompt tooltip constants, then render**
 
 Define beside the Prompt canvas constants:
 
@@ -135,7 +135,7 @@ yield Button(
 
 Only mutation and a clean working copy disable this action.
 
-- [ ] **Step 4: Rerun the exact test GREEN through the clean assertions**
+- [x] **Step 4: Rerun the exact test GREEN through the clean assertions**
 
 Run the Step 2 command and require the clean action assertions to pass.
 
@@ -145,7 +145,7 @@ Run the Step 2 command and require the clean action assertions to pass.
 - Modify: `Tests/UI/test_library_prompts_canvas.py:7897-7940`
 - Modify: `tldw_chatbook/UI/Screens/library_screen.py:18240-18335,18610-19010`
 
-- [ ] **Step 1: Strengthen the existing no-recompose regression**
+- [x] **Step 1: Strengthen the existing no-recompose regression**
 
 Capture the clean Discard widget identity. After editing, assert the same widget
 instance is enabled with exactly:
@@ -158,14 +158,14 @@ After the existing real save reaches `Saved.`, assert the same widget instance
 is disabled again with the clean tooltip. This node already proves the Prompt
 meta and editor fields do not recompose.
 
-- [ ] **Step 2: Run the exact test and verify RED**
+- [x] **Step 2: Run the exact test and verify RED**
 
 Run the Task 2 Step 2 command.
 
 Expected RED: the mounted action stays in its clean disabled state after the
 field change.
 
-- [ ] **Step 3: Implement one targeted Discard patcher**
+- [x] **Step 3: Implement one targeted Discard patcher**
 
 Add `_set_library_prompt_discard_enabled()` beside
 `_sync_library_prompt_save_action_widgets()`. It updates only `disabled` and
@@ -179,7 +179,7 @@ Call it from the common successful create/update save settlement after
 that already recompose project the correct state from `dirty` and need no second
 mechanism.
 
-- [ ] **Step 4: Rerun the exact test GREEN**
+- [x] **Step 4: Rerun the exact test GREEN**
 
 Run the Task 2 Step 2 command and require one pass.
 
@@ -190,7 +190,7 @@ Run the Task 2 Step 2 command and require one pass.
   the Prompt dirty-state tests)
 - Modify: `tldw_chatbook/UI/Screens/library_screen.py:19280-19335`
 
-- [ ] **Step 1: Add the compatibility dead-end regression**
+- [x] **Step 1: Add the compatibility dead-end regression**
 
 Use a real Prompt database/service and mount a compatibility-only structured
 artifact with blank System/User lanes. Prove `Update original` and
@@ -203,7 +203,7 @@ Discard enables. Press it and prove all of the established clean-Back tail:
 - the local source snapshot refreshes exactly once; and
 - deferred first-row focus lands on the first Prompt row.
 
-- [ ] **Step 2: Run the exact new node and verify RED**
+- [x] **Step 2: Run the exact new node and verify RED**
 
 ```bash
 ../../.venv/bin/python -m pytest \
@@ -214,7 +214,7 @@ Discard enables. Press it and prove all of the established clean-Back tail:
 Expected RED: pressing the mounted Discard action has no handler/list-return
 effect.
 
-- [ ] **Step 3: Add the explicit screen handler**
+- [x] **Step 3: Add the explicit screen handler**
 
 Handle `#library-prompt-discard`. Refuse during mutation or while clean.
 Otherwise reset the Prompt editor, request the current Prompt browse scope,
@@ -222,13 +222,13 @@ refresh the local source snapshot, and arm first-row focus using the same exact
 operations and ordering as the clean Back tail. Do not persist and do not add a
 confirmation modal or state.
 
-- [ ] **Step 4: Rerun the exact new node GREEN**
+- [x] **Step 4: Rerun the exact new node GREEN**
 
 Run the Step 2 command and require one pass.
 
 ### Task 5: Mutation proofs and affected verification
 
-- [ ] **Step 1: Prove all behavior boundaries are non-vacuous**
+- [x] **Step 1: Prove all behavior boundaries are non-vacuous**
 
 Temporarily bypass the Prompt notifier; Task 1's exact dirty-flush node must go
 RED while its clean assertion remains green. Restore it. Temporarily omit the
@@ -236,7 +236,7 @@ live Discard dirty patch; Task 3's exact node must go RED on the disabled action
 Restore it. Temporarily bypass the Discard handler; Task 4's exact node must go
 RED on its unchanged editor/list assertions. Restore and rerun all three GREEN.
 
-- [ ] **Step 2: Run focused sibling verification**
+- [x] **Step 2: Run focused sibling verification**
 
 ```bash
 ../../.venv/bin/python -m pytest \
@@ -245,7 +245,7 @@ RED on its unchanged editor/list assertions. Restore and rerun all three GREEN.
   -q -k 'flush_pending_work_vetoes_dirty_editor or prompt_discard or editing_shows_unsaved_marker_and_save_clears_it or flush_pending_work_skill_veto_notifies'
 ```
 
-- [ ] **Step 3: Run the full Prompt canvas file once**
+- [x] **Step 3: Run the full Prompt canvas file once**
 
 ```bash
 ../../.venv/bin/python -m pytest Tests/UI/test_library_prompts_canvas.py -q
@@ -254,7 +254,7 @@ RED on its unchanged editor/list assertions. Restore and rerun all three GREEN.
 Classify any failure against unchanged `origin/dev`; do not weaken unrelated
 tests.
 
-- [ ] **Step 4: Run static checks over every owned Python file**
+- [x] **Step 4: Run static checks over every owned Python file**
 
 ```bash
 ../../.venv/bin/ruff check \
@@ -294,7 +294,7 @@ The exact changed ranges above are baseline-green before implementation. If
 edits shift their end lines, widen only the affected range and record it. Do not
 whole-file-format the three monolithic files.
 
-- [ ] **Step 5: Run the Impeccable detector once at final state**
+- [x] **Step 5: Run the Impeccable detector once at final state**
 
 ```bash
 node /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.agents/skills/impeccable/scripts/detect.mjs \
@@ -307,7 +307,7 @@ node /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.agents/skills/impeccable
 
 ### Task 6: Commit behavior and close out TASK-2702
 
-- [ ] **Step 1: Commit the verified behavior**
+- [x] **Step 1: Commit the verified behavior**
 
 ```bash
 git add \
@@ -318,14 +318,14 @@ git add \
 git commit -m "fix(library): explain dirty Prompt navigation veto"
 ```
 
-- [ ] **Step 2: Complete task hygiene**
+- [x] **Step 2: Complete task hygiene**
 
 Check all acceptance criteria, add concise Implementation Notes with exact
 test/static evidence and the ADR decision, and set TASK-2702 to Done without a
 CLI operation that strips existing task sections. Add a lesson only if a new,
 generalizable incident actually occurred.
 
-- [ ] **Step 3: Commit closeout and verify the cumulative branch**
+- [x] **Step 3: Commit closeout and verify the cumulative branch**
 
 ```bash
 git add \

--- a/Docs/superpowers/specs/2026-08-13-task-2702-prompt-dirty-navigation-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-2702-prompt-dirty-navigation-design.md
@@ -10,23 +10,34 @@ currently looks like a dead control.
 
 ## Design
 
-Add one fixed, content-free Prompt warning message and one Prompt-specific
-notification helper beside the existing Skill helper. When
-`flush_pending_work()` receives a `False` result from the Prompt save barrier,
-invoke that helper before returning the combined admission result.
+Mirror the existing Skill dirty-exit contract at the Prompt editor boundary:
+
+- add one fixed, content-free Prompt warning message and one Prompt-specific
+  notification helper beside the existing Skill helper;
+- render a `Discard changes` action in the existing Prompt editor action region;
+- keep that action disabled, with a literal reason tooltip, until the editor is
+  dirty, then enable it in place without recomposing the live fields;
+- when pressed, discard the working copy and follow the same list-return/reset
+  tail as a clean Back action; and
+- when `flush_pending_work()` receives a `False` result from the Prompt save
+  barrier, invoke the warning helper before returning the combined admission
+  result.
 
 The message is:
 
-> Unsaved Prompt changes — Save before switching screens.
+> Unsaved Prompt changes — Save or Discard changes first.
 
-This names the blocked state and the recovery action that actually exists in the
-current editor. It deliberately does not promise a Discard action, because the
-Prompt editor currently exposes Save and a dirty-vetoed Back action but no general
-Discard control.
+This names the blocked state and two recovery classes that are always truthful.
+The concrete save label varies by artifact capability (`Save Prompt`, `Update
+original`, or `Convert and save as new Prompt`), while `Discard changes` is the
+stable recovery action in every dirty editor. In particular, a compatibility-only
+artifact with no convertible System/User text can have every save action disabled;
+Discard prevents that state from becoming a navigation dead end.
 
-The existing navigation result, draft state, focus, editor layout, and other
-note/skill barriers remain unchanged. No persistent status, new reactive state,
-CSS, worker, or shared notification abstraction is introduced.
+The existing navigation result, focus, editor scroll ownership, and other note/skill
+barriers remain unchanged. A veto preserves the draft; only an explicit Discard
+clears it. No persistent status, new reactive state, CSS, worker, confirmation
+modal, or shared notification abstraction is introduced.
 
 ## Error and privacy behavior
 
@@ -38,11 +49,18 @@ and the draft remains intact, matching current fail-closed behavior.
 ## Verification
 
 Strengthen the existing mounted Prompt `flush_pending_work()` regression to record
-notifications and prove all of the following in one flow:
+notifications and prove all of the following in one ordinary structured-Prompt
+flow:
 
 - the dirty Prompt still vetoes navigation;
 - the fixed warning is emitted once at warning severity;
 - the unsaved draft and dirty flag remain intact.
+
+Add a mounted compatibility-only case with no convertible Prompt body. Edit its
+metadata, prove its save/convert actions are unavailable but `Discard changes` is
+enabled, press Discard, and prove the list returns without persisting the edit.
+Also prove the Discard control is disabled with an explanatory tooltip on a clean
+editor and re-disables after a successful save.
 
 Keep the existing Skill veto regression green to prove the sibling behavior was not
 changed. Run scoped Ruff, formatting, `py_compile`, diff checks, and the Impeccable

--- a/Docs/superpowers/specs/2026-08-13-task-2702-prompt-dirty-navigation-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-2702-prompt-dirty-navigation-design.md
@@ -1,0 +1,57 @@
+# TASK-2702 — Prompt dirty-navigation feedback
+
+## Context
+
+Library's Prompt editor is explicit-save-only. When a Prompt has unsaved edits,
+`LibraryScreen.flush_pending_work()` correctly returns `False` and keeps the
+screen mounted, but app-level navigation only logs that refusal. The equivalent
+Skill-editor refusal already emits a warning notification, so Prompt navigation
+currently looks like a dead control.
+
+## Design
+
+Add one fixed, content-free Prompt warning message and one Prompt-specific
+notification helper beside the existing Skill helper. When
+`flush_pending_work()` receives a `False` result from the Prompt save barrier,
+invoke that helper before returning the combined admission result.
+
+The message is:
+
+> Unsaved Prompt changes — Save before switching screens.
+
+This names the blocked state and the recovery action that actually exists in the
+current editor. It deliberately does not promise a Discard action, because the
+Prompt editor currently exposes Save and a dirty-vetoed Back action but no general
+Discard control.
+
+The existing navigation result, draft state, focus, editor layout, and other
+note/skill barriers remain unchanged. No persistent status, new reactive state,
+CSS, worker, or shared notification abstraction is introduced.
+
+## Error and privacy behavior
+
+The warning is emitted at `warning` severity through the existing app notification
+seam. It contains no Prompt name, content, identifier, exception, or other dynamic
+value. If the app notification seam is unavailable, navigation is still refused
+and the draft remains intact, matching current fail-closed behavior.
+
+## Verification
+
+Strengthen the existing mounted Prompt `flush_pending_work()` regression to record
+notifications and prove all of the following in one flow:
+
+- the dirty Prompt still vetoes navigation;
+- the fixed warning is emitted once at warning severity;
+- the unsaved draft and dirty flag remain intact.
+
+Keep the existing Skill veto regression green to prove the sibling behavior was not
+changed. Run scoped Ruff, formatting, `py_compile`, diff checks, and the Impeccable
+detector over the changed UI/test files.
+
+## Architecture decision
+
+ADR required: no  
+ADR path: N/A  
+Reason: this is a routine UX bug fix that applies an existing Library notification
+pattern without changing state ownership, service contracts, persistence, security,
+or long-lived application structure.

--- a/Docs/superpowers/specs/2026-08-13-task-2702-prompt-dirty-navigation-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-2702-prompt-dirty-navigation-design.md
@@ -68,8 +68,8 @@ detector over the changed UI/test files.
 
 ## Architecture decision
 
-ADR required: no  
-ADR path: N/A  
+ADR required: no
+ADR path: N/A
 Reason: this is a routine UX bug fix that applies an existing Library notification
 pattern without changing state ownership, service contracts, persistence, security,
 or long-lived application structure.

--- a/Tests/UI/test_library_prompts_canvas.py
+++ b/Tests/UI/test_library_prompts_canvas.py
@@ -8797,6 +8797,7 @@ async def test_library_prompt_editor_geometry_keeps_actions_visible_without_cove
             (
                 "library-prompt-conflict-save-new",
                 "library-prompt-conflict-reload",
+                "library-prompt-discard",
             )
             if conflict
             else (
@@ -8806,6 +8807,7 @@ async def test_library_prompt_editor_geometry_keeps_actions_visible_without_cove
                 "library-prompt-copy",
                 "library-prompt-duplicate",
                 "library-prompt-delete",
+                "library-prompt-discard",
             )
         )
         for action_id in action_ids:

--- a/Tests/UI/test_library_prompts_canvas.py
+++ b/Tests/UI/test_library_prompts_canvas.py
@@ -7446,12 +7446,17 @@ async def test_library_prompt_flush_pending_work_vetoes_dirty_editor(tmp_path):
     app = _build_test_app()
     _wire_empty_non_prompt_services(app)
     app.prompt_scope_service = service
+    notifications: list[tuple[str, dict[str, object]]] = []
+    app.notify = lambda message, **kwargs: notifications.append((message, kwargs))
     host = LibraryHarness(app)
 
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         screen = _active_library_screen(host)
         await _wait_for_library_shell(screen, pilot)
         await _open_prompt_editor(screen, pilot, prompt_id)
+
+        assert await screen.flush_pending_work() is True
+        assert notifications == []
 
         screen.query_one("#library-prompt-author", Input).value = "Changed mid switch"
         await pilot.pause()
@@ -7460,7 +7465,16 @@ async def test_library_prompt_flush_pending_work_vetoes_dirty_editor(tmp_path):
         allowed = await screen.flush_pending_work()
 
         assert allowed is False
+        assert screen.query_one("#library-prompt-author", Input).value == (
+            "Changed mid switch"
+        )
         assert screen._library_prompt_dirty is True
+        assert notifications == [
+            (
+                "Unsaved Prompt changes — Save or Discard changes first.",
+                {"severity": "warning"},
+            )
+        ]
 
 
 @pytest.mark.asyncio
@@ -7918,6 +7932,10 @@ async def test_library_prompt_editing_shows_unsaved_marker_and_save_clears_it(tm
 
         meta_before = screen.query_one("#library-prompt-meta", Static)
         assert "Unsaved" not in str(meta_before.renderable)
+        discard = screen.query_one("#library-prompt-discard", Button)
+        assert str(discard.label) == "Discard changes"
+        assert discard.disabled is True
+        assert str(discard.tooltip) == "No unsaved Prompt changes to discard."
 
         screen.query_one("#library-prompt-author", Input).value = "Changed"
         await pilot.pause()
@@ -7926,6 +7944,12 @@ async def test_library_prompt_editing_shows_unsaved_marker_and_save_clears_it(tm
         meta_after_edit = screen.query_one("#library-prompt-meta", Static)
         assert meta_after_edit is meta_before  # no recompose -- same widget instance
         assert "• Unsaved changes" in str(meta_after_edit.renderable)
+        discard_after_edit = screen.query_one("#library-prompt-discard", Button)
+        assert discard_after_edit is discard
+        assert discard_after_edit.disabled is False
+        assert str(discard_after_edit.tooltip) == (
+            "Return to the Prompt list without saving these changes."
+        )
 
         screen.query_one("#library-prompt-save", Button).press()
         await pilot.pause()
@@ -7936,6 +7960,103 @@ async def test_library_prompt_editing_shows_unsaved_marker_and_save_clears_it(tm
         meta_after_save = screen.query_one("#library-prompt-meta", Static)
         assert meta_after_save is meta_before
         assert "Unsaved" not in str(meta_after_save.renderable)
+        discard_after_save = screen.query_one("#library-prompt-discard", Button)
+        assert discard_after_save is discard
+        assert discard_after_save.disabled is True
+        assert str(discard_after_save.tooltip) == (
+            "No unsaved Prompt changes to discard."
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_prompt_compatibility_editor_discard_returns_to_current_list(
+    tmp_path,
+    monkeypatch,
+):
+    """A dirty compatibility editor can leave even when no save path exists."""
+    db, service = _real_prompt_scope_service(tmp_path)
+    prompt_id, _uuid, _message = db.add_prompt(
+        name="Compatibility only",
+        author="Original",
+        details="No convertible lanes",
+        system_prompt="",
+        user_prompt="",
+        prompt_format="structured",
+        prompt_schema_version=2,
+        prompt_definition={
+            "kind": "block_recipe",
+            "schema_version": 2,
+            "lanes": [
+                {"id": "system", "blocks": []},
+                {"id": "user", "blocks": []},
+            ],
+        },
+        artifact_type="prompt",
+    )
+    before = db.fetch_prompt_details(prompt_id)
+    save_prompt = AsyncMock(wraps=service.save_prompt)
+    service.save_prompt = save_prompt
+    app = _build_test_app()
+    _wire_empty_non_prompt_services(app)
+    app.prompt_scope_service = service
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_prompt_editor(screen, pilot, prompt_id)
+
+        assert screen._library_prompt_block_state is None
+        assert screen.query_one("#library-prompt-save", Button).disabled is True
+        assert screen.query_one("#library-prompt-convert", Button).disabled is True
+
+        screen.query_one("#library-prompt-author", Input).value = "Discard me"
+        await pilot.pause()
+        discard = screen.query_one("#library-prompt-discard", Button)
+        assert screen._library_prompt_dirty is True
+        assert discard.disabled is False
+
+        scope_before = screen._library_prompt_browse_controller.scope
+        browse_calls: list[tuple[object, str | None]] = []
+        refresh_calls = 0
+        original_browse = screen._request_library_prompts_browse
+        original_refresh = screen._refresh_local_source_snapshot
+
+        def recording_browse(scope, *, focus_identity=None):
+            browse_calls.append((scope, focus_identity))
+            return original_browse(scope, focus_identity=focus_identity)
+
+        def recording_refresh():
+            nonlocal refresh_calls
+            refresh_calls += 1
+            return original_refresh()
+
+        monkeypatch.setattr(screen, "_request_library_prompts_browse", recording_browse)
+        monkeypatch.setattr(screen, "_refresh_local_source_snapshot", recording_refresh)
+
+        discard.press()
+        for _ in range(100):
+            await pilot.pause(0.02)
+            if (
+                screen._library_prompts_view == "list"
+                and len(screen.query(f"#library-prompt-row-{prompt_id}")) == 1
+            ):
+                break
+
+        assert screen._library_prompts_view == "list"
+        assert browse_calls == [(scope_before, None)]
+        assert refresh_calls == 1
+        row = screen.query_one(f"#library-prompt-row-{prompt_id}", Button)
+        for _ in range(100):
+            if screen.focused is row:
+                break
+            await pilot.pause(0.02)
+        assert screen.focused is row
+
+    save_prompt.assert_not_awaited()
+    after = db.fetch_prompt_details(prompt_id)
+    assert after["author"] == before["author"] == "Original"
+    assert after["version"] == before["version"]
 
 
 # ---------------------------------------------------------------------------
@@ -8854,6 +8975,7 @@ async def test_library_prompt_action_groups_preserve_normal_dom_and_focus_order(
             "library-prompt-actions-primary",
             "library-prompt-actions-content",
             "library-prompt-actions-lifecycle",
+            "library-prompt-discard",
         ]
         assert [button.id for button in primary.query(Button)] == [
             "library-prompt-save"
@@ -8874,6 +8996,7 @@ async def test_library_prompt_action_groups_preserve_normal_dom_and_focus_order(
             "library-prompt-copy",
             "library-prompt-duplicate",
             "library-prompt-delete",
+            "library-prompt-discard",
         ]
         assert str(pilot.app.query_one("#library-prompt-copy", Button).label) == (
             "Copy Markdown"
@@ -8895,10 +9018,12 @@ async def test_library_prompt_action_groups_preserve_conflict_action_order():
         assert [button.id for button in actions.query(Button)] == [
             "library-prompt-conflict-save-new",
             "library-prompt-conflict-reload",
+            "library-prompt-discard",
         ]
         assert [str(button.label) for button in actions.query(Button)] == [
             "Save as new",
             "Reload",
+            "Discard changes",
         ]
 
 

--- a/Tests/UI/test_library_prompts_canvas.py
+++ b/Tests/UI/test_library_prompts_canvas.py
@@ -7973,7 +7973,12 @@ async def test_library_prompt_compatibility_editor_discard_returns_to_current_li
     tmp_path,
     monkeypatch,
 ):
-    """A dirty compatibility editor can leave even when no save path exists."""
+    """A dirty compatibility editor can leave even when no save path exists.
+
+    Args:
+        tmp_path: Pytest-managed temporary directory for the real Prompt DB.
+        monkeypatch: Pytest helper used to observe browse and snapshot calls.
+    """
     db, service = _real_prompt_scope_service(tmp_path)
     prompt_id, _uuid, _message = db.add_prompt(
         name="Compatibility only",
@@ -8057,6 +8062,93 @@ async def test_library_prompt_compatibility_editor_discard_returns_to_current_li
     after = db.fetch_prompt_details(prompt_id)
     assert after["author"] == before["author"] == "Original"
     assert after["version"] == before["version"]
+
+
+@pytest.mark.asyncio
+async def test_library_prompt_discard_refuses_while_save_is_in_flight(tmp_path):
+    """Discard stays disabled and inert until an admitted save settles.
+
+    Args:
+        tmp_path: Pytest-managed temporary directory for the real Prompt DB.
+    """
+    db, service = _real_prompt_scope_service(tmp_path)
+    prompt_id, _uuid, _message = db.add_prompt(
+        name="Held save discard",
+        author="Original",
+        details="Before",
+    )
+    save_started = threading.Event()
+    save_release = threading.Event()
+    original_save = service.save_prompt
+
+    async def held_save(**kwargs: Any):
+        save_started.set()
+        await asyncio.to_thread(save_release.wait)
+        return await original_save(**kwargs)
+
+    service.save_prompt = held_save
+    app = _build_test_app()
+    _wire_empty_non_prompt_services(app)
+    app.prompt_scope_service = service
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_prompt_editor(screen, pilot, prompt_id)
+
+        author = screen.query_one("#library-prompt-author", Input)
+        author.value = "Saved after hold"
+        await pilot.pause()
+        discard = screen.query_one("#library-prompt-discard", Button)
+        assert screen._library_prompt_dirty is True
+        assert discard.disabled is False
+
+        screen.query_one("#library-prompt-save", Button).press()
+        for _ in range(100):
+            if save_started.is_set():
+                break
+            await pilot.pause(0.02)
+        assert save_started.is_set()
+
+        try:
+            busy_disabled = discard.disabled
+            busy_tooltip = str(discard.tooltip)
+            screen.handle_library_prompt_discard(Button.Pressed(discard))
+            await pilot.pause()
+            refused_view = screen._library_prompts_view
+            refused_prompt_id = screen._selected_prompt_id
+            refused_author = author.value
+            refused_dirty = screen._library_prompt_dirty
+        finally:
+            save_release.set()
+
+        for _ in range(150):
+            active = [
+                worker
+                for worker in screen.workers
+                if worker.group == "library_prompt_save" and not worker.is_finished
+            ]
+            if not active:
+                break
+            await pilot.pause(0.02)
+
+        assert busy_disabled is True
+        assert busy_tooltip == (
+            "Prompt changes are still in progress. Try again when they finish."
+        )
+        assert refused_view == "editor"
+        assert refused_prompt_id == prompt_id
+        assert refused_author == "Saved after hold"
+        assert refused_dirty is True
+        persisted = db.fetch_prompt_details(prompt_id)
+        assert persisted is not None
+        assert persisted["author"] == "Saved after hold"
+        assert screen._library_prompt_dirty is False
+        settled_discard = screen.query_one("#library-prompt-discard", Button)
+        assert settled_discard is discard
+        assert settled_discard.disabled is True
+        assert str(settled_discard.tooltip) == ("No unsaved Prompt changes to discard.")
 
 
 # ---------------------------------------------------------------------------

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -3662,3 +3662,25 @@ not just re-run the flaky test and hope: inject the exact transient exception
 deterministically (a fake service that raises on its Nth call, not the Mth) so the
 flap is reproducible on demand, and mutation-test the fix by temporarily re-
 merging the domains to confirm the ORIGINAL failure message comes back verbatim.
+
+---
+
+## A parent `on_mount()` cannot assume nested descendants are mounted (TASK-2702, 2026-08-13)
+
+**Incident.** Three Library Prompt-history tests repeatedly crashed while a
+`PromptBlockEditor` was being replaced during rapid recomposition. Its `on_mount()`
+queried `#prompt-editor-validation`, a grandchild inside the editor's status container,
+and raised `NoMatches`. Instrumentation at the exception showed the editor was attached
+and all three direct containers already existed, but their nested children did not. An
+unconditional `call_after_refresh` removed that race, then exposed the opposite defect:
+two ordinary-mount tests observed an empty footer because they legitimately inspected it
+before the deferred callback ran.
+
+**What to do.** A Textual parent's Mount event guarantees neither that every descendant
+message pump has finished mounting nor that consumers will wait through an extra refresh.
+Initialize synchronously when the required descendants are present; if `NoMatches` proves
+the nested-mount window is still open, defer that same initialization once. The deferred
+callback must no-op when its original widget has detached. Verify both paths: a rapid real
+recompose must kill the synchronous-only implementation, while an immediate normal-mount
+assertion must kill unconditional deferral. TASK-2702's final full Prompt-canvas run passed
+279 tests only after both boundaries were pinned together.

--- a/backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md
+++ b/backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-31'
-updated_date: '2026-08-13 09:45'
+updated_date: '2026-08-13 10:07'
 labels: [library, bug, ux]
 dependencies: []
 ---
@@ -41,6 +41,7 @@ veto is asking for isn't visibly available either).
 - [x] #1 Attempting to navigate away with an unsaved prompt tells the user why the switch was refused and what to do (same shape as the skills dirty veto)
 - [x] #2 The message names the resolution (Save, or discard/leave the editor) and matches whatever affordances actually exist after task-2701
 - [x] #3 A test covers the notify-on-veto path so it cannot regress to silence
+- [x] #4 Prompt editor footer state remains initialized during both ordinary mounts and rapid history-driven recomposition
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -83,16 +84,21 @@ Detailed execution plan:
   state, and no-op discard; notifier, live-patch, and handler mutations each made
   their exact tests fail before restoration.
 - Focused behavior verification passed 6 tests and the final normal/conflict
-  geometry matrix passed 8 tests. The one full Prompt-canvas run produced 274
-  passes and 5 failures: two stale action-order expectations were corrected and
-  passed exactly; the other three PromptBlockEditor mount-race failures reproduced
-  unchanged at pre-implementation commit `9bc505b72` and were not weakened or
-  worked around.
+  geometry matrix passed 8 tests. The initial full Prompt-canvas run produced 274
+  passes and exposed two stale action-order expectations plus three pre-existing
+  PromptBlockEditor mount-race failures. After the user-directed integration
+  follow-up, `PromptBlockEditor` now synchronizes its footer immediately on an
+  ordinary mount and defers only when Textual has not mounted nested controls yet;
+  detached deferred callbacks are no-ops. Both sides failed under their opposite
+  mutation, the 24 direct widget tests passed, and the final full Prompt-canvas run
+  passed all 279 tests.
 - Ruff lint, changed-range Ruff formatting, production `py_compile`, cumulative
   diff checking, and the final Impeccable detector passed. The detector returned
   no findings. No dependency, CSS, diagnostic, persistence, or service-contract
   changes were introduced.
 - ADR required: no. This is a routine application of the existing Library dirty
-  veto/discard pattern and changes no architectural boundary. No new lesson was
-  added because the implementation surfaced no new generalizable incident.
+  veto/discard pattern and a lifecycle correction inside the existing widget; neither
+  changes an architectural boundary. The nested-mount incident was added to
+  `backlog/docs/lessons-testing-evidence.md` because it generalizes to other Textual
+  parent widgets that query descendants from `on_mount()`.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md
+++ b/backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md
@@ -1,17 +1,18 @@
 ---
 id: TASK-2702
 title: 'Library: an unsaved prompt silently blocks screen navigation'
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-31'
-updated_date: '2026-08-13 16:00'
+updated_date: '2026-08-13 09:45'
 labels: [library, bug, ux]
 dependencies: []
 ---
 
-## Description (the why)
+## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 With unsaved edits in the Library prompt editor, clicking another
 destination in the nav bar does nothing at all — no screen change, no
 toast, no banner. The user is stuck on Library with no explanation and no
@@ -32,20 +33,19 @@ prompt, clicked "5 Roleplay" in the nav bar twice — stayed on Library,
 no notification either time. Made worse by task-2701 (the editor's Save
 button renders below the viewport at standard heights, so the fix the
 veto is asking for isn't visibly available either).
+<!-- SECTION:DESCRIPTION:END -->
 
-## Acceptance Criteria (the what)
+## Acceptance Criteria
 
-- [ ] Attempting to navigate away with an unsaved prompt tells the user
-      why the switch was refused and what to do (same shape as the skills
-      dirty veto).
-- [ ] The message names the resolution (Save, or discard/leave the
-      editor) and matches whatever affordances actually exist after
-      task-2701.
-- [ ] A test covers the notify-on-veto path so it cannot regress to
-      silence.
+<!-- AC:BEGIN -->
+- [x] #1 Attempting to navigate away with an unsaved prompt tells the user why the switch was refused and what to do (same shape as the skills dirty veto)
+- [x] #2 The message names the resolution (Save, or discard/leave the editor) and matches whatever affordances actually exist after task-2701
+- [x] #3 A test covers the notify-on-veto path so it cannot regress to silence
+<!-- AC:END -->
 
-## Implementation Plan (the how)
+## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 ADR required: no
 
 ADR path: N/A
@@ -63,3 +63,36 @@ security, or long-lived application structure.
 
 Detailed execution plan:
 `Docs/superpowers/plans/2026-08-13-task-2702-prompt-dirty-navigation.md`.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added a fixed, content-free warning when dirty Prompt state vetoes navigation:
+  `Unsaved Prompt changes — Save or Discard changes first.` Clean Prompt flushes
+  remain silent.
+- Added one stable `Discard changes` action to every Prompt editor state. It is
+  disabled with a literal explanation while clean, updates in place when fields
+  become dirty or save successfully, and returns to the current Prompt list
+  without persisting the working copy. Compatibility-only editors therefore
+  retain an explicit escape even when Update and Convert are unavailable.
+- Mounted real-SQLite regressions cover clean/dirty/save transitions, the exact
+  warning, compatibility discard without persistence, current-scope refresh,
+  first-row focus, normal/conflict DOM order, and action containment across four
+  terminal sizes. RED evidence was the absent warning/action, stale disabled
+  state, and no-op discard; notifier, live-patch, and handler mutations each made
+  their exact tests fail before restoration.
+- Focused behavior verification passed 6 tests and the final normal/conflict
+  geometry matrix passed 8 tests. The one full Prompt-canvas run produced 274
+  passes and 5 failures: two stale action-order expectations were corrected and
+  passed exactly; the other three PromptBlockEditor mount-race failures reproduced
+  unchanged at pre-implementation commit `9bc505b72` and were not weakened or
+  worked around.
+- Ruff lint, changed-range Ruff formatting, production `py_compile`, cumulative
+  diff checking, and the final Impeccable detector passed. The detector returned
+  no findings. No dependency, CSS, diagnostic, persistence, or service-contract
+  changes were introduced.
+- ADR required: no. This is a routine application of the existing Library dirty
+  veto/discard pattern and changes no architectural boundary. No new lesson was
+  added because the implementation surfaced no new generalizable incident.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md
+++ b/backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md
@@ -76,7 +76,9 @@ Detailed execution plan:
   disabled with a literal explanation while clean, updates in place when fields
   become dirty or save successfully, and returns to the current Prompt list
   without persisting the working copy. Compatibility-only editors therefore
-  retain an explicit escape even when Update and Convert are unavailable.
+  retain an explicit escape even when Update and Convert are unavailable. PR
+  review hardening also keeps Discard disabled and handler-guarded until any
+  admitted Prompt save settles, so a save cannot persist after a claimed discard.
 - Mounted real-SQLite regressions cover clean/dirty/save transitions, the exact
   warning, compatibility discard without persistence, current-scope refresh,
   first-row focus, normal/conflict DOM order, and action containment across four

--- a/backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md
+++ b/backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md
@@ -43,3 +43,23 @@ veto is asking for isn't visibly available either).
       task-2701.
 - [ ] A test covers the notify-on-veto path so it cannot regress to
       silence.
+
+## Implementation Plan (the how)
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: routine UX bug fix applying the existing Library dirty-veto/discard
+pattern without changing persistence, service contracts, state ownership,
+security, or long-lived application structure.
+
+1. Strengthen the mounted Prompt dirty-navigation test and add clean/save plus
+   compatibility-only Discard regressions, then capture the intended RED.
+2. Mirror the existing Skill warning/discard pattern in the current Prompt canvas
+   and screen seams without new state, CSS, workers, modals, or abstractions.
+3. Mutation-check both the warning and live Discard enablement, run the bounded
+   affected/static/UI-hardening gates, document evidence, and close the task.
+
+Detailed execution plan:
+`Docs/superpowers/plans/2026-08-13-task-2702-prompt-dirty-navigation.md`.

--- a/backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md
+++ b/backlog/tasks/task-2702 - Library-unsaved-prompt-silently-blocks-screen-navigation.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-2702
 title: 'Library: an unsaved prompt silently blocks screen navigation'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-31'
+updated_date: '2026-08-13 16:00'
 labels: [library, bug, ux]
 dependencies: []
 ---

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -354,6 +354,8 @@ from ...Widgets.Library import (
     LibraryRail,
     LibrarySearchRagPanel,
     LibrarySkillsListCanvas,
+    PROMPT_DISCARD_TOOLTIP_CLEAN,
+    PROMPT_DISCARD_TOOLTIP_DIRTY,
     SKILL_DISCARD_TOOLTIP_CLEAN,
     SKILL_DISCARD_TOOLTIP_DIRTY,
     library_dim_label_text,
@@ -568,6 +570,9 @@ LIBRARY_PROMPT_SAVE_STATUS_COPY = {
 # dedicated cap of their own -- reuses the note body's generous ceiling,
 # same reasoning as ``LIBRARY_PROMPT_TEXT_MAX_CHARS`` above.
 LIBRARY_SKILL_TEXT_MAX_CHARS = LIBRARY_NOTE_CONTENT_MAX_CHARS
+LIBRARY_PROMPT_DIRTY_VETO_COPY = (
+    "Unsaved Prompt changes — Save or Discard changes first."
+)
 # Exact outcome copy for the skill editor's #library-skill-save-status line,
 # keyed by ``classify_skill_save_error``'s return value. "version-conflict"
 # is deliberately absent -- it routes into the conflict banner instead (see
@@ -6089,6 +6094,8 @@ class LibraryScreen(BaseAppScreen):
         note_flush = await self._flush_library_note_save()
         prompt_flush_allowed = await self._flush_library_prompt_save()
         skill_flush_allowed = await self._flush_library_skill_save()
+        if not prompt_flush_allowed:
+            self._notify_prompt_dirty_veto()
         if not skill_flush_allowed:
             # task-449: the app-level navigation veto only logs, so tell
             # the user why the tab switch was refused -- same toast as the
@@ -18497,6 +18504,7 @@ class LibraryScreen(BaseAppScreen):
         if not was_dirty:
             self._update_library_prompt_meta_static()
             self._sync_library_prompt_history_region()
+            self._set_library_prompt_discard_enabled(True)
 
     @on(Input.Changed, "#library-prompt-name")
     @on(Input.Changed, "#library-prompt-author")
@@ -18540,6 +18548,7 @@ class LibraryScreen(BaseAppScreen):
         if not was_dirty:
             self._update_library_prompt_meta_static()
             self._sync_library_prompt_history_region()
+            self._set_library_prompt_discard_enabled(True)
 
     def on_prompt_block_editor_block_field_changed(
         self, event: PromptBlockEditor.BlockFieldChanged
@@ -18859,6 +18868,19 @@ class LibraryScreen(BaseAppScreen):
             return
         outer_save.label = "Update original"
         outer_save.disabled = not can_update
+
+    def _set_library_prompt_discard_enabled(self, enabled: bool) -> None:
+        """Patch the Prompt Discard action without remounting live fields."""
+        for button in self.query("#library-prompt-discard"):
+            if isinstance(button, Button):
+                button.disabled = (
+                    self._library_prompts_mutation_in_flight or not enabled
+                )
+                button.tooltip = (
+                    PROMPT_DISCARD_TOOLTIP_DIRTY
+                    if enabled
+                    else PROMPT_DISCARD_TOOLTIP_CLEAN
+                )
 
     @on(Button.Pressed, "#library-prompt-save")
     def handle_library_prompt_save(self, event: Button.Pressed) -> None:
@@ -19196,6 +19218,7 @@ class LibraryScreen(BaseAppScreen):
             self._library_prompt_detached_structured = False
             self._library_prompt_original_name = name
             self._library_prompt_dirty = False
+        self._set_library_prompt_discard_enabled(False)
         # Targeted updates only (no recompose): the fields already hold the
         # user's just-saved text, so nothing there needs to change -- only
         # the meta line's version and the status line need to reflect the
@@ -19285,6 +19308,12 @@ class LibraryScreen(BaseAppScreen):
             ``False`` when a dirty edit must be resolved first.
         """
         return not self._library_prompt_dirty
+
+    def _notify_prompt_dirty_veto(self) -> None:
+        """Explain a dirty Prompt navigation veto without exposing content."""
+        notify = getattr(self.app_instance, "notify", None)
+        if callable(notify):
+            notify(LIBRARY_PROMPT_DIRTY_VETO_COPY, severity="warning")
 
     def _apply_library_prompt_working_copy(
         self,
@@ -19510,6 +19539,20 @@ class LibraryScreen(BaseAppScreen):
             system_prompt=raw_system_prompt,
             user_prompt=raw_user_prompt,
         )
+
+    @on(Button.Pressed, "#library-prompt-discard")
+    def handle_library_prompt_discard(self, event: Button.Pressed) -> None:
+        """Leave the Prompt editor without persisting its working copy."""
+        event.stop()
+        if self._library_prompts_mutation_in_flight or not self._library_prompt_dirty:
+            return
+        self._reset_library_prompt_editor_state()
+        self._request_library_prompts_browse(
+            self._library_prompt_browse_controller.scope,
+            focus_identity=None,
+        )
+        self._refresh_local_source_snapshot()
+        self._arm_library_list_entry_focus()
 
     @on(Button.Pressed, "#library-prompt-back")
     async def handle_library_prompt_back(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -354,6 +354,7 @@ from ...Widgets.Library import (
     LibraryRail,
     LibrarySearchRagPanel,
     LibrarySkillsListCanvas,
+    PROMPT_DISCARD_TOOLTIP_BUSY,
     PROMPT_DISCARD_TOOLTIP_CLEAN,
     PROMPT_DISCARD_TOOLTIP_DIRTY,
     SKILL_DISCARD_TOOLTIP_CLEAN,
@@ -466,9 +467,7 @@ _LIBRARY_PROMPT_WRITE_WORKER_GROUPS = frozenset(
         _LIBRARY_PROMPTS_IMPORT_WORKER_GROUP,
     }
 )
-_LIBRARY_PROMPT_WRITE_IN_PROGRESS_COPY = (
-    "Prompt changes are still in progress. Try again when they finish."
-)
+_LIBRARY_PROMPT_WRITE_IN_PROGRESS_COPY = PROMPT_DISCARD_TOOLTIP_BUSY
 LIBRARY_SERVICE_ERROR_COPY = "Library source services unavailable; retry Library later."
 LIBRARY_SERVICE_UNAVAILABLE_COPY = (
     "Library source services are unavailable in this runtime."
@@ -8559,6 +8558,7 @@ class LibraryScreen(BaseAppScreen):
                             ),
                             membership_state=self._library_prompt_collections_controller.membership_state,
                             mutation_in_flight=self._library_prompts_mutation_in_flight,
+                            write_in_flight=self._library_prompt_write_worker_is_active(),
                             id="library-prompts-canvas",
                         )
                     elif self._library_prompt_detail is None:
@@ -8595,6 +8595,7 @@ class LibraryScreen(BaseAppScreen):
                             ),
                             membership_state=self._library_prompt_collections_controller.membership_state,
                             mutation_in_flight=self._library_prompts_mutation_in_flight,
+                            write_in_flight=self._library_prompt_write_worker_is_active(),
                             id="library-prompts-canvas",
                         )
                 elif shell.canvas_kind == "prompts":
@@ -18623,7 +18624,7 @@ class LibraryScreen(BaseAppScreen):
             return
         self._library_prompt_block_state = event.state
         self.run_worker(
-            self._await_library_prompt_durable_call(
+            self._await_library_prompt_save_call(
                 self._save_library_prompt(
                     target_artifact_type="prompt", save_as_new=True
                 )
@@ -18641,7 +18642,7 @@ class LibraryScreen(BaseAppScreen):
             return
         self._library_prompt_block_state = event.state
         self.run_worker(
-            self._await_library_prompt_durable_call(
+            self._await_library_prompt_save_call(
                 self._save_library_prompt(
                     target_artifact_type="recipe", save_as_new=True
                 )
@@ -18659,7 +18660,7 @@ class LibraryScreen(BaseAppScreen):
             return
         self._library_prompt_block_state = event.state
         self.run_worker(
-            self._await_library_prompt_durable_call(
+            self._await_library_prompt_save_call(
                 self._save_library_prompt(
                     target_artifact_type=event.state.artifact_type,
                     save_as_new=False,
@@ -18869,17 +18870,24 @@ class LibraryScreen(BaseAppScreen):
         outer_save.label = "Update original"
         outer_save.disabled = not can_update
 
-    def _set_library_prompt_discard_enabled(self, enabled: bool) -> None:
+    def _set_library_prompt_discard_enabled(
+        self, enabled: bool, *, write_in_flight: bool | None = None
+    ) -> None:
         """Patch the Prompt Discard action without remounting live fields."""
+        if write_in_flight is None:
+            write_in_flight = self._library_prompt_write_worker_is_active()
+        busy = self._library_prompts_mutation_in_flight or write_in_flight
         for button in self.query("#library-prompt-discard"):
             if isinstance(button, Button):
-                button.disabled = (
-                    self._library_prompts_mutation_in_flight or not enabled
-                )
+                button.disabled = busy or not enabled
                 button.tooltip = (
-                    PROMPT_DISCARD_TOOLTIP_DIRTY
-                    if enabled
-                    else PROMPT_DISCARD_TOOLTIP_CLEAN
+                    PROMPT_DISCARD_TOOLTIP_BUSY
+                    if busy
+                    else (
+                        PROMPT_DISCARD_TOOLTIP_DIRTY
+                        if enabled
+                        else PROMPT_DISCARD_TOOLTIP_CLEAN
+                    )
                 )
 
     @on(Button.Pressed, "#library-prompt-save")
@@ -18894,7 +18902,7 @@ class LibraryScreen(BaseAppScreen):
         if self._library_prompts_mutation_in_flight:
             return
         self.run_worker(
-            self._await_library_prompt_durable_call(self._save_library_prompt()),
+            self._await_library_prompt_save_call(self._save_library_prompt()),
             exclusive=True,
             group="library_prompt_save",
         )
@@ -19542,9 +19550,17 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-prompt-discard")
     def handle_library_prompt_discard(self, event: Button.Pressed) -> None:
-        """Leave the Prompt editor without persisting its working copy."""
+        """Leave the Prompt editor without persisting its working copy.
+
+        Args:
+            event: Button press event emitted by the editor's Discard action.
+        """
         event.stop()
-        if self._library_prompts_mutation_in_flight or not self._library_prompt_dirty:
+        if (
+            self._library_prompts_mutation_in_flight
+            or self._library_prompt_write_worker_is_active()
+            or not self._library_prompt_dirty
+        ):
             return
         self._reset_library_prompt_editor_state()
         self._request_library_prompts_browse(
@@ -20496,6 +20512,25 @@ class LibraryScreen(BaseAppScreen):
                 if task.done():
                     return task.result()
 
+    async def _await_library_prompt_save_call(self, awaitable: Any) -> Any:
+        """Keep Discard interlocked for the full durable save lifetime.
+
+        Args:
+            awaitable: Admitted Prompt save operation to drain to settlement.
+
+        Returns:
+            The save operation's settled result.
+        """
+        self._set_library_prompt_discard_enabled(
+            self._library_prompt_dirty, write_in_flight=True
+        )
+        try:
+            return await self._await_library_prompt_durable_call(awaitable)
+        finally:
+            self._set_library_prompt_discard_enabled(
+                self._library_prompt_dirty, write_in_flight=False
+            )
+
     def _sync_library_prompt_mutation_presentation(self) -> None:
         """Project mutation ownership into the currently mounted Prompt canvas."""
         try:
@@ -21240,7 +21275,7 @@ class LibraryScreen(BaseAppScreen):
         self.refresh(recompose=True)
         self.call_after_refresh(
             lambda: self.run_worker(
-                self._await_library_prompt_durable_call(
+                self._await_library_prompt_save_call(
                     self._save_library_prompt(
                         target_artifact_type=artifact_type,
                         save_as_new=True,
@@ -21263,7 +21298,7 @@ class LibraryScreen(BaseAppScreen):
         if self._library_prompts_mutation_in_flight:
             return
         self.run_worker(
-            self._await_library_prompt_durable_call(
+            self._await_library_prompt_save_call(
                 self._resolve_library_prompt_conflict(overwrite=False)
             ),
             exclusive=True,

--- a/tldw_chatbook/Widgets/Library/__init__.py
+++ b/tldw_chatbook/Widgets/Library/__init__.py
@@ -13,6 +13,7 @@ from .library_media_trash_canvas import LibraryMediaTrashCanvas
 from .library_media_viewer import LibraryMediaViewer
 from .library_notes_canvas import LibraryNotesCanvas
 from .library_prompts_canvas import (
+    PROMPT_DISCARD_TOOLTIP_BUSY,
     PROMPT_DISCARD_TOOLTIP_CLEAN,
     PROMPT_DISCARD_TOOLTIP_DIRTY,
     LibraryPromptsListCanvas,
@@ -64,6 +65,7 @@ from .library_skills_canvas import (
 
 __all__ = [
     "LIBRARY_RAIL_ROW_PREFIX",
+    "PROMPT_DISCARD_TOOLTIP_BUSY",
     "PROMPT_DISCARD_TOOLTIP_CLEAN",
     "PROMPT_DISCARD_TOOLTIP_DIRTY",
     "SKILL_DISCARD_TOOLTIP_CLEAN",

--- a/tldw_chatbook/Widgets/Library/__init__.py
+++ b/tldw_chatbook/Widgets/Library/__init__.py
@@ -12,7 +12,11 @@ from .library_media_canvas import LibraryMediaCanvas
 from .library_media_trash_canvas import LibraryMediaTrashCanvas
 from .library_media_viewer import LibraryMediaViewer
 from .library_notes_canvas import LibraryNotesCanvas
-from .library_prompts_canvas import LibraryPromptsListCanvas
+from .library_prompts_canvas import (
+    PROMPT_DISCARD_TOOLTIP_CLEAN,
+    PROMPT_DISCARD_TOOLTIP_DIRTY,
+    LibraryPromptsListCanvas,
+)
 from .library_rail import (
     LIBRARY_RAIL_ROW_PREFIX,
     LibraryNavigationRailHandle,
@@ -60,6 +64,8 @@ from .library_skills_canvas import (
 
 __all__ = [
     "LIBRARY_RAIL_ROW_PREFIX",
+    "PROMPT_DISCARD_TOOLTIP_CLEAN",
+    "PROMPT_DISCARD_TOOLTIP_DIRTY",
     "SKILL_DISCARD_TOOLTIP_CLEAN",
     "SKILL_DISCARD_TOOLTIP_DIRTY",
     "LibraryCollectionsPanel",

--- a/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
@@ -68,6 +68,8 @@ _PAGE_UNAVAILABLE_REASON = (
     "Current page is unavailable; selected items remain available for Export or Delete."
 )
 _MUTATION_PROGRESS = "Updating selected items…"
+PROMPT_DISCARD_TOOLTIP_CLEAN = "No unsaved Prompt changes to discard."
+PROMPT_DISCARD_TOOLTIP_DIRTY = "Return to the Prompt list without saving these changes."
 
 
 def _compact_receipt_name(value: str, limit: int = 42) -> str:
@@ -1035,6 +1037,18 @@ class LibraryPromptsListCanvas(PostRecomposeCallback, Vertical):
                             compact=True,
                             disabled=self.mutation_in_flight,
                         )
+                yield Button(
+                    "Discard changes",
+                    id="library-prompt-discard",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=self.mutation_in_flight or not self.dirty,
+                    tooltip=(
+                        PROMPT_DISCARD_TOOLTIP_DIRTY
+                        if self.dirty
+                        else PROMPT_DISCARD_TOOLTIP_CLEAN
+                    ),
+                )
 
     @staticmethod
     def _membership_ids_summary(

--- a/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
@@ -70,6 +70,9 @@ _PAGE_UNAVAILABLE_REASON = (
 _MUTATION_PROGRESS = "Updating selected items…"
 PROMPT_DISCARD_TOOLTIP_CLEAN = "No unsaved Prompt changes to discard."
 PROMPT_DISCARD_TOOLTIP_DIRTY = "Return to the Prompt list without saving these changes."
+PROMPT_DISCARD_TOOLTIP_BUSY = (
+    "Prompt changes are still in progress. Try again when they finish."
+)
 
 
 def _compact_receipt_name(value: str, limit: int = 42) -> str:
@@ -78,6 +81,7 @@ def _compact_receipt_name(value: str, limit: int = 42) -> str:
     if len(normalized) <= limit:
         return normalized
     return normalized[: limit - 1].rstrip() + "…"
+
 
 class LibraryPromptsListCanvas(PostRecomposeCallback, Vertical):
     """Render the Library prompts canvas: the list view, or the prompt editor.
@@ -122,6 +126,8 @@ class LibraryPromptsListCanvas(PostRecomposeCallback, Vertical):
             constructor argument only matters for the handful of flows that
             already do a full recompose while dirty (initial load, Duplicate,
             conflict entry/resolution).
+        write_in_flight: Editor mode only. Keeps Discard disabled while an
+            admitted Prompt writer may still persist the working copy.
         import_open: List-view only. When ``True``, renders the inline
             Import row (a path ``Input`` for a file OR folder, plus
             Import/Cancel actions) below the Sort/Import…/Export… toolbar.
@@ -160,6 +166,7 @@ class LibraryPromptsListCanvas(PostRecomposeCallback, Vertical):
         | PromptBatchDeleteResult
         | None = None,
         mutation_in_flight: bool = False,
+        write_in_flight: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -186,6 +193,7 @@ class LibraryPromptsListCanvas(PostRecomposeCallback, Vertical):
         self.membership_state = membership_state
         self.delete_receipt = delete_receipt
         self.mutation_in_flight = mutation_in_flight
+        self.write_in_flight = write_in_flight
         self.styles.width = "1fr"
         self.styles.min_width = 40
 
@@ -1042,11 +1050,19 @@ class LibraryPromptsListCanvas(PostRecomposeCallback, Vertical):
                     id="library-prompt-discard",
                     classes="library-canvas-action",
                     compact=True,
-                    disabled=self.mutation_in_flight or not self.dirty,
+                    disabled=(
+                        self.mutation_in_flight
+                        or self.write_in_flight
+                        or not self.dirty
+                    ),
                     tooltip=(
-                        PROMPT_DISCARD_TOOLTIP_DIRTY
-                        if self.dirty
-                        else PROMPT_DISCARD_TOOLTIP_CLEAN
+                        PROMPT_DISCARD_TOOLTIP_BUSY
+                        if self.mutation_in_flight or self.write_in_flight
+                        else (
+                            PROMPT_DISCARD_TOOLTIP_DIRTY
+                            if self.dirty
+                            else PROMPT_DISCARD_TOOLTIP_CLEAN
+                        )
                     ),
                 )
 

--- a/tldw_chatbook/Widgets/Prompts/prompt_block_editor.py
+++ b/tldw_chatbook/Widgets/Prompts/prompt_block_editor.py
@@ -579,7 +579,10 @@ class PromptBlockEditor(Vertical):
 
     def on_mount(self) -> None:
         self._set_responsive(self.size.width or self.app.size.width)
-        self._sync_footer()
+        try:
+            self._sync_footer()
+        except NoMatches:
+            self.call_after_refresh(self._sync_footer)
 
     def on_resize(self, event: events.Resize) -> None:
         self._set_responsive(event.size.width)
@@ -733,6 +736,8 @@ class PromptBlockEditor(Vertical):
                 user.value = True
 
     def _sync_footer(self) -> None:
+        if not self.is_attached:
+            return
         issue_count = len(self._state.issues)
         validation = self.query_one("#prompt-editor-validation", Static)
         if issue_count:


### PR DESCRIPTION
## Summary
- explain dirty Prompt navigation vetoes with fixed Save/Discard recovery copy
- add a stable Discard changes action across ordinary, conflict, and compatibility-only Prompt editors
- harden PromptBlockEditor footer initialization across ordinary mounts and rapid recomposition

## Test plan
- [x] `pytest Tests/UI/test_library_prompts_canvas.py Tests/UI/test_prompt_block_editor.py -q` — 303 passed
- [x] Ruff check on all changed Python files
- [x] py_compile on all changed production Python files
- [x] cumulative `git diff --check origin/dev...HEAD`
- [x] Impeccable detector — no findings

## Architecture
ADR required: no. This applies the existing Library dirty-veto/discard pattern and corrects an existing widget lifecycle seam without changing persistence, services, ownership, or dependencies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explains dirty Prompt navigation vetoes and adds a consistent, safe Discard flow. Previously, leaving a dirty Prompt failed silently; now it warns and offers Discard, while save remains explicit.

- Warns only when a dirty Prompt vetoes navigation: “Unsaved Prompt changes — Save or Discard changes first.” Clean flushes stay silent.
- Renders a “Discard changes” action across all Prompt editors; disabled when clean, during a mutation, or while a save is in flight; tooltips use literal copy from `Widgets/Library` (clean/dirty/busy).
- Interlocks Discard for the full lifetime of admitted saves; busy state disables the action and shows “try again when they finish.”
- Handles Discard in the screen: resets the working copy, returns to the current Prompt list, refreshes the local source snapshot, and focuses the first row; never persists and refuses while busy.
- Live-patches Discard enabled/tooltip in place as `dirty` and write-in-flight change; no field recomposition.
- Hardens `PromptBlockEditor` footer initialization: sync immediately when descendants exist; otherwise defer once via `call_after_refresh`; no-op if detached.
- Satisfies TASK-2702 acceptance criteria; no changes to persistence, service contracts, or dependencies.

<sup>Written for commit 72c7d3e96b312ce5e869b89b9786fe1e52a42b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

