### PR TITLE
style(hosted): satisfy late review rules

### DIFF
--- a/Docs/superpowers/plans/2026-08-13-pr-1612-review-follow-up.md
+++ b/Docs/superpowers/plans/2026-08-13-pr-1612-review-follow-up.md
@@ -93,3 +93,31 @@ its acceptance criteria, return it to `Done` through the Backlog CLI, commit the
 four source/test files plus task/design/plan documentation, push the follow-up
 branch, open a PR against `dev`, resolve both original PR #1612 threads with the
 correction commit/PR, wait for required checks, and merge.
+
+### Task 4: Close The Late Compliance Review
+
+**Files:**
+- Modify: `tldw_chatbook/LLM_Calls/zai.py`
+- Modify: `Tests/LLM_Calls/test_zai.py`
+- Modify: `Tests/LLM_Calls/test_hosted_chat.py`
+
+- [x] **Step 1: Name the Z.ai retry fallback**
+
+Introduce one provider-local default constant, use it in resolution, and have
+the existing defaults contract reference that owner.
+
+- [x] **Step 2: Document the new regression callable**
+
+Add a concise docstring to the new hosted transport test. No empty
+`Args`/`Returns`/`Raises` sections are needed because the test accepts nothing,
+returns nothing, and asserts rather than exposing an exception contract.
+
+- [x] **Step 3: Run only the directly related tests and static checks**
+
+Run the two exact regressions, both complete touched test modules, Ruff
+lint/format, MyPy for Z.ai, compileall for Z.ai, and `git diff --check`.
+
+- [ ] **Step 4: Resolve PR #1614's two threads and merge the final follow-up**
+
+Reply with the exact correction commit/PR, resolve both threads, verify there
+are no remaining actionable comments, and merge into `dev`.

--- a/Docs/superpowers/plans/2026-08-13-pr-1612-review-follow-up.md
+++ b/Docs/superpowers/plans/2026-08-13-pr-1612-review-follow-up.md
@@ -117,7 +117,7 @@ returns nothing, and asserts rather than exposing an exception contract.
 Run the two exact regressions, both complete touched test modules, Ruff
 lint/format, MyPy for Z.ai, compileall for Z.ai, and `git diff --check`.
 
-- [ ] **Step 4: Resolve PR #1614's two threads and merge the final follow-up**
+- [x] **Step 4: Resolve PR #1614's two threads and merge the final follow-up**
 
 Reply with the exact correction commit/PR, resolve both threads, verify there
 are no remaining actionable comments, and merge into `dev`.

--- a/Tests/LLM_Calls/test_hosted_chat.py
+++ b/Tests/LLM_Calls/test_hosted_chat.py
@@ -745,6 +745,7 @@ def test_transport_config_repr_hides_api_key() -> None:
 
 
 def test_owned_json_post_maps_invalid_base_url_to_redacted_transport_error() -> None:
+    """Map malformed bases to a redacted public transport error."""
     base_url = "https://user:RAW-URL-CANARY@example.com/v1"
 
     with pytest.raises(ChatProviderError) as exc_info:

--- a/Tests/LLM_Calls/test_zai.py
+++ b/Tests/LLM_Calls/test_zai.py
@@ -130,6 +130,7 @@ def test_resolve_zai_request_uses_canonical_precedence_and_current_defaults() ->
     )
     assert defaults.model == "glm-5.2"
     assert defaults.base_url == "https://api.z.ai/api/paas/v4"
+    assert zai._DEFAULT_RETRY_DELAY == 5.0
     assert defaults.retry_delay == zai._DEFAULT_RETRY_DELAY
 
 

--- a/Tests/LLM_Calls/test_zai.py
+++ b/Tests/LLM_Calls/test_zai.py
@@ -130,7 +130,7 @@ def test_resolve_zai_request_uses_canonical_precedence_and_current_defaults() ->
     )
     assert defaults.model == "glm-5.2"
     assert defaults.base_url == "https://api.z.ai/api/paas/v4"
-    assert defaults.retry_delay == 5.0
+    assert defaults.retry_delay == zai._DEFAULT_RETRY_DELAY
 
 
 def test_resolve_zai_request_rejects_normalized_table_alias_conflict() -> None:

--- a/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
+++ b/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-15676
 title: Harden Moonshot Kimi and Z.ai GLM as first-class hosted providers
-status: Done
+status: In Progress
 assignee: []
 created_date: '2026-08-12 20:45'
-updated_date: '2026-08-14 00:27'
+updated_date: '2026-08-14 00:32'
 labels: []
 dependencies:
   - TASK-15675
@@ -59,6 +59,9 @@ Bring the existing Moonshot AI and Z.ai integrations up to the same first-class 
    URL validation exception into its documented redacted public error contract,
    align Z.ai's adapter-only retry-delay fallback with canonical Console/config
    policy, and prove both through focused regressions before re-closing the task.
+8. Late compliance correction: give the Z.ai retry fallback one provider-local
+   named owner and document the added regression callable, then resolve both
+   PR #1614 rule threads through a final focused follow-up.
 
 Detailed plan:
 `Docs/superpowers/plans/2026-08-12-kimi-zai-hosted-chat-completions-implementation.md`
@@ -119,4 +122,9 @@ needed.
   independent code review were green. No broad suite was run under the user's
   related-test-only restriction. ADR-063 remains the governing decision; no new
   ADR was required.
+- Late compliance correction: PR #1614's post-merge rule review now has one
+  provider-local owner for the Z.ai retry fallback and a concise docstring on
+  the added transport regression. The same two exact regressions and complete
+  touched modules passed (`2` and `124` tests); focused Ruff lint/format, Z.ai
+  MyPy/compileall, diff checks, and independent review were green.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
+++ b/backlog/tasks/task-15676 - Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-15676
 title: Harden Moonshot Kimi and Z.ai GLM as first-class hosted providers
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-12 20:45'
-updated_date: '2026-08-14 00:32'
+updated_date: '2026-08-14 00:45'
 labels: []
 dependencies:
   - TASK-15675
@@ -126,5 +126,10 @@ needed.
   provider-local owner for the Z.ai retry fallback and a concise docstring on
   the added transport regression. The same two exact regressions and complete
   touched modules passed (`2` and `124` tests); focused Ruff lint/format, Z.ai
-  MyPy/compileall, diff checks, and independent review were green.
+  MyPy/compileall, diff checks, and independent review were green. PR #1615's
+  delayed review caught and closed one circular-test assertion: the test now
+  independently pins the numeric `5.0` policy and the resolver's use of its
+  named owner. Mutating the owner to `1.0` failed the exact test before it was
+  restored; the restored test and static checks passed, and the review thread
+  was replied to and resolved.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/zai.py
+++ b/tldw_chatbook/LLM_Calls/zai.py
@@ -44,6 +44,7 @@ from tldw_chatbook.config import (
 
 _DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4"
 _DEFAULT_MODEL = "glm-5.2"
+_DEFAULT_RETRY_DELAY = 5.0
 _FUNCTION_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]{2,63}$")
 _GLM_5_2_REASONING_EFFORTS = frozenset(
     {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
@@ -216,7 +217,11 @@ def resolve_zai_request(
         base_url=_resolve_base_url(explicit_base_url, settings),
         timeout=_positive_number(transport_settings, "timeout", 90.0),
         retries=_nonnegative_integer(transport_settings, "retries", 3),
-        retry_delay=_nonnegative_number(transport_settings, "retry_delay", 5.0),
+        retry_delay=_nonnegative_number(
+            transport_settings,
+            "retry_delay",
+            _DEFAULT_RETRY_DELAY,
+        ),
         streaming=_resolve_streaming(settings),
     )
 


### PR DESCRIPTION
## Summary

- give the Z.ai retry fallback one provider-local named owner
- document the new hosted transport regression callable
- close the two late Qodo compliance findings from #1614

## Verification

- 2 exact regressions passed
- 124 hosted Chat + Z.ai tests passed
- Ruff lint/format, Z.ai MyPy/compileall, diff checks, and independent review passed

No broad test suite was run, per the related-test-only scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes the Z.ai retry fallback into a provider-local `_DEFAULT_RETRY_DELAY` (5.0s) and updates tests and docs to close the late compliance review. Old behavior used a literal 5.0s; new behavior uses the named constant with the same effective delay; no functional change.

- Define `_DEFAULT_RETRY_DELAY` in `tldw_chatbook/LLM_Calls/zai.py` and use it in `resolve_zai_request`.
- Pin both the numeric policy and the named owner in `Tests/LLM_Calls/test_zai.py`.
- Add a concise docstring to `test_owned_json_post_maps_invalid_base_url_to_redacted_transport_error`.
- Update plan and task docs to mark the late compliance review closed and document the regression callable.
- Verification: 2 targeted regressions and 124 hosted Chat + Z.ai tests passed; Ruff, Z.ai MyPy/compileall, and diff checks are green.

<sup>Written for commit 2e7e13769b5abebaf65fc590499d11545f8e2004. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

