### PR TITLE
fix(console): make Inspect arrow a full button

### DIFF
--- a/Docs/superpowers/plans/2026-08-13-task-15865-inspector-arrow-button.md
+++ b/Docs/superpowers/plans/2026-08-13-task-15865-inspector-arrow-button.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Render `Inspect-->` as the complete nine-cell horizontal collapsed Inspector button while preserving every existing rail geometry, badge, tooltip, vertical-mode, and responsive contract.
+**Goal:** Render `Inspect->` as the complete nine-cell horizontal collapsed Inspector button while preserving every existing rail geometry, badge, tooltip, vertical-mode, and responsive contract.
 
-**Architecture:** Keep the shared `DestinationRailHandle` and all layout/CSS unchanged. Use the existing `ConsoleRailHandle._display_label()` presentation seam to replace the canonical horizontal right-side Inspector copy with one fixed nine-cell literal; strengthen existing component, mounted, interaction, and real-Console visual regressions around that seam.
+**Architecture:** Keep the shared `DestinationRailHandle`, CSS files, and layout geometry unchanged. Use the existing `ConsoleRailHandle._display_label()` presentation seam for one fixed nine-cell literal and clear Textual's default `line_pad=1` inline in the existing horizontal right Button block so the label uses all nine content cells; strengthen existing component, mounted, interaction, and real-Console visual regressions around those seams.
 
 **Tech Stack:** Python 3.11+, Textual 8.x, Rich cell geometry, pytest/Textual Pilot.
 
@@ -26,8 +26,8 @@
 - Modify `Tests/UI/test_console_shell_regions.py`: update the saved horizontal rail-style expectation while preserving stacked mode.
 - Modify `Tests/UI/test_settings_console_rail_labels.py`: update the mounted horizontal Inspector expectation in the failed-save state.
 - Modify `Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py`: update the core-loop mounted button label while preserving its tooltip contract.
-- Modify `Tests/UI/test_workbench_visual_snapshots.py`: require one composited `Inspect-->` row across the existing six real-Console viewport/badge states.
-- Modify `tldw_chatbook/Widgets/Console/console_rail_handle.py`: change the canonical horizontal Inspector display literal only.
+- Modify `Tests/UI/test_workbench_visual_snapshots.py`: require one composited `Inspect->` row across the existing six real-Console viewport/badge states.
+- Modify `tldw_chatbook/Widgets/Console/console_rail_handle.py`: change the canonical horizontal Inspector display literal and clear line padding on the existing horizontal right Button.
 - Modify `backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md`: complete acceptance criteria and record scoped verification after fresh evidence.
 
 ### Task 1: Pin the full-button label and arrow-end hit target
@@ -47,7 +47,7 @@ Change the horizontal Inspector assertion in `test_horizontal_defaults_preserve_
 
 ```python
 assert context._display_label() == CONSOLE_RAIL_CONTEXT_LABEL
-assert inspector._display_label() == "Inspect-->"
+assert inspector._display_label() == "Inspect->"
 ```
 
 The existing `test_vertical_inspector_label_stacks_without_direction_glyph` remains unchanged and continues to require stacked `Inspector`.
@@ -58,7 +58,7 @@ In `test_console_handle_abbreviates_the_inspector_label_on_the_right`, require:
 
 ```python
 button = app.query_one("#console-rail-open", Button)
-assert str(button.label) == "Inspect-->"
+assert str(button.label) == "Inspect->"
 assert button.tooltip == "Open Inspector rail"
 ```
 
@@ -76,7 +76,7 @@ In `test_clicking_open_then_collapse_toggles_visibility_and_persists`, replace t
 
 ```python
 open_button = pilot.app.screen.query_one("#console-inspector-rail-open", Button)
-assert str(open_button.label) == "Inspect-->"
+assert str(open_button.label) == "Inspect->"
 arrow_end = (open_button.region.width - 1, open_button.region.height // 2)
 assert await pilot.click(open_button, offset=arrow_end)
 ```
@@ -88,8 +88,8 @@ Keep every existing post-click open/hidden assertion and the collapse-back path.
 In `test_task_15783_console_collapsed_inspector_rail_visual_parity_sweep`, preserve the geometry/frame/badge/transcript assertions and change only the visible copy requirements:
 
 ```python
-assert _painted_region_rows(screen, inspector_button.region) == ["Inspect-->"]
-assert inspector_button.label == "Inspect-->"
+assert _painted_region_rows(screen, inspector_button.region) == ["Inspect->"]
+assert inspector_button.label == "Inspect->"
 ```
 
 Do not rename the historical TASK-15783 parity test; TASK-15865 strengthens its current UI contract without rewriting its provenance.
@@ -100,13 +100,13 @@ Change only the horizontal canonical Inspector expectations in these existing te
 
 ```python
 # Tests/UI/test_console_shell_regions.py
-(False, 13, 11, "Context ▸", "Inspect-->"),
+(False, 13, 11, "Context ▸", "Inspect->"),
 
 # Tests/UI/test_settings_console_rail_labels.py
-assert right._display_label() == "Inspect-->"
+assert right._display_label() == "Inspect->"
 
 # Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
-assert inspector_button.label == "Inspect-->"
+assert inspector_button.label == "Inspect->"
 ```
 
 Leave the stacked `Inspector`, left `Context ▸`, width, tooltip, and settings state assertions unchanged.
@@ -147,15 +147,21 @@ git commit -m "test(console): require full Inspect arrow button"
 **Files:**
 - Modify: `tldw_chatbook/Widgets/Console/console_rail_handle.py:94-100`
 
-- [ ] **Step 1: Make the minimal presentation change**
+- [ ] **Step 1: Make the minimal presentation changes**
 
-Change only the canonical horizontal right-side return literal:
+Change the canonical horizontal right-side return literal:
 
 ```python
-return "Inspect-->" if self.label == CONSOLE_RAIL_INSPECTOR_LABEL else self.label
+return "Inspect->" if self.label == CONSOLE_RAIL_INSPECTOR_LABEL else self.label
 ```
 
-Do not add constants, width calculations, child widgets, CSS, or layout changes. The existing branch order already protects vertical and left-side presentation.
+In the existing nonvertical right Button block, clear Textual's default line padding:
+
+```python
+child.styles.line_pad = 0
+```
+
+`Inspect->` is exactly nine terminal cells. Textual 8's default `line_pad=1` reserves one cell on each side, and a runtime compositor probe showed the label wrapping until this inline reset; the repository uses this inline pattern because TCSS rejects `line-pad: 0`. Do not add constants, width calculations, child widgets, CSS-file rules, or layout changes. The existing branch order protects vertical and left-side presentation.
 
 - [ ] **Step 2: Run the focused GREEN gates from Task 1**
 
@@ -283,7 +289,7 @@ git diff origin/dev...HEAD -- \
   Tests/UI/test_workbench_visual_snapshots.py
 ```
 
-Confirm the production diff is the one approved literal, the arrow-end click stays in bounds, and no shared handle, CSS, width, badge composition, or vertical copy changed.
+Confirm the production diff is the approved literal plus the inline line-pad reset on the existing horizontal right Button, the arrow-end click stays in bounds, and no shared handle, CSS file, width, badge composition, or vertical copy changed.
 
 - [ ] **Step 2: Complete the task record**
 
@@ -296,7 +302,7 @@ backlog task edit 15865 \
   --check-ac 3 \
   --check-ac 4 \
   --check-ac 5 \
-  --notes "Implemented the full-width Inspect arrow through the existing ConsoleRailHandle display seam using one fixed literal; no CSS, width, or child-widget changes were added. Modified console_rail_handle.py plus test_console_rail_handle.py, test_destination_rail.py, test_console_right_rail.py, test_console_shell_regions.py, test_settings_console_rail_labels.py, test_product_maturity_gate1_core_loop_screen_adaptation.py, and test_workbench_visual_snapshots.py. Directly related rail, interaction, compact-access, CSS-integrity, visual, Ruff, duplicate-ID, and diff checks passed. Per user instruction, no full repository suite was run. ADR required: no." \
+  --notes "Implemented the nine-cell Inspect arrow through the existing ConsoleRailHandle display seam using the fixed Inspect-> literal plus an inline line-pad reset on the existing horizontal right Button; no CSS-file, outer-width, child-widget, ID/class, or layout-structure changes were added. Modified console_rail_handle.py plus test_console_rail_handle.py, test_destination_rail.py, test_console_right_rail.py, test_console_shell_regions.py, test_settings_console_rail_labels.py, test_product_maturity_gate1_core_loop_screen_adaptation.py, and test_workbench_visual_snapshots.py. Directly related rail, interaction, compact-access, CSS-integrity, visual, Ruff, duplicate-ID, and diff checks passed. Per user instruction, no full repository suite was run. ADR required: no." \
   --status Done \
   --plain
 ```

--- a/Docs/superpowers/plans/2026-08-13-task-15865-inspector-arrow-button.md
+++ b/Docs/superpowers/plans/2026-08-13-task-15865-inspector-arrow-button.md
@@ -159,7 +159,7 @@ Do not add constants, width calculations, child widgets, CSS, or layout changes.
 
 - [ ] **Step 2: Run the focused GREEN gates from Task 1**
 
-Run the exact Task 1 Step 5 command again.
+Run the exact Task 1 Step 6 command again.
 
 Expected: all selected cases pass, including all six parameterized visual states.
 
@@ -217,12 +217,18 @@ Run:
   Tests/UI/test_console_rail_handle.py \
   Tests/UI/test_destination_rail.py \
   Tests/UI/test_console_right_rail.py \
+  Tests/UI/test_console_shell_regions.py \
+  Tests/UI/test_settings_console_rail_labels.py \
+  Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py \
   Tests/UI/test_workbench_visual_snapshots.py
 ../../.venv/bin/ruff format --check \
   tldw_chatbook/Widgets/Console/console_rail_handle.py \
   Tests/UI/test_console_rail_handle.py \
   Tests/UI/test_destination_rail.py \
   Tests/UI/test_console_right_rail.py \
+  Tests/UI/test_console_shell_regions.py \
+  Tests/UI/test_settings_console_rail_labels.py \
+  Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py \
   Tests/UI/test_workbench_visual_snapshots.py
 git diff --check
 ```
@@ -271,6 +277,9 @@ git diff origin/dev...HEAD -- \
   Tests/UI/test_console_rail_handle.py \
   Tests/UI/test_destination_rail.py \
   Tests/UI/test_console_right_rail.py \
+  Tests/UI/test_console_shell_regions.py \
+  Tests/UI/test_settings_console_rail_labels.py \
+  Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py \
   Tests/UI/test_workbench_visual_snapshots.py
 ```
 

--- a/Docs/superpowers/plans/2026-08-13-task-15865-inspector-arrow-button.md
+++ b/Docs/superpowers/plans/2026-08-13-task-15865-inspector-arrow-button.md
@@ -1,0 +1,313 @@
+# Full-Width Inspect Arrow Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render `Inspect-->` as the complete nine-cell horizontal collapsed Inspector button while preserving every existing rail geometry, badge, tooltip, vertical-mode, and responsive contract.
+
+**Architecture:** Keep the shared `DestinationRailHandle` and all layout/CSS unchanged. Use the existing `ConsoleRailHandle._display_label()` presentation seam to replace the canonical horizontal right-side Inspector copy with one fixed nine-cell literal; strengthen existing component, mounted, interaction, and real-Console visual regressions around that seam.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, Rich cell geometry, pytest/Textual Pilot.
+
+**Design spec:** `Docs/superpowers/specs/2026-08-13-task-15865-inspector-arrow-button-design.md`
+
+**ADR required:** no
+
+**ADR path:** N/A
+
+**Reason:** This is a reversible display-copy refinement inside an existing component seam; it changes no architecture, persistence, dependency, service, security, or ownership boundary.
+
+---
+
+## File map
+
+- Modify `Tests/UI/test_console_rail_handle.py`: pin the canonical horizontal display copy and preserve vertical/left-side variants.
+- Modify `Tests/UI/test_destination_rail.py`: pin the mounted production-stylesheet button label while retaining existing geometry, tooltip, and badge containment assertions.
+- Modify `Tests/UI/test_console_right_rail.py`: click the right/arrow end of the existing button and prove the same control opens the Inspector.
+- Modify `Tests/UI/test_console_shell_regions.py`: update the saved horizontal rail-style expectation while preserving stacked mode.
+- Modify `Tests/UI/test_settings_console_rail_labels.py`: update the mounted horizontal Inspector expectation in the failed-save state.
+- Modify `Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py`: update the core-loop mounted button label while preserving its tooltip contract.
+- Modify `Tests/UI/test_workbench_visual_snapshots.py`: require one composited `Inspect-->` row across the existing six real-Console viewport/badge states.
+- Modify `tldw_chatbook/Widgets/Console/console_rail_handle.py`: change the canonical horizontal Inspector display literal only.
+- Modify `backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md`: complete acceptance criteria and record scoped verification after fresh evidence.
+
+### Task 1: Pin the full-button label and arrow-end hit target
+
+**Files:**
+- Modify: `Tests/UI/test_console_rail_handle.py:188-194`
+- Modify: `Tests/UI/test_destination_rail.py:350-366`
+- Modify: `Tests/UI/test_console_right_rail.py:85-119`
+- Modify: `Tests/UI/test_console_shell_regions.py:113-145`
+- Modify: `Tests/UI/test_settings_console_rail_labels.py:190-206`
+- Modify: `Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py:220-236`
+- Modify: `Tests/UI/test_workbench_visual_snapshots.py:202-302`
+
+- [ ] **Step 1: Update the pure display contract to the approved literal**
+
+Change the horizontal Inspector assertion in `test_horizontal_defaults_preserve_context_and_abbreviate_inspector_label` while leaving the Context assertion unchanged:
+
+```python
+assert context._display_label() == CONSOLE_RAIL_CONTEXT_LABEL
+assert inspector._display_label() == "Inspect-->"
+```
+
+The existing `test_vertical_inspector_label_stacks_without_direction_glyph` remains unchanged and continues to require stacked `Inspector`.
+
+- [ ] **Step 2: Update the mounted button contract**
+
+In `test_console_handle_abbreviates_the_inspector_label_on_the_right`, require:
+
+```python
+button = app.query_one("#console-rail-open", Button)
+assert str(button.label) == "Inspect-->"
+assert button.tooltip == "Open Inspector rail"
+```
+
+Do not move the badge into the button. Existing badged geometry tests in the same file remain the authority for the separate row.
+
+- [ ] **Step 3: Strengthen the real click path at the arrow end**
+
+Import the real widget type:
+
+```python
+from textual.widgets import Button
+```
+
+In `test_clicking_open_then_collapse_toggles_visibility_and_persists`, replace the selector-centered open click with a selector-relative click one cell inside the button's right edge:
+
+```python
+open_button = pilot.app.screen.query_one("#console-inspector-rail-open", Button)
+assert str(open_button.label) == "Inspect-->"
+arrow_end = (open_button.region.width - 1, open_button.region.height // 2)
+assert await pilot.click(open_button, offset=arrow_end)
+```
+
+Keep every existing post-click open/hidden assertion and the collapse-back path. Supplying `open_button` is load-bearing: Textual's coordinate-only `pilot.click(offset=...)` can return success without proving which widget received the event, while the selector-relative call proves the rightmost arrow cells belong to this existing button.
+
+- [ ] **Step 4: Update the six-state real-Console compositor assertion**
+
+In `test_task_15783_console_collapsed_inspector_rail_visual_parity_sweep`, preserve the geometry/frame/badge/transcript assertions and change only the visible copy requirements:
+
+```python
+assert _painted_region_rows(screen, inspector_button.region) == ["Inspect-->"]
+assert inspector_button.label == "Inspect-->"
+```
+
+Do not rename the historical TASK-15783 parity test; TASK-15865 strengthens its current UI contract without rewriting its provenance.
+
+- [ ] **Step 5: Update every remaining focused label consumer**
+
+Change only the horizontal canonical Inspector expectations in these existing tests:
+
+```python
+# Tests/UI/test_console_shell_regions.py
+(False, 13, 11, "Context ▸", "Inspect-->"),
+
+# Tests/UI/test_settings_console_rail_labels.py
+assert right._display_label() == "Inspect-->"
+
+# Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
+assert inspector_button.label == "Inspect-->"
+```
+
+Leave the stacked `Inspector`, left `Context ▸`, width, tooltip, and settings state assertions unchanged.
+
+- [ ] **Step 6: Run the focused RED gates**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_console_rail_handle.py::test_horizontal_defaults_preserve_context_and_abbreviate_inspector_label \
+  Tests/UI/test_destination_rail.py::test_console_handle_abbreviates_the_inspector_label_on_the_right \
+  Tests/UI/test_console_right_rail.py::test_clicking_open_then_collapse_toggles_visibility_and_persists \
+  Tests/UI/test_console_shell_regions.py::test_fresh_console_composes_saved_rail_label_style \
+  Tests/UI/test_settings_console_rail_labels.py::test_console_rail_label_failed_save_keeps_draft_and_active_style \
+  Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py::test_console_core_loop_exposes_agentic_shell_regions \
+  Tests/UI/test_workbench_visual_snapshots.py::test_task_15783_console_collapsed_inspector_rail_visual_parity_sweep
+```
+
+Expected: every horizontal canonical Inspector copy expectation fails because production still returns `Inspect`; the stacked-mode parameter and unchanged geometry, badge, tooltip, and interaction assertions remain valid up to the copy mismatch.
+
+- [ ] **Step 7: Commit the RED regressions**
+
+```bash
+git add -- \
+  Tests/UI/test_console_rail_handle.py \
+  Tests/UI/test_destination_rail.py \
+  Tests/UI/test_console_right_rail.py \
+  Tests/UI/test_console_shell_regions.py \
+  Tests/UI/test_settings_console_rail_labels.py \
+  Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py \
+  Tests/UI/test_workbench_visual_snapshots.py
+git commit -m "test(console): require full Inspect arrow button"
+```
+
+### Task 2: Implement the fixed nine-cell label
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Console/console_rail_handle.py:94-100`
+
+- [ ] **Step 1: Make the minimal presentation change**
+
+Change only the canonical horizontal right-side return literal:
+
+```python
+return "Inspect-->" if self.label == CONSOLE_RAIL_INSPECTOR_LABEL else self.label
+```
+
+Do not add constants, width calculations, child widgets, CSS, or layout changes. The existing branch order already protects vertical and left-side presentation.
+
+- [ ] **Step 2: Run the focused GREEN gates from Task 1**
+
+Run the exact Task 1 Step 5 command again.
+
+Expected: all selected cases pass, including all six parameterized visual states.
+
+- [ ] **Step 3: Mutation-check the selector-relative arrow-end click**
+
+Now that the label expectations are GREEN, temporarily change the selector-relative x-coordinate from `open_button.region.width - 1` to the first out-of-bounds cell:
+
+```python
+arrow_end = (open_button.region.width, open_button.region.height // 2)
+```
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_console_right_rail.py::test_clicking_open_then_collapse_toggles_visibility_and_persists
+```
+
+Expected: FAIL because the click no longer opens the Inspector (or the click assertion itself returns false). Restore `open_button.region.width - 1`, rerun the node, and require PASS before continuing.
+
+- [ ] **Step 4: Run the directly related rail regression set**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_console_rail_handle.py \
+  Tests/UI/test_destination_rail.py \
+  Tests/UI/test_console_shell_regions.py::test_fresh_console_composes_saved_rail_label_style \
+  Tests/UI/test_settings_console_rail_labels.py \
+  Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py \
+  Tests/UI/test_console_right_rail.py \
+  Tests/UI/test_console_inspector_compact_access.py \
+  Tests/UI/test_css_build_integrity.py \
+  Tests/UI/test_console_internals_decomposition.py::test_console_workbench_panes_have_visible_terminal_frames
+```
+
+Then run the six-state sweep explicitly:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_workbench_visual_snapshots.py \
+  -k task_15783
+```
+
+Expected: all selected tests pass. Per user instruction, do not run the full repository suite.
+
+- [ ] **Step 5: Run focused static and integrity checks**
+
+Run:
+
+```bash
+../../.venv/bin/ruff check \
+  tldw_chatbook/Widgets/Console/console_rail_handle.py \
+  Tests/UI/test_console_rail_handle.py \
+  Tests/UI/test_destination_rail.py \
+  Tests/UI/test_console_right_rail.py \
+  Tests/UI/test_workbench_visual_snapshots.py
+../../.venv/bin/ruff format --check \
+  tldw_chatbook/Widgets/Console/console_rail_handle.py \
+  Tests/UI/test_console_rail_handle.py \
+  Tests/UI/test_destination_rail.py \
+  Tests/UI/test_console_right_rail.py \
+  Tests/UI/test_workbench_visual_snapshots.py
+git diff --check
+```
+
+Run the exact duplicate backlog task-ID guard from `.github/workflows/backlog-guard.yml`:
+
+```bash
+bash -euo pipefail -c '
+fail=0
+file_dupes=$(ls backlog/tasks | sed -nE "s/^(task-[0-9]+(\\.[0-9]+)*) - .*\\.md$/\\1/p" | sort | uniq -d)
+if [ -n "$file_dupes" ]; then
+  fail=1
+  printf "Duplicate filename task IDs:\n%s\n" "$file_dupes"
+fi
+fm_dupes=$(awk "FNR==1{seen=0} /^id:/ && !seen {seen=1; print tolower(\$2)}" backlog/tasks/*.md | sort | uniq -d)
+if [ -n "$fm_dupes" ]; then
+  fail=1
+  printf "Duplicate frontmatter task IDs:\n%s\n" "$fm_dupes"
+fi
+exit "$fail"
+'
+```
+
+Expected: exit 0 with no duplicate output.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add -- tldw_chatbook/Widgets/Console/console_rail_handle.py
+git commit -m "fix(console): make Inspect arrow fully clickable"
+```
+
+### Task 3: Close out TASK-15865 with fresh evidence
+
+**Files:**
+- Modify: `backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md`
+
+- [ ] **Step 1: Self-review the complete task diff**
+
+Run:
+
+```bash
+git diff --stat origin/dev...HEAD
+git diff origin/dev...HEAD -- \
+  tldw_chatbook/Widgets/Console/console_rail_handle.py \
+  Tests/UI/test_console_rail_handle.py \
+  Tests/UI/test_destination_rail.py \
+  Tests/UI/test_console_right_rail.py \
+  Tests/UI/test_workbench_visual_snapshots.py
+```
+
+Confirm the production diff is the one approved literal, the arrow-end click stays in bounds, and no shared handle, CSS, width, badge composition, or vertical copy changed.
+
+- [ ] **Step 2: Complete the task record**
+
+After every scoped gate passes, run this command exactly once to check AC #1-5, add concise Implementation Notes, and move TASK-15865 to Done:
+
+```bash
+backlog task edit 15865 \
+  --check-ac 1 \
+  --check-ac 2 \
+  --check-ac 3 \
+  --check-ac 4 \
+  --check-ac 5 \
+  --notes "Implemented the full-width Inspect arrow as one existing button. Directly related rail, interaction, compact-access, CSS-integrity, visual, Ruff, duplicate-ID, and diff checks passed. Per user instruction, no full repository suite was run. ADR required: no." \
+  --status Done \
+  --plain
+```
+
+Expected: TASK-15865 renders as Done with AC #1-5 checked and an Implementation Notes section. Do not run the command if any directly related gate is red. Diff the task file afterwards because Backlog CLI notes replace the notes section.
+
+- [ ] **Step 3: Commit closeout documentation**
+
+```bash
+git add -- 'backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md'
+git commit -m "docs(console): close TASK-15865"
+```
+
+- [ ] **Step 4: Final cleanliness check**
+
+Run:
+
+```bash
+git status --short
+git diff --check origin/dev...HEAD
+```
+
+Expected: clean worktree and no whitespace errors.

--- a/Docs/superpowers/plans/2026-08-13-task-15865-inspector-arrow-button.md
+++ b/Docs/superpowers/plans/2026-08-13-task-15865-inspector-arrow-button.md
@@ -296,7 +296,7 @@ backlog task edit 15865 \
   --check-ac 3 \
   --check-ac 4 \
   --check-ac 5 \
-  --notes "Implemented the full-width Inspect arrow as one existing button. Directly related rail, interaction, compact-access, CSS-integrity, visual, Ruff, duplicate-ID, and diff checks passed. Per user instruction, no full repository suite was run. ADR required: no." \
+  --notes "Implemented the full-width Inspect arrow through the existing ConsoleRailHandle display seam using one fixed literal; no CSS, width, or child-widget changes were added. Modified console_rail_handle.py plus test_console_rail_handle.py, test_destination_rail.py, test_console_right_rail.py, test_console_shell_regions.py, test_settings_console_rail_labels.py, test_product_maturity_gate1_core_loop_screen_adaptation.py, and test_workbench_visual_snapshots.py. Directly related rail, interaction, compact-access, CSS-integrity, visual, Ruff, duplicate-ID, and diff checks passed. Per user instruction, no full repository suite was run. ADR required: no." \
   --status Done \
   --plain
 ```

--- a/Docs/superpowers/specs/2026-08-13-task-15865-inspector-arrow-button-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-15865-inspector-arrow-button-design.md
@@ -1,0 +1,55 @@
+# TASK-15865 — Inspector Arrow Button Design
+
+## Goal
+
+Make the collapsed horizontal Inspector affordance read as one obvious control by changing its visible button label from `Inspect` to `Inspect-->`. The full nine-cell string is the existing button; users can click anywhere on it to open the Inspector rail.
+
+## Approved Direction
+
+Use the fixed literal `Inspect-->` for the canonical horizontal right-side Console handle. It occupies exactly the current nine-cell content width:
+
+```text
+Inspect-->
+```
+
+Do not widen the eleven-column outer rail, introduce a second arrow widget, or calculate a variable number of dashes. The current `Button` already owns the full content region, so changing its display label is sufficient to make the complete affordance clickable.
+
+## Alternatives Considered
+
+### `Inspect->`
+
+This leaves one unused content cell. It is visually quieter but does not deliver the requested repeated-arrow treatment.
+
+### Width-dependent arrow fill
+
+This could calculate the dash count from the live button width. It adds layout coupling and more test surface without user value because this rail intentionally has a fixed nine-cell content width.
+
+## Scope and Behavior
+
+- Change only the horizontal right-side `ConsoleRailHandle` display copy for the canonical Inspector label.
+- Preserve the single existing `Button`; do not add nested controls or a separate arrow hit target.
+- Preserve the fixed `Open Inspector rail` tooltip.
+- Preserve the optional badge as a separate row beneath the button, including `1 appr` / `3 appr` abbreviations and containment.
+- Preserve the vertical presentation as stacked `Inspector` without an arrow.
+- Preserve the left Context handle, shared `DestinationRailHandle`, eleven-column outer width, nine-column content width, full-height filled treatment, open rail, and compact-width behavior.
+
+## Verification
+
+Focused regressions will prove:
+
+1. The horizontal canonical Inspector display label is exactly `Inspect-->`.
+2. The mounted button paints that string on one row within its existing content region.
+3. Clicking the body of the button opens the Inspector rail; there is no separate arrow control.
+4. Badged and unbadged geometry remain contained.
+5. Vertical Inspector and left Context copy remain unchanged.
+6. Representative real-Console viewport states retain one-row label, full-height parity, and positive transcript width.
+
+Verification remains limited to directly modified and related functionality, following the user's standing instruction not to run the full repository suite.
+
+## Architecture Decision Record
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this is a reversible copy-only refinement inside the existing Console rail component and its established fixed-width interaction contract. It does not change application structure, persistence, service boundaries, dependencies, security policy, or long-lived UX ownership.

--- a/Docs/superpowers/specs/2026-08-13-task-15865-inspector-arrow-button-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-15865-inspector-arrow-button-design.md
@@ -2,23 +2,23 @@
 
 ## Goal
 
-Make the collapsed horizontal Inspector affordance read as one obvious control by changing its visible button label from `Inspect` to `Inspect-->`. The full nine-cell string is the existing button; users can click anywhere on it to open the Inspector rail.
+Make the collapsed horizontal Inspector affordance read as one obvious control by changing its visible button label from `Inspect` to `Inspect->`. The full nine-cell string is the existing button; users can click anywhere on it to open the Inspector rail.
 
 ## Approved Direction
 
-Use the fixed literal `Inspect-->` for the canonical horizontal right-side Console handle. It occupies exactly the current nine-cell content width:
+Use the fixed literal `Inspect->` for the canonical horizontal right-side Console handle. It occupies exactly the current nine-cell content width:
 
 ```text
-Inspect-->
+Inspect->
 ```
 
-Do not widen the eleven-column outer rail, introduce a second arrow widget, or calculate a variable number of dashes. The current `Button` already owns the full content region, so changing its display label is sufficient to make the complete affordance clickable.
+Do not widen the eleven-column outer rail, introduce a second arrow widget, or calculate a variable number of dashes. The current `Button` already owns the full content region. Clear Textual's default one-cell line padding inline on the existing horizontal right Button so the nine-cell literal uses that full region and remains one clickable row.
 
 ## Alternatives Considered
 
-### `Inspect->`
+### `Inspect-->`
 
-This leaves one unused content cell. It is visually quieter but does not deliver the requested repeated-arrow treatment.
+This is ten terminal cells (`Inspect` is seven and `-->` is three), so it cannot fit the fixed nine-cell content width on one row. Runtime compositor evidence showed it wrapping even after Textual's line padding was cleared.
 
 ### Width-dependent arrow fill
 
@@ -27,6 +27,7 @@ This could calculate the dash count from the live button width. It adds layout c
 ## Scope and Behavior
 
 - Change only the horizontal right-side `ConsoleRailHandle` display copy for the canonical Inspector label.
+- Clear `line_pad` inline only on the existing horizontal right Button. Textual 8 defaults to `line_pad=1`, reserving one cell on each side; the repository sets zero inline because TCSS rejects `line-pad: 0`.
 - Preserve the single existing `Button`; do not add nested controls or a separate arrow hit target.
 - Preserve the fixed `Open Inspector rail` tooltip.
 - Preserve the optional badge as a separate row beneath the button, including `1 appr` / `3 appr` abbreviations and containment.
@@ -37,7 +38,7 @@ This could calculate the dash count from the live button width. It adds layout c
 
 Focused regressions will prove:
 
-1. The horizontal canonical Inspector display label is exactly `Inspect-->`.
+1. The horizontal canonical Inspector display label is exactly `Inspect->`.
 2. The mounted button paints that string on one row within its existing content region.
 3. Clicking the body of the button opens the Inspector rail; there is no separate arrow control.
 4. Badged and unbadged geometry remain contained.

--- a/Tests/UI/test_console_rail_handle.py
+++ b/Tests/UI/test_console_rail_handle.py
@@ -190,7 +190,7 @@ def test_horizontal_defaults_preserve_context_and_abbreviate_inspector_label() -
     inspector = _handle(label=CONSOLE_RAIL_INSPECTOR_LABEL, side="right")
 
     assert context._display_label() == CONSOLE_RAIL_CONTEXT_LABEL
-    assert inspector._display_label() == "Inspect"
+    assert inspector._display_label() == "Inspect-->"
 
 
 def test_vertical_generic_label_normalizes_whitespace_before_stacking() -> None:

--- a/Tests/UI/test_console_rail_handle.py
+++ b/Tests/UI/test_console_rail_handle.py
@@ -90,7 +90,9 @@ def _assert_content_column_contained(handle, child) -> None:
 
 
 @pytest.mark.asyncio
-async def test_vertical_handles_use_bundled_full_height_geometry_and_keep_badge_visible() -> None:
+async def test_vertical_handles_use_bundled_full_height_geometry_and_keep_badge_visible() -> (
+    None
+):
     """Bundled TCSS makes both vertical rail sides narrow, tall, and contained."""
     app = _VerticalRailHandleHarness()
 
@@ -121,7 +123,9 @@ async def test_vertical_handles_use_bundled_full_height_geometry_and_keep_badge_
         assert left_button.region.height >= len(left._display_label().splitlines())
         assert right_button.region.height >= len(right._display_label().splitlines())
         assert right_badge.region.height >= len(right._display_badge().splitlines())
-        assert right_button.region.y + right_button.region.height == right_badge.region.y
+        assert (
+            right_button.region.y + right_button.region.height == right_badge.region.y
+        )
         assert right_badge.region.y >= right.content_region.y
         assert right_badge.region.y + right_badge.region.height == (
             right.content_region.y + right.content_region.height
@@ -150,9 +154,10 @@ async def test_vertical_buttons_paint_a_single_centered_column() -> None:
         )
 
         for handle, button in pairs:
-            expected_x = handle.region.x + (
-                handle.region.width - ConsoleRailHandle.VERTICAL_CONTENT_WIDTH
-            ) // 2
+            expected_x = (
+                handle.region.x
+                + (handle.region.width - ConsoleRailHandle.VERTICAL_CONTENT_WIDTH) // 2
+            )
             painted_lines = [
                 strip
                 for y in range(button.region.height)
@@ -161,8 +166,7 @@ async def test_vertical_buttons_paint_a_single_centered_column() -> None:
 
             assert painted_lines
             assert all(
-                cell_len(strip.text) == button.region.width
-                for strip in painted_lines
+                cell_len(strip.text) == button.region.width for strip in painted_lines
             )
             assert button.region.x == expected_x
 
@@ -215,7 +219,9 @@ def test_vertical_canonical_context_label_derives_visible_text_from_constant(
     monkeypatch,
 ) -> None:
     canonical_label = f"Orbit {GLYPH_COLLAPSED}"
-    monkeypatch.setattr(console_rail_handle, "CONSOLE_RAIL_CONTEXT_LABEL", canonical_label)
+    monkeypatch.setattr(
+        console_rail_handle, "CONSOLE_RAIL_CONTEXT_LABEL", canonical_label
+    )
     handle = _handle(label=canonical_label, vertical=True)
 
     assert handle._display_label() == "O\nr\nb\ni\nt"

--- a/Tests/UI/test_console_rail_handle.py
+++ b/Tests/UI/test_console_rail_handle.py
@@ -190,7 +190,7 @@ def test_horizontal_defaults_preserve_context_and_abbreviate_inspector_label() -
     inspector = _handle(label=CONSOLE_RAIL_INSPECTOR_LABEL, side="right")
 
     assert context._display_label() == CONSOLE_RAIL_CONTEXT_LABEL
-    assert inspector._display_label() == "Inspect-->"
+    assert inspector._display_label() == "Inspect->"
 
 
 def test_vertical_generic_label_normalizes_whitespace_before_stacking() -> None:

--- a/Tests/UI/test_console_right_rail.py
+++ b/Tests/UI/test_console_right_rail.py
@@ -102,7 +102,7 @@ async def test_clicking_open_then_collapse_toggles_visibility_and_persists():
         open_button = pilot.app.screen.query_one(
             "#console-inspector-rail-open", Button
         )
-        assert str(open_button.label) == "Inspect-->"
+        assert str(open_button.label) == "Inspect->"
         arrow_end = (
             open_button.region.width - 1,
             open_button.region.height // 2,

--- a/Tests/UI/test_console_right_rail.py
+++ b/Tests/UI/test_console_right_rail.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 
 import pytest
+from textual.widgets import Button
 
 from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
@@ -98,7 +99,15 @@ async def test_clicking_open_then_collapse_toggles_visibility_and_persists():
         await _wait_for_selector(
             pilot.app.screen, pilot, "#console-inspector-rail-open"
         )
-        await pilot.click("#console-inspector-rail-open")
+        open_button = pilot.app.screen.query_one(
+            "#console-inspector-rail-open", Button
+        )
+        assert str(open_button.label) == "Inspect-->"
+        arrow_end = (
+            open_button.region.width - 1,
+            open_button.region.height // 2,
+        )
+        assert await pilot.click(open_button, offset=arrow_end)
         await pilot.pause(0.2)
         assert _right_rail_open(pilot) is True
         assert _handle_visible(pilot) is False

--- a/Tests/UI/test_console_right_rail.py
+++ b/Tests/UI/test_console_right_rail.py
@@ -99,9 +99,7 @@ async def test_clicking_open_then_collapse_toggles_visibility_and_persists():
         await _wait_for_selector(
             pilot.app.screen, pilot, "#console-inspector-rail-open"
         )
-        open_button = pilot.app.screen.query_one(
-            "#console-inspector-rail-open", Button
-        )
+        open_button = pilot.app.screen.query_one("#console-inspector-rail-open", Button)
         assert str(open_button.label) == "Inspect->"
         arrow_end = (
             open_button.region.width - 1,

--- a/Tests/UI/test_console_shell_regions.py
+++ b/Tests/UI/test_console_shell_regions.py
@@ -123,20 +123,14 @@ async def test_fresh_console_composes_saved_rail_label_style(
 ):
     """A fresh Console reads the saved style for both collapsed handles."""
     app = _build_test_app()
-    app.app_config.setdefault("console", {})[
-        "stack_collapsed_rail_labels"
-    ] = stacked
+    app.app_config.setdefault("console", {})["stack_collapsed_rail_labels"] = stacked
     host = ConsoleHarness(app)
 
     async with host.run_test(size=(160, 45)) as pilot:
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
-        left = console.query_one(
-            "#console-context-rail-handle", ConsoleRailHandle
-        )
-        right = console.query_one(
-            "#console-inspector-rail-handle", ConsoleRailHandle
-        )
+        left = console.query_one("#console-context-rail-handle", ConsoleRailHandle)
+        right = console.query_one("#console-inspector-rail-handle", ConsoleRailHandle)
         left_button = console.query_one("#console-context-rail-open", Button)
         right_button = console.query_one("#console-inspector-rail-open", Button)
         right_badge = console.query_one("#console-inspector-rail-badge", Static)

--- a/Tests/UI/test_console_shell_regions.py
+++ b/Tests/UI/test_console_shell_regions.py
@@ -114,7 +114,7 @@ async def make_console_pilot(*, size):
 @pytest.mark.parametrize(
     ("stacked", "left_width", "right_width", "left_label", "right_label"),
     [
-        (False, 13, 11, "Context ▸", "Inspect-->"),
+        (False, 13, 11, "Context ▸", "Inspect->"),
         (True, 3, 3, "C\no\nn\nt\ne\nx\nt", "I\nn\ns\np\ne\nc\nt\no\nr"),
     ],
 )

--- a/Tests/UI/test_console_shell_regions.py
+++ b/Tests/UI/test_console_shell_regions.py
@@ -114,7 +114,7 @@ async def make_console_pilot(*, size):
 @pytest.mark.parametrize(
     ("stacked", "left_width", "right_width", "left_label", "right_label"),
     [
-        (False, 13, 11, "Context ▸", "Inspect"),
+        (False, 13, 11, "Context ▸", "Inspect-->"),
         (True, 3, 3, "C\no\nn\nt\ne\nx\nt", "I\nn\ns\np\ne\nc\nt\no\nr"),
     ],
 )

--- a/Tests/UI/test_destination_rail.py
+++ b/Tests/UI/test_destination_rail.py
@@ -353,7 +353,7 @@ async def test_console_handle_abbreviates_the_inspector_label_on_the_right():
     async with app.run_test(size=(40, 12)) as pilot:
         await pilot.pause()
         button = app.query_one("#console-rail-open", Button)
-        assert str(button.label) == "Inspect-->"
+        assert str(button.label) == "Inspect->"
         assert button.tooltip == "Open Inspector rail"
 
 

--- a/Tests/UI/test_destination_rail.py
+++ b/Tests/UI/test_destination_rail.py
@@ -352,7 +352,9 @@ async def test_console_handle_abbreviates_the_inspector_label_on_the_right():
     )
     async with app.run_test(size=(40, 12)) as pilot:
         await pilot.pause()
-        assert str(app.query_one("#console-rail-open", Button).label) == "Inspect"
+        button = app.query_one("#console-rail-open", Button)
+        assert str(button.label) == "Inspect-->"
+        assert button.tooltip == "Open Inspector rail"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_destination_rail.py
+++ b/Tests/UI/test_destination_rail.py
@@ -181,9 +181,7 @@ async def test_clicking_the_section_title_posts_the_same_pressed_message_as_the_
     app = _SectionHeaderHarness()
     async with app.run_test(size=(40, 12)) as pilot:
         await pilot.pause()
-        title = app.query_one(
-            "#console-rail-section-title-lab-details", Static
-        )
+        title = app.query_one("#console-rail-section-title-lab-details", Static)
         await pilot.click(title)
         await pilot.pause()
 
@@ -200,9 +198,7 @@ async def test_clicking_the_toggle_chip_itself_does_not_double_fire():
     app = _SectionHeaderHarness()
     async with app.run_test(size=(40, 12)) as pilot:
         await pilot.pause()
-        toggle = app.query_one(
-            f"#{RAIL_SECTION_TOGGLE_PREFIX}lab-details", Button
-        )
+        toggle = app.query_one(f"#{RAIL_SECTION_TOGGLE_PREFIX}lab-details", Button)
         await pilot.click(toggle)
         await pilot.pause()
 
@@ -319,10 +315,13 @@ async def test_console_handle_is_a_destination_rail_handle():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(("side", "expected"), [
-    ("left", "Open Context rail"),
-    ("right", "Open Inspector rail"),
-])
+@pytest.mark.parametrize(
+    ("side", "expected"),
+    [
+        ("left", "Open Context rail"),
+        ("right", "Open Inspector rail"),
+    ],
+)
 async def test_console_handle_keeps_its_fixed_tooltips(side, expected):
     """Console's tooltips are fixed strings, not derived from the label."""
     app = _HandleHarness(_console_handle(side=side, label="Anything"))
@@ -332,12 +331,15 @@ async def test_console_handle_keeps_its_fixed_tooltips(side, expected):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(("badge", "expected"), [
-    ("1 approval", "1 appr"),
-    ("3 approvals", "3 appr"),
-    ("artifact", "art"),
-    ("something else", "something else"),
-])
+@pytest.mark.parametrize(
+    ("badge", "expected"),
+    [
+        ("1 approval", "1 appr"),
+        ("3 approvals", "3 appr"),
+        ("artifact", "art"),
+        ("something else", "something else"),
+    ],
+)
 async def test_console_handle_abbreviates_right_side_badges(badge, expected):
     app = _HandleHarness(_console_handle(side="right", badge=badge))
     async with app.run_test(size=(40, 12)) as pilot:
@@ -362,7 +364,9 @@ async def test_console_handle_leaves_left_side_text_alone():
     app = _HandleHarness(_console_handle(side="left", badge="1 approval"))
     async with app.run_test(size=(40, 12)) as pilot:
         await pilot.pause()
-        assert str(app.query_one("#console-rail-badge", Static).renderable) == "1 approval"
+        assert (
+            str(app.query_one("#console-rail-badge", Static).renderable) == "1 approval"
+        )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
+++ b/Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
@@ -237,7 +237,7 @@ async def test_console_core_loop_exposes_agentic_shell_regions():
             or CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL in text
         )
         inspector_button = console.query_one("#console-inspector-rail-open", Button)
-        assert inspector_button.label == "Inspect-->"
+        assert inspector_button.label == "Inspect->"
         assert inspector_button.tooltip == "Open Inspector rail"
 
 

--- a/Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
+++ b/Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
@@ -6,7 +6,6 @@ import time
 from pathlib import Path
 
 import pytest
-from textual.app import App
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from textual.widgets import Button, Static

--- a/Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
+++ b/Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
@@ -237,7 +237,7 @@ async def test_console_core_loop_exposes_agentic_shell_regions():
             or CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL in text
         )
         inspector_button = console.query_one("#console-inspector-rail-open", Button)
-        assert inspector_button.label == "Inspect"
+        assert inspector_button.label == "Inspect-->"
         assert inspector_button.tooltip == "Open Inspector rail"
 
 

--- a/Tests/UI/test_settings_console_rail_labels.py
+++ b/Tests/UI/test_settings_console_rail_labels.py
@@ -203,7 +203,7 @@ async def test_console_rail_label_failed_save_keeps_draft_and_active_style(
         assert left.styles.width.value == 13
         assert right.styles.width.value == 11
         assert left._display_label() == "Context ▸"
-        assert right._display_label() == "Inspect-->"
+        assert right._display_label() == "Inspect->"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_settings_console_rail_labels.py
+++ b/Tests/UI/test_settings_console_rail_labels.py
@@ -138,22 +138,20 @@ async def test_console_rail_label_setting_saves_exact_payload_and_runtime_value(
         console = console_host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
 
-        left = console.query_one(
-            "#console-context-rail-handle", ConsoleRailHandle
-        )
-        right = console.query_one(
-            "#console-inspector-rail-handle", ConsoleRailHandle
-        )
+        left = console.query_one("#console-context-rail-handle", ConsoleRailHandle)
+        right = console.query_one("#console-inspector-rail-handle", ConsoleRailHandle)
         assert left.styles.width.value == ConsoleRailHandle.VERTICAL_WIDTH
         assert right.styles.width.value == ConsoleRailHandle.VERTICAL_WIDTH
         assert left._display_label() == "C\no\nn\nt\ne\nx\nt"
         assert right._display_label() == "I\nn\ns\np\ne\nc\nt\no\nr"
-        assert console.query_one(
-            "#console-context-rail-open", Button
-        ).tooltip == "Open Context rail"
-        assert console.query_one(
-            "#console-inspector-rail-open", Button
-        ).tooltip == "Open Inspector rail"
+        assert (
+            console.query_one("#console-context-rail-open", Button).tooltip
+            == "Open Context rail"
+        )
+        assert (
+            console.query_one("#console-inspector-rail-open", Button).tooltip
+            == "Open Inspector rail"
+        )
 
 
 @pytest.mark.asyncio
@@ -194,12 +192,8 @@ async def test_console_rail_label_failed_save_keeps_draft_and_active_style(
         console = console_host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
 
-        left = console.query_one(
-            "#console-context-rail-handle", ConsoleRailHandle
-        )
-        right = console.query_one(
-            "#console-inspector-rail-handle", ConsoleRailHandle
-        )
+        left = console.query_one("#console-context-rail-handle", ConsoleRailHandle)
+        right = console.query_one("#console-inspector-rail-handle", ConsoleRailHandle)
         assert left.styles.width.value == 13
         assert right.styles.width.value == 11
         assert left._display_label() == "Context ▸"

--- a/Tests/UI/test_settings_console_rail_labels.py
+++ b/Tests/UI/test_settings_console_rail_labels.py
@@ -203,7 +203,7 @@ async def test_console_rail_label_failed_save_keeps_draft_and_active_style(
         assert left.styles.width.value == 13
         assert right.styles.width.value == 11
         assert left._display_label() == "Context ▸"
-        assert right._display_label() == "Inspect"
+        assert right._display_label() == "Inspect-->"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_workbench_visual_snapshots.py
+++ b/Tests/UI/test_workbench_visual_snapshots.py
@@ -234,8 +234,8 @@ async def test_task_15783_console_collapsed_inspector_rail_visual_parity_sweep(
             transcript = screen.query_one("#console-transcript-region")
 
             assert inspector_handle.display is True
-            assert _painted_region_rows(screen, inspector_button.region) == ["Inspect"]
-            assert inspector_button.label == "Inspect"
+            assert _painted_region_rows(screen, inspector_button.region) == ["Inspect-->"]
+            assert inspector_button.label == "Inspect-->"
             assert inspector_button.tooltip == "Open Inspector rail"
             assert workspace.content_region.contains_region(inspector_handle.region), (
                 f"Inspector handle escapes workspace at {size}: "

--- a/Tests/UI/test_workbench_visual_snapshots.py
+++ b/Tests/UI/test_workbench_visual_snapshots.py
@@ -234,8 +234,8 @@ async def test_task_15783_console_collapsed_inspector_rail_visual_parity_sweep(
             transcript = screen.query_one("#console-transcript-region")
 
             assert inspector_handle.display is True
-            assert _painted_region_rows(screen, inspector_button.region) == ["Inspect-->"]
-            assert inspector_button.label == "Inspect-->"
+            assert _painted_region_rows(screen, inspector_button.region) == ["Inspect->"]
+            assert inspector_button.label == "Inspect->"
             assert inspector_button.tooltip == "Open Inspector rail"
             assert workspace.content_region.contains_region(inspector_handle.region), (
                 f"Inspector handle escapes workspace at {size}: "

--- a/Tests/UI/test_workbench_visual_snapshots.py
+++ b/Tests/UI/test_workbench_visual_snapshots.py
@@ -234,7 +234,9 @@ async def test_task_15783_console_collapsed_inspector_rail_visual_parity_sweep(
             transcript = screen.query_one("#console-transcript-region")
 
             assert inspector_handle.display is True
-            assert _painted_region_rows(screen, inspector_button.region) == ["Inspect->"]
+            assert _painted_region_rows(screen, inspector_button.region) == [
+                "Inspect->"
+            ]
             assert inspector_button.label == "Inspect->"
             assert inspector_button.tooltip == "Open Inspector rail"
             assert workspace.content_region.contains_region(inspector_handle.region), (

--- a/backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md
+++ b/backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md
@@ -31,3 +31,20 @@ Make the collapsed Console Inspector affordance read as one obvious, full-width 
 <!-- SECTION:DESIGN:BEGIN -->
 Approved design: `Docs/superpowers/specs/2026-08-13-task-15865-inspector-arrow-button-design.md`.
 <!-- SECTION:DESIGN:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+
+ADR path: N/A
+
+Reason: this is a reversible display-copy refinement inside the existing Console rail presentation seam.
+
+1. Add RED component, mounted, arrow-end interaction, and six-state compositor expectations for the exact `Inspect-->` button.
+2. Change only the canonical horizontal Inspector display literal in `ConsoleRailHandle._display_label()`.
+3. Run directly related rail, compact-access, CSS-integrity, visual, static, and duplicate-task-ID checks; do not run the full repository suite per user instruction.
+4. Self-review, record fresh evidence, complete AC #1-5, and mark TASK-15865 Done only if every scoped gate is green.
+
+Detailed plan: `Docs/superpowers/plans/2026-08-13-task-15865-inspector-arrow-button.md`.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md
+++ b/backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md
@@ -1,0 +1,33 @@
+---
+id: TASK-15865
+title: Make Inspect arrow a full button label
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-08-13 17:12'
+updated_date: '2026-08-13 17:12'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the collapsed Console Inspector affordance read as one obvious, full-width clickable control by combining its short label and repeated arrow into `Inspect-->`, without widening the rail or changing its badge and compact-layout behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The horizontal collapsed Inspector button displays exactly `Inspect-->` on one composited row within its existing nine-cell content width.
+- [ ] #2 The entire `Inspect-->` surface is one button that opens the Inspector rail and retains the `Open Inspector rail` tooltip.
+- [ ] #3 The optional approval badge remains a separate row beneath the button with its existing abbreviation and containment behavior.
+- [ ] #4 The vertical `Inspector` presentation, left Context handle, rail widths, open rail, and responsive behavior remain unchanged.
+- [ ] #5 Focused Console rail, interaction, compact-access, and visual regressions pass.
+<!-- AC:END -->
+
+## Design
+
+<!-- SECTION:DESIGN:BEGIN -->
+Approved design: `Docs/superpowers/specs/2026-08-13-task-15865-inspector-arrow-button-design.md`.
+<!-- SECTION:DESIGN:END -->

--- a/backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md
+++ b/backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-15865
 title: Make Inspect arrow a full button label
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-13 17:12'
-updated_date: '2026-08-13 17:12'
+updated_date: '2026-08-14 01:08'
 labels: []
 dependencies: []
 ---
@@ -17,20 +17,13 @@ Make the collapsed Console Inspector affordance read as one obvious, full-width 
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 The horizontal collapsed Inspector button displays exactly `Inspect->` on one composited row within its existing nine-cell content width.
-- [ ] #2 The entire `Inspect->` surface is one button that opens the Inspector rail and retains the `Open Inspector rail` tooltip.
-- [ ] #3 The optional approval badge remains a separate row beneath the button with its existing abbreviation and containment behavior.
-- [ ] #4 The vertical `Inspector` presentation, left Context handle, rail widths, open rail, and responsive behavior remain unchanged.
-- [ ] #5 Focused Console rail, interaction, compact-access, and visual regressions pass.
+- [x] #1 The horizontal collapsed Inspector button displays exactly `Inspect->` on one composited row within its existing nine-cell content width.
+- [x] #2 The entire `Inspect->` surface is one button that opens the Inspector rail and retains the `Open Inspector rail` tooltip.
+- [x] #3 The optional approval badge remains a separate row beneath the button with its existing abbreviation and containment behavior.
+- [x] #4 The vertical `Inspector` presentation, left Context handle, rail widths, open rail, and responsive behavior remain unchanged.
+- [x] #5 Focused Console rail, interaction, compact-access, and visual regressions pass.
 <!-- AC:END -->
-
-## Design
-
-<!-- SECTION:DESIGN:BEGIN -->
-Approved design: `Docs/superpowers/specs/2026-08-13-task-15865-inspector-arrow-button-design.md`.
-<!-- SECTION:DESIGN:END -->
 
 ## Implementation Plan
 
@@ -48,3 +41,15 @@ Reason: this is a reversible display-copy refinement inside the existing Console
 
 Detailed plan: `Docs/superpowers/plans/2026-08-13-task-15865-inspector-arrow-button.md`.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the nine-cell Inspect arrow through the existing ConsoleRailHandle display seam using the fixed Inspect-> literal plus an inline line-pad reset on the existing horizontal right Button; no CSS-file, outer-width, child-widget, ID/class, or layout-structure changes were added. Modified console_rail_handle.py plus test_console_rail_handle.py, test_destination_rail.py, test_console_right_rail.py, test_console_shell_regions.py, test_settings_console_rail_labels.py, test_product_maturity_gate1_core_loop_screen_adaptation.py, and test_workbench_visual_snapshots.py. Directly related rail, interaction, compact-access, CSS-integrity, visual, Ruff, duplicate-ID, and diff checks passed. Per user instruction, no full repository suite was run. ADR required: no.
+<!-- SECTION:NOTES:END -->
+
+## Design
+
+<!-- SECTION:DESIGN:BEGIN -->
+Approved design: `Docs/superpowers/specs/2026-08-13-task-15865-inspector-arrow-button-design.md`.
+<!-- SECTION:DESIGN:END -->

--- a/backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md
+++ b/backlog/tasks/task-15865 - Make-Inspect-arrow-a-full-button-label.md
@@ -13,14 +13,14 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Make the collapsed Console Inspector affordance read as one obvious, full-width clickable control by combining its short label and repeated arrow into `Inspect-->`, without widening the rail or changing its badge and compact-layout behavior.
+Make the collapsed Console Inspector affordance read as one obvious, full-width clickable control by combining its short label and arrow into `Inspect->`, without widening the rail or changing its badge and compact-layout behavior.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The horizontal collapsed Inspector button displays exactly `Inspect-->` on one composited row within its existing nine-cell content width.
-- [ ] #2 The entire `Inspect-->` surface is one button that opens the Inspector rail and retains the `Open Inspector rail` tooltip.
+- [ ] #1 The horizontal collapsed Inspector button displays exactly `Inspect->` on one composited row within its existing nine-cell content width.
+- [ ] #2 The entire `Inspect->` surface is one button that opens the Inspector rail and retains the `Open Inspector rail` tooltip.
 - [ ] #3 The optional approval badge remains a separate row beneath the button with its existing abbreviation and containment behavior.
 - [ ] #4 The vertical `Inspector` presentation, left Context handle, rail widths, open rail, and responsive behavior remain unchanged.
 - [ ] #5 Focused Console rail, interaction, compact-access, and visual regressions pass.
@@ -41,8 +41,8 @@ ADR path: N/A
 
 Reason: this is a reversible display-copy refinement inside the existing Console rail presentation seam.
 
-1. Add RED component, mounted, arrow-end interaction, and six-state compositor expectations for the exact `Inspect-->` button.
-2. Change only the canonical horizontal Inspector display literal in `ConsoleRailHandle._display_label()`.
+1. Add RED component, mounted, arrow-end interaction, and six-state compositor expectations for the exact `Inspect->` button.
+2. Change the canonical horizontal Inspector display literal in `ConsoleRailHandle._display_label()` and clear Textual's default `line_pad=1` inline on the existing horizontal right Button so the nine-cell label paints on one row. Runtime probing showed the original ten-cell `Inspect-->` direction could not fit the fixed nine-cell content width; the user selected `Inspect->` to preserve geometry.
 3. Run directly related rail, compact-access, CSS-integrity, visual, static, and duplicate-task-ID checks; do not run the full repository suite per user instruction.
 4. Self-review, record fresh evidence, complete AC #1-5, and mark TASK-15865 Done only if every scoped gate is green.
 

--- a/tldw_chatbook/Widgets/Console/console_rail_handle.py
+++ b/tldw_chatbook/Widgets/Console/console_rail_handle.py
@@ -122,7 +122,9 @@ class ConsoleRailHandle(DestinationRailHandle):
         if normalized_label == " ".join(CONSOLE_RAIL_CONTEXT_LABEL.split()):
             normalized_label = normalized_label.removesuffix(GLYPH_COLLAPSED).rstrip()
         elif normalized_label == " ".join(CONSOLE_RAIL_INSPECTOR_LABEL.split()):
-            normalized_label = normalized_label.removeprefix(GLYPH_COLLAPSE_LEFT).lstrip()
+            normalized_label = normalized_label.removeprefix(
+                GLYPH_COLLAPSE_LEFT
+            ).lstrip()
         return ConsoleRailHandle._stack_vertical_text(normalized_label)
 
     @staticmethod

--- a/tldw_chatbook/Widgets/Console/console_rail_handle.py
+++ b/tldw_chatbook/Widgets/Console/console_rail_handle.py
@@ -89,6 +89,7 @@ class ConsoleRailHandle(DestinationRailHandle):
                 child.styles.height = "1fr"
                 child.styles.min_height = 0
                 child.styles.max_height = "100%"
+                child.styles.line_pad = 0
             yield child
 
     def _display_label(self) -> str:
@@ -97,7 +98,7 @@ class ConsoleRailHandle(DestinationRailHandle):
             return self._stack_vertical_label(self.label)
         if self.side != "right":
             return self.label
-        return "Inspect" if self.label == CONSOLE_RAIL_INSPECTOR_LABEL else self.label
+        return "Inspect->" if self.label == CONSOLE_RAIL_INSPECTOR_LABEL else self.label
 
     def _display_badge(self) -> str:
         """Return badge copy that fits the collapsed inspector affordance."""


### PR DESCRIPTION
## Summary

- Render the collapsed Inspector affordance as one exact `Inspect->` button without widening the rail.
- Clear Textual's internal line padding on the existing right-side button so the nine-cell label stays on one composited row.
- Preserve the separate approval badge, tooltip, vertical/Context labels, responsive behavior, and rail structure while strengthening final-cell hit and visual coverage.

## Test plan

- `65 passed` — focused Console rail, interaction, compact-access, CSS-integrity, and frame regressions.
- `6 passed` — live 130/140/160-column compositor sweep, badged and unbadged.
- `5 passed` — rebased product-maturity test file after removing an inherited stale import.
- Scoped Ruff lint and format checks pass; `git diff --check` passes.
- Per request, no full repository suite was run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the collapsed Inspector control a single button labeled "Inspect->" so the whole nine-cell area is clickable, without changing rail width or layout. Previously the label was "Inspect"; now it is "Inspect->" and paints on one row while preserving tooltip, badge, and vertical mode.

- Implements the label via `ConsoleRailHandle._display_label()` and clears Textual `line_pad=0` on the existing horizontal right `Button` to use the full nine-cell content width.
- Verifies selector-relative clicks at the arrow end and updates focused Console rail, interaction, and visual snapshot tests; vertical `Inspector`, left `Context ▸`, tooltips, and badge separation remain unchanged.
- Adds concise design and plan docs; closes TASK-15865 with evidence. No CSS-file, geometry, or layout changes; no migrations required.

<sup>Written for commit 8235468f7cfc1f23ff99ea523188f75318f27645. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

