### PR TITLE
Harden Moonshot Kimi and Z.ai GLM hosted providers

### DIFF
--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -240,6 +240,62 @@ does not print the key, prompt, or response. Override the defaults only when
 your account requires it with `TLDW_LIVE_QWENCLOUD_MODEL` or
 `TLDW_LIVE_QWENCLOUD_API_BASE_URL`.
 
+#### Moonshot Kimi and Z.ai GLM in Console
+
+**Moonshot** and **Z.ai** use their stable provider identities and the ordinary
+streaming Console path. They support Chat Completions only—there is no Responses
+mode or provider conversation ID. Fresh defaults are `kimi-k3` at
+`https://api.moonshot.ai/v1` and `glm-5.2` at
+`https://api.z.ai/api/paas/v4`; saved historical models remain usable.
+Moonshot's China endpoint and intentional compatible custom endpoints are
+configured in **F9 ▸ Providers & Models**.
+
+- Existing Chatbook function tools use the same approval, cancellation,
+  execution, budget, and durable recovery loop for both providers. Moonshot
+  and Z.ai hosted search, retrieval, code, memory, and other built-in tools are
+  not exposed.
+- Kimi K3 uses always-on Preserved Thinking. Its retained assistant reasoning
+  is private but is replayed when K3 requires it. Other Kimi models follow only
+  their curated policy. GLM keeps reasoning for an active or restored function
+  tool run with `clear_thinking=false`; ordinary GLM chat clears prior thinking.
+- Private continuation data is assistant/variant-owned, bounded, and omitted
+  from the visible transcript, logs, summaries, ordinary exports, and usage
+  details. It still counts against the context window and is evicted atomically
+  with its visible owner.
+- Terminal usage reaches Console when the provider returns it. If a selected
+  model has no verified rate, **pricing unknown** means cost was not estimated;
+  it never means free.
+- Model discovery reuses the chat endpoint and credential. Moonshot discovery
+  is authenticated; Z.ai is best-effort, so a failed catalog refresh keeps the
+  configured/cached models and does not block generation.
+
+If a tool run is interrupted, opening the conversation does not execute
+anything. Use **Resume** only after checking the pending calls and approving
+them again; Console pins the original provider, model, Chat-Completions
+protocol, and normalized base while resolving the current credential. Use
+**Take over** to continue visibly without replaying the provider checkpoint, or
+**Discard** to clear it. Executing calls remain ambiguous and are blocked;
+completed and failed calls are not run again. Invalid endpoint/config errors
+must be repaired and saved in Settings before retrying.
+
+Optional live verification is paid and skipped by default. Export the relevant
+API key before running either command. Each command starts
+a fresh isolated profile, suppresses child output/logging, and proves one real
+Calculator result changes the final answer. It requires both the exact opt-in
+flag and a nonblank key:
+
+```bash
+TLDW_LIVE_MOONSHOT=1 .venv/bin/python -m pytest -q \
+  Tests/Chat/test_live_moonshot_zai_api.py -k moonshot
+
+TLDW_LIVE_ZAI=1 .venv/bin/python -m pytest -q \
+  Tests/Chat/test_live_moonshot_zai_api.py -k zai
+```
+
+Use `TLDW_LIVE_MOONSHOT_MODEL` / `TLDW_LIVE_MOONSHOT_API_BASE_URL` or
+`TLDW_LIVE_ZAI_MODEL` / `TLDW_LIVE_ZAI_API_BASE_URL` only when your account
+requires an override. The default test suite makes no paid request.
+
 ### Leaving Console during a run
 
 Agent runs are screen-scoped: navigating to any other screen cancels every

--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -198,6 +198,57 @@ Recovery is fail-closed:
   `[api_settings.qwencloud]` table, set a valid `api_mode`, then **Validate Raw
   TOML**, **Save Raw TOML**, and **Reload Config** under Diagnostics.
 
+#### Moonshot Kimi and Z.ai GLM
+
+Choose **Moonshot** or **ZAI** without changing their saved provider identity.
+They use Chat Completions only, so neither provider shows an **API mode**
+selector.
+
+| Provider | Fresh default | Credential | General endpoint | Reasoning for the default model |
+|---|---|---|---|---|
+| Moonshot / Kimi | `kimi-k3` | `MOONSHOT_API_KEY` | `https://api.moonshot.ai/v1` | exactly `low`, `high`, or `max` |
+| Z.ai / GLM | `glm-5.2` | `ZAI_API_KEY` | `https://api.z.ai/api/paas/v4` | exactly `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` |
+
+Moonshot can instead use the China base `https://api.moonshot.cn/v1` or a
+validated custom compatible base. Z.ai's coding-only
+`https://api.z.ai/api/coding/paas/v4` endpoint is not the general Chat default;
+save the general endpoint or an intentional custom compatible gateway here.
+Explicit historical IDs such as `moonshot-v1-128k` and `glm-4.5` remain
+selected and editable. Settings does not guess their capabilities: its help
+asks you to verify reasoning support instead of silently replacing the model.
+
+The provider/model profile owns the visible reasoning selector. Kimi K3 does
+not receive legacy sampler fields; its request uses the documented common
+output/stop/format/function-tool subset. Historical Moonshot families retain
+their curated sampler surface. GLM 5.2 accepts its documented sampler and
+reasoning fields. For function tools, Moonshot accepts an unset choice,
+`auto`, `none`, `required`, or an exact configured function selection; Z.ai
+accepts only an unset choice or `auto`. Unsupported choices and values block
+before network I/O.
+
+Kimi K3 Preserved Thinking is always on. Required Kimi reasoning and active or
+restored GLM function-tool reasoning are kept in bounded assistant-owned
+private continuation checkpoints. They are excluded from visible transcripts,
+logs, summaries, ordinary text/Markdown exports, and usage records, but their
+tokens still consume the shared context budget. Private-aware JSON/Chatbook
+exports show a warning. Ordinary GLM chat clears prior thinking; no separate
+Z.ai thinking selector is exposed.
+
+**Discover models** uses authenticated `GET {base}/models` for Moonshot and a
+best-effort request for Z.ai. Both reuse the exact normalized base and current
+credential that chat would use. Failures keep configured/cached IDs, never
+block an otherwise ready Z.ai chat, and never infer reasoning/tool support from
+a discovered name. The selector stays capped at 50 while the model picker can
+search the full cached list; the disk cache contains IDs and timestamps only.
+Usage is recorded when returned. **Pricing unknown** means Chatbook has no
+verified rate for that model, not that the call is free.
+
+If Test Provider reports invalid settings, keep exactly one canonical
+`[api_settings.moonshot]` or `[api_settings.zai]` table, remove normalized
+duplicates, enter a nonblank model and an absolute HTTP(S) base without
+credentials in the URL, then correct timeout/retry/streaming types in
+**Advanced Config**. Test the draft again before saving.
+
 ### Core — Speech & TTS
 
 Application-wide speech and text-to-speech defaults — which TTS provider

--- a/Docs/superpowers/plans/2026-08-12-kimi-zai-hosted-chat-completions-implementation.md
+++ b/Docs/superpowers/plans/2026-08-12-kimi-zai-hosted-chat-completions-implementation.md
@@ -37,8 +37,8 @@ Reason: This PR implements ADR-063's reusable hosted Chat wire boundary and prov
 
 ## Branch And Baseline Discipline
 
-- [ ] Begin only after TASK-15675 is merged. Create a fresh `codex/kimi-zai-hosted-chat` branch/worktree from current `origin/dev`; do not reuse the foundation worktree.
-- [ ] Put TASK-15676 In Progress before production edits, then add a structured Implementation Plan section to its task file that links this document and ADR-063; do not replace it with a one-line CLI plan:
+- [x] Begin only after TASK-15675 is merged. Create a fresh `codex/kimi-zai-hosted-chat` branch/worktree from current `origin/dev`; do not reuse the foundation worktree.
+- [x] Put TASK-15676 In Progress before production edits, then add a structured Implementation Plan section to its task file that links this document and ADR-063; do not replace it with a one-line CLI plan:
 
   ```bash
   backlog task edit 15676 -s "In Progress"
@@ -46,8 +46,8 @@ Reason: This PR implements ADR-063's reusable hosted Chat wire boundary and prov
   backlog task 15676 --plain
   ```
 
-- [ ] Record clean-base results for QwenCloud, Moonshot/Z.ai mocked calls, gateway/native tools, Settings, and model catalog. Reproduce any localhost-only failures outside the socket sandbox.
-- [ ] Every cycle must be observed RED at the named behavior before implementation and GREEN afterward. Use captured official-shaped fixtures and real loopback HTTP for transport/joined tests; do not mock away dispatcher/gateway/runtime boundaries.
+- [x] Record clean-base results for QwenCloud, Moonshot/Z.ai mocked calls, gateway/native tools, Settings, and model catalog. Reproduce any localhost-only failures outside the socket sandbox.
+- [x] Every cycle must be observed RED at the named behavior before implementation and GREEN afterward. Use captured official-shaped fixtures and real loopback HTTP for transport/joined tests; do not mock away dispatcher/gateway/runtime boundaries.
 
 ## Shared Interfaces To Implement
 
@@ -135,13 +135,13 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
 - Modify: `tldw_chatbook/LLM_Calls/qwencloud_streaming.py`
 - Modify: `Tests/LLM_Calls/test_qwencloud_streaming.py`
 
-- [ ] **Cycle 1A — URL RED:** add exact tests for HTTP(S), authority, userinfo/query/fragment, controls/backslashes, empty/doubled segments, terminal lowercase `/chat/completions`, `/responses`, case/lookalikes, repeated/stacked tails, encoded separators/dot segments/reserved tails, safe encoded ordinary data, IPv6/port, and the 2,000-character pre-parse cap. Implement the pure structural helper and assert source immutability.
-- [ ] The helper strips at most one exact terminal lowercase `/chat/completions`; it rejects `/responses` and ambiguous request tails. Chat URL is `{base}/chat/completions`; discovery later uses `{base}/models`.
-- [ ] **Cycle 1B — SSE framing RED:** copy the existing QwenCloud captured framing corpus into provider-neutral record tests: split UTF-8, CR/LF/CRLF, comments, ignored `id`/`retry`/unknown non-data fields, exact optional `event:` preservation, multiline `data`, blank-record dispatch, truncated EOF, line/record/event/depth/node/byte caps, and linear segment accumulation. Implement `SSERecordDecoder` without provider finish semantics.
-- [ ] **Cycle 1C — generic Chat normalization RED:** add text-only, tool-only, mixed text/tool, multiple interleaved call indexes, nullable fields, usage-only terminal, exact replay, finish disagreement, malformed arguments, deep JSON, and post-terminal cases. Keep provider finish sets and `reasoning_content` admission behind narrow supplied policies.
-- [ ] **Cycle 1D — route-neutral transport/lifecycle RED:** real loopback tests assert exact route, POST URL/headers/body/timeout; one global `retries+1` budget; POST-only 429/500/502/503/504 plus connect/timeout; integer/date/malformed Retry-After; no retry after a body byte or any 2xx body read; typed 401/403/429/4xx/5xx/network/malformed errors; and response/session closure exactly once on normal, error, cancellation, explicit/repeated close, and cleanup failures. Exercise both allowed routes without adding Responses semantics here.
-- [ ] **Cycle 1E — Qwen compatibility gate:** route only QwenCloud Chat SSE framing/generic normalization through the extracted primitives. Keep `qwencloud.py` transport and QwenCloud Responses untouched. Run the entire existing adapter/streaming/native suite before and after. Add a shared captured-event parity test and mutation-test one tool index or terminal finish; the mutation must fail.
-- [ ] Run:
+- [x] **Cycle 1A — URL RED:** add exact tests for HTTP(S), authority, userinfo/query/fragment, controls/backslashes, empty/doubled segments, terminal lowercase `/chat/completions`, `/responses`, case/lookalikes, repeated/stacked tails, encoded separators/dot segments/reserved tails, safe encoded ordinary data, IPv6/port, and the 2,000-character pre-parse cap. Implement the pure structural helper and assert source immutability.
+- [x] The helper strips at most one exact terminal lowercase `/chat/completions`; it rejects `/responses` and ambiguous request tails. Chat URL is `{base}/chat/completions`; discovery later uses `{base}/models`.
+- [x] **Cycle 1B — SSE framing RED:** copy the existing QwenCloud captured framing corpus into provider-neutral record tests: split UTF-8, CR/LF/CRLF, comments, ignored `id`/`retry`/unknown non-data fields, exact optional `event:` preservation, multiline `data`, blank-record dispatch, truncated EOF, line/record/event/depth/node/byte caps, and linear segment accumulation. Implement `SSERecordDecoder` without provider finish semantics.
+- [x] **Cycle 1C — generic Chat normalization RED:** add text-only, tool-only, mixed text/tool, multiple interleaved call indexes, nullable fields, usage-only terminal, exact replay, finish disagreement, malformed arguments, deep JSON, and post-terminal cases. Keep provider finish sets and `reasoning_content` admission behind narrow supplied policies.
+- [x] **Cycle 1D — route-neutral transport/lifecycle RED:** real loopback tests assert exact route, POST URL/headers/body/timeout; one global `retries+1` budget; POST-only 429/500/502/503/504 plus connect/timeout; integer/date/malformed Retry-After; no retry after a body byte or any 2xx body read; typed 401/403/429/4xx/5xx/network/malformed errors; and response/session closure exactly once on normal, error, cancellation, explicit/repeated close, and cleanup failures. Exercise both allowed routes without adding Responses semantics here.
+- [x] **Cycle 1E — Qwen compatibility gate:** route only QwenCloud Chat SSE framing/generic normalization through the extracted primitives. Keep `qwencloud.py` transport and QwenCloud Responses untouched. Run the entire existing adapter/streaming/native suite before and after. Add a shared captured-event parity test and mutation-test one tool index or terminal finish; the mutation must fail.
+- [x] Run:
 
   ```bash
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_hosted_chat.py Tests/LLM_Calls/test_hosted_chat_streaming.py Tests/LLM_Calls/test_qwencloud.py Tests/LLM_Calls/test_qwencloud_streaming.py Tests/Chat/test_qwencloud_native_tools.py
@@ -149,7 +149,7 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m mypy tldw_chatbook/LLM_Calls/hosted_chat.py tldw_chatbook/LLM_Calls/hosted_chat_streaming.py
   ```
 
-- [ ] Commit:
+- [x] Commit:
 
   ```bash
   git add tldw_chatbook/LLM_Calls/hosted_chat.py tldw_chatbook/LLM_Calls/hosted_chat_streaming.py tldw_chatbook/LLM_Calls/qwencloud_streaming.py Tests/LLM_Calls/test_hosted_chat.py Tests/LLM_Calls/test_hosted_chat_streaming.py Tests/LLM_Calls/test_qwencloud_streaming.py
@@ -166,7 +166,7 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
 - Modify: `tldw_chatbook/Chat/Chat_Functions.py`
 - Modify: `Tests/Chat/test_chat_unit_mocked_APIs.py`
 
-- [ ] Define pure public helpers:
+- [x] Define pure public helpers:
 
   ```python
   def resolve_moonshot_request(
@@ -192,20 +192,20 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
   ) -> dict[str, Any]: ...
   ```
 
-- [ ] **Cycle 2A — resolution RED:** canonical `api_settings.moonshot` beats its environment; explicit args beat config; configured env name falls back to `MOONSHOT_API_KEY`; malformed canonical table/blank/placeholder key/model/base/timeout/retry fields fail before lower-priority reads or network. `api_region` is fallback only when canonical base is absent. Remove the orphaned top-level `moonshot_api` lookup rather than creating a legacy owner.
-- [ ] **Cycle 2B — message/tool RED:** validate/deep-copy system/user/assistant/tool history, exact call/result pairing and ordering, unique IDs across outbound history, standard function schema, and Moonshot tool choices absent/`auto`/`none`/`required`/forced function. Reject provider-built-in tool types/private metadata and malformed/cross-batch/orphan results before I/O.
-- [ ] **Cycle 2C — K3 allowlist RED:** for `kimi-k3`, allow only `model`, `messages`, `stream`, `max_completion_tokens`, `stop`, `response_format`, `tools`, `tool_choice`, `reasoning_effort`, and adapter-owned `stream_options`. Accept effort `low|high|max`; map generic `max_tokens`; set `include_usage` only for streaming; omit valid unsupported generic sampler defaults but reject invalid supplied values.
-- [ ] **Cycle 2D — family policy RED:** cover curated `moonshot-v1-*` documented sampler ranges/relationships and conservative unknown-model subset. Do not infer capabilities from substrings or newly discovered IDs. Preserve explicit historical IDs.
-- [ ] **Cycle 2E — continuation RED:** expand TASK-15675 checkpoints so K3 replays every retained exact `reasoning_content`; active/restored supported Kimi tool runs replay only documented content. A tool-free K3 final response yields a complete reasoning-only round tied to the same visible owner. Assert no visible/log/error/usage/human-export leakage.
-- [ ] **Cycle 2F — response RED:** run nonstream and stream official-shaped fixtures through the neutral boundary. Enforce Moonshot finishes `stop|tool_calls|length`, mixed text/tools, exact terminal usage, malformed/empty success rejection, typed errors, cancellation, and strict budget usage.
-- [ ] Replace the large `LLM_API_Calls.py` function body with a compatibility import/wrapper preserving the public signature and metrics/provider labels. Keep dispatcher parameter mapping explicit.
-- [ ] Run:
+- [x] **Cycle 2A — resolution RED:** canonical `api_settings.moonshot` beats its environment; explicit args beat config; configured env name falls back to `MOONSHOT_API_KEY`; malformed canonical table/blank/placeholder key/model/base/timeout/retry fields fail before lower-priority reads or network. `api_region` is fallback only when canonical base is absent. Remove the orphaned top-level `moonshot_api` lookup rather than creating a legacy owner.
+- [x] **Cycle 2B — message/tool RED:** validate/deep-copy system/user/assistant/tool history, exact call/result pairing and ordering, unique IDs across outbound history, standard function schema, and Moonshot tool choices absent/`auto`/`none`/`required`/forced function. Reject provider-built-in tool types/private metadata and malformed/cross-batch/orphan results before I/O.
+- [x] **Cycle 2C — K3 allowlist RED:** for `kimi-k3`, allow only `model`, `messages`, `stream`, `max_completion_tokens`, `stop`, `response_format`, `tools`, `tool_choice`, `reasoning_effort`, and adapter-owned `stream_options`. Accept effort `low|high|max`; map generic `max_tokens`; set `include_usage` only for streaming; omit valid unsupported generic sampler defaults but reject invalid supplied values.
+- [x] **Cycle 2D — family policy RED:** cover curated `moonshot-v1-*` documented sampler ranges/relationships and conservative unknown-model subset. Do not infer capabilities from substrings or newly discovered IDs. Preserve explicit historical IDs.
+- [x] **Cycle 2E — continuation RED:** expand TASK-15675 checkpoints so K3 replays every retained exact `reasoning_content`; active/restored supported Kimi tool runs replay only documented content. A tool-free K3 final response yields a complete reasoning-only round tied to the same visible owner. Assert no visible/log/error/usage/human-export leakage.
+- [x] **Cycle 2F — response RED:** run nonstream and stream official-shaped fixtures through the neutral boundary. Enforce Moonshot finishes `stop|tool_calls|length`, mixed text/tools, exact terminal usage, malformed/empty success rejection, typed errors, cancellation, and strict budget usage.
+- [x] Replace the large `LLM_API_Calls.py` function body with a compatibility import/wrapper preserving the public signature and metrics/provider labels. Keep dispatcher parameter mapping explicit.
+- [x] Run:
 
   ```bash
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_moonshot.py Tests/LLM_Calls/test_hosted_chat.py Tests/LLM_Calls/test_hosted_chat_streaming.py Tests/Chat/test_chat_unit_mocked_APIs.py -k "moonshot or hosted_chat"
   ```
 
-- [ ] Commit:
+- [x] Commit:
 
   ```bash
   git add tldw_chatbook/LLM_Calls/moonshot.py tldw_chatbook/LLM_Calls/LLM_API_Calls.py tldw_chatbook/Chat/Chat_Functions.py Tests/LLM_Calls/test_moonshot.py Tests/Chat/test_chat_unit_mocked_APIs.py
@@ -224,19 +224,19 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
 - Modify: `Tests/Agents/test_native_tools.py`
 - Modify: `Tests/Chat/test_chat_unit_mocked_APIs.py`
 
-- [ ] Mirror Task 2's pure resolution/builder split, using exact canonical `api_settings.zai`, `ZAI_API_KEY`, general base `https://api.z.ai/api/paas/v4`, and default `glm-5.2`. Malformed exact tables block before environment/network and source mappings remain unchanged.
-- [ ] **Cycle 3A — allowlist RED:** allow only `model`, `messages`, `do_sample`, `stream`, `thinking`, `temperature`, `top_p`, `reasoning_effort`, `max_tokens`, `tools`, `tool_choice`, `stop`, `response_format`, `request_id`, and generic user identifier mapped to `user_id`. `glm-5.2` effort values are exactly `none|minimal|low|medium|high|xhigh|max`; other curated models own explicit policies. Unknown kwargs are omitted.
-- [ ] **Cycle 3B — thinking/tool RED:** ordinary/tool-free chat sends `clear_thinking=true`; only an active or explicitly restored function-tool run sends `thinking.clear_thinking=false` and exact checkpoint reasoning. Accept only function tools and tool choice absent/`auto`; reject forced/required/none/provider tool types. Keep `tool_stream` absent.
-- [ ] **Cycle 3C — response RED:** enforce usable finishes `stop|tool_calls|length`; map `sensitive`, `model_context_window_exceeded`, and `network_error` to safe terminal provider errors. Normalize bounded object arguments deterministically to a JSON string; reject other scalar/container shapes, incomplete calls, empty success, unknown/blank/conflicting finishes, and malformed usage.
-- [ ] Replace the legacy function body with a compatibility wrapper and keep Z.ai out of the native registry while its direct/gateway tests are developed.
-- [ ] **Cycle 3D — eligibility RED/GREEN:** add a registry test that is initially RED for missing `zai`. Run joined tool tests under a temporary capability fixture first; only after forwarding/history/cancellation/closure pass, add `zai` to `NATIVE_TOOLS_PROVIDERS`, remove the fixture, and rerun unpatched. The membership change is this task's last production change.
-- [ ] Run:
+- [x] Mirror Task 2's pure resolution/builder split, using exact canonical `api_settings.zai`, `ZAI_API_KEY`, general base `https://api.z.ai/api/paas/v4`, and default `glm-5.2`. Malformed exact tables block before environment/network and source mappings remain unchanged.
+- [x] **Cycle 3A — allowlist RED:** allow only `model`, `messages`, `do_sample`, `stream`, `thinking`, `temperature`, `top_p`, `reasoning_effort`, `max_tokens`, `tools`, `tool_choice`, `stop`, `response_format`, `request_id`, and generic user identifier mapped to `user_id`. `glm-5.2` effort values are exactly `none|minimal|low|medium|high|xhigh|max`; other curated models own explicit policies. Unknown kwargs are omitted.
+- [x] **Cycle 3B — thinking/tool RED:** ordinary/tool-free chat sends `clear_thinking=true`; only an active or explicitly restored function-tool run sends `thinking.clear_thinking=false` and exact checkpoint reasoning. Accept only function tools and tool choice absent/`auto`; reject forced/required/none/provider tool types. Keep `tool_stream` absent.
+- [x] **Cycle 3C — response RED:** enforce usable finishes `stop|tool_calls|length`; map `sensitive`, `model_context_window_exceeded`, and `network_error` to safe terminal provider errors. Normalize bounded object arguments deterministically to a JSON string; reject other scalar/container shapes, incomplete calls, empty success, unknown/blank/conflicting finishes, and malformed usage.
+- [x] Replace the legacy function body with a compatibility wrapper and keep Z.ai out of the native registry while its direct/gateway tests are developed.
+- [x] **Cycle 3D — eligibility RED/GREEN:** add a registry test that is initially RED for missing `zai`. Run joined tool tests under a temporary capability fixture first; only after forwarding/history/cancellation/closure pass, add `zai` to `NATIVE_TOOLS_PROVIDERS`, remove the fixture, and rerun unpatched. The membership change is this task's last production change.
+- [x] Run:
 
   ```bash
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_zai.py Tests/Agents/test_native_tools.py Tests/Chat/test_chat_unit_mocked_APIs.py -k "zai or hosted_chat or native_provider_contract"
   ```
 
-- [ ] Commit:
+- [x] Commit:
 
   ```bash
   git add tldw_chatbook/LLM_Calls/zai.py tldw_chatbook/LLM_Calls/LLM_API_Calls.py tldw_chatbook/Chat/Chat_Functions.py tldw_chatbook/Agents/native_tools.py Tests/LLM_Calls/test_zai.py Tests/Agents/test_native_tools.py Tests/Chat/test_chat_unit_mocked_APIs.py
@@ -254,10 +254,10 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
 - Modify: `Tests/Chat/test_console_agent_bridge.py`
 - Create: `Tests/Chat/test_kimi_zai_provider_contract.py`
 
-- [ ] **Cycle 4A — frozen handoff RED:** assert resolution freezes provider/model/base/key/timeout/retries/retry delay for the whole send and auxiliary calls. Mutate config and environment between model turns; exact pinned values remain. Do not add `api_mode` for either provider.
-- [ ] Extend the existing immutable Console resolution/kwargs paths with timeout/retry policy only if not already carried; do not create provider-specific Console resolution types. Provider-local frozen `MoonshotResolution`/`ZAIResolution` remain required at the adapter boundary. Sensitive keys remain repr/log safe and are never persisted in checkpoints.
-- [ ] **Cycle 4B — checkpoint handoff RED:** normalized provider responses carry only typed TASK-15675 candidates into `ModelTurn`. Tool batch/result/final reasoning checkpoints use the foundation hooks; hidden reasoning never appears in stream chunks or `AgentStep` summaries.
-- [ ] Extend the existing final native sentinel instead of adding a metadata bag:
+- [x] **Cycle 4A — frozen handoff RED:** assert resolution freezes provider/model/base/key/timeout/retries/retry delay for the whole send and auxiliary calls. Mutate config and environment between model turns; exact pinned values remain. Do not add `api_mode` for either provider.
+- [x] Extend the existing immutable Console resolution/kwargs paths with timeout/retry policy only if not already carried; do not create provider-specific Console resolution types. Provider-local frozen `MoonshotResolution`/`ZAIResolution` remain required at the adapter boundary. Sensitive keys remain repr/log safe and are never persisted in checkpoints.
+- [x] **Cycle 4B — checkpoint handoff RED:** normalized provider responses carry only typed TASK-15675 candidates into `ModelTurn`. Tool batch/result/final reasoning checkpoints use the foundation hooks; hidden reasoning never appears in stream chunks or `AgentStep` summaries.
+- [x] Extend the existing final native sentinel instead of adding a metadata bag:
 
   ```python
   @dataclass(frozen=True)
@@ -275,15 +275,15 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
   ```
 
   Nonstream adapters convert `HostedChatTurn` directly. Streaming adapters expose a provider-local wrapper whose metadata accessor converts `HostedChatStream.terminal_turn` only after clean exhaustion. `ConsoleProviderGateway.stream_chat` then yields the final `ProviderToolCalls` sentinel (including an empty call tuple when an agent turn has final continuation metadata); `_StreamingModelAdapter` validates it once and constructs `ModelTurn.provider_continuation`. Add direct seam tests for `HostedChatStream.terminal_turn -> provider wrapper -> stream_chat -> ProviderToolCalls -> _StreamingModelAdapter -> ModelTurn`, including cancellation-before-terminal/no-sentinel behavior, repr/log canaries, and concurrent-call isolation.
-- [ ] **Cycle 4C — usage RED:** terminal Moonshot/Z.ai raw usage reaches call-scoped Console signals; strict nonnegative integer prompt/completion/total/cached fields reach AgentService budget; bool/string/float/negative/inconsistent details use the existing estimator. Concurrent calls cannot exchange usage/checkpoint state.
-- [ ] **Cycle 4D — cancellation/tee RED:** cancellation before return, after retention, during hidden reasoning, visible text, or partial call closes iterator/response/session exactly once and executes no incomplete call. Close/reentrant-close/cleanup failures never mask the primary outcome.
-- [ ] Run:
+- [x] **Cycle 4C — usage RED:** terminal Moonshot/Z.ai raw usage reaches call-scoped Console signals; strict nonnegative integer prompt/completion/total/cached fields reach AgentService budget; bool/string/float/negative/inconsistent details use the existing estimator. Concurrent calls cannot exchange usage/checkpoint state.
+- [x] **Cycle 4D — cancellation/tee RED:** cancellation before return, after retention, during hidden reasoning, visible text, or partial call closes iterator/response/session exactly once and executes no incomplete call. Close/reentrant-close/cleanup failures never mask the primary outcome.
+- [x] Run:
 
   ```bash
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_kimi_zai_provider_contract.py Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_console_agent_bridge.py Tests/Agents/test_agent_service.py
   ```
 
-- [ ] Commit:
+- [x] Commit:
 
   ```bash
   git add tldw_chatbook/Chat/console_provider_gateway.py tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Agents/agent_service.py Tests/Chat/test_kimi_zai_provider_contract.py Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_console_agent_bridge.py
@@ -298,7 +298,7 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
 - Modify: `Tests/Agents/test_native_tools.py`
 - Modify: `Tests/Chat/test_console_provider_gateway.py`
 
-- [ ] Build one temporary scripted loopback server whose request validator rejects mismatched URL, headers, payload, complete assistant call batch, reasoning, or result ordering before releasing the next response. Traverse the real chain:
+- [x] Build one temporary scripted loopback server whose request validator rejects mismatched URL, headers, payload, complete assistant call batch, reasoning, or result ordering before releasing the next response. Traverse the real chain:
 
   ```text
   ConsoleAgentBridge -> AgentService/agent_runtime -> _StreamingModelAdapter
@@ -306,17 +306,17 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
   -> HostedChatStream -> loopback HTTP
   ```
 
-- [ ] **Cycle 5A — Moonshot joined RED:** run two calculator calls with exact IDs and results, no synthetic user row, mixed text/tool support, K3 reasoning preserved, first batch persisted before execution, final reasoning-only round on the same assistant owner, later-turn replay, and authoritative terminal usage.
-- [ ] **Cycle 5B — Z.ai joined RED:** prove complete multi-call batch/tool result history, `clear_thinking=false` only during the active/restored loop, ordinary next chat returns to true, exact reasoning replay for the loop, and usage budget handoff.
-- [ ] **Cycle 5C — error/restore RED:** structured tool failures continue; completed/failed restored calls never execute; executing restore blocks; pending requires explicit Resume plus fresh approval. Duplicate IDs and out-of-order/cross-batch results fail before server script advancement.
-- [ ] **Cycle 5D — partial cancellation RED:** the server emits incomplete function fragments plus a visible downstream text marker while holding a nonterminal chunked response open. Set cancellation only after the real parser/gateway/store path observes that marker and independently assert the parser had already entered incomplete-call state. Because incomplete fragments never form a checkpoint, assert no assistant continuation owner/checkpoint row, one response close, one request, zero executions/tool results/unpaired outputs, and no server timeout. A text-only fixture mutation must fail the partial-call guard.
-- [ ] Run:
+- [x] **Cycle 5A — Moonshot joined RED:** run two calculator calls with exact IDs and results, no synthetic user row, mixed text/tool support, K3 reasoning preserved, first batch persisted before execution, final reasoning-only round on the same assistant owner, later-turn replay, and authoritative terminal usage.
+- [x] **Cycle 5B — Z.ai joined RED:** prove complete multi-call batch/tool result history, `clear_thinking=false` only during the active/restored loop, ordinary next chat returns to true, exact reasoning replay for the loop, and usage budget handoff.
+- [x] **Cycle 5C — error/restore RED:** structured tool failures continue; completed/failed restored calls never execute; executing restore blocks; pending requires explicit Resume plus fresh approval. Duplicate IDs and out-of-order/cross-batch results fail before server script advancement.
+- [x] **Cycle 5D — partial cancellation RED:** the server emits incomplete function fragments plus a visible downstream text marker while holding a nonterminal chunked response open. Set cancellation only after the real parser/gateway/store path observes that marker and independently assert the parser had already entered incomplete-call state. Because incomplete fragments never form a checkpoint, assert no assistant continuation owner/checkpoint row, one response close, one request, zero executions/tool results/unpaired outputs, and no server timeout. A text-only fixture mutation must fail the partial-call guard.
+- [x] Run:
 
   ```bash
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_kimi_zai_native_tools.py Tests/Agents/test_native_tools.py Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_console_provider_gateway.py
   ```
 
-- [ ] Commit:
+- [x] Commit:
 
   ```bash
   git add Tests/Chat/test_kimi_zai_native_tools.py Tests/Agents/test_native_tools.py Tests/Chat/test_console_provider_gateway.py
@@ -343,18 +343,18 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
 - Modify: `Tests/Provider/test_provider_model_resolution.py`
 - Modify: `Tests/UI/test_provider_model_resolution.py`
 
-- [ ] **Cycle 6A — defaults RED:** assert fresh `[providers]` lists lead with `kimi-k3` and `glm-5.2`; `[api_settings]` defaults use those models, canonical env names, general bases, timeouts/retries, and streaming true. Explicit saved old IDs remain unchanged through load/save.
-- [ ] **Cycle 6B — readiness parity RED:** readiness/direct/chat/discovery share canonical settings, credential precedence, and the same URL helper. Malformed exact tables, placeholders, blank models, unsafe endpoints, bad numeric fields, and alias conflicts block safely before network.
-- [ ] **Cycle 6C — Settings RED:** real Pilot tests cover provider switch/draft isolation, model/endpoint/credential/reasoning controls, invalid recovery, atomic save/revert, second-save no-op, and field search/focus. No API-mode selector. K3 reasoning choices are exact `low|high|max`; `glm-5.2` choices exact `none|minimal|low|medium|high|xhigh|max`. Historical/unknown models retain user choice and conservative guidance.
-- [ ] Reuse the existing category draft/atomic save and generic reasoning control. Do not create provider-specific settings state or touch legacy Settings surfaces.
-- [ ] **Cycle 6D — discovery RED:** Moonshot authenticated `{base}/models`; Z.ai best-effort `{base}/models`. Use identical resolved base/key as chat, preserve prior cache on failure, keep IDs/timestamps only, cap selector at 50, keep uncapped picker searchable, and never infer capabilities from discovered names. Z.ai discovery failure must not block chat readiness.
-- [ ] Run:
+- [x] **Cycle 6A — defaults RED:** assert fresh `[providers]` lists lead with `kimi-k3` and `glm-5.2`; `[api_settings]` defaults use those models, canonical env names, general bases, timeouts/retries, and streaming true. Explicit saved old IDs remain unchanged through load/save.
+- [x] **Cycle 6B — readiness parity RED:** readiness/direct/chat/discovery share canonical settings, credential precedence, and the same URL helper. Malformed exact tables, placeholders, blank models, unsafe endpoints, bad numeric fields, and alias conflicts block safely before network.
+- [x] **Cycle 6C — Settings RED:** real Pilot tests cover provider switch/draft isolation, model/endpoint/credential/reasoning controls, invalid recovery, atomic save/revert, second-save no-op, and field search/focus. No API-mode selector. K3 reasoning choices are exact `low|high|max`; `glm-5.2` choices exact `none|minimal|low|medium|high|xhigh|max`. Historical/unknown models retain user choice and conservative guidance.
+- [x] Reuse the existing category draft/atomic save and generic reasoning control. Do not create provider-specific settings state or touch legacy Settings surfaces.
+- [x] **Cycle 6D — discovery RED:** Moonshot authenticated `{base}/models`; Z.ai best-effort `{base}/models`. Use identical resolved base/key as chat, preserve prior cache on failure, keep IDs/timestamps only, cap selector at 50, keep uncapped picker searchable, and never infer capabilities from discovered names. Z.ai discovery failure must not block chat readiness.
+- [x] Run:
 
   ```bash
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/test_config_model_catalog_defaults.py Tests/Chat/test_provider_readiness.py Tests/UI/test_settings_kimi_zai.py Tests/UI/test_settings_configuration_hub.py Tests/UI/test_settings_save_commit_models.py Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py Tests/Provider/test_provider_model_resolution.py Tests/UI/test_provider_model_resolution.py
   ```
 
-- [ ] Commit:
+- [x] Commit:
 
   ```bash
   git add tldw_chatbook/config.py tldw_chatbook/Chat/provider_readiness.py tldw_chatbook/Chat/console_provider_endpoints.py tldw_chatbook/UI/Screens/settings_screen.py tldw_chatbook/LLM_Provider_Catalog/openai_compatible_model_discovery.py tldw_chatbook/LLM_Provider_Catalog/local_llm_provider_catalog_service.py Tests/test_config_model_catalog_defaults.py Tests/Chat/test_provider_readiness.py Tests/UI/test_settings_kimi_zai.py Tests/UI/test_settings_configuration_hub.py Tests/UI/test_settings_save_commit_models.py Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py Tests/Provider/test_provider_model_resolution.py Tests/UI/test_provider_model_resolution.py
@@ -372,23 +372,28 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
 - Modify: `backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md`
 - Modify: `backlog/docs/lessons-testing-evidence.md` or `backlog/docs/lessons-live-verification.md` only for a genuinely new incident-backed lesson.
 
-- [ ] Document stable provider names, `MOONSHOT_API_KEY`/`ZAI_API_KEY`, current defaults and retained historical models, general/China/custom endpoints, Chat-only scope, exact reasoning/tool-choice subsets, usage, existing function tools/built-in exclusions, checkpoint privacy/context cost, discovery/cache, unknown pricing, and recovery.
-- [ ] Add default-skipped live cases requiring both `TLDW_LIVE_MOONSHOT=1` + key or `TLDW_LIVE_ZAI=1` + key. Each provider runs in a fresh subprocess with isolated HOME/XDG/config/data before imports, muted logs/stdout/stderr, randomized text/arithmetic, exactly one Calculator call/result, and a final marker derived only after the tool result. Assertion text contains no key/prompt/response/tool result.
-- [ ] Prove default collection makes no paid call:
+- [x] Document stable provider names, `MOONSHOT_API_KEY`/`ZAI_API_KEY`, current defaults and retained historical models, general/China/custom endpoints, Chat-only scope, exact reasoning/tool-choice subsets, usage, existing function tools/built-in exclusions, checkpoint privacy/context cost, discovery/cache, unknown pricing, and recovery.
+- [x] Add default-skipped live cases requiring both `TLDW_LIVE_MOONSHOT=1` + key or `TLDW_LIVE_ZAI=1` + key. Each provider runs in a fresh subprocess with isolated HOME/XDG/config/data before imports, muted logs/stdout/stderr, randomized text/arithmetic, exactly one Calculator call/result, and a final marker derived only after the tool result. Assertion text contains no key/prompt/response/tool result.
+- [x] Prove default collection makes no paid call:
 
   ```bash
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_live_moonshot_zai_api.py
   ```
 
   Expected: both provider cases skipped unless their exact gate and nonblank key are present.
-- [ ] Run the complete provider/Qwen/Console/Settings/catalog surface, then full repository suite:
+- [x] Run the provider/Qwen/Console/Settings/catalog surface within the final
+  user-authorized test scope. **Deviation:** on 2026-08-13 the user explicitly
+  stopped the broad run and required only tests for touched files or related
+  functionality. The full-repository command below was therefore not run;
+  focused named modules and selected continuation seams replaced it, with exact
+  evidence recorded in the Backlog task.
 
   ```bash
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/LLM_Calls/test_hosted_chat.py Tests/LLM_Calls/test_hosted_chat_streaming.py Tests/LLM_Calls/test_moonshot.py Tests/LLM_Calls/test_zai.py Tests/LLM_Calls/test_qwencloud.py Tests/LLM_Calls/test_qwencloud_streaming.py Tests/Chat/test_kimi_zai_provider_contract.py Tests/Chat/test_kimi_zai_native_tools.py Tests/Chat/test_live_moonshot_zai_api.py Tests/Agents/test_native_tools.py Tests/Agents/test_agent_service.py Tests/Agents/test_agent_runtime.py Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_provider_readiness.py Tests/UI/test_settings_kimi_zai.py Tests/LLM_Provider_Catalog
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q
   ```
 
-- [ ] Run static/security gates:
+- [x] Run static/security gates:
 
   ```bash
   git diff --check origin/dev...HEAD
@@ -398,8 +403,8 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m compileall -q tldw_chatbook/LLM_Calls
   ```
 
-- [ ] Self-review every AC and ADR-063 rule. Confirm Qwen Responses is untouched, Qwen Chat parity is green, no other provider migrated, no API mode/vendor built-in tools/server state/new schema, and default tests made no paid calls.
-- [ ] Check all ACs individually, add observed Implementation Notes/evidence/deviations to the task file, verify the rendered task, and set Done only after the gates pass:
+- [x] Self-review every AC and ADR-063 rule. Confirm Qwen Responses is untouched, Qwen Chat parity is green, no other provider migrated, no API mode/vendor built-in tools/server state/new schema, and default tests made no paid calls.
+- [x] Check all ACs individually, add observed Implementation Notes/evidence/deviations to the task file, verify the rendered task, and set Done only after the gates pass:
 
   ```bash
   backlog task edit 15676 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 --check-ac 6 --check-ac 7 --check-ac 8 --check-ac 9 --check-ac 10
@@ -408,7 +413,7 @@ The decoder preserves the exact optional SSE `event:` label and joined `data:` t
   backlog task edit 15676 -s Done
   ```
 
-- [ ] Commit closeout:
+- [x] Commit closeout:
 
   ```bash
   git add README.md Docs/User_Guide/settings.md Docs/User_Guide/console.md Docs/superpowers/plans/2026-08-12-kimi-zai-hosted-chat-completions-implementation.md Tests/Chat/test_live_moonshot_zai_api.py "backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md"

--- a/README.md
+++ b/README.md
@@ -636,6 +636,8 @@ API keys can also be set via environment variables:
 - `ANTHROPIC_API_KEY`
 - `COHERE_API_KEY`
 - `DASHSCOPE_API_KEY` (QwenCloud)
+- `MOONSHOT_API_KEY` (Moonshot / Kimi)
+- `ZAI_API_KEY` (Z.ai / GLM)
 - etc.
 
 ### QwenCloud
@@ -667,6 +669,26 @@ cached catalog, and model/mode compatibility is reported by the service rather
 than guessed from a model name. See [Settings](Docs/User_Guide/settings.md#qwencloud)
 and [Console](Docs/User_Guide/console.md#qwencloud-in-console) for parameter,
 endpoint, recovery, and optional live-test details.
+
+### Moonshot Kimi and Z.ai GLM
+
+Moonshot and Z.ai are first-class, Chat-Completions-only Console providers.
+Fresh configuration defaults to `kimi-k3` with `MOONSHOT_API_KEY` and
+`glm-5.2` with `ZAI_API_KEY`; explicit historical model selections remain
+unchanged. The defaults use `https://api.moonshot.ai/v1` and
+`https://api.z.ai/api/paas/v4`. Moonshot also supports its China base and both
+providers accept a validated custom compatible base.
+
+Both providers stream text, terminal usage, and existing Chatbook function
+tools through the normal approval and recovery path. Provider-hosted search,
+retrieval, code, and other built-in tools are excluded. Required Kimi/GLM
+reasoning is stored only in bounded private continuation checkpoints, counts
+against context limits, and never appears in the transcript. Model discovery
+uses the shared bounded cache; when no verified price is known, Console reports
+**pricing unknown** rather than treating the request as free. See
+[Settings](Docs/User_Guide/settings.md#moonshot-kimi-and-zai-glm) and
+[Console](Docs/User_Guide/console.md#moonshot-kimi-and-zai-glm-in-console) for
+exact controls, endpoints, recovery, and optional paid verification.
 
 ### Database Files
 Located at `~/.local/share/tldw_cli/`:

--- a/Tests/Agents/test_native_tools.py
+++ b/Tests/Agents/test_native_tools.py
@@ -37,6 +37,11 @@ def test_every_native_provider_forwards_tools_in_param_map():
         assert mapping.get("tools") == "tools", provider
 
 
+def test_zai_native_provider_contract_is_eligible() -> None:
+    assert "zai" in NATIVE_TOOLS_PROVIDERS
+    assert PROVIDER_PARAM_MAP["zai"]["tools"] == "tools"
+
+
 def test_native_provider_contract_requires_qwencloud_dispatch_and_history():
     """QwenCloud may be native only after all three seam invariants hold."""
     assert "qwencloud" in NATIVE_TOOLS_PROVIDERS

--- a/Tests/Chat/test_chat_unit_mocked_APIs.py
+++ b/Tests/Chat/test_chat_unit_mocked_APIs.py
@@ -462,6 +462,34 @@ def test_moonshot_reasoning_effort_reaches_public_handler() -> None:
     assert handler.call_args.kwargs["reasoning_effort"] == "high"
 
 
+def test_zai_provider_specific_fields_reach_public_handler() -> None:
+    handler = Mock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    handler.__name__ = "chat_with_zai"
+    original = API_CALL_HANDLERS["zai"]
+    API_CALL_HANDLERS["zai"] = handler
+    try:
+        chat_api_call(
+            api_endpoint="zai",
+            messages_payload=[{"role": "user", "content": "hi"}],
+            api_key="test_key",
+            model="glm-5.2",
+            reasoning_effort="xhigh",
+            tool_choice="auto",
+            stop=["done"],
+            response_format={"type": "json_object"},
+            user_identifier="user-1",
+            streaming=False,
+        )
+    finally:
+        API_CALL_HANDLERS["zai"] = original
+
+    assert handler.call_args.kwargs["reasoning_effort"] == "xhigh"
+    assert handler.call_args.kwargs["tool_choice"] == "auto"
+    assert handler.call_args.kwargs["stop"] == ["done"]
+    assert handler.call_args.kwargs["response_format"] == {"type": "json_object"}
+    assert handler.call_args.kwargs["user"] == "user-1"
+
+
 def test_provider_param_map_has_no_dead_generic_keys() -> None:
     """Pin the generic side of PROVIDER_PARAM_MAP to the dispatcher's truth.
 

--- a/Tests/Chat/test_chat_unit_mocked_APIs.py
+++ b/Tests/Chat/test_chat_unit_mocked_APIs.py
@@ -442,6 +442,26 @@ class TestTemperatureForwarding:
         assert handler.call_args.kwargs.get("temp") == 0.42
 
 
+def test_moonshot_reasoning_effort_reaches_public_handler() -> None:
+    handler = Mock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    handler.__name__ = "chat_with_moonshot"
+    original = API_CALL_HANDLERS["moonshot"]
+    API_CALL_HANDLERS["moonshot"] = handler
+    try:
+        chat_api_call(
+            api_endpoint="moonshot",
+            messages_payload=[{"role": "user", "content": "hi"}],
+            api_key="test_key",
+            model="kimi-k3",
+            reasoning_effort="high",
+            streaming=False,
+        )
+    finally:
+        API_CALL_HANDLERS["moonshot"] = original
+
+    assert handler.call_args.kwargs["reasoning_effort"] == "high"
+
+
 def test_provider_param_map_has_no_dead_generic_keys() -> None:
     """Pin the generic side of PROVIDER_PARAM_MAP to the dispatcher's truth.
 

--- a/Tests/Chat/test_kimi_zai_native_tools.py
+++ b/Tests/Chat/test_kimi_zai_native_tools.py
@@ -1,0 +1,927 @@
+"""Joined Kimi/GLM native-tool tests through the real Console HTTP path."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import threading
+from typing import Any
+
+import pytest
+import requests
+
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.Chat_Deps import ChatBadRequestError
+from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_history_budget import ProviderContinuationSidecar
+from tldw_chatbook.Chat.console_provider_gateway import (
+    ConsoleProviderGateway,
+    ConsoleProviderResolution,
+)
+from tldw_chatbook.Chat.provider_continuation import ContinuationRestoreTarget
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.LLM_Calls.moonshot import chat_with_moonshot
+from tldw_chatbook.LLM_Calls.zai import chat_with_zai
+
+
+_FINAL = "HOSTED-NATIVE-FINAL"
+_RESULT_A = '{"expression": "6*7", "result": 42, "result_type": "int"}'
+_RESULT_B = '{"expression": "8*8", "result": 64, "result_type": "int"}'
+_CANCEL_MARKER = "hosted-partial-call-observed"
+# StreamGate retains a fence-sized suffix, so keep visible padding after the
+# checkpoint that drives the cancellation hook.
+_CANCEL_STREAM_TEXT = f"{_CANCEL_MARKER}-visible-padding"
+_STREAM_HOLD_PADDING = b": hold-open\n\n" * 1024
+_Validator = Callable[[str, dict[str, str], dict[str, Any]], None]
+
+
+@dataclass(frozen=True)
+class _StalledSSE:
+    prefix: bytes
+    client_close_started: threading.Event
+
+
+_ScriptedBody = bytes | _StalledSSE
+
+
+def _sse(events: Sequence[dict[str, Any]], *, done: bool = True) -> bytes:
+    wire = b"".join(
+        b"data: " + json.dumps(event, separators=(",", ":")).encode() + b"\n\n"
+        for event in events
+    )
+    return wire + (b"data: [DONE]\n\n" if done else b"")
+
+
+def _tool_turn(provider: str) -> bytes:
+    return _sse(
+        [
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "Checking both.",
+                            "reasoning_content": f"PRIVATE-{provider}-TOOL-REASONING",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_A",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "calculator",
+                                        "arguments": '{"expression":"6*7"}',
+                                    },
+                                },
+                                {
+                                    "index": 1,
+                                    "id": "call_B",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "calculator",
+                                        "arguments": '{"expression":"8*8"}',
+                                    },
+                                },
+                            ],
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            {"choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]},
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 10,
+                    "total_tokens": 30,
+                },
+            },
+        ]
+    )
+
+
+def _error_tool_turn(provider: str) -> bytes:
+    return _sse(
+        [
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "",
+                            "reasoning_content": f"PRIVATE-{provider}-ERROR-REASONING",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_error",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "calculator",
+                                        "arguments": '{"expression":"1/0"}',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            },
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 8,
+                    "completion_tokens": 4,
+                    "total_tokens": 12,
+                },
+            },
+        ]
+    )
+
+
+def _partial_call_then_text(provider: str) -> bytes:
+    return _sse(
+        [
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": _CANCEL_STREAM_TEXT,
+                            "reasoning_content": f"PRIVATE-{provider}-PARTIAL",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_partial",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "calculator",
+                                        "arguments": '{"expression":',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            }
+        ],
+        done=False,
+    )
+
+
+def _assert_partial_call_precedes_marker(body: bytes) -> None:
+    events = [
+        json.loads(record.removeprefix(b"data: "))
+        for record in body.split(b"\n\n")
+        if record.startswith(b"data: {")
+    ]
+    matching = []
+    for event in events:
+        choices = event.get("choices")
+        if (
+            isinstance(choices, list)
+            and choices
+            and choices[0].get("delta", {}).get("content") == _CANCEL_STREAM_TEXT
+        ):
+            matching.append(event)
+    assert matching
+    tool_calls = matching[0]["choices"][0]["delta"].get("tool_calls")
+    assert isinstance(tool_calls, list) and len(tool_calls) == 1
+    assert tool_calls[0]["function"] == {
+        "name": "calculator",
+        "arguments": '{"expression":',
+    }
+
+
+def _final_turn(
+    provider: str,
+    *,
+    text: str = _FINAL,
+    reasoning: str | None = None,
+) -> bytes:
+    reasoning = reasoning or f"PRIVATE-{provider}-FINAL-REASONING"
+    return _sse(
+        [
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": text,
+                            "reasoning_content": reasoning,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 30,
+                    "completion_tokens": 5,
+                    "total_tokens": 35,
+                },
+            },
+        ]
+    )
+
+
+class _ScriptedServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self,
+        bodies: Sequence[_ScriptedBody],
+        validators: Sequence[_Validator],
+    ) -> None:
+        super().__init__(("127.0.0.1", 0), _ScriptedHandler)
+        self.bodies = list(bodies)
+        self.validators = list(validators)
+        self.requests: list[dict[str, Any]] = []
+        self.validation_errors: list[str] = []
+        self.stall_started = threading.Event()
+        self.stall_timed_out = threading.Event()
+        self._lock = threading.Lock()
+
+    def next_response(
+        self,
+        path: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+    ) -> tuple[int, _ScriptedBody]:
+        with self._lock:
+            self.requests.append({"path": path, "headers": headers, "payload": payload})
+            if not self.bodies or not self.validators:
+                self.validation_errors.append("provider script exhausted")
+                return 422, b'{"error":{"message":"provider script exhausted"}}'
+            try:
+                self.validators.pop(0)(path, headers, payload)
+            except AssertionError as exc:
+                message = str(exc) or "scripted request validation failed"
+                self.validation_errors.append(message)
+                return 422, json.dumps({"error": {"message": message}}).encode()
+            return 200, self.bodies.pop(0)
+
+
+class _ScriptedHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length))
+        server = self.server
+        assert isinstance(server, _ScriptedServer)
+        status, body = server.next_response(
+            self.path,
+            {key.lower(): value for key, value in self.headers.items()},
+            payload,
+        )
+        if isinstance(body, _StalledSSE):
+            self.send_response(status)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Transfer-Encoding", "chunked")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(f"{len(body.prefix):X}\r\n".encode())
+            self.wfile.write(body.prefix)
+            self.wfile.write(b"\r\n")
+            self.wfile.flush()
+            server.stall_started.set()
+            if not body.client_close_started.wait(timeout=2):
+                server.stall_timed_out.set()
+            try:
+                self.wfile.write(b"0\r\n\r\n")
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            self.close_connection = True
+            return
+        self.send_response(status)
+        self.send_header(
+            "Content-Type",
+            "text/event-stream" if status == 200 else "application/json",
+        )
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+        self.wfile.flush()
+        self.close_connection = True
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+@contextmanager
+def _scripted_server(
+    bodies: Sequence[_ScriptedBody],
+    validators: Sequence[_Validator],
+) -> Iterator[_ScriptedServer]:
+    server = _ScriptedServer(bodies, validators)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _resolution(server: _ScriptedServer, provider: str) -> ConsoleProviderResolution:
+    host, port = server.server_address[:2]
+    path = "/v1" if provider == "moonshot" else "/api/paas/v4"
+    return ConsoleProviderResolution(
+        provider=provider,
+        base_url=f"http://{host}:{port}{path}",
+        model="kimi-k3" if provider == "moonshot" else "glm-5.2",
+        ready=True,
+        readiness_key=provider,
+        execution_key=provider,
+        api_key="test-hosted-key",
+        streaming=True,
+        continuation_protocol="chat_completions",
+        request_timeout=5.0,
+        request_retries=0,
+        request_retry_delay=0.0,
+    )
+
+
+def _calls() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "call_A",
+            "type": "function",
+            "function": {
+                "name": "calculator",
+                "arguments": '{"expression":"6*7"}',
+            },
+        },
+        {
+            "id": "call_B",
+            "type": "function",
+            "function": {
+                "name": "calculator",
+                "arguments": '{"expression":"8*8"}',
+            },
+        },
+    ]
+
+
+def _validate_common(
+    provider: str,
+    path: str,
+    headers: dict[str, str],
+    payload: dict[str, Any],
+) -> None:
+    expected_prefix = "/v1" if provider == "moonshot" else "/api/paas/v4"
+    assert path == f"{expected_prefix}/chat/completions"
+    assert headers["authorization"] == "Bearer test-hosted-key"
+    assert headers["content-type"] == "application/json"
+    assert payload["model"] == ("kimi-k3" if provider == "moonshot" else "glm-5.2")
+    assert payload["stream"] is True
+    assert any(
+        tool.get("function", {}).get("name") == "calculator"
+        for tool in payload["tools"]
+    )
+    if provider == "moonshot":
+        assert payload["stream_options"] == {"include_usage": True}
+        assert "thinking" not in payload
+    else:
+        assert payload["thinking"] == {"type": "enabled", "clear_thinking": False}
+        assert "stream_options" not in payload
+
+
+def _initial_validator(provider: str) -> _Validator:
+    def validate(
+        path: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+    ) -> None:
+        _validate_common(provider, path, headers, payload)
+        assert payload["messages"][-1] == {
+            "role": "user",
+            "content": "Calculate two expressions.",
+        }
+        assert [row for row in payload["messages"] if row["role"] == "user"] == [
+            {"role": "user", "content": "Calculate two expressions."}
+        ]
+
+    return validate
+
+
+def _continuation_validator(provider: str) -> _Validator:
+    def validate(
+        path: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+    ) -> None:
+        _validate_common(provider, path, headers, payload)
+        assert payload["messages"][-3:] == [
+            {
+                "role": "assistant",
+                "content": "Checking both.",
+                "tool_calls": _calls(),
+                "reasoning_content": f"PRIVATE-{provider}-TOOL-REASONING",
+            },
+            {"role": "tool", "tool_call_id": "call_A", "content": _RESULT_A},
+            {"role": "tool", "tool_call_id": "call_B", "content": _RESULT_B},
+        ]
+        assert [row for row in payload["messages"] if row["role"] == "user"] == [
+            {"role": "user", "content": "Calculate two expressions."}
+        ]
+
+    return validate
+
+
+def _later_k3_validator() -> _Validator:
+    def validate(
+        path: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+    ) -> None:
+        _validate_common("moonshot", path, headers, payload)
+        assert payload["messages"][1:] == [
+            {"role": "user", "content": "Calculate two expressions."},
+            {
+                "role": "assistant",
+                "content": "Checking both.",
+                "reasoning_content": "PRIVATE-moonshot-TOOL-REASONING",
+                "tool_calls": _calls(),
+            },
+            {"role": "tool", "tool_call_id": "call_A", "content": _RESULT_A},
+            {"role": "tool", "tool_call_id": "call_B", "content": _RESULT_B},
+            {
+                "role": "assistant",
+                "content": _FINAL,
+                "reasoning_content": "PRIVATE-moonshot-FINAL-REASONING",
+            },
+            {"role": "user", "content": "What did you calculate?"},
+        ]
+
+    return validate
+
+
+def _zai_ordinary_validator() -> _Validator:
+    def validate(
+        path: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+    ) -> None:
+        expected_path = "/api/paas/v4/chat/completions"
+        assert path == expected_path
+        assert headers["authorization"] == "Bearer test-hosted-key"
+        assert payload["model"] == "glm-5.2"
+        assert payload["stream"] is True
+        assert payload["thinking"] == {
+            "type": "enabled",
+            "clear_thinking": True,
+        }
+        assert "tools" not in payload
+        assert "stream_options" not in payload
+        assert payload["messages"] == [
+            {"role": "user", "content": "Ordinary follow up."}
+        ]
+
+    return validate
+
+
+def _error_continuation_validator(provider: str) -> _Validator:
+    def validate(
+        path: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+    ) -> None:
+        _validate_common(provider, path, headers, payload)
+        assistant, result = payload["messages"][-2:]
+        assert assistant == {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_error",
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": '{"expression":"1/0"}',
+                    },
+                }
+            ],
+            "reasoning_content": f"PRIVATE-{provider}-ERROR-REASONING",
+        }
+        assert result["role"] == "tool"
+        assert result["tool_call_id"] == "call_error"
+        assert result["content"].startswith("ERROR: ")
+        assert "zero" in result["content"].lower()
+
+    return validate
+
+
+async def _collect_stream(stream: Any) -> list[Any]:
+    return [item async for item in stream]
+
+
+class _CaptureGateway(ConsoleProviderGateway):
+    def __init__(self) -> None:
+        super().__init__()
+        self.dispatches: list[dict[str, Any]] = []
+
+    def _chat_api_kwargs_from_prepared(self, resolution, request):
+        kwargs = super()._chat_api_kwargs_from_prepared(resolution, request)
+        self.dispatches.append(kwargs)
+        return kwargs
+
+
+class _CaptureStore(ConsoleChatStore):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.continuation_errors: list[str] = []
+
+    def persist_provider_continuation_event(self, event: Any) -> None:
+        try:
+            super().persist_provider_continuation_event(event)
+        except Exception as exc:
+            self.continuation_errors.append(f"{type(exc).__name__}: {exc}")
+            raise
+
+
+@pytest.mark.allow_network
+@pytest.mark.parametrize("provider", ["moonshot", "zai"])
+def test_console_runs_two_native_calls_with_private_continuation(
+    tmp_path: Any,
+    provider: str,
+) -> None:
+    bodies = [_tool_turn(provider), _final_turn(provider)]
+    validators = [_initial_validator(provider), _continuation_validator(provider)]
+    if provider == "moonshot":
+        bodies.append(
+            _final_turn(
+                provider,
+                text="K3-LATER-ANSWER",
+                reasoning="PRIVATE-moonshot-LATER-REASONING",
+            )
+        )
+        validators.append(_later_k3_validator())
+    else:
+        bodies.append(
+            _final_turn(
+                provider,
+                text="GLM-ORDINARY-ANSWER",
+                reasoning="PRIVATE-zai-ORDINARY-REASONING",
+            )
+        )
+        validators.append(_zai_ordinary_validator())
+    with _scripted_server(bodies, validators) as server:
+        db = AgentRunsDB(tmp_path / f"{provider}.db", client_id="hosted-native")
+        chat_db = CharactersRAGDB(
+            tmp_path / f"{provider}-chat.db", f"hosted-native-{provider}"
+        )
+        store = _CaptureStore(persistence=ChatPersistenceService(chat_db))
+        session = store.create_session(title="Hosted native continuation")
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="Calculate two expressions.",
+            persist=True,
+        )
+        assistant = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+            persist=True,
+        )
+        gateway = _CaptureGateway()
+        bridge = ConsoleAgentBridge(
+            agent_runs_db=db,
+            store=store,
+            provider_gateway=gateway,
+        )
+
+        _run_id, outcome = bridge.run_reply(
+            conversation_id=f"{provider}-conversation",
+            session_id=session.id,
+            resolution=_resolution(server, provider),
+            assistant_message_id=assistant.id,
+            model="kimi-k3" if provider == "moonshot" else "glm-5.2",
+            session_system_prompt="",
+            agent_messages=[{"role": "user", "content": "Calculate two expressions."}],
+            should_cancel=lambda: False,
+            native_tools_enabled=True,
+        )
+        later_outcome = None
+        ordinary_items = None
+        if provider == "moonshot":
+            checkpoint = store.get_message(assistant.id).provider_continuation
+            assert checkpoint is not None
+            store.append_message(
+                session.id,
+                role=ConsoleMessageRole.USER,
+                content="What did you calculate?",
+                persist=True,
+            )
+            later_assistant = store.append_message(
+                session.id,
+                role=ConsoleMessageRole.ASSISTANT,
+                content="",
+                persist=True,
+            )
+            _later_run_id, later_outcome = bridge.run_reply(
+                conversation_id=f"{provider}-conversation",
+                session_id=session.id,
+                resolution=_resolution(server, provider),
+                assistant_message_id=later_assistant.id,
+                model="kimi-k3",
+                session_system_prompt="",
+                agent_messages=[
+                    {"role": "user", "content": "Calculate two expressions."},
+                    {
+                        "role": "assistant",
+                        "content": _FINAL,
+                        "_owner": assistant.id,
+                    },
+                    {"role": "user", "content": "What did you calculate?"},
+                ],
+                should_cancel=lambda: False,
+                native_tools_enabled=True,
+                continuation_sidecar=(
+                    ProviderContinuationSidecar(assistant.id, checkpoint),
+                ),
+                continuation_target=ContinuationRestoreTarget(
+                    provider="moonshot",
+                    protocol="chat_completions",
+                    model="kimi-k3",
+                    api_base_url=_resolution(server, provider).base_url,
+                ),
+                continuation_owner_key="_owner",
+            )
+        else:
+            ordinary_items = asyncio.run(
+                _collect_stream(
+                    gateway.stream_chat(
+                        _resolution(server, provider),
+                        [{"role": "user", "content": "Ordinary follow up."}],
+                    )
+                )
+            )
+        chat_db.close_connection()
+
+    owner = store.get_message(assistant.id)
+    assert outcome.status == "done", {
+        "steps": [step.summary for step in outcome.steps],
+        "validation_errors": server.validation_errors,
+        "requests": server.requests,
+        "dispatch_messages": [
+            dispatch.get("messages_payload") for dispatch in gateway.dispatches
+        ],
+        "continuation_counts": [
+            len(dispatch.get("provider_continuations", ()))
+            for dispatch in gateway.dispatches
+        ],
+    }
+    assert outcome.final_text == _FINAL
+    assert outcome.total_tokens == 65
+    assert owner.content == _FINAL
+    assert owner.provider_continuation is not None
+    assert owner.provider_continuation.state == "complete"
+    assert owner.provider_continuation.rounds[0].reasoning_blocks == (
+        f"PRIVATE-{provider}-TOOL-REASONING",
+    )
+    if provider == "moonshot":
+        assert owner.provider_continuation.rounds[-1].reasoning_blocks == (
+            "PRIVATE-moonshot-FINAL-REASONING",
+        )
+    if provider == "moonshot":
+        assert later_outcome is not None
+        assert later_outcome.status == "done", {
+            "steps": [step.summary for step in later_outcome.steps],
+            "validation_errors": server.validation_errors,
+            "request_count": len(server.requests),
+            "continuation_errors": store.continuation_errors,
+        }
+        assert later_outcome.final_text == "K3-LATER-ANSWER"
+    else:
+        assert ordinary_items == ["GLM-ORDINARY-ANSWER"]
+    assert len(server.requests) == 3
+    assert server.validation_errors == []
+    assert server.validators == []
+    assert server.bodies == []
+    assert "PRIVATE-" not in owner.content
+
+
+@pytest.mark.allow_network
+@pytest.mark.parametrize("provider", ["moonshot", "zai"])
+def test_hosted_tool_error_continues_structurally(
+    tmp_path: Any,
+    provider: str,
+) -> None:
+    with _scripted_server(
+        [_error_tool_turn(provider), _final_turn(provider, text="ERROR-RECOVERED")],
+        [_initial_validator(provider), _error_continuation_validator(provider)],
+    ) as server:
+        db = AgentRunsDB(tmp_path / f"{provider}-error.db", client_id="hosted-error")
+        chat_db = CharactersRAGDB(
+            tmp_path / f"{provider}-error-chat.db", f"hosted-error-{provider}"
+        )
+        store = _CaptureStore(persistence=ChatPersistenceService(chat_db))
+        session = store.create_session(title="Hosted native error")
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="Calculate two expressions.",
+            persist=True,
+        )
+        assistant = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+            persist=True,
+        )
+        bridge = ConsoleAgentBridge(
+            agent_runs_db=db,
+            store=store,
+            provider_gateway=_CaptureGateway(),
+        )
+
+        _run_id, outcome = bridge.run_reply(
+            conversation_id=f"{provider}-error-conversation",
+            session_id=session.id,
+            resolution=_resolution(server, provider),
+            assistant_message_id=assistant.id,
+            model="kimi-k3" if provider == "moonshot" else "glm-5.2",
+            session_system_prompt="",
+            agent_messages=[{"role": "user", "content": "Calculate two expressions."}],
+            should_cancel=lambda: False,
+            native_tools_enabled=True,
+        )
+        owner = store.get_message(assistant.id)
+        chat_db.close_connection()
+
+    assert outcome.status == "done"
+    assert outcome.final_text == "ERROR-RECOVERED"
+    assert len(server.requests) == 2
+    assert server.validation_errors == []
+    assert store.continuation_errors == []
+    assert owner.provider_continuation is not None
+    call = owner.provider_continuation.rounds[0].calls[0]
+    assert call.state == "failed"
+    assert call.result is not None
+    assert call.result.value.startswith("ERROR: ")
+
+
+@pytest.mark.allow_network
+@pytest.mark.parametrize("provider", ["moonshot", "zai"])
+@pytest.mark.parametrize("malformed", ["duplicate_ids", "out_of_order"])
+def test_hosted_invalid_tool_history_fails_before_server_advancement(
+    provider: str,
+    malformed: str,
+) -> None:
+    calls = _calls()
+    if malformed == "duplicate_ids":
+        calls[1]["id"] = "call_A"
+    results = [
+        {"role": "tool", "tool_call_id": "call_A", "content": _RESULT_A},
+        {"role": "tool", "tool_call_id": "call_B", "content": _RESULT_B},
+    ]
+    if malformed == "out_of_order":
+        results.reverse()
+    messages = [
+        {"role": "user", "content": "Calculate two expressions."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": calls,
+        },
+        *results,
+    ]
+
+    with _scripted_server([], []) as server:
+        resolution = _resolution(server, provider)
+        handler = chat_with_moonshot if provider == "moonshot" else chat_with_zai
+        with pytest.raises(ChatBadRequestError):
+            handler(
+                input_data=messages,
+                model=resolution.model,
+                api_key="test-hosted-key",
+                streaming=True,
+                api_base_url=resolution.base_url,
+                request_retries=0,
+            )
+
+    assert server.requests == []
+
+
+def test_partial_call_fixture_rejects_text_only_mutation() -> None:
+    with pytest.raises(AssertionError):
+        _assert_partial_call_precedes_marker(
+            _final_turn("moonshot", text=_CANCEL_STREAM_TEXT)
+        )
+
+
+@pytest.mark.allow_network
+@pytest.mark.parametrize("provider", ["moonshot", "zai"])
+def test_hosted_partial_call_cancellation_never_executes(
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+) -> None:
+    from tldw_chatbook.Tools.tool_executor import CalculatorTool
+
+    executions: list[str] = []
+    real_execute = CalculatorTool.execute
+
+    async def recording_execute(self: CalculatorTool, expression: str) -> dict:
+        executions.append(expression)
+        return await real_execute(self, expression)
+
+    monkeypatch.setattr(CalculatorTool, "execute", recording_execute)
+    cancelled = threading.Event()
+    marker_observed = threading.Event()
+    client_close_started = threading.Event()
+    close_calls: list[int] = []
+    body = _partial_call_then_text(provider)
+    _assert_partial_call_precedes_marker(body)
+    real_append_stream_chunk = ConsoleChatStore.append_stream_chunk
+    real_response_close = requests.Response.close
+
+    def recording_stream_chunk(
+        store: ConsoleChatStore, message_id: str, chunk: str
+    ) -> Any:
+        message = real_append_stream_chunk(store, message_id, chunk)
+        if _CANCEL_MARKER in chunk:
+            marker_observed.set()
+            cancelled.set()
+        return message
+
+    monkeypatch.setattr(ConsoleChatStore, "append_stream_chunk", recording_stream_chunk)
+
+    with _scripted_server(
+        [_StalledSSE(body + _STREAM_HOLD_PADDING, client_close_started)],
+        [_initial_validator(provider)],
+    ) as server:
+        resolution = _resolution(server, provider)
+
+        def recording_response_close(response: requests.Response) -> None:
+            if str(response.url).startswith(resolution.base_url):
+                close_calls.append(id(response))
+                client_close_started.set()
+            real_response_close(response)
+
+        monkeypatch.setattr(requests.Response, "close", recording_response_close)
+        db = AgentRunsDB(tmp_path / f"{provider}-cancel.db", client_id="hosted-cancel")
+        chat_db = CharactersRAGDB(
+            tmp_path / f"{provider}-cancel-chat.db", f"hosted-cancel-{provider}"
+        )
+        store = _CaptureStore(persistence=ChatPersistenceService(chat_db))
+        session = store.create_session(title="Hosted native cancellation")
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="Calculate two expressions.",
+            persist=True,
+        )
+        assistant = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+            persist=True,
+        )
+        bridge = ConsoleAgentBridge(
+            agent_runs_db=db,
+            store=store,
+            provider_gateway=_CaptureGateway(),
+        )
+        _run_id, outcome = bridge.run_reply(
+            conversation_id=f"{provider}-cancel-conversation",
+            session_id=session.id,
+            resolution=resolution,
+            assistant_message_id=assistant.id,
+            model=resolution.model or "",
+            session_system_prompt="",
+            agent_messages=[{"role": "user", "content": "Calculate two expressions."}],
+            should_cancel=cancelled.is_set,
+            native_tools_enabled=True,
+        )
+        owner = store.get_message(assistant.id)
+        chat_db.close_connection()
+
+    assert outcome.status == "cancelled"
+    assert marker_observed.is_set()
+    assert server.stall_started.is_set()
+    assert not server.stall_timed_out.is_set()
+    assert len(server.requests) == 1
+    assert len(close_calls) == 1
+    assert executions == []
+    assert owner.provider_continuation is None
+    assert store.continuation_errors == []
+    assert not any(step.kind in {"tool_call", "tool_result"} for step in outcome.steps)

--- a/Tests/Chat/test_kimi_zai_provider_contract.py
+++ b/Tests/Chat/test_kimi_zai_provider_contract.py
@@ -1,0 +1,1045 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+from tldw_chatbook.Chat import console_provider_gateway as gateway_module
+from tldw_chatbook.Chat import Chat_Functions
+from tldw_chatbook.Chat.console_history_budget import ProviderContinuationSidecar
+from tldw_chatbook.Chat.provider_continuation import (
+    ContinuationCall,
+    ContinuationRound,
+    ContinuationRestoreTarget,
+    ContinuationResult,
+    ProviderContinuationCheckpoint,
+    parse_provider_continuation_json,
+)
+from tldw_chatbook.LLM_Calls import moonshot, zai
+import pytest
+
+from tldw_chatbook.Agents.agent_models import (
+    AgentConfig,
+    ContinuationEventContext,
+    ModelTurn,
+    ToolCall,
+    ToolResult,
+    ToolSchema,
+)
+from tldw_chatbook.Agents.agent_runtime import LoopDeps, run_agent_loop
+from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolCatalogRegistry
+from tldw_chatbook.LLM_Calls.hosted_chat import (
+    HostedChatProtocolError,
+    HostedChatStream,
+    HostedChatTurn,
+)
+from tldw_chatbook.LLM_Calls.hosted_chat_streaming import SSERecord
+from tldw_chatbook.Chat.console_agent_bridge import (
+    _ModelCallLifeline,
+    _StreamingModelAdapter,
+)
+from tldw_chatbook.Chat.console_chat_store import (
+    ConsoleChatStore,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+
+def _checkpoint(*, provider: str = "moonshot") -> ProviderContinuationCheckpoint:
+    return ProviderContinuationCheckpoint(
+        schema_version=1,
+        checkpoint_revision=1,
+        provider=provider,  # type: ignore[arg-type]
+        protocol="chat_completions",
+        model="kimi-k3" if provider == "moonshot" else "glm-5.2",
+        api_base_url=(
+            "https://api.moonshot.ai/v1"
+            if provider == "moonshot"
+            else "https://api.z.ai/api/paas/v4"
+        ),
+        state="complete",
+        rounds=(
+            ContinuationRound(
+                assistant_content="answer",
+                reasoning_blocks=("PRIVATE-REASONING-CANARY",),
+                calls=(),
+            ),
+        ),
+    )
+
+
+def _active_checkpoint(provider: str) -> ProviderContinuationCheckpoint:
+    return ProviderContinuationCheckpoint(
+        schema_version=1,
+        checkpoint_revision=1,
+        provider=provider,  # type: ignore[arg-type]
+        protocol="chat_completions",
+        model="kimi-k3" if provider == "moonshot" else "glm-5.2",
+        api_base_url=(
+            "https://api.moonshot.ai/v1"
+            if provider == "moonshot"
+            else "https://api.z.ai/api/paas/v4"
+        ),
+        state="active",
+        rounds=(
+            ContinuationRound(
+                assistant_content="",
+                reasoning_blocks=("PRIVATE-REASONING-CANARY",),
+                calls=(
+                    ContinuationCall(
+                        call_id="call_1",
+                        name="calculator",
+                        arguments='{"expression":"2+2"}',
+                        state="pending",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def test_terminal_metadata_is_typed_and_repr_safe() -> None:
+    metadata_type = getattr(gateway_module, "ProviderTurnMetadata", None)
+
+    assert metadata_type is not None
+    metadata = metadata_type(
+        finish_reason="stop",
+        provider_continuation=_checkpoint(),
+        usage={"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+    )
+    sentinel = gateway_module.ProviderToolCalls((), metadata=metadata)
+    hosted_turn = HostedChatTurn(
+        text="answer",
+        tool_calls=(),
+        assistant_message={
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": "PRIVATE-REASONING-CANARY",
+        },
+        finish_reason="stop",
+        reasoning_content="PRIVATE-REASONING-CANARY",
+        usage={"private_usage": "PRIVATE-REASONING-CANARY"},
+    )
+
+    assert sentinel.metadata is metadata
+    assert "PRIVATE-REASONING-CANARY" not in repr(metadata)
+    assert "PRIVATE-REASONING-CANARY" not in repr(sentinel)
+    assert "PRIVATE-REASONING-CANARY" not in repr(hosted_turn)
+
+
+def test_moonshot_nonstream_tool_turn_exposes_private_typed_candidate(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        moonshot,
+        "resolve_moonshot_request",
+        lambda **_kwargs: moonshot.MoonshotResolution(
+            provider="moonshot",
+            model="kimi-k3",
+            api_key="secret",
+            base_url="https://api.moonshot.ai/v1",
+            timeout=90.0,
+            retries=3,
+            retry_delay=1.0,
+            streaming=False,
+        ),
+    )
+    monkeypatch.setattr(
+        moonshot,
+        "hosted_chat_request",
+        lambda **_kwargs: HostedChatTurn(
+            text="checking",
+            tool_calls=(
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": '{"expression":"2+2"}',
+                    },
+                },
+            ),
+            assistant_message={
+                "role": "assistant",
+                "content": "checking",
+                "reasoning_content": "PRIVATE-REASONING-CANARY",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ],
+            },
+            finish_reason="tool_calls",
+            reasoning_content="PRIVATE-REASONING-CANARY",
+            usage={"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+        ),
+    )
+
+    response = moonshot.chat_with_moonshot(
+        input_data=[{"role": "user", "content": "2+2?"}],
+        model="kimi-k3",
+        api_key="secret",
+        streaming=False,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "description": "Calculate.",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    )
+
+    assert isinstance(response, dict)
+    assert "reasoning_content" not in response["choices"][0]["message"]
+    candidate = response.provider_continuation  # type: ignore[attr-defined]
+    assert candidate.provider == "moonshot"
+    assert candidate.state == "active"
+    assert candidate.checkpoint_revision == 1
+    assert candidate.rounds[0].assistant_content == "checking"
+    assert candidate.rounds[0].reasoning_blocks == ("PRIVATE-REASONING-CANARY",)
+    assert candidate.rounds[0].calls[0].call_id == "call_1"
+    assert candidate.rounds[0].calls[0].state == "pending"
+    assert "PRIVATE-REASONING-CANARY" not in repr(response)
+
+
+def test_zai_nonstream_tool_turn_exposes_private_typed_candidate(monkeypatch) -> None:
+    monkeypatch.setattr(
+        zai,
+        "resolve_zai_request",
+        lambda **_kwargs: zai.ZAIResolution(
+            provider="zai",
+            model="glm-5.2",
+            api_key="secret",
+            base_url="https://api.z.ai/api/paas/v4",
+            timeout=90.0,
+            retries=3,
+            retry_delay=1.0,
+            streaming=False,
+        ),
+    )
+    monkeypatch.setattr(
+        zai,
+        "owned_json_post",
+        lambda **_kwargs: {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "checking",
+                        "reasoning_content": "PRIVATE-REASONING-CANARY",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "calculator",
+                                    "arguments": {"expression": "2+2"},
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+        },
+    )
+
+    response = zai.chat_with_zai(
+        input_data=[{"role": "user", "content": "2+2?"}],
+        model="glm-5.2",
+        api_key="secret",
+        streaming=False,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "description": "Calculate.",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    )
+
+    assert isinstance(response, dict)
+    assert "reasoning_content" not in response["choices"][0]["message"]
+    candidate = response.provider_continuation  # type: ignore[attr-defined]
+    assert candidate.provider == "zai"
+    assert candidate.state == "active"
+    assert candidate.checkpoint_revision == 1
+    assert candidate.rounds[0].reasoning_blocks == ("PRIVATE-REASONING-CANARY",)
+    assert candidate.rounds[0].calls[0].arguments == '{"expression":"2+2"}'
+    assert "PRIVATE-REASONING-CANARY" not in repr(response)
+
+
+def test_moonshot_stream_candidate_requires_clean_terminal_exhaustion(
+    monkeypatch,
+) -> None:
+    resolution = moonshot.MoonshotResolution(
+        provider="moonshot",
+        model="kimi-k3",
+        api_key="secret",
+        base_url="https://api.moonshot.ai/v1",
+        timeout=90.0,
+        retries=3,
+        retry_delay=1.0,
+        streaming=True,
+    )
+    records = iter(
+        [
+            SSERecord(
+                event=None,
+                data=(
+                    '{"choices":[{"index":0,"delta":{"role":"assistant",'
+                    '"reasoning_content":"PRIVATE-REASONING-CANARY",'
+                    '"tool_calls":[{"index":0,"id":"call_1","type":"function",'
+                    '"function":{"name":"calculator",'
+                    '"arguments":"{\\"expression\\":\\"2+2\\"}"}}]},'
+                    '"finish_reason":"tool_calls"}]}'
+                ),
+            ),
+            SSERecord(
+                event=None,
+                data=(
+                    '{"choices":[],"usage":{"prompt_tokens":2,'
+                    '"completion_tokens":1,"total_tokens":3}}'
+                ),
+            ),
+            SSERecord(event=None, data="[DONE]"),
+        ]
+    )
+    monkeypatch.setattr(
+        moonshot, "resolve_moonshot_request", lambda **_kwargs: resolution
+    )
+    monkeypatch.setattr(
+        moonshot,
+        "hosted_chat_request",
+        lambda **_kwargs: HostedChatStream(
+            records, finish_policy=moonshot.MoonshotFinishPolicy()
+        ),
+    )
+
+    response = moonshot.chat_with_moonshot(
+        input_data=[{"role": "user", "content": "2+2?"}],
+        api_key="secret",
+        streaming=True,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "description": "Calculate.",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    )
+
+    with pytest.raises(HostedChatProtocolError):
+        _ = response.provider_continuation  # type: ignore[union-attr]
+    events = list(response)
+    candidate = response.provider_continuation  # type: ignore[union-attr]
+
+    assert "reasoning_content" not in events[0]["choices"][0]["delta"]
+    assert candidate is not None
+    assert candidate.rounds[-1].calls[0].call_id == "call_1"
+    assert candidate.rounds[-1].reasoning_blocks == ("PRIVATE-REASONING-CANARY",)
+
+
+def test_zai_stream_candidate_requires_clean_terminal_exhaustion(monkeypatch) -> None:
+    resolution = zai.ZAIResolution(
+        provider="zai",
+        model="glm-5.2",
+        api_key="secret",
+        base_url="https://api.z.ai/api/paas/v4",
+        timeout=90.0,
+        retries=3,
+        retry_delay=1.0,
+        streaming=True,
+    )
+    records = iter(
+        [
+            SSERecord(
+                event=None,
+                data=(
+                    '{"choices":[{"index":0,"delta":{"role":"assistant",'
+                    '"reasoning_content":"PRIVATE-REASONING-CANARY",'
+                    '"tool_calls":[{"index":0,"id":"call_1","type":"function",'
+                    '"function":{"name":"calculator",'
+                    '"arguments":"{\\"expression\\":\\"2+2\\"}"}}]},'
+                    '"finish_reason":"tool_calls"}]}'
+                ),
+            ),
+            SSERecord(
+                event=None,
+                data=(
+                    '{"choices":[],"usage":{"prompt_tokens":2,'
+                    '"completion_tokens":1,"total_tokens":3}}'
+                ),
+            ),
+            SSERecord(event=None, data="[DONE]"),
+        ]
+    )
+    monkeypatch.setattr(zai, "resolve_zai_request", lambda **_kwargs: resolution)
+    monkeypatch.setattr(zai, "owned_json_post", lambda **_kwargs: records)
+
+    response = zai.chat_with_zai(
+        input_data=[{"role": "user", "content": "2+2?"}],
+        api_key="secret",
+        streaming=True,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "description": "Calculate.",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    )
+
+    with pytest.raises(HostedChatProtocolError):
+        _ = response.provider_continuation  # type: ignore[union-attr]
+    list(response)
+    candidate = response.provider_continuation  # type: ignore[union-attr]
+
+    assert candidate is not None
+    assert candidate.provider == "zai"
+    assert candidate.rounds[-1].calls[0].call_id == "call_1"
+
+
+@pytest.mark.parametrize(
+    ("provider", "model", "base_url"),
+    [
+        ("moonshot", "kimi-k3", "https://api.moonshot.ai/v1"),
+        ("zai", "glm-5.2", "https://api.z.ai/api/paas/v4"),
+    ],
+)
+def test_prepared_kwargs_pin_hosted_base_and_private_checkpoints(
+    provider: str,
+    model: str,
+    base_url: str,
+) -> None:
+    rounds = (
+        [
+            {
+                "assistant_content": "answer",
+                "reasoning_blocks": ["PRIVATE-REASONING-CANARY"],
+                "calls": [],
+            }
+        ]
+        if provider == "moonshot"
+        else [
+            {
+                "assistant_content": "",
+                "reasoning_blocks": ["PRIVATE-REASONING-CANARY"],
+                "calls": [
+                    {
+                        "call_id": "call_1",
+                        "name": "calculator",
+                        "arguments": '{"expression":"2+2"}',
+                        "state": "completed",
+                        "result": "4",
+                    }
+                ],
+            }
+        ]
+    )
+    checkpoint = parse_provider_continuation_json(
+        {
+            "schema_version": 1,
+            "checkpoint_revision": 1,
+            "provider": provider,
+            "protocol": "chat_completions",
+            "model": model,
+            "api_base_url": base_url,
+            "state": "complete",
+            "rounds": rounds,
+        }
+    )
+    resolution = gateway_module.ConsoleProviderResolution(
+        provider=provider,
+        base_url=base_url,
+        model=model,
+        ready=True,
+        readiness_key=provider,
+        execution_key=provider,
+        api_key="PRIVATE-API-KEY-CANARY",
+        streaming=True,
+        continuation_protocol="chat_completions",
+    )
+    gateway = gateway_module.ConsoleProviderGateway(environ={})
+    prepared = gateway.prepare_chat_request(
+        resolution,
+        [
+            {"_owner": "a1", "role": "assistant", "content": "answer"},
+            {"_owner": "u2", "role": "user", "content": "next"},
+        ],
+        continuation_target=ContinuationRestoreTarget(
+            provider=provider,
+            model=model,
+            protocol="chat_completions",
+            api_base_url=base_url,
+        ),
+        continuation_sidecar=(ProviderContinuationSidecar("a1", checkpoint),),
+        continuation_owner_key="_owner",
+    )
+
+    kwargs = gateway._chat_api_kwargs_from_prepared(resolution, prepared)
+
+    assert kwargs["api_base_url"] == base_url
+    assert kwargs["provider_continuations"] == [checkpoint]
+    assert "api_mode" not in kwargs
+    assert "PRIVATE-API-KEY-CANARY" not in repr(prepared)
+
+
+@pytest.mark.parametrize("provider", ["moonshot", "zai"])
+def test_dispatcher_forwards_only_hosted_provider_continuations(
+    monkeypatch,
+    provider: str,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def handler(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setitem(Chat_Functions.API_CALL_HANDLERS, provider, handler)
+    checkpoint = _active_checkpoint(provider)
+
+    result = Chat_Functions.chat_api_call(
+        api_endpoint=provider,
+        messages_payload=[{"role": "user", "content": "next"}],
+        provider_continuations=(checkpoint,),
+    )
+
+    assert result == {"ok": True}
+    assert captured["provider_continuations"] == (checkpoint,)
+
+
+@pytest.mark.asyncio
+async def test_gateway_emits_one_final_typed_metadata_sentinel() -> None:
+    checkpoint = _active_checkpoint("moonshot")
+    turn = HostedChatTurn(
+        text="checking",
+        tool_calls=(
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "arguments": '{"expression":"2+2"}',
+                },
+            },
+        ),
+        assistant_message={
+            "role": "assistant",
+            "content": "checking",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": '{"expression":"2+2"}',
+                    },
+                }
+            ],
+        },
+        finish_reason="tool_calls",
+        reasoning_content="PRIVATE-REASONING-CANARY",
+        usage={"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+    )
+    response = moonshot.MoonshotResponse(
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": turn.assistant_message,
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": turn.usage,
+        },
+        terminal_turn=turn,
+        provider_continuation=checkpoint,
+    )
+    gateway = gateway_module.ConsoleProviderGateway(
+        chat_api_call_fn=lambda **_kwargs: response,
+        environ={},
+    )
+    resolution = gateway_module.ConsoleProviderResolution(
+        provider="moonshot",
+        base_url="https://api.moonshot.ai/v1",
+        model="kimi-k3",
+        ready=True,
+        execution_key="moonshot",
+        api_key="secret",
+        streaming=False,
+        continuation_protocol="chat_completions",
+    )
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "calculator",
+                "description": "Calculate.",
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+
+    items = [
+        item
+        async for item in gateway.stream_chat(
+            resolution,
+            [{"role": "user", "content": "2+2?"}],
+            tools=tools,
+        )
+    ]
+
+    assert items[0] == "checking"
+    assert len(items) == 2
+    sentinel = items[-1]
+    assert isinstance(sentinel, gateway_module.ProviderToolCalls)
+    assert sentinel.metadata is not None
+    assert sentinel.metadata.finish_reason == "tool_calls"
+    assert sentinel.metadata.provider_continuation == checkpoint
+    assert sentinel.metadata.usage == turn.usage
+
+
+@pytest.mark.asyncio
+async def test_gateway_cancellation_never_reads_terminal_provider_metadata() -> None:
+    class CancelledProviderStream:
+        def __init__(self) -> None:
+            self._first = True
+            self.closed = threading.Event()
+            self.exhausted = threading.Event()
+            self.terminal_accessed = threading.Event()
+            self.close_calls = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self._first:
+                self._first = False
+                return {"choices": [{"delta": {"content": "partial"}}]}
+            self.closed.wait(timeout=5)
+            self.exhausted.set()
+            raise StopIteration
+
+        @property
+        def terminal_turn(self):
+            self.terminal_accessed.set()
+            raise AssertionError("cancelled streams have no terminal metadata")
+
+        def close(self) -> None:
+            self.close_calls += 1
+            self.closed.set()
+
+    response = CancelledProviderStream()
+    gateway = gateway_module.ConsoleProviderGateway(
+        chat_api_call_fn=lambda **_kwargs: response,
+        environ={},
+    )
+    resolution = gateway_module.ConsoleProviderResolution(
+        provider="moonshot",
+        base_url="https://api.moonshot.ai/v1",
+        model="kimi-k3",
+        ready=True,
+        execution_key="moonshot",
+        api_key="secret",
+        streaming=True,
+        continuation_protocol="chat_completions",
+    )
+    stream = gateway.stream_chat(
+        resolution,
+        [{"role": "user", "content": "hello"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "description": "Calculate.",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    )
+
+    assert await anext(stream) == "partial"
+    await stream.aclose()
+    assert await asyncio.to_thread(response.exhausted.wait, 1)
+    await asyncio.sleep(0.05)
+
+    assert response.close_calls == 1
+    assert response.terminal_accessed.is_set() is False
+
+
+def test_streaming_adapter_carries_terminal_candidate_into_model_turn(tmp_path) -> None:
+    checkpoint = _active_checkpoint("moonshot")
+    metadata = gateway_module.ProviderTurnMetadata(
+        finish_reason="tool_calls",
+        provider_continuation=checkpoint,
+        usage={"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+    )
+    calls = (
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {
+                "name": "calculator",
+                "arguments": '{"expression":"2+2"}',
+            },
+        },
+    )
+
+    class Gateway:
+        async def stream_chat(self, _resolution, _messages, **_kwargs):
+            yield "checking"
+            yield gateway_module.ProviderToolCalls(calls, metadata=metadata)
+
+    class Resolution:
+        provider = "moonshot"
+        execution_key = "moonshot"
+        model = "kimi-k3"
+
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="2+2?")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    lifeline = _ModelCallLifeline("kimi-zai-contract-loop")
+    lifeline.start()
+    try:
+        adapter = _StreamingModelAdapter(
+            store=store,
+            provider_gateway=Gateway(),
+            resolution=Resolution(),
+            assistant_message_id=assistant.id,
+            should_cancel=lambda: False,
+            loop=lifeline.loop,
+        )
+        registry = ToolCatalogRegistry()
+        registry.register_provider(BuiltinToolProvider())
+        service = AgentService(
+            db=AgentRunsDB(tmp_path / "runs.db", client_id="contract"),
+            registry=registry,
+            chat_call=adapter.chat_call,
+        )
+        turn = service._make_call_model(
+            AgentConfig(model="kimi-k3", system_prompt="system", native_tools=True),
+            "moonshot",
+            [],
+        )([{"role": "user", "content": "2+2?"}], ())
+    finally:
+        lifeline.shutdown()
+
+    assert turn.provider_continuation == checkpoint
+    assert turn.tokens == 3
+    assert turn.assistant_message is not None
+    assert "PRIVATE-REASONING-CANARY" not in repr(turn.assistant_message)
+
+
+def test_runtime_passes_exact_transitioned_checkpoint_to_next_model_call() -> None:
+    first = _active_checkpoint("moonshot")
+    seen: list[ProviderContinuationCheckpoint | None] = []
+    call = ToolCall(
+        name="calculator",
+        args={"expression": "2+2"},
+        call_id="call_1",
+        raw_arguments='{"expression":"2+2"}',
+    )
+
+    def call_model_with_continuation(_messages, _active, current):
+        seen.append(current)
+        if current is None:
+            return ModelTurn(
+                text="",
+                tool_calls=(call,),
+                assistant_message={
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "calculator",
+                                "arguments": '{"expression":"2+2"}',
+                            },
+                        }
+                    ],
+                },
+                provider_continuation=first,
+            )
+        assert current.checkpoint_revision == 3
+        assert current.rounds[-1].calls[0].state == "completed"
+        return ModelTurn(
+            text="4",
+            provider_continuation=ProviderContinuationCheckpoint(
+                schema_version=1,
+                checkpoint_revision=4,
+                provider="moonshot",
+                protocol="chat_completions",
+                model="kimi-k3",
+                api_base_url="https://api.moonshot.ai/v1",
+                state="complete",
+                rounds=(
+                    *current.rounds,
+                    ContinuationRound(
+                        assistant_content="4",
+                        reasoning_blocks=("PRIVATE-FINAL-REASONING",),
+                        calls=(),
+                    ),
+                ),
+            ),
+        )
+
+    events = []
+    outcome = run_agent_loop(
+        AgentConfig(
+            model="kimi-k3",
+            system_prompt="system",
+            allowed_tools=("calculator",),
+        ),
+        [{"role": "user", "content": "2+2?"}],
+        [
+            ToolSchema(
+                id="builtin:calculator",
+                name="calculator",
+                description="Calculate.",
+                parameters={"type": "object"},
+            )
+        ],
+        LoopDeps(
+            call_model=lambda _messages, _active: pytest.fail(
+                "continuation-aware model seam was bypassed"
+            ),
+            call_model_with_continuation=call_model_with_continuation,
+            invoke_tool=lambda _call: ToolResult(ok=True, content="4"),
+            spawn=lambda _task: ToolResult(ok=False, error="unused"),
+            find_tools=lambda _query: [],
+            load_schemas=lambda _ids: [],
+            should_cancel=lambda: False,
+            clock=lambda: 0.0,
+            continuation_context=ContinuationEventContext(
+                "owner", "run", "primary", "persistent"
+            ),
+            persist_provider_continuation=events.append,
+        ),
+    )
+
+    assert outcome.status == "done"
+    assert outcome.final_text == "4"
+    assert seen[0] is None
+    assert seen[1] is not None
+
+
+def test_agent_service_forwards_current_checkpoint_as_one_owner_group(tmp_path) -> None:
+    captured: dict[str, object] = {}
+    current = ProviderContinuationCheckpoint(
+        schema_version=1,
+        checkpoint_revision=3,
+        provider="moonshot",
+        protocol="chat_completions",
+        model="kimi-k3",
+        api_base_url="https://api.moonshot.ai/v1",
+        state="active",
+        rounds=(
+            ContinuationRound(
+                assistant_content="",
+                reasoning_blocks=("PRIVATE-REASONING-CANARY",),
+                calls=(
+                    ContinuationCall(
+                        call_id="call_1",
+                        name="calculator",
+                        arguments='{"expression":"2+2"}',
+                        state="completed",
+                        result=ContinuationResult("4"),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    def chat_call(**kwargs):
+        captured.update(kwargs)
+        return {
+            "choices": [{"message": {"content": "4"}}],
+            "usage": {"total_tokens": 3},
+        }
+
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    service = AgentService(
+        db=AgentRunsDB(tmp_path / "service.db", client_id="contract"),
+        registry=registry,
+        chat_call=chat_call,
+        prepare_provider_continuation_request=True,
+    )
+    call_model = service._make_call_model(
+        AgentConfig(model="kimi-k3", system_prompt="system", native_tools=True),
+        "moonshot",
+        [],
+        continuation_owner_key="_owner",
+        continuation_owner_message_id="owner-1",
+    )
+
+    turn = call_model(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ],
+                "_owner": "owner-1",
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "4"},
+        ],
+        (),
+        current,
+    )
+
+    groups = captured["continuation_groups"]
+    assert isinstance(groups, tuple)
+    assert len(groups) == 1
+    assert groups[0].owner_message_id == "owner-1"
+    assert groups[0].checkpoint == current
+    assert captured["messages_payload"][1]["_owner"] == "owner-1"
+    assert turn.tokens == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "model", "base_url"),
+    [
+        ("moonshot", "kimi-k3", "https://api.moonshot.ai/v1"),
+        ("zai", "glm-5.2", "https://api.z.ai/api/paas/v4"),
+    ],
+)
+async def test_console_freezes_hosted_transport_policy_before_config_mutation(
+    provider: str,
+    model: str,
+    base_url: str,
+) -> None:
+    settings: dict[str, object] = {
+        "api_key": "PRIVATE-API-KEY-CANARY",
+        "model": model,
+        "api_base_url": base_url,
+        "timeout": 41.5,
+        "retries": 2,
+        "retry_delay": 0.25,
+    }
+    gateway = gateway_module.ConsoleProviderGateway(
+        config_provider=lambda: {"api_settings": {provider: settings}},
+        environ={},
+    )
+    resolution = await gateway.resolve_for_send(
+        gateway_module.ConsoleProviderSelection(provider=provider)
+    )
+    settings.update(timeout=999, retries=99, retry_delay=99)
+    prepared = gateway.prepare_chat_request(
+        resolution,
+        [{"role": "user", "content": "hello"}],
+    )
+
+    kwargs = gateway._chat_api_kwargs_from_prepared(resolution, prepared)
+
+    assert resolution.ready is True
+    assert kwargs["request_timeout"] == 41.5
+    assert kwargs["request_retries"] == 2
+    assert kwargs["request_retry_delay"] == 0.25
+    assert "api_mode" not in kwargs
+
+
+@pytest.mark.parametrize("provider", ["moonshot", "zai"])
+def test_strict_hosted_adapter_uses_frozen_transport_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+) -> None:
+    module = moonshot if provider == "moonshot" else zai
+    chat = module.chat_with_moonshot if provider == "moonshot" else module.chat_with_zai
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        module,
+        "get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    provider: {
+                        "timeout": 999,
+                        "retries": 99,
+                        "retry_delay": 99,
+                    }
+                }
+            }
+        ),
+    )
+    if provider == "moonshot":
+        monkeypatch.setattr(
+            module,
+            "hosted_chat_request",
+            lambda **kwargs: (
+                captured.update(kwargs)
+                or HostedChatTurn(
+                    text="answer",
+                    tool_calls=(),
+                    assistant_message={"role": "assistant", "content": "answer"},
+                    finish_reason="stop",
+                )
+            ),
+        )
+    else:
+        monkeypatch.setattr(
+            module,
+            "owned_json_post",
+            lambda **kwargs: (
+                captured.update(kwargs)
+                or {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "answer"},
+                            "finish_reason": "stop",
+                        }
+                    ]
+                }
+            ),
+        )
+
+    chat(
+        input_data=[{"role": "user", "content": "hello"}],
+        api_key="secret",
+        streaming=False,
+        request_timeout=41.5,
+        request_retries=2,
+        request_retry_delay=0.25,
+    )
+
+    config = captured["config"]
+    assert config.timeout == 41.5  # type: ignore[union-attr]
+    assert config.retries == 2  # type: ignore[union-attr]
+    assert config.retry_delay == 0.25  # type: ignore[union-attr]

--- a/Tests/Chat/test_live_moonshot_zai_api.py
+++ b/Tests/Chat/test_live_moonshot_zai_api.py
@@ -1,0 +1,384 @@
+"""Opt-in paid Moonshot and Z.ai Console tool-continuation checks."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from textwrap import dedent
+from types import SimpleNamespace
+
+import pytest
+
+
+_PROVIDERS = {
+    "moonshot": {
+        "gate": "TLDW_LIVE_MOONSHOT",
+        "key": "MOONSHOT_API_KEY",
+    },
+    "zai": {
+        "gate": "TLDW_LIVE_ZAI",
+        "key": "ZAI_API_KEY",
+    },
+}
+_TOOL_MARKER_PREFIX = "HOSTED_LIVE_TOOL_RESULT_"
+_TOOL_MARKER_SUFFIX = "_END"
+
+
+def _live_enabled(provider: str, environ: Mapping[str, str]) -> bool:
+    settings = _PROVIDERS[provider]
+    return environ.get(settings["gate"], "").strip() == "1" and bool(
+        environ.get(settings["key"], "").strip()
+    )
+
+
+def _live_subprocess_environment(
+    profile: Path,
+    provider: str,
+    environ: Mapping[str, str],
+) -> dict[str, str]:
+    env = dict(environ)
+    env.update(
+        {
+            "HOME": str(profile / "home"),
+            "XDG_CONFIG_HOME": str(profile / "xdg-config"),
+            "XDG_DATA_HOME": str(profile / "xdg-data"),
+            "TLDW_CONFIG_PATH": str(profile / "config" / "config.toml"),
+            "TLDW_LIVE_HOSTED_DATA_DIR": str(profile / "data"),
+            "TLDW_LIVE_HOSTED_PROVIDER": provider,
+        }
+    )
+    return env
+
+
+@pytest.mark.parametrize("provider", ["moonshot", "zai"])
+@pytest.mark.parametrize(
+    ("gate", "key", "expected"),
+    [
+        ("", "", False),
+        ("1", "", False),
+        ("", "test-key", False),
+        ("1", "test-key", True),
+    ],
+)
+def test_live_gate_requires_provider_opt_in_and_key(
+    provider: str,
+    gate: str,
+    key: str,
+    expected: bool,
+) -> None:
+    settings = _PROVIDERS[provider]
+    environ = {settings["gate"]: gate, settings["key"]: key}
+    assert _live_enabled(provider, environ) is expected
+
+
+def test_live_subprocess_isolates_profile_before_chatbook_imports() -> None:
+    profile = Path("/tmp/hosted-live-structural-test")
+    env = _live_subprocess_environment(profile, "moonshot", {})
+
+    assert env["HOME"] == str(profile / "home")
+    assert env["XDG_CONFIG_HOME"] == str(profile / "xdg-config")
+    assert env["XDG_DATA_HOME"] == str(profile / "xdg-data")
+    assert env["TLDW_CONFIG_PATH"] == str(profile / "config" / "config.toml")
+    assert env["TLDW_LIVE_HOSTED_DATA_DIR"] == str(profile / "data")
+    assert _LIVE_CHILD.index("config_path.write_text") < _LIVE_CHILD.index(
+        "from tldw_chatbook"
+    )
+    assert _LIVE_CHILD.index("config_path.chmod") < _LIVE_CHILD.index(
+        "from tldw_chatbook"
+    )
+    compile(_LIVE_CHILD, "<hosted-live-child>", "exec")
+
+
+def _build_probe_contract(
+    provider: str,
+    left: int,
+    right: int,
+    text_sentinel: str,
+) -> tuple[str, str, str]:
+    expression = f"{left} + {right}"
+    system_prompt = (
+        "Run one harmless provider contract probe. Call the calculator tool "
+        f"exactly once with expression {expression!r}. Only after the tool returns, "
+        f"reply with text marker {text_sentinel!r}, prefix "
+        f"{_TOOL_MARKER_PREFIX!r}, the exact integer result as ASCII digits, then "
+        f"suffix {_TOOL_MARKER_SUFFIX!r}."
+    )
+    return system_prompt, f"Run the {provider} contract probe now.", expression
+
+
+def _validate_probe_observation(
+    *,
+    provider: str,
+    status: str,
+    final_text: str,
+    steps: Sequence[object],
+    text_sentinel: str,
+    system_prompt: str,
+    user_prompt: str,
+    expression: str,
+    expected: int,
+) -> None:
+    tool_marker = f"{_TOOL_MARKER_PREFIX}{expected}{_TOOL_MARKER_SUFFIX}"
+    if tool_marker in system_prompt or tool_marker in user_prompt:
+        raise ValueError("Derived marker was disclosed before tool execution.")
+    if status != "done":
+        raise ValueError(f"{provider} live run did not complete.")
+    calls = [
+        step
+        for step in steps
+        if getattr(step, "kind", "") == "tool_call"
+        and getattr(step, "tool_name", "") == "calculator"
+    ]
+    results = [
+        step
+        for step in steps
+        if getattr(step, "kind", "") == "tool_result"
+        and getattr(step, "tool_name", "") == "calculator"
+    ]
+    if len(calls) != 1 or len(results) != 1:
+        raise ValueError(f"{provider} did not execute exactly one calculator call.")
+    if getattr(calls[0], "args", None) != {"expression": expression}:
+        raise ValueError(f"{provider} calculator arguments were unexpected.")
+    try:
+        result_payload = json.loads(str(getattr(results[0], "result", "")))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{provider} calculator result was malformed.") from exc
+    observed = (
+        result_payload.get("result") if isinstance(result_payload, Mapping) else None
+    )
+    if (
+        isinstance(observed, bool)
+        or not isinstance(observed, int)
+        or observed != expected
+    ):
+        raise ValueError(f"{provider} calculator result was incorrect.")
+    if text_sentinel not in final_text or tool_marker not in final_text:
+        raise ValueError(f"{provider} final answer did not use the tool result.")
+
+
+def test_live_probe_marker_requires_the_calculator_result() -> None:
+    provider = "moonshot"
+    left = 1_000_000_003
+    right = 2_000_000_033
+    expected = left + right
+    text_sentinel = "HOSTED_LIVE_TEXT_TEST"
+    system_prompt, user_prompt, expression = _build_probe_contract(
+        provider, left, right, text_sentinel
+    )
+    marker = f"{_TOOL_MARKER_PREFIX}{expected}{_TOOL_MARKER_SUFFIX}"
+    steps = [
+        SimpleNamespace(
+            kind="tool_call",
+            tool_name="calculator",
+            args={"expression": expression},
+        ),
+        SimpleNamespace(
+            kind="tool_result",
+            tool_name="calculator",
+            result=json.dumps({"result": expected}),
+        ),
+    ]
+
+    _validate_probe_observation(
+        provider=provider,
+        status="done",
+        final_text=f"{text_sentinel} {marker}",
+        steps=steps,
+        text_sentinel=text_sentinel,
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        expression=expression,
+        expected=expected,
+    )
+    steps[1].result = json.dumps({"result": expected + 1})
+    with pytest.raises(ValueError, match="incorrect"):
+        _validate_probe_observation(
+            provider=provider,
+            status="done",
+            final_text=f"{text_sentinel} {marker}",
+            steps=steps,
+            text_sentinel=text_sentinel,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            expression=expression,
+            expected=expected,
+        )
+
+
+_LIVE_CHILD = dedent(
+    r"""
+    from __future__ import annotations
+
+    import json
+    import os
+    from pathlib import Path
+    import secrets
+
+    provider = os.environ["TLDW_LIVE_HOSTED_PROVIDER"]
+    metadata = {
+        "moonshot": {
+            "display": "Moonshot",
+            "model_env": "TLDW_LIVE_MOONSHOT_MODEL",
+            "model": "kimi-k3",
+            "base_env": "TLDW_LIVE_MOONSHOT_API_BASE_URL",
+            "base": "https://api.moonshot.ai/v1",
+            "key_env": "MOONSHOT_API_KEY",
+        },
+        "zai": {
+            "display": "Z.ai",
+            "model_env": "TLDW_LIVE_ZAI_MODEL",
+            "model": "glm-5.2",
+            "base_env": "TLDW_LIVE_ZAI_API_BASE_URL",
+            "base": "https://api.z.ai/api/paas/v4",
+            "key_env": "ZAI_API_KEY",
+        },
+    }[provider]
+    model = os.environ.get(metadata["model_env"], metadata["model"]).strip()
+    base_url = os.environ.get(metadata["base_env"], metadata["base"]).strip()
+    config_path = Path(os.environ["TLDW_CONFIG_PATH"])
+    data_dir = Path(os.environ["TLDW_LIVE_HOSTED_DATA_DIR"])
+    config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    data_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    config_path.write_text(
+        "\n".join(
+            (
+                "[general]",
+                'users_name = "hosted-live-test"',
+                "",
+                "[paths]",
+                f"data_dir = {json.dumps(str(data_dir))}",
+                "",
+                f"[api_settings.{provider}]",
+                f"api_key_env_var = {json.dumps(metadata['key_env'])}",
+                f"api_base_url = {json.dumps(base_url)}",
+                f"model = {json.dumps(model)}",
+                "streaming = true",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    config_path.chmod(0o600)
+
+    from loguru import logger
+
+    logger.remove()
+
+    from Tests.Chat.test_live_moonshot_zai_api import (
+        _build_probe_contract,
+        _validate_probe_observation,
+    )
+    from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+    from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+    from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+    from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+    from tldw_chatbook.Chat.console_provider_gateway import (
+        ConsoleProviderGateway,
+        ConsoleProviderResolution,
+    )
+    from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+    text_sentinel = f"HOSTED_LIVE_TEXT_{secrets.token_hex(8).upper()}"
+    left = 10**12 + secrets.randbelow(10**11)
+    right = 10**12 + secrets.randbelow(10**11)
+    expected = left + right
+    system_prompt, user_prompt, expression = _build_probe_contract(
+        provider, left, right, text_sentinel
+    )
+    runs_db = AgentRunsDB(
+        data_dir / f"agent-runs-{provider}.db", client_id=f"{provider}-live"
+    )
+    chat_db = CharactersRAGDB(
+        data_dir / f"chat-{provider}.db", f"{provider}-live"
+    )
+    try:
+        store = ConsoleChatStore(persistence=ChatPersistenceService(chat_db))
+        session = store.create_session(title=f"{provider} live contract")
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content=user_prompt,
+            persist=True,
+        )
+        assistant = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+            persist=True,
+        )
+        bridge = ConsoleAgentBridge(
+            agent_runs_db=runs_db,
+            store=store,
+            provider_gateway=ConsoleProviderGateway(),
+        )
+        resolution = ConsoleProviderResolution(
+            provider=metadata["display"],
+            base_url=base_url,
+            model=model,
+            ready=True,
+            readiness_key=provider,
+            execution_key=provider,
+            api_key=os.environ[metadata["key_env"]],
+            streaming=True,
+            continuation_protocol="chat_completions",
+            request_timeout=90.0,
+            request_retries=1,
+            request_retry_delay=1.0,
+        )
+        _run_id, outcome = bridge.run_reply(
+            conversation_id=f"{provider}-live-conversation",
+            session_id=session.id,
+            resolution=resolution,
+            assistant_message_id=assistant.id,
+            model=model,
+            session_system_prompt=system_prompt,
+            agent_messages=[{"role": "user", "content": user_prompt}],
+            should_cancel=lambda: False,
+            native_tools_enabled=True,
+        )
+        _validate_probe_observation(
+            provider=provider,
+            status=outcome.status,
+            final_text=outcome.final_text,
+            steps=outcome.steps,
+            text_sentinel=text_sentinel,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            expression=expression,
+            expected=expected,
+        )
+    finally:
+        runs_db.close()
+        chat_db.close_connection()
+    """
+)
+
+
+@pytest.mark.allow_network
+@pytest.mark.integration
+@pytest.mark.parametrize("provider", ["moonshot", "zai"])
+def test_live_hosted_text_and_native_tool(tmp_path: Path, provider: str) -> None:
+    """Make one paid provider request only behind its exact double gate."""
+    if not _live_enabled(provider, os.environ):
+        settings = _PROVIDERS[provider]
+        pytest.skip(f"Set {settings['gate']}=1 and {settings['key']} to opt in.")
+    env = _live_subprocess_environment(tmp_path / provider, provider, os.environ)
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", _LIVE_CHILD],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=360,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"Live {provider} verification timed out with output suppressed.")
+    if completed.returncode != 0:
+        pytest.fail(f"Live {provider} verification failed with output suppressed.")

--- a/Tests/Chat/test_provider_readiness.py
+++ b/Tests/Chat/test_provider_readiness.py
@@ -306,6 +306,109 @@ def test_non_qwen_provider_lookup_keeps_first_normalized_match():
     assert readiness.api_key == "first-match-key"
 
 
+@pytest.mark.parametrize(
+    ("provider", "provider_key", "model", "base_url", "env_var"),
+    [
+        (
+            "Moonshot",
+            "moonshot",
+            "kimi-k3",
+            "https://api.moonshot.ai/v1",
+            "MOONSHOT_API_KEY",
+        ),
+        (
+            "Z.ai",
+            "zai",
+            "glm-5.2",
+            "https://api.z.ai/api/paas/v4",
+            "ZAI_API_KEY",
+        ),
+    ],
+)
+def test_hosted_readiness_validates_the_same_full_contract_as_send(
+    provider, provider_key, model, base_url, env_var
+):
+    readiness = get_provider_readiness(
+        provider,
+        {
+            "api_settings": {
+                provider_key: {
+                    "api_key_env_var": env_var,
+                    "model": model,
+                    "api_base_url": base_url,
+                    "timeout": 90,
+                    "retries": 3,
+                    "retry_delay": 1,
+                    "streaming": True,
+                }
+            }
+        },
+        environ={env_var: "hosted-secret-canary"},
+    )
+
+    assert readiness.ready is True
+    assert readiness.api_key == "hosted-secret-canary"
+    assert "hosted-secret-canary" not in readiness.user_message
+
+
+@pytest.mark.parametrize(
+    ("provider", "provider_key", "settings"),
+    [
+        ("Moonshot", "moonshot", {"model": " "}),
+        ("Moonshot", "moonshot", {"api_base_url": "https://user:pass@example.test/v1"}),
+        ("Moonshot", "moonshot", {"timeout": True}),
+        ("Z.ai", "zai", {"retries": -1}),
+        ("Z.ai", "zai", {"retry_delay": -1}),
+        ("Z.ai", "zai", {"streaming": "true"}),
+    ],
+)
+def test_hosted_readiness_blocks_malformed_send_settings(
+    provider, provider_key, settings
+):
+    source = {
+        "api_settings": {
+            provider_key: {
+                "api_key": "hosted-secret-canary",
+                **settings,
+            }
+        }
+    }
+    original = deepcopy(source)
+
+    readiness = get_provider_readiness(provider, source, environ={})
+
+    assert source == original
+    assert readiness.ready is False
+    assert readiness.reason == "Invalid provider settings"
+    assert f"api_settings.{provider_key}" in readiness.user_message
+    assert "hosted-secret-canary" not in readiness.user_message
+
+
+@pytest.mark.parametrize(
+    ("provider", "provider_key", "alias"),
+    [
+        ("Moonshot", "moonshot", " MOONSHOT "),
+        ("Z.ai", "zai", "ZAI"),
+    ],
+)
+def test_hosted_readiness_rejects_normalized_alias_conflicts(
+    provider, provider_key, alias
+):
+    source = {
+        "api_settings": {
+            alias: {"api_key": "alias-secret-canary"},
+            provider_key: {"api_key": "canonical-secret-canary"},
+        }
+    }
+
+    readiness = get_provider_readiness(provider, source, environ={})
+
+    assert readiness.ready is False
+    assert readiness.reason == "Invalid provider settings"
+    assert "alias-secret-canary" not in readiness.user_message
+    assert "canonical-secret-canary" not in readiness.user_message
+
+
 def test_keyless_local_provider_is_ready_without_api_key():
     readiness = get_provider_readiness(
         "Ollama",

--- a/Tests/Chat/test_sensitive_llm_logging.py
+++ b/Tests/Chat/test_sensitive_llm_logging.py
@@ -875,18 +875,10 @@ def test_sensitive_openai_compatible_error_bodies_are_not_logged(
     provider: str,
 ) -> None:
     session = _FakeSession(_FakeResponse({}, status_code=500, text="ERROR-BODY-CANARY"))
+    monkeypatch.setattr(hosted_chat.requests, "Session", lambda: session)
     if provider == "moonshot":
-        monkeypatch.setattr(hosted_chat.requests, "Session", lambda: session)
         call: Callable[..., object] = cloud_adapters.chat_with_moonshot
     else:
-        monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
-        monkeypatch.setattr(
-            cloud_adapters,
-            "get_runtime_config_snapshot",
-            lambda: _runtime_config(
-                "zai", {"api_key": "key", "api_base_url": "https://zai.test"}
-            ),
-        )
         call = cloud_adapters.chat_with_zai
 
     with _captured_logs() as logs, sensitive_llm_request():

--- a/Tests/Chat/test_sensitive_llm_logging.py
+++ b/Tests/Chat/test_sensitive_llm_logging.py
@@ -23,6 +23,7 @@ from loguru import logger
 import tldw_chatbook.Chat.Chat_Functions as chat_functions
 import tldw_chatbook.LLM_Calls.LLM_API_Calls as cloud_adapters
 import tldw_chatbook.LLM_Calls.LLM_API_Calls_Local as local_adapters
+import tldw_chatbook.LLM_Calls.hosted_chat as hosted_chat
 from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
 from tldw_chatbook.Chat.Chat_Functions import SENSITIVE_AUXILIARY_AUDITED_ENDPOINTS
 from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
@@ -874,20 +875,11 @@ def test_sensitive_openai_compatible_error_bodies_are_not_logged(
     provider: str,
 ) -> None:
     session = _FakeSession(_FakeResponse({}, status_code=500, text="ERROR-BODY-CANARY"))
-    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
     if provider == "moonshot":
-        monkeypatch.setattr(
-            cloud_adapters,
-            "load_settings",
-            lambda: {
-                "moonshot_api": {
-                    "api_key": "key",
-                    "api_base_url": "https://moonshot.test",
-                }
-            },
-        )
+        monkeypatch.setattr(hosted_chat.requests, "Session", lambda: session)
         call: Callable[..., object] = cloud_adapters.chat_with_moonshot
     else:
+        monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
         monkeypatch.setattr(
             cloud_adapters,
             "get_runtime_config_snapshot",

--- a/Tests/LLM_Calls/test_hosted_chat.py
+++ b/Tests/LLM_Calls/test_hosted_chat.py
@@ -1,0 +1,905 @@
+"""Contracts for the provider-neutral hosted Chat-Completions boundary."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from copy import deepcopy
+from email.utils import formatdate
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import threading
+import time
+from typing import Any
+
+import pytest
+import requests
+
+import tldw_chatbook.LLM_Calls.hosted_chat as hosted_chat
+from tldw_chatbook.Chat.Chat_Deps import (
+    ChatAuthenticationError,
+    ChatBadRequestError,
+    ChatProviderError,
+    ChatRateLimitError,
+)
+from tldw_chatbook.LLM_Calls.hosted_chat import (
+    HostedHTTPTransportConfig,
+    HostedChatProtocolError,
+    HostedChatStream,
+    HostedChatTurn,
+    normalize_hosted_chat_base_url,
+    normalize_hosted_chat_response,
+    owned_json_post,
+)
+from tldw_chatbook.LLM_Calls.hosted_chat_streaming import (
+    HostedSSEReadError,
+    OwnedSSEStream,
+    SSERecord,
+)
+from tldw_chatbook.Utils.sensitive_llm_logging import sensitive_llm_request
+
+
+class _FinishPolicy:
+    def validate_finish(
+        self,
+        *,
+        finish_reason: object,
+        has_text: bool,
+        has_calls: bool,
+    ) -> str:
+        if finish_reason not in {"stop", "tool_calls", "length"}:
+            raise HostedChatProtocolError("finish state is malformed")
+        if (finish_reason == "tool_calls") != has_calls:
+            raise HostedChatProtocolError("finish state conflicts with calls")
+        if finish_reason == "stop" and not has_text:
+            raise HostedChatProtocolError("finish state has no text")
+        return finish_reason
+
+    def validate_reasoning_content(self, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise HostedChatProtocolError("reasoning is malformed")
+        return value
+
+
+_POLICY = _FinishPolicy()
+
+
+class _ScriptedHostedServer(ThreadingHTTPServer):
+    def __init__(self, actions: list[dict[str, Any]]) -> None:
+        super().__init__(("127.0.0.1", 0), _ScriptedHostedHandler)
+        self.actions = actions
+        self.requests: list[dict[str, Any]] = []
+
+
+class _ScriptedHostedHandler(BaseHTTPRequestHandler):
+    server: _ScriptedHostedServer
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        self.server.requests.append(
+            {"path": self.path, "headers": dict(self.headers), "body": body}
+        )
+        action = self.server.actions.pop(0)
+        delay = action.get("delay", 0)
+        if delay:
+            time.sleep(delay)
+        status = action.get("status", 200)
+        response_body = action.get("body", b"{}")
+        headers = action.get("headers", {})
+        self.send_response(status)
+        self.send_header("Content-Type", action.get("content_type", "application/json"))
+        self.send_header(
+            "Content-Length",
+            str(len(response_body) + action.get("extra_content_length", 0)),
+        )
+        for name, value in headers.items():
+            self.send_header(name, value)
+        self.end_headers()
+        self.wfile.write(response_body)
+        self.wfile.flush()
+        if action.get("extra_content_length"):
+            self.close_connection = True
+
+    def log_message(self, _format: str, *args: object) -> None:
+        del args
+
+
+@contextmanager
+def _scripted_hosted_server(
+    actions: list[dict[str, Any]],
+) -> Any:
+    server = _ScriptedHostedServer(actions)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield server, f"http://{host}:{port}/v1"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+class _TrackingSession(requests.Session):
+    def __init__(self) -> None:
+        super().__init__()
+        self.close_calls = 0
+        self.response_close_calls: list[int] = []
+
+    def post(self, *args: Any, **kwargs: Any) -> requests.Response:
+        response = super().post(*args, **kwargs)
+        real_close = response.close
+        close_index = len(self.response_close_calls)
+        self.response_close_calls.append(0)
+
+        def tracked_close() -> None:
+            self.response_close_calls[close_index] += 1
+            real_close()
+
+        response.close = tracked_close  # type: ignore[method-assign]
+        return response
+
+    def close(self) -> None:
+        self.close_calls += 1
+        super().close()
+
+
+def _track_transport_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[_TrackingSession]:
+    sessions: list[_TrackingSession] = []
+
+    def create_session() -> _TrackingSession:
+        session = _TrackingSession()
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(hosted_chat.requests, "Session", create_session)
+    return sessions
+
+
+def _transport_config(base_url: str, **overrides: object) -> HostedHTTPTransportConfig:
+    values: dict[str, object] = {
+        "provider": "moonshot",
+        "base_url": base_url,
+        "api_key": "SECRET-TRANSPORT-CANARY",
+        "timeout": 0.2,
+        "retries": 0,
+        "retry_delay": 0.0,
+    }
+    values.update(overrides)
+    return HostedHTTPTransportConfig(**values)  # type: ignore[arg-type]
+
+
+def _tool_delta(
+    *,
+    index: int,
+    arguments: str,
+    call_id: str | None = None,
+    name: str | None = None,
+) -> dict[str, Any]:
+    tool: dict[str, Any] = {"index": index, "function": {"arguments": arguments}}
+    if call_id is not None:
+        tool.update({"id": call_id, "type": "function"})
+    if name is not None:
+        tool["function"]["name"] = name
+    return tool
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, "https://api.example/v1"),
+        ("https://api.example/v1", "https://api.example/v1"),
+        ("https://api.example/v1/", "https://api.example/v1"),
+        (
+            "https://api.example/tenant/v1/chat/completions",
+            "https://api.example/tenant/v1",
+        ),
+        (
+            "http://[2001:db8::1]:8080/tenant/v1",
+            "http://[2001:db8::1]:8080/tenant/v1",
+        ),
+        (
+            "https://api.example/tenant%20alpha/v1",
+            "https://api.example/tenant%20alpha/v1",
+        ),
+        (
+            "https://api.example/tenant%2520alpha/v1",
+            "https://api.example/tenant%2520alpha/v1",
+        ),
+        (
+            "https://api.example/responses-extra/v1",
+            "https://api.example/responses-extra/v1",
+        ),
+    ],
+)
+def test_normalize_hosted_chat_base_url_accepts_structural_bases(
+    value: object,
+    expected: str,
+) -> None:
+    original = value
+
+    assert (
+        normalize_hosted_chat_base_url(value, default="https://api.example/v1")
+        == expected
+    )
+    assert value == original
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        7,
+        "",
+        "   ",
+        " https://api.example/v1",
+        "https://api.example/v1 ",
+        "https://api.example/v1\n",
+        "api.example/v1",
+        "ftp://api.example/v1",
+        "https:///v1",
+        "https://user:secret@api.example/v1",
+        "https://api.example/v1?tenant=a",
+        "https://api.example/v1#fragment",
+        "https://api.example\\evil/v1",
+        "https://api.example//v1",
+        "https://api.example/v1/./chat/completions",
+        "https://api.example/v1/../chat/completions",
+        "https://api.example/v1/%zz",
+        "https://api.example/v1/responses",
+        "https://api.example/v1/RESPONSES",
+        "https://api.example/v1/models",
+        "https://api.example/v1/chat/COMPLETIONS",
+        "https://api.example/v1/CHAT/completions",
+        "https://api.example/v1/chat/completions/extra",
+        "https://api.example/v1/chat/completions/chat/completions",
+        "https://api.example/v1/responses/chat/completions",
+        "https://api.example/v1/chat/completions/responses",
+        "https://api.example/v1/api%2Fv2",
+        "https://api.example/v1/api%252fv2",
+        "https://api.example/v1/api%5Cv2",
+        "https://api.example/v1/%2e/chat/completions",
+        "https://api.example/v1/%252e%252e/chat/completions",
+        "https://api.example/v1/res%70onses",
+        "https://api.example/v1/chat/%63ompletions",
+    ],
+)
+def test_normalize_hosted_chat_base_url_rejects_ambiguous_or_unsafe_values(
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="Hosted Chat API base URL") as exc_info:
+        normalize_hosted_chat_base_url(value, default="https://api.example/v1")
+
+    assert "secret" not in str(exc_info.value)
+
+
+def test_normalize_hosted_chat_base_url_enforces_preparse_length_cap() -> None:
+    value = "https://api.example/" + ("a" * 2_000)
+
+    with pytest.raises(ValueError, match="Hosted Chat API base URL"):
+        normalize_hosted_chat_base_url(value, default="https://api.example/v1")
+
+
+@pytest.mark.parametrize("default", [None, "", 3, "https://api.example/responses"])
+def test_normalize_hosted_chat_base_url_validates_default(default: object) -> None:
+    with pytest.raises(ValueError, match="Hosted Chat API base URL"):
+        normalize_hosted_chat_base_url(None, default=default)
+
+
+def test_normalize_hosted_chat_response_preserves_text_tools_reasoning_and_usage() -> (
+    None
+):
+    response = {
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "The result is 4.",
+                    "reasoning_content": "Use the calculator.",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "calculator",
+                                "arguments": '{"expression":"2+2"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 8, "completion_tokens": 4, "total_tokens": 12},
+    }
+    original = deepcopy(response)
+
+    turn = normalize_hosted_chat_response(response, finish_policy=_POLICY)
+
+    assert turn == HostedChatTurn(
+        text="The result is 4.",
+        tool_calls=(
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "arguments": '{"expression":"2+2"}',
+                },
+            },
+        ),
+        assistant_message={
+            "role": "assistant",
+            "content": "The result is 4.",
+            "reasoning_content": "Use the calculator.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": '{"expression":"2+2"}',
+                    },
+                }
+            ],
+        },
+        finish_reason="tool_calls",
+        reasoning_content="Use the calculator.",
+        usage={"prompt_tokens": 8, "completion_tokens": 4, "total_tokens": 12},
+    )
+    assert response == original
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {},
+        {"choices": []},
+        {"choices": "wrong"},
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "user", "content": "wrong"},
+                    "finish_reason": "stop",
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": 7},
+                    "finish_reason": "stop",
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": ""},
+                    "finish_reason": "stop",
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_bad",
+                                "type": "function",
+                                "function": {
+                                    "name": "calculator",
+                                    "arguments": "not-json",
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "ok",
+                        "reasoning_content": 9,
+                    },
+                    "finish_reason": "stop",
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "unknown",
+                }
+            ]
+        },
+    ],
+)
+def test_normalize_hosted_chat_response_rejects_malformed_results(
+    response: object,
+) -> None:
+    with pytest.raises(HostedChatProtocolError):
+        normalize_hosted_chat_response(response, finish_policy=_POLICY)
+
+
+def test_normalize_hosted_chat_response_enforces_json_depth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(hosted_chat, "_MAX_JSON_DEPTH", 3)
+    response = {
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"nested": {"too": {"deep": 1}}},
+    }
+
+    with pytest.raises(HostedChatProtocolError, match="JSON"):
+        normalize_hosted_chat_response(response, finish_policy=_POLICY)
+
+
+def test_hosted_chat_stream_accumulates_interleaved_calls_and_terminal_usage() -> None:
+    events = [
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "role": "assistant",
+                        "content": "hel",
+                        "reasoning_content": "thin",
+                        "tool_calls": [
+                            _tool_delta(
+                                index=0,
+                                call_id="call_1",
+                                name="calculator",
+                                arguments='{"expression":"2+',
+                            )
+                        ],
+                    },
+                    "finish_reason": None,
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "content": "lo",
+                        "reasoning_content": "k",
+                        "tool_calls": [
+                            _tool_delta(index=0, arguments='2"}'),
+                            _tool_delta(
+                                index=1,
+                                call_id="call_2",
+                                name="calculator",
+                                arguments='{"expression":"3+3"}',
+                            ),
+                        ],
+                    },
+                    "finish_reason": None,
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        },
+    ]
+    records = [
+        *(SSERecord(event="message", data=json.dumps(event)) for event in events),
+        SSERecord(event=None, data="[DONE]"),
+    ]
+    stream = HostedChatStream(iter(records), finish_policy=_POLICY)
+
+    with pytest.raises(HostedChatProtocolError, match="incomplete"):
+        _ = stream.terminal_turn
+    assert list(stream) == events
+    assert stream.terminal_turn == HostedChatTurn(
+        text="hello",
+        tool_calls=(
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "arguments": '{"expression":"2+2"}',
+                },
+            },
+            {
+                "id": "call_2",
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "arguments": '{"expression":"3+3"}',
+                },
+            },
+        ),
+        assistant_message={
+            "role": "assistant",
+            "content": "hello",
+            "reasoning_content": "think",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": '{"expression":"2+2"}',
+                    },
+                },
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": '{"expression":"3+3"}',
+                    },
+                },
+            ],
+        },
+        finish_reason="tool_calls",
+        reasoning_content="think",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+
+
+def test_hosted_chat_stream_accepts_usage_only_after_terminal_choice() -> None:
+    records = iter(
+        [
+            SSERecord(
+                event=None,
+                data=json.dumps(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": "done"},
+                                "finish_reason": "stop",
+                            }
+                        ]
+                    }
+                ),
+            ),
+            SSERecord(
+                event=None,
+                data=json.dumps({"choices": [], "usage": {"total_tokens": 3}}),
+            ),
+            SSERecord(event=None, data="[DONE]"),
+        ]
+    )
+    stream = HostedChatStream(records, finish_policy=_POLICY)
+
+    assert len(list(stream)) == 2
+    assert stream.terminal_turn.usage == {"total_tokens": 3}
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        [SSERecord(event=None, data="[DONE]")],
+        [
+            SSERecord(
+                event=None,
+                data=json.dumps(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": "done"},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {"total_tokens": 3},
+                    }
+                ),
+            )
+        ],
+        [
+            SSERecord(
+                event=None,
+                data=json.dumps(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": "done"},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {"total_tokens": 3},
+                    }
+                ),
+            ),
+            SSERecord(
+                event=None,
+                data=json.dumps(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": "late"},
+                                "finish_reason": None,
+                            }
+                        ]
+                    }
+                ),
+            ),
+        ],
+    ],
+)
+def test_hosted_chat_stream_rejects_missing_or_post_terminal_data(
+    records: list[SSERecord],
+) -> None:
+    stream = HostedChatStream(iter(records), finish_policy=_POLICY)
+
+    with pytest.raises(HostedChatProtocolError):
+        list(stream)
+    with pytest.raises(HostedChatProtocolError, match="incomplete"):
+        _ = stream.terminal_turn
+
+
+def test_hosted_chat_stream_close_keeps_terminal_metadata_unavailable() -> None:
+    stream = HostedChatStream(iter(()), finish_policy=_POLICY)
+
+    stream.close()
+    stream.close()
+    assert list(stream) == []
+    with pytest.raises(HostedChatProtocolError, match="incomplete"):
+        _ = stream.terminal_turn
+
+
+def test_transport_config_repr_hides_api_key() -> None:
+    config = _transport_config("https://api.example/v1")
+
+    assert "SECRET-TRANSPORT-CANARY" not in repr(config)
+    assert config == _transport_config(
+        "https://api.example/v1", api_key="DIFFERENT-KEY"
+    )
+
+
+@pytest.mark.allow_network
+@pytest.mark.parametrize("route", ["chat/completions", "responses"])
+def test_owned_json_post_sends_exact_route_headers_payload_and_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    route: str,
+) -> None:
+    sessions = _track_transport_sessions(monkeypatch)
+    payload = {"model": "test-model", "stream": False}
+    with _scripted_hosted_server([{"body": json.dumps({"ok": True}).encode()}]) as (
+        server,
+        base_url,
+    ):
+        result = owned_json_post(
+            config=_transport_config(base_url, timeout=1.25),
+            route=route,  # type: ignore[arg-type]
+            payload=payload,
+            streaming=False,
+        )
+
+    assert result == {"ok": True}
+    assert server.requests == [
+        {
+            "path": f"/v1/{route}",
+            "headers": server.requests[0]["headers"],
+            "body": json.dumps(payload).encode(),
+        }
+    ]
+    assert server.requests[0]["headers"]["Authorization"] == (
+        "Bearer SECRET-TRANSPORT-CANARY"
+    )
+    assert server.requests[0]["headers"]["Content-Type"] == "application/json"
+    assert sessions[0].close_calls == 1
+    assert sessions[0].response_close_calls == [1]
+
+
+@pytest.mark.allow_network
+def test_owned_json_post_retries_statuses_with_one_global_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sessions = _track_transport_sessions(monkeypatch)
+    with _scripted_hosted_server(
+        [
+            {"status": 503, "body": b"service unavailable"},
+            {"status": 429, "headers": {"Retry-After": "0"}, "body": b"rate"},
+            {"body": b'{"ok":true}'},
+        ]
+    ) as (server, base_url):
+        result = owned_json_post(
+            config=_transport_config(base_url, retries=2),
+            route="chat/completions",
+            payload={"stream": False},
+            streaming=False,
+        )
+
+    assert result == {"ok": True}
+    assert len(server.requests) == 3
+    assert sessions[0].response_close_calls == [1, 1, 1]
+    assert sessions[0].close_calls == 1
+
+
+@pytest.mark.allow_network
+def test_owned_json_post_honors_http_date_and_malformed_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(hosted_chat.time, "sleep", sleeps.append)
+    future = formatdate(time.time() + 2, usegmt=True)
+    with _scripted_hosted_server(
+        [
+            {"status": 503, "headers": {"Retry-After": future}},
+            {"status": 503, "headers": {"Retry-After": "RAW-RETRY-CANARY"}},
+            {"body": b'{"ok":true}'},
+        ]
+    ) as (_server, base_url):
+        result = owned_json_post(
+            config=_transport_config(base_url, retries=2, retry_delay=0.25),
+            route="chat/completions",
+            payload={},
+            streaming=False,
+        )
+
+    assert result == {"ok": True}
+    assert 0 < sleeps[0] <= 2
+    assert sleeps[1] == pytest.approx(0.5)
+
+
+@pytest.mark.allow_network
+def test_sensitive_request_forces_transport_retries_to_zero() -> None:
+    with _scripted_hosted_server([{"status": 503}, {"body": b'{"ok":true}'}]) as (
+        server,
+        base_url,
+    ):
+        with sensitive_llm_request(), pytest.raises(ChatProviderError):
+            owned_json_post(
+                config=_transport_config(base_url, retries=5),
+                route="chat/completions",
+                payload={},
+                streaming=False,
+            )
+
+    assert len(server.requests) == 1
+
+
+@pytest.mark.allow_network
+@pytest.mark.parametrize(
+    ("status", "error_type"),
+    [
+        (401, ChatAuthenticationError),
+        (403, ChatAuthenticationError),
+        (429, ChatRateLimitError),
+        (400, ChatBadRequestError),
+        (500, ChatProviderError),
+    ],
+)
+def test_owned_json_post_maps_http_failures_without_body_disclosure(
+    status: int,
+    error_type: type[Exception],
+) -> None:
+    canary = b"RAW-RESPONSE-BODY-CANARY"
+    with _scripted_hosted_server([{"status": status, "body": canary}]) as (
+        _server,
+        base_url,
+    ):
+        with pytest.raises(error_type) as exc_info:
+            owned_json_post(
+                config=_transport_config(base_url),
+                route="chat/completions",
+                payload={},
+                streaming=False,
+            )
+
+    assert "RAW-RESPONSE-BODY-CANARY" not in str(exc_info.value)
+    assert "SECRET-TRANSPORT-CANARY" not in str(exc_info.value)
+    assert base_url not in str(exc_info.value)
+
+
+@pytest.mark.allow_network
+@pytest.mark.parametrize(
+    "action",
+    [
+        {"body": b"not-json"},
+        {"body": b"[]"},
+        {"body": b'{"ok":true}', "extra_content_length": 7},
+    ],
+)
+def test_nonstreaming_2xx_malformed_body_is_not_retried(
+    action: dict[str, Any],
+) -> None:
+    with _scripted_hosted_server([action, {"body": b'{"ok":true}'}]) as (
+        server,
+        base_url,
+    ):
+        with pytest.raises(ChatProviderError):
+            owned_json_post(
+                config=_transport_config(base_url, retries=2),
+                route="chat/completions",
+                payload={},
+                streaming=False,
+            )
+
+    assert len(server.requests) == 1
+
+
+@pytest.mark.allow_network
+def test_owned_sse_stream_transfers_ownership_and_closes_exactly_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sessions = _track_transport_sessions(monkeypatch)
+    body = b'data: {"ok":true}\n\ndata: [DONE]\n\n'
+    with _scripted_hosted_server(
+        [{"body": body, "content_type": "text/event-stream"}]
+    ) as (_server, base_url):
+        stream = owned_json_post(
+            config=_transport_config(base_url),
+            route="chat/completions",
+            payload={"stream": True},
+            streaming=True,
+        )
+        assert isinstance(stream, OwnedSSEStream)
+        assert sessions[0].close_calls == 0
+        assert list(stream) == [
+            SSERecord(event=None, data='{"ok":true}'),
+            SSERecord(event=None, data="[DONE]"),
+        ]
+        stream.close()
+        stream.close()
+
+    assert sessions[0].response_close_calls == [1]
+    assert sessions[0].close_calls == 1
+
+
+@pytest.mark.allow_network
+def test_owned_sse_stream_does_not_retry_after_any_body_byte(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sessions = _track_transport_sessions(monkeypatch)
+    action = {
+        "body": b"data: partial",
+        "content_type": "text/event-stream",
+        "extra_content_length": 20,
+    }
+    with _scripted_hosted_server(
+        [action, {"body": b"data: [DONE]\n\n", "content_type": "text/event-stream"}]
+    ) as (server, base_url):
+        stream = owned_json_post(
+            config=_transport_config(base_url, retries=2),
+            route="chat/completions",
+            payload={"stream": True},
+            streaming=True,
+        )
+        assert isinstance(stream, OwnedSSEStream)
+        with pytest.raises(HostedSSEReadError):
+            list(stream)
+
+    assert len(server.requests) == 1
+    assert sessions[0].response_close_calls == [1]
+    assert sessions[0].close_calls == 1

--- a/Tests/LLM_Calls/test_hosted_chat.py
+++ b/Tests/LLM_Calls/test_hosted_chat.py
@@ -26,6 +26,7 @@ from tldw_chatbook.LLM_Calls.hosted_chat import (
     HostedChatProtocolError,
     HostedChatStream,
     HostedChatTurn,
+    hosted_chat_request,
     normalize_hosted_chat_base_url,
     normalize_hosted_chat_response,
     owned_json_post,
@@ -63,6 +64,62 @@ class _FinishPolicy:
 
 
 _POLICY = _FinishPolicy()
+
+
+def test_hosted_chat_request_composes_nonstream_transport_and_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = {
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+    }
+    monkeypatch.setattr(hosted_chat, "owned_json_post", lambda **_kwargs: response)
+
+    result = hosted_chat_request(
+        config=HostedHTTPTransportConfig(
+            provider="moonshot",
+            base_url="https://example.test/v1",
+            api_key="secret",
+            timeout=10,
+            retries=0,
+            retry_delay=0,
+        ),
+        payload={"model": "kimi-k3", "messages": [], "stream": False},
+        streaming=False,
+        finish_policy=_POLICY,
+    )
+
+    assert isinstance(result, HostedChatTurn)
+    assert result.text == "hello"
+
+
+def test_hosted_chat_request_composes_stream_transport_and_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = iter([SSERecord(event=None, data="[DONE]")])
+    monkeypatch.setattr(hosted_chat, "owned_json_post", lambda **_kwargs: records)
+
+    result = hosted_chat_request(
+        config=HostedHTTPTransportConfig(
+            provider="moonshot",
+            base_url="https://example.test/v1",
+            api_key="secret",
+            timeout=10,
+            retries=0,
+            retry_delay=0,
+        ),
+        payload={"model": "kimi-k3", "messages": [], "stream": True},
+        streaming=True,
+        finish_policy=_POLICY,
+    )
+
+    assert isinstance(result, HostedChatStream)
 
 
 class _ScriptedHostedServer(ThreadingHTTPServer):

--- a/Tests/LLM_Calls/test_hosted_chat_streaming.py
+++ b/Tests/LLM_Calls/test_hosted_chat_streaming.py
@@ -1,0 +1,108 @@
+"""Strict SSE framing contracts for hosted provider transports."""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.LLM_Calls.hosted_chat_streaming import (
+    SSERecord,
+    SSERecordDecoder,
+)
+
+
+def test_sse_decoder_preserves_event_and_multiline_data_across_chunks() -> None:
+    decoder = SSERecordDecoder()
+
+    assert decoder.feed(b"event: message\r\ndata: caf\xc3") == ()
+    assert decoder.feed(b"\xa9\rdata: second\r") == ()
+    assert decoder.feed(b"\r") == (
+        SSERecord(event="message", data="caf\u00e9\nsecond"),
+    )
+    assert decoder.finish() == ()
+
+
+def test_sse_decoder_supports_cr_lf_crlf_and_multiple_records() -> None:
+    decoder = SSERecordDecoder()
+
+    assert decoder.feed(b"data: one\r\ndata: two\n\ndata: three\r\r") == (
+        SSERecord(event=None, data="one\ntwo"),
+        SSERecord(event=None, data="three"),
+    )
+
+
+def test_sse_decoder_ignores_comments_and_non_data_fields() -> None:
+    decoder = SSERecordDecoder()
+
+    assert decoder.feed(
+        b": heartbeat\nid: private-id\nretry: 10\nunknown: ignored\n"
+        b"event: completion\ndata:first\ndata:  second\n\n"
+    ) == (SSERecord(event="completion", data="first\n second"),)
+    assert decoder.feed(b"event: ignored-without-data\n\n") == ()
+    assert decoder.feed(b"data\n\n") == (SSERecord(event=None, data=""),)
+
+
+def test_sse_decoder_requires_blank_record_boundary() -> None:
+    decoder = SSERecordDecoder()
+
+    assert decoder.feed(b"data: pending\n") == ()
+    with pytest.raises(ValueError, match="incomplete"):
+        decoder.finish()
+
+
+def test_sse_decoder_rejects_invalid_utf8_and_non_bytes() -> None:
+    with pytest.raises(UnicodeDecodeError):
+        SSERecordDecoder().feed(b"data: \xff\n\n")
+    with pytest.raises(TypeError, match="bytes"):
+        SSERecordDecoder().feed("data: wrong\n\n")  # type: ignore[arg-type]
+
+
+def test_sse_decoder_close_state_rejects_more_input() -> None:
+    decoder = SSERecordDecoder()
+
+    assert decoder.finish() == ()
+    with pytest.raises(ValueError, match="finished"):
+        decoder.feed(b"data: late\n\n")
+    with pytest.raises(ValueError, match="finished"):
+        decoder.finish()
+
+
+@pytest.mark.parametrize(
+    ("constant", "limit", "chunks", "message"),
+    [
+        ("_MAX_SSE_BYTES", 3, [b"data"], "byte"),
+        ("_MAX_SSE_LINE_CHARS", 7, [b"data: abc\n\n"], "line"),
+        ("_MAX_SSE_LINE_SEGMENTS", 2, [b"da", b"ta", b": x\n\n"], "segment"),
+        ("_MAX_SSE_RECORD_CHARS", 3, [b"data: four\n\n"], "record"),
+        ("_MAX_SSE_DATA_LINES", 1, [b"data: a\ndata: b\n\n"], "data line"),
+        ("_MAX_SSE_RECORDS", 1, [b"data: a\n\ndata: b\n\n"], "record count"),
+    ],
+)
+def test_sse_decoder_enforces_independent_bounds(
+    constant: str,
+    limit: int,
+    chunks: list[bytes],
+    message: str,
+) -> None:
+    argument = {
+        "_MAX_SSE_BYTES": "max_bytes",
+        "_MAX_SSE_LINE_CHARS": "max_line_chars",
+        "_MAX_SSE_LINE_SEGMENTS": "max_line_segments",
+        "_MAX_SSE_RECORD_CHARS": "max_record_chars",
+        "_MAX_SSE_DATA_LINES": "max_data_lines",
+        "_MAX_SSE_RECORDS": "max_records",
+    }[constant]
+    decoder = SSERecordDecoder(**{argument: limit})
+
+    with pytest.raises(ValueError, match=message):
+        for chunk in chunks:
+            decoder.feed(chunk)
+
+
+def test_sse_decoder_accepts_many_small_segments_without_quadratic_joining() -> None:
+    decoder = SSERecordDecoder()
+
+    records: tuple[SSERecord, ...] = ()
+    for chunk in (bytes([value]) for value in b"data: linear\n\n"):
+        records += decoder.feed(chunk)
+
+    assert records == (SSERecord(event=None, data="linear"),)

--- a/Tests/LLM_Calls/test_moonshot.py
+++ b/Tests/LLM_Calls/test_moonshot.py
@@ -498,13 +498,16 @@ def test_chat_with_moonshot_joins_resolution_payload_transport_and_response(
                 "message": {
                     "role": "assistant",
                     "content": "Answer",
-                    "reasoning_content": "PRIVATE-REASONING",
                 },
                 "finish_reason": "stop",
             }
         ],
         "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
     }
+    assert result.provider_continuation is not None
+    assert result.provider_continuation.rounds[-1].reasoning_blocks == (
+        "PRIVATE-REASONING",
+    )
 
 
 def test_chat_with_moonshot_maps_malformed_success_to_provider_error(

--- a/Tests/LLM_Calls/test_moonshot.py
+++ b/Tests/LLM_Calls/test_moonshot.py
@@ -138,6 +138,27 @@ def test_resolve_moonshot_request_uses_exact_precedence_and_defaults() -> None:
     assert defaults.streaming is True
 
 
+def test_resolve_moonshot_request_rejects_normalized_table_alias_conflict() -> None:
+    with pytest.raises(ChatConfigurationError, match="unambiguous"):
+        resolve_moonshot_request(
+            app_config={
+                "api_settings": {
+                    " MOONSHOT ": {"api_key": "alias-secret-canary"},
+                    "moonshot": {"api_key": "canonical-secret-canary"},
+                }
+            },
+            environ={},
+        )
+
+
+def test_resolve_moonshot_request_rejects_null_canonical_table() -> None:
+    with pytest.raises(ChatConfigurationError, match="configuration table"):
+        resolve_moonshot_request(
+            app_config={"api_settings": {"moonshot": None}},
+            environ={"MOONSHOT_API_KEY": "must-not-enable-null-settings"},
+        )
+
+
 def test_resolve_moonshot_request_configured_env_and_region_fallback() -> None:
     resolution = resolve_moonshot_request(
         app_config={

--- a/Tests/LLM_Calls/test_moonshot.py
+++ b/Tests/LLM_Calls/test_moonshot.py
@@ -1,0 +1,598 @@
+"""Moonshot/Kimi provider-local resolution and request contracts."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from collections.abc import Iterator
+
+import pytest
+
+from tldw_chatbook.Chat.Chat_Deps import (
+    ChatBadRequestError,
+    ChatConfigurationError,
+    ChatProviderError,
+)
+from tldw_chatbook.Chat.provider_continuation import parse_provider_continuation_json
+from tldw_chatbook.LLM_Calls.moonshot import (
+    MoonshotFinishPolicy,
+    MoonshotResolution,
+    MoonshotStream,
+    build_moonshot_chat_payload,
+    chat_with_moonshot,
+    resolve_moonshot_request,
+)
+from tldw_chatbook.LLM_Calls.hosted_chat import (
+    HostedChatProtocolError,
+    HostedChatStream,
+    HostedChatTurn,
+)
+from tldw_chatbook.LLM_Calls.hosted_chat_streaming import SSERecord
+import tldw_chatbook.LLM_Calls.moonshot as moonshot
+import tldw_chatbook.LLM_Calls.LLM_API_Calls as legacy_adapters
+
+
+def _resolution(**overrides: object) -> MoonshotResolution:
+    values: dict[str, object] = {
+        "provider": "moonshot",
+        "model": "kimi-k3",
+        "api_key": "secret-key",
+        "base_url": "https://api.moonshot.ai/v1",
+        "timeout": 90.0,
+        "retries": 3,
+        "retry_delay": 1.0,
+        "streaming": True,
+    }
+    values.update(overrides)
+    return MoonshotResolution(**values)  # type: ignore[arg-type]
+
+
+def _tool(name: str = "calculator") -> dict[str, object]:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": "Evaluate arithmetic.",
+            "parameters": {
+                "type": "object",
+                "properties": {"expression": {"type": "string"}},
+                "required": ["expression"],
+            },
+        },
+    }
+
+
+def _tool_history() -> list[dict[str, object]]:
+    return [
+        {"role": "user", "content": "Calculate."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": '{"expression":"2+2"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "4"},
+        {"role": "assistant", "content": "The answer is 4."},
+    ]
+
+
+def test_resolve_moonshot_request_uses_exact_precedence_and_defaults() -> None:
+    config = {
+        "api_settings": {
+            "moonshot": {
+                "api_key": " config-key ",
+                "api_key_env_var": "CUSTOM_MOONSHOT_KEY",
+                "api_base_url": "https://config.example/v1/chat/completions",
+                "model": "moonshot-v1-32k",
+                "timeout": 12,
+                "retries": 4,
+                "retry_delay": 0.5,
+                "streaming": False,
+            }
+        }
+    }
+    original = deepcopy(config)
+    environ = {
+        "CUSTOM_MOONSHOT_KEY": "custom-env-key",
+        "MOONSHOT_API_KEY": "default-env-key",
+    }
+
+    configured = resolve_moonshot_request(app_config=config, environ=environ)
+    explicit = resolve_moonshot_request(
+        explicit_api_key=" explicit-key ",
+        explicit_base_url="https://explicit.example/v1",
+        explicit_model="kimi-k3",
+        app_config=config,
+        environ=environ,
+    )
+
+    assert configured == MoonshotResolution(
+        provider="moonshot",
+        model="moonshot-v1-32k",
+        api_key="config-key",
+        base_url="https://config.example/v1",
+        timeout=12.0,
+        retries=4,
+        retry_delay=0.5,
+        streaming=False,
+    )
+    assert explicit.model == "kimi-k3"
+    assert explicit.api_key == "explicit-key"
+    assert explicit.base_url == "https://explicit.example/v1"
+    assert config == original
+    assert "config-key" not in repr(configured)
+
+    defaults = resolve_moonshot_request(
+        app_config={"api_settings": {"moonshot": {}}},
+        environ={"MOONSHOT_API_KEY": "env-key"},
+    )
+    assert defaults.model == "kimi-k3"
+    assert defaults.base_url == "https://api.moonshot.ai/v1"
+    assert defaults.streaming is True
+
+
+def test_resolve_moonshot_request_configured_env_and_region_fallback() -> None:
+    resolution = resolve_moonshot_request(
+        app_config={
+            "api_settings": {
+                "moonshot": {
+                    "api_key_env_var": "TEAM_KIMI_KEY",
+                    "api_region": "china",
+                }
+            }
+        },
+        environ={"TEAM_KIMI_KEY": "team-key", "MOONSHOT_API_KEY": "fallback"},
+    )
+
+    assert resolution.api_key == "team-key"
+    assert resolution.base_url == "https://api.moonshot.cn/v1"
+
+
+@pytest.mark.parametrize(
+    "app_config",
+    [
+        {"api_settings": []},
+        {"api_settings": {"moonshot": []}},
+        {"api_settings": {"moonshot": {"api_key": "YOUR_KEY"}}},
+        {"api_settings": {"moonshot": {"model": " "}}},
+        {"api_settings": {"moonshot": {"api_base_url": "https://bad/v1/responses"}}},
+        {"api_settings": {"moonshot": {"timeout": True}}},
+        {"api_settings": {"moonshot": {"timeout": 0}}},
+        {"api_settings": {"moonshot": {"retries": 1.5}}},
+        {"api_settings": {"moonshot": {"retry_delay": -1}}},
+        {"api_settings": {"moonshot": {"streaming": "yes"}}},
+        {"api_settings": {"moonshot": {"api_region": "unknown"}}},
+        {"api_settings": {"moonshot": {"api_region": []}}},
+    ],
+)
+def test_resolve_moonshot_request_malformed_canonical_table_fails_closed(
+    app_config: object,
+) -> None:
+    with pytest.raises(ChatConfigurationError) as exc_info:
+        resolve_moonshot_request(
+            app_config=app_config,  # type: ignore[arg-type]
+            environ={"MOONSHOT_API_KEY": "must-not-rescue"},
+        )
+
+    assert exc_info.value.provider == "moonshot"
+    assert "must-not-rescue" not in str(exc_info.value)
+
+
+def test_build_moonshot_payload_copies_complete_tool_history_and_system() -> None:
+    messages = _tool_history()
+    tools = [_tool()]
+    original_messages = deepcopy(messages)
+    original_tools = deepcopy(tools)
+
+    payload = build_moonshot_chat_payload(
+        resolution=_resolution(),
+        messages_payload=messages,
+        system_message="Follow instructions.",
+        streaming=True,
+        tools=tools,
+        tool_choice="required",
+        reasoning_effort="high",
+        max_tokens=128,
+    )
+
+    assert payload == {
+        "model": "kimi-k3",
+        "messages": [{"role": "system", "content": "Follow instructions."}, *messages],
+        "stream": True,
+        "max_completion_tokens": 128,
+        "tools": tools,
+        "tool_choice": "required",
+        "reasoning_effort": "high",
+        "stream_options": {"include_usage": True},
+    }
+    assert messages == original_messages
+    assert tools == original_tools
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [{"role": "unknown", "content": "x"}],
+        [{"role": "user", "content": 3}],
+        [{"role": "tool", "tool_call_id": "missing", "content": "x"}],
+        _tool_history()[:-2],
+        [
+            *_tool_history(),
+            {"role": "tool", "tool_call_id": "call_1", "content": "again"},
+        ],
+        [
+            {"role": "user", "content": "Calculate."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": "not-json",
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "4"},
+        ],
+    ],
+)
+def test_build_moonshot_payload_rejects_malformed_or_unpaired_history(
+    messages: list[dict[str, object]],
+) -> None:
+    with pytest.raises(ChatBadRequestError):
+        build_moonshot_chat_payload(
+            resolution=_resolution(),
+            messages_payload=messages,
+        )
+
+
+@pytest.mark.parametrize("name", ["a", "ab", "1abc", "-bad", "has space"])
+def test_build_moonshot_payload_rejects_non_common_function_names(name: str) -> None:
+    with pytest.raises(ChatBadRequestError):
+        build_moonshot_chat_payload(
+            resolution=_resolution(),
+            messages_payload=[{"role": "user", "content": "use tool"}],
+            tools=[_tool(name)],
+        )
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        "auto",
+        "none",
+        "required",
+        {"type": "function", "function": {"name": "calculator"}},
+    ],
+)
+def test_build_moonshot_payload_accepts_documented_tool_choices(
+    tool_choice: object,
+) -> None:
+    payload = build_moonshot_chat_payload(
+        resolution=_resolution(),
+        messages_payload=[{"role": "user", "content": "use tool"}],
+        tools=[_tool()],
+        tool_choice=tool_choice,
+    )
+
+    assert payload["tool_choice"] == tool_choice
+
+
+@pytest.mark.parametrize("tool_choice", ["forced", 7, {"type": "web_search"}])
+def test_build_moonshot_payload_rejects_unsupported_tool_choices(
+    tool_choice: object,
+) -> None:
+    with pytest.raises(ChatBadRequestError):
+        build_moonshot_chat_payload(
+            resolution=_resolution(),
+            messages_payload=[{"role": "user", "content": "use tool"}],
+            tools=[_tool()],
+            tool_choice=tool_choice,
+        )
+
+
+def test_kimi_k3_payload_omits_legacy_sampler_fields() -> None:
+    payload = build_moonshot_chat_payload(
+        resolution=_resolution(),
+        messages_payload=[{"role": "user", "content": "hello"}],
+        streaming=False,
+        temperature=0.7,
+        top_p=0.9,
+        n=1,
+        presence_penalty=0,
+        frequency_penalty=0,
+        seed=7,
+        user="ignored",
+    )
+
+    assert set(payload) == {"model", "messages", "stream"}
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("reasoning_effort", "medium"),
+        ("reasoning_effort", {}),
+        ("max_tokens", True),
+        ("temperature", 3),
+        ("top_p", -1),
+        ("n", 0),
+        ("presence_penalty", 9),
+        ("frequency_penalty", -9),
+        ("seed", True),
+    ],
+)
+def test_kimi_k3_rejects_invalid_supplied_generic_values(
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(ChatBadRequestError):
+        build_moonshot_chat_payload(
+            resolution=_resolution(),
+            messages_payload=[{"role": "user", "content": "hello"}],
+            **{field: value},
+        )
+
+
+def test_legacy_moonshot_family_retains_documented_sampling_surface() -> None:
+    payload = build_moonshot_chat_payload(
+        resolution=_resolution(model="moonshot-v1-32k"),
+        messages_payload=[{"role": "user", "content": "hello"}],
+        temperature=0.4,
+        top_p=0.8,
+        n=2,
+        presence_penalty=0.2,
+        frequency_penalty=-0.2,
+    )
+
+    assert payload["temperature"] == 0.4
+    assert payload["top_p"] == 0.8
+    assert payload["n"] == 2
+    assert payload["presence_penalty"] == 0.2
+    assert payload["frequency_penalty"] == -0.2
+
+
+@pytest.mark.parametrize(
+    "response_format",
+    [
+        {"type": "json_object", "private": "metadata"},
+        {"type": "json_schema"},
+        {
+            "type": "json_schema",
+            "json_schema": {"schema": {"nested": {"too": {"deep": {}}}}},
+        },
+    ],
+)
+def test_moonshot_response_format_is_exact_and_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+    response_format: dict[str, object],
+) -> None:
+    monkeypatch.setattr(moonshot, "_MAX_JSON_DEPTH", 3)
+
+    with pytest.raises(ChatBadRequestError):
+        build_moonshot_chat_payload(
+            resolution=_resolution(),
+            messages_payload=[{"role": "user", "content": "hello"}],
+            response_format=response_format,
+        )
+
+
+def test_legacy_moonshot_multiple_choices_require_documented_temperature() -> None:
+    with pytest.raises(ChatBadRequestError):
+        build_moonshot_chat_payload(
+            resolution=_resolution(model="moonshot-v1-32k"),
+            messages_payload=[{"role": "user", "content": "hello"}],
+            temperature=0.2,
+            n=2,
+        )
+
+
+def test_kimi_k3_replays_validated_reasoning_from_complete_checkpoint() -> None:
+    checkpoint = parse_provider_continuation_json(
+        {
+            "schema_version": 1,
+            "checkpoint_revision": 1,
+            "provider": "moonshot",
+            "protocol": "chat_completions",
+            "model": "kimi-k3",
+            "api_base_url": "https://api.moonshot.ai/v1",
+            "state": "complete",
+            "rounds": [
+                {
+                    "assistant_content": "Visible answer",
+                    "reasoning_blocks": ["PRIVATE-REASONING"],
+                    "calls": [],
+                }
+            ],
+        }
+    )
+    payload = build_moonshot_chat_payload(
+        resolution=_resolution(),
+        messages_payload=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "Visible answer"},
+            {"role": "user", "content": "next"},
+        ],
+        provider_continuations=[checkpoint],
+    )
+
+    assert payload["messages"][1] == {
+        "role": "assistant",
+        "content": "Visible answer",
+        "reasoning_content": "PRIVATE-REASONING",
+    }
+
+
+def test_moonshot_finish_policy_accepts_mixed_tools_and_rejects_contradictions() -> (
+    None
+):
+    policy = MoonshotFinishPolicy()
+
+    assert (
+        policy.validate_finish(
+            finish_reason="tool_calls", has_text=True, has_calls=True
+        )
+        == "tool_calls"
+    )
+    with pytest.raises(HostedChatProtocolError):
+        policy.validate_finish(finish_reason="stop", has_text=True, has_calls=True)
+    with pytest.raises(HostedChatProtocolError):
+        policy.validate_finish(finish_reason="stop", has_text=False, has_calls=False)
+
+
+def test_chat_with_moonshot_joins_resolution_payload_transport_and_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        moonshot, "resolve_moonshot_request", lambda **_kwargs: _resolution()
+    )
+
+    def fake_request(**kwargs: object) -> HostedChatTurn:
+        captured.update(kwargs)
+        return HostedChatTurn(
+            text="Answer",
+            tool_calls=(),
+            assistant_message={
+                "role": "assistant",
+                "content": "Answer",
+                "reasoning_content": "PRIVATE-REASONING",
+            },
+            finish_reason="stop",
+            reasoning_content="PRIVATE-REASONING",
+            usage={"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+        )
+
+    monkeypatch.setattr(moonshot, "hosted_chat_request", fake_request)
+
+    result = chat_with_moonshot(
+        input_data=[{"role": "user", "content": "hello"}],
+        model="kimi-k3",
+        api_key="secret",
+        streaming=False,
+        reasoning_effort="high",
+    )
+
+    assert captured["streaming"] is False
+    assert captured["payload"] == {
+        "model": "kimi-k3",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": False,
+        "reasoning_effort": "high",
+    }
+    assert result == {
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Answer",
+                    "reasoning_content": "PRIVATE-REASONING",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+    }
+
+
+def test_chat_with_moonshot_maps_malformed_success_to_provider_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        moonshot, "resolve_moonshot_request", lambda **_kwargs: _resolution()
+    )
+    monkeypatch.setattr(
+        moonshot,
+        "hosted_chat_request",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            HostedChatProtocolError("PRIVATE-PROVIDER-PAYLOAD")
+        ),
+    )
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        chat_with_moonshot(
+            input_data=[{"role": "user", "content": "hello"}],
+            api_key="secret",
+            streaming=False,
+        )
+
+    assert exc_info.value.provider == "moonshot"
+    assert "PRIVATE-PROVIDER-PAYLOAD" not in str(exc_info.value)
+
+
+def test_legacy_moonshot_handler_delegates_without_rewriting_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_strict(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(legacy_adapters, "_strict_chat_with_moonshot", fake_strict)
+
+    result = legacy_adapters.chat_with_moonshot(
+        input_data=[{"role": "user", "content": "hello"}],
+        model="kimi-k3",
+        api_key="secret",
+        temp=0.4,
+        maxp=0.8,
+        streaming=False,
+        tool_choice="none",
+        reasoning_effort="max",
+    )
+
+    assert result == {"ok": True}
+    assert captured["input_data"] == [{"role": "user", "content": "hello"}]
+    assert captured["temp"] == 0.4
+    assert captured["maxp"] == 0.8
+    assert captured["tool_choice"] == "none"
+    assert captured["reasoning_effort"] == "max"
+
+
+def test_moonshot_stream_hides_reasoning_chunks_but_retains_terminal_turn() -> None:
+    records: Iterator[SSERecord] = iter(
+        [
+            SSERecord(
+                event=None,
+                data=(
+                    '{"choices":[{"index":0,"delta":{"role":"assistant",'
+                    '"content":"Answer","reasoning_content":"PRIVATE"},'
+                    '"finish_reason":"stop"}]}'
+                ),
+            ),
+            SSERecord(
+                event=None,
+                data=(
+                    '{"choices":[],"usage":{"prompt_tokens":2,'
+                    '"completion_tokens":1,"total_tokens":3}}'
+                ),
+            ),
+            SSERecord(event=None, data="[DONE]"),
+        ]
+    )
+    stream = MoonshotStream(
+        HostedChatStream(records, finish_policy=MoonshotFinishPolicy())
+    )
+
+    events = list(stream)
+
+    assert "reasoning_content" not in events[0]["choices"][0]["delta"]
+    assert stream.terminal_turn.reasoning_content == "PRIVATE"
+    assert stream.terminal_turn.usage == {
+        "prompt_tokens": 2,
+        "completion_tokens": 1,
+        "total_tokens": 3,
+    }

--- a/Tests/LLM_Calls/test_qwencloud_streaming.py
+++ b/Tests/LLM_Calls/test_qwencloud_streaming.py
@@ -15,6 +15,7 @@ from loguru import logger
 from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
 import tldw_chatbook.LLM_Calls.qwencloud as qwencloud
 import tldw_chatbook.LLM_Calls.qwencloud_streaming as qwencloud_streaming
+import tldw_chatbook.LLM_Calls.hosted_chat_streaming as hosted_streaming
 from tldw_chatbook.LLM_Calls.qwencloud_streaming import (
     QwenCloudStream,
     QwenResponsesStreamTranslator,
@@ -552,7 +553,7 @@ def test_sse_accepts_long_valid_record_below_private_caps(
 
 
 def test_sse_line_accumulation_is_structurally_linear() -> None:
-    source = inspect.getsource(qwencloud_streaming._iter_utf8_lines)
+    source = inspect.getsource(hosted_streaming.SSERecordDecoder._consume_text)
 
     assert "buffered +=" not in source
     assert "segments" in source

--- a/Tests/LLM_Calls/test_zai.py
+++ b/Tests/LLM_Calls/test_zai.py
@@ -132,6 +132,27 @@ def test_resolve_zai_request_uses_canonical_precedence_and_current_defaults() ->
     assert defaults.base_url == "https://api.z.ai/api/paas/v4"
 
 
+def test_resolve_zai_request_rejects_normalized_table_alias_conflict() -> None:
+    with pytest.raises(ChatConfigurationError, match="unambiguous"):
+        resolve_zai_request(
+            app_config={
+                "api_settings": {
+                    "ZAI": {"api_key": "alias-secret-canary"},
+                    "zai": {"api_key": "canonical-secret-canary"},
+                }
+            },
+            environ={},
+        )
+
+
+def test_resolve_zai_request_rejects_null_canonical_table() -> None:
+    with pytest.raises(ChatConfigurationError, match="configuration table"):
+        resolve_zai_request(
+            app_config={"api_settings": {"zai": None}},
+            environ={"ZAI_API_KEY": "must-not-enable-null-settings"},
+        )
+
+
 @pytest.mark.parametrize(
     "app_config",
     [

--- a/Tests/LLM_Calls/test_zai.py
+++ b/Tests/LLM_Calls/test_zai.py
@@ -1,0 +1,447 @@
+"""Z.ai/GLM provider-local resolution, request, and response contracts."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+import tldw_chatbook.LLM_Calls.LLM_API_Calls as legacy_adapters
+import tldw_chatbook.LLM_Calls.zai as zai
+from tldw_chatbook.Chat.Chat_Deps import (
+    ChatBadRequestError,
+    ChatConfigurationError,
+    ChatProviderError,
+)
+from tldw_chatbook.Chat.provider_continuation import parse_provider_continuation_json
+from tldw_chatbook.LLM_Calls.hosted_chat import (
+    HostedChatProtocolError,
+    HostedChatStream,
+)
+from tldw_chatbook.LLM_Calls.hosted_chat_streaming import SSERecord
+from tldw_chatbook.LLM_Calls.zai import (
+    ZAIFinishPolicy,
+    ZAIResolution,
+    build_zai_chat_payload,
+    chat_with_zai,
+    normalize_zai_response,
+    resolve_zai_request,
+)
+
+
+def _resolution(**overrides: object) -> ZAIResolution:
+    values: dict[str, object] = {
+        "provider": "zai",
+        "model": "glm-5.2",
+        "api_key": "secret-key",
+        "base_url": "https://api.z.ai/api/paas/v4",
+        "timeout": 90.0,
+        "retries": 3,
+        "retry_delay": 1.0,
+        "streaming": True,
+    }
+    values.update(overrides)
+    return ZAIResolution(**values)  # type: ignore[arg-type]
+
+
+def _tool(name: str = "calculator") -> dict[str, object]:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": "Evaluate arithmetic.",
+            "parameters": {
+                "type": "object",
+                "properties": {"expression": {"type": "string"}},
+                "required": ["expression"],
+            },
+        },
+    }
+
+
+def _history() -> list[dict[str, object]]:
+    return [
+        {"role": "user", "content": "Calculate."},
+        {
+            "role": "assistant",
+            "content": "Working.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": '{"expression":"2+2"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "4"},
+    ]
+
+
+def test_resolve_zai_request_uses_canonical_precedence_and_current_defaults() -> None:
+    config = {
+        "api_settings": {
+            "zai": {
+                "api_key": " config-key ",
+                "api_key_env_var": "TEAM_ZAI_KEY",
+                "api_base_url": "https://config.example/api/paas/v4/chat/completions",
+                "model": "glm-4.6",
+                "timeout": 12,
+                "retries": 4,
+                "retry_delay": 0.5,
+                "streaming": False,
+            }
+        }
+    }
+    original = deepcopy(config)
+
+    configured = resolve_zai_request(
+        app_config=config,
+        environ={"TEAM_ZAI_KEY": "env-key", "ZAI_API_KEY": "fallback"},
+    )
+    explicit = resolve_zai_request(
+        explicit_api_key=" explicit-key ",
+        explicit_base_url="https://explicit.example/v4",
+        explicit_model="glm-5.2",
+        app_config=config,
+        environ={},
+    )
+
+    assert configured == ZAIResolution(
+        provider="zai",
+        model="glm-4.6",
+        api_key="config-key",
+        base_url="https://config.example/api/paas/v4",
+        timeout=12.0,
+        retries=4,
+        retry_delay=0.5,
+        streaming=False,
+    )
+    assert explicit.model == "glm-5.2"
+    assert explicit.api_key == "explicit-key"
+    assert config == original
+    assert "config-key" not in repr(configured)
+
+    defaults = resolve_zai_request(
+        app_config={"api_settings": {"zai": {}}},
+        environ={"ZAI_API_KEY": "env-key"},
+    )
+    assert defaults.model == "glm-5.2"
+    assert defaults.base_url == "https://api.z.ai/api/paas/v4"
+
+
+@pytest.mark.parametrize(
+    "app_config",
+    [
+        {"api_settings": []},
+        {"api_settings": {"zai": []}},
+        {"api_settings": {"zai": {"api_key": "YOUR_KEY"}}},
+        {"api_settings": {"zai": {"model": " "}}},
+        {"api_settings": {"zai": {"api_base_url": "https://bad/v4/responses"}}},
+        {"api_settings": {"zai": {"timeout": True}}},
+        {"api_settings": {"zai": {"retries": 1.5}}},
+        {"api_settings": {"zai": {"retry_delay": -1}}},
+        {"api_settings": {"zai": {"streaming": "yes"}}},
+    ],
+)
+def test_resolve_zai_request_malformed_exact_table_fails_closed(
+    app_config: object,
+) -> None:
+    with pytest.raises(ChatConfigurationError) as exc_info:
+        resolve_zai_request(
+            app_config=app_config,  # type: ignore[arg-type]
+            environ={"ZAI_API_KEY": "must-not-rescue"},
+        )
+
+    assert exc_info.value.provider == "zai"
+    assert "must-not-rescue" not in str(exc_info.value)
+
+
+def test_zai_ordinary_chat_uses_clear_thinking_and_exact_allowlist() -> None:
+    payload = build_zai_chat_payload(
+        resolution=_resolution(),
+        messages_payload=[{"role": "user", "content": "hello"}],
+        streaming=False,
+        do_sample=True,
+        temperature=0.4,
+        top_p=0.8,
+        reasoning_effort="high",
+        max_tokens=128,
+        request_id="request-1",
+        user="user-1",
+        unknown_private="discarded",
+    )
+
+    assert payload == {
+        "model": "glm-5.2",
+        "messages": [{"role": "user", "content": "hello"}],
+        "do_sample": True,
+        "stream": False,
+        "thinking": {"type": "enabled", "clear_thinking": True},
+        "temperature": 0.4,
+        "top_p": 0.8,
+        "reasoning_effort": "high",
+        "max_tokens": 128,
+        "request_id": "request-1",
+        "user_id": "user-1",
+    }
+
+
+def test_zai_function_run_preserves_reasoning_and_complete_tool_history() -> None:
+    checkpoint = parse_provider_continuation_json(
+        {
+            "schema_version": 1,
+            "checkpoint_revision": 1,
+            "provider": "zai",
+            "protocol": "chat_completions",
+            "model": "glm-5.2",
+            "api_base_url": "https://api.z.ai/api/paas/v4",
+            "state": "complete",
+            "rounds": [
+                {
+                    "assistant_content": "Working.",
+                    "reasoning_blocks": ["PRIVATE-REASONING"],
+                    "calls": [
+                        {
+                            "call_id": "call_1",
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                            "state": "completed",
+                            "result": "4",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    history = _history()
+    payload = build_zai_chat_payload(
+        resolution=_resolution(),
+        messages_payload=history,
+        tools=[_tool()],
+        tool_choice="auto",
+        provider_continuations=[checkpoint],
+    )
+
+    assert payload["thinking"] == {"type": "enabled", "clear_thinking": False}
+    assert payload["messages"][1]["reasoning_content"] == "PRIVATE-REASONING"
+    assert payload["messages"][1]["tool_calls"] == history[1]["tool_calls"]
+    assert payload["tools"] == [_tool()]
+    assert "tool_stream" not in payload
+
+
+@pytest.mark.parametrize("tool_choice", ["none", "required", {"type": "function"}, 7])
+def test_zai_rejects_unsupported_tool_choice(tool_choice: object) -> None:
+    with pytest.raises(ChatBadRequestError):
+        build_zai_chat_payload(
+            resolution=_resolution(),
+            messages_payload=[{"role": "user", "content": "hello"}],
+            tools=[_tool()],
+            tool_choice=tool_choice,
+        )
+
+
+@pytest.mark.parametrize(
+    "effort", ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+)
+def test_glm_5_2_accepts_exact_reasoning_efforts(effort: str) -> None:
+    payload = build_zai_chat_payload(
+        resolution=_resolution(),
+        messages_payload=[{"role": "user", "content": "hello"}],
+        reasoning_effort=effort,
+    )
+    assert payload["reasoning_effort"] == effort
+
+
+@pytest.mark.parametrize("effort", ["", "auto", "ultra", {}, True])
+def test_zai_rejects_invalid_or_unsupported_reasoning_effort(effort: object) -> None:
+    with pytest.raises(ChatBadRequestError):
+        build_zai_chat_payload(
+            resolution=_resolution(),
+            messages_payload=[{"role": "user", "content": "hello"}],
+            reasoning_effort=effort,
+        )
+
+
+def test_zai_response_normalizes_object_arguments_deterministically() -> None:
+    response = {
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Working.",
+                    "reasoning_content": "PRIVATE",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "calculator",
+                                "arguments": {"z": 1, "a": "2+2"},
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 8, "completion_tokens": 4, "total_tokens": 12},
+    }
+
+    turn = normalize_zai_response(response)
+
+    assert turn.tool_calls[0]["function"]["arguments"] == '{"a":"2+2","z":1}'
+    assert turn.reasoning_content == "PRIVATE"
+    assert response["choices"][0]["message"]["tool_calls"][0]["function"][
+        "arguments"
+    ] == {"z": 1, "a": "2+2"}
+
+
+@pytest.mark.parametrize("arguments", [7, True, [], None])
+def test_zai_response_rejects_non_object_non_string_arguments(
+    arguments: object,
+) -> None:
+    response = {
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "calculator", "arguments": arguments},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ]
+    }
+    with pytest.raises(ChatProviderError):
+        normalize_zai_response(response)
+
+
+@pytest.mark.parametrize(
+    "finish_reason", ["sensitive", "model_context_window_exceeded", "network_error"]
+)
+def test_zai_terminal_error_finishes_are_safe_provider_errors(
+    finish_reason: str,
+) -> None:
+    with pytest.raises(ChatProviderError) as exc_info:
+        ZAIFinishPolicy().validate_finish(
+            finish_reason=finish_reason,
+            has_text=False,
+            has_calls=False,
+        )
+    assert exc_info.value.provider == "zai"
+    assert finish_reason not in str(exc_info.value)
+
+
+def test_zai_stream_preserves_safe_terminal_provider_error_type() -> None:
+    stream = HostedChatStream(
+        iter(
+            [
+                SSERecord(
+                    event=None,
+                    data=(
+                        '{"choices":[{"index":0,"delta":{},'
+                        '"finish_reason":"sensitive"}]}'
+                    ),
+                )
+            ]
+        ),
+        finish_policy=ZAIFinishPolicy(),
+    )
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        next(stream)
+
+    assert exc_info.value.provider == "zai"
+    assert "sensitive" not in str(exc_info.value)
+
+
+def test_chat_with_zai_joins_payload_transport_and_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(zai, "resolve_zai_request", lambda **_kwargs: _resolution())
+
+    def fake_request(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Answer"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+        }
+
+    monkeypatch.setattr(zai, "owned_json_post", fake_request)
+    result = chat_with_zai(
+        input_data=[{"role": "user", "content": "hello"}],
+        model="glm-5.2",
+        api_key="secret",
+        streaming=False,
+        reasoning_effort="max",
+    )
+
+    assert captured["streaming"] is False
+    assert captured["payload"]["reasoning_effort"] == "max"  # type: ignore[index]
+    assert result["choices"][0]["message"]["content"] == "Answer"
+
+
+def test_zai_malformed_success_is_redacted_provider_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(zai, "resolve_zai_request", lambda **_kwargs: _resolution())
+    monkeypatch.setattr(
+        zai,
+        "owned_json_post",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            HostedChatProtocolError("PRIVATE-PROVIDER-PAYLOAD")
+        ),
+    )
+    with pytest.raises(ChatProviderError) as exc_info:
+        chat_with_zai(
+            input_data=[{"role": "user", "content": "hello"}],
+            api_key="secret",
+            streaming=False,
+        )
+    assert "PRIVATE-PROVIDER-PAYLOAD" not in str(exc_info.value)
+
+
+def test_legacy_zai_handler_delegates_without_rewriting_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_strict(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(legacy_adapters, "_strict_chat_with_zai", fake_strict)
+    result = legacy_adapters.chat_with_zai(
+        input_data=[{"role": "user", "content": "hello"}],
+        model="glm-5.2",
+        api_key="secret",
+        temp=0.4,
+        maxp=0.8,
+        streaming=False,
+        tool_choice="auto",
+        reasoning_effort="max",
+    )
+
+    assert result == {"ok": True}
+    assert captured["temp"] == 0.4
+    assert captured["maxp"] == 0.8
+    assert captured["tool_choice"] == "auto"
+    assert captured["reasoning_effort"] == "max"

--- a/Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py
+++ b/Tests/LLM_Provider_Catalog/test_local_llm_provider_catalog_service.py
@@ -884,8 +884,112 @@ async def test_cloud_provider_default_endpoints_resolve(
         provider_catalog_loader=lambda: {list_key: ["placeholder-model"]},
         settings_loader=lambda: {},
         discovery_client=fake_client,
-        environ={},
+        environ={
+            "MOONSHOT_API_KEY": "test-moonshot-key",
+            "ZAI_API_KEY": "test-zai-key",
+        },
     )
     result = await service.discover_models(provider=list_key)
     assert result.status == "success"
     assert seen_urls == [expected_url]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "list_key", "model", "base_url", "env_var", "expected_base"),
+    [
+        (
+            "moonshot",
+            "Moonshot",
+            "kimi-k3",
+            "https://gateway.example/v1/chat/completions",
+            "TEAM_MOONSHOT_KEY",
+            "https://gateway.example/v1",
+        ),
+        (
+            "zai",
+            "ZAI",
+            "glm-5.2",
+            "https://gateway.example/api/paas/v4/chat/completions",
+            "TEAM_ZAI_KEY",
+            "https://gateway.example/api/paas/v4",
+        ),
+    ],
+)
+async def test_kimi_zai_discovery_reuses_exact_hosted_send_resolution(
+    provider, list_key, model, base_url, env_var, expected_base
+):
+    seen: list[dict] = []
+
+    async def fake_client(**kwargs):
+        seen.append(kwargs)
+        return ModelDiscoveryResult(
+            provider=kwargs["provider"],
+            provider_list_key=kwargs["provider_list_key"],
+            endpoint_fingerprint="fp",
+            status="success",
+            models=(),
+        )
+
+    service = LocalLLMProviderCatalogService(
+        provider_catalog_loader=lambda: {list_key: [model]},
+        settings_loader=lambda: {
+            "providers": {list_key: [model]},
+            "api_settings": {
+                provider: {
+                    "api_key_env_var": env_var,
+                    "model": model,
+                    "api_base_url": base_url,
+                    "timeout": 12,
+                    "retries": 1,
+                    "retry_delay": 0,
+                    "streaming": True,
+                }
+            },
+        },
+        discovery_client=fake_client,
+        environ={env_var: "catalog-secret-canary"},
+    )
+
+    result = await service.discover_models(provider=list_key)
+
+    assert result.status == "success"
+    assert len(seen) == 1
+    assert seen[0]["endpoint"] == expected_base
+    assert seen[0]["api_key"] == "catalog-secret-canary"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "list_key", "model"),
+    [
+        ("moonshot", "Moonshot", "kimi-k3"),
+        ("zai", "ZAI", "glm-5.2"),
+    ],
+)
+async def test_kimi_zai_discovery_blocks_invalid_send_settings_before_client(
+    provider, list_key, model
+):
+    client = AsyncMock()
+    service = LocalLLMProviderCatalogService(
+        provider_catalog_loader=lambda: {list_key: [model]},
+        settings_loader=lambda: {
+            "providers": {list_key: [model]},
+            "api_settings": {
+                provider: {
+                    "api_key": "catalog-secret-canary",
+                    "model": model,
+                    "timeout": True,
+                }
+            },
+        },
+        discovery_client=client,
+        environ={},
+    )
+
+    result = await service.discover_models(provider=list_key)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.kind == "invalid_provider_settings"
+    client.assert_not_awaited()

--- a/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
+++ b/Tests/LLM_Provider_Catalog/test_openai_compatible_model_discovery.py
@@ -750,17 +750,24 @@ def test_openrouter_api_v1_path_maps_to_models():
     )
 
 
-def test_zai_paas_v4_path_maps_to_models():
-    assert (
-        supports_openai_compatible_model_discovery(
-            "zai", "https://api.z.ai/api/paas/v4"
-        )
-        is True
-    )
-    assert (
-        build_models_url("https://api.z.ai/api/paas/v4", "zai")
-        == "https://api.z.ai/api/paas/v4/models"
-    )
+@pytest.mark.parametrize(
+    ("provider", "base_url", "models_url"),
+    [
+        (
+            "moonshot",
+            "https://api.moonshot.ai/v1",
+            "https://api.moonshot.ai/v1/models",
+        ),
+        (
+            "zai",
+            "https://api.z.ai/api/paas/v4",
+            "https://api.z.ai/api/paas/v4/models",
+        ),
+    ],
+)
+def test_kimi_zai_hosted_paths_map_to_models(provider, base_url, models_url):
+    assert supports_openai_compatible_model_discovery(provider, base_url) is True
+    assert build_models_url(base_url, provider) == models_url
 
 
 def test_anthropic_uses_x_api_key_headers():

--- a/Tests/UI/test_settings_kimi_zai.py
+++ b/Tests/UI/test_settings_kimi_zai.py
@@ -1,0 +1,169 @@
+"""Focused F9 Settings contracts for hosted Kimi and GLM providers."""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Input, Select, Static
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    _active_destination_screen,
+    _build_test_app,
+)
+from Tests.UI.test_settings_configuration_hub import _open_settings_category
+from Tests.UI.test_settings_configuration_hub import _settle_settings_mount_storm
+from tldw_chatbook.UI.Screens.settings_screen import SettingsCategoryId
+
+
+def _option_values(select: Select) -> set[str]:
+    return {
+        str(option[1]) for option in select._options if option[1] is not Select.NULL
+    }
+
+
+def _hosted_app(provider: str, model: str):
+    app = _build_test_app()
+    provider_key = "moonshot" if provider == "Moonshot" else "zai"
+    endpoint = (
+        "https://api.moonshot.ai/v1"
+        if provider_key == "moonshot"
+        else "https://api.z.ai/api/paas/v4"
+    )
+    env_var = "MOONSHOT_API_KEY" if provider_key == "moonshot" else "ZAI_API_KEY"
+    app.app_config["chat_defaults"] = {"provider": provider, "model": model}
+    app.app_config["api_settings"] = {
+        provider_key: {
+            "api_key": "settings-test-key",
+            "api_key_env_var": env_var,
+            "api_base_url": endpoint,
+            "model": model,
+            "streaming": True,
+        }
+    }
+    app.providers_models = {
+        "Moonshot": ["kimi-k3", "moonshot-v1-128k"],
+        "ZAI": ["glm-5.2", "glm-4.5"],
+    }
+    return app
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "model", "expected_endpoint", "expected_env", "reasoning"),
+    [
+        (
+            "Moonshot",
+            "kimi-k3",
+            "https://api.moonshot.ai/v1",
+            "MOONSHOT_API_KEY",
+            {"low", "high", "max"},
+        ),
+        (
+            "ZAI",
+            "glm-5.2",
+            "https://api.z.ai/api/paas/v4",
+            "ZAI_API_KEY",
+            {"none", "minimal", "low", "medium", "high", "xhigh", "max"},
+        ),
+    ],
+)
+async def test_settings_hosted_provider_controls_are_exact_and_actionable(
+    provider, model, expected_endpoint, expected_env, reasoning
+):
+    host = DestinationHarness(_hosted_app(provider, model), "settings")
+
+    async with host.run_test(size=(190, 58)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+
+        assert screen.query_one("#settings-model-value", Input).value == model
+        assert (
+            screen.query_one("#settings-provider-endpoint-value", Input).value
+            == expected_endpoint
+        )
+        assert (
+            screen.query_one("#settings-provider-credential-env-var", Input).value
+            == expected_env
+        )
+        api_mode_row = screen.query_one("#settings-provider-api-mode-row")
+        assert api_mode_row.has_class("settings-gated-profile-hidden")
+        assert screen.query_one("#settings-provider-api-mode", Select).disabled
+
+        reasoning_select = screen.query_one(
+            "#settings-model-profile-reasoning-effort", Select
+        )
+        assert reasoning_select.disabled is False
+        assert _option_values(reasoning_select) == reasoning
+
+        guidance = str(
+            screen.query_one("#settings-hosted-provider-guidance", Static).renderable
+        )
+        if provider == "Moonshot":
+            assert "international, China, or custom" in guidance
+            assert "Preserved Thinking" in guidance
+            assert "private" in guidance
+        else:
+            assert "general API" in guidance
+            assert "coding-only" in guidance
+            assert "private" in guidance
+
+
+@pytest.mark.asyncio
+async def test_settings_hosted_provider_switch_isolates_drafts_and_keeps_old_model():
+    app = _hosted_app("Moonshot", "moonshot-v1-128k")
+    app.app_config["api_settings"]["zai"] = {
+        "api_key": "settings-zai-key",
+        "api_key_env_var": "ZAI_API_KEY",
+        "api_base_url": "https://api.z.ai/api/paas/v4",
+        "model": "glm-5.2",
+        "streaming": True,
+    }
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(190, 58)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        endpoint = screen.query_one("#settings-provider-endpoint-value", Input)
+        endpoint.value = "https://unsaved-moonshot.example/v1"
+        await pilot.pause()
+
+        screen._apply_provider_value_change("zai")
+        await pilot.pause()
+        assert endpoint.value == "https://api.z.ai/api/paas/v4"
+        assert screen.query_one("#settings-model-value", Input).value == "glm-5.2"
+        assert _option_values(
+            screen.query_one("#settings-model-profile-reasoning-effort", Select)
+        ) == {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+
+        screen._apply_provider_value_change("moonshot")
+        await pilot.pause()
+        assert endpoint.value == "https://api.moonshot.ai/v1"
+        assert (
+            screen.query_one("#settings-model-value", Input).value == "moonshot-v1-128k"
+        )
+        assert "Verify reasoning support" in str(
+            screen.query_one("#settings-hosted-provider-guidance", Static).renderable
+        )
+
+
+@pytest.mark.asyncio
+async def test_settings_hosted_navigation_focuses_reasoning_control():
+    host = DestinationHarness(_hosted_app("Moonshot", "kimi-k3"), "settings")
+
+    async with host.run_test(size=(190, 58)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host)
+        screen.apply_navigation_context(
+            {
+                "category": SettingsCategoryId.PROVIDERS_MODELS.value,
+                "provider": "moonshot",
+                "model": "kimi-k3",
+                "field": "reasoning",
+            }
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen.query_one(
+            "#settings-model-profile-reasoning-effort", Select
+        ).has_focus

--- a/Tests/test_config_model_catalog_defaults.py
+++ b/Tests/test_config_model_catalog_defaults.py
@@ -25,12 +25,38 @@ def _temporary_config(tmp_path, monkeypatch, toml_text):
         config_module._SETTINGS_CACHE_SOURCE = original_settings_cache_source
 
 
-def test_zai_provider_and_settings_defaults_exist():
+def test_kimi_zai_provider_and_settings_defaults_are_current():
     parsed = tomllib.loads(CONFIG_TOML_CONTENT)
-    assert isinstance(parsed["providers"].get("ZAI"), list)
+    assert parsed["providers"]["Moonshot"][0] == "kimi-k3"
+    assert parsed["providers"]["ZAI"][0] == "glm-5.2"
+
+    moonshot_settings = parsed["api_settings"]["moonshot"]
+    assert moonshot_settings == {
+        "api_key_env_var": "MOONSHOT_API_KEY",
+        "model": "kimi-k3",
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": 4096,
+        "api_region": "international",
+        "api_base_url": "https://api.moonshot.ai/v1",
+        "timeout": 90,
+        "retries": 3,
+        "retry_delay": 1.0,
+        "streaming": True,
+    }
     zai_settings = parsed["api_settings"]["zai"]
-    assert zai_settings["api_key_env_var"] == "ZAI_API_KEY"
-    assert zai_settings["api_base_url"] == "https://api.z.ai/api/paas/v4"
+    assert zai_settings == {
+        "api_key_env_var": "ZAI_API_KEY",
+        "model": "glm-5.2",
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": 4096,
+        "api_base_url": "https://api.z.ai/api/paas/v4",
+        "timeout": 90,
+        "retries": 3,
+        "retry_delay": 5,
+        "streaming": True,
+    }
 
 
 def test_model_catalog_defaults_exist():
@@ -104,3 +130,18 @@ def test_load_settings_preserves_explicit_legacy_api_models(tmp_path, monkeypatc
         assert settings["anthropic_api"]["model"] == explicit_models["anthropic_model"]
         assert settings["deepseek_api"]["model"] == explicit_models["deepseek_model"]
         assert settings["openai_api"]["model"] == explicit_models["openai_model"]
+
+
+def test_load_settings_preserves_explicit_historical_kimi_glm_models(
+    tmp_path, monkeypatch
+):
+    config_text = """
+[api_settings.moonshot]
+model = "moonshot-v1-128k"
+
+[api_settings.zai]
+model = "glm-4.5"
+"""
+    with _temporary_config(tmp_path, monkeypatch, config_text) as settings:
+        assert settings["api_settings"]["moonshot"]["model"] == "moonshot-v1-128k"
+        assert settings["api_settings"]["zai"]["model"] == "glm-4.5"

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9,6 +9,25 @@ decays into folklore, and folklore is ignored. If you add one, bring the inciden
 
 ---
 
+## An exact live-test gate must be the first gate that can skip the test
+
+**TASK-15676, 2026-08-13.** The opt-in Moonshot/Z.ai paid harness required an
+exact provider flag plus a nonblank provider key, and its user documentation
+showed that two-part command. The first default run never reached that contract:
+the repository's `slow` marker skipped the test with `Need --run-slow`. Removing
+that marker exposed the same problem from `optional` and `--run-optional`. Even
+with the documented environment flag and key present, the documented command
+could not execute the live case because unrelated collection-time gates ran
+before the test body's explicit safety check.
+
+**What to do.** When the public contract is an exact environment/key gate, do
+not also apply repository markers whose plugins skip before the test body unless
+every required CLI flag is part of the documented contract. Keep descriptive
+markers such as `integration`/`allow_network`, put the paid-call guard at the
+top of the test, and cover its truth table plus the default skip reason. That
+makes default collection safe while ensuring the opt-in command can actually
+reach the code it claims to verify.
+
 ## A schema-version label does not make a synthetic database historical
 
 **TASK-15705/TASK-15707, 2026-08-12.** Raising ChaChaNotes from v35 to v36

--- a/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
+++ b/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-15676
 title: Harden Moonshot Kimi and Z.ai GLM as first-class hosted providers
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-12 20:45'
+updated_date: '2026-08-13 22:10'
 labels: []
 dependencies:
   - TASK-15675
@@ -23,20 +24,21 @@ Bring the existing Moonshot AI and Z.ai integrations up to the same first-class 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Moonshot and Z.ai preserve their stable provider identities and public handler compatibility while using the neutral hosted Chat-Completions boundary; unrelated providers do not change behavior.
-- [ ] #2 Fresh configuration defaults use `kimi-k3` for Moonshot and `glm-5.2` for Z.ai while explicit historical selections remain usable.
-- [ ] #3 Explicit arguments, canonical configuration, environment credentials, defaults, and structural endpoint validation follow one documented fail-closed contract without mutating source configuration or disclosing secrets.
-- [ ] #4 Streaming and non-streaming calls strictly validate payloads, errors, finish states, usage, retries, cancellation, ownership, and size/depth bounds.
-- [ ] #5 Existing Chatbook function tools complete joined Console continuation for both providers; private reasoning uses TASK-15675 checkpoints and vendor built-in tools remain excluded.
-- [ ] #6 Kimi K3 preserves and budgets every retained assistant reasoning turn required by its always-on Preserved Thinking contract; other curated Kimi/GLM models follow their exact policies, with GLM using `clear_thinking=false` only for active/restored tool runs.
-- [ ] #7 Moonshot and best-effort Z.ai model discovery use the same normalized endpoint and credential resolution as chat, preserve prior cache on failure, and never log sensitive payloads.
-- [ ] #8 Canonical Settings exposes actionable readiness, save, search/focus, endpoint, credential, model, and reasoning guidance without an API-mode selector.
-- [ ] #9 QwenCloud Chat behavior remains unchanged after any shared parser extraction, proven by its complete contract suite and mutation checks.
-- [ ] #10 Documentation and optional doubly-gated isolated live tests cover the current defaults, endpoints, controls, tools, recovery, and no-paid-default contract.
+- [x] #1 Moonshot and Z.ai preserve their stable provider identities and public handler compatibility while using the neutral hosted Chat-Completions boundary; unrelated providers do not change behavior.
+- [x] #2 Fresh configuration defaults use `kimi-k3` for Moonshot and `glm-5.2` for Z.ai while explicit historical selections remain usable.
+- [x] #3 Explicit arguments, canonical configuration, environment credentials, defaults, and structural endpoint validation follow one documented fail-closed contract without mutating source configuration or disclosing secrets.
+- [x] #4 Streaming and non-streaming calls strictly validate payloads, errors, finish states, usage, retries, cancellation, ownership, and size/depth bounds.
+- [x] #5 Existing Chatbook function tools complete joined Console continuation for both providers; private reasoning uses TASK-15675 checkpoints and vendor built-in tools remain excluded.
+- [x] #6 Kimi K3 preserves and budgets every retained assistant reasoning turn required by its always-on Preserved Thinking contract; other curated Kimi/GLM models follow their exact policies, with GLM using `clear_thinking=false` only for active/restored tool runs.
+- [x] #7 Moonshot and best-effort Z.ai model discovery use the same normalized endpoint and credential resolution as chat, preserve prior cache on failure, and never log sensitive payloads.
+- [x] #8 Canonical Settings exposes actionable readiness, save, search/focus, endpoint, credential, model, and reasoning guidance without an API-mode selector.
+- [x] #9 QwenCloud Chat behavior remains unchanged after any shared parser extraction, proven by its complete contract suite and mutation checks.
+- [x] #10 Documentation and optional doubly-gated isolated live tests cover the current defaults, endpoints, controls, tools, recovery, and no-paid-default contract.
 <!-- AC:END -->
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 1. Establish focused baselines for the existing Moonshot, Z.ai, QwenCloud,
    Console native-tool, Settings, readiness, and model-discovery contracts.
 2. Add the minimal provider-neutral hosted Chat-Completions URL, HTTP ownership,
@@ -65,3 +67,38 @@ ADR path:
 Reason: this task implements ADR-063's reusable hosted Chat wire boundary and
 provider-specific durable continuation policies; no additional decision is
 needed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added a provider-neutral hosted Chat-Completions HTTP/SSE boundary with
+  bounded parsing, strict response normalization, retry/resource ownership, and
+  redacted typed failures. Moonshot/Kimi and Z.ai/GLM now use provider-local
+  resolution, request allowlists, model/reasoning policy, continuation
+  translation, and compatibility wrappers; QwenCloud reuses only the proven
+  Chat framing/normalization seam.
+- Joined both providers to Console/AgentService function tools, terminal usage,
+  cancellation, private TASK-15675 checkpoints, context budgeting, and recovery.
+  Kimi K3 retains required historical reasoning; GLM retains thinking only for
+  active/restored tool runs. Vendor built-in tools, Responses mode, provider
+  session state, and schema changes remain out of scope.
+- Refreshed fresh defaults, canonical Settings/readiness, normalized discovery,
+  cache behavior, and user guidance. Added an isolated paid-live harness whose
+  provider case requires both its exact opt-in flag and nonblank API key; default
+  collection made no paid request. ADR-063 remains the governing decision and no
+  additional ADR was required.
+- Verification evidence: the focused hosted-provider/Qwen matrix passed 467
+  tests; joined Console/native-tool/live-harness coverage passed 48 with the two
+  paid cases skipped by their explicit gates; selected AgentService/gateway
+  continuation seams passed 5 with 483 unrelated cases deselected. The Task 6
+  Settings/readiness/catalog matrix passed 609 tests, with its focused post-audit
+  matrix passing 349. The four provider modules pass MyPy, LLM modules compile,
+  and cumulative diff checks pass. Ruff lint/format passes for all changed files
+  except exact pre-feature debt reproduced in two legacy lint files (8 findings)
+  and eight legacy formatter files; those unrelated files were not churned.
+- Test-scope deviation: on 2026-08-13 the user explicitly stopped broad/full-suite
+  execution and required only tests related to touched files or functionality.
+  No full-repository or broad-directory result is claimed. The exact focused
+  commands and this deviation are retained in the implementation plan/evidence.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
+++ b/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15676
 title: Harden Moonshot Kimi and Z.ai GLM as first-class hosted providers
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-12 20:45'
 labels: []
@@ -34,3 +34,34 @@ Bring the existing Moonshot AI and Z.ai integrations up to the same first-class 
 - [ ] #9 QwenCloud Chat behavior remains unchanged after any shared parser extraction, proven by its complete contract suite and mutation checks.
 - [ ] #10 Documentation and optional doubly-gated isolated live tests cover the current defaults, endpoints, controls, tools, recovery, and no-paid-default contract.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Establish focused baselines for the existing Moonshot, Z.ai, QwenCloud,
+   Console native-tool, Settings, readiness, and model-discovery contracts.
+2. Add the minimal provider-neutral hosted Chat-Completions URL, HTTP ownership,
+   SSE framing, and OpenAI-shaped normalization boundary, preserving QwenCloud
+   behavior through focused parity tests.
+3. Migrate Moonshot/Kimi and Z.ai/GLM behind provider-local resolution, payload,
+   finish, usage, and durable-reasoning policies while retaining public handler
+   compatibility.
+4. Carry frozen provider resolution, terminal metadata, private continuation,
+   and usage through the existing Console/AgentService path, then prove joined
+   function-tool continuation and cancellation through loopback HTTP.
+5. Refresh defaults, readiness, canonical Settings, and model discovery without
+   changing explicit historical selections or unrelated providers.
+6. Update user documentation, add default-skipped isolated live-test gates, run
+   only the focused provider-related verification authorized for this task,
+   self-review each acceptance criterion, and record observed evidence.
+
+Detailed plan:
+`Docs/superpowers/plans/2026-08-12-kimi-zai-hosted-chat-completions-implementation.md`
+
+ADR required: yes
+
+ADR path:
+`backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md`
+
+Reason: this task implements ADR-063's reusable hosted Chat wire boundary and
+provider-specific durable continuation policies; no additional decision is
+needed.

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -275,6 +275,13 @@ class LoopDeps:
     load_schemas: Callable[[list], list]
     should_cancel: Callable[[], bool]
     clock: Callable[[], float]
+    call_model_with_continuation: (
+        Callable[
+            [list, tuple, ProviderContinuationCheckpoint | None],
+            ModelTurn,
+        ]
+        | None
+    ) = None
     on_step: Callable[[AgentStep], None] = lambda step: None
     # Optional pre-dispatch batch-review hook (P5 Task 4): the generic seam
     # the MCP approval flow (Task 6) rides on. When set, called ONCE per
@@ -893,7 +900,15 @@ def run_agent_loop(
             turn = ModelTurn(tool_calls=tuple(calls))
         else:
             restored_calls = None
-            turn = deps.call_model(messages, tuple(active))
+            turn = (
+                deps.call_model_with_continuation(
+                    messages,
+                    tuple(active),
+                    continuation_checkpoint,
+                )
+                if deps.call_model_with_continuation is not None
+                else deps.call_model(messages, tuple(active))
+            )
             model_turns += 1
             total_tokens += turn.tokens
             calls = list(turn.tool_calls)

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -803,6 +803,7 @@ class AgentService:
         log_active: bool = False,
         continuation_groups: tuple[ContinuationOwnerGroup, ...] = (),
         continuation_owner_key: str | None = None,
+        continuation_owner_message_id: str | None = None,
     ):
         native = config.native_tools and provider_supports_native_tools(api_endpoint)
         # TASK-1272 (Phase 3): the ONLY gate on whether eviction may run at
@@ -833,7 +834,11 @@ class AgentService:
         protocol_key: tuple | None = None
         protocol_text = ""
 
-        def call_model(messages: list[dict], active_schemas: tuple) -> ModelTurn:
+        def call_model(
+            messages: list[dict],
+            active_schemas: tuple,
+            current_continuation: ProviderContinuationCheckpoint | None = None,
+        ) -> ModelTurn:
             nonlocal protocol_key, protocol_text
             schemas = runtime_schemas + list(active_schemas)
             system_content = config.system_prompt
@@ -857,9 +862,39 @@ class AgentService:
             # `run_agent_loop`'s own `messages` -- that list is untouched,
             # see `bound_history_for_send`'s docstring. A no-op (returns
             # `raw_payload` unchanged) whenever `evict_enabled` is False.
-            raw_payload = [{"role": "system", "content": system_content}] + messages
+            effective_groups = continuation_groups
+            payload_messages = [dict(message) for message in messages]
+            if current_continuation is not None:
+                if not continuation_owner_key or not continuation_owner_message_id:
+                    raise ValueError("Active provider continuation requires an owner.")
+                current_group = ContinuationOwnerGroup(
+                    owner_message_id=continuation_owner_message_id,
+                    checkpoint=current_continuation,
+                    rounds=current_continuation.rounds,
+                )
+                effective_groups = tuple(
+                    group
+                    for group in continuation_groups
+                    if group.owner_message_id != continuation_owner_message_id
+                ) + (current_group,)
+                expected_call_ids = tuple(
+                    call.call_id for call in current_continuation.rounds[-1].calls
+                )
+                for message in reversed(payload_messages):
+                    raw_calls = message.get("tool_calls")
+                    call_ids = tuple(
+                        call.get("id")
+                        for call in raw_calls
+                        if isinstance(call, Mapping)
+                    ) if isinstance(raw_calls, list) else ()
+                    if message.get("role") == "assistant" and call_ids == expected_call_ids:
+                        message[continuation_owner_key] = continuation_owner_message_id
+                        break
+            raw_payload = [
+                {"role": "system", "content": system_content}
+            ] + payload_messages
             gateway_prepares_continuation = bool(
-                continuation_groups and self.prepare_provider_continuation_request
+                effective_groups and self.prepare_provider_continuation_request
             )
             payload = bound_history_for_send(
                 raw_payload,
@@ -869,7 +904,7 @@ class AgentService:
                 enabled=evict_enabled,
                 min_recent_rounds=min_recent_rounds,
                 continuation_groups=(
-                    () if gateway_prepares_continuation else continuation_groups
+                    () if gateway_prepares_continuation else effective_groups
                 ),
                 continuation_owner_key=continuation_owner_key or "id",
             )
@@ -885,6 +920,8 @@ class AgentService:
                     }
                     for message in payload
                 ]
+            if gateway_prepares_continuation:
+                call_kwargs["continuation_groups"] = effective_groups
             resp = self.chat_call(
                 api_endpoint=api_endpoint,
                 messages_payload=payload,
@@ -894,6 +931,11 @@ class AgentService:
             )
             text = _response_text(resp)
             tokens = _usage_total_tokens(resp)
+            provider_continuation = getattr(resp, "provider_continuation", None)
+            if provider_continuation is not None and not isinstance(
+                provider_continuation, ProviderContinuationCheckpoint
+            ):
+                raise ValueError("Provider continuation metadata is malformed.")
             if tokens is None:
                 # Provider reported no usage -> estimate from sent payload +
                 # response text (native tool_calls JSON is not separately
@@ -910,7 +952,11 @@ class AgentService:
                     payload, est_model, provider=api_endpoint
                 ) + estimate_tokens(text, est_model, provider=api_endpoint)
             if not native:
-                return ModelTurn(text=text, tokens=tokens)
+                return ModelTurn(
+                    text=text,
+                    tokens=tokens,
+                    provider_continuation=provider_continuation,
+                )
             message = _response_message(resp)
             # Id-less entries get synthesized ids BEFORE parsing, and the
             # SAME normalized list feeds the assistant echo — the echo and
@@ -927,11 +973,20 @@ class AgentService:
                     "content": text,
                     "tool_calls": raw_calls,
                 }
+                if (
+                    provider_continuation is not None
+                    and continuation_owner_key
+                    and continuation_owner_message_id
+                ):
+                    assistant_message[continuation_owner_key] = (
+                        continuation_owner_message_id
+                    )
             return ModelTurn(
                 text=text,
                 tool_calls=tool_calls,
                 assistant_message=assistant_message,
                 tokens=tokens,
+                provider_continuation=provider_continuation,
             )
 
         return call_model
@@ -2774,15 +2829,18 @@ class AgentService:
                 call_id=str(payload.get("call_id", "")),
             )
 
+        call_model = self._make_call_model(
+            config,
+            api_endpoint,
+            runtime_schemas,
+            log_active,
+            continuation_groups,
+            continuation_owner_key,
+            continuation_owner_message_id,
+        )
         deps = LoopDeps(
-            call_model=self._make_call_model(
-                config,
-                api_endpoint,
-                runtime_schemas,
-                log_active,
-                continuation_groups,
-                continuation_owner_key,
-            ),
+            call_model=call_model,
+            call_model_with_continuation=call_model,
             invoke_tool=invoke_tool,
             spawn=spawn,
             find_tools=find_tools,

--- a/tldw_chatbook/Agents/native_tools.py
+++ b/tldw_chatbook/Agents/native_tools.py
@@ -32,6 +32,7 @@ NATIVE_TOOLS_PROVIDERS = frozenset(
         "mistral",
         "deepseek",
         "moonshot",
+        "zai",
         # TASK-3771: both QwenCloud wire modes normalize function calls to
         # OpenAI shape and translate canonical assistant/tool continuation.
         # Joined Console tests exercise the real dispatcher and HTTP boundary.

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -722,6 +722,7 @@ PROVIDER_PARAM_MAP = {
         "response_format": "response_format",
         "n": "n",
         "user_identifier": "user",
+        "reasoning_effort": "reasoning_effort",
     },
     "zai": {
         "api_key": "api_key",

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -88,6 +88,7 @@ from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram  # n
 from tldw_chatbook.config import load_settings  # noqa: E402
 from .chat_persistence_service import ChatPersistenceService  # noqa: E402
 from .provider_continuation import (  # noqa: E402
+    ProviderContinuationCheckpoint,
     dump_provider_continuation_json,
     read_provider_continuation_json,
 )
@@ -723,6 +724,10 @@ PROVIDER_PARAM_MAP = {
         "n": "n",
         "user_identifier": "user",
         "reasoning_effort": "reasoning_effort",
+        "provider_continuations": "provider_continuations",
+        "request_timeout": "request_timeout",
+        "request_retries": "request_retries",
+        "request_retry_delay": "request_retry_delay",
     },
     "zai": {
         "api_key": "api_key",
@@ -739,6 +744,10 @@ PROVIDER_PARAM_MAP = {
         "response_format": "response_format",
         "user_identifier": "user",
         "reasoning_effort": "reasoning_effort",
+        "provider_continuations": "provider_continuations",
+        "request_timeout": "request_timeout",
+        "request_retries": "request_retries",
+        "request_retry_delay": "request_retry_delay",
     },
     # Add other providers here
 }
@@ -817,6 +826,10 @@ def chat_api_call(
     llm_fixed_tokens_kobold: Optional[bool] = False,  # Added
     api_base_url: Optional[str] = None,
     api_mode: Optional[str] = None,
+    provider_continuations: Tuple[ProviderContinuationCheckpoint, ...] = (),
+    request_timeout: Optional[float] = None,
+    request_retries: Optional[int] = None,
+    request_retry_delay: Optional[float] = None,
 ):
     """
     Acts as a unified dispatcher to call various LLM API providers.

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -734,6 +734,11 @@ PROVIDER_PARAM_MAP = {
         "model": "model",
         "max_tokens": "max_tokens",
         "tools": "tools",
+        "tool_choice": "tool_choice",
+        "stop": "stop",
+        "response_format": "response_format",
+        "user_identifier": "user",
+        "reasoning_effort": "reasoning_effort",
     },
     # Add other providers here
 }

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1599,7 +1599,10 @@ class _StreamingModelAdapter:
             stream_kwargs = {"tools": tools} if tools is not None else {}
             prepare_request = getattr(self._gateway, "prepare_chat_request", None)
             if continuation_groups and callable(prepare_request):
-                if self._continuation_target is None or not self._continuation_owner_key:
+                if (
+                    self._continuation_target is None
+                    or not self._continuation_owner_key
+                ):
                     raise ValueError("Provider continuation request is not pinned.")
                 owner_ids = {group.owner_message_id for group in continuation_groups}
                 semantic_messages: list[dict[str, Any]] = []
@@ -2575,6 +2578,24 @@ class ConsoleAgentBridge:
         continuation_target: ContinuationRestoreTarget | None = None,
         continuation_owner_key: str | None = None,
     ) -> tuple[str, RunOutcome]:
+        protocol = getattr(resolution, "continuation_protocol", None)
+        if continuation_target is None and isinstance(protocol, str) and protocol:
+            provider = getattr(resolution, "execution_key", None)
+            model_name = getattr(resolution, "model", None)
+            base_url = getattr(resolution, "base_url", None)
+            if not all(
+                isinstance(value, str) and value
+                for value in (provider, model_name, base_url)
+            ):
+                raise ValueError("Provider continuation request is not pinned.")
+            continuation_target = ContinuationRestoreTarget(
+                provider=provider,
+                protocol=protocol,
+                model=model_name,
+                api_base_url=base_url,
+            )
+        if continuation_target is not None and continuation_owner_key is None:
+            continuation_owner_key = CONTINUATION_OWNER_KEY
         # Per-run tool registry + allow-list (Task 12, extended by P5-T6 for
         # MCP, by task-545/T6 for a per-run builtin_gate, and extended again
         # for local tools): rebuilt FRESH for this run whenever there is a
@@ -3235,7 +3256,7 @@ class ConsoleAgentBridge:
             ),
             expand_provider_continuation=expand_provider_continuation,
             prepare_provider_continuation_request=bool(
-                continuation_sidecar
+                continuation_target is not None
                 and callable(getattr(self._gateway, "prepare_chat_request", None))
             ),
             # PR3a-1 Task 1: every fleet child gets its own model-call

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -68,13 +68,19 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleMessageRole,
 )
 from tldw_chatbook.Chat.console_history_budget import ProviderContinuationSidecar
+from tldw_chatbook.Chat.console_prepared_request import (
+    CONTINUATION_OWNER_KEY,
+    build_console_request,
+)
 from tldw_chatbook.Chat.console_provider_gateway import (
     ConsoleProviderCallSignals,
     ConsoleProviderGateway,
     ConsoleProviderStreamSignals,
     ProviderToolCalls,
+    ProviderTurnMetadata,
 )
 from tldw_chatbook.Chat.provider_continuation import (
+    ContinuationOwnerGroup,
     ContinuationRestoreTarget,
     ProviderContinuationCheckpoint,
 )
@@ -1349,6 +1355,24 @@ def _openai_usage_from_provider_call(
     return usage
 
 
+class _StreamingProviderResponse(dict[str, Any]):
+    """OpenAI-shaped public response plus one private typed continuation."""
+
+    def __init__(
+        self,
+        value: Mapping[str, Any],
+        metadata: ProviderTurnMetadata | None,
+    ) -> None:
+        super().__init__(value)
+        self._provider_continuation = (
+            metadata.provider_continuation if metadata is not None else None
+        )
+
+    @property
+    def provider_continuation(self) -> ProviderContinuationCheckpoint | None:
+        return self._provider_continuation
+
+
 class _StreamingModelAdapter:
     """chat_call-compatible adapter that streams every PRIMARY turn live.
 
@@ -1540,12 +1564,14 @@ class _StreamingModelAdapter:
         api_endpoint=None,
         streaming=False,
         tools=None,
+        continuation_groups: tuple[ContinuationOwnerGroup, ...] = (),
         **_ignored,
     ) -> dict:
         is_subagent = self._is_subagent(messages_payload)
         gate = StreamGate()
         any_streamed = False
         native_calls: list[dict] = []
+        terminal_metadata: ProviderTurnMetadata | None = None
         call_signals: ConsoleProviderCallSignals | None = None
         gateway_signals: (
             ConsoleProviderStreamSignals | ConsoleProviderCallSignals | None
@@ -1558,7 +1584,7 @@ class _StreamingModelAdapter:
             gateway_signals = call_signals
 
         async def _consume() -> None:
-            nonlocal any_streamed
+            nonlocal any_streamed, terminal_metadata
             # Forwarding `tools=` only when it is non-None (rather than
             # always passing the keyword, even as None) keeps every
             # pre-Task-5 gateway fake elsewhere in the test suite — whose
@@ -1572,7 +1598,28 @@ class _StreamingModelAdapter:
             dispatch_messages = messages_payload
             stream_kwargs = {"tools": tools} if tools is not None else {}
             prepare_request = getattr(self._gateway, "prepare_chat_request", None)
-            if self._continuation_sidecar and callable(prepare_request):
+            if continuation_groups and callable(prepare_request):
+                if self._continuation_target is None or not self._continuation_owner_key:
+                    raise ValueError("Provider continuation request is not pinned.")
+                owner_ids = {group.owner_message_id for group in continuation_groups}
+                semantic_messages: list[dict[str, Any]] = []
+                for message in messages_payload:
+                    row = dict(message)
+                    owner_id = row.pop(self._continuation_owner_key, None)
+                    if type(owner_id) is str and owner_id in owner_ids:
+                        row[CONTINUATION_OWNER_KEY] = owner_id
+                    semantic_messages.append(row)
+                dispatch_messages = prepare_request(
+                    self._resolution,
+                    build_console_request(
+                        semantic_messages,
+                        tools=tools or (),
+                        continuation_groups=continuation_groups,
+                    ),
+                    continuation_target=self._continuation_target,
+                )
+                stream_kwargs.pop("tools", None)
+            elif self._continuation_sidecar and callable(prepare_request):
                 dispatch_messages = prepare_request(
                     self._resolution,
                     messages_payload,
@@ -1587,11 +1634,17 @@ class _StreamingModelAdapter:
             async for chunk in self._gateway.stream_chat(
                 self._resolution, dispatch_messages, **stream_kwargs
             ):
+                if terminal_metadata is not None:
+                    raise ValueError("Provider terminal metadata must be final.")
                 if isinstance(chunk, ProviderToolCalls):
                     # Plan-B contract: structured deltas never hit the
                     # transcript — captured here, surfaced only through the
                     # returned message dict's `tool_calls`.
                     native_calls.extend(chunk.tool_calls)
+                    if chunk.metadata is not None:
+                        if not isinstance(chunk.metadata, ProviderTurnMetadata):
+                            raise ValueError("Provider terminal metadata is malformed.")
+                        terminal_metadata = chunk.metadata
                     continue
                 visible = gate.feed(chunk)
                 if visible and not is_subagent:
@@ -1655,15 +1708,23 @@ class _StreamingModelAdapter:
         if native_calls:
             message["tool_calls"] = native_calls
         response: dict[str, Any] = {"choices": [{"message": message}]}
-        if call_signals is not None:
+        usage_payload = (
+            terminal_metadata.usage if terminal_metadata is not None else None
+        )
+        usage = _openai_usage_from_provider_call(
+            usage_payload,
+            provider=self._resolution.provider,
+            model=self._resolution.model or model or "",
+        )
+        if usage is None and call_signals is not None:
             usage = _openai_usage_from_provider_call(
                 call_signals.usage_snapshot(),
                 provider=self._resolution.provider,
                 model=self._resolution.model or model or "",
             )
-            if usage is not None:
-                response["usage"] = usage
-        return response
+        if usage is not None:
+            response["usage"] = usage
+        return _StreamingProviderResponse(response, terminal_metadata)
 
     @staticmethod
     def _is_subagent(messages_payload) -> bool:

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -5238,7 +5238,7 @@ class ConsoleChatStore:
 
         message_version: int | None
         if message.persisted_message_id is None:
-            if not isinstance(event, ToolBatchReady) or (
+            if not isinstance(event, (ToolBatchReady, FinalContinuation)) or (
                 event.expected_checkpoint_revision is not None
             ):
                 raise RuntimeError("Durable continuation owner is unavailable.")
@@ -5321,6 +5321,16 @@ class ConsoleChatStore:
             ):
                 raise RuntimeError("Continuation revision conflict.")
             return event.checkpoint, message.content
+        if isinstance(event, FinalContinuation):
+            if event.expected_checkpoint_revision is None:
+                if current is not None:
+                    raise RuntimeError("Continuation revision conflict.")
+            elif (
+                current is None
+                or current.checkpoint_revision != event.expected_checkpoint_revision
+            ):
+                raise RuntimeError("Continuation revision conflict.")
+            return event.checkpoint, event.assistant_content
         if current is None:
             raise RuntimeError("Durable continuation owner is unavailable.")
         if isinstance(event, ToolCallExecuting):
@@ -5340,13 +5350,6 @@ class ConsoleChatStore:
                 result=event.result,
             )
             return checkpoint, message.content
-        if isinstance(event, FinalContinuation):
-            if event.expected_checkpoint_revision is None:
-                if current is not None:
-                    raise RuntimeError("Continuation revision conflict.")
-            elif current.checkpoint_revision != event.expected_checkpoint_revision:
-                raise RuntimeError("Continuation revision conflict.")
-            return event.checkpoint, event.assistant_content
         raise RuntimeError("Unsupported continuation event.")
 
     def _enqueue_sync_v2_message_if_ready(

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -2821,6 +2821,8 @@ def _content_from_provider_mapping(item: Mapping[str, Any]) -> str | object:
             text = first.get("text")
             if isinstance(text, str):
                 return text
+    elif choices == [] and isinstance(item.get("usage"), Mapping):
+        return _EMPTY_RESPONSE
 
     candidates = item.get("candidates")
     if isinstance(candidates, list) and candidates:

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -10,6 +10,7 @@ import threading
 import weakref
 from collections.abc import Iterator, Mapping
 from contextvars import copy_context
+from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from types import GeneratorType, MappingProxyType
 from typing import Any, AsyncIterator, Callable, Literal, cast
@@ -53,6 +54,7 @@ from tldw_chatbook.Chat.console_history_budget import (
 from tldw_chatbook.Chat.provider_continuation import (
     ContinuationConflictError,
     ContinuationRestoreTarget,
+    ProviderContinuationCheckpoint,
     validate_continuation_restore,
 )
 from tldw_chatbook.Chat.console_provider_support import (
@@ -65,6 +67,7 @@ from tldw_chatbook.LLM_Calls.qwencloud import (
     normalize_qwencloud_api_mode,
     normalize_qwencloud_base_url,
 )
+from tldw_chatbook.LLM_Calls.hosted_chat import HostedChatTurn
 from tldw_chatbook.config import ProviderSettingsError, provider_settings_for_key
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.sensitive_llm_logging import (
@@ -475,6 +478,9 @@ class ConsoleProviderResolution:
     prompt_caching: bool | None = None
     api_mode: str | None = None
     continuation_protocol: str | None = None
+    request_timeout: float | None = None
+    request_retries: int | None = None
+    request_retry_delay: float | None = None
 
 
 def _freeze_auxiliary_value(value: Any) -> Any:
@@ -606,8 +612,23 @@ class _QueueItem:
         return cls("done")
 
     @classmethod
-    def native_tool_calls(cls, calls: tuple) -> "_QueueItem":
-        return cls("tool_calls", payload=calls)
+    def native_tool_calls(
+        cls,
+        calls: tuple[dict, ...],
+        metadata: ProviderTurnMetadata | None = None,
+    ) -> "_QueueItem":
+        return cls("tool_calls", payload=ProviderToolCalls(calls, metadata=metadata))
+
+
+@dataclass(frozen=True)
+class ProviderTurnMetadata:
+    """Typed terminal state for one completed provider call."""
+
+    finish_reason: str
+    provider_continuation: ProviderContinuationCheckpoint | None = field(
+        default=None, repr=False
+    )
+    usage: Mapping[str, Any] | None = field(default=None, repr=False)
 
 
 @dataclass(frozen=True)
@@ -618,6 +639,29 @@ class ProviderToolCalls:
     streaming fragments already merged."""
 
     tool_calls: tuple[dict, ...]
+    metadata: ProviderTurnMetadata | None = field(default=None, repr=False)
+
+
+def _provider_turn_metadata(response: Any) -> ProviderTurnMetadata | None:
+    """Read one provider-local terminal turn after clean exhaustion."""
+
+    try:
+        turn = response.terminal_turn
+    except AttributeError:
+        return None
+    if not isinstance(turn, HostedChatTurn):
+        raise ChatProviderError("Provider terminal metadata is malformed.")
+    candidate = getattr(response, "provider_continuation", None)
+    if candidate is not None and not isinstance(
+        candidate, ProviderContinuationCheckpoint
+    ):
+        raise ChatProviderError("Provider continuation metadata is malformed.")
+    usage = deepcopy(turn.usage) if isinstance(turn.usage, Mapping) else None
+    return ProviderTurnMetadata(
+        finish_reason=turn.finish_reason,
+        provider_continuation=candidate,
+        usage=usage,
+    )
 
 
 _PRESERVED_FRAGMENT_EXTRAS = frozenset(
@@ -1666,6 +1710,31 @@ class ConsoleProviderGateway:
             if identity.execution_key == "deepseek"
             else None
         )
+        request_timeout: float | None = None
+        request_retries: int | None = None
+        request_retry_delay: float | None = None
+        if identity.execution_key in {"moonshot", "zai"}:
+            try:
+                (
+                    request_timeout,
+                    request_retries,
+                    request_retry_delay,
+                ) = _hosted_transport_policy(
+                    provider_settings,
+                    provider=identity.execution_key,
+                )
+            except ChatConfigurationError:
+                return self._blocked_resolution(
+                    selection,
+                    provider=selection.provider,
+                    model=model,
+                    visible_copy=(
+                        f"{selection.provider} blocked: invalid timeout or retry "
+                        "settings. Correct the provider transport policy in Settings."
+                    ),
+                    readiness_key=identity.readiness_key,
+                    execution_key=identity.execution_key,
+                )
 
         return ConsoleProviderResolution(
             provider=selection.provider,
@@ -1679,6 +1748,9 @@ class ConsoleProviderGateway:
             prompt_caching=prompt_caching,
             api_mode=api_mode,
             continuation_protocol=continuation_protocol,
+            request_timeout=request_timeout,
+            request_retries=request_retries,
+            request_retry_delay=request_retry_delay,
             temperature=selection.temperature,
             top_p=selection.top_p,
             min_p=selection.min_p,
@@ -2192,6 +2264,7 @@ class ConsoleProviderGateway:
             try:
                 kwargs = self._chat_api_kwargs_from_prepared(resolution, request)
                 response = self._chat_api_call(**kwargs)
+                provider_response = response
                 accumulator = _ToolCallAccumulator() if request.tools else None
                 if accumulator is not None:
                     response = _tee_tool_calls(response, accumulator)
@@ -2215,10 +2288,13 @@ class ConsoleProviderGateway:
                     if text:
                         emitted_content = True
                     enqueue(_QueueItem.content(text))
+                if stop_event.is_set():
+                    return
                 if accumulator is not None:
                     calls = accumulator.calls()
-                    if calls:
-                        enqueue(_QueueItem.native_tool_calls(calls))
+                    metadata = _provider_turn_metadata(provider_response)
+                    if calls or metadata is not None:
+                        enqueue(_QueueItem.native_tool_calls(calls, metadata))
                     elif not emitted_content:
                         # PR #648 review Minor 1: the turn produced NEITHER
                         # visible content NOR tool-calls. On the fence path
@@ -2278,7 +2354,7 @@ class ConsoleProviderGateway:
                         else 502,
                     )
                 if item.kind == "tool_calls":
-                    yield ProviderToolCalls(tuple(item.payload))
+                    yield cast(ProviderToolCalls, item.payload)
                     continue
                 if item.text:
                     yield item.text
@@ -2398,6 +2474,15 @@ class ConsoleProviderGateway:
         if resolution.execution_key == "qwencloud":
             kwargs["api_mode"] = resolution.api_mode
             kwargs["api_base_url"] = resolution.base_url or None
+        elif resolution.execution_key in {"moonshot", "zai"}:
+            kwargs["api_base_url"] = resolution.base_url or None
+            kwargs["request_timeout"] = resolution.request_timeout
+            kwargs["request_retries"] = resolution.request_retries
+            kwargs["request_retry_delay"] = resolution.request_retry_delay
+            if request.continuation_groups:
+                kwargs["provider_continuations"] = [
+                    group.checkpoint for group in request.continuation_groups
+                ]
         elif resolution.execution_key == "anthropic":
             kwargs["api_base_url"] = resolution.base_url or None
         elif (
@@ -2774,6 +2859,31 @@ def _provider_settings(
 ) -> Mapping[str, object]:
     api_settings = _mapping_value(app_config, "api_settings")
     return provider_settings_for_key(api_settings, provider_key)
+
+
+def _hosted_transport_policy(
+    settings: Mapping[str, object],
+    *,
+    provider: str,
+) -> tuple[float, int, float]:
+    delay_default = 1.0 if provider == "moonshot" else 5.0
+    timeout = settings.get("timeout", 90.0)
+    retries = settings.get("retries", 3)
+    retry_delay = settings.get("retry_delay", delay_default)
+    if (
+        isinstance(timeout, bool)
+        or not isinstance(timeout, (int, float))
+        or not math.isfinite(float(timeout))
+        or timeout <= 0
+        or type(retries) is not int
+        or retries < 0
+        or isinstance(retry_delay, bool)
+        or not isinstance(retry_delay, (int, float))
+        or not math.isfinite(float(retry_delay))
+        or retry_delay < 0
+    ):
+        raise ChatConfigurationError("Hosted provider transport policy is invalid.")
+    return float(timeout), retries, float(retry_delay)
 
 
 def _first_string(*values: object) -> str | None:

--- a/tldw_chatbook/Chat/provider_readiness.py
+++ b/tldw_chatbook/Chat/provider_readiness.py
@@ -6,6 +6,8 @@ import os
 from dataclasses import dataclass
 from typing import Mapping, Optional
 
+from .Chat_Deps import ChatConfigurationError
+
 # "Valid provider API key" has exactly ONE definition in this codebase --
 # PR-T2 Task 7 -- shared with `config.py`'s `_normalize_legacy_provider_
 # api_key` (the credential bridge that keeps this module's readiness check
@@ -97,6 +99,7 @@ _DEFAULT_API_KEY_ENV_VAR_ALIASES = {
     "mistralai": "MISTRAL_API_KEY",
     "qwencloud": "DASHSCOPE_API_KEY",
 }
+_STRICT_HOSTED_PROVIDER_KEYS = frozenset({"moonshot", "zai"})
 
 
 @dataclass(frozen=True)
@@ -162,6 +165,49 @@ def default_api_key_env_var(provider_key: str) -> Optional[str]:
     )
 
 
+def _resolved_hosted_api_key(
+    provider_key: str,
+    app_config: Mapping[str, object],
+    environ: Mapping[str, str],
+) -> str | None:
+    """Validate hosted readiness through the provider's send resolver."""
+    if provider_key == "moonshot":
+        from tldw_chatbook.LLM_Calls.moonshot import resolve_moonshot_request
+
+        return resolve_moonshot_request(
+            app_config=app_config,
+            environ=environ,
+        ).api_key
+    if provider_key == "zai":
+        from tldw_chatbook.LLM_Calls.zai import resolve_zai_request
+
+        return resolve_zai_request(
+            app_config=app_config,
+            environ=environ,
+        ).api_key
+    return None
+
+
+def _invalid_settings_readiness(
+    provider_name: str,
+    provider_key: str,
+) -> ProviderReadiness:
+    return ProviderReadiness(
+        provider=provider_name,
+        provider_key=provider_key,
+        requires_api_key=_requires_api_key(provider_key),
+        ready=False,
+        api_key=None,
+        api_key_source=None,
+        env_var=None,
+        reason="Invalid provider settings",
+        recovery=(
+            f"Replace api_settings.{provider_key} with one valid configuration "
+            "table in Advanced Config or config.toml."
+        ),
+    )
+
+
 def get_provider_readiness(
     provider: Optional[str],
     app_config: Mapping[str, object],
@@ -200,36 +246,10 @@ def get_provider_readiness(
     try:
         provider_settings = provider_settings_for_key(api_settings, provider_key)
     except ProviderSettingsError:
-        return ProviderReadiness(
-            provider=provider_name,
-            provider_key=provider_key,
-            requires_api_key=_requires_api_key(provider_key),
-            ready=False,
-            api_key=None,
-            api_key_source=None,
-            env_var=None,
-            reason="Invalid provider settings",
-            recovery=(
-                "Replace api_settings.qwencloud with a configuration table "
-                "in Advanced Config or config.toml."
-            ),
-        )
+        return _invalid_settings_readiness(provider_name, provider_key)
 
     requires_api_key = _requires_api_key(provider_key)
     configured_key = _valid_api_key(provider_settings.get("api_key"))
-    if configured_key:
-        return ProviderReadiness(
-            provider=provider_name,
-            provider_key=provider_key,
-            requires_api_key=requires_api_key,
-            ready=True,
-            api_key=configured_key,
-            api_key_source=f"config:api_settings.{provider_key}.api_key",
-            env_var=None,
-            reason="Ready",
-            recovery=None,
-        )
-
     env_var_value = provider_settings.get("api_key_env_var")
     env_var = (
         env_var_value.strip()
@@ -237,15 +257,26 @@ def get_provider_readiness(
         else default_api_key_env_var(provider_key)
     )
     env_key = _valid_api_key(env.get(env_var, "")) if env_var else None
-    if env_key:
+    resolved_key = configured_key or env_key
+    if resolved_key and provider_key in _STRICT_HOSTED_PROVIDER_KEYS:
+        try:
+            resolved_key = _resolved_hosted_api_key(provider_key, app_config, env)
+        except ChatConfigurationError:
+            return _invalid_settings_readiness(provider_name, provider_key)
+    if resolved_key:
+        from_config = configured_key is not None
         return ProviderReadiness(
             provider=provider_name,
             provider_key=provider_key,
             requires_api_key=requires_api_key,
             ready=True,
-            api_key=env_key,
-            api_key_source=f"env:{env_var}",
-            env_var=env_var,
+            api_key=resolved_key,
+            api_key_source=(
+                f"config:api_settings.{provider_key}.api_key"
+                if from_config
+                else f"env:{env_var}"
+            ),
+            env_var=None if from_config else env_var,
             reason="Ready",
             recovery=None,
         )

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -57,6 +57,7 @@ from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
 from tldw_chatbook.LLM_Calls.moonshot import (
     chat_with_moonshot as _strict_chat_with_moonshot,
 )
+from tldw_chatbook.LLM_Calls.zai import chat_with_zai as _strict_chat_with_zai
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.sensitive_llm_logging import (
     is_sensitive_llm_request,
@@ -5260,328 +5261,68 @@ def chat_with_moonshot(
 
 
 def chat_with_zai(
-    input_data: List[Dict[str, Any]],  # Mapped from 'messages_payload'
-    model: Optional[str] = None,  # Mapped from 'model'
-    api_key: Optional[str] = None,  # Mapped from 'api_key'
-    system_message: Optional[str] = None,  # Mapped from 'system_message'
-    temp: Optional[float] = None,  # Mapped from 'temp' (temperature)
-    maxp: Optional[float] = None,  # Mapped from 'maxp' (top_p)
-    streaming: Optional[bool] = False,  # Mapped from 'streaming'
-    # Z.AI specific parameters
+    input_data: List[Dict[str, Any]],
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    system_message: Optional[str] = None,
+    temp: Optional[float] = None,
+    maxp: Optional[float] = None,
+    streaming: Optional[bool] = False,
     max_tokens: Optional[int] = None,
     tools: Optional[List[Dict[str, Any]]] = None,
     do_sample: Optional[bool] = None,
     request_id: Optional[str] = None,
-    custom_prompt_arg: Optional[str] = None,  # Legacy
+    custom_prompt_arg: Optional[str] = None,
     api_base_url: Optional[str] = None,
+    tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+    stop: Optional[Union[str, List[str]]] = None,
+    response_format: Optional[Dict[str, Any]] = None,
+    user: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
 ):
-    """
-    Sends a chat completion request to the Z.AI API.
-
-    Z.AI provides GLM model access through an OpenAI-compatible API endpoint, supporting models:
-    - glm-4.5: Standard GLM-4.5 model
-    - glm-4.5-air: GLM-4.5 optimized for speed
-    - glm-4.5-x: GLM-4.5 extended capabilities
-    - glm-4.5-airx: GLM-4.5 air with extended features
-    - glm-4.5-flash: Fast inference GLM-4.5 model
-    - glm-4-32b-0414-128k: GLM-4 32B with 128K context
-
-    Args:
-        input_data: List of message objects (OpenAI format).
-        model: ID of the model to use (e.g., glm-4.5-flash).
-        api_key: Z.AI API key.
-        system_message: Optional system message to prepend.
-        temp: Sampling temperature (0-1).
-        maxp: Top-p (nucleus) sampling parameter.
-        streaming: Whether to stream the response.
-        max_tokens: Maximum number of tokens to generate.
-        tools: A list of tools the model may call.
-        do_sample: Whether to use sampling (temperature/top_p).
-        request_id: Optional request ID for tracking.
-        custom_prompt_arg: Legacy, largely ignored.
-    """
-    cli_api_settings = get_runtime_config_snapshot().values.get("api_settings", {})
-    zai_config = cli_api_settings.get("zai", {})
-
-    final_api_key = api_key or zai_config.get("api_key")
-    if not final_api_key:
-        logger.error("Z.AI: API key is missing.")
-        raise ChatConfigurationError(
-            provider="zai", message="Z.AI API Key is required but not found."
-        )
-
-    logger.debug("Z.AI: API key provided.")
-
-    # Resolve parameters
-    current_model = model or zai_config.get("model", "glm-4.5-flash")
-    current_temp = (
-        temp if temp is not None else float(zai_config.get("temperature", 0.7))
-    )
-    current_top_p = maxp if maxp is not None else float(zai_config.get("top_p", 0.95))
-    current_streaming_cfg = zai_config.get("streaming", False)
-    current_streaming = (
-        streaming
-        if streaming is not None
-        else (
-            str(current_streaming_cfg).lower() == "true"
-            if isinstance(current_streaming_cfg, str)
-            else bool(current_streaming_cfg)
-        )
-    )
-    current_max_tokens = (
-        max_tokens
-        if max_tokens is not None
-        else _safe_cast(zai_config.get("max_tokens"), int, 4096)
-    )
-
-    # Log request metrics
-    log_counter(
-        "zai_api_request",
-        labels={"model": current_model, "streaming": str(current_streaming)},
-    )
-
-    # Build messages array
-    api_messages = []
-    if system_message:
-        api_messages.append({"role": "system", "content": system_message})
-    api_messages.extend(input_data)
-
-    # Build request payload
-    payload = {
-        "model": current_model,
-        "messages": api_messages,
-        "stream": current_streaming,
-    }
-
-    # Add optional parameters
-    if current_temp is not None:
-        payload["temperature"] = current_temp
-    if current_top_p is not None:
-        payload["top_p"] = current_top_p
-    if current_max_tokens is not None:
-        payload["max_tokens"] = current_max_tokens
-    if do_sample is not None:
-        payload["do_sample"] = do_sample
-    if tools is not None:
-        payload["tools"] = tools
-    if request_id is not None:
-        payload["request_id"] = request_id
-
-    headers = {
-        "Authorization": f"Bearer {final_api_key}",
-        "Content-Type": "application/json",
-    }
-
-    effective_api_base_url = (
-        api_base_url
-        or zai_config.get("api_base_url")
-        or builtin_provider_endpoint("zai", zai_config)
-    )
-    api_url = effective_api_base_url.rstrip("/") + "/chat/completions"
-
-    if not is_sensitive_llm_request():
-        # task-2116: see the OpenAI branch above for why this is gated.
-        # task-2117 Qodo round: allowlisted summary, see the Anthropic
-        # branch above for why a denylist isn't safe here.
-        logger.debug(
-            "Z.AI Request Payload (safe fields only): "
-            f"{safe_llm_request_payload_summary(payload)}"
-        )
-
-    start_time = time.time()
-
+    """Compatibility wrapper for the strict first-class Z.ai adapter."""
+    started_at = time.time()
+    labels = {"model": model or "configured", "streaming": str(bool(streaming))}
+    log_counter("zai_api_request", labels=labels)
     try:
-        if current_streaming:
-            logger.debug("Z.AI: Posting request (streaming)")
-            with requests.Session() as session:
-                response = session.post(
-                    api_url, headers=headers, json=payload, stream=True, timeout=180
-                )
-                response.raise_for_status()
-
-                # Log streaming success metrics
-                duration = time.time() - start_time
-                log_histogram(
-                    "zai_api_response_time",
-                    duration,
-                    labels={
-                        "model": current_model,
-                        "streaming": "true",
-                        "status_code": str(response.status_code),
-                    },
-                )
-                log_counter(
-                    "zai_api_success",
-                    labels={"model": current_model, "streaming": "true"},
-                )
-
-                def stream_generator():
-                    try:
-                        for line in response.iter_lines(decode_unicode=True):
-                            if line and line.strip():
-                                # Z.AI provides OpenAI-compatible SSE
-                                yield line if line.endswith("\n") else line + "\n"
-                    except requests.exceptions.ChunkedEncodingError as e:
-                        logger.opt(exception=True).error(
-                            f"Z.AI: ChunkedEncodingError: {e}"
-                        )
-                        yield f"data: {json.dumps({'error': {'message': f'Stream error: {str(e)}', 'type': 'zai_stream_error'}})}\n\n"
-                    except Exception as e:
-                        logger.opt(exception=True).error(
-                            f"Z.AI: Stream iteration error: {e}"
-                        )
-                        yield f"data: {json.dumps({'error': {'message': f'Stream iteration error: {str(e)}', 'type': 'zai_stream_error'}})}\n\n"
-                    finally:
-                        yield "data: [DONE]\n\n"
-                        if response:
-                            response.close()
-
-                return stream_generator()
-
-        else:  # Non-streaming
-            logger.debug("Z.AI: Posting request (non-streaming)")
-            retry_count = int(zai_config.get("api_retries", 3))
-            retry_delay = float(zai_config.get("api_retry_delay", 1.0))
-
-            retry_strategy = Retry(
-                total=llm_retry_count(retry_count),
-                backoff_factor=retry_delay,
-                status_forcelist=[429, 500, 502, 503, 504],
-                allowed_methods=["POST"],
-            )
-            adapter = HTTPAdapter(max_retries=retry_strategy)
-            with requests.Session() as session:
-                session.mount("https://", adapter)
-                response = session.post(
-                    api_url,
-                    headers=headers,
-                    json=payload,
-                    timeout=float(zai_config.get("api_timeout", 90.0)),
-                )
-
-            response.raise_for_status()
-            result = response.json()
-
-            # Log non-streaming success metrics
-            duration = time.time() - start_time
-            log_histogram(
-                "zai_api_response_time",
-                duration,
-                labels={
-                    "model": current_model,
-                    "streaming": "false",
-                    "status_code": str(response.status_code),
-                },
-            )
-            log_counter(
-                "zai_api_success", labels={"model": current_model, "streaming": "false"}
-            )
-
-            # Log token usage if available
-            usage = result.get("usage", {})
-            if usage:
-                log_histogram(
-                    "zai_api_prompt_tokens",
-                    usage.get("prompt_tokens", 0),
-                    labels={"model": current_model},
-                )
-                log_histogram(
-                    "zai_api_completion_tokens",
-                    usage.get("completion_tokens", 0),
-                    labels={"model": current_model},
-                )
-                log_histogram(
-                    "zai_api_total_tokens",
-                    usage.get("total_tokens", 0),
-                    labels={"model": current_model},
-                )
-
-            logger.debug("Z.AI: Non-streaming request successful.")
-            return result
-
-    except requests.exceptions.HTTPError as e:
-        status_code = e.response.status_code if e.response is not None else 500
-        raw_error_text = (
-            e.response.text if e.response is not None else safe_llm_exception_message(e)
+        result = _strict_chat_with_zai(
+            input_data=input_data,
+            model=model,
+            api_key=api_key,
+            system_message=system_message,
+            temp=temp,
+            maxp=maxp,
+            streaming=streaming,
+            max_tokens=max_tokens,
+            tools=tools,
+            do_sample=do_sample,
+            request_id=request_id,
+            custom_prompt_arg=custom_prompt_arg,
+            api_base_url=api_base_url,
+            tool_choice=tool_choice,
+            stop=stop,
+            response_format=response_format,
+            user=user,
+            reasoning_effort=reasoning_effort,
         )
-        error_text = str(safe_llm_error_detail(raw_error_text))
-
-        # Log HTTP error metrics
-        duration = time.time() - start_time
+    except Exception as exc:
         log_counter(
             "zai_api_error",
-            labels={
-                "model": current_model,
-                "error_type": "http_error",
-                "status_code": str(status_code),
-            },
+            labels={**labels, "error_type": type(exc).__name__},
         )
         log_histogram(
             "zai_api_error_response_time",
-            duration,
-            labels={"model": current_model, "status_code": str(status_code)},
+            time.time() - started_at,
+            labels=labels,
         )
-
-        logger.error(
-            f"Z.AI request failed; status={status_code}; detail={error_text[:500]}"
-        )
-
-        if status_code == 401:
-            raise ChatAuthenticationError(
-                provider="zai", message=f"Auth failed. Detail: {error_text[:200]}"
-            )
-        elif status_code == 429:
-            raise ChatRateLimitError(
-                provider="zai", message=f"Rate limit. Detail: {error_text[:200]}"
-            )
-        elif 400 <= status_code < 500:
-            raise ChatBadRequestError(
-                provider="zai",
-                message=f"Bad request ({status_code}). Detail: {error_text[:200]}",
-            )
-        else:
-            raise ChatProviderError(
-                provider="zai",
-                message=f"API error ({status_code}). Detail: {error_text[:200]}",
-                status_code=status_code,
-            )
-
-    except requests.exceptions.RequestException as e:
-        # Log network error metrics
-        duration = time.time() - start_time
-        log_counter(
-            "zai_api_error",
-            labels={"model": current_model, "error_type": "network_error"},
-        )
-        log_histogram(
-            "zai_api_error_response_time",
-            duration,
-            labels={"model": current_model, "error_type": "network"},
-        )
-        error_detail = safe_llm_exception_message(e)
-        if is_sensitive_llm_request():
-            logger.error(f"Z.AI RequestException: {error_detail}")
-        else:
-            logger.opt(exception=True).error(f"Z.AI RequestException: {error_detail}")
-        raise ChatProviderError(
-            provider="zai", message=f"Network error: {error_detail}"
-        )
-
-    except Exception as e:
-        # Log unexpected error metrics
-        duration = time.time() - start_time
-        log_counter(
-            "zai_api_error", labels={"model": current_model, "error_type": "unexpected"}
-        )
-        error_detail = safe_llm_exception_message(e)
-        error_copy = f"Z.AI: Unexpected error: {error_detail}"
-        if is_sensitive_llm_request():
-            logger.error(error_copy)
-        else:
-            logger.opt(exception=True).error(error_copy)
-        raise ChatProviderError(
-            provider="zai", message=f"Unexpected error: {error_detail}"
-        )
+        raise
+    log_counter("zai_api_success", labels=labels)
+    log_histogram(
+        "zai_api_response_time",
+        time.time() - started_at,
+        labels=labels,
+    )
+    return result
 
 
 #

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -54,6 +54,9 @@ from tldw_chatbook.config import (
     resolve_provider_api_key,
 )
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
+from tldw_chatbook.LLM_Calls.moonshot import (
+    chat_with_moonshot as _strict_chat_with_moonshot,
+)
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.sensitive_llm_logging import (
     is_sensitive_llm_request,
@@ -5188,443 +5191,72 @@ def chat_with_openrouter(
 
 
 def chat_with_moonshot(
-    input_data: List[Dict[str, Any]],  # Mapped from 'messages_payload'
-    model: Optional[str] = None,  # Mapped from 'model'
-    api_key: Optional[str] = None,  # Mapped from 'api_key'
-    system_message: Optional[str] = None,  # Mapped from 'system_message'
-    temp: Optional[float] = None,  # Mapped from 'temp' (temperature)
-    maxp: Optional[float] = None,  # Mapped from 'maxp' (top_p)
-    streaming: Optional[bool] = False,  # Mapped from 'streaming'
-    # Moonshot/OpenAI compatible parameters
+    input_data: List[Dict[str, Any]],
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    system_message: Optional[str] = None,
+    temp: Optional[float] = None,
+    maxp: Optional[float] = None,
+    streaming: Optional[bool] = False,
     frequency_penalty: Optional[float] = None,
     max_tokens: Optional[int] = None,
-    n: Optional[int] = None,  # Number of completions
+    n: Optional[int] = None,
     presence_penalty: Optional[float] = None,
-    response_format: Optional[Dict[str, str]] = None,  # e.g., {"type": "json_object"}
+    response_format: Optional[Dict[str, str]] = None,
     seed: Optional[int] = None,
     stop: Optional[Union[str, List[str]]] = None,
     tools: Optional[List[Dict[str, Any]]] = None,
     tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
-    user: Optional[str] = None,  # User identifier
-    custom_prompt_arg: Optional[str] = None,  # Legacy
+    user: Optional[str] = None,
+    custom_prompt_arg: Optional[str] = None,
     api_base_url: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
 ):
-    """
-    Sends a chat completion request to the Moonshot AI API.
-
-    Moonshot AI provides an OpenAI-compatible API endpoint, supporting models:
-    - kimi-latest: Latest Kimi model
-    - kimi-thinking-preview: Kimi model with thinking capabilities
-    - kimi-k2-0711-preview: Kimi K2 preview model
-    - moonshot-v1-auto: Automatic model selection
-    - moonshot-v1-8k: 8K context window
-    - moonshot-v1-32k: 32K context window
-    - moonshot-v1-128k: 128K context window
-    - moonshot-v1-8k-vision-preview: 8K context with vision support
-    - moonshot-v1-32k-vision-preview: 32K context with vision support
-    - moonshot-v1-128k-vision-preview: 128K context with vision support
-
-    Args:
-        input_data: List of message objects (OpenAI format).
-        model: ID of the model to use (moonshot-v1-8k, moonshot-v1-32k, moonshot-v1-128k).
-        api_key: Moonshot API key.
-        system_message: Optional system message to prepend.
-        temp: Sampling temperature (0-1).
-        maxp: Top-p (nucleus) sampling parameter.
-        streaming: Whether to stream the response.
-        frequency_penalty: Penalizes new tokens based on their existing frequency.
-        max_tokens: Maximum number of tokens to generate.
-        n: How many chat completion choices to generate (Note: n>1 only works with temp>0.3).
-        presence_penalty: Penalizes new tokens based on whether they appear in the text so far.
-        response_format: An object specifying the format that the model must output.
-        seed: If specified, the system will make a best effort to sample deterministically.
-        stop: Up to 4 sequences where the API will stop generating further tokens.
-        tools: A list of tools the model may call.
-        tool_choice: Controls which (if any) function is called by the model (Note: "required" not supported).
-        user: A unique identifier representing your end-user.
-        custom_prompt_arg: Legacy, largely ignored.
-    """
-    loaded_config_data = load_settings()
-    moonshot_config = loaded_config_data.get("moonshot_api", {})
-
-    final_api_key = api_key or moonshot_config.get("api_key")
-    if not final_api_key:
-        logger.error("Moonshot: API key is missing.")
-        raise ChatConfigurationError(
-            provider="moonshot", message="Moonshot API Key is required but not found."
-        )
-
-    logger.debug("Moonshot: API key provided.")
-
-    # Resolve parameters: User-provided > Function arg default > Config default > Hardcoded default
-    final_model = (
-        model if model is not None else moonshot_config.get("model", "moonshot-v1-8k")
-    )
-    final_temp = (
-        temp if temp is not None else float(moonshot_config.get("temperature", 0.7))
-    )
-    final_top_p = (
-        maxp if maxp is not None else float(moonshot_config.get("top_p", 0.95))
-    )
-
-    # Validate temperature for n>1 as per Moonshot documentation
-    final_n = n if n is not None else 1
-    if final_n > 1 and final_temp < 0.3:
-        logger.warning(
-            f"Moonshot: n={final_n} requested but temperature={final_temp} < 0.3. Setting n=1."
-        )
-        final_n = 1
-
-    final_streaming_cfg = moonshot_config.get("streaming", False)
-    final_streaming = (
-        streaming
-        if streaming is not None
-        else (
-            str(final_streaming_cfg).lower() == "true"
-            if isinstance(final_streaming_cfg, str)
-            else bool(final_streaming_cfg)
-        )
-    )
-
-    final_max_tokens = (
-        max_tokens
-        if max_tokens is not None
-        else _safe_cast(moonshot_config.get("max_tokens"), int)
-    )
-
-    if custom_prompt_arg:
-        logger.warning(
-            "Moonshot: 'custom_prompt_arg' was provided but is generally ignored if 'input_data' and 'system_message' are used correctly."
-        )
-
-    # Construct messages for Moonshot API (OpenAI format)
-    api_messages = []
-    has_system_message_in_input = any(msg.get("role") == "system" for msg in input_data)
-    if system_message and not has_system_message_in_input:
-        api_messages.append({"role": "system", "content": system_message})
-
-    # Process messages to ensure proper format
-    is_vision_model = "vision" in final_model.lower()
-
-    for msg in input_data:
-        role = msg.get("role")
-        content = msg.get("content")
-
-        # Handle different content formats
-        if isinstance(content, list):
-            if is_vision_model:
-                # For vision models, convert to Moonshot's expected format
-                moonshot_content = []
-                for part in content:
-                    if isinstance(part, dict):
-                        if part.get("type") == "text":
-                            moonshot_content.append(
-                                {"type": "text", "text": part.get("text", "")}
-                            )
-                        elif part.get("type") == "image_url":
-                            image_url_obj = part.get("image_url", {})
-                            url_str = image_url_obj.get("url", "")
-                            # Parse data URL for vision models
-                            parsed_image = _parse_data_url_for_multimodal(url_str)
-                            if parsed_image:
-                                mime_type, b64_data = parsed_image
-                                moonshot_content.append(
-                                    {
-                                        "type": "image_url",
-                                        "image_url": {
-                                            "url": url_str  # Keep original data URL
-                                        },
-                                    }
-                                )
-                            else:
-                                # Regular URL
-                                moonshot_content.append(
-                                    {"type": "image_url", "image_url": {"url": url_str}}
-                                )
-                    elif isinstance(part, str):
-                        moonshot_content.append({"type": "text", "text": part})
-
-                # For vision models, keep structured content
-                api_messages.append({"role": role, "content": moonshot_content})
-            else:
-                # For non-vision models, extract only text
-                text_parts = []
-                has_images = False
-                for part in content:
-                    if isinstance(part, dict) and part.get("type") == "text":
-                        text_parts.append(part.get("text", ""))
-                    elif isinstance(part, dict) and part.get("type") == "image_url":
-                        has_images = True
-                    elif isinstance(part, str):
-                        text_parts.append(part)
-
-                if has_images:
-                    logger.warning(
-                        f"Moonshot: Non-vision model {final_model} cannot process images. Extracting text only."
-                    )
-
-                content_str = " ".join(text_parts).strip()
-                api_messages.append({"role": role, "content": content_str})
-        else:
-            # Simple string content
-            if content is None:
-                content = ""
-            elif not isinstance(content, str):
-                content = str(content)
-
-            api_messages.append({"role": role, "content": content})
-
-    payload = {
-        "model": final_model,
-        "messages": api_messages,
-        "stream": final_streaming,
-    }
-
-    # Add optional parameters if they have a value
-    if final_temp is not None:
-        payload["temperature"] = final_temp
-    if final_top_p is not None:
-        payload["top_p"] = final_top_p
-    if final_max_tokens is not None:
-        payload["max_tokens"] = final_max_tokens
-    if frequency_penalty is not None:
-        payload["frequency_penalty"] = frequency_penalty
-    if final_n is not None and final_n > 1:
-        payload["n"] = final_n
-    if presence_penalty is not None:
-        payload["presence_penalty"] = presence_penalty
-    if response_format is not None:
-        payload["response_format"] = response_format
-    if seed is not None:
-        payload["seed"] = seed
-    if stop is not None:
-        payload["stop"] = stop
-    if tools is not None:
-        payload["tools"] = tools
-
-    # Handle tool_choice - Moonshot doesn't support "required"
-    if payload.get("tools") and tool_choice is not None:
-        if tool_choice == "required":
-            logger.warning(
-                "Moonshot: tool_choice='required' is not supported. Using 'auto' instead."
-            )
-            payload["tool_choice"] = "auto"
-        else:
-            payload["tool_choice"] = tool_choice
-    elif tool_choice == "none":  # Allow "none" even if no tools are present
-        payload["tool_choice"] = "none"
-
-    if user is not None:
-        payload["user"] = user
-
-    headers = {
-        "Authorization": f"Bearer {final_api_key}",
-        "Content-Type": "application/json",
-    }
-    if not is_sensitive_llm_request():
-        # task-2116: see the OpenAI branch above for why this is gated.
-        # task-2117 Qodo round: allowlisted summary, see the Anthropic
-        # branch above for why a denylist isn't safe here.
-        logger.debug(
-            "Moonshot Request Payload (safe fields only): "
-            f"{safe_llm_request_payload_summary(payload)}"
-        )
-
-    # Determine API endpoint based on config (default to international)
-    if api_base_url:
-        effective_api_base_url = api_base_url
-    else:
-        effective_api_base_url = moonshot_config.get(
-            "api_base_url"
-        ) or builtin_provider_endpoint("moonshot", moonshot_config)
-
-    api_url = effective_api_base_url.rstrip("/") + "/chat/completions"
-
-    start_time = time.time()
-    log_counter(
-        "moonshot_api_request",
-        labels={"model": final_model, "streaming": str(final_streaming)},
-    )
-
+    """Compatibility wrapper for the strict first-class Moonshot adapter."""
+    started_at = time.time()
+    labels = {"model": model or "configured", "streaming": str(bool(streaming))}
+    log_counter("moonshot_api_request", labels=labels)
     try:
-        if final_streaming:
-            logger.debug("Moonshot: Posting request (streaming)")
-            with requests.Session() as session:
-                response = session.post(
-                    api_url, headers=headers, json=payload, stream=True, timeout=180
-                )
-                response.raise_for_status()
-
-                def stream_generator():
-                    try:
-                        for line in response.iter_lines(decode_unicode=True):
-                            if line and line.strip():
-                                # Pass through Moonshot's SSE lines directly (OpenAI compatible)
-                                yield line if line.endswith("\n") else line + "\n"
-                    except requests.exceptions.ChunkedEncodingError as e_chunk:
-                        logger.opt(exception=True).error(
-                            f"Moonshot: ChunkedEncodingError during stream: {e_chunk}"
-                        )
-                        error_content = json.dumps(
-                            {
-                                "error": {
-                                    "message": f"Stream connection error: {str(e_chunk)}",
-                                    "type": "moonshot_stream_error",
-                                }
-                            }
-                        )
-                        yield f"data: {error_content}\n\n"
-                    except Exception as e_stream:
-                        logger.opt(exception=True).error(
-                            f"Moonshot: Error during stream iteration: {e_stream}"
-                        )
-                        error_content = json.dumps(
-                            {
-                                "error": {
-                                    "message": f"Stream iteration error: {str(e_stream)}",
-                                    "type": "moonshot_stream_error",
-                                }
-                            }
-                        )
-                        yield f"data: {error_content}\n\n"
-                    finally:
-                        yield "data: [DONE]\n\n"
-                        if response:
-                            response.close()
-
-                return stream_generator()
-
-        else:  # Non-streaming
-            logger.debug("Moonshot: Posting request (non-streaming)")
-            retry_count = int(moonshot_config.get("api_retries", 3))
-            retry_delay = float(moonshot_config.get("api_retry_delay", 1.0))
-
-            retry_strategy = Retry(
-                total=llm_retry_count(retry_count),
-                backoff_factor=retry_delay,
-                status_forcelist=[429, 500, 502, 503, 504],
-                allowed_methods=["POST"],
-            )
-            adapter = HTTPAdapter(max_retries=retry_strategy)
-            with requests.Session() as session:
-                session.mount("https://", adapter)
-                session.mount("http://", adapter)
-                response = session.post(
-                    api_url,
-                    headers=headers,
-                    json=payload,
-                    timeout=float(moonshot_config.get("api_timeout", 90.0)),
-                )
-
-            logger.debug(f"Moonshot: Full API response status: {response.status_code}")
-            response.raise_for_status()
-            response_data = response.json()
-
-            # Log success metrics
-            duration = time.time() - start_time
-            log_histogram(
-                "moonshot_api_response_time",
-                duration,
-                labels={
-                    "model": final_model,
-                    "streaming": "false",
-                    "status_code": str(response.status_code),
-                },
-            )
-            log_counter(
-                "moonshot_api_success",
-                labels={"model": final_model, "streaming": "false"},
-            )
-
-            # Log token usage if available
-            usage = response_data.get("usage", {})
-            if usage:
-                log_histogram(
-                    "moonshot_api_prompt_tokens",
-                    usage.get("prompt_tokens", 0),
-                    labels={"model": final_model},
-                )
-                log_histogram(
-                    "moonshot_api_completion_tokens",
-                    usage.get("completion_tokens", 0),
-                    labels={"model": final_model},
-                )
-                log_histogram(
-                    "moonshot_api_total_tokens",
-                    usage.get("total_tokens", 0),
-                    labels={"model": final_model},
-                )
-
-            logger.debug("Moonshot: Non-streaming request successful.")
-            return response_data
-
-    except requests.exceptions.HTTPError as e:
-        status_code = e.response.status_code if e.response is not None else 0
-
-        # Log error metrics
-        duration = time.time() - start_time
+        result = _strict_chat_with_moonshot(
+            input_data=input_data,
+            model=model,
+            api_key=api_key,
+            system_message=system_message,
+            temp=temp,
+            maxp=maxp,
+            streaming=streaming,
+            frequency_penalty=frequency_penalty,
+            max_tokens=max_tokens,
+            n=n,
+            presence_penalty=presence_penalty,
+            response_format=response_format,
+            seed=seed,
+            stop=stop,
+            tools=tools,
+            tool_choice=tool_choice,
+            user=user,
+            custom_prompt_arg=custom_prompt_arg,
+            api_base_url=api_base_url,
+            reasoning_effort=reasoning_effort,
+        )
+    except Exception as exc:
         log_counter(
             "moonshot_api_error",
-            labels={
-                "model": final_model,
-                "error_type": "http_error",
-                "status_code": str(status_code),
-            },
+            labels={**labels, "error_type": type(exc).__name__},
         )
         log_histogram(
             "moonshot_api_error_response_time",
-            duration,
-            labels={"model": final_model, "status_code": str(status_code)},
+            time.time() - started_at,
+            labels=labels,
         )
-
-        if e.response is not None:
-            error_detail = str(safe_llm_error_detail(e.response.text))
-            logger.error(
-                "Moonshot request failed; "
-                f"status={e.response.status_code}; detail={error_detail}"
-            )
-        else:
-            logger.error(
-                "Moonshot HTTPError with no response object; "
-                f"error_type={safe_llm_exception_message(e)}"
-            )
         raise
-    except requests.exceptions.RequestException as e:
-        # Log network error metrics
-        duration = time.time() - start_time
-        log_counter(
-            "moonshot_api_error",
-            labels={"model": final_model, "error_type": "network_error"},
-        )
-        log_histogram(
-            "moonshot_api_error_response_time",
-            duration,
-            labels={"model": final_model, "error_type": "network"},
-        )
-        error_detail = safe_llm_exception_message(e)
-        if is_sensitive_llm_request():
-            logger.error(f"Moonshot RequestException: {error_detail}")
-        else:
-            logger.opt(exception=True).error(
-                f"Moonshot RequestException: {error_detail}"
-            )
-        raise
-    except Exception as e:
-        # Log unexpected error metrics
-        duration = time.time() - start_time
-        log_counter(
-            "moonshot_api_error",
-            labels={"model": final_model, "error_type": "unexpected"},
-        )
-        error_detail = safe_llm_exception_message(e)
-        error_copy = f"Moonshot: Unexpected error: {error_detail}"
-        if is_sensitive_llm_request():
-            logger.error(error_copy)
-        else:
-            logger.opt(exception=True).error(error_copy)
-        raise ChatProviderError(
-            provider="moonshot", message=f"Unexpected error: {error_detail}"
-        )
+    log_counter("moonshot_api_success", labels=labels)
+    log_histogram(
+        "moonshot_api_response_time",
+        time.time() - started_at,
+        labels=labels,
+    )
+    return result
 
 
 def chat_with_zai(

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -47,6 +47,7 @@ from tldw_chatbook.Chat.Chat_Deps import (
     ChatConfigurationError,
 )
 from tldw_chatbook.Chat.console_provider_endpoints import builtin_provider_endpoint
+from tldw_chatbook.Chat.provider_continuation import ProviderContinuationCheckpoint
 from tldw_chatbook.config import (
     get_cli_setting,
     get_runtime_config_snapshot,
@@ -5212,6 +5213,10 @@ def chat_with_moonshot(
     custom_prompt_arg: Optional[str] = None,
     api_base_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    provider_continuations: Tuple[ProviderContinuationCheckpoint, ...] = (),
+    request_timeout: Optional[float] = None,
+    request_retries: Optional[int] = None,
+    request_retry_delay: Optional[float] = None,
 ):
     """Compatibility wrapper for the strict first-class Moonshot adapter."""
     started_at = time.time()
@@ -5239,6 +5244,10 @@ def chat_with_moonshot(
             custom_prompt_arg=custom_prompt_arg,
             api_base_url=api_base_url,
             reasoning_effort=reasoning_effort,
+            provider_continuations=provider_continuations,
+            request_timeout=request_timeout,
+            request_retries=request_retries,
+            request_retry_delay=request_retry_delay,
         )
     except Exception as exc:
         log_counter(
@@ -5279,6 +5288,10 @@ def chat_with_zai(
     response_format: Optional[Dict[str, Any]] = None,
     user: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    provider_continuations: Tuple[ProviderContinuationCheckpoint, ...] = (),
+    request_timeout: Optional[float] = None,
+    request_retries: Optional[int] = None,
+    request_retry_delay: Optional[float] = None,
 ):
     """Compatibility wrapper for the strict first-class Z.ai adapter."""
     started_at = time.time()
@@ -5304,6 +5317,10 @@ def chat_with_zai(
             response_format=response_format,
             user=user,
             reasoning_effort=reasoning_effort,
+            provider_continuations=provider_continuations,
+            request_timeout=request_timeout,
+            request_retries=request_retries,
+            request_retry_delay=request_retry_delay,
         )
     except Exception as exc:
         log_counter(

--- a/tldw_chatbook/LLM_Calls/hosted_chat.py
+++ b/tldw_chatbook/LLM_Calls/hosted_chat.py
@@ -403,6 +403,28 @@ def normalize_hosted_chat_response(
     )
 
 
+def hosted_chat_request(
+    *,
+    config: HostedHTTPTransportConfig,
+    payload: Mapping[str, Any],
+    streaming: bool,
+    finish_policy: HostedChatFinishPolicy,
+) -> HostedChatTurn | HostedChatStream:
+    """Run one hosted Chat-Completions request through the shared boundary."""
+    response = owned_json_post(
+        config=config,
+        route="chat/completions",
+        payload=payload,
+        streaming=streaming,
+    )
+    if streaming:
+        return HostedChatStream(
+            cast(Iterator[SSERecord], response),
+            finish_policy=finish_policy,
+        )
+    return normalize_hosted_chat_response(response, finish_policy=finish_policy)
+
+
 def owned_json_post(
     *,
     config: HostedHTTPTransportConfig,

--- a/tldw_chatbook/LLM_Calls/hosted_chat.py
+++ b/tldw_chatbook/LLM_Calls/hosted_chat.py
@@ -154,7 +154,7 @@ class HostedChatStream(Iterator[dict[str, Any]]):
             raise HostedChatProtocolError("Hosted Chat stream JSON is malformed.")
         try:
             safe_event = self._consume_event(cast(Mapping[str, Any], event))
-        except HostedChatProtocolError:
+        except (HostedChatProtocolError, ChatProviderError):
             self.close()
             raise
         except Exception:
@@ -625,7 +625,7 @@ def _validate_reasoning(
 ) -> str | None:
     try:
         reasoning = policy.validate_reasoning_content(value)
-    except HostedChatProtocolError:
+    except (HostedChatProtocolError, ChatProviderError):
         raise
     except Exception:
         raise HostedChatProtocolError(
@@ -649,7 +649,7 @@ def _validate_finish(
             has_text=has_text,
             has_calls=has_calls,
         )
-    except HostedChatProtocolError:
+    except (HostedChatProtocolError, ChatProviderError):
         raise
     except Exception:
         raise HostedChatProtocolError(

--- a/tldw_chatbook/LLM_Calls/hosted_chat.py
+++ b/tldw_chatbook/LLM_Calls/hosted_chat.py
@@ -80,7 +80,7 @@ class HostedChatTurn:
 
     text: str
     tool_calls: tuple[dict[str, Any], ...]
-    assistant_message: dict[str, Any] | None
+    assistant_message: dict[str, Any] | None = field(repr=False)
     finish_reason: str
     reasoning_content: str | None = field(default=None, repr=False)
     usage: dict[str, Any] | None = field(default=None, repr=False)

--- a/tldw_chatbook/LLM_Calls/hosted_chat.py
+++ b/tldw_chatbook/LLM_Calls/hosted_chat.py
@@ -1,0 +1,919 @@
+"""Provider-neutral hosted Chat-Completions transport and normalization."""
+
+from __future__ import annotations
+
+import re
+import json
+import math
+import time
+from collections.abc import Iterator, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Literal, Never, Protocol, cast
+from urllib.parse import unquote, urlsplit
+
+import requests
+from requests.adapters import HTTPAdapter
+from requests.exceptions import RequestException, Timeout as RequestsTimeout
+from urllib3.util import Retry
+
+from tldw_chatbook.Chat.Chat_Deps import (
+    ChatAuthenticationError,
+    ChatBadRequestError,
+    ChatProviderError,
+    ChatRateLimitError,
+)
+from tldw_chatbook.LLM_Calls.hosted_chat_streaming import OwnedSSEStream, SSERecord
+from tldw_chatbook.Utils.sensitive_llm_logging import llm_retry_count
+
+
+_MAX_URL_LENGTH = 2_000
+_MAX_PATH_DECODE_PASSES = 3
+_PERCENT_ESCAPE_RE = re.compile(r"%[0-9A-Fa-f]{2}")
+_ENCODED_PATH_SEPARATOR_RE = re.compile(r"%(?:2[fF]|5[cC])")
+_MAX_JSON_DEPTH = 128
+_MAX_JSON_NODES = 1_000_000
+_MAX_OUTPUT_CHARS = 32 * 1024 * 1024
+_MAX_METADATA_CHARS = 4 * 1024
+_MAX_TOOL_CALLS = 128
+_JSON_DECODE_FAILED = object()
+_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+class HostedChatBaseURLValidationError(ValueError):
+    """Raised when a hosted Chat API base URL is malformed or ambiguous."""
+
+
+class HostedChatProtocolError(ValueError):
+    """Raised when a hosted provider returns malformed Chat data."""
+
+
+class HostedChatFinishPolicy(Protocol):
+    """Provider-owned finish and reasoning validation policy."""
+
+    def validate_finish(
+        self,
+        *,
+        finish_reason: object,
+        has_text: bool,
+        has_calls: bool,
+    ) -> str: ...
+
+    def validate_reasoning_content(self, value: object) -> str | None: ...
+
+
+@dataclass(frozen=True)
+class HostedHTTPTransportConfig:
+    """Resolved immutable values for one hosted HTTP transport."""
+
+    provider: str
+    base_url: str
+    api_key: str = field(repr=False, compare=False)
+    timeout: float
+    retries: int
+    retry_delay: float
+
+
+@dataclass(frozen=True)
+class HostedChatTurn:
+    """One normalized hosted Chat assistant turn."""
+
+    text: str
+    tool_calls: tuple[dict[str, Any], ...]
+    assistant_message: dict[str, Any] | None
+    finish_reason: str
+    reasoning_content: str | None = field(default=None, repr=False)
+    usage: dict[str, Any] | None = field(default=None, repr=False)
+
+
+@dataclass
+class _StreamToolState:
+    call_id: str
+    name: str
+    arguments: list[str]
+
+
+class HostedChatStream(Iterator[dict[str, Any]]):
+    """Normalize one stream of OpenAI-shaped hosted Chat SSE records."""
+
+    def __init__(
+        self,
+        records: Iterator[SSERecord],
+        *,
+        finish_policy: HostedChatFinishPolicy,
+    ) -> None:
+        self._records = records
+        self._finish_policy = finish_policy
+        self._text_segments: list[str] = []
+        self._reasoning_segments: list[str] = []
+        self._tools: dict[int, _StreamToolState] = {}
+        self._call_ids: set[str] = set()
+        self._finish_reason: str | None = None
+        self._usage: dict[str, Any] | None = None
+        self._terminal_turn: HostedChatTurn | None = None
+        self._output_chars = 0
+        self._closed = False
+
+    def __iter__(self) -> HostedChatStream:
+        return self
+
+    def __next__(self) -> dict[str, Any]:
+        if self._closed:
+            raise StopIteration
+        try:
+            record = next(self._records)
+        except StopIteration:
+            self.close()
+            raise HostedChatProtocolError(
+                "Hosted Chat stream ended before a clean terminal record."
+            ) from None
+        except Exception:
+            self.close()
+            raise HostedChatProtocolError("Hosted Chat stream read failed.") from None
+        if record.data == "[DONE]":
+            if self._finish_reason is None or self._usage is None:
+                self.close()
+                raise HostedChatProtocolError(
+                    "Hosted Chat stream terminated before required metadata."
+                )
+            self._terminal_turn = _build_turn(
+                text="".join(self._text_segments),
+                reasoning_content="".join(self._reasoning_segments)
+                if self._reasoning_segments
+                else None,
+                tool_calls=_finish_stream_tools(self._tools),
+                finish_reason=self._finish_reason,
+                usage=self._usage,
+            )
+            self.close()
+            raise StopIteration
+
+        event = _strict_json_loads(record.data)
+        if event is _JSON_DECODE_FAILED or not isinstance(event, Mapping):
+            self.close()
+            raise HostedChatProtocolError("Hosted Chat stream JSON is malformed.")
+        try:
+            safe_event = self._consume_event(cast(Mapping[str, Any], event))
+        except HostedChatProtocolError:
+            self.close()
+            raise
+        except Exception:
+            self.close()
+            raise HostedChatProtocolError(
+                "Hosted Chat stream data is malformed."
+            ) from None
+        return safe_event
+
+    @property
+    def terminal_turn(self) -> HostedChatTurn:
+        """Return terminal metadata after clean stream exhaustion."""
+        if self._terminal_turn is None:
+            raise HostedChatProtocolError("Hosted Chat stream metadata is incomplete.")
+        return self._terminal_turn
+
+    def close(self) -> None:
+        """Close this stream."""
+        if self._closed:
+            return
+        self._closed = True
+        close = getattr(self._records, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+
+    def _consume_event(self, event: Mapping[str, Any]) -> dict[str, Any]:
+        if set(event) - {"id", "object", "created", "model", "choices", "usage"}:
+            raise HostedChatProtocolError("Hosted Chat stream event is malformed.")
+        choices = event.get("choices")
+        usage = event.get("usage")
+        if not isinstance(choices, Sequence) or isinstance(choices, (str, bytes)):
+            raise HostedChatProtocolError("Hosted Chat stream choices are malformed.")
+        if usage is not None and not isinstance(usage, Mapping):
+            raise HostedChatProtocolError("Hosted Chat stream usage is malformed.")
+        if not choices:
+            if self._finish_reason is None or usage is None or self._usage is not None:
+                raise HostedChatProtocolError("Hosted Chat stream usage is misplaced.")
+            self._usage = deepcopy(dict(usage))
+            return deepcopy(dict(event))
+        if self._finish_reason is not None:
+            raise HostedChatProtocolError(
+                "Hosted Chat stream data followed terminal state."
+            )
+        if len(choices) != 1:
+            raise HostedChatProtocolError(
+                "Hosted Chat stream choice count is unsupported."
+            )
+        choice = choices[0]
+        if not isinstance(choice, Mapping) or set(choice) - {
+            "index",
+            "delta",
+            "finish_reason",
+        }:
+            raise HostedChatProtocolError("Hosted Chat stream choice is malformed.")
+        if type(choice.get("index")) is not int or choice.get("index") != 0:
+            raise HostedChatProtocolError(
+                "Hosted Chat stream choice index is malformed."
+            )
+        delta = choice.get("delta")
+        if not isinstance(delta, Mapping) or set(delta) - {
+            "role",
+            "content",
+            "reasoning_content",
+            "tool_calls",
+        }:
+            raise HostedChatProtocolError("Hosted Chat stream delta is malformed.")
+        if "role" in delta and delta.get("role") != "assistant":
+            raise HostedChatProtocolError("Hosted Chat stream role is malformed.")
+        content = delta.get("content")
+        if content is not None and not isinstance(content, str):
+            raise HostedChatProtocolError("Hosted Chat stream content is malformed.")
+        if isinstance(content, str):
+            self._reserve_output(len(content))
+            self._text_segments.append(content)
+        if "reasoning_content" in delta:
+            reasoning = _validate_reasoning(
+                self._finish_policy, delta.get("reasoning_content")
+            )
+            if reasoning is not None:
+                self._reserve_output(len(reasoning))
+                self._reasoning_segments.append(reasoning)
+        if delta.get("tool_calls") is not None:
+            self._consume_tool_deltas(delta["tool_calls"])
+
+        finish_reason = choice.get("finish_reason")
+        if finish_reason is not None:
+            calls = _finish_stream_tools(self._tools)
+            self._finish_reason = _validate_finish(
+                self._finish_policy,
+                finish_reason=finish_reason,
+                has_text=bool("".join(self._text_segments)),
+                has_calls=bool(calls),
+            )
+            if usage is not None:
+                self._usage = deepcopy(dict(usage))
+        elif usage is not None:
+            raise HostedChatProtocolError(
+                "Hosted Chat stream usage preceded terminal state."
+            )
+        return deepcopy(dict(event))
+
+    def _consume_tool_deltas(self, value: object) -> None:
+        if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+            raise HostedChatProtocolError("Hosted Chat stream tools are malformed.")
+        event_indexes: set[int] = set()
+        for raw_tool in value:
+            if not isinstance(raw_tool, Mapping) or set(raw_tool) - {
+                "index",
+                "id",
+                "type",
+                "function",
+            }:
+                raise HostedChatProtocolError("Hosted Chat stream tool is malformed.")
+            index = raw_tool.get("index")
+            if type(index) is not int or index < 0 or index >= _MAX_TOOL_CALLS:
+                raise HostedChatProtocolError(
+                    "Hosted Chat stream tool index is malformed."
+                )
+            if index in event_indexes:
+                raise HostedChatProtocolError(
+                    "Hosted Chat stream tool index was duplicated."
+                )
+            event_indexes.add(index)
+            function = raw_tool.get("function")
+            if not isinstance(function, Mapping) or set(function) - {
+                "name",
+                "arguments",
+            }:
+                raise HostedChatProtocolError(
+                    "Hosted Chat stream function is malformed."
+                )
+            arguments = function.get("arguments", "")
+            if not isinstance(arguments, str):
+                raise HostedChatProtocolError(
+                    "Hosted Chat stream arguments are malformed."
+                )
+            state = self._tools.get(index)
+            if state is None:
+                call_id = _required_metadata(raw_tool.get("id"), "tool ID")
+                name = _required_metadata(function.get("name"), "tool name")
+                if raw_tool.get("type") != "function" or call_id in self._call_ids:
+                    raise HostedChatProtocolError(
+                        "Hosted Chat stream tool identity is malformed."
+                    )
+                self._call_ids.add(call_id)
+                state = _StreamToolState(call_id=call_id, name=name, arguments=[])
+                self._tools[index] = state
+                self._reserve_output(len(call_id) + len(name))
+            else:
+                if "id" in raw_tool and raw_tool.get("id") != state.call_id:
+                    raise HostedChatProtocolError(
+                        "Hosted Chat stream tool identity changed."
+                    )
+                if "type" in raw_tool and raw_tool.get("type") != "function":
+                    raise HostedChatProtocolError(
+                        "Hosted Chat stream tool type changed."
+                    )
+                if "name" in function and function.get("name") != state.name:
+                    raise HostedChatProtocolError(
+                        "Hosted Chat stream tool name changed."
+                    )
+            self._reserve_output(len(arguments))
+            state.arguments.append(arguments)
+
+    def _reserve_output(self, characters: int) -> None:
+        if characters < 0 or self._output_chars + characters > _MAX_OUTPUT_CHARS:
+            raise HostedChatProtocolError(
+                "Hosted Chat stream output limit was exceeded."
+            )
+        self._output_chars += characters
+
+
+def normalize_hosted_chat_response(
+    response: object,
+    *,
+    finish_policy: HostedChatFinishPolicy,
+) -> HostedChatTurn:
+    """Normalize one non-streaming OpenAI-shaped Chat response."""
+    if not _json_shape_is_safe(response) or not isinstance(response, Mapping):
+        raise HostedChatProtocolError("Hosted Chat response JSON is malformed.")
+    if set(response) - {
+        "id",
+        "object",
+        "created",
+        "model",
+        "system_fingerprint",
+        "choices",
+        "usage",
+    }:
+        raise HostedChatProtocolError("Hosted Chat response is malformed.")
+    choices = response.get("choices")
+    if (
+        not isinstance(choices, Sequence)
+        or isinstance(choices, (str, bytes))
+        or len(choices) != 1
+    ):
+        raise HostedChatProtocolError("Hosted Chat response choices are malformed.")
+    choice = choices[0]
+    if not isinstance(choice, Mapping) or set(choice) - {
+        "index",
+        "message",
+        "finish_reason",
+    }:
+        raise HostedChatProtocolError("Hosted Chat response choice is malformed.")
+    if type(choice.get("index")) is not int or choice.get("index") != 0:
+        raise HostedChatProtocolError("Hosted Chat response choice index is malformed.")
+    message = choice.get("message")
+    if not isinstance(message, Mapping) or set(message) - {
+        "role",
+        "content",
+        "reasoning_content",
+        "tool_calls",
+    }:
+        raise HostedChatProtocolError("Hosted Chat response message is malformed.")
+    if message.get("role") != "assistant":
+        raise HostedChatProtocolError("Hosted Chat response role is malformed.")
+    content = message.get("content")
+    if content is not None and not isinstance(content, str):
+        raise HostedChatProtocolError("Hosted Chat response content is malformed.")
+    text = content or ""
+    reasoning = _validate_reasoning(finish_policy, message.get("reasoning_content"))
+    tool_calls = _normalize_tool_calls(message.get("tool_calls", ()))
+    if (
+        len(text) + len(reasoning or "") + _tool_character_count(tool_calls)
+        > _MAX_OUTPUT_CHARS
+    ):
+        raise HostedChatProtocolError("Hosted Chat response output limit was exceeded.")
+    finish_reason = _validate_finish(
+        finish_policy,
+        finish_reason=choice.get("finish_reason"),
+        has_text=bool(text),
+        has_calls=bool(tool_calls),
+    )
+    usage = response.get("usage")
+    if usage is not None and not isinstance(usage, Mapping):
+        raise HostedChatProtocolError("Hosted Chat response usage is malformed.")
+    return _build_turn(
+        text=text,
+        reasoning_content=reasoning,
+        tool_calls=tool_calls,
+        finish_reason=finish_reason,
+        usage=deepcopy(dict(usage)) if isinstance(usage, Mapping) else None,
+    )
+
+
+def owned_json_post(
+    *,
+    config: HostedHTTPTransportConfig,
+    route: Literal["chat/completions", "responses"],
+    payload: Mapping[str, Any],
+    streaming: bool,
+) -> dict[str, Any] | OwnedSSEStream:
+    """POST JSON with bounded retries and explicit response/session ownership.
+
+    Args:
+        config: Fully resolved provider transport values.
+        route: Exact hosted generation route.
+        payload: Already-built provider request body.
+        streaming: Transfer resource ownership to an SSE stream when true.
+
+    Returns:
+        A decoded object response or an owned SSE record stream.
+
+    Raises:
+        ChatAuthenticationError: For authentication failures.
+        ChatRateLimitError: For exhausted rate limiting.
+        ChatBadRequestError: For other client request failures.
+        ChatProviderError: For network, service, or malformed response failures.
+    """
+    if route not in {"chat/completions", "responses"}:
+        raise _transport_error(config.provider, "request route is invalid")
+    base_url = normalize_hosted_chat_base_url(config.base_url, default=config.base_url)
+    if (
+        not isinstance(config.provider, str)
+        or not config.provider
+        or not isinstance(config.api_key, str)
+        or not config.api_key
+        or isinstance(config.timeout, bool)
+        or not isinstance(config.timeout, (int, float))
+        or not math.isfinite(float(config.timeout))
+        or config.timeout <= 0
+        or isinstance(config.retries, bool)
+        or not isinstance(config.retries, int)
+        or isinstance(config.retry_delay, bool)
+        or not isinstance(config.retry_delay, (int, float))
+        or not math.isfinite(float(config.retry_delay))
+        or config.retry_delay < 0
+        or not isinstance(payload, Mapping)
+    ):
+        raise _transport_error(config.provider, "transport configuration is invalid")
+
+    retries = llm_retry_count(max(0, config.retries))
+    url = f"{base_url}/{route}"
+    session = requests.Session()
+    response: requests.Response | None = None
+    stream_owns_session = False
+    try:
+        retry_policy = Retry(
+            total=0,
+            connect=0,
+            read=0,
+            redirect=0,
+            status=0,
+            other=0,
+            allowed_methods=frozenset({"POST"}),
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry_policy)
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        for attempt in range(retries + 1):
+            response = None
+            try:
+                response = session.post(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {config.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=deepcopy(dict(payload)),
+                    timeout=float(config.timeout),
+                    stream=True,
+                )
+                status = int(response.status_code)
+                if status in _RETRYABLE_STATUS_CODES and attempt < retries:
+                    delay = _retry_delay(
+                        response,
+                        attempt=attempt,
+                        retry_delay=float(config.retry_delay),
+                    )
+                    _best_effort_close(response)
+                    response = None
+                    if delay > 0:
+                        time.sleep(delay)
+                    continue
+                if status >= 400:
+                    _raise_http_error(config.provider, status)
+                if streaming:
+                    stream = OwnedSSEStream(response=response, session=session)
+                    response = None
+                    stream_owns_session = True
+                    return stream
+                try:
+                    result = response.json()
+                except Exception:
+                    raise _transport_error(
+                        config.provider, "returned malformed provider JSON"
+                    ) from None
+                if not isinstance(result, Mapping):
+                    raise _transport_error(
+                        config.provider, "response envelope must be an object"
+                    )
+                return deepcopy(dict(result))
+            except (ChatAuthenticationError, ChatRateLimitError, ChatBadRequestError):
+                raise
+            except ChatProviderError:
+                raise
+            except (requests.ConnectionError, RequestsTimeout) as exc:
+                if attempt < retries:
+                    if response is not None:
+                        _best_effort_close(response)
+                        response = None
+                    delay = float(config.retry_delay) * (2**attempt)
+                    if delay > 0:
+                        time.sleep(delay)
+                    continue
+                raise _transport_error(
+                    config.provider,
+                    "network request failed",
+                    status_code=504 if isinstance(exc, RequestsTimeout) else 502,
+                ) from None
+            except RequestException:
+                raise _transport_error(
+                    config.provider, "network request failed"
+                ) from None
+            finally:
+                if response is not None:
+                    _best_effort_close(response)
+                    response = None
+    finally:
+        if not stream_owns_session:
+            _best_effort_close(session)
+    raise _transport_error(config.provider, "request attempts were exhausted")
+
+
+def _reject_json_constant(_value: str) -> Never:
+    raise ValueError
+
+
+def _json_shape_is_safe(value: object) -> bool:
+    stack: list[tuple[object, int]] = [(value, 1)]
+    scheduled_nodes = 1
+    try:
+        while stack:
+            node, depth = stack.pop()
+            if depth > _MAX_JSON_DEPTH:
+                return False
+            if type(node) is dict:
+                for key, child in cast(dict[object, object], node).items():
+                    if not isinstance(key, str):
+                        return False
+                    scheduled_nodes += 1
+                    if scheduled_nodes > _MAX_JSON_NODES:
+                        return False
+                    stack.append((child, depth + 1))
+                continue
+            if type(node) is list:
+                for child in cast(list[object], node):
+                    scheduled_nodes += 1
+                    if scheduled_nodes > _MAX_JSON_NODES:
+                        return False
+                    stack.append((child, depth + 1))
+                continue
+            if node is None or isinstance(node, (str, bool)):
+                continue
+            if isinstance(node, int) and not isinstance(node, bool):
+                continue
+            if isinstance(node, float) and math.isfinite(node):
+                continue
+            return False
+    except (RecursionError, TypeError, ValueError):
+        return False
+    return True
+
+
+def _strict_json_loads(value: str) -> object:
+    try:
+        decoded = json.loads(value, parse_constant=_reject_json_constant)
+    except (RecursionError, TypeError, ValueError):
+        return _JSON_DECODE_FAILED
+    return decoded if _json_shape_is_safe(decoded) else _JSON_DECODE_FAILED
+
+
+def _required_metadata(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > _MAX_METADATA_CHARS:
+        raise HostedChatProtocolError(f"Hosted Chat {label} is malformed.")
+    return value
+
+
+def _validate_reasoning(
+    policy: HostedChatFinishPolicy,
+    value: object,
+) -> str | None:
+    try:
+        reasoning = policy.validate_reasoning_content(value)
+    except HostedChatProtocolError:
+        raise
+    except Exception:
+        raise HostedChatProtocolError(
+            "Hosted Chat reasoning metadata is malformed."
+        ) from None
+    if reasoning is not None and not isinstance(reasoning, str):
+        raise HostedChatProtocolError("Hosted Chat reasoning metadata is malformed.")
+    return reasoning
+
+
+def _validate_finish(
+    policy: HostedChatFinishPolicy,
+    *,
+    finish_reason: object,
+    has_text: bool,
+    has_calls: bool,
+) -> str:
+    try:
+        normalized = policy.validate_finish(
+            finish_reason=finish_reason,
+            has_text=has_text,
+            has_calls=has_calls,
+        )
+    except HostedChatProtocolError:
+        raise
+    except Exception:
+        raise HostedChatProtocolError(
+            "Hosted Chat finish state is malformed."
+        ) from None
+    if not isinstance(normalized, str) or not normalized:
+        raise HostedChatProtocolError("Hosted Chat finish state is malformed.")
+    return normalized
+
+
+def _normalize_tool_calls(value: object) -> tuple[dict[str, Any], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise HostedChatProtocolError("Hosted Chat tool calls are malformed.")
+    if len(value) > _MAX_TOOL_CALLS:
+        raise HostedChatProtocolError("Hosted Chat tool call limit was exceeded.")
+    calls: list[dict[str, Any]] = []
+    call_ids: set[str] = set()
+    for raw_call in value:
+        if not isinstance(raw_call, Mapping) or set(raw_call) != {
+            "id",
+            "type",
+            "function",
+        }:
+            raise HostedChatProtocolError("Hosted Chat tool call is malformed.")
+        call_id = _required_metadata(raw_call.get("id"), "tool ID")
+        if raw_call.get("type") != "function" or call_id in call_ids:
+            raise HostedChatProtocolError("Hosted Chat tool identity is malformed.")
+        function = raw_call.get("function")
+        if not isinstance(function, Mapping) or set(function) != {"name", "arguments"}:
+            raise HostedChatProtocolError("Hosted Chat tool function is malformed.")
+        name = _required_metadata(function.get("name"), "tool name")
+        arguments = function.get("arguments")
+        if not isinstance(arguments, str):
+            raise HostedChatProtocolError("Hosted Chat tool arguments are malformed.")
+        decoded_arguments = _strict_json_loads(arguments)
+        if decoded_arguments is _JSON_DECODE_FAILED or not isinstance(
+            decoded_arguments, Mapping
+        ):
+            raise HostedChatProtocolError("Hosted Chat tool arguments are malformed.")
+        call_ids.add(call_id)
+        calls.append(
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": arguments},
+            }
+        )
+    return tuple(calls)
+
+
+def _finish_stream_tools(
+    states: Mapping[int, _StreamToolState],
+) -> tuple[dict[str, Any], ...]:
+    if not states:
+        return ()
+    if tuple(sorted(states)) != tuple(range(len(states))):
+        raise HostedChatProtocolError("Hosted Chat stream tool indexes are incomplete.")
+    return _normalize_tool_calls(
+        [
+            {
+                "id": states[index].call_id,
+                "type": "function",
+                "function": {
+                    "name": states[index].name,
+                    "arguments": "".join(states[index].arguments),
+                },
+            }
+            for index in range(len(states))
+        ]
+    )
+
+
+def _tool_character_count(tool_calls: Sequence[Mapping[str, Any]]) -> int:
+    return sum(
+        len(cast(str, call["id"]))
+        + len(cast(str, cast(Mapping[str, Any], call["function"])["name"]))
+        + len(cast(str, cast(Mapping[str, Any], call["function"])["arguments"]))
+        for call in tool_calls
+    )
+
+
+def _build_turn(
+    *,
+    text: str,
+    reasoning_content: str | None,
+    tool_calls: tuple[dict[str, Any], ...],
+    finish_reason: str,
+    usage: dict[str, Any] | None,
+) -> HostedChatTurn:
+    assistant_message: dict[str, Any] = {"role": "assistant", "content": text}
+    if reasoning_content is not None:
+        assistant_message["reasoning_content"] = reasoning_content
+    if tool_calls:
+        assistant_message["tool_calls"] = deepcopy(list(tool_calls))
+    return HostedChatTurn(
+        text=text,
+        tool_calls=deepcopy(tool_calls),
+        assistant_message=assistant_message,
+        finish_reason=finish_reason,
+        reasoning_content=reasoning_content,
+        usage=deepcopy(usage),
+    )
+
+
+def _best_effort_close(resource: object) -> None:
+    try:
+        cast(Any, resource).close()
+    except Exception:
+        pass
+
+
+def _transport_error(
+    provider: str,
+    detail: str,
+    *,
+    status_code: int = 502,
+) -> ChatProviderError:
+    return ChatProviderError(
+        provider=provider,
+        message=f"{provider} {detail}.",
+        status_code=status_code,
+    )
+
+
+def _raise_http_error(provider: str, status: int) -> Never:
+    if status in {401, 403}:
+        raise ChatAuthenticationError(
+            provider=provider,
+            message=f"{provider} authentication failed. Check the API key.",
+        ) from None
+    if status == 429:
+        raise ChatRateLimitError(
+            provider=provider,
+            message=f"{provider} rate limit exceeded. Retry later.",
+        ) from None
+    if 400 <= status < 500:
+        raise ChatBadRequestError(
+            provider=provider,
+            message=f"{provider} rejected the request (status {status}).",
+        ) from None
+    raise _transport_error(
+        provider,
+        f"service failed (status {status})",
+        status_code=status,
+    ) from None
+
+
+def _retry_delay(
+    response: requests.Response,
+    *,
+    attempt: int,
+    retry_delay: float,
+) -> float:
+    raw_value = response.headers.get("Retry-After")
+    if raw_value is not None:
+        try:
+            if raw_value.strip().isdigit():
+                return max(0.0, float(int(raw_value.strip())))
+            from email.utils import parsedate_to_datetime
+
+            parsed = parsedate_to_datetime(raw_value)
+            return max(0.0, parsed.timestamp() - time.time())
+        except (OverflowError, TypeError, ValueError):
+            pass
+    return retry_delay * (2**attempt)
+
+
+def _invalid_base_url() -> HostedChatBaseURLValidationError:
+    return HostedChatBaseURLValidationError("Hosted Chat API base URL is malformed.")
+
+
+def _endpoint_markers(path: str) -> frozenset[tuple[int, str]]:
+    segments = tuple(segment.casefold() for segment in path.strip("/").split("/"))
+    markers = {
+        (index, segment)
+        for index, segment in enumerate(segments)
+        if segment == "responses"
+        or (segment == "models" and index == len(segments) - 1)
+    }
+    markers.update(
+        (index, "chat/completions")
+        for index in range(len(segments) - 1)
+        if segments[index : index + 2] == ("chat", "completions")
+    )
+    return frozenset(markers)
+
+
+def _terminal_chat_suffix_is_valid(path: str) -> bool:
+    segments = tuple(path.strip("/").split("/"))
+    markers = _endpoint_markers(path)
+    if not markers:
+        return True
+    return markers == {(len(segments) - 2, "chat/completions")} and segments[-2:] == (
+        "chat",
+        "completions",
+    )
+
+
+def _validate_percent_encoded_path(path: str) -> None:
+    validation_path = path
+    markers = _endpoint_markers(validation_path)
+    for _pass in range(_MAX_PATH_DECODE_PASSES):
+        if _ENCODED_PATH_SEPARATOR_RE.search(validation_path):
+            raise _invalid_base_url()
+        try:
+            decoded_path = unquote(validation_path, errors="strict")
+        except UnicodeDecodeError as exc:
+            raise _invalid_base_url() from exc
+        if decoded_path == validation_path:
+            break
+        decoded_markers = _endpoint_markers(decoded_path)
+        if (
+            any(
+                ord(character) < 32 or ord(character) == 127
+                for character in decoded_path
+            )
+            or "\\" in decoded_path
+            or any(segment in {".", ".."} for segment in decoded_path.split("/"))
+            or decoded_markers - markers
+        ):
+            raise _invalid_base_url()
+        validation_path = decoded_path
+        markers = decoded_markers
+    if _PERCENT_ESCAPE_RE.search(validation_path) is not None:
+        raise _invalid_base_url()
+
+
+def normalize_hosted_chat_base_url(value: object, *, default: str) -> str:
+    """Return one structural hosted Chat API base without a request suffix.
+
+    Args:
+        value: Configured base URL. ``None`` selects ``default``.
+        default: Provider-owned default base URL.
+
+    Returns:
+        The validated base URL without a trailing slash or terminal exact
+        lowercase ``/chat/completions`` suffix.
+
+    Raises:
+        HostedChatBaseURLValidationError: If the URL is malformed, unsafe, or
+            already names an ambiguous request/discovery endpoint.
+    """
+    candidate = default if value is None else value
+    if (
+        not isinstance(candidate, str)
+        or not candidate
+        or len(candidate) > _MAX_URL_LENGTH
+        or candidate != candidate.strip()
+        or any(character.isspace() for character in candidate)
+        or any(ord(character) < 32 or ord(character) == 127 for character in candidate)
+        or "\\" in candidate
+        or "?" in candidate
+        or "#" in candidate
+    ):
+        raise _invalid_base_url()
+
+    try:
+        parsed = urlsplit(candidate)
+        port = parsed.port
+    except ValueError as exc:
+        raise _invalid_base_url() from exc
+    if parsed.scheme.casefold() not in {"http", "https"} or not parsed.hostname:
+        raise _invalid_base_url()
+    if parsed.username is not None or parsed.password is not None:
+        raise _invalid_base_url()
+    if any(character in parsed.netloc for character in '\\%|^{}<>"`'):
+        raise _invalid_base_url()
+    if parsed.query or parsed.fragment:
+        raise _invalid_base_url()
+    if parsed.netloc.endswith(":") or (port is not None and not 0 < port < 65_536):
+        raise _invalid_base_url()
+
+    path = parsed.path
+    if (
+        "//" in path
+        or re.search(r"%(?![0-9A-Fa-f]{2})", path) is not None
+        or any(segment in {".", ".."} for segment in path.split("/"))
+        or not _terminal_chat_suffix_is_valid(path)
+    ):
+        raise _invalid_base_url()
+    _validate_percent_encoded_path(path)
+
+    path = path.rstrip("/")
+    suffix = "/chat/completions"
+    if path.endswith(suffix):
+        path = path[: -len(suffix)]
+    return f"{parsed.scheme.casefold()}://{parsed.netloc}{path}".rstrip("/")

--- a/tldw_chatbook/LLM_Calls/hosted_chat_streaming.py
+++ b/tldw_chatbook/LLM_Calls/hosted_chat_streaming.py
@@ -1,0 +1,227 @@
+"""Strict provider-neutral SSE framing and owned streaming primitives."""
+
+from __future__ import annotations
+
+import codecs
+from collections import deque
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+
+_MAX_SSE_BYTES = 64 * 1024 * 1024
+_MAX_SSE_LINE_CHARS = 16 * 1024 * 1024
+_MAX_SSE_RECORD_CHARS = 16 * 1024 * 1024
+_MAX_SSE_LINE_SEGMENTS = 65_536
+_MAX_SSE_DATA_LINES = 65_536
+_MAX_SSE_RECORDS = 200_000
+
+
+@dataclass(frozen=True)
+class SSERecord:
+    """One complete Server-Sent Events record."""
+
+    event: str | None
+    data: str
+
+
+class HostedSSEReadError(ValueError):
+    """Raised when an owned hosted SSE response cannot be read safely."""
+
+
+class SSERecordDecoder:
+    """Incrementally decode strict UTF-8 Server-Sent Events records."""
+
+    def __init__(
+        self,
+        *,
+        max_bytes: int | None = _MAX_SSE_BYTES,
+        max_line_chars: int = _MAX_SSE_LINE_CHARS,
+        max_record_chars: int = _MAX_SSE_RECORD_CHARS,
+        max_line_segments: int = _MAX_SSE_LINE_SEGMENTS,
+        max_data_lines: int = _MAX_SSE_DATA_LINES,
+        max_records: int = _MAX_SSE_RECORDS,
+    ) -> None:
+        self._decoder = codecs.getincrementaldecoder("utf-8")(errors="strict")
+        self._line_segments: list[str] = []
+        self._line_chars = 0
+        self._data_lines: list[str] = []
+        self._record_chars = 0
+        self._event: str | None = None
+        self._total_bytes = 0
+        self._record_count = 0
+        self._skip_leading_lf = False
+        self._finished = False
+        self._max_bytes = max_bytes
+        self._max_line_chars = max_line_chars
+        self._max_record_chars = max_record_chars
+        self._max_line_segments = max_line_segments
+        self._max_data_lines = max_data_lines
+        self._max_records = max_records
+
+    def feed(self, chunk: bytes) -> tuple[SSERecord, ...]:
+        """Consume one response-body byte chunk.
+
+        Args:
+            chunk: Raw response bytes.
+
+        Returns:
+            Complete records dispatched by a blank line in this chunk.
+
+        Raises:
+            TypeError: If ``chunk`` is not bytes.
+            UnicodeDecodeError: If the stream is not valid UTF-8.
+            ValueError: If the decoder is finished or a bound is exceeded.
+        """
+        if self._finished:
+            raise ValueError("Hosted SSE decoder is already finished.")
+        if not isinstance(chunk, bytes):
+            raise TypeError("Hosted SSE chunks must be bytes.")
+        self._total_bytes += len(chunk)
+        if self._max_bytes is not None and self._total_bytes > self._max_bytes:
+            raise ValueError("Hosted SSE byte limit was exceeded.")
+        return self._consume_text(self._decoder.decode(chunk, final=False))
+
+    def finish(self) -> tuple[SSERecord, ...]:
+        """Finish decoding at response-body EOF.
+
+        Returns:
+            Complete records dispatched by final decoded input.
+
+        Raises:
+            UnicodeDecodeError: If an incomplete UTF-8 sequence remains.
+            ValueError: If a record/line is incomplete or already finished.
+        """
+        if self._finished:
+            raise ValueError("Hosted SSE decoder is already finished.")
+        self._finished = True
+        records = self._consume_text(self._decoder.decode(b"", final=True))
+        if self._line_segments or self._data_lines or self._event is not None:
+            raise ValueError("Hosted SSE data record is incomplete.")
+        return records
+
+    def _consume_text(self, decoded: str) -> tuple[SSERecord, ...]:
+        records: list[SSERecord] = []
+        cursor = 0
+        if self._skip_leading_lf:
+            if decoded.startswith("\n"):
+                cursor = 1
+            self._skip_leading_lf = False
+        segment_start = cursor
+        while cursor < len(decoded):
+            character = decoded[cursor]
+            if character not in {"\r", "\n"}:
+                cursor += 1
+                continue
+            self._append_line_segment(decoded[segment_start:cursor])
+            records.extend(self._consume_line("".join(self._line_segments)))
+            self._line_segments.clear()
+            self._line_chars = 0
+            cursor += 1
+            if character == "\r":
+                if cursor < len(decoded) and decoded[cursor] == "\n":
+                    cursor += 1
+                elif cursor == len(decoded):
+                    self._skip_leading_lf = True
+            segment_start = cursor
+        self._append_line_segment(decoded[segment_start:])
+        return tuple(records)
+
+    def _append_line_segment(self, segment: str) -> None:
+        if not segment:
+            return
+        self._line_chars += len(segment)
+        if self._line_chars > self._max_line_chars:
+            raise ValueError("Hosted SSE line limit was exceeded.")
+        if len(self._line_segments) >= self._max_line_segments:
+            raise ValueError("Hosted SSE line segment limit was exceeded.")
+        self._line_segments.append(segment)
+
+    def _consume_line(self, line: str) -> tuple[SSERecord, ...]:
+        if line == "":
+            if not self._data_lines:
+                self._event = None
+                return ()
+            if self._record_count >= self._max_records:
+                raise ValueError("Hosted SSE record count limit was exceeded.")
+            self._record_count += 1
+            record = SSERecord(event=self._event, data="\n".join(self._data_lines))
+            self._data_lines.clear()
+            self._record_chars = 0
+            self._event = None
+            return (record,)
+        if line.startswith(":"):
+            return ()
+        field, separator, value = line.partition(":")
+        if separator and value.startswith(" "):
+            value = value[1:]
+        if field == "event":
+            self._event = value if separator else ""
+            return ()
+        if field != "data":
+            return ()
+        if not separator:
+            value = ""
+        added_chars = len(value) + (1 if self._data_lines else 0)
+        if self._record_chars + added_chars > self._max_record_chars:
+            raise ValueError("Hosted SSE record limit was exceeded.")
+        if len(self._data_lines) >= self._max_data_lines:
+            raise ValueError("Hosted SSE data line limit was exceeded.")
+        self._record_chars += added_chars
+        self._data_lines.append(value)
+        return ()
+
+
+class OwnedSSEStream(Iterator[SSERecord]):
+    """Own one response/session pair for its complete SSE body lifetime."""
+
+    def __init__(self, *, response: Any, session: Any) -> None:
+        self._response = response
+        self._session = session
+        self._chunks: Iterable[bytes] = response.iter_content(chunk_size=8192)
+        self._iterator = iter(self._chunks)
+        self._decoder = SSERecordDecoder()
+        self._pending: deque[SSERecord] = deque()
+        self._closed = False
+
+    def __iter__(self) -> OwnedSSEStream:
+        return self
+
+    def __next__(self) -> SSERecord:
+        if self._closed:
+            raise StopIteration
+        while not self._pending:
+            try:
+                chunk = next(self._iterator)
+            except StopIteration:
+                try:
+                    self._pending.extend(self._decoder.finish())
+                except Exception:
+                    self.close()
+                    raise HostedSSEReadError(
+                        "Hosted SSE response was incomplete."
+                    ) from None
+                self.close()
+                if not self._pending:
+                    raise StopIteration
+                break
+            except Exception:
+                self.close()
+                raise HostedSSEReadError("Hosted SSE response read failed.") from None
+            try:
+                self._pending.extend(self._decoder.feed(chunk))
+            except Exception:
+                self.close()
+                raise HostedSSEReadError("Hosted SSE response was malformed.") from None
+        return self._pending.popleft()
+
+    def close(self) -> None:
+        """Close the response and its dedicated session exactly once."""
+        if self._closed:
+            return
+        self._closed = True
+        for resource in (self._response, self._session):
+            try:
+                resource.close()
+            except Exception:
+                pass

--- a/tldw_chatbook/LLM_Calls/moonshot.py
+++ b/tldw_chatbook/LLM_Calls/moonshot.py
@@ -1,0 +1,792 @@
+"""Strict Moonshot/Kimi Chat-Completions adapter policy."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from tldw_chatbook.Chat.Chat_Deps import (
+    ChatBadRequestError,
+    ChatConfigurationError,
+    ChatProviderError,
+)
+from tldw_chatbook.Chat.provider_continuation import (
+    ContinuationRestoreTarget,
+    ProviderContinuationCheckpoint,
+    validate_continuation_restore,
+)
+from tldw_chatbook.LLM_Calls.hosted_chat import (
+    HostedChatProtocolError,
+    HostedChatStream,
+    HostedChatTurn,
+    HostedHTTPTransportConfig,
+    hosted_chat_request,
+    normalize_hosted_chat_base_url,
+)
+from tldw_chatbook.config import (
+    get_runtime_config_snapshot,
+    resolve_provider_api_key,
+)
+
+
+_DEFAULT_BASE_URL = "https://api.moonshot.ai/v1"
+_CHINA_BASE_URL = "https://api.moonshot.cn/v1"
+_DEFAULT_MODEL = "kimi-k3"
+_FUNCTION_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]{2,63}$")
+_K3_REASONING_EFFORTS = frozenset({"low", "high", "max"})
+_MAX_JSON_DEPTH = 64
+_MAX_JSON_NODES = 50_000
+_MAX_JSON_STRING_CHARS = 16 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class MoonshotResolution:
+    """Immutable resolved Moonshot request identity and transport policy."""
+
+    provider: str
+    model: str
+    api_key: str = field(repr=False, compare=False)
+    base_url: str
+    timeout: float
+    retries: int
+    retry_delay: float
+    streaming: bool
+
+
+class MoonshotFinishPolicy:
+    """Validate Moonshot finish and reasoning fields."""
+
+    def validate_finish(
+        self,
+        *,
+        finish_reason: object,
+        has_text: bool,
+        has_calls: bool,
+    ) -> str:
+        if finish_reason not in {"stop", "tool_calls", "length"}:
+            raise HostedChatProtocolError("Moonshot finish state is malformed.")
+        if finish_reason == "tool_calls":
+            if not has_calls:
+                raise HostedChatProtocolError("Moonshot finish state is inconsistent.")
+        elif has_calls or not has_text:
+            raise HostedChatProtocolError("Moonshot finish state is inconsistent.")
+        return cast(str, finish_reason)
+
+    def validate_reasoning_content(self, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise HostedChatProtocolError("Moonshot reasoning content is malformed.")
+        return value
+
+
+class MoonshotStream(Iterator[dict[str, Any]]):
+    """Expose visible Moonshot chunks while retaining private terminal reasoning."""
+
+    def __init__(self, stream: HostedChatStream) -> None:
+        self._stream = stream
+
+    def __iter__(self) -> MoonshotStream:
+        return self
+
+    def __next__(self) -> dict[str, Any]:
+        event = deepcopy(next(self._stream))
+        for choice in event.get("choices", ()):
+            if isinstance(choice, dict) and isinstance(choice.get("delta"), dict):
+                choice["delta"].pop("reasoning_content", None)
+        return event
+
+    @property
+    def terminal_turn(self) -> HostedChatTurn:
+        """Return private terminal state after clean stream exhaustion."""
+        return self._stream.terminal_turn
+
+    def close(self) -> None:
+        """Close the owned response/session pair."""
+        self._stream.close()
+
+
+_FINISH_POLICY = MoonshotFinishPolicy()
+
+
+def chat_with_moonshot(
+    input_data: list[dict[str, Any]],
+    model: str | None = None,
+    api_key: str | None = None,
+    system_message: str | None = None,
+    temp: float | None = None,
+    maxp: float | None = None,
+    streaming: bool | None = False,
+    frequency_penalty: float | None = None,
+    max_tokens: int | None = None,
+    n: int | None = None,
+    presence_penalty: float | None = None,
+    response_format: dict[str, str] | None = None,
+    seed: int | None = None,
+    stop: str | list[str] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: str | dict[str, Any] | None = None,
+    user: str | None = None,
+    custom_prompt_arg: str | None = None,
+    api_base_url: str | None = None,
+    reasoning_effort: str | None = None,
+    provider_continuations: Sequence[ProviderContinuationCheckpoint] = (),
+) -> dict[str, Any] | MoonshotStream:
+    """Send one Moonshot Chat-Completions request through the hosted boundary."""
+    del custom_prompt_arg
+    resolution = resolve_moonshot_request(
+        explicit_api_key=api_key,
+        explicit_base_url=api_base_url,
+        explicit_model=model,
+    )
+    payload = build_moonshot_chat_payload(
+        resolution=resolution,
+        messages_payload=input_data,
+        system_message=system_message,
+        streaming=streaming,
+        tools=tools,
+        tool_choice=tool_choice,
+        reasoning_effort=reasoning_effort,
+        provider_continuations=provider_continuations,
+        max_tokens=max_tokens,
+        stop=stop,
+        response_format=response_format,
+        temperature=temp,
+        top_p=maxp,
+        n=n,
+        presence_penalty=presence_penalty,
+        frequency_penalty=frequency_penalty,
+        seed=seed,
+        user=user,
+    )
+    try:
+        result = hosted_chat_request(
+            config=HostedHTTPTransportConfig(
+                provider="moonshot",
+                base_url=resolution.base_url,
+                api_key=resolution.api_key,
+                timeout=resolution.timeout,
+                retries=resolution.retries,
+                retry_delay=resolution.retry_delay,
+            ),
+            payload=payload,
+            streaming=cast(bool, payload["stream"]),
+            finish_policy=_FINISH_POLICY,
+        )
+    except HostedChatProtocolError:
+        raise ChatProviderError(
+            provider="moonshot",
+            message="Moonshot returned a malformed successful response.",
+            status_code=502,
+        ) from None
+    if isinstance(result, HostedChatStream):
+        return MoonshotStream(result)
+    return _moonshot_turn_response(result)
+
+
+def _moonshot_turn_response(turn: HostedChatTurn) -> dict[str, Any]:
+    message = deepcopy(turn.assistant_message)
+    if message is None:
+        raise HostedChatProtocolError("Moonshot response message is incomplete.")
+    response: dict[str, Any] = {
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": turn.finish_reason,
+            }
+        ]
+    }
+    if turn.usage is not None:
+        response["usage"] = deepcopy(turn.usage)
+    return response
+
+
+def _configuration_error(message: str) -> ChatConfigurationError:
+    return ChatConfigurationError(provider="moonshot", message=message)
+
+
+def _bad_request(message: str) -> ChatBadRequestError:
+    return ChatBadRequestError(provider="moonshot", message=message)
+
+
+def resolve_moonshot_request(
+    *,
+    explicit_api_key: object = None,
+    explicit_base_url: object = None,
+    explicit_model: object = None,
+    app_config: Mapping[str, Any] | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> MoonshotResolution:
+    """Resolve one Moonshot request from canonical immutable sources.
+
+    Args:
+        explicit_api_key: Trusted call-supplied credential override.
+        explicit_base_url: Trusted call-supplied endpoint override.
+        explicit_model: Trusted call-supplied model override.
+        app_config: Loaded application configuration; runtime snapshot when absent.
+        environ: Environment mapping; ``os.environ`` when absent.
+
+    Returns:
+        A frozen Moonshot resolution.
+
+    Raises:
+        ChatConfigurationError: If any authoritative source is malformed or a
+            usable credential cannot be resolved.
+    """
+    config: object = (
+        get_runtime_config_snapshot().values if app_config is None else app_config
+    )
+    if not isinstance(config, Mapping):
+        raise _configuration_error("Moonshot application configuration is invalid.")
+    api_settings = config.get("api_settings", {})
+    if not isinstance(api_settings, Mapping):
+        raise _configuration_error(
+            "Moonshot api_settings must be a configuration table."
+        )
+    if "moonshot" in api_settings and not isinstance(
+        api_settings.get("moonshot"), Mapping
+    ):
+        raise _configuration_error(
+            "Moonshot api_settings.moonshot must be a configuration table."
+        )
+    settings = cast(Mapping[str, object], api_settings.get("moonshot", {}))
+    environment = os.environ if environ is None else environ
+
+    api_key = _resolve_api_key(explicit_api_key, settings, environment)
+    model = _resolve_nonblank_string(
+        explicit_model,
+        settings,
+        "model",
+        _DEFAULT_MODEL,
+        "model",
+    )
+    base_url = _resolve_base_url(explicit_base_url, settings)
+    timeout = _positive_number(settings, "timeout", 90.0)
+    retries = _nonnegative_integer(settings, "retries", 3)
+    retry_delay = _nonnegative_number(settings, "retry_delay", 1.0)
+    streaming = settings.get("streaming", True)
+    if type(streaming) is not bool:
+        raise _configuration_error("Moonshot streaming must be a boolean.")
+    return MoonshotResolution(
+        provider="moonshot",
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+        timeout=timeout,
+        retries=retries,
+        retry_delay=retry_delay,
+        streaming=streaming,
+    )
+
+
+def build_moonshot_chat_payload(
+    *,
+    resolution: MoonshotResolution,
+    messages_payload: Sequence[Mapping[str, Any]],
+    system_message: object = None,
+    streaming: object = None,
+    tools: object = None,
+    tool_choice: object = None,
+    reasoning_effort: object = None,
+    provider_continuations: Sequence[ProviderContinuationCheckpoint] = (),
+    max_tokens: object = None,
+    stop: object = None,
+    response_format: object = None,
+    temperature: object = None,
+    top_p: object = None,
+    n: object = None,
+    presence_penalty: object = None,
+    frequency_penalty: object = None,
+    seed: object = None,
+    user: object = None,
+    **_generic: object,
+) -> dict[str, Any]:
+    """Build one validated Moonshot request without mutating inputs."""
+    if type(resolution) is not MoonshotResolution or resolution.provider != "moonshot":
+        raise _bad_request("Moonshot resolution is invalid.")
+    stream = resolution.streaming if streaming is None else streaming
+    if type(stream) is not bool:
+        raise _bad_request("Moonshot streaming must be a boolean.")
+
+    messages = _normalize_messages(messages_payload, system_message=system_message)
+    _apply_continuations(messages, provider_continuations, resolution)
+    validated_tools = _normalize_tools(tools)
+    validated_choice = _normalize_tool_choice(tool_choice, validated_tools)
+    _validate_optional_generic_values(
+        temperature=temperature,
+        top_p=top_p,
+        n=n,
+        presence_penalty=presence_penalty,
+        frequency_penalty=frequency_penalty,
+        seed=seed,
+        user=user,
+    )
+
+    payload: dict[str, Any] = {
+        "model": resolution.model,
+        "messages": messages,
+        "stream": stream,
+    }
+    if max_tokens is not None:
+        payload["max_completion_tokens"] = _positive_integer("max_tokens", max_tokens)
+    if stop is not None:
+        payload["stop"] = _normalize_stop(stop)
+    if response_format is not None:
+        payload["response_format"] = _normalize_response_format(response_format)
+    if validated_tools is not None:
+        payload["tools"] = validated_tools
+    if validated_choice is not None:
+        payload["tool_choice"] = validated_choice
+
+    if resolution.model == _DEFAULT_MODEL:
+        if reasoning_effort is not None:
+            if (
+                not isinstance(reasoning_effort, str)
+                or reasoning_effort not in _K3_REASONING_EFFORTS
+            ):
+                raise _bad_request("Moonshot Kimi K3 reasoning effort is invalid.")
+            payload["reasoning_effort"] = reasoning_effort
+    elif reasoning_effort is not None:
+        raise _bad_request("Moonshot reasoning effort is unsupported for this model.")
+
+    if resolution.model.startswith("moonshot-v1-"):
+        legacy_n = cast(int | None, n)
+        legacy_temperature = cast(int | float | None, temperature)
+        if (
+            legacy_n is not None
+            and legacy_n > 1
+            and (legacy_temperature is None or legacy_temperature < 0.3)
+        ):
+            raise _bad_request(
+                "Moonshot multiple choices require temperature of at least 0.3."
+            )
+        for key, value in (
+            ("temperature", temperature),
+            ("top_p", top_p),
+            ("n", n),
+            ("presence_penalty", presence_penalty),
+            ("frequency_penalty", frequency_penalty),
+        ):
+            if value is not None:
+                payload[key] = value
+    if stream:
+        payload["stream_options"] = {"include_usage": True}
+    return payload
+
+
+def _resolve_api_key(
+    explicit: object,
+    settings: Mapping[str, object],
+    environ: Mapping[str, str],
+) -> str:
+    if explicit is not None:
+        resolved = resolve_provider_api_key(explicit)
+        if resolved is None:
+            raise _configuration_error("Moonshot explicit API key is invalid.")
+        return resolved
+    if "api_key" in settings:
+        resolved = resolve_provider_api_key(settings.get("api_key"))
+        if resolved is None:
+            raise _configuration_error(
+                "Moonshot api_settings.moonshot.api_key is invalid."
+            )
+        return resolved
+    env_name = settings.get("api_key_env_var", "MOONSHOT_API_KEY")
+    if not isinstance(env_name, str) or not env_name.strip():
+        raise _configuration_error(
+            "Moonshot api_settings.moonshot.api_key_env_var is invalid."
+        )
+    for candidate_name in dict.fromkeys((env_name.strip(), "MOONSHOT_API_KEY")):
+        resolved = resolve_provider_api_key(environ.get(candidate_name))
+        if resolved is not None:
+            return resolved
+    raise _configuration_error("Moonshot API key is required.")
+
+
+def _resolve_nonblank_string(
+    explicit: object,
+    settings: Mapping[str, object],
+    field_name: str,
+    default: str,
+    label: str,
+) -> str:
+    value = explicit if explicit is not None else settings.get(field_name, default)
+    if not isinstance(value, str) or not value.strip():
+        raise _configuration_error(f"Moonshot {label} is invalid.")
+    return value.strip()
+
+
+def _resolve_base_url(
+    explicit: object,
+    settings: Mapping[str, object],
+) -> str:
+    if explicit is not None:
+        candidate = explicit
+    elif "api_base_url" in settings:
+        candidate = settings.get("api_base_url")
+    else:
+        region = settings.get("api_region", "international")
+        if not isinstance(region, str) or region not in {"international", "china"}:
+            raise _configuration_error("Moonshot API region is invalid.")
+        candidate = _CHINA_BASE_URL if region == "china" else _DEFAULT_BASE_URL
+    try:
+        return normalize_hosted_chat_base_url(candidate, default=_DEFAULT_BASE_URL)
+    except ValueError:
+        raise _configuration_error("Moonshot API base URL is invalid.") from None
+
+
+def _positive_number(
+    settings: Mapping[str, object], name: str, default: float
+) -> float:
+    value = settings.get(name, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise _configuration_error(f"Moonshot {name} must be numeric.")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized <= 0:
+        raise _configuration_error(f"Moonshot {name} must be positive and finite.")
+    return normalized
+
+
+def _nonnegative_number(
+    settings: Mapping[str, object], name: str, default: float
+) -> float:
+    value = settings.get(name, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise _configuration_error(f"Moonshot {name} must be numeric.")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized < 0:
+        raise _configuration_error(f"Moonshot {name} must be non-negative.")
+    return normalized
+
+
+def _nonnegative_integer(
+    settings: Mapping[str, object], name: str, default: int
+) -> int:
+    value = settings.get(name, default)
+    if type(value) is not int or value < 0:
+        raise _configuration_error(f"Moonshot {name} must be a non-negative integer.")
+    return value
+
+
+def _normalize_messages(
+    value: object,
+    *,
+    system_message: object,
+) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise _bad_request("Moonshot messages must be a sequence.")
+    result: list[dict[str, Any]] = []
+    has_system = any(
+        isinstance(message, Mapping) and message.get("role") == "system"
+        for message in value
+    )
+    if system_message is not None:
+        if not isinstance(system_message, str) or has_system:
+            raise _bad_request("Moonshot system message ownership is invalid.")
+        result.append({"role": "system", "content": system_message})
+
+    call_ids: set[str] = set()
+    pending_ids: list[str] = []
+    for raw_message in value:
+        if not isinstance(raw_message, Mapping):
+            raise _bad_request("Moonshot message is malformed.")
+        role = raw_message.get("role")
+        if role not in {"system", "user", "assistant", "tool"}:
+            raise _bad_request("Moonshot message role is invalid.")
+        if role == "tool":
+            if not pending_ids:
+                raise _bad_request("Moonshot tool result is orphaned.")
+            if set(raw_message) != {"role", "tool_call_id", "content"}:
+                raise _bad_request("Moonshot tool result is malformed.")
+            call_id = raw_message.get("tool_call_id")
+            content = raw_message.get("content")
+            if call_id != pending_ids[0] or not isinstance(content, str):
+                raise _bad_request("Moonshot tool result ordering is invalid.")
+            pending_ids.pop(0)
+            result.append(deepcopy(dict(raw_message)))
+            continue
+        if pending_ids:
+            raise _bad_request("Moonshot tool call batch is incomplete.")
+        allowed = {"role", "content"} | (
+            {"tool_calls"} if role == "assistant" else set()
+        )
+        if set(raw_message) - allowed:
+            raise _bad_request("Moonshot message fields are unsupported.")
+        content = raw_message.get("content")
+        if role == "assistant":
+            if content is not None and not isinstance(content, str):
+                raise _bad_request("Moonshot assistant content is invalid.")
+        elif not isinstance(content, str):
+            raise _bad_request("Moonshot message content is invalid.")
+        safe = {"role": role, "content": "" if content is None else content}
+        if role == "assistant" and "tool_calls" in raw_message:
+            calls = _normalize_call_batch(raw_message.get("tool_calls"), call_ids)
+            safe["tool_calls"] = list(calls)
+            pending_ids = [cast(str, call["id"]) for call in calls]
+        result.append(deepcopy(safe))
+    if pending_ids:
+        raise _bad_request("Moonshot tool call batch is incomplete.")
+    return result
+
+
+def _normalize_call_batch(
+    value: object,
+    prior_ids: set[str],
+) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)) or not value:
+        raise _bad_request("Moonshot tool call batch is invalid.")
+    calls: list[dict[str, Any]] = []
+    for raw_call in value:
+        if not isinstance(raw_call, Mapping) or set(raw_call) != {
+            "id",
+            "type",
+            "function",
+        }:
+            raise _bad_request("Moonshot tool call is malformed.")
+        call_id = raw_call.get("id")
+        function = raw_call.get("function")
+        if (
+            not isinstance(call_id, str)
+            or not call_id
+            or call_id in prior_ids
+            or raw_call.get("type") != "function"
+            or not isinstance(function, Mapping)
+            or set(function) != {"name", "arguments"}
+            or not isinstance(function.get("name"), str)
+            or not _FUNCTION_NAME.fullmatch(cast(str, function.get("name")))
+            or not isinstance(function.get("arguments"), str)
+        ):
+            raise _bad_request("Moonshot tool call is malformed.")
+        try:
+            arguments = json.loads(cast(str, function.get("arguments")))
+        except (TypeError, ValueError):
+            raise _bad_request("Moonshot tool call arguments are invalid.") from None
+        if not isinstance(arguments, dict) or not _json_shape_is_bounded(arguments):
+            raise _bad_request("Moonshot tool call arguments are invalid.")
+        prior_ids.add(call_id)
+        calls.append(deepcopy(dict(raw_call)))
+    return tuple(calls)
+
+
+def _normalize_tools(value: object) -> list[dict[str, Any]] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)) or not value:
+        raise _bad_request("Moonshot tools are malformed.")
+    names: set[str] = set()
+    result: list[dict[str, Any]] = []
+    for raw_tool in value:
+        if not isinstance(raw_tool, Mapping) or set(raw_tool) != {"type", "function"}:
+            raise _bad_request("Moonshot supports function tools only.")
+        function = raw_tool.get("function")
+        if raw_tool.get("type") != "function" or not isinstance(function, Mapping):
+            raise _bad_request("Moonshot supports function tools only.")
+        if set(function) != {"name", "description", "parameters"}:
+            raise _bad_request("Moonshot function tool is malformed.")
+        name = function.get("name")
+        description = function.get("description")
+        parameters = function.get("parameters")
+        if (
+            not isinstance(name, str)
+            or not _FUNCTION_NAME.fullmatch(name)
+            or name in names
+            or not isinstance(description, str)
+            or not description.strip()
+            or not isinstance(parameters, Mapping)
+            or parameters.get("type") != "object"
+            or not _json_shape_is_bounded(parameters)
+        ):
+            raise _bad_request("Moonshot function tool is malformed.")
+        names.add(name)
+        result.append(deepcopy(dict(raw_tool)))
+    return result
+
+
+def _normalize_tool_choice(
+    value: object,
+    tools: Sequence[Mapping[str, Any]] | None,
+) -> object:
+    if value is None:
+        return None
+    if isinstance(value, str) and value in {"auto", "none", "required"}:
+        if value != "none" and tools is None:
+            raise _bad_request("Moonshot tool choice requires tools.")
+        return value
+    if isinstance(value, Mapping) and set(value) == {"type", "function"}:
+        function = value.get("function")
+        if (
+            value.get("type") == "function"
+            and isinstance(function, Mapping)
+            and set(function) == {"name"}
+            and isinstance(function.get("name"), str)
+            and tools is not None
+            and function.get("name")
+            in {cast(Mapping[str, Any], tool["function"])["name"] for tool in tools}
+        ):
+            return deepcopy(dict(value))
+    raise _bad_request("Moonshot tool choice is unsupported.")
+
+
+def _validate_optional_generic_values(**values: object) -> None:
+    for name in ("temperature", "top_p"):
+        value = values[name]
+        if value is not None and (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or not 0 <= float(value) <= 1
+        ):
+            raise _bad_request(f"Moonshot {name} is invalid.")
+    n = values["n"]
+    if n is not None and (type(n) is not int or n <= 0):
+        raise _bad_request("Moonshot n is invalid.")
+    for name in ("presence_penalty", "frequency_penalty"):
+        value = values[name]
+        if value is not None and (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or not -2 <= float(value) <= 2
+        ):
+            raise _bad_request(f"Moonshot {name} is invalid.")
+    seed = values["seed"]
+    if seed is not None and type(seed) is not int:
+        raise _bad_request("Moonshot seed is invalid.")
+    user = values["user"]
+    if user is not None and (not isinstance(user, str) or not user.strip()):
+        raise _bad_request("Moonshot user is invalid.")
+
+
+def _positive_integer(name: str, value: object) -> int:
+    if type(value) is not int or value <= 0:
+        raise _bad_request(f"Moonshot {name} is invalid.")
+    return value
+
+
+def _normalize_stop(value: object) -> object:
+    if isinstance(value, str) and value:
+        return value
+    if (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes))
+        and 1 <= len(value) <= 4
+        and all(isinstance(item, str) and item for item in value)
+    ):
+        return list(value)
+    raise _bad_request("Moonshot stop is invalid.")
+
+
+def _normalize_response_format(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or not _json_shape_is_bounded(value):
+        raise _bad_request("Moonshot response format is invalid.")
+    format_type = value.get("type")
+    if format_type in {"text", "json_object"}:
+        if set(value) != {"type"}:
+            raise _bad_request("Moonshot response format is invalid.")
+    elif format_type == "json_schema":
+        if set(value) != {"type", "json_schema"} or not isinstance(
+            value.get("json_schema"), Mapping
+        ):
+            raise _bad_request("Moonshot response format is invalid.")
+    else:
+        raise _bad_request("Moonshot response format is invalid.")
+    return deepcopy(dict(value))
+
+
+def _json_shape_is_bounded(value: object) -> bool:
+    stack: list[tuple[object, int]] = [(value, 1)]
+    nodes = 0
+    while stack:
+        current, depth = stack.pop()
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > _MAX_JSON_DEPTH:
+            return False
+        if current is None or type(current) in {bool, int}:
+            continue
+        if isinstance(current, float):
+            if not math.isfinite(current):
+                return False
+            continue
+        if isinstance(current, str):
+            if len(current) > _MAX_JSON_STRING_CHARS:
+                return False
+            continue
+        if isinstance(current, Mapping):
+            for key, item in current.items():
+                if not isinstance(key, str) or len(key) > _MAX_JSON_STRING_CHARS:
+                    return False
+                stack.append((item, depth + 1))
+            continue
+        if isinstance(current, Sequence) and not isinstance(current, (str, bytes)):
+            stack.extend((item, depth + 1) for item in current)
+            continue
+        return False
+    return True
+
+
+def _apply_continuations(
+    messages: list[dict[str, Any]],
+    checkpoints: Sequence[ProviderContinuationCheckpoint],
+    resolution: MoonshotResolution,
+) -> None:
+    if not isinstance(checkpoints, Sequence):
+        raise _bad_request("Moonshot provider continuation is invalid.")
+    cursor = 0
+    for checkpoint in checkpoints:
+        try:
+            validate_continuation_restore(
+                checkpoint,
+                ContinuationRestoreTarget(
+                    provider="moonshot",
+                    protocol="chat_completions",
+                    model=resolution.model,
+                    api_base_url=resolution.base_url,
+                ),
+            )
+        except Exception:
+            raise _bad_request("Moonshot provider continuation is invalid.") from None
+        for round_ in checkpoint.rounds:
+            call_ids = tuple(call.call_id for call in round_.calls)
+            match_index = _find_round_owner(
+                messages,
+                assistant_content=round_.assistant_content,
+                call_ids=call_ids,
+                start=cursor,
+            )
+            if match_index is None:
+                raise _bad_request("Moonshot continuation owner is missing.")
+            if round_.reasoning_blocks:
+                messages[match_index]["reasoning_content"] = "".join(
+                    round_.reasoning_blocks
+                )
+            cursor = match_index + 1
+
+
+def _find_round_owner(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    assistant_content: str,
+    call_ids: tuple[str, ...],
+    start: int,
+) -> int | None:
+    for index in range(start, len(messages)):
+        message = messages[index]
+        if (
+            message.get("role") != "assistant"
+            or message.get("content") != assistant_content
+        ):
+            continue
+        raw_calls = message.get("tool_calls", ())
+        message_ids = tuple(
+            call.get("id") for call in raw_calls if isinstance(call, Mapping)
+        )
+        if message_ids == call_ids:
+            return index
+    return None

--- a/tldw_chatbook/LLM_Calls/moonshot.py
+++ b/tldw_chatbook/LLM_Calls/moonshot.py
@@ -34,7 +34,9 @@ from tldw_chatbook.LLM_Calls.hosted_chat import (
     normalize_hosted_chat_base_url,
 )
 from tldw_chatbook.config import (
+    ProviderSettingsError,
     get_runtime_config_snapshot,
+    provider_settings_for_key,
     resolve_provider_api_key,
 )
 
@@ -410,13 +412,12 @@ def resolve_moonshot_request(
         raise _configuration_error(
             "Moonshot api_settings must be a configuration table."
         )
-    if "moonshot" in api_settings and not isinstance(
-        api_settings.get("moonshot"), Mapping
-    ):
+    try:
+        settings = provider_settings_for_key(api_settings, "moonshot")
+    except ProviderSettingsError:
         raise _configuration_error(
-            "Moonshot api_settings.moonshot must be a configuration table."
-        )
-    settings = cast(Mapping[str, object], api_settings.get("moonshot", {}))
+            "Moonshot api_settings.moonshot must be one unambiguous configuration table."
+        ) from None
     transport_settings = dict(settings)
     if explicit_timeout is not None:
         transport_settings["timeout"] = explicit_timeout

--- a/tldw_chatbook/LLM_Calls/moonshot.py
+++ b/tldw_chatbook/LLM_Calls/moonshot.py
@@ -919,6 +919,50 @@ def _apply_continuations(
             )
         except Exception:
             raise _bad_request("Moonshot provider continuation is invalid.") from None
+        if checkpoint.state == "complete" and resolution.model == _DEFAULT_MODEL:
+            final_round = checkpoint.rounds[-1]
+            match_index = _find_round_owner(
+                messages,
+                assistant_content=final_round.assistant_content,
+                call_ids=(),
+                start=cursor,
+            )
+            if match_index is None:
+                raise _bad_request("Moonshot continuation owner is missing.")
+            expanded: list[dict[str, Any]] = []
+            for round_ in checkpoint.rounds:
+                assistant: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": round_.assistant_content,
+                }
+                if round_.reasoning_blocks:
+                    assistant["reasoning_content"] = "".join(round_.reasoning_blocks)
+                if round_.calls:
+                    assistant["tool_calls"] = [
+                        {
+                            "id": call.call_id,
+                            "type": "function",
+                            "function": {
+                                "name": call.name,
+                                "arguments": call.arguments,
+                            },
+                        }
+                        for call in round_.calls
+                    ]
+                expanded.append(assistant)
+                for call in round_.calls:
+                    if call.result is None:
+                        raise _bad_request("Moonshot provider continuation is invalid.")
+                    expanded.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": call.call_id,
+                            "content": call.result.value,
+                        }
+                    )
+            messages[match_index : match_index + 1] = expanded
+            cursor = match_index + len(expanded)
+            continue
         for round_ in checkpoint.rounds:
             call_ids = tuple(call.call_id for call in round_.calls)
             match_index = _find_round_owner(

--- a/tldw_chatbook/LLM_Calls/moonshot.py
+++ b/tldw_chatbook/LLM_Calls/moonshot.py
@@ -17,8 +17,12 @@ from tldw_chatbook.Chat.Chat_Deps import (
     ChatProviderError,
 )
 from tldw_chatbook.Chat.provider_continuation import (
+    ContinuationCall,
+    ContinuationRound,
     ContinuationRestoreTarget,
     ProviderContinuationCheckpoint,
+    dump_provider_continuation_json,
+    parse_provider_continuation_json,
     validate_continuation_restore,
 )
 from tldw_chatbook.LLM_Calls.hosted_chat import (
@@ -89,8 +93,16 @@ class MoonshotFinishPolicy:
 class MoonshotStream(Iterator[dict[str, Any]]):
     """Expose visible Moonshot chunks while retaining private terminal reasoning."""
 
-    def __init__(self, stream: HostedChatStream) -> None:
+    def __init__(
+        self,
+        stream: HostedChatStream,
+        *,
+        resolution: MoonshotResolution | None = None,
+        provider_continuations: Sequence[ProviderContinuationCheckpoint] = (),
+    ) -> None:
         self._stream = stream
+        self._resolution = resolution
+        self._provider_continuations = tuple(provider_continuations)
 
     def __iter__(self) -> MoonshotStream:
         return self
@@ -107,9 +119,43 @@ class MoonshotStream(Iterator[dict[str, Any]]):
         """Return private terminal state after clean stream exhaustion."""
         return self._stream.terminal_turn
 
+    @property
+    def provider_continuation(self) -> ProviderContinuationCheckpoint | None:
+        """Return a canonical candidate only after clean stream exhaustion."""
+        if self._resolution is None:
+            raise HostedChatProtocolError("Moonshot stream metadata is incomplete.")
+        return _moonshot_continuation_candidate(
+            self.terminal_turn,
+            resolution=self._resolution,
+            provider_continuations=self._provider_continuations,
+        )
+
     def close(self) -> None:
         """Close the owned response/session pair."""
         self._stream.close()
+
+
+class MoonshotResponse(dict[str, Any]):
+    """Public response mapping with private terminal state kept out of repr."""
+
+    def __init__(
+        self,
+        value: Mapping[str, Any],
+        *,
+        terminal_turn: HostedChatTurn,
+        provider_continuation: ProviderContinuationCheckpoint | None,
+    ) -> None:
+        super().__init__(value)
+        self._terminal_turn = terminal_turn
+        self._provider_continuation = provider_continuation
+
+    @property
+    def terminal_turn(self) -> HostedChatTurn:
+        return self._terminal_turn
+
+    @property
+    def provider_continuation(self) -> ProviderContinuationCheckpoint | None:
+        return self._provider_continuation
 
 
 _FINISH_POLICY = MoonshotFinishPolicy()
@@ -137,6 +183,9 @@ def chat_with_moonshot(
     api_base_url: str | None = None,
     reasoning_effort: str | None = None,
     provider_continuations: Sequence[ProviderContinuationCheckpoint] = (),
+    request_timeout: float | None = None,
+    request_retries: int | None = None,
+    request_retry_delay: float | None = None,
 ) -> dict[str, Any] | MoonshotStream:
     """Send one Moonshot Chat-Completions request through the hosted boundary."""
     del custom_prompt_arg
@@ -144,6 +193,9 @@ def chat_with_moonshot(
         explicit_api_key=api_key,
         explicit_base_url=api_base_url,
         explicit_model=model,
+        explicit_timeout=request_timeout,
+        explicit_retries=request_retries,
+        explicit_retry_delay=request_retry_delay,
     )
     payload = build_moonshot_chat_payload(
         resolution=resolution,
@@ -186,14 +238,28 @@ def chat_with_moonshot(
             status_code=502,
         ) from None
     if isinstance(result, HostedChatStream):
-        return MoonshotStream(result)
-    return _moonshot_turn_response(result)
+        return MoonshotStream(
+            result,
+            resolution=resolution,
+            provider_continuations=provider_continuations,
+        )
+    return _moonshot_turn_response(
+        result,
+        resolution=resolution,
+        provider_continuations=provider_continuations,
+    )
 
 
-def _moonshot_turn_response(turn: HostedChatTurn) -> dict[str, Any]:
+def _moonshot_turn_response(
+    turn: HostedChatTurn,
+    *,
+    resolution: MoonshotResolution,
+    provider_continuations: Sequence[ProviderContinuationCheckpoint],
+) -> MoonshotResponse:
     message = deepcopy(turn.assistant_message)
     if message is None:
         raise HostedChatProtocolError("Moonshot response message is incomplete.")
+    message.pop("reasoning_content", None)
     response: dict[str, Any] = {
         "choices": [
             {
@@ -205,7 +271,98 @@ def _moonshot_turn_response(turn: HostedChatTurn) -> dict[str, Any]:
     }
     if turn.usage is not None:
         response["usage"] = deepcopy(turn.usage)
-    return response
+    return MoonshotResponse(
+        response,
+        terminal_turn=turn,
+        provider_continuation=_moonshot_continuation_candidate(
+            turn,
+            resolution=resolution,
+            provider_continuations=provider_continuations,
+        ),
+    )
+
+
+def _moonshot_continuation_candidate(
+    turn: HostedChatTurn,
+    *,
+    resolution: MoonshotResolution,
+    provider_continuations: Sequence[ProviderContinuationCheckpoint],
+) -> ProviderContinuationCheckpoint | None:
+    active = tuple(
+        checkpoint
+        for checkpoint in provider_continuations
+        if checkpoint.state == "active"
+    )
+    if len(active) > 1:
+        raise HostedChatProtocolError("Moonshot continuation state is ambiguous.")
+    current = active[0] if active else None
+    if turn.tool_calls:
+        round_ = ContinuationRound(
+            assistant_content=turn.text,
+            reasoning_blocks=(turn.reasoning_content,)
+            if turn.reasoning_content is not None
+            else (),
+            calls=tuple(
+                ContinuationCall(
+                    call_id=cast(str, call["id"]),
+                    name=cast(str, call["function"]["name"]),
+                    arguments=cast(str, call["function"]["arguments"]),
+                    state="pending",
+                )
+                for call in turn.tool_calls
+            ),
+        )
+        candidate = ProviderContinuationCheckpoint(
+            schema_version=1,
+            checkpoint_revision=(current.checkpoint_revision + 1 if current else 1),
+            provider="moonshot",
+            protocol="chat_completions",
+            model=resolution.model,
+            api_base_url=resolution.base_url,
+            state="active",
+            rounds=((*current.rounds, round_) if current else (round_,)),
+        )
+    elif current is not None:
+        rounds = current.rounds
+        if resolution.model == _DEFAULT_MODEL:
+            rounds = (
+                *rounds,
+                ContinuationRound(
+                    assistant_content=turn.text,
+                    reasoning_blocks=(turn.reasoning_content or "",),
+                    calls=(),
+                ),
+            )
+        candidate = ProviderContinuationCheckpoint(
+            schema_version=1,
+            checkpoint_revision=current.checkpoint_revision + 1,
+            provider="moonshot",
+            protocol="chat_completions",
+            model=resolution.model,
+            api_base_url=resolution.base_url,
+            state="complete",
+            rounds=rounds,
+        )
+    elif resolution.model == _DEFAULT_MODEL and turn.reasoning_content:
+        candidate = ProviderContinuationCheckpoint(
+            schema_version=1,
+            checkpoint_revision=1,
+            provider="moonshot",
+            protocol="chat_completions",
+            model=resolution.model,
+            api_base_url=resolution.base_url,
+            state="complete",
+            rounds=(
+                ContinuationRound(
+                    assistant_content=turn.text,
+                    reasoning_blocks=(turn.reasoning_content,),
+                    calls=(),
+                ),
+            ),
+        )
+    else:
+        return None
+    return parse_provider_continuation_json(dump_provider_continuation_json(candidate))
 
 
 def _configuration_error(message: str) -> ChatConfigurationError:
@@ -221,6 +378,9 @@ def resolve_moonshot_request(
     explicit_api_key: object = None,
     explicit_base_url: object = None,
     explicit_model: object = None,
+    explicit_timeout: object = None,
+    explicit_retries: object = None,
+    explicit_retry_delay: object = None,
     app_config: Mapping[str, Any] | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> MoonshotResolution:
@@ -257,6 +417,13 @@ def resolve_moonshot_request(
             "Moonshot api_settings.moonshot must be a configuration table."
         )
     settings = cast(Mapping[str, object], api_settings.get("moonshot", {}))
+    transport_settings = dict(settings)
+    if explicit_timeout is not None:
+        transport_settings["timeout"] = explicit_timeout
+    if explicit_retries is not None:
+        transport_settings["retries"] = explicit_retries
+    if explicit_retry_delay is not None:
+        transport_settings["retry_delay"] = explicit_retry_delay
     environment = os.environ if environ is None else environ
 
     api_key = _resolve_api_key(explicit_api_key, settings, environment)
@@ -268,9 +435,9 @@ def resolve_moonshot_request(
         "model",
     )
     base_url = _resolve_base_url(explicit_base_url, settings)
-    timeout = _positive_number(settings, "timeout", 90.0)
-    retries = _nonnegative_integer(settings, "retries", 3)
-    retry_delay = _nonnegative_number(settings, "retry_delay", 1.0)
+    timeout = _positive_number(transport_settings, "timeout", 90.0)
+    retries = _nonnegative_integer(transport_settings, "retries", 3)
+    retry_delay = _nonnegative_number(transport_settings, "retry_delay", 1.0)
     streaming = settings.get("streaming", True)
     if type(streaming) is not bool:
         raise _configuration_error("Moonshot streaming must be a boolean.")

--- a/tldw_chatbook/LLM_Calls/qwencloud_streaming.py
+++ b/tldw_chatbook/LLM_Calls/qwencloud_streaming.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import codecs
 import hashlib
 import json
 import math
@@ -15,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Never, cast
 import requests
 
 from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
+from tldw_chatbook.LLM_Calls.hosted_chat_streaming import SSERecordDecoder
 
 if TYPE_CHECKING:
     from tldw_chatbook.LLM_Calls.qwencloud import QwenCloudAPIMode
@@ -1026,66 +1026,6 @@ class QwenCloudStream(Iterator[dict[str, Any]]):
         return decoded
 
 
-def _iter_utf8_lines(chunks: Iterable[bytes]) -> Iterator[tuple[str, bool]]:
-    """Decode byte chunks with linear segment accumulation and newline framing."""
-    decoder = codecs.getincrementaldecoder("utf-8")(errors="strict")
-
-    def decoded_segments() -> Iterator[str]:
-        for chunk in chunks:
-            if not isinstance(chunk, bytes):
-                raise TypeError("QwenCloud SSE chunks must be bytes.")
-            decoded = decoder.decode(chunk, final=False)
-            if decoded:
-                yield decoded
-        final = decoder.decode(b"", final=True)
-        if final:
-            yield final
-
-    segments: list[str] = []
-    line_chars = 0
-    skip_leading_lf = False
-    for decoded in decoded_segments():
-        cursor = 0
-        if skip_leading_lf:
-            if decoded.startswith("\n"):
-                cursor = 1
-            skip_leading_lf = False
-        segment_start = cursor
-        while cursor < len(decoded):
-            character = decoded[cursor]
-            if character not in {"\r", "\n"}:
-                cursor += 1
-                continue
-            segment = decoded[segment_start:cursor]
-            if segment:
-                line_chars += len(segment)
-                if line_chars > _MAX_SSE_LINE_CHARS:
-                    raise ValueError("QwenCloud SSE line limit was exceeded.")
-                if len(segments) >= _MAX_SSE_LINE_SEGMENTS:
-                    raise ValueError("QwenCloud SSE line segment limit was exceeded.")
-                segments.append(segment)
-            yield "".join(segments), True
-            segments.clear()
-            line_chars = 0
-            cursor += 1
-            if character == "\r":
-                if cursor < len(decoded) and decoded[cursor] == "\n":
-                    cursor += 1
-                elif cursor == len(decoded):
-                    skip_leading_lf = True
-            segment_start = cursor
-        segment = decoded[segment_start:]
-        if segment:
-            line_chars += len(segment)
-            if line_chars > _MAX_SSE_LINE_CHARS:
-                raise ValueError("QwenCloud SSE line limit was exceeded.")
-            if len(segments) >= _MAX_SSE_LINE_SEGMENTS:
-                raise ValueError("QwenCloud SSE line segment limit was exceeded.")
-            segments.append(segment)
-    if segments:
-        yield "".join(segments), False
-
-
 def iter_sse_data_records(chunks: Iterable[bytes]) -> Iterator[str]:
     """Yield complete SSE data records from arbitrary response byte chunks.
 
@@ -1104,35 +1044,15 @@ def iter_sse_data_records(chunks: Iterable[bytes]) -> Iterator[str]:
         TypeError: If a chunk is not bytes.
         ValueError: If EOF interrupts a data record before its blank terminator.
     """
-    data_lines: list[str] = []
-    record_chars = 0
-    for line, terminated in _iter_utf8_lines(chunks):
-        if not terminated:
-            if line.startswith("data:") or line == "data" or data_lines:
-                raise ValueError("QwenCloud SSE data record is incomplete.")
-            continue
-        if line == "":
-            if data_lines:
-                yield "\n".join(data_lines)
-                data_lines.clear()
-                record_chars = 0
-            continue
-        if line.startswith(":"):
-            continue
-        field, separator, value = line.partition(":")
-        if field != "data":
-            continue
-        if not separator:
-            value = ""
-        elif value.startswith(" "):
-            value = value[1:]
-        added_chars = len(value) + (1 if data_lines else 0)
-        if record_chars + added_chars > _MAX_SSE_RECORD_CHARS:
-            raise ValueError("QwenCloud SSE record limit was exceeded.")
-        if len(data_lines) >= _MAX_SSE_DATA_LINES:
-            raise ValueError("QwenCloud SSE data line limit was exceeded.")
-        record_chars += added_chars
-        data_lines.append(value)
-
-    if data_lines:
-        raise ValueError("QwenCloud SSE data record is incomplete.")
+    decoder = SSERecordDecoder(
+        max_bytes=None,
+        max_line_chars=_MAX_SSE_LINE_CHARS,
+        max_record_chars=_MAX_SSE_RECORD_CHARS,
+        max_line_segments=_MAX_SSE_LINE_SEGMENTS,
+        max_data_lines=_MAX_SSE_DATA_LINES,
+    )
+    for chunk in chunks:
+        for record in decoder.feed(chunk):
+            yield record.data
+    for record in decoder.finish():
+        yield record.data

--- a/tldw_chatbook/LLM_Calls/zai.py
+++ b/tldw_chatbook/LLM_Calls/zai.py
@@ -34,7 +34,12 @@ from tldw_chatbook.LLM_Calls.hosted_chat import (
     normalize_hosted_chat_response,
     owned_json_post,
 )
-from tldw_chatbook.config import get_runtime_config_snapshot, resolve_provider_api_key
+from tldw_chatbook.config import (
+    ProviderSettingsError,
+    get_runtime_config_snapshot,
+    provider_settings_for_key,
+    resolve_provider_api_key,
+)
 
 
 _DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4"
@@ -190,11 +195,12 @@ def resolve_zai_request(
     api_settings = config.get("api_settings", {})
     if not isinstance(api_settings, Mapping):
         raise _configuration_error("Z.ai api_settings must be a configuration table.")
-    if "zai" in api_settings and not isinstance(api_settings.get("zai"), Mapping):
+    try:
+        settings = provider_settings_for_key(api_settings, "zai")
+    except ProviderSettingsError:
         raise _configuration_error(
-            "Z.ai api_settings.zai must be a configuration table."
-        )
-    settings = cast(Mapping[str, object], api_settings.get("zai", {}))
+            "Z.ai api_settings.zai must be one unambiguous configuration table."
+        ) from None
     transport_settings = dict(settings)
     if explicit_timeout is not None:
         transport_settings["timeout"] = explicit_timeout

--- a/tldw_chatbook/LLM_Calls/zai.py
+++ b/tldw_chatbook/LLM_Calls/zai.py
@@ -17,8 +17,12 @@ from tldw_chatbook.Chat.Chat_Deps import (
     ChatProviderError,
 )
 from tldw_chatbook.Chat.provider_continuation import (
+    ContinuationCall,
+    ContinuationRound,
     ContinuationRestoreTarget,
     ProviderContinuationCheckpoint,
+    dump_provider_continuation_json,
+    parse_provider_continuation_json,
     validate_continuation_restore,
 )
 from tldw_chatbook.LLM_Calls.hosted_chat import (
@@ -98,8 +102,16 @@ class ZAIFinishPolicy:
 class ZAIStream(Iterator[dict[str, Any]]):
     """Expose visible Z.ai chunks while retaining private terminal reasoning."""
 
-    def __init__(self, stream: HostedChatStream) -> None:
+    def __init__(
+        self,
+        stream: HostedChatStream,
+        *,
+        resolution: ZAIResolution | None = None,
+        provider_continuations: Sequence[ProviderContinuationCheckpoint] = (),
+    ) -> None:
         self._stream = stream
+        self._resolution = resolution
+        self._provider_continuations = tuple(provider_continuations)
 
     def __iter__(self) -> ZAIStream:
         return self
@@ -116,9 +128,43 @@ class ZAIStream(Iterator[dict[str, Any]]):
         """Return private terminal state after clean stream exhaustion."""
         return self._stream.terminal_turn
 
+    @property
+    def provider_continuation(self) -> ProviderContinuationCheckpoint | None:
+        """Return a canonical candidate only after clean stream exhaustion."""
+        if self._resolution is None:
+            raise HostedChatProtocolError("Z.ai stream metadata is incomplete.")
+        return _zai_continuation_candidate(
+            self.terminal_turn,
+            resolution=self._resolution,
+            provider_continuations=self._provider_continuations,
+        )
+
     def close(self) -> None:
         """Close the owned response/session pair."""
         self._stream.close()
+
+
+class ZAIResponse(dict[str, Any]):
+    """Public response mapping with private terminal state kept out of repr."""
+
+    def __init__(
+        self,
+        value: Mapping[str, Any],
+        *,
+        terminal_turn: HostedChatTurn,
+        provider_continuation: ProviderContinuationCheckpoint | None,
+    ) -> None:
+        super().__init__(value)
+        self._terminal_turn = terminal_turn
+        self._provider_continuation = provider_continuation
+
+    @property
+    def terminal_turn(self) -> HostedChatTurn:
+        return self._terminal_turn
+
+    @property
+    def provider_continuation(self) -> ProviderContinuationCheckpoint | None:
+        return self._provider_continuation
 
 
 _FINISH_POLICY = ZAIFinishPolicy()
@@ -129,6 +175,9 @@ def resolve_zai_request(
     explicit_api_key: object = None,
     explicit_base_url: object = None,
     explicit_model: object = None,
+    explicit_timeout: object = None,
+    explicit_retries: object = None,
+    explicit_retry_delay: object = None,
     app_config: Mapping[str, Any] | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> ZAIResolution:
@@ -146,15 +195,22 @@ def resolve_zai_request(
             "Z.ai api_settings.zai must be a configuration table."
         )
     settings = cast(Mapping[str, object], api_settings.get("zai", {}))
+    transport_settings = dict(settings)
+    if explicit_timeout is not None:
+        transport_settings["timeout"] = explicit_timeout
+    if explicit_retries is not None:
+        transport_settings["retries"] = explicit_retries
+    if explicit_retry_delay is not None:
+        transport_settings["retry_delay"] = explicit_retry_delay
     environment = os.environ if environ is None else environ
     return ZAIResolution(
         provider="zai",
         model=_resolve_string(explicit_model, settings, "model", _DEFAULT_MODEL),
         api_key=_resolve_api_key(explicit_api_key, settings, environment),
         base_url=_resolve_base_url(explicit_base_url, settings),
-        timeout=_positive_number(settings, "timeout", 90.0),
-        retries=_nonnegative_integer(settings, "retries", 3),
-        retry_delay=_nonnegative_number(settings, "retry_delay", 1.0),
+        timeout=_positive_number(transport_settings, "timeout", 90.0),
+        retries=_nonnegative_integer(transport_settings, "retries", 3),
+        retry_delay=_nonnegative_number(transport_settings, "retry_delay", 1.0),
         streaming=_resolve_streaming(settings),
     )
 
@@ -304,6 +360,9 @@ def chat_with_zai(
     user: str | None = None,
     reasoning_effort: str | None = None,
     provider_continuations: Sequence[ProviderContinuationCheckpoint] = (),
+    request_timeout: float | None = None,
+    request_retries: int | None = None,
+    request_retry_delay: float | None = None,
 ) -> dict[str, Any] | ZAIStream:
     """Send one Z.ai Chat-Completions request through the hosted boundary."""
     del custom_prompt_arg
@@ -311,6 +370,9 @@ def chat_with_zai(
         explicit_api_key=api_key,
         explicit_base_url=api_base_url,
         explicit_model=model,
+        explicit_timeout=request_timeout,
+        explicit_retries=request_retries,
+        explicit_retry_delay=request_retry_delay,
     )
     payload = build_zai_chat_payload(
         resolution=resolution,
@@ -346,7 +408,11 @@ def chat_with_zai(
         )
         if payload["stream"]:
             return ZAIStream(
-                HostedChatStream(cast(Iterator[Any], raw), finish_policy=_FINISH_POLICY)
+                HostedChatStream(
+                    cast(Iterator[Any], raw), finish_policy=_FINISH_POLICY
+                ),
+                resolution=resolution,
+                provider_continuations=provider_continuations,
             )
         turn = normalize_zai_response(raw)
     except ChatProviderError:
@@ -357,13 +423,23 @@ def chat_with_zai(
             message="Z.ai returned a malformed successful response.",
             status_code=502,
         ) from None
-    return _turn_response(turn)
+    return _turn_response(
+        turn,
+        resolution=resolution,
+        provider_continuations=provider_continuations,
+    )
 
 
-def _turn_response(turn: HostedChatTurn) -> dict[str, Any]:
+def _turn_response(
+    turn: HostedChatTurn,
+    *,
+    resolution: ZAIResolution,
+    provider_continuations: Sequence[ProviderContinuationCheckpoint],
+) -> ZAIResponse:
     message = deepcopy(turn.assistant_message)
     if message is None:
         raise HostedChatProtocolError("Z.ai response message is incomplete.")
+    message.pop("reasoning_content", None)
     response: dict[str, Any] = {
         "choices": [
             {
@@ -375,7 +451,71 @@ def _turn_response(turn: HostedChatTurn) -> dict[str, Any]:
     }
     if turn.usage is not None:
         response["usage"] = deepcopy(turn.usage)
-    return response
+    return ZAIResponse(
+        response,
+        terminal_turn=turn,
+        provider_continuation=_zai_continuation_candidate(
+            turn,
+            resolution=resolution,
+            provider_continuations=provider_continuations,
+        ),
+    )
+
+
+def _zai_continuation_candidate(
+    turn: HostedChatTurn,
+    *,
+    resolution: ZAIResolution,
+    provider_continuations: Sequence[ProviderContinuationCheckpoint],
+) -> ProviderContinuationCheckpoint | None:
+    active = tuple(
+        checkpoint
+        for checkpoint in provider_continuations
+        if checkpoint.state == "active"
+    )
+    if len(active) > 1:
+        raise HostedChatProtocolError("Z.ai continuation state is ambiguous.")
+    current = active[0] if active else None
+    if turn.tool_calls:
+        round_ = ContinuationRound(
+            assistant_content=turn.text,
+            reasoning_blocks=(turn.reasoning_content,)
+            if turn.reasoning_content is not None
+            else (),
+            calls=tuple(
+                ContinuationCall(
+                    call_id=cast(str, call["id"]),
+                    name=cast(str, call["function"]["name"]),
+                    arguments=cast(str, call["function"]["arguments"]),
+                    state="pending",
+                )
+                for call in turn.tool_calls
+            ),
+        )
+        candidate = ProviderContinuationCheckpoint(
+            schema_version=1,
+            checkpoint_revision=(current.checkpoint_revision + 1 if current else 1),
+            provider="zai",
+            protocol="chat_completions",
+            model=resolution.model,
+            api_base_url=resolution.base_url,
+            state="active",
+            rounds=((*current.rounds, round_) if current else (round_,)),
+        )
+    elif current is not None:
+        candidate = ProviderContinuationCheckpoint(
+            schema_version=1,
+            checkpoint_revision=current.checkpoint_revision + 1,
+            provider="zai",
+            protocol="chat_completions",
+            model=resolution.model,
+            api_base_url=resolution.base_url,
+            state="complete",
+            rounds=current.rounds,
+        )
+    else:
+        return None
+    return parse_provider_continuation_json(dump_provider_continuation_json(candidate))
 
 
 def _configuration_error(message: str) -> ChatConfigurationError:

--- a/tldw_chatbook/LLM_Calls/zai.py
+++ b/tldw_chatbook/LLM_Calls/zai.py
@@ -1,0 +1,773 @@
+"""Strict Z.ai/GLM Chat-Completions adapter policy."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from tldw_chatbook.Chat.Chat_Deps import (
+    ChatBadRequestError,
+    ChatConfigurationError,
+    ChatProviderError,
+)
+from tldw_chatbook.Chat.provider_continuation import (
+    ContinuationRestoreTarget,
+    ProviderContinuationCheckpoint,
+    validate_continuation_restore,
+)
+from tldw_chatbook.LLM_Calls.hosted_chat import (
+    HostedChatProtocolError,
+    HostedChatStream,
+    HostedChatTurn,
+    HostedHTTPTransportConfig,
+    normalize_hosted_chat_base_url,
+    normalize_hosted_chat_response,
+    owned_json_post,
+)
+from tldw_chatbook.config import get_runtime_config_snapshot, resolve_provider_api_key
+
+
+_DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4"
+_DEFAULT_MODEL = "glm-5.2"
+_FUNCTION_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]{2,63}$")
+_GLM_5_2_REASONING_EFFORTS = frozenset(
+    {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+)
+_MAX_JSON_DEPTH = 64
+_MAX_JSON_NODES = 50_000
+_MAX_JSON_STRING_CHARS = 16 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ZAIResolution:
+    """Immutable resolved Z.ai request identity and transport policy."""
+
+    provider: str
+    model: str
+    api_key: str = field(repr=False, compare=False)
+    base_url: str
+    timeout: float
+    retries: int
+    retry_delay: float
+    streaming: bool
+
+
+class ZAIFinishPolicy:
+    """Validate Z.ai finishes and allowlisted reasoning content."""
+
+    def validate_finish(
+        self,
+        *,
+        finish_reason: object,
+        has_text: bool,
+        has_calls: bool,
+    ) -> str:
+        if finish_reason in {
+            "sensitive",
+            "model_context_window_exceeded",
+            "network_error",
+        }:
+            raise ChatProviderError(
+                provider="zai",
+                message="Z.ai ended the request with a provider terminal error.",
+                status_code=502,
+            )
+        if finish_reason not in {"stop", "tool_calls", "length"}:
+            raise HostedChatProtocolError("Z.ai finish state is malformed.")
+        if finish_reason == "tool_calls":
+            if not has_calls:
+                raise HostedChatProtocolError("Z.ai finish state is inconsistent.")
+        elif has_calls or not has_text:
+            raise HostedChatProtocolError("Z.ai finish state is inconsistent.")
+        return cast(str, finish_reason)
+
+    def validate_reasoning_content(self, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise HostedChatProtocolError("Z.ai reasoning content is malformed.")
+        return value
+
+
+class ZAIStream(Iterator[dict[str, Any]]):
+    """Expose visible Z.ai chunks while retaining private terminal reasoning."""
+
+    def __init__(self, stream: HostedChatStream) -> None:
+        self._stream = stream
+
+    def __iter__(self) -> ZAIStream:
+        return self
+
+    def __next__(self) -> dict[str, Any]:
+        event = deepcopy(next(self._stream))
+        for choice in event.get("choices", ()):
+            if isinstance(choice, dict) and isinstance(choice.get("delta"), dict):
+                choice["delta"].pop("reasoning_content", None)
+        return event
+
+    @property
+    def terminal_turn(self) -> HostedChatTurn:
+        """Return private terminal state after clean stream exhaustion."""
+        return self._stream.terminal_turn
+
+    def close(self) -> None:
+        """Close the owned response/session pair."""
+        self._stream.close()
+
+
+_FINISH_POLICY = ZAIFinishPolicy()
+
+
+def resolve_zai_request(
+    *,
+    explicit_api_key: object = None,
+    explicit_base_url: object = None,
+    explicit_model: object = None,
+    app_config: Mapping[str, Any] | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> ZAIResolution:
+    """Resolve one Z.ai request from canonical immutable sources."""
+    config: object = (
+        get_runtime_config_snapshot().values if app_config is None else app_config
+    )
+    if not isinstance(config, Mapping):
+        raise _configuration_error("Z.ai application configuration is invalid.")
+    api_settings = config.get("api_settings", {})
+    if not isinstance(api_settings, Mapping):
+        raise _configuration_error("Z.ai api_settings must be a configuration table.")
+    if "zai" in api_settings and not isinstance(api_settings.get("zai"), Mapping):
+        raise _configuration_error(
+            "Z.ai api_settings.zai must be a configuration table."
+        )
+    settings = cast(Mapping[str, object], api_settings.get("zai", {}))
+    environment = os.environ if environ is None else environ
+    return ZAIResolution(
+        provider="zai",
+        model=_resolve_string(explicit_model, settings, "model", _DEFAULT_MODEL),
+        api_key=_resolve_api_key(explicit_api_key, settings, environment),
+        base_url=_resolve_base_url(explicit_base_url, settings),
+        timeout=_positive_number(settings, "timeout", 90.0),
+        retries=_nonnegative_integer(settings, "retries", 3),
+        retry_delay=_nonnegative_number(settings, "retry_delay", 1.0),
+        streaming=_resolve_streaming(settings),
+    )
+
+
+def build_zai_chat_payload(
+    *,
+    resolution: ZAIResolution,
+    messages_payload: Sequence[Mapping[str, Any]],
+    system_message: object = None,
+    streaming: object = None,
+    tools: object = None,
+    tool_choice: object = None,
+    reasoning_effort: object = None,
+    provider_continuations: Sequence[ProviderContinuationCheckpoint] = (),
+    do_sample: object = None,
+    temperature: object = None,
+    top_p: object = None,
+    max_tokens: object = None,
+    stop: object = None,
+    response_format: object = None,
+    request_id: object = None,
+    user: object = None,
+    **_generic: object,
+) -> dict[str, Any]:
+    """Build one validated Z.ai request without mutating inputs."""
+    if type(resolution) is not ZAIResolution or resolution.provider != "zai":
+        raise _bad_request("Z.ai resolution is invalid.")
+    stream = resolution.streaming if streaming is None else streaming
+    if type(stream) is not bool:
+        raise _bad_request("Z.ai streaming must be a boolean.")
+    if do_sample is not None and type(do_sample) is not bool:
+        raise _bad_request("Z.ai do_sample must be a boolean.")
+    _validate_sampler("temperature", temperature)
+    _validate_sampler("top_p", top_p)
+    messages = _normalize_messages(messages_payload, system_message=system_message)
+    validated_tools = _normalize_tools(tools)
+    validated_choice = _normalize_tool_choice(tool_choice, validated_tools)
+    active_tool_run = validated_tools is not None or bool(provider_continuations)
+    _apply_continuations(messages, provider_continuations, resolution)
+
+    payload: dict[str, Any] = {
+        "model": resolution.model,
+        "messages": messages,
+        "stream": stream,
+        "thinking": {"type": "enabled", "clear_thinking": not active_tool_run},
+    }
+    for key, value in (
+        ("do_sample", do_sample),
+        ("temperature", temperature),
+        ("top_p", top_p),
+    ):
+        if value is not None:
+            payload[key] = value
+    if max_tokens is not None:
+        payload["max_tokens"] = _positive_integer("max_tokens", max_tokens)
+    if stop is not None:
+        payload["stop"] = _normalize_stop(stop)
+    if response_format is not None:
+        payload["response_format"] = _normalize_response_format(response_format)
+    if request_id is not None:
+        payload["request_id"] = _bounded_identifier("request_id", request_id)
+    if user is not None:
+        payload["user_id"] = _bounded_identifier("user", user)
+    if validated_tools is not None:
+        payload["tools"] = validated_tools
+    if validated_choice is not None:
+        payload["tool_choice"] = validated_choice
+    if reasoning_effort is not None:
+        if (
+            resolution.model != _DEFAULT_MODEL
+            or not isinstance(reasoning_effort, str)
+            or reasoning_effort not in _GLM_5_2_REASONING_EFFORTS
+        ):
+            raise _bad_request("Z.ai reasoning effort is unsupported or invalid.")
+        payload["reasoning_effort"] = reasoning_effort
+    return payload
+
+
+def normalize_zai_response(response: object) -> HostedChatTurn:
+    """Normalize one official-shaped Z.ai response through the hosted boundary."""
+    safe = deepcopy(response)
+    try:
+        if isinstance(safe, Mapping):
+            choices = safe.get("choices")
+            if isinstance(choices, Sequence) and not isinstance(choices, (str, bytes)):
+                for choice in choices:
+                    if not isinstance(choice, Mapping):
+                        continue
+                    message = choice.get("message")
+                    if not isinstance(message, Mapping):
+                        continue
+                    calls = message.get("tool_calls")
+                    if not isinstance(calls, Sequence) or isinstance(
+                        calls, (str, bytes)
+                    ):
+                        continue
+                    for call in calls:
+                        if not isinstance(call, dict):
+                            continue
+                        function = call.get("function")
+                        if not isinstance(function, dict):
+                            continue
+                        arguments = function.get("arguments")
+                        if isinstance(arguments, Mapping):
+                            if not _json_shape_is_bounded(arguments):
+                                raise HostedChatProtocolError(
+                                    "Z.ai tool arguments are malformed."
+                                )
+                            function["arguments"] = json.dumps(
+                                arguments,
+                                sort_keys=True,
+                                separators=(",", ":"),
+                                ensure_ascii=False,
+                            )
+                        elif not isinstance(arguments, str):
+                            raise HostedChatProtocolError(
+                                "Z.ai tool arguments are malformed."
+                            )
+        return normalize_hosted_chat_response(safe, finish_policy=_FINISH_POLICY)
+    except ChatProviderError:
+        raise
+    except HostedChatProtocolError:
+        raise ChatProviderError(
+            provider="zai",
+            message="Z.ai returned a malformed successful response.",
+            status_code=502,
+        ) from None
+
+
+def chat_with_zai(
+    input_data: list[dict[str, Any]],
+    model: str | None = None,
+    api_key: str | None = None,
+    system_message: str | None = None,
+    temp: float | None = None,
+    maxp: float | None = None,
+    streaming: bool | None = False,
+    max_tokens: int | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    do_sample: bool | None = None,
+    request_id: str | None = None,
+    custom_prompt_arg: str | None = None,
+    api_base_url: str | None = None,
+    tool_choice: str | dict[str, Any] | None = None,
+    stop: str | list[str] | None = None,
+    response_format: dict[str, Any] | None = None,
+    user: str | None = None,
+    reasoning_effort: str | None = None,
+    provider_continuations: Sequence[ProviderContinuationCheckpoint] = (),
+) -> dict[str, Any] | ZAIStream:
+    """Send one Z.ai Chat-Completions request through the hosted boundary."""
+    del custom_prompt_arg
+    resolution = resolve_zai_request(
+        explicit_api_key=api_key,
+        explicit_base_url=api_base_url,
+        explicit_model=model,
+    )
+    payload = build_zai_chat_payload(
+        resolution=resolution,
+        messages_payload=input_data,
+        system_message=system_message,
+        streaming=streaming,
+        tools=tools,
+        tool_choice=tool_choice,
+        reasoning_effort=reasoning_effort,
+        provider_continuations=provider_continuations,
+        do_sample=do_sample,
+        temperature=temp,
+        top_p=maxp,
+        max_tokens=max_tokens,
+        stop=stop,
+        response_format=response_format,
+        request_id=request_id,
+        user=user,
+    )
+    try:
+        raw = owned_json_post(
+            config=HostedHTTPTransportConfig(
+                provider="zai",
+                base_url=resolution.base_url,
+                api_key=resolution.api_key,
+                timeout=resolution.timeout,
+                retries=resolution.retries,
+                retry_delay=resolution.retry_delay,
+            ),
+            route="chat/completions",
+            payload=payload,
+            streaming=cast(bool, payload["stream"]),
+        )
+        if payload["stream"]:
+            return ZAIStream(
+                HostedChatStream(cast(Iterator[Any], raw), finish_policy=_FINISH_POLICY)
+            )
+        turn = normalize_zai_response(raw)
+    except ChatProviderError:
+        raise
+    except HostedChatProtocolError:
+        raise ChatProviderError(
+            provider="zai",
+            message="Z.ai returned a malformed successful response.",
+            status_code=502,
+        ) from None
+    return _turn_response(turn)
+
+
+def _turn_response(turn: HostedChatTurn) -> dict[str, Any]:
+    message = deepcopy(turn.assistant_message)
+    if message is None:
+        raise HostedChatProtocolError("Z.ai response message is incomplete.")
+    response: dict[str, Any] = {
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": turn.finish_reason,
+            }
+        ]
+    }
+    if turn.usage is not None:
+        response["usage"] = deepcopy(turn.usage)
+    return response
+
+
+def _configuration_error(message: str) -> ChatConfigurationError:
+    return ChatConfigurationError(provider="zai", message=message)
+
+
+def _bad_request(message: str) -> ChatBadRequestError:
+    return ChatBadRequestError(provider="zai", message=message)
+
+
+def _resolve_string(
+    explicit: object,
+    settings: Mapping[str, object],
+    name: str,
+    default: str,
+) -> str:
+    value = explicit if explicit is not None else settings.get(name, default)
+    if not isinstance(value, str) or not value.strip():
+        raise _configuration_error(f"Z.ai {name} is invalid.")
+    return value.strip()
+
+
+def _resolve_api_key(
+    explicit: object,
+    settings: Mapping[str, object],
+    environ: Mapping[str, str],
+) -> str:
+    if explicit is not None:
+        resolved = resolve_provider_api_key(explicit)
+        if resolved is None:
+            raise _configuration_error("Z.ai explicit API key is invalid.")
+        return resolved
+    if "api_key" in settings:
+        resolved = resolve_provider_api_key(settings.get("api_key"))
+        if resolved is None:
+            raise _configuration_error("Z.ai api_settings.zai.api_key is invalid.")
+        return resolved
+    env_name = settings.get("api_key_env_var", "ZAI_API_KEY")
+    if not isinstance(env_name, str) or not env_name.strip():
+        raise _configuration_error("Z.ai api_settings.zai.api_key_env_var is invalid.")
+    for candidate in dict.fromkeys((env_name.strip(), "ZAI_API_KEY")):
+        resolved = resolve_provider_api_key(environ.get(candidate))
+        if resolved is not None:
+            return resolved
+    raise _configuration_error("Z.ai API key is required.")
+
+
+def _resolve_base_url(explicit: object, settings: Mapping[str, object]) -> str:
+    candidate = (
+        explicit
+        if explicit is not None
+        else settings.get("api_base_url", _DEFAULT_BASE_URL)
+    )
+    try:
+        return normalize_hosted_chat_base_url(candidate, default=_DEFAULT_BASE_URL)
+    except ValueError:
+        raise _configuration_error("Z.ai API base URL is invalid.") from None
+
+
+def _positive_number(
+    settings: Mapping[str, object], name: str, default: float
+) -> float:
+    value = settings.get(name, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise _configuration_error(f"Z.ai {name} must be numeric.")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized <= 0:
+        raise _configuration_error(f"Z.ai {name} must be positive and finite.")
+    return normalized
+
+
+def _nonnegative_number(
+    settings: Mapping[str, object], name: str, default: float
+) -> float:
+    value = settings.get(name, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise _configuration_error(f"Z.ai {name} must be numeric.")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized < 0:
+        raise _configuration_error(f"Z.ai {name} must be non-negative.")
+    return normalized
+
+
+def _nonnegative_integer(
+    settings: Mapping[str, object], name: str, default: int
+) -> int:
+    value = settings.get(name, default)
+    if type(value) is not int or value < 0:
+        raise _configuration_error(f"Z.ai {name} must be a non-negative integer.")
+    return value
+
+
+def _resolve_streaming(settings: Mapping[str, object]) -> bool:
+    value = settings.get("streaming", True)
+    if type(value) is not bool:
+        raise _configuration_error("Z.ai streaming must be a boolean.")
+    return value
+
+
+def _normalize_messages(
+    value: object,
+    *,
+    system_message: object,
+) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise _bad_request("Z.ai messages must be a sequence.")
+    result: list[dict[str, Any]] = []
+    has_system = any(
+        isinstance(message, Mapping) and message.get("role") == "system"
+        for message in value
+    )
+    if system_message is not None:
+        if not isinstance(system_message, str) or has_system:
+            raise _bad_request("Z.ai system message ownership is invalid.")
+        result.append({"role": "system", "content": system_message})
+
+    call_ids: set[str] = set()
+    pending_ids: list[str] = []
+    for raw_message in value:
+        if not isinstance(raw_message, Mapping):
+            raise _bad_request("Z.ai message is malformed.")
+        role = raw_message.get("role")
+        if role not in {"system", "user", "assistant", "tool"}:
+            raise _bad_request("Z.ai message role is invalid.")
+        if role == "tool":
+            if not pending_ids or set(raw_message) != {
+                "role",
+                "tool_call_id",
+                "content",
+            }:
+                raise _bad_request("Z.ai tool result is malformed or orphaned.")
+            call_id = raw_message.get("tool_call_id")
+            content = raw_message.get("content")
+            if call_id != pending_ids[0] or not isinstance(content, str):
+                raise _bad_request("Z.ai tool result ordering is invalid.")
+            pending_ids.pop(0)
+            result.append(deepcopy(dict(raw_message)))
+            continue
+        if pending_ids:
+            raise _bad_request("Z.ai tool call batch is incomplete.")
+        allowed = {"role", "content"} | (
+            {"tool_calls"} if role == "assistant" else set()
+        )
+        if set(raw_message) - allowed:
+            raise _bad_request("Z.ai message fields are unsupported.")
+        content = raw_message.get("content")
+        if role == "assistant":
+            if content is not None and not isinstance(content, str):
+                raise _bad_request("Z.ai assistant content is invalid.")
+        elif not isinstance(content, str):
+            raise _bad_request("Z.ai message content is invalid.")
+        safe: dict[str, Any] = {
+            "role": role,
+            "content": "" if content is None else content,
+        }
+        if role == "assistant" and "tool_calls" in raw_message:
+            calls = _normalize_call_batch(raw_message.get("tool_calls"), call_ids)
+            safe["tool_calls"] = list(calls)
+            pending_ids = [cast(str, call["id"]) for call in calls]
+        result.append(safe)
+    if pending_ids:
+        raise _bad_request("Z.ai tool call batch is incomplete.")
+    return result
+
+
+def _normalize_call_batch(
+    value: object,
+    prior_ids: set[str],
+) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)) or not value:
+        raise _bad_request("Z.ai tool call batch is invalid.")
+    calls: list[dict[str, Any]] = []
+    for raw_call in value:
+        if not isinstance(raw_call, Mapping) or set(raw_call) != {
+            "id",
+            "type",
+            "function",
+        }:
+            raise _bad_request("Z.ai tool call is malformed.")
+        call_id = raw_call.get("id")
+        function = raw_call.get("function")
+        if (
+            not isinstance(call_id, str)
+            or not call_id
+            or call_id in prior_ids
+            or raw_call.get("type") != "function"
+            or not isinstance(function, Mapping)
+            or set(function) != {"name", "arguments"}
+            or not isinstance(function.get("name"), str)
+            or not _FUNCTION_NAME.fullmatch(cast(str, function.get("name")))
+            or not isinstance(function.get("arguments"), str)
+        ):
+            raise _bad_request("Z.ai tool call is malformed.")
+        try:
+            arguments = json.loads(cast(str, function.get("arguments")))
+        except (TypeError, ValueError):
+            raise _bad_request("Z.ai tool call arguments are invalid.") from None
+        if not isinstance(arguments, dict) or not _json_shape_is_bounded(arguments):
+            raise _bad_request("Z.ai tool call arguments are invalid.")
+        prior_ids.add(call_id)
+        calls.append(deepcopy(dict(raw_call)))
+    return tuple(calls)
+
+
+def _normalize_tools(value: object) -> list[dict[str, Any]] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)) or not value:
+        raise _bad_request("Z.ai tools are malformed.")
+    names: set[str] = set()
+    result: list[dict[str, Any]] = []
+    for raw_tool in value:
+        if not isinstance(raw_tool, Mapping) or set(raw_tool) != {"type", "function"}:
+            raise _bad_request("Z.ai supports function tools only.")
+        function = raw_tool.get("function")
+        if raw_tool.get("type") != "function" or not isinstance(function, Mapping):
+            raise _bad_request("Z.ai supports function tools only.")
+        if set(function) != {"name", "description", "parameters"}:
+            raise _bad_request("Z.ai function tool is malformed.")
+        name = function.get("name")
+        parameters = function.get("parameters")
+        if (
+            not isinstance(name, str)
+            or not _FUNCTION_NAME.fullmatch(name)
+            or name in names
+            or not isinstance(function.get("description"), str)
+            or not cast(str, function.get("description")).strip()
+            or not isinstance(parameters, Mapping)
+            or parameters.get("type") != "object"
+            or not _json_shape_is_bounded(parameters)
+        ):
+            raise _bad_request("Z.ai function tool is malformed.")
+        names.add(name)
+        result.append(deepcopy(dict(raw_tool)))
+    return result
+
+
+def _normalize_tool_choice(
+    value: object,
+    tools: Sequence[Mapping[str, Any]] | None,
+) -> str | None:
+    if value is None:
+        return None
+    if value == "auto" and tools is not None:
+        return "auto"
+    raise _bad_request("Z.ai tool choice is unsupported.")
+
+
+def _apply_continuations(
+    messages: list[dict[str, Any]],
+    checkpoints: Sequence[ProviderContinuationCheckpoint],
+    resolution: ZAIResolution,
+) -> None:
+    if not isinstance(checkpoints, Sequence):
+        raise _bad_request("Z.ai provider continuation is invalid.")
+    cursor = 0
+    for checkpoint in checkpoints:
+        try:
+            validate_continuation_restore(
+                checkpoint,
+                ContinuationRestoreTarget(
+                    provider="zai",
+                    protocol="chat_completions",
+                    model=resolution.model,
+                    api_base_url=resolution.base_url,
+                ),
+            )
+        except Exception:
+            raise _bad_request("Z.ai provider continuation is invalid.") from None
+        for round_ in checkpoint.rounds:
+            call_ids = tuple(call.call_id for call in round_.calls)
+            match_index = _find_owner(
+                messages,
+                assistant_content=round_.assistant_content,
+                call_ids=call_ids,
+                start=cursor,
+            )
+            if match_index is None:
+                raise _bad_request("Z.ai continuation owner is missing.")
+            if round_.reasoning_blocks:
+                messages[match_index]["reasoning_content"] = "".join(
+                    round_.reasoning_blocks
+                )
+            cursor = match_index + 1
+
+
+def _find_owner(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    assistant_content: str,
+    call_ids: tuple[str, ...],
+    start: int,
+) -> int | None:
+    for index in range(start, len(messages)):
+        message = messages[index]
+        if (
+            message.get("role") != "assistant"
+            or message.get("content") != assistant_content
+        ):
+            continue
+        raw_calls = message.get("tool_calls", ())
+        ids = tuple(call.get("id") for call in raw_calls if isinstance(call, Mapping))
+        if ids == call_ids:
+            return index
+    return None
+
+
+def _validate_sampler(name: str, value: object) -> None:
+    if value is None:
+        return
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or not 0 <= float(value) <= 1
+    ):
+        raise _bad_request(f"Z.ai {name} is invalid.")
+
+
+def _positive_integer(name: str, value: object) -> int:
+    if type(value) is not int or value <= 0:
+        raise _bad_request(f"Z.ai {name} is invalid.")
+    return value
+
+
+def _normalize_stop(value: object) -> object:
+    if isinstance(value, str) and value:
+        return value
+    if (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes))
+        and 1 <= len(value) <= 4
+        and all(isinstance(item, str) and item for item in value)
+    ):
+        return list(value)
+    raise _bad_request("Z.ai stop is invalid.")
+
+
+def _normalize_response_format(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or not _json_shape_is_bounded(value):
+        raise _bad_request("Z.ai response format is invalid.")
+    kind = value.get("type")
+    if kind in {"text", "json_object"}:
+        if set(value) != {"type"}:
+            raise _bad_request("Z.ai response format is invalid.")
+    elif kind == "json_schema":
+        if set(value) != {"type", "json_schema"} or not isinstance(
+            value.get("json_schema"), Mapping
+        ):
+            raise _bad_request("Z.ai response format is invalid.")
+    else:
+        raise _bad_request("Z.ai response format is invalid.")
+    return deepcopy(dict(value))
+
+
+def _bounded_identifier(name: str, value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value) > 256
+        or any(ord(character) < 32 for character in value)
+    ):
+        raise _bad_request(f"Z.ai {name} is invalid.")
+    return value
+
+
+def _json_shape_is_bounded(value: object) -> bool:
+    stack: list[tuple[object, int]] = [(value, 1)]
+    nodes = 0
+    while stack:
+        current, depth = stack.pop()
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > _MAX_JSON_DEPTH:
+            return False
+        if current is None or type(current) in {bool, int}:
+            continue
+        if isinstance(current, float):
+            if not math.isfinite(current):
+                return False
+            continue
+        if isinstance(current, str):
+            if len(current) > _MAX_JSON_STRING_CHARS:
+                return False
+            continue
+        if isinstance(current, Mapping):
+            for key, item in current.items():
+                if not isinstance(key, str) or len(key) > _MAX_JSON_STRING_CHARS:
+                    return False
+                stack.append((item, depth + 1))
+            continue
+        if isinstance(current, Sequence) and not isinstance(current, (str, bytes)):
+            stack.extend((item, depth + 1) for item in current)
+            continue
+        return False
+    return True

--- a/tldw_chatbook/LLM_Provider_Catalog/local_llm_provider_catalog_service.py
+++ b/tldw_chatbook/LLM_Provider_Catalog/local_llm_provider_catalog_service.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from loguru import logger
 
+from tldw_chatbook.Chat.Chat_Deps import ChatConfigurationError
 from tldw_chatbook.Chat.console_provider_endpoints import (
     effective_provider_endpoint,
     first_configured_endpoint,
@@ -53,6 +54,8 @@ from tldw_chatbook.LLM_Provider_Catalog.openai_compatible_model_discovery import
     fingerprint_endpoint,
     supports_openai_compatible_model_discovery,
 )
+from tldw_chatbook.LLM_Calls.moonshot import resolve_moonshot_request
+from tldw_chatbook.LLM_Calls.zai import resolve_zai_request
 from tldw_chatbook.Utils.input_validation import validate_url
 
 from ..config import (
@@ -67,6 +70,7 @@ from ..config import (
 
 DiscoveryClient = Callable[..., Awaitable[ModelDiscoveryResult]]
 SettingsLoader = Callable[[], Mapping[str, Any]]
+_STRICT_HOSTED_PROVIDER_KEYS = frozenset({"moonshot", "zai"})
 
 
 class LocalLLMProviderCatalogService:
@@ -188,7 +192,7 @@ class LocalLLMProviderCatalogService:
         settings: Mapping[str, Any] | None,
         provider_key: str,
     ) -> Mapping[str, Any]:
-        if provider_key == "qwencloud":
+        if provider_key in {"qwencloud", *_STRICT_HOSTED_PROVIDER_KEYS}:
             api_settings = (
                 settings.get("api_settings", {})
                 if isinstance(settings, Mapping)
@@ -220,6 +224,55 @@ class LocalLLMProviderCatalogService:
         cls, provider_settings: Mapping[str, Any]
     ) -> str | None:
         return first_configured_endpoint(provider_settings)
+
+    @staticmethod
+    def _combined_hosted_settings(
+        saved_settings: Mapping[str, Any],
+        staged_settings: Mapping[str, Any] | None,
+        provider_key: str,
+    ) -> Mapping[str, Any]:
+        combined = dict(saved_settings)
+        saved_api = saved_settings.get("api_settings", {})
+        merged_api = dict(saved_api) if isinstance(saved_api, Mapping) else saved_api
+        staged_api = (
+            staged_settings.get("api_settings", {})
+            if isinstance(staged_settings, Mapping)
+            else {}
+        )
+        if isinstance(merged_api, dict) and isinstance(staged_api, Mapping):
+            for key, value in staged_api.items():
+                if (
+                    key == provider_key
+                    and isinstance(value, Mapping)
+                    and isinstance(merged_api.get(key), Mapping)
+                ):
+                    merged_api[key] = {**merged_api[key], **value}
+                else:
+                    merged_api[key] = value
+        combined["api_settings"] = merged_api
+        return combined
+
+    def _resolve_hosted_provider(
+        self,
+        *,
+        provider_key: str,
+        saved_settings: Mapping[str, Any],
+        staged_settings: Mapping[str, Any] | None,
+    ) -> tuple[str, str]:
+        config = self._combined_hosted_settings(
+            saved_settings, staged_settings, provider_key
+        )
+        if provider_key == "moonshot":
+            resolution = resolve_moonshot_request(
+                app_config=config,
+                environ=self.environ,
+            )
+        else:
+            resolution = resolve_zai_request(
+                app_config=config,
+                environ=self.environ,
+            )
+        return resolution.base_url, resolution.api_key
 
     def _resolve_endpoint(
         self,
@@ -295,11 +348,22 @@ class LocalLLMProviderCatalogService:
         provider_key: str,
         staged_settings: Mapping[str, Any] | None = None,
     ) -> str | None:
-        endpoint = self._resolve_endpoint(
-            provider_key=provider_key,
-            saved_settings=self._settings(),
-            staged_settings=staged_settings,
-        )
+        saved_settings = self._settings()
+        if provider_key in _STRICT_HOSTED_PROVIDER_KEYS:
+            try:
+                endpoint, _api_key = self._resolve_hosted_provider(
+                    provider_key=provider_key,
+                    saved_settings=saved_settings,
+                    staged_settings=staged_settings,
+                )
+            except ChatConfigurationError:
+                return None
+        else:
+            endpoint = self._resolve_endpoint(
+                provider_key=provider_key,
+                saved_settings=saved_settings,
+                staged_settings=staged_settings,
+            )
         return fingerprint_endpoint(endpoint) if endpoint else None
 
     def get_health(self) -> dict[str, Any]:
@@ -448,11 +512,34 @@ class LocalLLMProviderCatalogService:
                 ),
             )
 
-        endpoint = self._resolve_endpoint(
-            provider_key=provider_key,
-            saved_settings=saved_settings,
-            staged_settings=staged_settings,
-        )
+        api_key: str | None = None
+        if provider_key in _STRICT_HOSTED_PROVIDER_KEYS:
+            try:
+                endpoint, api_key = self._resolve_hosted_provider(
+                    provider_key=provider_key,
+                    saved_settings=saved_settings,
+                    staged_settings=staged_settings,
+                )
+            except ChatConfigurationError:
+                return ModelDiscoveryResult(
+                    provider=provider,
+                    provider_list_key=provider_resolution.provider_list_key,
+                    endpoint_fingerprint=None,
+                    status="error",
+                    error=ModelDiscoveryError(
+                        kind="invalid_provider_settings",
+                        message="Provider settings are invalid for model discovery.",
+                        recovery_hint=(
+                            f"Repair api_settings.{provider_key} before discovering models."
+                        ),
+                    ),
+                )
+        else:
+            endpoint = self._resolve_endpoint(
+                provider_key=provider_key,
+                saved_settings=saved_settings,
+                staged_settings=staged_settings,
+            )
         if endpoint is None:
             return ModelDiscoveryResult(
                 provider=provider,
@@ -481,12 +568,13 @@ class LocalLLMProviderCatalogService:
                 ),
             )
 
-        api_key = self._resolve_api_key(
-            provider=provider,
-            provider_key=provider_key,
-            saved_settings=saved_settings,
-            staged_settings=staged_settings,
-        )
+        if api_key is None:
+            api_key = self._resolve_api_key(
+                provider=provider,
+                provider_key=provider_key,
+                saved_settings=saved_settings,
+                staged_settings=staged_settings,
+            )
         provider_list_key = provider_resolution.provider_list_key or provider
         result = await self.discovery_client(
             provider=provider,

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -312,7 +312,7 @@ PROVIDER_MODEL_PROFILE_FIELD_KEYS = {
     "model_profile_streaming": "streaming",
 }
 REASONING_EFFORT_OPTIONS = frozenset(
-    {"", "none", "minimal", "low", "medium", "high", "xhigh"}
+    {"", "none", "minimal", "low", "medium", "high", "xhigh", "max"}
 )
 REASONING_SUMMARY_OPTIONS = frozenset({"", "auto", "concise", "detailed", "none"})
 VERBOSITY_OPTIONS = frozenset({"", "low", "medium", "high"})
@@ -323,6 +323,16 @@ THINKING_EFFORT_OPTIONS = frozenset(
 # ordered option lists (blank = inherit/not set), so invalid values are
 # impossible by construction instead of rejected at save.
 REASONING_EFFORT_SELECT_OPTIONS = ("none", "minimal", "low", "medium", "high", "xhigh")
+KIMI_K3_REASONING_EFFORT_SELECT_OPTIONS = ("low", "high", "max")
+GLM_5_2_REASONING_EFFORT_SELECT_OPTIONS = (
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+)
 REASONING_SUMMARY_SELECT_OPTIONS = ("auto", "concise", "detailed", "none")
 VERBOSITY_SELECT_OPTIONS = ("low", "medium", "high")
 THINKING_EFFORT_SELECT_OPTIONS = ("off", "low", "medium", "high", "xhigh", "max")
@@ -347,10 +357,10 @@ MODEL_PROFILE_SELECT_FIELD_KEYS = frozenset(
     }
 )
 OPENAI_REASONING_PROVIDER_KEYS = frozenset({"openai"})
+REASONING_EFFORT_PROVIDER_KEYS = frozenset({"openai", "moonshot", "zai"})
 ANTHROPIC_THINKING_PROVIDER_KEYS = frozenset({"anthropic"})
 OPENAI_REASONING_PROFILE_FIELD_KEYS = frozenset(
     {
-        "model_profile_reasoning_effort",
         "model_profile_reasoning_summary",
         "model_profile_verbosity",
     }
@@ -565,11 +575,13 @@ PROVIDER_ENDPOINT_PLACEHOLDERS = {
     "local_vllm": "http://127.0.0.1:8000/v1",
     "mistral": "https://api.mistral.ai/v1",
     "mistralai": "https://api.mistral.ai/v1",
+    "moonshot": "https://api.moonshot.ai/v1",
     "ollama": "http://127.0.0.1:11434",
     "openai": "https://api.openai.com/v1",
     "openrouter": "https://openrouter.ai/api/v1",
     "oobabooga": "http://127.0.0.1:5000/v1",
     "vllm": "http://127.0.0.1:8000/v1",
+    "zai": "https://api.z.ai/api/paas/v4",
 }
 PROVIDER_CREDENTIAL_ENV_VAR_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
 QWENCLOUD_API_MODE_OPTIONS: tuple[tuple[str, str], ...] = (
@@ -3886,9 +3898,15 @@ class SettingsScreen(BaseAppScreen):
     ) -> Select:
         """Build the staged closed-enum Select for a model-profile field."""
         supported = self._model_profile_field_supported(provider, draft_key)
-        allowed = CLOSED_ENUM_SELECT_OPTIONS[
-            PROVIDER_MODEL_PROFILE_FIELD_KEYS[draft_key]
-        ]
+        allowed = (
+            self._model_profile_reasoning_effort_options(
+                provider, values.get("model")
+            )
+            if draft_key == "model_profile_reasoning_effort"
+            else CLOSED_ENUM_SELECT_OPTIONS[
+                PROVIDER_MODEL_PROFILE_FIELD_KEYS[draft_key]
+            ]
+        )
         return Select(
             [(value, value) for value in allowed],
             value=(
@@ -8290,12 +8308,33 @@ class SettingsScreen(BaseAppScreen):
         )
 
     @staticmethod
+    def _provider_supports_reasoning_effort(provider: object) -> bool:
+        return (
+            provider_config_key(str(provider or ""))
+            in REASONING_EFFORT_PROVIDER_KEYS
+        )
+
+    @staticmethod
+    def _model_profile_reasoning_effort_options(
+        provider: object, model: object
+    ) -> tuple[str, ...]:
+        provider_key = provider_config_key(str(provider or ""))
+        model_key = str(model or "").strip().lower()
+        if provider_key == "moonshot" and model_key == "kimi-k3":
+            return KIMI_K3_REASONING_EFFORT_SELECT_OPTIONS
+        if provider_key == "zai" and model_key == "glm-5.2":
+            return GLM_5_2_REASONING_EFFORT_SELECT_OPTIONS
+        return REASONING_EFFORT_SELECT_OPTIONS
+
+    @staticmethod
     def _provider_supports_anthropic_thinking(provider: object) -> bool:
         return (
             provider_config_key(str(provider or "")) in ANTHROPIC_THINKING_PROVIDER_KEYS
         )
 
     def _model_profile_field_supported(self, provider: object, draft_key: str) -> bool:
+        if draft_key == "model_profile_reasoning_effort":
+            return self._provider_supports_reasoning_effort(provider)
         if draft_key in OPENAI_REASONING_PROFILE_FIELD_KEYS:
             return self._provider_supports_openai_reasoning(provider)
         if draft_key in ANTHROPIC_THINKING_PROFILE_FIELD_KEYS:
@@ -8338,7 +8377,7 @@ class SettingsScreen(BaseAppScreen):
         if not provider_label:
             provider_label = "this provider"
         unavailable: list[str] = []
-        if not self._provider_supports_openai_reasoning(provider):
+        if not self._provider_supports_reasoning_effort(provider):
             unavailable.append("Reasoning")
         if not self._provider_supports_anthropic_thinking(provider):
             unavailable.append("Thinking")
@@ -9041,12 +9080,23 @@ class SettingsScreen(BaseAppScreen):
                                 else Select.NULL
                             )
                         else:
+                            allowed = (
+                                self._model_profile_reasoning_effort_options(
+                                    provider, model
+                                )
+                                if draft_key == "model_profile_reasoning_effort"
+                                else CLOSED_ENUM_SELECT_OPTIONS[
+                                    PROVIDER_MODEL_PROFILE_FIELD_KEYS[draft_key]
+                                ]
+                            )
+                            if draft_key == "model_profile_reasoning_effort":
+                                select.set_options(
+                                    [(option, option) for option in allowed]
+                                )
                             select.value = (
                                 self._select_option_value(
                                     value,
-                                    CLOSED_ENUM_SELECT_OPTIONS[
-                                        PROVIDER_MODEL_PROFILE_FIELD_KEYS[draft_key]
-                                    ],
+                                    allowed,
                                 )
                                 if supported
                                 else Select.NULL
@@ -9148,6 +9198,35 @@ class SettingsScreen(BaseAppScreen):
         if provider_key in API_URL_PROVIDER_KEYS:
             return "https://host:port/v1"
         return "Optional provider endpoint override"
+
+    @staticmethod
+    def _hosted_provider_guidance(provider: object, model: object) -> str:
+        provider_key = provider_config_key(str(provider or ""))
+        model_key = str(model or "").strip().lower()
+        if provider_key == "moonshot":
+            if model_key == "kimi-k3":
+                return (
+                    "Moonshot Kimi K3: choose the international, China, or custom "
+                    "endpoint. Preserved Thinking is always on; retained reasoning "
+                    "and tool state is private and consumes context."
+                )
+            return (
+                "Moonshot: choose the international, China, or custom endpoint. "
+                "Verify reasoning support for this historical or unknown model; "
+                "private continuation state may consume context."
+            )
+        if provider_key == "zai":
+            qualifier = (
+                "GLM 5.2 supports the reasoning choices shown."
+                if model_key == "glm-5.2"
+                else "Verify reasoning support for this historical or unknown model."
+            )
+            return (
+                "Z.ai: use the general API endpoint; the coding-only endpoint is not "
+                f"supported here. {qualifier} Restored function-tool reasoning is "
+                "private and consumes context."
+            )
+        return ""
 
     def _provider_endpoint_summary(
         self, provider: str, endpoint: object | None = None
@@ -10031,6 +10110,12 @@ class SettingsScreen(BaseAppScreen):
             ).value.strip()
         except QueryError:
             endpoint = self._provider_endpoint_value(provider)
+        try:
+            model = self.query_one("#settings-model-value", Input).value.strip()
+        except QueryError:
+            model = str(
+                self._provider_setting_values_mapping().get("model") or ""
+            ).strip()
         readiness_label = self._provider_readiness_label()
         resolved = self._resolve_provider_model_for_settings()
         self._set_static_text(
@@ -10066,6 +10151,14 @@ class SettingsScreen(BaseAppScreen):
             clear_button.disabled = not self._provider_saved_api_key_present(
                 provider
             ) and not bool(api_key_input.value.strip())
+            hosted_guidance = self._hosted_provider_guidance(provider, model)
+            guidance = self.query_one(
+                "#settings-hosted-provider-guidance", Static
+            )
+            guidance.update(hosted_guidance)
+            guidance.set_class(
+                not hosted_guidance, "settings-gated-profile-hidden"
+            )
         except QueryError:
             pass
         self._refresh_generation_support_summary(provider)
@@ -11099,6 +11192,18 @@ class SettingsScreen(BaseAppScreen):
                 "Env vars are safer for shells, shared machines, and CI. This field stores the variable name, not the secret.",
                 id="settings-provider-credential-guidance",
                 classes="settings-status-row",
+            )
+            hosted_guidance = self._hosted_provider_guidance(
+                provider, values.get("model")
+            )
+            yield Static(
+                hosted_guidance,
+                id="settings-hosted-provider-guidance",
+                classes=(
+                    "settings-status-row"
+                    if hosted_guidance
+                    else "settings-status-row settings-gated-profile-hidden"
+                ),
             )
             # task-189: the Test affordance closes the first-run Connect job
             # (provider -> model -> endpoint -> credentials -> test) before
@@ -15006,6 +15111,7 @@ class SettingsScreen(BaseAppScreen):
             "api_key": "#settings-provider-api-key",
             "endpoint": "#settings-provider-endpoint-value",
             "credential_env_var": "#settings-provider-credential-env-var",
+            "reasoning": "#settings-model-profile-reasoning-effort",
         }
         selector = field_selectors.get(str(field or "").strip())
         if not selector:

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -874,7 +874,10 @@ def normalize_provider_config_key(provider: object) -> str:
         A stripped, lowercase provider key with spaces and hyphens replaced by
         underscores.
     """
-    return str(provider or "").strip().lower().replace(" ", "_").replace("-", "_")
+    normalized = (
+        str(provider or "").strip().lower().replace(" ", "_").replace("-", "_")
+    )
+    return "zai" if normalized == "z.ai" else normalized
 
 
 class ProviderSettingsError(ValueError):
@@ -887,10 +890,10 @@ def provider_settings_for_key(
 ) -> Mapping[str, object]:
     """Return provider settings without mutating the loaded configuration.
 
-    QwenCloud historically accepted normalized alias table names. When an
-    exact canonical table is also present, alias fields remain fallbacks while
-    exact ``api_settings.qwencloud`` fields win regardless of insertion order.
-    Other providers retain the existing first-normalized-match behavior.
+    QwenCloud historically accepts normalized aliases with the exact table
+    taking precedence. Moonshot and Z.ai require one exact canonical table and
+    reject normalized duplicates. Other providers retain the existing
+    first-normalized-match behavior.
 
     Args:
         api_settings: Loaded ``api_settings`` value.
@@ -900,11 +903,26 @@ def provider_settings_for_key(
         The resolved provider settings, or an empty mapping when none exist.
 
     Raises:
-        ProviderSettingsError: If QwenCloud's authoritative table is present
-            but malformed, or its first normalized alias is malformed when no
-            canonical table exists.
+        ProviderSettingsError: If an authoritative table is malformed or a
+            strict provider has ambiguous normalized tables.
     """
     if not isinstance(api_settings, Mapping):
+        return {}
+
+    if provider_key in {"moonshot", "zai"}:
+        canonical_settings = api_settings.get(provider_key)
+        aliases = tuple(
+            configured_provider
+            for configured_provider in api_settings
+            if configured_provider != provider_key
+            and normalize_provider_config_key(configured_provider) == provider_key
+        )
+        if provider_key in api_settings:
+            if not isinstance(canonical_settings, Mapping) or aliases:
+                raise ProviderSettingsError(
+                    f"api_settings.{provider_key} must be one unambiguous configuration table."
+                )
+            return canonical_settings
         return {}
 
     if provider_key == "qwencloud":
@@ -2921,10 +2939,10 @@ Groq = ["gemma2-9b-it", "mmeta-llama/Llama-Guard-4-12B", "llama-3.3-70b-versatil
 Google = ["gemini-2.5-flash", "gemini-2.5-flash-preview-05-20", "gemini-2.5-pro-preview-05-06", "gemini-2.0-flash", "gemini-2.0-flash-lite", "gemini-1.5-flash", "gemini-1.5-flash-8b", "gemini-1.5-pro", ]
 HuggingFace = ["openai/gpt-oss-120b", "meta-llama/Meta-Llama-3.1-8B-Instruct", "meta-llama/Meta-Llama-3.1-70B-Instruct",]
 MistralAI = ["open-mistral-nemo", "mistral-medium-2505", "codestral-2501", "mistral-saba-2502", "mistral-large-2411", "ministral-3b-2410", "ministral-8b-2410", "mistral-moderation-2411", "devstral-small-2505", "mistral-small-2503", ]
-Moonshot = ["kimi-latest", "kimi-thinking-preview", "moonshot-v1-auto", "moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k", "moonshot-v1-8k-vision-preview", "moonshot-v1-32k-vision-preview", "moonshot-v1-128k-vision-preview", "kimi-k2-0711-preview"]
+Moonshot = ["kimi-k3", "kimi-latest", "kimi-thinking-preview", "moonshot-v1-auto", "moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k", "moonshot-v1-8k-vision-preview", "moonshot-v1-32k-vision-preview", "moonshot-v1-128k-vision-preview", "kimi-k2-0711-preview"]
 OpenRouter = ["openai/gpt-4o-mini", "anthropic/claude-3.7-sonnet", "google/gemini-2.0-flash-001", "google/gemini-2.5-pro-preview", "google/gemini-2.5-flash-preview", "deepseek/deepseek-chat-v3-0324:free", "deepseek/deepseek-chat-v3-0324", "openai/gpt-4.1", "anthropic/claude-sonnet-4", "deepseek/deepseek-r1:free", "anthropic/claude-3.7-sonnet:thinking", "google/gemini-flash-1.5-8b", "mistralai/mistral-nemo", "google/gemini-2.5-flash-preview-05-20", ]
 QwenCloud = ["qwen3.8-max"]
-ZAI = ["glm-4.6", "glm-4.5", "glm-4.5-air", "glm-4.5-flash", "glm-4.5v", "glm-4-32b-0414-128k"]
+ZAI = ["glm-5.2", "glm-4.6", "glm-4.5", "glm-4.5-air", "glm-4.5-flash", "glm-4.5v", "glm-4-32b-0414-128k"]
 # Local Providers
 Llama_cpp = ["None"]
 koboldcpp = ["None"]
@@ -3073,7 +3091,7 @@ write_to_config = [] # exact [providers] keys whose new models append to this fi
     [api_settings.moonshot]
     api_key_env_var = "MOONSHOT_API_KEY"
     # api_key = "" # Less secure fallback - use env var instead
-    model = "kimi-latest"  # Latest Kimi model, or use moonshot-v1-auto for auto selection
+    model = "kimi-k3"
     temperature = 0.7
     top_p = 0.95 # Moonshot uses top_p (OpenAI compatible)
     max_tokens = 4096
@@ -3082,7 +3100,7 @@ write_to_config = [] # exact [providers] keys whose new models append to this fi
     timeout = 90
     retries = 3
     retry_delay = 1.0
-    streaming = false
+    streaming = true
 
     [api_settings.qwencloud]
     api_mode = "responses"
@@ -3097,7 +3115,7 @@ write_to_config = [] # exact [providers] keys whose new models append to this fi
     [api_settings.zai] # Matches key in [providers]
     api_key_env_var = "ZAI_API_KEY"
     # api_key = "" # Less secure fallback - use env var instead
-    model = "glm-4.5"
+    model = "glm-5.2"
     temperature = 0.7
     top_p = 0.95
     max_tokens = 4096
@@ -3105,7 +3123,7 @@ write_to_config = [] # exact [providers] keys whose new models append to this fi
     timeout = 90
     retries = 3
     retry_delay = 5
-    streaming = false
+    streaming = true
 
     # --- Local Providers ---
     # Local providers default to streaming = true so slow generations render


### PR DESCRIPTION
## Summary

- add a provider-neutral hosted Chat-Completions HTTP/SSE boundary with strict parsing, retry/resource ownership, redacted errors, and QwenCloud Chat parity
- make Moonshot/Kimi and Z.ai/GLM first-class Console providers with current defaults, strict model/tool/reasoning policies, terminal usage, and durable private continuation
- refresh Settings, readiness, model discovery, documentation, and an isolated doubly-gated paid-live harness

## Architecture and scope

- implements TASK-15676 and ADR-063 on top of TASK-15675
- preserves stable `moonshot` and `zai` identities and public handler compatibility
- Chat Completions only; no Responses mode, provider session state, vendor built-in tools, or schema changes
- paid live calls remain opt-in through the exact provider flag plus nonblank key

## Test plan

- [x] focused hosted-provider/Qwen matrix: 467 passed
- [x] joined Console/native-tool/live-harness surface: 48 passed, 2 paid cases skipped by explicit gates
- [x] selected AgentService/Gateway continuation seams: 5 passed, 483 unrelated deselected
- [x] Settings/readiness/catalog matrix: 609 passed; focused post-audit matrix: 349 passed
- [x] MyPy on the four provider modules, LLM compileall, Ruff for new/non-baseline changed files, and cumulative diff checks
- [ ] paid Moonshot/Z.ai live requests (not enabled)
- [ ] broad/full repository suite (not run: user explicitly restricted verification to touched files and related functionality)

Exact pre-feature Ruff debt remains in two legacy lint files and eight legacy formatter files; this PR does not churn those unrelated regions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden Moonshot Kimi and Z.ai GLM as first‑class, Chat‑Completions‑only Console providers behind a strict hosted HTTP/SSE boundary. Keeps the `moonshot`/`zai` identities and public handler while enforcing model, tool, and reasoning policies.

- Provider‑neutral hosted boundary: strict JSON and SSE parsing (QwenCloud streaming now uses the shared decoder, no behavior change), owned sessions, retries, URL normalization, and redacted error bodies.
- New strict adapters `chat_with_moonshot` and `chat_with_zai`; legacy `LLM_API_Calls` shims delegate to them. Config normalizes “Z.AI” to `zai`.
- Console: native‑tool lifecycle, durable private provider continuation across gateway/agent, terminal usage, and per‑provider reasoning‑effort options.
- Defaults and endpoints: Moonshot `kimi-k3` at `https://api.moonshot.ai/v1` (China base allowed); Z.ai `glm-5.2` at `https://api.z.ai/api/paas/v4`. Reasoning effort: Moonshot exactly `low|high|max`; Z.ai exactly `none|minimal|low|medium|high|xhigh|max`. Chat only; no Responses mode or provider conversation ID.
- Readiness and discovery validate via strict resolvers and map hosted bases to models. Sensitive error bodies from hosted calls remain suppressed.
- Implements TASK-15676 and ADR-063.

**Rollout and migration**
- Set `MOONSHOT_API_KEY` and/or `ZAI_API_KEY`. Configure a base URL if you use a non‑default endpoint.
- Do not rely on Responses mode or vendor built‑in tools for these providers; use Console native tools.
- Live verification is opt‑in: set `TLDW_LIVE_MOONSHOT=1` with `MOONSHOT_API_KEY` or `TLDW_LIVE_ZAI=1` with `ZAI_API_KEY`.

<sup>Written for commit ff765e994888b9c91f02b316f57c300e84be34e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

