### PR TITLE
feat(notes): add Database Notes folder navigator

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2301,8 +2301,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 98,
-      "diagnostic_digest": "d9df75cd443ea72258f9",
+      "call_count": 102,
+      "diagnostic_digest": "9ef5d30ceae5a1eee27e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3605,6 +3605,6 @@
     "owner_files": 489,
     "persistent_sink_files": 6,
     "task_492_calls": 1198,
-    "task_494_calls": 6940
+    "task_494_calls": 6944
   }
 }

--- a/Docs/superpowers/plans/2026-08-13-task-15706-database-notes-folder-navigator.md
+++ b/Docs/superpowers/plans/2026-08-13-task-15706-database-notes-folder-navigator.md
@@ -1,0 +1,104 @@
+# Database Notes Folder Navigator Implementation Plan
+
+> **For Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task by task.
+
+**Goal:** Replace the flat Database Notes list with a lazy, placement-aware folder navigator that supports manual organization without regressing the existing note editor or File Notes.
+
+**Architecture:** A pure projection module will merge bounded `NoteFolderPage` batches into immutable tree rows and stable navigation state. `LibraryScreen` will own service calls, generations, mutations, and focus restoration; `LibraryNotesCanvas` will only render the projection and emit controls. All storage access remains behind `NotesScopeService`, in accordance with ADR-059 and ADR-060.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, dataclasses, pytest/pytest-asyncio, Rich/Textual screenshot export.
+
+**Backlog task:** `TASK-15706`
+
+**Architecture decisions:**
+
+- ADR required: no
+- Existing ADRs: `backlog/decisions/059-notes-folder-import-and-device-local-sync-ownership.md`; `backlog/decisions/060-notes-sync-round-trip-and-interoperability-constraints.md`
+- Reason: these ADRs already define normalized folder services, placement identity, managed ownership, lazy rendering, and local/server separation.
+
+**Known baseline:** The focused baseline has 109 passing tests and one unrelated existing failure in `Tests/UI/test_library_multiselect_notes.py`; its fake screen omits the already-required `_library_notes_mutation_in_flight` attribute.
+
+---
+
+## Task 1: Pure placement-aware tree projection
+
+**Files:**
+
+- Create: `tldw_chatbook/Library/library_notes_tree_state.py`
+- Create: `Tests/Library/test_library_notes_tree_state.py`
+
+1. Write failing tests for root/nested ordering, Unfiled, distinct placement IDs for one note, breadcrumb derivation, manual ancestor+descendant duplicates, generated managed-ancestor collapse, and inactive-owner decoration.
+2. Run `python -m pytest Tests/Library/test_library_notes_tree_state.py -q` and confirm the missing module/behavior fails.
+3. Add immutable row, projection, cache, paging, and navigation dataclasses. Keep folder placement identity separate from note identity, use semantic glyph+label text in addition to style roles, and expose bounded-load cursors.
+4. Implement pure page merging and visible-row projection. Preserve all surviving expanded IDs, prefer the same placement on refresh, and fall back to another placement of the same note only when needed.
+5. Re-run the focused tests to green, then run Ruff on the new module and test.
+
+## Task 2: Render the lazy folder navigator
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Library/library_notes_canvas.py`
+- Modify: `Tests/Widgets/Library/test_library_notes_canvas.py`
+- Modify: `tldw_chatbook/css/components/_library.tcss` or the existing Library stylesheet owning Notes geometry
+
+1. Add failing widget tests for folder expand controls, nested indentation, Unfiled, duplicate note placement metadata, breadcrumbs, non-color managed/inactive-managed cues, loading/more rows, and compact labels.
+2. Extend the canvas list inputs with an optional tree projection and compose folder/note buttons using stable DOM-safe IDs. Continue assigning `note_id` for the existing editor/select handler and also assign `placement_id`, `folder_id`, `membership_id`, `breadcrumb`, `ownership`, and `owner_active`.
+3. Add keyboard-operable action buttons and semantic classes using theme tokens only. Ensure glyphs and text remain sufficient with color removed.
+4. Verify widget tests and export a 60x20 frame for inspection.
+
+## Task 3: Load and preserve tree state through LibraryScreen
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Create: `Tests/UI/test_library_notes_folder_navigator.py`
+
+1. Add failing screen tests proving the initial root batch is loaded once, expansion issues one bounded bulk request, no per-note detail calls occur until a note is opened, stale generations are ignored, and in-memory async tests stay on their owning thread.
+2. Add screen-owned tree cache, expanded IDs, paging state, placement focus, loading/error state, and request generation. Start the root load on the Database Notes route and merge expanded-folder batches through the pure projector.
+3. Use the normalized `NotesScopeService` methods only. Route file-backed synchronous calls through the existing worker boundary and allow already-async/in-memory test doubles to remain thread-local.
+4. Extend semantic focus capture/restore to use placement identity first and note identity second; keep the active editor keyed only by note ID.
+5. Run the focused screen and current Notes workflow tests.
+
+## Task 4: Manual folder and placement operations
+
+**Files:**
+
+- Create: `tldw_chatbook/Widgets/Library/library_note_folder_dialog.py`
+- Modify: `tldw_chatbook/Widgets/Library/library_notes_canvas.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `Tests/UI/test_library_notes_folder_navigator.py`
+
+1. Add failing tests for create, rename, move, remove, restore, attach, detach/move placement, optimistic conflicts, cancellation, and managed/inactive-managed protection.
+2. Add a small reusable modal for folder name/target selection and explicit confirmation for remove. Keep restored folders discoverable through a visible recovery action.
+3. Wire mutations through `NotesScopeService`, supplying expected versions and membership versions where required. Treat moving a manual note as attach-then-detach with safe recovery if detach fails; adding a placement never removes existing memberships.
+4. Disable manual mutation controls for managed or inactive managed rows and explain why in visible text/tooltips.
+5. Reload affected branches and restore expansion/focus/editor identity after each successful mutation; surface collision, conflict, capability, and generic failures without discarding state.
+
+## Task 5: Selection, filtering, responsive layout, and regressions
+
+**Files:**
+
+- Modify: `tldw_chatbook/Library/library_notes_tree_state.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `Tests/UI/test_library_notes_folder_navigator.py`
+- Modify: `Tests/UI/test_library_multiselect_notes.py` only for the confirmed baseline fixture omission
+- Modify: relevant rendered/accessibility Library tests under `Tests/UI/`
+
+1. Add failing tests for duplicate-placement selection, filter breadcrumbs, reorder/refresh preservation, collapsed-folder fallback, resize/recompose focus, and exact 60x20 allocation.
+2. Make selection note-based across duplicate placements while focus remains placement-based. Filter by note title/path and show every matching breadcrumb without mutating expansion state.
+3. Keep navigator action rows bounded at 60 columns and preserve the existing editor, create, sync, and File Notes routes.
+4. Add a rendered-frame assertion/export and inspect hierarchy, status, controls, and clipping with theme color ignored.
+
+## Task 6: Performance, host routing, and verification
+
+**Files:**
+
+- Modify: `Tests/UI/test_library_notes_folder_navigator.py`
+- Modify: `Tests/UI/test_library_shell.py` or the narrow existing host-routing test
+- Modify: `backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md`
+
+1. Add request-count tests proving bulk loads are bounded and no N+1 note calls occur for a representative multi-folder tree.
+2. Run focused suites for tree state, canvas, screen, folder service, current note editor, multiselect, responsive Library, and File Notes.
+3. Run the broader Library/Notes test groups plus Ruff on changed Python files.
+4. Exercise a real file-backed database and restart the app against a scratch profile; verify root load, nested expansion, duplicate placement opening, folder mutation, editor return, File Notes routing, and a 60x20 frame.
+5. Self-review the diff, record evidence and the known-baseline disposition, add concise Implementation Notes with ADR links, check every acceptance/DoD box, and set the task status to Done only if every requirement has evidence.

--- a/Tests/Architecture/test_persistent_diagnostic_inventory.py
+++ b/Tests/Architecture/test_persistent_diagnostic_inventory.py
@@ -116,6 +116,15 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
         "Pending sidebar-state write failed": ("type(error).__name__",),
     },
     "tldw_chatbook/UI/Screens/library_screen.py": {
+        "Failed to continue the Database Notes folder navigator": (
+            "type(exc).__name__",
+        ),
+        "Failed to load the Database Notes folder navigator": ("type(exc).__name__",),
+        "Database Notes move kept both placements": ("type(exc).__name__",),
+        "Database Notes tree mutation": (
+            "operation",
+            "type(exc).__name__",
+        ),
         "in bulk delete": (),
         "Failed to restore a Library media item in bulk-delete undo": (
             "type(exc).__name__",

--- a/Tests/Library/test_library_notes_tree_state.py
+++ b/Tests/Library/test_library_notes_tree_state.py
@@ -98,9 +98,11 @@ def test_projects_nested_folders_and_unfiled_notes_with_breadcrumbs():
         ("unfiled", "Unfiled", 0),
         ("note", "Loose thought", 1),
     ]
-    garden = projection.row(FolderPlacementId.note("ideas", "garden"))
+    garden = projection.row(FolderPlacementId.note("ideas", "garden", "m-garden"))
     loose = projection.row(FolderPlacementId.unfiled("loose"))
-    assert garden is not None and garden.breadcrumb == "Personal / Ideas / Garden redesign"
+    assert (
+        garden is not None and garden.breadcrumb == "Personal / Ideas / Garden redesign"
+    )
     assert loose is not None and loose.breadcrumb == "Unfiled / Loose thought"
 
 
@@ -125,14 +127,41 @@ def test_same_note_has_distinct_placement_rows_but_one_note_identity():
     rows = [row for row in projection.rows if row.note_id == "n1"]
 
     assert [row.placement_id for row in rows] == [
-        FolderPlacementId.note("ideas", "n1"),
-        FolderPlacementId.note("reading", "n1"),
+        FolderPlacementId.note("ideas", "n1", "m1"),
+        FolderPlacementId.note("reading", "n1", "m2"),
     ]
     assert {row.note_id for row in rows} == {"n1"}
     assert [row.breadcrumb for row in rows] == [
         "Ideas / Shared note",
         "Reading / Shared note",
     ]
+
+
+def test_manual_and_managed_memberships_in_same_folder_keep_distinct_identity():
+    folder = _folder("ideas", None, "/Ideas")
+    projection = build_library_notes_tree(
+        root_page=_page(folders=(folder,)),
+        expanded_page=_page(
+            memberships=(
+                _membership("manual", "ideas", "n1"),
+                _membership(
+                    "managed",
+                    "ideas",
+                    "n1",
+                    ownership="managed",
+                    owner_id="sync-root",
+                ),
+            ),
+            notes=({"id": "n1", "title": "Shared note"},),
+        ),
+        expanded_folder_ids={"ideas"},
+    )
+
+    rows = [row for row in projection.rows if row.note_id == "n1"]
+    assert len(rows) == 2
+    assert len({row.placement_id for row in rows}) == 2
+    assert {row.membership_id for row in rows} == {"manual", "managed"}
+    assert {row.protected for row in rows} == {False, True}
 
 
 def test_generated_managed_ancestor_collapses_but_manual_duplicate_remains():
@@ -260,9 +289,7 @@ def test_projection_exposes_bounded_more_rows_for_each_cursor():
 def test_identity_reconciliation_preserves_placement_then_note_then_visible_row():
     folder = _folder("ideas", None, "/Ideas")
     first = build_library_notes_tree(
-        root_page=_page(
-            folders=(folder,), notes=({"id": "loose", "title": "Loose"},)
-        ),
+        root_page=_page(folders=(folder,), notes=({"id": "loose", "title": "Loose"},)),
         expanded_page=_page(
             memberships=(_membership("m", "ideas", "n1"),),
             notes=({"id": "n1", "title": "Note"},),
@@ -270,7 +297,7 @@ def test_identity_reconciliation_preserves_placement_then_note_then_visible_row(
         expanded_folder_ids={"ideas"},
     )
     identity = LibraryNotesTreeIdentity(
-        placement_id=FolderPlacementId.note("ideas", "n1"), note_id="n1"
+        placement_id=FolderPlacementId.note("ideas", "n1", "m"), note_id="n1"
     )
     assert reconcile_library_notes_tree_identity(first, identity) == identity
 

--- a/Tests/Library/test_library_notes_tree_state.py
+++ b/Tests/Library/test_library_notes_tree_state.py
@@ -57,6 +57,7 @@ def _page(
     next_folder_offset=None,
     next_note_offset=None,
     next_membership_offset=None,
+    unfiled_note_ids=None,
 ) -> NoteFolderPage:
     return NoteFolderPage(
         folders=tuple(folders),
@@ -69,6 +70,7 @@ def _page(
         total_memberships=len(memberships)
         + (1 if next_membership_offset is not None else 0),
         next_membership_offset=next_membership_offset,
+        unfiled_note_ids=unfiled_note_ids,
     )
 
 
@@ -270,6 +272,29 @@ def test_managed_folder_protection_propagates_to_loaded_ancestors():
     assert project.semantic_status == "connected"
 
 
+def test_authoritative_managed_summary_protects_collapsed_folder():
+    folder = _folder("work", None, "/Work")
+    root = NoteFolderPage(
+        folders=(folder,),
+        memberships=(),
+        notes=(),
+        total_folders=1,
+        total_notes=0,
+        next_offset=None,
+        managed_folder_ids=("work",),
+    )
+
+    projection = build_library_notes_tree(
+        root_page=root,
+        expanded_page=_page(),
+        expanded_folder_ids=set(),
+    )
+
+    row = projection.row(FolderPlacementId.folder("work"))
+    assert row is not None and row.protected
+    assert row.status_text == "⇄ Sync managed"
+
+
 def test_projection_exposes_bounded_more_rows_for_each_cursor():
     projection = build_library_notes_tree(
         root_page=_page(
@@ -354,6 +379,90 @@ def test_filter_shows_every_matching_placement_with_its_breadcrumb():
         "Reading / Garden plan",
     ]
     assert all(row.label != "Unrelated" for row in projection.rows)
+
+
+def test_filter_temporarily_reveals_matches_under_collapsed_folders():
+    parent = _folder("work", None, "/Work")
+    child = _folder("project", "work", "/Work/Project")
+    search_page = _page(
+        folders=(parent, child),
+        memberships=(_membership("m1", "project", "n1"),),
+        notes=({"id": "n1", "title": "Hidden garden plan"},),
+        unfiled_note_ids=(),
+    )
+
+    projection = build_library_notes_tree(
+        root_page=search_page,
+        expanded_page=search_page,
+        expanded_folder_ids=set(),
+        filter_text="garden",
+    )
+
+    assert [row.breadcrumb for row in projection.rows if row.kind == "note"] == [
+        "Work / Project / Hidden garden plan"
+    ]
+    assert [row.label for row in projection.rows if row.kind == "folder"] == [
+        "Work",
+        "Project",
+    ]
+    assert all(row.expanded for row in projection.rows if row.kind == "folder")
+
+
+def test_search_result_identity_keeps_content_only_matches_visible():
+    folder = _folder("work", None, "/Work")
+    search_page = _page(
+        folders=(folder,),
+        memberships=(_membership("m1", "work", "n1"),),
+        notes=({"id": "n1", "title": "Weekly plan"},),
+        unfiled_note_ids=(),
+    )
+
+    projection = build_library_notes_tree(
+        root_page=search_page,
+        expanded_page=search_page,
+        expanded_folder_ids=set(),
+        filter_text="garden",
+        matched_note_ids=frozenset({"n1"}),
+    )
+
+    assert [row.breadcrumb for row in projection.rows if row.kind == "note"] == [
+        "Work / Weekly plan"
+    ]
+
+
+def test_search_keeps_inactive_managed_and_unfiled_breadcrumbs_distinct():
+    folder = _folder("work", None, "/Work")
+    page = NoteFolderPage(
+        folders=(folder,),
+        memberships=(
+            _membership(
+                "managed",
+                "work",
+                "n1",
+                ownership="managed",
+                owner_id="missing",
+                owner_active=False,
+            ),
+        ),
+        notes=({"id": "n1", "title": "Recovered"},),
+        total_folders=1,
+        total_notes=1,
+        next_offset=None,
+        unfiled_note_ids=("n1",),
+    )
+
+    projection = build_library_notes_tree(
+        root_page=page,
+        expanded_page=page,
+        expanded_folder_ids=set(),
+        filter_text="body-only match",
+        matched_note_ids=frozenset({"n1"}),
+    )
+
+    assert [row.breadcrumb for row in projection.rows if row.kind == "note"] == [
+        "Work / Recovered",
+        "Unfiled / Recovered",
+    ]
 
 
 def test_bounded_pages_merge_by_domain_identity_without_duplicates():

--- a/Tests/Library/test_library_notes_tree_state.py
+++ b/Tests/Library/test_library_notes_tree_state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from tldw_chatbook.Library.library_notes_tree_state import (
     UNFILED_PLACEMENT_ID,
     LibraryNotesTreeIdentity,
+    _effective_memberships,
     build_library_notes_tree,
     merge_note_folder_pages,
     reconcile_library_notes_tree_identity,
@@ -201,6 +202,44 @@ def test_generated_managed_ancestor_collapses_but_manual_duplicate_remains():
         "explicit-parent",
         "generated-child",
     }
+
+
+def test_managed_ancestor_collapse_walks_each_folder_chain_once():
+    class CountingFolders(dict[str, NoteFolder]):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.get_calls = 0
+
+        def get(self, key, default=None):
+            self.get_calls += 1
+            return super().get(key, default)
+
+    folder_count = 40
+    folders = CountingFolders(
+        {
+            f"folder-{index}": _folder(
+                f"folder-{index}",
+                f"folder-{index - 1}" if index else None,
+                "/" + "/".join(f"Folder {part}" for part in range(index + 1)),
+            )
+            for index in range(folder_count)
+        }
+    )
+    memberships = tuple(
+        _membership(
+            f"membership-{index}",
+            f"folder-{index}",
+            "note-1",
+            ownership="managed",
+            owner_id="sync-root",
+        )
+        for index in reversed(range(folder_count))
+    )
+
+    effective = _effective_memberships(memberships, folders)
+
+    assert [membership.folder_id for membership in effective] == ["folder-39"]
+    assert folders.get_calls <= folder_count * 2
 
 
 def test_managed_and_restored_without_owner_are_textually_distinct_and_protected():

--- a/Tests/Library/test_library_notes_tree_state.py
+++ b/Tests/Library/test_library_notes_tree_state.py
@@ -263,3 +263,32 @@ def test_unfiled_identity_is_stable_constant():
         expanded_folder_ids=set(),
     )
     assert projection.rows[0].placement_id == UNFILED_PLACEMENT_ID
+
+
+def test_filter_shows_every_matching_placement_with_its_breadcrumb():
+    folders = (
+        _folder("ideas", None, "/Ideas"),
+        _folder("reading", None, "/Reading"),
+    )
+    projection = build_library_notes_tree(
+        root_page=_page(folders=folders),
+        expanded_page=_page(
+            memberships=(
+                _membership("m1", "ideas", "n1"),
+                _membership("m2", "reading", "n1"),
+                _membership("m3", "reading", "n2"),
+            ),
+            notes=(
+                {"id": "n1", "title": "Garden plan"},
+                {"id": "n2", "title": "Unrelated"},
+            ),
+        ),
+        expanded_folder_ids={"ideas", "reading"},
+        filter_text="garden",
+    )
+    notes = [row for row in projection.rows if row.kind == "note"]
+    assert [row.breadcrumb for row in notes] == [
+        "Ideas / Garden plan",
+        "Reading / Garden plan",
+    ]
+    assert all(row.label != "Unrelated" for row in projection.rows)

--- a/Tests/Library/test_library_notes_tree_state.py
+++ b/Tests/Library/test_library_notes_tree_state.py
@@ -1,0 +1,265 @@
+"""Pure behavior tests for the Database Notes folder-tree projection."""
+
+from __future__ import annotations
+
+from tldw_chatbook.Library.library_notes_tree_state import (
+    UNFILED_PLACEMENT_ID,
+    LibraryNotesTreeIdentity,
+    build_library_notes_tree,
+    reconcile_library_notes_tree_identity,
+)
+from tldw_chatbook.Notes.note_folder_models import (
+    FolderPlacementId,
+    NoteFolder,
+    NoteFolderMembership,
+    NoteFolderPage,
+)
+
+
+def _folder(folder_id: str, parent_id: str | None, path: str) -> NoteFolder:
+    return NoteFolder(
+        folder_id=folder_id,
+        parent_id=parent_id,
+        name=path.rsplit("/", 1)[-1],
+        path=path,
+        normalized_path=path.casefold(),
+        version=1,
+        deleted=False,
+    )
+
+
+def _membership(
+    membership_id: str,
+    folder_id: str,
+    note_id: str,
+    *,
+    ownership: str = "manual",
+    owner_id: str = "",
+    owner_active: bool = True,
+) -> NoteFolderMembership:
+    return NoteFolderMembership(
+        membership_id=membership_id,
+        folder_id=folder_id,
+        note_id=note_id,
+        ownership=ownership,
+        owner_id=owner_id,
+        owner_active=owner_active,
+        version=1,
+    )
+
+
+def _page(
+    *,
+    folders=(),
+    memberships=(),
+    notes=(),
+    next_folder_offset=None,
+    next_note_offset=None,
+    next_membership_offset=None,
+) -> NoteFolderPage:
+    return NoteFolderPage(
+        folders=tuple(folders),
+        memberships=tuple(memberships),
+        notes=tuple(notes),
+        total_folders=len(folders) + (1 if next_folder_offset is not None else 0),
+        total_notes=len(notes) + (1 if next_note_offset is not None else 0),
+        next_offset=next_note_offset,
+        next_folder_offset=next_folder_offset,
+        total_memberships=len(memberships)
+        + (1 if next_membership_offset is not None else 0),
+        next_membership_offset=next_membership_offset,
+    )
+
+
+def test_projects_nested_folders_and_unfiled_notes_with_breadcrumbs():
+    personal = _folder("personal", None, "/Personal")
+    ideas = _folder("ideas", "personal", "/Personal/Ideas")
+    root = _page(
+        folders=(personal,),
+        notes=({"id": "loose", "title": "Loose thought"},),
+    )
+    expanded = _page(
+        folders=(ideas,),
+        memberships=(_membership("m-garden", "ideas", "garden"),),
+        notes=({"id": "garden", "title": "Garden redesign"},),
+    )
+
+    projection = build_library_notes_tree(
+        root_page=root,
+        expanded_page=expanded,
+        expanded_folder_ids={"personal", "ideas"},
+    )
+
+    assert [(row.kind, row.label, row.depth) for row in projection.rows] == [
+        ("folder", "Personal", 0),
+        ("folder", "Ideas", 1),
+        ("note", "Garden redesign", 2),
+        ("unfiled", "Unfiled", 0),
+        ("note", "Loose thought", 1),
+    ]
+    garden = projection.row(FolderPlacementId.note("ideas", "garden"))
+    loose = projection.row(FolderPlacementId.unfiled("loose"))
+    assert garden is not None and garden.breadcrumb == "Personal / Ideas / Garden redesign"
+    assert loose is not None and loose.breadcrumb == "Unfiled / Loose thought"
+
+
+def test_same_note_has_distinct_placement_rows_but_one_note_identity():
+    folders = (
+        _folder("ideas", None, "/Ideas"),
+        _folder("reading", None, "/Reading"),
+    )
+    expanded = _page(
+        memberships=(
+            _membership("m1", "ideas", "n1"),
+            _membership("m2", "reading", "n1"),
+        ),
+        notes=({"id": "n1", "title": "Shared note"},),
+    )
+
+    projection = build_library_notes_tree(
+        root_page=_page(folders=folders),
+        expanded_page=expanded,
+        expanded_folder_ids={"ideas", "reading"},
+    )
+    rows = [row for row in projection.rows if row.note_id == "n1"]
+
+    assert [row.placement_id for row in rows] == [
+        FolderPlacementId.note("ideas", "n1"),
+        FolderPlacementId.note("reading", "n1"),
+    ]
+    assert {row.note_id for row in rows} == {"n1"}
+    assert [row.breadcrumb for row in rows] == [
+        "Ideas / Shared note",
+        "Reading / Shared note",
+    ]
+
+
+def test_generated_managed_ancestor_collapses_but_manual_duplicate_remains():
+    parent = _folder("parent", None, "/Work")
+    child = _folder("child", "parent", "/Work/Project")
+    memberships = (
+        _membership(
+            "generated-parent",
+            "parent",
+            "n1",
+            ownership="managed",
+            owner_id="root-a",
+        ),
+        _membership(
+            "generated-child",
+            "child",
+            "n1",
+            ownership="managed",
+            owner_id="root-a",
+        ),
+        _membership("explicit-parent", "parent", "n1"),
+    )
+    projection = build_library_notes_tree(
+        root_page=_page(folders=(parent,)),
+        expanded_page=_page(
+            folders=(child,),
+            memberships=memberships,
+            notes=({"id": "n1", "title": "Plan"},),
+        ),
+        expanded_folder_ids={"parent", "child"},
+    )
+
+    rows = [row for row in projection.rows if row.note_id == "n1"]
+    assert {row.membership_id for row in rows} == {
+        "explicit-parent",
+        "generated-child",
+    }
+
+
+def test_managed_and_restored_without_owner_are_textually_distinct_and_protected():
+    folder = _folder("work", None, "/Work")
+    projection = build_library_notes_tree(
+        root_page=_page(folders=(folder,)),
+        expanded_page=_page(
+            memberships=(
+                _membership(
+                    "active", "work", "n1", ownership="managed", owner_id="root"
+                ),
+                _membership(
+                    "inactive",
+                    "work",
+                    "n2",
+                    ownership="managed",
+                    owner_id="missing-root",
+                    owner_active=False,
+                ),
+            ),
+            notes=(
+                {"id": "n1", "title": "Weekly"},
+                {"id": "n2", "title": "Recovered"},
+            ),
+        ),
+        expanded_folder_ids={"work"},
+    )
+
+    active = next(row for row in projection.rows if row.note_id == "n1")
+    inactive = next(row for row in projection.rows if row.note_id == "n2")
+    assert active.status_text == "⇄ Synced placement"
+    assert inactive.status_text == "! Needs owner review"
+    assert active.protected and inactive.protected
+    assert active.semantic_status == "connected"
+    assert inactive.semantic_status == "needs_attention"
+
+
+def test_projection_exposes_bounded_more_rows_for_each_cursor():
+    projection = build_library_notes_tree(
+        root_page=_page(
+            notes=({"id": "n1", "title": "One"},),
+            next_folder_offset=500,
+            next_note_offset=1000,
+        ),
+        expanded_page=_page(next_membership_offset=1000),
+        expanded_folder_ids=set(),
+    )
+    assert projection.next_folder_offset == 500
+    assert projection.next_note_offset == 1000
+    assert projection.next_membership_offset == 1000
+    assert projection.has_more
+
+
+def test_identity_reconciliation_preserves_placement_then_note_then_visible_row():
+    folder = _folder("ideas", None, "/Ideas")
+    first = build_library_notes_tree(
+        root_page=_page(
+            folders=(folder,), notes=({"id": "loose", "title": "Loose"},)
+        ),
+        expanded_page=_page(
+            memberships=(_membership("m", "ideas", "n1"),),
+            notes=({"id": "n1", "title": "Note"},),
+        ),
+        expanded_folder_ids={"ideas"},
+    )
+    identity = LibraryNotesTreeIdentity(
+        placement_id=FolderPlacementId.note("ideas", "n1"), note_id="n1"
+    )
+    assert reconcile_library_notes_tree_identity(first, identity) == identity
+
+    moved = build_library_notes_tree(
+        root_page=_page(notes=({"id": "n1", "title": "Note"},)),
+        expanded_page=_page(),
+        expanded_folder_ids=set(),
+    )
+    assert reconcile_library_notes_tree_identity(moved, identity) == (
+        LibraryNotesTreeIdentity(
+            placement_id=FolderPlacementId.unfiled("n1"), note_id="n1"
+        )
+    )
+
+    empty = build_library_notes_tree(
+        root_page=_page(), expanded_page=_page(), expanded_folder_ids=set()
+    )
+    assert reconcile_library_notes_tree_identity(empty, identity) is None
+
+
+def test_unfiled_identity_is_stable_constant():
+    projection = build_library_notes_tree(
+        root_page=_page(notes=({"id": "n1", "title": "One"},)),
+        expanded_page=_page(),
+        expanded_folder_ids=set(),
+    )
+    assert projection.rows[0].placement_id == UNFILED_PLACEMENT_ID

--- a/Tests/Library/test_library_notes_tree_state.py
+++ b/Tests/Library/test_library_notes_tree_state.py
@@ -6,6 +6,7 @@ from tldw_chatbook.Library.library_notes_tree_state import (
     UNFILED_PLACEMENT_ID,
     LibraryNotesTreeIdentity,
     build_library_notes_tree,
+    merge_note_folder_pages,
     reconcile_library_notes_tree_identity,
 )
 from tldw_chatbook.Notes.note_folder_models import (
@@ -205,6 +206,40 @@ def test_managed_and_restored_without_owner_are_textually_distinct_and_protected
     assert active.semantic_status == "connected"
     assert inactive.semantic_status == "needs_attention"
 
+    protected_folder = projection.row(FolderPlacementId.folder("work"))
+    assert protected_folder is not None and protected_folder.protected
+    assert protected_folder.semantic_status == "needs_attention"
+    assert protected_folder.status_text == "! Needs owner review"
+
+
+def test_managed_folder_protection_propagates_to_loaded_ancestors():
+    parent = _folder("work", None, "/Work")
+    child = _folder("project", "work", "/Work/Project")
+    projection = build_library_notes_tree(
+        root_page=_page(folders=(parent,)),
+        expanded_page=_page(
+            folders=(child,),
+            memberships=(
+                _membership(
+                    "managed",
+                    "project",
+                    "n1",
+                    ownership="managed",
+                    owner_id="root-a",
+                ),
+            ),
+            notes=({"id": "n1", "title": "Plan"},),
+        ),
+        expanded_folder_ids={"work", "project"},
+    )
+
+    work = projection.row(FolderPlacementId.folder("work"))
+    project = projection.row(FolderPlacementId.folder("project"))
+    assert work is not None and work.protected
+    assert project is not None and project.protected
+    assert work.status_text == "⇄ Sync managed"
+    assert project.semantic_status == "connected"
+
 
 def test_projection_exposes_bounded_more_rows_for_each_cursor():
     projection = build_library_notes_tree(
@@ -292,3 +327,22 @@ def test_filter_shows_every_matching_placement_with_its_breadcrumb():
         "Reading / Garden plan",
     ]
     assert all(row.label != "Unrelated" for row in projection.rows)
+
+
+def test_bounded_pages_merge_by_domain_identity_without_duplicates():
+    first = _page(
+        folders=(_folder("a", None, "/A"),),
+        notes=({"id": "n1", "title": "One"},),
+        next_note_offset=1,
+    )
+    second = _page(
+        folders=(_folder("a", None, "/A"), _folder("b", None, "/B")),
+        notes=(
+            {"id": "n1", "title": "One"},
+            {"id": "n2", "title": "Two"},
+        ),
+    )
+    merged = merge_note_folder_pages(first, second)
+    assert [folder.folder_id for folder in merged.folders] == ["a", "b"]
+    assert [note["id"] for note in merged.notes] == ["n1", "n2"]
+    assert merged.next_offset is None

--- a/Tests/Notes/test_note_folder_repository.py
+++ b/Tests/Notes/test_note_folder_repository.py
@@ -347,6 +347,27 @@ def test_load_tree_batch_loads_roots_and_unfiled_notes(
     assert page.next_offset is None
 
 
+def test_load_tree_batch_can_skip_exhausted_note_query(
+    repository: LocalNoteFolderRepository,
+) -> None:
+    repository.create_folder(name="Work", parent_id=None)
+    note_id = repository.db.add_note("Unfiled", "Body")
+    assert note_id is not None
+    statements: list[str] = []
+    connection = repository.db.get_connection()
+    connection.set_trace_callback(statements.append)
+
+    page = repository.load_tree_batch(
+        expanded_folder_ids=(), note_limit=50, load_notes=False
+    )
+
+    connection.set_trace_callback(None)
+    assert page.notes == ()
+    assert page.total_notes == 0
+    assert page.next_offset is None
+    assert not any("AS CANDIDATE ORDER BY TITLE" in sql.upper() for sql in statements)
+
+
 def test_root_batch_reports_managed_descendants_without_expanding_them(
     repository: LocalNoteFolderRepository,
 ) -> None:

--- a/Tests/Notes/test_note_folder_repository.py
+++ b/Tests/Notes/test_note_folder_repository.py
@@ -347,6 +347,119 @@ def test_load_tree_batch_loads_roots_and_unfiled_notes(
     assert page.next_offset is None
 
 
+def test_root_batch_reports_managed_descendants_without_expanding_them(
+    repository: LocalNoteFolderRepository,
+) -> None:
+    root = repository.create_folder(name="Work", parent_id=None)
+    child = repository.create_folder(name="Project", parent_id=root.folder_id)
+    note_id = repository.db.add_note("Plan", "Body")
+    assert note_id is not None
+    _attach_membership(
+        repository,
+        folder_id=child.folder_id,
+        note_id=note_id,
+        ownership="managed",
+        owner_id="sync-root",
+    )
+
+    page = repository.load_tree_batch(expanded_folder_ids=(), note_limit=50)
+
+    assert page.managed_folder_ids == (root.folder_id,)
+    assert page.inactive_managed_folder_ids == ()
+
+
+def test_search_batch_loads_matching_note_placements_and_all_ancestors(
+    repository: LocalNoteFolderRepository,
+) -> None:
+    root = repository.create_folder(name="Work", parent_id=None)
+    child = repository.create_folder(name="Project", parent_id=root.folder_id)
+    note_id = repository.db.add_note("Hidden garden plan", "Body")
+    assert note_id is not None
+    membership_id = _attach_membership(
+        repository,
+        folder_id=child.folder_id,
+        note_id=note_id,
+    )
+
+    page = repository.load_tree_search(note_ids=(note_id,))
+
+    assert {folder.folder_id for folder in page.folders} == {
+        root.folder_id,
+        child.folder_id,
+    }
+    assert [membership.membership_id for membership in page.memberships] == [
+        membership_id
+    ]
+    assert [note["id"] for note in page.notes] == [note_id]
+
+
+def test_managed_subtree_cannot_be_renamed_through_repository_boundary(
+    repository: LocalNoteFolderRepository,
+) -> None:
+    root = repository.create_folder(name="Work", parent_id=None)
+    child = repository.create_folder(name="Project", parent_id=root.folder_id)
+    note_id = repository.db.add_note("Plan", "Body")
+    assert note_id is not None
+    _attach_membership(
+        repository,
+        folder_id=child.folder_id,
+        note_id=note_id,
+        ownership="managed",
+        owner_id="sync-root",
+    )
+
+    with pytest.raises(RuntimeError, match="managed by sync"):
+        repository.rename_folder(
+            root.folder_id,
+            name="Renamed",
+            expected_version=root.version,
+        )
+
+    assert repository.get_folder(root.folder_id) == root
+
+
+def test_managed_subtree_rejects_create_move_and_delete_at_repository_boundary(
+    repository: LocalNoteFolderRepository,
+) -> None:
+    managed_root = repository.create_folder(name="Managed", parent_id=None)
+    managed_child = repository.create_folder(
+        name="Project", parent_id=managed_root.folder_id
+    )
+    manual = repository.create_folder(name="Manual", parent_id=None)
+    note_id = repository.db.add_note("Plan", "Body")
+    assert note_id is not None
+    _attach_membership(
+        repository,
+        folder_id=managed_child.folder_id,
+        note_id=note_id,
+        ownership="managed",
+        owner_id="sync-root",
+    )
+
+    with pytest.raises(RuntimeError, match="managed by sync"):
+        repository.create_folder(name="Blocked", parent_id=managed_root.folder_id)
+    with pytest.raises(RuntimeError, match="managed by sync"):
+        repository.move_folder(
+            manual.folder_id,
+            parent_id=managed_root.folder_id,
+            expected_version=manual.version,
+        )
+    with pytest.raises(RuntimeError, match="managed by sync"):
+        repository.move_folder(
+            managed_root.folder_id,
+            parent_id=None,
+            expected_version=managed_root.version,
+        )
+    with pytest.raises(RuntimeError, match="managed by sync"):
+        repository.soft_delete_folder(
+            managed_root.folder_id,
+            expected_version=managed_root.version,
+        )
+
+    assert repository.get_folder(manual.folder_id) == manual
+    assert repository.get_folder(managed_root.folder_id) == managed_root
+
+
 def test_load_tree_batch_bulk_loads_expanded_folders_and_inactive_owner_rows(
     repository: LocalNoteFolderRepository,
 ) -> None:
@@ -384,14 +497,14 @@ def test_load_tree_batch_bulk_loads_expanded_folders_and_inactive_owner_rows(
         for statement in statements
         if statement.lstrip().upper().startswith(("SELECT", "WITH"))
     ]
-    assert sum("FROM note_folders" in statement for statement in selects) == 1
-    assert (
-        sum("FROM note_folder_memberships" in statement for statement in selects) == 1
-    )
+    # One additional constant-shape recursive query carries authoritative
+    # managed-folder ownership through collapsed and paginated branches.
+    assert sum("FROM note_folders" in statement for statement in selects) == 2
+    assert sum("FROM note_folder_memberships" in statement for statement in selects) == 1
     # The membership query repeats the bounded note-page CTE so it never binds
     # every returned note ID and remains compatible with SQLite's 999-variable cap.
     assert sum("FROM notes AS n" in statement for statement in selects) == 2
-    assert len(selects) == 3
+    assert 3 <= len(selects) <= 4
 
 
 def test_load_tree_batch_limits_notes_and_reports_next_offset(
@@ -1713,7 +1826,7 @@ def test_load_tree_batch_query_count_is_constant_for_placements(
         if statement.lstrip().upper().startswith(("SELECT", "WITH"))
     ]
     assert len(page.notes) == placement_count
-    assert len(selects) == 3
+    assert 3 <= len(selects) <= 4
     assert len(selects) <= 4
 
 

--- a/Tests/Notes/test_note_folder_repository.py
+++ b/Tests/Notes/test_note_folder_repository.py
@@ -368,6 +368,35 @@ def test_root_batch_reports_managed_descendants_without_expanding_them(
     assert page.inactive_managed_folder_ids == ()
 
 
+def test_managed_folder_lookup_walks_from_memberships_to_ancestors(
+    repository: LocalNoteFolderRepository,
+) -> None:
+    root = repository.create_folder(name="Work", parent_id=None)
+    child = repository.create_folder(name="Project", parent_id=root.folder_id)
+    note_id = repository.db.add_note("Plan", "Body")
+    assert note_id is not None
+    _attach_membership(
+        repository,
+        folder_id=child.folder_id,
+        note_id=note_id,
+        ownership="managed",
+        owner_id="sync-root",
+    )
+    statements: list[str] = []
+    connection = repository.db.get_connection()
+    connection.set_trace_callback(statements.append)
+
+    repository.load_tree_batch(expanded_folder_ids=(), note_limit=50)
+
+    connection.set_trace_callback(None)
+    managed_query = next(
+        statement for statement in statements if "managed_ancestors" in statement
+    )
+    assert "SELECT DISTINCT membership.folder_id" in managed_query
+    assert "JOIN managed_ancestors" in managed_query
+    assert "JOIN subtree" not in managed_query
+
+
 def test_search_batch_loads_matching_note_placements_and_all_ancestors(
     repository: LocalNoteFolderRepository,
 ) -> None:
@@ -382,6 +411,31 @@ def test_search_batch_loads_matching_note_placements_and_all_ancestors(
     )
 
     page = repository.load_tree_search(note_ids=(note_id,))
+
+    assert {folder.folder_id for folder in page.folders} == {
+        root.folder_id,
+        child.folder_id,
+    }
+    assert [membership.membership_id for membership in page.memberships] == [
+        membership_id
+    ]
+    assert [note["id"] for note in page.notes] == [note_id]
+
+
+def test_search_batch_loads_collapsed_placements_matching_folder_path(
+    repository: LocalNoteFolderRepository,
+) -> None:
+    root = repository.create_folder(name="Work", parent_id=None)
+    child = repository.create_folder(name="Project", parent_id=root.folder_id)
+    note_id = repository.db.add_note("Unrelated title", "No content match")
+    assert note_id is not None
+    membership_id = _attach_membership(
+        repository,
+        folder_id=child.folder_id,
+        note_id=note_id,
+    )
+
+    page = repository.load_tree_search(note_ids=(), folder_query="work / project")
 
     assert {folder.folder_id for folder in page.folders} == {
         root.folder_id,
@@ -500,7 +554,7 @@ def test_load_tree_batch_bulk_loads_expanded_folders_and_inactive_owner_rows(
     # One additional constant-shape recursive query carries authoritative
     # managed-folder ownership through collapsed and paginated branches.
     assert sum("FROM note_folders" in statement for statement in selects) == 2
-    assert sum("FROM note_folder_memberships" in statement for statement in selects) == 1
+    assert sum("FROM note_folder_memberships" in statement for statement in selects) == 2
     # The membership query repeats the bounded note-page CTE so it never binds
     # every returned note ID and remains compatible with SQLite's 999-variable cap.
     assert sum("FROM notes AS n" in statement for statement in selects) == 2

--- a/Tests/Notes/test_notes_scope_service_folders.py
+++ b/Tests/Notes/test_notes_scope_service_folders.py
@@ -53,6 +53,7 @@ class RecordingFolderRepository:
         folder_offset: int,
         membership_limit: int,
         membership_offset: int,
+        load_notes: bool,
     ) -> NoteFolderPage:
         self._record(
             (
@@ -64,6 +65,7 @@ class RecordingFolderRepository:
                 folder_offset,
                 membership_limit,
                 membership_offset,
+                load_notes,
             )
         )
         return _empty_page()
@@ -229,9 +231,10 @@ LOCAL_FOLDER_CASES = [
             "folder_offset": 10,
             "membership_limit": 60,
             "membership_offset": 30,
+            "load_notes": False,
         },
         "notes.list.local",
-        ("load_tree_batch", ("folder-1",), 100, 20, 40, 10, 60, 30),
+        ("load_tree_batch", ("folder-1",), 100, 20, 40, 10, 60, 30, False),
     ),
     (
         "load_note_folder_search",

--- a/Tests/Notes/test_notes_scope_service_folders.py
+++ b/Tests/Notes/test_notes_scope_service_folders.py
@@ -68,6 +68,10 @@ class RecordingFolderRepository:
         )
         return _empty_page()
 
+    def load_tree_search(self, *, note_ids: tuple[str, ...]) -> NoteFolderPage:
+        self._record(("load_tree_search", note_ids))
+        return _empty_page()
+
     def create_folder(self, *, name: str, parent_id: str | None) -> NoteFolder:
         self._record(("create_folder", name, parent_id))
         return _folder()
@@ -226,6 +230,12 @@ LOCAL_FOLDER_CASES = [
         },
         "notes.list.local",
         ("load_tree_batch", ("folder-1",), 100, 20, 40, 10, 60, 30),
+    ),
+    (
+        "load_note_folder_search",
+        {"note_ids": ("note-1", "note-2")},
+        "notes.list.local",
+        ("load_tree_search", ("note-1", "note-2")),
     ),
     (
         "create_note_folder",
@@ -501,6 +511,7 @@ async def test_local_folder_methods_fail_closed_when_repository_is_missing(
         == {
             "list_note_folder_children": "list",
             "load_note_folder_tree_batch": "list",
+            "load_note_folder_search": "list",
             "create_note_folder": "create",
             "rename_note_folder": "rename",
             "move_note_folder": "move",
@@ -552,6 +563,7 @@ async def test_unsupported_folder_scopes_fail_closed_without_backend_calls(
     operation = {
         "list_note_folder_children": "list",
         "load_note_folder_tree_batch": "list",
+        "load_note_folder_search": "list",
         "create_note_folder": "create",
         "rename_note_folder": "rename",
         "move_note_folder": "move",

--- a/Tests/Notes/test_notes_scope_service_folders.py
+++ b/Tests/Notes/test_notes_scope_service_folders.py
@@ -68,8 +68,10 @@ class RecordingFolderRepository:
         )
         return _empty_page()
 
-    def load_tree_search(self, *, note_ids: tuple[str, ...]) -> NoteFolderPage:
-        self._record(("load_tree_search", note_ids))
+    def load_tree_search(
+        self, *, note_ids: tuple[str, ...], folder_query: str
+    ) -> NoteFolderPage:
+        self._record(("load_tree_search", note_ids, folder_query))
         return _empty_page()
 
     def create_folder(self, *, name: str, parent_id: str | None) -> NoteFolder:
@@ -233,9 +235,9 @@ LOCAL_FOLDER_CASES = [
     ),
     (
         "load_note_folder_search",
-        {"note_ids": ("note-1", "note-2")},
+        {"note_ids": ("note-1", "note-2"), "folder_query": "work"},
         "notes.list.local",
-        ("load_tree_search", ("note-1", "note-2")),
+        ("load_tree_search", ("note-1", "note-2"), "work"),
     ),
     (
         "create_note_folder",

--- a/Tests/UI/test_library_multiselect_notes.py
+++ b/Tests/UI/test_library_multiselect_notes.py
@@ -33,7 +33,6 @@ def _fake(select_mode):
     return SimpleNamespace(
         _library_notes_select_mode=select_mode,
         _library_notes_row_selection=RowSelection("notes"),
-        _library_notes_mutation_in_flight=False,
         _selected_note_id="",
         _library_note_dirty=False,
         _refreshed=0,

--- a/Tests/UI/test_library_multiselect_notes.py
+++ b/Tests/UI/test_library_multiselect_notes.py
@@ -105,6 +105,46 @@ def test_notes_select_all_uses_unique_note_ids_visible_in_folder_tree():
     assert fake._library_notes_row_selection.ids == frozenset({"n1", "n2"})
 
 
+def test_tree_selection_is_not_pruned_by_unrelated_legacy_note_page(monkeypatch):
+    fake = _fake(True)
+    fake._library_notes_row_selection.select_all(["tree-note"])
+    fake._library_notes_filter_records = None
+    fake._local_source_records = {"notes": ({"id": "legacy-note"},)}
+    fake._local_source_counts = {"notes": 200}
+    fake._library_notes_sort = "newest"
+    fake._library_notes_filter = ""
+    fake._library_notes_sort_choices_visible = False
+    fake._library_notes_notice = ""
+    fake._library_notes_tree_error = ""
+    fake._library_notes_tree_loading = False
+    fake._library_note_delete_receipt = None
+    fake._library_notes_operation_for_active_region = lambda: None
+    fake._build_library_notes_tree_projection = lambda: LibraryNotesTreeProjection(
+        rows=(
+            LibraryNotesTreeRow(
+                "tree-placement",
+                "note",
+                "Tree note",
+                1,
+                note_id="tree-note",
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.library_screen.build_library_notes_list_state",
+        lambda *args, **kwargs: LibraryNotesListState(
+            rows=(LibraryNotesListRow("legacy-note", "Legacy", "", False),),
+            header_copy="Notes (200)",
+            status_copy="",
+            empty_copy="",
+        ),
+    )
+
+    LibraryScreen._build_library_notes_state(fake)
+
+    assert fake._library_notes_row_selection.ids == frozenset({"tree-note"})
+
+
 # -- F-018: "Export selected" explains its disabled state -----------------
 
 

--- a/Tests/UI/test_library_multiselect_notes.py
+++ b/Tests/UI/test_library_multiselect_notes.py
@@ -8,18 +8,25 @@ from textual.app import App
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from textual.widgets import Button
 
-from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
-from tldw_chatbook.Library.row_selection import RowSelection
 from tldw_chatbook.Library.library_export_scope import ExportScope
-from tldw_chatbook.Library.library_notes_state import (
-    LibraryNotesListRow,
-    LibraryNotesListState,
-)
-from tldw_chatbook.Widgets.Library.library_notes_canvas import LibraryNotesCanvas
 from tldw_chatbook.Library.library_notes_session import (
     NoteFlushOutcome,
     NoteFlushOutcomeKind,
 )
+from tldw_chatbook.Library.library_notes_state import (
+    LibraryNotesListRow,
+    LibraryNotesListState,
+)
+from tldw_chatbook.Library.library_notes_tree_state import (
+    LibraryNotesTreeProjection,
+    LibraryNotesTreeRow,
+)
+from tldw_chatbook.Library.row_selection import RowSelection
+from tldw_chatbook.UI.Screens.library_screen import (
+    LibraryScreen,
+    _apply_library_row_toggle,
+)
+from tldw_chatbook.Widgets.Library.library_notes_canvas import LibraryNotesCanvas
 
 
 def _fake(select_mode):
@@ -70,6 +77,34 @@ async def test_notes_export_selected_scope():
     assert fake._opened == [ExportScope(kind="notes", ids=("n1", "n2"))]
 
 
+def test_notes_select_all_uses_unique_note_ids_visible_in_folder_tree():
+    fake = _fake(True)
+    fake._build_library_notes_state = lambda: LibraryNotesListState(
+        rows=(
+            LibraryNotesListRow("n1", "One", "", False),
+            LibraryNotesListRow("n2", "Two", "", False),
+            LibraryNotesListRow("hidden", "Hidden", "", False),
+        ),
+        header_copy="Notes (3)",
+        status_copy="",
+        empty_copy="",
+    )
+    fake._build_library_notes_tree_projection = lambda: LibraryNotesTreeProjection(
+        rows=(
+            LibraryNotesTreeRow("p1", "note", "One", 1, note_id="n1"),
+            LibraryNotesTreeRow("p2", "note", "One", 1, note_id="n1"),
+            LibraryNotesTreeRow("p3", "note", "Two", 1, note_id="n2"),
+        )
+    )
+    fake.refresh = lambda **kwargs: None
+
+    LibraryScreen.handle_library_notes_select_all(
+        fake, SimpleNamespace(stop=lambda: None)
+    )
+
+    assert fake._library_notes_row_selection.ids == frozenset({"n1", "n2"})
+
+
 # -- F-018: "Export selected" explains its disabled state -----------------
 
 
@@ -101,6 +136,57 @@ class _NotesCanvasApp(ConsolidatedCSSApp):
             list_state=_select_mode_notes_state(self._selected_count),
             id="library-notes-canvas",
         )
+
+
+class _DuplicatePlacementNotesCanvasApp(App):
+    def __init__(self):
+        super().__init__()
+        self._library_notes_row_selection = RowSelection("notes")
+
+    def compose(self):
+        state = LibraryNotesListState(
+            rows=(
+                LibraryNotesListRow(
+                    note_id="n1",
+                    title="Shared note",
+                    age_label="today",
+                    checked=False,
+                ),
+            ),
+            header_copy="Notes (1)",
+            status_copy="",
+            empty_copy="",
+            select_mode=True,
+            selected_count=0,
+        )
+        projection = LibraryNotesTreeProjection(
+            rows=(
+                LibraryNotesTreeRow(
+                    "placement-a", "note", "Shared note", 1, note_id="n1"
+                ),
+                LibraryNotesTreeRow(
+                    "placement-b", "note", "Shared note", 1, note_id="n1"
+                ),
+            )
+        )
+        yield LibraryNotesCanvas(
+            list_state=state,
+            tree_projection=projection,
+            id="library-notes-canvas",
+        )
+
+
+@pytest.mark.asyncio
+async def test_toggling_duplicate_placement_updates_every_visible_checkbox():
+    app = _DuplicatePlacementNotesCanvasApp()
+    async with app.run_test() as pilot:
+        rows = list(app.query(".library-notes-row"))
+        app._library_notes_row_selection.toggle("n1")
+
+        _apply_library_row_toggle(app, "notes", rows[0], "n1")
+        await pilot.pause()
+
+        assert all(str(row.label).startswith("☑ ") for row in rows)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_multiselect_notes.py
+++ b/Tests/UI/test_library_multiselect_notes.py
@@ -26,6 +26,7 @@ def _fake(select_mode):
     return SimpleNamespace(
         _library_notes_select_mode=select_mode,
         _library_notes_row_selection=RowSelection("notes"),
+        _library_notes_mutation_in_flight=False,
         _selected_note_id="",
         _library_note_dirty=False,
         _refreshed=0,

--- a/Tests/UI/test_library_notes_folder_navigator.py
+++ b/Tests/UI/test_library_notes_folder_navigator.py
@@ -2,23 +2,54 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+from html import unescape
 from types import SimpleNamespace
 
 import pytest
 
-from tldw_chatbook.Notes.note_folder_models import NoteFolder, NoteFolderPage
+from Tests.UI.test_destination_shells import StaticLibraryNotesScopeService
+from Tests.UI.test_library_shell import (
+    LibraryHarness,
+    _active_library_screen,
+    _build_test_app,
+    _seed_conversations,
+    _two_conversations,
+    _two_notes,
+    _wait_for_library_shell,
+)
+from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_NOTES
+from tldw_chatbook.Notes.note_folder_models import (
+    FolderCapabilityError,
+    FolderCollisionError,
+    FolderConflictError,
+    FolderValidationError,
+    NoteFolder,
+    NoteFolderMembership,
+    NoteFolderPage,
+)
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 
 
-def _page(*, folders=(), notes=(), memberships=()) -> NoteFolderPage:
+def _page(
+    *,
+    folders=(),
+    notes=(),
+    memberships=(),
+    next_folder_offset=None,
+    next_note_offset=None,
+    next_membership_offset=None,
+) -> NoteFolderPage:
     return NoteFolderPage(
         folders=tuple(folders),
         memberships=tuple(memberships),
         notes=tuple(notes),
         total_folders=len(folders),
         total_notes=len(notes),
-        next_offset=None,
+        next_offset=next_note_offset,
+        next_folder_offset=next_folder_offset,
         total_memberships=len(memberships),
+        next_membership_offset=next_membership_offset,
     )
 
 
@@ -31,6 +62,20 @@ def _folder(folder_id: str, parent_id: str | None, path: str) -> NoteFolder:
         normalized_path=path.casefold(),
         version=1,
         deleted=False,
+    )
+
+
+def _membership(
+    membership_id: str, folder_id: str, note_id: str
+) -> NoteFolderMembership:
+    return NoteFolderMembership(
+        membership_id=membership_id,
+        folder_id=folder_id,
+        note_id=note_id,
+        ownership="manual",
+        owner_id="",
+        owner_active=True,
+        version=1,
     )
 
 
@@ -118,3 +163,427 @@ async def test_stale_tree_result_does_not_replace_newer_state():
 
     assert fake._library_notes_tree_root_page is None
     assert fake._library_notes_tree_loading is True
+
+
+class _PagingFolderService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def load_note_folder_tree_batch(self, **kwargs):
+        self.calls.append(kwargs)
+        if kwargs.get("membership_offset") == 1:
+            return _page(
+                notes=({"id": "n1", "title": "One"},),
+                memberships=(_membership("m1b", "ideas", "n1"),),
+                next_note_offset=1,
+            )
+        return _page(
+            notes=({"id": "n2", "title": "Two"},),
+            memberships=(_membership("m2", "ideas", "n2"),),
+        )
+
+
+@pytest.mark.asyncio
+async def test_membership_cursor_finishes_current_note_page_before_advancing_notes():
+    service = _PagingFolderService()
+    fake = _screen_fake(service)  # type: ignore[arg-type]
+    fake._library_notes_tree_root_page = _page()
+    fake._library_notes_tree_expanded_ids = {"ideas"}
+    fake._library_notes_tree_expanded_page = _page(
+        notes=({"id": "n1", "title": "One"},),
+        memberships=(_membership("m1a", "ideas", "n1"),),
+        next_note_offset=1,
+        next_membership_offset=1,
+    )
+    fake._library_notes_tree_membership_note_offset = 0
+
+    fake._library_notes_tree_generation = 2
+    await LibraryScreen._load_more_library_notes_tree(fake, generation=2)
+    assert service.calls[-1]["note_offset"] == 0
+    assert service.calls[-1]["membership_offset"] == 1
+    assert {item.membership_id for item in fake._library_notes_tree_expanded_page.memberships} == {
+        "m1a",
+        "m1b",
+    }
+
+    fake._library_notes_tree_generation = 3
+    fake._library_notes_tree_loading = True
+    await LibraryScreen._load_more_library_notes_tree(fake, generation=3)
+    assert service.calls[-1]["note_offset"] == 1
+    assert service.calls[-1]["membership_offset"] == 0
+    assert fake._library_notes_tree_membership_note_offset == 1
+
+
+@pytest.mark.asyncio
+async def test_paging_does_not_reopen_an_already_exhausted_independent_cursor():
+    class _ReplayService:
+        async def load_note_folder_tree_batch(self, **kwargs):
+            return _page(
+                folders=(_folder("first", None, "/First"),),
+                notes=({"id": "n2", "title": "Two"},),
+                next_folder_offset=1,
+            )
+
+    fake = _screen_fake(_ReplayService())  # type: ignore[arg-type]
+    fake._library_notes_tree_root_page = _page(
+        folders=(_folder("first", None, "/First"),),
+        notes=({"id": "n1", "title": "One"},),
+        next_note_offset=1,
+    )
+    fake._library_notes_tree_expanded_page = _page()
+    fake._library_notes_tree_generation = 2
+
+    await LibraryScreen._load_more_library_notes_tree(fake, generation=2)
+
+    assert fake._library_notes_tree_root_page.next_offset is None
+    assert fake._library_notes_tree_root_page.next_folder_offset is None
+
+
+class _MutationService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def create_note_folder(self, **kwargs):
+        self.calls.append(("create", kwargs))
+        return _folder("new", kwargs["parent_id"], "/New")
+
+    async def attach_note_to_folder(self, **kwargs):
+        self.calls.append(("attach", kwargs))
+        return SimpleNamespace(membership_id="new-membership")
+
+    async def detach_note_from_folder(self, **kwargs):
+        self.calls.append(("detach", kwargs))
+        return True
+
+    async def rename_note_folder(self, **kwargs):
+        self.calls.append(("rename", kwargs))
+        return SimpleNamespace(folder=replace(_folder("ideas", None, "/Renamed"), version=2))
+
+    async def move_note_folder(self, **kwargs):
+        self.calls.append(("move_folder", kwargs))
+        return SimpleNamespace(folder=replace(_folder("ideas", "work", "/Work/Ideas"), version=2))
+
+    async def delete_note_folder(self, **kwargs):
+        self.calls.append(("delete_folder", kwargs))
+        return SimpleNamespace(
+            folder=replace(_folder("ideas", None, "/Ideas"), version=2, deleted=True)
+        )
+
+    async def restore_note_folder(self, **kwargs):
+        self.calls.append(("restore_folder", kwargs))
+        return SimpleNamespace(folder=replace(_folder("ideas", None, "/Ideas"), version=3))
+
+
+class _FailingMutationService(_MutationService):
+    def __init__(self, failure: Exception) -> None:
+        super().__init__()
+        self.failure = failure
+
+    async def create_note_folder(self, **kwargs):
+        raise self.failure
+
+
+class _PartialMoveService(_MutationService):
+    async def detach_note_from_folder(self, **kwargs):
+        self.calls.append(("detach", kwargs))
+        raise FolderConflictError("Membership changed during mutation.")
+
+
+def _mutation_fake(service: _MutationService):
+    fake = _screen_fake(service)  # type: ignore[arg-type]
+    fake._library_notes_mutation_in_flight = False
+    fake._library_notes_notice = ""
+    fake._library_notes_deleted_folder_receipt = None
+    fake._library_notes_tree_selected_placement_id = ""
+    fake._refreshes = []
+    fake._request_library_notes_tree_refresh = (
+        lambda **kwargs: fake._refreshes.append(kwargs)
+    )
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_create_folder_mutation_uses_normalized_service_and_refreshes_tree():
+    service = _MutationService()
+    fake = _mutation_fake(service)
+
+    ok = await LibraryScreen._execute_library_notes_tree_mutation(
+        fake,
+        "create_folder",
+        name="New",
+        parent_id="personal",
+    )
+
+    assert ok
+    assert service.calls == [
+        (
+            "create",
+            {
+                "scope": "local_note",
+                "name": "New",
+                "parent_id": "personal",
+                "user_id": "tester",
+            },
+        )
+    ]
+    assert fake._refreshes == [{"refresh_root": True}]
+
+
+@pytest.mark.asyncio
+async def test_move_manual_placement_attaches_before_detaching_original():
+    service = _MutationService()
+    fake = _mutation_fake(service)
+
+    ok = await LibraryScreen._execute_library_notes_tree_mutation(
+        fake,
+        "move_placement",
+        note_id="n1",
+        destination_folder_id="reading",
+        source_folder_id="ideas",
+        membership_version=3,
+        protected=False,
+    )
+
+    assert ok
+    assert [name for name, _ in service.calls] == ["attach", "detach"]
+    assert service.calls[1][1]["expected_version"] == 3
+
+
+@pytest.mark.asyncio
+async def test_managed_placement_mutation_is_rejected_before_service_call():
+    service = _MutationService()
+    fake = _mutation_fake(service)
+
+    ok = await LibraryScreen._execute_library_notes_tree_mutation(
+        fake,
+        "move_placement",
+        note_id="n1",
+        destination_folder_id="reading",
+        source_folder_id="ideas",
+        membership_version=3,
+        protected=True,
+    )
+
+    assert not ok
+    assert service.calls == []
+    assert "sync" in fake._library_notes_notice.lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("operation", "payload", "expected_call"),
+    (
+        (
+            "rename_folder",
+            {"folder_id": "ideas", "name": "Renamed", "expected_version": 1},
+            "rename",
+        ),
+        (
+            "move_folder",
+            {"folder_id": "ideas", "parent_id": "work", "expected_version": 1},
+            "move_folder",
+        ),
+        (
+            "add_placement",
+            {"folder_id": "ideas", "note_id": "n1"},
+            "attach",
+        ),
+        (
+            "detach_placement",
+            {"folder_id": "ideas", "note_id": "n1", "expected_version": 1},
+            "detach",
+        ),
+    ),
+)
+async def test_folder_and_membership_operations_route_to_normalized_service(
+    operation, payload, expected_call
+):
+    service = _MutationService()
+    fake = _mutation_fake(service)
+    assert await LibraryScreen._execute_library_notes_tree_mutation(
+        fake, operation, **payload
+    )
+    assert service.calls[0][0] == expected_call
+
+
+@pytest.mark.asyncio
+async def test_folder_remove_creates_exact_restore_receipt_and_restore_consumes_it():
+    service = _MutationService()
+    fake = _mutation_fake(service)
+    assert await LibraryScreen._execute_library_notes_tree_mutation(
+        fake,
+        "delete_folder",
+        folder_id="ideas",
+        expected_version=1,
+    )
+    receipt = fake._library_notes_deleted_folder_receipt
+    assert (receipt.folder_id, receipt.expected_version) == ("ideas", 2)
+
+    assert await LibraryScreen._execute_library_notes_tree_mutation(
+        fake,
+        "restore_folder",
+        folder_id=receipt.folder_id,
+        expected_version=receipt.expected_version,
+    )
+    assert fake._library_notes_deleted_folder_receipt is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "expected_copy"),
+    (
+        (FolderCollisionError("collision"), "already exists"),
+        (FolderConflictError("conflict"), "changed elsewhere"),
+        (FolderValidationError("invalid"), "not valid"),
+        (
+            FolderCapabilityError(
+                reason_code="unsupported", user_message="Folders unavailable here."
+            ),
+            "Folders unavailable here.",
+        ),
+    ),
+)
+async def test_typed_folder_failures_produce_actionable_status(failure, expected_copy):
+    fake = _mutation_fake(_FailingMutationService(failure))
+
+    assert not await LibraryScreen._execute_library_notes_tree_mutation(
+        fake,
+        "create_folder",
+        name="New",
+        parent_id=None,
+    )
+
+    assert expected_copy.casefold() in fake._library_notes_notice.casefold()
+
+
+@pytest.mark.asyncio
+async def test_move_detach_conflict_keeps_both_placements_and_refreshes():
+    service = _PartialMoveService()
+    fake = _mutation_fake(service)
+
+    ok = await LibraryScreen._execute_library_notes_tree_mutation(
+        fake,
+        "move_placement",
+        note_id="n1",
+        destination_folder_id="reading",
+        source_folder_id="ideas",
+        membership_version=3,
+    )
+
+    assert ok
+    assert [name for name, _ in service.calls] == ["attach", "detach"]
+    assert "both folders" in fake._library_notes_notice.casefold()
+    assert fake._refreshes == [{"refresh_root": True}]
+
+
+class _TreeCapableNotesService(StaticLibraryNotesScopeService):
+    def __init__(self, notes):
+        super().__init__(notes)
+        self.tree_calls: list[dict[str, object]] = []
+
+    async def load_note_folder_tree_batch(self, **kwargs):
+        self.tree_calls.append(kwargs)
+        expanded = tuple(kwargs["expanded_folder_ids"])
+        ideas = _folder("ideas", None, "/Ideas")
+        reading = _folder("reading", None, "/Reading")
+        if not expanded:
+            return _page(folders=(ideas, reading))
+        memberships = tuple(
+            NoteFolderMembership(
+                membership_id=f"m-{folder_id}",
+                folder_id=folder_id,
+                note_id="n-1",
+                ownership="managed",
+                owner_id=f"sync-{folder_id}",
+                owner_active=folder_id != "reading",
+                version=1,
+            )
+            for folder_id in expanded
+        )
+        return _page(
+            memberships=memberships,
+            notes=({"id": "n-1", "title": "Q3 retro"},),
+        )
+
+
+async def _wait_until(pilot, predicate, *, attempts: int = 150):
+    for _ in range(attempts):
+        if predicate():
+            await pilot.pause()
+            return
+        await pilot.pause(0.02)
+    raise AssertionError("Library Notes folder state did not settle")
+
+
+@pytest.mark.asyncio
+async def test_live_host_renders_duplicate_placements_and_preserves_focus_at_60x20():
+    app = _build_test_app()
+    notes = _two_notes()
+    _seed_conversations(app, _two_conversations(), notes=notes)
+    service = _TreeCapableNotesService(notes)
+    app.notes_scope_service = service
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot, lambda: len(screen.query(".library-notes-folder-row")) == 2
+        )
+        for folder_id in ("ideas", "reading"):
+            folder = next(
+                row
+                for row in screen.query(".library-notes-folder-row")
+                if getattr(row, "folder_id", "") == folder_id
+            )
+            folder.press()
+            await _wait_until(
+                pilot,
+                lambda folder_id=folder_id: any(
+                    getattr(row, "folder_id", "") == folder_id
+                    for row in screen.query(".library-notes-row")
+                ),
+            )
+
+        placements = [
+            row
+            for row in screen.query(".library-notes-row")
+            if getattr(row, "note_id", "") == "n-1"
+        ]
+        assert len(placements) == 2
+        assert len({row.placement_id for row in placements}) == 2
+        assert service.detail_calls == []
+
+        placements[-1].focus()
+        focused_placement = placements[-1].placement_id
+        await _wait_until(
+            pilot,
+            lambda: str(getattr(screen.focused, "placement_id", ""))
+            == focused_placement,
+        )
+        screen.refresh(recompose=True)
+        await _wait_until(
+            pilot,
+            lambda: str(getattr(screen.focused, "placement_id", ""))
+            == focused_placement,
+        )
+
+        await pilot.resize_terminal(60, 20)
+        await _wait_until(pilot, lambda: screen._library_notes_compact is True)
+        focused = next(
+            row
+            for row in screen.query(".library-notes-row")
+            if row.placement_id == focused_placement
+        )
+        focused.scroll_visible()
+        await pilot.pause()
+        assert focused.region.width <= screen.query_one("#library-canvas").region.width
+        screenshot = host.export_screenshot(simplify=True)
+        painted = unescape(screenshot).replace("\xa0", " ")
+        assert "Q3 retro" in painted
+        assert any(label in painted for label in ("Ideas", "Reading"))
+        assert any(
+            status in painted
+            for status in ("Synced placement", "Needs owner review")
+        )

--- a/Tests/UI/test_library_notes_folder_navigator.py
+++ b/Tests/UI/test_library_notes_folder_navigator.py
@@ -39,6 +39,7 @@ def _page(
     next_folder_offset=None,
     next_note_offset=None,
     next_membership_offset=None,
+    unfiled_note_ids=None,
 ) -> NoteFolderPage:
     return NoteFolderPage(
         folders=tuple(folders),
@@ -50,6 +51,7 @@ def _page(
         next_folder_offset=next_folder_offset,
         total_memberships=len(memberships),
         next_membership_offset=next_membership_offset,
+        unfiled_note_ids=unfiled_note_ids,
     )
 
 
@@ -126,6 +128,118 @@ async def test_initial_tree_load_uses_one_bounded_bulk_call_and_no_note_detail()
     assert 1 <= call["membership_limit"] <= 1000
     assert fake._library_notes_tree_root_page.total_folders == 1
     assert fake._library_notes_tree_loading is False
+
+
+@pytest.mark.asyncio
+async def test_filter_loads_placements_for_matches_outside_expanded_branches(
+    monkeypatch,
+):
+    parent = _folder("work", None, "/Work")
+    child = _folder("project", "work", "/Work/Project")
+    search_page = _page(
+        folders=(parent, child),
+        memberships=(_membership("m1", "project", "n1"),),
+        notes=({"id": "n1", "title": "Hidden garden plan"},),
+        unfiled_note_ids=(),
+    )
+
+    class _SearchService:
+        def __init__(self) -> None:
+            self.note_ids = ()
+
+        async def search_notes(self, **kwargs):
+            return ({"id": "n1", "title": "Hidden garden plan"},)
+
+        async def load_note_folder_search(self, **kwargs):
+            self.note_ids = kwargs["note_ids"]
+            return search_page
+
+    service = _SearchService()
+    fake = _screen_fake(service)  # type: ignore[arg-type]
+    fake._library_notes_filter = "garden"
+    fake._library_notes_filter_records = None
+    fake._library_notes_tree_search_page = None
+    fake._source_record_id = lambda record: record["id"]
+    fake._focus_library_notes_filter_input = lambda: None
+    fake._run_library_service_call = lambda method, **kwargs: method(**kwargs)
+    fake._library_notes_tree_root_page = _page(folders=(parent,))
+    fake._library_notes_tree_expanded_page = _page()
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.library_screen._sync_library_canvas",
+        lambda *args, **kwargs: None,
+    )
+
+    await LibraryScreen._run_library_notes_filter(fake, "garden")
+
+    assert service.note_ids == ("n1",)
+    projection = LibraryScreen._build_library_notes_tree_projection(fake)
+    assert projection is not None
+    assert [row.breadcrumb for row in projection.rows if row.kind == "note"] == [
+        "Work / Project / Hidden garden plan"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_filter_without_folder_search_capability_keeps_loaded_tree(
+    monkeypatch,
+):
+    class _LegacySearchService:
+        async def search_notes(self, **kwargs):
+            return ({"id": "n1", "title": "Garden plan"},)
+
+    service = _LegacySearchService()
+    fake = _screen_fake(service)  # type: ignore[arg-type]
+    fake._library_notes_filter = "garden"
+    fake._library_notes_filter_records = None
+    fake._library_notes_tree_search_page = None
+    fake._source_record_id = lambda record: record["id"]
+    fake._focus_library_notes_filter_input = lambda: None
+    fake._run_library_service_call = lambda method, **kwargs: method(**kwargs)
+    fake._library_notes_tree_root_page = _page(
+        notes=({"id": "n1", "title": "Garden plan"},),
+        unfiled_note_ids=("n1",),
+    )
+    fake._library_notes_tree_expanded_page = _page()
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.library_screen._sync_library_canvas",
+        lambda *args, **kwargs: None,
+    )
+
+    await LibraryScreen._run_library_notes_filter(fake, "garden")
+
+    assert fake._library_notes_tree_search_page is None
+    projection = LibraryScreen._build_library_notes_tree_projection(fake)
+    assert projection is not None
+    assert [row.note_id for row in projection.rows if row.kind == "note"] == ["n1"]
+
+
+def test_submitting_new_filter_clears_previous_result_state():
+    worker_calls = []
+
+    async def _filter(query):
+        return None
+
+    def _run_worker(awaitable, **kwargs):
+        worker_calls.append(kwargs)
+        awaitable.close()
+
+    fake = SimpleNamespace(
+        _library_notes_filter="old",
+        _library_notes_filter_records=[{"id": "old-note"}],
+        _library_notes_tree_search_page=_page(notes=({"id": "old-note"},)),
+        _library_notes_select_mode=True,
+        _library_notes_row_selection=SimpleNamespace(clear=lambda: None),
+        _run_library_notes_filter=_filter,
+        _safe_text=lambda value, max_length: value[:max_length],
+        run_worker=_run_worker,
+    )
+    event = SimpleNamespace(value="new", stop=lambda: None)
+
+    LibraryScreen.handle_library_notes_filter(fake, event)
+
+    assert fake._library_notes_filter_records is None
+    assert fake._library_notes_tree_search_page is None
+    assert worker_calls == [{"exclusive": True, "group": "library_notes_filter"}]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_notes_folder_navigator.py
+++ b/Tests/UI/test_library_notes_folder_navigator.py
@@ -1,0 +1,120 @@
+"""Library-screen orchestration tests for the Database Notes folder tree."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Notes.note_folder_models import NoteFolder, NoteFolderPage
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+
+def _page(*, folders=(), notes=(), memberships=()) -> NoteFolderPage:
+    return NoteFolderPage(
+        folders=tuple(folders),
+        memberships=tuple(memberships),
+        notes=tuple(notes),
+        total_folders=len(folders),
+        total_notes=len(notes),
+        next_offset=None,
+        total_memberships=len(memberships),
+    )
+
+
+def _folder(folder_id: str, parent_id: str | None, path: str) -> NoteFolder:
+    return NoteFolder(
+        folder_id=folder_id,
+        parent_id=parent_id,
+        name=path.rsplit("/", 1)[-1],
+        path=path,
+        normalized_path=path.casefold(),
+        version=1,
+        deleted=False,
+    )
+
+
+class _FolderService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def load_note_folder_tree_batch(self, **kwargs):
+        self.calls.append(kwargs)
+        expanded = tuple(kwargs["expanded_folder_ids"])
+        if not expanded:
+            return _page(
+                folders=(_folder("personal", None, "/Personal"),),
+                notes=({"id": "loose", "title": "Loose"},),
+            )
+        return _page(
+            folders=(_folder("ideas", "personal", "/Personal/Ideas"),)
+        )
+
+
+def _screen_fake(service: _FolderService):
+    return SimpleNamespace(
+        app_instance=SimpleNamespace(
+            notes_scope_service=service,
+            notes_user_id="tester",
+        ),
+        _library_notes_tree_root_page=None,
+        _library_notes_tree_expanded_page=None,
+        _library_notes_tree_expanded_ids=set(),
+        _library_notes_tree_generation=1,
+        _library_notes_tree_loading=True,
+        _library_notes_tree_error="",
+        _library_notes_user_id=lambda: "tester",
+        is_mounted=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_initial_tree_load_uses_one_bounded_bulk_call_and_no_note_detail():
+    service = _FolderService()
+    fake = _screen_fake(service)
+
+    await LibraryScreen._load_library_notes_tree(
+        fake, generation=1, refresh_root=True
+    )
+
+    assert len(service.calls) == 1
+    call = service.calls[0]
+    assert call["expanded_folder_ids"] == ()
+    assert 1 <= call["folder_limit"] <= 500
+    assert 1 <= call["note_limit"] <= 1000
+    assert 1 <= call["membership_limit"] <= 1000
+    assert fake._library_notes_tree_root_page.total_folders == 1
+    assert fake._library_notes_tree_loading is False
+
+
+@pytest.mark.asyncio
+async def test_expansion_reuses_root_and_issues_one_bulk_branch_call():
+    service = _FolderService()
+    fake = _screen_fake(service)
+    await LibraryScreen._load_library_notes_tree(
+        fake, generation=1, refresh_root=True
+    )
+    fake._library_notes_tree_expanded_ids.add("personal")
+    fake._library_notes_tree_generation = 2
+
+    await LibraryScreen._load_library_notes_tree(
+        fake, generation=2, refresh_root=False
+    )
+
+    assert len(service.calls) == 2
+    assert service.calls[-1]["expanded_folder_ids"] == ("personal",)
+    assert fake._library_notes_tree_expanded_page.folders[0].folder_id == "ideas"
+
+
+@pytest.mark.asyncio
+async def test_stale_tree_result_does_not_replace_newer_state():
+    service = _FolderService()
+    fake = _screen_fake(service)
+    fake._library_notes_tree_generation = 2
+
+    await LibraryScreen._load_library_notes_tree(
+        fake, generation=1, refresh_root=True
+    )
+
+    assert fake._library_notes_tree_root_page is None
+    assert fake._library_notes_tree_loading is True

--- a/Tests/UI/test_library_notes_folder_navigator.py
+++ b/Tests/UI/test_library_notes_folder_navigator.py
@@ -91,9 +91,7 @@ class _FolderService:
                 folders=(_folder("personal", None, "/Personal"),),
                 notes=({"id": "loose", "title": "Loose"},),
             )
-        return _page(
-            folders=(_folder("ideas", "personal", "/Personal/Ideas"),)
-        )
+        return _page(folders=(_folder("ideas", "personal", "/Personal/Ideas"),))
 
 
 def _screen_fake(service: _FolderService):
@@ -118,9 +116,7 @@ async def test_initial_tree_load_uses_one_bounded_bulk_call_and_no_note_detail()
     service = _FolderService()
     fake = _screen_fake(service)
 
-    await LibraryScreen._load_library_notes_tree(
-        fake, generation=1, refresh_root=True
-    )
+    await LibraryScreen._load_library_notes_tree(fake, generation=1, refresh_root=True)
 
     assert len(service.calls) == 1
     call = service.calls[0]
@@ -136,15 +132,11 @@ async def test_initial_tree_load_uses_one_bounded_bulk_call_and_no_note_detail()
 async def test_expansion_reuses_root_and_issues_one_bulk_branch_call():
     service = _FolderService()
     fake = _screen_fake(service)
-    await LibraryScreen._load_library_notes_tree(
-        fake, generation=1, refresh_root=True
-    )
+    await LibraryScreen._load_library_notes_tree(fake, generation=1, refresh_root=True)
     fake._library_notes_tree_expanded_ids.add("personal")
     fake._library_notes_tree_generation = 2
 
-    await LibraryScreen._load_library_notes_tree(
-        fake, generation=2, refresh_root=False
-    )
+    await LibraryScreen._load_library_notes_tree(fake, generation=2, refresh_root=False)
 
     assert len(service.calls) == 2
     assert service.calls[-1]["expanded_folder_ids"] == ("personal",)
@@ -157,12 +149,52 @@ async def test_stale_tree_result_does_not_replace_newer_state():
     fake = _screen_fake(service)
     fake._library_notes_tree_generation = 2
 
-    await LibraryScreen._load_library_notes_tree(
-        fake, generation=1, refresh_root=True
-    )
+    await LibraryScreen._load_library_notes_tree(fake, generation=1, refresh_root=True)
 
     assert fake._library_notes_tree_root_page is None
     assert fake._library_notes_tree_loading is True
+
+
+@pytest.mark.asyncio
+async def test_missing_folder_capability_finishes_loading_and_repaints_status(
+    monkeypatch,
+):
+    fake = _screen_fake(SimpleNamespace())  # type: ignore[arg-type]
+    fake._status_repaints = 0
+    monkeypatch.setattr(
+        LibraryScreen,
+        "_sync_library_notes_tree_canvas_if_present",
+        lambda self: setattr(self, "_status_repaints", self._status_repaints + 1),
+    )
+
+    await LibraryScreen._load_library_notes_tree(fake, generation=1, refresh_root=True)
+
+    assert fake._library_notes_tree_loading is False
+    assert "unavailable" in fake._library_notes_tree_error.casefold()
+    assert fake._status_repaints == 1
+
+
+@pytest.mark.asyncio
+async def test_load_more_failure_repaints_actionable_status(monkeypatch):
+    class _FailingPagingService:
+        async def load_note_folder_tree_batch(self, **kwargs):
+            raise RuntimeError("offline")
+
+    fake = _screen_fake(_FailingPagingService())  # type: ignore[arg-type]
+    fake._library_notes_tree_root_page = _page(next_note_offset=1)
+    fake._library_notes_tree_expanded_page = _page()
+    fake._status_repaints = 0
+    monkeypatch.setattr(
+        LibraryScreen,
+        "_sync_library_notes_tree_canvas_if_present",
+        lambda self: setattr(self, "_status_repaints", self._status_repaints + 1),
+    )
+
+    await LibraryScreen._load_more_library_notes_tree(fake, generation=1)
+
+    assert fake._library_notes_tree_loading is False
+    assert "try again" in fake._library_notes_tree_error.casefold()
+    assert fake._status_repaints == 1
 
 
 class _PagingFolderService:
@@ -201,7 +233,10 @@ async def test_membership_cursor_finishes_current_note_page_before_advancing_not
     await LibraryScreen._load_more_library_notes_tree(fake, generation=2)
     assert service.calls[-1]["note_offset"] == 0
     assert service.calls[-1]["membership_offset"] == 1
-    assert {item.membership_id for item in fake._library_notes_tree_expanded_page.memberships} == {
+    assert {
+        item.membership_id
+        for item in fake._library_notes_tree_expanded_page.memberships
+    } == {
         "m1a",
         "m1b",
     }
@@ -257,11 +292,15 @@ class _MutationService:
 
     async def rename_note_folder(self, **kwargs):
         self.calls.append(("rename", kwargs))
-        return SimpleNamespace(folder=replace(_folder("ideas", None, "/Renamed"), version=2))
+        return SimpleNamespace(
+            folder=replace(_folder("ideas", None, "/Renamed"), version=2)
+        )
 
     async def move_note_folder(self, **kwargs):
         self.calls.append(("move_folder", kwargs))
-        return SimpleNamespace(folder=replace(_folder("ideas", "work", "/Work/Ideas"), version=2))
+        return SimpleNamespace(
+            folder=replace(_folder("ideas", "work", "/Work/Ideas"), version=2)
+        )
 
     async def delete_note_folder(self, **kwargs):
         self.calls.append(("delete_folder", kwargs))
@@ -271,7 +310,9 @@ class _MutationService:
 
     async def restore_note_folder(self, **kwargs):
         self.calls.append(("restore_folder", kwargs))
-        return SimpleNamespace(folder=replace(_folder("ideas", None, "/Ideas"), version=3))
+        return SimpleNamespace(
+            folder=replace(_folder("ideas", None, "/Ideas"), version=3)
+        )
 
 
 class _FailingMutationService(_MutationService):
@@ -296,8 +337,8 @@ def _mutation_fake(service: _MutationService):
     fake._library_notes_deleted_folder_receipt = None
     fake._library_notes_tree_selected_placement_id = ""
     fake._refreshes = []
-    fake._request_library_notes_tree_refresh = (
-        lambda **kwargs: fake._refreshes.append(kwargs)
+    fake._request_library_notes_tree_refresh = lambda **kwargs: fake._refreshes.append(
+        kwargs
     )
     return fake
 
@@ -559,14 +600,16 @@ async def test_live_host_renders_duplicate_placements_and_preserves_focus_at_60x
         focused_placement = placements[-1].placement_id
         await _wait_until(
             pilot,
-            lambda: str(getattr(screen.focused, "placement_id", ""))
-            == focused_placement,
+            lambda: (
+                str(getattr(screen.focused, "placement_id", "")) == focused_placement
+            ),
         )
         screen.refresh(recompose=True)
         await _wait_until(
             pilot,
-            lambda: str(getattr(screen.focused, "placement_id", ""))
-            == focused_placement,
+            lambda: (
+                str(getattr(screen.focused, "placement_id", "")) == focused_placement
+            ),
         )
 
         await pilot.resize_terminal(60, 20)
@@ -584,6 +627,5 @@ async def test_live_host_renders_duplicate_placements_and_preserves_focus_at_60x
         assert "Q3 retro" in painted
         assert any(label in painted for label in ("Ideas", "Reading"))
         assert any(
-            status in painted
-            for status in ("Synced placement", "Needs owner review")
+            status in painted for status in ("Synced placement", "Needs owner review")
         )

--- a/Tests/UI/test_library_notes_folder_navigator.py
+++ b/Tests/UI/test_library_notes_folder_navigator.py
@@ -389,6 +389,7 @@ async def test_membership_cursor_finishes_current_note_page_before_advancing_not
     fake._library_notes_tree_generation = 2
     await LibraryScreen._load_more_library_notes_tree(fake, generation=2)
     assert service.calls[-1]["note_offset"] == 0
+    assert service.calls[-1]["load_notes"] is True
     assert service.calls[-1]["membership_offset"] == 1
     assert {
         item.membership_id
@@ -404,6 +405,21 @@ async def test_membership_cursor_finishes_current_note_page_before_advancing_not
     assert service.calls[-1]["note_offset"] == 1
     assert service.calls[-1]["membership_offset"] == 0
     assert fake._library_notes_tree_membership_note_offset == 1
+
+
+@pytest.mark.asyncio
+async def test_folder_only_continuation_skips_exhausted_note_queries():
+    service = _PagingFolderService()
+    fake = _screen_fake(service)  # type: ignore[arg-type]
+    fake._library_notes_tree_root_page = _page(next_folder_offset=1)
+    fake._library_notes_tree_expanded_ids = {"ideas"}
+    fake._library_notes_tree_expanded_page = _page(next_folder_offset=1)
+    fake._library_notes_tree_generation = 2
+
+    await LibraryScreen._load_more_library_notes_tree(fake, generation=2)
+
+    assert len(service.calls) == 2
+    assert [call["load_notes"] for call in service.calls] == [False, False]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_notes_folder_navigator.py
+++ b/Tests/UI/test_library_notes_folder_navigator.py
@@ -180,6 +180,49 @@ async def test_filter_loads_placements_for_matches_outside_expanded_branches(
 
 
 @pytest.mark.asyncio
+async def test_filter_reveals_collapsed_note_from_folder_path_match(monkeypatch):
+    parent = _folder("work", None, "/Work")
+    child = _folder("project", "work", "/Work/Project")
+    search_page = _page(
+        folders=(parent, child),
+        memberships=(_membership("m1", "project", "n1"),),
+        notes=({"id": "n1", "title": "Unrelated title"},),
+        unfiled_note_ids=(),
+    )
+
+    class _PathSearchService:
+        async def search_notes(self, **kwargs):
+            return ()
+
+        async def load_note_folder_search(self, **kwargs):
+            assert kwargs["folder_query"] == "work / project"
+            return search_page
+
+    fake = _screen_fake(_PathSearchService())  # type: ignore[arg-type]
+    fake._library_notes_filter = "work / project"
+    fake._library_notes_filter_records = None
+    fake._library_notes_tree_search_page = None
+    fake._source_record_id = lambda record: record["id"]
+    fake._focus_library_notes_filter_input = lambda: None
+    fake._run_library_service_call = lambda method, **kwargs: method(**kwargs)
+    fake._library_notes_tree_root_page = _page(folders=(parent,))
+    fake._library_notes_tree_expanded_page = _page()
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.library_screen._sync_library_canvas",
+        lambda *args, **kwargs: None,
+    )
+
+    await LibraryScreen._run_library_notes_filter(fake, "work / project")
+
+    assert [record["id"] for record in fake._library_notes_filter_records] == ["n1"]
+    projection = LibraryScreen._build_library_notes_tree_projection(fake)
+    assert projection is not None
+    assert [row.breadcrumb for row in projection.rows if row.kind == "note"] == [
+        "Work / Project / Unrelated title"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_filter_without_folder_search_capability_keeps_loaded_tree(
     monkeypatch,
 ):

--- a/Tests/Widgets/Library/test_library_note_folder_dialog.py
+++ b/Tests/Widgets/Library/test_library_note_folder_dialog.py
@@ -1,0 +1,45 @@
+"""Tests for Database Notes folder name and destination dialogs."""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App
+from textual.widgets import Input, Select, Static
+
+from tldw_chatbook.Widgets.Library.library_note_folder_dialog import (
+    LibraryNoteFolderNameDialog,
+    LibraryNoteFolderTargetDialog,
+)
+
+
+@pytest.mark.asyncio
+async def test_name_dialog_echoes_action_and_initial_name():
+    app = App()
+    async with app.run_test() as pilot:
+        await app.push_screen(
+            LibraryNoteFolderNameDialog(
+                title="Rename folder", initial_name="Ideas"
+            )
+        )
+        await pilot.pause()
+        assert str(app.screen.query_one("#library-note-folder-dialog-title", Static).renderable) == (
+            "Rename folder"
+        )
+        assert app.screen.query_one("#library-note-folder-name", Input).value == "Ideas"
+
+
+@pytest.mark.asyncio
+async def test_target_dialog_includes_root_and_bounded_folder_choices():
+    app = App()
+    async with app.run_test() as pilot:
+        await app.push_screen(
+            LibraryNoteFolderTargetDialog(
+                title="Move folder",
+                folders=(("Personal", "personal"), ("Personal / Ideas", "ideas")),
+                include_root=True,
+            )
+        )
+        await pilot.pause()
+        select = app.screen.query_one("#library-note-folder-target", Select)
+        assert select.value == ""
+        assert len(select._options) == 3

--- a/Tests/Widgets/Library/test_library_note_folder_dialog.py
+++ b/Tests/Widgets/Library/test_library_note_folder_dialog.py
@@ -17,14 +17,12 @@ async def test_name_dialog_echoes_action_and_initial_name():
     app = App()
     async with app.run_test() as pilot:
         await app.push_screen(
-            LibraryNoteFolderNameDialog(
-                title="Rename folder", initial_name="Ideas"
-            )
+            LibraryNoteFolderNameDialog(title="Rename folder", initial_name="Ideas")
         )
         await pilot.pause()
-        assert str(app.screen.query_one("#library-note-folder-dialog-title", Static).renderable) == (
-            "Rename folder"
-        )
+        assert str(
+            app.screen.query_one("#library-note-folder-dialog-title", Static).renderable
+        ) == ("Rename folder")
         assert app.screen.query_one("#library-note-folder-name", Input).value == "Ideas"
 
 

--- a/Tests/Widgets/Library/test_library_notes_canvas.py
+++ b/Tests/Widgets/Library/test_library_notes_canvas.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import pytest
-from textual.widgets import Static
+from textual.widgets import Button, Static
 
 from Tests.textual_test_utils import widget_pilot  # noqa: F401
 from tldw_chatbook.Library.library_notes_state import LibraryNotesListState
 from tldw_chatbook.Library.library_notes_sync_state import LibraryNotesSyncState
+from tldw_chatbook.Library.library_notes_tree_state import (
+    LibraryNotesTreeProjection,
+    LibraryNotesTreeRow,
+)
 from tldw_chatbook.Widgets.Library.library_notes_canvas import LibraryNotesCanvas
-
 
 pytestmark = pytest.mark.asyncio
 
@@ -31,6 +34,64 @@ def _sync_state() -> LibraryNotesSyncState:
         auto_sync=False,
         status_line="idle",
         activity_lines=(),
+    )
+
+
+def _tree_projection() -> LibraryNotesTreeProjection:
+    return LibraryNotesTreeProjection(
+        rows=(
+            LibraryNotesTreeRow(
+                placement_id="folder:personal",
+                kind="folder",
+                label="Personal",
+                depth=0,
+                folder_id="personal",
+                breadcrumb="Personal",
+                expanded=True,
+                version=2,
+            ),
+            LibraryNotesTreeRow(
+                placement_id="folder:ideas",
+                kind="folder",
+                label="Ideas",
+                depth=1,
+                folder_id="ideas",
+                breadcrumb="Personal / Ideas",
+                expanded=True,
+                version=1,
+            ),
+            LibraryNotesTreeRow(
+                placement_id="note:ideas:n1",
+                kind="note",
+                label="Garden redesign",
+                depth=2,
+                note_id="n1",
+                folder_id="ideas",
+                membership_id="m1",
+                breadcrumb="Personal / Ideas / Garden redesign",
+                ownership="managed",
+                protected=True,
+                semantic_status="connected",
+                status_text="⇄ Synced placement",
+            ),
+            LibraryNotesTreeRow(
+                placement_id="virtual:unfiled",
+                kind="unfiled",
+                label="Unfiled",
+                depth=0,
+                breadcrumb="Unfiled",
+                expanded=True,
+            ),
+            LibraryNotesTreeRow(
+                placement_id="unfiled:n2",
+                kind="note",
+                label="Loose thought",
+                depth=1,
+                note_id="n2",
+                breadcrumb="Unfiled / Loose thought",
+            ),
+        ),
+        next_note_offset=1000,
     )
 
 
@@ -67,3 +128,68 @@ async def test_sync_mode_placement_sentence_names_files_mode(widget_pilot):  # n
         assert "Files mode" in text
         assert "directly" in text
         assert "mirror" in text.lower()
+
+
+async def test_tree_projection_renders_hierarchy_and_placement_metadata(widget_pilot):  # noqa: F811
+    async with await widget_pilot(
+        LibraryNotesCanvas,
+        list_state=_list_state(),
+        tree_projection=_tree_projection(),
+    ) as pilot:
+        await pilot.pause()
+        folders = list(pilot.app.query(".library-notes-folder-row"))
+        notes = list(pilot.app.query(".library-notes-row"))
+
+        assert [str(button.label) for button in folders] == [
+            "▾ Personal",
+            "  ▾ Ideas",
+            "▾ Unfiled",
+        ]
+        assert [button.note_id for button in notes] == ["n1", "n2"]
+        assert notes[0].placement_id == "note:ideas:n1"
+        assert notes[0].breadcrumb == "Personal / Ideas / Garden redesign"
+        assert notes[0].membership_id == "m1"
+        assert notes[0].protected_placement is True
+        assert "⇄ Synced placement" in str(notes[0].label)
+
+
+async def test_tree_projection_renders_visible_more_action(widget_pilot):  # noqa: F811
+    async with await widget_pilot(
+        LibraryNotesCanvas,
+        list_state=_list_state(),
+        tree_projection=_tree_projection(),
+    ) as pilot:
+        await pilot.pause()
+        more = pilot.app.query_one("#library-notes-tree-more", Button)
+        assert "more" in str(more.label).lower()
+
+
+async def test_tree_managed_state_remains_legible_without_color(widget_pilot):  # noqa: F811
+    projection = LibraryNotesTreeProjection(
+        rows=(
+            LibraryNotesTreeRow(
+                placement_id="note:work:n1",
+                kind="note",
+                label="Recovered",
+                depth=1,
+                note_id="n1",
+                folder_id="work",
+                membership_id="m1",
+                breadcrumb="Work / Recovered",
+                ownership="managed",
+                owner_active=False,
+                protected=True,
+                semantic_status="needs_attention",
+                status_text="! Needs owner review",
+            ),
+        )
+    )
+    async with await widget_pilot(
+        LibraryNotesCanvas,
+        list_state=_list_state(),
+        tree_projection=projection,
+    ) as pilot:
+        await pilot.pause()
+        row = pilot.app.query_one(".library-notes-row", Button)
+        assert "! Needs owner review" in str(row.label)
+        assert row.has_class("library-notes-tree-needs-attention")

--- a/Tests/Widgets/Library/test_library_notes_canvas.py
+++ b/Tests/Widgets/Library/test_library_notes_canvas.py
@@ -126,9 +126,7 @@ async def test_sync_mode_placement_sentence_names_files_mode(widget_pilot):  # n
         sync_panel_state=_sync_state(),
     ) as pilot:
         await pilot.pause()
-        purpose = pilot.app.query_one(
-            "#library-notes-sync-purpose", Static
-        ).renderable
+        purpose = pilot.app.query_one("#library-notes-sync-purpose", Static).renderable
         text = getattr(purpose, "plain", str(purpose))
         assert "Files mode" in text
         assert "directly" in text
@@ -219,9 +217,17 @@ async def test_selected_folder_exposes_manual_folder_actions(widget_pilot):  # n
     ) as pilot:
         await pilot.pause()
         assert pilot.app.query_one("#library-notes-folder-new", Button)
-        assert pilot.app.query_one("#library-notes-folder-rename", Button).disabled is False
-        assert pilot.app.query_one("#library-notes-folder-move", Button).disabled is False
-        assert pilot.app.query_one("#library-notes-folder-remove", Button).disabled is False
+        assert (
+            pilot.app.query_one("#library-notes-folder-rename", Button).disabled
+            is False
+        )
+        assert (
+            pilot.app.query_one("#library-notes-folder-move", Button).disabled is False
+        )
+        assert (
+            pilot.app.query_one("#library-notes-folder-remove", Button).disabled
+            is False
+        )
 
 
 async def test_selected_managed_folder_disables_folder_mutations(widget_pilot):  # noqa: F811
@@ -253,8 +259,14 @@ async def test_managed_placement_disables_move_and_remove_but_allows_add(
         tree_selected_placement_id="note:ideas:n1",
     ) as pilot:
         await pilot.pause()
-        assert pilot.app.query_one("#library-notes-placement-add", Button).disabled is False
-        assert pilot.app.query_one("#library-notes-placement-move", Button).disabled is True
+        assert (
+            pilot.app.query_one("#library-notes-placement-add", Button).disabled
+            is False
+        )
+        assert (
+            pilot.app.query_one("#library-notes-placement-move", Button).disabled
+            is True
+        )
         remove = pilot.app.query_one("#library-notes-placement-remove", Button)
         assert remove.disabled is True
         assert "sync" in str(remove.tooltip).lower()

--- a/Tests/Widgets/Library/test_library_notes_canvas.py
+++ b/Tests/Widgets/Library/test_library_notes_canvas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 from textual.widgets import Button, Static
 
@@ -57,6 +59,9 @@ def _tree_projection() -> LibraryNotesTreeProjection:
                 depth=1,
                 folder_id="ideas",
                 breadcrumb="Personal / Ideas",
+                protected=True,
+                semantic_status="connected",
+                status_text="⇄ Sync managed",
                 expanded=True,
                 version=1,
             ),
@@ -142,7 +147,7 @@ async def test_tree_projection_renders_hierarchy_and_placement_metadata(widget_p
 
         assert [str(button.label) for button in folders] == [
             "▾ Personal",
-            "  ▾ Ideas",
+            "  ▾ Ideas  ⇄ Sync managed",
             "▾ Unfiled",
         ]
         assert [button.note_id for button in notes] == ["n1", "n2"]
@@ -193,3 +198,74 @@ async def test_tree_managed_state_remains_legible_without_color(widget_pilot):  
         row = pilot.app.query_one(".library-notes-row", Button)
         assert "! Needs owner review" in str(row.label)
         assert row.has_class("library-notes-tree-needs-attention")
+
+
+async def test_selected_folder_exposes_manual_folder_actions(widget_pilot):  # noqa: F811
+    projection = _tree_projection()
+    manual_rows = tuple(
+        replace(row, protected=False, semantic_status="normal", status_text="")
+        if row.placement_id == "folder:ideas"
+        else row
+        for row in projection.rows
+    )
+    async with await widget_pilot(
+        LibraryNotesCanvas,
+        list_state=_list_state(),
+        tree_projection=LibraryNotesTreeProjection(
+            rows=manual_rows,
+            next_note_offset=projection.next_note_offset,
+        ),
+        tree_selected_placement_id="folder:ideas",
+    ) as pilot:
+        await pilot.pause()
+        assert pilot.app.query_one("#library-notes-folder-new", Button)
+        assert pilot.app.query_one("#library-notes-folder-rename", Button).disabled is False
+        assert pilot.app.query_one("#library-notes-folder-move", Button).disabled is False
+        assert pilot.app.query_one("#library-notes-folder-remove", Button).disabled is False
+
+
+async def test_selected_managed_folder_disables_folder_mutations(widget_pilot):  # noqa: F811
+    async with await widget_pilot(
+        LibraryNotesCanvas,
+        list_state=_list_state(),
+        tree_projection=_tree_projection(),
+        tree_selected_placement_id="folder:ideas",
+    ) as pilot:
+        await pilot.pause()
+        for button_id in (
+            "#library-notes-folder-new",
+            "#library-notes-folder-rename",
+            "#library-notes-folder-move",
+            "#library-notes-folder-remove",
+        ):
+            button = pilot.app.query_one(button_id, Button)
+            assert button.disabled is True
+            assert "sync" in str(button.tooltip).lower()
+
+
+async def test_managed_placement_disables_move_and_remove_but_allows_add(
+    widget_pilot,  # noqa: F811
+):
+    async with await widget_pilot(
+        LibraryNotesCanvas,
+        list_state=_list_state(),
+        tree_projection=_tree_projection(),
+        tree_selected_placement_id="note:ideas:n1",
+    ) as pilot:
+        await pilot.pause()
+        assert pilot.app.query_one("#library-notes-placement-add", Button).disabled is False
+        assert pilot.app.query_one("#library-notes-placement-move", Button).disabled is True
+        remove = pilot.app.query_one("#library-notes-placement-remove", Button)
+        assert remove.disabled is True
+        assert "sync" in str(remove.tooltip).lower()
+
+
+async def test_deleted_folder_receipt_exposes_restore_action(widget_pilot):  # noqa: F811
+    async with await widget_pilot(
+        LibraryNotesCanvas,
+        list_state=_list_state(),
+        tree_projection=_tree_projection(),
+        tree_deleted_folder_available=True,
+    ) as pilot:
+        await pilot.pause()
+        assert pilot.app.query_one("#library-notes-folder-restore", Button)

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -793,6 +793,23 @@ to carry — and each read as live to a grep.
 
 ---
 
+## Run source-inspection tests on a supported interpreter before changing them
+
+**TASK-15706, 2026-08-13.** A repository-wide collection under Python 3.14
+failed in `test_profile_store_lock.py` because the test compared integer source
+lines with `None`. The production code and test were unchanged from `dev`;
+inspection showed Python 3.14 emitted 12 `dis.findlinestarts()` entries whose
+line is `None`. The same repository collected all 42,613 tests under the
+installed, project-supported Python 3.12 interpreter.
+
+**What to do.** When a test derives source locations from bytecode or
+introspection APIs, check the interpreter version and inspect the raw API output
+before patching application code. Re-run collection under a supported project
+interpreter to distinguish an interpreter-assumption failure from a product
+regression, and record both results.
+
+---
+
 ## A suite that no gate runs can rot invisibly for days
 
 **TASK-1310, 2026-07-28.** `Tests/UI/test_settings_configuration_hub.py` carried 22

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -28,6 +28,28 @@ top of the test, and cover its truth table plus the default skip reason. That
 makes default collection safe while ensuring the opt-in command can actually
 reach the code it claims to verify.
 
+---
+
+## A targeted async completion must not rebuild a surface that is transitioning away
+
+**TASK-15706, 2026-08-13.** Database Notes began loading its folder tree in a
+background worker. If the user switched to File Notes before that worker
+finished, the completion path tried to synchronize `#library-notes-canvas`.
+That canvas was legitimately absent during the source transition, so the shared
+sync helper used its generic full-screen recompose fallback. The fallback
+invalidated the just-pressed Files source control and intermittently left the
+transition without its retained File Notes surface. Folder-tree tests all
+passed; only the production-shell source-switch tests reproduced the race.
+
+**What to do.** An async completion that owns one optional child surface should
+first confirm that exact surface is still mounted. If it is absent because the
+user navigated away, treat the result as cached state and skip the paint; do not
+invoke a generic whole-screen fallback. Verify the fix through the real route
+transition, and compare the same test against the untouched baseline before
+attributing nearby focus failures to the branch.
+
+---
+
 ## A schema-version label does not make a synthetic database historical
 
 **TASK-15705/TASK-15707, 2026-08-12.** Raising ChaChaNotes from v35 to v36

--- a/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
+++ b/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15706
 title: Render and operate the Database Notes folder navigator
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-13 01:43'
 labels:
@@ -43,3 +43,17 @@ Expose the local folder foundation in Library Database Notes as a lazy hierarchi
 - [ ] ADR-059 and ADR-060 are linked from the implementation plan and notes.
 - [ ] A rendered-frame self-review confirms hierarchy and status remain legible at 60×20 without color.
 - [ ] The task is set to Done only after all requirements above are complete.
+
+## Implementation Plan
+
+ADR required: no
+ADR paths: `backlog/decisions/059-notes-folder-import-and-device-local-sync-ownership.md`, `backlog/decisions/060-notes-sync-round-trip-and-interoperability-constraints.md`
+Reason: this task implements the folder UI, placement identity, ownership, and service boundaries already accepted by those ADRs; it does not introduce a new architectural choice.
+
+1. Add a Textual-independent folder-tree projection that consumes bounded `NoteFolderPage` batches, preserves placement-aware identities, produces breadcrumbs and Unfiled rows, distinguishes managed/inactive-managed placements without relying on color, and reconciles expansion/selection/focus by stable identity.
+2. Add focused unit tests for hierarchy, duplicate placements, generated-owner ancestor collapsing, manual duplicates, paging metadata, semantic labels, and stable state reconciliation; observe each test fail before implementing its behavior.
+3. Extend `LibraryNotesCanvas` with a keyboard-operable lazy navigator plus compact folder action surfaces. Keep note buttons compatible with the existing editor/select handlers while carrying a separate placement identity and breadcrumb.
+4. Add screen-owned async loading and mutation orchestration through `NotesScopeService`, including stale-result guards, bounded batch reads, file-backed off-loop behavior, thread-safe in-memory test handling, and actionable capability/error states.
+5. Wire create, rename, move, remove, restore, move-note, and add-placement actions. Protect managed/inactive-managed placements from manual detachment or destructive folder actions, and refresh without losing surviving expansion, placement focus, note selection, or editor identity.
+6. Add widget, screen, host-routing, accessibility, compact 60x20 rendered-frame, performance, and regression tests for Database Notes and File Notes. Correct the pre-existing multiselect fixture only if the touched handler requires it.
+7. Run focused and broader Library/Notes suites, static checks, a real file-backed smoke path, and live TUI restart verification. Review the rendered 60x20 frame without color, document evidence and trade-offs, link ADR-059/060 in Implementation Notes, check every criterion, and only then set TASK-15706 to Done.

--- a/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
+++ b/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
@@ -127,11 +127,20 @@ Evidence:
   managed state walks from managed memberships toward loaded ancestors. The
   returned path matches are also merged into list state by note ID so result
   counts, Select all, and checkbox state agree with the rendered tree.
-- The final post-review focused gate passes `279` tests, including repository,
+- Qodo's final review raised six findings. Google-style API documentation was
+  completed for the three named callables, search bounds now use named policy
+  constants, folder-only continuations skip exhausted note queries at both root
+  and expanded scopes, and managed-placement collapse now memoizes folder
+  ancestry instead of rescanning every membership pair. Regression tests cover
+  the query skip, membership continuation, repository/service flag propagation,
+  and bounded ancestry-walk cost.
+- The final post-Qodo focused gate passes `282` tests, including repository,
   normalized service, pure projection, screen orchestration, multiselect,
   dialogs/canvas, and the reviewed-diagnostic metadata gate. Focused fatal/error
-  Ruff checks, `compileall`, and `git diff --check` pass. A broader File Notes run
-  has one focus-confirmation failure reproduced unchanged on latest `dev`.
+  Ruff checks, `compileall`, and `git diff --check` pass. Five broader diagnostic
+  ledger failures reproduce identically on untouched latest `dev`; a broader
+  File Notes run likewise has one focus-confirmation failure reproduced unchanged
+  on latest `dev`.
 
 Trade-offs: this task intentionally exposes the already-landed local folder
 foundation. Server-backed folder capability and the import/sync setup flow stay

--- a/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
+++ b/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
@@ -118,6 +118,20 @@ Evidence:
   branch and untouched `dev` at the first 40×20 resize. Baseline comparison
   establishes that it is pre-existing; all source-transition cases affected by
   this work pass, so the branch introduces no File Notes regression.
+- The final `dev` rebase review added authoritative managed-folder metadata and
+  repository mutation guards, exact collapsed-branch search pages, tree-aware
+  selection reconciliation, and a legacy-search fallback that cannot retain a
+  prior query's records. Independent review then found and drove fixes for
+  path-only folder searches and repeated descendant traversal in managed-state
+  lookup: path matches now union bounded placements with content matches, and
+  managed state walks from managed memberships toward loaded ancestors. The
+  returned path matches are also merged into list state by note ID so result
+  counts, Select all, and checkbox state agree with the rendered tree.
+- The final post-review focused gate passes `279` tests, including repository,
+  normalized service, pure projection, screen orchestration, multiselect,
+  dialogs/canvas, and the reviewed-diagnostic metadata gate. Focused fatal/error
+  Ruff checks, `compileall`, and `git diff --check` pass. A broader File Notes run
+  has one focus-confirmation failure reproduced unchanged on latest `dev`.
 
 Trade-offs: this task intentionally exposes the already-landed local folder
 foundation. Server-backed folder capability and the import/sync setup flow stay

--- a/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
+++ b/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
@@ -98,6 +98,17 @@ Evidence:
   pass `ruff format --check`; targeted `compileall` and `git diff --check`
   passed. `library_screen.py` retains the same 154 pre-existing Ruff findings
   as untouched `dev`, with no new finding from this task.
+- The four navigator failure diagnostics were reviewed against the persistent
+  logging boundary, changed from traceback capture to bounded operation/error
+  type metadata, and added to the generated diagnostic inventory. The focused
+  architecture and navigator gate passes `23` tests; the complete post-review
+  Notes/Library plus diagnostic-architecture regression run passes `680` tests.
+- A full Python 3.12 collection reaches all `42,613` tests. The full run was
+  stopped after `1,609 passed` when it reproduced seven unchanged media-ingest
+  test failures; the same seven fail on latest untouched `dev`. Latest `dev`
+  also has unrelated pre-existing diagnostic-inventory drift across several
+  recently merged modules, while this task's own inventory delta is reviewed
+  and green on its current base.
 - The final 60×20 SVG frame was rendered and visually reviewed: nested rows,
   focus, action labels, `⇄ Sync managed` / `⇄ Synced placement`, and
   `! Needs owner review` remain legible without color.

--- a/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
+++ b/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15706
 title: Render and operate the Database Notes folder navigator
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-13 01:43'
 labels:
@@ -26,23 +26,23 @@ Expose the local folder foundation in Library Database Notes as a lazy hierarchi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Database Notes renders root folders, nested folders, notes, and Unfiled lazily with bounded bulk reads and no per-note service calls.
-- [ ] #2 A note in multiple folders has distinct placement rows that open one note identity and show the correct breadcrumb.
-- [ ] #3 Users can create, rename, move, remove, and restore folders; move notes; and add a note to another folder without deleting note content.
-- [ ] #4 Managed and restored-without-owner placements are visibly distinguished, color-independent, and protected from manual mutation.
-- [ ] #5 Selection, expansion, focus, and editor identity remain stable across refresh, reorder, resize, and compact 60x20 layouts.
-- [ ] #6 Database work runs off the Textual event loop for file-backed databases while in-memory test databases keep their thread-local safety.
-- [ ] #7 Rendered-frame, accessibility, host-routing, performance, and live restart tests pass without regressing the existing Database Note editor or File Notes.
+- [x] #1 Database Notes renders root folders, nested folders, notes, and Unfiled lazily with bounded bulk reads and no per-note service calls.
+- [x] #2 A note in multiple folders has distinct placement rows that open one note identity and show the correct breadcrumb.
+- [x] #3 Users can create, rename, move, remove, and restore folders; move notes; and add a note to another folder without deleting note content.
+- [x] #4 Managed and restored-without-owner placements are visibly distinguished, color-independent, and protected from manual mutation.
+- [x] #5 Selection, expansion, focus, and editor identity remain stable across refresh, reorder, resize, and compact 60x20 layouts.
+- [x] #6 Database work runs off the Textual event loop for file-backed databases while in-memory test databases keep their thread-local safety.
+- [x] #7 Rendered-frame, accessibility, host-routing, performance, and live restart tests pass without regressing the existing Database Note editor or File Notes.
 <!-- AC:END -->
 
 ## Definition of Done
 
-- [ ] Every acceptance criterion is checked with automated or recorded evidence.
-- [ ] Focused tests, broader Library/Notes regressions, static analysis, and live TUI verification pass.
-- [ ] Implementation Notes summarize the approach, files, trade-offs, and evidence.
-- [ ] ADR-059 and ADR-060 are linked from the implementation plan and notes.
-- [ ] A rendered-frame self-review confirms hierarchy and status remain legible at 60×20 without color.
-- [ ] The task is set to Done only after all requirements above are complete.
+- [x] Every acceptance criterion is checked with automated or recorded evidence.
+- [x] Focused tests, broader Library/Notes regressions, static analysis, and live TUI verification pass.
+- [x] Implementation Notes summarize the approach, files, trade-offs, and evidence.
+- [x] ADR-059 and ADR-060 are linked from the implementation plan and notes.
+- [x] A rendered-frame self-review confirms hierarchy and status remain legible at 60×20 without color.
+- [x] The task is set to Done only after all requirements above are complete.
 
 ## Implementation Plan
 
@@ -57,3 +57,56 @@ Reason: this task implements the folder UI, placement identity, ownership, and s
 5. Wire create, rename, move, remove, restore, move-note, and add-placement actions. Protect managed/inactive-managed placements from manual detachment or destructive folder actions, and refresh without losing surviving expansion, placement focus, note selection, or editor identity.
 6. Add widget, screen, host-routing, accessibility, compact 60x20 rendered-frame, performance, and regression tests for Database Notes and File Notes. Correct the pre-existing multiselect fixture only if the touched handler requires it.
 7. Run focused and broader Library/Notes suites, static checks, a real file-backed smoke path, and live TUI restart verification. Review the rendered 60x20 frame without color, document evidence and trade-offs, link ADR-059/060 in Implementation Notes, check every criterion, and only then set TASK-15706 to Done.
+
+## Implementation Notes
+
+Implemented the local Database Notes folder navigator defined by
+[`ADR-059`](../../backlog/decisions/059-notes-folder-import-and-device-local-sync-ownership.md)
+and
+[`ADR-060`](../../backlog/decisions/060-notes-sync-round-trip-and-interoperability-constraints.md).
+No new ADR was required because the task preserves those decisions and the
+existing normalized `NotesScopeService` boundary.
+
+- Added a pure bounded-page tree projection with lazy expansion, Unfiled,
+  breadcrumbs, generated managed-ancestor collapse, exact membership-aware row
+  identities, and placement-first focus reconciliation.
+- Extended the Database Notes canvas with folder/note rows, semantic status
+  text plus theme-token coloring, compact actions, duplicate-placement
+  selection behavior, and managed/inactive-owner protections.
+- Added screen orchestration for generation-gated loads, independent paging
+  cursors, off-loop normalized service calls, typed errors, optimistic folder
+  and membership mutations, safe attach-before-detach moves, and one-session
+  folder restore receipts.
+- Kept File Notes independent. A folder-load completion now updates only a
+  still-mounted Database Notes canvas, preventing a late completion from
+  rebuilding a source transition.
+- Primary modified surfaces are `library_notes_tree_state.py`,
+  `library_notes_canvas.py`, `library_screen.py`, the folder dialogs, both
+  canonical/aggregate CSS files, and their focused Library/Notes tests.
+
+Evidence:
+
+- Red/green review regressions: five tests first failed for same-folder
+  membership identity, duplicate checkbox synchronization, visible-tree Select
+  all, and missing/error status repaints; all five passed after the fixes.
+- Final combined navigator, folder repository/service, Database Note, File
+  Notes service/owner, dialog/canvas, live host, and File Notes routing run:
+  `453 passed in 50.47s`.
+- The folder repository/service subset independently passed `397` tests; the
+  related File Notes source-switch/compact suite passed `8` tests.
+- Ruff passed for every new/directly modified module and test; eight task files
+  pass `ruff format --check`; targeted `compileall` and `git diff --check`
+  passed. `library_screen.py` retains the same 154 pre-existing Ruff findings
+  as untouched `dev`, with no new finding from this task.
+- The final 60×20 SVG frame was rendered and visually reviewed: nested rows,
+  focus, action labels, `⇄ Sync managed` / `⇄ Synced placement`, and
+  `! Needs owner review` remain legible without color.
+- One deeper File Notes editor-focus breakpoint test fails identically on this
+  branch and untouched `dev` at the first 40×20 resize. Baseline comparison
+  establishes that it is pre-existing; all source-transition cases affected by
+  this work pass, so the branch introduces no File Notes regression.
+
+Trade-offs: this task intentionally exposes the already-landed local folder
+foundation. Server-backed folder capability and the import/sync setup flow stay
+behind their later work items; the UI degrades to the existing flat Database
+Notes list when the folder capability is unavailable.

--- a/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
+++ b/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-15706
 title: Render and operate the Database Notes folder navigator
-status: Done
+status: In Progress
 assignee: []
 created_date: '2026-08-13 01:43'
+updated_date: '2026-08-14 00:49'
 labels:
   - notes
   - folders
@@ -35,17 +36,9 @@ Expose the local folder foundation in Library Database Notes as a lazy hierarchi
 - [x] #7 Rendered-frame, accessibility, host-routing, performance, and live restart tests pass without regressing the existing Database Note editor or File Notes.
 <!-- AC:END -->
 
-## Definition of Done
-
-- [x] Every acceptance criterion is checked with automated or recorded evidence.
-- [x] Focused tests, broader Library/Notes regressions, static analysis, and live TUI verification pass.
-- [x] Implementation Notes summarize the approach, files, trade-offs, and evidence.
-- [x] ADR-059 and ADR-060 are linked from the implementation plan and notes.
-- [x] A rendered-frame self-review confirms hierarchy and status remain legible at 60×20 without color.
-- [x] The task is set to Done only after all requirements above are complete.
-
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 ADR required: no
 ADR paths: `backlog/decisions/059-notes-folder-import-and-device-local-sync-ownership.md`, `backlog/decisions/060-notes-sync-round-trip-and-interoperability-constraints.md`
 Reason: this task implements the folder UI, placement identity, ownership, and service boundaries already accepted by those ADRs; it does not introduce a new architectural choice.
@@ -58,8 +51,17 @@ Reason: this task implements the folder UI, placement identity, ownership, and s
 6. Add widget, screen, host-routing, accessibility, compact 60x20 rendered-frame, performance, and regression tests for Database Notes and File Notes. Correct the pre-existing multiselect fixture only if the touched handler requires it.
 7. Run focused and broader Library/Notes suites, static checks, a real file-backed smoke path, and live TUI restart verification. Review the rendered 60x20 frame without color, document evidence and trade-offs, link ADR-059/060 in Implementation Notes, check every criterion, and only then set TASK-15706 to Done.
 
+### Review Follow-up Plan
+
+1. Rebase onto current `dev`, preserving both upstream and task-owned generated documentation changes.
+2. Add failing regressions for authoritative managed-folder protection, filtering collapsed/unloaded placements, and selection reconciliation beyond the legacy notes page.
+3. Fix each verified issue at its owning model/service/screen boundary, then rerun its focused tests before continuing.
+4. Update task evidence and the PR, request automated and independent review, resolve every actionable thread, and merge only after required checks pass.
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 Implemented the local Database Notes folder navigator defined by
 [`ADR-059`](../../backlog/decisions/059-notes-folder-import-and-device-local-sync-ownership.md)
 and
@@ -121,3 +123,14 @@ Trade-offs: this task intentionally exposes the already-landed local folder
 foundation. Server-backed folder capability and the import/sync setup flow stay
 behind their later work items; the UI degrades to the existing flat Database
 Notes list when the folder capability is unavailable.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Every acceptance criterion is checked with automated or recorded evidence.
+- [x] #2 Focused tests, broader Library/Notes regressions, static analysis, and live TUI verification pass.
+- [x] #3 Implementation Notes summarize the approach, files, trade-offs, and evidence.
+- [x] #4 ADR-059 and ADR-060 are linked from the implementation plan and notes.
+- [x] #5 A rendered-frame self-review confirms hierarchy and status remain legible at 60×20 without color.
+- [ ] #6 The task is set to Done only after all requirements above are complete.
+<!-- DOD:END -->

--- a/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
+++ b/backlog/tasks/task-15706 - Render-and-operate-the-Database-Notes-folder-navigator.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-15706
 title: Render and operate the Database Notes folder navigator
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-13 01:43'
-updated_date: '2026-08-14 00:49'
+updated_date: '2026-08-14 01:49'
 labels:
   - notes
   - folders
@@ -146,5 +146,5 @@ Notes list when the folder capability is unavailable.
 - [x] #3 Implementation Notes summarize the approach, files, trade-offs, and evidence.
 - [x] #4 ADR-059 and ADR-060 are linked from the implementation plan and notes.
 - [x] #5 A rendered-frame self-review confirms hierarchy and status remain legible at 60×20 without color.
-- [ ] #6 The task is set to Done only after all requirements above are complete.
+- [x] #6 The task is set to Done only after all requirements above are complete.
 <!-- DOD:END -->

--- a/tldw_chatbook/Library/library_notes_tree_state.py
+++ b/tldw_chatbook/Library/library_notes_tree_state.py
@@ -14,9 +14,7 @@ from tldw_chatbook.Notes.note_folder_models import (
 )
 
 LibraryNotesTreeRowKind = Literal["folder", "note", "unfiled"]
-LibraryNotesTreeSemanticStatus = Literal[
-    "normal", "connected", "needs_attention"
-]
+LibraryNotesTreeSemanticStatus = Literal["normal", "connected", "needs_attention"]
 
 UNFILED_PLACEMENT_ID = "virtual:unfiled"
 
@@ -43,10 +41,7 @@ def merge_note_folder_pages(
         membership.membership_id: membership for membership in base.memberships
     }
     memberships.update(
-        {
-            membership.membership_id: membership
-            for membership in incoming.memberships
-        }
+        {membership.membership_id: membership for membership in incoming.memberships}
     )
     notes = {_record_id(note): note for note in base.notes}
     notes.update({_record_id(note): note for note in incoming.notes})
@@ -58,9 +53,7 @@ def merge_note_folder_pages(
         total_notes=max(base.total_notes, incoming.total_notes),
         next_offset=incoming.next_offset,
         next_folder_offset=incoming.next_folder_offset,
-        total_memberships=max(
-            base.total_memberships, incoming.total_memberships
-        ),
+        total_memberships=max(base.total_memberships, incoming.total_memberships),
         next_membership_offset=incoming.next_membership_offset,
     )
 
@@ -200,7 +193,9 @@ def _note_row(
         status_text = ""
     path = folder.path.strip("/").replace("/", " / ")
     return LibraryNotesTreeRow(
-        placement_id=FolderPlacementId.note(folder.folder_id, note_id),
+        placement_id=FolderPlacementId.note(
+            folder.folder_id, note_id, membership.membership_id
+        ),
         kind="note",
         label=title,
         depth=depth,
@@ -249,8 +244,7 @@ def build_library_notes_tree(
         while folder_id is not None and folder_id not in seen:
             seen.add(folder_id)
             managed_folder_active[folder_id] = (
-                managed_folder_active.get(folder_id, True)
-                and membership.owner_active
+                managed_folder_active.get(folder_id, True) and membership.owner_active
             )
             folder = folders.get(folder_id)
             folder_id = folder.parent_id if folder is not None else None

--- a/tldw_chatbook/Library/library_notes_tree_state.py
+++ b/tldw_chatbook/Library/library_notes_tree_state.py
@@ -33,6 +33,38 @@ def empty_note_folder_page() -> NoteFolderPage:
     )
 
 
+def merge_note_folder_pages(
+    base: NoteFolderPage, incoming: NoteFolderPage
+) -> NoteFolderPage:
+    """Merge continued bounded pages by stable storage identity."""
+    folders = {folder.folder_id: folder for folder in base.folders}
+    folders.update({folder.folder_id: folder for folder in incoming.folders})
+    memberships = {
+        membership.membership_id: membership for membership in base.memberships
+    }
+    memberships.update(
+        {
+            membership.membership_id: membership
+            for membership in incoming.memberships
+        }
+    )
+    notes = {_record_id(note): note for note in base.notes}
+    notes.update({_record_id(note): note for note in incoming.notes})
+    return NoteFolderPage(
+        folders=tuple(folders.values()),
+        memberships=tuple(memberships.values()),
+        notes=tuple(notes.values()),
+        total_folders=max(base.total_folders, incoming.total_folders),
+        total_notes=max(base.total_notes, incoming.total_notes),
+        next_offset=incoming.next_offset,
+        next_folder_offset=incoming.next_folder_offset,
+        total_memberships=max(
+            base.total_memberships, incoming.total_memberships
+        ),
+        next_membership_offset=incoming.next_membership_offset,
+    )
+
+
 @dataclass(frozen=True)
 class LibraryNotesTreeRow:
     """One visible folder, virtual Unfiled, or note-placement row."""
@@ -208,6 +240,20 @@ def build_library_notes_tree(
     memberships_by_folder: dict[str, list[NoteFolderMembership]] = {}
     for membership in memberships:
         memberships_by_folder.setdefault(membership.folder_id, []).append(membership)
+    managed_folder_active: dict[str, bool] = {}
+    for membership in memberships:
+        if membership.ownership != "managed":
+            continue
+        folder_id: str | None = membership.folder_id
+        seen: set[str] = set()
+        while folder_id is not None and folder_id not in seen:
+            seen.add(folder_id)
+            managed_folder_active[folder_id] = (
+                managed_folder_active.get(folder_id, True)
+                and membership.owner_active
+            )
+            folder = folders.get(folder_id)
+            folder_id = folder.parent_id if folder is not None else None
     children: dict[str | None, list[NoteFolder]] = {}
     for folder in folders.values():
         children.setdefault(folder.parent_id, []).append(folder)
@@ -226,6 +272,16 @@ def build_library_notes_tree(
 
     def add_folder(folder: NoteFolder, depth: int) -> None:
         expanded = folder.folder_id in expanded_folder_ids
+        protected = folder.folder_id in managed_folder_active
+        owner_active = managed_folder_active.get(folder.folder_id, True)
+        semantic_status: LibraryNotesTreeSemanticStatus = "normal"
+        status_text = ""
+        if protected and owner_active:
+            semantic_status = "connected"
+            status_text = "⇄ Sync managed"
+        elif protected:
+            semantic_status = "needs_attention"
+            status_text = "! Needs owner review"
         rows.append(
             LibraryNotesTreeRow(
                 placement_id=FolderPlacementId.folder(folder.folder_id),
@@ -234,6 +290,11 @@ def build_library_notes_tree(
                 depth=depth,
                 folder_id=folder.folder_id,
                 breadcrumb=folder.path.strip("/").replace("/", " / "),
+                ownership="managed" if protected else None,
+                owner_active=owner_active,
+                protected=protected,
+                semantic_status=semantic_status,
+                status_text=status_text,
                 expanded=expanded,
                 version=folder.version,
             )

--- a/tldw_chatbook/Library/library_notes_tree_state.py
+++ b/tldw_chatbook/Library/library_notes_tree_state.py
@@ -1,0 +1,294 @@
+"""Pure, placement-aware display state for the Database Notes folder tree."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal
+
+from tldw_chatbook.Notes.note_folder_models import (
+    FolderPlacementId,
+    NoteFolder,
+    NoteFolderMembership,
+    NoteFolderPage,
+)
+
+LibraryNotesTreeRowKind = Literal["folder", "note", "unfiled"]
+LibraryNotesTreeSemanticStatus = Literal[
+    "normal", "connected", "needs_attention"
+]
+
+UNFILED_PLACEMENT_ID = "virtual:unfiled"
+
+
+@dataclass(frozen=True)
+class LibraryNotesTreeRow:
+    """One visible folder, virtual Unfiled, or note-placement row."""
+
+    placement_id: str
+    kind: LibraryNotesTreeRowKind
+    label: str
+    depth: int
+    note_id: str | None = None
+    folder_id: str | None = None
+    membership_id: str | None = None
+    breadcrumb: str = ""
+    ownership: Literal["manual", "managed"] | None = None
+    owner_active: bool = True
+    protected: bool = False
+    semantic_status: LibraryNotesTreeSemanticStatus = "normal"
+    status_text: str = ""
+    expanded: bool = False
+    version: int | None = None
+
+
+@dataclass(frozen=True)
+class LibraryNotesTreeIdentity:
+    """Stable navigator identity: placement first, underlying note second."""
+
+    placement_id: str
+    note_id: str | None = None
+
+
+@dataclass(frozen=True)
+class LibraryNotesTreeProjection:
+    """Visible rows plus the bounded cursors needed to continue loading."""
+
+    rows: tuple[LibraryNotesTreeRow, ...]
+    next_folder_offset: int | None = None
+    next_note_offset: int | None = None
+    next_membership_offset: int | None = None
+
+    @property
+    def has_more(self) -> bool:
+        """Return whether any bounded page has another cursor."""
+        return any(
+            cursor is not None
+            for cursor in (
+                self.next_folder_offset,
+                self.next_note_offset,
+                self.next_membership_offset,
+            )
+        )
+
+    def row(self, placement_id: str) -> LibraryNotesTreeRow | None:
+        """Return one visible row by exact placement identity."""
+        return next(
+            (row for row in self.rows if row.placement_id == placement_id), None
+        )
+
+
+def _record_id(note: Mapping[str, object]) -> str:
+    return str(note.get("id", note.get("note_id", "")) or "")
+
+
+def _record_title(note: Mapping[str, object]) -> str:
+    return str(note.get("title", "") or "Untitled")
+
+
+def _folder_is_ancestor(
+    ancestor_id: str,
+    descendant_id: str,
+    folders: Mapping[str, NoteFolder],
+) -> bool:
+    current = folders.get(descendant_id)
+    seen: set[str] = set()
+    while current is not None and current.parent_id is not None:
+        if current.parent_id == ancestor_id:
+            return True
+        if current.parent_id in seen:
+            return False
+        seen.add(current.parent_id)
+        current = folders.get(current.parent_id)
+    return False
+
+
+def _effective_memberships(
+    memberships: tuple[NoteFolderMembership, ...],
+    folders: Mapping[str, NoteFolder],
+) -> tuple[NoteFolderMembership, ...]:
+    """Collapse generated ancestor placements for the same note and owner."""
+    effective: list[NoteFolderMembership] = []
+    for candidate in memberships:
+        if candidate.ownership == "managed" and any(
+            other.membership_id != candidate.membership_id
+            and other.ownership == "managed"
+            and other.note_id == candidate.note_id
+            and other.owner_id == candidate.owner_id
+            and _folder_is_ancestor(candidate.folder_id, other.folder_id, folders)
+            for other in memberships
+        ):
+            continue
+        effective.append(candidate)
+    return tuple(effective)
+
+
+def _note_row(
+    *,
+    note: Mapping[str, object],
+    folder: NoteFolder | None,
+    membership: NoteFolderMembership | None,
+    depth: int,
+) -> LibraryNotesTreeRow:
+    note_id = _record_id(note)
+    title = _record_title(note)
+    if folder is None:
+        return LibraryNotesTreeRow(
+            placement_id=FolderPlacementId.unfiled(note_id),
+            kind="note",
+            label=title,
+            depth=depth,
+            note_id=note_id,
+            breadcrumb=f"Unfiled / {title}",
+        )
+
+    assert membership is not None
+    managed = membership.ownership == "managed"
+    active = membership.owner_active
+    if managed and active:
+        semantic_status: LibraryNotesTreeSemanticStatus = "connected"
+        status_text = "⇄ Synced placement"
+    elif managed:
+        semantic_status = "needs_attention"
+        status_text = "! Needs owner review"
+    else:
+        semantic_status = "normal"
+        status_text = ""
+    path = folder.path.strip("/").replace("/", " / ")
+    return LibraryNotesTreeRow(
+        placement_id=FolderPlacementId.note(folder.folder_id, note_id),
+        kind="note",
+        label=title,
+        depth=depth,
+        note_id=note_id,
+        folder_id=folder.folder_id,
+        membership_id=membership.membership_id,
+        breadcrumb=f"{path} / {title}" if path else title,
+        ownership=membership.ownership,
+        owner_active=active,
+        protected=managed,
+        semantic_status=semantic_status,
+        status_text=status_text,
+        version=membership.version,
+    )
+
+
+def build_library_notes_tree(
+    *,
+    root_page: NoteFolderPage,
+    expanded_page: NoteFolderPage,
+    expanded_folder_ids: set[str] | frozenset[str],
+) -> LibraryNotesTreeProjection:
+    """Project bounded root/expanded batches into one lazy visible tree."""
+    folders = {
+        folder.folder_id: folder
+        for folder in (*root_page.folders, *expanded_page.folders)
+        if not folder.deleted
+    }
+    notes = {
+        _record_id(note): note
+        for note in (*root_page.notes, *expanded_page.notes)
+        if _record_id(note)
+    }
+    memberships = _effective_memberships(expanded_page.memberships, folders)
+    memberships_by_folder: dict[str, list[NoteFolderMembership]] = {}
+    for membership in memberships:
+        memberships_by_folder.setdefault(membership.folder_id, []).append(membership)
+    children: dict[str | None, list[NoteFolder]] = {}
+    for folder in folders.values():
+        children.setdefault(folder.parent_id, []).append(folder)
+    for group in children.values():
+        group.sort(key=lambda folder: (folder.normalized_path, folder.folder_id))
+    for group in memberships_by_folder.values():
+        group.sort(
+            key=lambda membership: (
+                _record_title(notes.get(membership.note_id, {})).casefold(),
+                membership.note_id,
+                membership.membership_id,
+            )
+        )
+
+    rows: list[LibraryNotesTreeRow] = []
+
+    def add_folder(folder: NoteFolder, depth: int) -> None:
+        expanded = folder.folder_id in expanded_folder_ids
+        rows.append(
+            LibraryNotesTreeRow(
+                placement_id=FolderPlacementId.folder(folder.folder_id),
+                kind="folder",
+                label=folder.name,
+                depth=depth,
+                folder_id=folder.folder_id,
+                breadcrumb=folder.path.strip("/").replace("/", " / "),
+                expanded=expanded,
+                version=folder.version,
+            )
+        )
+        if not expanded:
+            return
+        for child in children.get(folder.folder_id, ()):
+            add_folder(child, depth + 1)
+        for membership in memberships_by_folder.get(folder.folder_id, ()):
+            note = notes.get(membership.note_id)
+            if note is not None:
+                rows.append(
+                    _note_row(
+                        note=note,
+                        folder=folder,
+                        membership=membership,
+                        depth=depth + 1,
+                    )
+                )
+
+    for root in children.get(None, ()):
+        add_folder(root, 0)
+
+    unfiled_notes = sorted(
+        root_page.notes, key=lambda note: (_record_title(note).casefold(), _record_id(note))
+    )
+    if unfiled_notes or root_page.next_offset is not None:
+        rows.append(
+            LibraryNotesTreeRow(
+                placement_id=UNFILED_PLACEMENT_ID,
+                kind="unfiled",
+                label="Unfiled",
+                depth=0,
+                breadcrumb="Unfiled",
+                expanded=True,
+            )
+        )
+        rows.extend(
+            _note_row(note=note, folder=None, membership=None, depth=1)
+            for note in unfiled_notes
+        )
+
+    return LibraryNotesTreeProjection(
+        rows=tuple(rows),
+        next_folder_offset=(
+            expanded_page.next_folder_offset or root_page.next_folder_offset
+        ),
+        next_note_offset=expanded_page.next_offset or root_page.next_offset,
+        next_membership_offset=expanded_page.next_membership_offset,
+    )
+
+
+def reconcile_library_notes_tree_identity(
+    projection: LibraryNotesTreeProjection,
+    identity: LibraryNotesTreeIdentity | None,
+) -> LibraryNotesTreeIdentity | None:
+    """Keep a placement, then its note, otherwise the first surviving row."""
+    if identity is None:
+        return None
+    exact = projection.row(identity.placement_id)
+    if exact is not None:
+        return LibraryNotesTreeIdentity(exact.placement_id, exact.note_id)
+    if identity.note_id:
+        same_note = next(
+            (row for row in projection.rows if row.note_id == identity.note_id), None
+        )
+        if same_note is not None:
+            return LibraryNotesTreeIdentity(same_note.placement_id, same_note.note_id)
+    fallback = next((row for row in projection.rows if row.kind == "note"), None)
+    if fallback is None:
+        return None
+    return LibraryNotesTreeIdentity(fallback.placement_id, fallback.note_id)

--- a/tldw_chatbook/Library/library_notes_tree_state.py
+++ b/tldw_chatbook/Library/library_notes_tree_state.py
@@ -21,6 +21,18 @@ LibraryNotesTreeSemanticStatus = Literal[
 UNFILED_PLACEMENT_ID = "virtual:unfiled"
 
 
+def empty_note_folder_page() -> NoteFolderPage:
+    """Return an empty bounded page for an unloaded branch set."""
+    return NoteFolderPage(
+        folders=(),
+        memberships=(),
+        notes=(),
+        total_folders=0,
+        total_notes=0,
+        next_offset=None,
+    )
+
+
 @dataclass(frozen=True)
 class LibraryNotesTreeRow:
     """One visible folder, virtual Unfiled, or note-placement row."""
@@ -178,8 +190,10 @@ def build_library_notes_tree(
     root_page: NoteFolderPage,
     expanded_page: NoteFolderPage,
     expanded_folder_ids: set[str] | frozenset[str],
+    filter_text: str = "",
 ) -> LibraryNotesTreeProjection:
     """Project bounded root/expanded batches into one lazy visible tree."""
+    query = filter_text.strip().casefold()
     folders = {
         folder.folder_id: folder
         for folder in (*root_page.folders, *expanded_page.folders)
@@ -231,21 +245,26 @@ def build_library_notes_tree(
         for membership in memberships_by_folder.get(folder.folder_id, ()):
             note = notes.get(membership.note_id)
             if note is not None:
-                rows.append(
-                    _note_row(
-                        note=note,
-                        folder=folder,
-                        membership=membership,
-                        depth=depth + 1,
-                    )
+                note_row = _note_row(
+                    note=note,
+                    folder=folder,
+                    membership=membership,
+                    depth=depth + 1,
                 )
+                if not query or query in note_row.breadcrumb.casefold():
+                    rows.append(note_row)
 
     for root in children.get(None, ()):
         add_folder(root, 0)
 
-    unfiled_notes = sorted(
-        root_page.notes, key=lambda note: (_record_title(note).casefold(), _record_id(note))
-    )
+    unfiled_notes = [
+        note
+        for note in sorted(
+            root_page.notes,
+            key=lambda note: (_record_title(note).casefold(), _record_id(note)),
+        )
+        if not query or query in f"Unfiled / {_record_title(note)}".casefold()
+    ]
     if unfiled_notes or root_page.next_offset is not None:
         rows.append(
             LibraryNotesTreeRow(

--- a/tldw_chatbook/Library/library_notes_tree_state.py
+++ b/tldw_chatbook/Library/library_notes_tree_state.py
@@ -147,41 +147,60 @@ def _record_title(note: Mapping[str, object]) -> str:
     return str(note.get("title", "") or "Untitled")
 
 
-def _folder_is_ancestor(
-    ancestor_id: str,
-    descendant_id: str,
-    folders: Mapping[str, NoteFolder],
-) -> bool:
-    current = folders.get(descendant_id)
-    seen: set[str] = set()
-    while current is not None and current.parent_id is not None:
-        if current.parent_id == ancestor_id:
-            return True
-        if current.parent_id in seen:
-            return False
-        seen.add(current.parent_id)
-        current = folders.get(current.parent_id)
-    return False
-
-
 def _effective_memberships(
     memberships: tuple[NoteFolderMembership, ...],
     folders: Mapping[str, NoteFolder],
 ) -> tuple[NoteFolderMembership, ...]:
     """Collapse generated ancestor placements for the same note and owner."""
-    effective: list[NoteFolderMembership] = []
-    for candidate in memberships:
-        if candidate.ownership == "managed" and any(
-            other.membership_id != candidate.membership_id
-            and other.ownership == "managed"
-            and other.note_id == candidate.note_id
-            and other.owner_id == candidate.owner_id
-            and _folder_is_ancestor(candidate.folder_id, other.folder_id, folders)
-            for other in memberships
-        ):
+    managed_folders_by_owner: dict[tuple[str, str], set[str]] = {}
+    for membership in memberships:
+        if membership.ownership == "managed":
+            managed_folders_by_owner.setdefault(
+                (membership.note_id, membership.owner_id), set()
+            ).add(membership.folder_id)
+
+    managed_folder_ids = (
+        set().union(*managed_folders_by_owner.values())
+        if (managed_folders_by_owner)
+        else set()
+    )
+    ancestors_by_folder: dict[str, frozenset[str]] = {}
+    for folder_id in managed_folder_ids:
+        if folder_id in ancestors_by_folder:
             continue
-        effective.append(candidate)
-    return tuple(effective)
+        chain: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        current_id = folder_id
+        while current_id not in ancestors_by_folder:
+            if current_id in seen:
+                chain.clear()
+                ancestors_by_folder[folder_id] = frozenset()
+                break
+            seen.add(current_id)
+            current = folders.get(current_id)
+            if current is None or current.parent_id is None:
+                ancestors_by_folder[current_id] = frozenset()
+                break
+            chain.append((current_id, current.parent_id))
+            current_id = current.parent_id
+        ancestor_ids = ancestors_by_folder.get(current_id, frozenset())
+        for child_id, parent_id in reversed(chain):
+            ancestor_ids = ancestor_ids.union((parent_id,))
+            ancestors_by_folder[child_id] = ancestor_ids
+
+    shadowed_folders_by_owner: dict[tuple[str, str], set[str]] = {}
+    for owner_key, folder_ids in managed_folders_by_owner.items():
+        shadowed = shadowed_folders_by_owner.setdefault(owner_key, set())
+        for folder_id in folder_ids:
+            shadowed.update(ancestors_by_folder[folder_id].intersection(folder_ids))
+
+    return tuple(
+        membership
+        for membership in memberships
+        if membership.ownership != "managed"
+        or membership.folder_id
+        not in shadowed_folders_by_owner[(membership.note_id, membership.owner_id)]
+    )
 
 
 def _note_row(
@@ -244,7 +263,18 @@ def build_library_notes_tree(
     filter_text: str = "",
     matched_note_ids: frozenset[str] | None = None,
 ) -> LibraryNotesTreeProjection:
-    """Project bounded root/expanded batches into one lazy visible tree."""
+    """Project bounded root and expanded batches into one lazy visible tree.
+
+    Args:
+        root_page: Bounded root-folder and unfiled-note page.
+        expanded_page: Bounded children, memberships, and notes for expanded folders.
+        expanded_folder_ids: Folder identifiers whose immediate contents are visible.
+        filter_text: Optional case-insensitive folder/note filter.
+        matched_note_ids: Optional authoritative note IDs from bounded search.
+
+    Returns:
+        Visible placement-aware rows and the cursors needed to continue loading.
+    """
     query = filter_text.strip().casefold()
     folders = {
         folder.folder_id: folder

--- a/tldw_chatbook/Library/library_notes_tree_state.py
+++ b/tldw_chatbook/Library/library_notes_tree_state.py
@@ -55,6 +55,30 @@ def merge_note_folder_pages(
         next_folder_offset=incoming.next_folder_offset,
         total_memberships=max(base.total_memberships, incoming.total_memberships),
         next_membership_offset=incoming.next_membership_offset,
+        managed_folder_ids=tuple(
+            sorted({*base.managed_folder_ids, *incoming.managed_folder_ids})
+        ),
+        inactive_managed_folder_ids=tuple(
+            sorted(
+                {
+                    *base.inactive_managed_folder_ids,
+                    *incoming.inactive_managed_folder_ids,
+                }
+            )
+        ),
+        unfiled_note_ids=(
+            tuple(
+                sorted(
+                    {
+                        *(base.unfiled_note_ids or ()),
+                        *(incoming.unfiled_note_ids or ()),
+                    }
+                )
+            )
+            if base.unfiled_note_ids is not None
+            or incoming.unfiled_note_ids is not None
+            else None
+        ),
     )
 
 
@@ -218,6 +242,7 @@ def build_library_notes_tree(
     expanded_page: NoteFolderPage,
     expanded_folder_ids: set[str] | frozenset[str],
     filter_text: str = "",
+    matched_note_ids: frozenset[str] | None = None,
 ) -> LibraryNotesTreeProjection:
     """Project bounded root/expanded batches into one lazy visible tree."""
     query = filter_text.strip().casefold()
@@ -235,7 +260,17 @@ def build_library_notes_tree(
     memberships_by_folder: dict[str, list[NoteFolderMembership]] = {}
     for membership in memberships:
         memberships_by_folder.setdefault(membership.folder_id, []).append(membership)
-    managed_folder_active: dict[str, bool] = {}
+    managed_ids = {
+        *root_page.managed_folder_ids,
+        *expanded_page.managed_folder_ids,
+    }
+    inactive_managed_ids = {
+        *root_page.inactive_managed_folder_ids,
+        *expanded_page.inactive_managed_folder_ids,
+    }
+    managed_folder_active: dict[str, bool] = {
+        folder_id: folder_id not in inactive_managed_ids for folder_id in managed_ids
+    }
     for membership in memberships:
         if membership.ownership != "managed":
             continue
@@ -264,8 +299,8 @@ def build_library_notes_tree(
 
     rows: list[LibraryNotesTreeRow] = []
 
-    def add_folder(folder: NoteFolder, depth: int) -> None:
-        expanded = folder.folder_id in expanded_folder_ids
+    def folder_rows(folder: NoteFolder, depth: int) -> list[LibraryNotesTreeRow]:
+        expanded = folder.folder_id in expanded_folder_ids or bool(query)
         protected = folder.folder_id in managed_folder_active
         owner_active = managed_folder_active.get(folder.folder_id, True)
         semantic_status: LibraryNotesTreeSemanticStatus = "normal"
@@ -276,27 +311,26 @@ def build_library_notes_tree(
         elif protected:
             semantic_status = "needs_attention"
             status_text = "! Needs owner review"
-        rows.append(
-            LibraryNotesTreeRow(
-                placement_id=FolderPlacementId.folder(folder.folder_id),
-                kind="folder",
-                label=folder.name,
-                depth=depth,
-                folder_id=folder.folder_id,
-                breadcrumb=folder.path.strip("/").replace("/", " / "),
-                ownership="managed" if protected else None,
-                owner_active=owner_active,
-                protected=protected,
-                semantic_status=semantic_status,
-                status_text=status_text,
-                expanded=expanded,
-                version=folder.version,
-            )
+        folder_row = LibraryNotesTreeRow(
+            placement_id=FolderPlacementId.folder(folder.folder_id),
+            kind="folder",
+            label=folder.name,
+            depth=depth,
+            folder_id=folder.folder_id,
+            breadcrumb=folder.path.strip("/").replace("/", " / "),
+            ownership="managed" if protected else None,
+            owner_active=owner_active,
+            protected=protected,
+            semantic_status=semantic_status,
+            status_text=status_text,
+            expanded=expanded,
+            version=folder.version,
         )
         if not expanded:
-            return
+            return [folder_row]
+        descendant_rows: list[LibraryNotesTreeRow] = []
         for child in children.get(folder.folder_id, ()):
-            add_folder(child, depth + 1)
+            descendant_rows.extend(folder_rows(child, depth + 1))
         for membership in memberships_by_folder.get(folder.folder_id, ()):
             note = notes.get(membership.note_id)
             if note is not None:
@@ -306,19 +340,40 @@ def build_library_notes_tree(
                     membership=membership,
                     depth=depth + 1,
                 )
-                if not query or query in note_row.breadcrumb.casefold():
-                    rows.append(note_row)
+                if not query or (
+                    membership.note_id in matched_note_ids
+                    if matched_note_ids is not None
+                    else query in note_row.breadcrumb.casefold()
+                ):
+                    descendant_rows.append(note_row)
+        folder_matches = (
+            matched_note_ids is None and query in folder_row.breadcrumb.casefold()
+        )
+        if query and not descendant_rows and not folder_matches:
+            return []
+        return [folder_row, *descendant_rows]
 
     for root in children.get(None, ()):
-        add_folder(root, 0)
+        rows.extend(folder_rows(root, 0))
 
+    unfiled_note_ids = (
+        {_record_id(note) for note in root_page.notes}
+        if root_page.unfiled_note_ids is None
+        else set(root_page.unfiled_note_ids)
+    )
     unfiled_notes = [
         note
         for note in sorted(
             root_page.notes,
             key=lambda note: (_record_title(note).casefold(), _record_id(note)),
         )
-        if not query or query in f"Unfiled / {_record_title(note)}".casefold()
+        if _record_id(note) in unfiled_note_ids
+        if not query
+        or (
+            _record_id(note) in matched_note_ids
+            if matched_note_ids is not None
+            else query in f"Unfiled / {_record_title(note)}".casefold()
+        )
     ]
     if unfiled_notes or root_page.next_offset is not None:
         rows.append(

--- a/tldw_chatbook/Notes/note_folder_models.py
+++ b/tldw_chatbook/Notes/note_folder_models.py
@@ -130,7 +130,16 @@ class FolderPlacementId:
 
     @staticmethod
     def note(folder_id: str, note_id: str, membership_id: str | None = None) -> str:
-        """Return a folder/note identity, optionally for one exact membership."""
+        """Return a folder/note identity, optionally for one exact membership.
+
+        Args:
+            folder_id: Folder containing the note placement.
+            note_id: Note represented by the placement.
+            membership_id: Exact membership identity for duplicate placements.
+
+        Returns:
+            A URL-escaped, stable tree placement identifier.
+        """
         placement = f"note:{quote(folder_id, safe='')}:{quote(note_id, safe='')}"
         if membership_id is None:
             return placement

--- a/tldw_chatbook/Notes/note_folder_models.py
+++ b/tldw_chatbook/Notes/note_folder_models.py
@@ -126,9 +126,12 @@ class FolderPlacementId:
         return f"folder:{quote(folder_id, safe='')}"
 
     @staticmethod
-    def note(folder_id: str, note_id: str) -> str:
-        """Return the tree placement identifier for a note in one folder."""
-        return f"note:{quote(folder_id, safe='')}:{quote(note_id, safe='')}"
+    def note(folder_id: str, note_id: str, membership_id: str | None = None) -> str:
+        """Return a folder/note identity, optionally for one exact membership."""
+        placement = f"note:{quote(folder_id, safe='')}:{quote(note_id, safe='')}"
+        if membership_id is None:
+            return placement
+        return f"{placement}:{quote(membership_id, safe='')}"
 
     @staticmethod
     def unfiled(note_id: str) -> str:

--- a/tldw_chatbook/Notes/note_folder_models.py
+++ b/tldw_chatbook/Notes/note_folder_models.py
@@ -97,6 +97,9 @@ class NoteFolderPage:
     next_folder_offset: int | None = None
     total_memberships: int = 0
     next_membership_offset: int | None = None
+    managed_folder_ids: tuple[str, ...] = ()
+    inactive_managed_folder_ids: tuple[str, ...] = ()
+    unfiled_note_ids: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/Notes/note_folder_repository.py
+++ b/tldw_chatbook/Notes/note_folder_repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import unicodedata
 import uuid
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
@@ -430,12 +431,15 @@ class LocalNoteFolderRepository:
         except CharactersRAGDBError as exc:
             _raise_wrapped_repository_error(exc)
 
-    def load_tree_search(self, *, note_ids: Iterable[str]) -> NoteFolderPage:
-        """Load bounded search-note placements plus their complete breadcrumbs."""
+    def load_tree_search(
+        self, *, note_ids: Iterable[str], folder_query: str = ""
+    ) -> NoteFolderPage:
+        """Load bounded content/path matches plus their complete breadcrumbs."""
         normalized_note_ids = _normalize_ids(note_ids, field="note_ids")
         if len(normalized_note_ids) > 250:
             raise FolderValidationError("note_ids exceeds the allowed range.")
-        if not normalized_note_ids:
+        normalized_folder_query = _normalize_folder_search_query(folder_query)
+        if not normalized_note_ids and not normalized_folder_query:
             return NoteFolderPage(
                 folders=(),
                 memberships=(),
@@ -444,16 +448,68 @@ class LocalNoteFolderRepository:
                 total_notes=0,
                 next_offset=None,
             )
-        placeholders = _placeholders(len(normalized_note_ids))
         with self.db.transaction() as cursor:
+            path_note_ids: tuple[str, ...] = ()
+            if normalized_folder_query:
+                path_note_rows = cursor.execute(
+                    """
+                    SELECT DISTINCT m.note_id
+                    FROM note_folder_memberships AS m
+                    JOIN note_folders AS f ON f.id = m.folder_id
+                    JOIN notes AS n ON n.id = m.note_id
+                    WHERE m.deleted = 0 AND f.deleted = 0 AND n.deleted = 0
+                      AND instr(f.normalized_path, ?) > 0
+                    ORDER BY m.note_id
+                    LIMIT 251
+                    """,
+                    (normalized_folder_query,),
+                ).fetchall()
+                path_note_ids = tuple(str(row["note_id"]) for row in path_note_rows)
+                if len(path_note_ids) > 250:
+                    raise FolderValidationError(
+                        "Folder search has too many notes; narrow the search."
+                    )
+            selected_note_ids = tuple(
+                sorted({*normalized_note_ids, *path_note_ids})
+            )
+            if len(selected_note_ids) > 250:
+                raise FolderValidationError(
+                    "Folder search has too many notes; narrow the search."
+                )
+            if not selected_note_ids:
+                return NoteFolderPage(
+                    folders=(),
+                    memberships=(),
+                    notes=(),
+                    total_folders=0,
+                    total_notes=0,
+                    next_offset=None,
+                )
+
+            membership_predicates: list[str] = []
+            membership_parameters: list[str] = []
+            if normalized_note_ids:
+                content_placeholders = _placeholders(len(normalized_note_ids))
+                membership_predicates.append(
+                    f"m.note_id IN ({content_placeholders})"
+                )
+                membership_parameters.extend(normalized_note_ids)
+            if normalized_folder_query:
+                membership_predicates.append("instr(f.normalized_path, ?) > 0")
+                membership_parameters.append(normalized_folder_query)
+            membership_match = " OR ".join(membership_predicates)
+
             folder_rows = cursor.execute(
                 f"""
-                WITH RECURSIVE ancestors(folder_id) AS (
+                WITH RECURSIVE matched_folders(folder_id) AS (
                     SELECT DISTINCT m.folder_id
                     FROM note_folder_memberships AS m
                     JOIN note_folders AS f ON f.id = m.folder_id
                     WHERE m.deleted = 0 AND f.deleted = 0
-                      AND m.note_id IN ({placeholders})
+                      AND ({membership_match})
+                ),
+                ancestors(folder_id) AS (
+                    SELECT folder_id FROM matched_folders
                     UNION
                     SELECT f.parent_id
                     FROM note_folders AS f
@@ -467,7 +523,7 @@ class LocalNoteFolderRepository:
                 ORDER BY note_folders.normalized_path, note_folders.id
                 LIMIT 501
                 """,
-                normalized_note_ids,
+                tuple(membership_parameters),
             ).fetchall()
             membership_rows = cursor.execute(
                 f"""
@@ -475,12 +531,13 @@ class LocalNoteFolderRepository:
                 FROM note_folder_memberships AS m
                 JOIN note_folders AS f ON f.id = m.folder_id
                 WHERE m.deleted = 0 AND f.deleted = 0
-                  AND m.note_id IN ({placeholders})
+                  AND ({membership_match})
                 ORDER BY f.normalized_path, m.note_id, m.ownership, m.owner_id, m.id
                 LIMIT 1001
                 """,
-                normalized_note_ids,
+                tuple(membership_parameters),
             ).fetchall()
+            selected_placeholders = _placeholders(len(selected_note_ids))
             note_rows = cursor.execute(
                 f"""
                 SELECT n.{_NOTE_COLUMNS.replace(', ', ', n.')},
@@ -492,10 +549,10 @@ class LocalNoteFolderRepository:
                              AND f.deleted = 0 AND m.owner_active = 1
                        ) AS _unfiled
                 FROM notes AS n
-                WHERE n.deleted = 0 AND n.id IN ({placeholders})
+                WHERE n.deleted = 0 AND n.id IN ({selected_placeholders})
                 ORDER BY n.title COLLATE NOCASE, n.id
                 """,
-                normalized_note_ids,
+                selected_note_ids,
             ).fetchall()
             if len(folder_rows) > 500 or len(membership_rows) > 1000:
                 raise FolderValidationError(
@@ -1625,27 +1682,40 @@ def _load_managed_folder_rows(
     placeholders = _placeholders(len(normalized_folder_ids))
     return cursor.execute(
         f"""
-        WITH RECURSIVE subtree(target_id, folder_id) AS (
-            SELECT id, id
-            FROM note_folders
-            WHERE deleted = 0 AND id IN ({placeholders})
+        WITH RECURSIVE managed_ancestors(folder_id, owner_active) AS (
+            SELECT DISTINCT membership.folder_id, membership.owner_active
+            FROM note_folder_memberships AS membership
+            JOIN note_folders AS folder ON folder.id = membership.folder_id
+            WHERE membership.deleted = 0
+              AND membership.ownership = 'managed'
+              AND folder.deleted = 0
             UNION
-            SELECT subtree.target_id, child.id
-            FROM note_folders AS child
-            JOIN subtree ON child.parent_id = subtree.folder_id
-            WHERE child.deleted = 0
+            SELECT folder.parent_id, managed_ancestors.owner_active
+            FROM note_folders AS folder
+            JOIN managed_ancestors ON managed_ancestors.folder_id = folder.id
+            WHERE folder.deleted = 0 AND folder.parent_id IS NOT NULL
         )
-        SELECT subtree.target_id AS folder_id,
-               MIN(membership.owner_active) AS owner_active
-        FROM subtree
-        JOIN note_folder_memberships AS membership
-          ON membership.folder_id = subtree.folder_id
-        WHERE membership.deleted = 0 AND membership.ownership = 'managed'
-        GROUP BY subtree.target_id
-        ORDER BY subtree.target_id
+        SELECT folder_id, MIN(owner_active) AS owner_active
+        FROM managed_ancestors
+        WHERE folder_id IN ({placeholders})
+        GROUP BY folder_id
+        ORDER BY folder_id
         """,
         normalized_folder_ids,
     ).fetchall()
+
+
+def _normalize_folder_search_query(query: str) -> str:
+    """Normalize a bounded user breadcrumb query for stored path matching."""
+    if not isinstance(query, str):
+        raise FolderValidationError("folder_query must be text.")
+    display = query.strip()
+    if not display:
+        return ""
+    if len(display) > 200 or "\x00" in display:
+        raise FolderValidationError("folder_query exceeds the allowed range.")
+    normalized = unicodedata.normalize("NFKC", display).casefold()
+    return "/".join(part.strip() for part in normalized.split("/"))
 
 
 def _folder_from_row(row: sqlite3.Row) -> NoteFolder:

--- a/tldw_chatbook/Notes/note_folder_repository.py
+++ b/tldw_chatbook/Notes/note_folder_repository.py
@@ -35,6 +35,9 @@ _NOTE_COLUMNS = (
 _COLLISION_PREFLIGHT_CHUNK_SIZE = 400
 _MEMBERSHIP_QUERY_CHUNK_SIZE = 400
 _MEMBERSHIP_ID_INSERT_ATTEMPTS = 3
+_TREE_SEARCH_NOTE_LIMIT = 250
+_TREE_SEARCH_FOLDER_LIMIT = 500
+_TREE_SEARCH_MEMBERSHIP_LIMIT = 1000
 _MEMBERSHIP_COLUMNS = (
     "id, folder_id, note_id, ownership, owner_id, owner_active, version"
 )
@@ -203,8 +206,27 @@ class LocalNoteFolderRepository:
         folder_offset: int = 0,
         membership_limit: int = 1000,
         membership_offset: int = 0,
+        load_notes: bool = True,
     ) -> NoteFolderPage:
-        """Bulk-load roots or the immediate contents of expanded folders."""
+        """Bulk-load roots or the immediate contents of expanded folders.
+
+        Args:
+            expanded_folder_ids: Folders whose immediate contents should load.
+            note_limit: Maximum notes to return when note loading is enabled.
+            note_offset: Offset into the bounded note page.
+            folder_limit: Maximum child folders to return.
+            folder_offset: Offset into the bounded folder page.
+            membership_limit: Maximum memberships for the current note page.
+            membership_offset: Offset into the bounded membership page.
+            load_notes: Whether to query notes and their memberships. Disable this
+                when only an independent folder cursor remains.
+
+        Returns:
+            One bounded folder-tree page with independent continuation cursors.
+
+        Raises:
+            FolderValidationError: If a bound or flag is invalid.
+        """
         _validate_int_bound("note_limit", note_limit, minimum=1, maximum=1000)
         _validate_int_bound("note_offset", note_offset, minimum=0)
         _validate_int_bound("folder_limit", folder_limit, minimum=1, maximum=500)
@@ -213,6 +235,8 @@ class LocalNoteFolderRepository:
             "membership_limit", membership_limit, minimum=1, maximum=1000
         )
         _validate_int_bound("membership_offset", membership_offset, minimum=0)
+        if not isinstance(load_notes, bool):
+            raise FolderValidationError("load_notes must be a boolean.")
         expanded_ids = _normalize_folder_ids(expanded_folder_ids)
         with self.db.transaction() as cursor:
             if expanded_ids:
@@ -233,13 +257,17 @@ class LocalNoteFolderRepository:
                     "ORDER BY normalized_path, id LIMIT ? OFFSET ?",
                     (*expanded_ids, folder_limit, folder_offset),
                 ).fetchall()
-                note_rows = cursor.execute(
-                    f"SELECT candidate.*, COUNT(*) OVER() AS _total_notes FROM ("
-                    f"{note_candidates_sql}"
-                    ") AS candidate ORDER BY title COLLATE NOCASE, id "
-                    "LIMIT ? OFFSET ?",
-                    (*expanded_ids, note_limit, note_offset),
-                ).fetchall()
+                note_rows = (
+                    cursor.execute(
+                        f"SELECT candidate.*, COUNT(*) OVER() AS _total_notes FROM ("
+                        f"{note_candidates_sql}"
+                        ") AS candidate ORDER BY title COLLATE NOCASE, id "
+                        "LIMIT ? OFFSET ?",
+                        (*expanded_ids, note_limit, note_offset),
+                    ).fetchall()
+                    if load_notes
+                    else ()
+                )
             else:
                 folder_rows = cursor.execute(
                     f"SELECT {_FOLDER_COLUMNS}, COUNT(*) OVER() AS _total_folders "
@@ -247,20 +275,24 @@ class LocalNoteFolderRepository:
                     "ORDER BY normalized_path, id LIMIT ? OFFSET ?",
                     (folder_limit, folder_offset),
                 ).fetchall()
-                note_rows = cursor.execute(
-                    f"SELECT candidate.*, COUNT(*) OVER() AS _total_notes FROM ("
-                    f"SELECT n.{_NOTE_COLUMNS.replace(', ', ', n.')} "
-                    "FROM notes AS n WHERE n.deleted = 0 AND NOT EXISTS ("
-                    "SELECT 1 FROM note_folder_memberships AS m "
-                    "JOIN note_folders AS f "
-                    "ON f.id = m.folder_id AND f.deleted = 0 "
-                    "WHERE m.note_id = n.id AND m.deleted = 0 "
-                    "AND m.owner_active = 1"
-                    ")"
-                    ") AS candidate ORDER BY title COLLATE NOCASE, id "
-                    "LIMIT ? OFFSET ?",
-                    (note_limit, note_offset),
-                ).fetchall()
+                note_rows = (
+                    cursor.execute(
+                        f"SELECT candidate.*, COUNT(*) OVER() AS _total_notes FROM ("
+                        f"SELECT n.{_NOTE_COLUMNS.replace(', ', ', n.')} "
+                        "FROM notes AS n WHERE n.deleted = 0 AND NOT EXISTS ("
+                        "SELECT 1 FROM note_folder_memberships AS m "
+                        "JOIN note_folders AS f "
+                        "ON f.id = m.folder_id AND f.deleted = 0 "
+                        "WHERE m.note_id = n.id AND m.deleted = 0 "
+                        "AND m.owner_active = 1"
+                        ")"
+                        ") AS candidate ORDER BY title COLLATE NOCASE, id "
+                        "LIMIT ? OFFSET ?",
+                        (note_limit, note_offset),
+                    ).fetchall()
+                    if load_notes
+                    else ()
+                )
 
             page_note_ids = tuple(str(row["id"]) for row in note_rows)
             if expanded_ids and page_note_ids:
@@ -436,7 +468,7 @@ class LocalNoteFolderRepository:
     ) -> NoteFolderPage:
         """Load bounded content/path matches plus their complete breadcrumbs."""
         normalized_note_ids = _normalize_ids(note_ids, field="note_ids")
-        if len(normalized_note_ids) > 250:
+        if len(normalized_note_ids) > _TREE_SEARCH_NOTE_LIMIT:
             raise FolderValidationError("note_ids exceeds the allowed range.")
         normalized_folder_query = _normalize_folder_search_query(folder_query)
         if not normalized_note_ids and not normalized_folder_query:
@@ -460,19 +492,19 @@ class LocalNoteFolderRepository:
                     WHERE m.deleted = 0 AND f.deleted = 0 AND n.deleted = 0
                       AND instr(f.normalized_path, ?) > 0
                     ORDER BY m.note_id
-                    LIMIT 251
+                    LIMIT ?
                     """,
-                    (normalized_folder_query,),
+                    (normalized_folder_query, _TREE_SEARCH_NOTE_LIMIT + 1),
                 ).fetchall()
                 path_note_ids = tuple(str(row["note_id"]) for row in path_note_rows)
-                if len(path_note_ids) > 250:
+                if len(path_note_ids) > _TREE_SEARCH_NOTE_LIMIT:
                     raise FolderValidationError(
                         "Folder search has too many notes; narrow the search."
                     )
             selected_note_ids = tuple(
                 sorted({*normalized_note_ids, *path_note_ids})
             )
-            if len(selected_note_ids) > 250:
+            if len(selected_note_ids) > _TREE_SEARCH_NOTE_LIMIT:
                 raise FolderValidationError(
                     "Folder search has too many notes; narrow the search."
                 )
@@ -521,9 +553,9 @@ class LocalNoteFolderRepository:
                 JOIN ancestors ON ancestors.folder_id = note_folders.id
                 WHERE note_folders.deleted = 0
                 ORDER BY note_folders.normalized_path, note_folders.id
-                LIMIT 501
+                LIMIT ?
                 """,
-                tuple(membership_parameters),
+                (*membership_parameters, _TREE_SEARCH_FOLDER_LIMIT + 1),
             ).fetchall()
             membership_rows = cursor.execute(
                 f"""
@@ -533,9 +565,9 @@ class LocalNoteFolderRepository:
                 WHERE m.deleted = 0 AND f.deleted = 0
                   AND ({membership_match})
                 ORDER BY f.normalized_path, m.note_id, m.ownership, m.owner_id, m.id
-                LIMIT 1001
+                LIMIT ?
                 """,
-                tuple(membership_parameters),
+                (*membership_parameters, _TREE_SEARCH_MEMBERSHIP_LIMIT + 1),
             ).fetchall()
             selected_placeholders = _placeholders(len(selected_note_ids))
             note_rows = cursor.execute(
@@ -554,7 +586,10 @@ class LocalNoteFolderRepository:
                 """,
                 selected_note_ids,
             ).fetchall()
-            if len(folder_rows) > 500 or len(membership_rows) > 1000:
+            if (
+                len(folder_rows) > _TREE_SEARCH_FOLDER_LIMIT
+                or len(membership_rows) > _TREE_SEARCH_MEMBERSHIP_LIMIT
+            ):
                 raise FolderValidationError(
                     "Folder search has too many placements; narrow the search."
                 )

--- a/tldw_chatbook/Notes/note_folder_repository.py
+++ b/tldw_chatbook/Notes/note_folder_repository.py
@@ -11,6 +11,7 @@ from typing import NoReturn
 
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError
 from tldw_chatbook.Notes.note_folder_models import (
+    FolderCapabilityError,
     FolderCollisionError,
     FolderConflictError,
     FolderMutationResult,
@@ -81,6 +82,7 @@ class LocalNoteFolderRepository:
                         raise FolderValidationError(
                             "Parent folder does not exist or is inactive."
                         )
+                    _require_manual_folder_subtree(cursor, parent_id)
                     parent_path = str(parent_row["path"])
                     parent_normalized_path = str(parent_row["normalized_path"])
 
@@ -294,6 +296,10 @@ class LocalNoteFolderRepository:
             else:
                 membership_rows = ()
 
+            managed_folder_rows = _load_managed_folder_rows(
+                cursor, (str(row["id"]) for row in folder_rows)
+            )
+
             total_memberships = (
                 int(membership_rows[0]["_total_memberships"])
                 if membership_rows
@@ -366,6 +372,14 @@ class LocalNoteFolderRepository:
         note_end = note_offset + len(notes)
         folder_end = folder_offset + len(folders)
         membership_end = membership_offset + len(memberships)
+        managed_folder_ids = tuple(
+            str(row["folder_id"]) for row in managed_folder_rows
+        )
+        inactive_managed_folder_ids = tuple(
+            str(row["folder_id"])
+            for row in managed_folder_rows
+            if not bool(row["owner_active"])
+        )
         return NoteFolderPage(
             folders=folders,
             memberships=memberships,
@@ -381,6 +395,13 @@ class LocalNoteFolderRepository:
                 membership_end
                 if memberships and membership_end < total_memberships
                 else None
+            ),
+            managed_folder_ids=managed_folder_ids,
+            inactive_managed_folder_ids=inactive_managed_folder_ids,
+            unfiled_note_ids=(
+                tuple(str(row["id"]) for row in note_rows)
+                if not expanded_ids
+                else ()
             ),
         )
 
@@ -408,6 +429,103 @@ class LocalNoteFolderRepository:
             _raise_mutation_operational_error(exc)
         except CharactersRAGDBError as exc:
             _raise_wrapped_repository_error(exc)
+
+    def load_tree_search(self, *, note_ids: Iterable[str]) -> NoteFolderPage:
+        """Load bounded search-note placements plus their complete breadcrumbs."""
+        normalized_note_ids = _normalize_ids(note_ids, field="note_ids")
+        if len(normalized_note_ids) > 250:
+            raise FolderValidationError("note_ids exceeds the allowed range.")
+        if not normalized_note_ids:
+            return NoteFolderPage(
+                folders=(),
+                memberships=(),
+                notes=(),
+                total_folders=0,
+                total_notes=0,
+                next_offset=None,
+            )
+        placeholders = _placeholders(len(normalized_note_ids))
+        with self.db.transaction() as cursor:
+            folder_rows = cursor.execute(
+                f"""
+                WITH RECURSIVE ancestors(folder_id) AS (
+                    SELECT DISTINCT m.folder_id
+                    FROM note_folder_memberships AS m
+                    JOIN note_folders AS f ON f.id = m.folder_id
+                    WHERE m.deleted = 0 AND f.deleted = 0
+                      AND m.note_id IN ({placeholders})
+                    UNION
+                    SELECT f.parent_id
+                    FROM note_folders AS f
+                    JOIN ancestors ON ancestors.folder_id = f.id
+                    WHERE f.parent_id IS NOT NULL AND f.deleted = 0
+                )
+                SELECT {_FOLDER_COLUMNS}
+                FROM note_folders
+                JOIN ancestors ON ancestors.folder_id = note_folders.id
+                WHERE note_folders.deleted = 0
+                ORDER BY note_folders.normalized_path, note_folders.id
+                LIMIT 501
+                """,
+                normalized_note_ids,
+            ).fetchall()
+            membership_rows = cursor.execute(
+                f"""
+                SELECT m.{_MEMBERSHIP_COLUMNS.replace(', ', ', m.')}
+                FROM note_folder_memberships AS m
+                JOIN note_folders AS f ON f.id = m.folder_id
+                WHERE m.deleted = 0 AND f.deleted = 0
+                  AND m.note_id IN ({placeholders})
+                ORDER BY f.normalized_path, m.note_id, m.ownership, m.owner_id, m.id
+                LIMIT 1001
+                """,
+                normalized_note_ids,
+            ).fetchall()
+            note_rows = cursor.execute(
+                f"""
+                SELECT n.{_NOTE_COLUMNS.replace(', ', ', n.')},
+                       NOT EXISTS (
+                           SELECT 1
+                           FROM note_folder_memberships AS m
+                           JOIN note_folders AS f ON f.id = m.folder_id
+                           WHERE m.note_id = n.id AND m.deleted = 0
+                             AND f.deleted = 0 AND m.owner_active = 1
+                       ) AS _unfiled
+                FROM notes AS n
+                WHERE n.deleted = 0 AND n.id IN ({placeholders})
+                ORDER BY n.title COLLATE NOCASE, n.id
+                """,
+                normalized_note_ids,
+            ).fetchall()
+            if len(folder_rows) > 500 or len(membership_rows) > 1000:
+                raise FolderValidationError(
+                    "Folder search has too many placements; narrow the search."
+                )
+            managed_folder_rows = _load_managed_folder_rows(
+                cursor, (str(row["id"]) for row in folder_rows)
+            )
+
+        managed_folder_ids = tuple(
+            str(row["folder_id"]) for row in managed_folder_rows
+        )
+        return NoteFolderPage(
+            folders=tuple(_folder_from_row(row) for row in folder_rows),
+            memberships=tuple(_membership_from_row(row) for row in membership_rows),
+            notes=tuple(_note_from_row(row) for row in note_rows),
+            total_folders=len(folder_rows),
+            total_notes=len(note_rows),
+            next_offset=None,
+            total_memberships=len(membership_rows),
+            managed_folder_ids=managed_folder_ids,
+            inactive_managed_folder_ids=tuple(
+                str(row["folder_id"])
+                for row in managed_folder_rows
+                if not bool(row["owner_active"])
+            ),
+            unfiled_note_ids=tuple(
+                str(row["id"]) for row in note_rows if bool(row["_unfiled"])
+            ),
+        )
 
     def detach_manual(
         self, *, folder_id: str, note_id: str, expected_version: int
@@ -739,6 +857,7 @@ class LocalNoteFolderRepository:
                     expected_version=expected_version,
                     deleted=False,
                 )
+                _require_manual_folder_subtree(cursor, folder_id)
                 subtree = _load_subtree(cursor, target, deleted=False)
                 parent = _load_destination_parent(
                     cursor, parent_id=target["parent_id"]
@@ -813,8 +932,11 @@ class LocalNoteFolderRepository:
                     expected_version=expected_version,
                     deleted=False,
                 )
+                _require_manual_folder_subtree(cursor, folder_id)
                 subtree = _load_subtree(cursor, target, deleted=False)
                 parent = _load_destination_parent(cursor, parent_id=parent_id)
+                if parent_id is not None:
+                    _require_manual_folder_subtree(cursor, parent_id)
                 if parent_id is not None and _has_ancestor(
                     cursor, folder_id=parent_id, ancestor_id=folder_id
                 ):
@@ -884,6 +1006,7 @@ class LocalNoteFolderRepository:
                     expected_version=expected_version,
                     deleted=False,
                 )
+                _require_manual_folder_subtree(cursor, folder_id)
                 subtree = _load_subtree(cursor, target, deleted=False)
                 now = _unique_deleted_folder_timestamp(cursor)
                 for row in subtree:
@@ -1459,6 +1582,70 @@ def _raise_wrapped_repository_error(exc: CharactersRAGDBError) -> NoReturn:
         if current.__context__ is not None:
             pending.append(current.__context__)
     raise exc
+
+
+def _require_manual_folder_subtree(
+    cursor: sqlite3.Cursor, folder_id: str
+) -> None:
+    """Reject direct folder mutations that would alter a sync-owned subtree."""
+    managed = cursor.execute(
+        """
+        WITH RECURSIVE subtree(folder_id) AS (
+            SELECT id FROM note_folders WHERE id = ? AND deleted = 0
+            UNION ALL
+            SELECT child.id
+            FROM note_folders AS child
+            JOIN subtree AS parent ON child.parent_id = parent.folder_id
+            WHERE child.deleted = 0
+        )
+        SELECT 1
+        FROM note_folder_memberships AS membership
+        JOIN subtree ON subtree.folder_id = membership.folder_id
+        WHERE membership.deleted = 0 AND membership.ownership = 'managed'
+        LIMIT 1
+        """,
+        (folder_id,),
+    ).fetchone()
+    if managed is not None:
+        raise FolderCapabilityError(
+            reason_code="sync_managed_folder",
+            user_message=(
+                "This folder is managed by sync; change its sync root instead."
+            ),
+        )
+
+
+def _load_managed_folder_rows(
+    cursor: sqlite3.Cursor, folder_ids: Iterable[str]
+) -> Sequence[sqlite3.Row]:
+    """Return every active managed folder and ancestor with aggregate owner state."""
+    normalized_folder_ids = _normalize_ids(folder_ids, field="folder_ids")
+    if not normalized_folder_ids:
+        return ()
+    placeholders = _placeholders(len(normalized_folder_ids))
+    return cursor.execute(
+        f"""
+        WITH RECURSIVE subtree(target_id, folder_id) AS (
+            SELECT id, id
+            FROM note_folders
+            WHERE deleted = 0 AND id IN ({placeholders})
+            UNION
+            SELECT subtree.target_id, child.id
+            FROM note_folders AS child
+            JOIN subtree ON child.parent_id = subtree.folder_id
+            WHERE child.deleted = 0
+        )
+        SELECT subtree.target_id AS folder_id,
+               MIN(membership.owner_active) AS owner_active
+        FROM subtree
+        JOIN note_folder_memberships AS membership
+          ON membership.folder_id = subtree.folder_id
+        WHERE membership.deleted = 0 AND membership.ownership = 'managed'
+        GROUP BY subtree.target_id
+        ORDER BY subtree.target_id
+        """,
+        normalized_folder_ids,
+    ).fetchall()
 
 
 def _folder_from_row(row: sqlite3.Row) -> NoteFolder:

--- a/tldw_chatbook/Notes/notes_scope_service.py
+++ b/tldw_chatbook/Notes/notes_scope_service.py
@@ -313,6 +313,7 @@ class NotesScopeService:
         *,
         scope: ScopeType | str,
         note_ids: Sequence[str],
+        folder_query: str = "",
         user_id: str | None = None,
     ) -> NoteFolderPage:
         """Load matching placements and ancestors for a bounded note search."""
@@ -322,6 +323,7 @@ class NotesScopeService:
         return await self._run_folder_repository(
             repository.load_tree_search,
             note_ids=tuple(note_ids),
+            folder_query=folder_query,
         )
 
     async def rename_note_folder(

--- a/tldw_chatbook/Notes/notes_scope_service.py
+++ b/tldw_chatbook/Notes/notes_scope_service.py
@@ -308,6 +308,22 @@ class NotesScopeService:
             parent_id=parent_id,
         )
 
+    async def load_note_folder_search(
+        self,
+        *,
+        scope: ScopeType | str,
+        note_ids: Sequence[str],
+        user_id: str | None = None,
+    ) -> NoteFolderPage:
+        """Load matching placements and ancestors for a bounded note search."""
+        repository = self._folder_repository_for_action(
+            scope=scope, user_id=user_id, action="list", operation="list"
+        )
+        return await self._run_folder_repository(
+            repository.load_tree_search,
+            note_ids=tuple(note_ids),
+        )
+
     async def rename_note_folder(
         self,
         *,

--- a/tldw_chatbook/Notes/notes_scope_service.py
+++ b/tldw_chatbook/Notes/notes_scope_service.py
@@ -275,8 +275,29 @@ class NotesScopeService:
         folder_offset: int = 0,
         membership_limit: int = 1000,
         membership_offset: int = 0,
+        load_notes: bool = True,
         user_id: str | None = None,
     ) -> NoteFolderPage:
+        """Load one bounded local folder-tree page off the event loop.
+
+        Args:
+            scope: Note scope to query.
+            expanded_folder_ids: Folders whose immediate contents should load.
+            note_limit: Maximum notes in the page.
+            note_offset: Offset into the note page.
+            folder_limit: Maximum child folders in the page.
+            folder_offset: Offset into the folder page.
+            membership_limit: Maximum memberships in the page.
+            membership_offset: Offset into the membership page.
+            load_notes: Whether to query notes and memberships for this page.
+            user_id: Local database user identifier.
+
+        Returns:
+            The normalized bounded folder-tree page.
+
+        Raises:
+            FolderCapabilityError: If the scope does not support folder listing.
+        """
         repository = self._folder_repository_for_action(
             scope=scope, user_id=user_id, action="list", operation="list"
         )
@@ -289,6 +310,7 @@ class NotesScopeService:
             folder_offset=folder_offset,
             membership_limit=membership_limit,
             membership_offset=membership_offset,
+            load_notes=load_notes,
         )
 
     async def create_note_folder(

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -177,6 +177,11 @@ from ...Library.library_notes_sync_state import (
     sync_conflict_label,
     sync_status_line,
 )
+from ...Library.library_notes_tree_state import (
+    LibraryNotesTreeProjection,
+    build_library_notes_tree,
+    empty_note_folder_page,
+)
 from ...Library.library_prompts_state import (
     PromptBrowseResult,
     PromptBrowseScope,
@@ -2916,6 +2921,12 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_filter: str = ""
         self._library_notes_filter_records: list | None = None
         self._library_notes_notice: str = ""
+        self._library_notes_tree_root_page = None
+        self._library_notes_tree_expanded_page = None
+        self._library_notes_tree_expanded_ids: set[str] = set()
+        self._library_notes_tree_generation: int = 0
+        self._library_notes_tree_loading: bool = False
+        self._library_notes_tree_error: str = ""
         self._library_note_create_counter: int = 0
         self._library_note_create_token: str | None = None
         self._library_note_create_running: bool = False
@@ -5388,6 +5399,11 @@ class LibraryScreen(BaseAppScreen):
                 # paint.
                 self.refresh(recompose=True)
         self._refresh_local_source_snapshot()
+        if (
+            self._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+            and self._library_notes_source == LIBRARY_NOTES_SOURCE_DATABASE
+        ):
+            self._request_library_notes_tree_refresh(refresh_root=True)
         if (
             self._library_selected_row_id
             in (LIBRARY_ROW_BROWSE_PROMPTS, LIBRARY_ROW_CREATE_PROMPT)
@@ -9302,7 +9318,14 @@ class LibraryScreen(BaseAppScreen):
             operation_status=(
                 operation.status_line
                 if operation is not None
-                else self._library_notes_notice
+                else (
+                    getattr(self, "_library_notes_tree_error", "")
+                    or (
+                        "Loading folders…"
+                        if getattr(self, "_library_notes_tree_loading", False)
+                        else self._library_notes_notice
+                    )
+                )
             ),
             operation_running=(
                 bool(operation and operation.running)
@@ -9313,6 +9336,98 @@ class LibraryScreen(BaseAppScreen):
         if self._library_notes_select_mode:
             self._library_notes_row_selection.reconcile(r.note_id for r in state.rows)
         return state
+
+    def _build_library_notes_tree_projection(
+        self,
+    ) -> LibraryNotesTreeProjection | None:
+        """Build the visible tree only after its bounded root batch arrives."""
+        root_page = getattr(self, "_library_notes_tree_root_page", None)
+        if root_page is None and getattr(self, "_library_notes_tree_error", ""):
+            # Degraded hosts used by older/local-only integrations keep the
+            # pre-folder flat browser available with an explicit warning.
+            return None
+        return build_library_notes_tree(
+            root_page=root_page or empty_note_folder_page(),
+            expanded_page=(
+                getattr(self, "_library_notes_tree_expanded_page", None)
+                or empty_note_folder_page()
+            ),
+            expanded_folder_ids=getattr(
+                self, "_library_notes_tree_expanded_ids", set()
+            ),
+            filter_text=self._library_notes_filter,
+        )
+
+    def _request_library_notes_tree_refresh(self, *, refresh_root: bool) -> None:
+        """Start one generation-gated normalized tree load."""
+        self._library_notes_tree_generation += 1
+        generation = self._library_notes_tree_generation
+        self._library_notes_tree_loading = True
+        self._library_notes_tree_error = ""
+        self.run_worker(
+            self._load_library_notes_tree(
+                generation=generation,
+                refresh_root=refresh_root,
+            ),
+            exclusive=True,
+            group="library_notes_folder_tree",
+        )
+
+    async def _load_library_notes_tree(
+        self,
+        *,
+        generation: int,
+        refresh_root: bool,
+    ) -> None:
+        """Load root and expanded branches through bounded bulk service calls."""
+        service = getattr(self.app_instance, "notes_scope_service", None)
+        load_batch = getattr(service, "load_note_folder_tree_batch", None)
+        if not callable(load_batch):
+            if generation == self._library_notes_tree_generation:
+                self._library_notes_tree_loading = False
+                self._library_notes_tree_error = "Folder navigation is unavailable."
+            return
+        call_kwargs = {
+            "scope": "local_note",
+            "note_limit": 250,
+            "folder_limit": 250,
+            "membership_limit": 500,
+            "user_id": self._library_notes_user_id(),
+        }
+        try:
+            root_page = self._library_notes_tree_root_page
+            if refresh_root or root_page is None:
+                root_page = await load_batch(
+                    expanded_folder_ids=(),
+                    **call_kwargs,
+                )
+            expanded_page = empty_note_folder_page()
+            expanded_ids = tuple(sorted(self._library_notes_tree_expanded_ids))
+            if expanded_ids:
+                expanded_page = await load_batch(
+                    expanded_folder_ids=expanded_ids,
+                    **call_kwargs,
+                )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Failed to load the Database Notes folder navigator."
+            )
+            if generation == self._library_notes_tree_generation:
+                self._library_notes_tree_loading = False
+                self._library_notes_tree_error = (
+                    "Could not load note folders — retry from the navigator."
+                )
+                if self.is_mounted:
+                    _sync_library_canvas(self, "notes")
+            return
+        if generation != self._library_notes_tree_generation:
+            return
+        self._library_notes_tree_root_page = root_page
+        self._library_notes_tree_expanded_page = expanded_page
+        self._library_notes_tree_loading = False
+        self._library_notes_tree_error = ""
+        if self.is_mounted:
+            _sync_library_canvas(self, "notes")
 
     def _remove_library_note_source_record(self, note_id: str) -> None:
         """Patch one successful delete into the cached Notes rows and count."""
@@ -9352,6 +9467,7 @@ class LibraryScreen(BaseAppScreen):
             "mode": "list",
             "presentation_state": None,
             "sync_panel_state": None,
+            "tree_projection": self._build_library_notes_tree_projection(),
             "title_placeholder_only": False,
             "compact": self._library_notes_compact,
             "create_running": self._library_note_create_running,
@@ -13474,6 +13590,11 @@ class LibraryScreen(BaseAppScreen):
             # failure must not leak into a later fresh Create entry.
             self._library_note_create_status = ""
         self._library_selected_row_id = row_id
+        if (
+            row_id == LIBRARY_ROW_BROWSE_NOTES
+            and self._library_notes_source == LIBRARY_NOTES_SOURCE_DATABASE
+        ):
+            self._request_library_notes_tree_refresh(refresh_root=True)
         try:
             shell_width = self.query_one("#library-shell-grid").region.width
         except (NoMatches, QueryError):
@@ -24871,6 +24992,20 @@ class LibraryScreen(BaseAppScreen):
         if note_id:
             self._begin_library_note_load(note_id)
         _sync_library_canvas(self, "notes")
+
+    @on(Button.Pressed, ".library-notes-folder-row")
+    def handle_library_notes_folder_row(self, event: Button.Pressed) -> None:
+        """Expand or collapse one real folder through stable folder identity."""
+        event.stop()
+        folder_id = str(getattr(event.button, "folder_id", "") or "")
+        if not folder_id:
+            return
+        if folder_id in self._library_notes_tree_expanded_ids:
+            self._library_notes_tree_expanded_ids.remove(folder_id)
+        else:
+            self._library_notes_tree_expanded_ids.add(folder_id)
+        _sync_library_canvas(self, "notes")
+        self._request_library_notes_tree_refresh(refresh_root=False)
 
     @on(Button.Pressed, "#library-notes-select-toggle")
     async def handle_library_notes_select_toggle(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -9434,9 +9434,7 @@ class LibraryScreen(BaseAppScreen):
             matched_note_ids=(
                 frozenset(
                     note_id
-                    for record in (
-                        getattr(self, "_library_notes_filter_records", None) or ()
-                    )
+                    for record in root_page.notes
                     if (note_id := self._source_record_id(record))
                 )
                 if filter_text.strip() and search_page is not None
@@ -15335,6 +15333,7 @@ class LibraryScreen(BaseAppScreen):
                         for record in filtered_records
                         if (note_id := self._source_record_id(record))
                     ),
+                    folder_query=query,
                     user_id=getattr(self.app_instance, "notes_user_id", None)
                     or "default_user",
                 )
@@ -15343,6 +15342,18 @@ class LibraryScreen(BaseAppScreen):
                 # flat search capability. Keep their loaded tree available
                 # instead of replacing it with an artificial empty page.
                 search_page = None
+            if search_page is not None:
+                seen_note_ids = {
+                    note_id
+                    for record in filtered_records
+                    if (note_id := self._source_record_id(record))
+                }
+                for record in search_page.notes:
+                    note_id = self._source_record_id(record)
+                    if not note_id or note_id in seen_note_ids:
+                        continue
+                    filtered_records.append(record)
+                    seen_note_ids.add(note_id)
         except Exception:
             logger.opt(exception=True).warning("Library notes filter failed.")
             return

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -9512,6 +9512,7 @@ class LibraryScreen(BaseAppScreen):
                     expanded_folder_ids=(),
                     note_offset=root_note_cursor or 0,
                     folder_offset=root_folder_cursor or 0,
+                    load_notes=root_note_cursor is not None,
                     **common,
                 )
                 root_page = merge_note_folder_pages(root_page, incoming)
@@ -9560,6 +9561,10 @@ class LibraryScreen(BaseAppScreen):
                     note_offset=note_offset,
                     folder_offset=expanded_folder_cursor or 0,
                     membership_offset=expanded_membership_cursor or 0,
+                    load_notes=(
+                        continuing_memberships
+                        or expanded_note_cursor is not None
+                    ),
                     **common,
                 )
                 expanded_page = merge_note_folder_pages(expanded_page, incoming)
@@ -25519,7 +25524,11 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-notes-folder-new")
     def handle_library_notes_folder_new(self, event: Button.Pressed) -> None:
-        """Create a root folder or a child of the selected folder."""
+        """Create a root folder or a child of the selected folder.
+
+        Args:
+            event: Press event from the new-folder action button.
+        """
         event.stop()
         selected = self._selected_library_notes_tree_row()
         if selected is not None and selected.kind == "folder" and selected.protected:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -9556,9 +9556,11 @@ class LibraryScreen(BaseAppScreen):
                 )
                 if not continuing_memberships:
                     membership_note_offset = note_offset
-        except Exception:  # noqa: BLE001 - normalized folder service boundary
-            logger.opt(exception=True).warning(
-                "Failed to continue the Database Notes folder navigator."
+        except Exception as exc:  # noqa: BLE001 - normalized service boundary
+            logger.warning(
+                "Failed to continue the Database Notes folder navigator; "
+                "error_type={}",
+                type(exc).__name__,
             )
             if generation == self._library_notes_tree_generation:
                 self._library_notes_tree_error = (
@@ -9612,9 +9614,10 @@ class LibraryScreen(BaseAppScreen):
                     expanded_folder_ids=expanded_ids,
                     **call_kwargs,
                 )
-        except Exception:  # noqa: BLE001 - normalized folder service boundary
-            logger.opt(exception=True).warning(
-                "Failed to load the Database Notes folder navigator."
+        except Exception as exc:  # noqa: BLE001 - normalized service boundary
+            logger.warning(
+                "Failed to load the Database Notes folder navigator; error_type={}",
+                type(exc).__name__,
             )
             if generation == self._library_notes_tree_generation:
                 self._library_notes_tree_loading = False
@@ -9715,10 +9718,11 @@ class LibraryScreen(BaseAppScreen):
                             note_id=note_id,
                             expected_version=int(payload["membership_version"]),
                         )
-                    except Exception:  # noqa: BLE001 - preserve both placements
-                        logger.opt(exception=True).warning(
+                    except Exception as exc:  # noqa: BLE001 - preserve placements
+                        logger.warning(
                             "Database Notes move kept both placements after "
-                            "the source detach failed."
+                            "the source detach failed; error_type={}",
+                            type(exc).__name__,
                         )
                         self._library_notes_notice = (
                             "Note added to the new folder, but the original "
@@ -9777,9 +9781,11 @@ class LibraryScreen(BaseAppScreen):
         except PolicyDeniedError as exc:
             self._library_notes_notice = exc.user_message
             return False
-        except Exception:  # noqa: BLE001 - render a safe mutation failure
-            logger.opt(exception=True).warning(
-                f"Database Notes tree mutation {operation!r} failed."
+        except Exception as exc:  # noqa: BLE001 - render a safe mutation failure
+            logger.warning(
+                "Database Notes tree mutation {!r} failed; error_type={}",
+                operation,
+                type(exc).__name__,
             )
             self._library_notes_notice = (
                 "Could not update folder organization — refresh and try again."

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -178,9 +178,12 @@ from ...Library.library_notes_sync_state import (
     sync_status_line,
 )
 from ...Library.library_notes_tree_state import (
+    LibraryNotesTreeIdentity,
     LibraryNotesTreeProjection,
     build_library_notes_tree,
     empty_note_folder_page,
+    merge_note_folder_pages,
+    reconcile_library_notes_tree_identity,
 )
 from ...Library.library_prompts_state import (
     PromptBrowseResult,
@@ -305,6 +308,13 @@ from ...Local_Ingestion.parakeet_v2_artifact import (
 )
 from ...Local_Ingestion.stt_batch_routing import resolve_batch_stt_route
 from ...Library.row_selection import RowSelection
+from ...Notes.note_folder_models import (
+    FolderCapabilityError,
+    FolderCollisionError,
+    FolderConflictError,
+    FolderPlacementId,
+    FolderValidationError,
+)
 from ...runtime_policy.server_event_scope import event_principal_id_from_active_context
 from ...runtime_policy.types import PolicyDeniedError, RuntimeSourceState
 from ...Skills_Interop.skill_remote_fetch import (
@@ -393,6 +403,10 @@ from ...Widgets.Library import (
 )
 from ...Widgets.Library.library_file_notes_workspace import (
     LibraryFileNotesWorkspace,
+)
+from ...Widgets.Library.library_note_folder_dialog import (
+    LibraryNoteFolderNameDialog,
+    LibraryNoteFolderTargetDialog,
 )
 from ...Widgets.Library.library_notes_canvas import LibraryNotePresentationState
 from ...Widgets.ModelArtifacts import (
@@ -651,6 +665,15 @@ class _LibraryNotesRestoreGuard:
     recompose_generation: int | None = None
     scroll_generation: int | None = None
     focus_generation: int | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class _LibraryNotesDeletedFolderReceipt:
+    """One-session recovery authority for the last removed folder subtree."""
+
+    folder_id: str
+    name: str
+    expected_version: int
 
 
 # PR-3 Task 4: the retrieval outcomes phase two runs on. `ready` is the
@@ -2924,9 +2947,12 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_tree_root_page = None
         self._library_notes_tree_expanded_page = None
         self._library_notes_tree_expanded_ids: set[str] = set()
+        self._library_notes_tree_membership_note_offset: int = 0
         self._library_notes_tree_generation: int = 0
         self._library_notes_tree_loading: bool = False
         self._library_notes_tree_error: str = ""
+        self._library_notes_tree_selected_placement_id: str = ""
+        self._library_notes_deleted_folder_receipt = None
         self._library_note_create_counter: int = 0
         self._library_note_create_token: str | None = None
         self._library_note_create_running: bool = False
@@ -3920,7 +3946,14 @@ class LibraryScreen(BaseAppScreen):
             return f"library-row:{row_id}"
         note_id = str(getattr(focused, "note_id", "") or "")
         if note_id and focused.has_class("library-notes-row"):
+            placement_id = str(getattr(focused, "placement_id", "") or "")
+            if placement_id:
+                return f"note-placement:{placement_id}"
             return f"note-row:{note_id}"
+        if focused.has_class("library-notes-folder-row"):
+            placement_id = str(getattr(focused, "placement_id", "") or "")
+            if placement_id:
+                return f"folder-placement:{placement_id}"
         template_key = str(getattr(focused, "template_key", "") or "")
         if template_key:
             return f"create-template:{template_key}"
@@ -4001,6 +4034,8 @@ class LibraryScreen(BaseAppScreen):
         role = self._library_notes_semantic_role(focused)
         snapshot = self._library_note_session.snapshot
         note_id = snapshot.note_id if snapshot is not None else None
+        if note_id is None and region == "navigator":
+            note_id = str(getattr(focused, "note_id", "") or "") or None
         selection_start: tuple[int, int] | None = None
         selection_end: tuple[int, int] | None = None
         if region in {"editor", "preview", "context"}:
@@ -4136,6 +4171,16 @@ class LibraryScreen(BaseAppScreen):
             row_id = role.removeprefix("library-row:")
             for row in self.query(".library-rail-row"):
                 if str(getattr(row, "row_id", "") or "") == row_id:
+                    return row
+        elif role.startswith("note-placement:"):
+            placement_id = role.removeprefix("note-placement:")
+            for row in self.query(".library-notes-row"):
+                if str(getattr(row, "placement_id", "") or "") == placement_id:
+                    return row
+        elif role.startswith("folder-placement:"):
+            placement_id = role.removeprefix("folder-placement:")
+            for row in self.query(".library-notes-folder-row"):
+                if str(getattr(row, "placement_id", "") or "") == placement_id:
                     return row
         elif role.startswith("note-row:"):
             note_id = role.removeprefix("note-row:")
@@ -9355,7 +9400,7 @@ class LibraryScreen(BaseAppScreen):
             expanded_folder_ids=getattr(
                 self, "_library_notes_tree_expanded_ids", set()
             ),
-            filter_text=self._library_notes_filter,
+            filter_text=getattr(self, "_library_notes_filter", ""),
         )
 
     def _request_library_notes_tree_refresh(self, *, refresh_root: bool) -> None:
@@ -9372,6 +9417,152 @@ class LibraryScreen(BaseAppScreen):
             exclusive=True,
             group="library_notes_folder_tree",
         )
+
+    def _sync_library_notes_tree_canvas_if_present(self) -> None:
+        """Patch a mounted Notes canvas without tearing down a transitioning shell."""
+        if not self.is_mounted:
+            return
+        try:
+            self.query_one("#library-notes-canvas", LibraryNotesCanvas)
+        except (NoMatches, QueryError):
+            return
+        _sync_library_canvas(self, "notes")
+
+    def _request_library_notes_tree_more(self) -> None:
+        """Continue every non-exhausted root/expanded cursor in bounded pages."""
+        if self._library_notes_tree_loading:
+            return
+        self._library_notes_tree_generation += 1
+        generation = self._library_notes_tree_generation
+        self._library_notes_tree_loading = True
+        self.run_worker(
+            self._load_more_library_notes_tree(generation=generation),
+            exclusive=True,
+            group="library_notes_folder_tree",
+        )
+
+    async def _load_more_library_notes_tree(self, *, generation: int) -> None:
+        """Merge the next bounded page for visible root and expanded scopes."""
+        service = getattr(self.app_instance, "notes_scope_service", None)
+        load_batch = getattr(service, "load_note_folder_tree_batch", None)
+        if not callable(load_batch):
+            self._library_notes_tree_loading = False
+            return
+        common = {
+            "scope": "local_note",
+            "note_limit": 250,
+            "folder_limit": 250,
+            "membership_limit": 500,
+            "user_id": self._library_notes_user_id(),
+        }
+        root_page = self._library_notes_tree_root_page
+        expanded_page = self._library_notes_tree_expanded_page
+        membership_note_offset = getattr(
+            self, "_library_notes_tree_membership_note_offset", 0
+        )
+        try:
+            if root_page is not None and any(
+                cursor is not None
+                for cursor in (root_page.next_offset, root_page.next_folder_offset)
+            ):
+                root_note_cursor = root_page.next_offset
+                root_folder_cursor = root_page.next_folder_offset
+                incoming = await load_batch(
+                    expanded_folder_ids=(),
+                    note_offset=root_note_cursor or 0,
+                    folder_offset=root_folder_cursor or 0,
+                    **common,
+                )
+                root_page = merge_note_folder_pages(root_page, incoming)
+                root_page = dataclasses.replace(
+                    root_page,
+                    next_offset=(
+                        root_page.next_offset
+                        if root_note_cursor is not None
+                        else None
+                    ),
+                    next_folder_offset=(
+                        root_page.next_folder_offset
+                        if root_folder_cursor is not None
+                        else None
+                    ),
+                )
+            if expanded_page is not None and any(
+                cursor is not None
+                for cursor in (
+                    expanded_page.next_offset,
+                    expanded_page.next_folder_offset,
+                    expanded_page.next_membership_offset,
+                )
+            ):
+                expanded_note_cursor = expanded_page.next_offset
+                expanded_folder_cursor = expanded_page.next_folder_offset
+                expanded_membership_cursor = (
+                    expanded_page.next_membership_offset
+                )
+                continuing_memberships = (
+                    expanded_membership_cursor is not None
+                )
+                note_offset = (
+                    membership_note_offset
+                    if continuing_memberships
+                    else (
+                        expanded_note_cursor
+                        if expanded_note_cursor is not None
+                        else membership_note_offset
+                    )
+                )
+                incoming = await load_batch(
+                    expanded_folder_ids=tuple(
+                        sorted(self._library_notes_tree_expanded_ids)
+                    ),
+                    note_offset=note_offset,
+                    folder_offset=expanded_folder_cursor or 0,
+                    membership_offset=expanded_membership_cursor or 0,
+                    **common,
+                )
+                expanded_page = merge_note_folder_pages(expanded_page, incoming)
+                expanded_page = dataclasses.replace(
+                    expanded_page,
+                    next_offset=(
+                        expanded_page.next_offset
+                        if expanded_note_cursor is not None
+                        else None
+                    ),
+                    next_folder_offset=(
+                        expanded_page.next_folder_offset
+                        if expanded_folder_cursor is not None
+                        else None
+                    ),
+                    next_membership_offset=(
+                        expanded_page.next_membership_offset
+                        if (
+                            continuing_memberships
+                            or expanded_note_cursor is not None
+                        )
+                        else None
+                    ),
+                )
+                if not continuing_memberships:
+                    membership_note_offset = note_offset
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Failed to continue the Database Notes folder navigator."
+            )
+            if generation == self._library_notes_tree_generation:
+                self._library_notes_tree_error = (
+                    "Could not load more folder contents — try again."
+                )
+                self._library_notes_tree_loading = False
+            return
+        if generation != self._library_notes_tree_generation:
+            return
+        self._library_notes_tree_root_page = root_page
+        self._library_notes_tree_expanded_page = expanded_page
+        self._library_notes_tree_membership_note_offset = membership_note_offset
+        self._library_notes_tree_loading = False
+        self._library_notes_tree_error = ""
+        LibraryScreen._sync_library_notes_tree_canvas_if_present(self)
 
     async def _load_library_notes_tree(
         self,
@@ -9417,17 +9608,229 @@ class LibraryScreen(BaseAppScreen):
                 self._library_notes_tree_error = (
                     "Could not load note folders — retry from the navigator."
                 )
-                if self.is_mounted:
-                    _sync_library_canvas(self, "notes")
+                LibraryScreen._sync_library_notes_tree_canvas_if_present(self)
             return
         if generation != self._library_notes_tree_generation:
             return
+        previous_projection = LibraryScreen._build_library_notes_tree_projection(self)
+        selected_id = getattr(self, "_library_notes_tree_selected_placement_id", "")
+        previous_row = (
+            previous_projection.row(selected_id)
+            if previous_projection is not None and selected_id
+            else None
+        )
         self._library_notes_tree_root_page = root_page
         self._library_notes_tree_expanded_page = expanded_page
+        self._library_notes_tree_membership_note_offset = 0
         self._library_notes_tree_loading = False
         self._library_notes_tree_error = ""
+        if selected_id:
+            reconciled = reconcile_library_notes_tree_identity(
+                LibraryScreen._build_library_notes_tree_projection(self)
+                or LibraryNotesTreeProjection(rows=()),
+                LibraryNotesTreeIdentity(
+                    placement_id=selected_id,
+                    note_id=previous_row.note_id if previous_row is not None else None,
+                ),
+            )
+            self._library_notes_tree_selected_placement_id = (
+                reconciled.placement_id if reconciled is not None else ""
+            )
+        LibraryScreen._sync_library_notes_tree_canvas_if_present(self)
+
+    async def _execute_library_notes_tree_mutation(
+        self,
+        operation: str,
+        **payload: Any,
+    ) -> bool:
+        """Run one guarded normalized folder or placement mutation."""
+        preclaimed = bool(payload.pop("_preclaimed", False))
+        if payload.get("protected"):
+            self._library_notes_notice = (
+                "This item is managed by sync; change its sync root instead."
+            )
+            if preclaimed:
+                self._library_notes_mutation_in_flight = False
+            return False
+        if self._library_notes_mutation_in_flight and not preclaimed:
+            return False
+        service = getattr(self.app_instance, "notes_scope_service", None)
+        methods = {
+            "create_folder": "create_note_folder",
+            "rename_folder": "rename_note_folder",
+            "move_folder": "move_note_folder",
+            "delete_folder": "delete_note_folder",
+            "restore_folder": "restore_note_folder",
+            "add_placement": "attach_note_to_folder",
+            "detach_placement": "detach_note_from_folder",
+        }
+        required_methods = (
+            ("attach_note_to_folder", "detach_note_from_folder")
+            if operation == "move_placement"
+            else (methods.get(operation, ""),)
+        )
+        if not required_methods[0] or any(
+            not callable(getattr(service, method_name, None))
+            for method_name in required_methods
+        ):
+            self._library_notes_notice = "That folder action is unavailable."
+            if preclaimed:
+                self._library_notes_mutation_in_flight = False
+            return False
+
+        common = {
+            "scope": "local_note",
+            "user_id": self._library_notes_user_id(),
+        }
+        self._library_notes_mutation_in_flight = True
+        try:
+            result: Any = None
+            if operation == "move_placement":
+                note_id = str(payload["note_id"])
+                destination_id = str(payload["destination_folder_id"])
+                source_id = str(payload.get("source_folder_id") or "")
+                await service.attach_note_to_folder(
+                    **common,
+                    folder_id=destination_id,
+                    note_id=note_id,
+                )
+                if source_id and source_id != destination_id:
+                    try:
+                        result = await service.detach_note_from_folder(
+                            **common,
+                            folder_id=source_id,
+                            note_id=note_id,
+                            expected_version=int(payload["membership_version"]),
+                        )
+                    except Exception:
+                        logger.opt(exception=True).warning(
+                            "Database Notes move kept both placements after "
+                            "the source detach failed."
+                        )
+                        self._library_notes_notice = (
+                            "Note added to the new folder, but the original "
+                            "changed; it remains safely in both folders."
+                        )
+                        self._request_library_notes_tree_refresh(refresh_root=True)
+                        return True
+                else:
+                    result = True
+            else:
+                method = getattr(service, methods[operation])
+                kwargs = {key: value for key, value in payload.items() if key != "protected"}
+                result = await method(**common, **kwargs)
+
+            if operation == "delete_folder":
+                folder = result.folder
+                self._library_notes_deleted_folder_receipt = (
+                    _LibraryNotesDeletedFolderReceipt(
+                        folder_id=folder.folder_id,
+                        name=folder.name,
+                        expected_version=folder.version,
+                    )
+                )
+                self._library_notes_tree_selected_placement_id = ""
+            elif operation == "restore_folder":
+                self._library_notes_deleted_folder_receipt = None
+                folder = result.folder
+                self._library_notes_tree_selected_placement_id = (
+                    FolderPlacementId.folder(folder.folder_id)
+                )
+            elif operation == "create_folder":
+                self._library_notes_tree_selected_placement_id = (
+                    FolderPlacementId.folder(result.folder_id)
+                )
+            self._library_notes_notice = "Folder organization updated."
+            self._request_library_notes_tree_refresh(refresh_root=True)
+            return True
+        except FolderCollisionError:
+            self._library_notes_notice = (
+                "A folder with that name already exists in this location."
+            )
+            return False
+        except FolderConflictError:
+            self._library_notes_notice = (
+                "That folder changed elsewhere — refresh and try again."
+            )
+            return False
+        except FolderValidationError:
+            self._library_notes_notice = (
+                "That folder name or destination is not valid."
+            )
+            return False
+        except FolderCapabilityError as exc:
+            self._library_notes_notice = exc.user_message
+            return False
+        except PolicyDeniedError as exc:
+            self._library_notes_notice = exc.user_message
+            return False
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"Database Notes tree mutation {operation!r} failed."
+            )
+            self._library_notes_notice = (
+                "Could not update folder organization — refresh and try again."
+            )
+            return False
+        finally:
+            self._library_notes_mutation_in_flight = False
+            LibraryScreen._sync_library_notes_tree_canvas_if_present(self)
+
+    def _schedule_library_notes_tree_mutation(
+        self, operation: str, **payload: Any
+    ) -> None:
+        """Synchronously claim the mutation interlock before starting a worker."""
+        if self._library_notes_mutation_in_flight:
+            return
+        self._library_notes_mutation_in_flight = True
+        self.run_worker(
+            self._execute_library_notes_tree_mutation(
+                operation,
+                _preclaimed=True,
+                **payload,
+            ),
+            exclusive=True,
+            group="library_note_mutation",
+        )
         if self.is_mounted:
             _sync_library_canvas(self, "notes")
+
+    def _selected_library_notes_tree_row(self):
+        """Return the selected visible placement, if it still survives."""
+        projection = self._build_library_notes_tree_projection()
+        if projection is None:
+            return None
+        return projection.row(self._library_notes_tree_selected_placement_id)
+
+    def _library_notes_folder_target_options(
+        self, *, exclude_folder_id: str | None = None
+    ) -> tuple[tuple[str, str], ...]:
+        """Return bounded loaded folder choices, excluding a moved subtree."""
+        pages = (
+            self._library_notes_tree_root_page,
+            self._library_notes_tree_expanded_page,
+        )
+        folders = {
+            folder.folder_id: folder
+            for page in pages
+            if page is not None
+            for folder in page.folders
+        }
+        excluded_path = (
+            folders[exclude_folder_id].normalized_path
+            if exclude_folder_id in folders
+            else ""
+        )
+        choices = [
+            (folder.path.strip("/").replace("/", " / "), folder.folder_id)
+            for folder in folders.values()
+            if folder.folder_id != exclude_folder_id
+            and not (
+                excluded_path
+                and folder.normalized_path.startswith(f"{excluded_path}/")
+            )
+        ]
+        return tuple(sorted(choices, key=lambda item: (item[0].casefold(), item[1])))
 
     def _remove_library_note_source_record(self, note_id: str) -> None:
         """Patch one successful delete into the cached Notes rows and count."""
@@ -9468,6 +9871,13 @@ class LibraryScreen(BaseAppScreen):
             "presentation_state": None,
             "sync_panel_state": None,
             "tree_projection": self._build_library_notes_tree_projection(),
+            "tree_selected_placement_id": getattr(
+                self, "_library_notes_tree_selected_placement_id", ""
+            ),
+            "tree_deleted_folder_available": (
+                getattr(self, "_library_notes_deleted_folder_receipt", None)
+                is not None
+            ),
             "title_placeholder_only": False,
             "compact": self._library_notes_compact,
             "create_running": self._library_note_create_running,
@@ -24975,6 +25385,9 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         if self._library_notes_mutation_in_flight:
             return
+        self._library_notes_tree_selected_placement_id = str(
+            getattr(event.button, "placement_id", "") or ""
+        )
         note_flush = await self._flush_library_note_save()
         if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
@@ -25000,12 +25413,227 @@ class LibraryScreen(BaseAppScreen):
         folder_id = str(getattr(event.button, "folder_id", "") or "")
         if not folder_id:
             return
+        self._library_notes_tree_selected_placement_id = str(
+            getattr(event.button, "placement_id", "") or ""
+        )
         if folder_id in self._library_notes_tree_expanded_ids:
             self._library_notes_tree_expanded_ids.remove(folder_id)
         else:
             self._library_notes_tree_expanded_ids.add(folder_id)
         _sync_library_canvas(self, "notes")
         self._request_library_notes_tree_refresh(refresh_root=False)
+
+    @on(Button.Pressed, "#library-notes-tree-more")
+    def handle_library_notes_tree_more(self, event: Button.Pressed) -> None:
+        """Continue bounded folder, note, and membership cursors."""
+        event.stop()
+        self._request_library_notes_tree_more()
+
+    @on(Button.Pressed, "#library-notes-folder-new")
+    def handle_library_notes_folder_new(self, event: Button.Pressed) -> None:
+        """Create a root folder or a child of the selected folder."""
+        event.stop()
+        selected = self._selected_library_notes_tree_row()
+        if selected is not None and selected.kind == "folder" and selected.protected:
+            self._library_notes_notice = (
+                "This folder is managed by sync; change its sync root instead."
+            )
+            _sync_library_canvas(self, "notes")
+            return
+        parent_id = (
+            selected.folder_id
+            if selected is not None and selected.kind == "folder"
+            else None
+        )
+        self.app.push_screen(
+            LibraryNoteFolderNameDialog(title="New folder"),
+            lambda name: (
+                self._schedule_library_notes_tree_mutation(
+                    "create_folder", name=name, parent_id=parent_id
+                )
+                if name
+                else None
+            ),
+        )
+
+    @on(Button.Pressed, "#library-notes-folder-rename")
+    def handle_library_notes_folder_rename(self, event: Button.Pressed) -> None:
+        """Rename the selected manual folder with optimistic locking."""
+        event.stop()
+        selected = self._selected_library_notes_tree_row()
+        if (
+            selected is None
+            or selected.kind != "folder"
+            or selected.version is None
+            or selected.protected
+        ):
+            return
+        self.app.push_screen(
+            LibraryNoteFolderNameDialog(
+                title="Rename folder", initial_name=selected.label
+            ),
+            lambda name: (
+                self._schedule_library_notes_tree_mutation(
+                    "rename_folder",
+                    folder_id=selected.folder_id,
+                    name=name,
+                    expected_version=selected.version,
+                    protected=selected.protected,
+                )
+                if name
+                else None
+            ),
+        )
+
+    @on(Button.Pressed, "#library-notes-folder-move")
+    def handle_library_notes_folder_move(self, event: Button.Pressed) -> None:
+        """Move the selected folder beneath another loaded folder or root."""
+        event.stop()
+        selected = self._selected_library_notes_tree_row()
+        if (
+            selected is None
+            or selected.kind != "folder"
+            or selected.version is None
+            or selected.protected
+        ):
+            return
+        self.app.push_screen(
+            LibraryNoteFolderTargetDialog(
+                title=f"Move {selected.label}",
+                folders=self._library_notes_folder_target_options(
+                    exclude_folder_id=selected.folder_id
+                ),
+                include_root=True,
+            ),
+            lambda target_id: (
+                self._schedule_library_notes_tree_mutation(
+                    "move_folder",
+                    folder_id=selected.folder_id,
+                    parent_id=target_id or None,
+                    expected_version=selected.version,
+                    protected=selected.protected,
+                )
+                if target_id is not None
+                else None
+            ),
+        )
+
+    @on(Button.Pressed, "#library-notes-folder-remove")
+    def handle_library_notes_folder_remove(self, event: Button.Pressed) -> None:
+        """Require confirmation before removing a folder subtree organization."""
+        event.stop()
+        selected = self._selected_library_notes_tree_row()
+        if (
+            selected is None
+            or selected.kind != "folder"
+            or selected.version is None
+            or selected.protected
+        ):
+            return
+        modal = ConfirmationDialog(
+            title="Remove folder organization?",
+            message=(
+                f"Remove {selected.label} and its nested folder organization? "
+                "Notes are not deleted; they remain in other folders or Unfiled."
+            ),
+            confirm_label="Remove folder",
+            cancel_label="Cancel",
+        )
+        self.app.push_screen(
+            modal,
+            lambda confirmed: (
+                self._schedule_library_notes_tree_mutation(
+                    "delete_folder",
+                    folder_id=selected.folder_id,
+                    expected_version=selected.version,
+                    protected=selected.protected,
+                )
+                if confirmed
+                else None
+            ),
+        )
+
+    @on(Button.Pressed, "#library-notes-folder-restore")
+    def handle_library_notes_folder_restore(self, event: Button.Pressed) -> None:
+        """Restore the exact last removed folder subtree."""
+        event.stop()
+        receipt = self._library_notes_deleted_folder_receipt
+        if receipt is None:
+            return
+        self._schedule_library_notes_tree_mutation(
+            "restore_folder",
+            folder_id=receipt.folder_id,
+            expected_version=receipt.expected_version,
+        )
+
+    def _choose_library_notes_placement_target(self, *, move: bool) -> None:
+        """Open a destination picker for adding or moving one note placement."""
+        selected = self._selected_library_notes_tree_row()
+        if selected is None or selected.kind != "note" or not selected.note_id:
+            return
+        if move and selected.protected:
+            self._library_notes_notice = (
+                "This placement is managed by sync; change its sync root instead."
+            )
+            _sync_library_canvas(self, "notes")
+            return
+        self.app.push_screen(
+            LibraryNoteFolderTargetDialog(
+                title="Move note" if move else "Add note to folder",
+                folders=self._library_notes_folder_target_options(),
+            ),
+            lambda target_id: (
+                self._schedule_library_notes_tree_mutation(
+                    "move_placement" if move else "add_placement",
+                    **(
+                        {
+                            "note_id": selected.note_id,
+                            "destination_folder_id": target_id,
+                            "source_folder_id": selected.folder_id,
+                            "membership_version": selected.version,
+                            "protected": selected.protected,
+                        }
+                        if move
+                        else {
+                            "folder_id": target_id,
+                            "note_id": selected.note_id,
+                        }
+                    ),
+                )
+                if target_id is not None
+                else None
+            ),
+        )
+
+    @on(Button.Pressed, "#library-notes-placement-add")
+    def handle_library_notes_placement_add(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._choose_library_notes_placement_target(move=False)
+
+    @on(Button.Pressed, "#library-notes-placement-move")
+    def handle_library_notes_placement_move(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._choose_library_notes_placement_target(move=True)
+
+    @on(Button.Pressed, "#library-notes-placement-remove")
+    def handle_library_notes_placement_remove(self, event: Button.Pressed) -> None:
+        """Detach one manual placement without deleting the note."""
+        event.stop()
+        selected = self._selected_library_notes_tree_row()
+        if (
+            selected is None
+            or selected.kind != "note"
+            or not selected.folder_id
+            or selected.version is None
+        ):
+            return
+        self._schedule_library_notes_tree_mutation(
+            "detach_placement",
+            folder_id=selected.folder_id,
+            note_id=selected.note_id,
+            expected_version=selected.version,
+            protected=selected.protected,
+        )
 
     @on(Button.Pressed, "#library-notes-select-toggle")
     async def handle_library_notes_select_toggle(self, event: Button.Pressed) -> None:
@@ -25107,11 +25735,16 @@ class LibraryScreen(BaseAppScreen):
         if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return False
         navigation_generation = self._supersede_library_notes_navigation()
+        placement_id = self._library_notes_tree_selected_placement_id
         identity = LibraryNotesFocusIdentity(
             stage="notes",
             region="navigator",
             note_id=note_id or None,
-            semantic_role=f"note-row:{note_id}" if note_id else "filter",
+            semantic_role=(
+                f"note-placement:{placement_id}"
+                if note_id and placement_id
+                else (f"note-row:{note_id}" if note_id else "filter")
+            ),
         )
         self._library_notes_pending_focus_identity = identity
         self._library_notes_pending_focus_waits_for_snapshot = True

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1321,9 +1321,18 @@ def _apply_library_row_toggle(
         # (PR #665 review; same escape lesson as the Library redesign). A
         # missing stash (unexpected widget shape) raises into the fallback
         # full recompose below.
-        label_rest = button._library_row_label_rest
         glyph = f"{marker} " if kind == "notes" else marker
-        button.label = f"{glyph}{label_rest}"
+        if kind == "notes":
+            matching_buttons = tuple(
+                candidate
+                for candidate in screen.query(".library-notes-row")
+                if str(getattr(candidate, "note_id", "") or "") == row_id
+            )
+        else:
+            matching_buttons = (button,)
+        for matching_button in matching_buttons:
+            label_rest = matching_button._library_row_label_rest
+            matching_button.label = f"{glyph}{label_rest}"
         count_static.update(f"{selection.count} selected")
         export_button.disabled = selection.count == 0
         # F-018: the reason/action tooltip flips in place with `disabled`
@@ -9447,6 +9456,8 @@ class LibraryScreen(BaseAppScreen):
         load_batch = getattr(service, "load_note_folder_tree_batch", None)
         if not callable(load_batch):
             self._library_notes_tree_loading = False
+            self._library_notes_tree_error = "Folder navigation is unavailable."
+            LibraryScreen._sync_library_notes_tree_canvas_if_present(self)
             return
         common = {
             "scope": "local_note",
@@ -9545,7 +9556,7 @@ class LibraryScreen(BaseAppScreen):
                 )
                 if not continuing_memberships:
                     membership_note_offset = note_offset
-        except Exception:
+        except Exception:  # noqa: BLE001 - normalized folder service boundary
             logger.opt(exception=True).warning(
                 "Failed to continue the Database Notes folder navigator."
             )
@@ -9554,6 +9565,7 @@ class LibraryScreen(BaseAppScreen):
                     "Could not load more folder contents — try again."
                 )
                 self._library_notes_tree_loading = False
+                LibraryScreen._sync_library_notes_tree_canvas_if_present(self)
             return
         if generation != self._library_notes_tree_generation:
             return
@@ -9577,6 +9589,7 @@ class LibraryScreen(BaseAppScreen):
             if generation == self._library_notes_tree_generation:
                 self._library_notes_tree_loading = False
                 self._library_notes_tree_error = "Folder navigation is unavailable."
+                LibraryScreen._sync_library_notes_tree_canvas_if_present(self)
             return
         call_kwargs = {
             "scope": "local_note",
@@ -9599,7 +9612,7 @@ class LibraryScreen(BaseAppScreen):
                     expanded_folder_ids=expanded_ids,
                     **call_kwargs,
                 )
-        except Exception:
+        except Exception:  # noqa: BLE001 - normalized folder service boundary
             logger.opt(exception=True).warning(
                 "Failed to load the Database Notes folder navigator."
             )
@@ -9702,7 +9715,7 @@ class LibraryScreen(BaseAppScreen):
                             note_id=note_id,
                             expected_version=int(payload["membership_version"]),
                         )
-                    except Exception:
+                    except Exception:  # noqa: BLE001 - preserve both placements
                         logger.opt(exception=True).warning(
                             "Database Notes move kept both placements after "
                             "the source detach failed."
@@ -9764,7 +9777,7 @@ class LibraryScreen(BaseAppScreen):
         except PolicyDeniedError as exc:
             self._library_notes_notice = exc.user_message
             return False
-        except Exception:
+        except Exception:  # noqa: BLE001 - render a safe mutation failure
             logger.opt(exception=True).warning(
                 f"Database Notes tree mutation {operation!r} failed."
             )
@@ -25668,8 +25681,18 @@ class LibraryScreen(BaseAppScreen):
         Rebuilds only the mounted Notes canvas.
         """
         event.stop()
-        rows = self._build_library_notes_state().rows
-        self._library_notes_row_selection.select_all(r.note_id for r in rows)
+        projection = self._build_library_notes_tree_projection()
+        if projection is None:
+            note_ids = (
+                row.note_id for row in self._build_library_notes_state().rows
+            )
+        else:
+            note_ids = (
+                row.note_id
+                for row in projection.rows
+                if row.kind == "note" and row.note_id
+            )
+        self._library_notes_row_selection.select_all(note_ids)
         _sync_library_canvas(self, "notes")
 
     @on(Button.Pressed, "#library-notes-select-clear")

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -314,6 +314,7 @@ from ...Notes.note_folder_models import (
     FolderConflictError,
     FolderPlacementId,
     FolderValidationError,
+    NoteFolderPage,
 )
 from ...runtime_policy.server_event_scope import event_principal_id_from_active_context
 from ...runtime_policy.types import PolicyDeniedError, RuntimeSourceState
@@ -2952,6 +2953,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_sort_choices_visible: bool = False
         self._library_notes_filter: str = ""
         self._library_notes_filter_records: list | None = None
+        self._library_notes_tree_search_page: NoteFolderPage | None = None
         self._library_notes_notice: str = ""
         self._library_notes_tree_root_page = None
         self._library_notes_tree_expanded_page = None
@@ -9388,14 +9390,29 @@ class LibraryScreen(BaseAppScreen):
             delete_receipt=self._library_note_delete_receipt,
         )
         if self._library_notes_select_mode:
-            self._library_notes_row_selection.reconcile(r.note_id for r in state.rows)
+            projection = self._build_library_notes_tree_projection()
+            if projection is None:
+                visible_note_ids = (row.note_id for row in state.rows)
+            else:
+                visible_note_ids = (
+                    row.note_id
+                    for row in projection.rows
+                    if row.kind == "note" and row.note_id
+                )
+            self._library_notes_row_selection.reconcile(visible_note_ids)
         return state
 
     def _build_library_notes_tree_projection(
         self,
     ) -> LibraryNotesTreeProjection | None:
         """Build the visible tree only after its bounded root batch arrives."""
-        root_page = getattr(self, "_library_notes_tree_root_page", None)
+        filter_text = getattr(self, "_library_notes_filter", "")
+        search_page = getattr(self, "_library_notes_tree_search_page", None)
+        root_page = (
+            search_page
+            if filter_text.strip() and search_page is not None
+            else getattr(self, "_library_notes_tree_root_page", None)
+        )
         if root_page is None and getattr(self, "_library_notes_tree_error", ""):
             # Degraded hosts used by older/local-only integrations keep the
             # pre-folder flat browser available with an explicit warning.
@@ -9403,13 +9420,28 @@ class LibraryScreen(BaseAppScreen):
         return build_library_notes_tree(
             root_page=root_page or empty_note_folder_page(),
             expanded_page=(
-                getattr(self, "_library_notes_tree_expanded_page", None)
-                or empty_note_folder_page()
+                search_page
+                if filter_text.strip() and search_page is not None
+                else (
+                    getattr(self, "_library_notes_tree_expanded_page", None)
+                    or empty_note_folder_page()
+                )
             ),
             expanded_folder_ids=getattr(
                 self, "_library_notes_tree_expanded_ids", set()
             ),
-            filter_text=getattr(self, "_library_notes_filter", ""),
+            filter_text=filter_text,
+            matched_note_ids=(
+                frozenset(
+                    note_id
+                    for record in (
+                        getattr(self, "_library_notes_filter_records", None) or ()
+                    )
+                    if (note_id := self._source_record_id(record))
+                )
+                if filter_text.strip() and search_page is not None
+                else None
+            ),
         )
 
     def _request_library_notes_tree_refresh(self, *, refresh_root: bool) -> None:
@@ -14062,6 +14094,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_content_mode = "raw"
         self._library_notes_filter = ""
         self._library_notes_filter_records = None
+        self._library_notes_tree_search_page = None
         self._reset_library_note_editor_state()
         self._reset_library_prompt_editor_state()
         self._reset_library_skills_import_state()
@@ -15228,6 +15261,7 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         self._library_notes_filter = ""
         self._library_notes_filter_records = None
+        self._library_notes_tree_search_page = None
         self._library_notes_sort_choices_visible = False
         self._library_notes_select_mode = False
         self._library_notes_row_selection.clear()
@@ -15245,10 +15279,13 @@ class LibraryScreen(BaseAppScreen):
         if submitted == self._library_notes_filter:
             return
         self._library_notes_filter = submitted
+        self._library_notes_filter_records = None
+        self._library_notes_tree_search_page = None
         self._library_notes_select_mode = False
         self._library_notes_row_selection.clear()
         if not submitted:
             self._library_notes_filter_records = None
+            self._library_notes_tree_search_page = None
             _sync_library_canvas(self, "notes")
             return
         self.run_worker(
@@ -15286,12 +15323,33 @@ class LibraryScreen(BaseAppScreen):
                 or "default_user",
                 isolate_in_worker=True,
             )
+            if query != self._library_notes_filter:
+                return
+            filtered_records = list(records or [])
+            load_search = getattr(service, "load_note_folder_search", None)
+            if callable(load_search):
+                search_page = await load_search(
+                    scope="local_note",
+                    note_ids=tuple(
+                        note_id
+                        for record in filtered_records
+                        if (note_id := self._source_record_id(record))
+                    ),
+                    user_id=getattr(self.app_instance, "notes_user_id", None)
+                    or "default_user",
+                )
+            else:
+                # Older/local integrations can still provide the original
+                # flat search capability. Keep their loaded tree available
+                # instead of replacing it with an artificial empty page.
+                search_page = None
         except Exception:
             logger.opt(exception=True).warning("Library notes filter failed.")
             return
         if query != self._library_notes_filter:
             return
-        self._library_notes_filter_records = list(records or [])
+        self._library_notes_filter_records = filtered_records
+        self._library_notes_tree_search_page = search_page
         _sync_library_canvas(self, "notes", then=self._focus_library_notes_filter_input)
 
     def _focus_library_notes_filter_input(self) -> None:
@@ -26110,6 +26168,7 @@ class LibraryScreen(BaseAppScreen):
         # rendering as a ghost row until the filter box is resubmitted.
         self._library_notes_filter = ""
         self._library_notes_filter_records = None
+        self._library_notes_tree_search_page = None
         if self.is_mounted:
             self.refresh(recompose=True)
 
@@ -26539,6 +26598,7 @@ class LibraryScreen(BaseAppScreen):
                 self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
                 self._library_notes_filter = ""
                 self._library_notes_filter_records = None
+                self._library_notes_tree_search_page = None
             if self.is_mounted:
                 self.refresh(recompose=True)
             return LibraryNoteCreateOutcome("created_not_opened", created_id)
@@ -26547,6 +26607,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
         self._library_notes_filter = ""
         self._library_notes_filter_records = None
+        self._library_notes_tree_search_page = None
         self._selected_note_id = created_id
         self._library_notes_view = "editor"
         self._library_note_load_state = "loaded"
@@ -26655,6 +26716,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
         self._library_notes_filter = ""
         self._library_notes_filter_records = None
+        self._library_notes_tree_search_page = None
         self._remove_library_note_source_record(admission.note_id)
         if self.is_mounted:
             self.refresh(recompose=True)

--- a/tldw_chatbook/Widgets/Library/library_note_folder_dialog.py
+++ b/tldw_chatbook/Widgets/Library/library_note_folder_dialog.py
@@ -1,0 +1,142 @@
+"""Small keyboard-first dialogs for Database Note folder mutations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from textual import on
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Select, Static
+
+
+class LibraryNoteFolderNameDialog(ModalScreen[str | None]):
+    """Collect a validated-by-service folder name without transforming it."""
+
+    BINDINGS = (Binding("escape", "cancel", "Cancel", show=False),)
+    AUTO_FOCUS = "#library-note-folder-name"
+
+    DEFAULT_CSS = """
+    LibraryNoteFolderNameDialog { align: center middle; }
+    LibraryNoteFolderNameDialog > Vertical {
+        width: 56; height: auto; padding: 1 2;
+        border: tall $accent; background: $surface;
+    }
+    #library-note-folder-dialog-actions { height: auto; align-horizontal: right; }
+    """
+
+    def __init__(self, *, title: str, initial_name: str = "") -> None:
+        super().__init__()
+        self._title = title
+        self._initial_name = initial_name
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static(
+                self._title,
+                id="library-note-folder-dialog-title",
+                classes="destination-section",
+            )
+            yield Input(
+                value=self._initial_name,
+                placeholder="Folder name",
+                id="library-note-folder-name",
+            )
+            with Horizontal(id="library-note-folder-dialog-actions"):
+                yield Button("Cancel", id="library-note-folder-dialog-cancel")
+                yield Button(
+                    "Save", id="library-note-folder-dialog-confirm", variant="primary"
+                )
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def _submit(self) -> None:
+        value = self.query_one("#library-note-folder-name", Input).value.strip()
+        if value:
+            self.dismiss(value)
+
+    @on(Button.Pressed, "#library-note-folder-dialog-cancel")
+    def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#library-note-folder-dialog-confirm")
+    def _confirm(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._submit()
+
+    @on(Input.Submitted, "#library-note-folder-name")
+    def _name_submitted(self, event: Input.Submitted) -> None:
+        event.stop()
+        self._submit()
+
+
+class LibraryNoteFolderTargetDialog(ModalScreen[str | None]):
+    """Choose one bounded, already-loaded folder destination."""
+
+    BINDINGS = (Binding("escape", "cancel", "Cancel", show=False),)
+    AUTO_FOCUS = "#library-note-folder-target"
+
+    DEFAULT_CSS = """
+    LibraryNoteFolderTargetDialog { align: center middle; }
+    LibraryNoteFolderTargetDialog > Vertical {
+        width: 64; height: auto; padding: 1 2;
+        border: tall $accent; background: $surface;
+    }
+    #library-note-folder-target-actions { height: auto; align-horizontal: right; }
+    """
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        folders: Sequence[tuple[str, str]],
+        include_root: bool = False,
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._folders = tuple(folders)
+        self._include_root = include_root
+
+    def compose(self) -> ComposeResult:
+        options = list(self._folders)
+        if self._include_root:
+            options.insert(0, ("Top level", ""))
+        with Vertical():
+            yield Static(
+                self._title,
+                id="library-note-folder-target-title",
+                classes="destination-section",
+            )
+            yield Select(
+                options,
+                value="" if self._include_root else Select.BLANK,
+                allow_blank=not self._include_root,
+                id="library-note-folder-target",
+            )
+            with Horizontal(id="library-note-folder-target-actions"):
+                yield Button("Cancel", id="library-note-folder-target-cancel")
+                yield Button(
+                    "Choose", id="library-note-folder-target-confirm", variant="primary"
+                )
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def _submit(self) -> None:
+        value = self.query_one("#library-note-folder-target", Select).value
+        if value is not Select.BLANK:
+            self.dismiss(str(value))
+
+    @on(Button.Pressed, "#library-note-folder-target-cancel")
+    def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#library-note-folder-target-confirm")
+    def _confirm(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._submit()

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -17,22 +17,26 @@ from tldw_chatbook.Library.library_notes_state import (
     build_library_note_template_rows,
     ellipsize_note_title_cells,
 )
-from tldw_chatbook.Library.library_shell_state import (
-    LIBRARY_EXPORT_SELECTED_DISABLED_TOOLTIP,
-    LIBRARY_EXPORT_SELECTED_TOOLTIP,
-    LIBRARY_SELECT_TOGGLE_DISABLED_TOOLTIP,
-    library_disabled_action_label,
-)
 from tldw_chatbook.Library.library_notes_sync_state import (
     LibraryNotesSyncState,
     auto_sync_label,
     sync_conflict_label,
     sync_direction_label,
 )
+from tldw_chatbook.Library.library_notes_tree_state import (
+    LibraryNotesTreeProjection,
+    LibraryNotesTreeRow,
+)
+from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_EXPORT_SELECTED_DISABLED_TOOLTIP,
+    LIBRARY_EXPORT_SELECTED_TOOLTIP,
+    LIBRARY_SELECT_TOGGLE_DISABLED_TOOLTIP,
+    library_disabled_action_label,
+)
+from tldw_chatbook.Widgets.Library.library_canvas_sync import PostRecomposeCallback
 from tldw_chatbook.Widgets.Library.library_choice_strip import (
     compose_library_choice_strip,
 )
-from tldw_chatbook.Widgets.Library.library_canvas_sync import PostRecomposeCallback
 from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 
 _SORT_LABELS = {"newest": "Newest", "oldest": "Oldest", "title": "Title"}
@@ -123,6 +127,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         mode: str = "list",
         presentation_state: LibraryNotePresentationState | None = None,
         sync_panel_state: LibraryNotesSyncState | None = None,
+        tree_projection: LibraryNotesTreeProjection | None = None,
         title_placeholder_only: bool = False,
         compact: bool = False,
         create_running: bool = False,
@@ -141,6 +146,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 or sync.
             presentation_state: Canonical editor snapshot and UI-only flags.
             sync_panel_state: Display state for the sync surface.
+            tree_projection: Placement-aware folder rows for list mode.
             title_placeholder_only: Render an empty title with an Untitled
                 placeholder for a pristine newly-created note.
             compact: Whether 60-column-safe controls and labels are active.
@@ -157,6 +163,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         self.mode = mode
         self.presentation_state = presentation_state
         self.sync_panel_state = sync_panel_state
+        self.tree_projection = tree_projection
         self.title_placeholder_only = title_placeholder_only
         self.compact = compact
         self.create_running = create_running
@@ -207,6 +214,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         mode: str,
         presentation_state: LibraryNotePresentationState | None,
         sync_panel_state: LibraryNotesSyncState | None,
+        tree_projection: LibraryNotesTreeProjection | None,
         title_placeholder_only: bool,
         compact: bool,
         create_running: bool,
@@ -229,6 +237,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             mode: Canvas surface to render.
             presentation_state: Note editor/create presentation snapshot.
             sync_panel_state: Notes folder-sync panel snapshot.
+            tree_projection: Placement-aware folder rows for list mode.
             title_placeholder_only: Whether the title is placeholder-only.
             compact: Whether compact editor controls are enabled.
             create_running: Whether note creation is in progress.
@@ -243,6 +252,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         self.mode = mode
         self.presentation_state = presentation_state
         self.sync_panel_state = sync_panel_state
+        self.tree_projection = tree_projection
         self.title_placeholder_only = title_placeholder_only
         self.compact = compact
         self.create_running = create_running
@@ -319,7 +329,16 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         # Gate/label off the RENDERED rows, not any total-count field -- only
         # rendered rows are selectable, matching the media/conversations
         # canvases' ``len(rows)`` convention.
-        rendered_count = len(list_state.rows)
+        rendered_note_ids = (
+            {
+                row.note_id
+                for row in self.tree_projection.rows
+                if row.kind == "note" and row.note_id
+            }
+            if self.tree_projection is not None
+            else {row.note_id for row in list_state.rows}
+        )
+        rendered_count = len(rendered_note_ids)
         if select_mode:
             action_row = Horizontal(
                 id="library-notes-selection-actions", classes="ds-toolbar"
@@ -511,6 +530,9 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                     compact=True,
                     disabled=list_state.operation_running,
                 )
+        if self.tree_projection is not None:
+            yield from self._compose_tree_rows(list_state)
+            return
         if not list_state.rows:
             yield Static(list_state.empty_copy, id="library-notes-empty", markup=False)
             return
@@ -548,6 +570,81 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 # user titles).
                 button._library_row_label_rest = label_rest
                 yield button
+
+    def _compose_tree_rows(self, list_state: LibraryNotesListState) -> ComposeResult:
+        """Render placement-aware rows while retaining legacy note handlers."""
+        projection = self.tree_projection
+        if projection is None:
+            return
+        if not projection.rows:
+            yield Static(
+                list_state.empty_copy,
+                id="library-notes-empty",
+                markup=False,
+            )
+            return
+        checked_ids = {row.note_id for row in list_state.rows if row.checked}
+        with Vertical(id="library-notes-list", classes="library-notes-tree"):
+            for index, row in enumerate(projection.rows):
+                indent = "  " * row.depth
+                if row.kind in {"folder", "unfiled"}:
+                    glyph = "▾" if row.expanded else "▸"
+                    button = Button(
+                        f"{indent}{glyph} {escape_markup(row.label)}",
+                        id=f"library-notes-tree-folder-{index}",
+                        classes="library-notes-folder-row",
+                        compact=True,
+                    )
+                    self._set_tree_row_metadata(button, row)
+                    yield button
+                    continue
+
+                title = f"{indent}{escape_markup(row.label)}"
+                if row.status_text:
+                    title = f"{title}  {row.status_text}"
+                if list_state.select_mode:
+                    marker = "☑ " if row.note_id in checked_ids else "☐ "
+                    label_rest = title
+                    label = f"{marker}{label_rest}"
+                else:
+                    label_rest = title
+                    label = label_rest
+                classes = "library-notes-row library-notes-tree-note-row"
+                if row.semantic_status == "connected":
+                    classes += " library-notes-tree-connected"
+                elif row.semantic_status == "needs_attention":
+                    classes += " library-notes-tree-needs-attention"
+                button = Button(
+                    label,
+                    id=f"library-notes-tree-note-{index}",
+                    classes=classes,
+                    compact=True,
+                    tooltip=row.breadcrumb,
+                )
+                self._set_tree_row_metadata(button, row)
+                button._library_row_label_rest = label_rest
+                yield button
+        if projection.has_more:
+            yield Button(
+                "Load more folder contents",
+                id="library-notes-tree-more",
+                classes="library-canvas-action",
+                compact=True,
+            )
+
+    @staticmethod
+    def _set_tree_row_metadata(button: Button, row: LibraryNotesTreeRow) -> None:
+        """Attach stable domain identities without encoding them in DOM ids."""
+        button.tree_kind = row.kind
+        button.placement_id = row.placement_id
+        button.note_id = row.note_id or ""
+        button.folder_id = row.folder_id or ""
+        button.membership_id = row.membership_id or ""
+        button.breadcrumb = row.breadcrumb
+        button.ownership = row.ownership or ""
+        button.owner_active = row.owner_active
+        button.protected_placement = row.protected
+        button.folder_version = row.version
 
     def _compose_editor(self) -> ComposeResult:
         """Mount every editor-session presentation surface exactly once."""

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -673,9 +673,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             else None
         )
         selected_folder_protected = bool(
-            selected is not None
-            and selected.kind == "folder"
-            and selected.protected
+            selected is not None and selected.kind == "folder" and selected.protected
         )
         protected_reason = (
             "This folder is managed by sync; change its sync root instead."
@@ -687,9 +685,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 classes="library-canvas-action",
                 compact=True,
                 disabled=operation_running or selected_folder_protected,
-                tooltip=(
-                    protected_reason if selected_folder_protected else None
-                ),
+                tooltip=(protected_reason if selected_folder_protected else None),
             )
             if selected is not None and selected.kind == "folder":
                 for label, button_id in (

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -128,6 +128,8 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         presentation_state: LibraryNotePresentationState | None = None,
         sync_panel_state: LibraryNotesSyncState | None = None,
         tree_projection: LibraryNotesTreeProjection | None = None,
+        tree_selected_placement_id: str = "",
+        tree_deleted_folder_available: bool = False,
         title_placeholder_only: bool = False,
         compact: bool = False,
         create_running: bool = False,
@@ -147,6 +149,8 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             presentation_state: Canonical editor snapshot and UI-only flags.
             sync_panel_state: Display state for the sync surface.
             tree_projection: Placement-aware folder rows for list mode.
+            tree_selected_placement_id: Context row for folder actions.
+            tree_deleted_folder_available: Whether Undo folder removal is available.
             title_placeholder_only: Render an empty title with an Untitled
                 placeholder for a pristine newly-created note.
             compact: Whether 60-column-safe controls and labels are active.
@@ -164,6 +168,8 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         self.presentation_state = presentation_state
         self.sync_panel_state = sync_panel_state
         self.tree_projection = tree_projection
+        self.tree_selected_placement_id = tree_selected_placement_id
+        self.tree_deleted_folder_available = tree_deleted_folder_available
         self.title_placeholder_only = title_placeholder_only
         self.compact = compact
         self.create_running = create_running
@@ -215,6 +221,8 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         presentation_state: LibraryNotePresentationState | None,
         sync_panel_state: LibraryNotesSyncState | None,
         tree_projection: LibraryNotesTreeProjection | None,
+        tree_selected_placement_id: str,
+        tree_deleted_folder_available: bool,
         title_placeholder_only: bool,
         compact: bool,
         create_running: bool,
@@ -238,6 +246,8 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             presentation_state: Note editor/create presentation snapshot.
             sync_panel_state: Notes folder-sync panel snapshot.
             tree_projection: Placement-aware folder rows for list mode.
+            tree_selected_placement_id: Context row for folder actions.
+            tree_deleted_folder_available: Whether Undo folder removal is available.
             title_placeholder_only: Whether the title is placeholder-only.
             compact: Whether compact editor controls are enabled.
             create_running: Whether note creation is in progress.
@@ -253,6 +263,8 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         self.presentation_state = presentation_state
         self.sync_panel_state = sync_panel_state
         self.tree_projection = tree_projection
+        self.tree_selected_placement_id = tree_selected_placement_id
+        self.tree_deleted_folder_available = tree_deleted_folder_available
         self.title_placeholder_only = title_placeholder_only
         self.compact = compact
         self.create_running = create_running
@@ -482,6 +494,10 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                         compact=True,
                         disabled=list_state.operation_running,
                     )
+            if self.tree_projection is not None:
+                yield from self._compose_tree_actions(
+                    operation_running=list_state.operation_running
+                )
         status_row = Horizontal(id="library-notes-status-row")
         status_row.styles.height = "auto"
         status_row.display = not select_mode
@@ -589,17 +605,31 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 indent = "  " * row.depth
                 if row.kind in {"folder", "unfiled"}:
                     glyph = "▾" if row.expanded else "▸"
+                    label = f"{indent}{glyph} {escape_markup(row.label)}"
+                    if row.status_text:
+                        label = f"{label}  {row.status_text}"
+                    classes = "library-notes-folder-row"
+                    if row.semantic_status == "connected":
+                        classes += " library-notes-tree-connected"
+                    elif row.semantic_status == "needs_attention":
+                        classes += " library-notes-tree-needs-attention"
                     button = Button(
-                        f"{indent}{glyph} {escape_markup(row.label)}",
+                        label,
                         id=f"library-notes-tree-folder-{index}",
-                        classes="library-notes-folder-row",
+                        classes=classes,
                         compact=True,
+                        tooltip=row.breadcrumb,
                     )
+                    if row.placement_id == self.tree_selected_placement_id:
+                        button.add_class("is-selected")
                     self._set_tree_row_metadata(button, row)
                     yield button
                     continue
 
                 title = f"{indent}{escape_markup(row.label)}"
+                if self.filter_value and row.breadcrumb:
+                    parent_breadcrumb = row.breadcrumb.rsplit(" / ", 1)[0]
+                    title = f"{title}  — {escape_markup(parent_breadcrumb)}"
                 if row.status_text:
                     title = f"{title}  {row.status_text}"
                 if list_state.select_mode:
@@ -621,6 +651,8 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                     compact=True,
                     tooltip=row.breadcrumb,
                 )
+                if row.placement_id == self.tree_selected_placement_id:
+                    button.add_class("is-selected")
                 self._set_tree_row_metadata(button, row)
                 button._library_row_label_rest = label_rest
                 yield button
@@ -631,6 +663,94 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 classes="library-canvas-action",
                 compact=True,
             )
+
+    def _compose_tree_actions(self, *, operation_running: bool) -> ComposeResult:
+        """Render actions appropriate to the selected folder-tree placement."""
+        projection = self.tree_projection
+        selected = (
+            projection.row(self.tree_selected_placement_id)
+            if projection is not None and self.tree_selected_placement_id
+            else None
+        )
+        selected_folder_protected = bool(
+            selected is not None
+            and selected.kind == "folder"
+            and selected.protected
+        )
+        protected_reason = (
+            "This folder is managed by sync; change its sync root instead."
+        )
+        with Horizontal(id="library-notes-tree-actions", classes="ds-toolbar"):
+            yield Button(
+                "New folder",
+                id="library-notes-folder-new",
+                classes="library-canvas-action",
+                compact=True,
+                disabled=operation_running or selected_folder_protected,
+                tooltip=(
+                    protected_reason if selected_folder_protected else None
+                ),
+            )
+            if selected is not None and selected.kind == "folder":
+                for label, button_id in (
+                    ("Rename", "library-notes-folder-rename"),
+                    ("Move", "library-notes-folder-move"),
+                    ("Remove", "library-notes-folder-remove"),
+                ):
+                    yield Button(
+                        label,
+                        id=button_id,
+                        classes="library-canvas-action",
+                        compact=True,
+                        disabled=operation_running or selected.protected,
+                        tooltip=protected_reason if selected.protected else None,
+                    )
+            elif selected is not None and selected.kind == "note":
+                protected = selected.protected
+                protected_placement_reason = (
+                    "This placement is managed by sync; change its sync root instead."
+                )
+                yield Button(
+                    "Add to folder",
+                    id="library-notes-placement-add",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=operation_running,
+                )
+                yield Button(
+                    "Move note",
+                    id="library-notes-placement-move",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=operation_running or protected,
+                    tooltip=protected_placement_reason if protected else None,
+                )
+                yield Button(
+                    "Remove placement",
+                    id="library-notes-placement-remove",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=(
+                        operation_running or protected or not selected.membership_id
+                    ),
+                    tooltip=(
+                        protected_placement_reason
+                        if protected
+                        else (
+                            "Unfiled is shown automatically; move the note into a folder."
+                            if not selected.membership_id
+                            else None
+                        )
+                    ),
+                )
+            if self.tree_deleted_folder_available:
+                yield Button(
+                    "Restore folder",
+                    id="library-notes-folder-restore",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=operation_running,
+                )
 
     @staticmethod
     def _set_tree_row_metadata(button: Button, row: LibraryNotesTreeRow) -> None:

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -1344,6 +1344,43 @@ ConsoleRunLogModal {
     text-style: bold underline;
     outline: none;
 }
+.library-notes-folder-row {
+    width: 100%;
+    min-width: 0;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-align: left;
+    content-align: left middle;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+    border: none;
+    background: $ds-surface-panel;
+    color: $ds-text-primary;
+}
+
+.library-notes-folder-row:focus {
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
+    text-style: bold underline;
+    outline: none;
+}
+
+.library-notes-tree-note-row {
+    height: 1;
+    min-height: 1;
+    margin: 0;
+}
+
+.library-notes-tree-connected {
+    color: $ds-focus-accent;
+}
+
+.library-notes-tree-needs-attention {
+    color: $ds-status-warning;
+}
+
 
 /* Same look as .library-notes-row, on a separate class: the notes Create
    view's Blank note / template rows must not also match the list view's

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -1381,6 +1381,12 @@ ConsoleRunLogModal {
     color: $ds-status-warning;
 }
 
+.library-notes-folder-row.is-selected,
+.library-notes-tree-note-row.is-selected {
+    text-style: bold;
+    background: $ds-focus-bg;
+}
+
 
 /* Same look as .library-notes-row, on a separate class: the notes Create
    view's Blank note / template rows must not also match the list view's

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -3252,6 +3252,43 @@ ConsoleRunLogModal {
     text-style: bold underline;
     outline: none;
 }
+.library-notes-folder-row {
+    width: 100%;
+    min-width: 0;
+    height: 1;
+    min-height: 1;
+    margin: 0;
+    padding: 0 1;
+    text-align: left;
+    content-align: left middle;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+    border: none;
+    background: $ds-surface-panel;
+    color: $ds-text-primary;
+}
+
+.library-notes-folder-row:focus {
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
+    text-style: bold underline;
+    outline: none;
+}
+
+.library-notes-tree-note-row {
+    height: 1;
+    min-height: 1;
+    margin: 0;
+}
+
+.library-notes-tree-connected {
+    color: $ds-focus-accent;
+}
+
+.library-notes-tree-needs-attention {
+    color: $ds-status-warning;
+}
+
 
 /* Same look as .library-notes-row, on a separate class: the notes Create
    view's Blank note / template rows must not also match the list view's

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -3289,6 +3289,12 @@ ConsoleRunLogModal {
     color: $ds-status-warning;
 }
 
+.library-notes-folder-row.is-selected,
+.library-notes-tree-note-row.is-selected {
+    text-style: bold;
+    background: $ds-focus-bg;
+}
+
 
 /* Same look as .library-notes-row, on a separate class: the notes Create
    view's Blank note / template rows must not also match the list view's


### PR DESCRIPTION
## Summary
- render Database Notes as a lazy hierarchical folder tree with Unfiled and membership-aware duplicate placements
- add folder and placement actions with managed-sync status, stable focus and selection, compact 60x20 rendering, and safe async refreshes
- harden navigator diagnostics to retain only bounded operation and error-type metadata

## Test plan
- [x] 680 Notes, Library, and diagnostic-architecture tests pass
- [x] focused pre-PR gate: 23 passed
- [x] Python 3.12 full collection: 42,613 tests collected
- [ ] repository-wide run is baseline-red: seven media-ingestion tests reproduce on untouched dev

## Pre-merge review items
- [ ] derive managed-folder protection from authoritative folder or sync metadata and enforce it at mutation boundaries
- [ ] make filtering include placements inside collapsed or unloaded folders
- [ ] reconcile tree selections against visible tree note identities instead of the legacy 100-note page

## Architecture
Implements ADR-059 and ADR-060. No new ADR is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the flat Database Notes list with a lazy, hierarchical folder navigator that renders folders, placement-aware note duplicates, and Unfiled notes. This improves browsing accuracy, protects managed subtrees from manual edits, and prevents UI rebuilds during source switches.

- Pure projection in `tldw_chatbook/Library/library_notes_tree_state.py` merges paged `NoteFolderPage`s into immutable rows, reconciles identity, and marks semantic statuses; includes `UNFILED_PLACEMENT_ID` and an `empty_note_folder_page`.
- `LibraryScreen` lazily loads and paginates the tree, continues pages, performs folder/placement mutations, and runs bounded search that returns matches plus ancestors; it only recomposes while Database Notes is mounted and adds targeted diagnostics for load/continue/mutations and move edge cases.
- Repository/service: `NoteFolderPage` adds `managed_folder_ids`, `inactive_managed_folder_ids`, and `unfiled_note_ids`; root batches surface managed descendants without expanding; `load_tree_batch` can skip note queries with `load_notes=False`; search endpoints return matches with ancestors; managed-subtree mutations are enforced.
- UI: `LibraryNotesCanvas` renders compact tree rows with stable focus/selection and status styling; adds `LibraryNoteFolderNameDialog` and `LibraryNoteFolderTargetDialog`; CSS styles folders, notes, and statuses.
- Aligns with TASK-15706 for lazy tree rendering, placement-aware operations, managed-folder protections, and stable async behavior.

**Migration**
- `FolderPlacementId.note(folder_id, note_id, membership_id=None)` adds an optional `membership_id`. Existing calls work; pass `membership_id` to target one placement.
- Mutating folders inside a managed subtree raises `FolderCapabilityError`. Callers must avoid manual mutations in managed folders.
- `NotesScopeService.load_note_folder_tree_batch(..., load_notes: bool = True, ...)` adds a `load_notes` parameter. Existing calls work; pass `load_notes=False` to skip exhausted note queries.

<sup>Written for commit 5db0e2fff9f2418e84cf3f02c41c50cc3d39689d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

