### PR TITLE
perf: batch config writes and take them off the click path (task-15470)

### DIFF
--- a/Tests/Local_Ingestion/test_dictation_window_provider_ids.py
+++ b/Tests/Local_Ingestion/test_dictation_window_provider_ids.py
@@ -134,7 +134,7 @@ def test_load_settings_normalizes_legacy_provider_id(monkeypatch) -> None:
     save_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     monkeypatch.setattr(
         dwi,
-        "save_setting_to_cli_config",
+        "save_settings_to_cli_config",
         lambda *args, **kwargs: save_calls.append((args, kwargs)),
     )
 

--- a/Tests/UI/test_chat_screen_sidebar_state_debounce.py
+++ b/Tests/UI/test_chat_screen_sidebar_state_debounce.py
@@ -14,6 +14,9 @@ pending write so a toggle immediately followed by quit is not lost.
 
 from __future__ import annotations
 
+import asyncio
+import threading
+
 import toml
 
 from Tests.UI.app_factory import _build_test_app
@@ -149,3 +152,79 @@ async def test_reset_settings_schedules_a_write_even_from_an_empty_state():
         await pilot.pause()
 
         assert screen._sidebar_state_dirty is True
+
+
+async def test_toggle_during_in_flight_write_survives_a_quit():
+    """Review round (task-15470): a toggle landing WHILE a debounced write
+    is still in flight must survive a quit -- not just a toggle landing
+    before the debounce timer ever fires (the case
+    `test_quit_immediately_after_toggle_flushes_the_pending_write` covers).
+
+    Reproduced without the fix: `_persist_sidebar_state_off_loop` cleared
+    `_sidebar_state_dirty` only AFTER its write completed, so toggle 2's
+    `dirty=True` (set while toggle 1's write was still inside `to_thread`)
+    was silently clobbered back to False the instant toggle 1's write
+    finished. Separately, `_flush_sidebar_state_now` `return`ed immediately
+    after awaiting an in-flight worker, never re-checking
+    `_sidebar_state_dirty` at all -- so even a dirty flag that legitimately
+    survived to that point would have been dropped. Both fixes are
+    required; this test forces the exact race by blocking toggle 1's write
+    on a `threading.Event` and calling `_flush_sidebar_state_now` directly
+    while it is still blocked.
+    """
+    app = _build_test_app()
+    harness = ConsoleHarness(app)
+    async with harness.run_test(size=APP_SIZE) as pilot:
+        screen = await _mounted_console_screen(pilot)
+
+        write_started = threading.Event()
+        proceed = threading.Event()
+        real_write = screen._write_sidebar_state_snapshot
+
+        def slow_write(snapshot):
+            write_started.set()
+            assert proceed.wait(timeout=5), "test stalled waiting to proceed"
+            real_write(snapshot)
+
+        screen._write_sidebar_state_snapshot = slow_write
+
+        # Toggle 1: goes through the real debounce + worker dispatch.
+        screen.ui_state.set_collapsible_state("task-15470-inflight-1", True)
+        screen.sidebar_state = dict(screen.ui_state.collapsible_states)
+        await pilot.pause(0.7)  # past SIDEBAR_STATE_SAVE_DEBOUNCE_SECONDS
+
+        assert write_started.wait(timeout=2), "worker never started its write"
+        worker = screen._sidebar_state_persist_worker
+        assert worker is not None and not worker.is_finished, (
+            "toggle 1's worker must still be in flight for this test to "
+            "mean anything"
+        )
+
+        # Toggle 2 lands while toggle 1's write is still blocked in flight.
+        screen.ui_state.set_collapsible_state("task-15470-inflight-2", True)
+        screen.sidebar_state = dict(screen.ui_state.collapsible_states)
+        assert screen._sidebar_state_dirty is True
+
+        # Call the real flush path directly, while toggle 1's worker is
+        # still blocked -- it must wait for that worker, THEN notice
+        # toggle 2's dirty flag and flush it too.
+        flush_task = asyncio.create_task(screen._flush_sidebar_state_now())
+        await pilot.pause()
+        await pilot.pause()
+        assert not flush_task.done(), (
+            "_flush_sidebar_state_now returned without waiting for the "
+            "in-flight worker -- this test is not exercising the race it "
+            "claims to"
+        )
+
+        proceed.set()
+        await flush_task
+
+    on_disk = toml.load(_ui_state_path())
+    collapsible_states = on_disk["sidebar"]["collapsible_states"]
+    assert collapsible_states.get("task-15470-inflight-1") is True, (
+        "toggle 1 should have landed"
+    )
+    assert collapsible_states.get("task-15470-inflight-2") is True, (
+        "toggle 2 LOST"
+    )

--- a/Tests/UI/test_chat_screen_sidebar_state_debounce.py
+++ b/Tests/UI/test_chat_screen_sidebar_state_debounce.py
@@ -1,0 +1,151 @@
+"""task-15470: Console sidebar-state persistence must not do synchronous file
+I/O on the event loop, and must never lose a toggle to a quit.
+
+Before this task, `ChatScreen.watch_sidebar_state` called `_save_sidebar_state()`
+directly -- an open+parse+rewrite of `ui_state.toml` on the event loop, once
+per `Collapsible.Toggled` (every sidebar toggle, plus expand-all/collapse-all/
+reset). These tests pin the replacement: the reactive assignment only marks
+the state dirty and arms a debounce timer (no write); the write itself runs
+off the loop via `asyncio.to_thread`; and `on_unmount` (the screen's quit
+path -- see `ChatScreen.on_unmount`, which Textual's `App._shutdown` ->
+`_close_all` -> `_prune` drives for the active screen) force-flushes any
+pending write so a toggle immediately followed by quit is not lost.
+"""
+
+from __future__ import annotations
+
+import toml
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_destination_shells import _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.config import _get_effective_config_path
+
+APP_SIZE = (160, 48)
+
+
+def _ui_state_path():
+    return _get_effective_config_path().parent / "ui_state.toml"
+
+
+async def _mounted_console_screen(pilot):
+    screen = pilot.app.screen_stack[-1]
+    await _wait_for_selector(screen, pilot, "#console-native-composer")
+    return screen
+
+
+async def test_toggle_does_not_write_synchronously_on_the_event_loop():
+    """AC #2: a sidebar toggle performs no synchronous file I/O.
+
+    Reassigning `sidebar_state` (what every `Collapsible.Toggled` handler
+    does) must only arm the debounce timer -- the file must not exist (or
+    must not yet carry the new id) immediately afterwards, before the
+    debounce timer has had any chance to fire.
+    """
+    app = _build_test_app()
+    async with ConsoleHarness(app).run_test(size=APP_SIZE) as pilot:
+        screen = await _mounted_console_screen(pilot)
+
+        screen.ui_state.set_collapsible_state("task-15470-probe", True)
+        screen.sidebar_state = dict(screen.ui_state.collapsible_states)
+
+        # No `await pilot.pause(...)` long enough for the 0.5s debounce to
+        # fire -- the assertions below run before any timer could have.
+        ui_state_path = _ui_state_path()
+        if ui_state_path.exists():
+            on_disk = toml.load(ui_state_path)
+            collapsible_states = on_disk.get("sidebar", {}).get(
+                "collapsible_states", {}
+            )
+            assert "task-15470-probe" not in collapsible_states, (
+                "the toggle wrote to disk synchronously instead of "
+                "debouncing"
+            )
+        assert screen._sidebar_state_dirty is True
+        assert screen._sidebar_state_save_timer is not None
+
+
+async def test_debounced_write_lands_after_the_timer_fires():
+    """The debounce mechanism itself must actually persist -- not just skip.
+
+    A mutant that deleted the timer callback's write (or never armed a
+    timer at all) would pass the first test above; this one requires the
+    write to actually happen once the debounce interval elapses.
+    """
+    app = _build_test_app()
+    async with ConsoleHarness(app).run_test(size=APP_SIZE) as pilot:
+        screen = await _mounted_console_screen(pilot)
+
+        screen.ui_state.set_collapsible_state("task-15470-lands", True)
+        screen.sidebar_state = dict(screen.ui_state.collapsible_states)
+
+        # Debounce is 0.5s (SIDEBAR_STATE_SAVE_DEBOUNCE_SECONDS); wait past it
+        # and let the dispatched worker's `to_thread` write complete.
+        await pilot.pause(0.7)
+        for _ in range(20):
+            if not screen._sidebar_state_dirty:
+                break
+            await pilot.pause(0.05)
+
+        on_disk = toml.load(_ui_state_path())
+        assert (
+            on_disk["sidebar"]["collapsible_states"]["task-15470-lands"] is True
+        )
+
+
+async def test_quit_immediately_after_toggle_flushes_the_pending_write():
+    """AC #2 flush test: toggle, then quit before the debounce fires.
+
+    Exiting the harness's `run_test()` context tears the app down through
+    `App._shutdown` -> `_close_all` -> `_prune`, which unmounts the active
+    screen and (per `ChatScreen.on_unmount`'s own docstring) runs
+    `_flush_sidebar_state_now` before any other teardown step. No
+    `pilot.pause()` long enough for the natural debounce timer is used here
+    -- if quit relied on that timer, this test would still be waiting on a
+    write that never happened.
+    """
+    app = _build_test_app()
+    harness = ConsoleHarness(app)
+    async with harness.run_test(size=APP_SIZE) as pilot:
+        screen = await _mounted_console_screen(pilot)
+
+        screen.ui_state.set_collapsible_state("task-15470-quit-flush", True)
+        screen.sidebar_state = dict(screen.ui_state.collapsible_states)
+
+        assert screen._sidebar_state_dirty is True
+        # Exiting the `async with` block below tears the app down (quit),
+        # deliberately with no further pause -- the pending write must
+        # survive on the unmount path alone.
+
+    on_disk = toml.load(_ui_state_path())
+    assert (
+        on_disk["sidebar"]["collapsible_states"]["task-15470-quit-flush"] is True
+    )
+
+
+async def test_reset_settings_schedules_a_write_even_from_an_empty_state():
+    """`handle_reset_settings` must not silently drop its persistence.
+
+    Resetting from an already-empty `sidebar_state` reassigns `{}` to `{}`,
+    which Textual's reactive treats as a no-op and never calls
+    `watch_sidebar_state` for -- so the reset handler must explicitly
+    schedule a save rather than relying on the reactive alone. This flushes
+    on unmount the same as a real toggle would.
+    """
+    app = _build_test_app()
+    harness = ConsoleHarness(app)
+    async with harness.run_test(size=APP_SIZE) as pilot:
+        screen = await _mounted_console_screen(pilot)
+        # Confirm the premise: sidebar_state is already the reactive default.
+        assert screen.sidebar_state == {}
+
+        # Call the handler directly (matches the `@on(Button.Pressed, ...)`
+        # decorator's dispatch signature but does not depend on the reset
+        # button being reachable/visible in this harness's default view --
+        # the method body never reads `event`).
+        screen.handle_reset_settings(None)
+        await pilot.pause()
+
+        assert screen._sidebar_state_dirty is True

--- a/Tests/UI/test_dictation_settings_debounce.py
+++ b/Tests/UI/test_dictation_settings_debounce.py
@@ -1,0 +1,158 @@
+"""task-15470: dictation-settings persistence must be one batched write, off
+the event loop, and never fire synchronously on a parsing keystroke.
+
+Before this task, `_save_settings` made 6-9 sequential
+`save_setting_to_cli_config` calls -- each its own full config.toml
+read+atomic-rewrite+cache-reload cycle -- and `_persist_settings` (the single
+gate every switch/input handler calls) invoked it synchronously on the event
+loop. The buffer-duration input fired this once per keystroke that happened
+to parse as an in-range integer.
+
+These tests pin the replacement: `_persist_settings` only marks settings
+dirty and arms a debounce timer; the write itself is one call to the batch
+API (`save_settings_to_cli_config`), dispatched off the loop via
+`asyncio.to_thread`; and `on_unmount` (fired both when the Dictation view is
+switched away from in `STTS_Window` and when the app quits while it is
+mounted) force-flushes any pending write.
+"""
+
+from __future__ import annotations
+
+import toml
+from textual.app import App, ComposeResult
+from textual.widgets import Input
+
+from tldw_chatbook.config import _get_effective_config_path
+from tldw_chatbook.UI.Dictation_Window_Improved import (
+    DICTATION_SETTINGS_SAVE_DEBOUNCE_SECONDS,
+    ImprovedDictationWindow,
+)
+
+
+class _DictationHarness(App[None]):
+    """Mounts the widget alone -- it needs no TldwCli/Screen scaffolding."""
+
+    def compose(self) -> ComposeResult:
+        yield ImprovedDictationWindow()
+
+
+async def _mounted_window(pilot):
+    window = pilot.app.query_one(ImprovedDictationWindow)
+    # Let the mount-time `call_after_refresh(self._finish_mounting)` clear
+    # `_settings_are_mounting` -- until it does, `_persist_settings` is a
+    # deliberate no-op (see its own module-mount-noise guard), and asserting
+    # against it before that would test the wrong thing.
+    for _ in range(20):
+        if not getattr(window, "_settings_are_mounting", True):
+            break
+        await pilot.pause()
+    return window
+
+
+def _config_path():
+    return _get_effective_config_path()
+
+
+async def test_buffer_duration_keystroke_does_not_write_synchronously():
+    """AC #1: no config rewrite fires on a parsing keystroke."""
+    async with _DictationHarness().run_test() as pilot:
+        window = await _mounted_window(pilot)
+
+        buffer_input = window.query_one("#buffer-duration-input", Input)
+        buffer_input.value = "300"
+        await pilot.pause()
+
+        assert window._settings_dirty is True
+        assert window._settings_save_timer is not None
+
+        config_path = _config_path()
+        if config_path.exists():
+            on_disk = toml.load(config_path)
+            assert (
+                on_disk.get("dictation", {}).get("buffer_duration_ms") != 300
+            ), "the keystroke wrote to disk synchronously instead of debouncing"
+
+
+async def test_burst_of_edits_collapses_into_one_batched_write():
+    """AC #1: the eventual write is ONE atomic batched mutation.
+
+    Edits three different settings (two switches, one input) in a burst,
+    then lets the debounce fire once. `save_settings_to_cli_config` must be
+    called exactly once, carrying every changed field in a single mapping --
+    not the 6-9 sequential single-key calls this replaced.
+    """
+    async with _DictationHarness().run_test() as pilot:
+        window = await _mounted_window(pilot)
+
+        calls: list[dict] = []
+        original = window._write_settings_snapshot
+
+        def spy(snapshot):
+            calls.append(snapshot)
+            original(snapshot)
+
+        window._write_settings_snapshot = spy
+
+        window.settings["punctuation"] = False
+        window._persist_settings()
+        window.settings["commands"] = False
+        window._persist_settings()
+        buffer_input = window.query_one("#buffer-duration-input", Input)
+        buffer_input.value = "250"
+        await pilot.pause()
+
+        assert calls == [], "a write landed before the debounce fired"
+
+        await pilot.pause(DICTATION_SETTINGS_SAVE_DEBOUNCE_SECONDS + 0.3)
+        for _ in range(20):
+            if not window._settings_dirty:
+                break
+            await pilot.pause(0.05)
+
+        assert len(calls) == 1, f"expected exactly one batched write, got {len(calls)}"
+        snapshot = calls[0]
+        assert snapshot["dictation"]["punctuation"] is False
+        assert snapshot["dictation"]["commands"] is False
+        assert snapshot["dictation"]["buffer_duration_ms"] == 250
+
+        on_disk = toml.load(_config_path())
+        assert on_disk["dictation"]["punctuation"] is False
+        assert on_disk["dictation"]["commands"] is False
+        assert on_disk["dictation"]["buffer_duration_ms"] == 250
+
+
+async def test_switch_away_immediately_after_edit_flushes_the_pending_write():
+    """AC #1/#3 flush test: unmount (matching STTS_Window's view switch,
+    which calls `content_container.remove_children()`) before the debounce
+    timer fires must not lose the edit.
+    """
+    async with _DictationHarness().run_test() as pilot:
+        window = await _mounted_window(pilot)
+
+        window.settings["commands"] = False
+        window._persist_settings()
+        assert window._settings_dirty is True
+
+        # Remove the widget the same way STTS_Window does when switching
+        # views -- deliberately with no pause long enough for the natural
+        # debounce timer, so only the unmount flush can be responsible for
+        # what lands on disk.
+        await window.remove()
+
+    on_disk = toml.load(_config_path())
+    assert on_disk["dictation"]["commands"] is False
+
+
+async def test_quit_immediately_after_edit_flushes_the_pending_write():
+    """AC #1/#3 flush test: app quit while the Dictation view is mounted."""
+    async with _DictationHarness().run_test() as pilot:
+        window = await _mounted_window(pilot)
+
+        window.settings["punctuation"] = False
+        window._persist_settings()
+        assert window._settings_dirty is True
+        # Exiting the `async with` block below tears the app down (quit),
+        # deliberately with no further pause.
+
+    on_disk = toml.load(_config_path())
+    assert on_disk["dictation"]["punctuation"] is False

--- a/Tests/UI/test_dictation_settings_debounce.py
+++ b/Tests/UI/test_dictation_settings_debounce.py
@@ -18,6 +18,9 @@ mounted) force-flushes any pending write.
 
 from __future__ import annotations
 
+import asyncio
+import threading
+
 import toml
 from textual.app import App, ComposeResult
 from textual.widgets import Input
@@ -156,3 +159,70 @@ async def test_quit_immediately_after_edit_flushes_the_pending_write():
 
     on_disk = toml.load(_config_path())
     assert on_disk["dictation"]["punctuation"] is False
+
+
+async def test_edit_during_in_flight_write_survives_a_quit():
+    """Review round (task-15470): an edit landing WHILE a debounced write
+    is still in flight must survive a quit -- not just an edit landing
+    before the debounce timer ever fires (the case the other flush tests
+    cover).
+
+    Reproduced without the fix: `_persist_settings_off_loop` cleared
+    `_settings_dirty` only AFTER its write completed, so edit 2's
+    `dirty=True` (set while edit 1's write was still inside `to_thread`)
+    was silently clobbered back to False the instant edit 1's write
+    finished. Separately, `on_unmount`'s flush `return`ed immediately
+    after awaiting an in-flight worker, never re-checking `_settings_dirty`
+    at all -- so even a dirty flag that legitimately survived to that point
+    would have been dropped. Both fixes are required; this test forces the
+    exact race by blocking edit 1's write on a `threading.Event` and
+    calling `on_unmount` directly while it is still blocked.
+    """
+    async with _DictationHarness().run_test() as pilot:
+        window = await _mounted_window(pilot)
+
+        write_started = threading.Event()
+        proceed = threading.Event()
+        real_write = window._write_settings_snapshot
+
+        def slow_write(snapshot):
+            write_started.set()
+            assert proceed.wait(timeout=5), "test stalled waiting to proceed"
+            real_write(snapshot)
+
+        window._write_settings_snapshot = slow_write
+
+        # Edit 1: goes through the real debounce + worker dispatch.
+        window.settings["punctuation"] = False
+        window._persist_settings()
+        await pilot.pause(DICTATION_SETTINGS_SAVE_DEBOUNCE_SECONDS + 0.2)
+
+        assert write_started.wait(timeout=2), "worker never started its write"
+        worker = window._settings_persist_worker
+        assert worker is not None and not worker.is_finished, (
+            "edit 1's worker must still be in flight for this test to mean "
+            "anything"
+        )
+
+        # Edit 2 lands while edit 1's write is still blocked in flight.
+        window.settings["commands"] = False
+        window._persist_settings()
+        assert window._settings_dirty is True
+
+        # Call the real flush path directly, while edit 1's worker is
+        # still blocked -- it must wait for that worker, THEN notice edit
+        # 2's dirty flag and flush it too.
+        unmount_task = asyncio.create_task(window.on_unmount())
+        await pilot.pause()
+        await pilot.pause()
+        assert not unmount_task.done(), (
+            "on_unmount returned without waiting for the in-flight worker "
+            "-- this test is not exercising the race it claims to"
+        )
+
+        proceed.set()
+        await unmount_task
+
+    on_disk = toml.load(_config_path())
+    assert on_disk["dictation"]["punctuation"] is False, "edit 1 should have landed"
+    assert on_disk["dictation"]["commands"] is False, "edit 2 LOST"

--- a/Tests/UI/test_enhanced_file_dialog_mount.py
+++ b/Tests/UI/test_enhanced_file_dialog_mount.py
@@ -13,12 +13,15 @@ from __future__ import annotations
 import re
 from pathlib import Path
 from typing import Optional
+from unittest.mock import patch
 
 import pytest
+import toml
 from textual import events
 from textual.app import App, ComposeResult
 from textual.widgets import Input, Static
 
+from tldw_chatbook.config import _get_effective_config_path
 from tldw_chatbook.Third_Party.textual_fspicker import Filters
 from tldw_chatbook.Widgets.enhanced_file_picker import (
     EnhancedFileOpen,
@@ -315,6 +318,154 @@ async def test_open_dialog_confirms_selected_file(tmp_path):
         result.append(app._result)
 
     assert result[0] == test_file
+
+
+@pytest.mark.asyncio
+async def test_dismiss_does_not_write_config_synchronously(tmp_path):
+    """task-15470 review round: ``dismiss()`` must not run
+    ``recent_locations.add()``'s synchronous ``save_to_config()`` (nor the
+    last-directory write) on the event loop.
+
+    Calls ``dialog.dismiss(...)`` directly rather than driving it through a
+    ``Button.press()`` + ``pilot.pause()``: ``Button.press()`` only posts a
+    ``Button.Pressed`` message (confirmed by reading `_button.py`) -- the
+    handler that actually calls ``dismiss()`` does not run until a pause
+    lets the message queue process it, so asserting "no write yet"
+    immediately after ``press()`` alone is checking nothing (nothing has
+    run yet either way, bug or no bug). ``dismiss()`` is itself a plain
+    synchronous method; calling it directly and checking spy state in the
+    SAME synchronous call stack (no ``await`` at all) is deterministic --
+    Python cannot preempt into a worker thread until this code yields
+    control back to the event loop, so a still-empty spy here can only mean
+    the write was genuinely deferred, not a timing accident.
+
+    Spies on BOTH ``save_settings_to_cli_config`` (the batch API
+    `_persist_recent_and_last_directory` calls) AND ``save_setting_to_cli_
+    config`` (the singular API ``RecentLocations.save_to_config`` calls
+    internally -- a DIFFERENT function; a spy on only the batch API would
+    have stayed silent if ``dismiss()`` regressed to calling
+    ``recent_locations.add()`` with its default ``persist=True``, since
+    that path never touches the batch API at all).
+    """
+    test_file = tmp_path / "confirm_me_sync_check.txt"
+    test_file.write_text("hello")
+
+    batch_calls: list[dict] = []
+    singular_calls: list[tuple] = []
+    import tldw_chatbook.Widgets.enhanced_file_picker as efp_module
+
+    def batch_spy(section_values):
+        batch_calls.append(section_values)
+        return True
+
+    def singular_spy(section, key, value):
+        singular_calls.append((section, key, value))
+        return True
+
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Dismiss Sync Check",
+        context="test_dismiss_sync_check",
+    )
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Mounting/populating the dialog (bookmarks defaults, recent-list
+        # load, etc.) can trigger its OWN unrelated singular-API writes;
+        # only calls made by the `dismiss()` call below are this test's
+        # actual subject.
+        with (
+            patch.object(efp_module, "save_settings_to_cli_config", batch_spy),
+            patch.object(efp_module, "save_setting_to_cli_config", singular_spy),
+        ):
+            dialog.dismiss(test_file)
+
+            # No `await` above this line: this assertion runs in the same
+            # synchronous call as `dismiss()` itself.
+            assert batch_calls == [] and singular_calls == [], (
+                "a config write fired synchronously from dismiss() instead "
+                f"of being deferred to a worker (batch={batch_calls!r}, "
+                f"singular={singular_calls!r})"
+            )
+
+
+@pytest.mark.asyncio
+async def test_confirm_coalesces_recent_and_last_dir_into_one_write(tmp_path):
+    """task-15470 review round: once persistence does run, it must be the
+    single coalesced ``save_settings_to_cli_config`` batch call carrying
+    both the ``recent_<context>`` and ``last_dir_<context>`` keys -- not
+    two separate writes -- and the on-disk state must end up correct.
+
+    Real end-to-end path: drives the dialog through an actual Select
+    button press, and the host app actually exits mid-test (`_DialogHost`
+    calls `self.exit()` from the dismiss callback), so this also proves
+    the deferred write is not simply discarded by app shutdown before the
+    worker thread gets a chance to run.
+    """
+    test_file = tmp_path / "confirm_me_coalesced.txt"
+    test_file.write_text("hello")
+
+    batch_calls: list[dict] = []
+    import tldw_chatbook.Widgets.enhanced_file_picker as efp_module
+
+    real_save_settings = efp_module.save_settings_to_cli_config
+
+    def batch_spy(section_values):
+        batch_calls.append(section_values)
+        return real_save_settings(section_values)
+
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Confirm Open Coalesced",
+        context="test_confirm_open_coalesced",
+    )
+    app = _DialogHost(dialog)
+
+    with patch.object(efp_module, "save_settings_to_cli_config", batch_spy):
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+            for _ in range(20):
+                if dir_nav.option_count > 0:
+                    break
+                await pilot.pause()
+
+            file_index = None
+            for index in range(dir_nav.option_count):
+                option = dir_nav.get_option_at_index(index)
+                if option.location == test_file:
+                    file_index = index
+                    break
+            assert file_index is not None
+
+            dir_nav.highlighted = file_index
+            dir_nav.action_select()
+            await pilot.pause()
+
+            dialog.query_one("#select").press()
+            await pilot.pause()
+
+    # The host app has now fully exited (this test's whole point: the
+    # deferred worker must still have gotten to run before teardown threw
+    # its result away).
+    assert len(batch_calls) == 1, (
+        f"expected exactly one coalesced write, got {len(batch_calls)}"
+    )
+    section = batch_calls[0]["filepicker"]
+    assert "recent_test_confirm_open_coalesced" in section
+    assert "last_dir_test_confirm_open_coalesced" in section
+    assert section["last_dir_test_confirm_open_coalesced"] == str(tmp_path)
+
+    on_disk = toml.load(_get_effective_config_path())
+    saved_recent = on_disk["filepicker"]["recent_test_confirm_open_coalesced"]
+    assert saved_recent, "recent-locations entry was not actually persisted"
+    assert saved_recent[0]["path"] == str(test_file)
+    assert (
+        on_disk["filepicker"]["last_dir_test_confirm_open_coalesced"]
+        == str(tmp_path)
+    )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_ingest_canvas.py
+++ b/Tests/UI/test_library_ingest_canvas.py
@@ -1839,11 +1839,16 @@ def test_external_prepare_retains_before_enqueue(
         "tldw_chatbook.UI.Screens.library_screen.get_current_worker",
         lambda: SimpleNamespace(is_cancelled=False),
     )
-    monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.library_screen.save_settings_to_cli_config",
-        lambda values: saved_settings.append(values),
-    )
     screen = object.__new__(LibraryScreen)
+    # task-15470: the actual write moved into a `@work(thread=True)`
+    # instance method (`_save_library_ingest_options`), which needs a real
+    # running app to dispatch through `run_worker` -- `fake_app` above is a
+    # bare `SimpleNamespace` stand-in for sequencing, not a mounted app, and
+    # has no `_thread_id`. Patching the instance method (rather than the
+    # module-level `save_settings_to_cli_config` it wraps) keeps this
+    # test's own subject -- that sensitive/internal fields are stripped
+    # before persisting -- intact.
+    screen._save_library_ingest_options = lambda values: saved_settings.append(values)
     screen.app_instance = SimpleNamespace(
         submit_library_ingest_job=submit,
         _ensure_parakeet_source_service=lambda: service,
@@ -2144,13 +2149,18 @@ def test_backend_switch_during_external_hash_cancels_and_fences_callback(
     screen._prepare_library_external_submission = MagicMock(return_value=worker)
     screen.refresh = MagicMock()
 
-    def save_backend(_section: str, _key: str, target: str) -> None:
+    def save_backend(target: str) -> None:
         backend["value"] = target
 
-    monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.library_screen.save_setting_to_cli_config",
-        save_backend,
-    )
+    # task-15470: the actual persistence call moved into a
+    # `@work(thread=True)` instance method (`_save_library_ingest_backend`),
+    # which needs a running app to dispatch through `run_worker` -- this
+    # bare, unmounted screen has none. Patching the instance method itself
+    # (rather than the module-level `save_setting_to_cli_config`) keeps this
+    # test's actual subject -- cancellation/fencing of the external hash
+    # worker -- decoupled from how the backend choice eventually reaches
+    # disk, which has its own coverage.
+    screen._save_library_ingest_backend = save_backend
     LibraryScreen._do_submit_ingest(screen, "/tmp/speech.wav")
     generation, scope_id, *_rest = (
         screen._prepare_library_external_submission.call_args.args
@@ -2204,10 +2214,14 @@ def test_option_reset_during_external_hash_preserves_reset_and_fences_callback(
     worker = MagicMock(is_finished=False)
     screen._prepare_library_external_submission = MagicMock(return_value=worker)
     screen._refresh_library_ingest_canvas_preserving_context = MagicMock()
-    monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.library_screen.save_settings_to_cli_config",
-        MagicMock(),
-    )
+    # task-15470: the actual persistence call moved into a
+    # `@work(thread=True)` instance method (`_save_library_ingest_options`),
+    # which needs a running app to dispatch through `run_worker` -- this
+    # bare, unmounted screen has none. Patching the instance method itself
+    # keeps this test's actual subject -- cancellation/fencing of the
+    # external hash worker -- decoupled from how reset options eventually
+    # reach disk, which has its own coverage.
+    screen._save_library_ingest_options = MagicMock()
 
     LibraryScreen._do_submit_ingest(screen, "/tmp/speech.wav")
     generation, scope_id, *_rest = (

--- a/Tests/UI/test_library_ingest_retry_last.py
+++ b/Tests/UI/test_library_ingest_retry_last.py
@@ -118,7 +118,7 @@ def test_retry_last_shows_once_the_queue_has_settled():
 def test_do_submit_ingest_captures_the_last_submission_snapshot(tmp_path):
     """The snapshot is taken BEFORE the form clears: source, metadata,
     generic toggles, and a per-group copy of the options."""
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import MagicMock
 
     from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 
@@ -145,12 +145,14 @@ def test_do_submit_ingest_captures_the_last_submission_snapshot(tmp_path):
     screen.call_after_refresh = MagicMock()
     screen.app_instance = MagicMock()
 
-    with patch.object(
-        library_screen_module,
-        "save_settings_to_cli_config",
-        lambda *_a, **_k: True,
-    ):
-        screen._do_submit_ingest("/tmp/talk.mp3")
+    # task-15470: the actual write moved into a `@work(thread=True)`
+    # instance method (`_save_library_ingest_options`), which needs a
+    # running app to dispatch through `run_worker` -- this screen was never
+    # mounted. Patching that instance method (rather than the module-level
+    # `save_settings_to_cli_config` it wraps) keeps this test's own
+    # subject -- the pre-clear submission snapshot -- intact.
+    screen._save_library_ingest_options = lambda *_a, **_k: True
+    screen._do_submit_ingest("/tmp/talk.mp3")
 
     snapshot = screen._library_ingest_last_submission
     assert snapshot is not None

--- a/Tests/UI/test_library_screen.py
+++ b/Tests/UI/test_library_screen.py
@@ -190,13 +190,16 @@ def test_do_submit_ingest_persists_options(monkeypatch) -> None:
         "audio_video": {"transcription_model": "small"},
     }
 
+    # task-15470: the actual write moved into a `@work(thread=True)`
+    # instance method (`_save_library_ingest_options`), which needs a
+    # running app to dispatch through `run_worker` -- this screen was never
+    # mounted. Patching that instance method (rather than the module-level
+    # `save_settings_to_cli_config` it wraps) keeps this test's own
+    # subject -- the batched shape of what the submit path decides to
+    # persist -- intact.
     batches: list[dict] = []
-    monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.library_screen.save_settings_to_cli_config",
-        lambda section_values: batches.append(
-            {s: dict(v) for s, v in section_values.items()}
-        )
-        or True,
+    screen._save_library_ingest_options = lambda section_values: (
+        batches.append({s: dict(v) for s, v in section_values.items()}) or True
     )
 
     screen._do_submit_ingest("/tmp/test.pdf")
@@ -287,13 +290,13 @@ def test_task_3303_options_round_trip_persisted_config(monkeypatch) -> None:
     }
     form.type_options = {g: dict(v) for g, v in submitted_options.items()}
 
+    # task-15470: see `test_do_submit_ingest_persists_options` for why this
+    # patches the `@work(thread=True)` instance method rather than the
+    # module-level config function it wraps.
     saved_sections: dict[str, dict] = {}
-    monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.library_screen.save_settings_to_cli_config",
-        lambda section_values: saved_sections.update(
-            {s: dict(v) for s, v in section_values.items()}
-        )
-        or True,
+    screen._save_library_ingest_options = lambda section_values: (
+        saved_sections.update({s: dict(v) for s, v in section_values.items()})
+        or True
     )
 
     screen._do_submit_ingest("/tmp/report.docx")
@@ -348,13 +351,13 @@ def test_task_3306_av_options_round_trip_persisted_config(monkeypatch) -> None:
     }
     form.type_options = {g: dict(v) for g, v in submitted.items()}
 
+    # task-15470: see `test_do_submit_ingest_persists_options` for why this
+    # patches the `@work(thread=True)` instance method rather than the
+    # module-level config function it wraps.
     saved_sections: dict[str, dict] = {}
-    monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.library_screen.save_settings_to_cli_config",
-        lambda section_values: saved_sections.update(
-            {s: dict(v) for s, v in section_values.items()}
-        )
-        or True,
+    screen._save_library_ingest_options = lambda section_values: (
+        saved_sections.update({s: dict(v) for s, v in section_values.items()})
+        or True
     )
 
     screen._do_submit_ingest("/tmp/talk.mp3")
@@ -694,10 +697,15 @@ def test_backend_switch_flips_and_persists_the_target(monkeypatch) -> None:
     screen.app_instance._resolve_ingest_backend = MagicMock(return_value="local")
     screen.refresh = MagicMock()
 
+    # task-15470: the actual write moved into a `@work(thread=True)`
+    # instance method (`_save_library_ingest_backend`), which needs a
+    # running app to dispatch through `run_worker` -- this screen was never
+    # mounted. Patching that instance method (rather than the module-level
+    # `save_setting_to_cli_config` it wraps) keeps this test's own subject
+    # -- which target the handler decides to persist -- intact.
     saved: list[tuple] = []
-    monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.library_screen.save_setting_to_cli_config",
-        lambda section, key, value: saved.append((section, key, value)) or True,
+    screen._save_library_ingest_backend = (
+        lambda target: saved.append(("library.ingest", "backend", target)) or True
     )
 
     screen.handle_library_ingest_backend_switch(MagicMock())
@@ -712,10 +720,12 @@ def test_backend_switch_returns_to_local(monkeypatch) -> None:
     screen.app_instance._resolve_ingest_backend = MagicMock(return_value="server")
     screen.refresh = MagicMock()
 
+    # task-15470: see the sibling test above for why this patches the
+    # `@work(thread=True)` instance method rather than the module-level
+    # config function it wraps.
     saved: list[tuple] = []
-    monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.library_screen.save_setting_to_cli_config",
-        lambda section, key, value: saved.append((section, key, value)) or True,
+    screen._save_library_ingest_backend = (
+        lambda target: saved.append(("library.ingest", "backend", target)) or True
     )
 
     screen.handle_library_ingest_backend_switch(MagicMock())
@@ -757,13 +767,13 @@ def test_task_3307_image_options_round_trip_persisted_config(monkeypatch) -> Non
     }
     form.type_options = {g: dict(v) for g, v in submitted.items()}
 
+    # task-15470: see `test_do_submit_ingest_persists_options` for why this
+    # patches the `@work(thread=True)` instance method rather than the
+    # module-level config function it wraps.
     saved_sections: dict[str, dict] = {}
-    monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.library_screen.save_settings_to_cli_config",
-        lambda section_values: saved_sections.update(
-            {s: dict(v) for s, v in section_values.items()}
-        )
-        or True,
+    screen._save_library_ingest_options = lambda section_values: (
+        saved_sections.update({s: dict(v) for s, v in section_values.items()})
+        or True
     )
 
     screen._do_submit_ingest("/tmp/scan.png")

--- a/Tests/UI/test_library_screen.py
+++ b/Tests/UI/test_library_screen.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 import pytest
 import pytest_asyncio
+import toml
 from textual.widgets import Button
 from unittest.mock import MagicMock
 
+from tldw_chatbook.config import _get_effective_config_path, get_cli_setting
 from tldw_chatbook.Library.library_ingest_jobs import (
     DEFAULT_CHUNK_SIZE,
     IngestJobState,
@@ -731,6 +733,34 @@ def test_backend_switch_returns_to_local(monkeypatch) -> None:
     screen.handle_library_ingest_backend_switch(MagicMock())
 
     assert saved == [("library.ingest", "backend", "local")]
+
+
+def test_save_library_ingest_backend_writes_the_real_dotted_section() -> None:
+    """task-15470 review round: the sibling tests above patch
+    `_save_library_ingest_backend` itself (unavoidable -- it is
+    `@work(thread=True)`, which needs a running app to dispatch through
+    `run_worker`, and none of these screens are mounted), so none of them
+    exercise the REAL method body -- specifically its literal
+    ``"library.ingest"``/``"backend"`` section/key strings, which a typo
+    there (e.g. ``"library.Ingest"``) would let every mocked test above
+    stay green through.
+
+    `@work` wraps with `functools.wraps`, so `.__wrapped__` is the
+    undecorated body -- calling it directly bypasses `run_worker` (and the
+    app it needs) entirely while still running the exact production code,
+    against the real (test-sandboxed, per the root conftest's autouse
+    profile isolation) `save_setting_to_cli_config`. This is the one
+    representative site the review round asked for; the same
+    `.__wrapped__` pattern already used for `_prepare_library_external_
+    submission` elsewhere in this test suite.
+    """
+    screen = _minimal_ingest_screen()
+
+    LibraryScreen._save_library_ingest_backend.__wrapped__(screen, "server")
+
+    assert get_cli_setting("library.ingest", "backend", None) == "server"
+    on_disk = toml.load(_get_effective_config_path())
+    assert on_disk["library"]["ingest"]["backend"] == "server"
 
 
 def test_switch_is_not_offered_when_the_server_seam_cannot_submit() -> None:

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -8531,10 +8531,17 @@ def test_remote_images_toggle_persists_and_pokes_live_config(monkeypatch):
     app = _build_test_app()
     app.app_config["COMPREHENSIVE_CONFIG_RAW"] = {"chat": {"images": {}}}
     screen = SettingsScreen(app)
+    # task-15470: the actual write moved into a `@work(thread=True)`
+    # instance method (`_persist_remote_images_toggle`), which needs a
+    # running/mounted app to dispatch through `run_worker` -- this screen
+    # is constructed but never pushed onto `app`'s screen stack. Patching
+    # the instance method (rather than the module-level
+    # `save_settings_to_cli_config` it wraps) keeps this test's own
+    # subject -- the dotted section shape and the live app_config poke --
+    # intact.
     saved = []
-    monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.save_settings_to_cli_config",
-        lambda section_values: (saved.append(section_values), True)[1],
+    screen._persist_remote_images_toggle = lambda next_value: saved.append(
+        {"chat.images": {"render_remote_images": next_value}}
     )
 
     enabled = screen._toggle_remote_images()

--- a/Tests/UI/test_settings_splash_screen_viewer.py
+++ b/Tests/UI/test_settings_splash_screen_viewer.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch
 from textual.app import App
 from textual.css.query import NoMatches
-from textual.widgets import Button, Checkbox, Input, OptionList, Select
+from textual.widgets import Button, Checkbox, Input, OptionList, Select, Static
 
 from tldw_chatbook.Widgets import settings_splash_screen_viewer as splash_module
 from tldw_chatbook.Widgets.settings_splash_screen_viewer import (
@@ -179,3 +179,74 @@ async def test_settings_splash_viewer_default_select_persists_on_change(
 
         assert ("splash_screen", "card_selection", target) in saved
         assert viewer._config["card_selection"] == target
+
+
+@pytest.mark.asyncio
+async def test_failing_persist_worker_surfaces_error_without_crashing_the_app(
+    splash_app, monkeypatch
+):
+    """task-15470 review round: `_persist_splash_config_value` used to call
+    `self.call_from_thread(...)` on its failure path -- but `call_from_
+    thread` exists only on `App`, not on this `Vertical` widget. When the
+    config write actually raised, the `except` handler's own
+    `self.call_from_thread` call raised a SECOND, uncaught `AttributeError`
+    inside a `@work(thread=True)` worker -- fatal to the whole app by
+    default (`exit_on_error=True`). Textual re-raises that fatal exception
+    when `run_test()`'s context manager exits, so with the bug present this
+    test fails with an `AttributeError` traceback instead of ever reaching
+    the assertions below (confirmed by temporarily reverting the fix and
+    re-running this exact test).
+
+    Also pins the adjacent fix: a failed write must not leave `_config`
+    diverged from what is actually on disk -- the optimistic in-memory
+    update must revert.
+    """
+
+    def failing_save(section: str, key: str, value: object) -> None:
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(splash_module, "save_setting_to_cli_config", failing_save)
+
+    async with splash_app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        viewer = splash_app.query_one(SettingsSplashScreenViewer)
+        previous = viewer._config["skip_on_keypress"]
+
+        checkbox = viewer.query_one("#settings-splash-skip-on-keypress", Checkbox)
+        checkbox.value = not previous
+        await pilot.pause()
+
+        status = viewer.query_one("#settings-splash-status", Static)
+        for _ in range(50):
+            if "Error saving skip_on_keypress" in str(status.renderable):
+                break
+            await pilot.pause(0.02)
+        else:
+            raise AssertionError(
+                f"failure status never appeared; last seen: {status.renderable!r}"
+            )
+
+        # The optimistic in-memory value must not diverge from what is
+        # actually on disk once the write is known to have failed.
+        assert viewer._config["skip_on_keypress"] == previous
+
+        # The app must still be alive and responsive -- not merely "the
+        # exception hasn't been re-raised yet" (that only happens when the
+        # `async with` block exits, below). Driving a second, independent
+        # control through a full failure-and-revert cycle proves the
+        # message loop, workers, and `call_from_thread` callbacks are all
+        # still functioning normally after the first failure.
+        other_checkbox = viewer.query_one("#settings-splash-enabled", Checkbox)
+        other_previous = viewer._config["enabled"]
+        other_checkbox.value = not other_previous
+
+        for _ in range(50):
+            if "Error saving enabled" in str(status.renderable):
+                break
+            await pilot.pause(0.02)
+        else:
+            raise AssertionError(
+                "second control's failure status never appeared -- app "
+                f"stopped responding; last seen: {status.renderable!r}"
+            )
+        assert viewer._config["enabled"] == other_previous

--- a/Tests/integration/test_library_ingest_flow.py
+++ b/Tests/integration/test_library_ingest_flow.py
@@ -144,16 +144,17 @@ def test_options_persist_to_config(monkeypatch):
         saved_batches.append(section_values)
         return True
 
-    monkeypatch.setattr(
-        library_screen_module,
-        "save_settings_to_cli_config",
-        fake_save,
-    )
-
     submitted_jobs = []
     screen = library_screen_module.LibraryScreen.__new__(
         library_screen_module.LibraryScreen
     )
+    # task-15470: the actual write moved into a `@work(thread=True)`
+    # instance method (`_save_library_ingest_options`), which needs a
+    # running app to dispatch through `run_worker` -- this screen was never
+    # mounted. Patching that instance method (rather than the module-level
+    # `save_settings_to_cli_config` it wraps) keeps this test's own
+    # subject -- the one atomic batch shape -- intact.
+    screen._save_library_ingest_options = fake_save
     screen.app_instance = SimpleNamespace(
         submit_library_ingest_job=lambda **kwargs: submitted_jobs.append(kwargs)
     )
@@ -204,16 +205,14 @@ def test_snapshot_coerces_display_string_chunk_numbers(monkeypatch):
     """task-3301: the generic panel's Inputs hand back display text
     (``"1000"``); the submitted snapshot must carry ints so processors and
     the persisted config never see a string chunk size/overlap."""
-    monkeypatch.setattr(
-        library_screen_module,
-        "save_settings_to_cli_config",
-        lambda section_values: True,
-    )
-
     submitted_jobs = []
     screen = library_screen_module.LibraryScreen.__new__(
         library_screen_module.LibraryScreen
     )
+    # task-15470: see `test_options_persist_to_config` above for why this
+    # patches the `@work(thread=True)` instance method rather than the
+    # module-level config function it wraps.
+    screen._save_library_ingest_options = lambda section_values: True
     screen.app_instance = SimpleNamespace(
         submit_library_ingest_job=lambda **kwargs: submitted_jobs.append(kwargs)
     )

--- a/backlog/tasks/task-15470 - Config-persistence---batch-writes-and-take-them-off-the-click-path.md
+++ b/backlog/tasks/task-15470 - Config-persistence---batch-writes-and-take-them-off-the-click-path.md
@@ -104,3 +104,21 @@ this task's diff.
 `Tests/UI/test_library_ingest_retry_last.py`,
 `Tests/integration/test_library_ingest_flow.py`,
 `Tests/UI/test_settings_configuration_hub.py` updated).
+
+### Review round 1 (fix commit a73eda6cc)
+
+The independent review found 1 Critical + 2 Important defects in the original round, all
+probe-proven: the splash viewer's worker error branch called `self.call_from_thread` (App-only
+API) and crashed the app via exit_on_error; both debounced sites could silently lose an edit
+landing during an in-flight write on quit (dirty cleared after the write; flush returned without
+re-checking); and the file-picker conversion was neutered by `recent_locations.add()`'s sync
+write on the same dismiss path. All fixed: `self.app.call_from_thread` + failure reverts the
+in-memory value; dirty clears at snapshot time and the flush re-checks after awaiting in-flight
+(race tests born red at both sites); recents + last-dir coalesced into one deferred write with
+an end-to-end persistence test. The three library swallows now log; one test pins production's
+real dotted config strings.
+
+Provenance: the fix was authored by the task's implementer agent, which was interrupted
+mid-verification (session limit, then stopped); the controlling session completed the remaining
+test batches (50 + 31 green, ruff attributed) and committed the staged work as a73eda6cc. The
+scoped re-review independently mutation-verified the Critical and one flush-race site.

--- a/backlog/tasks/task-15470 - Config-persistence---batch-writes-and-take-them-off-the-click-path.md
+++ b/backlog/tasks/task-15470 - Config-persistence---batch-writes-and-take-them-off-the-click-path.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15470
 title: Config persistence: batch writes and take them off the click path
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-11 12:05'
@@ -20,9 +20,9 @@ Fix direction: batch the dictation save into one call; debounce + `to_thread` th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The dictation save performs one batched config write; no config rewrite fires on a parsing keystroke
-- [ ] #2 Sidebar toggles perform no synchronous file I/O on the event loop; state survives restart including quit-immediately-after-toggle (flush test)
-- [ ] #3 Each listed per-click rewrite site is converted or explicitly justified in the notes
+- [x] #1 The dictation save performs one batched config write; no config rewrite fires on a parsing keystroke
+- [x] #2 Sidebar toggles perform no synchronous file I/O on the event loop; state survives restart including quit-immediately-after-toggle (flush test)
+- [x] #3 Each listed per-click rewrite site is converted or explicitly justified in the notes
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -35,3 +35,72 @@ Fix direction: batch the dictation save into one call; debounce + `to_thread` th
 6. Update every existing test that called a handler on a bare/unmounted screen and hit `run_worker`'s `NoActiveAppError` -- patch the new per-site worker method instead of the module-level config function it wraps, preserving each test's actual subject.
 7. Write flush-on-quit tests for dictation and sidebar; mutation-verify by disabling the flush and confirming the test goes red, then restore via Edit.
 8. Run the full affected test surface; write the report.
+
+## Implementation Notes
+
+All thirteen sites from the audit (dictation, sidebar, plus the ~10 per-click
+sites) are converted to debounce+worker or `to_thread` dispatch; one more
+(`settings_screen.py`'s model-catalog stale-hours `Input.Changed` handler) was
+found and fixed alongside the remote-images toggle -- same per-keystroke
+defect class as dictation, not in the audit's literal citation.
+
+**Per-site classification:**
+
+| Site | Treatment |
+|---|---|
+| Dictation `_save_settings`/`_persist_settings` (buffer-duration keystroke + 4 switches) | Debounced (0.6s) + batched into ONE `save_settings_to_cli_config` call (`dictation`+`dictation.privacy`), dispatched via `run_worker`+`asyncio.to_thread`; `on_unmount` flush |
+| Chat sidebar `watch_sidebar_state` (Collapsible toggles, expand/collapse/reset) | Debounced (0.5s), `asyncio.to_thread` dispatch; `on_unmount` flush (waits on in-flight worker instead of double-writing) |
+| Library notes-sync (folder submit/browse, direction/conflict choice, auto-sync toggle, validated sync run -- 6 sites) | `@work(thread=True)` via shared `_save_library_notes_sync_setting` helper (one-shot user actions, no burst risk -- no debounce needed) |
+| Library ingest backend switch | `@work(thread=True)` |
+| Library ingest browse (`_remember_library_ingest_location`) | `@work(thread=True)` thin wrapper (`_persist_library_ingest_location`); the method itself stays synchronous since existing tests call it directly without a mounted app |
+| Library ingest submit (option batch save) | `@work(thread=True)`; the batching itself was already done by earlier work (task-3313-adjacent), this task only moved it off the loop |
+| Library ingest option reset | `@work(thread=True)`, reusing the submit path's helper |
+| `enhanced_file_picker.py` `_save_last_directory` | `@work(thread=True)` (it's a `ModalScreen`, `self.app` always available) |
+| `settings_splash_screen_viewer.py` (6 Checkbox/Select/Input handlers via `_save_config_value`) | In-memory update + message stay synchronous; only the disk write deferred to a new `@work(thread=True)` worker |
+| `settings_screen.py` remote-images toggle | `@work(thread=True)`; in-memory `app_config` poke (read live by the transcript gate) stays synchronous |
+| `settings_screen.py` model-catalog stale-hours `Input.Changed` (bonus find) | Same treatment as the toggle; the existing no-op guard (cheap, cache-only) stays synchronous |
+| `console_settings_modal.py` "Save as default" button | `await asyncio.to_thread(...)`, NOT fire-and-forget -- its success/failure UX contract (inline error vs. dismiss) needs the awaited result |
+| `enhanced_file_picker.py`'s `RecentLocations`/`BookmarksManager` | NOT converted -- plain non-Widget classes with no `self.app`; not the line the audit cited (`:1137` = `_save_last_directory` only); out of the enumerated scope |
+
+**Stability guards added on review:** every new `@work(thread=True)`/`run_worker` callback wraps its `save_setting(s)_to_cli_config` call in `try/except` -- an uncaught worker exception is fatal to the whole app by default (`exit_on_error=True`), which would have been a worse regression than the synchronous-write bug this task fixes. Two workers (`_persist_remote_images_toggle`, `_persist_model_catalog_section_values`) were missing this guard in an earlier pass and were fixed in a follow-up commit. Every debounced write that snapshots mutable state (`self.ui_state`, `self.settings`) does so on the calling (main) thread before handing off to `to_thread`, so a further edit arriving mid-write cannot race the worker's read of the same dict.
+
+**Tests:** two new files (`test_chat_screen_sidebar_state_debounce.py`, `test_dictation_settings_debounce.py`) cover the debounce-armed / no-sync-write / natural-fire / flush-on-quit behavior; the flush-on-quit tests were mutation-verified (temporarily disabled the `on_unmount` flush call, confirmed the test goes red, restored via Edit). Eight existing tests across `test_library_ingest_canvas.py`, `test_library_screen.py`, `test_library_ingest_retry_last.py`, `test_library_ingest_flow.py`, and `test_settings_configuration_hub.py` called a handler on a bare/unmounted screen and broke on `run_worker`'s `NoActiveAppError`; each now patches the new per-site worker method instead of the module-level config function it wraps.
+
+Consolidated run across every directly touched test file: 612-619 passed
+(counted across two overlapping runs), 7 failures -- all confirmed
+pre-existing and unrelated to this task: a `QwenCloud`-provider test-data
+drift (`test_model_catalog_toggles_initialize_from_saved_config`, caused by
+an unrelated earlier commit, `assert set` doesn't touch anywhere this task
+edited), a generic-ingest-options content mismatch exposed only once the
+`run_worker` crash this task fixed stopped masking it
+(`test_options_persist_to_config` -- schema drift, not a threading bug),
+two dependency-presence governance fixtures whose premise requires PDF/audio
+tooling to be ABSENT (`test_forecast_counts_equal_the_real_receipt_for_a_*`),
+one OCR-backend-absence-dependent consent-routing test
+(`test_the_same_folder_still_imports_on_this_machine`), and two rendering/
+geometry tests (`test_schema_disabled_fields_paint_legibly_inert`,
+`test_the_fold_pays_for_itself_in_the_shipped_screen`) -- the latter two
+directly A/B-probed by temporarily reverting the one changed line back to
+the synchronous call and confirming the SAME failure. A separate full run
+of `Tests/UI/test_library_shell.py` + 3 sibling files (598 passed, 15 failed)
+surfaced the same failure classes (missing-dependency governance fixtures,
+label-text drift, geometry, `Local prompt/quiz/study backend is
+unavailable` fixture gaps) plus two directly probed the same way (the
+"reset to defaults" title-receipt test and a sync-navigator-focus test, the
+latter never even calling any handler this task touched); none intersect
+this task's diff.
+
+**Modified files:** `tldw_chatbook/UI/Dictation_Window_Improved.py`,
+`tldw_chatbook/UI/Screens/chat_screen.py`,
+`tldw_chatbook/UI/Screens/library_screen.py`,
+`tldw_chatbook/UI/Screens/settings_screen.py`,
+`tldw_chatbook/Widgets/Console/console_settings_modal.py`,
+`tldw_chatbook/Widgets/enhanced_file_picker.py`,
+`tldw_chatbook/Widgets/settings_splash_screen_viewer.py`, plus test files
+(`Tests/UI/test_chat_screen_sidebar_state_debounce.py` and
+`Tests/UI/test_dictation_settings_debounce.py` new;
+`Tests/Local_Ingestion/test_dictation_window_provider_ids.py`,
+`Tests/UI/test_library_ingest_canvas.py`, `Tests/UI/test_library_screen.py`,
+`Tests/UI/test_library_ingest_retry_last.py`,
+`Tests/integration/test_library_ingest_flow.py`,
+`Tests/UI/test_settings_configuration_hub.py` updated).

--- a/backlog/tasks/task-15470 - Config-persistence---batch-writes-and-take-them-off-the-click-path.md
+++ b/backlog/tasks/task-15470 - Config-persistence---batch-writes-and-take-them-off-the-click-path.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15470
 title: Config persistence: batch writes and take them off the click path
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-11 12:05'
 labels:
   - perf
@@ -23,3 +24,14 @@ Fix direction: batch the dictation save into one call; debounce + `to_thread` th
 - [ ] #2 Sidebar toggles perform no synchronous file I/O on the event loop; state survives restart including quit-immediately-after-toggle (flush test)
 - [ ] #3 Each listed per-click rewrite site is converted or explicitly justified in the notes
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Verify each audit-cited site at HEAD (line numbers have shifted / some already partially fixed by other sessions since the audit).
+2. Dictation window: batch `_save_settings` into one `save_settings_to_cli_config` call (`dictation` + `dictation.privacy` sections); make `_persist_settings` (the single mount-noise gate) debounce (0.6s) instead of writing synchronously; dispatch the write to a worker off the loop; snapshot `self.settings` on the main thread before handing to the worker; add `on_unmount` to force-flush a pending write.
+3. Chat sidebar: convert `watch_sidebar_state` from a synchronous `_save_sidebar_state()` call to a debounce (0.5s) + worker dispatch (`asyncio.to_thread`), snapshotting `ui_state` on the main thread first; add `on_unmount` flush (waiting on an in-flight worker rather than double-writing); route `handle_reset_settings` through the same scheduling helper since reassigning an already-`{}` `sidebar_state` is a reactive no-op that never calls the watcher.
+4. Library screen notes-sync cluster (6 call sites) and ingest backend/browse/submit/reset (4 call sites): wrap each write in a `@work(thread=True)` helper, matching the file's existing `_save_library_search_history`/`_save_library_rail_preferences` convention. Keep `_remember_library_ingest_location` itself synchronous (existing tests call it directly without a mounted app) with a thin `@work` wrapper (`_persist_library_ingest_location`) at its one production call site instead.
+5. Remaining four listed sites: `enhanced_file_picker.py`'s `_save_last_directory` (`@work`, it's a `ModalScreen` so `self.app` is always available), `settings_splash_screen_viewer.py`'s `_save_config_value` (split the in-memory update from the deferred write), `settings_screen.py`'s remote-images toggle AND the model-catalog stale-hours `Input.Changed` handler (found in the same ADR-020 immediate-write cluster while fixing the toggle -- same per-keystroke defect class as dictation, not in the audit's literal citation but the same bug), `console_settings_modal.py`'s Save-as-default button (`asyncio.to_thread`, not fire-and-forget, since its success/failure UX contract needs the awaited result before deciding whether to dismiss or show an inline error).
+6. Update every existing test that called a handler on a bare/unmounted screen and hit `run_worker`'s `NoActiveAppError` -- patch the new per-site worker method instead of the module-level config function it wraps, preserving each test's actual subject.
+7. Write flush-on-quit tests for dictation and sidebar; mutation-verify by disabling the flush and confirming the test goes red, then restore via Edit.
+8. Run the full affected test surface; write the report.

--- a/tldw_chatbook/UI/Dictation_Window_Improved.py
+++ b/tldw_chatbook/UI/Dictation_Window_Improved.py
@@ -873,9 +873,16 @@ Performance Tips:
         applies every section/key in `snapshot` under a single config-file
         lock, atomic replace, and cache reload -- the 6-9 sequential
         `save_setting_to_cli_config` calls this replaced each did all three
-        independently.
+        independently. Guarded broadly: this now also runs inside a
+        `run_worker` coroutine (`_persist_settings_off_loop`), where an
+        uncaught exception is fatal to the whole app by default
+        (`exit_on_error=True`) -- a config-write hiccup must not crash the
+        session.
         """
-        save_settings_to_cli_config(snapshot)
+        try:
+            save_settings_to_cli_config(snapshot)
+        except Exception:
+            logger.exception("Failed to persist dictation settings")
 
     def _save_settings(self):
         """Save dictation settings, synchronously, on this thread.

--- a/tldw_chatbook/UI/Dictation_Window_Improved.py
+++ b/tldw_chatbook/UI/Dictation_Window_Improved.py
@@ -6,6 +6,7 @@ Improved dictation interface with privacy settings and better error handling.
 from typing import List, Dict, Any
 from pathlib import Path
 from datetime import datetime
+import asyncio
 import time
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, ScrollableContainer, Container
@@ -25,11 +26,26 @@ from textual.binding import Binding
 from loguru import logger
 
 # Local imports
-from ..config import get_cli_setting, get_user_data_dir, save_setting_to_cli_config
+from ..config import (
+    get_cli_setting,
+    get_user_data_dir,
+    save_settings_to_cli_config,
+)
 from ..Audio.dictation_service_lazy import LazyLiveDictationService, DictationState
 from ..Event_Handlers.Audio_Events import VoiceCommandEvent
 from ..Utils.local_stt_providers import normalize_provider_id
 from ..Widgets.audio_troubleshooting_dialog import AudioTroubleshootingDialog
+
+
+# task-15470: `_persist_settings` used to write straight to config.toml --
+# 6-9 sequential `save_setting_to_cli_config` calls, each its own full
+# read+atomic-rewrite+cache-reload cycle -- and the buffer-duration input
+# fired it on every keystroke that happened to parse. This debounce
+# coalesces a burst of edits (a typed duration, several switch flips) into
+# one batched write, dispatched off the event loop; `on_unmount` flushes any
+# pending write so an edit immediately followed by navigating away or
+# quitting is not lost.
+DICTATION_SETTINGS_SAVE_DEBOUNCE_SECONDS = 0.6
 
 
 def dictation_export_directory() -> Path:
@@ -198,6 +214,12 @@ class ImprovedDictationWindow(Widget):
 
         # Settings
         self.settings = self._load_settings()
+
+        # task-15470: debounce state for `_persist_settings` -- see
+        # `DICTATION_SETTINGS_SAVE_DEBOUNCE_SECONDS`.
+        self._settings_save_timer = None
+        self._settings_dirty = False
+        self._settings_persist_worker = None
 
         # Start time tracking
         self._start_time = None
@@ -468,15 +490,74 @@ class ImprovedDictationWindow(Widget):
         self._settings_are_mounting = False
 
     def _persist_settings(self) -> None:
-        """Save settings unless the controls are still mounting.
+        """Schedule a debounced settings save unless controls are mounting.
 
         The single gate. Handlers call this rather than `_save_settings`
         directly, so a new handler cannot reintroduce the write-on-open by
-        forgetting to check.
+        forgetting to check. task-15470: this used to call `_save_settings()`
+        directly and synchronously -- 6-9 sequential config.toml
+        read-rewrite-reload cycles on the event loop, and the
+        buffer-duration input called it once per parsing keystroke. It now
+        only marks settings dirty and (re)arms a debounce timer; the actual
+        write is one batched atomic mutation, dispatched off the loop by
+        `_flush_settings_after_debounce`. `on_unmount` force-flushes any
+        pending write.
         """
         if getattr(self, "_settings_are_mounting", False):
             return
-        self._save_settings()
+        self._settings_dirty = True
+        if self._settings_save_timer is not None:
+            self._settings_save_timer.stop()
+        self._settings_save_timer = self.set_timer(
+            DICTATION_SETTINGS_SAVE_DEBOUNCE_SECONDS,
+            self._flush_settings_after_debounce,
+        )
+
+    def _flush_settings_after_debounce(self) -> None:
+        """Debounce timer callback: hand the actual write to a worker."""
+        self._settings_save_timer = None
+        self._settings_persist_worker = self.run_worker(
+            self._persist_settings_off_loop(),
+            exclusive=True,
+            group="dictation-settings-persist",
+        )
+
+    async def _persist_settings_off_loop(self) -> None:
+        """Write settings on a worker thread, off the event loop.
+
+        Snapshots `self.settings` here, on the main thread, before handing
+        the write to `to_thread` -- a further keystroke/switch can still
+        arrive and mutate `self.settings` while this write is in flight, and
+        it must not race the worker thread's read of that same dict.
+        """
+        snapshot = self._settings_snapshot()
+        await asyncio.to_thread(self._write_settings_snapshot, snapshot)
+        self._settings_dirty = False
+
+    async def on_unmount(self) -> None:
+        """Flush a pending debounced settings write.
+
+        Fires both when this view is switched away from (`STTS_Window`'s
+        `content_container.remove_children()`) and when the app quits while
+        the Dictation view is mounted -- Textual's `App._shutdown` prunes
+        every mounted descendant, this widget included. If a debounced
+        write is already in flight, waits for it rather than dispatching a
+        second writer against the same config file.
+        """
+        if self._settings_save_timer is not None:
+            self._settings_save_timer.stop()
+            self._settings_save_timer = None
+        worker = self._settings_persist_worker
+        if worker is not None and not worker.is_finished:
+            try:
+                await worker.wait()
+            except Exception as error:
+                logger.error(f"Pending dictation settings write failed: {error}")
+            return
+        if self._settings_dirty:
+            snapshot = self._settings_snapshot()
+            await asyncio.to_thread(self._write_settings_snapshot, snapshot)
+            self._settings_dirty = False
 
     def on_switch_changed(self, event: Switch.Changed) -> None:
         """Handle switch changes."""
@@ -762,22 +843,50 @@ Performance Tips:
             settings["language"] = "en"
         return settings
 
-    def _save_settings(self):
-        """Save dictation settings."""
-        save_setting_to_cli_config("dictation", "provider", self.settings["provider"])
-        save_setting_to_cli_config("dictation", "model", self.settings.get("model"))
-        save_setting_to_cli_config("dictation", "language", self.settings["language"])
-        save_setting_to_cli_config(
-            "dictation", "punctuation", self.settings["punctuation"]
-        )
-        save_setting_to_cli_config("dictation", "commands", self.settings["commands"])
-        save_setting_to_cli_config(
-            "dictation", "buffer_duration_ms", self.settings["buffer_duration_ms"]
-        )
+    def _settings_snapshot(self) -> Dict[str, Any]:
+        """Copy the persisted fields off `self.settings`.
 
-        # Save privacy settings
-        for key, value in self.settings["privacy"].items():
-            save_setting_to_cli_config("dictation.privacy", key, value)
+        `self.settings` is a plain mutable dict; taking this copy on the
+        caller's thread (always the main/event-loop thread -- see
+        `_persist_settings_off_loop`) before handing the write to a worker
+        thread means the worker never reads `self.settings` directly, so a
+        further keystroke/switch arriving while that write is in flight
+        cannot race it.
+        """
+        return {
+            "dictation": {
+                "provider": self.settings["provider"],
+                "model": self.settings.get("model"),
+                "language": self.settings["language"],
+                "punctuation": self.settings["punctuation"],
+                "commands": self.settings["commands"],
+                "buffer_duration_ms": self.settings["buffer_duration_ms"],
+            },
+            "dictation.privacy": dict(self.settings["privacy"]),
+        }
+
+    def _write_settings_snapshot(self, snapshot: Dict[str, Any]) -> None:
+        """Persist a pre-captured settings snapshot with one atomic write.
+
+        Safe to call from a worker thread: touches only the passed-in
+        `snapshot`, never `self.settings`. `save_settings_to_cli_config`
+        applies every section/key in `snapshot` under a single config-file
+        lock, atomic replace, and cache reload -- the 6-9 sequential
+        `save_setting_to_cli_config` calls this replaced each did all three
+        independently.
+        """
+        save_settings_to_cli_config(snapshot)
+
+    def _save_settings(self):
+        """Save dictation settings, synchronously, on this thread.
+
+        Convenience wrapper around `_settings_snapshot` +
+        `_write_settings_snapshot` for a caller that is already off the
+        event loop (a worker thread via `to_thread`). A caller on the event
+        loop that must not block it should go through `_persist_settings`'s
+        debounce instead.
+        """
+        self._write_settings_snapshot(self._settings_snapshot())
 
     def _update_stats(self):
         """Update statistics display."""

--- a/tldw_chatbook/UI/Dictation_Window_Improved.py
+++ b/tldw_chatbook/UI/Dictation_Window_Improved.py
@@ -529,10 +529,22 @@ class ImprovedDictationWindow(Widget):
         the write to `to_thread` -- a further keystroke/switch can still
         arrive and mutate `self.settings` while this write is in flight, and
         it must not race the worker thread's read of that same dict.
+
+        Clears `_settings_dirty` immediately after taking the snapshot, NOT
+        after the write completes (review round, task-15470): the awaited
+        `to_thread` call below yields to the event loop, and a further edit
+        can land while this write is still in flight. Clearing dirty only
+        after the write finished would blindly stamp it False again on
+        completion -- clobbering the True a mid-flight edit had just set --
+        so a quit landing before that edit's own new debounce timer fires
+        would see `dirty=False` and lose it (reproduced: "edit 2 LOST").
+        Clearing right here instead means the dirty flag always answers
+        "is there an edit newer than the snapshot this worker is holding",
+        which a mid-flight edit correctly flips back to True.
         """
         snapshot = self._settings_snapshot()
-        await asyncio.to_thread(self._write_settings_snapshot, snapshot)
         self._settings_dirty = False
+        await asyncio.to_thread(self._write_settings_snapshot, snapshot)
 
     async def on_unmount(self) -> None:
         """Flush a pending debounced settings write.
@@ -553,7 +565,11 @@ class ImprovedDictationWindow(Widget):
                 await worker.wait()
             except Exception as error:
                 logger.error(f"Pending dictation settings write failed: {error}")
-            return
+            # Falls through to the dirty re-check below (review round,
+            # task-15470) rather than returning here: an edit can land
+            # while THIS await was in flight, re-dirtying settings after
+            # the awaited worker already took its own snapshot. Returning
+            # unconditionally after the wait would silently drop it.
         if self._settings_dirty:
             snapshot = self._settings_snapshot()
             await asyncio.to_thread(self._write_settings_snapshot, snapshot)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -21997,10 +21997,23 @@ class ChatScreen(BaseAppScreen):
         the write to `to_thread` -- a further toggle can still arrive and
         mutate `collapsible_states` while this write is in flight, and it
         must not race the worker thread's read of that same dict.
+
+        Clears `_sidebar_state_dirty` immediately after taking the
+        snapshot, NOT after the write completes (review round,
+        task-15470): the awaited `to_thread` call below yields to the
+        event loop, and a further toggle can land while this write is
+        still in flight. Clearing dirty only after the write finished
+        would blindly stamp it False again on completion -- clobbering
+        the True a mid-flight toggle had just set -- so a quit landing
+        before that toggle's own new debounce timer fires would see
+        `dirty=False` and lose it. Clearing right here instead means the
+        dirty flag always answers "is there a toggle newer than the
+        snapshot this worker is holding", which a mid-flight toggle
+        correctly flips back to True.
         """
         snapshot = self._sidebar_state_snapshot()
-        await asyncio.to_thread(self._write_sidebar_state_snapshot, snapshot)
         self._sidebar_state_dirty = False
+        await asyncio.to_thread(self._write_sidebar_state_snapshot, snapshot)
 
     async def _flush_sidebar_state_now(self) -> None:
         """Force-flush a pending sidebar-state write (unmount/quit path).
@@ -22023,7 +22036,11 @@ class ChatScreen(BaseAppScreen):
                 await worker.wait()
             except Exception as error:
                 logger.error(f"Pending sidebar-state write failed: {error}")
-            return
+            # Falls through to the dirty re-check below (review round,
+            # task-15470) rather than returning here: a toggle can land
+            # while THIS await was in flight, re-dirtying the state after
+            # the awaited worker already took its own snapshot. Returning
+            # unconditionally after the wait would silently drop it.
         if self._sidebar_state_dirty:
             snapshot = self._sidebar_state_snapshot()
             await asyncio.to_thread(self._write_sidebar_state_snapshot, snapshot)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -676,6 +676,13 @@ CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS = 2.0
 # call to notice -- needs its own slow repaint timer. 10s keeps the
 # countdown's staleness bound well under the 300s cache TTL it is watching.
 CONSOLE_COST_TTL_TICK_SECONDS = 10.0
+# task-15470: every `Collapsible.Toggled` (plus expand-all/collapse-all/reset)
+# used to reassign `sidebar_state` and have `watch_sidebar_state` open+parse+
+# rewrite `ui_state.toml` synchronously on the event loop, per click. This
+# debounce coalesces a burst of toggles into one write, dispatched off the
+# loop (see `_flush_sidebar_state_after_debounce`); `on_unmount` force-flushes
+# so a toggle immediately followed by quit is never lost.
+SIDEBAR_STATE_SAVE_DEBOUNCE_SECONDS = 0.5
 # P3c Task 3: the "Character" rail avatar box's fitted cell size (mirrors
 # the transcript inline-image row's `fit_image_cell_size` usage, sized
 # smaller for the rail's narrower column).
@@ -3594,6 +3601,11 @@ class ChatScreen(BaseAppScreen):
         self._console_expression_spec_cache: dict[tuple[int, str], dict] = {}
         self.ui_state = UIState()
         self._load_sidebar_state()
+        # task-15470: debounce state for `watch_sidebar_state` -- see
+        # `SIDEBAR_STATE_SAVE_DEBOUNCE_SECONDS`.
+        self._sidebar_state_save_timer: Any | None = None
+        self._sidebar_state_dirty = False
+        self._sidebar_state_persist_worker: Any | None = None
 
     # Sections `load_settings()` always injects into a disk-loaded config but
     # which Console test fakes never carry. Used to tell a real boot snapshot
@@ -14477,6 +14489,11 @@ class ChatScreen(BaseAppScreen):
 
     async def on_unmount(self) -> None:
         """Release Console-native resources owned by this screen."""
+        # task-15470: flush a pending debounced sidebar-state write FIRST,
+        # ahead of every other teardown step below -- several of those can
+        # raise, and a raised exception must not strand an unpersisted
+        # toggle-then-quit.
+        await self._flush_sidebar_state_now()
         registry = self._h3_image_edit_registry()
         store = self._console_chat_store
         if store is not None:
@@ -21934,8 +21951,83 @@ class ChatScreen(BaseAppScreen):
                 return
 
     def watch_sidebar_state(self, new_state: dict) -> None:
-        """Auto-save when sidebar state changes."""
-        self._save_sidebar_state()
+        """Debounce persistence when sidebar state changes.
+
+        task-15470: this used to call `_save_sidebar_state()` directly --
+        synchronous open+parse+rewrite of `ui_state.toml` on the event loop,
+        once per `Collapsible.Toggled`. Now it only marks the state dirty and
+        (re)arms one debounce timer; a burst of toggles collapses into a
+        single write, dispatched off the loop by
+        `_flush_sidebar_state_after_debounce`. `on_unmount` force-flushes any
+        pending write so a toggle immediately followed by quit is not lost.
+        """
+        self._schedule_sidebar_state_save()
+
+    def _schedule_sidebar_state_save(self) -> None:
+        """Mark the sidebar state dirty and (re)arm the debounce timer.
+
+        The single scheduling point -- `watch_sidebar_state` and any direct
+        caller that mutates `ui_state.collapsible_states` without going
+        through the reactive (e.g. a bulk reset that may reassign an
+        already-`{}` `sidebar_state`, which the reactive would then treat as
+        a no-op and never call the watcher for) both route through here so
+        a pending write is unconditionally scheduled.
+        """
+        self._sidebar_state_dirty = True
+        if self._sidebar_state_save_timer is not None:
+            self._sidebar_state_save_timer.stop()
+        self._sidebar_state_save_timer = self.set_timer(
+            SIDEBAR_STATE_SAVE_DEBOUNCE_SECONDS,
+            self._flush_sidebar_state_after_debounce,
+        )
+
+    def _flush_sidebar_state_after_debounce(self) -> None:
+        """Debounce timer callback: hand the actual write to a worker."""
+        self._sidebar_state_save_timer = None
+        self._sidebar_state_persist_worker = self.run_worker(
+            self._persist_sidebar_state_off_loop(),
+            exclusive=True,
+            group="sidebar-state-persist",
+        )
+
+    async def _persist_sidebar_state_off_loop(self) -> None:
+        """Write `ui_state.toml` on a worker thread, off the event loop.
+
+        Snapshots `self.ui_state` here, on the main thread, before handing
+        the write to `to_thread` -- a further toggle can still arrive and
+        mutate `collapsible_states` while this write is in flight, and it
+        must not race the worker thread's read of that same dict.
+        """
+        snapshot = self._sidebar_state_snapshot()
+        await asyncio.to_thread(self._write_sidebar_state_snapshot, snapshot)
+        self._sidebar_state_dirty = False
+
+    async def _flush_sidebar_state_now(self) -> None:
+        """Force-flush a pending sidebar-state write (unmount/quit path).
+
+        Cancels any pending debounce timer and writes off the loop via
+        `to_thread` so the screen never unmounts with an unpersisted toggle
+        -- the AC #2 flush-on-quit guarantee. If a debounced write is
+        already in flight (the timer fired moments before quit), this waits
+        for it rather than dispatching a second writer against the same
+        file -- `_write_sidebar_state_snapshot` does an unlocked
+        read-modify-write of `ui_state.toml`, so two concurrent writers
+        could interleave.
+        """
+        if self._sidebar_state_save_timer is not None:
+            self._sidebar_state_save_timer.stop()
+            self._sidebar_state_save_timer = None
+        worker = self._sidebar_state_persist_worker
+        if worker is not None and not worker.is_finished:
+            try:
+                await worker.wait()
+            except Exception as error:
+                logger.error(f"Pending sidebar-state write failed: {error}")
+            return
+        if self._sidebar_state_dirty:
+            snapshot = self._sidebar_state_snapshot()
+            await asyncio.to_thread(self._write_sidebar_state_snapshot, snapshot)
+            self._sidebar_state_dirty = False
 
     def _load_sidebar_state(self) -> None:
         """Load sidebar state from config file."""
@@ -21968,8 +22060,27 @@ class ChatScreen(BaseAppScreen):
             logger.error(f"Failed to load sidebar state: {e}")
             self.sidebar_state = {}
 
-    def _save_sidebar_state(self) -> None:
-        """Save sidebar state to config file."""
+    def _sidebar_state_snapshot(self) -> Dict[str, Any]:
+        """Copy the sidebar-persisted fields off `self.ui_state`.
+
+        `collapsible_states` is a plain mutable dict; taking this copy on
+        the caller's thread (always the main/event-loop thread -- see
+        `_persist_sidebar_state_off_loop`) before handing the write to a
+        worker thread means the worker never reads `self.ui_state` directly,
+        so a toggle arriving while that write is in flight cannot race it.
+        """
+        return {
+            "collapsible_states": dict(self.ui_state.collapsible_states),
+            "search_query": self.ui_state.sidebar_search_query,
+            "last_active_section": self.ui_state.last_active_section,
+        }
+
+    def _write_sidebar_state_snapshot(self, snapshot: Dict[str, Any]) -> None:
+        """Write a pre-captured sidebar-state snapshot to `ui_state.toml`.
+
+        Safe to call from a worker thread: touches only the passed-in
+        `snapshot`, never `self.ui_state`.
+        """
         config_path = _get_effective_config_path().parent / "ui_state.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -21982,21 +22093,28 @@ class ChatScreen(BaseAppScreen):
                 data = {}
 
             # Update sidebar section
-            data["sidebar"] = {
-                "collapsible_states": dict(self.ui_state.collapsible_states),
-                "search_query": self.ui_state.sidebar_search_query,
-                "last_active_section": self.ui_state.last_active_section,
-            }
+            data["sidebar"] = snapshot
 
             # Save back to file
             with open(config_path, "w") as f:
                 toml.dump(data, f)
 
             logger.debug(
-                f"Saved sidebar state with {len(self.ui_state.collapsible_states)} collapsibles"
+                f"Saved sidebar state with {len(snapshot['collapsible_states'])} collapsibles"
             )
         except Exception as e:
             logger.error(f"Failed to save sidebar state: {e}")
+
+    def _save_sidebar_state(self) -> None:
+        """Save sidebar state to config file, synchronously, on this thread.
+
+        Convenience wrapper around `_sidebar_state_snapshot` +
+        `_write_sidebar_state_snapshot` for a caller that is already off the
+        event loop (a worker thread via `to_thread`) or does not care (a
+        direct test call). Callers on the event loop that must NOT block it
+        should go through `watch_sidebar_state`'s debounce instead.
+        """
+        self._write_sidebar_state_snapshot(self._sidebar_state_snapshot())
 
     def _restore_collapsible_states(self) -> None:
         """Restore collapsible states from saved state."""
@@ -22111,7 +22229,7 @@ class ChatScreen(BaseAppScreen):
                 else:
                     collapsible.collapsed = True
 
-            self._save_sidebar_state()
+            self._schedule_sidebar_state_save()
             logger.info("Reset sidebar to default state")
             self.notify("Settings reset to defaults", severity="success")
         except Exception as e:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -21290,9 +21290,16 @@ class LibraryScreen(BaseAppScreen):
         loop, once per file picked via the Browse dialog. Kept as a thin
         wrapper -- not folded into ``_remember_library_ingest_location``
         itself -- so that method stays directly unit-testable (it is the
-        one existing tests call, and does not need a running app).
+        one existing tests call, and does not need a running app; its own
+        body is deliberately left without a broad guard on the save call
+        to preserve that). The guard lives here instead: an uncaught
+        exception in a ``@work(thread=True)`` worker is fatal to the app
+        by default (``exit_on_error=True``).
         """
-        self._remember_library_ingest_location(selected_path)
+        try:
+            self._remember_library_ingest_location(selected_path)
+        except Exception:
+            logger.error("Failed to persist Library ingest browse location")
 
     def _remember_library_ingest_location(self, selected_path: Path) -> None:
         """Persist the directory a source was picked from, for next time."""

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -20464,7 +20464,7 @@ class LibraryScreen(BaseAppScreen):
         try:
             save_setting_to_cli_config("notes", key, value)
         except Exception:
-            pass
+            logger.error(f"Failed to persist notes.{key}")
 
     @on(Button.Pressed, "#library-notes-sync-browse")
     async def handle_library_notes_sync_browse(self, event: Button.Pressed) -> None:
@@ -20986,7 +20986,7 @@ class LibraryScreen(BaseAppScreen):
         try:
             save_setting_to_cli_config("library.ingest", "backend", target)
         except Exception:
-            pass
+            logger.error(f"Failed to persist library.ingest.backend={target}")
 
     @on(Button.Pressed, "#library-ingest-clear-path")
     def handle_library_ingest_clear_path(self, event: Button.Pressed) -> None:
@@ -22691,7 +22691,9 @@ class LibraryScreen(BaseAppScreen):
         try:
             save_settings_to_cli_config(option_settings)
         except Exception:
-            pass
+            logger.error(
+                f"Failed to persist library ingest options for {list(option_settings)}"
+            )
 
     def _load_library_ingest_options_from_config(self) -> None:
         """Load persisted per-type ingest options into the form echo.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -20443,7 +20443,28 @@ class LibraryScreen(BaseAppScreen):
         if self._library_notes_sync_active_token is not None:
             return
         self._library_notes_sync_folder_text = event.value
-        save_setting_to_cli_config("notes", "sync_directory", event.value)
+        self._save_library_notes_sync_setting("sync_directory", event.value)
+
+    @work(thread=True)
+    def _save_library_notes_sync_setting(self, key: str, value: Any) -> None:
+        """Persist one ``[notes]`` sync setting without blocking the UI thread.
+
+        task-15470: each of this cluster's commit points (Enter, Browse,
+        direction/conflict choice, auto-sync toggle, a validated Sync run)
+        used to call ``save_setting_to_cli_config`` directly on the event
+        loop -- a full config.toml read+atomic-rewrite+cache-reload
+        synchronously inside a button-press/submit handler. These are
+        discrete, already-gated-by-user-intent actions (not a keystroke
+        burst -- see ``handle_library_notes_sync_folder_changed`` above,
+        which deliberately does NOT persist per keystroke), so the fix is
+        the same off-loop dispatch this file already uses for Library
+        search history and rail preferences (``_save_library_search_
+        history``, ``_save_library_rail_preferences`` above), not a timer.
+        """
+        try:
+            save_setting_to_cli_config("notes", key, value)
+        except Exception:
+            pass
 
     @on(Button.Pressed, "#library-notes-sync-browse")
     async def handle_library_notes_sync_browse(self, event: Button.Pressed) -> None:
@@ -20470,7 +20491,7 @@ class LibraryScreen(BaseAppScreen):
         if not path or self._library_notes_sync_active_token is not None:
             return
         self._library_notes_sync_folder_text = str(path)
-        save_setting_to_cli_config("notes", "sync_directory", str(path))
+        self._save_library_notes_sync_setting("sync_directory", str(path))
         if self._library_notes_view == "sync":
             _sync_library_canvas(self, "notes")
 
@@ -20488,8 +20509,8 @@ class LibraryScreen(BaseAppScreen):
         if value not in SYNC_DIRECTIONS:
             return
         self._library_notes_sync_direction = value
-        save_setting_to_cli_config(
-            "notes", "sync_direction", self._library_notes_sync_direction
+        self._save_library_notes_sync_setting(
+            "sync_direction", self._library_notes_sync_direction
         )
         _sync_library_canvas(self, "notes")
 
@@ -20507,8 +20528,8 @@ class LibraryScreen(BaseAppScreen):
         if value not in SYNC_CONFLICTS:
             return
         self._library_notes_sync_conflict = value
-        save_setting_to_cli_config(
-            "notes", "sync_conflict_resolution", self._library_notes_sync_conflict
+        self._save_library_notes_sync_setting(
+            "sync_conflict_resolution", self._library_notes_sync_conflict
         )
         _sync_library_canvas(self, "notes")
 
@@ -20530,7 +20551,9 @@ class LibraryScreen(BaseAppScreen):
         if self._library_notes_sync_active_token is not None:
             return
         self._library_notes_sync_auto = not self._library_notes_sync_auto
-        save_setting_to_cli_config("notes", "auto_sync", self._library_notes_sync_auto)
+        self._save_library_notes_sync_setting(
+            "auto_sync", self._library_notes_sync_auto
+        )
         if self._library_notes_sync_auto:
             self._arm_library_notes_auto_sync_timer()
         else:
@@ -20566,7 +20589,7 @@ class LibraryScreen(BaseAppScreen):
         # A validated run is a commit point for a typed-but-unsubmitted
         # folder (see handle_library_notes_sync_folder_changed): the folder
         # a run actually used is always the one that persists.
-        save_setting_to_cli_config("notes", "sync_directory", folder_value)
+        self._save_library_notes_sync_setting("sync_directory", folder_value)
         token = self._begin_library_notes_sync_run(folder)
         if token is None:
             return
@@ -20954,8 +20977,16 @@ class LibraryScreen(BaseAppScreen):
         resolve_backend = getattr(self.app_instance, "_resolve_ingest_backend", None)
         current = resolve_backend() if callable(resolve_backend) else "local"
         target = "local" if current == "server" else "server"
-        save_setting_to_cli_config("library.ingest", "backend", target)
+        self._save_library_ingest_backend(target)
         _sync_library_canvas(self, "ingest")
+
+    @work(thread=True)
+    def _save_library_ingest_backend(self, target: str) -> None:
+        """Persist the ingest backend choice without blocking the UI thread."""
+        try:
+            save_setting_to_cli_config("library.ingest", "backend", target)
+        except Exception:
+            pass
 
     @on(Button.Pressed, "#library-ingest-clear-path")
     def handle_library_ingest_clear_path(self, event: Button.Pressed) -> None:
@@ -21192,7 +21223,7 @@ class LibraryScreen(BaseAppScreen):
             if selected_path is None:
                 return
             self._invalidate_library_external_submission()
-            self._remember_library_ingest_location(selected_path)
+            self._persist_library_ingest_location(selected_path)
             self._adopt_library_ingest_path(str(selected_path))
             self.refresh(recompose=True)
             self._trigger_library_ingest_preflight(str(selected_path))
@@ -21248,6 +21279,20 @@ class LibraryScreen(BaseAppScreen):
             except OSError:
                 pass
         return str(Path.home())
+
+    @work(thread=True)
+    def _persist_library_ingest_location(self, selected_path: Path) -> None:
+        """Dispatch ``_remember_library_ingest_location`` off the loop.
+
+        task-15470: ``browse_callback`` used to call
+        ``_remember_library_ingest_location`` (a stat syscall plus a full
+        config.toml read+atomic-rewrite+cache-reload) straight on the event
+        loop, once per file picked via the Browse dialog. Kept as a thin
+        wrapper -- not folded into ``_remember_library_ingest_location``
+        itself -- so that method stays directly unit-testable (it is the
+        one existing tests call, and does not need a running app).
+        """
+        self._remember_library_ingest_location(selected_path)
 
     def _remember_library_ingest_location(self, selected_path: Path) -> None:
         """Persist the directory a source was picked from, for next time."""
@@ -22585,7 +22630,7 @@ class LibraryScreen(BaseAppScreen):
             if persisted:
                 option_settings[f"library.ingest_options.{group}"] = persisted
         if option_settings:
-            save_settings_to_cli_config(option_settings)
+            self._save_library_ingest_options(option_settings)
         form = self._library_ingest_form
         # (task-3313) Session-scoped snapshot of what was just submitted,
         # captured BEFORE the form clears, so "Retry this batch" can
@@ -22620,6 +22665,26 @@ class LibraryScreen(BaseAppScreen):
         # queue's outcome area sat below the fold on every submit. After
         # the recompose settles, bring the queue heading into view.
         self.call_after_refresh(self._scroll_library_ingest_queue_into_view)
+
+    @work(thread=True)
+    def _save_library_ingest_options(
+        self, option_settings: dict[str, dict[str, Any]]
+    ) -> None:
+        """Persist submitted per-type ingest options without blocking the UI.
+
+        task-15470: the batched call itself (one atomic mutation for every
+        changed type-options group, replacing what used to be one
+        ``save_setting_to_cli_config`` call per option) already landed
+        separately; this only moves that one call off the event loop,
+        matching this file's established ``@work(thread=True)`` pattern for
+        click-path config writes. ``option_settings`` is a fresh dict built
+        by the caller from a point-in-time snapshot, so no further mutation
+        of it races this worker thread's read.
+        """
+        try:
+            save_settings_to_cli_config(option_settings)
+        except Exception:
+            pass
 
     def _load_library_ingest_options_from_config(self) -> None:
         """Load persisted per-type ingest options into the form echo.
@@ -23204,7 +23269,7 @@ class LibraryScreen(BaseAppScreen):
             form.analyze = bool(defaults.get("analyze", False))
             form.chunk = bool(defaults.get("chunk", True))
             form.chunk_size = str(defaults.get("chunk_size", 1000))
-        save_settings_to_cli_config({f"library.ingest_options.{group}": {}})
+        self._save_library_ingest_options({f"library.ingest_options.{group}": {}})
         self._refresh_library_ingest_canvas_preserving_context()
 
     def _update_library_ingest_group_receipt(self, group: str) -> None:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -3616,9 +3616,7 @@ class SettingsScreen(BaseAppScreen):
             The new (post-toggle) enabled value.
         """
         next_value = not self._remote_images_enabled()
-        save_settings_to_cli_config(
-            {"chat.images": {"render_remote_images": next_value}}
-        )
+        self._persist_remote_images_toggle(next_value)
         app_config = getattr(self.app_instance, "app_config", None)
         if isinstance(app_config, dict):
             raw = app_config.get("COMPREHENSIVE_CONFIG_RAW")
@@ -3632,6 +3630,21 @@ class SettingsScreen(BaseAppScreen):
             ):
                 chat_section["images"]["render_remote_images"] = next_value
         return next_value
+
+    @work(thread=True)
+    def _persist_remote_images_toggle(self, next_value: bool) -> None:
+        """Write the render_remote_images preference off the event loop.
+
+        task-15470: this was a synchronous ``save_settings_to_cli_config``
+        call straight in a Button.Pressed handler -- a full config.toml
+        read+atomic-rewrite+cache-reload per click. The in-memory
+        ``app_config`` update in ``_toggle_remote_images`` (which the
+        transcript gate reads live) stays synchronous; only the disk write
+        moves to a worker.
+        """
+        save_settings_to_cli_config(
+            {"chat.images": {"render_remote_images": next_value}}
+        )
 
     def _paste_collapse_threshold_value(self) -> int | str:
         draft = self._settings_drafts.get(SettingsCategoryId.CONSOLE_BEHAVIOR)
@@ -9433,6 +9446,22 @@ class SettingsScreen(BaseAppScreen):
             load_settings()
         ):
             return
+        self._persist_model_catalog_section_values(section_values)
+
+    @work(thread=True)
+    def _persist_model_catalog_section_values(
+        self, section_values: dict[str, dict[str, object]]
+    ) -> None:
+        """Write ``[model_catalog]`` off the event loop.
+
+        task-15470: ``#settings-model-catalog-stale-hours`` is bound to
+        ``Input.Changed`` -- this used to call ``save_settings_to_cli_
+        config`` (a full config.toml read+atomic-rewrite+cache-reload)
+        synchronously on the event loop once per keystroke that parses as a
+        valid, changed value (every digit of a multi-digit number). The
+        no-op guard above (cheap: reads the cached settings, no I/O) stays
+        synchronous; only the actual write is deferred.
+        """
         save_settings_to_cli_config(section_values)
 
     def _provider_readiness_test_report(self) -> tuple[str, str, bool]:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -3640,11 +3640,19 @@ class SettingsScreen(BaseAppScreen):
         read+atomic-rewrite+cache-reload per click. The in-memory
         ``app_config`` update in ``_toggle_remote_images`` (which the
         transcript gate reads live) stays synchronous; only the disk write
-        moves to a worker.
+        moves to a worker. Guarded broadly: an uncaught exception in a
+        ``@work(thread=True)`` worker is fatal to the app by default
+        (``exit_on_error=True``), so a config-write hiccup must not crash
+        the whole session.
         """
-        save_settings_to_cli_config(
-            {"chat.images": {"render_remote_images": next_value}}
-        )
+        try:
+            save_settings_to_cli_config(
+                {"chat.images": {"render_remote_images": next_value}}
+            )
+        except Exception:
+            logger.warning(
+                "Failed to persist render_remote_images.", exc_info=True
+            )
 
     def _paste_collapse_threshold_value(self) -> int | str:
         draft = self._settings_drafts.get(SettingsCategoryId.CONSOLE_BEHAVIOR)
@@ -9460,9 +9468,16 @@ class SettingsScreen(BaseAppScreen):
         synchronously on the event loop once per keystroke that parses as a
         valid, changed value (every digit of a multi-digit number). The
         no-op guard above (cheap: reads the cached settings, no I/O) stays
-        synchronous; only the actual write is deferred.
+        synchronous; only the actual write is deferred. Guarded broadly: an
+        uncaught exception in a ``@work(thread=True)`` worker is fatal to
+        the app by default (``exit_on_error=True``).
         """
-        save_settings_to_cli_config(section_values)
+        try:
+            save_settings_to_cli_config(section_values)
+        except Exception:
+            logger.warning(
+                "Failed to persist model_catalog settings.", exc_info=True
+            )
 
     def _provider_readiness_test_report(self) -> tuple[str, str, bool]:
         """Run the local provider readiness test against the DRAFT config.

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Mapping
 
@@ -1198,15 +1199,25 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSettingsResult | None]):
         self.dismiss(result)
 
     @on(Button.Pressed, "#console-settings-save-default")
-    def _save_as_default(self, event: Button.Pressed) -> None:
-        """Apply the draft to the session and write it through to config defaults."""
+    async def _save_as_default(self, event: Button.Pressed) -> None:
+        """Apply the draft to the session and write it through to config defaults.
+
+        task-15470: the write itself now runs via ``asyncio.to_thread``
+        rather than straight on the event loop -- a full config.toml
+        read+atomic-rewrite+cache-reload could otherwise stall the UI
+        thread for the duration of the write on slow storage. The
+        success/failure contract is unchanged: this handler still awaits
+        the result before showing the error copy or dismissing, exactly as
+        the synchronous call did.
+        """
         event.stop()
         result = self._validated_result_or_show_errors()
         if result is None:
             return
         try:
-            saved = save_settings_to_cli_config(
-                self._default_persist_sections(result.settings)
+            saved = await asyncio.to_thread(
+                save_settings_to_cli_config,
+                self._default_persist_sections(result.settings),
             )
         except Exception:
             saved = False

--- a/tldw_chatbook/Widgets/enhanced_file_picker.py
+++ b/tldw_chatbook/Widgets/enhanced_file_picker.py
@@ -28,7 +28,11 @@ from ..Third_Party.textual_fspicker.parts.directory_navigation import DirectoryE
 from ..Third_Party.textual_fspicker.path_maker import MakePath
 from ..Third_Party.textual_fspicker.safe_tests import is_dir, is_file
 from ..Utils.path_validation import validate_path_simple
-from ..config import get_cli_setting, save_setting_to_cli_config
+from ..config import (
+    get_cli_setting,
+    save_setting_to_cli_config,
+    save_settings_to_cli_config,
+)
 
 
 class RecentLocations:
@@ -59,8 +63,19 @@ class RecentLocations:
         except Exception as e:
             logger.error(f"Failed to save recent locations: {e}")
 
-    def add(self, path: Path, file_type: str = "file"):
-        """Add a path to recent locations"""
+    def add(self, path: Path, file_type: str = "file", *, persist: bool = True):
+        """Add a path to recent locations.
+
+        Args:
+            persist: When True (default), also writes to disk immediately
+                (synchronously, on whatever thread calls this). task-15470
+                review round: ``EnhancedFileDialog`` passes ``persist=False``
+                and coalesces the actual disk write with its last-directory
+                write into one deferred, off-event-loop mutation instead --
+                calling this with the default from a click handler
+                reproduces the exact bug that round found (a config
+                rewrite still firing on the click path).
+        """
         path_str = str(path.resolve())
 
         # Remove if already exists
@@ -76,7 +91,8 @@ class RecentLocations:
 
         # Trim to max
         self._recent = self._recent[:self.max_items]
-        self.save_to_config()
+        if persist:
+            self.save_to_config()
 
     def get_recent(self) -> List[Dict[str, Any]]:
         """Get recent locations"""
@@ -1135,21 +1151,45 @@ class EnhancedFileDialog(BaseFileDialog):
         return None
 
     @work(thread=True)
-    def _save_last_directory(self, path: Path):
-        """Save the last used directory for this context.
+    def _persist_recent_and_last_directory(
+        self, last_directory: Optional[Path]
+    ) -> None:
+        """Persist recent-locations and the last directory as ONE deferred write.
 
-        task-15470: this fired a stat call (``is_dir()``) plus a full
-        config.toml read+atomic-rewrite+cache-reload straight on the event
-        loop, once per navigation/selection (``_add_to_recent``'s three call
-        sites). Dispatched as a worker off the loop; `EnhancedFileDialog` is
-        a `ModalScreen`, so `self.app`/`run_worker` are always available
-        while it is open.
+        task-15470: this used to be two separate concerns, both firing a
+        full config.toml read+atomic-rewrite+cache-reload straight on the
+        event loop -- ``RecentLocations.add()`` persisted synchronously as
+        part of its own body (called from ``_add_to_recent`` on every
+        navigation, and from ``dismiss`` on every confirm), and
+        ``_save_last_directory`` did the same for the last-dir key
+        immediately next to it. Deferring only the last-dir half (the
+        first task-15470 pass) left the recent-locations write still
+        firing inline right beside it, neutering the fix for this click
+        path entirely (review round). Both callers now update
+        ``self.recent_locations`` in memory only (``persist=False``) and
+        hand off here, which does both writes as one atomic
+        ``save_settings_to_cli_config`` mutation instead of two separate
+        ones. ``EnhancedFileDialog`` is a ``ModalScreen``, so
+        ``self.app``/``run_worker`` are always available while it is open.
         """
         try:
-            dir_path = path if path.is_dir() else path.parent
-            save_setting_to_cli_config("filepicker", f"last_dir_{self.context}", str(dir_path))
+            section_values: dict[str, dict[str, object]] = {
+                "filepicker": {
+                    f"recent_{self.context}": self.recent_locations.get_recent(),
+                }
+            }
+            if last_directory is not None:
+                dir_path = (
+                    last_directory
+                    if last_directory.is_dir()
+                    else last_directory.parent
+                )
+                section_values["filepicker"][f"last_dir_{self.context}"] = str(
+                    dir_path
+                )
+            save_settings_to_cli_config(section_values)
         except Exception as e:
-            logger.error(f"Failed to save last directory: {e}")
+            logger.error(f"Failed to persist file-picker recent/last-dir state: {e}")
 
     def compose(self) -> ComposeResult:
         """Compose the enhanced file picker UI.
@@ -1802,8 +1842,8 @@ class EnhancedFileDialog(BaseFileDialog):
 
     def _add_to_recent(self, path: Path, file_type: str) -> None:
         """Persist a recent location and refresh the list."""
-        self.recent_locations.add(path, file_type)
-        self._save_last_directory(path)
+        self.recent_locations.add(path, file_type, persist=False)
+        self._persist_recent_and_last_directory(path)
         self._load_recent_locations()
 
     def _update_bookmarks_list(self):
@@ -2073,23 +2113,40 @@ class EnhancedFileDialog(BaseFileDialog):
         self.action_toggle_selection()
 
     def dismiss(self, result: Optional[Union[Path, List[Path]]]) -> None:
-        """Override dismiss to save recent location(s) and last directory."""
+        """Override dismiss to save recent location(s) and last directory.
+
+        task-15470 review round: this used to call ``recent_locations.add()``
+        (which persisted synchronously as part of its own body) directly on
+        the event loop, once per confirm -- the exact click-path config
+        rewrite the audit was about, still firing here even after
+        ``_save_last_directory`` (right below it) had already been deferred.
+        The in-memory update stays here (cheap, no I/O); persistence for
+        both recent-locations and the last directory is coalesced into one
+        deferred, off-loop write via `_persist_recent_and_last_directory`.
+        """
         if isinstance(result, list):
             for path in result:
                 self.recent_locations.add(
-                    path, "file" if path.is_file() else "directory"
+                    path, "file" if path.is_file() else "directory", persist=False
                 )
         elif result:
             self.recent_locations.add(
-                result, "file" if result.is_file() else "directory"
+                result, "file" if result.is_file() else "directory", persist=False
             )
-            self._save_last_directory(result)
 
+        # Preserves the original ordering: dir_nav.location wins when the
+        # query succeeds (even for a list `result`, which never set one
+        # itself), otherwise a single non-list `result` is the fallback.
+        last_directory: Optional[Path] = (
+            result if not isinstance(result, list) and result else None
+        )
         try:
             dir_nav = self.query_one(SearchableDirectoryNavigation)
-            self._save_last_directory(dir_nav.location)
+            last_directory = dir_nav.location
         except Exception:
             pass
+
+        self._persist_recent_and_last_directory(last_directory)
 
         super().dismiss(result)
 

--- a/tldw_chatbook/Widgets/enhanced_file_picker.py
+++ b/tldw_chatbook/Widgets/enhanced_file_picker.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from loguru import logger
 from rich.console import RenderableType
 from rich.table import Table
-from textual import events, on
+from textual import events, on, work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
@@ -1134,8 +1134,17 @@ class EnhancedFileDialog(BaseFileDialog):
             pass
         return None
 
+    @work(thread=True)
     def _save_last_directory(self, path: Path):
-        """Save the last used directory for this context"""
+        """Save the last used directory for this context.
+
+        task-15470: this fired a stat call (``is_dir()``) plus a full
+        config.toml read+atomic-rewrite+cache-reload straight on the event
+        loop, once per navigation/selection (``_add_to_recent``'s three call
+        sites). Dispatched as a worker off the loop; `EnhancedFileDialog` is
+        a `ModalScreen`, so `self.app`/`run_worker` are always available
+        while it is open.
+        """
         try:
             dir_path = path if path.is_dir() else path.parent
             save_setting_to_cli_config("filepicker", f"last_dir_{self.context}", str(dir_path))

--- a/tldw_chatbook/Widgets/settings_splash_screen_viewer.py
+++ b/tldw_chatbook/Widgets/settings_splash_screen_viewer.py
@@ -239,25 +239,62 @@ class SettingsSplashScreenViewer(Vertical):
         through this one method, and it used to call
         ``save_setting_to_cli_config`` -- a full config.toml read+atomic-
         rewrite+cache-reload -- synchronously on the event loop, once per
-        click/submit. The in-memory ``_config`` update and
+        click/submit, returning True/False for real, synchronously-known
+        success/failure. The in-memory ``_config`` update and
         ``SplashConfigChanged`` message (both pure, no I/O) still happen
-        immediately here; only the disk write is deferred to a worker.
+        immediately here, optimistically; only the disk write is deferred
+        to a worker, so this can no longer report a confirmed outcome --
+        the return value now means "dispatched", not "saved". If the
+        write actually fails, `_persist_splash_config_value` reverts
+        `_config[key]` back to `previous` (so memory never diverges from
+        what is actually on disk) and overwrites the status line with the
+        error, so an optimistic "... saved." message a caller shows right
+        after this call is always eventually corrected rather than
+        silently wrong. Callers no longer gate their "saved" message on
+        this return value (review round: it was always True, making six
+        `if` guards dead weight) -- they call it unconditionally now.
         """
+        previous = self._config.get(key)
         self._config[key] = value
         self.post_message(self.SplashConfigChanged("splash_screen", key, value))
-        self._persist_splash_config_value(key, value)
+        self._persist_splash_config_value(key, value, previous)
         return True
 
     @work(thread=True)
-    def _persist_splash_config_value(self, key: str, value: Any) -> None:
-        """Write one ``[splash_screen]`` config value on a worker thread."""
+    def _persist_splash_config_value(
+        self, key: str, value: Any, previous: Any
+    ) -> None:
+        """Write one ``[splash_screen]`` config value on a worker thread.
+
+        On failure, hands the correction back to the main thread via
+        ``self.app.call_from_thread`` -- ``call_from_thread`` is an ``App``
+        method, not available on a ``Widget``; calling it as
+        ``self.call_from_thread`` crashed the whole app on any write
+        failure here, since the resulting ``AttributeError`` was raised
+        from inside this ``except`` block, uncaught, inside a
+        ``@work(thread=True)`` worker, where an uncaught exception is
+        fatal by default (``exit_on_error=True``).
+        """
         try:
             save_setting_to_cli_config("splash_screen", key, value)
         except Exception as exc:
             logger.error("Failed to save splash_screen.{}: {}", key, exc)
-            self.call_from_thread(
-                self._update_status, f"Error saving {key}: {exc}"
+            self.app.call_from_thread(
+                self._handle_persist_failure, key, previous, exc
             )
+
+    def _handle_persist_failure(self, key: str, previous: Any, exc: Exception) -> None:
+        """Revert the optimistic in-memory value and surface the error.
+
+        Runs on the main thread (via ``call_from_thread``). Reverting
+        `_config[key]` closes the memory/disk divergence the optimistic
+        update in `_save_config_value` would otherwise leave behind on a
+        failed write; the corrective `SplashConfigChanged` message mirrors
+        the optimistic one posted there, for the same reason.
+        """
+        self._config[key] = previous
+        self.post_message(self.SplashConfigChanged("splash_screen", key, previous))
+        self._update_status(f"Error saving {key}: {exc}")
 
     def _float_or_default(self, raw: str, default: float) -> float:
         raw = raw.strip()
@@ -273,35 +310,35 @@ class SettingsSplashScreenViewer(Vertical):
         self.query_one("#settings-splash-enabled-state", Static).update(
             switch_state_label(bool(event.value))
         )
-        if self._save_config_value("enabled", event.value):
-            self._update_status("Splash screen enabled setting saved.")
+        self._save_config_value("enabled", event.value)
+        self._update_status("Splash screen enabled setting saved.")
 
     @on(Checkbox.Changed, "#settings-splash-show-progress")
     def handle_show_progress_changed(self, event: Checkbox.Changed) -> None:
         self.query_one("#settings-splash-show-progress-state", Static).update(
             switch_state_label(bool(event.value))
         )
-        if self._save_config_value("show_progress", event.value):
-            self._update_status("Show progress setting saved.")
+        self._save_config_value("show_progress", event.value)
+        self._update_status("Show progress setting saved.")
 
     @on(Checkbox.Changed, "#settings-splash-skip-on-keypress")
     def handle_skip_on_keypress_changed(self, event: Checkbox.Changed) -> None:
-        if self._save_config_value("skip_on_keypress", event.value):
-            self._update_status("Skip on keypress setting saved.")
+        self._save_config_value("skip_on_keypress", event.value)
+        self._update_status("Skip on keypress setting saved.")
 
     @on(Select.Changed, "#settings-splash-default-select")
     def handle_default_changed(self, event: Select.Changed) -> None:
         value = str(event.value) if event.value is not None else "random"
-        if self._save_config_value("card_selection", value):
-            self._update_status(f"Default splash card set to {value}.")
+        self._save_config_value("card_selection", value)
+        self._update_status(f"Default splash card set to {value}.")
 
     @on(Input.Submitted, "#settings-splash-duration")
     def handle_duration_submitted(self, event: Input.Submitted) -> None:
         value = self._float_or_default(event.value, DEFAULT_SPLASH_CONFIG["duration"])
         if value < 0:
             value = 0
-        if self._save_config_value("duration", value):
-            self._update_status(f"Splash duration set to {value}s.")
+        self._save_config_value("duration", value)
+        self._update_status(f"Splash duration set to {value}s.")
 
     @on(Input.Submitted, "#settings-splash-animation-speed")
     def handle_animation_speed_submitted(self, event: Input.Submitted) -> None:
@@ -310,8 +347,8 @@ class SettingsSplashScreenViewer(Vertical):
         )
         if value <= 0:
             value = DEFAULT_SPLASH_CONFIG["animation_speed"]
-        if self._save_config_value("animation_speed", value):
-            self._update_status(f"Animation speed set to {value}x.")
+        self._save_config_value("animation_speed", value)
+        self._update_status(f"Animation speed set to {value}x.")
 
     @on(OptionList.OptionHighlighted, "#settings-splash-card-list")
     def handle_card_highlighted(self, event: OptionList.OptionHighlighted) -> None:

--- a/tldw_chatbook/Widgets/settings_splash_screen_viewer.py
+++ b/tldw_chatbook/Widgets/settings_splash_screen_viewer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from loguru import logger
-from textual import on
+from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import QueryError
@@ -233,15 +233,31 @@ class SettingsSplashScreenViewer(Vertical):
         status.update(message)
 
     def _save_config_value(self, key: str, value: Any) -> bool:
+        """Apply one splash_screen setting and persist it off the event loop.
+
+        task-15470: six Checkbox/Select/Input handlers below all funnel
+        through this one method, and it used to call
+        ``save_setting_to_cli_config`` -- a full config.toml read+atomic-
+        rewrite+cache-reload -- synchronously on the event loop, once per
+        click/submit. The in-memory ``_config`` update and
+        ``SplashConfigChanged`` message (both pure, no I/O) still happen
+        immediately here; only the disk write is deferred to a worker.
+        """
+        self._config[key] = value
+        self.post_message(self.SplashConfigChanged("splash_screen", key, value))
+        self._persist_splash_config_value(key, value)
+        return True
+
+    @work(thread=True)
+    def _persist_splash_config_value(self, key: str, value: Any) -> None:
+        """Write one ``[splash_screen]`` config value on a worker thread."""
         try:
             save_setting_to_cli_config("splash_screen", key, value)
-            self._config[key] = value
-            self.post_message(self.SplashConfigChanged("splash_screen", key, value))
-            return True
         except Exception as exc:
             logger.error("Failed to save splash_screen.{}: {}", key, exc)
-            self._update_status(f"Error saving {key}: {exc}")
-            return False
+            self.call_from_thread(
+                self._update_status, f"Error saving {key}: {exc}"
+            )
 
     def _float_or_default(self, raw: str, default: float) -> float:
         raw = raw.strip()


### PR DESCRIPTION
## Summary

Task 15470 from the input-latency audit. The dictation save ran 8-10 full config.toml read-rewrite-reload cycles — firing per parsing keystroke; every chat-sidebar toggle rewrote ui_state.toml synchronously on the loop; ~10 more surfaces did one full rewrite per click.

- Dictation: one batched write on a 0.6s debounce, nothing on keystrokes; sidebar: in-memory state + debounced threaded snapshot writes; library notes-sync/ingest, splash viewer, settings, console modal, file picker all converted (per-site classification table in the task file); config.py untouched — the writer's RLock+interprocess lock and atomic replace preserved, coalescing is last-writer-wins by construction
- Review round closed three probe-proven defects the first cut shipped: a worker error branch that CRASHED the app (`call_from_thread` on a widget), an edit-during-in-flight-write loss window on quit at both debounced sites (now: dirty clears at snapshot time, flush re-checks after awaiting — race tests born red), and a picker conversion neutered by a sibling sync write (now coalesced into one deferred write with an end-to-end persistence test)
- Flush-on-quit pinned and mutation-discriminating at both sites; failure paths log and revert in-memory state

## Verification
Independent opus review (Not-approved round; all three defects reproduced by probe) + scoped re-review (all ADDRESSED; Critical and one flush-race site independently mutation-verified; 50+31+9 counts reproduced). Provenance note: the fix round's agent was interrupted mid-verification; the controller completed verification and committed, recorded in the task file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch config writes and move all remaining per-click/keystroke persistence off the Textual event loop to remove UI stalls and prevent data loss on quit (Linear task-15470). Previously: dictation did 6–9 sequential writes and fired on parsing keystrokes; the chat sidebar rewrote `ui_state.toml` per toggle; several settings, splash viewer, file picker, and library screens wrote synchronously. Now: debounced, off-loop writes with flush-on-unmount and guarded failure paths.

- Dictation: 0.6s debounce; single batched `save_settings_to_cli_config` covering `dictation` and `dictation.privacy`; snapshot before write; flush on unmount; no keystroke writes.
- Chat sidebar: 0.5s debounce; off-loop write via worker; snapshot+dirty flag; flush on unmount to avoid losing a last toggle.
- Library: move notes-sync and ingest option persistence to `@work(thread=True)` helpers; `remember` path wrapped with a worker at the production call site; tests patch instance workers.
- Settings: remote-images toggle and model-catalog settings persist via workers; in-memory `app_config` updates remain synchronous.
- Splash viewer: persistence moved to a worker; fix failure path to use `self.app.call_from_thread`; error surfaces without crashing.
- File picker: coalesce recent-locations and last-directory writes into the deferred worker; no synchronous writes on dismiss.
- Console settings modal: “Save as default” awaits `asyncio.to_thread(...)` to keep UX while avoiding loop blocking.
- Stability: all new workers log and do not exit the app on error; `config.py` writer semantics (RLock, interprocess lock, atomic replace) unchanged.

- Tests: add debounce/flush coverage; update affected tests to patch instance worker methods; one rename to `save_settings_to_cli_config`.

<sup>Written for commit 1a68b94c48ed1de1c677646a2e674b29800b5a94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

