### PR TITLE
docs: close task-15211 — full Tests/UI sweep complete, inventory filed

### DIFF
--- a/Docs/Design/2026-08-13-tests-ui-sweep-inventory.md
+++ b/Docs/Design/2026-08-13-tests-ui-sweep-inventory.md
@@ -1,0 +1,138 @@
+# Tests/UI full-suite sweep — task-15211 (2026-08-13)
+
+**The first end-to-end run of the whole `Tests/UI` suite.** 503 modules in 16
+checkpointed chunks against a worktree frozen at dev `e9f5f80e4`:
+**10,811 passed, 117 failed rows, ~13 errors** (teardown-class, see below).
+Raw per-chunk logs and the failure list were captured per-chunk so environment
+kills lose one chunk, not the run — this is what let the sweep survive the
+process kill and TCC lockout that had destroyed all three earlier monolithic
+attempts.
+
+## The task's core question: what attempts network egress?
+
+**One distinct source in the entire suite**: `llm_screen._probe_local_server`
+-> `127.0.0.1:11434`, firing at TEARDOWN of any test that mounts the Lab/LLM
+screen (interval + deferred-mount one-shot flushing during shutdown).
+Fixed during the sweep (PR #1596: widget-owned worker + the same autouse
+harness stub the Console screen got in task-15111). The task-15111-era
+"tests POST real inference" class did NOT reappear. Chunk 12 shows a
+possible sibling: two provider-Test-button teardown errors in settings —
+see the follow-up task.
+
+## Fixed during the sweep (merged)
+
+- **PR #1591** — four NEW unbounded background waits (the task-14912 hang
+  class), caught by the guard on chunk 0.
+- **PR #1596** — the Ollama probe above. Also cured the sweep's own chunk-5
+  **failure-to-exit** (pytest printed its summary, then sat at zero CPU with
+  two event loops parked in kevent and the main thread joining a non-daemon
+  thread). Re-run of the same 32 modules on post-fix dev: clean exit, zero
+  egress. This failure mode is the best explanation for every earlier
+  full-suite attempt dying.
+- **PR #1603** — 35 task files with lowercase `id: task-` frontmatter the
+  maturity harness counts as no id at all (chunk 10's catch).
+
+## Failure inventory (frozen-tree dev-red, attributed)
+
+Chunk summaries:
+- chunk 0 (rc=1): 1 failed, 344 passed, 4 warnings in 99.96s (0:01:39)
+- chunk 1 (rc=1): 2 failed, 695 passed, 2 warnings in 473.66s (0:07:53)
+- chunk 2 (rc=1): 5 failed, 880 passed, 1 xfailed, 8 warnings in 794.70s (0:13:14)
+- chunk 3 (rc=1): 4 failed, 718 passed, 3 warnings in 581.16s (0:09:41)
+- chunk 4 (rc=1): 13 failed, 310 passed, 2 warnings in 216.69s (0:03:36)
+- chunk 5 (rc=143): 9 failed, 589 passed, 1 skipped, 3 warnings, 1 error in 894.06s (0:14:54)
+- chunk 6 (rc=1): 1 failed, 575 passed, 1 skipped, 3 warnings, 6 errors in 459.39s (0:07:39)
+- chunk 7 (rc=1): 32 failed, 954 passed, 2 warnings in 1860.63s (0:31:00)
+- chunk 8 (rc=1): 16 failed, 1630 passed, 9 warnings, 2 errors in 1823.60s (0:30:23)
+- chunk 9 (rc=1): 509 passed, 4 warnings, 1 error in 253.75s (0:04:13)
+- chunk 10 (rc=1): 8 failed, 736 passed, 7 warnings, 2 errors in 707.39s (0:11:47)
+- chunk 11 (rc=1): 8 failed, 766 passed, 3 warnings in 623.45s (0:10:23)
+- chunk 12 (rc=1): 7 failed, 746 passed, 3 warnings, 2 errors in 597.79s (0:09:57)
+- chunk 13 (rc=1): 2 failed, 482 passed, 3 warnings in 424.21s (0:07:04)
+- chunk 14 (rc=1): 5 failed, 460 passed, 6 warnings, 4 errors in 549.97s (0:09:09)
+- chunk 15 (rc=1): 4 failed, 417 passed, 2 warnings in 905.67s (0:15:05)
+
+Failures by module:
+-  15  test_library_file_notes_git.py
+-  15  test_library_shell.py
+-   7  test_console_staged_evidence_strip.py
+-   6  test_destination_visual_parity_correction.py
+-   4  test_console_shell_regions.py
+-   4  test_library_file_notes_git_push.py
+-   4  test_personas_generation_wiring.py
+-   4  test_workbench_visual_snapshots.py
+-   3  test_console_rail_width_budget.py
+-   3  test_library_prompts_canvas.py
+-   3  test_settings_rag_profile_region.py
+-   2  test_console_dictionary_send_integration.py
+-   2  test_console_world_info_send_integration.py
+-   2  test_library_choice_strips.py
+-   2  test_library_export_receipt.py
+-   2  test_library_file_notes_workspace.py
+-   2  test_library_ingest_structural.py
+-   2  test_settings_workspaces_category.py
+-   2  test_ui_responsiveness.py
+-   1  test_background_signal_bounds.py
+-   1  test_console_citation_sources.py
+-   1  test_console_composer_collapse.py
+-   1  test_console_fleet_discoverability.py
+-   1  test_console_internals_decomposition.py
+-   1  test_console_live_work_handoffs.py
+-   1  test_console_rail_sections.py
+-   1  test_console_shell_chip_actions.py
+-   1  test_console_tab_scope.py
+-   1  test_destination_headers.py
+-   1  test_focus_accessibility.py
+-   1  test_library_ingest_keyboard.py
+-   1  test_library_multiselect_notes.py
+-   1  test_library_skills_canvas.py
+-   1  test_product_maturity_phase1_empty_setup_states.py
+-   1  test_product_maturity_phase1_first_run.py
+-   1  test_product_maturity_phase1_harness.py
+-   1  test_product_maturity_phase1_keyboard_focus.py
+-   1  test_product_maturity_phase6_first_time_release_replay.py
+-   1  test_product_maturity_phase6_focus_visual_sweep.py
+-   1  test_product_maturity_phase6_packaging_data_safety.py
+-   1  test_product_maturity_phase6_power_user_replay.py
+-   1  test_product_maturity_phase6_recovery_docs.py
+-   1  test_schedules_ux_fixes.py
+-   1  test_screen_navigation.py
+-   1  test_settings_configuration_hub.py
+-   1  test_settings_footer_hints.py
+-   1  test_settings_model_catalog_toggles.py
+-   1  test_speech_rail_navigation.py
+-   1  test_speech_tts_settings_ownership_closeout.py
+-   1  test_stts_profile_library.py
+-   1  test_unified_shell_phase5_recovery_taxonomy.py
+-   1  test_watchlists_check_now_failure.py
+
+### Clusters
+
+| cluster | size | attribution / next step |
+|---|---|---|
+| file-notes drift (color contract x10, push copy x3, library_shell notes focus/rows x15, workspace/export/choice-strip stragglers) | ~35 | the file-notes arcs (#1515/#1551 era); modules never re-run whole since — task filed |
+| console contract drift (staged-evidence "Sources: N staged" x6 [7dbbc401b dropped the suffix], shell-region size2 geometry x4, rail width x2, chip-swap signature, dictionary/world-info sends x4, misc) | ~25 | console batch task filed |
+| destination/workbench visual contracts (parity x~9, visual snapshots x4) | ~13 | one task; snapshot refresh needs a HUMAN eye on renders |
+| settings (rag_profile_region x3, workspaces x2, catalog, footer-hints [known, 537451cb8..61f6ae575]) | ~7 | settings batch in the same task as the probe sibling |
+| stale doubles (set_presentation_context, _library_export_quality_choices_visible, _library_notes_mutation_in_flight, memo-split residue) | >=5 | recurring class; folded into the batch tasks |
+| StopIteration -> RuntimeError in coroutine (library_prompts_canvas x2) | 2 | POSSIBLE REAL BUG (PEP-479 conversion) — own task, high priority within the batch |
+| personas_generation_wiring | 4 | singleton batch |
+| product_maturity_phase1 timeouts ("condition not met within 10s") | 3 | suspect CONTENTION (4 concurrent suites); re-run before filing as real |
+| speech / schedules / navigation / responsiveness / watchlists / skills / phase6 singletons | ~12 | singleton batch |
+
+Frozen-tree residue that is NOT open work: settings_configuration_hub /
+workbench_contract rows (fixed in #1554), stts wait-bounds rows (#1591),
+every `ERROR at teardown` naming an Ollama/llamacpp/lab test (#1596).
+
+### Notable negative results
+
+- task-15741's blank-note `ConflictError` did NOT reproduce anywhere in the
+  full sweep (library_shell's chunk-8 failures are all focus/rows drift).
+- No test attempted egress to anything but 127.0.0.1:11434.
+
+## Method notes (why this run finished when three before it did not)
+
+Checkpointed chunks with per-chunk logs + resumability; a hung chunk was
+diagnosed live (zero CPU accrual + native thread sample), killed, and its
+already-printed summary still recorded; the worktree stayed FROZEN while
+fixes went out on separate branches from a second worktree.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -3684,3 +3684,29 @@ callback must no-op when its original widget has detached. Verify both paths: a 
 recompose must kill the synchronous-only implementation, while an immediate normal-mount
 assertion must kill unconditional deferral. TASK-2702's final full Prompt-canvas run passed
 279 tests only after both boundaries were pinned together.
+
+## A full-suite sweep is a checkpointed pipeline, not a command (task-15211)
+
+**Incident.** Three attempts to run all of `Tests/UI` in one pytest invocation
+died at 25-32%, each time losing everything. The fourth attempt split the 503
+modules into 16 chunks, appended each chunk's summary and failures to a results
+file as it completed, and skipped already-recorded chunks on relaunch. It
+survived a hung chunk, an environment process-kill, and a TCC lockout, and
+finished: 10,811 passed, 117 attributed failures.
+
+**What the monoliths actually died of.** Not slowness: a product defect. The
+Lab/LLM screen's Ollama probe held two event-loop threads open, so pytest
+PRINTED ITS FINAL SUMMARY and then never exited -- zero CPU, main thread
+joining a non-daemon thread. A wrapper waiting on the child sees an eternal
+hang after a successful-looking run. Diagnosis that worked without root:
+compare `ps -o time` across an interval (zero accrual = hung, not slow), then
+`sample <pid>` for native thread stacks -- two threads parked in kevent were
+the loops that should have died with their screen.
+
+**Rules.** (1) Never run a >20-minute suite as one process; checkpoint per
+chunk and make relaunch skip recorded work. (2) "The log stopped growing" has
+two different causes -- a hung TEST (mid-run) and a hung EXIT (summary already
+printed); check for the summary line before assuming the former. (3) Keep the
+sweep's worktree frozen and ship fixes from another one; the sweep's chunk
+results stay comparable, and later chunks re-finding an already-fixed class is
+CONFIRMATION, not new work.

--- a/backlog/tasks/task-15211 - Complete-the-full-Tests-UI-sweep-under-the-network-guard.md
+++ b/backlog/tasks/task-15211 - Complete-the-full-Tests-UI-sweep-under-the-network-guard.md
@@ -2,7 +2,7 @@
 id: TASK-15211
 title: >-
   Complete the full Tests/UI sweep under the network guard
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-11 07:00'
 labels:
@@ -25,7 +25,48 @@ Run it on a quiet machine, in disjoint halves if needed, and record READ counts 
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The full `Tests/UI` suite completes under the network guard with READ pass counts (disjoint halves acceptable, stated as such)
-- [ ] #2 Any module that hangs or blocks is fixed at its source — marked `allow_network` with a reason if it legitimately needs a loopback server, or stubbed if it does not
-- [ ] #3 A fixture-server module missing the marker fails fast rather than hanging, so this cannot reintroduce the run-killing hang class
+- [x] #1 The full `Tests/UI` suite completes under the network guard with READ pass counts (disjoint halves acceptable, stated as such)
+- [x] #2 Any module that hangs or blocks is fixed at its source — marked `allow_network` with a reason if it legitimately needs a loopback server, or stubbed if it does not
+- [x] #3 A fixture-server module missing the marker fails fast rather than hanging, so this cannot reintroduce the run-killing hang class
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Run all 503 Tests/UI modules in 16 checkpointed, resumable chunks against a frozen worktree
+2. Fix guard-class catches immediately on separate branches; leave the frozen tree untouched
+3. Attribute every failure row to a cluster; file the inventory
+
+## Implementation Notes
+
+**Complete: 10,811 passed / 117 failed rows across 16/16 chunks** — the first
+end-to-end run of the whole suite. Full inventory:
+`Docs/Design/2026-08-13-tests-ui-sweep-inventory.md`.
+
+**The egress answer**: ONE distinct source in the entire suite —
+`llm_screen._probe_local_server` -> 127.0.0.1:11434 at teardown of any test
+mounting the Lab/LLM screen. Fixed mid-sweep (PR #1596, worker lifetime + the
+task-15111 harness-stub pattern). The "tests POST real inference" class from
+task-15111 did not reappear. One possible sibling flagged for follow-up (the
+settings provider-Test teardown pair, task-15791).
+
+**Three catches fixed and merged during the run**: #1591 (four NEW unbounded
+background waits, the 14912 hang class, caught by the guard on chunk 0);
+#1596 (the probe — which also cured the sweep's own chunk-5 FAILURE-TO-EXIT:
+pytest printed its summary then sat forever, two event loops parked in kevent;
+re-run on post-fix dev exits clean with zero egress. That failure mode is the
+best explanation for all three earlier monolithic sweep attempts dying);
+#1603 (35 task files whose lowercase `id:` frontmatter the maturity harness
+counts as no id).
+
+**Why this attempt finished when three before it did not**: checkpointed
+chunks with per-chunk logs and resume-by-skipping; a hung chunk diagnosed
+live (zero CPU accrual + native thread sample), killed, its already-printed
+summary still recorded; the worktree frozen for the sweep's whole life with
+fixes shipped from a second worktree. The run survived one environment
+process-kill and one TCC lockout.
+
+**Inventory filed as** task-15790 (file-notes arcs, ~35 tests, StopIteration
+pair triaged first) and task-15791 (console/destination drift, ~38 tests,
+incl. the probe-sibling check). Frozen-tree residue of #1554/#1591/#1596 is
+recorded as such, not re-filed. Negative result recorded on task-15741: the
+blank-note ConflictError did not reproduce anywhere in the full sweep.

--- a/backlog/tasks/task-15790 - Sweep-inventory-file-notes-arcs-left-35-Library-tests-behind.md
+++ b/backlog/tasks/task-15790 - Sweep-inventory-file-notes-arcs-left-35-Library-tests-behind.md
@@ -1,0 +1,40 @@
+---
+id: TASK-15790
+title: 'Sweep inventory: file-notes arcs left ~35 Library tests behind'
+status: To Do
+assignee: []
+labels:
+  - test-health
+  - library
+priority: medium
+---
+
+## Description
+
+From the task-15211 full-suite sweep (`Docs/Design/2026-08-13-tests-ui-sweep-inventory.md`,
+chunks 7-8): ~35 Library tests are red on dev, all consistent with the
+file-notes feature arcs shipping without their module contracts re-run:
+
+- 10x one color contract in `test_library_file_notes_git.py`
+  (`Color(51,66,78)` vs `Color(81,103,126)`) — a theme change unpropagated.
+- 3x push copy: `'Push checking'` vs `'Review session changes (2) · Checking push'`.
+- 15x `test_library_shell.py` notes cluster: focus-target drift
+  (`'library-note-preview-region'` vs `'library-note-save'`), `NoMatches` on
+  notes rows, id-set diffs.
+- Stragglers in workspace/export-receipt/choice-strips/multiselect/prompts
+  modules, including 2x stale doubles missing new production attributes and
+  2x `coroutine raised StopIteration` in `test_library_prompts_canvas.py` —
+  **triage the StopIteration pair first**: a PEP-479 conversion can mask a
+  real exhausted-iterator bug in production, and "possible real bug" outranks
+  every stale contract here.
+
+Per the 15512 precedent: attribute each cluster to its causing commit before
+adjusting any expectation, and treat "the test is old" as evidence about the
+test only after the product behaviour is confirmed intended.
+
+## Acceptance Criteria
+
+- [ ] The StopIteration pair is attributed (real bug vs test artifact) with evidence, before any contract is updated
+- [ ] Each cluster is attributed to its causing commit
+- [ ] Genuine product breaks are fixed rather than absorbed into expectations
+- [ ] The listed modules pass whole on dev

--- a/backlog/tasks/task-15791 - Sweep-inventory-console-and-destination-contract-drift.md
+++ b/backlog/tasks/task-15791 - Sweep-inventory-console-and-destination-contract-drift.md
@@ -1,0 +1,46 @@
+---
+id: TASK-15791
+title: 'Sweep inventory: console and destination contract drift (~38 tests)'
+status: To Do
+assignee: []
+labels:
+  - test-health
+  - console
+priority: medium
+---
+
+## Description
+
+From the task-15211 full-suite sweep (`Docs/Design/2026-08-13-tests-ui-sweep-inventory.md`,
+chunks 2-5, 15): console and destination-frame contract drift on dev:
+
+- 6x `test_console_staged_evidence_strip.py` assert `"Sources: N staged"`;
+  production's label lost the ` staged` suffix in `7dbbc401b` (2026-08-07,
+  TASK-2154). Decide which copy is right BEFORE updating either side.
+- 4x `test_console_shell_regions.py` size2 geometry; 2x rail width budget;
+  chip-swap `_swap_console_session_character()` signature drift; 4x
+  dictionary/world-info send-integration; tab-scope focus tour; citation
+  cache; composer collapse; live-work handoff retry.
+- ~9x `test_destination_visual_parity_correction.py` workbench contracts and
+  4x `test_workbench_visual_snapshots.py` — snapshot refresh needs a human
+  eye on the renders, not a blind re-record.
+- 4x `test_personas_generation_wiring.py`; settings batch
+  (`rag_profile_region` x3, `workspaces` x2, catalog toggle); singletons
+  (speech x2, schedules, navigation, responsiveness x2, watchlists
+  check-now, skills canvas, phase6 x2, recovery taxonomy).
+- 3x `product_maturity_phase1` "condition not met within 10s" — suspected
+  CONTENTION (four suites shared the machine); re-run alone before treating
+  as real.
+
+Also: chunk 12 recorded two teardown errors on the settings provider-Test
+button pair — check whether `settings_screen`'s endpoint-probe worker can
+outlive its test the way the LLM screen's Ollama probe did (fixed in #1596);
+if so, the same worker-lifetime + harness-seam remedy applies.
+
+## Acceptance Criteria
+
+- [ ] The Sources-staged copy question is decided (product vs tests) with the 7dbbc401b context, then applied consistently
+- [ ] The settings endpoint-probe teardown pair is attributed, and fixed with the #1596 pattern if it is the same class
+- [ ] The maturity-phase1 timeouts are re-run without contention before being treated as failures
+- [ ] Each remaining cluster is attributed to its causing commit; genuine breaks fixed, not absorbed
+- [ ] The listed modules pass whole on dev


### PR DESCRIPTION
## What

Closes **task-15211**: the full `Tests/UI` sweep under the network guard, attempted three times before and never finished — now complete. **10,811 passed / 117 failed rows** across all 503 modules, run as 16 checkpointed chunks against a frozen worktree.

Docs-only: the inventory (`Docs/Design/2026-08-13-tests-ui-sweep-inventory.md`), two filed cluster tasks (TASK-15790, TASK-15791), the task close-out, and a lessons entry.

## The task's question, answered

**One** distinct egress source in the entire suite: the Lab/LLM screen's Ollama probe (`127.0.0.1:11434`, teardown class) — found on chunk 5, fixed mid-sweep (#1596). The task-15111-era "tests POST real inference at a dev's llama.cpp" class did **not** reappear. One possible sibling (the settings provider-Test teardown pair) is flagged in TASK-15791 rather than assumed.

## Fixed and merged during the run

- **#1591** — four new unbounded background waits (the 14912 hang class), caught by the guard on chunk 0
- **#1596** — the probe; also cured the sweep's own chunk-5 **failure-to-exit** (summary printed, process never exits, two event loops parked in kevent) — confirmed by re-running the same 32 modules on post-fix dev: clean exit, zero egress. That failure mode is the best explanation for all three earlier monolithic attempts dying
- **#1603** — 35 task files whose lowercase `id:` frontmatter the maturity harness counts as no id

## Filed, with attribution

- **TASK-15790** — file-notes arcs left ~35 Library tests behind (color contract ×10, push copy ×3, notes focus/rows ×15, stragglers). The `StopIteration → RuntimeError` pair goes first: possibly a real bug, and "possible real bug" outranks every stale contract
- **TASK-15791** — console/destination drift ~38 tests (the `Sources: N staged` copy question from `7dbbc401b`, geometry/snapshot contracts, the probe-sibling check, contention-suspect maturity timeouts)

Frozen-tree residue of #1554/#1591/#1596 is recorded as residue, not re-filed. Negative result recorded for task-15741: the blank-note `ConflictError` did not reproduce anywhere in the full sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes Linear TASK-15211 by documenting the first complete `Tests/UI` sweep under the network guard and filing follow‑ups. This is a docs-only closeout that records sweep metrics, the single egress source found and fixed, attributed failures, and next actions.

- Adds `Docs/Design/2026-08-13-tests-ui-sweep-inventory.md` with 503-module sweep results (10,811 passed, 117 failed), the egress answer (only the Lab/LLM Ollama probe; fixed mid-sweep), attributed failure clusters, and notable negative results.
- Updates `backlog/docs/lessons-testing-evidence.md` with the checkpointed sweep method and exit-hang diagnosis.
- Marks `task-15211` as Done and files `TASK-15790` (Library file-notes clusters; prioritize StopIteration triage) and `TASK-15791` (console/destination drift and settings probe-sibling check).

**Reviewer focus**
- Confirm the inventory document captures the sweep scope, guard findings, and failure attribution clearly.
- Verify `task-15211` acceptance criteria are satisfied and that `TASK-15790`/`TASK-15791` cover remaining work.
- No runtime or test code changes; no rollout or migration required.

<sup>Written for commit bed4c8be5226d6785cd3f18bceb97a7150f94d84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

