### PR TITLE
docs: file the input-latency burn-down follow-ups (tasks 15764-15782)

### DIFF
--- a/Docs/Design/2026-08-11-input-latency-audit.md
+++ b/Docs/Design/2026-08-11-input-latency-audit.md
@@ -156,3 +156,31 @@ self-assignment can never fire → **15479**. Dead schedulers/DB modules that lo
 The checked-out venv's editable install currently resolves `tldw_chatbook` to
 `.worktrees/task-2512-mcp-unified` — not the main checkout, and not the CWD. Any probe or
 `python -c` import must assert `tldw_chatbook.__file__` and pin `PYTHONPATH` to the intended tree.
+
+## Follow-ups filed (2026-08-13)
+
+Residuals, review-round findings, and pre-existing red tests surfaced while closing out
+task-15450 - task-15481, each verified live against dev before filing (one candidate
+from the original sweep, RAG top_k config-isolation, turned out already resolved by
+task-15512's test fix and was not filed; the chat_screen size-ratchet breach is already
+tracked as task-3070).
+
+- **task-15764** — Watchlists: move `URLMonitor`'s HTML extraction + difflib work off the event loop (the piece task-15463 deliberately left out).
+- **task-15765** — Repair the v17-to-v18 ChaChaNotes migration fixture broken by v35-to-v36's `note_folders` table (supersedes the stale "V33->V34 compaction_representation" framing, which task-15730 already fixed).
+- **task-15766** — Batch of 7 pre-existing red tests found as asides (library_collections_panel, TTS Protocol-isinstance, console coalescing flake, rail_sections, citation-sources test double, console chip-swap TypeError, QwenCloud test-dict drift).
+- **task-15767** — File Notes back-navigation (`test_action_library_notes_files_back_returns_to_database`) broke when task-15503's destructive-reload confirm shipped.
+- **task-15768** — Media hub local-mode reading-highlight CRUD is `AttributeError` end to end (naming mismatch found by task-15467).
+- **task-15769** — Character JSON backup export crashes on any image-bearing card (found by task-15474).
+- **task-15770** — Watchlists unread-badge count still scans instead of using task-15464's `effective_date` index.
+- **task-15771** — Sweep non-callable `reactive([])`/`reactive({})` defaults shared by identity across widget instances (proven instance: `character_voice_widget`, found by task-15479).
+- **task-15772** — STTS Select widgets (import-source, audiobook provider/format) compose `options=` backwards, so set-value calls silently fail.
+- **task-15773** — `ChapterEditorWidget`/`Select` mount race under high-volume DataTable population (dodged, not fixed, by task-15478).
+- **task-15774** — Library media viewer search status/nav controls sit below the fold at 80x24 (task-15458's macOS re-verification).
+- **task-15775** — Watchlists screen's `region_layout` reactive default disagrees with the shipped first-run default, composing then discarding the Inspector rail every visit.
+- **task-15776** — Watchlists: collapse `_ArticleRow`/`_DayHeader` into one self-rendering widget (the one lever task-15462's profiling handed over, ~15-18% of a push).
+- **task-15777** — Console transcript: unbounded reveal on a far jump, and a scroll-back reachability ceiling at the low prune watermark (task-15455's residuals).
+- **task-15778** — Watchlists: batch the cold Read-tab region swap and drop `_build_detail_pane`'s pre-mount seeding recompose (task-15461's residuals #1/#4).
+- **task-15779** — Watchlists artifacts pane: briefing selection destroys the briefings `DataTable` and its keyboard focus (task-15461's residual #3).
+- **task-15780** — Verify-then-retire `CCPDictionaryEditorWidget`/`CCPPromptEditorWidget` (zero production callers; the CCP `__init__` docstring already says the chrome was retired).
+- **task-15781** — Verify-then-trim `NotesSyncService`'s `SyncProfile` CRUD surface (zero production callers beyond `sync_folder`).
+- **task-15782** — Repair `test_options_persist_to_config`'s stale hardcoded expectation (found by task-15470, unmasked once its `run_worker` crash fix stopped swallowing it).

--- a/backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md
+++ b/backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md
@@ -1,0 +1,42 @@
+---
+id: TASK-15764
+title: 'Watchlists: URLMonitor extraction and diff work off the event loop'
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - perf
+  - watchlists
+priority: medium
+---
+
+## Description
+
+Follow-up named explicitly in task-15463's "Scope" section (input-latency
+burn-down, `Docs/Design/2026-08-11-input-latency-audit.md`): task-15463 moved
+the watchlist scheduler's sqlite work and feed-body parsing off the event
+loop, but deliberately left `URLMonitor`'s own CPU work on the loop as "a
+separate, larger change." For `url`/`url_list`/`sitemap` sources this covers:
+
+- `ContentExtractor.extract_text_from_html` (BeautifulSoup over a page up to
+  `MAX_FETCH_BYTES_PAGE`, reached from `monitoring_engine._fetch_url_content`)
+- the difflib work in `check_url` (`_segment_for_diff` called twice,
+  `build_change_diff`, `added_and_removed_text`, `classify_change_type`)
+
+Both are pure CPU with no sqlite involvement, so `asyncio.to_thread` applies
+without task-15463's in-memory-connection hazard (no `:memory:` guard is
+needed here — this is not a DB call). A `url_list` source multiplies both
+costs by its URL count, so a source that watches several URLs pays this
+synchronously on the loop once per check, per URL.
+
+## Acceptance Criteria
+
+- [ ] `ContentExtractor.extract_text_from_html` runs off the event loop for
+      `url`/`url_list`/`sitemap` checks (evidence: thread-identity test)
+- [ ] `check_url`'s difflib work (`_segment_for_diff` ×2, `build_change_diff`,
+      `added_and_removed_text`, `classify_change_type`) runs off the event loop
+- [ ] A `url_list` source with multiple URLs shows the same off-loop behavior
+      for each URL, not just the first
+- [ ] Existing Watchlists/Subscriptions suites (including task-15463's
+      `test_watchlists_db_instance_and_off_loop.py`) stay green; due-detection,
+      run records, and change-classification semantics are unchanged

--- a/backlog/tasks/task-15765 - Repair-the-v17-to-v18-ChaChaNotes-migration-fixture-broken-by-v35-to-v36.md
+++ b/backlog/tasks/task-15765 - Repair-the-v17-to-v18-ChaChaNotes-migration-fixture-broken-by-v35-to-v36.md
@@ -1,0 +1,57 @@
+---
+id: TASK-15765
+title: Repair the v17-to-v18 ChaChaNotes migration fixture broken by v35-to-v36
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - database
+  - migrations
+  - tests
+priority: medium
+---
+
+## Description
+
+**Correction to an earlier framing.** The input-latency burn-down's evidence
+trail (task-15469's Implementation Notes, then task-15707/task-15730) named a
+"~32 tests red" ChaChaNotes V33->V34 migration-fixture cluster tied to a
+`compaction_representation` duplicate-column bug. Re-verified live on this
+worktree (dev `6b57458b8`, `Tests/DB/` + `Tests/ChaChaNotesDB/`): that cluster
+is gone — 1084 passed, 1 skipped, 1 failed, not 34 failed. Task-15730's v35
+fixture repair evidently closed it. That original claim is stale; do not
+re-file it.
+
+**What is still genuinely red**, same fixture-shaped bug class, one instance:
+`Tests/ChaChaNotesDB/test_chachanotes_db.py::TestDBInitialization::
+test_conversations_migrate_from_v17_to_v18_adds_system_prompt_column` fails
+with `tldw_chatbook.DB.ChaChaNotes_DB.SchemaError: Migration from V35 to V36
+failed for 'rag_char_chat_schema': table note_folders already exists`.
+
+Root cause (read from the fixture and `_migrate_from_v35_to_v36`): the test
+opens a **fresh** `CharactersRAGDB` (which bootstraps all the way to the
+current version, v36, via incremental migrations — so `note_folders` already
+exists from that construction), then "rolls back" to a v17-shaped DB by
+dropping the sync triggers, the column under test, and the newer RAG
+provenance tables, and resetting `db_schema_version` to 17 before reopening.
+The rollback never drops `note_folders` (added by v35->v36's
+`chachanotes_v35_to_v36_note_folders.sql`, `CREATE TABLE note_folders`,
+likely introduced by task-15705), so replaying v35->v36 against the reopened
+DB collides with the table the fresh bootstrap already created. Same shape as
+task-15707's world-book fix and task-15730's v35 fixture repairs: the
+fixture's "recorded version" pointer moved back, but a later migration's
+target state did not.
+
+## Acceptance Criteria
+
+- [ ] The v17 fixture in `test_conversations_migrate_from_v17_to_v18_adds_system_prompt_column`
+      also removes `note_folders` (and any note_folders-only triggers) before
+      rolling `db_schema_version` back to 17, so replaying v35->v36 finds a
+      genuine pre-v36 shape
+- [ ] The test asserts its v17/v18 preconditions (column and trigger absence)
+      before reopening at the current version, matching task-15707's pattern
+- [ ] `Tests/ChaChaNotesDB/test_chachanotes_db.py` and
+      `Tests/DB/test_chachanotes_console_context_memory_migration.py` pass
+      with zero regressions elsewhere in `Tests/DB/` + `Tests/ChaChaNotesDB/`
+- [ ] No production migration or schema code changes — this is a test-fixture
+      correction only

--- a/backlog/tasks/task-15766 - Repair-a-batch-of-pre-existing-red-tests-found-during-the-latency-burn-down.md
+++ b/backlog/tasks/task-15766 - Repair-a-batch-of-pre-existing-red-tests-found-during-the-latency-burn-down.md
@@ -1,0 +1,61 @@
+---
+id: TASK-15766
+title: Repair a batch of pre-existing red tests found during the latency burn-down
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - test-health
+priority: low
+---
+
+## Description
+
+Small, unrelated pre-existing test failures surfaced as asides while closing
+out the input-latency burn-down (task-15450 - task-15481), each individually
+too small to justify its own task but worth tracking as one batch rather than
+being silently re-attributed to whatever branch happens to run next to them
+(the same rationale task-15512 used for its own cluster). All re-verified
+live against dev `6b57458b8` in this worktree on 2026-08-13 except where
+noted as a flake.
+
+1. **`Tests/Widgets/test_library_collections_panel.py::
+   test_library_collections_panel_empty_state_renders_message_once`** —
+   confirmed pre-existing and unrelated by task-15479's notes (reproduces in
+   isolation on unmodified files).
+2. **`Tests/TTS/test_tts_profile_capabilities.py`** — 3 of 43 tests fail on
+   standing pre-existing Protocol-`isinstance` checks, called out in
+   task-15479's notes as untouched by that task's change.
+3. **`Tests/UI/test_console_control_bar_coalescing.py`** — intermittent;
+   task-3070's notes record it failing 2/3 on dev "independently of any
+   fleet change" at the commits it measured. Passed 2/2 in this session's
+   run — file as a flake, not a deterministic red.
+4. **`Tests/UI/test_console_internals_decomposition.py::
+   test_console_left_rail_sections_use_available_space`** — confirmed
+   red live: `ConsoleWorkspaceContextTray`'s parent is
+   `console-rail-section-body-conversations`, expected
+   `console-rail-section-body-session`.
+5. **`Tests/UI/test_console_citation_sources.py::
+   test_zero_only_count_cache_does_not_refresh_unchanged_transcript`** —
+   confirmed red live: `AttributeError: 'types.SimpleNamespace' object has no
+   attribute 'set_presentation_context'` at `chat_screen.py:15551` — a test
+   double drifted behind a production call that now expects the method.
+6. **`Tests/UI/test_console_shell_chip_actions.py::
+   test_swap_seeds_greeting_only_into_an_empty_chat`** — confirmed red live:
+   `TypeError: ConsoleSessionController._swap_console_session_character()
+   takes 4 positional arguments but 6 were given`. Flagged as an unrelated,
+   pre-existing signature mismatch in task-15476's notes.
+7. **`Tests/UI/test_settings_model_catalog_toggles.py::
+   test_model_catalog_toggles_initialize_from_saved_config`** — a
+   QwenCloud-provider test-data drift, flagged as pre-existing and unrelated
+   in task-15470's notes ("caused by an unrelated earlier commit").
+
+## Acceptance Criteria
+
+- [ ] Each of the seven tests above is diagnosed to its causing change (commit
+      or drifted contract) and either fixed or the assertion updated to match
+      current, intended behavior
+- [ ] Item 3 (coalescing flake) is either stabilized (root cause of the
+      intermittency identified and fixed) or documented as a known flake with
+      its trigger condition, not silently left red
+- [ ] All seven pass on dev; no other test in the same files regresses

--- a/backlog/tasks/task-15767 - File-Notes-back-navigation-broke-when-the-destructive-reload-confirm-shipped.md
+++ b/backlog/tasks/task-15767 - File-Notes-back-navigation-broke-when-the-destructive-reload-confirm-shipped.md
@@ -1,0 +1,55 @@
+---
+id: TASK-15767
+title: File Notes back-navigation broke when the destructive-reload confirm shipped
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - notes
+  - filesystem
+  - regression
+priority: high
+---
+
+## Description
+
+`Tests/UI/test_screen_navigation.py::
+test_action_library_notes_files_back_returns_to_database` is red on dev.
+Confirmed live: `AttributeError: 'WorkspaceProbe' object has no attribute
+'cancel_reload_confirmation'`.
+
+Controller bisect (per the reviewing session's finding): first-bad commit is
+`062c3ee30` ("fix: confirm destructive File Notes reload"), task-15503's PR
+which added the retained inline confirmation before a conflict/error reload
+can replace the File Notes draft (see task-15503's Implementation Notes —
+the new opener, "Discard draft and reload", and its Cancel/Confirm/Escape
+flow). That PR's own regression matrix passed 17 tests at the time, so this
+is a drift introduced afterward or missed by that matrix's scope, not a
+defect in the confirmation feature itself.
+
+Two things need reconciling:
+1. `test_action_library_notes_files_back_returns_to_database`'s own test
+   double (`WorkspaceProbe`, defined multiple times in
+   `test_screen_navigation.py`) needs a `cancel_reload_confirmation` method to
+   match whatever the production back-navigation path now calls on it.
+2. The production back-navigation path itself needs auditing against
+   task-15503's confirmation state: if a user presses "back" while the new
+   confirmation dialog is open (or in a conflict/error state that the
+   confirmation now gates), the current behavior needs to be intentional, not
+   an unhandled attribute lookup.
+
+## Acceptance Criteria
+
+- [ ] `test_action_library_notes_files_back_returns_to_database` passes on
+      dev without weakening what it originally asserted (back navigation from
+      File Notes returns to the database view)
+- [ ] Every `WorkspaceProbe` double in `test_screen_navigation.py` that the
+      back-navigation path can reach implements whatever contract production
+      now expects, verified against the real
+      `library_file_notes_workspace.py` shape from task-15503 (not a stub
+      that merely silences the error)
+- [ ] Pressing "back" while File Notes is mid-confirmation (or in the
+      conflict/error state task-15503 added) has explicit, tested behavior —
+      not a crash
+- [ ] `Tests/UI/test_library_file_notes_workspace.py` (task-15503's own
+      regression matrix) stays green

--- a/backlog/tasks/task-15768 - Media-hub-local-mode-reading-highlights-all-four-CRUD-methods-AttributeError.md
+++ b/backlog/tasks/task-15768 - Media-hub-local-mode-reading-highlights-all-four-CRUD-methods-AttributeError.md
@@ -1,0 +1,47 @@
+---
+id: TASK-15768
+title: 'Media hub local mode: reading-highlights CRUD all AttributeError against the real service'
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - bug
+  - media
+priority: high
+---
+
+## Description
+
+Found and confirmed during task-15467 (input-latency burn-down), explicitly
+left unfixed as out of scope for that task's off-loop-threading AC:
+`MediaReadingScopeService` calls `list_reading_highlights`,
+`create_reading_highlight`, `update_reading_highlight`, and
+`delete_reading_highlight` in local mode, but `LocalMediaReadingService` only
+implements the unprefixed `list_highlights`/`create_highlight`/
+`update_highlight`/`delete_highlight`. All four calls `AttributeError`
+against a real local service — confirmed directly
+(`getattr(service, method_name)` raises for all four).
+
+Every local-mode media-item click already hits this: loading highlights is
+swallowed by `_load_media_item_detail`'s broad `except Exception` and
+silently presents zero highlights, and every local-mode highlight
+create/update/delete action hits the identical `AttributeError`. The
+Library screen's own, separate call sites already use the correct unprefixed
+names and work fine — this is specifically the Media hub's scope-service
+bridge, which never matched `LocalMediaReadingService`'s actual method
+names.
+
+## Acceptance Criteria
+
+- [ ] `MediaReadingScopeService`'s local-mode calls for list/create/update/delete
+      reading highlights reach `LocalMediaReadingService`'s real methods (no
+      `AttributeError`), by renaming one side to match the other
+- [ ] A local-mode media item with existing highlights shows them in the
+      Media hub item detail (regression test against a real
+      `LocalMediaReadingService`, not a mock that hides the name mismatch)
+- [ ] Creating, updating, and deleting a highlight from the Media hub in
+      local mode works end-to-end (tests)
+- [ ] The broad `except Exception` around the detail load in
+      `_load_media_item_detail` is narrowed or logged so a future
+      naming/contract drift is visible instead of silently presenting empty
+      state

--- a/backlog/tasks/task-15769 - Character-JSON-backup-export-crashes-on-any-image-bearing-card.md
+++ b/backlog/tasks/task-15769 - Character-JSON-backup-export-crashes-on-any-image-bearing-card.md
@@ -1,0 +1,44 @@
+---
+id: TASK-15769
+title: Character JSON backup export crashes on any image-bearing card
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - bug
+  - characters
+priority: medium
+---
+
+## Description
+
+Found and confirmed during task-15474 (input-latency burn-down), flagged as
+pre-existing and explicitly out of scope for that task's own fix:
+`Tools_Settings_Window._export_characters_worker` (the JSON backup dump)
+calls `json.dumps()` over character card rows that include the raw `image`
+BLOB (`bytes`) whenever a card has an image, and nothing base64-encodes it
+first. `bytes` is not JSON-serializable, so exporting any character list
+that includes an image-bearing card crashes today.
+
+Task-15474 changed `list_character_cards`/`list_character_cards_page`'s
+default projection to exclude `image` (a separate, deliberate perf fix), which
+means the export worker's crash is now masked for callers that adopt the new
+default — but `_export_characters_worker` itself was not touched, so if it
+(or any future caller) opts into `include_image=True` to actually include
+images in a backup, the crash reproduces exactly as today. This task is
+about fixing the export path itself, not relying on the masking side effect.
+
+## Acceptance Criteria
+
+- [ ] Exporting a character list that includes an image-bearing card via
+      `Tools_Settings_Window._export_characters_worker` succeeds (no
+      `TypeError: Object of type bytes is not JSON serializable`)
+- [ ] The exported JSON either base64-encodes the image (matching the
+      compatibility shape `Chat_Functions.load_characters` already uses for
+      `image_base64`) or explicitly and intentionally omits it with a
+      visible note in the export — pick one and make it correct, not an
+      accidental silent drop
+- [ ] A round-trip test: export an image-bearing card, confirm the output is
+      valid JSON, and (if images are included) confirm the image round-trips
+      byte-for-byte through base64
+- [ ] Existing character-export tests stay green

--- a/backlog/tasks/task-15770 - Watchlists-unread-badge-count-still-scans-instead-of-using-the-effective-date-index.md
+++ b/backlog/tasks/task-15770 - Watchlists-unread-badge-count-still-scans-instead-of-using-the-effective-date-index.md
@@ -1,0 +1,38 @@
+---
+id: TASK-15770
+title: 'Watchlists: unread-badge count still scans instead of using the effective_date index'
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - perf
+  - watchlists
+  - db
+priority: low
+---
+
+## Description
+
+Cheap follow-up named explicitly in task-15464's "Deliberate scope
+boundaries" section (input-latency burn-down). Task-15464 added
+`SubscriptionsDB`'s `effective_date` generated column and index (replacing
+the unindexable `COALESCE(datetime(published_date), datetime(created_at))`
+ordering used by the items list) but deliberately left
+`get_unread_items_count_since` — a COUNT-only badge query — on the old
+inline `COALESCE(...)` expression, since it was out of that task's "items
+list queries" AC scope. It is still correct (the `effective_date` column's
+existence doesn't change what the inline expression computes), just not
+using the index task-15464 built.
+
+## Acceptance Criteria
+
+- [ ] `get_unread_items_count_since` uses the `effective_date` indexed
+      column instead of recomputing the inline `COALESCE(datetime(...))`
+      expression
+- [ ] `EXPLAIN QUERY PLAN` for the rewritten query shows the index is used
+      (no full-table scan)
+- [ ] The returned count is identical to today's for both legacy rows
+      (pre-migration, backfilled) and newly-inserted rows (parity test,
+      mirroring task-15464's own ordering-parity test)
+- [ ] The Today badge's displayed count is unchanged before/after (existing
+      Watchlists UI tests stay green)

--- a/backlog/tasks/task-15771 - Sweep-non-callable-reactive-list-dict-defaults-shared-by-identity-across-widget-instances.md
+++ b/backlog/tasks/task-15771 - Sweep-non-callable-reactive-list-dict-defaults-shared-by-identity-across-widget-instances.md
@@ -1,0 +1,48 @@
+---
+id: TASK-15771
+title: Sweep non-callable reactive list/dict defaults shared by identity across widget instances
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - bug
+  - textual
+priority: medium
+---
+
+## Description
+
+Found and confirmed during task-15479 (input-latency burn-down), flagged as
+independent of that task's own fix and explicitly out of scope: Textual's
+`Reactive._initialize_reactive` installs `default_or_callable() if
+callable(...) else default_or_callable` — since a bare `[]` or `{}` literal
+is not callable, the exact same list/dict object is installed as the
+reactive's backing attribute on every widget instance that has not
+explicitly reassigned it. This is the classic Python mutable-default-argument
+trap, applied to a Textual `reactive()` default.
+
+The proven instance is `Widgets/TTS/character_voice_widget.py`'s
+`characters = reactive([])`: two `CharacterVoiceWidget` instances that both
+start from the un-set default and never reassign `characters` share and
+cross-mutate the same underlying list. Task-15479 found this only because it
+made its own new tests order-dependent within one pytest session (one test's
+`.append()` leaked into a later test's row count via the shared default);
+its tests work around it defensively by assigning a fresh list before use,
+documented in that file's test-module docstring. This is a live production
+hazard, not just a test-isolation nuisance: any two instances of the same
+widget class that both rely on the declared default will alias state.
+
+## Acceptance Criteria
+
+- [ ] `character_voice_widget.py`'s `characters` reactive uses a factory
+      (e.g. `reactive(list)` / a `default=` callable) so each instance gets
+      its own list, not a shared one
+- [ ] A test proves two `CharacterVoiceWidget` instances no longer alias:
+      mutating one's `characters` does not affect the other's
+- [ ] A repo-wide sweep for the same shape — `reactive([...])` /
+      `reactive({...})` with a literal (not a callable) default — classifies
+      each hit and fixes any other widget instantiated more than once per
+      app session where cross-instance aliasing is plausible; sites that are
+      genuinely singleton-per-app or already reassign the attribute before
+      first read are recorded as reviewed, not touched
+- [ ] Existing `character_voice_widget` and STTS test suites stay green

--- a/backlog/tasks/task-15772 - STTS-Select-widgets-compose-options-in-the-wrong-tuple-order-so-set-value-calls-fail.md
+++ b/backlog/tasks/task-15772 - STTS-Select-widgets-compose-options-in-the-wrong-tuple-order-so-set-value-calls-fail.md
@@ -1,0 +1,53 @@
+---
+id: TASK-15772
+title: STTS Select widgets compose options in the wrong tuple order, so set-value calls fail
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - bug
+  - stts
+priority: medium
+---
+
+## Description
+
+Found during task-15478's review (input-latency burn-down) for one Select
+and confirmed here to be a repeated pattern across `UI/STTS_Window.py`.
+Textual's `Select.options` expects `(label, value)` tuples, but multiple
+Selects in this file are composed with `(id, label)` — the reverse:
+
+- `#import-source-select` (`options=[("file", "Text File"), ...]`, flagged
+  in task-15478's notes) — `_import_content`'s
+  `if import_source == "file":` branches check the id, but the widget's
+  actual `.value` after selection is the display label ("Text File"), never
+  the lowercase id. All four "Import From" dispatch branches
+  (file/notes/conversation/paste) are non-functional today via this Select.
+- `#audiobook-provider-select` (`options=[("openai", "OpenAI"),
+  ("elevenlabs", "ElevenLabs"), ("kokoro", "Kokoro (Local)"),
+  ("chatterbox", "Chatterbox (Local)")]`) and `#audiobook-format-select`
+  (`options=[("mp3", "MP3"), ...]`) — same reversed shape, confirmed by
+  reading the compose call. `_initialize_audiobook_defaults` (STTS_Window.py,
+  scheduled via `set_timer(0.1, ...)` on mount) then does
+  `provider_select.value = "openai"` / `format_select.value = "m4b"` inside a
+  bare `try/except Exception: logger.debug(...)` — since "openai"/"m4b" are
+  never present among the Select's actual values (the labels are), Textual's
+  illegal-value validation fires and the default-selection attempt silently
+  no-ops into the debug log on every STTS window mount.
+
+## Acceptance Criteria
+
+- [ ] `#import-source-select`, `#audiobook-provider-select`, and
+      `#audiobook-format-select` all compose `options=` in Textual's real
+      `(label, value)` order
+- [ ] Every `.value` comparison and assignment against these three Selects
+      (`_import_content`'s branch checks;
+      `_initialize_audiobook_defaults`'s provider/format assignment) is
+      updated to match, and actually selects the intended default on mount
+      (not silently swallowed by the surrounding `try/except`)
+- [ ] All four "Import From" dispatch branches (file/notes/conversation/paste)
+      are reachable and functional through the Select, not just through a
+      direct method call (test drives the Select, not `_import_content`
+      called directly)
+- [ ] `_initialize_audiobook_defaults` no longer logs an illegal-select-value
+      warning on a fresh STTS window mount (test asserts no such log line)

--- a/backlog/tasks/task-15773 - ChapterEditorWidget-Select-mount-race-under-high-volume-DataTable-population.md
+++ b/backlog/tasks/task-15773 - ChapterEditorWidget-Select-mount-race-under-high-volume-DataTable-population.md
@@ -1,0 +1,43 @@
+---
+id: TASK-15773
+title: ChapterEditorWidget/Select mount race under high-volume DataTable population
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - bug
+  - stts
+  - flake
+priority: low
+---
+
+## Description
+
+Found and documented as an out-of-scope dodge in task-15478's Review round 3
+(input-latency burn-down). While testing chapter-detection on very large
+pastes, an unrelated, pre-existing race in `ChapterEditorWidget`/`Select`'s
+mount sequence tripped when the chapter table populated a very large number
+of rows in one reactive update — observed once in a full-file test run with
+`_make_large_book` producing ~999 chapters for a 3M-word book (2000
+words/chapter density).
+
+Task-15478 worked around it by reducing `_make_large_book`'s chapter density
+(2000 -> 60,000 words per chapter), which made the flake reproduce 0/4
+afterward in its own suite — a real dodge, not a fix. The race itself (what
+in `ChapterEditorWidget`'s mount sequence loses ordering when `Select` is
+populated with a very large row count in one shot) is still there and
+unowned.
+
+## Acceptance Criteria
+
+- [ ] The `ChapterEditorWidget`/`Select` mount-sequence race is reproduced
+      deterministically (e.g. via the original higher-density
+      `_make_large_book` shape, or a targeted stress test that populates the
+      table with hundreds+ of rows in one reactive update)
+- [ ] Root cause is identified (an ordering assumption between the table
+      populate and the Select's own mount/options-set) and fixed at the
+      source, not worked around by capping row counts in tests
+- [ ] A regression test pins the fix at a row count that reproduced the race
+      before the fix
+- [ ] `Tests/UI/test_speech_audiobook_chapter_detection.py` stays green,
+      including at its original (pre-workaround) chapter density if restored

--- a/backlog/tasks/task-15774 - Library-media-viewer-search-status-and-nav-controls-sit-below-the-fold-at-80x24.md
+++ b/backlog/tasks/task-15774 - Library-media-viewer-search-status-and-nav-controls-sit-below-the-fold-at-80x24.md
@@ -1,0 +1,40 @@
+---
+id: TASK-15774
+title: Library media viewer search status and nav controls sit below the fold at 80x24
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - ux
+  - library
+priority: low
+---
+
+## Description
+
+Found during task-15458's 2026-08-13 macOS re-verification (input-latency
+burn-down), recorded rather than fixed since it needs a layout decision: at
+an 80x24 terminal, the media viewer's search status line and Prev/Next match
+controls sit below the visible fold. Task-15458 already fixed the equivalent
+issue at 170x48 (`ae757d8d4`, sizing the search-controls container to its
+content), but that fix does not carry through to the compact 80x24 case —
+the controls container is `height: auto` and the stack order is unchanged,
+so at this size the content body still pushes the controls out of view. This
+is the viewer's overall vertical density at small sizes, not a defect in
+task-15458's in-place-navigation conversion itself (which task-15458's own
+`..._inplace_navigation_holds_at_compact_size` test confirms: identity,
+focus, and zero reparse all hold at 80x24 — the controls are simply
+unreachable without scrolling/focusing first).
+
+## Acceptance Criteria
+
+- [ ] At 80x24, the media viewer's search status and Prev/Next controls are
+      reachable without requiring the user to already know to scroll or
+      focus first (visible on open, or a clear, discoverable affordance)
+- [ ] The fix is a genuine layout decision (e.g. compact-mode chrome,
+      collapsible content region, or reordered stack) rather than papering
+      over the geometry with a scroll-into-view hack
+- [ ] `Tests/UI/test_library_shell.py`'s 170x48 and 80x24 in-place-navigation
+      tests (task-15458's) stay green; a new compositor-based test pins the
+      80x24 chrome as visibly painted, mirroring the 170x48
+      non-overlapping-regions test task-15458 already has

--- a/backlog/tasks/task-15775 - Watchlists-screen-reactive-default-disagrees-with-the-shipped-first-run-region-layout.md
+++ b/backlog/tasks/task-15775 - Watchlists-screen-reactive-default-disagrees-with-the-shipped-first-run-region-layout.md
@@ -1,0 +1,50 @@
+---
+id: TASK-15775
+title: Watchlists screen reactive default disagrees with the shipped first-run region layout
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - perf
+  - watchlists
+priority: low
+---
+
+## Description
+
+Found and measured during task-15462's profiling investigation (input-latency
+burn-down), deliberately not shipped there because the cost/benefit did not
+justify the risk of reordering config-writing code. `WatchlistsCollectionsScreen`'s
+reactive default is `region_layout = RegionLayout()` (nothing collapsed),
+while the shipped first-run default is `_FIRST_RUN_DEFAULT =
+RegionLayout(collapsed={RIGHT_RAIL})`. Every single screen visit therefore
+composes the expanded Inspector rail (13 widgets), and `on_mount`'s
+`_apply_layout(load_region_layout())` immediately tears it down and mounts
+the one-line collapsed header in its place.
+
+Task-15462 measured this precisely: 13 widgets discarded, 1 mounted, ~5-10 ms
+of a ~450 ms push (1-2%). A prototype (seeding `region_layout` from
+`load_region_layout()` before compose, rather than after) was built and
+verified to remove the swap entirely — `_apply_layout` sees `equal=True`,
+zero `_swap_region_widget` calls, identical final widget counts — but a
+paired A/B could not reliably detect the wall-clock difference (6/12 pairs
+faster, median delta -1 ms). Not shipped because `load_region_layout()`
+performs a one-time synchronous migration write, and moving it into screen
+construction changes its ordering relative to `_last_persisted_collapsed`
+priming, which `_schedule_layout_persist`'s no-op guard depends on — a real
+migration-ordering risk task-15462 chose not to take inside a profiling task.
+
+## Acceptance Criteria
+
+- [ ] `WatchlistsCollectionsScreen`'s `region_layout` reactive default agrees
+      with (or is seeded from) the persisted/first-run layout before compose,
+      so a normal visit does not compose-then-discard the Inspector rail
+- [ ] `load_region_layout()`'s one-time migration write and
+      `_last_persisted_collapsed` priming are proven correctly ordered
+      relative to the earlier construction point (task-15462's flagged risk),
+      with a test that would fail if the ordering regressed
+- [ ] `_apply_layout` performs zero `_swap_region_widget` calls on a normal
+      screen visit (regression test, mirroring task-15462's prototype
+      verification)
+- [ ] Existing Watchlists screen-navigation and layout-persistence suites
+      stay green

--- a/backlog/tasks/task-15776 - Watchlists-collapse-ArticleRow-DayHeader-from-a-ListItem-wrapping-a-Static-into-one-widget.md
+++ b/backlog/tasks/task-15776 - Watchlists-collapse-ArticleRow-DayHeader-from-a-ListItem-wrapping-a-Static-into-one-widget.md
@@ -1,0 +1,52 @@
+---
+id: TASK-15776
+title: 'Watchlists: collapse _ArticleRow/_DayHeader from a ListItem-wrapping-a-Static into one widget'
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - perf
+  - watchlists
+priority: medium
+---
+
+## Description
+
+The one structural lever task-15462's profiling investigation actually found
+and handed over rather than shipping inline (input-latency burn-down).
+Task-15462's cProfile + widget-count sweep of a Watchlists screen push found
+the screen's own chrome is a median-cost screen (200 ms, in line with every
+other screen); its entire excess is the article feed, which is 224 widgets
+because `_load_items` pages at a hard-coded `limit=100` and every
+`_ArticleRow`/`_DayHeader` is a `ListItem` wrapping one `Static` (112 rows x
+2 widgets each).
+
+Two independent estimates agree the win is real: the sweep's dose-response
+slope (112 x ~0.55 ms/widget approx 62 ms approx 15-18% of the push) and a
+prototype where the rows render the same `Text` with no child widget
+(interleaved runs: paint 414/479 ms -> 335/372 ms). Not shipped inside
+task-15462 because it is a structural rewrite of `article_list.py` — a file
+task-15460 hardened three tasks earlier in the same programme — requiring an
+audit of every `.article-row`/`.article-day-header` and `ListItem > Static`
+selector across the CSS bundle, plus rerouting `_repaint_row`'s
+`query_one(Static).update()`, plus re-validating in-place filtering, `j`/`k`
+cursor skipping, and highlight styling.
+
+A cheaper variant worth considering in the same task, per task-15462's own
+note: `_load_items`'s hard-coded `limit=100` is not viewport-proportionate,
+so a smaller page (where the viewport allows it) shrinks the same problem
+without the structural rewrite.
+
+## Acceptance Criteria
+
+- [ ] `_ArticleRow`/`_DayHeader` render as a single self-rendering `ListItem`
+      instead of a `ListItem` wrapping a child `Static`, removing ~half the
+      feed's mounted widgets
+- [ ] Every `.article-row`/`.article-day-header`/`ListItem > Static` CSS
+      selector affected by the change is audited and updated; visual
+      appearance is unchanged
+- [ ] `_repaint_row`, in-place filtering (task-15460), `j`/`k` cursor
+      skipping, and selection/highlight styling all keep their current
+      behavior (tests)
+- [ ] A measured before/after on a 100-item feed shows the predicted
+      ~15-18% reduction in screen-push cost, recorded in the task notes

--- a/backlog/tasks/task-15777 - Console-transcript-unbounded-reveal-and-a-scroll-back-reachability-ceiling.md
+++ b/backlog/tasks/task-15777 - Console-transcript-unbounded-reveal-and-a-scroll-back-reachability-ceiling.md
@@ -1,0 +1,54 @@
+---
+id: TASK-15777
+title: 'Console transcript: unbounded reveal on a far jump, and a scroll-back reachability ceiling'
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - perf
+  - console
+  - design
+priority: medium
+---
+
+## Description
+
+Two untracked residuals recorded explicitly "for the controller to file" in
+task-15455's Implementation Notes (input-latency burn-down's Console
+transcript windowing work). Both are inherited from the merged windowing
+design (task-15455), not introduced by its later reconciliation PR, and both
+need a design decision rather than a small tweak:
+
+1. **Unbounded reveal on a far jump.** Selecting or jumping to a message near
+   the start of a long session reveals everything from it to the tail in one
+   pass — measured ~490 rows mounted for message 10 of 500. Latent for any
+   future "jump to search hit" feature, which would hit the same cost.
+2. **Scroll-back reachability ceiling.** Once the mounted view reaches the
+   LOW prune watermark (~12,000 rendered rows by default), scroll-back stops
+   loading older history entirely; that content is reachable only via export
+   or a jump, not by continuing to scroll. Removing the ceiling needs
+   two-sided windowing (trimming the tail as the head grows), which neither
+   the merged implementation nor its reconciliation has, and which would
+   touch tail-follow, streaming, and the jump-pill mechanics task-15455
+   built.
+
+Related context (already fixed, not part of this task): task-15455's
+reconciliation PR already fixed a read-order defect in `restore_reading_state`
+(clamping against the pre-reveal `max_scroll_y` used to silently drop the
+reader elsewhere); that fix is why a design for #1/#2 needs to account for
+reveal-then-restore ordering rather than re-deriving it from scratch.
+
+## Acceptance Criteria
+
+- [ ] A design decision is made and documented for bounding the reveal cost
+      of a far jump (e.g. windowed reveal + progressive hydration toward the
+      target, rather than mounting everything between the jump target and
+      the tail in one pass)
+- [ ] A design decision is made and documented for two-sided windowing (or an
+      explicit, justified decision not to pursue it), covering how it
+      interacts with tail-follow, in-flight streaming, and the jump pill
+- [ ] Whichever lever(s) ship are covered by tests pinning: bounded mount
+      count on a far jump, and (if two-sided windowing ships) that
+      scroll-back remains reachable past the current low-watermark ceiling
+- [ ] `Tests/UI/test_console_transcript_window_reconcile.py` and
+      `Tests/UI/test_console_transcript_windowing.py` stay green

--- a/backlog/tasks/task-15778 - Watchlists-batch-the-cold-Read-tab-region-swap-and-drop-the-pre-mount-seeding-recompose.md
+++ b/backlog/tasks/task-15778 - Watchlists-batch-the-cold-Read-tab-region-swap-and-drop-the-pre-mount-seeding-recompose.md
@@ -1,0 +1,53 @@
+---
+id: TASK-15778
+title: 'Watchlists: batch the cold Read-tab region swap and drop the pre-mount seeding recompose'
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - perf
+  - watchlists
+priority: low
+---
+
+## Description
+
+Two related residuals recorded "for the controller to file" in task-15461's
+Implementation Notes (input-latency burn-down's Watchlists scoped-rebuild
+work). Both are about construction-order cost inside the same region-build
+plumbing task-15461 converted from whole-screen recomposes to scoped
+rebuilds.
+
+1. **Cold Read-tab wall-clock did not improve despite halving DOM work.**
+   Measured 75 -> 110 ms (best-of-two) for the one section switch
+   (`section: Read`, cold) that has to re-mount the CONTENT region. Every
+   other measured section switch improved with task-15461's scoped rebuild;
+   this one regressed on wall clock because the scoped path does the CONTENT
+   remount as its own discrete remove/mount pair rather than inside one
+   batched recompose. Task-15461's own notes point at Textual's `batch()` as
+   "the obvious next move."
+2. **`_build_detail_pane`'s pre-mount seeding costs one pane recompose per
+   region build.** `[] != [row]` on a freshly constructed pane triggers an
+   extra recompose; pre-existing and unchanged by task-15461, invisible on
+   an empty fixture (which is why it surfaced only once task-15461's review
+   asked for a seeded row). Fixing it means seeding with `set_reactive`
+   instead of a plain assignment, which is not safe blind: `RunsPane`'s
+   seeding ORDER is load-bearing (`selected_run` clears the detail, so the
+   detail must be set after it) — any fix must preserve that ordering
+   per-pane, not apply one blanket change.
+
+## Acceptance Criteria
+
+- [ ] The cold `section: Read` switch's CONTENT-region remount is batched
+      (e.g. via Textual's `batch()`) into the same pass as its other DOM
+      work, and the wall-clock regression measured in task-15461 is closed
+      (before/after recorded)
+- [ ] `_build_detail_pane`'s pre-mount seeding uses `set_reactive` (or an
+      equivalent that avoids the extra recompose) without breaking any
+      pane's load-bearing seeding order — `RunsPane`'s `selected_run`-before-
+      detail ordering explicitly verified by test
+- [ ] Every other pane that uses `_build_detail_pane` is checked for its own
+      seeding-order dependencies before the change lands, not just
+      `RunsPane`
+- [ ] `Tests/Watchlists/test_watchlists_scoped_rebuilds.py` and the sources/
+      rules pane suites stay green

--- a/backlog/tasks/task-15779 - Watchlists-artifacts-pane-briefing-selection-destroys-the-briefings-table-and-its-focus.md
+++ b/backlog/tasks/task-15779 - Watchlists-artifacts-pane-briefing-selection-destroys-the-briefings-table-and-its-focus.md
@@ -1,0 +1,39 @@
+---
+id: TASK-15779
+title: 'Watchlists artifacts pane: briefing selection destroys the briefings table and its keyboard focus'
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - bug
+  - watchlists
+  - ux
+priority: medium
+---
+
+## Description
+
+Pre-existing UX defect found and recorded ("worth its own task") in
+task-15461's Implementation Notes (input-latency burn-down's Watchlists
+scoped-rebuild work). Task-15461 reduced the artifacts pane's recompose count
+on a briefing selection from 2 down to 1, but that remaining recompose still
+rebuilds the pane wholesale: selecting a briefing recomposes `ArtifactsPane`,
+which destroys and rebuilds the briefings `DataTable`, which loses keyboard
+focus. A second arrow-key press then does nothing until the user manually
+re-focuses the table — measured on the pre-task-15461 code too, so this is
+not something task-15461 introduced, just something it exposed by getting
+the recompose count down to a level where the remaining one is now the
+visibly broken step.
+
+## Acceptance Criteria
+
+- [ ] Selecting a briefing in the artifacts pane does not destroy the
+      briefings `DataTable` widget instance (in-place update instead of a
+      recompose that tears it down), OR the recompose explicitly restores
+      focus and cursor position to the table afterward
+- [ ] A second arrow-key press immediately after selecting a briefing moves
+      the cursor to the next row (regression test — this is the concrete
+      symptom: today it does nothing until the user re-focuses)
+- [ ] The scripts/audio/citations clearing task-15461 folded into
+      `watch_selected_briefing` (via `set_reactive`) keeps working unchanged
+- [ ] `Tests/Watchlists/test_watchlists_artifacts_pane.py` stays green

--- a/backlog/tasks/task-15780 - Verify-then-retire-the-CCP-dictionary-prompt-editor-widgets.md
+++ b/backlog/tasks/task-15780 - Verify-then-retire-the-CCP-dictionary-prompt-editor-widgets.md
@@ -1,0 +1,50 @@
+---
+id: TASK-15780
+title: Verify-then-retire the CCP dictionary/prompt editor widgets
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - cleanup
+priority: low
+---
+
+## Description
+
+Verify-then-retire candidate surfaced while reviewing task-15476 (input-latency
+burn-down's picker-debounce task, which touched
+`ccp_dictionary_editor_widget.py:730/:848` and `ccp_prompt_editor_widget.py:876`
+for consistency without checking whether the widgets are actually reachable
+in production). Confirmed by a repo-wide grep: `CCPDictionaryEditorWidget`
+and `CCPPromptEditorWidget` are referenced only inside their own module and
+`Widgets/CCP_Widgets/__init__.py`'s re-export — zero other production
+importers anywhere in `tldw_chatbook/`. The package's own `__init__.py`
+docstring says as much: "Surviving prompt/dictionary editor widgets. The
+legacy CCP screen chrome (sidebar, character card/editor, conversation view,
+persona card/editor) was retired in favor of the Personas workbench
+(tldw_chatbook/Widgets/Persona_Widgets/)."
+
+This is exactly the same shape as task-15481's dead-scheduler/dead-DB-module
+sweep in the same programme: code that looks alive (and gets reflexively
+touched by unrelated fixes, as task-15476 did) but is unreachable from any
+production screen. Per the same standing preference task-15481 applied:
+delete (with git-log provenance) or explicitly quarantine — do not leave a
+loaded gun a future contributor might wire up without noticing it was
+already retired.
+
+## Acceptance Criteria
+
+- [ ] Re-verify at implementation time (not trusting this task's grep without
+      re-checking) that `CCPDictionaryEditorWidget` and
+      `CCPPromptEditorWidget` have zero production callers/importers outside
+      their own module and `__init__.py`
+- [ ] If still dead: delete both widget modules (with git-log provenance
+      recorded in the notes) and their now-orphaned test-only importers, or
+      trim tests that also cover live code the same way task-15481 did for
+      `Research_DB`/`Sync_Client`
+- [ ] If a live caller is found (contradicting the grep above): the task
+      closes as "not dead," with the caller documented, and no deletion
+      happens
+- [ ] `pytest --collect-only` over the whole tree has zero errors after the
+      change; a final grep sweep for both class names returns no production
+      hits

--- a/backlog/tasks/task-15781 - Verify-then-trim-NotesSyncServices-SyncProfile-CRUD-surface.md
+++ b/backlog/tasks/task-15781 - Verify-then-trim-NotesSyncServices-SyncProfile-CRUD-surface.md
@@ -1,0 +1,47 @@
+---
+id: TASK-15781
+title: Verify-then-trim NotesSyncService's SyncProfile CRUD surface
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - cleanup
+  - notes
+priority: low
+---
+
+## Description
+
+Verify-then-trim candidate surfaced by task-15481's disclosure (input-latency
+burn-down's dead-code sweep). Task-15481 trimmed `Notes/sync_service.py`'s
+dead auto-sync-loop machinery (`create_profile`, `start_auto_sync`,
+`stop_auto_sync`, `stop_all_auto_syncs`) but explicitly left `SyncProfile`,
+profile load/save, `get_profile`, `list_profiles`, and `sync_with_profile` in
+place, on the grounds that they were "not named dead by the task and not a
+crash-on-touch landmine" — i.e. task-15481 did not investigate whether
+these remaining methods have production callers, only that they were out of
+its own AC's scope.
+
+Re-verified here by a repo-wide grep: `library_screen.py` is the sole
+production importer of `NotesSyncService`, and it calls exactly one method
+on the instance it constructs — `service.sync_folder(...)`. No production
+code anywhere calls `NotesSyncService.get_profile`, `.list_profiles`,
+`.sync_with_profile`, or constructs a `SyncProfile`. (Several *other*,
+unrelated `get_profile`/`list_profiles` methods exist elsewhere in the
+codebase — TTS profile managers, RAG profile managers, MCP local control —
+none of which touch `Notes/sync_service.py`; they are not evidence against
+this finding.)
+
+## Acceptance Criteria
+
+- [ ] Re-verify at implementation time that `SyncProfile`, `get_profile`,
+      `list_profiles`, and `sync_with_profile` in `Notes/sync_service.py`
+      have zero production callers (grep, not trusting this task's finding
+      blind)
+- [ ] If still dead: remove the CRUD surface (with git-log provenance
+      recorded) and its now-orphaned test-only coverage, keeping
+      `NotesSyncService.sync_folder` and everything it depends on untouched
+- [ ] If a live caller is found: the task closes as "not dead," with the
+      caller documented, and no removal happens
+- [ ] `Tests/Notes/` and `Tests/Sync_Interop/` stay green; a final grep
+      sweep for the removed names returns no production hits

--- a/backlog/tasks/task-15782 - Repair-the-generic-ingest-options-snapshot-test-asserting-a-stale-hardcoded-dict.md
+++ b/backlog/tasks/task-15782 - Repair-the-generic-ingest-options-snapshot-test-asserting-a-stale-hardcoded-dict.md
@@ -1,0 +1,35 @@
+---
+id: TASK-15782
+title: Repair the generic ingest-options snapshot test asserting a stale hardcoded dict
+status: To Do
+assignee: []
+created_date: '2026-08-13 12:31'
+labels:
+  - test-health
+  - library
+priority: low
+---
+
+## Description
+
+Found and flagged as pre-existing and unrelated in task-15470's
+Implementation Notes (input-latency burn-down's config-persistence task):
+`test_options_persist_to_config` fails on a content mismatch — a schema
+drift, not a threading bug. Task-15470's notes record that this failure was
+"exposed only once the `run_worker` crash this task fixed stopped masking
+it," meaning the test has likely been silently failing-or-skipped-via-crash
+for a while and nobody noticed once the underlying worker exception stopped
+swallowing it. The test itself asserts against a hardcoded dict of expected
+generic-ingest options that has drifted out of sync with whatever the ingest
+options form/save path actually persists today.
+
+## Acceptance Criteria
+
+- [ ] `test_options_persist_to_config`'s expected dict is reconciled against
+      current production behavior — diagnosed as either a genuinely stale
+      test expectation (update the test) or a real regression in what gets
+      persisted (fix production and keep the test's original intent)
+- [ ] The specific drifted key(s)/value(s) are identified and documented in
+      the task notes, not just "test updated"
+- [ ] The test passes on dev without weakening its coverage (it should still
+      catch a genuine future persistence regression, not just always pass)


### PR DESCRIPTION
## Summary

Closes the loop on the input-latency burn-down programme (30 of 32 audit tasks merged; the CSS finale is in flight): 19 follow-up tasks filed from findings the programme's reviews unearthed along the way, each with commit/PR-level evidence in its description.

- Perf residue: URLMonitor off-loop, Watchlists article-row collapse (~15-18%) + region_layout default disagreement + swap batching/seeding, transcript two-sided windowing bundle, Today-badge index, media viewer 80×24 layout
- Live bugs: STTS Select options tuples backwards (import dispatch dead today — two more instances found during filing), media reading-highlights naming mismatch (4 methods), character JSON export crash on images, PR #1546's navigation regression + WorkspaceProbe drift (controller-bisected), artifacts-pane focus loss
- Hygiene: pre-existing red-test batch (7 live-confirmed sub-items), one still-red migration test, shared-mutable reactive defaults, CCP dead-code candidates, sync_service uncalled CRUD, ingest-options test drift
- Verify-before-filing caught 2 stale candidates (the V33→V34 baseline was already fixed by task-15730; the top_k leak resolved via task-15512) and dropped 3 unlocatable sub-items rather than guessing
- `Docs/Design/2026-08-11-input-latency-audit.md` gains a "Follow-ups filed" section

IDs claimed at board-max+20 after a full remote+worktree sweep, re-verified pre-merge; two-namespace dup check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files 19 follow-up tasks from the input‑latency burn‑down and adds a “Follow-ups filed” index to the audit doc, so all residual findings are tracked with evidence and acceptance criteria. No runtime behavior or tests change.

- Adds `backlog/tasks/task-15764`–`task-15782` covering: 
  - Perf residues (e.g., Watchlists off‑loop work, row/widget collapse, batching/swaps).
  - Live bugs (e.g., STTS Select value/order, media highlights API mismatch, character JSON export, navigation/back behavior, artifacts-pane focus).
  - Hygiene/cleanup (red tests, a migration fixture, reactive defaults, dead CCP widgets, unused SyncProfile CRUD, a stale snapshot test).
- Updates `Docs/Design/2026-08-11-input-latency-audit.md` with a one‑line index for each task.
- Review: skim the audit section for task coverage, spot‑check a few tasks for clear evidence and ACs, and confirm task IDs/names are unique and references correct. No migrations, config changes, or runtime verification required.

<sup>Written for commit 4901e03c2c2396ad132a2ffa8dcdc8b0067458e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

