### PR TITLE
test: lock Console decomposition Wave 6 inventory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -242,6 +244,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
@@ -324,6 +328,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: dev
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+++ b/Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
@@ -1,0 +1,251 @@
+# Console Decomposition Wave 6 Design
+
+**Status:** approved in conversation 2026-08-13; written review pending
+
+## Problem
+
+The one-way Console size ratchet is genuinely red on current `origin/dev`:
+
+- `tldw_chatbook/UI/Screens/chat_screen.py`: **22,204 lines** versus a **17,727**-line ceiling
+- `ChatScreen`: **699 methods** versus a **593**-method ceiling
+
+The overage is 4,477 lines and 106 methods. Raising either ceiling is forbidden by
+`Tests/Architecture/test_screen_size_ratchet.py`; it would erase the protection that
+the earlier decomposition waves established. This wave must earn a reduction by moving
+coherent ownership out of the screen.
+
+The growth is concentrated in three feature families added after wave 4:
+
+| Candidate family | Name-based measurement | Intended owner |
+|---|---:|---|
+| Image generation and MiniMax H3 image edits | 1,261 lines / 33 methods | `ConsoleImageController` |
+| Generated-video lifecycle, publication, playback, save and regeneration | 1,303 / 34 | `ConsoleVideoController` |
+| Conversation browser plus retrieval/RAG scope and execution | 2,286 / 81 before false-positive removal | `ConsoleConversationBrowserController` and `ConsoleRetrievalController` |
+
+The raw candidate total is 4,850 lines and 148 methods. Not every matched method may
+move: Textual handlers resolved by name stay defined on the screen, DOM work stays with
+the screen or a region widget, and false-positive name matches are excluded after source
+inspection. The implementation plan must therefore retain margin: if the honest movable
+set does not clear 4,477/106 after delegation overhead, the next coherent cluster is
+chosen by the same ownership rule rather than compressing code or raising the ratchet.
+
+## Existing Architecture
+
+This design is revision work under the already-approved screen decomposition contract:
+
+- `Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md`
+- `DESIGN.md` section 7
+- `tldw_chatbook/UI/Console_Modules/wiring.py`
+
+The existing rules remain binding:
+
+1. A region widget owns pixels; a controller owns non-DOM state and behaviour.
+2. `action_*`, `@on(...)`, and other Textual entry points stay defined on `ChatScreen`.
+   Their bodies may become short, mutation-tested delegations.
+3. Controllers do not use `query_one`; screen/region code passes data or named
+   operations through explicit callables.
+4. Dependencies are named, keyword-only constructor arguments wired as late-binding
+   callables in `UI/Console_Modules/wiring.py`.
+5. Cross-controller traffic uses those named callables, never a controller reaching
+   through the screen to a sibling controller.
+6. State formerly assignable on the screen retains read/write proxy compatibility.
+7. Existing worker group names, cancellation ownership, persistence ordering, and
+   remount/shutdown behaviour are preserved.
+
+No new ADR is required. ADR-like architecture is already canonical in the approved
+decomposition spec and `DESIGN.md`; this wave applies it.
+
+## Options Considered
+
+### 1. Strict controller/region extraction — chosen
+
+Move each coherent non-DOM feature family into one focused controller, keep Textual and
+DOM boundaries on the screen, and wire dependencies explicitly. This removes actual
+responsibilities and methods from `ChatScreen`, makes future image/video/RAG work land in
+the owning modules, and preserves the ratchet's meaning.
+
+### 2. Mixin relocation — rejected
+
+Moving methods into base classes would reduce the measured file but leave `ChatScreen`
+with implicit inherited responsibilities and hidden dependency access. It would satisfy
+the counter while defeating the ownership goal.
+
+### 3. Raise or reset the ratchet — rejected
+
+The current ceiling is intentionally one-way. Updating it upward would convert a hard
+architecture failure into accepted growth and contradict TASK-3070's acceptance criteria.
+
+## Component Boundaries
+
+### `ConsoleImageController`
+
+Owns the non-DOM image and H3 lifecycle:
+
+- transcript image-spec construction and remote-image extension/fetch
+- generation-card image projection and image request preparation
+- pending attachment resolution and image-generation session/message ownership
+- H3 reference snapshots, registry lookup, completion reconciliation, failure merge,
+  current-screen settlement, and registry-owned operation execution
+- generate-image command orchestration after the screen entry point has supplied any DOM
+  input
+
+The screen keeps:
+
+- `action_paste_clipboard_image`, because Textual resolves it by name
+- clipboard acquisition and any composer/widget mutation that directly touches DOM;
+  these become either short screen helpers or data passed into the controller
+- message-image save entry points required by external callers, as delegations when the
+  implementation is controller-owned
+
+The controller consumes explicit callables for session/store access, transcript/store
+sync, attachment snapshots, generation workers, status/control refresh, and app-owned H3
+registry access. It never queries the DOM.
+
+### `ConsoleVideoController`
+
+Owns generated-video lifecycle and publication:
+
+- per-session cancellation/in-flight state and video-store resolution
+- generation-card spec construction and stable storage identifiers
+- pending artifact ownership, publication gates, shielded task execution and drain
+- external-copy validation, precommit checks, publication, retry and save resolution
+- generation outcome persistence, playback/copy/regeneration orchestration, and stream
+  command preparation
+
+Pure path/stat/open helpers move with this controller. The screen keeps named Textual
+entry points and any modal/picker interaction that must touch the mounted app; those
+handlers pass immutable choices to the controller. The exact same cancellation event,
+worker group, storage identity, commit-before-cleanup order, and remount/shutdown drains
+must survive the move.
+
+### `ConsoleConversationBrowserController`
+
+Owns the browser's non-DOM data/state pipeline:
+
+- persisted, membership and native row acquisition
+- row filtering, identity, starring and merge rules
+- query token/timer/results/error state
+- background search computation and post-selection refresh
+- collapse/config state projection
+
+The existing `on_console_workspace_conversation_search_changed` handler stays on the
+screen and delegates after reading the input event. Focus operations and row rendering
+remain screen/region responsibilities. Existing workspace/session/message controllers
+are reached only through named callables wired at construction.
+
+### `ConsoleRetrievalController`
+
+Owns retrieval/RAG policy and execution that has no DOM:
+
+- staged-RAG capture and effective-scope resolution/cache warming
+- scope read/write, clear/save policy and picker input/output preparation
+- library-RAG request scope, execution, outcome application and degraded-state policy
+- auto-retrieve-on-send decisions and placeholder lifecycle
+- RAG source status, active dictionary/world-book scope derivation and summary inputs
+
+The screen keeps `@on`/`@work` entry points where Textual resolves them and any direct
+widget synchronization. Those become narrow delegates. Picker/modal presentation stays
+on the screen; the controller owns validation and state transitions around the returned
+choice.
+
+Conversation-browser and retrieval code are separate controllers because one owns
+conversation inventory/search state while the other owns retrieval policy and RAG
+execution. Combining them would create a 2,000-line generic "browser/RAG" bucket and
+hide their distinct invariants.
+
+## Data and Control Flow
+
+Each extraction follows the same shape:
+
+1. A Textual handler or command remains on `ChatScreen` when framework name resolution
+   requires it.
+2. The handler reads event/DOM values and passes plain values to its controller.
+3. The controller performs state transitions, persistence and asynchronous orchestration
+   using explicit dependencies.
+4. The controller returns a value or invokes a narrowly named screen callback for the
+   required UI refresh.
+5. The screen/region applies DOM changes.
+
+Controller construction is added to `build_console_controllers`. Construction order is
+not semantically load-bearing: every sibling dependency is late-bound. Controllers may
+retain stable app-owned service identities only when the existing binding contract
+already permits that snapshot and the constructor docstring records why.
+
+## Error, Cancellation and Privacy Contracts
+
+This is a behavior-preserving refactor. Existing public/sanitized error copy and
+metadata-only logging remain byte-equivalent unless a test proves that formatting must
+change solely because the owner module name changed.
+
+For image and video operations, cancellation is an ownership contract, not an
+implementation detail. The same event instance must flow from screen action through
+registry/task/worker/adapter; late outcomes must reconcile only onto the current matching
+screen/session/generation. Drains remain bounded and app shutdown still owns definitive
+cleanup.
+
+No attachment bytes, prompts, paths, message/session IDs, signed URLs, provider payloads
+or exception messages may be added to persistent diagnostics by the move.
+
+## Testing Strategy
+
+Every controller is characterized before extraction and moved in its own commit.
+
+### Cross-cutting architecture tests
+
+- controller modules contain no `query_one` or direct sibling-controller reach-through
+- screen entry points remain present with their decorators/binding names
+- worker group names and cancellation events are unchanged
+- baseline assignable screen attributes retain read/write proxies
+- import/re-export consumers in tests are repointed to defining modules before obsolete
+  screen imports are removed
+- AST ownership inventory proves moved methods are gone from `ChatScreen` except for
+  documented short delegations with real callers
+
+### Image/H3 evidence
+
+- generation actions/cards and mounted Console image tests
+- H3 lifecycle, cancellation, fresh-screen/remount and attachment-stash tests
+- mutation checks removing generation/session gates or current-screen settlement
+
+### Video evidence
+
+- Console generate/play/save/regenerate/stream tests
+- video-store, capacity, cancellation, publication and remount tests
+- exact container/storage identity and external-copy failure contracts
+
+### Browser/retrieval evidence
+
+- conversation browser search, grouping, selection, collapse and persistence tests
+- retrieval-scope picker, RAG scope, library RAG and auto-retrieve tests
+- real SQLite-backed scope/session tests where existing suites provide them
+
+### Final gates
+
+After the final rebase, measure actual lines/methods. The ratchet is lowered to the exact
+earned numbers; it is never raised. Run the complete relevant suites plus all
+architecture tests, Ruff, formatter, py_compile, privacy/diff checks, and the repository
+full suite required by the project DoD.
+
+## Delivery Sequence
+
+1. Commit characterization and ownership-map tests.
+2. Extract `ConsoleImageController`; verify and commit.
+3. Extract `ConsoleVideoController`; verify and commit.
+4. Extract `ConsoleConversationBrowserController`; verify and commit.
+5. Extract `ConsoleRetrievalController`; verify and commit.
+6. Rebase, measure, lower the ratchet, update the canonical decomposition progress and
+   TASK-3070 notes, then run final verification.
+
+If any extraction's honest boundary yields too little reduction, stop and revise the
+plan before choosing another cluster. Do not widen a controller merely to chase line
+count.
+
+## Success Criteria
+
+- The current screen-size and method-count ratchet passes without increasing either
+  budget.
+- `ChatScreen` loses at least 4,477 lines and 106 methods relative to the final rebased
+  starting measurement, accounting for delegation overhead.
+- Image/H3, video, conversation-browser and retrieval/RAG behavior is unchanged.
+- New work in these families has an obvious owner under `UI/Console_Modules/`.
+- All automated, static, privacy, cancellation, persistence and lifecycle gates pass.

--- a/Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+++ b/Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
@@ -1,33 +1,51 @@
 # Console Decomposition Wave 6 Design
 
-**Status:** approved in conversation 2026-08-13; written review pending
+**Status:** approved after written spec and quality review 2026-08-13
 
 ## Problem
 
 The one-way Console size ratchet is genuinely red on current `origin/dev`:
 
-- `tldw_chatbook/UI/Screens/chat_screen.py`: **22,204 lines** versus a **17,727**-line ceiling
-- `ChatScreen`: **699 methods** versus a **593**-method ceiling
+- `tldw_chatbook/UI/Screens/chat_screen.py`: **22,338 lines** versus a **17,727**-line ceiling
+- `ChatScreen`: **705 methods** versus a **593**-method ceiling
 
-The overage is 4,477 lines and 106 methods. Raising either ceiling is forbidden by
+TASK-3070.1 records implementation base
+`bed39af6b004e4db86218fad01d2ea515b332135`. The rebase added unrelated continuation,
+provider, and configuration work to `ChatScreen`, but every reviewed Wave 6 definition
+and its aggregate source span remains unchanged from the originally reviewed inventory.
+
+The overage is 4,611 lines and 112 methods. Raising either ceiling is forbidden by
 `Tests/Architecture/test_screen_size_ratchet.py`; it would erase the protection that
 the earlier decomposition waves established. This wave must earn a reduction by moving
 coherent ownership out of the screen.
 
-The growth is concentrated in three feature families added after wave 4:
+The first draft used name matching and four controllers. Review rejected that arithmetic:
+the four honest clusters contained only 4,415 method-body lines before delegation
+overhead, and their framework entry points would leave too little method-count margin.
+The amended design uses a source-inspected move/stay inventory: five independently
+testable new controllers plus one coherent extension of the existing Workspace
+controller.
 
-| Candidate family | Name-based measurement | Intended owner |
-|---|---:|---|
-| Image generation and MiniMax H3 image edits | 1,261 lines / 33 methods | `ConsoleImageController` |
-| Generated-video lifecycle, publication, playback, save and regeneration | 1,303 / 34 | `ConsoleVideoController` |
-| Conversation browser plus retrieval/RAG scope and execution | 2,286 / 81 before false-positive removal | `ConsoleConversationBrowserController` and `ConsoleRetrievalController` |
+| Controller | Inspected candidate bodies | Screen residue budget | Projected net line reduction | Projected method reduction |
+|---|---:|---:|---:|---:|
+| `ConsoleImageController` | 1,335 / 31 methods | at most 79 lines / 6 definitions | at least 1,256 | 25 |
+| `ConsoleVideoController` | 1,292 / 33 | at most 10 / 2 | at least 1,282 | 31 |
+| `ConsoleWorkspaceController` browser extension | 912 / 21 | at most 5 lines / 1 definition | at least 907 | 20 |
+| `ConsoleRetrievalController` | 992 / 34 | at most 10 / 2 | at least 982 | 32 |
+| `ConsoleSkillController` plus dead-path removal | 339 / 16 | at most 15 / 3 | at least 324 | 13 |
+| `ConsoleCharacterController` | 281 / 8 | 0 / 0 | 281 | 8 |
+| Compatibility descriptors | 0 / 0 | at most 64 lines / 0 methods | -64 | 0 |
+| **Total** | **5,151 / 143** | **at most 183 / 14** | **at least 4,968** | **129** |
 
-The raw candidate total is 4,850 lines and 148 methods. Not every matched method may
-move: Textual handlers resolved by name stay defined on the screen, DOM work stays with
-the screen or a region widget, and false-positive name matches are excluded after source
-inspection. The implementation plan must therefore retain margin: if the honest movable
-set does not clear 4,477/106 after delegation overhead, the next coherent cluster is
-chosen by the same ownership rule rather than compressing code or raising the ratchet.
+Production screen consumers are rewired to the owning controller, while every moved
+plain assignable screen attribute is preserved through one small reusable module-level
+read/write descriptor class plus explicit class assignments (31 attributes, budgeted
+as at most 64 physical lines and zero direct `ChatScreen` methods). The projected method
+reduction is therefore 129, 17 methods beyond the required 112, and the line projection
+has 357 lines of margin. If characterization discovers another baseline plain
+attribute, it must add the descriptor assignment and revalidate both margins before
+production extraction. If either margin no longer clears, implementation stops for
+another design review; no cluster is widened and no budget is raised.
 
 ## Existing Architecture
 
@@ -40,212 +58,433 @@ This design is revision work under the already-approved screen decomposition con
 The existing rules remain binding:
 
 1. A region widget owns pixels; a controller owns non-DOM state and behaviour.
-2. `action_*`, `@on(...)`, and other Textual entry points stay defined on `ChatScreen`.
-   Their bodies may become short, mutation-tested delegations.
+2. `action_*`, `@on(...)`, `@work(...)`, and command-dispatch names stay defined on
+   `ChatScreen` when Textual or the command registry resolves them there. Their bodies
+   become short, mutation-tested delegations.
 3. Controllers do not use `query_one`; screen/region code passes data or named
    operations through explicit callables.
 4. Dependencies are named, keyword-only constructor arguments wired as late-binding
    callables in `UI/Console_Modules/wiring.py`.
 5. Cross-controller traffic uses those named callables, never a controller reaching
    through the screen to a sibling controller.
-6. State formerly assignable on the screen retains read/write proxy compatibility.
+6. Every state name that was a plain assignable screen attribute retains read/write
+   proxy compatibility, whether or not the current caller scan observes an assignment.
 7. Existing worker group names, cancellation ownership, persistence ordering, and
    remount/shutdown behaviour are preserved.
 
-No new ADR is required. ADR-like architecture is already canonical in the approved
-decomposition spec and `DESIGN.md`; this wave applies it.
+No new ADR is required. The approved decomposition spec and `DESIGN.md` already govern
+this module boundary; this wave applies them without changing a runtime, storage,
+security, or service contract.
+
+Wave 6 implements the canonical baseline-attribute rule with a small module-level
+descriptor class rather than two direct `ChatScreen` methods per field. The descriptor
+stores only two explicit constructor names (owning controller and target state), so its
+`__get__`/`__set__` implementation and 31 one-line assignments fit a conservative
+64-line budget without generated methods or closure factories. Each assignment reads/writes
+the named controller attribute and raises `RuntimeError` if accessed before that
+controller exists; setters never create shadow screen state. All moved defaults are
+initialized by their controller, and the corresponding `ChatScreen.__init__`
+assignments are removed rather than routed through a controller that is not built yet.
+This compatibility begins after `build_console_controllers` returns. A getter or setter
+before its owning controller exists raises `RuntimeError`; focused `__new__` fixtures
+must construct the owning controller before assigning an override.
+The screen owner names are fixed as `_image`, `_video`, `_workspace`, `_retrieval`,
+`_skill`, and `_character`; descriptor families may land independently with their
+owning extraction, but every family lands all of its descriptors and defaults together.
 
 ## Options Considered
 
 ### 1. Strict controller/region extraction — chosen
 
 Move each coherent non-DOM feature family into one focused controller, keep Textual and
-DOM boundaries on the screen, and wire dependencies explicitly. This removes actual
-responsibilities and methods from `ChatScreen`, makes future image/video/RAG work land in
-the owning modules, and preserves the ratchet's meaning.
+DOM boundaries on the screen or existing region widget, and wire dependencies
+explicitly. This removes actual responsibilities and gives new work an obvious owner.
 
 ### 2. Mixin relocation — rejected
 
-Moving methods into base classes would reduce the measured file but leave `ChatScreen`
-with implicit inherited responsibilities and hidden dependency access. It would satisfy
-the counter while defeating the ownership goal.
+Mixins reduce the measured file while leaving implicit inherited responsibilities and
+hidden dependency access. They satisfy the counter but not the ownership goal.
 
 ### 3. Raise or reset the ratchet — rejected
 
 The current ceiling is intentionally one-way. Updating it upward would convert a hard
-architecture failure into accepted growth and contradict TASK-3070's acceptance criteria.
+architecture failure into accepted growth.
 
 ## Component Boundaries
 
 ### `ConsoleImageController`
 
-Owns the non-DOM image and H3 lifecycle:
+Owns transcript/generation image projections, remote image retrieval, generation-card
+state, H3 reference snapshots and registry lifecycle, completion reconciliation,
+failure merging, current-screen settlement, and generate/regenerate/select/keep
+orchestration. Ordinary image generation retains its existing behaviour: it has no
+shared cancellation event today, and this refactor must not invent one.
 
-- transcript image-spec construction and remote-image extension/fetch
-- generation-card image projection and image request preparation
-- pending attachment resolution and image-generation session/message ownership
-- H3 reference snapshots, registry lookup, completion reconciliation, failure merge,
-  current-screen settlement, and registry-owned operation execution
-- generate-image command orchestration after the screen entry point has supplied any DOM
-  input
-
-The screen keeps:
-
-- `action_paste_clipboard_image`, because Textual resolves it by name
-- clipboard acquisition and any composer/widget mutation that directly touches DOM;
-  these become either short screen helpers or data passed into the controller
-- message-image save entry points required by external callers, as delegations when the
-  implementation is controller-owned
-
-The controller consumes explicit callables for session/store access, transcript/store
-sync, attachment snapshots, generation workers, status/control refresh, and app-owned H3
-registry access. It never queries the DOM.
+H3 keeps the exact existing cancellation-event identity from screen action through
+registry/task/worker/adapter. The screen keeps the image-view DOM constructor, picker
+presentation, composer/image preparation, command-palette paste, and modal launch.
+`ConsoleMessageController` receives late-bound callables directly to this controller
+for regenerate/select/keep/toggle; those calls do not detour through screen methods.
 
 ### `ConsoleVideoController`
 
-Owns generated-video lifecycle and publication:
+Owns in-flight/cancellation state, video-store resolution, card specs and storage IDs,
+pending artifacts, publication gates, shielded execution/drain, external-copy
+validation and publication, outcome persistence, and generate/play/save/regenerate/
+stream orchestration.
 
-- per-session cancellation/in-flight state and video-store resolution
-- generation-card spec construction and stable storage identifiers
-- pending artifact ownership, publication gates, shielded task execution and drain
-- external-copy validation, precommit checks, publication, retry and save resolution
-- generation outcome persistence, playback/copy/regeneration orchestration, and stream
-  command preparation
+The controller resolves and validates a presentation request. The screen retains the
+actual Textual modal/picker presentation and OS-player launch behind named callbacks;
+the controller does not call `app.push_screen`, `query_one`, or OS launch APIs. Video
+keeps the exact cancellation event, worker group, storage identity,
+commit-before-cleanup order, and remount/shutdown drains.
+`ConsoleMessageController` receives direct late-bound controller callables for
+play/save/regenerate; its existing missing video-regenerate dependency is added in this
+wave rather than routing that action through `ChatScreen`.
 
-Pure path/stat/open helpers move with this controller. The screen keeps named Textual
-entry points and any modal/picker interaction that must touch the mounted app; those
-handlers pass immutable choices to the controller. The exact same cancellation event,
-worker group, storage identity, commit-before-cleanup order, and remount/shutdown drains
-must survive the move.
+### `ConsoleWorkspaceController` conversation-browser extension
 
-### `ConsoleConversationBrowserController`
+Owns conversation row acquisition, identity/filter/star/merge rules, persisted-row
+cache, query token/timer/results/error state, background search, and post-selection
+refresh.
 
-Owns the browser's non-DOM data/state pipeline:
-
-- persisted, membership and native row acquisition
-- row filtering, identity, starring and merge rules
-- query token/timer/results/error state
-- background search computation and post-selection refresh
-- collapse/config state projection
-
-The existing `on_console_workspace_conversation_search_changed` handler stays on the
-screen and delegates after reading the input event. Focus operations and row rendering
-remain screen/region responsibilities. Existing workspace/session/message controllers
-are reached only through named callables wired at construction.
+`ConsoleWorkspaceController` already owns grouped-browser collapse preferences,
+configuration, workspace activation/resume, the two toggle operations, and the legacy
+conversation-search state. Extending that controller gives the whole browser lifecycle
+one owner instead of creating a second query/timer/token/results authority plus a
+mirror seam. The newer `_console_conversation_browser_*` compatibility names and the
+existing `_console_workspace_conversation_*` scalar compatibility names become aliases
+over the same Workspace-owned canonical query/timer/token/total/error state;
+persisted-row cache state also moves there. Rows have one canonical rich representation:
+`tuple[ConsoleConversationBrowserInputRow, ...]`. The legacy
+`_console_workspace_conversation_search_rows` getter projects rich rows into
+`ConsoleWorkspaceConversationRow`; its compatibility setter converts legacy rows into
+bounded rich rows with explicit default metadata. The legacy Workspace refresh and
+after-selection implementations are retired in favor of the canonical rich-row
+pipeline, so no second writer can change the stored runtime row type. No
+controller-to-controller browser mirror exists. The existing search event handler
+stays on the screen as a delegate, and existing Workspace tests gain isolated no-mount
+coverage for the added browser transitions and both projection directions.
 
 ### `ConsoleRetrievalController`
 
-Owns retrieval/RAG policy and execution that has no DOM:
+Owns staged-RAG capture, effective-scope resolution/cache warming, scope read/write and
+save policy, picker input/output validation, library-RAG request execution and outcome
+policy, auto-retrieve-on-send decisions, both dictionary and world-book cached summary
+projections/actions, and degraded/placeholder state.
 
-- staged-RAG capture and effective-scope resolution/cache warming
-- scope read/write, clear/save policy and picker input/output preparation
-- library-RAG request scope, execution, outcome application and degraded-state policy
-- auto-retrieve-on-send decisions and placeholder lifecycle
-- RAG source status, active dictionary/world-book scope derivation and summary inputs
+The screen retains decorated `@work` entry points and direct widget synchronization.
+Picker/modal presentation stays screen-owned; the controller accepts/returns plain
+values and invokes narrowly named refresh/notification callbacks.
 
-The screen keeps `@on`/`@work` entry points where Textual resolves them and any direct
-widget synchronization. Those become narrow delegates. Picker/modal presentation stays
-on the screen; the controller owns validation and state transitions around the returned
-choice.
+### `ConsoleSkillController`
 
-Conversation-browser and retrieval code are separate controllers because one owns
-conversation inventory/search state while the other owns retrieval policy and RAG
-execution. Combining them would create a 2,000-line generic "browser/RAG" bucket and
-hide their distinct invariants.
+Owns skill-context retrieval, trusted/blocked candidate projection, blocked-match
+policy, refusal-row construction, and pending install/script state. The live
+command-registry name and two Textual decision handlers stay as short screen delegates.
+
+Source review found that the fallback resolver has no registered producer and the
+picker chain is intentionally unreachable. Wave 6 deletes that dead surface instead of
+giving it a new owner: the `KIND_FALLBACK` dispatch branch,
+`_console_command_run_skill`, `_console_skill_search`,
+`_run_resolved_console_skill`, `_open_console_skill_picker`, the unused picker widget,
+its CSS selectors/cross-references, its stale mentions in the resolver/style-picker
+source and style-picker tests, and their now-obsolete focused tests/imports. Live
+`/skills`, `$name` substitution, blocked/refusal handling, candidate refresh, and
+install/script decisions remain and move as described.
+
+### `ConsoleCharacterController`
+
+Owns picker-option projection, character handoff/session choice policy, active
+conversation/character identity, card/avatar byte retrieval, and avatar refresh
+decision/state. The screen and `ConsoleLeftRail` keep modal presentation and avatar DOM
+rendering. `_refresh_active_character_avatar_if_scope_changed` is split: controller
+computes whether/what to refresh, and a screen/region callback applies the pixels.
+
+## Source-Inspected Ownership Inventory
+
+Legend: **M** removes the `ChatScreen` definition and rewires production callers
+directly to the controller; **D** moves the body but keeps a framework-required screen
+delegate whose complete AST definition span (`end_lineno - lineno + 1`, decorators
+excluded) is at most five physical source lines; **S** stays screen/region-owned and is
+included only in the residue budget, not claimed as an extracted method.
+
+### Image/H3
+
+**M (25):** `_build_console_image_specs`, `_extend_specs_with_remote_images`,
+`_fetch_remote_transcript_image`, `_build_generation_card_specs`,
+`_pending_console_generation_card_images`, `_console_imagegen_inflight_sessions`,
+`_console_imagegen_inflight_message_ids`, `_console_generate_image_conversation_pairs`,
+`_console_generate_image_llm_context_options`, `_h3_image_edit_registry`,
+`_h3_reference_snapshot`, `_h3_reference_from_snapshot`,
+`_filter_h3_attachment_from_app_stash`, `_h3_origin_screen_is_live`,
+`_cleanup_h3_completion_in_store`, `_reconcile_h3_image_edit_completions`,
+`_merge_h3_failure_notice_in_store`, `_settle_current_h3_outcome`,
+`_schedule_current_h3_settlement`, `_append_h3_image_edit_error`,
+`_run_h3_image_edit_command`, `_regenerate_console_generation_variant`,
+`_select_console_generation_variant`, `_keep_console_generation_variant`, and
+`_handle_console_toggle_image_view`.
+
+**D (1):** `_console_command_generate_image`, retained because the command registry
+resolves the handler on the screen.
+
+**S (5):** `_ensure_console_image_view`, `_console_generation_browse`,
+`_prep_console_images`, `_open_console_generate_image_modal`, and
+`_paste_console_generate_image_command`.
+
+### Video
+
+**M (31):** `_console_videogen_inflight_sessions`,
+`_console_videogen_cancel_events`, `_ensure_console_video_store`,
+`_build_video_card_specs`, `_video_storage_message_id`,
+`_pending_console_video_artifacts`, `_owns_pending_console_video`,
+`_close_pending_console_video`, `_register_console_video_publication_gate`,
+`_release_console_video_publication_gate`, `_begin_pending_console_video_operation`,
+`_end_pending_console_video_operation`, `_await_shielded_console_video_task`,
+`_run_pending_console_video_operation`, `_run_console_video_generation_operation`,
+`_drain_pending_console_videos`, `_external_video_target_identity`,
+`_external_video_stat_identity`, `_external_video_cleanup_identity`,
+`_external_video_parent_identity`, `_require_external_video_pinned_capabilities`,
+`_external_video_precommit_check`, `_copy_pending_video_external`,
+`_retry_pending_console_video`, `_save_pending_console_video_external`,
+`_normalize_pending_video_target`, `_resolve_generated_video_outcome`,
+`_persist_generated_video_tuple`, `_play_console_video`,
+`_save_console_video_copy`, and `_regenerate_console_video_message`.
+
+**D (2):** `_console_command_generate_video` and `_console_command_stream_video`,
+retained because the command registry resolves them on the screen.
+
+**S:** `_open_video_with_os` and `_wait_for_console_screen_result`; they are presentation
+seams and are not counted in the 1,292 candidate lines.
+
+### Conversation browser
+
+**M (20):** `_start_console_conversation_browser_search`,
+`_console_browser_row_key`, `_console_browser_row_scope_copy`,
+`_console_browser_row_matches_query`, `_filter_console_browser_rows_for_query`,
+`_find_console_browser_row`, `_console_browser_display_identity`,
+`_starred_console_conversation_ids`, `_apply_console_browser_star_state`,
+`_native_console_browser_rows`, `_membership_console_browser_rows`,
+`_persisted_console_browser_rows`, `_invalidate_console_persisted_rows_cache`,
+`_sync_persisted_console_browser_rows`, `_compute_persisted_console_browser_rows`,
+`_merge_console_browser_rows`, `_current_console_browser_rows`,
+`_refresh_console_conversation_browser_search`,
+`_refresh_console_conversation_browser_after_selection`, and
+`_with_console_conversation_browser_state`. The screen's existing decorated input
+handler arms the timer with a late-bound controller callback directly.
+
+**D (1):** `on_console_workspace_conversation_search_changed` retains its `@on`
+decorator, extracts the event's plain query/disabled state, and delegates the transition
+to the controller within the five-line physical-span limit.
+
+**S:** none. Collapse/config helpers and toggle operations already belong to Workspace
+and remain there; they are not part of the 912-line screen-removal inventory.
+
+### Retrieval/RAG
+
+**M (32):** `_capture_console_staged_rag`, `_build_console_retrieval_scope_state`,
+`_console_retrieval_scope_run_recipe_count`, `_resolve_console_effective_scope_state`,
+`_refresh_console_effective_scope_and_sync`,
+`_warm_console_effective_scope_cache_if_stale`, `_read_console_retrieval_scope`,
+`_write_console_retrieval_scope`, `_console_scope_picker_listers`,
+`_apply_console_retrieval_scope_save`, `_console_rag_source_status`,
+`_active_console_dictionary_scope_ids`,
+`_refresh_active_dictionaries_summary_if_scope_changed`,
+`refresh_active_dictionaries_summary`, `_active_console_world_book_scope_ids`,
+`refresh_active_world_books_summary`,
+`_refresh_active_world_books_summary_if_scope_changed`,
+`_console_dictionary_inspector_rows`, `_console_world_book_inspector_rows`,
+`_console_dictionary_inspector_actions`, `_console_world_book_inspector_actions`,
+`_console_library_rag_scope_label`, `_stage_console_library_rag_launch`,
+`_maybe_auto_retrieve_for_send`, `_apply_console_rag_settings_choice`,
+`_resolve_console_library_rag_scope`, `_apply_console_library_rag_search_outcome`,
+`_rag_service_still_initializing`, `_notify_console_auto_rag_scope_empty`,
+`_notify_auto_rag_degraded`, `_notify_console_auto_rag`, and
+`_clear_console_auto_rag_placeholder`.
+
+**D (2):** `_persist_console_rag_auto_retrieve_on_send` and
+`_execute_console_library_rag_search` retain their `@work` decorators and worker groups.
+
+**S:** picker/modal handlers and direct DOM sync methods, including
+`_sync_console_retrieval_scope_row`, `_open_console_retrieval_scope_picker`,
+`_set_console_library_rag_source_scope`, and the decorated button/input handlers.
+
+### Skills
+
+**M (9):** `_fetch_console_skill_context`,
+`_console_skill_trusted_candidates_from_context`, `_console_skill_blocked_summaries`,
+`_refresh_console_skill_candidates`, `_split_console_skill_name_args`,
+`_console_skill_blocked_match_response`, `_append_skill_refuse_row`,
+`_set_console_pending_skill_install`, and `_set_console_pending_skill_script`.
+
+**D (3):** `_console_command_skills`,
+`handle_console_skill_install_decided`, and `handle_console_skill_script_decided`.
+The live registered command and decision paths call the controller directly; no screen
+fallback method is retained.
+
+**X — deleted as unreachable (4):** `_console_skill_search`,
+`_console_command_run_skill`, `_run_resolved_console_skill`, and
+`_open_console_skill_picker`, plus the dispatcher branch and picker module that only
+supported them.
+
+### Character
+
+**M (8):** `_console_character_picker_options`,
+`_current_console_rail_conversation_id`, `_current_console_rail_character_id`,
+`_current_console_rail_character_name`, `_fetch_character_card_for_avatar`,
+`_fetch_expression_image_bytes`, `_apply_console_character_choice_async`, and
+`_refresh_active_character_avatar_if_scope_changed`. Existing screen callers and the
+picker callback invoke the controller directly; the controller uses a named screen/
+region callback only for the final pixel application.
+
+## Baseline Attribute Compatibility Inventory
+
+The following 31 names require assignable `ChatScreen` compatibility on the
+implementation base. Thirty are discovered from plain `self.<name>` assignments (some
+lazy); `_console_video_store` is the one additional externally written test-override
+seam, read through `getattr` in production but assigned by focused video tests. Defaults
+move into the owning controller and `ChatScreen` retains an explicit read/write
+descriptor assignment for every name:
+
+- Image (3): `_imagegen_inflight_sessions`, `_imagegen_inflight_message_ids`,
+  `_console_h3_ui_generations`.
+- Video (8): `_console_videogen_inflight`, `_console_videogen_cancels`,
+  `_console_video_store`, `_pending_video_artifacts`,
+  `_pending_video_artifacts_closed`, `_pending_video_operation_cancels`,
+  `_pending_video_active_operations`, `_pending_video_deferred_closes`.
+- Conversation browser (9): `_console_persisted_rows_cache`,
+  `_console_persisted_rows_cache_key`, `_console_persisted_rows_cache_at`,
+  `_console_conversation_browser_query`,
+  `_console_conversation_browser_search_timer`,
+  `_console_conversation_browser_search_token`, `_console_conversation_browser_rows`,
+  `_console_conversation_browser_total`, `_console_conversation_browser_error`.
+- Retrieval (6): `_console_retrieval_scope_cache`, `_console_effective_scope_cache`,
+  `_active_dictionaries_summary`, `_last_console_dictionary_scope_ids`,
+  `_active_world_books_summary`, `_last_console_world_book_scope_ids`.
+- Skills (1): `_console_skill_candidates`.
+- Character (4): `_active_character_avatar`, `_active_character_avatar_name`,
+  `_last_console_avatar_scope`, `_console_expression_spec_cache`.
+
+An AST baseline test compares the 30-name assignment subset to plain `self.<name>`
+assignments on the recorded implementation base. A separate caller/source assertion
+locks `_console_video_store` as the explicit external-write override seam. Both tests
+prove every current class assignment is a read/write descriptor targeting the correct
+controller/name pair. Characterization also proves all controller defaults exist before
+the first post-construction read; both descriptor reads and writes raise `RuntimeError`
+before the owning controller exists; `getattr(screen, name, default)` and
+`hasattr(screen, name)` cannot hide that missing controller because it never raises
+`AttributeError`; and the external `_console_video_store` override remains writable
+after construction. Existing `ChatScreen.__new__` fixtures that assign controller state
+must construct or directly target the owning controller first. Descriptor getter/setter
+mutations must fail these tests; shadow attributes are forbidden.
 
 ## Data and Control Flow
 
-Each extraction follows the same shape:
-
-1. A Textual handler or command remains on `ChatScreen` when framework name resolution
-   requires it.
+1. A Textual handler or registered command remains on `ChatScreen` when framework name
+   resolution requires it.
 2. The handler reads event/DOM values and passes plain values to its controller.
-3. The controller performs state transitions, persistence and asynchronous orchestration
-   using explicit dependencies.
-4. The controller returns a value or invokes a narrowly named screen callback for the
-   required UI refresh.
-5. The screen/region applies DOM changes.
+3. The controller performs state transitions, persistence, and async orchestration
+   through explicit dependencies.
+4. The controller returns a value or invokes a narrowly named screen callback.
+5. The screen or existing region widget applies DOM/presentation changes.
 
-Controller construction is added to `build_console_controllers`. Construction order is
-not semantically load-bearing: every sibling dependency is late-bound. Controllers may
-retain stable app-owned service identities only when the existing binding contract
-already permits that snapshot and the constructor docstring records why.
+Construction for the five new controllers is added to `build_console_controllers`; the
+existing Workspace construction receives the added browser dependencies and state.
+Construction order is not semantically load-bearing: sibling dependencies are
+late-bound callables.
 
 ## Error, Cancellation and Privacy Contracts
 
-This is a behavior-preserving refactor. Existing public/sanitized error copy and
-metadata-only logging remain byte-equivalent unless a test proves that formatting must
-change solely because the owner module name changed.
+This is a behaviour-preserving refactor. Public/sanitized error copy and metadata-only
+logging remain byte-equivalent unless a focused test requires an owner-name-only change.
 
-For image and video operations, cancellation is an ownership contract, not an
-implementation detail. The same event instance must flow from screen action through
-registry/task/worker/adapter; late outcomes must reconcile only onto the current matching
-screen/session/generation. Drains remain bounded and app shutdown still owns definitive
-cleanup.
+The exact same cancellation event applies to H3 image edits and generated-video
+operations only. Ordinary image generation has no such event and remains non-cancellable.
+Late outcomes reconcile only onto the current matching screen/session/generation;
+drains remain bounded and app shutdown keeps definitive ownership.
 
-No attachment bytes, prompts, paths, message/session IDs, signed URLs, provider payloads
-or exception messages may be added to persistent diagnostics by the move.
+No attachment bytes, prompts, paths, message/session IDs, signed URLs, provider
+payloads, or exception messages may be added to persistent diagnostics.
 
 ## Testing Strategy
 
-Every controller is characterized before extraction and moved in its own commit.
+Every controller family is characterized before extraction and moved in its own child
+PR.
+
+### Isolated controller tests
+
+Each new controller gets a dedicated unit test module that constructs it with plain
+fakes/call recorders and **does not mount a Textual app or screen**. The Workspace
+browser extension adds the equivalent cases to the existing Workspace controller unit
+module. These tests prove state transitions, dependency ordering, error containment,
+and each controller's primary async/cancellation seam. Mounted tests remain for DOM
+integration only.
 
 ### Cross-cutting architecture tests
 
-- controller modules contain no `query_one` or direct sibling-controller reach-through
-- screen entry points remain present with their decorators/binding names
-- worker group names and cancellation events are unchanged
-- baseline assignable screen attributes retain read/write proxies
-- import/re-export consumers in tests are repointed to defining modules before obsolete
-  screen imports are removed
-- AST ownership inventory proves moved methods are gone from `ChatScreen` except for
-  documented short delegations with real callers
+- AST inspection rejects any call whose attribute name is `query_one` inside the five
+  new controllers or the moved Workspace browser methods; this is structural, not a
+  substring check.
+- AST ownership inventory proves every **M** method is absent from `ChatScreen` and every
+  **D** method has a complete definition span of at most five physical lines, excluding
+  decorator lines, with a real framework/registry caller.
+- screen entry points retain decorators/binding names and worker groups
+- recorded baseline evidence determines the complete compatibility inventory: the
+  30-name assignment AST plus the explicit `_console_video_store` caller/source
+  assertion; later caller scans may add integration tests but never remove a proxy
+- controller imports are repointed to defining modules; no screen re-export is added
+- named dependency tests reject direct sibling-controller reach-through
 
-### Image/H3 evidence
+### Product-boundary evidence
 
-- generation actions/cards and mounted Console image tests
-- H3 lifecycle, cancellation, fresh-screen/remount and attachment-stash tests
-- mutation checks removing generation/session gates or current-screen settlement
+- Image/H3: generation actions/cards, mounted image flow, H3 cancellation,
+  fresh-screen/remount, and attachment-stash tests.
+- Video: generate/play/save/regenerate/stream, store/capacity/publication/cancellation,
+  remount, container identity, and external-copy failure tests.
+- Browser/retrieval: search/group/select/persistence, scope picker, library RAG,
+  auto-retrieve, and existing real-SQLite scope/session cases.
+- Skills/character: live `/skills` and `$name` routing, trust/block/install/script
+  decisions, absence of the dead skill-picker surface, character picker/prompt
+  seed/handoff, avatar refresh, and rail rendering.
 
-### Video evidence
-
-- Console generate/play/save/regenerate/stream tests
-- video-store, capacity, cancellation, publication and remount tests
-- exact container/storage identity and external-copy failure contracts
-
-### Browser/retrieval evidence
-
-- conversation browser search, grouping, selection, collapse and persistence tests
-- retrieval-scope picker, RAG scope, library RAG and auto-retrieve tests
-- real SQLite-backed scope/session tests where existing suites provide them
+Required mutation checks remove each screen delegate, cross-session/generation gate,
+shared cancellation-event handoff, persistence-before-cleanup step, and unified
+Workspace browser-state alias one at a time.
 
 ### Final gates
 
-After the final rebase, measure actual lines/methods. The ratchet is lowered to the exact
-earned numbers; it is never raised. Run the complete relevant suites plus all
-architecture tests, Ruff, formatter, py_compile, privacy/diff checks, and the repository
-full suite required by the project DoD.
+After the final rebase, measure actual lines/methods. Lower the ratchet to the exact
+earned values; never raise it. Run focused and mounted product suites, all architecture
+tests, Ruff, formatter, isolated `py_compile`, privacy/diff checks, and the full repository
+suite required by the project DoD.
 
-## Delivery Sequence
+## Atomic Delivery
 
-1. Commit characterization and ownership-map tests.
-2. Extract `ConsoleImageController`; verify and commit.
-3. Extract `ConsoleVideoController`; verify and commit.
-4. Extract `ConsoleConversationBrowserController`; verify and commit.
-5. Extract `ConsoleRetrievalController`; verify and commit.
-6. Rebase, measure, lower the ratchet, update the canonical decomposition progress and
-   TASK-3070 notes, then run final verification.
+TASK-3070 is the coordinated wave. Its child tasks are atomic and independently
+reviewable:
 
-If any extraction's honest boundary yields too little reduction, stop and revise the
-plan before choosing another cluster. Do not widen a controller merely to chase line
-count.
+1. TASK-3070.1 characterizes and locks the ownership/ratchet inventory.
+2. TASK-3070.2 extracts image/H3.
+3. TASK-3070.3 extracts video.
+4. TASK-3070.4 consolidates the conversation browser into Workspace.
+5. TASK-3070.5 extracts retrieval/RAG.
+6. TASK-3070.6 extracts skills.
+7. TASK-3070.7 extracts character policy/avatar state.
+8. TASK-3070.8 rebases, lowers the ratchet, updates canonical progress, and
+   closes the parent.
+
+Each child is delivered as one atomic PR and must return its focused gate to green
+before it is reviewed and merged. TASK-3070.2 through TASK-3070.7 branch from the latest
+`dev` only after their predecessor PR merges; TASK-3070.8 is the final rebase/ratchet/
+closeout PR after every extraction predecessor lands. Commits inside a child PR remain
+focused on that child. If a rebase changes the inventory enough to invalidate the
+projection, stop and amend this design before implementation.
 
 ## Success Criteria
 
-- The current screen-size and method-count ratchet passes without increasing either
-  budget.
-- `ChatScreen` loses at least 4,477 lines and 106 methods relative to the final rebased
-  starting measurement, accounting for delegation overhead.
-- Image/H3, video, conversation-browser and retrieval/RAG behavior is unchanged.
-- New work in these families has an obvious owner under `UI/Console_Modules/`.
-- All automated, static, privacy, cancellation, persistence and lifecycle gates pass.
+- The size and method ratchets pass without increasing either budget.
+- Relative to the final rebased starting measurement, `ChatScreen` loses at least the
+  exact overage in both dimensions, with the ratchet lowered to the earned result.
+- Image/H3, video, browser, retrieval, skill, and character behaviour is unchanged.
+- Each family has an obvious non-DOM owner and isolated no-mount unit tests.
+- All automated, static, privacy, cancellation, persistence, and lifecycle gates pass.

--- a/Tests/Architecture/test_console_wave6_inventory.py
+++ b/Tests/Architecture/test_console_wave6_inventory.py
@@ -1,0 +1,1020 @@
+"""Architecture evidence for Console decomposition Wave 6 (TASK-3070.1)."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCREEN_PATH = _REPO_ROOT / "tldw_chatbook/UI/Screens/chat_screen.py"
+IMPLEMENTATION_BASE = "bed39af6b004e4db86218fad01d2ea515b332135"
+BASELINE_LINES = 22_338
+BASELINE_METHODS = 705
+LINE_OVERAGE = 4_611
+METHOD_OVERAGE = 112
+DESCRIPTOR_LINE_BUDGET = 64
+
+
+@dataclass(frozen=True)
+class Wave6Group:
+    """One reviewed ownership family and its implementation-base evidence."""
+
+    target_path: str
+    target_class: str
+    owner_name: str
+    moved: frozenset[str]
+    delegates: frozenset[str] = frozenset()
+    stays: frozenset[str] = frozenset()
+    deleted: frozenset[str] = frozenset()
+    raw_lines: int = 0
+    residue_lines: int = 0
+
+    @property
+    def raw_names(self) -> frozenset[str]:
+        """All implementation-base definitions counted by this family."""
+        return self.moved | self.delegates | self.stays | self.deleted
+
+    @property
+    def removed_methods(self) -> int:
+        """Direct ChatScreen methods removed when this family completes."""
+        return len(self.moved | self.deleted)
+
+
+WAVE6_GROUPS = {
+    "image": Wave6Group(
+        target_path="tldw_chatbook/UI/Console_Modules/image.py",
+        target_class="ConsoleImageController",
+        owner_name="_image",
+        moved=frozenset(
+            {
+                "_build_console_image_specs",
+                "_extend_specs_with_remote_images",
+                "_fetch_remote_transcript_image",
+                "_build_generation_card_specs",
+                "_pending_console_generation_card_images",
+                "_console_imagegen_inflight_sessions",
+                "_console_imagegen_inflight_message_ids",
+                "_console_generate_image_conversation_pairs",
+                "_console_generate_image_llm_context_options",
+                "_h3_image_edit_registry",
+                "_h3_reference_snapshot",
+                "_h3_reference_from_snapshot",
+                "_filter_h3_attachment_from_app_stash",
+                "_h3_origin_screen_is_live",
+                "_cleanup_h3_completion_in_store",
+                "_reconcile_h3_image_edit_completions",
+                "_merge_h3_failure_notice_in_store",
+                "_settle_current_h3_outcome",
+                "_schedule_current_h3_settlement",
+                "_append_h3_image_edit_error",
+                "_run_h3_image_edit_command",
+                "_regenerate_console_generation_variant",
+                "_select_console_generation_variant",
+                "_keep_console_generation_variant",
+                "_handle_console_toggle_image_view",
+            }
+        ),
+        delegates=frozenset({"_console_command_generate_image"}),
+        stays=frozenset(
+            {
+                "_ensure_console_image_view",
+                "_console_generation_browse",
+                "_prep_console_images",
+                "_open_console_generate_image_modal",
+                "_paste_console_generate_image_command",
+            }
+        ),
+        raw_lines=1_335,
+        residue_lines=79,
+    ),
+    "video": Wave6Group(
+        target_path="tldw_chatbook/UI/Console_Modules/video.py",
+        target_class="ConsoleVideoController",
+        owner_name="_video",
+        moved=frozenset(
+            {
+                "_console_videogen_inflight_sessions",
+                "_console_videogen_cancel_events",
+                "_ensure_console_video_store",
+                "_build_video_card_specs",
+                "_video_storage_message_id",
+                "_pending_console_video_artifacts",
+                "_owns_pending_console_video",
+                "_close_pending_console_video",
+                "_register_console_video_publication_gate",
+                "_release_console_video_publication_gate",
+                "_begin_pending_console_video_operation",
+                "_end_pending_console_video_operation",
+                "_await_shielded_console_video_task",
+                "_run_pending_console_video_operation",
+                "_run_console_video_generation_operation",
+                "_drain_pending_console_videos",
+                "_external_video_target_identity",
+                "_external_video_stat_identity",
+                "_external_video_cleanup_identity",
+                "_external_video_parent_identity",
+                "_require_external_video_pinned_capabilities",
+                "_external_video_precommit_check",
+                "_copy_pending_video_external",
+                "_retry_pending_console_video",
+                "_save_pending_console_video_external",
+                "_normalize_pending_video_target",
+                "_resolve_generated_video_outcome",
+                "_persist_generated_video_tuple",
+                "_play_console_video",
+                "_save_console_video_copy",
+                "_regenerate_console_video_message",
+            }
+        ),
+        delegates=frozenset(
+            {"_console_command_generate_video", "_console_command_stream_video"}
+        ),
+        raw_lines=1_292,
+        residue_lines=10,
+    ),
+    "browser": Wave6Group(
+        target_path="tldw_chatbook/UI/Console_Modules/workspace.py",
+        target_class="ConsoleWorkspaceController",
+        owner_name="_workspace",
+        moved=frozenset(
+            {
+                "_start_console_conversation_browser_search",
+                "_console_browser_row_key",
+                "_console_browser_row_scope_copy",
+                "_console_browser_row_matches_query",
+                "_filter_console_browser_rows_for_query",
+                "_find_console_browser_row",
+                "_console_browser_display_identity",
+                "_starred_console_conversation_ids",
+                "_apply_console_browser_star_state",
+                "_native_console_browser_rows",
+                "_membership_console_browser_rows",
+                "_persisted_console_browser_rows",
+                "_invalidate_console_persisted_rows_cache",
+                "_sync_persisted_console_browser_rows",
+                "_compute_persisted_console_browser_rows",
+                "_merge_console_browser_rows",
+                "_current_console_browser_rows",
+                "_refresh_console_conversation_browser_search",
+                "_refresh_console_conversation_browser_after_selection",
+                "_with_console_conversation_browser_state",
+            }
+        ),
+        delegates=frozenset({"on_console_workspace_conversation_search_changed"}),
+        raw_lines=912,
+        residue_lines=5,
+    ),
+    "retrieval": Wave6Group(
+        target_path="tldw_chatbook/UI/Console_Modules/retrieval.py",
+        target_class="ConsoleRetrievalController",
+        owner_name="_retrieval",
+        moved=frozenset(
+            {
+                "_capture_console_staged_rag",
+                "_build_console_retrieval_scope_state",
+                "_console_retrieval_scope_run_recipe_count",
+                "_resolve_console_effective_scope_state",
+                "_refresh_console_effective_scope_and_sync",
+                "_warm_console_effective_scope_cache_if_stale",
+                "_read_console_retrieval_scope",
+                "_write_console_retrieval_scope",
+                "_console_scope_picker_listers",
+                "_apply_console_retrieval_scope_save",
+                "_console_rag_source_status",
+                "_active_console_dictionary_scope_ids",
+                "_refresh_active_dictionaries_summary_if_scope_changed",
+                "refresh_active_dictionaries_summary",
+                "_active_console_world_book_scope_ids",
+                "refresh_active_world_books_summary",
+                "_refresh_active_world_books_summary_if_scope_changed",
+                "_console_dictionary_inspector_rows",
+                "_console_world_book_inspector_rows",
+                "_console_dictionary_inspector_actions",
+                "_console_world_book_inspector_actions",
+                "_console_library_rag_scope_label",
+                "_stage_console_library_rag_launch",
+                "_maybe_auto_retrieve_for_send",
+                "_apply_console_rag_settings_choice",
+                "_resolve_console_library_rag_scope",
+                "_apply_console_library_rag_search_outcome",
+                "_rag_service_still_initializing",
+                "_notify_console_auto_rag_scope_empty",
+                "_notify_auto_rag_degraded",
+                "_notify_console_auto_rag",
+                "_clear_console_auto_rag_placeholder",
+            }
+        ),
+        delegates=frozenset(
+            {
+                "_persist_console_rag_auto_retrieve_on_send",
+                "_execute_console_library_rag_search",
+            }
+        ),
+        raw_lines=992,
+        residue_lines=10,
+    ),
+    "skill": Wave6Group(
+        target_path="tldw_chatbook/UI/Console_Modules/skill.py",
+        target_class="ConsoleSkillController",
+        owner_name="_skill",
+        moved=frozenset(
+            {
+                "_fetch_console_skill_context",
+                "_console_skill_trusted_candidates_from_context",
+                "_console_skill_blocked_summaries",
+                "_refresh_console_skill_candidates",
+                "_split_console_skill_name_args",
+                "_console_skill_blocked_match_response",
+                "_append_skill_refuse_row",
+                "_set_console_pending_skill_install",
+                "_set_console_pending_skill_script",
+            }
+        ),
+        delegates=frozenset(
+            {
+                "_console_command_skills",
+                "handle_console_skill_install_decided",
+                "handle_console_skill_script_decided",
+            }
+        ),
+        deleted=frozenset(
+            {
+                "_console_skill_search",
+                "_console_command_run_skill",
+                "_run_resolved_console_skill",
+                "_open_console_skill_picker",
+            }
+        ),
+        raw_lines=339,
+        residue_lines=15,
+    ),
+    "character": Wave6Group(
+        target_path="tldw_chatbook/UI/Console_Modules/character.py",
+        target_class="ConsoleCharacterController",
+        owner_name="_character",
+        moved=frozenset(
+            {
+                "_console_character_picker_options",
+                "_current_console_rail_conversation_id",
+                "_current_console_rail_character_id",
+                "_current_console_rail_character_name",
+                "_fetch_character_card_for_avatar",
+                "_fetch_expression_image_bytes",
+                "_apply_console_character_choice_async",
+                "_refresh_active_character_avatar_if_scope_changed",
+            }
+        ),
+        raw_lines=281,
+    ),
+}
+
+COMPATIBILITY_TARGETS = {
+    "_image": frozenset(
+        {
+            "_imagegen_inflight_sessions",
+            "_imagegen_inflight_message_ids",
+            "_console_h3_ui_generations",
+        }
+    ),
+    "_video": frozenset(
+        {
+            "_console_videogen_inflight",
+            "_console_videogen_cancels",
+            "_console_video_store",
+            "_pending_video_artifacts",
+            "_pending_video_artifacts_closed",
+            "_pending_video_operation_cancels",
+            "_pending_video_active_operations",
+            "_pending_video_deferred_closes",
+        }
+    ),
+    "_workspace": frozenset(
+        {
+            "_console_persisted_rows_cache",
+            "_console_persisted_rows_cache_key",
+            "_console_persisted_rows_cache_at",
+            "_console_conversation_browser_query",
+            "_console_conversation_browser_search_timer",
+            "_console_conversation_browser_search_token",
+            "_console_conversation_browser_rows",
+            "_console_conversation_browser_total",
+            "_console_conversation_browser_error",
+        }
+    ),
+    "_retrieval": frozenset(
+        {
+            "_console_retrieval_scope_cache",
+            "_console_effective_scope_cache",
+            "_active_dictionaries_summary",
+            "_last_console_dictionary_scope_ids",
+            "_active_world_books_summary",
+            "_last_console_world_book_scope_ids",
+        }
+    ),
+    "_skill": frozenset({"_console_skill_candidates"}),
+    "_character": frozenset(
+        {
+            "_active_character_avatar",
+            "_active_character_avatar_name",
+            "_last_console_avatar_scope",
+            "_console_expression_spec_cache",
+        }
+    ),
+}
+EXTERNAL_COMPATIBILITY_NAME = "_console_video_store"
+EXTERNAL_WRITE_SOURCES = {
+    "Tests/Chat/test_console_video_actions.py",
+    "Tests/Chat/test_console_video_message.py",
+}
+BASELINE_DEFAULTS = {
+    "_imagegen_inflight_sessions": ("set",),
+    "_imagegen_inflight_message_ids": ("set",),
+    "_console_h3_ui_generations": ("dict",),
+    "_console_videogen_inflight": ("set",),
+    "_console_videogen_cancels": ("dict",),
+    "_console_video_store": ("constant", "NoneType", None),
+    "_pending_video_artifacts": ("dict",),
+    "_pending_video_artifacts_closed": ("constant", "bool", False),
+    "_pending_video_operation_cancels": ("dict",),
+    "_pending_video_active_operations": ("dict",),
+    "_pending_video_deferred_closes": ("dict",),
+    "_console_persisted_rows_cache": ("constant", "NoneType", None),
+    "_console_persisted_rows_cache_key": ("constant", "NoneType", None),
+    "_console_persisted_rows_cache_at": ("constant", "float", 0.0),
+    "_console_conversation_browser_query": ("constant", "str", ""),
+    "_console_conversation_browser_search_timer": ("constant", "NoneType", None),
+    "_console_conversation_browser_search_token": ("constant", "int", 0),
+    "_console_conversation_browser_rows": ("tuple",),
+    "_console_conversation_browser_total": ("constant", "NoneType", None),
+    "_console_conversation_browser_error": ("constant", "str", ""),
+    "_console_retrieval_scope_cache": ("dict",),
+    "_console_effective_scope_cache": ("dict",),
+    "_active_dictionaries_summary": ("constant", "NoneType", None),
+    "_last_console_dictionary_scope_ids": ("constant", "NoneType", None),
+    "_active_world_books_summary": ("constant", "NoneType", None),
+    "_last_console_world_book_scope_ids": ("constant", "NoneType", None),
+    "_console_skill_candidates": ("tuple",),
+    "_active_character_avatar": ("constant", "NoneType", None),
+    "_active_character_avatar_name": ("constant", "NoneType", None),
+    "_last_console_avatar_scope": ("constant", "NoneType", None),
+    "_console_expression_spec_cache": ("dict",),
+}
+DELEGATE_BINDINGS = {
+    "_console_command_generate_image": "_dispatch_console_command",
+    "_console_command_generate_video": "_dispatch_console_command",
+    "_console_command_stream_video": "_dispatch_console_command",
+    "on_console_workspace_conversation_search_changed": "@on",
+    "_persist_console_rag_auto_retrieve_on_send": "_open_console_rag_settings",
+    "_execute_console_library_rag_search": "_run_console_library_rag_from_visible_action",
+    "_console_command_skills": "_dispatch_console_command",
+    "handle_console_skill_install_decided": "@on",
+    "handle_console_skill_script_decided": "@on",
+}
+
+
+def _class_node(path: Path, class_name: str) -> tuple[str, ast.ClassDef]:
+    source = path.read_text(encoding="utf-8")
+    return source, _class_node_from_source(source, class_name, path)
+
+
+def _class_node_from_source(
+    source: str, class_name: str, source_name: Path | str
+) -> ast.ClassDef:
+    tree = ast.parse(source)
+    classes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    ]
+    assert len(classes) == 1, f"expected exactly one {class_name} in {source_name}"
+    return classes[0]
+
+
+def _source_at_revision(revision: str, path: Path) -> str:
+    relative_path = path.relative_to(_REPO_ROOT).as_posix()
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{relative_path}"],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout
+
+
+def _methods_from_class(class_node: ast.ClassDef) -> dict[str, ast.AST]:
+    return {
+        node.name: node
+        for node in class_node.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _method_count(class_node: ast.ClassDef) -> int:
+    return sum(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        for node in class_node.body
+    )
+
+
+def _methods(path: Path, class_name: str) -> dict[str, ast.AST]:
+    _, class_node = _class_node(path, class_name)
+    return _methods_from_class(class_node)
+
+
+def _span(node: ast.AST) -> int:
+    return node.end_lineno - node.lineno + 1  # type: ignore[attr-defined]
+
+
+def _is_property(node: ast.AST) -> bool:
+    return any(
+        isinstance(decorator, ast.Name) and decorator.id == "property"
+        for decorator in node.decorator_list  # type: ignore[attr-defined]
+    )
+
+
+def _self_assignments(root: ast.AST) -> set[str]:
+    assigned: set[str] = set()
+    for node in ast.walk(root):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "self"
+            ):
+                assigned.add(target.attr)
+    return assigned
+
+
+def _default_signature(node: ast.AST) -> tuple[object, ...]:
+    if isinstance(node, ast.Constant):
+        return ("constant", type(node.value).__name__, node.value)
+    if isinstance(node, ast.Dict) and not node.keys:
+        return ("dict",)
+    if isinstance(node, ast.Tuple) and not node.elts:
+        return ("tuple",)
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in {"dict", "set", "tuple"}
+        and not node.args
+        and not node.keywords
+    ):
+        return (node.func.id,)
+    return ("expression", ast.dump(node, include_attributes=False))
+
+
+def _resolved_default_signature(
+    value: ast.AST, method: ast.AST, before_line: int
+) -> tuple[object, ...]:
+    if not isinstance(value, ast.Name):
+        return _default_signature(value)
+    candidates: list[tuple[int, ast.AST]] = []
+    for node in ast.walk(method):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        if node.lineno >= before_line:
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if any(
+            isinstance(target, ast.Name) and target.id == value.id for target in targets
+        ):
+            candidates.append((node.lineno, node.value))
+    if not candidates:
+        return _default_signature(value)
+    line, initializer = max(candidates)
+    return _resolved_default_signature(initializer, method, line)
+
+
+def _assignment_signatures(
+    class_node: ast.ClassDef, attribute: str
+) -> set[tuple[object, ...]]:
+    signatures: set[tuple[object, ...]] = set()
+    for method in _methods_from_class(class_node).values():
+        for node in ast.walk(method):
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            if any(
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "self"
+                and target.attr == attribute
+                for target in targets
+            ):
+                signatures.add(
+                    _resolved_default_signature(node.value, method, node.lineno)
+                )
+    return signatures
+
+
+def _getattr_default_signatures(
+    class_node: ast.ClassDef, attribute: str
+) -> set[tuple[object, ...]]:
+    return {
+        _default_signature(node.args[2])
+        for node in ast.walk(class_node)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "getattr"
+        and len(node.args) == 3
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "self"
+        and isinstance(node.args[1], ast.Constant)
+        and node.args[1].value == attribute
+    }
+
+
+def _first_self_attribute_access(
+    method: ast.AST, attribute: str
+) -> tuple[str, ast.AST] | None:
+    accesses: list[tuple[int, int, str, ast.AST]] = []
+    for node in ast.walk(method):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+            and node.attr == attribute
+        ):
+            kind = "store" if isinstance(node.ctx, ast.Store) else "load"
+            accesses.append((node.lineno, node.col_offset, kind, node))
+    if not accesses:
+        return None
+    _, _, kind, node = min(accesses)
+    return kind, node
+
+
+def _build_call_line(method: ast.AST) -> int:
+    calls = [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "build_console_controllers"
+    ]
+    assert len(calls) == 1
+    return calls[0].lineno
+
+
+def _first_assignment_value(method: ast.AST, attribute: str) -> ast.AST:
+    assignments: list[tuple[int, ast.AST]] = []
+    for node in ast.walk(method):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if any(
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "self"
+            and target.attr == attribute
+            for target in targets
+        ):
+            assignments.append((node.lineno, node.value))
+    assert assignments, f"{attribute} has no controller default"
+    return min(assignments)[1]
+
+
+def _screen_read_lines(method: ast.AST, attribute: str) -> list[int]:
+    lines = [
+        node.lineno
+        for node in ast.walk(method)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+        and node.attr == attribute
+        and isinstance(node.ctx, ast.Load)
+    ]
+    lines.extend(
+        node.lineno
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in {"getattr", "hasattr"}
+        and len(node.args) >= 2
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "self"
+        and isinstance(node.args[1], ast.Constant)
+        and node.args[1].value == attribute
+    )
+    return lines
+
+
+def _assert_controller_default(
+    method: ast.AST, attribute: str, expected: tuple[object, ...]
+) -> None:
+    first_access = _first_self_attribute_access(method, attribute)
+    assert first_access is not None and first_access[0] == "store"
+    assert _default_signature(_first_assignment_value(method, attribute)) == expected
+
+
+def _assert_screen_reads_after_build(
+    method: ast.AST, attribute: str, build_line: int
+) -> None:
+    assert all(line >= build_line for line in _screen_read_lines(method, attribute))
+
+
+def _has_external_default_none(base_methods: dict[str, ast.AST]) -> bool:
+    method = base_methods["_ensure_console_video_store"]
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "getattr"
+        and len(node.args) == 3
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "self"
+        and isinstance(node.args[1], ast.Constant)
+        and node.args[1].value == EXTERNAL_COMPATIBILITY_NAME
+        and isinstance(node.args[2], ast.Constant)
+        and node.args[2].value is None
+        for node in ast.walk(method)
+    )
+
+
+def _assert_owner_is_wired(group: Wave6Group) -> None:
+    wiring_path = _REPO_ROOT / "tldw_chatbook/UI/Console_Modules/wiring.py"
+    wiring_tree = ast.parse(wiring_path.read_text(encoding="utf-8"))
+    build = next(
+        node
+        for node in wiring_tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "build_console_controllers"
+    )
+    assignments = []
+    for node in ast.walk(build):
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "screen"
+            and target.attr == group.owner_name
+            for target in node.targets
+        ):
+            assignments.append(node)
+    assert len(assignments) == 1
+    value = assignments[0].value
+    assert isinstance(value, ast.Call)
+    assert isinstance(value.func, ast.Name)
+    assert value.func.id == group.target_class
+
+
+def _class_assignments(class_node: ast.ClassDef) -> set[str]:
+    assigned: set[str] = set()
+    for node in class_node.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        if isinstance(node, ast.AnnAssign) and node.value is None:
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        assigned.update(target.id for target in targets if isinstance(target, ast.Name))
+    return assigned
+
+
+def _calls_query_one(node: ast.AST) -> bool:
+    return any(
+        isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Attribute)
+        and child.func.attr == "query_one"
+        for child in ast.walk(node)
+    )
+
+
+def _has_on_binding(method: ast.AST) -> bool:
+    for decorator in method.decorator_list:  # type: ignore[attr-defined]
+        function = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(function, ast.Name) and function.id == "on":
+            return True
+    return False
+
+
+def _has_real_delegate_binding(
+    screen_methods: dict[str, ast.AST], method_name: str
+) -> bool:
+    binding = DELEGATE_BINDINGS[method_name]
+    if binding == "@on":
+        return _has_on_binding(screen_methods[method_name])
+    caller = screen_methods.get(binding)
+    return caller is not None and any(
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+        and node.attr == method_name
+        and isinstance(node.ctx, ast.Load)
+        for node in ast.walk(caller)
+    )
+
+
+def _assert_no_dom_access(methods: object) -> None:
+    assert not any(_calls_query_one(node) for node in methods)  # type: ignore[arg-type]
+
+
+def _assert_delegate_contract(
+    screen_methods: dict[str, ast.AST], method_name: str, *, complete: bool
+) -> None:
+    assert _has_real_delegate_binding(screen_methods, method_name)
+    if complete:
+        assert _span(screen_methods[method_name]) <= 5
+
+
+def _assigns_attribute(path: Path, attribute: str) -> bool:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if any(
+            isinstance(target, ast.Attribute) and target.attr == attribute
+            for target in targets
+        ):
+            return True
+    return False
+
+
+def _assert_descriptor_contract(
+    screen_type: type, owner_name: str, state_name: str
+) -> None:
+    screen = screen_type.__new__(screen_type)
+    for read in (
+        lambda: getattr(screen, state_name),
+        lambda: getattr(screen, state_name, object()),
+        lambda: hasattr(screen, state_name),
+    ):
+        try:
+            read()
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError(f"{state_name} did not fail loudly before wiring")
+    try:
+        setattr(screen, state_name, object())
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError(f"{state_name} accepted a pre-wiring write")
+
+    initial = object()
+    owner = SimpleNamespace(**{state_name: initial})
+    object.__setattr__(screen, owner_name, owner)
+    assert getattr(screen, state_name) is initial
+
+    replacement = object()
+    setattr(screen, state_name, replacement)
+    assert getattr(owner, state_name) is replacement
+    assert state_name not in screen.__dict__
+
+
+@pytest.mark.unit
+def test_wave6_inventory_matches_the_implementation_base() -> None:
+    """Lock every reviewed definition, its source span, and its migration owner."""
+    base_source = _source_at_revision(IMPLEMENTATION_BASE, _SCREEN_PATH)
+    base_class = _class_node_from_source(base_source, "ChatScreen", _SCREEN_PATH)
+    base_methods = _methods_from_class(base_class)
+    screen_source, screen_class = _class_node(_SCREEN_PATH, "ChatScreen")
+    screen_methods = _methods(_SCREEN_PATH, "ChatScreen")
+
+    assert len(base_source.splitlines()) == BASELINE_LINES
+    assert _method_count(base_class) == BASELINE_METHODS
+    assert len(screen_source.splitlines()) <= BASELINE_LINES, IMPLEMENTATION_BASE
+    assert _method_count(screen_class) <= BASELINE_METHODS, IMPLEMENTATION_BASE
+    assert set(WAVE6_GROUPS) == {
+        "image",
+        "video",
+        "browser",
+        "retrieval",
+        "skill",
+        "character",
+    }
+    assert set(DELEGATE_BINDINGS) == set().union(
+        *(group.delegates for group in WAVE6_GROUPS.values())
+    )
+    all_names: set[str] = set()
+    for name, group in WAVE6_GROUPS.items():
+        overlap = all_names & group.raw_names
+        assert not overlap, f"Wave 6 methods counted twice: {sorted(overlap)}"
+        all_names.update(group.raw_names)
+
+        target_path = _REPO_ROOT / group.target_path
+        target_methods = (
+            _methods(target_path, group.target_class) if target_path.exists() else {}
+        )
+        target_owners = {
+            method_name: node
+            for method_name, node in target_methods.items()
+            if not _is_property(node)
+        }
+        for method_name in group.moved:
+            owners = int(method_name in screen_methods) + int(
+                method_name in target_owners
+            )
+            assert owners == 1, f"{name}.{method_name} must have exactly one owner"
+            if method_name in target_owners:
+                assert not _calls_query_one(target_owners[method_name])
+        assert group.delegates <= screen_methods.keys()
+        assert group.stays <= screen_methods.keys()
+        assert not (group.deleted & target_owners.keys())
+
+        assert group.raw_names <= base_methods.keys()
+        assert sum(_span(base_methods[item]) for item in group.raw_names) == (
+            group.raw_lines
+        )
+
+        complete = not (group.moved & screen_methods.keys()) and not (
+            group.deleted & screen_methods.keys()
+        )
+        if complete:
+            residue = group.delegates | group.stays
+            assert sum(_span(screen_methods[item]) for item in residue) <= (
+                group.residue_lines
+            )
+            for method_name in group.delegates:
+                _assert_delegate_contract(screen_methods, method_name, complete=True)
+        else:
+            for method_name in group.delegates:
+                _assert_delegate_contract(screen_methods, method_name, complete=False)
+
+        if target_path.exists():
+            methods_to_scan = (
+                target_methods.values()
+                if name != "browser"
+                else (
+                    target_methods[method_name]
+                    for method_name in group.moved
+                    if method_name in target_methods
+                )
+            )
+            _assert_no_dom_access(methods_to_scan)
+
+
+@pytest.mark.unit
+def test_wave6_projection_clears_both_ratchet_overages() -> None:
+    """The conservative reviewed projection must retain real implementation margin."""
+    raw_lines = sum(group.raw_lines for group in WAVE6_GROUPS.values())
+    residue_lines = sum(group.residue_lines for group in WAVE6_GROUPS.values())
+    removed_methods = sum(group.removed_methods for group in WAVE6_GROUPS.values())
+
+    assert raw_lines == 5_151
+    assert residue_lines + DESCRIPTOR_LINE_BUDGET == 183
+    assert raw_lines - residue_lines - DESCRIPTOR_LINE_BUDGET == 4_968
+    assert removed_methods == 129
+    assert 4_968 > LINE_OVERAGE
+    assert removed_methods > METHOD_OVERAGE
+
+
+@pytest.mark.unit
+def test_wave6_compatibility_inventory_is_complete_and_phase_safe() -> None:
+    """Lock baseline assignments now and the descriptor contract once it lands."""
+    base_source = _source_at_revision(IMPLEMENTATION_BASE, _SCREEN_PATH)
+    base_class = _class_node_from_source(base_source, "ChatScreen", _SCREEN_PATH)
+    base_methods = _methods_from_class(base_class)
+    _, screen_class = _class_node(_SCREEN_PATH, "ChatScreen")
+    screen_methods = _methods_from_class(screen_class)
+    compatibility_names = frozenset().union(*COMPATIBILITY_TARGETS.values())
+    base_assigned_names = _self_assignments(base_class) & compatibility_names
+    assigned_names = _self_assignments(screen_class) & compatibility_names
+    descriptors = _class_assignments(screen_class) & compatibility_names
+
+    assert len(compatibility_names) == 31
+    assert set(BASELINE_DEFAULTS) == compatibility_names
+    assert base_assigned_names == compatibility_names - {EXTERNAL_COMPATIBILITY_NAME}
+    for state_name in base_assigned_names:
+        observed_defaults = _assignment_signatures(
+            base_class, state_name
+        ) | _getattr_default_signatures(base_class, state_name)
+        assert BASELINE_DEFAULTS[state_name] in observed_defaults
+    assert _has_external_default_none(base_methods)
+    assert all(
+        _assigns_attribute(_REPO_ROOT / path, EXTERNAL_COMPATIBILITY_NAME)
+        for path in EXTERNAL_WRITE_SOURCES
+    )
+    build_line = _build_call_line(screen_methods["__init__"])
+
+    for owner_name, names in COMPATIBILITY_TARGETS.items():
+        family_descriptors = descriptors & names
+        baseline_assignments = names - {EXTERNAL_COMPATIBILITY_NAME}
+        if not family_descriptors:
+            assert assigned_names & names == baseline_assignments
+            continue
+        assert family_descriptors == names
+        assert not (assigned_names & names)
+
+        group = next(
+            group for group in WAVE6_GROUPS.values() if group.owner_name == owner_name
+        )
+        target_path = _REPO_ROOT / group.target_path
+        assert target_path.exists()
+        target_methods = _methods(target_path, group.target_class)
+        assert "__init__" in target_methods
+        target_init = target_methods["__init__"]
+        assert names <= _self_assignments(target_init)
+        for state_name in names:
+            _assert_controller_default(
+                target_init, state_name, BASELINE_DEFAULTS[state_name]
+            )
+            _assert_screen_reads_after_build(
+                screen_methods["__init__"], state_name, build_line
+            )
+        _assert_owner_is_wired(group)
+
+        from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+        for state_name in names:
+            _assert_descriptor_contract(ChatScreen, owner_name, state_name)
+
+
+@pytest.mark.unit
+def test_descriptor_contract_oracle_is_non_vacuous() -> None:
+    """The phase-safe oracle itself rejects pre-wiring and shadow-state regressions."""
+
+    class ReferenceDescriptor:
+        def __get__(self, instance: object, owner: type | None = None) -> object:
+            if instance is None:
+                return self
+            try:
+                target = object.__getattribute__(instance, "_owner")
+            except AttributeError as exc:
+                raise RuntimeError("controller not wired") from exc
+            return target.state
+
+        def __set__(self, instance: object, value: object) -> None:
+            try:
+                target = object.__getattribute__(instance, "_owner")
+            except AttributeError as exc:
+                raise RuntimeError("controller not wired") from exc
+            target.state = value
+
+    class ReferenceScreen:
+        state = ReferenceDescriptor()
+
+    _assert_descriptor_contract(ReferenceScreen, "_owner", "state")
+
+    class ShadowDescriptor:
+        def __get__(self, instance: object, owner: type | None = None) -> object:
+            if instance is None:
+                return self
+            return instance.__dict__.get("state")
+
+        def __set__(self, instance: object, value: object) -> None:
+            instance.__dict__["state"] = value
+
+    class ShadowScreen:
+        state = ShadowDescriptor()
+
+    with pytest.raises(AssertionError, match="did not fail loudly"):
+        _assert_descriptor_contract(ShadowScreen, "_owner", "state")
+
+
+@pytest.mark.unit
+def test_wave6_structural_oracles_are_non_vacuous() -> None:
+    """The DOM, reachability, and physical-delegate guards reject regressions."""
+    sample = ast.parse(
+        """
+class Sample:
+    def __init__(self):
+        seen = self.state
+        self.state = {}
+
+    def caller(self):
+        return self.delegate()
+
+    def delegate(self):
+        first = 1
+        second = 2
+        third = 3
+        fourth = 4
+        return first + second + third + fourth
+
+    def touches_dom(self):
+        return self.query_one('#forbidden')
+"""
+    ).body[0]
+    assert isinstance(sample, ast.ClassDef)
+    sample_methods = _methods_from_class(sample)
+    with pytest.raises(AssertionError):
+        _assert_controller_default(sample_methods["__init__"], "state", ("dict",))
+    with pytest.raises(AssertionError):
+        _assert_screen_reads_after_build(sample_methods["__init__"], "state", 5)
+    original_binding = DELEGATE_BINDINGS.get("delegate")
+    DELEGATE_BINDINGS["delegate"] = "caller"
+    try:
+        assert _has_real_delegate_binding(sample_methods, "delegate")
+        with pytest.raises(AssertionError):
+            _assert_delegate_contract(sample_methods, "delegate", complete=True)
+        with pytest.raises(AssertionError):
+            _assert_no_dom_access(sample_methods.values())
+        DELEGATE_BINDINGS["delegate"] = "missing_caller"
+        with pytest.raises(AssertionError):
+            _assert_delegate_contract(sample_methods, "delegate", complete=False)
+    finally:
+        if original_binding is None:
+            del DELEGATE_BINDINGS["delegate"]
+        else:
+            DELEGATE_BINDINGS["delegate"] = original_binding

--- a/Tests/Architecture/test_console_wave6_inventory.py
+++ b/Tests/Architecture/test_console_wave6_inventory.py
@@ -22,7 +22,11 @@ DESCRIPTOR_LINE_BUDGET = 64
 
 @dataclass(frozen=True)
 class Wave6Group:
-    """One reviewed ownership family and its implementation-base evidence."""
+    """Describe one reviewed Wave 6 ownership family.
+
+    The record locks the implementation-base definitions, their destination,
+    and the conservative residue retained on ``ChatScreen``.
+    """
 
     target_path: str
     target_class: str
@@ -491,7 +495,10 @@ def _resolved_default_signature(
             candidates.append((node.lineno, node.value))
     if not candidates:
         return _default_signature(value)
-    line, initializer = max(candidates)
+    line, initializer = max(
+        candidates,
+        key=lambda item: (item[0], item[1].col_offset),
+    )
     return _resolved_default_signature(initializer, method, line)
 
 
@@ -580,7 +587,10 @@ def _first_assignment_value(method: ast.AST, attribute: str) -> ast.AST:
         ):
             assignments.append((node.lineno, node.value))
     assert assignments, f"{attribute} has no controller default"
-    return min(assignments)[1]
+    return min(
+        assignments,
+        key=lambda item: (item[0], item[1].col_offset),
+    )[1]
 
 
 def _screen_read_lines(method: ast.AST, attribute: str) -> list[int]:
@@ -774,7 +784,11 @@ def _assert_descriptor_contract(
 
 @pytest.mark.unit
 def test_wave6_inventory_matches_the_implementation_base() -> None:
-    """Lock every reviewed definition, its source span, and its migration owner."""
+    """Lock every reviewed definition to its implementation-base evidence.
+
+    Each definition retains an exact source span and one migration owner while
+    the current tree moves through the extraction phases.
+    """
     base_source = _source_at_revision(IMPLEMENTATION_BASE, _SCREEN_PATH)
     base_class = _class_node_from_source(base_source, "ChatScreen", _SCREEN_PATH)
     base_methods = _methods_from_class(base_class)
@@ -856,7 +870,11 @@ def test_wave6_inventory_matches_the_implementation_base() -> None:
 
 @pytest.mark.unit
 def test_wave6_projection_clears_both_ratchet_overages() -> None:
-    """The conservative reviewed projection must retain real implementation margin."""
+    """Require the reviewed projection to clear both ratchet overages.
+
+    The conservative line and method estimates must retain implementation
+    margin after all documented residue is included.
+    """
     raw_lines = sum(group.raw_lines for group in WAVE6_GROUPS.values())
     residue_lines = sum(group.residue_lines for group in WAVE6_GROUPS.values())
     removed_methods = sum(group.removed_methods for group in WAVE6_GROUPS.values())
@@ -871,7 +889,11 @@ def test_wave6_projection_clears_both_ratchet_overages() -> None:
 
 @pytest.mark.unit
 def test_wave6_compatibility_inventory_is_complete_and_phase_safe() -> None:
-    """Lock baseline assignments now and the descriptor contract once it lands."""
+    """Lock compatibility assignments across every extraction phase.
+
+    Baseline assignments remain authoritative until an entire family moves;
+    afterward, descriptors must preserve the reviewed controller contract.
+    """
     base_source = _source_at_revision(IMPLEMENTATION_BASE, _SCREEN_PATH)
     base_class = _class_node_from_source(base_source, "ChatScreen", _SCREEN_PATH)
     base_methods = _methods_from_class(base_class)
@@ -932,7 +954,10 @@ def test_wave6_compatibility_inventory_is_complete_and_phase_safe() -> None:
 
 @pytest.mark.unit
 def test_descriptor_contract_oracle_is_non_vacuous() -> None:
-    """The phase-safe oracle itself rejects pre-wiring and shadow-state regressions."""
+    """Prove the phase-safe descriptor oracle rejects known regressions.
+
+    Pre-wiring access and screen-local shadow state must both fail the oracle.
+    """
 
     class ReferenceDescriptor:
         def __get__(self, instance: object, owner: type | None = None) -> object:
@@ -974,7 +999,11 @@ def test_descriptor_contract_oracle_is_non_vacuous() -> None:
 
 @pytest.mark.unit
 def test_wave6_structural_oracles_are_non_vacuous() -> None:
-    """The DOM, reachability, and physical-delegate guards reject regressions."""
+    """Prove the structural oracles reject representative regressions.
+
+    The fixture exercises DOM access, delegate reachability, physical span,
+    initialization order, and controller-default failures.
+    """
     sample = ast.parse(
         """
 class Sample:
@@ -1018,3 +1047,35 @@ class Sample:
             del DELEGATE_BINDINGS["delegate"]
         else:
             DELEGATE_BINDINGS["delegate"] = original_binding
+
+
+@pytest.mark.unit
+def test_assignment_oracles_order_same_line_ast_nodes_without_comparing_them() -> None:
+    """Select assignments by source position when several share one line.
+
+    Bare tuple ordering falls through from equal line numbers to comparing
+    ``ast.AST`` objects, which raises ``TypeError``.
+    """
+    sample = ast.parse(
+        "class Sample:\n"
+        "    def initialize(self):\n"
+        "        value = {}; value = set()\n"
+        "        self.state = value; self.state = tuple()\n"
+    ).body[0]
+    assert isinstance(sample, ast.ClassDef)
+    method = _methods_from_class(sample)["initialize"]
+    state_assignments = [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Attribute) and target.attr == "state"
+            for target in node.targets
+        )
+    ]
+
+    assert _resolved_default_signature(
+        ast.Name(id="value"), method, state_assignments[0].lineno
+    ) == ("set",)
+    first = _first_assignment_value(method, "state")
+    assert isinstance(first, ast.Name) and first.id == "value"

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -22,6 +22,13 @@ def _all_tests_job_block() -> str:
     return workflow[start:end]
 
 
+def _core_tests_job_block() -> str:
+    workflow = _workflow_text()
+    start = workflow.index("  core-tests:")
+    end = workflow.index("  artifact-lease-spike:", start)
+    return workflow[start:end]
+
+
 def _nightly_deep_job_block() -> str:
     workflow = _workflow_text()
     start = workflow.index("  nightly-deep:")
@@ -124,6 +131,22 @@ def test_full_suite_job_is_bounded_and_manual_only() -> None:
     assert "pull_request" not in all_tests_job
     assert "name: Full Test Suite (Manual)" in all_tests_job
     assert "pytest ./Tests/" in all_tests_job
+
+
+def test_jobs_running_architecture_tests_fetch_pinned_history() -> None:
+    """Keep immutable architecture baselines available in every full test job.
+
+    The Wave 6 inventory reads a pinned source blob with ``git show``. GitHub's
+    default depth-one checkout does not contain that historical commit.
+    """
+    for block in (
+        _core_tests_job_block(),
+        _all_tests_job_block(),
+        _nightly_deep_job_block(),
+    ):
+        checkout_start = block.index("    - uses: actions/checkout@v4")
+        checkout_end = block.index("\n    - name:", checkout_start)
+        assert "fetch-depth: 0" in block[checkout_start:checkout_end]
 
 
 def test_ci_exercises_mcp_against_minimum_textual() -> None:

--- a/backlog/tasks/task-3070 - chat_screen-size-ratchet-red-on-dev-after-console-decomposition-wave-3.md
+++ b/backlog/tasks/task-3070 - chat_screen-size-ratchet-red-on-dev-after-console-decomposition-wave-3.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-07 18:20'
-updated_date: '2026-08-11 04:55'
+updated_date: '2026-08-13 18:05'
 labels:
   - console
   - architecture-gate
@@ -17,22 +17,23 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-`Tests/Architecture/test_screen_size_ratchet.py::test_screen_does_not_grow_past_its_budget[tldw_chatbook/UI/Screens/chat_screen.py]`
-fails on dev: 18,930 lines against a budget of 18,909. Introduced by PR #1408 (console
-decomposition wave 3) itself — confirmed byte-identical on a clean dev-tip worktree at
-`15407a641` during the TASK-3035/3045 architecture-gate refresh (PR #1416), so it is not
-an artifact of any other branch. The decomposition stream is actively shrinking this
-screen; the 21-line overage is presumably transitional. Filed so the red gate is owned
-rather than becoming the next "pre-existing noise" that hides something real (see
-lessons-testing-evidence.md's TASK-2610 entry for how that ends). Resolve by shrinking
-the screen below budget in the next wave — not by raising the budget, unless the
-decomposition stream's owner explicitly decides the budget is wrong.
+The Console's one-way architecture ratchets are materially red on verified current
+`origin/dev`: `tldw_chatbook/UI/Screens/chat_screen.py` is 22,338 lines against a
+17,727-line ceiling, and `ChatScreen` has 705 direct methods against a 593-method
+ceiling. This task was originally filed at a 21-line overage after wave 3; later waves
+lowered the allowed ceiling while unrelated feature work kept accumulating in the
+screen. The result is now 4,611 lines and 112 methods over budget, not transitional
+noise. Resolve it through the reviewed Wave 6 controller extractions and lower the
+ratchets to the exact earned counts; never raise either budget to accept the growth.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The chat_screen size-ratchet test passes on dev
-- [ ] #2 The resolution shrinks the screen (or an explicit, documented owner decision adjusts the budget)
+- [ ] #1 On the final rebased dev base, both the `chat_screen.py` line-count and `ChatScreen` method-count ratchets pass without increasing either budget.
+- [ ] #2 The source-inspected Wave 6 move/delegate/stay inventory is enforced by AST ownership tests, and every retained screen delegate is framework-required, has a real caller, and its complete definition span (decorators excluded) is bounded to five physical source lines.
+- [ ] #3 Image/H3, video, conversation-browser, retrieval/RAG, skill, and character ownership moves to the reviewed controllers without changing DOM ownership, persistence ordering, worker groups, cancellation identity, remount/shutdown behavior, privacy, or user-visible outcomes.
+- [ ] #4 Every extracted family has isolated controller coverage using plain fakes without mounting Textual, including the Workspace browser extension, and the mounted product suites continue to cover screen/region integration.
+- [ ] #5 The coordinated child tasks TASK-3070.1 through TASK-3070.8 are completed independently with their focused verification evidence before this parent is closed.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,11 +43,11 @@ ADR required: no
 ADR path: N/A (governed by `Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md` and `DESIGN.md` section 7)
 Reason: This is the next implementation wave of the existing, approved Console decomposition architecture; it does not introduce a new runtime, storage, security, or cross-module policy.
 
-1. Record the current post-rebase measurement and map the image/H3, video, conversation-browser, and retrieval/RAG ownership clusters method by method.
-2. Write and review a wave-6 design that preserves Textual entry points on `ChatScreen`, keeps DOM work in regions/screen handlers, and puts non-DOM state/behaviour in explicit controllers wired through `UI/Console_Modules/wiring.py`.
-3. Characterize each cluster through its real product boundary before moving code, then extract one controller at a time with exact dependency signatures and separate commits.
-4. Run the controller, UI, Chat, Video Generation, RAG, architecture, worker-group, and import/reference regression suites after each extraction; mutation-check the screen delegations and controller ownership seams.
-5. Rebase onto final `origin/dev`, measure again, lower the ratchet to the exact earned line/method counts, update the decomposition spec/task notes, and run repository-level verification before marking Done.
+1. Complete TASK-3070.1: record the rebased line/method baseline and lock the reviewed source-inspected ownership inventory, residue budget, and AST rules before production movement.
+2. Complete TASK-3070.2 through TASK-3070.7 one PR at a time after its predecessor merges: characterize the real product boundary, add isolated no-mount controller tests, extract one family with named late-bound dependencies, and prove its screen delegates and invariants.
+3. Extend the existing Workspace controller as the single conversation-browser state owner while preserving collapse/config and activation/resume behavior; keep Textual decorators, direct DOM, modal/picker presentation, and OS-player launch on the screen or existing region widgets.
+4. After each extraction, run its isolated controller tests, focused product/mounted suites, AST ownership/dependency checks, required mutations, static checks, and privacy/diff gates before beginning the next child.
+5. Complete TASK-3070.8: rebase onto final `origin/dev`, repeat the baseline comparison, lower both ratchets to the exact earned counts, update canonical decomposition progress and every task's notes, run the full repository DoD, and only then close this parent.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-3070 - chat_screen-size-ratchet-red-on-dev-after-console-decomposition-wave-3.md
+++ b/backlog/tasks/task-3070 - chat_screen-size-ratchet-red-on-dev-after-console-decomposition-wave-3.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-3070
 title: chat_screen size ratchet red on dev after console decomposition wave 3
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-08-07 18:20'
 updated_date: '2026-08-11 04:55'
 labels:
@@ -33,6 +34,20 @@ decomposition stream's owner explicitly decides the budget is wrong.
 - [ ] #1 The chat_screen size-ratchet test passes on dev
 - [ ] #2 The resolution shrinks the screen (or an explicit, documented owner decision adjusts the budget)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A (governed by `Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md` and `DESIGN.md` section 7)
+Reason: This is the next implementation wave of the existing, approved Console decomposition architecture; it does not introduce a new runtime, storage, security, or cross-module policy.
+
+1. Record the current post-rebase measurement and map the image/H3, video, conversation-browser, and retrieval/RAG ownership clusters method by method.
+2. Write and review a wave-6 design that preserves Textual entry points on `ChatScreen`, keeps DOM work in regions/screen handlers, and puts non-DOM state/behaviour in explicit controllers wired through `UI/Console_Modules/wiring.py`.
+3. Characterize each cluster through its real product boundary before moving code, then extract one controller at a time with exact dependency signatures and separate commits.
+4. Run the controller, UI, Chat, Video Generation, RAG, architecture, worker-group, and import/reference regression suites after each extraction; mutation-check the screen delegations and controller ownership seams.
+5. Rebase onto final `origin/dev`, measure again, lower the ratchet to the exact earned line/method counts, update the decomposition spec/task notes, and run repository-level verification before marking Done.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 

--- a/backlog/tasks/task-3070.1 - Characterize-Console-Wave-6-ownership-and-ratchet-inventory.md
+++ b/backlog/tasks/task-3070.1 - Characterize-Console-Wave-6-ownership-and-ratchet-inventory.md
@@ -1,0 +1,88 @@
+---
+id: TASK-3070.1
+title: Characterize Console Wave 6 ownership and ratchet inventory
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-13 17:08'
+updated_date: '2026-08-13 19:35'
+labels:
+  - console
+  - architecture-gate
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+parent_task_id: TASK-3070
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Lock the source-inspected move/delegate/stay inventory and rebased ratchet baseline before any Wave 6 extraction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 AST inventory matches the reviewed Wave 6 design and fails on ownership drift
+- [x] #2 Projected net reduction clears both ratchet overages with the documented margin
+- [x] #3 No production behavior changes
+- [x] #4 Compatibility evidence locks the 30 assigned attributes plus the explicit `_console_video_store` seam, controller-owned defaults, initialization order, post-construction read/write behavior, fail-loud pre-controller getters and setters, and `getattr`/`hasattr` behavior
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Record the exact implementation-base commit and current ChatScreen line/method baseline.
+2. Add a test-owned Wave 6 inventory manifest for move/delegate/delete methods, residue budgets, and compatibility attributes.
+3. Add AST tests that compare the manifest to the implementation-base source and prove the projected reduction clears both overages.
+4. Characterize descriptor compatibility requirements, initialization order, and the explicit video-store override without editing production.
+5. Mutation-check the architecture evidence, run focused/static/privacy gates, and document results.
+
+ADR required: no
+ADR path: N/A
+Reason: This is test-only characterization under the existing screen-decomposition design and DESIGN.md section 7; it changes no runtime or ownership boundary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a test-owned, source-inspected manifest for all six Wave 6 families: 143
+implementation-base definitions, their exact physical spans, current/target ownership,
+retained delegates, real framework/registry bindings, DOM-free controller boundaries,
+and the conservative 4,968-line/129-method reduction. The test reads the immutable
+implementation base with `git show`, so later extraction PRs cannot erase the baseline
+evidence they are measured against.
+
+Locked all 31 compatibility attributes: the exact 30 implementation-base assignments,
+the externally written `_console_video_store` seam, lazy and eager default semantics,
+controller initialization before reads, owner wiring, post-build read/write forwarding,
+and fail-loud pre-build getter/setter/`getattr`/`hasattr` behavior. Negative fixtures and
+production mutations proved the base SHA, ownership, external write, default, DOM,
+delegate-reachability, delegate-span, read-before-write, and shadow-state checks are
+non-vacuous. No production source changed.
+
+Verification:
+
+- Focused inventory: 5 passed; Ruff check/format and `git diff --check` passed.
+- Full Architecture suite: 45 passed and 3 known baseline failures (the two existing
+  persistent-diagnostic inventory failures plus the intentionally red 22,338/17,727
+  Console line ratchet this Wave closes).
+- A serial full-suite run was stopped after 658.11s at 13 failed, 3,618 passed, 60
+  skipped; failures were outside this task's test/docs-only scope. A subsequent xdist
+  attempt was stopped at 12% because shared-state tests produced a materially different
+  failure explosion, so it was not treated as valid regression evidence. TASK-3070.8
+  owns the final rebased full-suite DoD after the ratchet is lowered.
+- Independent final specification/quality review approved the current bytes with no
+  Critical, Important, or Minor findings.
+
+Rebase verification on 2026-08-13 updated the immutable implementation base to
+`bed39af6b004e4db86218fad01d2ea515b332135`: 22,338 lines, 705 methods, and overages of
+4,611/112. All 143 reviewed definitions and their 5,151 aggregate physical lines were
+unchanged, so the conservative projection still clears both ratchets with 357 lines and
+17 methods of margin.
+
+Modified files are the Wave 6 design, parent/child Backlog records, and
+`Tests/Architecture/test_console_wave6_inventory.py`. ADR check: no new ADR; this is
+test-only characterization under the existing decomposition architecture.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3070.2 - Extract-Console-image-and-H3-controller.md
+++ b/backlog/tasks/task-3070.2 - Extract-Console-image-and-H3-controller.md
@@ -1,0 +1,31 @@
+---
+id: TASK-3070.2
+title: Extract Console image and H3 controller
+status: To Do
+assignee:
+  - '@codex'
+created_date: '2026-08-13 17:08'
+updated_date: '2026-08-13 17:14'
+labels:
+  - console
+  - image-generation
+dependencies:
+  - TASK-3070.1
+references:
+  - Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+parent_task_id: TASK-3070
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the reviewed non-DOM image-generation and H3 lifecycle ownership out of ChatScreen.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Image/H3 move inventory is controller-owned and screen entry points are bounded delegates
+- [ ] #2 H3 cancellation, remount, settlement, persistence, and attachment behavior is unchanged
+- [ ] #3 Isolated controller tests run without mounting Textual
+<!-- AC:END -->

--- a/backlog/tasks/task-3070.3 - Extract-Console-video-controller.md
+++ b/backlog/tasks/task-3070.3 - Extract-Console-video-controller.md
@@ -1,0 +1,31 @@
+---
+id: TASK-3070.3
+title: Extract Console video controller
+status: To Do
+assignee:
+  - '@codex'
+created_date: '2026-08-13 17:08'
+updated_date: '2026-08-13 17:14'
+labels:
+  - console
+  - video
+dependencies:
+  - TASK-3070.2
+references:
+  - Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+parent_task_id: TASK-3070
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move generated-video lifecycle, publication, persistence, and orchestration ownership out of ChatScreen while presentation stays screen-owned.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Video move inventory is controller-owned and screen entry points are bounded delegates
+- [ ] #2 Cancellation identity, worker groups, storage/publication order, remount drains, and presentation behavior are unchanged
+- [ ] #3 Isolated controller tests run without mounting Textual
+<!-- AC:END -->

--- a/backlog/tasks/task-3070.4 - Consolidate-Console-conversation-browser-into-Workspace-controller.md
+++ b/backlog/tasks/task-3070.4 - Consolidate-Console-conversation-browser-into-Workspace-controller.md
@@ -1,0 +1,32 @@
+---
+id: TASK-3070.4
+title: Consolidate Console conversation browser into Workspace controller
+status: To Do
+assignee:
+  - '@codex'
+created_date: '2026-08-13 17:09'
+updated_date: '2026-08-13 18:10'
+labels:
+  - console
+  - conversation-browser
+dependencies:
+  - TASK-3070.3
+references:
+  - Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+parent_task_id: TASK-3070
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move conversation row, cache, filtering, and search ownership out of ChatScreen by extending the existing Workspace owner, eliminating the duplicate search-state authority.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ConsoleWorkspaceController owns one canonical browser query/timer/token/result lifecycle and the screen search handler is a bounded delegate
+- [ ] #2 Rich browser rows are canonical; legacy Workspace rows are an explicit read/write projection, and no legacy refresh path remains as a second writer
+- [ ] #3 Existing and newer scalar browser compatibility names read and write the same Workspace-owned state while collapse/config and activation/resume behavior remain unchanged
+- [ ] #4 Existing Workspace controller tests cover the browser transitions and row projections without mounting Textual, and AST checks reject `query_one` in every moved browser method
+<!-- AC:END -->

--- a/backlog/tasks/task-3070.5 - Extract-Console-retrieval-controller.md
+++ b/backlog/tasks/task-3070.5 - Extract-Console-retrieval-controller.md
@@ -1,0 +1,31 @@
+---
+id: TASK-3070.5
+title: Extract Console retrieval controller
+status: To Do
+assignee:
+  - '@codex'
+created_date: '2026-08-13 17:09'
+updated_date: '2026-08-13 17:15'
+labels:
+  - console
+  - rag
+dependencies:
+  - TASK-3070.4
+references:
+  - Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+parent_task_id: TASK-3070
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move retrieval scope, library-RAG, auto-retrieve, and cached inspector policy out of ChatScreen while DOM and decorated worker entry points stay screen-owned.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Retrieval move inventory is controller-owned and decorated screen entry points are bounded delegates
+- [ ] #2 Scope persistence, worker groups, auto-retrieve, degraded-state, and inspector behavior are unchanged
+- [ ] #3 Isolated controller tests run without mounting Textual
+<!-- AC:END -->

--- a/backlog/tasks/task-3070.6 - Extract-Console-skill-controller.md
+++ b/backlog/tasks/task-3070.6 - Extract-Console-skill-controller.md
@@ -1,0 +1,32 @@
+---
+id: TASK-3070.6
+title: Extract Console skill controller
+status: To Do
+assignee:
+  - '@codex'
+created_date: '2026-08-13 17:09'
+updated_date: '2026-08-13 18:10'
+labels:
+  - console
+  - skills
+dependencies:
+  - TASK-3070.5
+references:
+  - Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+parent_task_id: TASK-3070
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move live skill discovery, trust/block policy, refusal, and pending-decision state out of ChatScreen while deleting the unreachable fallback/picker chain.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Live skill move inventory is controller-owned and command/Textual entry points are bounded delegates
+- [ ] #2 The unregistered fallback dispatch, dead run/search/picker methods, unused picker widget, CSS/cross-references, imports, obsolete tests, and surviving resolver/style-picker documentation references are removed or rewritten rather than extracted
+- [ ] #3 Live `/skills`, `$name`, trust, refusal, install, and script behavior is unchanged
+- [ ] #4 Isolated controller tests run without mounting Textual
+<!-- AC:END -->

--- a/backlog/tasks/task-3070.7 - Extract-Console-character-controller.md
+++ b/backlog/tasks/task-3070.7 - Extract-Console-character-controller.md
@@ -1,0 +1,31 @@
+---
+id: TASK-3070.7
+title: Extract Console character controller
+status: To Do
+assignee:
+  - '@codex'
+created_date: '2026-08-13 17:09'
+updated_date: '2026-08-13 17:15'
+labels:
+  - console
+  - characters
+dependencies:
+  - TASK-3070.6
+references:
+  - Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+parent_task_id: TASK-3070
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move character picker projection, handoff policy, identity, and avatar retrieval state out of ChatScreen while modal and rail pixels stay screen/region-owned.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Character move inventory is controller-owned and screen/region presentation seams are bounded
+- [ ] #2 Prompt seed, session handoff, avatar refresh, and rail rendering behavior is unchanged
+- [ ] #3 Isolated controller tests run without mounting Textual
+<!-- AC:END -->

--- a/backlog/tasks/task-3070.8 - Close-Console-decomposition-Wave-6-ratchet.md
+++ b/backlog/tasks/task-3070.8 - Close-Console-decomposition-Wave-6-ratchet.md
@@ -1,0 +1,37 @@
+---
+id: TASK-3070.8
+title: Close Console decomposition Wave 6 ratchet
+status: To Do
+assignee:
+  - '@codex'
+created_date: '2026-08-13 17:09'
+updated_date: '2026-08-13 17:16'
+labels:
+  - console
+  - architecture-gate
+dependencies:
+  - TASK-3070.1
+  - TASK-3070.2
+  - TASK-3070.3
+  - TASK-3070.4
+  - TASK-3070.5
+  - TASK-3070.6
+  - TASK-3070.7
+references:
+  - Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+parent_task_id: TASK-3070
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase the completed Wave 6 extractions, lower the one-way ratchet to the exact earned values, update canonical progress, and close the coordinated parent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Final rebased ChatScreen line and method counts pass ratchets without increasing a budget
+- [ ] #2 All focused, mounted, architecture, static, privacy, and full-suite gates pass
+- [ ] #3 TASK-3070 and all completed child tasks contain implementation notes and satisfy repository DoD
+<!-- AC:END -->


### PR DESCRIPTION
## Summary
- pin the immutable Wave 6 ChatScreen method/span inventory
- lock controller ownership, delegate, DOM, and compatibility descriptor contracts
- prove the projected extraction clears the existing line and method ratchets

## Verification
- `pytest Tests/Architecture/test_console_wave6_inventory.py -q` — 5 passed
- `ruff check Tests/Architecture/test_console_wave6_inventory.py`
- `git diff origin/dev...HEAD --check`

## Scope
TASK-3070.1 is test/docs-only. The intentionally red ChatScreen size ratchet is closed by the serial extraction child PRs TASK-3070.2 through TASK-3070.8.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks the Wave 6 Console decomposition inventory and ratchet baseline, with CI now fetching full git history to support pinned-source tests. No runtime behavior changes; CI checkout switches from shallow to full history.

- Proves the rebased baseline (22,338 lines, 705 methods) and that the reviewed projection clears both overages (at least 4,968 lines and 129 methods removed).
- Enforces six ownership families (image/H3, video, conversation browser into `ConsoleWorkspaceController`, retrieval/RAG, skills with dead fallback/picker deleted, character); controllers are DOM-free and screen delegates stay framework-required and ≤5 lines.
- Locks 31 `ChatScreen` compatibility names via a small read/write descriptor plan; preserves the external `_console_video_store` override seam.
- Adds the Wave 6 design spec and updates `TASK-3070` backlog records; hardens CI by setting `fetch-depth: 0` for jobs running architecture tests and asserts this in `Tests/CI/test_github_actions_test_workflow.py`.

**Review notes**
- Read `Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md` for boundaries and budgets.
- Run `pytest Tests/Architecture/test_console_wave6_inventory.py -q`. CI must use full history; the workflow sets `fetch-depth: 0` and the CI test verifies it.

**Rollout**
- Connects to `TASK-3070` and completes `TASK-3070.1` (test/docs-only characterization). No migration actions.
- Child PRs `TASK-3070.2`–`TASK-3070.7` will extract each family; `TASK-3070.8` will rebase and lower the ratchets to the earned values.

<sup>Written for commit 56422686fb356d74c392f9eed8b223095f917099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

