### PR TITLE
fix(hosted): close PR 1612 review findings

### DIFF
--- a/Docs/superpowers/plans/2026-08-13-pr-1612-review-follow-up.md
+++ b/Docs/superpowers/plans/2026-08-13-pr-1612-review-follow-up.md
@@ -1,0 +1,95 @@
+# PR 1612 Review Follow-Up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close both late Qodo findings from PR #1612 with focused, contract-preserving fixes.
+
+**Architecture:** Keep validation and retry policy in their existing owners. Translate the shared transport's internal URL exception at the public boundary, and align only Z.ai's adapter fallback with its established canonical default.
+
+**Tech Stack:** Python 3.12, pytest, Ruff
+
+**ADR required:** no new ADR
+
+**ADR path:** `backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md`
+
+**Reason:** The correction restores the existing typed-error and provider-default contracts without changing ADR-063's boundary or policy.
+
+---
+
+### Task 1: Reopen And Record The Follow-Up
+
+**Files:**
+- Modify: `backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md`
+
+- [x] **Step 1: Reopen TASK-15676 before implementation**
+
+Use the Backlog CLI to set the task to `In Progress` and record this post-merge
+review correction in its implementation plan.
+
+### Task 2: Pin The Late Review Findings
+
+**Files:**
+- Modify: `Tests/LLM_Calls/test_hosted_chat.py`
+- Modify: `Tests/LLM_Calls/test_zai.py`
+
+- [x] **Step 1: Add the hosted transport regression**
+
+Add a test that supplies a malformed URL containing a canary, asserts the exact
+public `ChatProviderError` type and suppressed exception context, and asserts
+that neither the URL nor canary appears in the formatted traceback.
+
+- [x] **Step 2: Add the Z.ai fallback regression**
+
+Extend the existing defaults assertion to require `retry_delay == 5.0` while
+retaining the configured and explicit-precedence assertions.
+
+- [x] **Step 3: Run both tests to verify RED**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q \
+  Tests/LLM_Calls/test_hosted_chat.py::test_owned_json_post_maps_invalid_base_url_to_redacted_transport_error \
+  Tests/LLM_Calls/test_zai.py::test_resolve_zai_request_uses_canonical_precedence_and_current_defaults
+```
+
+Expected: two failures matching the reported exception leak and `1.0 != 5.0`.
+
+### Task 3: Apply The Minimal Corrections
+
+**Files:**
+- Modify: `tldw_chatbook/LLM_Calls/hosted_chat.py`
+- Modify: `tldw_chatbook/LLM_Calls/zai.py`
+
+- [x] **Step 1: Translate the URL validation exception**
+
+Wrap only `normalize_hosted_chat_base_url()` and raise the existing context-free
+transport configuration error from `None`.
+
+- [x] **Step 2: Align the Z.ai fallback**
+
+Change the adapter-only `retry_delay` fallback from `1.0` to `5.0`.
+
+- [x] **Step 3: Run the two regressions GREEN**
+
+Run the exact Task 2 command. Expected: `2 passed`.
+
+- [x] **Step 4: Run focused related verification**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/LLM_Calls/test_hosted_chat.py Tests/LLM_Calls/test_zai.py
+.venv/bin/ruff check tldw_chatbook/LLM_Calls/hosted_chat.py tldw_chatbook/LLM_Calls/zai.py Tests/LLM_Calls/test_hosted_chat.py Tests/LLM_Calls/test_zai.py
+.venv/bin/ruff format --check tldw_chatbook/LLM_Calls/hosted_chat.py tldw_chatbook/LLM_Calls/zai.py Tests/LLM_Calls/test_hosted_chat.py Tests/LLM_Calls/test_zai.py
+.venv/bin/python -m compileall -q tldw_chatbook/LLM_Calls/hosted_chat.py tldw_chatbook/LLM_Calls/zai.py
+git diff --check
+```
+
+- [ ] **Step 5: Commit, push, review, and merge**
+
+Record the correction and evidence in TASK-15676's Implementation Notes, check
+its acceptance criteria, return it to `Done` through the Backlog CLI, commit the
+four source/test files plus task/design/plan documentation, push the follow-up
+branch, open a PR against `dev`, resolve both original PR #1612 threads with the
+correction commit/PR, wait for required checks, and merge.

--- a/Docs/superpowers/plans/2026-08-13-pr-1612-review-follow-up.md
+++ b/Docs/superpowers/plans/2026-08-13-pr-1612-review-follow-up.md
@@ -86,7 +86,7 @@ Run:
 git diff --check
 ```
 
-- [ ] **Step 5: Commit, push, review, and merge**
+- [x] **Step 5: Commit, push, review, and merge**
 
 Record the correction and evidence in TASK-15676's Implementation Notes, check
 its acceptance criteria, return it to `Done` through the Backlog CLI, commit the

--- a/Docs/superpowers/specs/2026-08-13-pr-1612-review-follow-up-design.md
+++ b/Docs/superpowers/specs/2026-08-13-pr-1612-review-follow-up-design.md
@@ -1,0 +1,45 @@
+# PR 1612 Review Follow-Up Design
+
+## Context
+
+PR #1612 merged after rebasing onto `dev`. Two inline Qodo findings arrived
+immediately after the merge: the shared hosted transport can expose its private
+base-URL validation exception, and Z.ai's adapter-only retry-delay fallback
+differs from the canonical Console/config default.
+
+This is a correction to TASK-15676 and its existing ADR-063 boundary, not a new
+feature or architectural decision.
+
+## Design
+
+`owned_json_post()` will catch only `HostedChatBaseURLValidationError` from its
+existing normalizer and translate it to the same context-free
+`ChatProviderError` used for invalid transport configuration. The malformed URL
+and any embedded credentials remain absent from the public error.
+
+`resolve_zai_request()` will use `5.0` seconds when no retry delay is configured,
+matching both the shipped `[api_settings.zai]` default and Console's hosted
+transport policy. Explicit configuration and explicit call arguments retain
+their existing precedence.
+
+Two narrow regression tests will pin the exception type/redaction and the Z.ai
+fallback. No shared retry-default abstraction or unrelated provider change is
+introduced.
+
+## Verification
+
+- Run the two new tests RED before production changes and GREEN afterward.
+- Run the complete hosted Chat and Z.ai unit modules.
+- Run Ruff lint/format checks and compile the two touched production modules.
+- Use GitHub checks and resolve both original PR review threads before merging
+  the follow-up PR.
+
+## ADR Check
+
+ADR required: no new ADR
+
+ADR path:
+`backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md`
+
+Reason: this directly restores the typed-error and provider-default contracts
+already established by ADR-063; it does not change a boundary or policy.

--- a/Tests/LLM_Calls/test_hosted_chat.py
+++ b/Tests/LLM_Calls/test_hosted_chat.py
@@ -9,6 +9,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import threading
 import time
+import traceback
 from typing import Any
 
 import pytest
@@ -741,6 +742,30 @@ def test_transport_config_repr_hides_api_key() -> None:
     assert config == _transport_config(
         "https://api.example/v1", api_key="DIFFERENT-KEY"
     )
+
+
+def test_owned_json_post_maps_invalid_base_url_to_redacted_transport_error() -> None:
+    base_url = "https://user:RAW-URL-CANARY@example.com/v1"
+
+    with pytest.raises(ChatProviderError) as exc_info:
+        owned_json_post(
+            config=_transport_config(base_url),
+            route="chat/completions",
+            payload={},
+            streaming=False,
+        )
+
+    assert type(exc_info.value) is ChatProviderError
+    assert exc_info.value.__suppress_context__ is True
+    rendered = "".join(
+        traceback.format_exception(
+            exc_info.type,
+            exc_info.value,
+            exc_info.tb,
+        )
+    )
+    assert base_url not in rendered
+    assert "RAW-URL-CANARY" not in rendered
 
 
 @pytest.mark.allow_network

--- a/Tests/LLM_Calls/test_zai.py
+++ b/Tests/LLM_Calls/test_zai.py
@@ -130,6 +130,7 @@ def test_resolve_zai_request_uses_canonical_precedence_and_current_defaults() ->
     )
     assert defaults.model == "glm-5.2"
     assert defaults.base_url == "https://api.z.ai/api/paas/v4"
+    assert defaults.retry_delay == 5.0
 
 
 def test_resolve_zai_request_rejects_normalized_table_alias_conflict() -> None:

--- a/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
+++ b/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-15676
 title: Harden Moonshot Kimi and Z.ai GLM as first-class hosted providers
-status: Done
+status: In Progress
 assignee: []
 created_date: '2026-08-12 20:45'
-updated_date: '2026-08-13 22:10'
+updated_date: '2026-08-14 00:19'
 labels: []
 dependencies:
   - TASK-15675
@@ -55,6 +55,10 @@ Bring the existing Moonshot AI and Z.ai integrations up to the same first-class 
 6. Update user documentation, add default-skipped isolated live-test gates, run
    only the focused provider-related verification authorized for this task,
    self-review each acceptance criterion, and record observed evidence.
+7. Post-merge review correction: translate the hosted transport's private base
+   URL validation exception into its documented redacted public error contract,
+   align Z.ai's adapter-only retry-delay fallback with canonical Console/config
+   policy, and prove both through focused regressions before re-closing the task.
 
 Detailed plan:
 `Docs/superpowers/plans/2026-08-12-kimi-zai-hosted-chat-completions-implementation.md`

--- a/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
+++ b/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-15676
 title: Harden Moonshot Kimi and Z.ai GLM as first-class hosted providers
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-12 20:45'
-updated_date: '2026-08-14 00:19'
+updated_date: '2026-08-14 00:27'
 labels: []
 dependencies:
   - TASK-15675
@@ -105,4 +105,18 @@ needed.
   execution and required only tests related to touched files or functionality.
   No full-repository or broad-directory result is claimed. The exact focused
   commands and this deviation are retained in the implementation plan/evidence.
+- Post-merge review correction: Qodo's two late PR #1612 findings were reproduced
+  and fixed in follow-up PR #1614. The shared hosted transport now converts its
+  private base-URL validation exception into a context-free, redacted
+  `ChatProviderError`, and Z.ai's absent-setting retry fallback is `5.0` seconds,
+  matching canonical Console/config policy without changing explicit precedence.
+  Both original review threads were replied to with the exact correction commit
+  and resolved.
+- Follow-up evidence: the two regressions failed before production edits and then
+  passed; the complete hosted Chat and Z.ai modules passed 124 tests outside the
+  localhost socket sandbox; four exact hosted catalog checks passed. Ruff lint
+  and format, MyPy for both production modules, compileall, diff checks, and an
+  independent code review were green. No broad suite was run under the user's
+  related-test-only restriction. ADR-063 remains the governing decision; no new
+  ADR was required.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/hosted_chat.py
+++ b/tldw_chatbook/LLM_Calls/hosted_chat.py
@@ -451,7 +451,16 @@ def owned_json_post(
     """
     if route not in {"chat/completions", "responses"}:
         raise _transport_error(config.provider, "request route is invalid")
-    base_url = normalize_hosted_chat_base_url(config.base_url, default=config.base_url)
+    try:
+        base_url = normalize_hosted_chat_base_url(
+            config.base_url,
+            default=config.base_url,
+        )
+    except HostedChatBaseURLValidationError:
+        raise _transport_error(
+            config.provider,
+            "transport configuration is invalid",
+        ) from None
     if (
         not isinstance(config.provider, str)
         or not config.provider

--- a/tldw_chatbook/LLM_Calls/zai.py
+++ b/tldw_chatbook/LLM_Calls/zai.py
@@ -216,7 +216,7 @@ def resolve_zai_request(
         base_url=_resolve_base_url(explicit_base_url, settings),
         timeout=_positive_number(transport_settings, "timeout", 90.0),
         retries=_nonnegative_integer(transport_settings, "retries", 3),
-        retry_delay=_nonnegative_number(transport_settings, "retry_delay", 1.0),
+        retry_delay=_nonnegative_number(transport_settings, "retry_delay", 5.0),
         streaming=_resolve_streaming(settings),
     )
 


### PR DESCRIPTION
## Summary

- translate malformed hosted base URLs into the documented redacted ChatProviderError boundary
- align Z.ai adapter fallback retry delay with Console and shipped config at 5.0 seconds
- add focused regressions for traceback redaction and fallback policy

Follow-up to #1612 for late Qodo findings.

## Verification

- 2 focused RED then GREEN regressions
- 124 hosted Chat + Z.ai tests passed
- 4 focused hosted model-catalog tests passed
- Ruff lint/format, MyPy, compileall, and git diff --check passed

No broad test suite was run, per the requested related-test-only scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts hosted Chat base-URL validation errors and aligns the Z.ai adapter’s default retry delay to 5.0s. Previously, invalid base URLs leaked the raw URL via a private validation exception; now `owned_json_post` raises a context-free `ChatProviderError` with suppressed context, and Z.ai’s fallback `retry_delay` increases from 1.0s to 5.0s without changing precedence.

**Review focus**
- `tldw_chatbook/LLM_Calls/hosted_chat.py`: catch `HostedChatBaseURLValidationError` in `owned_json_post` and raise `_transport_error(..., "transport configuration is invalid")` from None.
- `tldw_chatbook/LLM_Calls/zai.py`: set adapter-only default `retry_delay` to 5.0.
- Tests: add a redaction regression for hosted transport and a default assertion for Z.ai. Docs/spec and task notes added; no runtime impact.

**Impact**
- No change for valid configs; hosted errors now redact URLs and credentials in tracebacks.
- If you relied on a 1.0s Z.ai fallback, set `retry_delay=1.0` explicitly in settings or per call.

<sup>Written for commit 2aeb1af4bf8cd60bdfb9d7350d00c5e1d2f2a60c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

