### PR TITLE
fix(backlog): uppercase 35 lowercase task-id frontmatter fields (task-15211 sweep catch 3)

### DIFF
--- a/backlog/tasks/task-15511 - Console-run-state-and-image-toggle-diverge-under-a-realistic-config.md
+++ b/backlog/tasks/task-15511 - Console-run-state-and-image-toggle-diverge-under-a-realistic-config.md
@@ -1,5 +1,5 @@
 ---
-id: task-15511
+id: TASK-15511
 title: Console run state and image toggle diverge under a realistic config
 status: Done
 assignee: []

--- a/backlog/tasks/task-15512 - Five-Settings-and-Console-contract-tests-are-red-on-dev.md
+++ b/backlog/tasks/task-15512 - Five-Settings-and-Console-contract-tests-are-red-on-dev.md
@@ -1,5 +1,5 @@
 ---
-id: task-15512
+id: TASK-15512
 title: Six Settings, Console and Library tests are red on dev
 status: To Do
 assignee: []

--- a/backlog/tasks/task-15513 - Surface-the-high-value-server-only-ingest-options-in-server-mode.md
+++ b/backlog/tasks/task-15513 - Surface-the-high-value-server-only-ingest-options-in-server-mode.md
@@ -1,5 +1,5 @@
 ---
-id: task-15513
+id: TASK-15513
 title: Expose high-value ingest options with local parity
 status: Done
 assignee:

--- a/backlog/tasks/task-15673 - Settings-navigation-preselect-applies-the-provider-then-silently-drops-the-model.md
+++ b/backlog/tasks/task-15673 - Settings-navigation-preselect-applies-the-provider-then-silently-drops-the-model.md
@@ -1,5 +1,5 @@
 ---
-id: task-15673
+id: TASK-15673
 title: Settings navigation preselect applies the provider then silently drops the model
 status: Done
 assignee: []

--- a/backlog/tasks/task-15740 - Pressing-Save-in-Providers-Models-marks-untouched-fields-dirty-and-refuses-the-save.md
+++ b/backlog/tasks/task-15740 - Pressing-Save-in-Providers-Models-marks-untouched-fields-dirty-and-refuses-the-save.md
@@ -1,5 +1,5 @@
 ---
-id: task-15740
+id: TASK-15740
 title: Pressing Save in Providers & Models marks untouched fields dirty and refuses the save
 status: Done
 assignee: []

--- a/backlog/tasks/task-15741 - Blank-note-GC-test-fails-only-in-a-multi-module-run.md
+++ b/backlog/tasks/task-15741 - Blank-note-GC-test-fails-only-in-a-multi-module-run.md
@@ -1,5 +1,5 @@
 ---
-id: task-15741
+id: TASK-15741
 title: Blank-note GC test fails only in a multi-module run
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2110 - STT-configured-provider-unavailable-falls-back-silently-with-status-ok.md
+++ b/backlog/tasks/task-2110 - STT-configured-provider-unavailable-falls-back-silently-with-status-ok.md
@@ -1,5 +1,5 @@
 ---
-id: task-2110
+id: TASK-2110
 title: 'STT: configured provider unavailable falls back silently with status=ok'
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2111 - Config-exit-write-clobbers-external-edits-made-while-app-runs.md
+++ b/backlog/tasks/task-2111 - Config-exit-write-clobbers-external-edits-made-while-app-runs.md
@@ -1,5 +1,5 @@
 ---
-id: task-2111
+id: TASK-2111
 title: Config exit-write clobbers external edits made while app runs
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2150 - RAG-Answer-live-smoke-with-a-real-provider.md
+++ b/backlog/tasks/task-2150 - RAG-Answer-live-smoke-with-a-real-provider.md
@@ -1,5 +1,5 @@
 ---
-id: task-2150
+id: TASK-2150
 title: RAG Answer live smoke with a real provider
 status: Done
 assignee:

--- a/backlog/tasks/task-2151 - RAG-answer-display-clamp-word-boundary.md
+++ b/backlog/tasks/task-2151 - RAG-answer-display-clamp-word-boundary.md
@@ -1,5 +1,5 @@
 ---
-id: task-2151
+id: TASK-2151
 title: RAG answer display clamp should cut at a word boundary with ellipsis
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2210 - Console-staged-evidence-concurrent-send-double-spend-window.md
+++ b/backlog/tasks/task-2210 - Console-staged-evidence-concurrent-send-double-spend-window.md
@@ -1,5 +1,5 @@
 ---
-id: task-2210
+id: TASK-2210
 title: Console staged evidence concurrent-send double-spend window
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2211 - Staged-strip-and-tray-stale-status-mapping-divergence.md
+++ b/backlog/tasks/task-2211 - Staged-strip-and-tray-stale-status-mapping-divergence.md
@@ -1,5 +1,5 @@
 ---
-id: task-2211
+id: TASK-2211
 title: Staged strip and tray render 'stale' reference status differently
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2212 - Post-release-send-abort-loses-consumed-evidence-silently.md
+++ b/backlog/tasks/task-2212 - Post-release-send-abort-loses-consumed-evidence-silently.md
@@ -1,5 +1,5 @@
 ---
-id: task-2212
+id: TASK-2212
 title: Post-release send abort loses consumed staged evidence silently
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2370 - Console staged-evidence tray and inspector told two different truths (critique D1).md
+++ b/backlog/tasks/task-2370 - Console staged-evidence tray and inspector told two different truths (critique D1).md
@@ -1,5 +1,5 @@
 ---
-id: task-2370
+id: TASK-2370
 title: Console staged-evidence tray and inspector told two different truths (critique D1)
 status: Done
 assignee:

--- a/backlog/tasks/task-2371 - Console first send on a fresh session could vanish silently (critique D2).md
+++ b/backlog/tasks/task-2371 - Console first send on a fresh session could vanish silently (critique D2).md
@@ -1,5 +1,5 @@
 ---
-id: task-2371
+id: TASK-2371
 title: Console first send on a fresh session could vanish silently (critique D2)
 status: Done
 assignee:

--- a/backlog/tasks/task-2372 - Staged evidence and sent-notice were destroyed by Console navigation (critique D3).md
+++ b/backlog/tasks/task-2372 - Staged evidence and sent-notice were destroyed by Console navigation (critique D3).md
@@ -1,5 +1,5 @@
 ---
-id: task-2372
+id: TASK-2372
 title: Staged evidence and sent-notice were destroyed by Console navigation (critique D3)
 status: Done
 assignee:

--- a/backlog/tasks/task-2373 - Scope-off source rows stayed visible and stageable in Library RAG (critique D4).md
+++ b/backlog/tasks/task-2373 - Scope-off source rows stayed visible and stageable in Library RAG (critique D4).md
@@ -1,5 +1,5 @@
 ---
-id: task-2373
+id: TASK-2373
 title: Scope-off source rows stayed visible and stageable in Library RAG (critique D4)
 status: Done
 assignee:

--- a/backlog/tasks/task-2374 - Media notes and conversation Use-in-Console handoffs delivered zero content to the model.md
+++ b/backlog/tasks/task-2374 - Media notes and conversation Use-in-Console handoffs delivered zero content to the model.md
@@ -1,5 +1,5 @@
 ---
-id: task-2374
+id: TASK-2374
 title: Media, notes, and conversation Use-in-Console handoffs delivered zero content to the model
 status: Done
 assignee:

--- a/backlog/tasks/task-2375 - Five more Console handoff kinds still deliver zero content to the model.md
+++ b/backlog/tasks/task-2375 - Five more Console handoff kinds still deliver zero content to the model.md
@@ -1,5 +1,5 @@
 ---
-id: task-2375
+id: TASK-2375
 title: Five more Console handoff kinds still deliver zero content to the model
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2376 - Media and conversation handoff snippets are thin generic labels not excerpts.md
+++ b/backlog/tasks/task-2376 - Media and conversation handoff snippets are thin generic labels not excerpts.md
@@ -1,5 +1,5 @@
 ---
-id: task-2376
+id: TASK-2376
 title: Media and conversation handoff snippets are thin generic labels, not excerpts
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2377 - Library RAG scope-recovery cache desync window and stale refresh-caller docstring.md
+++ b/backlog/tasks/task-2377 - Library RAG scope-recovery cache desync window and stale refresh-caller docstring.md
@@ -1,5 +1,5 @@
 ---
-id: task-2377
+id: TASK-2377
 title: Library RAG scope-recovery cache desync window and stale refresh-caller docstring
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2500 - Zero-session serialization drops staged evidence.md
+++ b/backlog/tasks/task-2500 - Zero-session serialization drops staged evidence.md
@@ -1,5 +1,5 @@
 ---
-id: task-2500
+id: TASK-2500
 title: Zero-session serialization drops staged evidence
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2501 - HTML-escape artifacts reach user-visible labels.md
+++ b/backlog/tasks/task-2501 - HTML-escape artifacts reach user-visible labels.md
@@ -1,5 +1,5 @@
 ---
-id: task-2501
+id: TASK-2501
 title: HTML-escape artifacts reach user-visible labels
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2502 - _consume_pending_console_launch is no longer a pure read.md
+++ b/backlog/tasks/task-2502 - _consume_pending_console_launch is no longer a pure read.md
@@ -1,5 +1,5 @@
 ---
-id: task-2502
+id: TASK-2502
 title: _consume_pending_console_launch is no longer a pure read
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2520 - Library landing footer advertises the wrong keyboard story.md
+++ b/backlog/tasks/task-2520 - Library landing footer advertises the wrong keyboard story.md
@@ -1,5 +1,5 @@
 ---
-id: task-2520
+id: TASK-2520
 title: Library landing footer advertises the wrong keyboard story
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2521 - Unknown-but-dispatchable providers are blocked from Library RAG Answer.md
+++ b/backlog/tasks/task-2521 - Unknown-but-dispatchable providers are blocked from Library RAG Answer.md
@@ -1,5 +1,5 @@
 ---
-id: task-2521
+id: TASK-2521
 title: Unknown-but-dispatchable providers are blocked from Library RAG Answer
 status: Done
 assignee: []

--- a/backlog/tasks/task-2522 - Library RAG Answer's blocked copy names the wrong remedy.md
+++ b/backlog/tasks/task-2522 - Library RAG Answer's blocked copy names the wrong remedy.md
@@ -1,5 +1,5 @@
 ---
-id: task-2522
+id: TASK-2522
 title: Library RAG Answer's blocked copy names the wrong remedy
 status: Done
 assignee: []

--- a/backlog/tasks/task-2523 - Legacy-key bridge's modern-key lookup is exact-key while the readiness reader's is normalized.md
+++ b/backlog/tasks/task-2523 - Legacy-key bridge's modern-key lookup is exact-key while the readiness reader's is normalized.md
@@ -1,5 +1,5 @@
 ---
-id: task-2523
+id: TASK-2523
 title: Legacy-key bridge's modern-key lookup is exact-key while the readiness reader's is normalized
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2524 - api_key_env_var override is honored by readiness but not by the legacy-key bridge.md
+++ b/backlog/tasks/task-2524 - api_key_env_var override is honored by readiness but not by the legacy-key bridge.md
@@ -1,5 +1,5 @@
 ---
-id: task-2524
+id: TASK-2524
 title: api_key_env_var override is honored by readiness but not by the legacy-key bridge
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2525 - Console context-cost estimate has three small modelling gaps.md
+++ b/backlog/tasks/task-2525 - Console context-cost estimate has three small modelling gaps.md
@@ -1,5 +1,5 @@
 ---
-id: task-2525
+id: TASK-2525
 title: Console context/cost estimate has three small modelling gaps
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2526 - tiktoken is not a declared dependency.md
+++ b/backlog/tasks/task-2526 - tiktoken is not a declared dependency.md
@@ -1,5 +1,5 @@
 ---
-id: task-2526
+id: TASK-2526
 title: tiktoken is not a declared dependency
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2540 - MCP search_rag has no coverage-note equivalent for unreached sources.md
+++ b/backlog/tasks/task-2540 - MCP search_rag has no coverage-note equivalent for unreached sources.md
@@ -1,5 +1,5 @@
 ---
-id: task-2540
+id: TASK-2540
 title: MCP search_rag has no coverage-note equivalent for unreached sources
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2541 - Advanced panel tool.execute path logs no argument-name provenance.md
+++ b/backlog/tasks/task-2541 - Advanced panel tool.execute path logs no argument-name provenance.md
@@ -1,5 +1,5 @@
 ---
-id: task-2541
+id: TASK-2541
 title: Advanced panel tool.execute path logs no argument-name provenance
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2542 - _toast helper is duplicated between mcp_inspector.py and mcp_workbench.py.md
+++ b/backlog/tasks/task-2542 - _toast helper is duplicated between mcp_inspector.py and mcp_workbench.py.md
@@ -1,5 +1,5 @@
 ---
-id: task-2542
+id: TASK-2542
 title: _toast helper is duplicated between mcp_inspector.py and mcp_workbench.py
 status: To Do
 assignee: []

--- a/backlog/tasks/task-2543 - Non-HTTP provider failures still report HTTP 502 in Console error copy.md
+++ b/backlog/tasks/task-2543 - Non-HTTP provider failures still report HTTP 502 in Console error copy.md
@@ -1,5 +1,5 @@
 ---
-id: task-2543
+id: TASK-2543
 title: Non-HTTP provider failures still report "HTTP 502" in Console error copy
 status: To Do
 assignee: []


### PR DESCRIPTION
## What

Sweep catch #3: chunk 10 failed `test_backlog_task_frontmatter_ids_are_unique` — not on a duplicate, but on the helper's premise that every task file carries exactly one id matching `TASK-[0-9]+` (uppercase, the pattern the Backlog.md CLI itself writes). **35 hand-authored files used lowercase `id: task-NNNNN`**, which the harness counts as no id at all — several of them filed by this programme, including the file the assertion happened to name first.

Mechanical: uppercase the `id:` value in all 35. No titles, statuses, or content touched. The harness module passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize backlog task frontmatter IDs to uppercase TASK-<number> to match the Backlog.md CLI and test expectations. Previously 35 files used lowercase task-<number>, which the harness treated as missing IDs, causing test_backlog_task_frontmatter_ids_are_unique to fail.

- Touches 35 task files; only changes the frontmatter id value. No titles, statuses, or content changed.
- Restores passing status for the backlog harness; aligns all tasks to the canonical TASK- pattern.
- Migration: If any downstream tooling parsed lowercase task- IDs, update it to accept uppercase or parse case-insensitively.
- Addresses TASK-15211.

<sup>Written for commit 10e8d223eaac0b52f76e4dc52332df70f154f06d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

