### PR TITLE
fix(console): workspace context follows the conversation, including global (task-15120)

### DIFF
--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -32,6 +32,7 @@ from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
 from tldw_chatbook.Chat.attachment_core import PendingAttachment
+from tldw_chatbook.Workspaces.models import DEFAULT_WORKSPACE_ID
 from tldw_chatbook.Chat.console_chat_models import (
     CONSOLE_GLOBAL_WORKSPACE_ID,
     ConsoleChatMessage,
@@ -7090,18 +7091,21 @@ async def test_console_browser_selecting_default_persisted_row_switches_to_defau
         )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "task-15120: opening a global-scoped conversation leaves the workspace "
-        "SERVICE on ws-a while the store's workspace_context flips to 'global'. "
-        "This test could never reach that assertion while the click failed with "
-        "OutOfBounds; repairing the click exposed it. strict=True so a fix flips "
-        "this loudly instead of passing unnoticed."
-    ),
-)
 @pytest.mark.asyncio
-async def test_console_browser_selecting_global_persisted_row_preserves_active_workspace():
+async def test_console_browser_selecting_global_persisted_row_switches_context_to_global():
+    """task-15120 (owner ruling): the workspace context FOLLOWS the conversation.
+
+    A user keeps conversations open across multiple workspaces at once, and
+    selecting one switches the context to that conversation's workspace -- for
+    a global-scoped conversation, the global scope, on BOTH layers. The
+    registry's stable representation of "no explicit workspace" is the
+    built-in Default workspace (`ensure_default_workspace` floors every
+    context read to it -- capability-less by design), so a global
+    conversation lands the registry on Default while the store's context
+    reads "global". What can no longer happen is what task-15120 measured:
+    the PREVIOUS workspace (ws-a) staying active, its capabilities bleeding
+    into a global conversation.
+    """
     app = _build_test_app()
     _configure_native_ready_console(app)
     app.conversation_local_marks_service = FakeConversationLocalMarksService()
@@ -7151,9 +7155,15 @@ async def test_console_browser_selecting_global_persisted_row_preserves_active_w
         )
 
         after = service.get_active_workspace()
-        assert after is not None
-        assert after.workspace_id == "ws-a"
-        assert store.workspace_context.active_workspace_id == "ws-a"
+        assert after is not None and after.workspace_id == DEFAULT_WORKSPACE_ID, (
+            "opening a global conversation must land the registry on the "
+            "capability-less Default workspace, not stay on "
+            f"{getattr(after, 'workspace_id', None)!r}"
+        )
+        assert (
+            store.workspace_context.active_workspace_id
+            == CONSOLE_GLOBAL_WORKSPACE_ID
+        )
         assert session.workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID
 
 

--- a/backlog/tasks/task-15120 - Store-workspace-context-and-workspace-service-disagree-when-a-global-conversation-opens.md
+++ b/backlog/tasks/task-15120 - Store-workspace-context-and-workspace-service-disagree-when-a-global-conversation-opens.md
@@ -2,7 +2,7 @@
 id: TASK-15120
 title: >-
   Store workspace context and workspace service disagree when a global conversation opens
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-11 05:00'
 labels:
@@ -32,7 +32,49 @@ The test is marked `xfail(strict=True)` pointing here, so the divergence stays v
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 A ruling is recorded on what `store.workspace_context.active_workspace_id` means when the open conversation is globally scoped
-- [ ] #2 The store and the workspace service cannot report different active workspaces for the same state
-- [ ] #3 The `xfail(strict=True)` on `test_console_browser_selecting_global_persisted_row_preserves_active_workspace` is removed and the test asserts the ruled behaviour
+- [x] #1 A ruling is recorded on what `store.workspace_context.active_workspace_id` means when the open conversation is globally scoped
+- [x] #2 The store and the workspace service cannot report different active workspaces for the same state
+- [x] #3 The `xfail(strict=True)` on `test_console_browser_selecting_global_persisted_row_preserves_active_workspace` is removed and the test asserts the ruled behaviour
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Record the owner ruling; identify which layer violates it
+2. Find why the follow-the-conversation seam skips global conversations
+3. Map "global" onto the registry's own representation; mutation-check
+
+## Implementation Notes
+
+**Owner ruling (2026-08-13): the workspace context FOLLOWS the conversation.**
+A user keeps conversations open across multiple workspaces at once; selecting
+one switches the context to that conversation's workspace. So the STORE's
+behaviour (context flipping to "global") was right and the SERVICE staying on
+ws-a was the bug -- the pinning test's "preserves active workspace" premise
+was wrong per the ruling, and it is rewritten, not just unmarked.
+
+The seam already followed the ruling for real workspaces
+(`_set_active_workspace_for_console_session`); it simply early-returned for
+global conversations, leaving the previous workspace -- and its capabilities
+-- active under a global conversation.
+
+**One design correction along the way**: the first fix represented global as
+"no active workspace" (registry -> None). That fights a deliberate design --
+`_current_console_workspace_context` floors every read through
+`ensure_default_workspace()`, which resurrects the built-in Default whenever
+no workspace is active, precisely so a concrete-but-capability-less workspace
+always exists. So the registry's stable representation of "no explicit
+workspace" IS the Default workspace, and a global conversation now lands
+there (clear + ensure), while the store's context reads "global". The two
+layers agree by design rather than by accident: store="global" <->
+registry=Default-with-no-capabilities.
+
+Added `LocalWorkspaceRegistryService.clear_active_workspace()` as the
+primitive. Mutation-checked: restoring the early-return turns the rewritten
+test red. Both directions verified: global->Default (rewritten test) and
+ws->ws (`test_activate_native_console_session_realigns_active_workspace`,
+unchanged). 309 passed in the native module -- its last xfail is gone; 305
+passed across session-controller/Workspaces/workbench modules.
+
+Modified: `tldw_chatbook/Workspaces/registry_service.py`,
+`tldw_chatbook/UI/Console_Modules/workspace.py`,
+`Tests/UI/test_console_native_chat_flow.py`.

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -118,6 +118,7 @@ from ...Chat.console_display_state import evidence_bundle_from_launch
 from ...Chat.console_live_work import ConsoleLiveWorkLaunch
 from ...Chat.console_roleplay_metadata import parse_console_roleplay_context
 from ...Chat.rag_scope import RagScope
+from ...Workspaces.models import DEFAULT_WORKSPACE_ID
 from ...Widgets.confirmation_dialog import ConfirmationDialog
 from ...Widgets.Console import (
     ConsoleWorkspaceContextTray,
@@ -1099,8 +1100,6 @@ class ConsoleWorkspaceController:
         if target_session is None:
             return
         workspace_id = str(target_session.workspace_id or "").strip()
-        if not workspace_id or workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID:
-            return
         registry_service = getattr(
             self.app_instance, "workspace_registry_service", None
         )
@@ -1108,6 +1107,29 @@ class ConsoleWorkspaceController:
             return
         try:
             active_workspace = registry_service.get_active_workspace()
+            if not workspace_id or workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID:
+                # task-15120 (owner ruling): the workspace context follows the
+                # conversation -- a global conversation's context IS the
+                # global scope, on both layers. This used to early-return,
+                # leaving the registry on the previous workspace while the
+                # store's context flipped to "global": two sources of truth
+                # disagreeing, and the previous workspace's capabilities
+                # bleeding into a global conversation. The registry's stable
+                # representation of "no explicit workspace" is the built-in
+                # Default (`ensure_default_workspace` floors every context
+                # read to it, deliberately -- capability-less, safe), so a
+                # global conversation lands there, not on bare None.
+                if (
+                    active_workspace is not None
+                    and active_workspace.workspace_id != DEFAULT_WORKSPACE_ID
+                ):
+                    registry_service.clear_active_workspace()
+                    ensure_default = getattr(
+                        registry_service, "ensure_default_workspace", None
+                    )
+                    if callable(ensure_default):
+                        ensure_default()
+                return
             if (
                 active_workspace is not None
                 and active_workspace.workspace_id == workspace_id

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -383,6 +383,27 @@ class LocalWorkspaceRegistryService:
             raise WorkspaceRegistryServiceError("Active workspace update failed.")
         return active
 
+    def clear_active_workspace(self) -> None:
+        """Deselect every workspace, leaving no active record.
+
+        task-15120 (owner ruling): the workspace context follows the
+        conversation being viewed, and a GLOBAL conversation's context is the
+        global scope -- which this registry represents as "no active
+        workspace" (`get_active_workspace()` -> None), the same state a fresh
+        registry starts in. Capability gates that require an explicit active
+        workspace read exactly that, so a global conversation carries global
+        capabilities rather than borrowing the previous workspace's.
+
+        Raises:
+            WorkspaceRegistryServiceError: If workspace storage cannot be
+                updated.
+        """
+        try:
+            with self.db.transaction() as conn:
+                conn.execute("UPDATE workspace_records SET active = 0")
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+
     def get_active_workspace(self) -> WorkspaceRecord | None:
         """Return the active workspace if one is selected."""
 


### PR DESCRIPTION
## What

Implements the owner ruling on task-15120: **the workspace context follows the conversation** — a user keeps conversations open across multiple workspaces at once, and selecting one switches context to that conversation's workspace.

Under the ruling, the measured divergence resolves cleanly: the **store** was right (context flips to `global`) and the **registry service** was the bug (stayed on `ws-a`, its capabilities bleeding into a global conversation). The `xfail(strict=True)` pinning test asserted *preservation* — wrong premise per the ruling — so it is **rewritten**, not just unmarked.

## How

The follow-the-conversation seam (`_set_active_workspace_for_console_session`) already handled real workspaces and early-returned for global ones. It now lands global conversations on the registry's own stable representation of "no explicit workspace": the **built-in Default workspace** — capability-less by design.

Worth recording: the first cut represented global as bare `None` (clear the active record). That could not stick — `_current_console_workspace_context` floors every read through `ensure_default_workspace()`, which deliberately resurrects Default whenever nothing is active. So `store="global"` ↔ `registry=Default` is the consistent pair *by design*, and the fix works with that design rather than fighting it.

Adds `LocalWorkspaceRegistryService.clear_active_workspace()` as the primitive (clear + ensure = switch to Default).

## Verification

- Rewritten test passes and is **mutation-checked** (restoring the early-return turns it red)
- Both hop directions green: global→Default (new) and ws→ws (`test_activate_native_console_session_realigns_active_workspace`, unchanged)
- `Tests/UI/test_console_native_chat_flow.py` whole: **309 passed — its last xfail is gone**
- Session-controller + Workspaces + workbench modules: 305 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Workspace context now follows the selected conversation, including global. Previously, opening a global conversation left the registry on the prior workspace while the store flipped to "global", leaking capabilities; now the registry switches to Default and the store reads "global" (task-15120).

**Key changes**
- Update `_set_active_workspace_for_console_session` to handle global: call `clear_active_workspace()` and then `ensure_default_workspace()`. Registry resolves to Default; store shows `CONSOLE_GLOBAL_WORKSPACE_ID`.
- Add `LocalWorkspaceRegistryService.clear_active_workspace()` to clear the active record safely.
- Rewrite the pinned test to assert the ruling: registry -> `DEFAULT_WORKSPACE_ID`, store -> `CONSOLE_GLOBAL_WORKSPACE_ID`; remove `xfail(strict=True)`.
- No migrations or config changes.

<sup>Written for commit 1c56a13335e177214726dfb17ccf352eedc95b6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

