### PR TITLE
fix(tests): burn down the sweep's Library inventory, batch 1 (task-15790)

### DIFF
--- a/Tests/UI/test_library_choice_strips.py
+++ b/Tests/UI/test_library_choice_strips.py
@@ -513,6 +513,8 @@ def test_prompts_sort_choice_requests_exact_scope():
 
     def make_fake(sort_by: str):
         return SimpleNamespace(
+            # task-15790: production gained this in-flight guard; stale double.
+            _library_prompts_mutation_in_flight=False,
             _library_prompts_sort_choices_visible=True,
             _library_prompt_browse_controller=SimpleNamespace(
                 scope=PromptBrowseScope(sort_by=sort_by)

--- a/Tests/UI/test_library_export_receipt.py
+++ b/Tests/UI/test_library_export_receipt.py
@@ -211,6 +211,9 @@ async def test_apply_library_export_counts_patches_tooltip_alongside_disabled():
                 "destination_exists": False,
             },
             _library_export_running=False,
+            # task-15790: production gained this flag (library_screen
+            # __init__); the double predates it -- the stale-double class.
+            _library_export_quality_choices_visible=False,
             _library_export_status="",
             _library_export_error="",
             _library_export_last_path="",
@@ -266,6 +269,9 @@ async def test_update_library_export_canvas_after_run_patches_receipt_and_toolti
                 "destination_exists": False,
             },
             _library_export_running=False,
+            # task-15790: production gained this flag (library_screen
+            # __init__); the double predates it -- the stale-double class.
+            _library_export_quality_choices_visible=False,
             _library_export_status="",
             _library_export_error="",
             _library_export_last_path="/tmp/out.zip",

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -1094,6 +1094,16 @@ def _assert_visible_editor_actions_fit(
 
 async def _assert_visible_panel_buttons_fit(panel, pilot) -> None:
     bounds = panel.content_region
+    # task-15790 (sweep inventory): this helper pinned the retired fixed
+    # `$ds-focus-bg` literal (#51677e). task-15509 (77998601b) made focus
+    # surfaces follow the ACTIVE THEME -- background from the theme's
+    # `primary-background` variable -- and its own test asserts the fixed
+    # token is gone from the panel CSS. Assert the semantic contract the
+    # way that test does, so these ten cases stop re-pinning a retired
+    # constant and start guarding the theming they actually run under.
+    expected_focus = Color.parse(
+        str(panel.app.get_css_variables()["primary-background"])
+    )
     for button in panel.query(Button):
         if not _is_effectively_displayed(button):
             continue
@@ -1108,7 +1118,7 @@ async def _assert_visible_panel_buttons_fit(panel, pilot) -> None:
         assert button.region.y >= bounds.y
         assert button.region.bottom <= bounds.bottom
         assert not button.styles.outline
-        assert button.styles.background == Color.parse("#51677e")
+        assert button.styles.background == expected_focus
         assert button.styles.text_style.bold
         assert button.styles.text_style.underline
 
@@ -1144,7 +1154,12 @@ async def test_commit_panel_count_uses_only_the_authorized_projection() -> None:
             _commit_draft_projection(staged_note_count=0)
         )
         await pilot.pause()
-        assert str(commit_button.label) == "Commit staged (0)"
+        # task-15790: the Library a11y batch's disabled-presentation
+        # convention prefixes a "○ " marker onto disabled actions
+        # (`_sync_disabled_action_presentation`); at zero staged notes the
+        # commit action is disabled (and hidden -- asserted below), so the
+        # label carries the marker.
+        assert str(commit_button.label) == "○ Commit staged (0)"
         assert not commit_button.display
         assert zero_copy.display
         assert _text(zero_copy) == "Stage at least one session note to commit"
@@ -3104,10 +3119,19 @@ async def test_thousand_unrelated_notes_send_only_three_session_groups_and_resto
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         files_tree = workspace.query_one("#file-notes-tree", Tree)
         search_tree = workspace.query_one("#file-notes-search-results", Tree)
+        # task-15790: same dataclass migration as the "folder" lookup below
+        # -- folders carry `_FolderNodeData(relative_path)` now.
         archive_node = next(
-            node
-            for node in files_tree.root.children
-            if node.data == ("folder", "archive")
+            (
+                node
+                for node in files_tree.root.children
+                if getattr(node.data, "relative_path", None) == "archive"
+            ),
+            None,
+        )
+        assert archive_node is not None, (
+            "the 'archive' navigator node is missing: "
+            f"{[node.data for node in files_tree.root.children]!r}"
         )
         search = workspace.query_one("#file-notes-search", Input)
         search.value = "scale marker 1004"
@@ -4115,7 +4139,11 @@ async def test_stage_flushes_then_gate_keeps_editor_back_and_one_latest_refresh(
         assert not workspace.query_one("#file-notes-git-back", Button).disabled
         assert workspace.query_one("#file-notes-new", Button).disabled
         assert workspace.query_one("#file-notes-move", Button).disabled
-        assert not workspace.query_one("#file-notes-protect", Button).disabled
+        # task-15790: dca0594a5 (quiet focus and distill file actions) added
+        # Protect to the structurally-gated set, so during an unsaved edit it
+        # is disabled exactly like Move/New above -- the old exemption is the
+        # stale premise here.
+        assert workspace.query_one("#file-notes-protect", Button).disabled
         assert not await workspace.flush_pending_work()
 
         assert owner.record_change(binding, SessionChange("modified", "latest.md"))
@@ -4801,7 +4829,24 @@ async def test_narrow_git_navigation_retains_editor_search_tree_and_row_selectio
         search.value = "needle"
         await pilot.pause()
         tree = workspace.query_one("#file-notes-tree", Tree)
-        folder = next(node for node in tree.root.children if node.data == ("folder", "folder"))
+        # task-15790: folders now carry `_FolderNodeData(relative_path)` (a
+        # frozen dataclass), not the old ("folder", value) tuple -- leaves
+        # kept tuples, so the tuple lookup silently matched NOTHING and
+        # `next()` with no default converted "node missing" into an opaque
+        # StopIteration -> RuntimeError. Match on the dataclass field, and
+        # fail with a message when the node is genuinely absent.
+        folder = next(
+            (
+                node
+                for node in tree.root.children
+                if getattr(node.data, "relative_path", None) == "folder"
+            ),
+            None,
+        )
+        assert folder is not None, (
+            "the 'folder' navigator node is missing: "
+            f"{[node.data for node in tree.root.children]!r}"
+        )
         folder.expand()
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
@@ -5288,7 +5333,16 @@ async def test_narrow_delete_confirmation_keeps_complete_action_labels(
 
         assert str(delete.label) == "Confirm delete"
         assert delete.has_class("-confirm-delete")
-        assert delete.styles.column_span == 2
+        # task-15790: a85232c37 (improve navigation and delete safety) added a
+        # narrower `-single-editor-actions` refinement UNDER the stacked mode;
+        # in a single-column toolbar every action spans the one column, so
+        # "Confirm delete spans the full width" is span 1 there and span 2 in
+        # the two-column stack. The label-fit helper below still guards
+        # legibility either way.
+        expected_span = (
+            1 if workspace.has_class("-single-editor-actions") else 2
+        )
+        assert delete.styles.column_span == expected_span
         _assert_visible_editor_actions_fit(workspace)
 
         editor = workspace.query_one("#file-notes-editor", TextArea)

--- a/Tests/UI/test_library_file_notes_git_push.py
+++ b/Tests/UI/test_library_file_notes_git_push.py
@@ -2355,7 +2355,10 @@ async def test_workspace_push_recovery_authorizes_then_queries_retained_endpoint
             "#file-notes-session-changes",
             Button,
         )
-        assert "Push checking" in str(session_git.label)
+        # task-15790: the indicator's phase copy moved into a suffix --
+        # "Review session changes (N) · Checking push" (67fec3f35 polish);
+        # the phase-visibility claim is unchanged, the spelling is.
+        assert "Checking push" in str(session_git.label)
         assert session_git.has_focus
 
         recovery_release.set()
@@ -2725,7 +2728,7 @@ async def test_workspace_edit_stales_rows_without_hiding_push_candidate(
         workspace._refresh_session_changes()
 
         assert workspace._push_availability == candidate
-        assert "Push checking" in str(
+        assert "Checking push" in str(
             workspace.query_one("#file-notes-session-changes").label
         )
         release.set()
@@ -2779,7 +2782,7 @@ async def test_workspace_first_rehydrate_rejects_stale_retained_candidate(
         assert workspace._push_availability == candidate_b
         assert workspace._push_observer_task is None
         assert workspace._push_phase == "idle"
-        assert "Push checking" not in str(
+        assert "Checking push" not in str(
             workspace.query_one("#file-notes-session-changes").label
         )
 
@@ -2923,7 +2926,7 @@ async def test_workspace_binding_change_rejects_old_push_settlement(
         assert workspace._push_phase == "idle"
         assert not workspace._rehydrate_git_presentation()
         assert workspace._push_phase == "idle"
-        assert "Push checking" not in str(
+        assert "Checking push" not in str(
             workspace.query_one("#file-notes-session-changes").label
         )
 
@@ -3539,7 +3542,7 @@ async def test_workspace_session_git_indicator_shows_hidden_push_checking(
             "workspace initialization did not settle",
         )
 
-        assert "Push checking" in str(
+        assert "Checking push" in str(
             workspace.query_one("#file-notes-session-changes").label
         )
         assert workspace._navigator_mode == "files"
@@ -3590,7 +3593,7 @@ async def test_workspace_back_to_files_keeps_push_publication_and_attention(
             lambda: workspace.initialized,
             "workspace initialization did not settle",
         )
-        assert "Push checking" in str(
+        assert "Checking push" in str(
             workspace.query_one("#file-notes-session-changes").label
         )
 

--- a/Tests/UI/test_library_ingest_structural.py
+++ b/Tests/UI/test_library_ingest_structural.py
@@ -348,9 +348,18 @@ async def test_schema_disabled_fields_paint_legibly_inert():
                 f"disabled field still faded: opacity={model_dir.styles.opacity}"
             )
 
+            # task-15790: the 15513 Import-behavior controls grew the panel,
+            # pushing Language below the 46-row viewport -- an off-screen
+            # widget paints nothing, so the style probe returned None. Bring
+            # each field on-screen before reading its painted style; the
+            # contrast contract itself is unchanged.
+            model_dir.scroll_visible(animate=False)
+            await pilot.pause()
             disabled_style = _painted_style_of_text(
                 pilot.app, model_dir.region, "/models/parakeet-v2"
             )
+            language.scroll_visible(animate=False)
+            await pilot.pause()
             enabled_style = _painted_style_of_text(
                 pilot.app, language.region, "en"
             )
@@ -945,32 +954,37 @@ async def test_the_fold_pays_for_itself_in_the_shipped_screen():
         screen = await _shipped_ingest_screen(host, pilot)
         canvas = screen.query_one(LibraryIngestCanvas)
         breakdown = screen.query_one("#ingest-type-breakdown", Static)
-        viewport = canvas.container_size.height
-        breakdown_y = breakdown.virtual_region.y
-        folded_start = screen.query_one(
-            "#library-ingest-start", Button
-        ).virtual_region.y
-
-        # Unfold the tooling detail in place: the wall's cost, measured on
-        # the same surface, is the difference between these two.
-        screen.query_one(
+        # task-15790: `virtual_region.y` stopped being an absolute row in
+        # the canvas content when the 15513 Import-behavior work nested the
+        # form's actions in their own Vertical -- Start's y became relative
+        # to that small parent (measured: y=2 folded AND unfolded, "saving"
+        # 0). The fold's cost is the COLLAPSIBLE's own rendered height
+        # delta, which no re-nesting can distort; the breakdown check
+        # switches to screen-space visibility for the same reason.
+        detail = screen.query_one(
             "#ingest-preflight-tooling-detail", Collapsible
-        ).collapsed = False
-        await pilot.pause()
-        await pilot.pause()
-        unfolded_start = screen.query_one(
-            "#library-ingest-start", Button
-        ).virtual_region.y
+        )
+        folded_height = detail.region.height
+        breakdown_visible = (
+            breakdown.region.height > 0
+            and breakdown.region.y < canvas.region.bottom
+        )
 
-    assert breakdown_y < viewport, (
-        f"type breakdown below the fold in the shipped screen: "
-        f"y={breakdown_y} viewport={viewport}"
+        detail.collapsed = False
+        await pilot.pause()
+        await pilot.pause()
+        unfolded_height = screen.query_one(
+            "#ingest-preflight-tooling-detail", Collapsible
+        ).region.height
+
+    assert breakdown_visible, (
+        "type breakdown below the fold in the shipped screen"
     )
-    saving = unfolded_start - folded_start
+    saving = unfolded_height - folded_height
     assert saving >= 25, (
         "the fold no longer pays for itself in the shipped screen: "
-        f"folded start y={folded_start}, unfolded y={unfolded_start} "
-        f"(saving {saving} rows; measured 33)"
+        f"folded detail height={folded_height}, unfolded "
+        f"height={unfolded_height} (saving {saving} rows)"
     )
 
 

--- a/Tests/UI/test_library_multiselect_notes.py
+++ b/Tests/UI/test_library_multiselect_notes.py
@@ -28,6 +28,8 @@ def _fake(select_mode):
         _opened=[],
         _flushed=0,
         _library_notes_view="list",
+        # task-15790: production gained this in-flight guard; stale double.
+        _library_notes_mutation_in_flight=False,
     )
 
 

--- a/backlog/tasks/task-15790 - Sweep-inventory-file-notes-arcs-left-35-Library-tests-behind.md
+++ b/backlog/tasks/task-15790 - Sweep-inventory-file-notes-arcs-left-35-Library-tests-behind.md
@@ -34,7 +34,63 @@ test only after the product behaviour is confirmed intended.
 
 ## Acceptance Criteria
 
-- [ ] The StopIteration pair is attributed (real bug vs test artifact) with evidence, before any contract is updated
-- [ ] Each cluster is attributed to its causing commit
-- [ ] Genuine product breaks are fixed rather than absorbed into expectations
+- [x] The StopIteration pair is attributed (real bug vs test artifact) with evidence, before any contract is updated
+- [x] Each cluster is attributed to its causing commit
+- [x] Genuine product breaks are fixed rather than absorbed into expectations (one found and fixed: the skills trust-panel ordering)
 - [ ] The listed modules pass whole on dev
+
+## Implementation Notes (batch 1)
+
+Re-baselined every module on CURRENT dev before touching anything -- dev had
+moved so fast that the sweep's inventory was already partly stale in both
+directions: `test_library_prompts_canvas.py` (the filed StopIteration pair)
+now passes whole (280/280), while the file-notes cluster had GROWN to 28
+failures.
+
+**The StopIteration class: test artifact, twice over.** Both remaining
+instances were `next(gen)` with no default in tests, converting "expected
+tree node missing" into an opaque `RuntimeError: coroutine raised
+StopIteration`. The nodes were missing because folders in the file-notes
+navigator now carry `_FolderNodeData(relative_path)` (a frozen dataclass)
+while the tests matched the old `("folder", value)` tuples. Both lookups now
+match the dataclass field and fail with a message listing actual node data.
+
+**One real product bug found and fixed: the skills trust panel could stick at
+"not granted" for a granted skill.** task-15457 made the skill editor's
+recompose CANVAS-scoped, driven by the canvas's own message pump -- which a
+screen-level `call_after_refresh` has no ordering against. The grant-fetch
+coroutine's deferred `_render_library_skill_trust_panel` fired before the
+canvas's children existed, swallowed `NoMatches`, and never retried (measured:
+grant stored True, render ran, button absent). It now rides the same canvas
+post-recompose hook the editor's arming follow-up already rides. This is the
+exact stuck-forever race the method's own docstring said `call_after_refresh`
+prevented -- 15457 quietly invalidated its premise.
+
+**Stale contracts updated with attribution** (each verified deliberate via
+its causing commit): the file-notes-git focus color x10 (task-15509 made
+focus theme-driven; the helper now asserts the active theme's
+`primary-background`, the same way 15509's own test does); Protect joining
+the structurally-gated set (dca0594a5); confirm-delete span under the new
+`-single-editor-actions` narrow mode (a85232c37); the disabled-marker prefix
+on the commit label (Library a11y convention); "Push checking" -> the
+"· Checking push" phase suffix x4 (67fec3f35). Stale doubles taught 4 new
+production attributes (export-quality visibility, notes/prompts mutation
+in-flight). Two measurement repairs in ingest_structural: the fold's cost is
+now the collapsible's own height delta (`virtual_region.y` stopped being an
+absolute anchor when 15513 nested the actions), and the contrast probe
+scrolls its fields on-screen first (15513's new controls pushed Language
+below the 46-row viewport -- an off-screen widget paints nothing).
+
+Green after batch 1: file_notes_git 148/148, git_push 60/60, export_receipt +
+multiselect 17/17, choice_strips + skills_canvas 230/230 (incl. the product
+fix), ingest_structural 22/22, prompts_canvas 280/280 (no change needed).
+
+## Remainder (open)
+
+- `test_library_file_notes_workspace.py` x2 and `test_library_shell.py` x6:
+  both workspace failures are FOCUS assertions (cancel-first confirmation no
+  longer focuses Cancel; editor focus lost to NOWHERE at 40x20). dca0594a5
+  ("quiet focus and distill file actions") deliberately changed focus
+  behaviour, so each needs the deliberate-or-regression call made against
+  that commit's intent -- focus lost to nowhere is suspicious. Not batched
+  with the mechanical fixes above on purpose.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -17234,11 +17234,19 @@ class LibraryScreen(BaseAppScreen):
         # ``except (NoMatches, QueryError): pass`` guards, and never retry
         # -- leaving the panel stuck showing "not granted"/disabled forever
         # even though ``_library_skill_script_grant`` is correctly True in
-        # memory. ``call_after_refresh`` (the same deferral this method's
-        # caller already uses for ``_arm_library_skill_editor``) posts an
-        # ``InvokeLater`` behind whatever recompose is already queued, so
-        # it always fires after the editor's widgets are actually mounted.
-        self.call_after_refresh(self._render_library_skill_trust_panel)
+        # memory. ``call_after_refresh`` was the original answer, and
+        # task-15457 quietly invalidated it: the editor recompose it was
+        # ordering against became CANVAS-scoped (`_sync_library_canvas`,
+        # driven by the canvas's own message pump), which a SCREEN-level
+        # ``call_after_refresh`` has no ordering against -- the render fired
+        # before the canvas's children existed, swallowed ``NoMatches``, and
+        # never retried (task-15790, measured: grant stored True, render ran,
+        # button absent). Ride the same canvas post-recompose hook the
+        # caller's arming follow-up already rides; it runs `then` only once
+        # the canvas's new children are actually mounted.
+        _sync_library_canvas(
+            self, "skills", then=self._render_library_skill_trust_panel
+        )
 
     async def _request_library_skill_trust_bootstrap_passphrase(self) -> str | None:
         """Push the confirm-passphrase bootstrap modal and await a passphrase.


### PR DESCRIPTION
## What

First batch of TASK-15790 (the sweep's file-notes/Library inventory, ~35 tests). Re-baselined on **current** dev before touching anything — the inventory was stale in both directions: the filed `StopIteration` pair had been fixed by dev's own motion (`test_library_prompts_canvas.py` now 280/280), while the file-notes cluster had **grown** to 28 failures.

## One real product bug, found and fixed

**The skills trust panel could stick at "not granted" for a granted skill.** task-15457 made the skill editor's recompose canvas-scoped, driven by the canvas's own message pump — which a screen-level `call_after_refresh` has no ordering against. The grant-fetch's deferred render fired before the canvas's children existed, swallowed `NoMatches`, and never retried. Measured with a spy: grant stored `True`, render ran, button absent. This is the exact stuck-forever race the method's own docstring said `call_after_refresh` prevented — 15457 quietly invalidated its premise. The render now rides the same canvas post-recompose hook as the editor's arming follow-up.

## The "possible real bug" resolved as test artifact

Both remaining `StopIteration → RuntimeError` instances were tests calling `next()` with no default over navigator tree children whose node data moved from `("folder", value)` tuples to the `_FolderNodeData` dataclass — "expected node missing" rendered as an opaque coroutine crash. The lookups now match the dataclass field and fail with the actual node list.

## Stale contracts, each attributed to its causing commit

- focus color ×10 — task-15509 made focus **theme-driven**; the helper now asserts the active theme's `primary-background`, exactly as 15509's own test does
- Protect structurally gated during dirty edits (`dca0594a5`)
- confirm-delete span under the new `-single-editor-actions` narrow mode (`a85232c37`)
- the disabled-marker `○` commit label (Library a11y convention)
- `"Push checking"` → the `· Checking push` phase suffix ×4 (`67fec3f35`)
- four stale doubles taught new production attributes

Plus two measurement repairs after 15513's panel growth: the fold test asserts the collapsible's own height delta (`virtual_region.y` stopped being an absolute anchor when the actions were nested — measured "saving 0" on an unmoved anchor), and the contrast probe scrolls its fields on-screen before painting (an off-screen widget paints nothing).

## Verification

**767 green** across the seven touched modules: file_notes_git 148, git_push 60, ingest_structural 22, export_receipt+multiselect 17, choice_strips+skills 230, prompts_canvas 280 (untouched, verified).

## Remainder, recorded not hidden

Two focus failures in `file_notes_workspace` (cancel-first confirmation no longer focuses Cancel; editor focus lost to **nowhere** at 40×20) plus six in `library_shell`. `dca0594a5` ("quiet focus…") deliberately changed focus behavior, so each needs a deliberate-or-regression call against that commit's intent — deliberately not batched with mechanical fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race that left the Library skills trust panel stuck at “not granted,” and rebaselines Library tests to current intended behavior (task-15790). Previously the render deferred at the screen level and could run before the canvas existed; now it runs after the canvas recompose so granted state displays reliably.

- Product behavior: In `library_screen`, move the trust-panel render from a screen-level deferral to a canvas post-recompose callback. Old: panel could remain “not granted” despite a stored grant. New: panel renders after children mount and shows the correct granted state. No API changes or user-visible side effects beyond correct status.
- Review notes (tests only): Align expectations to current contracts introduced on dev—theme-driven focus color, Protect disabled during unsaved edits, confirm-delete spanning one column in single-column toolbars, disabled-action “○” prefix, push phase shown as “· Checking push,” folder nodes matched via dataclass `relative_path` with explicit missing-node assertions, ingest measurements taken from the collapsible’s height and after scrolling fields into view, and stale doubles updated with new in-flight/visibility flags. All affected modules are green. No migrations or config changes required.

<sup>Written for commit 3b32cbbc94e026f49fc098f083166eb1b9263017. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

