### PR TITLE
fix(notes): cancel-first focus and wide-to-narrow editor routing (task-15790 batch 2)

### DIFF
--- a/backlog/tasks/task-15790 - Sweep-inventory-file-notes-arcs-left-35-Library-tests-behind.md
+++ b/backlog/tasks/task-15790 - Sweep-inventory-file-notes-arcs-left-35-Library-tests-behind.md
@@ -85,12 +85,36 @@ Green after batch 1: file_notes_git 148/148, git_push 60/60, export_receipt +
 multiselect 17/17, choice_strips + skills_canvas 230/230 (incl. the product
 fix), ingest_structural 22/22, prompts_canvas 280/280 (no change needed).
 
+## Implementation Notes (batch 2 -- the focus pair; BOTH were product bugs)
+
+The dca0594a5 suspicion was wrong -- that commit changed focus VISUALS only.
+Both failures were real product defects with different mechanisms:
+
+**1. The cancel-first confirmation focus NEVER worked.** Its feature test was
+born red at 1fbd46ec6 (verified by running it at that exact commit) and
+nobody saw, because the module never ran whole -- the born-red-test class
+again. Mechanism: `call_after_refresh(cancel.focus)` on the WORKSPACE widget
+waits for the workspace's own refresh, and `_update_controls` patches
+children in place, so that refresh never comes and the callback never fires
+(spy: same instance, mounted, focus still on the pressed button). Third
+variant of the never-firing-deferral family in one day (screen-vs-canvas in
+the skills panel, screen-vs-canvas in 15270's era, widget-vs-children here).
+Fix: `call_later` -- message-queue ordering, needs no repaint.
+
+**2. Wide->narrow hid the editor out from under its own focus.** Genuine
+regression, bisected (git bisect run, 6 steps) into 4202930d6's era; the
+test passed at its birth commit d642336e6. `_narrow_view` was only set to
+"editor" when a document was opened WHILE ALREADY NARROW, so opening on a
+wide terminal and then shrinking routed the narrow shell to the navigator --
+hiding the pane under the focused editor (Textual blurs a hidden widget's
+focus to None). User-visible: open a note, shrink the window, the note
+vanishes into the files list. Fix: on the wide->narrow TRANSITION with an
+open document, derive the view as "editor"; transition-only so Back's
+explicit navigator choice, made while narrow, keeps winning.
+
+`test_library_file_notes_workspace.py` whole: 88/88.
+
 ## Remainder (open)
 
-- `test_library_file_notes_workspace.py` x2 and `test_library_shell.py` x6:
-  both workspace failures are FOCUS assertions (cancel-first confirmation no
-  longer focuses Cancel; editor focus lost to NOWHERE at 40x20). dca0594a5
-  ("quiet focus and distill file actions") deliberately changed focus
-  behaviour, so each needs the deliberate-or-regression call made against
-  that commit's intent -- focus lost to nowhere is suspicious. Not batched
-  with the mechanical fixes above on purpose.
+- `test_library_shell.py` x6 (current-dev set: metadata placeholders, reset
+  to defaults, note sync-routes focus, recompose/fifty-cycles baseline, +2).

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -1867,7 +1867,21 @@ class LibraryFileNotesWorkspace(Vertical):
     def _apply_responsive_layout(self, width: int) -> None:
         if not self._active or not self.is_mounted:
             return
+        was_narrow = self._narrow
         self._narrow = width < 80
+        if self._narrow and not was_narrow and (
+            self._opened is not None or self._selected_deleted_path
+        ):
+            # task-15790 (bisected to 4202930d6's era, born-green then
+            # regressed): `_narrow_view` was only ever set to "editor" when a
+            # document was opened WHILE ALREADY NARROW, so opening on a wide
+            # terminal and then shrinking routed the narrow shell to the
+            # NAVIGATOR -- hiding the pane out from under its own focused
+            # editor (the hide blurs it; focus fell to None). Entering narrow
+            # with an open document means the user's context is that
+            # document. Transition-only on purpose: while ALREADY narrow,
+            # Back's explicit navigator choice must keep winning.
+            self._narrow_view = "editor"
         navigator = self.query_one("#file-notes-navigator")
         editor = self.query_one("#file-notes-editor-pane")
         back = self.query_one("#file-notes-back", Button)
@@ -1969,7 +1983,15 @@ class LibraryFileNotesWorkspace(Vertical):
             )
             self._update_controls()
             cancel = self.query_one("#file-notes-reload-cancel", Button)
-            self.call_after_refresh(cancel.focus)
+            # task-15790: `call_after_refresh` here NEVER FIRED -- it waits
+            # for THIS widget's own refresh, and `_update_controls` patches
+            # children in place, so no workspace-level refresh ever comes.
+            # The cancel-first safety focus therefore never happened: the
+            # feature's own test was born red at 1fbd46ec6 and nobody saw
+            # it until the full-suite sweep. `call_later` orders on the
+            # message queue instead, which needs no repaint to flush; focus
+            # placement does not need paint.
+            self.call_later(cancel.focus)
         if not was_active:
             self.post_message(self.ReloadConfirmationChanged(True))
 


### PR DESCRIPTION
## What

Batch 2 of TASK-15790: the two focus failures deliberately held out of batch 1 (#1618) pending a deliberate-vs-regression call. **Both turned out to be real product bugs** — and the `dca0594a5` ("quiet focus") suspicion was wrong; that commit changed focus *visuals* only.

## 1. The destructive-reload confirmation never focused Cancel

Its own feature test was **born red** at `1fbd46ec6` — verified by running it at that exact commit — and nobody saw, because the module never ran whole until the 15211 sweep. The born-red-test class again.

Mechanism, spy-measured (same instance, mounted, focus still on the pressed button): `call_after_refresh(cancel.focus)` on the **workspace widget** waits for the workspace's *own* refresh — and `_update_controls` patches children in place, so that refresh never comes and the deferred focus never fires. This is the **third variant of the never-firing-deferral family in one day** (screen-level vs canvas pump in the skills panel; widget-level vs children here). Fixed with `call_later`: message-queue ordering, needs no repaint.

## 2. Wide→narrow hid the editor out from under its own focus

Genuine regression, **git-bisected** (6 steps; the test passed at its birth commit `d642336e6`). `_narrow_view` only became `"editor"` when a document was opened *while already narrow* — so opening a note on a wide terminal and then shrinking routed the compact shell to the **navigator**, and hiding the pane blurred the focused editor to `None`. User-visible: open a note, shrink the window, the note vanishes into the files list.

Fix: on the wide→narrow **transition** with an open document, derive the view as `"editor"` — transition-only on purpose, so Back's explicit navigator choice made while narrow keeps winning.

## Verification

`test_library_file_notes_workspace.py` whole: **88/88**. Batch 1's seven modules unaffected (no shared files).

Remainder recorded in the task: `library_shell` ×6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Library notes workspace bugs: the destructive-reload dialog now focuses Cancel first, and resizing from wide to narrow keeps an open editor visible and focused. Prevents accidental destructive actions and losing editor focus on resize. Part of TASK-15790.

- In `_apply_responsive_layout`, when transitioning to narrow with an open document (or a selected deleted path), set `_narrow_view = "editor"`. While already narrow, keep the user’s explicit navigator choice.
- In `_set_reload_confirmation`, replace `call_after_refresh(cancel.focus)` with `call_later(cancel.focus)` after `_update_controls` so focus is applied without requiring a widget-level refresh.
- No API changes.

**QA**
- Open a note in wide layout and resize below 80 columns: the editor remains visible and focused (not routed to the navigator).
- Trigger the destructive-reload confirmation: Cancel is focused by default.
- `test_library_file_notes_workspace.py` passes 88/88.

<sup>Written for commit 5da96167a3768293f29caab9dd2ca3ed47ccdc1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

