### PR TITLE
fix(tests): close the sweep's Library inventory — the shell six (task-15790 batch 3)

### DIFF
--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -11650,6 +11650,15 @@ async def test_library_shell_note_delete_receipt_dismiss_keeps_note_deleted():
         )
 
         assert app.notes_scope_service.restore_calls == []
+        # task-15790: the rail is sectioned now (Inspector-rail parity), and
+        # in the immersive notes stage the Browse rows are not mounted -- the
+        # count row cannot be read without leaving the stage. Exit the way a
+        # user does (Escape backs the notes stage out to the rail); the claim
+        # under test -- the post-delete count reaches the shell -- is
+        # unchanged.
+        if not screen.query("#library-row-browse-notes"):
+            await screen.action_library_notes_escape()
+            await _wait_for_selector(screen, pilot, "#library-row-browse-notes")
         assert "(1)" in str(screen.query_one("#library-row-browse-notes").label)
 
 
@@ -11688,9 +11697,14 @@ async def test_library_shell_note_undo_blocks_concurrent_create_and_delete():
 
             # Opening another note is itself refused while Undo owns the list,
             # so no second delete/save session can begin against stale rows.
-            remaining_row = screen.query_one(".library-notes-row", Button)
-            remaining_row.press()
-            await pilot.pause()
+            # task-15790: with the sectioned-shell/receipt work the rows may
+            # not be RENDERED at all during the in-flight undo -- the refusal
+            # enforced structurally is a stronger form of the same claim. When
+            # a row does render, pressing it must still be a no-op.
+            remaining_rows = screen.query(".library-notes-row")
+            if remaining_rows:
+                remaining_rows.first(Button).press()
+                await pilot.pause()
             assert screen._library_notes_view == "list"
             assert len(service.delete_attempts) == 1
 
@@ -17275,17 +17289,35 @@ async def test_library_ingest_canvas_metadata_placeholders_are_optional_labeled(
 
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         await pilot.pause()
+        # task-15790: 6a607b692 (ingestion UAT remediation) moved the
+        # "(optional)" marking into PERSISTENT LABELS above the fields --
+        # placeholders vanish the moment the user types, so they cannot
+        # carry field identity -- and placeholders became example/default
+        # guidance. The A5 claim ("optional is spelled out") now lives on
+        # the labels; assert both halves of the new contract.
         assert (
-            host.query_one("#library-ingest-title", Input).placeholder
+            str(host.query_one("#library-ingest-title-label", Static).renderable)
             == "Title (optional)"
         )
         assert (
-            host.query_one("#library-ingest-author", Input).placeholder
+            host.query_one("#library-ingest-title", Input).placeholder
+            == "Defaults to source name"
+        )
+        assert (
+            str(host.query_one("#library-ingest-author-label", Static).renderable)
             == "Author (optional)"
         )
         assert (
+            host.query_one("#library-ingest-author", Input).placeholder
+            == "e.g. Ada Lovelace"
+        )
+        assert (
+            str(host.query_one("#library-ingest-keywords-label", Static).renderable)
+            == "Keywords (optional)"
+        )
+        assert (
             host.query_one("#library-ingest-keywords", Input).placeholder
-            == "Keywords, comma-separated (optional)"
+            == "comma-separated"
         )
 
 
@@ -21356,8 +21388,14 @@ async def test_reset_to_defaults_resets_text_inputs_and_persistence(tmp_path):
         assert fresh_input.value == "1000", (
             "Reset left the stale value in the chunk-size Input"
         )
-        assert "Chunk size: 1000" in str(
-            screen.query_one("#type-group-generic", Collapsible).title
+        # task-15790: the collapsed-title receipt rule (build_type_group_title)
+        # shows a field only when it CHANGED from its schema default -- "a
+        # receipt is for what you changed". After a reset, chunk_size==1000 IS
+        # the default again, so the title is the bare group label; asserting
+        # the receipt's presence contradicted the rule this panel ships.
+        title = str(screen.query_one("#type-group-generic", Collapsible).title)
+        assert "Chunk size" not in title, (
+            f"reset left a changed-value receipt in the title: {title!r}"
         )
 
 
@@ -22575,7 +22613,21 @@ async def test_library_note_sync_routes_cancel_pending_navigator_focus() -> None
 
         assert screen._library_notes_pending_focus_identity is None
         assert screen._library_notes_view == "list"
-        assert getattr(screen.focused, "id", None) == "library-notes-filter"
+        # task-15790: the routing contract under test is the CANCEL -- the
+        # back-press supersedes the navigation generation, so the seeded
+        # intent is discarded and no restore runs (traced: gen mismatch,
+        # identity already None at release). The old `library-notes-filter`
+        # pin was never this routing's doing: it was Textual's incidental
+        # nearest-focusable after the sync panel unmounted, which the
+        # sectioned rail (Inspector parity) legitimately changed. Assert
+        # focus landed on a live focusable rather than a stranded sync
+        # widget; where the shell CHOOSES to put it belongs to the rail
+        # arc's own tests.
+        focused_id = getattr(screen.focused, "id", None)
+        assert screen.focused is not None
+        assert focused_id is not None and not str(focused_id).startswith(
+            "library-notes-sync"
+        )
 
 
 @pytest.mark.asyncio
@@ -24755,11 +24807,13 @@ async def test_library_note_recompose_and_fifty_route_cycles_return_to_baseline(
         await screen.workers.wait_for_complete()
         await pilot.pause()
         coordinator = screen._library_note_session
+        # task-15790: 4d4dceebc (notes delete undo receipt) consolidated the
+        # create/delete workers onto one "library_note_mutation" group -- the
+        # per-verb groups no longer exist in production.
         note_worker_groups = {
             "library_note_save",
             "library_note_conflict",
-            "library_note_create",
-            "library_note_delete",
+            "library_note_mutation",
         }
         baseline_active_groups = {
             worker.group

--- a/backlog/tasks/task-15790 - Sweep-inventory-file-notes-arcs-left-35-Library-tests-behind.md
+++ b/backlog/tasks/task-15790 - Sweep-inventory-file-notes-arcs-left-35-Library-tests-behind.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15790
 title: 'Sweep inventory: file-notes arcs left ~35 Library tests behind'
-status: To Do
+status: Done
 assignee: []
 labels:
   - test-health
@@ -37,7 +37,7 @@ test only after the product behaviour is confirmed intended.
 - [x] The StopIteration pair is attributed (real bug vs test artifact) with evidence, before any contract is updated
 - [x] Each cluster is attributed to its causing commit
 - [x] Genuine product breaks are fixed rather than absorbed into expectations (one found and fixed: the skills trust-panel ordering)
-- [ ] The listed modules pass whole on dev
+- [x] The listed modules pass whole on dev
 
 ## Implementation Notes (batch 1)
 
@@ -114,7 +114,30 @@ explicit navigator choice, made while narrow, keeps winning.
 
 `test_library_file_notes_workspace.py` whole: 88/88.
 
-## Remainder (open)
+## Implementation Notes (batch 3 -- the shell six; module now 586/586)
 
-- `test_library_shell.py` x6 (current-dev set: metadata placeholders, reset
-  to defaults, note sync-routes focus, recompose/fifty-cycles baseline, +2).
+All six were stale contracts against deliberate arcs, each attributed:
+
+- metadata placeholders: 6a607b692 moved "(optional)" into PERSISTENT labels
+  (placeholders vanish on typing and cannot carry field identity);
+  placeholders are guidance now. Test asserts both halves of the new
+  contract.
+- reset-to-defaults: the collapsed-title receipt rule shows a field only
+  when CHANGED from default -- asserting "Chunk size: 1000" after a reset
+  contradicted the rule the panel ships. Test asserts the receipt's absence.
+- worker-group baseline: 4d4dceebc consolidated create/delete onto one
+  "library_note_mutation" group.
+- delete-receipt count: the sectioned rail (Inspector parity) does not mount
+  Browse rows in the immersive notes stage; the test exits the stage the way
+  a user does (Escape) before reading the count.
+- undo interlock: rows may not RENDER during an in-flight undo -- structural
+  refusal is a stronger form of the same claim; when a row renders, pressing
+  it must still be a no-op.
+- sync-routes focus: traced -- the back-press supersedes the navigation
+  generation and the CANCEL is the contract (identity discarded, no restore
+  runs); the old `library-notes-filter` pin was Textual's incidental
+  nearest-focusable after the sync panel unmounted, changed legitimately by
+  the sectioned rail. The pin is relaxed to "a live focusable, not a
+  stranded sync widget"; where the shell chooses to put focus belongs to the
+  rail arc's own tests. (Left open as a UX question for that arc: after
+  backing out of notes sync, focus lands on the rail's Details toggle.)


### PR DESCRIPTION
## What

Final batch of TASK-15790: the six `test_library_shell.py` failures. All six were stale contracts against deliberate arcs — each attributed to its causing commit before updating, none absorbed blind:

- **metadata placeholders** — `6a607b692` moved "(optional)" into persistent labels (placeholders vanish on typing and can't carry field identity); the test now asserts both halves of the label+guidance contract
- **reset-to-defaults** — the collapsed-title receipt rule shows a field only when *changed from default*; asserting a receipt after a reset contradicted the rule the panel ships
- **worker-group baseline** — `4d4dceebc` consolidated create/delete onto one `library_note_mutation` group
- **delete-receipt count** — the sectioned rail (Inspector parity) doesn't mount Browse rows in the immersive notes stage; the test exits the stage the way a user does (Escape) before reading the count
- **undo interlock** — rows may not render during an in-flight undo; structural refusal is a *stronger* form of the same claim, and a rendered row still must be a no-op
- **sync-back focus** — traced: the back-press supersedes the navigation generation, so the **cancel** is the routing contract (intent discarded, no restore runs); the old `library-notes-filter` pin was Textual's incidental nearest-focusable, legitimately changed by the sectioned rail. Pin relaxed to "a live focusable, not a stranded sync widget"; one UX question recorded for the rail arc rather than silently blessed (focus lands on the rail's Details toggle after backing out).

## Verification

`Tests/UI/test_library_shell.py` whole: **586/586**.

**TASK-15790 closed**: 41 tests repaired across three batches (#1618, #1621, this), with two real product bugs found and fixed along the way — the stuck skills trust panel and the cancel-focus/wide-to-narrow routing pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the final six failures in the Library shell test suite by aligning stale expectations with intended UI behavior. No product changes; tests now reflect the sectioned rail, persistent optional labels, consolidated worker groups, and cancel-first routing in TASK-15790.

- Metadata placeholders: optional moved from placeholders to persistent labels; placeholders are guidance. Tests assert label text and guidance text.
- Reset-to-defaults: collapsed title shows only fields changed from defaults. After reset, assert no "Chunk size" receipt in the title.
- Worker groups: create/delete consolidated into one mutation group. Tests expect the `library_note_mutation` group.
- Delete count: immersive notes stage does not mount Browse rows. Tests exit the stage via Escape before reading the count.
- Undo interlock: rows may not render during in-flight undo; if a row renders, pressing it is a no-op. Tests guard for both.
- Sync-back focus: cancel supersedes navigation generation; do not pin focus to `library-notes-filter`. Assert focus is on a live focusable and not a `library-notes-sync*` widget.

Verification: `Tests/UI/test_library_shell.py` now passes 586/586. TASK-15790 inventory marked Done with batch-3 notes added.

<sup>Written for commit 0e4f441508ed202e02feb04c9917a8cea8a6ec12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

